### PR TITLE
Minor README reorg

### DIFF
--- a/README
+++ b/README
@@ -29,11 +29,6 @@ you can view the documentation for *the most recent rsyslog version*
 online at
     http://www.rsyslog.com/doc
 
-Development Model
-=================
-Rsyslog uses the "integration manager" workflow as described here:
-    http://git-scm.com/book/en/Distributed-Git-Distributed-Workflows
-
 Project Philosophy
 ==================
 We are an open source project in all aspects and very open to outside feedback


### PR DESCRIPTION
- I'd personally remove the Project Philosophy section because it adds a bit too much noise IMHO without adding much value.  I'd rather use the limited space and people's attention to tell them how to build rsyslog!
