### PR TITLE
typedefs.h: include sys/types.h instead of unistd.h to get off_t

### DIFF
--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -25,12 +25,8 @@
  */
 #ifndef INCLUDED_TYPEDEFS_H
 #define INCLUDED_TYPEDEFS_H
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || !defined(HAVE_LSEEK64)
 #include <sys/types.h>
-#endif
-
-#ifndef HAVE_LSEEK64
-#include <unistd.h>
 #endif
 
 /* some universal fixed size integer defines ... */


### PR DESCRIPTION
Compilation of rsyslog-7.4.7 on Debian Etch fails with the following error:

make[4]: Entering directory `/var/home/karol/deb-src/rsyslog/rsyslog/grammar'
/bin/sh ../libtool --tag=CC --mode=compile gcc -DHAVE_CONFIG_H -I. -I. -I..  -I../runtime -I.. -I../grammar  -I/usr/include/json     -g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g -c -o libgrammar_la-grammar.lo`test -f 'grammar.c' || echo './'`grammar.c
mkdir .libs
 gcc -DHAVE_CONFIG_H -I. -I. -I.. -I../runtime -I.. -I../grammar -I/usr/include/json -g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g -c grammar.c  -fPIC -DPIC -o .libs/libgrammar_la-grammar.o
In file included from rainerscript.h:5,
                 from grammar.y:34:
../runtime/typedefs.h:159: error: expected ‘=’, ‘,’, ‘;’, ‘asm’ or ‘__attribute__’ before ‘off64_t’
make[4]: *** [libgrammar_la-grammar.lo] Error 1
make[4]: Leaving directory`/var/home/karol/deb-src/rsyslog/rsyslog/grammar'

While it's not obvious the problem is that off_t is not defined. This is because runtime/typedefs.h includes unistd.h and the definition of off_t is in sys/types.h.
