### PR TITLE
Add default ownership directives to overall omfile module config

### DIFF
--- a/doc/omfile.html
+++ b/doc/omfile.html
@@ -14,18 +14,81 @@
 
 <p><b>Module Parameters</b>:</p>
 <ul>
-	<li><strong>Template </strong>[templateName]<br>
-	Set the default template to be used if an action is not
-	configured to use a specific template.<br></li>
+	<li>
+        <strong>Template </strong>[templateName]<br>
+        Set the default template to be used if an action is not
+        configured to use a specific template.<br><br>
+    </li>
 
-	<li><strong>DirCreateMode </strong>[default 0700]<br>
-	Sets the default DirCreateMode to be used for an action
-	if no explicit one is specified.</br>
+	<li>
+        <strong>DirCreateMode </strong>[default 0700]<br>
+        Sets the default DirCreateMode to be used for an action
+        if no explicit one is specified.<br><br>
+    </li>
 	
-	<li><strong>FileCreateMode </strong>[default 0644]<br>
-	Sets the default DirCreateMode to be used for an action
-	if no explicit one is specified.</br>
+	<li>
+        <strong>FileCreateMode </strong>[default 0644]<br>
+        Sets the default DirCreateMode to be used for an action
+        if no explicit one is specified.<br><br>
+    </li>
+
+    <li>
+        <strong>DirOwner </strong><br>
+        Set the default file owner for directories newly created. Please note that this setting does not affect the
+        owner of directories already existing. The parameter is a user name, for which the userid is obtained by
+        rsyslogd during startup processing. Interim changes to the user mapping are not detected.<br><br>
+    </li>
+
+    <li>
+        <strong>DirOwnerNum </strong><br>
+        Set the default file owner for directories newly created. Please note that this setting does not affect the
+        owner of directories already existing. The parameter is a numerical ID, which is used regardless of whether the
+        user actually exists. This can be useful if the user mapping is not available to rsyslog during startup.<br><br>
+    </li>
+
+    <li>
+        <strong>DirGroup </strong><br>
+        Set the default group for directories newly created. Please note that this setting does not affect the group of
+        directories already existing. The parameter is a group name, for which the groupid is obtained by rsyslogd on
+        during startup processing. Interim changes to the user mapping are not detected.<br><br>
+    </li>
+
+    <li>
+        <strong>DirGroupNum </strong><br>
+        Set the default group for directories newly created. Please note that this setting does not affect the group of
+        directories already existing. The parameter is a numerical ID, which is used regardless of whether the group
+        actually exists. This can be useful if the group mapping is not available to rsyslog during startup.<br><br>
+    </li>
+
+    <li>
+        <strong>FileOwner </strong><br>
+        Set the default file owner for files newly created. Please note that this setting does not affect the owner of
+        files already existing. The parameter is a user name, for which the userid is obtained by rsyslogd during
+        startup processing. Interim changes to the user mapping are not detected.<br><br>
+    </li>
+
+    <li>
+        <strong>FileOwnerNum </strong><br>
+        Set the default file owner for files newly created. Please note that this setting does not affect the owner of
+        files already existing. The parameter is a numerical ID, which which is used regardless of whether the user
+        actually exists. This can be useful if the user mapping is not available to rsyslog during startup.<br><br>
+    </li>
+
+    <li>
+        <strong>FileGroup </strong><br>
+        Set the default group for files newly created. Please note that this setting does not affect the group of files
+        already existing. The parameter is a group name, for which the groupid is obtained by rsyslogd during startup
+        processing. Interim changes to the user mapping are not detected.<br><br>
+    </li>
+
+    <li>
+        <strong>FileGroupNum </strong><br>
+        Set the default group for files newly created. Please note that this setting does not affect the group of files
+        already existing. The parameter is a numerical ID, which is used regardless of whether the group actually
+        exists. This can be useful if the group mapping is not available to rsyslog during startup.<br><br>
+    </li>
 </ul>
+
 <p>&nbsp;</p>
 <p><b>Action Parameters</b>:</p>
 <ul>
@@ -153,10 +216,15 @@ unusable.
 </ul>
 <p><b>Sample:</b></p>
 <p>The following command writes all syslog messages into a file.</p>
-<textarea rows="5" cols="60">action(type="omfile" 
-       DirCreateMode="0700"
-       FileCreateMode="0644"
-       File="/var/log/messages")
+<textarea rows="10" cols="90">
+# Set defaults for every output file
+module(load="builtin:omfile" FileCreateMode="0644" DirCreateMode="0700" FileOwner="syslog")
+
+# Output everything to /var/log/messages
+*.* action(type="omfile" File="/var/log/messages")
+
+# Output auth notices to /var/log/auth.log and only allow the owner to access it
+auth,authpriv.* action(type="omfile" File="/var/log/auth.log" FileCreateMode="0600")
 </textarea>
 
 <br><br>


### PR DESCRIPTION
When switching over to using the new config directives I found it a bit heavyweight to set file/dir owners per output file.

This allows you to set the default values for the following
- dirOwner
- dirOwnerNum
- dirGroup
- dirGroupNum
- fileOwner
- fileOwnerNum
- fileGroup
- fileGroupNum

Example:

```
module(load="builtin:omfile" dirOwner="syslog")
```
