### PR TITLE
Add pom to package easily the java part with maven

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ checklog
 logfile*
 *.conf
 log
+/target

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,52 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+  http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.rsyslog</groupId>
+  <artifactId>rsyslog</artifactId>
+  <version>8.1.6</version>
+  <packaging>jar</packaging>
+  <name>rsyslog java part</name>
+  <url>https://github.com/rsyslog/rsyslog</url>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <sourceDirectory>java</sourceDirectory>
+
+    <plugins>
+      <!-- Create jar of sources and javadocs -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.2.1</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <version>2.9.1</version>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+
+  </build>
+</project>


### PR DESCRIPTION
Maven will create a target dir with its compilation files and three jars,
one with compiled classes, one with classes source code and one with
javadocs.

The generated jar is not executable directly. For instance, we will
have to do:
    java -cp target/rsyslog-8.1.6.jar com.rsyslog.gui.diaggui.DiagGUI
to execute the main in com.rsyslog.gui.diaggui.DiagGUI class.

The previous build system with makefile is not affected by this patch.
