### PR TITLE
Use automake 'subdir-objects' option

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ(2.61)
 AC_INIT([rsyslog],[7.6.0],[rsyslog@lists.adiscon.com])
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 


### PR DESCRIPTION
Newer automake versions complain if we use source files in subdirectories:

autoreconf: running: automake --add-missing --copy --force-missing
plugins/omelasticsearch/Makefile.am:4: warning: source file 'cJSON/cjson.c' is in a subdirectory,
plugins/omelasticsearch/Makefile.am:4: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled.  For now, the corresponding output
automake: object file(s) will be placed in the top-level directory.  However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
runtime/Makefile.am:7: warning: source file '../action.c' is in a subdirectory,
runtime/Makefile.am:7: but option 'subdir-objects' is disabled
runtime/Makefile.am:7: warning: source file '../threads.c' is in a subdirectory,
runtime/Makefile.am:7: but option 'subdir-objects' is disabled
runtime/Makefile.am:7: warning: source file '../parse.c' is in a subdirectory,
runtime/Makefile.am:7: but option 'subdir-objects' is disabled
runtime/Makefile.am:7: warning: source file '../outchannel.c' is in a subdirectory,
runtime/Makefile.am:7: but option 'subdir-objects' is disabled
runtime/Makefile.am:7: warning: source file '../template.c' is in a subdirectory,
runtime/Makefile.am:7: but option 'subdir-objects' is disabled
autoreconf: Leaving directory `.'

Explicitly set the 'subdir-objects' option to avoid any future issues.

Fixes #33
