### PR TITLE
Fix json includes

### DIFF
--- a/plugins/mmcount/mmcount.c
+++ b/plugins/mmcount/mmcount.c
@@ -30,7 +30,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <stdint.h>
-#include <json/json.h>
+#include <json.h>
 #include "conf.h"
 #include "syslogd-types.h"
 #include "srUtils.h"

--- a/plugins/mmsequence/mmsequence.c
+++ b/plugins/mmsequence/mmsequence.c
@@ -35,7 +35,7 @@
 #include <stdint.h>
 #include <time.h>
 #include <limits.h>
-#include <json/json.h>
+#include <json.h>
 #include <pthread.h>
 #include "conf.h"
 #include "syslogd-types.h"

--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -26,8 +26,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <json/json.h>
-#include <json/json.h>
+#include <json.h>
 #include <assert.h>
 
 #include "rsyslog.h"


### PR DESCRIPTION
Rely on the include paths set by json-c.pc instead of hardcoding
the include to be <json/json.h> since this breaks with newer versions of
json-c where the files are installed in /usr/include/json-c.

While at it, remove a duplicate include.
