### PR TITLE
Fix rfc3195 configure check

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1127,7 +1127,7 @@ AC_ARG_ENABLE(rfc3195,
         [enable_rfc3195=no]
 )
 if test "x$enable_rfc3195" = "xyes"; then
-	PKG_CHECK_MODULES(LIBLOGGING, liblogging >= 0.7.1)
+	PKG_CHECK_MODULES(LIBLOGGING, liblogging-rfc3195 >= 1.0.1)
 fi
 AM_CONDITIONAL(ENABLE_RFC3195, test x$enable_rfc3195 = xyes)
 


### PR DESCRIPTION
Newer versions of liblogging were restructured and now also contain
other components besides rfc3195. As a result the original liblogging
library was split and the rfc3195 component was renamed to
liblogging-rfc3195 along with its pkg-config file.

Update the configure check accordingly.
Since we require liblogging >= 1.0.1 anyway, don't add a fallback check
for the old pkg-config name.

Fixes #30
