### PR TITLE
Add getter for local port of server socket

### DIFF
--- a/java/com/rsyslog/lib/SyslogServerTCP.java
+++ b/java/com/rsyslog/lib/SyslogServerTCP.java
@@ -2,9 +2,9 @@
  * Implementation of a tcp-based syslog server.
  *
  * This is a limited-capability implementation of a syslog tcp server.
- * 
+ *
  * @author Rainer Gerhards
- * 
+ *
  * Copyright 2009 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
@@ -121,6 +121,10 @@ public class SyslogServerTCP extends Thread {
 		catch(Exception e) {
 			System.out.println("Error during server run " + e.toString());
 		}
-			
+
+	}
+
+	public int getSocketLocalPort() {
+		return lstnSock.getLocalPort();
 	}
 }


### PR DESCRIPTION
Having a getter for the local port of the server socket permits the
use of port 0.

While creating a ServerSocket, port 0 means the socket will use any
available port of the system. To know which port was chosen, you need
the getter added by this commit.
