### PR TITLE
add defaultNetstreamDriverCertFile option to the global() object

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -109,6 +109,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "debug.logfile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdrivercafile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdriverkeyfile", eCmdHdlrString, 0 },
+        { "defaultnetstreamdrivercertfile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdriver", eCmdHdlrString, 0 },
 	{ "maxmessagesize", eCmdHdlrSize, 0 },
 	{ "action.reportsuspension", eCmdHdlrBinary, 0 }
@@ -694,6 +695,10 @@ glblDoneLoadCnf(void)
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdriverkeyfile")) {
 			free(pszDfltNetstrmDrvrKeyFile);
 			pszDfltNetstrmDrvrKeyFile = (uchar*)
+				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercertfile")) {
+			free(pszDfltNetstrmDrvrCertFile);
+			pszDfltNetstrmDrvrCertFile = (uchar*)
 				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercafile")) {
 			free(pszDfltNetstrmDrvrCAF);


### PR DESCRIPTION
I didn't see an equivalent of $DefaultNetstreamDriverCertFile in the [global object](http://www.rsyslog.com/doc/global.html). This was the only missing piece for me to [configure TLS in rsyslog](http://www.rsyslog.com/doc/rsyslog_secure_tls.html) with the [new config format (RainerScript)](http://www.rsyslog.com/doc/rainerscript.html).

So I've added it. Again, don't trust me because I'm a newbie, so I just copy-pasted and changed what made sense to me. And I tested it on my machine and it works. Here's my config on the server side:

```
module(  # TCP listener for TLS traffic
  load="imtcp"
  StreamDriver.AuthMode="anon" # don't try to authenticate clients
  StreamDriver.Mode="1" # run driver in TLS-only mode
)

# make gtls driver the default and show it the certificates
global (
 defaultNetstreamDriver="gtls"
 defaultNetstreamDriverCAFile="/root/rsyslog-tls/ca.pem"
 defaultNetstreamDriverKeyFile="/root/rsyslog-tls/machine-key.pem"
 defaultNetstreamDriverCertFile="/root/rsyslog-tls/machine-cert.pem"
)

input( # start up TLS listener
  type="imtcp"
  port="10514"
)

action( # write everything to a file
  type="omfile"
  file="/var/log/messages"
)
```

As always, I'll contribute the doc counterpart if/when the code commit turns out to be OK :)
