### PR TITLE
Check for "rst2man" and "rst2man.py"

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1124,8 +1124,8 @@ if test "x$enable_cached_man_pages" = "xno"; then
 # obtain path for rst2man
   if test "x$enable_libgcrypt" = "xyes" || \
      test "x$enable_guardtime" = "xyes"; then
-        AC_PATH_PROG([RST2MAN], [rst2man])
-        if test "x${RST2MAN}" == "x"; then
+        AC_PATH_PROGS([RST2MAN], [rst2man rst2man.py], "no")
+        if test "x${RST2MAN}" == "xno"; then
             AC_MSG_FAILURE([rst2man not found in PATH])
         fi
   fi


### PR DESCRIPTION
docutils installs "rst2man.py" per default, so we need to check for both
variants:
- "rst2man" when using python-docutils from Ubuntu
- "rst2man.py" when using docutils from upstream

This will fix issue #51.
