### PR TITLE
Patch for bug in omzmq plugin

### DIFF
--- a/plugins/omzmq3/omzmq3.c
+++ b/plugins/omzmq3/omzmq3.c
@@ -255,21 +255,18 @@ static rsRetVal initZMQ(instanceData* pData) {
     RETiRet;
 }
 
-rsRetVal writeZMQ(uchar* msg, instanceData* pData) {
-	DEFiRet;
+rsRetVal writeZMQ(uchar* umsg, instanceData* pData) {
+        DEFiRet;
 
     /* initialize if necessary */
     if(NULL == pData->socket)
-		CHKiRet(initZMQ(pData));
-    
+                CHKiRet(initZMQ(pData));
+
     /* send it */
-    int result = zstr_send(pData->socket, (char*)msg);
-    
-    /* whine if things went wrong */
-    if (result == -1) {
-        errmsg.LogError(0, NO_ERRCODE, "omzmq3: send of %s failed: %s", msg, zmq_strerror(errno));
-        ABORT_FINALIZE(RS_RET_ERR);
-    }
+    char* msg;
+    msg = (char*)umsg;
+    zmq_send(pData->socket, msg, strlen(msg), ZMQ_NOBLOCK);
+
  finalize_it:
     RETiRet;
 }


### PR DESCRIPTION
I had an issue with rsyslog backing up and consuming tons of memory if there wasn't a zmq socket listening for messages when using the `omzmq3` plugin. Setting the `sendHWM` option was not working because zstr_send blocks when the HWM (High water mark) is hit, causing the buffer on rsyslog to continue to fill up. Switching to `zmq_send` and specifying ZMQ_NOBLOCK does the trick. Now settings HWM and other options actually work.

My C code writing isn't the best so if there is a better way to write this i'm all ears. I just figured I would submit a patch instead of sitting on it.
