### PR TITLE
plugins: Remove $(RSRT_LIBS) from imuxsock's LIBADD

### DIFF
--- a/plugins/imuxsock/Makefile.am
+++ b/plugins/imuxsock/Makefile.am
@@ -3,4 +3,4 @@ pkglib_LTLIBRARIES = imuxsock.la
 imuxsock_la_SOURCES = imuxsock.c
 imuxsock_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 imuxsock_la_LDFLAGS = -module -avoid-version
-imuxsock_la_LIBADD = $(RSRT_LIBS)
+imuxsock_la_LIBADD =


### PR DESCRIPTION
imuxsock.c plugin uses some functions from sd-daemon.h that are
compiled as part of librsyslog.a. Including $(RSRT_LIB) to the LIBADD
variable on these plugins means that we are linking librsyslog.a
statically into that plugin. Nevertheless, the rsyslogd binary
already includes librsyslog.a and exposes its symbols. Because of
this, we can let those functions undefined in the plugin .so file
and let dlopen() link those undefined functions against the global
symbols from rsyslogd.
