### PR TITLE
plugins: Remove $(RSRT_LIBS) from imuxsock's LIBADD

### DIFF
--- a/plugins/imuxsock/Makefile.am
+++ b/plugins/imuxsock/Makefile.am
@@ -3,4 +3,4 @@ pkglib_LTLIBRARIES = imuxsock.la
 imuxsock_la_SOURCES = imuxsock.c
 imuxsock_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 imuxsock_la_LDFLAGS = -module -avoid-version
-imuxsock_la_LIBADD = $(RSRT_LIBS)
+imuxsock_la_LIBADD =

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -39,12 +39,13 @@ rsyslogd_SOURCES = \
 	pidfile.h \
 	\
 	../dirty.h
-rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) -DSD_EXPORT_SYMBOLS
 # note: it looks like librsyslog.la must be explicitely given on LDDADD,
-# otherwise dependencies are not properly calculated (resulting in a 
+# otherwise dependencies are not properly calculated (resulting in a
 # potentially incomplete build, a problem we had several times...)
 rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS) $(LIBLOGGING_STDLOG_LIBS)
-rsyslogd_LDFLAGS = -export-dynamic
+rsyslogd_LDFLAGS = -export-dynamic \
+	-Wl,--whole-archive,$(top_builddir)/runtime/.libs/librsyslog.a,--no-whole-archive
 
 EXTRA_DIST = $(man_MANS) \
 	rsgtutil.rst \


### PR DESCRIPTION
imuxsock.c plugin uses some functions from sd-daemon.h that are
compiled as part of librsyslog.a. Including $(RSRT_LIB) to the LIBADD
variable on these plugins means that we are linking librsyslog.a
statically into that plugin. Nevertheless, the rsyslogd binary
already includes most of the librsyslog.a and exposes its symbols.
Because of this, we can let those functions undefined in the plugin
.so file and let dlopen() link those undefined functions against the
global symbols from rsyslogd.

This patch removes the static library from imuxsock.so and ensures
that all the objects from the librsyslog.a are included on rsyslogd.
