### PR TITLE
Omudpspoof source ports are not generated properly

### DIFF
--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -383,7 +383,7 @@ UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, char *msg, size_t l
 
 	if(len > 65528) {
 		DBGPRINTF("omudpspoof: msg with length %d truncated to 64k: '%.768s'\n",
-			  len, msg);
+			  (int) len, msg);
 		len = 65528;
 	}
 
@@ -455,7 +455,7 @@ UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, char *msg, size_t l
 			 * it is useful for consolidating with strace output.
 			 */
 			DBGPRINTF("omudpspoof: write error (total len %d): pktLen %d, sent %d, fd %d: %s\n",
-				  len, LIBNET_IPV4_H+LIBNET_UDP_H+pktLen, lsent, pWrkrData->libnet_handle->fd,
+				  (int) len, LIBNET_IPV4_H+LIBNET_UDP_H+pktLen, lsent, pWrkrData->libnet_handle->fd,
 				  libnet_geterror(pWrkrData->libnet_handle));
 			if(lsent != -1) {
 				bSendSuccess = RSTRUE;
@@ -504,7 +504,7 @@ UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, char *msg, size_t l
 			lsent = libnet_write(pWrkrData->libnet_handle);
 			if(lsent != (int) (LIBNET_IPV4_H+pktLen)) {
 				DBGPRINTF("omudpspoof: fragment write error len %d, sent %d: %s\n",
-					  LIBNET_IPV4_H+LIBNET_UDP_H+len, lsent, libnet_geterror(pWrkrData->libnet_handle));
+					  (int) (LIBNET_IPV4_H+LIBNET_UDP_H+len), lsent, libnet_geterror(pWrkrData->libnet_handle));
 				bSendSuccess = RSFALSE;
 				continue;
 			}


### PR DESCRIPTION
Here was a bugfix at 4ae292e664260f148e7da6c1641d1490c059371e. It is apparently wrong for source ports, because they were in host order already.

Also here is minor cleanup of compiler warnings (size_t vs %d). Strictly speaking, all this should be converted to size_t, but, as far as I googled, proper printf format for size_t is not well settled yet.
