### PR TITLE
Fix build error.

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -106,8 +106,8 @@ else
 librsyslog_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -D_PATH_MODDIR=\"$(pkglibdir)/\" -I\$(top_srcdir) -I\$(top_srcdir)/grammar
 endif
 #librsyslog_la_LDFLAGS = -module -avoid-version
-librsyslog_la_CPPFLAGS += $(PTHREADS_CFLAGS) $(LIBUUID_CFLAGS) $(JSON_C_CFLAGS) -I\$(top_srcdir)/tools
-librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(JSON_C_LIBS)
+librsyslog_la_CPPFLAGS += $(PTHREADS_CFLAGS) $(LIBUUID_CFLAGS) $(JSON_C_CFLAGS) ${LIBLOGGING_STDLOG_CFLAGS} -I\$(top_srcdir)/tools
+librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(JSON_C_LIBS) ${LIBLOGGING_STDLOG_LIBS}
 
 #
 # regular expression support


### PR DESCRIPTION
Fixes rsyslog.c:62:31: error: liblogging/stdlog.h: No such file or directory

This PR addresses https://github.com/rsyslog/rsyslog/issues/117

It works for me, but, I'm an automake/autoconf novice so please double check this is the correct fix before merging.

Kind Regards,
Alex
