### PR TITLE
build fix for systems without 64bit atomic builtins

### DIFF
--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -139,7 +139,7 @@ PROTOTYPEObj(statsobj);
  */
 #define STATSCOUNTER_DEF(ctr, mut) \
 	intctr_t ctr; \
-	DEF_ATOMIC_HELPER_MUT64(mut)
+	DEF_ATOMIC_HELPER_MUT64(mut);
 
 #define STATSCOUNTER_INIT(ctr, mut) \
 	INIT_ATOMIC_HELPER_MUT64(mut); \


### PR DESCRIPTION
Triggered for instance when cross compiling to armv6.
