### PR TITLE
Fixing bug with keep-alive with gtls.

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1586,7 +1586,9 @@ finalize_it:
 static rsRetVal
 EnableKeepAlive(nsd_t *pNsd)
 {
-	return nsd_ptcp.EnableKeepAlive(pNsd);
+	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
+	ISOBJ_TYPE_assert(pThis, nsd_gtls);
+	return nsd_ptcp.EnableKeepAlive(pThis->pTcp);
 }
 
 


### PR DESCRIPTION
Self-explanatory -fixing to cast nsd_gtls_t structure per the gtls method.
