### PR TITLE
fix build with json-c 0.12 if it provides a compatibility json.pc

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -32,13 +32,15 @@ PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
 PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3)
 PKG_CHECK_MODULES([JSON_C], [json],, [
-	PKG_CHECK_MODULES([JSON_C], [json-c],
-	       [AC_DEFINE([HAVE_JSON_TOKENER_ERROR_DESC], [1], [we have the newer JSON-C API])])
+	PKG_CHECK_MODULES([JSON_C], [json-c],,)
 ])
 
 # if int64 is supported, use it
 AC_CHECK_LIB(json-c, json_object_new_object,,)
 AC_CHECK_FUNCS(json_object_new_int64,,)
+
+# look for newer API
+AC_CHECK_FUNCS(json_tokener_error_desc,,)
 
 case "${host}" in
   *-*-linux*)


### PR DESCRIPTION
json-c on openSUSE provides a compatibility pkg-config for "json".
The autoconf check find it first, assuming it does not provide
the function `json_tokener_error_desc`. Check for availability of
function using `AC_CHECK_FUNCS` instead to define the corresponding
`HAVE_JSON_TOKENER_ERROR_DESC` macro.

> checking for JSON_C... yes
> checking for json_object_new_object in -ljson-c... yes
> checking for json_object_new_int64... yes
> checking for json_tokener_error_desc... yes

See rsyslog@6b47dd542d07ed557f02af9970d1004eb262e1c1
