### PR TITLE
Added libestr dependency to librsyslog_la automake target

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,8 +14,8 @@ lmtcpsrv_la_SOURCES = \
 	tcps_sess.h \
 	tcpsrv.c \
 	tcpsrv.h
-lmtcpsrv_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmtcpsrv_la_LDFLAGS = -module -avoid-version
+lmtcpsrv_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmtcpsrv_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 lmtcpsrv_la_LIBADD = 
 
 #
@@ -24,8 +24,8 @@ lmtcpsrv_la_LIBADD =
 lmtcpclt_la_SOURCES = \
 	tcpclt.c \
 	tcpclt.h
-lmtcpclt_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmtcpclt_la_LDFLAGS = -module -avoid-version
+lmtcpclt_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmtcpclt_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 lmtcpclt_la_LIBADD = 
 
 endif # if ENABLE_INET

--- a/grammar/Makefile.am
+++ b/grammar/Makefile.am
@@ -11,7 +11,7 @@ libgrammar_la_SOURCES = \
 	rainerscript.h \
 	parserif.h \
 	grammar.h
-libgrammar_la_CPPFLAGS =  $(RSRT_CFLAGS)
+libgrammar_la_CPPFLAGS =  $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
 
 #testdriver_SOURCES = testdriver.c libgrammar.la
 #testdriver_CPPFLAGS =  $(RSRT_CFLAGS)

--- a/plugins/imklog/Makefile.am
+++ b/plugins/imklog/Makefile.am
@@ -10,6 +10,6 @@ if ENABLE_IMKLOG_LINUX
 imklog_la_SOURCES += bsd.c
 endif
 
-imklog_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-imklog_la_LDFLAGS = -module -avoid-version
+imklog_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+imklog_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 imklog_la_LIBADD = 

--- a/plugins/immark/Makefile.am
+++ b/plugins/immark/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = immark.la
 
 immark_la_SOURCES = immark.c immark.h
-immark_la_CPPFLAGS = $(RSRT_CFLAGS) -I$(top_srcdir) $(PTHREADS_CFLAGS)
-immark_la_LDFLAGS = -module -avoid-version
+immark_la_CPPFLAGS = $(RSRT_CFLAGS) -I$(top_srcdir) $(PTHREADS_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+immark_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 immark_la_LIBADD = 

--- a/plugins/imtcp/Makefile.am
+++ b/plugins/imtcp/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imtcp.la
 
 imtcp_la_SOURCES = imtcp.c
-imtcp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-imtcp_la_LDFLAGS = -module -avoid-version
+imtcp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+imtcp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 imtcp_la_LIBADD = 

--- a/plugins/imudp/Makefile.am
+++ b/plugins/imudp/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imudp.la
 
 imudp_la_SOURCES = imudp.c
-imudp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-imudp_la_LDFLAGS = -module -avoid-version
+imudp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+imudp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 imudp_la_LIBADD = $(IMUDP_LIBS)

--- a/plugins/imuxsock/Makefile.am
+++ b/plugins/imuxsock/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imuxsock.la
 
 imuxsock_la_SOURCES = imuxsock.c
-imuxsock_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-imuxsock_la_LDFLAGS = -module -avoid-version
+imuxsock_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+imuxsock_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 imuxsock_la_LIBADD =

--- a/plugins/mmexternal/Makefile.am
+++ b/plugins/mmexternal/Makefile.am
@@ -1,8 +1,8 @@
 pkglib_LTLIBRARIES = mmexternal.la
 
 mmexternal_la_SOURCES = mmexternal.c
-mmexternal_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
-mmexternal_la_LDFLAGS = -module -avoid-version
+mmexternal_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+mmexternal_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 mmexternal_la_LIBADD = 
 
 EXTRA_DIST = 

--- a/plugins/omtesting/Makefile.am
+++ b/plugins/omtesting/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = omtesting.la
 
 omtesting_la_SOURCES = omtesting.c
-omtesting_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-omtesting_la_LDFLAGS = -module -avoid-version
+omtesting_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+omtesting_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 omtesting_la_LIBADD = 

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -115,8 +115,8 @@ librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(JSON_C_LIBS) ${L
 if ENABLE_REGEXP
 pkglib_LTLIBRARIES += lmregexp.la
 lmregexp_la_SOURCES = regexp.c regexp.h
-lmregexp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmregexp_la_LDFLAGS = -module -avoid-version
+lmregexp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmregexp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 lmregexp_la_LIBADD =
 endif
 
@@ -126,8 +126,8 @@ endif
 if ENABLE_ZLIB
 pkglib_LTLIBRARIES += lmzlibw.la
 lmzlibw_la_SOURCES = zlibw.c zlibw.h
-lmzlibw_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmzlibw_la_LDFLAGS = -module -avoid-version
+lmzlibw_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmzlibw_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 lmzlibw_la_LIBADD =
 endif
 
@@ -137,8 +137,8 @@ pkglib_LTLIBRARIES += lmnet.la lmnetstrms.la
 # network support
 # 
 lmnet_la_SOURCES = net.c net.h
-lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo
+lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo $(LIBLOGGING_STDLOG_LIBS)
 lmnet_la_LIBADD =
 
 # network stream master class and stream factory
@@ -146,15 +146,15 @@ lmnetstrms_la_SOURCES = netstrms.c netstrms.h \
 			netstrm.c netstrm.h \
 			nssel.c nssel.h \
 			nspoll.c nspoll.h
-lmnetstrms_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmnetstrms_la_LDFLAGS = -module -avoid-version
+lmnetstrms_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmnetstrms_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 lmnetstrms_la_LIBADD =
 
 # generic stream server framework
 pkglib_LTLIBRARIES += lmstrmsrv.la
 lmstrmsrv_la_SOURCES = strmsrv.c strmsrv.h strms_sess.c strms_sess.h
-lmstrmsrv_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmstrmsrv_la_LDFLAGS = -module -avoid-version
+lmstrmsrv_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmstrmsrv_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 lmstrmsrv_la_LIBADD =
 
 # netstream drivers
@@ -164,8 +164,8 @@ pkglib_LTLIBRARIES += lmnsd_ptcp.la
 lmnsd_ptcp_la_SOURCES = nsd_ptcp.c nsd_ptcp.h \
 		  	nsdsel_ptcp.c nsdsel_ptcp.h \
 			nsdpoll_ptcp.c nsdpoll_ptcp.h
-lmnsd_ptcp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
-lmnsd_ptcp_la_LDFLAGS = -module -avoid-version
+lmnsd_ptcp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
+lmnsd_ptcp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
 lmnsd_ptcp_la_LIBADD =
 endif # if ENABLE_INET
 

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -39,7 +39,7 @@ rsyslogd_SOURCES = \
 	pidfile.h \
 	\
 	../dirty.h
-rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) -DSD_EXPORT_SYMBOLS
+rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS) -DSD_EXPORT_SYMBOLS
 # note: it looks like librsyslog.la must be explicitely given on LDDADD,
 # otherwise dependencies are not properly calculated (resulting in a
 # potentially incomplete build, a problem we had several times...)


### PR DESCRIPTION
When using LIBESTR_CFLAGS and LIBESTR_LIBS directly, build fails without this.
