### PR TITLE
bugfix imkmsg: infinite loop on OpenVZ VMs

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -315,7 +315,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_VAR_NOT_FOUND = -2142, /**< variable not found */
 	RS_RET_EMPTY_MSG = -2143, /**< provided (raw) MSG is empty */
 	RS_RET_PEER_CLOSED_CONN = -2144, /**< remote peer closed connection (information, no error) */
-	RS_RET_ERR_OPEN_KLOG = -2145, /**< error opening the kernel log socket (primarily solaris) */
+	RS_RET_ERR_OPEN_KLOG = -2145, /**< error opening or reading the kernel log socket */
 	RS_RET_ERR_AQ_CONLOG = -2146, /**< error aquiring console log (on solaris) */
 	RS_RET_ERR_DOOR = -2147, /**< some problems with handling the Solaris door functionality */
 	RS_RET_NO_SRCNAME_TPL = -2150, /**< sourcename template was not specified where one was needed (omudpspoof spoof addr) */


### PR DESCRIPTION
On an OpenVZ VM, open("/dev/kmsg", ...) is successful, but read() fails.  This triggers an unthrottled infinite loop since klogLogKMsg() does not propagate read errors up to runInput (presumably so that rsyslog can recover from transient read errors).

This pull request fixes the issue by calling read(0) and checking for EBADF before entering the loop.

See https://bugs.launchpad.net/ubuntu/+source/rsyslog/+bug/1366829
