### PR TITLE
imtcp: add options to configure keep-alive params

### DIFF
--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -141,7 +141,8 @@ finalize_it:
  */
 static rsRetVal
 LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
-	 uchar *pLstnPort, uchar *pLstnIP, int iSessMax)
+	uchar *pLstnPort, uchar *pLstnIP, int iSessMax, int bKeepAlive,
+	int iKeepAliveIntvl, int iKeepAliveProbes, int iKeepAliveTime)
 {
 	DEFiRet;
 
@@ -149,7 +150,9 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 	assert(fAddLstn != NULL);
 	assert(pLstnPort != NULL);
 
-	CHKiRet(pNS->Drvr.LstnInit(pNS, pUsr, fAddLstn, pLstnPort, pLstnIP, iSessMax));
+	CHKiRet(pNS->Drvr.LstnInit(pNS, pUsr, fAddLstn, pLstnPort, pLstnIP,
+		iSessMax, bKeepAlive, iKeepAliveIntvl, iKeepAliveProbes,
+		iKeepAliveTime));
 
 finalize_it:
 	RETiRet;

--- a/runtime/netstrm.h
+++ b/runtime/netstrm.h
@@ -43,7 +43,8 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*Destruct)(netstrm_t **ppThis);
 	rsRetVal (*AbortDestruct)(netstrm_t **ppThis);
 	rsRetVal (*LstnInit)(netstrms_t *pNS, void *pUsr, rsRetVal(*)(void*,netstrm_t*),
-		             uchar *pLstnPort, uchar *pLstnIP, int iSessMax);
+		uchar *pLstnPort, uchar *pLstnIP, int iSessMax, int bKeepAlive,
+		int iKeepAliveIntvl, int iKeepAliveProbes, int iKeepAliveTime);
 	rsRetVal (*AcceptConnReq)(netstrm_t *pThis, netstrm_t **ppNew);
 	rsRetVal (*Rcv)(netstrm_t *pThis, uchar *pRcvBuf, ssize_t *pLenBuf);
 	rsRetVal (*Send)(netstrm_t *pThis, uchar *pBuf, ssize_t *pLenBuf);
@@ -72,12 +73,13 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 	/* v4 */
 	rsRetVal (*EnableKeepAlive)(netstrm_t *pThis);
 ENDinterface(netstrm)
-#define netstrmCURR_IF_VERSION 6 /* increment whenever you change the interface structure! */
+#define netstrmCURR_IF_VERSION 7 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()
  * interface version 4 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 5 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06
  * interface version 6 changed signature of GetRemoteIP() -- rgerhards, 2013-01-21
- * */
+ * interface version 7 added new parameters to LstnInit() - this should, in practice, make the EnableKeepAlive() interface obsolete
+ */
 
 /* prototypes */
 PROTOTYPEObj(netstrm);

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -56,7 +56,8 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*Send)(nsd_t *pThis, uchar *pBuf, ssize_t *pLenBuf);
 	rsRetVal (*Connect)(nsd_t *pThis, int family, unsigned char *port, unsigned char *host);
 	rsRetVal (*LstnInit)(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
-			     uchar *pLstnPort, uchar *pLstnIP, int iSessMax);
+		uchar *pLstnPort, uchar *pLstnIP, int iSessMax, int bKeepAlive,
+		int iKeepAliveIntvl, int iKeepAliveProbes, int iKeepAliveTime);
 	rsRetVal (*AcceptConnReq)(nsd_t *pThis, nsd_t **ppThis);
 	rsRetVal (*GetRemoteHName)(nsd_t *pThis, uchar **pszName);
 	rsRetVal (*GetRemoteIP)(nsd_t *pThis, prop_t **ip);
@@ -80,11 +81,12 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 	/* v5 */
 	rsRetVal (*EnableKeepAlive)(nsd_t *pThis);
 ENDinterface(nsd)
-#define nsdCURR_IF_VERSION 7 /* increment whenever you change the interface structure! */
+#define nsdCURR_IF_VERSION 8 /* increment whenever you change the interface structure! */
 /* interface version 4 added GetRemAddr()
  * interface version 5 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 6 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06
  * interface version 7 changed signature ofGetRempoteIP() -- rgerhards, 2013-01-21
+ * interface version 8 added new parameters to LstnInit() - this should, in practice, make the EnableKeepAlive() interface obsolete
  */
 
 /* interface  for the select call */

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1318,11 +1318,14 @@ Abort(nsd_t *pNsd)
  */
 static rsRetVal
 LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
-	 uchar *pLstnPort, uchar *pLstnIP, int iSessMax)
+	uchar *pLstnPort, uchar *pLstnIP, int iSessMax, int bKeepAlive,
+	int iKeepAliveIntvl, int iKeepAliveProbes, int iKeepAliveTime)
 {
 	DEFiRet;
 	CHKiRet(gtlsGlblInitLstn());
-	iRet = nsd_ptcp.LstnInit(pNS, pUsr, fAddLstn, pLstnPort, pLstnIP, iSessMax);
+	iRet = nsd_ptcp.LstnInit(pNS, pUsr, fAddLstn, pLstnPort, pLstnIP,
+		iSessMax, bKeepAlive, iKeepAliveIntvl, iKeepAliveProbes,
+		iKeepAliveTime);
 finalize_it:
 	RETiRet;
 }

--- a/runtime/nsd_ptcp.h
+++ b/runtime/nsd_ptcp.h
@@ -34,6 +34,11 @@ struct nsd_ptcp_s {
 	uchar *pRemHostName; /**< host name of remote peer (currently used in server mode, only) */
 	struct sockaddr_storage remAddr; /**< remote addr as sockaddr - used for legacy ACL code */
 	int sock;	/**< the socket we use for regular, single-socket, operations */
+	/* keep-alive packets settings, see tcp(7) */
+	int bKeepAlive;		/**< use socket layer KEEPALIVE packets? (see tcp(7)) */
+	int iKeepAliveIntvl;	/**< tcp_keepalive_intvl (see tcp(7)) */
+	int iKeepAliveProbes;	/**< tcp_keepalive_probes (see tcp(7)) */
+	int iKeepAliveTime;	/**< tcp_keepalive_time (see tcp(7)) */
 };
 
 /* interface is defined in nsd.h, we just implement it! */

--- a/runtime/strmsrv.c
+++ b/runtime/strmsrv.c
@@ -361,7 +361,7 @@ initSTRMListener(strmsrv_t *pThis, strmLstnPortList_t *pPortEntry)
 	assert(pPortEntry != NULL);
 
 	/* TODO: add capability to specify local listen address! */
-	CHKiRet(netstrm.LstnInit(pThis->pNS, (void*)pPortEntry, addStrmLstn, pPortEntry->pszPort, NULL, pThis->iSessMax));
+	CHKiRet(netstrm.LstnInit(pThis->pNS, (void*)pPortEntry, addStrmLstn, pPortEntry->pszPort, NULL, pThis->iSessMax, 0, 0, 0, 0));
 
 finalize_it:
 	RETiRet;

--- a/tcpsrv.c
+++ b/tcpsrv.c
@@ -138,6 +138,10 @@ addNewLstnPort(tcpsrv_t *pThis, uchar *pszPort, int bSuppOctetFram)
 	pEntry->pSrv = pThis;
 	pEntry->pRuleset = pThis->pRuleset;
 	pEntry->bSuppOctetFram = bSuppOctetFram;
+	pEntry->bKeepAlive = pThis->bKeepAlive;
+	pEntry->iKeepAliveIntvl = pThis->iKeepAliveIntvl;
+	pEntry->iKeepAliveProbes = pThis->iKeepAliveProbes;
+	pEntry->iKeepAliveTime = pThis->iKeepAliveTime;
 
 	/* we need to create a property */ 
 	CHKiRet(prop.Construct(&pEntry->pInputName));
@@ -362,7 +366,10 @@ initTCPListener(tcpsrv_t *pThis, tcpLstnPortList_t *pPortEntry)
 		TCPLstnPort = pPortEntry->pszPort;
 
 	/* TODO: add capability to specify local listen address! */
-	CHKiRet(netstrm.LstnInit(pThis->pNS, (void*)pPortEntry, addTcpLstn, TCPLstnPort, NULL, pThis->iSessMax));
+	CHKiRet(netstrm.LstnInit(pThis->pNS, (void*)pPortEntry, addTcpLstn,
+		TCPLstnPort, NULL, pThis->iSessMax, pPortEntry->bKeepAlive,
+		pPortEntry->iKeepAliveIntvl, pPortEntry->iKeepAliveProbes,
+		pPortEntry->iKeepAliveTime));
 
 finalize_it:
 	RETiRet;
@@ -438,10 +445,6 @@ SessAccept(tcpsrv_t *pThis, tcpLstnPortList_t *pLstnInfo, tcps_sess_t **ppSess, 
 		errno = 0;
 		errmsg.LogError(0, RS_RET_MAX_SESS_REACHED, "too many tcp sessions - dropping incoming request");
 		ABORT_FINALIZE(RS_RET_MAX_SESS_REACHED);
-	}
-
-	if(pThis->bUseKeepAlive) {
-		CHKiRet(netstrm.EnableKeepAlive(pNewStrm));
 	}
 
 	/* we found a free spot and can construct our session object */
@@ -1076,11 +1079,13 @@ SetUsrP(tcpsrv_t *pThis, void *pUsr)
 }
 
 static rsRetVal
-SetKeepAlive(tcpsrv_t *pThis, int iVal)
+SetKeepAlive(tcpsrv_t *pThis, int bKeepAlive, int iKeepAliveIntvl, int iKeepAliveProbes, int iKeepAliveTime)
 {
 	DEFiRet;
-	DBGPRINTF("tcpsrv: keep-alive set to %d\n", iVal);
-	pThis->bUseKeepAlive = iVal;
+	pThis->bKeepAlive = bKeepAlive;
+	pThis->iKeepAliveIntvl = iKeepAliveIntvl;
+	pThis->iKeepAliveProbes = iKeepAliveProbes;
+	pThis->iKeepAliveTime = iKeepAliveTime;
 	RETiRet;
 }
 

--- a/tcpsrv.h
+++ b/tcpsrv.h
@@ -44,6 +44,10 @@ struct tcpLstnPortList_s {
 	sbool bSuppOctetFram;	/**< do we support octect-counted framing? (if no->legay only!)*/
 	ratelimit_t *ratelimiter;
 	uchar dfltTZ[8];		/**< default TZ if none in timestamp; '\0' =No Default */
+	int bKeepAlive;			/**< use socket layer KEEPALIVE packets? (see tcp(7)) */
+	int iKeepAliveIntvl;		/**< tcp_keepalive_intvl (see tcp(7)) */
+	int iKeepAliveProbes;		/**< tcp_keepalive_probes (see tcp(7)) */
+	int iKeepAliveTime;		/**< tcp_keepalive_time (see tcp(7)) */
 	STATSCOUNTER_DEF(ctrSubmit, mutCtrSubmit)
 	tcpLstnPortList_t *pNext;	/**< next port or NULL */
 };
@@ -53,7 +57,6 @@ struct tcpLstnPortList_s {
 /* the tcpsrv object */
 struct tcpsrv_s {
 	BEGINobjInstance;	/**< Data to implement generic object - MUST be the first data element! */
-	int bUseKeepAlive;	/**< use socket layer KEEPALIVE handling? */
 	netstrms_t *pNS;	/**< pointer to network stream subsystem */
 	int iDrvrMode;		/**< mode of the stream driver to use */
 	uchar *pszDrvrAuthMode;	/**< auth mode of the stream driver to use */
@@ -70,6 +73,10 @@ struct tcpsrv_s {
 	int iLstnMax;		/**< max number of listeners supported */
 	int iSessMax;		/**< max number of sessions supported */
 	uchar dfltTZ[8];	/**< default TZ if none in timestamp; '\0' =No Default */
+	int bKeepAlive;		/**< use socket layer KEEPALIVE packets? (see tcp(7)) */
+	int iKeepAliveIntvl;	/**< tcp_keepalive_intvl (see tcp(7)) */
+	int iKeepAliveProbes;	/**< tcp_keepalive_probes (see tcp(7)) */
+	int iKeepAliveTime;	/**< tcp_keepalive_time (see tcp(7)) */
 	tcpLstnPortList_t *pLstnPorts;	/**< head pointer for listen ports */
 
 	int addtlFrameDelim;	/**< additional frame delimiter for plain TCP syslog framing (e.g. to handle NetScreen) */
@@ -146,7 +153,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	/* added v10 -- rgerhards, 2011-04-01 */
 	rsRetVal (*SetUseFlowControl)(tcpsrv_t*, int);
 	/* added v11 -- rgerhards, 2011-05-09 */
-	rsRetVal (*SetKeepAlive)(tcpsrv_t*, int);
+	rsRetVal (*SetKeepAlive)(tcpsrv_t*, int, int, int, int);
 	/* added v13 -- rgerhards, 2012-10-15 */
 	rsRetVal (*SetLinuxLikeRatelimiters)(tcpsrv_t *pThis, int interval, int burst);
 	/* added v14 -- rgerhards, 2013-07-28 */
@@ -154,12 +161,13 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	/* added v15 -- rgerhards, 2013-09-17 */
 	rsRetVal (*SetDrvrName)(tcpsrv_t *pThis, uchar *pszName);
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 15 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 16 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10
  * change for v5 and up: see above
  * for v12: param bSuppOctetFram added to configureTCPListen
+ * for v16: added more options to SetKeepAlive()
  */
 
 


### PR DESCRIPTION
New options:        (legacy counterparts)
keepalive.time      $inputtcpserverkeepalive_time
keepalive.probes    $inputtcpserverkeepalive_probes
keepalive.interval  $inputtcpserverkeepalive_interval

The options are set separately for each instance.

This patch bumps the interface version of the nsd,
netstrm and tcpsrv modules.

Part of this code is inspired by imptcp.

At first, I've tried to avoid changing the existing interface by adding a new one specifically for these parameters, but there doesn't seem to be a clean way of passing the information between the layers; either the lower-layer object doesn't exist yet, or, after it is created, the higher-level information is not reachable.

One other change is that the params are stored at the lowes level (nsd) and they are applied immediately after socket creation. This should also make the method EnableKeepAlive() unnecessary (as a public interface).
