### PR TITLE
Make liblogging-stdlog optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,6 @@ PKG_PROG_PKG_CONFIG
 
 # modules we require
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
-PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.1)
 PKG_CHECK_MODULES([JSON_C], [json],, [
 	PKG_CHECK_MODULES([JSON_C], [json-c],,)
 ])
@@ -1075,6 +1074,24 @@ fi
 AM_CONDITIONAL(ENABLE_GUARDTIME, test x$enable_guardtime = xyes)
 
 
+# liblogging-stdlog support
+AC_ARG_ENABLE(liblogging-stdlog,
+        [AS_HELP_STRING([--enable-liblogging-stdlog],[Enable liblogging-stdlog support @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_liblogging_stdlog="yes" ;;
+          no) enable_liblogging_stdlog="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-liblogging-stdlog) ;;
+         esac],
+        [enable_liblogging_stdlog=yes]
+)
+if test "x$enable_liblogging_stdlog" = "xyes"; then
+	PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.1,
+		AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.])
+        )
+fi
+AM_CONDITIONAL(ENABLE_LIBLOGGING_STDLOG, test x$enable_liblogging_stdlog = xyes)
+
+
 # RFC 3195 support
 AC_ARG_ENABLE(rfc3195,
         [AS_HELP_STRING([--enable-rfc3195],[Enable RFC3195 support @<:@default=no@:>@])],
@@ -1611,6 +1628,7 @@ echo "    Log file encryption support:              $enable_libgcrypt"
 echo "    anonymization support enabled:            $enable_mmanon"
 echo "    message counting support enabled:         $enable_mmcount"
 echo "    mmfields enabled:                         $enable_mmfields"
+echo "    liblogging-stdlog support enabled:        $enable_liblogging_stdlog"
 echo
 echo "---{ input plugins }---"
 echo "    Klog functionality enabled:               $enable_klog ($os_type)"

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -660,6 +660,15 @@ glblProcessCnf(struct cnfobj *o)
 			continue;
 		if(!strcmp(paramblk.descr[i].name, "processinternalmessages")) {
 			bProcessInternalMessages = (int) cnfparamvals[i].val.d.n;
+#ifndef HAVE_LIBLOGGING_STDLOG
+			if(bProcessInternalMessages != 1) {
+				bProcessInternalMessages = 1;
+				errmsg.LogError(0, RS_RET_ERR, "rsyslog wasn't "
+					"compiled with liblogging-stdlog support. "
+					"The 'ProcessInternalMessages' parameter "
+					"is ignored.\n");
+			}
+#endif
 		}
 	}
 }

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -43,13 +43,17 @@ rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 # note: it looks like librsyslog.la must be explicitely given on LDDADD,
 # otherwise dependencies are not properly calculated (resulting in a 
 # potentially incomplete build, a problem we had several times...)
-rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS) $(LIBLOGGING_STDLOG_LIBS)
+rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS)
 rsyslogd_LDFLAGS = -export-dynamic
 
 EXTRA_DIST = $(man_MANS) \
 	rsgtutil.rst \
 	rscryutil.rst \
 	recover_qi.pl
+
+if ENABLE_LIBLOGGING_STDLOG
+rsyslogd_LDADD += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 if ENABLE_DIAGTOOLS
 sbin_PROGRAMS += rsyslog_diag_hostname msggen

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -25,7 +25,9 @@
 #include "rsyslog.h"
 
 #include <signal.h>
+#ifdef HAVE_LIBLOGGING_STDLOG
 #include <liblogging/stdlog.h>
+#endif
 #ifdef OS_SOLARIS
 #	include <errno.h>
 #else
@@ -555,9 +557,11 @@ logmsgInternal(int iErr, int pri, const uchar *const msg, int flags)
 		CHKiRet(logmsgInternalSelf(iErr, pri, lenMsg,
 					   (bufModMsg == NULL) ? (char*)msg : bufModMsg,
 					   flags));
+#ifdef HAVE_LIBLOGGING_STDLOG
 	} else {
 		stdlog_log(NULL, pri2sev(pri), "%s",
 			   (bufModMsg == NULL) ? (char*)msg : bufModMsg);
+#endif
 	}
 
 	/* we now check if we should print internal messages out to stderr. This was


### PR DESCRIPTION
This change add a configure flag to turn off the functionality provided by liblogging-stdlog.

I think it's usefull to have this even in v7, but can rebase the branch to master if necessary.
