### PR TITLE
Remove references to deleted files from Makefiles

### DIFF
--- a/plugins/ommysql/Makefile.am
+++ b/plugins/ommysql/Makefile.am
@@ -5,4 +5,4 @@ ommysql_la_CPPFLAGS =  $(RSRT_CFLAGS) $(MYSQL_CFLAGS) $(PTHREADS_CFLAGS)
 ommysql_la_LDFLAGS = -module -avoid-version
 ommysql_la_LIBADD = $(MYSQL_LIBS)
 
-EXTRA_DIST = createDB.sql contrib/delete_mysql 
+EXTRA_DIST = createDB.sql

--- a/plugins/ompgsql/Makefile.am
+++ b/plugins/ompgsql/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = ompgsql.la
 
-ompgsql_la_SOURCES = ompgsql.c ompgsql.h
+ompgsql_la_SOURCES = ompgsql.c
 ompgsql_la_CPPFLAGS = -I$(top_srcdir) $(PGSQL_CFLAGS) $(RSRT_CFLAGS)
 ompgsql_la_LDFLAGS = -module -avoid-version
 ompgsql_la_LIBADD = $(PGSQL_LIBS)


### PR DESCRIPTION
After the recent cleanup, couple of references were forgotten in Makefile.am. This made 'make dist' fail.
These files were removed in commits dadec46 and 77ef11a.

PS:
Rainer, does the regular testbench run try to do dist or dist check?
For some reason, I now see some failing tests (queue-persist.sh, imptcp_conndrop-vg.sh) that weren't failing few days ago. Also, make distcheck seems to be broken (not sure if that ever worked). I'll try to look into it later.
