### PR TITLE
Make liblogging-stdlog optional

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,6 @@ PKG_PROG_PKG_CONFIG
 
 # modules we require
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
-PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3)
 PKG_CHECK_MODULES([JSON_C], [json],, [
 	PKG_CHECK_MODULES([JSON_C], [json-c],,)
 ])
@@ -1050,6 +1049,24 @@ fi
 AM_CONDITIONAL(ENABLE_GUARDTIME, test x$enable_guardtime = xyes)
 
 
+# liblogging-stdlog support
+AC_ARG_ENABLE(liblogging-stdlog,
+        [AS_HELP_STRING([--enable-liblogging-stdlog],[Enable liblogging-stdlog support @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_liblogging_stdlog="yes" ;;
+          no) enable_liblogging_stdlog="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-liblogging-stdlog) ;;
+         esac],
+        [enable_liblogging_stdlog=yes]
+)
+if test "x$enable_liblogging_stdlog" = "xyes"; then
+        PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
+		AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.])
+        )
+fi
+AM_CONDITIONAL(ENABLE_LIBLOGGING_STDLOG, test x$enable_liblogging_stdlog = xyes)
+
+
 # RFC 3195 support
 AC_ARG_ENABLE(rfc3195,
         [AS_HELP_STRING([--enable-rfc3195],[Enable RFC3195 support @<:@default=no@:>@])],
@@ -1539,6 +1556,7 @@ echo "    Log file encryption support:              $enable_libgcrypt"
 echo "    anonymization support enabled:            $enable_mmanon"
 echo "    message counting support enabled:         $enable_mmcount"
 echo "    mmfields enabled:                         $enable_mmfields"
+echo "    liblogging-stdlog support enabled:        $enable_liblogging_stdlog"
 echo
 echo "---{ input plugins }---"
 echo "    Klog functionality enabled:               $enable_klog ($os_type)"

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -67,7 +67,9 @@ DEFobjCurrIf(net)
  * class...
  */
 int glblDebugOnShutdown = 0;	/* start debug log when we are shut down */
+#ifdef HAVE_LIBLOGGING_STDLOG
 stdlog_channel_t stdlog_hdl = NULL;	/* handle to be used for stdlog */
+#endif
 
 static struct cnfobj *mainqCnfObj = NULL;/* main queue object, to be used later in startup sequence */
 int bProcessInternalMessages = 1;	/* Should rsyslog itself process internal messages?
@@ -75,7 +77,9 @@ int bProcessInternalMessages = 1;	/* Should rsyslog itself process internal mess
 					 * 0 - send them to libstdlog (e.g. to push to journal)
 					 */
 static uchar *pszWorkDir = NULL;
+#ifdef HAVE_LIBLOGGING_STDLOG
 static uchar *stdlog_chanspec = NULL;
+#endif
 static int bOptimizeUniProc = 1;	/* enable uniprocessor optimizations */
 static int bParseHOSTNAMEandTAG = 1;	/* parser modification (based on startup params!) */
 static int bPreserveFQDN = 0;		/* should FQDNs always be preserved? */
@@ -831,11 +835,27 @@ glblProcessCnf(struct cnfobj *o)
 			continue;
 		if(!strcmp(paramblk.descr[i].name, "processinternalmessages")) {
 			bProcessInternalMessages = (int) cnfparamvals[i].val.d.n;
+#ifndef HAVE_LIBLOGGING_STDLOG
+			if(bProcessInternalMessages != 1) {
+				bProcessInternalMessages = 1;
+				errmsg.LogError(0, RS_RET_ERR, "rsyslog wasn't "
+					"compiled with liblogging-stdlog support. "
+					"The 'ProcessInternalMessages' parameter "
+					"is ignored.\n");
+			}
+#endif
 		} else if(!strcmp(paramblk.descr[i].name, "stdlog.channelspec")) {
+#ifndef HAVE_LIBLOGGING_STDLOG
+			errmsg.LogError(0, RS_RET_ERR, "rsyslog wasn't "
+				"compiled with liblogging-stdlog support. "
+				"The 'stdlog.channelspec' parameter "
+				"is ignored.\n");
+#else
 			stdlog_chanspec = (uchar*)
 				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 			stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG,
 					(char*) stdlog_chanspec);
+#endif
 		}
 	}
 }

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -31,7 +31,9 @@
 #define GLBL_H_INCLUDED
 
 #include <sys/types.h>
+#ifdef HAVE_LIBLOGGING_STDLOG
 #include <liblogging/stdlog.h>
+#endif
 #include "rainerscript.h"
 #include "prop.h"
 
@@ -39,7 +41,9 @@
 
 extern pid_t glbl_ourpid;
 extern int bProcessInternalMessages;
+#ifdef HAVE_LIBLOGGING_STDLOG
 extern stdlog_channel_t stdlog_hdl;
+#endif
 
 /* interfaces */
 BEGINinterface(glbl) /* name must also be changed in ENDinterface macro! */

--- a/runtime/rsyslog.c
+++ b/runtime/rsyslog.c
@@ -59,7 +59,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
+#ifdef HAVE_LIBLOGGING_STDLOG
 #include <liblogging/stdlog.h>
+#endif
 
 #include "rsyslog.h"
 #include "obj.h"
@@ -137,8 +139,10 @@ rsrtInit(char **ppErrObj, obj_if_t *pObjIF)
 
 	if(iRefCount == 0) {
 		/* init runtime only if not yet done */
+#ifdef HAVE_LIBLOGGING_STDLOG
 		stdlog_init(0);
 		stdlog_hdl = NULL;
+#endif
 #ifdef HAVE_PTHREAD_SETSCHEDPARAM
 	    	CHKiRet(pthread_getschedparam(pthread_self(),
 			    		      &default_thr_sched_policy,

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -41,7 +41,7 @@ rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAG
 # note: it looks like librsyslog.la must be explicitely given on LDDADD,
 # otherwise dependencies are not properly calculated (resulting in a
 # potentially incomplete build, a problem we had several times...)
-rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS) $(LIBLOGGING_STDLOG_LIBS)
+rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS)
 rsyslogd_LDFLAGS = -export-dynamic \
 	-Wl,--whole-archive,$(top_builddir)/runtime/.libs/librsyslog.a,--no-whole-archive
 
@@ -49,6 +49,10 @@ EXTRA_DIST = $(man_MANS) \
 	rsgtutil.rst \
 	rscryutil.rst \
 	recover_qi.pl
+
+if ENABLE_LIBLOGGING_STDLOG
+rsyslogd_LDADD += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 if ENABLE_DIAGTOOLS
 sbin_PROGRAMS += rsyslog_diag_hostname msggen

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -26,7 +26,9 @@
 
 #include <signal.h>
 #include <sys/wait.h>
+#ifdef HAVE_LIBLOGGING_STDLOG
 #include <liblogging/stdlog.h>
+#endif
 #ifdef OS_SOLARIS
 #	include <errno.h>
 #else
@@ -765,9 +767,11 @@ logmsgInternal(int iErr, const syslog_pri_t pri, const uchar *const msg, int fla
 		CHKiRet(logmsgInternalSelf(iErr, pri, lenMsg,
 					   (bufModMsg == NULL) ? (char*)msg : bufModMsg,
 					   flags));
+#ifdef HAVE_LIBLOGGING_STDLOG
 	} else {
 		stdlog_log(stdlog_hdl, pri2sev(pri), "%s",
 			   (bufModMsg == NULL) ? (char*)msg : bufModMsg);
+#endif
 	}
 
 	/* we now check if we should print internal messages out to stderr. This was


### PR DESCRIPTION
This change add a configure flag to turn off the functionality provided by liblogging-stdlog.
