### PR TITLE
Two small changes to tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,7 +4,6 @@ check_PROGRAMS = $(TESTRUNS) ourtail nettester tcpflood chkseq msleep randomgen 
 TESTS = $(TESTRUNS) 
 #TESTS = $(TESTRUNS) cfg.sh
 
-if ENABLE_IMDIAG
 TESTS +=  \
 	stop-localvar.sh \
 	stop-msgvar.sh \
@@ -111,7 +110,6 @@ TESTS +=  \
 	udp-msgreduc-orgmsg-vg.sh \
 	tcp-msgreduc-vg.sh
 endif # HAVE_VALGRIND
-endif # ENABLE_IMDIAG
 
 
 if ENABLE_MYSQL_TESTS
@@ -226,10 +224,8 @@ endif
 endif
 
 if ENABLE_OMRULESET
-if ENABLE_IMDIAG
 TESTS += omruleset.sh \
 	 omruleset-queue.sh
-endif
 endif
 
 if ENABLE_EXTENDED_TESTS
@@ -320,7 +316,7 @@ EXTRA_DIST= 1.rstest 2.rstest 3.rstest err1.rstest \
 	   testsuites/date3.parse1 \
 	   testsuites/date4.parse1 \
 	   testsuites/date5.parse1 \
-   	   testsuites/rfc3164.parse1 \
+	   testsuites/rfc3164.parse1 \
 	   testsuites/rfc5424-1.parse1 \
 	   testsuites/rfc5424-2.parse1 \
 	   testsuites/rfc5424-3.parse1 \


### PR DESCRIPTION
I think the dependency on ENABLE_IMDIAG should be dropped, as configure makes sure it's enabled if testbench is. Additionally, it seems that the set of tests that requires imdiag is bigger that what was specified in the make file. Therefore, rather than correcting it, I just got rid of it.

@Rainer: not much of a cleanup so far, I just wanted to push this early as you also seem to be making changes in /tests. I plan to look at make distcheck next.
