### PR TITLE
Adding options for tcp keep alive.

### DIFF
--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -247,7 +247,38 @@ EnableKeepAlive(netstrm_t *pThis)
 	RETiRet;
 }
 
+/* Keep-Alive options
+ */
+static rsRetVal
+SetKeepAliveProbes(netstrm_t *pThis, int keepAliveProbes)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetKeepAliveProbes(pThis->pDrvrData, keepAliveProbes);
+	RETiRet;
+}
 
+/* Keep-Alive options
+ */
+static rsRetVal
+SetKeepAliveTime(netstrm_t *pThis, int keepAliveTime)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetKeepAliveTime(pThis->pDrvrData, keepAliveTime);
+	RETiRet;
+}
+
+/* Keep-Alive options
+ */
+static rsRetVal
+SetKeepAliveIntvl(netstrm_t *pThis, int keepAliveIntvl)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetKeepAliveIntvl(pThis->pDrvrData, keepAliveIntvl);
+	RETiRet;
+}
 
 /* check connection - slim wrapper for NSD driver function */
 static rsRetVal
@@ -353,6 +384,9 @@ CODESTARTobjQueryInterface(netstrm)
 	pIf->CheckConnection = CheckConnection;
 	pIf->GetSock = GetSock;
 	pIf->EnableKeepAlive = EnableKeepAlive;
+	pIf->SetKeepAliveProbes = SetKeepAliveProbes;
+	pIf->SetKeepAliveTime = SetKeepAliveTime;
+	pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
 finalize_it:
 ENDobjQueryInterface(netstrm)
 

--- a/runtime/netstrm.h
+++ b/runtime/netstrm.h
@@ -71,6 +71,9 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 	 */
 	/* v4 */
 	rsRetVal (*EnableKeepAlive)(netstrm_t *pThis);
+	rsRetVal (*SetKeepAliveProbes)(netstrm_t *pThis, int keepAliveProbes);
+	rsRetVal (*SetKeepAliveTime)(netstrm_t *pThis, int keepAliveTime);
+	rsRetVal (*SetKeepAliveIntvl)(netstrm_t *pThis, int keepAliveIntvl);
 ENDinterface(netstrm)
 #define netstrmCURR_IF_VERSION 6 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -79,6 +79,9 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 	 */
 	/* v5 */
 	rsRetVal (*EnableKeepAlive)(nsd_t *pThis);
+	rsRetVal (*SetKeepAliveIntvl)(nsd_t *pThis, int keepAliveIntvl);
+	rsRetVal (*SetKeepAliveProbes)(nsd_t *pThis, int keepAliveProbes);
+	rsRetVal (*SetKeepAliveTime)(nsd_t *pThis, int keepAliveTime);
 ENDinterface(nsd)
 #define nsdCURR_IF_VERSION 7 /* increment whenever you change the interface structure! */
 /* interface version 4 added GetRemAddr()

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1290,6 +1290,57 @@ SetSock(nsd_t *pNsd, int sock)
 }
 
 
+/* Keep Alive Options
+ */
+static rsRetVal
+SetKeepAliveIntvl(nsd_t *pNsd, int keepAliveIntvl)
+{
+	DEFiRet;
+	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
+
+	ISOBJ_TYPE_assert((pThis), nsd_gtls);
+	assert(keepAliveIntvl >= 0);
+
+	nsd_ptcp.SetKeepAliveIntvl(pThis->pTcp, keepAliveIntvl);
+
+	RETiRet;
+}
+
+
+/* Keep Alive Options
+ */
+static rsRetVal
+SetKeepAliveProbes(nsd_t *pNsd, int keepAliveProbes)
+{
+	DEFiRet;
+	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
+
+	ISOBJ_TYPE_assert((pThis), nsd_gtls);
+	assert(keepAliveProbes >= 0);
+
+	nsd_ptcp.SetKeepAliveProbes(pThis->pTcp, keepAliveProbes);
+
+	RETiRet;
+}
+
+
+/* Keep Alive Options
+ */
+static rsRetVal
+SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime)
+{
+	DEFiRet;
+	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
+
+	ISOBJ_TYPE_assert((pThis), nsd_gtls);
+	assert(keepAliveTime >= 0);
+
+	nsd_ptcp.SetKeepAliveTime(pThis->pTcp, keepAliveTime);
+
+	RETiRet;
+}
+
+
 /* abort a connection. This is meant to be called immediately
  * before the Destruct call. -- rgerhards, 2008-03-24
  */
@@ -1591,8 +1642,6 @@ EnableKeepAlive(nsd_t *pNsd)
 	return nsd_ptcp.EnableKeepAlive(pThis->pTcp);
 }
 
-
-
 /* open a connection to a remote host (server). With GnuTLS, we always
  * open a plain tcp socket and then, if in TLS mode, do a handshake on it.
  * rgerhards, 2008-03-19
@@ -1702,6 +1751,9 @@ CODESTARTobjQueryInterface(nsd_gtls)
 	pIf->GetRemoteIP = GetRemoteIP;
 	pIf->GetRemAddr = GetRemAddr;
 	pIf->EnableKeepAlive = EnableKeepAlive;
+	pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
+	pIf->SetKeepAliveProbes = SetKeepAliveProbes;
+	pIf->SetKeepAliveTime = SetKeepAliveTime;
 finalize_it:
 ENDobjQueryInterface(nsd_gtls)
 

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -37,6 +37,7 @@
 #include <fnmatch.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <netinet/tcp.h>
 
 #include "syslogd-types.h"
 #include "module-template.h"
@@ -215,6 +216,53 @@ SetSock(nsd_t *pNsd, int sock)
 	RETiRet;
 }
 
+/* Keep Alive Options
+ */
+static rsRetVal
+SetKeepAliveIntvl(nsd_t *pNsd, int keepAliveIntvl)
+{
+	nsd_ptcp_t *pThis = (nsd_ptcp_t*) pNsd;
+	DEFiRet;
+
+	ISOBJ_TYPE_assert((pThis), nsd_ptcp);
+	assert(sock >= 0);
+
+	pThis->iKeepAliveIntvl = keepAliveIntvl;
+
+	RETiRet;
+}
+
+/* Keep Alive Options
+ */
+static rsRetVal
+SetKeepAliveProbes(nsd_t *pNsd, int keepAliveProbes)
+{
+	nsd_ptcp_t *pThis = (nsd_ptcp_t*) pNsd;
+	DEFiRet;
+
+	ISOBJ_TYPE_assert((pThis), nsd_ptcp);
+	assert(sock >= 0);
+
+	pThis->iKeepAliveProbes = keepAliveProbes;
+
+	RETiRet;
+}
+
+/* Keep Alive Options
+ */
+static rsRetVal
+SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime)
+{
+	nsd_ptcp_t *pThis = (nsd_ptcp_t*) pNsd;
+	DEFiRet;
+
+	ISOBJ_TYPE_assert((pThis), nsd_ptcp);
+	assert(sock >= 0);
+
+	pThis->iKeepAliveTime = keepAliveTime;
+
+	RETiRet;
+}
 
 /* abort a connection. This is meant to be called immediately
  * before the Destruct call. -- rgerhards, 2008-03-24
@@ -607,10 +655,56 @@ EnableKeepAlive(nsd_t *pNsd)
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 
-	dbgprintf("KEEPALIVE enabled for nsd %p\n", pThis);
+#	if defined(TCP_KEEPCNT)
+	if(pThis->iKeepAliveProbes > 0) {
+		optval = pThis->iKeepAliveProbes;
+		optlen = sizeof(optval);
+		ret = setsockopt(pThis->sock, SOL_TCP, TCP_KEEPCNT, &optval, optlen);
+	} else {
+		ret = 0;
+	}
+#	else
+	ret = -1;
+#	endif
+	if(ret < 0) {
+		errmsg.LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive probes - ignored");
+	}
+
+#	if defined(TCP_KEEPCNT)
+	if(pThis->iKeepAliveTime > 0) {
+		optval = pThis->iKeepAliveTime;
+		optlen = sizeof(optval);
+		ret = setsockopt(pThis->sock, SOL_TCP, TCP_KEEPIDLE, &optval, optlen);
+	} else {
+		ret = 0;
+	}
+#	else
+	ret = -1;
+#	endif
+	if(ret < 0) {
+		errmsg.LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive time - ignored");
+	}
+
+#	if defined(TCP_KEEPCNT)
+	if(pThis->iKeepAliveIntvl > 0) {
+		optval = pThis->iKeepAliveIntvl;
+		optlen = sizeof(optval);
+		ret = setsockopt(pThis->sock, SOL_TCP, TCP_KEEPINTVL, &optval, optlen);
+	} else {
+		ret = 0;
+	}
+#	else
+	ret = -1;
+#	endif
+	if(ret < 0) {
+		errmsg.LogError(errno, NO_ERRCODE, "imptcp cannot set keepalive intvl - ignored");
+	}
+
+	dbgprintf("KEEPALIVE enabled for socket %d\n", pThis->sock);
 
 finalize_it:
 	RETiRet;
+
 }
 
 
@@ -754,6 +848,9 @@ CODESTARTobjQueryInterface(nsd_ptcp)
 	pIf->GetRemoteIP = GetRemoteIP;
 	pIf->CheckConnection = CheckConnection;
 	pIf->EnableKeepAlive = EnableKeepAlive;
+	pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
+	pIf->SetKeepAliveProbes = SetKeepAliveProbes;
+	pIf->SetKeepAliveTime = SetKeepAliveTime;
 finalize_it:
 ENDobjQueryInterface(nsd_ptcp)
 

--- a/runtime/nsd_ptcp.h
+++ b/runtime/nsd_ptcp.h
@@ -34,6 +34,9 @@ struct nsd_ptcp_s {
 	uchar *pRemHostName; /**< host name of remote peer (currently used in server mode, only) */
 	struct sockaddr_storage remAddr; /**< remote addr as sockaddr - used for legacy ACL code */
 	int sock;	/**< the socket we use for regular, single-socket, operations */
+	int iKeepAliveIntvl;	/**< socket layer KEEPALIVE interval */
+	int iKeepAliveProbes;	/**< socket layer KEEPALIVE probes */
+	int iKeepAliveTime;	/**< socket layer KEEPALIVE timeout */
 };
 
 /* interface is defined in nsd.h, we just implement it! */

--- a/runtime/strmsrv.c
+++ b/runtime/strmsrv.c
@@ -436,6 +436,9 @@ SessAccept(strmsrv_t *pThis, strmLstnPortList_t *pLstnInfo, strms_sess_t **ppSes
 	}
 
 	if(pThis->bUseKeepAlive) {
+		CHKiRet(netstrm.SetKeepAliveProbes(pNewStrm, pThis->iKeepAliveProbes));
+		CHKiRet(netstrm.SetKeepAliveTime(pNewStrm, pThis->iKeepAliveTime));
+		CHKiRet(netstrm.SetKeepAliveIntvl(pNewStrm, pThis->iKeepAliveIntvl));
 		CHKiRet(netstrm.EnableKeepAlive(pNewStrm));
 	}
 
@@ -774,6 +777,33 @@ SetKeepAlive(strmsrv_t *pThis, int iVal)
 }
 
 static rsRetVal
+SetKeepAliveIntvl(strmsrv_t *pThis, int iVal)
+{
+	DEFiRet;
+	DBGPRINTF("strmsrv: keep-alive set to %d\n", iVal);
+	pThis->iKeepAliveIntvl = iVal;
+	RETiRet;
+}
+
+static rsRetVal
+SetKeepAliveProbes(strmsrv_t *pThis, int iVal)
+{
+	DEFiRet;
+	DBGPRINTF("strmsrv: keep-alive set to %d\n", iVal);
+	pThis->iKeepAliveProbes = iVal;
+	RETiRet;
+}
+
+static rsRetVal
+SetKeepAliveTime(strmsrv_t *pThis, int iVal)
+{
+	DEFiRet;
+	DBGPRINTF("strmsrv: keep-alive set to %d\n", iVal);
+	pThis->iKeepAliveTime = iVal;
+	RETiRet;
+}
+
+static rsRetVal
 SetOnCharRcvd(strmsrv_t *pThis, rsRetVal (*OnCharRcvd)(strms_sess_t*, uchar))
 {
 	DEFiRet;
@@ -876,12 +906,13 @@ CODESTARTobjQueryInterface(strmsrv)
 	pIf->Construct = strmsrvConstruct;
 	pIf->ConstructFinalize = strmsrvConstructFinalize;
 	pIf->Destruct = strmsrvDestruct;
-
 	pIf->configureSTRMListen = configureSTRMListen;
 	pIf->create_strm_socket = create_strm_socket;
 	pIf->Run = Run;
-
 	pIf->SetKeepAlive = SetKeepAlive;
+	pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
+	pIf->SetKeepAliveProbes = SetKeepAliveProbes;
+	pIf->SetKeepAliveTime = SetKeepAliveTime;
 	pIf->SetUsrP = SetUsrP;
 	pIf->SetInputName = SetInputName;
 	pIf->SetSessMax = SetSessMax;

--- a/runtime/strmsrv.h
+++ b/runtime/strmsrv.h
@@ -37,6 +37,9 @@ struct strmLstnPortList_s {
 struct strmsrv_s {
 	BEGINobjInstance;	/**< Data to implement generic object - MUST be the first data element! */
 	int bUseKeepAlive;	/**< use socket layer KEEPALIVE handling? */
+	int iKeepAliveIntvl;	/**< socket layer KEEPALIVE interval */
+	int iKeepAliveProbes;	/**< socket layer KEEPALIVE probes */
+	int iKeepAliveTime;	/**< socket layer KEEPALIVE timeout */
 	netstrms_t *pNS;	/**< pointer to network stream subsystem */
 	int iDrvrMode;		/**< mode of the stream driver to use */
 	uchar *pszDrvrAuthMode;	/**< auth mode of the stream driver to use */
@@ -80,6 +83,9 @@ BEGINinterface(strmsrv) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetAddtlFrameDelim)(strmsrv_t*, int);
 	rsRetVal (*SetInputName)(strmsrv_t*, uchar*);
 	rsRetVal (*SetKeepAlive)(strmsrv_t*, int);
+	rsRetVal (*SetKeepAliveProbes)(strmsrv_t *pThis, int keepAliveProbes);
+	rsRetVal (*SetKeepAliveTime)(strmsrv_t *pThis, int keepAliveTime);
+	rsRetVal (*SetKeepAliveIntvl)(strmsrv_t *pThis, int keepAliveIntvl);
 	rsRetVal (*SetUsrP)(strmsrv_t*, void*);
 	rsRetVal (*SetCBIsPermittedHost)(strmsrv_t*, int (*) (struct sockaddr *addr, char*, void*, void*));
 	rsRetVal (*SetCBOpenLstnSocks)(strmsrv_t *, rsRetVal (*)(strmsrv_t*));

--- a/tcpsrv.c
+++ b/tcpsrv.c
@@ -442,6 +442,9 @@ SessAccept(tcpsrv_t *pThis, tcpLstnPortList_t *pLstnInfo, tcps_sess_t **ppSess, 
 	}
 
 	if(pThis->bUseKeepAlive) {
+	        CHKiRet(netstrm.SetKeepAliveProbes(pNewStrm, pThis->iKeepAliveProbes));
+	        CHKiRet(netstrm.SetKeepAliveTime(pNewStrm, pThis->iKeepAliveTime));
+	        CHKiRet(netstrm.SetKeepAliveIntvl(pNewStrm, pThis->iKeepAliveIntvl));
 		CHKiRet(netstrm.EnableKeepAlive(pNewStrm));
 	}
 
@@ -1087,6 +1090,33 @@ SetKeepAlive(tcpsrv_t *pThis, int iVal)
 }
 
 static rsRetVal
+SetKeepAliveIntvl(tcpsrv_t *pThis, int iVal)
+{
+       DEFiRet;
+       DBGPRINTF("tcpsrv: keep-alive interval set to %d\n", iVal);
+       pThis->iKeepAliveIntvl = iVal;
+       RETiRet;
+}
+
+static rsRetVal
+SetKeepAliveProbes(tcpsrv_t *pThis, int iVal)
+{
+       DEFiRet;
+       DBGPRINTF("tcpsrv: keep-alive probes set to %d\n", iVal);
+       pThis->iKeepAliveProbes = iVal;
+       RETiRet;
+}
+
+static rsRetVal
+SetKeepAliveTime(tcpsrv_t *pThis, int iVal)
+{
+       DEFiRet;
+       DBGPRINTF("tcpsrv: keep-alive timeout set to %d\n", iVal);
+       pThis->iKeepAliveTime = iVal;
+       RETiRet;
+}
+
+static rsRetVal
 SetOnMsgReceive(tcpsrv_t *pThis, rsRetVal (*OnMsgReceive)(tcps_sess_t*, uchar*, int))
 {
 	DEFiRet;
@@ -1305,6 +1335,9 @@ CODESTARTobjQueryInterface(tcpsrv)
 	pIf->Run = Run;
 
 	pIf->SetKeepAlive = SetKeepAlive;
+	pIf->SetKeepAliveIntvl = SetKeepAliveIntvl;
+	pIf->SetKeepAliveProbes = SetKeepAliveProbes;
+	pIf->SetKeepAliveTime = SetKeepAliveTime;
 	pIf->SetUsrP = SetUsrP;
 	pIf->SetInputName = SetInputName;
 	pIf->SetOrigin = SetOrigin;

--- a/tcpsrv.h
+++ b/tcpsrv.h
@@ -54,6 +54,9 @@ struct tcpLstnPortList_s {
 struct tcpsrv_s {
 	BEGINobjInstance;	/**< Data to implement generic object - MUST be the first data element! */
 	int bUseKeepAlive;	/**< use socket layer KEEPALIVE handling? */
+	int iKeepAliveIntvl;	/**< socket layer KEEPALIVE interval */
+	int iKeepAliveProbes;	/**< socket layer KEEPALIVE probes */
+	int iKeepAliveTime;	/**< socket layer KEEPALIVE timeout */
 	netstrms_t *pNS;	/**< pointer to network stream subsystem */
 	int iDrvrMode;		/**< mode of the stream driver to use */
 	uchar *pszDrvrAuthMode;	/**< auth mode of the stream driver to use */
@@ -148,6 +151,9 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetUseFlowControl)(tcpsrv_t*, int);
 	/* added v11 -- rgerhards, 2011-05-09 */
 	rsRetVal (*SetKeepAlive)(tcpsrv_t*, int);
+	rsRetVal (*SetKeepAliveIntvl)(tcpsrv_t*, int);
+	rsRetVal (*SetKeepAliveProbes)(tcpsrv_t*, int);
+	rsRetVal (*SetKeepAliveTime)(tcpsrv_t*, int);
 	/* added v13 -- rgerhards, 2012-10-15 */
 	rsRetVal (*SetLinuxLikeRatelimiters)(tcpsrv_t *pThis, int interval, int burst);
 	/* added v14 -- rgerhards, 2013-07-28 */


### PR DESCRIPTION
Adding more options for TCP Keep Alive like probe/intervals.  Example conf with the additional options:

<p><code>
# imtcp
module(
  load="imtcp"
  KeepAlive="on"
  KeepAlive.probes="3"
  Keepalive.Time="3"
  Keepalive.Interval="3"
)
</code></p>


The source might need to be cleaned up to meet rsyslog conventions.
