### PR TITLE
Bug in perl external omprog skeleton

### DIFF
--- a/plugins/external/skeletons/perl/plugin.pl
+++ b/plugins/external/skeletons/perl/plugin.pl
@@ -78,7 +78,7 @@ while ($keepRunning) {
 		# We seem to have not timeout for select - or do we?
 		if ($STDIN->can_read($pollPeriod)) {
 			$stdInLine = <STDIN>;
-			# Catch EOF, run onRecieve onr last time and exit
+			# Catch EOF, run onRecieve one last time and exit
 			if (eof()){
 				$keepRunning = 0;
 				last;


### PR DESCRIPTION
Was in the middle of using this example to wrote a ActiveMQ output module and noticed the script never terminated.  After I got to looking at my code I noticed I had completely forgotten to watch for the EOF and handle it properly.  Once I had my code working I reviewed the example and noticed it had the same bug. 

Figured I would submit a pull to hopefully save someone else time in the future.  I wrote in in such a way that is will run onReceive() one last time so no messages are missing.

Thanks!
