### PR TITLE
omkafka: add stats and dynamic topic

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -38,6 +38,8 @@
 #include "module-template.h"
 #include "errmsg.h"
 #include "atomic.h"
+#include "statsobj.h"
+#include "unicode-helper.h"
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP
@@ -47,6 +49,14 @@ MODULE_CNFNAME("omkafka")
  */
 DEF_OMOD_STATIC_DATA
 DEFobjCurrIf(errmsg)
+DEFobjCurrIf(statsobj)
+
+statsobj_t *kafkaStats;
+STATSCOUNTER_DEF(ctrTopicSubmit, mutCtrTopicSubmit);
+STATSCOUNTER_DEF(ctrKafkaFail, mutCtrKafkaFail);
+STATSCOUNTER_DEF(ctrCacheMiss, mutCtrCacheMiss);
+STATSCOUNTER_DEF(ctrCacheEvict, mutCtrCacheEvict);
+STATSCOUNTER_DEF(ctrCacheSkip, mutCtrCacheSkip);
 
 #define MAX_ERRMSG 1024 /* max size of error messages that we support */
 
@@ -57,8 +67,42 @@ struct kafka_params {
 	const char *val;
 };
 
+#if HAVE_ATOMIC_BUILTINS64
+static uint64 clockTopicAccess = 0;
+#else
+static unsigned clockTopicAccess = 0;
+#endif
+/* and the "tick" function */
+#ifndef HAVE_ATOMIC_BUILTINS
+static pthread_mutex_t mutClock;
+#endif
+static inline uint64
+getClockTopicAccess(void)
+{
+#if HAVE_ATOMIC_BUILTINS64
+	return ATOMIC_INC_AND_FETCH_uint64(&clockTopicAccess, &mutClock);
+#else
+	return ATOMIC_INC_AND_FETCH_unsigned(&clockTopicAccess, &mutClock);
+#endif
+}
+
+/* dynamic topic cache */
+struct s_dynaTopicCacheEntry {
+	uchar *pName;
+	rd_kafka_topic_t *pTopic;
+	uint64 clkTickAccessed;
+};
+typedef struct s_dynaTopicCacheEntry dynaTopicCacheEntry;
+
 typedef struct _instanceData {
-	char *topic;
+	uchar *topic;
+	sbool dynaTopic;
+	dynaTopicCacheEntry **dynCache;
+	rd_kafka_topic_t *pTopic;
+	int iCurrElt;
+	int iCurrCacheSize;
+	int bReportErrs;
+	int iDynaTopicCacheSize;
 	uchar *tplName;		/* assigned output template */
 	char *brokers;
 	int fixedPartition;
@@ -71,14 +115,13 @@ typedef struct _instanceData {
 	uchar *errorFile;
 	int fdErrFile;		/* error file fd or -1 if not open */
 	pthread_mutex_t mutErrFile;
+	int bIsOpen;
+	rd_kafka_t *rk;
 } instanceData;
 
 typedef struct wrkrInstanceData {
 	instanceData *pData;
-	int bIsOpen;
 	int bReportErrs;
-	rd_kafka_t *rk;
-	rd_kafka_topic_t *rkt;
 } wrkrInstanceData_t;
 
 
@@ -86,6 +129,8 @@ typedef struct wrkrInstanceData {
 /* action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {
 	{ "topic", eCmdHdlrString, CNFPARAM_REQUIRED },
+	{ "dynatopic", eCmdHdlrBinary, 0 },
+	{ "dynatopic.cachesize", eCmdHdlrInt, 0 },
 	{ "partitions.number", eCmdHdlrPositiveInt, 0 },
 	{ "partitions.usefixed", eCmdHdlrNonNegInt, 0 }, /* expert parameter, "nails" partition */
 	{ "broker", eCmdHdlrArray, 0 },
@@ -113,16 +158,230 @@ getPartition(instanceData *const __restrict__ pData)
 		:  pData->fixedPartition;
 }
 
-BEGINdoHUP
-CODESTARTdoHUP
-	pthread_mutex_lock(&pData->mutErrFile);
-	if(pData->fdErrFile != -1) {
-		close(pData->fdErrFile);
-		pData->fdErrFile = -1;
-	}
-	pthread_mutex_unlock(&pData->mutErrFile);
-ENDdoHUP
+/* destroy topic item */
+static rsRetVal
+closeTopic(instanceData *__restrict__ const pData)
+{
+	DEFiRet;
+	DBGPRINTF("omkafka: closing topic %s\n", rd_kafka_topic_name(pData->pTopic));
+	rd_kafka_topic_destroy(pData->pTopic);
+	RETiRet;
 
+}
+
+/* these dynaTopic* functions are only slightly modified versions of those found in omfile.c.
+ * check the sources in omfile.c for more descriptive comments about each of these functions.
+ * i will only put the bare descriptions in this one. 2015-01-09 - Tait Clarridge
+ */
+
+/* delete a cache entry from the dynamic topic cache */
+static rsRetVal
+dynaTopicDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, const int bFreeEntry)
+{
+	dynaTopicCacheEntry **pCache = pData->dynCache;
+	DEFiRet;
+	ASSERT(pCache != NULL);
+
+	if(pCache[iEntry] == NULL)
+		FINALIZE;
+
+	DBGPRINTF("Removing entry %d for topic '%s' from dynaCache.\n", iEntry,
+		pCache[iEntry]->pName == NULL ? UCHAR_CONSTANT("[OPEN FAILED]") : pCache[iEntry]->pName);
+
+	if(pCache[iEntry]->pName != NULL) {
+		d_free(pCache[iEntry]->pName);
+		pCache[iEntry]->pName = NULL;
+	}
+
+	if(bFreeEntry) {
+		d_free(pCache[iEntry]);
+		pCache[iEntry] = NULL;
+	}
+
+finalize_it:
+	RETiRet;
+}
+
+/* clear the entire dynamic topic cache */
+static inline void
+dynaTopicFreeCacheEntries(instanceData *__restrict__ const pData)
+{
+	register int i;
+	ASSERT(pData != NULL);
+
+	BEGINfunc;
+	for(i = 0 ; i < pData->iCurrCacheSize ; ++i) {
+		dynaTopicDelCacheEntry(pData, i, 1);
+	}
+	pData->iCurrElt = -1; /* invalidate current element */
+	ENDfunc;
+}
+
+/* free the entire cache and free dynCache from instanceData*/
+static void dynaTopicFreeCache(instanceData *__restrict__ const pData)
+{
+	ASSERT(pData != NULL);
+
+	BEGINfunc;
+	dynaTopicFreeCacheEntries(pData);
+	if(pData->dynCache != NULL)
+		d_free(pData->dynCache);
+	ENDfunc;
+}
+
+/* create the topic object */
+static rsRetVal
+prepareTopic(instanceData *__restrict__ const pData, const uchar *__restrict__ const newTopicName)
+{
+	/* Get a new topic conf */
+	rd_kafka_topic_conf_t *const topicconf = rd_kafka_topic_conf_new();
+	char errstr[MAX_ERRMSG];
+	rd_kafka_topic_t *rkt = NULL;
+	DEFiRet;
+
+	pData->pTopic = NULL;
+
+	if(topicconf == NULL) {
+		errmsg.LogError(0, RS_RET_KAFKA_ERROR,
+			"omkafka: error creating kafka topic conf obj: %s\n",
+			rd_kafka_err2str(rd_kafka_errno2err(errno)));
+		ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
+	}
+	for(int i = 0 ; i < pData->nTopicConfParams ; ++i) {
+		if(rd_kafka_topic_conf_set(topicconf,
+				     pData->topicConfParams[i].name,
+				     pData->topicConfParams[i].val,
+				     errstr, sizeof(errstr))
+		!= RD_KAFKA_CONF_OK) {
+			if(pData->bReportErrs) {
+				errmsg.LogError(0, RS_RET_PARAM_ERROR, "error in kafka "
+						"topic conf parameter '%s=%s': %s",
+						pData->topicConfParams[i].name,
+						pData->topicConfParams[i].val, errstr);
+			}
+			ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+		}
+	}
+	rkt = rd_kafka_topic_new(pData->rk, (char *)newTopicName, topicconf);
+	if(rkt == NULL) {
+		errmsg.LogError(0, RS_RET_KAFKA_ERROR,
+			"omkafka: error creating kafka topic: %s\n", 
+			rd_kafka_err2str(rd_kafka_errno2err(errno)));
+		ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
+	}
+	pData->pTopic = rkt;
+
+finalize_it:
+	if(iRet != RS_RET_OK) {
+		if(pData->pTopic != NULL) {
+			closeTopic(pData);
+		}
+	}
+	RETiRet;
+}
+
+/* check dynamic topic cache for existence of the already created topic.
+ * if it does not exist, create a new one, or if we are currently using it
+ * as of the last message, keep using it.
+ */
+static inline rsRetVal
+prepareDynTopic(instanceData *__restrict__ const pData, const uchar *__restrict__ const newTopicName)
+{
+	uint64 ctOldest;
+	int iOldest;
+	int i;
+	int iFirstFree;
+	rsRetVal localRet;
+	dynaTopicCacheEntry **pCache;
+	DEFiRet;
+	ASSERT(pData != NULL);
+	ASSERT(newTopicName != NULL);
+
+	pCache = pData->dynCache;
+	/* first check, if we still have the current topic */
+	if ((pData->iCurrElt != -1)
+		&& !ustrcmp(newTopicName, pCache[pData->iCurrElt]->pName)) {
+			/* great, we are all set */
+			pCache[pData->iCurrElt]->clkTickAccessed = getClockTopicAccess();
+			STATSCOUNTER_INC(ctrCacheSkip, mutCtrCacheSkip);
+			FINALIZE;
+	}
+
+	/* ok, no luck. Now let's search the table if we find a matching spot.
+	 * While doing so, we also prepare for creation of a new one.
+	 */
+	pData->iCurrElt = -1;
+	iFirstFree = -1;
+	iOldest = 0;
+	ctOldest = getClockTopicAccess();
+	for(i = 0 ; i < pData->iCurrCacheSize ; ++i) {
+		if(pCache[i] == NULL || pCache[i]->pName == NULL) {
+			if(iFirstFree == -1)
+				iFirstFree = i;
+		} else { /*got an element, let's see if it matches */
+			if(!ustrcmp(newTopicName, pCache[i]->pName)) {
+				/* we found our element! */
+				pData->pTopic = pCache[i]->pTopic;
+				pData->iCurrElt = i;
+				pCache[i]->clkTickAccessed = getClockTopicAccess(); /* update "timestamp" for LRU */
+				FINALIZE;
+			}
+			/* did not find it - so lets keep track of the counters for LRU */
+			if(pCache[i]->clkTickAccessed < ctOldest) {
+				ctOldest = pCache[i]->clkTickAccessed;
+				iOldest = i;
+			}
+		}
+	}
+	STATSCOUNTER_INC(ctrCacheMiss, mutCtrCacheMiss);
+
+	/* invalidate iCurrElt as we may error-exit out of this function when the currrent
+	 * iCurrElt has been freed or otherwise become unusable. This is a precaution, and
+	 * performance-wise it may be better to do that in each of the exits. However, that
+	 * is error-prone, so I prefer to do it here. -- rgerhards, 2010-03-02
+	 */
+	pData->iCurrElt = -1;
+	/* similarly, we need to set the current pTopic to NULL, because otherwise, if prepareTopic() fails,
+	 * we may end up using an old topic. This bug depends on how exactly prepareTopic fails,
+	 * but it could be triggered in the common case of a failed open() system call.
+	 * rgerhards, 2010-03-22
+	 */
+	pData->pTopic = NULL;
+
+	if(iFirstFree == -1 && (pData->iCurrCacheSize < pData->iDynaTopicCacheSize)) {
+		/* there is space left, so set it to that index */
+		iFirstFree = pData->iCurrCacheSize++;
+	}
+
+	if(iFirstFree == -1) {
+		dynaTopicDelCacheEntry(pData, iOldest, 0);
+		STATSCOUNTER_INC(ctrCacheEvict, mutCtrCacheEvict);
+		iFirstFree = iOldest; /* this one *is* now free ;) */
+	} else {
+		/* we need to allocate memory for the cache structure */
+		CHKmalloc(pCache[iFirstFree] = (dynaTopicCacheEntry*) calloc(1, sizeof(dynaTopicCacheEntry)));
+	}
+
+	/* Ok, we finally can open the topic */
+	localRet = prepareTopic(pData, newTopicName);
+
+	if(localRet != RS_RET_OK) {
+		errmsg.LogError(0, localRet, "Could not open dynamic topic '%s' [state %d] - discarding message", newTopicName, localRet);
+		ABORT_FINALIZE(localRet);
+	}
+
+	if((pCache[iFirstFree]->pName = ustrdup(newTopicName)) == NULL) {
+		closeTopic(pData);
+		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+	}
+	pCache[iFirstFree]->pTopic = pData->pTopic;
+	pCache[iFirstFree]->clkTickAccessed = getClockTopicAccess();
+	pData->iCurrElt = iFirstFree;
+	DBGPRINTF("Added new entry %d for topic cache, topic '%s'.\n", iFirstFree, newTopicName);
+
+finalize_it:
+	RETiRet;
+}
 
 /* write data error request/replies to separate error file
  * Note: we open the file but never close it before exit. If it
@@ -215,8 +474,12 @@ kafkaLogger(const rd_kafka_t __attribute__((unused)) *rk, int level,
 static inline void
 do_rd_kafka_destroy(wrkrInstanceData_t *const __restrict pWrkrData)
 {
-	rd_kafka_destroy(pWrkrData->rk);
-	pWrkrData->rk = NULL;
+	DBGPRINTF("omkafka: closing - items left in outqueue: %d\n",
+		  rd_kafka_outq_len(pWrkrData->pData->rk));
+	while (rd_kafka_outq_len(pWrkrData->pData->rk) > 0)
+		rd_kafka_poll(pWrkrData->pData->rk, 10);
+	rd_kafka_destroy(pWrkrData->pData->rk);
+	pWrkrData->pData->rk = NULL;
 }
 
 
@@ -224,10 +487,10 @@ static rsRetVal
 closeKafka(wrkrInstanceData_t *const __restrict__ pWrkrData)
 {
 	DEFiRet;
-	if(!pWrkrData->bIsOpen)
+	if(!pWrkrData->pData->bIsOpen)
 		FINALIZE;
 	do_rd_kafka_destroy(pWrkrData);
-	pWrkrData->bIsOpen = 0;
+	pWrkrData->pData->bIsOpen = 0;
 finalize_it:
 	RETiRet;
 }
@@ -241,6 +504,7 @@ errorCallback(rd_kafka_t __attribute__((unused)) *rk,
 	errmsg.LogError(0, RS_RET_KAFKA_ERROR,
 		"omkafka: kafka message %s", reason);
 }
+
 
 
 #if 0 /* the stock librdkafka version in Ubuntu 14.04 LTS does NOT support metadata :-( */
@@ -270,7 +534,7 @@ openKafka(wrkrInstanceData_t *const __restrict__ pWrkrData)
 	int nBrokers = 0;
 	DEFiRet;
 
-	if(pWrkrData->bIsOpen)
+	if(pWrkrData->pData->bIsOpen)
 		FINALIZE;
 
 	/* main conf */
@@ -300,77 +564,62 @@ openKafka(wrkrInstanceData_t *const __restrict__ pWrkrData)
 	rd_kafka_conf_set_dr_cb(conf, deliveryCallback);
 	rd_kafka_conf_set_error_cb(conf, errorCallback);
 
-	/* topic conf */
-	rd_kafka_topic_conf_t *const topicconf = rd_kafka_topic_conf_new();
-	if(topicconf == NULL) {
-		errmsg.LogError(0, RS_RET_KAFKA_ERROR,
-			"omkafka: error creating kafka topic conf obj: %s\n", 
-			rd_kafka_err2str(rd_kafka_errno2err(errno)));
-		ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
-	}
-	for(int i = 0 ; i < pData->nTopicConfParams ; ++i) {
-		if(rd_kafka_topic_conf_set(topicconf,
-				     pData->topicConfParams[i].name, 
-				     pData->topicConfParams[i].val, 
-				     errstr, sizeof(errstr))
-	 	   != RD_KAFKA_CONF_OK) {
-			if(pWrkrData->bReportErrs) {
-				errmsg.LogError(0, RS_RET_PARAM_ERROR, "error in kafka "
-						"topic conf parameter '%s=%s': %s", 
-						pData->topicConfParams[i].name, 
-						pData->topicConfParams[i].val, errstr);
-			}
-			ABORT_FINALIZE(RS_RET_PARAM_ERROR);
-		}
-	} 
-
 	char kafkaErrMsg[1024];
-	pWrkrData->rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf,
+	pWrkrData->pData->rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf,
 				     kafkaErrMsg, sizeof(kafkaErrMsg));
-	if(pWrkrData->rk == NULL) {
+	if(pWrkrData->pData->rk == NULL) {
 		errmsg.LogError(0, RS_RET_KAFKA_ERROR,
 			"omkafka: error creating kafka handle: %s\n", kafkaErrMsg);
 		ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
 	}
-	rd_kafka_set_logger(pWrkrData->rk, kafkaLogger);
-	if((nBrokers = rd_kafka_brokers_add(pWrkrData->rk, (char*)pData->brokers)) == 0) {
+	rd_kafka_set_logger(pWrkrData->pData->rk, kafkaLogger);
+	if((nBrokers = rd_kafka_brokers_add(pWrkrData->pData->rk, (char*)pData->brokers)) == 0) {
 		errmsg.LogError(0, RS_RET_KAFKA_NO_VALID_BROKERS,
 			"omkafka: no valid brokers specified: %s\n", pData->brokers);
 		ABORT_FINALIZE(RS_RET_KAFKA_NO_VALID_BROKERS);
 	}
 
-	pWrkrData->rkt = rd_kafka_topic_new(pWrkrData->rk, pData->topic, topicconf);
-	if(pWrkrData->rkt == NULL) {
-		errmsg.LogError(0, RS_RET_KAFKA_ERROR,
-			"omkafka: error creating kafka topic: %s\n", 
-			rd_kafka_err2str(rd_kafka_errno2err(errno)));
-		ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
-	}
-
-	pWrkrData->bIsOpen = 1;
+	pWrkrData->pData->bIsOpen = 1;
 finalize_it:
 	if(iRet == RS_RET_OK) {
 		pWrkrData->bReportErrs = 1;
 	} else {
 		pWrkrData->bReportErrs = 0;
-		if(pWrkrData->rk != NULL) {
+		if(pWrkrData->pData->rk != NULL) {
 			do_rd_kafka_destroy(pWrkrData);
 		}
 	}
 	RETiRet;
 }
 
+BEGINdoHUP
+CODESTARTdoHUP
+	pthread_mutex_lock(&pData->mutErrFile);
+	if(pData->fdErrFile != -1) {
+		close(pData->fdErrFile);
+		pData->fdErrFile = -1;
+	}
+	if(pData->dynaTopic) {
+		dynaTopicFreeCacheEntries(pData);
+	} else {
+		closeTopic(pData);
+	}
+	pthread_mutex_unlock(&pData->mutErrFile);
+ENDdoHUP
+
 BEGINcreateInstance
 CODESTARTcreateInstance
 	pData->currPartition = 0;
+	pData->bIsOpen = 0;
 	pData->fdErrFile = -1;
+	pData->pTopic = NULL;
+	pData->bReportErrs = 1;
 	pthread_mutex_init(&pData->mutErrFile, NULL);
 ENDcreateInstance
 
 
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
-	pWrkrData->bIsOpen = 0;
 	pWrkrData->bReportErrs = 1;
 ENDcreateWrkrInstance
 
@@ -396,6 +645,11 @@ CODESTARTfreeInstance
 	}
 	if(pData->fdErrFile != -1)
 		close(pData->fdErrFile);
+	if(pData->dynaTopic) {
+		dynaTopicFreeCache(pData);
+	} else if(pData->pTopic != NULL) {
+		closeTopic(pData);
+	}
 	pthread_mutex_destroy(&pData->mutErrFile);
 ENDfreeInstance
 
@@ -432,26 +686,41 @@ ENDtryResume
 
 
 static rsRetVal
-writeKafka(wrkrInstanceData_t *pWrkrData, uchar *msg)
+writeKafka(wrkrInstanceData_t *pWrkrData, uchar *msg, uchar *topic)
 {
 	DEFiRet;
 	const int partition = getPartition(pWrkrData->pData);
 
 	DBGPRINTF("omkafka: trying to send: '%s'\n", msg);
 	CHKiRet(openKafka(pWrkrData));
-	if(rd_kafka_produce(pWrkrData->rkt, partition, RD_KAFKA_MSG_F_COPY,
+
+	/* check if we are using dynamic topic names */
+	if(pWrkrData->pData->dynaTopic) {
+		DBGPRINTF("omkafka: topic to insert to: %s\n", topic);
+		CHKiRet(prepareDynTopic(pWrkrData->pData, topic));
+	} else {
+		if(pWrkrData->pData->pTopic == NULL) {
+			CHKiRet(prepareTopic(pWrkrData->pData, topic));
+			if(pWrkrData->pData->pTopic == NULL) {
+				errmsg.LogError(0, RS_RET_KAFKA_PRODUCE_ERR,
+					"Could not open topic '%s'", topic);
+			}
+		}
+	}
+	if(rd_kafka_produce(pWrkrData->pData->pTopic, partition, RD_KAFKA_MSG_F_COPY,
 	                    msg, strlen((char*)msg), NULL, 0, NULL) == -1) {
 		errmsg.LogError(0, RS_RET_KAFKA_PRODUCE_ERR,
 			"omkafka: Failed to produce to topic '%s' "
 			"partition %d: %s\n",
-			rd_kafka_topic_name(pWrkrData->rkt), partition, 
+			rd_kafka_topic_name(pWrkrData->pData->pTopic), partition,
 			rd_kafka_err2str(rd_kafka_errno2err(errno)));
+		STATSCOUNTER_INC(ctrKafkaFail, mutCtrKafkaFail);
 		ABORT_FINALIZE(RS_RET_KAFKA_PRODUCE_ERR);
 	}
-	const int callbacksCalled = rd_kafka_poll(pWrkrData->rk, 0); /* call callbacks */
+	const int callbacksCalled = rd_kafka_poll(pWrkrData->pData->rk, 0); /* call callbacks */
 
 	DBGPRINTF("omkafka: kafka outqueue length: %d, callbacks called %d\n",
-		  rd_kafka_outq_len(pWrkrData->rk), callbacksCalled);
+		  rd_kafka_outq_len(pWrkrData->pData->rk), callbacksCalled);
 
 finalize_it:
 	DBGPRINTF("omkafka: writeKafka returned %d\n", iRet);
@@ -459,13 +728,18 @@ finalize_it:
 		closeKafka(pWrkrData);
 		iRet = RS_RET_SUSPENDED;
 	}
+	STATSCOUNTER_INC(ctrTopicSubmit, mutCtrTopicSubmit);
 	RETiRet;
 }
 
 
 BEGINdoAction
 CODESTARTdoAction
-	iRet = writeKafka(pWrkrData, ppString[0]);
+	/* support dynamic topic */
+	if (pWrkrData->pData->dynaTopic)
+		iRet = writeKafka(pWrkrData, ppString[0], ppString[1]);
+	else
+		iRet = writeKafka(pWrkrData, ppString[0], pWrkrData->pData->topic);
 ENDdoAction
 
 
@@ -473,6 +747,8 @@ static inline void
 setInstParamDefaults(instanceData *pData)
 {
 	pData->topic = NULL;
+	pData->dynaTopic = 0;
+	pData->iDynaTopicCacheSize = 50;
 	pData->brokers = NULL;
 	pData->fixedPartition = NO_FIXED_PARTITION;
 	pData->nPartitions = 1;
@@ -506,6 +782,7 @@ finalize_it:
 BEGINnewActInst
 	struct cnfparamvals *pvals;
 	int i;
+	int iNumTpls;
 CODESTARTnewActInst
 	if((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -514,12 +791,15 @@ CODESTARTnewActInst
 	CHKiRet(createInstance(&pData));
 	setInstParamDefaults(pData);
 
-	CODE_STD_STRING_REQUESTnewActInst(1)
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
 		if(!strcmp(actpblk.descr[i].name, "topic")) {
-			pData->topic = es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->topic = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "dynatopic")) {
+			pData->dynaTopic = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "dynatopic.cachesize")) {
+			pData->iDynaTopicCacheSize = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "partitions.number")) {
 			pData->nPartitions = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "partitions.usefixed")) {
@@ -567,9 +847,26 @@ CODESTARTnewActInst
 	if(pData->brokers == NULL)
 		CHKmalloc(pData->brokers = strdup("localhost:9092"));
 
+	if(pData->dynaTopic && pData->topic == NULL) {
+        errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+            "omkafka: requested dynamic topic, but no "
+            "name for topic template given - action definition invalid");
+        ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+	}
+
+	iNumTpls = 1;
+	if(pData->dynaTopic) ++iNumTpls;
+	CODE_STD_STRING_REQUESTnewActInst(iNumTpls);
 	CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)strdup((pData->tplName == NULL) ? 
 						"RSYSLOG_FileFormat" : (char*)pData->tplName),
 						OMSR_NO_RQD_TPL_OPTS));
+	if(pData->dynaTopic) {
+        CHKiRet(OMSRsetEntry(*ppOMSR, 1, ustrdup(pData->topic),
+            OMSR_NO_RQD_TPL_OPTS));
+        CHKmalloc(pData->dynCache = (dynaTopicCacheEntry**)
+			calloc(pData->iDynaTopicCacheSize, sizeof(dynaTopicCacheEntry*)));
+        pData->iCurrElt = -1;
+	}
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst
@@ -591,7 +888,10 @@ ENDparseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
+	statsobj.Destruct(&kafkaStats);
 	CHKiRet(objRelease(errmsg, CORE_COMPONENT));
+	CHKiRet(objRelease(statsobj, CORE_COMPONENT));
+	DESTROY_ATOMIC_HELPER_MUT(mutClock);
 finalize_it:
 ENDmodExit
 
@@ -612,7 +912,29 @@ INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(errmsg, CORE_COMPONENT));
+	CHKiRet(objUse(statsobj, CORE_COMPONENT));
+
+	INIT_ATOMIC_HELPER_MUT(mutClock);
+
 	DBGPRINTF("omkafka %s using librdkafka version %s\n",
 	          VERSION, rd_kafka_version_str());
+	CHKiRet(statsobj.Construct(&kafkaStats));
+	CHKiRet(statsobj.SetName(kafkaStats, (uchar *)"omkafka"));
+	STATSCOUNTER_INIT(ctrTopicSubmit, mutCtrTopicSubmit);
+	CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"submitted",
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrTopicSubmit));
+	STATSCOUNTER_INIT(ctrKafkaFail, mutCtrKafkaFail);
+	CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"failures",
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrKafkaFail));
+	STATSCOUNTER_INIT(ctrCacheSkip, mutCtrCacheSkip);
+	CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"topicdynacache.skipped",
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrCacheSkip));
+	STATSCOUNTER_INIT(ctrCacheMiss, mutCtrCacheMiss);
+	CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"topicdynacache.miss",
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrCacheMiss));
+	STATSCOUNTER_INIT(ctrCacheEvict, mutCtrCacheEvict);
+	CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"topicdynacache.evicted",
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrCacheEvict));
+	CHKiRet(statsobj.ConstructFinalize(kafkaStats));
 CODEmodInit_QueryRegCFSLineHdlr
 ENDmodInit


### PR DESCRIPTION
stats:
  - submitted: producer submitted message to broker.
  - failures: producer failed to submit message to broker.

Topic is able to be a template, the topics are stored in the instanceData and the kafka_rd_t object has been moved into instanceData. This is alright because librdkafka is threadsafe and to acheive the dynamic topic results it is required.
The topics are stored in a hashtable due to librdkafka leaking memory when passing in a conf object, plus us keeping a local topic "list" makes the subsequent topic conf and rd_kafka_topic_new calls unnecessary. The move of the topic down the writeKafka is for dynamic parsing of the topic for each message that comes through.

Additional items:
  - Added safety to rd_kafka_t destruction, where it flushes the queued messages before object destruction.
  - Dynamic topic is enabled with dyntopic="on" in the configuration.
  - On HUP the active topics are closed, since we only give the topic hashtable 50 items, this could cause issues when rsyslog is running over a long period of time with lots of dynamically parsed topics from templates.
    - Not sure if 50 is an acceptable number of items for the hashtable, I'm open to either increasing or decreasing it.
    - After the HUP, writeKafka should instantiate a new topic and add it back to the hashtable at a minimal performance hit.

These changes have been run through valgrind and I can confirm there is no leaking (at least within my setup).