### PR TITLE
bugfix imklog/imkmsg: infinite loop on OpenVZ VMs

### DIFF
--- a/contrib/imkmsg/imkmsg.c
+++ b/contrib/imkmsg/imkmsg.c
@@ -208,7 +208,7 @@ ENDcheckCnf
 BEGINactivateCnfPrePrivDrop
 CODESTARTactivateCnfPrePrivDrop
 	runModConf = pModConf;
-        iRet = klogWillRun(runModConf);
+        iRet = klogWillRunPrePrivDrop(runModConf);
 ENDactivateCnfPrePrivDrop
 
 
@@ -224,6 +224,7 @@ ENDfreeCnf
 
 BEGINwillRun
 CODESTARTwillRun
+        iRet = klogWillRunPostPrivDrop(runModConf);
 ENDwillRun
 
 

--- a/contrib/imkmsg/kmsg.c
+++ b/contrib/imkmsg/kmsg.c
@@ -163,7 +163,7 @@ klogWillRunPrePrivDrop(modConfData_t *pModConf)
 
 	fklog = open(_PATH_KLOG, O_RDONLY, 0);
 	if (fklog < 0) {
-		imkmsgLogIntMsg(RS_RET_ERR_OPEN_KLOG, "imkmsg: cannot open kernel log(%s): %s.",
+		imkmsgLogIntMsg(LOG_ERR, "imkmsg: cannot open kernel log (%s): %s.",
 			_PATH_KLOG, rs_strerror_r(errno, errmsg, sizeof(errmsg)));
 		ABORT_FINALIZE(RS_RET_ERR_OPEN_KLOG);
 	}
@@ -185,7 +185,7 @@ klogWillRunPostPrivDrop(modConfData_t *pModConf)
 	/* on an OpenVZ VM, we get EPERM */
 	r = read(fklog, NULL, 0);
 	if (r < 0 && errno != EINVAL) {
-		imkmsgLogIntMsg(RS_RET_ERR_OPEN_KLOG, "imkmsg: cannot open kernel log(%s): %s.",
+		imkmsgLogIntMsg(LOG_ERR, "imkmsg: cannot open kernel log (%s): %s.",
 			_PATH_KLOG, rs_strerror_r(errno, errmsg, sizeof(errmsg)));
 		fklog = -1;
 		ABORT_FINALIZE(RS_RET_ERR_OPEN_KLOG);

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -383,7 +383,7 @@ ENDcheckCnf
 BEGINactivateCnfPrePrivDrop
 CODESTARTactivateCnfPrePrivDrop
 	runModConf = pModConf;
-        iRet = klogWillRun(runModConf);
+        iRet = klogWillRunPrePrivDrop(runModConf);
 ENDactivateCnfPrePrivDrop
 
 
@@ -399,6 +399,7 @@ ENDfreeCnf
 
 BEGINwillRun
 CODESTARTwillRun
+        iRet = klogWillRunPostPrivDrop(runModConf);
 ENDwillRun
 
 


### PR DESCRIPTION
The previous fix for imkmsg in https://github.com/rsyslog/rsyslog/pull/138 was unreliable. Commit ac4fb31 updates it to make it reliable.

The same problem also affects the imklog plugin.  Commit 244d365 applies the same fix to imklog.

I also happened to notice an unrelated bugfix was recently applied to imklog but not imkmsg.  Commit 9b32fd5 applies that bug fix to imkmsg.

Thanks!