### PR TITLE
fix build regression in imkmsg from ee035ef

### DIFF
--- a/contrib/imkmsg/imkmsg.h
+++ b/contrib/imkmsg/imkmsg.h
@@ -42,7 +42,8 @@ struct modConfData_s {
  * rgerhards, 2008-04-09
  */
 rsRetVal klogLogKMsg(modConfData_t *pModConf);
-rsRetVal klogWillRun(modConfData_t *pModConf);
+rsRetVal klogWillRunPrePrivDrop(modConfData_t *pModConf);
+rsRetVal klogWillRunPostPrivDrop(modConfData_t *pModConf);
 rsRetVal klogAfterRun(modConfData_t *pModConf);
 int klogFacilIntMsg();
 


### PR DESCRIPTION
Sorry, I missed the header files in both imklog and imkmsg in my commits in https://github.com/rsyslog/rsyslog/pull/198 ... it looks like you fixed imklog.h in commit https://github.com/rsyslog/rsyslog/commit/7e309e38e81993e8752d1e4ec6d8844fcf1e03fb but did not fix imkmsg.h.  This commit fixes imkmsg.h.

Thanks!