### PR TITLE
bugfix header in platform/redhat/rsyslog.conf

### DIFF
--- a/platform/redhat/rsyslog.conf
+++ b/platform/redhat/rsyslog.conf
@@ -1,13 +1,12 @@
-/* rsyslog configuration file (for Red Hat-based systems)
- * note that most of this config file uses old-style format,
- * because it is well-known AND quite suitable for simple cases
- * like we have with the default config. For more advanced 
- * things, RainerScript configuration is suggested.
- *
- * For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
- * or latest version online at http://www.rsyslog.com/doc/rsyslog_conf.html 
- * If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
- */
+# rsyslog configuration file (for Red Hat-based systems)
+# note that most of this config file uses old-style format,
+# because it is well-known AND quite suitable for simple cases
+# like we have with the default config. For more advanced 
+# things, RainerScript configuration is suggested.
+#
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# or latest version online at http://www.rsyslog.com/doc/rsyslog_conf.html 
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
 
 #### MODULES ####
 


### PR DESCRIPTION
the "For more information" doc path includes the string "*/", breaking c-style comment format. fixes #202.