### PR TITLE
Make configure fail when building with "--enable-omkafka" but librdkafka wasn't found

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1374,8 +1374,12 @@ AC_ARG_ENABLE(omkafka,
         [enable_omkafka=no]
 )
 if test "x$enable_omkafka"; then
-	#PKG_CHECK_MODULES(LIBRDKAFKA, librdkafka)
-	AC_CHECK_HEADERS([librdkafka/rdkafka.h])
+	PKG_CHECK_MODULES([LIBRDKAFKA], [librdkafka], [], [
+		AC_CHECK_HEADERS([librdkafka/rdkafka.h],
+			[],
+			AC_MSG_ERROR([librdkafka not found])
+		)
+	])
 fi
 AM_CONDITIONAL(ENABLE_OMKAFKA, test x$enable_omkafka = xyes)
 


### PR DESCRIPTION
We were only checking for headers but haven't defined an "if-not-found" action.
So when building with "--enable-omkafka" but without librdkafka installed,
compilation would fail.

Now we are checking for librdkafak first via PKG_CHECK_MODULES but will fall back to
AC_CHECK_HEADER for librdkafka packages not providing a .pc file.
If these checks will fail, we will now show a friendly error message.