### PR TITLE
Fix for ubuntu-12.04 json_array_looping.sh segfault

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -609,7 +609,8 @@ void rsrtSetErrLogger(void (*errLogger)(const int, const int, const uchar*));
 		json_object_object_get_ex((obj), (key), (retobj))
 #else
 #	define RS_json_object_object_get_ex(obj, key, retobj) \
-		((*(retobj) = json_object_object_get((obj), (key))) == NULL) ? FALSE : TRUE
+		(json_object_is_type(obj, json_type_object) && \
+				(*(retobj) = json_object_object_get((obj), (key))) == NULL) ? FALSE : TRUE
 #endif
 
 #ifndef HAVE_JSON_BOOL

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -609,7 +609,7 @@ void rsrtSetErrLogger(void (*errLogger)(const int, const int, const uchar*));
 		json_object_object_get_ex((obj), (key), (retobj))
 #else
 #	define RS_json_object_object_get_ex(obj, key, retobj) \
-		(json_object_is_type(obj, json_type_object) && \
+		(!json_object_is_type(obj, json_type_object) || \
 				(*(retobj) = json_object_object_get((obj), (key))) == NULL) ? FALSE : TRUE
 #endif
 


### PR DESCRIPTION
It was caused by unchecked use of json_object as linked-hashtable. In that test, first few instances are strings, which causes segfault.

The segfault was showing an unknown frame because it was dereferencing hash_fn from invalid object.