### PR TITLE
testbench bugfix: fixed typo

### DIFF
--- a/README
+++ b/README
@@ -1,1 +1,3 @@
+ttest
+
 see README.md -- this file here is just required for autotools

--- a/tests/testsuites/asynwr_simple.conf
+++ b/tests/testsuites/asynwr_simple.conf
@@ -10,6 +10,6 @@ $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"rsyslog.out.log" # trick to use relative path names!
 $OMFileFlushOnTXEnd off
 $OMFileFlushInterval 2
-$OMFileFlushIOBufferSize 10k
+$OMFileIOBufferSize 10k
 $OMFileAsyncWriting on
 :msg, contains, "msgnum:" ?dynfile;outfmt


### PR DESCRIPTION
Fixed typo: "OMFileFlushIOBufferSize" to "$OMFileIOBufferSize"