### PR TITLE
imudp: more precise error message in case of send failure

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -452,9 +452,9 @@ static rsRetVal UDPSend(wrkrInstanceData_t *__restrict__ const pWrkrData,
 		} else {
 			dbgprintf("error forwarding via udp, suspending\n");
 			if(pWrkrData->errsToReport > 0) {
-				rs_strerror_r(lasterrno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_ERR_UDPSEND, "omfwd: error sending "
-						"via udp: %s", errStr);
+				errmsg.LogError(lasterrno, RS_RET_ERR_UDPSEND,
+						"omfwd: error %d sending "
+						"via udp", lasterrno);
 				if(pWrkrData->errsToReport == 1) {
 					errmsg.LogError(0, RS_RET_LAST_ERRREPORT, "omfwd: "
 							"max number of error message emitted "


### PR DESCRIPTION
It now contains the errno as numerical value in order to be
able to more precisely nail down the problem cause. The
strerror() generated message sometimes seems to be a bit
questionable.

Also refactored error processing a bit to take advantage of
the improved error reporting subsystem.