### PR TITLE
Adding new format support for error file in omelasticsearch bulk insert mode

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -198,6 +198,7 @@ CODESTARTfreeWrkrInstance
 		pWrkrData->curlHandle = NULL;
 	}
 	free(pWrkrData->restURL);
+	es_deleteStr(pWrkrData->batch.data);
 ENDfreeWrkrInstance
 
 BEGINdbgPrintInstInfo

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -524,7 +524,7 @@ getSection(const char* bulkRequest,char **bulkRequestNextSectionStart )
 {
 		DEFiRet;
 		char* index =0;
-		if( (index = strchr(bulkRequest,'\n')) != 0)//intermediate section
+		if( (index = strchr(bulkRequest,'\n')) != 0)/*intermediate section*/
 		{
 			*bulkRequestNextSectionStart = ++index;
 		}
@@ -554,7 +554,7 @@ getSingleRequest(const char* bulkRequest, char** singleRequest ,char **lastLocat
 	if (getSection(req,&req)!=RS_RET_OK)
 			ABORT_FINALIZE(RS_RET_ERR);
 
-    *singleRequest = (char*) calloc (req - start+ 1 + 1,sizeof(char));// (req - start+ 1 == length of data + 1 for terminal char)
+    *singleRequest = (char*) calloc (req - start+ 1 + 1,sizeof(char));/* (req - start+ 1 == length of data + 1 for terminal char)*/
     if (*singleRequest==NULL) ABORT_FINALIZE(RS_RET_ERR);
     memcpy(*singleRequest,start,req - start);
     *lastLocation=req;
@@ -570,7 +570,9 @@ int checkReplyStatus(cJSON* ok) {
 	return (ok == NULL || ok->type != cJSON_Number || ok->valueint < 0 || ok->valueint > 299);
 }
 
-//Context object for error file content creation or status check
+/*
+ * Context object for error file content creation or status check
+ */
 typedef struct exeContext{
 	int statusCheckOnly;
 	cJSON *errRoot;
@@ -579,7 +581,9 @@ typedef struct exeContext{
 
 } context;
 
-//get content to be written in error file using context passed
+/*
+ * get content to be written in error file using context passed
+ */
 static inline rsRetVal
 parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,cJSON **pReplyRoot,uchar *reqmsg,context *ctx)
 {
@@ -590,7 +594,7 @@ parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,cJSON **pReplyRo
 	cJSON *items=0;
 
 
-	//iterate over items
+	/*iterate over items*/
 	items = cJSON_GetObjectItem(replyRoot, "items");
 	if(items == NULL || items->type != cJSON_Array) {
 		DBGPRINTF("omelasticsearch: error in elasticsearch reply: "
@@ -650,15 +654,15 @@ parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,cJSON **pReplyRo
 
 			if(*response==NULL)
 			{
-				free(request);//as its has been assigned.
+				free(request);/*as its has been assigned.*/
 				DBGPRINTF("omelasticsearch: Error getting cJSON_PrintUnformatted. Cannot continue\n");
 				ABORT_FINALIZE(RS_RET_ERR);
 			}
 
-			//call the context
+			/*call the context*/
 			rsRetVal ret = ctx->prepareErrorFileContent(ctx, itemStatus, request,response);
 
-			//free memory in any case
+			/*free memory in any case*/
 			free(request);
 			free(response);
 
@@ -725,7 +729,7 @@ getDataInterleaved(context *ctx,int itemStatus,char *request,char *response)
 	}
 
 	cJSON *interleavedNode=0;
-	//create interleaved node that has req and response json data
+	/*create interleaved node that has req and response json data*/
 	if((interleavedNode=cJSON_CreateObject()) == NULL)
 	{
 		DBGPRINTF("omelasticsearch: Failed to create interleaved node. Cann't continue\n");
@@ -761,7 +765,9 @@ getDataErrorOnlyInterleaved(context *ctx,int itemStatus,char *request,char *resp
 		RETiRet;
 }
 
-//get erroronly context
+/*
+ * get erroronly context
+ */
 static inline rsRetVal
 initializeErrorOnlyConext(wrkrInstanceData_t *pWrkrData,context *ctx){
 	DEFiRet;
@@ -790,7 +796,9 @@ initializeErrorOnlyConext(wrkrInstanceData_t *pWrkrData,context *ctx){
 		RETiRet;
 }
 
-//get interleaved context
+/*
+ * get interleaved context
+ */
 static inline rsRetVal
 initializeInterleavedConext(wrkrInstanceData_t *pWrkrData,context *ctx){
 	DEFiRet;
@@ -812,7 +820,7 @@ initializeInterleavedConext(wrkrInstanceData_t *pWrkrData,context *ctx){
 		RETiRet;
 }
 
-//get interleaved context
+/*get interleaved context*/
 static inline rsRetVal
 initializeErrorInterleavedConext(wrkrInstanceData_t *pWrkrData,context *ctx){
 	DEFiRet;
@@ -862,7 +870,7 @@ writeDataError(wrkrInstanceData_t *pWrkrData, instanceData *pData, cJSON **pRepl
 
 	context ctx;
 	ctx.errRoot=0;
-	if(pData->interleaved ==0 && pData->errorOnly ==0)//default write
+	if(pData->interleaved ==0 && pData->errorOnly ==0)/*default write*/
 	{
 		if(getDataErrorDefault(pWrkrData,pReplyRoot,reqmsg,&rendered) != RS_RET_OK) {
 			ABORT_FINALIZE(RS_RET_ERR);
@@ -870,7 +878,7 @@ writeDataError(wrkrInstanceData_t *pWrkrData, instanceData *pData, cJSON **pRepl
 	}
 	else
 	{
-		//get correct context.
+		/*get correct context.*/
 		if(pData->interleaved && pData->errorOnly)
 		{
 			if(initializeErrorInterleavedConext(pWrkrData,&ctx) != RS_RET_OK) {
@@ -901,7 +909,7 @@ writeDataError(wrkrInstanceData_t *pWrkrData, instanceData *pData, cJSON **pRepl
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
 
-		//execute context
+		/*execute context*/
 		if(parseRequestAndResponseForContext(pWrkrData,pReplyRoot,reqmsg,&ctx)!= RS_RET_OK) {
 			DBGPRINTF("omelasticsearch: error creating file content.\n");
 			ABORT_FINALIZE(RS_RET_ERR);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -175,7 +175,11 @@ TESTS +=  \
 	elasticsearch-basic-errorfile-empty.sh \
 	elasticsearch-basic-errorfile-populated.sh \
 	elasticsearch-bulk-errorfile-empty.sh \
-	elasticsearch-bulk-errorfile-populated.sh
+	elasticsearch-bulk-errorfile-populated.sh \
+	elasticsearch-bulk-errorfile-populated-default-format.sh \
+	elasticsearch-bulk-errorfile-populated-erroronly.sh \
+	elasticsearch-bulk-errorfile-populated-erroronly-interleaved.sh \
+	elasticsearch-bulk-errorfile-populated-default-interleaved.sh
 endif
 
 if ENABLE_MMPSTRUCDATA
@@ -467,6 +471,14 @@ EXTRA_DIST= 1.rstest 2.rstest 3.rstest err1.rstest \
 	   testsuites/elasticsearch-bulk-errorfile-empty.conf \
 	   elasticsearch-bulk-errorfile-populated.sh \
 	   testsuites/elasticsearch-bulk-errorfile-populated.conf \
+	   elasticsearch-bulk-errorfile-populated-default-format.sh \
+	   testsuites/elasticsearch-bulk-errorfile-populated-erroronly.conf \
+	   elasticsearch-bulk-errorfile-populated-erroronly.sh \
+	   testsuites/elasticsearch-bulk-errorfile-populated-default-format.conf \
+	   elasticsearch-bulk-errorfile-populated-erroronly-interleaved \
+	   testsuites/elasticsearch-bulk-errorfile-populated-erroronly-interleaved.conf \
+	   elasticsearch-bulk-errorfile-populated-default-interleaved \
+	   testsuites/elasticsearch-bulk-errorfile-populated-default-interleaved.conf \
 	   linkedlistqueue.sh \
 	   testsuites/linkedlistqueue.conf \
 	   da-mainmsg-q.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -475,9 +475,9 @@ EXTRA_DIST= 1.rstest 2.rstest 3.rstest err1.rstest \
 	   testsuites/elasticsearch-bulk-errorfile-populated-erroronly.conf \
 	   elasticsearch-bulk-errorfile-populated-erroronly.sh \
 	   testsuites/elasticsearch-bulk-errorfile-populated-default-format.conf \
-	   elasticsearch-bulk-errorfile-populated-erroronly-interleaved \
+	   elasticsearch-bulk-errorfile-populated-erroronly-interleaved.sh \
 	   testsuites/elasticsearch-bulk-errorfile-populated-erroronly-interleaved.conf \
-	   elasticsearch-bulk-errorfile-populated-default-interleaved \
+	   elasticsearch-bulk-errorfile-populated-default-interleaved.sh \
 	   testsuites/elasticsearch-bulk-errorfile-populated-default-interleaved.conf \
 	   linkedlistqueue.sh \
 	   testsuites/linkedlistqueue.conf \

--- a/tests/elasticsearch-bulk-errorfile-populated-default-format.sh
+++ b/tests/elasticsearch-bulk-errorfile-populated-default-format.sh
@@ -1,0 +1,22 @@
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[elasticsearch-bulk-errorfile-populated\]: basic test for elasticsearch functionality
+source $srcdir/diag.sh init
+source $srcdir/diag.sh es-init
+echo '{ "name" : "foo" }
+{"name": bar"}
+{"name": "baz"}
+{"name": foz"}' > inESData.inputfile
+source $srcdir/diag.sh startup elasticsearch-bulk-errorfile-populated-default-format.conf
+source $srcdir/diag.sh shutdown-when-empty
+source $srcdir/diag.sh wait-shutdown
+rm -f inESData.inputfile
+
+python $srcdir/elasticsearch-error-format-check.py default
+
+if [ $? -ne 0 ]
+then
+    echo "error: Format for error file different! " $?
+    exit 1
+fi
+source $srcdir/diag.sh exit

--- a/tests/elasticsearch-bulk-errorfile-populated-default-interleaved.sh
+++ b/tests/elasticsearch-bulk-errorfile-populated-default-interleaved.sh
@@ -1,0 +1,22 @@
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[elasticsearch-bulk-errorfile-populated\]: basic test for elasticsearch functionality
+source $srcdir/diag.sh init
+source $srcdir/diag.sh es-init
+echo '{ "name" : "foo" }
+{"name": bar"}
+{"name": "baz"}
+{"name": foz"}' > inESData.inputfile
+source $srcdir/diag.sh startup elasticsearch-bulk-errorfile-populated-default-interleaved.conf
+source $srcdir/diag.sh shutdown-when-empty
+source $srcdir/diag.sh wait-shutdown
+rm -f inESData.inputfile
+
+python $srcdir/elasticsearch-error-format-check.py interleaved
+
+if [ $? -ne 0 ]
+then
+    echo "error: Format for error file different! " $?
+    exit 1
+fi
+source $srcdir/diag.sh exit

--- a/tests/elasticsearch-bulk-errorfile-populated-erroronly-interleaved.sh
+++ b/tests/elasticsearch-bulk-errorfile-populated-erroronly-interleaved.sh
@@ -1,0 +1,22 @@
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[elasticsearch-bulk-errorfile-populated\]: basic test for elasticsearch functionality
+source $srcdir/diag.sh init
+source $srcdir/diag.sh es-init
+echo '{ "name" : "foo" }
+{"name": bar"}
+{"name": "baz"}
+{"name": foz"}' > inESData.inputfile
+source $srcdir/diag.sh startup elasticsearch-bulk-errorfile-populated-erroronly-interleaved.conf
+source $srcdir/diag.sh shutdown-when-empty
+source $srcdir/diag.sh wait-shutdown
+rm -f inESData.inputfile
+
+python $srcdir/elasticsearch-error-format-check.py errorinterleaved
+
+if [ $? -ne 0 ]
+then
+    echo "error: Format for error file different! " $?
+    exit 1
+fi
+source $srcdir/diag.sh exit

--- a/tests/elasticsearch-bulk-errorfile-populated-erroronly.sh
+++ b/tests/elasticsearch-bulk-errorfile-populated-erroronly.sh
@@ -1,0 +1,22 @@
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[elasticsearch-bulk-errorfile-populated\]: basic test for elasticsearch functionality
+source $srcdir/diag.sh init
+source $srcdir/diag.sh es-init
+echo '{ "name" : "foo" }
+{"name": bar"}
+{"name": "baz"}
+{"name": foz"}' > inESData.inputfile
+source $srcdir/diag.sh startup elasticsearch-bulk-errorfile-populated-erroronly.conf
+source $srcdir/diag.sh shutdown-when-empty
+source $srcdir/diag.sh wait-shutdown
+rm -f inESData.inputfile
+
+python $srcdir/elasticsearch-error-format-check.py erroronly
+
+if [ $? -ne 0 ]
+then
+    echo "error: Format for error file different! " $?
+    exit 1
+fi
+source $srcdir/diag.sh exit

--- a/tests/elasticsearch-error-format-check.py
+++ b/tests/elasticsearch-error-format-check.py
@@ -1,0 +1,136 @@
+import json
+import sys
+def checkDefaultErrorFile():
+    with open("rsyslog.errorfile") as json_file:
+        json_data = json.load(json_file)
+        indexCount =0
+        replyCount=0
+        for item in json_data:
+            if item == "request":
+                for reqItem in json_data[item]:
+                    if reqItem == "url":
+                        print "url found"
+                        print reqItem
+                    elif reqItem == "postdata":
+                        print "postdata found"
+                        indexCount = str(json_data[item]).count('\"_index\":')
+                        print reqItem
+                    else:
+                        print reqItem
+                        print "Unknown item found"
+                        sys.exit(1)
+                
+            elif item == "reply":
+                for replyItem in json_data[item]:
+                    if replyItem == "items":
+                        print json_data[item][replyItem]
+                        replyCount = str(json_data[item][replyItem]).count('_index')
+                    elif replyItem == "errors":
+                        print "error node found"
+                    elif replyItem == "took":
+                        print "took node found"
+                    else:
+                        print replyItem
+                        print "Unknown item found"
+                        sys.exit(3)
+
+            else:
+                print item
+                print "Unknown item found"
+                print "error"
+                sys.exit(4)
+    if replyCount == indexCount :
+        return 0
+    else:
+        sys.exit(7)
+    return 0
+
+
+def checkErrorOnlyFile():
+    with open("rsyslog.errorfile") as json_file:
+        json_data = json.load(json_file)
+        indexCount =0
+        replyCount=0
+        for item in json_data:
+            if item == "request":
+                print json_data[item]
+                indexCount = str(json_data[item]).count('\"_index\":')
+                
+                
+            elif item == "url":
+                print "url found"
+                
+            
+            elif item == "reply":
+                print json_data[item]
+                replyCount = str(json_data[item]).count('\"_index\":')
+
+            else:
+                print item
+                print "Unknown item found"
+                print "error"
+                sys.exit(4)
+    if replyCount == indexCount :
+        return 0
+    else:
+        sys.exit(7)
+    return 0
+
+def checkErrorInterleaved():
+    with open("rsyslog.errorfile") as json_file:
+        json_data = json.load(json_file)
+        indexCount =0
+        replyCount=0
+        for item in json_data:
+            print item
+            if item == "response":
+                for responseItem in json_data[item]:
+                    print responseItem
+                    for res in responseItem:
+                        print res
+                        if res == "request":
+                            print responseItem[res]
+                            indexCount = str(responseItem[res]).count('\"_index\":')
+                            print "request count ", indexCount
+                        elif res == "reply":
+                            print responseItem[res]
+                            replyCount = str(responseItem[res]).count('\"_index\":')
+                            print "reply count ", replyCount
+                        else:
+                            print res
+                            print "Unknown item found"
+                            sys.exit(9)
+                    if replyCount != indexCount :
+                        sys.exit(8)
+            
+                
+                
+            elif item == "url":
+                print "url found"
+                
+            
+           
+
+            else:
+                print item
+                print "Unknown item found"
+                sys.exit(4)
+    
+    return 0
+
+def checkInterleaved():
+    return checkErrorInterleaved()
+
+if __name__ == "__main__":
+    option = sys.argv[1]
+    if option == "default":
+        checkDefaultErrorFile()
+    elif option == "erroronly":
+        checkErrorOnlyFile()
+    elif option == "errorinterleaved":
+        checkErrorInterleaved()
+    elif option == "interleaved":
+        checkErrorInterleaved()
+    else:
+        print "Usage: <script> <default|erroronly|errorinterleaved>"
+        sys.exit(6)

--- a/tests/testsuites/elasticsearch-bulk-errorfile-populated-default-format.conf
+++ b/tests/testsuites/elasticsearch-bulk-errorfile-populated-default-format.conf
@@ -1,0 +1,29 @@
+$IncludeConfig diag-common.conf
+
+# Note: we must mess up with the template, because we can not
+# instruct ES to put further constraints on the data type and
+# values. So we require integer and make sure it is none.
+template(name="tpl" type="list") {
+	 constant(value="{\"")        
+        property(name="$!key") constant(value="\":") property(name="$!obj")
+      constant(value="}")   
+}
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+module(load="../plugins/imfile/.libs/imfile")
+ruleset(name="foo") {
+  set $!key = "my_obj";
+  set $!obj = $msg;
+  action(type="omelasticsearch"
+	 template="tpl"
+	 searchIndex="rsyslog_testbench"
+	 searchType="test-type"
+	 bulkmode="on"
+	 errorFile="./rsyslog.errorfile")
+}
+
+input(type="imfile" File="./inESData.inputfile"
+      Tag="foo"
+      StateFile="in_log.state"
+      Severity="info"
+      ruleset="foo")

--- a/tests/testsuites/elasticsearch-bulk-errorfile-populated-default-interleaved.conf
+++ b/tests/testsuites/elasticsearch-bulk-errorfile-populated-default-interleaved.conf
@@ -1,0 +1,30 @@
+$IncludeConfig diag-common.conf
+
+# Note: we must mess up with the template, because we can not
+# instruct ES to put further constraints on the data type and
+# values. So we require integer and make sure it is none.
+template(name="tpl" type="list") {
+	 constant(value="{\"")        
+        property(name="$!key") constant(value="\":") property(name="$!obj")
+      constant(value="}")   
+}
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+module(load="../plugins/imfile/.libs/imfile")
+ruleset(name="foo") {
+  set $!key = "my_obj";
+  set $!obj = $msg;
+  action(type="omelasticsearch"
+	 template="tpl"
+	 searchIndex="rsyslog_testbench"
+	 searchType="test-type"
+	 bulkmode="on"
+	 errorFile="./rsyslog.errorfile"
+	 interleaved="on")
+}
+
+input(type="imfile" File="./inESData.inputfile"
+      Tag="foo"
+      StateFile="in_log.state"
+      Severity="info"
+      ruleset="foo")

--- a/tests/testsuites/elasticsearch-bulk-errorfile-populated-erroronly-interleaved.conf
+++ b/tests/testsuites/elasticsearch-bulk-errorfile-populated-erroronly-interleaved.conf
@@ -1,0 +1,31 @@
+$IncludeConfig diag-common.conf
+
+# Note: we must mess up with the template, because we can not
+# instruct ES to put further constraints on the data type and
+# values. So we require integer and make sure it is none.
+template(name="tpl" type="list") {
+	 constant(value="{\"")        
+        property(name="$!key") constant(value="\":") property(name="$!obj")
+      constant(value="}")   
+}
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+module(load="../plugins/imfile/.libs/imfile")
+ruleset(name="foo") {
+  set $!key = "my_obj";
+  set $!obj = $msg;
+  action(type="omelasticsearch"
+	 template="tpl"
+	 searchIndex="rsyslog_testbench"
+	 searchType="test-type"
+	 bulkmode="on"
+	 errorFile="./rsyslog.errorfile"
+	erroronly="on"		 
+	interleaved="on")
+}
+
+input(type="imfile" File="./inESData.inputfile"
+      Tag="foo"
+      StateFile="in_log.state"
+      Severity="info"
+      ruleset="foo")

--- a/tests/testsuites/elasticsearch-bulk-errorfile-populated-erroronly.conf
+++ b/tests/testsuites/elasticsearch-bulk-errorfile-populated-erroronly.conf
@@ -1,0 +1,30 @@
+$IncludeConfig diag-common.conf
+
+# Note: we must mess up with the template, because we can not
+# instruct ES to put further constraints on the data type and
+# values. So we require integer and make sure it is none.
+template(name="tpl" type="list") {
+	 constant(value="{\"")        
+        property(name="$!key") constant(value="\":") property(name="$!obj")
+      constant(value="}")   
+}
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+module(load="../plugins/imfile/.libs/imfile")
+ruleset(name="foo") {
+  set $!key = "my_obj";
+  set $!obj = $msg;
+  action(type="omelasticsearch"
+	 template="tpl"
+	 searchIndex="rsyslog_testbench"
+	 searchType="test-type"
+	 bulkmode="on"
+	 errorFile="./rsyslog.errorfile"
+	 erroronly="on")
+}
+
+input(type="imfile" File="./inESData.inputfile"
+      Tag="foo"
+      StateFile="in_log.state"
+      Severity="info"
+      ruleset="foo")


### PR DESCRIPTION
Currently omelasticsearch dumps entire post data and response in error file in case for a failure in bulk insert mode. Wanted to introduce two format flags in action to format data in error file (Both of the flags can be used independently as well as together).

1. erroronly => This flag checks the response stream and logs only failed requests and response.
2. interleaved => This flag interleaves the request to its response and dumps it as pair.

When both flags are used we get only failed request in an interleaved format.

sample: action(server="localhost"
    XXX
    type="omelasticsearch"
    XXX
   errorfile="bad_message.log"
   erroronly="on"
   interleaved="on")

BugFix:
While checking if my code is causing any leaks or not, I found a valgrind error for "pWrkrData->batch.data" not sure if that was intentional or not. but I fixed it anyway.