### PR TITLE
bugfix: large memory consumption on suspended action

### DIFF
--- a/action.c
+++ b/action.c
@@ -1183,7 +1183,6 @@ actionTryCommit(action_t *__restrict__ const pThis, wti_t *__restrict__ const pW
 	iRet = getReturnCode(pThis, pWti);
 
 finalize_it:
-	pWti->actWrkrInfo[pThis->iActionNbr].p.tx.currIParam = 0; /* reset to beginning */
 	RETiRet;
 }
 
@@ -1235,6 +1234,7 @@ actionCommit(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti)
 		}
 	} while(!bDone);
 finalize_it:
+	pWti->actWrkrInfo[pThis->iActionNbr].p.tx.currIParam = 0; /* reset to beginning */
 	RETiRet;
 }
 


### PR DESCRIPTION
When an action is suspended, rsyslog's memory consumption continues
to grow. On very busy systems, this can lead to system stability
errors as it is possible that rsyslog allocates too much memory.

The root cause of this issue is the invalid management of a string
cache index, which is reset to the beginning in the wrong function,
one that is not reached when suspended. This in turn leads to
continous increase of the cache.

This fix moves the reset to the proper location.

Note that this problem was not detectable by our valgrind tests
because proper cleanup was done on rsyslog termination (but only
then).

closes https://github.com/rsyslog/rsyslog/issues/253