### PR TITLE
added test for imfile ReadMode=2

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -109,6 +109,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "debug.logfile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdrivercafile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdriverkeyfile", eCmdHdlrString, 0 },
+        { "defaultnetstreamdrivercertfile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdriver", eCmdHdlrString, 0 },
 	{ "maxmessagesize", eCmdHdlrSize, 0 },
 	{ "action.reportsuspension", eCmdHdlrBinary, 0 }
@@ -694,6 +695,10 @@ glblDoneLoadCnf(void)
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdriverkeyfile")) {
 			free(pszDfltNetstrmDrvrKeyFile);
 			pszDfltNetstrmDrvrKeyFile = (uchar*)
+				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercertfile")) {
+			free(pszDfltNetstrmDrvrCertFile);
+			pszDfltNetstrmDrvrCertFile = (uchar*)
 				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercafile")) {
 			free(pszDfltNetstrmDrvrCAF);

--- a/tests/imfile-readmode2-polling.sh
+++ b/tests/imfile-readmode2-polling.sh
@@ -1,0 +1,57 @@
+# This is part of the rsyslog testbench, licensed under GPLv3
+echo [imfile-readmode2.sh]
+source $srcdir/diag.sh init
+source $srcdir/diag.sh startup imfile-readmode2-polling.conf
+
+# write the beginning of the file
+echo 'msgnum:0
+ msgnum:1' > rsyslog.input
+echo 'msgnum:2' >> rsyslog.input
+
+# sleep a little to give rsyslog a chance to begin processing
+sleep 2
+
+# write some more lines (see https://github.com/rsyslog/rsyslog/issues/144)
+echo 'msgnum:3
+ msgnum:4' >> rsyslog.input
+echo 'msgnum:5' >> rsyslog.input # this one shouldn't be written to the output file because of ReadMode 2
+
+# give it time to finish
+sleep 1
+
+source $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+source $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+
+# give it time to write the output file
+sleep 1
+
+## check if we have the correct number of messages
+
+NUMLINES=$(grep -c HEADER $srcdir/rsyslog.out.log 2>/dev/null)
+
+if [ -z $NUMLINES ]; then
+  echo "ERROR: expecting at least a match for HEADER, maybe rsyslog.out.log wasn't even written?"
+  source $srcdir/diag.sh exit
+  exit 1
+else
+  if [ ! $NUMLINES -eq 3 ]; then
+    echo "ERROR: expecting 3 headers, got $NUMLINES"
+    source $srcdir/diag.sh exit
+    exit 1
+  fi
+fi
+
+## check if all the data we expect to get in the file is there
+
+for i in {1..4}; do
+  grep msgnum:$i $srcdir/rsyslog.out.log > /dev/null 2>&1
+  if [ ! $? -eq 0 ]; then
+    echo "ERROR: expecting the string 'msgnum:$i', it's not there"
+    source $srcdir/diag.sh exit
+    exit 1
+  fi
+done
+
+## if we got here, all is good :)
+
+source $srcdir/diag.sh exit

--- a/tests/imfile-readmode2.sh
+++ b/tests/imfile-readmode2.sh
@@ -1,0 +1,57 @@
+# This is part of the rsyslog testbench, licensed under GPLv3
+echo [imfile-readmode2.sh]
+source $srcdir/diag.sh init
+source $srcdir/diag.sh startup imfile-readmode2.conf
+
+# write the beginning of the file
+echo 'msgnum:0
+ msgnum:1' > rsyslog.input
+echo 'msgnum:2' >> rsyslog.input
+
+# sleep a little to give rsyslog a chance to begin processing
+sleep 1
+
+# write some more lines (see https://github.com/rsyslog/rsyslog/issues/144)
+echo 'msgnum:3
+ msgnum:4' >> rsyslog.input
+echo 'msgnum:5' >> rsyslog.input # this one shouldn't be written to the output file because of ReadMode 2
+
+# give it time to finish
+sleep 1
+
+source $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+source $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+
+# give it time to write the output file
+sleep 1
+
+## check if we have the correct number of messages
+
+NUMLINES=$(grep -c HEADER $srcdir/rsyslog.out.log 2>/dev/null)
+
+if [ -z $NUMLINES ]; then
+  echo "ERROR: expecting at least a match for HEADER, maybe rsyslog.out.log wasn't even written?"
+  source $srcdir/diag.sh exit
+  exit 1
+else
+  if [ ! $NUMLINES -eq 3 ]; then
+    echo "ERROR: expecting 3 headers, got $NUMLINES"
+    source $srcdir/diag.sh exit
+    exit 1
+  fi
+fi
+
+## check if all the data we expect to get in the file is there
+
+for i in {1..4}; do
+  grep msgnum:$i $srcdir/rsyslog.out.log > /dev/null 2>&1
+  if [ ! $? -eq 0 ]; then
+    echo "ERROR: expecting the string 'msgnum:$i', it's not there"
+    source $srcdir/diag.sh exit
+    exit 1
+  fi
+done
+
+## if we got here, all is good :)
+
+source $srcdir/diag.sh exit

--- a/tests/testsuites/imfile-readmode2-polling.conf
+++ b/tests/testsuites/imfile-readmode2-polling.conf
@@ -1,0 +1,22 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imfile/.libs/imfile" mode="polling" PollingInterval="1")
+
+input(type="imfile"
+      File="./rsyslog.input"
+      Tag="file:"
+      StateFile="stat-file1"
+      ReadMode="2")
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )

--- a/tests/testsuites/imfile-readmode2.conf
+++ b/tests/testsuites/imfile-readmode2.conf
@@ -1,0 +1,22 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imfile/.libs/imfile")
+
+input(type="imfile"
+      File="./rsyslog.input"
+      Tag="file:"
+      StateFile="stat-file1"
+      ReadMode="2")
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )


### PR DESCRIPTION
See https://github.com/rsyslog/rsyslog/issues/144

At the moment, the test fails because of that bug. A couple of notes:
- if you set ReadMode to 0, the test still fails (more headers than expected), but at least all data gets through
- when starting rsyslog, there's a warning about the deprecated use of StateFile. I guess the clean way around that is to remove the StateFile option from all imfile tests and change diag.sh to remove all imfile-state* files. I can do that as a separate PR if it's needed