### PR TITLE
bugfix: size-based legacy config statements did not work properly

### DIFF
--- a/runtime/cfsysline.c
+++ b/runtime/cfsysline.c
@@ -161,7 +161,7 @@ finalize_it:
  * param value must be int64!
  * rgerhards, 2008-01-09
  */
-static rsRetVal doGetSize(uchar **pp, rsRetVal (*pSetHdlr)(void*, uid_t), void *pVal)
+static rsRetVal doGetSize(uchar **pp, rsRetVal (*pSetHdlr)(void*, int64), void *pVal)
 {
 	DEFiRet;
 	int64 i;


### PR DESCRIPTION
on some platforms they misadressed memory, which could also lead
to a segfault on startup. The problem is NOT experience on amd686
in 64bit builds -- that's probably the reason this bug was uncovered
very late. We assume, it's present in all v8 versions.

Thanks to Michael Biebl for alerting us of it.

closes https://github.com/rsyslog/rsyslog/issues/270