### PR TITLE
Fix field name for pszStrucData in MsgSerialize (Issue #264)

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1139,7 +1139,7 @@ static rsRetVal MsgSerialize(msg_t *pThis, strm_t *pStrm)
 	psz = getRcvFromIP(pThis); 
 	CHKiRet(obj.SerializeProp(pStrm, UCHAR_CONSTANT("pszRcvFromIP"), PROPTYPE_PSZ, (void*) psz));
 	psz = pThis->pszStrucData; 
-	CHKiRet(obj.SerializeProp(pStrm, UCHAR_CONSTANT("pszRcvStrucData"), PROPTYPE_PSZ, (void*) psz));
+	CHKiRet(obj.SerializeProp(pStrm, UCHAR_CONSTANT("pszStrucData"), PROPTYPE_PSZ, (void*) psz));
 	if(pThis->json != NULL) {
 		psz = (uchar*) json_object_get_string(pThis->json);
 		CHKiRet(obj.SerializeProp(pStrm, UCHAR_CONSTANT("json"), PROPTYPE_PSZ, (void*) psz));


### PR DESCRIPTION
Rename the field for serializing pszStrucData so MsgSerialize and MsgDeserialize align.