### PR TITLE
Make llDestroy safe

### DIFF
--- a/runtime/linkedlist.c
+++ b/runtime/linkedlist.c
@@ -90,22 +90,24 @@ rsRetVal llDestroy(linkedList_t *pThis)
 {
 	DEFiRet;
 	llElt_t *pElt;
-	llElt_t *pEltPrev;
 
 	assert(pThis != NULL);
 
 	pElt = pThis->pRoot;
 	while(pElt != NULL) {
-		pEltPrev = pElt;
-		pElt = pElt->pNext;
+		/* keep the list structure in a consistent state as
+		 * the destructor bellow may reference it again
+		 */
+		pThis->pRoot = pElt->pNext;
+		if(pElt->pNext == NULL)
+			pThis->pLast = NULL;
+
 		/* we ignore errors during destruction, as we need to try
 		 * finish the linked list in any case.
 		 */
-		llDestroyElt(pThis, pEltPrev);
+		llDestroyElt(pThis, pElt);
+		pElt = pThis->pRoot;
 	}
-	/* now clean up the pointers */
-	pThis->pRoot = NULL;
-	pThis->pLast = NULL;
 
 	RETiRet;
 }


### PR DESCRIPTION
Keep the destructed list in a consistent state as the provided
destructor may access the very same list again before llDestroy
finishes.

The previous approach could actually trigger a segmentation violation
error for specific scenarios and configurations.
In one particular case, destructing the list of rulesets lead to
shutdown of an action DA queue and spooling its messages to disk which
in turn triggered a search for the ruleset name of the message trought
the destructed list.

The change probably slightly degrades performace, but that shouldn't
have an observable effect in the current code base.