### PR TITLE
Added brace glob expansion to imfile wildcard

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1456,7 +1456,7 @@ in_setupFileWatchStatic(lstn_t *const __restrict__ pLstn)
 			  "expansion\n", pLstn->pszFileName);
 		glob_t files;
 		const int ret = glob((char*)pLstn->pszFileName,
-					GLOB_MARK|GLOB_NOSORT, NULL, &files);
+					GLOB_MARK|GLOB_NOSORT|GLOB_BRACE, NULL, &files);
 		if(ret == 0) {
 			for(unsigned i = 0 ; i < files.gl_pathc ; i++) {
 				uchar basen[MAXFNAME];

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -645,11 +645,11 @@ containsGlobWildcard(char *str)
 		return 0;
 	}
 	/* From Linux Programmer's Guide:
-	 * "A string is a wildcard pattern if it contains one of the characters '?', '*' or '['"
-	 * "One can remove the special meaning of '?', '*' and '[' by preceding them by a backslash"
+	 * "A string is a wildcard pattern if it contains one of the characters '?', '*', '{' or '['"
+	 * "One can remove the special meaning of '?', '*', '{' and '[' by preceding them by a backslash"
 	 */
 	for(p = str; *p != '\0'; p++) {
-		if((*p == '?' || *p == '*' || *p == '[') &&
+		if((*p == '?' || *p == '*' || *p == '[' || *p == '{') &&
 				(p == str || *(p-1) != '\\')) {
 			return 1;
 		}


### PR DESCRIPTION
The globbing currently only supports *, ? and []. This adds the ability to use {}.

    input(type="imfile" File="/var/log/{*.log,dmesg,syslog}")

Should I open an issue too and link this pull request to it, or is just a pull request sufficient?