### PR TITLE
imuxsock: fix a crash when setting a hostname

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -364,8 +364,7 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	inst->bParseHost = UNSET;
 	inst->next = NULL;
 
-	/* some legacy conf processing */
-	free(cs.pLogHostName); /* reset hostname for next socket */
+	/* reset hostname for next socket */
 	cs.pLogHostName = NULL;
 
 finalize_it:


### PR DESCRIPTION
Setting a hostname via the legacy directive would lead to a crash
during shutdown caused by a double-free.
