### PR TITLE
Revert "imuxsock: fix a crash when setting a hostname"

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -364,7 +364,8 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	inst->bParseHost = UNSET;
 	inst->next = NULL;
 
-	/* reset hostname for next socket */
+	/* some legacy conf processing */
+	free(cs.pLogHostName); /* reset hostname for next socket */
 	cs.pLogHostName = NULL;
 
 finalize_it:


### PR DESCRIPTION
Reverts rsyslog/rsyslog#307 ; merged into wrong branch (not an emergency fix, thus needs to go into master)