### PR TITLE
Make configure checks dependend on build source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
 
 install:
   - travis_retry sudo apt-get install -qq build-essential automake pkg-config libtool autoconf autotools-dev gdb valgrind
-  - travis_retry sudo apt-get install -qq libestr-dev librelp-dev libjson0-dev zlib1g-dev uuid-dev libgcrypt11-dev liblogging-stdlog-dev bison flex
+  - travis_retry sudo apt-get install -qq libestr-dev librelp-dev libjson0-dev zlib1g-dev uuid-dev libgcrypt11-dev liblogging-stdlog-dev bison flex python-docutils
 
 script:
   - autoreconf --force --verbose --install

--- a/ChangeLog
+++ b/ChangeLog
@@ -12,6 +12,11 @@ Version 8.10.0 [v8-stable] 2015-05-19
   Setting a hostname via the legacy directive would lead to a crash
   during shutdown caused by a double-free.
   Thanks to Tomas Heinrich for the patch.
+- When building from git source we now require rst2man and yacc (or a
+  replacement like bison).
+  That isn't any new requirement, we only added missing configure checks.
+- Configure option "--enable-generate-man-pages" is now disabled for non git
+  source builds per default but enforced when building from git source.
 ------------------------------------------------------------------------------
 Version 8.9.0 [v8-stable] 2015-04-07
 - omprog: add option "hup.forward" to forwards HUP to external plugins

--- a/Makefile.am
+++ b/Makefile.am
@@ -314,4 +314,8 @@ DISTCHECK_CONFIGURE_FLAGS=	--enable-imfile \
 #				--enable-gssapi_krb5 \
 #				--enable-extended-tests \
 #				--enable-pgsql 
+
+dist-hook:
+	$(AM_V_GEN)echo $(VERSION) > $(distdir)/.tarball-version
+
 ACLOCAL_AMFLAGS = -I m4

--- a/configure.ac
+++ b/configure.ac
@@ -1536,48 +1536,50 @@ AM_CONDITIONAL(ENABLE_OMHIREDIS, test x$enable_omhiredis = xyes)
 # END HIREDIS SUPPORT
 
 
-AC_CHECKING([if required man pages already exist])
+# man pages
 have_to_generate_man_pages="no"
-
-# man pages for libgcrypt module
-if test "x$enable_usertools" = "xyes" && test "x$enable_libgcrypt" = "xyes"; then
-    AC_CHECK_FILES(["tools/rscryutil.1" "tools/rsgtutil.1"],
-        [],
-        [have_to_generate_man_pages="yes"]
-    )
-fi
-
-# man pages for GuardTime module
-if test "x$enable_usertools" = "xyes" && test "x$enable_guardtime" = "xyes"; then
-    AC_CHECK_FILES(["tools/rscryutil.1" "tools/rsgtutil.1"],
-        [],
-        [have_to_generate_man_pages="yes"]
-    )
-fi
-
 AC_ARG_ENABLE(generate-man-pages,
-        [AS_HELP_STRING([--enable-generate-man-pages],[Generate man pages from source @<:@default=yes@:>@])],
+        [AS_HELP_STRING([--enable-generate-man-pages],[Generate man pages from source @<:@default=no@:>@])],
         [case "${enableval}" in
          yes) have_to_generate_man_pages="yes" ;;
           no) have_to_generate_man_pages="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-generate-man-pages) ;;
          esac],
-        [have_to_generate_man_pages=yes]
+        [have_to_generate_man_pages=no]
 )
 
-if test "x$have_to_generate_man_pages" = "xyes"; then
-    AC_MSG_RESULT([Some man pages are missing or --enable-generate-man-pages given. We need rst2man to generate man pages from source...])
+
+# Running from git source?
+in_git_src=no
+AS_IF([test -d "$srcdir"/.git && ! test -f  "$srcdir"/.tarball-version], [in_git_src=yes])
+
+if test "x$in_git_src" = "xyes"; then
+        AC_MSG_NOTICE([Running from git source])
+
+        have_to_generate_man_pages=yes
+
+        if test "x$LEX" != "xflex"; then
+                AC_MSG_ERROR([flex program is needed to build rsyslog, please install flex.])
+        fi
+
+        if test "x$YACC" = "xyacc"; then
+                # AC_PROG_YACC only checks for yacc replacements, not for yacc itself
+                AC_CHECK_PROG([YACC_FOUND], [yacc], [yes], [no])
+                if test "x$YACC_FOUND" = "xno"; then
+                        AC_MSG_ERROR([A yacc program is needed to build rsyslog, please install bison.])
+                fi
+        fi
 else
-    AC_MSG_RESULT([All required man pages found. We don't need rst2man!])
+        AC_MSG_NOTICE([Not running from git source])
 fi
 
-if test "x$have_to_generate_man_pages" = "xyes"; then
-    # We need rst2man to generate our man pages
-    AC_CHECK_PROGS([RST2MAN], [rst2man rst2man.py], [])
-    if test -z "$RST2MAN"; then
-        AC_MSG_ERROR([rst2man is required to build man pages. You can use the release tarball with pregenerated man pages to avoid this depedency. Use the --disable-generate-man-pages configure option in that case.])
-    fi
+
+# rst2man
+AC_CHECK_PROGS([RST2MAN], [rst2man rst2man.py], [false])
+if test "x$have_to_generate_man_pages" = "xyes" && test "x$RST2MAN" = "xfalse"; then
+        AC_MSG_ERROR([rst2man is required when building from git source or --enable-generate-man-pages option was set, please install python-docutils.])
 fi
+
 
 AC_CONFIG_FILES([Makefile \
 		runtime/Makefile \


### PR DESCRIPTION
We are now checking if we are running from git source. If we do that, we will require `rst2man` and `yacc`.

This PR is based on @davidelang report from http://lists.adiscon.net/pipermail/rsyslog/2015-April/thread.html#40318