### PR TITLE
Testbench: add some tests for the directive $AbortOnUncleanConfig (bad case & good case)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ TESTS +=  \
 	asynwr_deadlock4.sh \
 	abort-uncleancfg-goodcfg.sh \
 	abort-uncleancfg-badcfg-check.sh \
+	abort-uncleancfg-badcfg-check_1.sh \
 	gzipwr_large.sh \
 	gzipwr_large_dynfile.sh \
 	dynfile_invld_async.sh \
@@ -644,7 +645,9 @@ EXTRA_DIST= 1.rstest 2.rstest 3.rstest err1.rstest \
 	   abort-uncleancfg-goodcfg.sh \
 	   testsuites/abort-uncleancfg-goodcfg.conf \
 	   abort-uncleancfg-badcfg-check.sh \
-	   testsuites/abort-uncleancfg-badcfg.conf \
+           testsuites/abort-uncleancfg-badcfg.conf 
+	   abort-uncleancfg-badcfg-check_1.sh \
+	   testsuites/abort-uncleancfg-badcfg_1.conf \
 	   gzipwr_large.sh \
 	   testsuites/gzipwr_large.conf \
 	   gzipwr_large_dynfile.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -60,6 +60,7 @@ TESTS +=  \
 	asynwr_deadlock2.sh \
 	asynwr_deadlock4.sh \
 	abort-uncleancfg-goodcfg.sh \
+	abort-uncleancfg-badcfg-check.sh \
 	gzipwr_large.sh \
 	gzipwr_large_dynfile.sh \
 	dynfile_invld_async.sh \
@@ -642,6 +643,8 @@ EXTRA_DIST= 1.rstest 2.rstest 3.rstest err1.rstest \
 	   testsuites/asynwr_deadlock4.conf \
 	   abort-uncleancfg-goodcfg.sh \
 	   testsuites/abort-uncleancfg-goodcfg.conf \
+	   abort-uncleancfg-badcfg-check.sh \
+	   testsuites/abort-uncleancfg-badcfg.conf \
 	   gzipwr_large.sh \
 	   testsuites/gzipwr_large.conf \
 	   gzipwr_large_dynfile.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -60,6 +60,7 @@ TESTS +=  \
 	asynwr_deadlock2.sh \
 	asynwr_deadlock4.sh \
 	abort-uncleancfg-goodcfg.sh \
+	abort-uncleancfg-goodcfg-check.sh \
 	abort-uncleancfg-badcfg-check.sh \
 	abort-uncleancfg-badcfg-check_1.sh \
 	gzipwr_large.sh \
@@ -643,6 +644,8 @@ EXTRA_DIST= 1.rstest 2.rstest 3.rstest err1.rstest \
 	   asynwr_deadlock4.sh \
 	   testsuites/asynwr_deadlock4.conf \
 	   abort-uncleancfg-goodcfg.sh \
+	   testsuites/abort-uncleancfg-goodcfg.conf \
+	   abort-uncleancfg-goodcfg-check.sh \
 	   testsuites/abort-uncleancfg-goodcfg.conf \
 	   abort-uncleancfg-badcfg-check.sh \
            testsuites/abort-uncleancfg-badcfg.conf 

--- a/tests/abort-uncleancfg-badcfg-check.sh
+++ b/tests/abort-uncleancfg-badcfg-check.sh
@@ -1,0 +1,14 @@
+# Copyright 2015-01-29 by Tim Eifler
+# This file is part of the rsyslog project, released  under ASL 2.0
+# The configuration test should fail because of the invalid config file.
+echo ===============================================================================
+echo \[abort-uncleancfg-badcfg.sh\]: testing abort on unclean configuration
+echo "testing a bad Configuration verification run"
+source $srcdir/diag.sh init
+../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/abort-uncleancfg-badcfg.conf -M../runtime/.libs:../.libs
+if [ $? == 0 ]; then
+   echo "Error: config check should fail"
+   exit 1 
+fi
+source $srcdir/diag.sh exit
+

--- a/tests/abort-uncleancfg-badcfg-check_1.sh
+++ b/tests/abort-uncleancfg-badcfg-check_1.sh
@@ -1,0 +1,14 @@
+# Copyright 2015-01-29 by Tim Eifler
+# This file is part of the rsyslog project, released  under ASL 2.0
+# The configuration test should fail because of the invalid config file.
+echo ===============================================================================
+echo \[abort-uncleancfg-badcfg_1.sh\]: testing abort on unclean configuration
+echo "testing a bad Configuration verification run"
+source $srcdir/diag.sh init
+../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/abort-uncleancfg-badcfg_1.conf -M../runtime/.libs:../.libs
+if [ $? == 0 ]; then
+   echo "Error: config check should fail"
+   exit 1 
+fi
+source $srcdir/diag.sh exit
+

--- a/tests/abort-uncleancfg-goodcfg-check.sh
+++ b/tests/abort-uncleancfg-goodcfg-check.sh
@@ -1,0 +1,14 @@
+# Copyright 2015-01-29 by Tim Eifler
+# This file is part of the rsyslog project, released  under ASL 2.0
+# The configuration test should pass because of the good config file.
+echo ===============================================================================
+echo \[abort-uncleancfg-goodcfg-check.sh\]: testing abort on unclean configuration
+echo "testing a good Configuration verification run"
+source $srcdir/diag.sh init
+../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/abort-uncleancfg-goodcfg.conf -M../runtime/.libs:../.libs
+if [ $? -ne 0 ]; then
+   echo "Error: config check fail"
+   exit 1 
+fi
+source $srcdir/diag.sh exit
+

--- a/tests/testsuites/abort-uncleancfg-badcfg.conf
+++ b/tests/testsuites/abort-uncleancfg-badcfg.conf
@@ -1,0 +1,13 @@
+$IncludeConfig diag-common.conf
+
+$AbortOnUncleanConfig on
+
+$ModLoad ../plugins/imtcp/.libs/imtcp
+$MainMsgQueueTimeoutShutdown 10000
+$InputTCPServerRun 13514
+
+$WrongParameter
+
+$template outfmt,"%msg:F,58:2%\n"
+$template dynfile,"rsyslog.out.log" # trick to use relative path names!
+:msg, contains, "msgnum:" ?dynfile;outfmt

--- a/tests/testsuites/abort-uncleancfg-badcfg_1.conf
+++ b/tests/testsuites/abort-uncleancfg-badcfg_1.conf
@@ -1,0 +1,16 @@
+$IncludeConfig diag-common.conf
+
+
+global (
+    AbortOnUncleanConfig="on"
+)
+
+$ModLoad ../plugins/imtcp/.libs/imtcp
+$MainMsgQueueTimeoutShutdown 10000
+$InputTCPServerRun 13514
+
+input(type="imXudp" port="514")
+
+$template outfmt,"%msg:F,58:2%\n"
+$template dynfile,"rsyslog.out.log" # trick to use relative path names!
+:msg, contains, "msgnum:" ?dynfile;outfmt


### PR DESCRIPTION
This is another test for the directive "$AbortOnUncleanConfig" with a invalid configuration. 

The test works with the return code of the configuration check. If the return code of the configuration check is not equals null then the test passed otherwise the test should returns a fail.
