### PR TITLE
Add an option to disable the generation of debug symbols

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 ------------------------------------------------------------------------------
 Version 8.10.0 [v8-stable] 2015-05-19
+- Configure option "--disable-debug-symbols" added which is disabled per
+  default. If you set the new option, configure won't set the appropriate
+  compiler flag to generate debug symbols anymore.
 - pmrfc3164: add new parameters
   * "detect.yearAfterTimestamp"
     This supports timestamps as generated e.g. by some Aruba Networks

--- a/configure.ac
+++ b/configure.ac
@@ -450,6 +450,18 @@ if test "$enable_debug" = "no"; then
 fi
 
 
+# debug-symbols
+AC_ARG_ENABLE(debug_symbols,
+        [AS_HELP_STRING([--disable-debug-symbols],[Disable debugging symbols @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_debug_symbols="yes" ;;
+          no) enable_debug_symbols="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --disable-debug-symbols) ;;
+         esac],
+        [enable_debug_symbols="yes"]
+)
+
+
 # runtime instrumentation
 AC_ARG_ENABLE(rtinst,
         [AS_HELP_STRING([--enable-rtinst],[Enable runtime instrumentation mode @<:@default=no@:>@])],
@@ -801,11 +813,15 @@ fi
 AM_CONDITIONAL(ENABLE_RSYSLOGRT, test x$enable_rsyslogrt = xyes)
 RSRT_CFLAGS="\$(RSRT_CFLAGS1) \$(LIBESTR_CFLAGS) \$(JSON_C_CFLAGS)"
 if test "$GCC" = "yes"; then
-  RSRT_CFLAGS="$RSRT_CFLAGS -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g"
+  RSRT_CFLAGS="$RSRT_CFLAGS -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute"
   if $CC -Werror=implicit-function-declaration -x c -c /dev/null 2>/dev/null; then
     RSRT_CFLAGS="$RSRT_CFLAGS -Werror=implicit-function-declaration"
   elif $CC -Werror-implicit-function-declaration -x c -c /dev/null 2>/dev/null; then
     RSRT_CFLAGS="$RSRT_CFLAGS -Werror-implicit-function-declaration"
+  fi
+
+  if test "x$enable_debug_symbols" = "xyes"; then
+    RSRT_CFLAGS="$RSRT_CFLAGS -g"
   fi
 fi
 RSRT_LIBS="\$(RSRT_LIBS1) \$(LIBESTR_LIBS) \$(JSON_C_LIBS)"


### PR DESCRIPTION
This PR only **adds** a new option, it doesn't change any known behavior if you don't use the new option, so this change doesn't break anything.

Reason for doing that:
  1. You don't want `-g` in general. If your project is small, you don't mind but building a large project with `-g` if you aren't interested in debug information makes the compiled project unnecessary large.

  2. `-g` can cause troubles, see https://blog.flameeyes.eu/2011/08/are-g-options-really-safe

  3. Especially on Gentoo we don't like this option. People interested in debug information have their own options to build with debug information. Having an option to disable configure from setting the `-g` flag will save us a custom patch.


