### PR TITLE
cosmetic: fix compiler warning

### DIFF
--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -104,7 +104,7 @@ finalize_it:
 }
 
 BEGINnewParserInst
-	struct cnfparamvals *pvals;
+	struct cnfparamvals *pvals = NULL;
 	int i;
 CODESTARTnewParserInst
 	DBGPRINTF("newParserInst (pmrfc3164)\n");


### PR DESCRIPTION
fixes a warning about potential uninitialized use. However, the warning
was invalid and based on incomplete static code analysis. Anyhow, we
"fix" it, as this does not add any real overhead - and it's nicer to
compile cleanly.