### PR TITLE
Add zbeacon UDP advertisement support to imczmq and omczmq

### DIFF
--- a/contrib/imczmq/README
+++ b/contrib/imczmq/README
@@ -15,21 +15,20 @@ input(
 	topics="topic1,topic2,topic3"
 	socktype="PULL"
 	authtype="CURVESERVER"
-	curveclientcert="/etc/curve.d/"
-	curveservercert="/etc/curve.d/example_curve_server_cert"
+	clientcertpath="/etc/curve.d/"
+	servercertpath="/etc/curve.d/example_curve_server_cert"
 )
 -------------------------------------------------------------------------------
 
 Explanation of Options:
 
-name: name of this action
 type: type of action (imczmq for this plugin)
 endpoints: comma delimited list of zeromq endpoints (see zeromq documentation)
 socktype: zeromq socket type (currently supports PULL and SUB)
 authtype: CURVECLIENT or CURVESERVER
-curveclientcert: 
+clientcertpath: 
 	if CURVECLIENT, this client's cert
 	if CURVESERVER, "*" for all, or a directory of allowed public certs
-curveservercert: 
+servercertpath: 
 	if CURVECLIENT, the servers public cert you wish to connect to
 	if CURVESERVER, this servers cert

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -275,7 +275,7 @@ static rsRetVal addListener(instanceConf_t* iconf){
 	}
 
 	/* if a beacon is set start it */
-	if((iconf->beacon != NULL) && (iconf->beaconPort <= 0)) {
+	if((iconf->beacon != NULL) && (iconf->beaconPort > 0)) {
 		DBGPRINTF ("imczmq: starting beacon actor...\n");
 
 		/* create the beacon actor, if it fails abort */	

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -56,6 +56,9 @@ typedef struct _pollerData_t {
 
 
 struct instanceConf_s {
+	bool is_server;
+	char *beacon;
+	int beaconPort;
 	int sockType;
 	char *sockEndpoints;
 	char *topicList;
@@ -75,6 +78,7 @@ struct modConfData_s {
 };
 
 struct lstn_s {
+	zactor_t *beaconActor;
 	zsock_t *sock;
 	zcert_t *clientCert;
 	zcert_t *serverCert;
@@ -100,6 +104,8 @@ static struct cnfparamblk modpblk = {
 };
 
 static struct cnfparamdescr inppdescr[] = {
+	{ "beacon", eCmdHdlrGetWord, 0 },
+	{ "beaconport", eCmdHdlrGetWord, 0 },
 	{ "endpoints", eCmdHdlrGetWord, 1 },
 	{ "socktype", eCmdHdlrGetWord, 1 },
 	{ "authtype", eCmdHdlrGetWord, 0 },
@@ -118,6 +124,9 @@ static struct cnfparamblk inppblk = {
 };
 
 static void setDefaults(instanceConf_t* iconf) {
+	iconf->is_server = false;
+	iconf->beacon = NULL;
+	iconf->beaconPort = -1;
 	iconf->sockType = -1;
 	iconf->sockEndpoints = NULL;
 	iconf->topicList = NULL;
@@ -169,6 +178,16 @@ static rsRetVal createListener(struct cnfparamvals* pvals) {
 		else if(!strcmp(inppblk.descr[i].name, "endpoints")) {
 			inst->sockEndpoints = es_str2cstr(pvals[i].val.d.estr, NULL);
 		} 
+
+		/* get beacon argument */
+		else if (!strcmp(inppblk.descr[i].name, "beacon")) {
+			inst->beacon = es_str2cstr(pvals[i].val.d.estr, NULL);
+		}
+		
+		/* get beacon port */
+		else if (!strcmp(inppblk.descr[i].name, "beaconport")) {
+			inst->beaconPort = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
+		}
 
 		/* get the socket type */
 		else if(!strcmp(inppblk.descr[i].name, "socktype")){
@@ -255,14 +274,37 @@ static rsRetVal addListener(instanceConf_t* iconf){
 		ABORT_FINALIZE(RS_RET_NO_ERRCODE);
 	}
 
-	bool is_server = false;
+	/* if a beacon is set start it */
+	if((iconf->beacon != NULL) && (iconf->beaconPort <= 0)) {
+		DBGPRINTF ("imczmq: starting beacon actor...\n");
+
+		/* create the beacon actor, if it fails abort */	
+		pData->beaconActor = zactor_new(zbeacon, NULL);
+		if (!pData->beaconActor) {
+			errmsg.LogError(0, RS_RET_NO_ERRCODE,
+					"imczmq: could not create beacon service");
+			ABORT_FINALIZE (RS_RET_NO_ERRCODE);
+		}
+
+		/* configure the beacon and abort if UDP broadcasting ont available */
+		zsock_send(pData->beaconActor, "si", "CONFIGURE", iconf->beaconPort);
+		char *hostname = zstr_recv(pData->beaconActor);
+		if (!*hostname) {
+			errmsg.LogError(0, RS_RET_NO_ERRCODE,
+					"imczmq: no UDP broadcasting available");
+			ABORT_FINALIZE (RS_RET_NO_ERRCODE);
+		}
+
+		/* start publishing the beacon */
+		zsock_send(pData->beaconActor, "sbi", "PUBLISH", pData->beaconActor, strlen(iconf->beacon));
+	}
 
 	DBGPRINTF("imczmq: authtype is: %s\n", iconf->authType);
 
 	/* if we are a CURVE server */
 	if (!strcmp(iconf->authType, "CURVESERVER")) {
 
-		is_server = true;
+		iconf->is_server = true;
 
 		/* set global auth domain */
 		zsock_set_zap_domain(pData->sock, "global");
@@ -290,7 +332,7 @@ static rsRetVal addListener(instanceConf_t* iconf){
 	if (!strcmp(iconf->authType, "CURVECLIENT")) {
 		DBGPRINTF("imczmq: we are a curve client...\n");
 
-		is_server = false;
+		iconf->is_server = false;
 
 		/* get our client cert */
 		pData->clientCert = zcert_load(iconf->clientCertPath);

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -48,6 +48,7 @@ static pthread_mutex_t mutDoAct = PTHREAD_MUTEX_INITIALIZER;
 
 typedef struct _instanceData {
 	zactor_t *authActor;
+	zactor_t *beaconActor;
 	zsock_t *sock;
 	zcert_t *clientCert;
 	zcert_t *serverCert;
@@ -57,6 +58,8 @@ typedef struct _instanceData {
 	char *clientCertPath;
 	char *serverCertPath;
 	uchar *tplName;
+	char *beacon;
+	int beaconport;
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -66,6 +69,8 @@ typedef struct wrkrInstanceData {
 static struct cnfparamdescr actpdescr[] = {
 	{ "endpoints", eCmdHdlrGetWord, 1 },
 	{ "socktype", eCmdHdlrGetWord, 1 },
+	{ "beacon", eCmdHdlrGetWord, 1},
+	{ "beaconport", eCmdHdlrGetWord, 1 },
 	{ "authtype", eCmdHdlrGetWord, 0 },
 	{ "clientcertpath", eCmdHdlrGetWord, 0 },
 	{ "servercertpath", eCmdHdlrGetWord, 0 },
@@ -86,24 +91,49 @@ static rsRetVal initCZMQ(instanceData* pData) {
 
 	/* create new auth actor */
 	DBGPRINTF ("omczmq: starting auth actor...\n");
-	pData->authActor = zactor_new (zauth, NULL);
+	pData->authActor = zactor_new(zauth, NULL);
 	if (!pData->authActor) {
-		errmsg.LogError (0, RS_RET_NO_ERRCODE,
+		errmsg.LogError(0, RS_RET_NO_ERRCODE,
 				"omczmq: could not create auth service");
 		ABORT_FINALIZE (RS_RET_NO_ERRCODE);
 	}
 
 	/* create our zeromq socket */
 	DBGPRINTF ("omczmq: creating zeromq socket...\n");
-	pData->sock = zsock_new (pData->sockType);
+	pData->sock = zsock_new(pData->sockType);
 	if (!pData->sock) {
-		errmsg.LogError (0, RS_RET_NO_ERRCODE,
+		errmsg.LogError(0, RS_RET_NO_ERRCODE,
 				"omczmq: new socket failed for endpoints: %s",
 				pData->sockEndpoints);
 		ABORT_FINALIZE(RS_RET_NO_ERRCODE);
 	}
 
 	bool is_server = false;
+
+	/* if a beacon is set start it */
+	if((pData->beacon != NULL) && (pData->beaconport <= 0)) {
+		DBGPRINTF ("omczmq: starting beacon actor...\n");
+
+		/* create the beacon actor, if it fails abort */	
+		pData->beaconActor = zactor_new(zbeacon, NULL);
+		if (!pData->beaconActor) {
+			errmsg.LogError(0, RS_RET_NO_ERRCODE,
+					"omczmq: could not create beacon service");
+			ABORT_FINALIZE (RS_RET_NO_ERRCODE);
+		}
+
+		/* configure the beacon and abort if UDP broadcasting ont available */
+		zsock_send(pData->beaconActor, "si", "CONFIGURE", pData->beaconport);
+		char *hostname = zstr_recv(pData->beaconActor);
+		if (!*hostname) {
+			errmsg.LogError(0, RS_RET_NO_ERRCODE,
+					"omczmq: no UDP broadcasting available");
+			ABORT_FINALIZE (RS_RET_NO_ERRCODE);
+		}
+
+		/* start publishing the beacon */
+		zsock_send(pData->beaconActor, "sbi", "PUBLISH", pData->beacon, strlen(pData->beacon));
+	}
 
 	/* if we are a CURVE server */
 	if (!strcmp(pData->authType, "CURVESERVER")) {
@@ -205,6 +235,7 @@ setInstParamDefaults(instanceData* pData) {
 	pData->tplName = NULL;
 	pData->sockType = -1;
 	pData->authActor = NULL;
+	pData->beaconActor = NULL;
 	pData->authType = NULL;
 	pData->clientCertPath = NULL;
 	pData->serverCertPath = NULL;
@@ -238,6 +269,7 @@ BEGINfreeInstance
 CODESTARTfreeInstance
 	zsock_destroy(&pData->sock);
 	zactor_destroy(&pData->authActor);
+	zactor_destroy(&pData->beaconActor);
 	zcert_destroy(&pData->serverCert);
 	zcert_destroy(&pData->clientCert);
 
@@ -344,6 +376,16 @@ CODESTARTnewActInst
 		/* get server cert argument */
 		else if (!strcmp(actpblk.descr[i].name, "servercertpath")) {
 			pData->serverCertPath = es_str2cstr(pvals[i].val.d.estr, NULL);
+		}
+
+		/* get beacon argument */
+		else if (!strcmp(actpblk.descr[i].name, "beacon")) {
+			pData->beacon = es_str2cstr(pvals[i].val.d.estr, NULL);
+		}
+		
+		/* get beacon port */
+		else if (!strcmp(actpblk.descr[i].name, "beaconport")) {
+			pData->beaconport = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
 		}
 
 		/* the config has a bad option */

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -111,7 +111,7 @@ static rsRetVal initCZMQ(instanceData* pData) {
 	bool is_server = false;
 
 	/* if a beacon is set start it */
-	if((pData->beacon != NULL) && (pData->beaconport <= 0)) {
+	if((pData->beacon != NULL) && (pData->beaconport > 0)) {
 		DBGPRINTF ("omczmq: starting beacon actor...\n");
 
 		/* create the beacon actor, if it fails abort */	

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -69,8 +69,8 @@ typedef struct wrkrInstanceData {
 static struct cnfparamdescr actpdescr[] = {
 	{ "endpoints", eCmdHdlrGetWord, 1 },
 	{ "socktype", eCmdHdlrGetWord, 1 },
-	{ "beacon", eCmdHdlrGetWord, 1},
-	{ "beaconport", eCmdHdlrGetWord, 1 },
+	{ "beacon", eCmdHdlrGetWord, 0 },
+	{ "beaconport", eCmdHdlrGetWord, 0 },
 	{ "authtype", eCmdHdlrGetWord, 0 },
 	{ "clientcertpath", eCmdHdlrGetWord, 0 },
 	{ "servercertpath", eCmdHdlrGetWord, 0 },


### PR DESCRIPTION
This PR adds the ability for zeromq input and outputs to advertise their presence on UDP via the zbeacon API (see: http://api.zeromq.org/czmq3-0:zbeacon ) on networks that support UDP broadcast.