### PR TITLE
bugfix: fix default action naming

### DIFF
--- a/action.c
+++ b/action.c
@@ -385,7 +385,7 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 	}
 	/* generate a friendly name for us action stats */
 	if(pThis->pszName == NULL) {
-		snprintf((char*) pszAName, sizeof(pszAName)/sizeof(uchar), "action %d", iActionNbr);
+		snprintf((char*) pszAName, sizeof(pszAName)/sizeof(uchar), "action %d", pThis->iActionNbr);
 		pThis->pszName = ustrdup(pszAName);
 	}
 


### PR DESCRIPTION
The default name generated for an action references a global counter
instead of the action-specific number. In practice this means that the
number in the name will be greater by at least one than the assined
number most of the time.

NB: The code generating various action-related messages is using the
action name inconsistently; sometimes the generated name is used,
sometimes the action number is used, thus producing "action N" or
"action N+1" identifiers at different locations in the code.