### PR TITLE
bugfix: build system strndup was used even if not present

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 ------------------------------------------------------------------------------
 Version 8.11.0 [v8-stable] 2015-06-30
+- bugfix: build system strndup was used even if not present
+  now added compatibility function. This came up on Solaris builds.
+  Thanks to Dagobert Michelsen for reporting the problem.
+  closes https://github.com/rsyslog/rsyslog/issues/347
 ------------------------------------------------------------------------------
 Version 8.10.0 [v8-stable] 2015-05-19
 - imfile: add capability to process multi-line messages based on regex

--- a/compat/Makefile.am
+++ b/compat/Makefile.am
@@ -1,6 +1,6 @@
 noinst_LTLIBRARIES = compat.la
 
-compat_la_SOURCES = getifaddrs.c ifaddrs.h
+compat_la_SOURCES = getifaddrs.c ifaddrs.h strndup.c
 compat_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 compat_la_LDFLAGS = -module -avoid-version
 compat_la_LIBADD = $(IMUDP_LIBS)

--- a/compat/strndup.c
+++ b/compat/strndup.c
@@ -1,0 +1,40 @@
+/* compatibility file for systems without strndup.
+ *
+ * Copyright 2015 Rainer Gerhards and Adiscon
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#ifndef HAVE_STRNDUP
+
+#include <stdlib.h>
+#include <string.h>
+char *
+strndup(const char *s, size_t n)
+{
+	const size_t len = strlen(s);
+	if(len <= n)
+		return strdup(s);
+	char *const new_s = malloc(len+1);
+	if(new_s == NULL)
+		return NULL;
+	memcpy(new_s, s, len);
+	new_s[len] = '\0';
+	return new_s;
+}
+
+#endif /* #ifndef HAVE_STRNDUP */

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -3,7 +3,7 @@
  *
  * Begun 2005-09-15 RGerhards
  *
- * Copyright (C) 2005-2014 by Rainer Gerhards and Adiscon GmbH
+ * Copyright (C) 2005-2015 by Rainer Gerhards and Adiscon GmbH
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -636,5 +636,15 @@ typedef int json_bool;
 extern rsconf_t *ourConf; /* defined by syslogd.c, a hack for functions that do not
 			     yet receive a copy, so that we can incrementially
 			     compile and change... -- rgerhars, 2011-04-19 */
+
+
+/* here we add some stuff from the compatibility layer. A separate include
+ * would be cleaner, but would potentially require changes all over the
+ * place. So doing it here is better. The respective replacement
+ * functions should usually be found under ./compat -- rgerhards, 2015-05-20
+ */
+#ifndef HAVE_STRNDUP
+char * strndup(const char *s, size_t n);
+#endif
 
 #endif /* multi-include protection */


### PR DESCRIPTION
now added compatibility function. This came up on Solaris builds.
Thanks to Dagobert Michelsen for reporting the problem.
closes https://github.com/rsyslog/rsyslog/issues/347