### PR TITLE
omkafka concurrency fixes

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -478,12 +478,16 @@ kafkaLogger(const rd_kafka_t __attribute__((unused)) *rk, int level,
 static inline void
 do_rd_kafka_destroy(instanceData *const __restrict pData)
 {
-	DBGPRINTF("omkafka: closing - items left in outqueue: %d\n",
-		  rd_kafka_outq_len(pData->rk));
-	while (rd_kafka_outq_len(pData->rk) > 0)
-		rd_kafka_poll(pData->rk, 10);
-	rd_kafka_destroy(pData->rk);
-	pData->rk = NULL;
+	if (pData->rk == NULL) {
+		DBGPRINTF("omkafka: can't close, handle wasn't open\n");
+	} else {
+		DBGPRINTF("omkafka: closing - items left in outqueue: %d\n",
+				  rd_kafka_outq_len(pData->rk));
+		while (rd_kafka_outq_len(pData->rk) > 0)
+			rd_kafka_poll(pData->rk, 10);
+		rd_kafka_destroy(pData->rk);
+		pData->rk = NULL;
+	}
 }
 
 


### PR DESCRIPTION
Plugin omkafka had several data-races, this patchset fixes them.

The symptom was regular crashes under load. Most of them pointed to omkafka(and librdkafka) area (statistically).

This should fix all of them (or all that I could find by reading code).

@rgerhards I may not be capable of seeing more races in this. Im too tainted at this point. So please review carefully, it may have some more.