### PR TITLE
Global variable atomicity

### DIFF
--- a/contrib/mmcount/mmcount.c
+++ b/contrib/mmcount/mmcount.c
@@ -321,7 +321,7 @@ finalize_it:
 	}
 
 	if(json) {
-		msgAddJSON(pMsg, (uchar *)JSON_COUNT_NAME, json, 0);
+		msgAddJSON(pMsg, (uchar *)JSON_COUNT_NAME, json, 0, 0);
 	}
 ENDdoAction
 

--- a/contrib/mmsequence/mmsequence.c
+++ b/contrib/mmsequence/mmsequence.c
@@ -373,7 +373,7 @@ CODESTARTdoAction
 	if (json == NULL) {
 		errmsg.LogError(0, RS_RET_OBJ_CREATION_FAILED,
 				"mmsequence: unable to create JSON");
-	} else if (RS_RET_OK != msgAddJSON(pMsg, (uchar *)pData->pszVar + 1, json, 0)) {
+	} else if (RS_RET_OK != msgAddJSON(pMsg, (uchar *)pData->pszVar + 1, json, 0, 0)) {
 		errmsg.LogError(0, RS_RET_OBJ_CREATION_FAILED,
 				"mmsequence: unable to pass out the value");
 		json_object_put(json);

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -172,7 +172,7 @@ finalize_it:
  * by the caller.
  */
 static rsRetVal
-enqMsg(uchar *msg, uchar *pszTag, int iFacility, int iSeverity, struct timeval *tp, struct json_object *json)
+enqMsg(uchar *msg, uchar *pszTag, int iFacility, int iSeverity, struct timeval *tp, struct json_object *json, int sharedJsonProperties)
 {
 	struct syslogTime st;
 	msg_t *pMsg;
@@ -200,7 +200,7 @@ enqMsg(uchar *msg, uchar *pszTag, int iFacility, int iSeverity, struct timeval *
 	pMsg->iSeverity = iSeverity;
 
 	if(json != NULL) {
-		msgAddJSON(pMsg, (uchar*)"!", json, 0);
+		msgAddJSON(pMsg, (uchar*)"!", json, 0, sharedJsonProperties);
 	}
 
 	CHKiRet(ratelimitAddMsg(ratelimiter, NULL, pMsg));
@@ -412,7 +412,7 @@ readjournal() {
 	}
 
 	/* submit message */
-	enqMsg((uchar *)message, (uchar *) sys_iden_help, facility, severity, &tv, json);
+	enqMsg((uchar *)message, (uchar *) sys_iden_help, facility, severity, &tv, json, 0);
 
 finalize_it:
 	if (sys_iden_help != NULL)

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -846,7 +846,7 @@ SubmitMsg(uchar *pRcv, int lenRcv, lstn_t *pLstn, struct ucred *cred, struct tim
 			/* as per lumberjack spec, these properties need to go into
 			 * the CEE root.
 			 */
-			msgAddJSON(pMsg, (uchar*)"!", json, 0);
+			msgAddJSON(pMsg, (uchar*)"!", json, 0, 0);
 
 			MsgSetRawMsg(pMsg, (char*)pRcv, lenRcv);
 		} else {

--- a/plugins/mmaudit/mmaudit.c
+++ b/plugins/mmaudit/mmaudit.c
@@ -275,7 +275,7 @@ dbgprintf("mmaudit: msg is '%s'\n", buf);
 	jval = json_object_new_int(typeID);
 	json_object_object_add(json, "type", jval);
 
-	msgAddJSON(pMsg, (uchar*)"!audit", jsonRoot, 0);
+	msgAddJSON(pMsg, (uchar*)"!audit", jsonRoot, 0, 0);
 	bSuccess = 1;
 
 finalize_it:

--- a/plugins/mmfields/mmfields.c
+++ b/plugins/mmfields/mmfields.c
@@ -230,7 +230,7 @@ parse_fields(instanceData *pData, msg_t *pMsg, uchar *msgtext, int lenMsg)
 		json_object_object_add(json, (char*)fieldname, jval);
 		field++;
 	}
- 	msgAddJSON(pMsg, pData->jsonRoot, json, 0);
+ 	msgAddJSON(pMsg, pData->jsonRoot, json, 0, 0);
 finalize_it:
 	RETiRet;
 }

--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -205,7 +205,7 @@ processJSON(wrkrInstanceData_t *pWrkrData, msg_t *pMsg, char *buf, size_t lenBuf
 		ABORT_FINALIZE(RS_RET_NO_CEE_MSG);
 	}
  
- 	msgAddJSON(pMsg, pWrkrData->pData->container, json, 0);
+ 	msgAddJSON(pMsg, pWrkrData->pData->container, json, 0, 0);
 finalize_it:
 	RETiRet;
 }
@@ -247,7 +247,7 @@ finalize_it:
 		json = json_object_new_object();
 		jval = json_object_new_string((char*)buf);
 		json_object_object_add(json, "msg", jval);
-		msgAddJSON(pMsg, pData->container, json, 0);
+		msgAddJSON(pMsg, pData->container, json, 0, 0);
 		iRet = RS_RET_OK;
 	}
 	MsgSetParseSuccess(pMsg, bSuccess);

--- a/plugins/mmnormalize/mmnormalize.c
+++ b/plugins/mmnormalize/mmnormalize.c
@@ -243,7 +243,7 @@ CODESTARTdoAction
 		MsgSetParseSuccess(pMsg, 1);
 	}
 
-	msgAddJSON(pMsg, (uchar*)pWrkrData->pData->pszPath + 1, json, 0);
+	msgAddJSON(pMsg, (uchar*)pWrkrData->pData->pszPath + 1, json, 0, 0);
 
 ENDdoAction
 

--- a/plugins/mmpstrucdata/mmpstrucdata.c
+++ b/plugins/mmpstrucdata/mmpstrucdata.c
@@ -325,7 +325,7 @@ parse_sd(instanceData *pData, msg_t *pMsg)
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	json_object_object_add(jroot, "rfc5424-sd", json);
- 	msgAddJSON(pMsg, pData->jsonRoot, jroot, 0);
+ 	msgAddJSON(pMsg, pData->jsonRoot, jroot, 0, 0);
 finalize_it:
 	if(iRet != RS_RET_OK && json != NULL)
 		json_object_put(json);

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2825,6 +2825,8 @@ msgGetJSONPropJSON(msg_t * const pMsg, msgPropDescr_t *pProp, struct json_object
 	struct json_object *parent;
 	DEFiRet;
 
+	*pjson = NULL;
+
 	if(pProp->id == PROP_CEE) {
 		jroot = pMsg->json;
 	} else if(pProp->id == PROP_LOCAL_VAR) {

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3952,97 +3952,11 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 	return(pRes);
 }
 
-
-/* This function can be used as a generic way to set properties.
- * We have to handle a lot of legacy, so our return value is not always
- * 100% correct (called functions do not always provide one, should
- * change over time).
- * rgerhards, 2008-01-07
- */
-#define isProp(name) !rsCStrSzStrCmp(pProp->pcsName, (uchar*) name, sizeof(name) - 1)
-rsRetVal MsgSetProperty(msg_t *pThis, var_t *pProp)
-{
-	prop_t *myProp;
-	prop_t *propRcvFrom = NULL;
-	prop_t *propRcvFromIP = NULL;
-	struct json_tokener *tokener;
-	struct json_object *json;
-	DEFiRet;
-
-	ISOBJ_TYPE_assert(pThis, msg);
-	assert(pProp != NULL);
-
- 	if(isProp("iProtocolVersion")) {
-		setProtocolVersion(pThis, pProp->val.num);
- 	} else if(isProp("iSeverity")) {
-		pThis->iSeverity = pProp->val.num;
- 	} else if(isProp("iFacility")) {
-		pThis->iFacility = pProp->val.num;
- 	} else if(isProp("msgFlags")) {
-		pThis->msgFlags = pProp->val.num;
- 	} else if(isProp("offMSG")) {
-		MsgSetMSGoffs(pThis, pProp->val.num);
-	} else if(isProp("pszRawMsg")) {
-		MsgSetRawMsg(pThis, (char*) rsCStrGetSzStrNoNULL(pProp->val.pStr), cstrLen(pProp->val.pStr));
-	} else if(isProp("pszUxTradMsg")) {
-		/*IGNORE*/; /* this *was* a property, but does no longer exist */
-	} else if(isProp("pszTAG")) {
-		MsgSetTAG(pThis, rsCStrGetSzStrNoNULL(pProp->val.pStr), cstrLen(pProp->val.pStr));
-	} else if(isProp("pszInputName")) {
-		/* we need to create a property */ 
-		CHKiRet(prop.Construct(&myProp));
-		CHKiRet(prop.SetString(myProp, rsCStrGetSzStrNoNULL(pProp->val.pStr), rsCStrLen(pProp->val.pStr)));
-		CHKiRet(prop.ConstructFinalize(myProp));
-		MsgSetInputName(pThis, myProp);
-		prop.Destruct(&myProp);
-	} else if(isProp("pszRcvFromIP")) {
-		MsgSetRcvFromIPStr(pThis, rsCStrGetSzStrNoNULL(pProp->val.pStr), rsCStrLen(pProp->val.pStr), &propRcvFromIP);
-		prop.Destruct(&propRcvFromIP);
-	} else if(isProp("pszRcvFrom")) {
-		MsgSetRcvFromStr(pThis, rsCStrGetSzStrNoNULL(pProp->val.pStr), rsCStrLen(pProp->val.pStr), &propRcvFrom);
-		prop.Destruct(&propRcvFrom);
-	} else if(isProp("pszHOSTNAME")) {
-		MsgSetHOSTNAME(pThis, rsCStrGetSzStrNoNULL(pProp->val.pStr), rsCStrLen(pProp->val.pStr));
-	} else if(isProp("pszStrucData")) {
-		MsgSetStructuredData(pThis, (char*) rsCStrGetSzStrNoNULL(pProp->val.pStr));
-	} else if(isProp("pCSAPPNAME")) {
-		MsgSetAPPNAME(pThis, (char*) rsCStrGetSzStrNoNULL(pProp->val.pStr));
-	} else if(isProp("pCSPROCID")) {
-		MsgSetPROCID(pThis, (char*) rsCStrGetSzStrNoNULL(pProp->val.pStr));
-	} else if(isProp("pCSMSGID")) {
-		MsgSetMSGID(pThis, (char*) rsCStrGetSzStrNoNULL(pProp->val.pStr));
- 	} else if(isProp("ttGenTime")) {
-		pThis->ttGenTime = pProp->val.num;
-	} else if(isProp("tRcvdAt")) {
-		memcpy(&pThis->tRcvdAt, &pProp->val.vSyslogTime, sizeof(struct syslogTime));
-	} else if(isProp("tTIMESTAMP")) {
-		memcpy(&pThis->tTIMESTAMP, &pProp->val.vSyslogTime, sizeof(struct syslogTime));
-	} else if(isProp("pszRuleset")) {
-		MsgSetRulesetByName(pThis, pProp->val.pStr);
-	} else if(isProp("pszMSG")) {
-		dbgprintf("no longer supported property pszMSG silently ignored\n");
-	} else if(isProp("json")) {
-		tokener = json_tokener_new();
-		json = json_tokener_parse_ex(tokener, (char*)rsCStrGetSzStrNoNULL(pProp->val.pStr),
-					     cstrLen(pProp->val.pStr));
-		json_tokener_free(tokener);
-		msgAddJSON(pThis, (uchar*)"!", json, 0);
-	} else {
-		dbgprintf("unknown supported property '%s' silently ignored\n",
-			  rsCStrGetSzStrNoNULL(pProp->pcsName));
-	}
-
-finalize_it:
-	RETiRet;
-}
-#undef	isProp
-
-
 /* Set a single property based on the JSON object provided. The
  * property name is extracted from the JSON object.
  */
 static rsRetVal
-msgSetPropViaJSON(msg_t *__restrict__ const pMsg, const char *name, struct json_object *json)
+msgSetPropViaJSON(msg_t *__restrict__ const pMsg, const char *name, struct json_object *json, int sharedReference)
 {
 	const char *psz;
 	int val;
@@ -4097,7 +4011,7 @@ msgSetPropViaJSON(msg_t *__restrict__ const pMsg, const char *name, struct json_
 		psz = json_object_get_string(json);
 		MsgSetRcvFromIPStr(pMsg, (const uchar*)psz, strlen(psz), &propRcvFromIP);
 	} else if(!strcmp(name, "$!")) {
-		msgAddJSON(pMsg, (uchar*)"!", json, 0);
+		msgAddJSON(pMsg, (uchar*)"!", json, 0, sharedReference);
 	} else {
 		/* we ignore unknown properties */
 		DBGPRINTF("msgSetPropViaJSON: unkonwn property ignored: %s\n",
@@ -4157,7 +4071,7 @@ MsgSetPropsViaJSON(msg_t *__restrict__ const pMsg, const uchar *__restrict__ con
 	}
  
 	json_object_object_foreach(json, name, val) {
-		msgSetPropViaJSON(pMsg, name, val);
+		msgSetPropViaJSON(pMsg, name, val, 0);
 	}
 	json_object_put(json);
 
@@ -4324,11 +4238,12 @@ finalize_it:
 }
 
 rsRetVal
-msgAddJSON(msg_t * const pM, uchar *name, struct json_object *json, int force_reset)
+msgAddJSON(msg_t * const pM, uchar *name, struct json_object *json, int force_reset, int sharedReference)
 {
 	/* TODO: error checks! This is a quick&dirty PoC! */
 	struct json_object **pjroot;
 	struct json_object *parent, *leafnode;
+	struct json_object *given = NULL;
 	uchar *leaf;
 	DEFiRet;
 
@@ -4337,9 +4252,17 @@ msgAddJSON(msg_t * const pM, uchar *name, struct json_object *json, int force_re
 		pjroot = &pM->json;
 	} else if(name[0] == '.') {
 		pjroot = &pM->localvars;
-	} else { /* globl var */
+	} else if (name[0] == '/') { /* globl var */
 		pthread_rwlock_wrlock(&glblVars_rwlock);
 		pjroot = &global_var_root;
+		if (sharedReference) {
+			given = json;
+			json = jsonDeepCopy(json);
+			json_object_put(given);
+		}
+	} else {
+		DBGPRINTF("Passed name %s is unknown kind of variable (It is not CEE, Local or Global variable).", name);
+		ABORT_FINALIZE(RS_RET_INVLD_SETOP);
 	}
 
 	if(name[1] == '\0') { /* full tree? */
@@ -4412,9 +4335,12 @@ msgDelJSON(msg_t * const pM, uchar *name)
 		jroot = &pM->json;
 	} else if(name[0] == '.') {
 		jroot = &pM->localvars;
-	} else { /* globl var */
+	} else if (name[0] == '/') { /* globl var */
 		pthread_rwlock_wrlock(&glblVars_rwlock);
 		jroot = &global_var_root;
+	} else {
+		DBGPRINTF("Passed name %s is unknown kind of variable (It is not CEE, Local or Global variable).", name);
+		ABORT_FINALIZE(RS_RET_INVLD_SETOP);
 	}
 	if(jroot == NULL) {
 		DBGPRINTF("msgDelJSONVar; jroot empty in unset for property %s\n",
@@ -4476,7 +4402,7 @@ msgAddMetadata(msg_t *const __restrict__ pMsg,
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
 	json_object_object_add(json, (const char *const)metaname, jval);
-	iRet = msgAddJSON(pMsg, (uchar*)"!metadata", json, 0);
+	iRet = msgAddJSON(pMsg, (uchar*)"!metadata", json, 0, 0);
 finalize_it:
 	RETiRet;
 }
@@ -4560,7 +4486,7 @@ msgSetJSONFromVar(msg_t * const pMsg, uchar *varname, struct var *v, int force_r
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 
-	msgAddJSON(pMsg, varname, json, force_reset);
+	msgAddJSON(pMsg, varname, json, force_reset, 0);
 finalize_it:
 	RETiRet;
 }

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2854,8 +2854,14 @@ msgGetJSONPropJSON(msg_t * const pMsg, msgPropDescr_t *pProp, struct json_object
 	}
 
 finalize_it:
-	if(pProp->id == PROP_GLOBAL_VAR)
+	if(pProp->id == PROP_GLOBAL_VAR) {
+		if (*pjson != NULL)
+			*pjson = jsonDeepCopy(*pjson);
 		pthread_rwlock_unlock(&glblVars_rwlock);
+	} else {
+		if (*pjson != NULL)
+			json_object_get(*pjson);
+	}
 	RETiRet;
 }
 

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -192,7 +192,7 @@ void getTAG(msg_t *pM, uchar **ppBuf, int *piLen);
 char *getTimeReported(msg_t *pM, enum tplFormatTypes eFmt);
 char *getPRI(msg_t *pMsg);
 void getRawMsg(msg_t *pM, uchar **pBuf, int *piLen);
-rsRetVal msgAddJSON(msg_t *pM, uchar *name, struct json_object *json, int force_reset);
+rsRetVal msgAddJSON(msg_t *pM, uchar *name, struct json_object *json, int force_reset, int sharedReference);
 rsRetVal msgAddMetadata(msg_t *msg, uchar *metaname, uchar *metaval);
 rsRetVal MsgGetSeverity(msg_t *pThis, int *piSeverity);
 rsRetVal MsgDeserialize(msg_t *pMsg, strm_t *pStrm);

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -271,7 +271,7 @@ finalize_it:
 static rsRetVal
 execForeach(struct cnfstmt *stmt, msg_t *pMsg, wti_t *pWti)
 {
-	json_object *arr;
+	json_object *arr = NULL;
 	DEFiRet;
 	arr = cnfexprEvalCollection(stmt->d.s_foreach.iter->collection, pMsg);
 	if (arr == NULL || !json_object_is_type(arr, json_type_array)) {
@@ -290,6 +290,7 @@ execForeach(struct cnfstmt *stmt, msg_t *pMsg, wti_t *pWti)
 	}
 	CHKiRet(msgDelJSON(pMsg, (uchar*)stmt->d.s_foreach.iter->var));
 finalize_it:
+	if (arr != NULL) json_object_put(arr);
 	RETiRet;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -115,7 +115,8 @@ TESTS +=  \
 	incltest_dir.sh \
 	incltest_dir_wildcard.sh \
 	incltest_dir_empty_wildcard.sh \
-	linkedlistqueue.sh
+	linkedlistqueue.sh \
+	key_dereference_on_uninitialized_variable_space.sh
 
 if HAVE_VALGRIND
 TESTS +=  \
@@ -810,6 +811,8 @@ EXTRA_DIST= \
 	testsuites/mmnormalize_regex_disabled.conf \
 	mmnormalize_regex_defaulted.sh \
 	testsuites/mmnormalize_regex_defaulted.conf \
+	key_dereference_on_uninitialized_variable_space.sh \
+	testsuites/key_dereference_on_uninitialized_variable_space.conf \
 	cfg.sh
 
 # TODO: re-enable

--- a/tests/key_dereference_on_uninitialized_variable_space.sh
+++ b/tests/key_dereference_on_uninitialized_variable_space.sh
@@ -1,0 +1,13 @@
+# added 2015-05-27 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[key_dereference_on_uninitialized_variable_space.sh\]: test to dereference key from a not-yet-created cee or local json-object
+source $srcdir/diag.sh init key_dereference_on_uninitialized_variable_space.sh
+source $srcdir/diag.sh startup key_dereference_on_uninitialized_variable_space.conf
+source $srcdir/diag.sh tcpflood -m 10
+echo doing shutdown
+source $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+source $srcdir/diag.sh wait-shutdown
+source $srcdir/diag.sh content-check 'cee:'
+source $srcdir/diag.sh exit

--- a/tests/testsuites/key_dereference_on_uninitialized_variable_space.conf
+++ b/tests/testsuites/key_dereference_on_uninitialized_variable_space.conf
@@ -1,0 +1,16 @@
+$IncludeConfig diag-common.conf
+
+template(name="corge" type="string" string="cee:%$!%\n")
+
+module(load="../plugins/imptcp/.libs/imptcp")
+
+ruleset(name="echo") {
+  if ($!foo == "bar") then {
+    set $!baz = "quux";
+  }
+  action(type="omfile" file="./rsyslog.out.log" template="corge")
+}
+
+input(type="imptcp" port="13514")
+
+call echo


### PR DESCRIPTION
This change ensures global-variables are written and read atomically.

This makes things such as:
    set $/count = $/count + 1;
    set $.i = $/count % 16;
work across multiple threads.

It also kills an unused function.