### PR TITLE
bugfix: on FreeBSD, endless loop when started at boot time with some …

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1063,7 +1063,11 @@ tryTTYRecover(strm_t *pThis, int err)
 {
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, strm);
+#ifndef __FreeBSD__
 	if(err == ERR_TTYHUP) {
+#else
+	if(err == ERR_TTYHUP || err == ENXIO) {
+#endif /* __FreeBSD__ */
 		close(pThis->fd);
 		CHKiRet(doPhysOpen(pThis));
 	}


### PR DESCRIPTION
…rules to write on the console

Here is a bug report about rsyslog. A patch is attached to correct this bug.
It occurs only on FreeBSD. I've already sent a bug report on the FreeBSD reporting tool: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=200429

I'm sending this mail on this list for the patch to be included in the mainstream distribution of rsyslog.

Here is the description of the bug:
When rsyslog is started at boot time on FreeBSD (by means of rc scripts or /etc/rc.local), and when rsyslog is simultaneously configured to output some streams to "/dev/console", the daemon will start correctly but, at the near end of the boot sequence of FreeBSD, it will fail permanently, in an endless loop, using 100% CPU.

Attached to this bug report, please find a patch to correct this behaviour.

Here is a complete explanation of the steps that make the bug happen:

1- when init launches rc scripts, rsyslogd starts

2- rsyslogd reads rsyslog.conf and if some stuff must be logged to the console, because of a line like "*.err;kern.warning;auth.notice;mail.crit /dev/console" in the configuration file, the daemon calls open to get a file descriptor to write on "/dev/console". It starts writing corresponding logs to this descriptor.

3- Later during the boot sequence, init configures the console, and for this to be done, it starts by calling the revoke syscall: revoke("/dev/console").

4- Once /dev/console is revoked, further writes to any file descriptor previously opened on this file return -1 with ENXIO as errno, even if this descriptor was opened in another process than init.

5- thus, rsyslogd gets this error in runtime/stream.c:doWriteCall(), and calls runtime/stream.c:tryTTYRecover() since the error occured on a tty.

6- but runtime/stream.c:tryTTYRecover() tries to reopen the tty only if the error is EIO on Linux or EBADF on any other operating system. Since the error is ENXIO, that is distinct from EBADF, runtime/stream.c:tryTTYRecover() returns RS_RET_OK and runtime/stream.c:doWriteCall() loops, endlessly.

closes https://github.com/rsyslog/rsyslog/issues/371