### PR TITLE
bugfix imfile: regex multiline mode ignored escapeLF option

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
 ------------------------------------------------------------------------------
 Version 8.11.0 [v8-stable] 2015-06-30
 - build system: re-enable use of "make distcheck"
+- bugfix imfile: regex multiline mode ignored escapeLF option
+  Thanks to Ciprian Hacman for reporting the problem
+  closes https://github.com/rsyslog/rsyslog/issues/370
 - bugfix omkafka: fixed several concurrency issues, most of them related
   to dynamic topics.
   Thanks to Janmejay Singh for the patch.

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -859,7 +859,11 @@ dbgprintf("DDDD: readMultiLine: have match and msg %p\n", *ppCStr);
 			
 		} else {
 			CHKiRet(cstrAppendCStr(pThis->prevMsgSegment, thisLine));
-			rsCStrAppendStrWithLen(pThis->prevMsgSegment, (uchar*)"\\n", 2);
+			if(bEscapeLF) {
+				rsCStrAppendStrWithLen(pThis->prevMsgSegment, (uchar*)"\\n", 2);
+			} else {
+				cstrAppendChar(pThis->prevMsgSegment, '\n');
+			}
 			/* we could do this faster, but for now keep it simple */
 		}
 		cstrDestruct(&thisLine);


### PR DESCRIPTION
Thanks to Ciprian Hacman for reporting the problem
closes https://github.com/rsyslog/rsyslog/issues/370