### PR TITLE
fix memleak in mmjsonparse plugin

### DIFF
--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -202,6 +202,10 @@ processJSON(wrkrInstanceData_t *pWrkrData, msg_t *pMsg, char *buf, size_t lenBuf
 	if(json == NULL
 	   || ((size_t)pWrkrData->tokener->char_offset < lenBuf)
 	   || (!json_object_is_type(json, json_type_object))) {
+		//Release json object as we are not going to add it to pMsg
+		if(json != NULL) {
+			json_object_put(json);
+		}
 		ABORT_FINALIZE(RS_RET_NO_CEE_MSG);
 	}
  

--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -202,7 +202,7 @@ processJSON(wrkrInstanceData_t *pWrkrData, msg_t *pMsg, char *buf, size_t lenBuf
 	if(json == NULL
 	   || ((size_t)pWrkrData->tokener->char_offset < lenBuf)
 	   || (!json_object_is_type(json, json_type_object))) {
-		//Release json object as we are not going to add it to pMsg
+		/* Release json object as we are not going to add it to pMsg */
 		if(json != NULL) {
 			json_object_put(json);
 		}


### PR DESCRIPTION
During json processing it was not add into message if it was not parsed fully even when json is not null. It resulted in memory leak and this patch fixes this behaviour.