### PR TITLE
add sha1 property to message object

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -719,6 +719,23 @@ fi
 AM_CONDITIONAL(ENABLE_UUID, test x$enable_uuid = xyes)
 
 
+# sha1 support
+AC_ARG_ENABLE(sha1,
+        [AS_HELP_STRING([--enable-sha1],[Enable support for sha1 @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_sha1="yes" ;;
+          no) enable_sha1="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-sha1) ;;
+         esac],
+        [enable_sha1=yes]
+)
+if test "x$enable_sha1" = "xyes"; then
+	PKG_CHECK_MODULES([LIBOPENSSL], [openssl])
+	AC_DEFINE(USE_SHA1, 1, [Define if you want to enable sha1 support])
+fi
+AM_CONDITIONAL(ENABLE_SHA1, test x$enable_sha1 = xyes)
+
+
 # elasticsearch support
 AC_ARG_ENABLE(elasticsearch,
         [AS_HELP_STRING([--enable-elasticsearch],[Enable elasticsearch output module @<:@default=no@:>@])],
@@ -1714,6 +1731,7 @@ echo "    rsyslogd will be built:                   $enable_rsyslogd"
 echo "    have to generate man pages:               $have_to_generate_man_pages"
 echo "    Unlimited select() support enabled:       $enable_unlimited_select"
 echo "    uuid support enabled:                     $enable_uuid"
+echo "    sha1 support enabled:                     $enable_sha1"
 echo "    Log file signing support:                 $enable_guardtime"
 echo "    Log file encryption support:              $enable_libgcrypt"
 echo "    anonymization support enabled:            $enable_mmanon"

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -106,8 +106,8 @@ else
 librsyslog_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -D_PATH_MODDIR=\"$(pkglibdir)/\" -I\$(top_srcdir) -I\$(top_srcdir)/grammar
 endif
 #librsyslog_la_LDFLAGS = -module -avoid-version
-librsyslog_la_CPPFLAGS += $(PTHREADS_CFLAGS) $(LIBUUID_CFLAGS) $(JSON_C_CFLAGS) ${LIBESTR_CFLAGS} ${LIBLOGGING_STDLOG_CFLAGS} -I\$(top_srcdir)/tools
-librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(JSON_C_LIBS) ${LIBESTR_LIBS} ${LIBLOGGING_STDLOG_LIBS}
+librsyslog_la_CPPFLAGS += $(PTHREADS_CFLAGS) $(LIBUUID_CFLAGS) $(LIBOPENSSL_CFLAGS) $(JSON_C_CFLAGS) ${LIBESTR_CFLAGS} ${LIBLOGGING_STDLOG_CFLAGS} -I\$(top_srcdir)/tools
+librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(LIBOPENSSL_LIBS) $(JSON_C_LIBS) ${LIBESTR_LIBS} ${LIBLOGGING_STDLOG_LIBS}
 
 #
 # regular expression support

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -129,6 +129,7 @@ struct msg {
 	char pszRcvdAt_Unix[12];
 	char dfltTZ[8];	    /* 7 chars max, less overhead than ptr! */
 	uchar *pszUUID; /* The message's UUID */
+	uchar *pszSHA1; /* The message's SHA1 */
 };
 
 

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -206,6 +206,7 @@ typedef uintTiny	propid_t;
 #define PROP_SYS_BOM			159
 #define PROP_SYS_UPTIME			160
 #define PROP_UUID			161
+#define PROP_SHA1			162
 #define PROP_CEE			200
 #define PROP_CEE_ALL_JSON		201
 #define PROP_LOCAL_VAR			202

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -415,6 +415,11 @@ printVersion(void)
 #else
 	printf("\tuuid support:\t\t\t\tNo\n");
 #endif
+#ifdef	USE_SHA1
+	printf("\tsha1 support:\t\t\t\tYes\n");
+#else
+	printf("\tsha1 support:\t\t\t\tNo\n");
+#endif
 #ifdef HAVE_JSON_OBJECT_NEW_INT64
 	printf("\tNumber of Bits in RainerScript integers: 64\n");
 #else


### PR DESCRIPTION
This property returns the SHA1 (160-bit) checksums of the raw message.
For users looking after a unique identifier of the message the sha1 can be
prefered over the uuid approach that is random based.