### PR TITLE
typo fix: paramter → parameter

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -384,9 +384,9 @@ Version 8.3.4 [v8-devel] 2014-07-11
 ---------------------------------------------------------------------------
 Version 8.3.3 [v8-devel] 2014-06-26
 - unify input object naming
-  imudp now supports "name" paramter, as other inputs do. "inputname" has
+  imudp now supports "name" parameter, as other inputs do. "inputname" has
   been deprecated, but can still be used. Same applies to "appendport"
-  subparamter". Thanks to "Nick Syslog" for the suggestion.
+  subparameter". Thanks to "Nick Syslog" for the suggestion.
 - made the missing (contributed) modules build under v8 [import from 8.2.2]
   Modules:
   * mmrfc5424addhmac
@@ -967,7 +967,7 @@ This starts a new stable branch based on 7.5.8 plus the following changes:
 ---------------------------------------------------------------------------
 Version 7.5.8 [v7-release candidate] 2014-01-09
 - add exec_template() RainerScript function
-- add debug.onShutdown and debug.logFile global paramters
+- add debug.onShutdown and debug.logFile global parameters
   These enebale the new "debug on shutdown" mode, which can be used to
   track hard to find problems that occur during system shutdown.
 - Add directives for numerically specifying GIDs/UIDs
@@ -1154,7 +1154,7 @@ Version 7.5.3 [devel] 2013-09-11
 - imudp: add ability to specify SO_RCVBUF size (rcvbufSize parameter)
 - imudp: use inputname for statistics, if configured
 - impstats: add process resource usage counters [via getrusage()]
-- impstats: add paramter "resetCounters" to report delta values
+- impstats: add parameter "resetCounters" to report delta values
   possible for most, but not all, counters. See doc for details.
 - librelp 1.2.0 is now required
 - make use of new librelp generic error reporting facility
@@ -1821,7 +1821,7 @@ Version 7.3.0  [devel] 2012-10-09
   * support for config load phases & module() parameters
   * support for default templates
   * driverdirectory is now cleanly a global parameter, but can no longer
-    be specified as an action paramter. Note that in previous versions
+    be specified as an action parameter. Note that in previous versions
     this parameter was ignored in all but the first action definition
 - improved omfile zip writer to increase compression
   This was achieved by somewhat reducing the robustness of the zip archive.
@@ -1874,7 +1874,7 @@ Version 7.2.7  [v7-stable] 2013-04-17
 - bugfix: using group resolution could lead to endless loop
   Thanks to Tomas Heinrich for the patch.
   closes: http://bugzilla.adiscon.com/show_bug.cgi?id=310
-- bugfix: $mmnormalizeuseramsg paramter was specified with wrong type
+- bugfix: $mmnormalizeuseramsg parameter was specified with wrong type
   Thank to Renzhong Zhang for alerting us of the problem.
   closes: http://bugzilla.adiscon.com/show_bug.cgi?id=420
 - bugfix: RainerScript getenv() function caused segfault when var was

--- a/action.c
+++ b/action.c
@@ -397,7 +397,7 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 			if(pThis->peParamPassing[i] != ACT_STRING_PASSING) {
 				errmsg.LogError(0, RS_RET_INVLD_OMOD, "action '%s'(%d) is transactional but "
 						"parameter %d "
-						"uses invalid paramter passing mode -- disabling "
+						"uses invalid parameter passing mode -- disabling "
 						"action. This is probably caused by a pre-v7 "
 						"output module that needs upgrade.",
 						pThis->pszName, pThis->iActionNbr, i);

--- a/runtime/librsksi_read.c
+++ b/runtime/librsksi_read.c
@@ -696,7 +696,7 @@ rsksi_objfree(uint16_t tlvtype, void *obj)
 /**
  * Read block parameters. This detects if the block contains the
  * individual log hashes, the intermediate hashes and the overall
- * block paramters (from the signature block). As we do not have any
+ * block parameters (from the signature block). As we do not have any
  * begin of block record, we do not know e.g. the hash algorithm or IV
  * until reading the block signature record. And because the file is
  * purely sequential and variable size, we need to read all records up to

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1090,7 +1090,7 @@ CODESTARTnewActInst
 		pData->bSendToAll = send_to_all;
 	} else {
 		if(pData->protocol == FORW_TCP) {
-			errmsg.LogError(0, RS_RET_PARAM_ERROR, "omfwd: paramter udp.sendToAll "
+			errmsg.LogError(0, RS_RET_PARAM_ERROR, "omfwd: parameter udp.sendToAll "
 					"cannot be used with tcp transport -- ignored");
 		}
 	}

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -87,7 +87,7 @@ CODESTARTisCompatibleWithFeature
 ENDisCompatibleWithFeature
 
 
-/* create input instance, set default paramters, and
+/* create input instance, set default parameters, and
  * add it to the list of instances.
  */
 static rsRetVal

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1128,13 +1128,13 @@ initAll(int argc, char **argv)
                 case 'A':
 			fprintf (stderr, "rsyslogd: the -A command line option will go away "
 				 "soon.\n"
-				 "Please use the omfwd paramter \"upd.sendToAll\" instead.\n");
+				 "Please use the omfwd parameter \"upd.sendToAll\" instead.\n");
                         send_to_all++;
                         break;
 		case 'S':		/* Source IP for local client to be used on multihomed host */
 			fprintf (stderr, "rsyslogd: the -S command line option will go away "
 				 "soon.\n"
-				 "Please use the omrelp paramter \"localClientIP\" instead.\n");
+				 "Please use the omrelp parameter \"localClientIP\" instead.\n");
 			if(glbl.GetSourceIPofLocalClient() != NULL) {
 				fprintf (stderr, "rsyslogd: Only one -S argument allowed, the first one is taken.\n");
 			} else {


### PR DESCRIPTION
Followup fix for 6fbacdc41d37ce3091709e71f6f0e66912237606