### PR TITLE
fix memory leak in strmCloseFile

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -448,13 +448,13 @@ static rsRetVal strmCloseFile(strm_t *pThis)
 			DBGPRINTF("error %d unlinking '%s' - ignored: %s\n",
 				   errno, pThis->pszCurrFName, errStr);
 		}
-		free(pThis->pszCurrFName);
-		pThis->pszCurrFName = NULL;
 	}
 
 	pThis->iCurrOffs = 0;	/* we are back at begin of file */
 
 finalize_it:
+	free(pThis->pszCurrFName);
+	pThis->pszCurrFName = NULL;
 	RETiRet;
 }
 


### PR DESCRIPTION
Here we need to free pThis->pszCurrFName in any case, even if
pThis->bDeleteOnClose is not true.  Otherwise we leak memory if
this stream gets reopened later, for instance after closing by
doSizeLimitProcessing.