### PR TITLE
omfile: unconditionally include fcntl.h.

### DIFF
--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -48,9 +48,7 @@
 #include <libgen.h>
 #include <unistd.h>
 #include <sys/file.h>
-#ifdef OS_SOLARIS
-#	include <fcntl.h>
-#endif
+#include <fcntl.h>
 #ifdef HAVE_ATOMIC_BUILTINS
 #	include <pthread.h>
 #endif


### PR DESCRIPTION
required for open() flags.

See: http://pubs.opengroup.org/onlinepubs/007908775/xsh/fcntl.h.html