### PR TITLE
testbench: Fixed multiple minor problems

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -43,7 +43,6 @@ TESTS +=  \
 	imtcp_addtlframedelim.sh \
 	imtcp_no_octet_counted.sh \
 	imtcp_spframingfix.sh \
-	imptcp_spframingfix.sh \
 	sndrcv.sh \
 	sndrcv_failover.sh \
 	sndrcv_gzip.sh \
@@ -126,6 +125,7 @@ TESTS +=  \
 	linkedlistqueue.sh \
 	key_dereference_on_uninitialized_variable_space.sh
 
+
 if HAVE_VALGRIND
 TESTS +=  \
 	discard-rptdmsg-vg.sh \
@@ -173,6 +173,7 @@ TESTS +=  \
 	imptcp_addtlframedelim.sh \
 	imptcp_conndrop.sh \
 	imptcp_no_octet_counted.sh \
+	imptcp_spframingfix.sh \
 	rscript_replace.sh \
 	rscript_replace_complex.sh \
 	rscript_wrap2.sh \

--- a/tests/testsuites/key_dereference_on_uninitialized_variable_space.conf
+++ b/tests/testsuites/key_dereference_on_uninitialized_variable_space.conf
@@ -2,7 +2,7 @@ $IncludeConfig diag-common.conf
 
 template(name="corge" type="string" string="cee:%$!%\n")
 
-module(load="../plugins/imptcp/.libs/imptcp")
+module(load="../plugins/imtcp/.libs/imtcp")
 
 ruleset(name="echo") {
   if ($!foo == "bar") then {
@@ -11,6 +11,6 @@ ruleset(name="echo") {
   action(type="omfile" file="./rsyslog.out.log" template="corge")
 }
 
-input(type="imptcp" port="13514")
+input(type="imtcp" port="13514")
 
 call echo

--- a/tests/testsuites/sndrcv_relp_sender.conf
+++ b/tests/testsuites/sndrcv_relp_sender.conf
@@ -2,7 +2,7 @@
 $IncludeConfig diag-common2.conf
 
 module(load="../plugins/omrelp/.libs/omrelp")
-module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")	/* this port for tcpflood! */
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")	/* this port for tcpflood! */
 
 action(type="omrelp" protocol="tcp" target="127.0.0.1" port="13515")


### PR DESCRIPTION
- Testbench imptcp_spframingfix.sh is now only executed
  if imptcp is enabled
- Changed imptcp to imtcp in Testbenches sndrcv_relp.sh and
  key_dereference_on_uninitialized_variable_space.sh. Tests failed
  if imptcp was not enabled.