### PR TITLE
Fix race-condition detection in path-creation code

### DIFF
--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -214,6 +214,7 @@ int makeFileParentDirs(const uchar *const szFile, size_t lenFile, mode_t mode,
                 if(*p == '/') {
 			/* temporarily terminate string, create dir and go on */
                         *p = '\0';
+			iTry = 0;
 again:
                         if(access((char*)pszWork, F_OK)) {
                                 if((err = mkdir((char*)pszWork, mode)) == 0) {


### PR DESCRIPTION
The affected code is used to detect a race condition in between
testing for the existence of a directory and creating it if it didn't
exist.  The variable tracking the number of attempts wasn't reset for
subsequent elements in the path, thus limiting the number of
reattempts to one per the whole path, instead of one per each path
element.
This solution was provided by Martin Poole.