### PR TITLE
testbench: Add contitional compilation for liblogging-stdlog

### DIFF
--- a/tests/imuxsock_ccmiddle.sh
+++ b/tests/imuxsock_ccmiddle.sh
@@ -1,7 +1,7 @@
 echo \[imuxsock_ccmiddle.sh\]: test trailing LF handling in imuxsock
 ./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
 no_liblogging_stdlog=$?
-if [ $no_liblogging_stdlog ];then
+if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi

--- a/tests/imuxsock_ccmiddle.sh
+++ b/tests/imuxsock_ccmiddle.sh
@@ -1,4 +1,10 @@
 echo \[imuxsock_ccmiddle.sh\]: test trailing LF handling in imuxsock
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
 source $srcdir/diag.sh init
 source $srcdir/diag.sh startup imuxsock_ccmiddle.conf
 # send a message with trailing LF

--- a/tests/imuxsock_ccmiddle_root.sh
+++ b/tests/imuxsock_ccmiddle_root.sh
@@ -5,6 +5,12 @@ echo This test must be run as root with no other active syslogd
 if [ "$EUID" -ne 0 ]; then
     exit 77 # Not root, skip this test
 fi
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
 source $srcdir/diag.sh init
 source $srcdir/diag.sh startup imuxsock_ccmiddle_root.conf
 # send a message with trailing LF

--- a/tests/imuxsock_ccmiddle_root.sh
+++ b/tests/imuxsock_ccmiddle_root.sh
@@ -7,7 +7,7 @@ if [ "$EUID" -ne 0 ]; then
 fi
 ./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
 no_liblogging_stdlog=$?
-if [ $no_liblogging_stdlog ];then
+if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi

--- a/tests/imuxsock_hostname.sh
+++ b/tests/imuxsock_hostname.sh
@@ -1,7 +1,7 @@
 echo \[imuxsock_hostname.sh\]: test set hostname
 ./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
 no_liblogging_stdlog=$?
-if [ $no_liblogging_stdlog ];then
+if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi

--- a/tests/imuxsock_hostname.sh
+++ b/tests/imuxsock_hostname.sh
@@ -1,4 +1,10 @@
 echo \[imuxsock_hostname.sh\]: test set hostname
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
 source $srcdir/diag.sh init
 source $srcdir/diag.sh startup imuxsock_hostname.conf
 # the message itself is irrelevant. The only important thing is

--- a/tests/imuxsock_traillf.sh
+++ b/tests/imuxsock_traillf.sh
@@ -1,6 +1,6 @@
 ./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
 no_liblogging_stdlog=$?
-if [ $no_liblogging_stdlog ];then
+if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi

--- a/tests/imuxsock_traillf.sh
+++ b/tests/imuxsock_traillf.sh
@@ -1,3 +1,9 @@
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
 source $srcdir/diag.sh init
 source $srcdir/diag.sh startup imuxsock_traillf.conf
 # send a message with trailing LF

--- a/tests/imuxsock_traillf_root.sh
+++ b/tests/imuxsock_traillf_root.sh
@@ -5,6 +5,12 @@ echo This test must be run as root with no other active syslogd
 if [ "$EUID" -ne 0 ]; then
     exit 77 # Not root, skip this test
 fi
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
 source $srcdir/diag.sh init
 source $srcdir/diag.sh startup imuxsock_traillf_root.conf
 # send a message with trailing LF

--- a/tests/imuxsock_traillf_root.sh
+++ b/tests/imuxsock_traillf_root.sh
@@ -7,7 +7,7 @@ if [ "$EUID" -ne 0 ]; then
 fi
 ./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
 no_liblogging_stdlog=$?
-if [ $no_liblogging_stdlog ];then
+if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi

--- a/tests/syslog_caller.c
+++ b/tests/syslog_caller.c
@@ -5,8 +5,6 @@
  *
  * -s severity (0..7 accoding to syslog spec, r "rolling", default 6)
  * -m number of messages to generate (default 500)
- * -C liblognorm-stdlog channel description
- * -f message format to use
  *
  * Part of the testbench for rsyslog.
  *
@@ -47,6 +45,7 @@ static void usage(void)
 }
 
 
+#ifdef HAVE_LIBLOGGING_STDLOG
 /* buffer must be large "enough" [4K?] */
 static void
 genMsg(char *buf, const int sev, const int iRun)
@@ -63,6 +62,7 @@ genMsg(char *buf, const int sev, const int iRun)
 		break;
 	}
 }
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -73,23 +73,29 @@ int main(int argc, char *argv[])
 	int msgs = 500;
 #ifdef HAVE_LIBLOGGING_STDLOG
 	stdlog_channel_t logchan = NULL;
-#endif
 	const char *chandesc = "syslog:";
 	char msgbuf[4096];
+#endif
 
 #ifdef HAVE_LIBLOGGING_STDLOG
 	stdlog_init(STDLOG_USE_DFLT_OPTS);
-#endif
 	while((opt = getopt(argc, argv, "m:s:C:f:")) != -1) {
+#endif
+	while((opt = getopt(argc, argv, "m:s:")) != -1) {
 		switch (opt) {
 		case 's':	if(*optarg == 'r') {
 					bRollingSev = 1;
 					sev = 0;
 				} else
+#ifdef HAVE_LIBLOGGING_STDLOG
 					sev = atoi(optarg) % 8;
+#else
+					sev = atoi(optarg);
+#endif
 				break;
 		case 'm':	msgs = atoi(optarg);
 				break;
+#ifdef HAVE_LIBLOGGING_STDLOG
 		case 'C':	chandesc = optarg;
 				break;
 		case 'f':	if(!strcmp(optarg, "syslog_inject-l"))
@@ -99,8 +105,11 @@ int main(int argc, char *argv[])
 				else
 					usage();
 				break;
+#endif
 		default:	usage();
+#ifdef HAVE_LIBLOGGING_STDLOG
 				exit(1);
+#endif
 				break;
 		}
 	}

--- a/tests/syslog_caller.c
+++ b/tests/syslog_caller.c
@@ -28,6 +28,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+#include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <getopt.h>
@@ -82,8 +83,9 @@ int main(int argc, char *argv[])
 #ifdef HAVE_LIBLOGGING_STDLOG
 	stdlog_init(STDLOG_USE_DFLT_OPTS);
 	while((opt = getopt(argc, argv, "m:s:C:f:")) != -1) {
-#endif
+#else
 	while((opt = getopt(argc, argv, "m:s:")) != -1) {
+#endif
 		switch (opt) {
 		case 's':	if(*optarg == 'r') {
 					bRollingSev = 1;

--- a/tests/syslog_caller.c
+++ b/tests/syslog_caller.c
@@ -5,6 +5,8 @@
  *
  * -s severity (0..7 accoding to syslog spec, r "rolling", default 6)
  * -m number of messages to generate (default 500)
+ * -C liblognorm-stdlog channel description
+ * -f message format to use
  *
  * Part of the testbench for rsyslog.
  *


### PR DESCRIPTION
When built with --disable-liblogging-stdlog, syslog_caller fails
to compile. This will enable compilation when the library is not
used.
Resolves: #445

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>