### PR TITLE
usertools: Fixed issue making rscryutil (usertools enabled)

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -100,7 +100,7 @@ rscryutil = rscryutil.c
 rscryutil_CPPFLAGS = -I../runtime $(RSRT_CFLAGS) $(LIBGCRYPT_CFLAGS)
 rscryutil_LDADD = ../runtime/libgcry.la $(LIBGCRYPT_LIBS)
 rscryutil_LDFLAGS = \
-	-Wl,--whole-archive,$(top_builddir)/runtime/.libs/librsyslog.a,--no-whole-archive
+	-Wl,--whole-archive,--no-whole-archive
 rscryutil.1: rscryutil.rst
 	$(AM_V_GEN) $(RST2MAN) $< $@
 man1_MANS += rscryutil.1


### PR DESCRIPTION
The problem was introduced due the changes of this commit:
https://github.com/rsyslog/rsyslog/commit/fb4fd2ddd2f08380ad65a8cafc5f124890b136ad

Removing librsyslog.a from the rscryutil_LDFLAGS solved the problem.
closes https://github.com/rsyslog/rsyslog/issues/447