### PR TITLE
Tools: Man pages for tools were generated even with --disable-generat…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1607,6 +1607,7 @@ AC_ARG_ENABLE(generate-man-pages,
          esac],
         [have_to_generate_man_pages=no]
 )
+AM_CONDITIONAL(ENABLE_GENERATE_MAN_PAGES, test x$have_to_generate_man_pages = xyes)
 
 
 # This provides a work-around to use "make distcheck" by disabling

--- a/tests/loop.sh
+++ b/tests/loop.sh
@@ -18,7 +18,7 @@ while [ $RUN -le $MAXRUN ]; do
      	 let FAIL+=1
 	 echo "FAIL!"
 	 #vi work
-         #exit 1
+         exit 1
      else
      	let SUCCESS+=1
      fi

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -72,11 +72,14 @@ bin_PROGRAMS += rsgtutil
 rsgtutil = rsgtutil.c
 rsgtutil_CPPFLAGS = $(RSRT_CFLAGS) $(GUARDTIME_CFLAGS) -DENABLEGT
 rsgtutil_LDADD = ../runtime/librsgt.la $(GUARDTIME_LIBS)
-rsgtutil.1: rsgtutil.rst
-	$(AM_V_GEN) $(RST2MAN) $< $@
+if ENABLE_GENERATE_MAN_PAGES
+RSTMANFILE = rsgtutil.rst
+rsgtutil.1: $(RSTMANFILE)
+	$(AM_V_GEN) $(RST2MAN) $(RSTMANFILE) $@
 man1_MANS += rsgtutil.1
 CLEANFILES += rsgtutil.1
 EXTRA_DIST+= rsgtutil.1
+endif
 if ENABLE_GT_KSI
 rsgtutil_CPPFLAGS += $(GT_KSI_CFLAGS) -DENABLEKSI
 rsgtutil_LDADD += ../runtime/librsksi.la $(GT_KSI_LIBS)
@@ -87,11 +90,14 @@ bin_PROGRAMS += rsgtutil
 rsgtutil = rsgtutil.c
 rsgtutil_CPPFLAGS = $(RSRT_CFLAGS) $(GT_KSI_CFLAGS) -DENABLEKSI
 rsgtutil_LDADD = ../runtime/librsksi.la $(GT_KSI_LIBS)
-rsgtutil.1: rsgtutil.rst
-	$(AM_V_GEN) $(RST2MAN) $< $@
+if ENABLE_GENERATE_MAN_PAGES
+RSTMANFILE = rsgtutil.rst
+rsgtutil.1: $(RSTMANFILE) 
+	$(AM_V_GEN) $(RST2MAN) $(RSTMANFILE) $@
 man1_MANS += rsgtutil.1
 CLEANFILES += rsgtutil.1
 EXTRA_DIST+= rsgtutil.1
+endif
 endif
 endif
 if ENABLE_LIBGCRYPT
@@ -101,10 +107,13 @@ rscryutil_CPPFLAGS = -I../runtime $(RSRT_CFLAGS) $(LIBGCRYPT_CFLAGS)
 rscryutil_LDADD = ../runtime/libgcry.la $(LIBGCRYPT_LIBS)
 rscryutil_LDFLAGS = \
 	-Wl,--whole-archive,--no-whole-archive
-rscryutil.1: rscryutil.rst
-	$(AM_V_GEN) $(RST2MAN) $< $@
+if ENABLE_GENERATE_MAN_PAGES
+RSTMANFILE = rscryutil.rst
+rscryutil.1: $(RSTMANFILE) 
+	$(AM_V_GEN) $(RST2MAN) $(RSTMANFILE) $@
 man1_MANS += rscryutil.1
 CLEANFILES += rscryutil.1
 EXTRA_DIST+= rscryutil.1
+endif
 endif
 endif


### PR DESCRIPTION
…e-man-pages

Man pages are not generated anymore when "--disable-generate-man-pages" is
configured. Also changed man-page rulepatterns makefile. The method
using $< refering to the prerequisite did not work proberly on FreeBSD.