### PR TITLE
Debugoutput: Replaced write calls(Only in debugmode 2)  with printf

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1453,11 +1453,11 @@ rsyslogdDoDie(int sig)
 	static int iRetries = 0; /* debug aid */
 	dbgprintf(MSG1);
 	if(Debug == DEBUG_FULL) {
-		if(write(1, MSG1, sizeof(MSG1) - 1)) {}
+		printf(MSG1);
 	}
 	if(iRetries++ == 4) {
 		if(Debug == DEBUG_FULL) {
-			if(write(1, MSG2, sizeof(MSG2) - 1)) {}
+			printf(MSG2);
 		}
 		abort();
 	}


### PR DESCRIPTION
In rsyslogdDoDie, the Write function was used on static FD 1 (should
have been STDOUT in normal cases). But appearently it could also
lead to FD of queue files. Replaced the write calls with printf
which ends in STDOUT by default.

closes https://github.com/rsyslog/rsyslog/issues/390