### PR TITLE
 build system: Failure action in AC_CHECK_LIB check for gnutls_global_...

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -769,7 +769,7 @@ if test "x$enable_gnutls" = "xyes"; then
 	    [
 	     AC_DEFINE(HAVE_LIB_GNUTLS, 1, [gnutls is available])
 	    ],
-	    [AC_MSG_FAILURE([gnutls library is missing])],
+	    [AC_MSG_WARN([gnutls_global_init function missing or not detected])],
 	    []
 	)
 	AC_CHECK_FUNCS(gnutls_certificate_set_retrieve_function,,)


### PR DESCRIPTION
…init changed

Instead of an failure, only a warning message is generated now.
On Freebsd the function check does not detect the gnutls_global_init
proberly. This caused configure to fail even if gnutls was installed.