### PR TITLE
mmnormalize: liblognorm error messages are now reported

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 ------------------------------------------------------------------------------
 Version 8.12.0 [v8-stable] 2015-08-11
+- build requirement for rsyslog/mmnormalize is now liblognorm 1.1.2
 - Harmonize resetConfigVariables values and defaults
   see also https://github.com/rsyslog/rsyslog/pull/413
   Thanks to Tomas Heinrich for the patch.
@@ -7,6 +8,11 @@ Version 8.12.0 [v8-stable] 2015-08-11
   The file format is incompatible to previous format, but tools have been
   upgraded to handle both and also an option been added to convert from
   old to new format.
+- mmnormalize: liblognorm error messages are now emitted via regular
+  rsyslog error reporting mechanism (aka "are now logged")
+  This is possible due to a new API in liblognorm 1.1.2;
+  Note that the amount of error messages depends on the version of
+  liblognorm used.
 - bugfix: ommysql did not work when gnutls was enabled
   as it turned out, this was due to a check for GnuTLS functions
   with the side-effect that

--- a/configure.ac
+++ b/configure.ac
@@ -932,7 +932,7 @@ AC_ARG_ENABLE(mmnormalize,
         [enable_mmnormalize=no]
 )
 if test "x$enable_mmnormalize" = "xyes"; then
-	PKG_CHECK_MODULES(LIBLOGNORM, lognorm >= 1.0.2)
+	PKG_CHECK_MODULES(LIBLOGNORM, lognorm >= 1.1.2)
 
 	save_CFLAGS="$CFLAGS"
 	save_LIBS="$LIBS"

--- a/plugins/mmnormalize/mmnormalize.c
+++ b/plugins/mmnormalize/mmnormalize.c
@@ -6,7 +6,7 @@
  *
  * File begun on 2010-01-01 by RGerhards
  *
- * Copyright 2010-2013 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2010-2015 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -110,6 +110,13 @@ struct modConfData_s {
 static modConfData_t *loadModConf = NULL;/* modConf ptr to use for the current load process */
 static modConfData_t *runModConf = NULL;/* modConf ptr to use for the current exec process */
 
+/* callback for liblognorm error messages */
+void
+errCallBack(void __attribute__((unused)) *cookie, const char *msg,
+	    size_t __attribute__((unused)) lenMsg)
+{
+	errmsg.LogError(0, RS_RET_ERR_LIBLOGNORM, "liblognorm error: %s", msg);
+}
 
 /* to be called to build the liblognorm part of the instance ONCE ALL PARAMETERS ARE CORRECT
  * (and set within pData!).
@@ -124,6 +131,7 @@ buildInstance(instanceData *pData)
 		ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_INIT);
 	}
 	ln_setCtxOpts(pData->ctxln, loadModConf->allow_regex);
+	ln_setErrMsgCB(pData->ctxln, errCallBack, NULL);
 	if(ln_loadSamples(pData->ctxln, (char*) pData->rulebase) != 0) {
 		errmsg.LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
 				"could not be loaded cannot activate action", pData->rulebase);

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -441,6 +441,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_KAFKA_PRODUCE_ERR = -2424,/**< error during Kafka produce function */
 	RS_RET_CONF_PARAM_INVLD = -2425,/**< config parameter is invalid */
 	RS_RET_KSI_ERR = -2426,/**< error in KSI subsystem */
+	RS_RET_ERR_LIBLOGNORM = -2427,/**< cannot obtain liblognorm ctx */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */


### PR DESCRIPTION
This is possible due to a new API in liblognorm 1.1.2;
Note that the amount of error messages depends on the version of
liblognorm used. Consequently, liblognorm 1.1.2 is now required
to run mmnormalize.

**Note: merge only after buildbot tests indicate "OK"**