### PR TITLE
Fix generating rscryutil.1

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1615,7 +1615,6 @@ AC_ARG_ENABLE(generate-man-pages,
          esac],
         [have_to_generate_man_pages=no]
 )
-AM_CONDITIONAL(ENABLE_GENERATE_MAN_PAGES, test x$have_to_generate_man_pages = xyes)
 
 
 # This provides a work-around to use "make distcheck" by disabling
@@ -1656,6 +1655,8 @@ else
         AC_MSG_NOTICE([Not running from git source])
 fi
 
+
+AM_CONDITIONAL(ENABLE_GENERATE_MAN_PAGES, test x$have_to_generate_man_pages = xyes)
 
 # rst2man
 AC_CHECK_PROGS([RST2MAN], [rst2man rst2man.py], [false])


### PR DESCRIPTION
In commit 3b13693 commiter uses variable before executing another block of code which sets this variable and any changes in that block won't apply.
This bug appears when user runs "make dist" in the git repo and the generated tarball doesn't contain rscryutil.1.