### PR TITLE
freebsd: Added a patch for console output on freebsd

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1097,11 +1097,28 @@ doWriteCall(strm_t *pThis, uchar *pBuf, size_t *pLenBuf)
 	char *pWriteBuf;
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, strm);
+#ifdef __FreeBSD__
+	sbool crnlNow = 0;
+#endif /* __FreeBSD__ */
 
 	lenBuf = *pLenBuf;
 	pWriteBuf = (char*) pBuf;
 	iTotalWritten = 0;
 	do {
+#ifdef __FreeBSD__
+		if (pThis->bIsTTY && !pThis->iZipLevel && !pThis->cryprov) {
+			char *pNl = NULL;
+			if (crnlNow == 0) pNl = strchr(pWriteBuf, '\n');
+			else crnlNow = 0;
+			if (pNl == pWriteBuf) {
+				iWritten = write(pThis->fd, "\r", 1);
+				if (iWritten > 0) {
+					crnlNow = 1;
+					iWritten = 0;
+				}
+			} else iWritten = write(pThis->fd, pWriteBuf, pNl ? pNl - pWriteBuf : lenBuf);
+		} else
+#endif /* __FreeBSD__ */
 		iWritten = write(pThis->fd, pWriteBuf, lenBuf);
 		if(iWritten < 0) {
 			char errStr[1024];


### PR DESCRIPTION
The patch was from AlexandreFenyo and is a result
of this bug report on freebsd.org:
https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=199767#c4

closes https://github.com/rsyslog/rsyslog/issues/372