### PR TITLE
diskqueue: Fixed two minor issues when syncqueuefiles is enabled.

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -743,6 +743,7 @@ qqueueLoadPersStrmInfoFixup(strm_t *pStrm, qqueue_t __attribute__((unused)) *pTh
 	ISOBJ_TYPE_assert(pStrm, strm);
 	ISOBJ_TYPE_assert(pThis, qqueue);
 	CHKiRet(strm.SetDir(pStrm, pThis->pszSpoolDir, pThis->lenSpoolDir));
+	CHKiRet(strm.SetbSync(pStrm, pThis->bSyncQueueFiles));
 finalize_it:
 	RETiRet;
 }

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -920,7 +920,7 @@ static rsRetVal strmConstructFinalize(strm_t *pThis)
 	}
 
 	/* if we are set to sync, we must obtain a file handle to the directory for fsync() purposes */
-	if(pThis->bSync && !pThis->bIsTTY) {
+	if(pThis->bSync && !pThis->bIsTTY && pThis->pszDir != NULL) {
 		pThis->fdDir = open((char*)pThis->pszDir, O_RDONLY | O_CLOEXEC | O_NOCTTY);
 		if(pThis->fdDir == -1) {
 			char errStr[1024];


### PR DESCRIPTION
First issue: Error 14 was generated on the .qi file directory handle.
As the .qi filestream does not have a directory set, fsync
was called on an empty directory causing a error 14 in debug log.
closes https://github.com/rsyslog/rsyslog/issues/402

Second issue: When queue files existed on startup, the bSyncQueueFiles
strm property was not set to 1. This is now done in the
qqueueLoadPersStrmInfoFixup function.
closes https://github.com/rsyslog/rsyslog/issues/403