### PR TITLE
Fix detection of the GnuTLS package

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -763,18 +763,13 @@ AC_ARG_ENABLE(gnutls,
 if test "x$enable_gnutls" = "xyes"; then
 	PKG_CHECK_MODULES(GNUTLS, gnutls >= 1.4.0)
 	AC_DEFINE([ENABLE_GNUTLS], [1], [Indicator that GnuTLS is present])
-	AC_CHECK_LIB(
-	    [gnutls],
-	    [gnutls_global_init],
-	    [
-	     AC_DEFINE(HAVE_LIB_GNUTLS, 1, [gnutls is available])
-	    ],
-	    [AC_MSG_WARN([gnutls_global_init function missing or not detected])],
-	    []
-	)
+	save_libs=$LIBS
+	LIBS="$LIBS $GNUTLS_LIBS"
 	AC_CHECK_FUNCS(gnutls_certificate_set_retrieve_function,,)
 	AC_CHECK_FUNCS(gnutls_certificate_type_set_priority,,)
+	LIBS=$save_libs
 fi
+
 AM_CONDITIONAL(ENABLE_GNUTLS, test x$enable_gnutls = xyes)
 
 # libgcrypt support
@@ -1654,7 +1649,6 @@ if test "x$in_git_src" = "xyes"; then
 else
         AC_MSG_NOTICE([Not running from git source])
 fi
-
 
 AM_CONDITIONAL(ENABLE_GENERATE_MAN_PAGES, test x$have_to_generate_man_pages = xyes)
 


### PR DESCRIPTION
This commit fixes a number of issues that cropped up from these changes:
23c5b3e replace deprecated GnuTLS functions with newer ones if available
88f0651 bugfix: ommysql did not work when gnutls was enabled
ce560b6 build system: Failure action in AC_CHECK_LIB check for

The solution is based on the assumption that the call to AC_CHECK_LIB()
was added purely to satisfy the subsequent calls to AC_CHECK_FUNCS().
23c5b3e had the unintentional result of libgnutls being added to LIBS
and linked to undesired components.
The next commit removed libgnutls from LIBS which made the following
calls to AC_CHECK_FUNCS() nonfunctional.
Another commit made the processing not stop upon detecting a missing
component which, again, makes the calls to AC_CHECK_FUNCS() malfunction.

The solution is to get rid of AC_CHECK_LIB() and temporarily override
LIBS for use by AC_CHECK_FUNCS().