### PR TITLE
Fix for parallel build issue "cannot find ../runtime/.libs/librsyslog.a: No such file or directory" (Fixes #479)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@ Version 8.13.0 [v8-stable] 2015-09-22
 - bugfix omkafka: Fixes a bug not accepting new messages anymore. 
   see also: https://github.com/rsyslog/rsyslog/pull/472
   Thanks to Janmejay Singh
+- bugfix: Parallel build issue "cannot find ../runtime/.libs/librsyslog.a:
+  No such file or directory" (#479) fixed.
+  Thanks to Thomas D. (Whissi) for the patch.
 ------------------------------------------------------------------------------
 Version 8.12.0 [v8-stable] 2015-08-11
 - Harmonize resetConfigVariables values and defaults

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -186,6 +186,7 @@ if ENABLE_LIBGCRYPT
    libgcry_la_SOURCES = libgcry.c libgcry_common.c libgcry.h
    libgcry_la_CPPFLAGS = $(RSRT_CFLAGS) $(LIBGCRYPT_CFLAGS)
    pkglib_LTLIBRARIES += lmcry_gcry.la
+   lmcry_gcry_la_DEPENDENCIES = librsyslog.la
    lmcry_gcry_la_SOURCES = lmcry_gcry.c lmcry_gcry.h
    lmcry_gcry_la_CPPFLAGS = $(RSRT_CFLAGS) $(LIBGCRYPT_CFLAGS)
    lmcry_gcry_la_LDFLAGS = -module -avoid-version \


### PR DESCRIPTION
This issue was introduced with commit fb4fd2ddd2f08380ad65a8cafc5f124890b136ad.

Fixes #479 