### PR TITLE
Add fixed-width option

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3573,7 +3573,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			if(iTo > 0)
 				--iTo;
 		}
-		if(iFrom == 0 && iTo >=  bufLen) { 
+		if(iFrom == 0 && iTo >= bufLen && pTpe->data.field.options.bFixedWidth == 0) {
 			/* in this case, the requested string is a superset of what we already have,
 			 * so there is no need to do any processing. This is a frequent case for size-limited
 			 * fields like TAG in the default forwarding template (so it is a useful optimization
@@ -3581,8 +3581,10 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			 */
 			; /*DO NOTHING*/
 		} else {
-			if(iTo > bufLen) /* iTo is very large, if no to-position is set in the template! */
-				iTo = bufLen;
+			if(iTo > bufLen)  /* iTo is very large, if no to-position is set in the template! */
+				if (pTpe->data.field.options.bFixedWidth == 0)
+					iTo = bufLen;
+
 			iLen = iTo - iFrom + 1; /* the +1 is for an actual char, NOT \0! */
 			pBufStart = pBuf = MALLOC((iLen + 1) * sizeof(uchar));
 			if(pBuf == NULL) {
@@ -3602,9 +3604,13 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			}
 			/* OK, we are at the begin - now let's copy... */
 			bufLen = iLen;
-			while(*pSb && iLen) {
-				*pBuf++ = *pSb;
-				++pSb;
+			while(iLen) {
+				if (*pSb) {
+					*pBuf++ = *pSb;
+					++pSb;
+				} else {
+					*pBuf++ = ' ';
+				}
 				--iLen;
 			}
 			*pBuf = '\0';

--- a/template.c
+++ b/template.c
@@ -89,6 +89,7 @@ static struct cnfparamdescr cnfparamdescrProperty[] = {
 	{ "regex.match", eCmdHdlrInt, 0 },
 	{ "regex.submatch", eCmdHdlrInt, 0 },
 	{ "droplastlf", eCmdHdlrBinary, 0 },
+	{ "fixedwidth", eCmdHdlrBinary, 0 },
 	{ "mandatory", eCmdHdlrBinary, 0 },
 	{ "spifno1stsp", eCmdHdlrBinary, 0 }
 };
@@ -755,6 +756,8 @@ static void doOptions(unsigned char **pp, struct templateEntry *pTpe)
 			pTpe->data.field.options.bSecPathReplace = 1;
 		 } else if(!strcmp((char*)Buf, "pos-end-relative")) {
 			pTpe->data.field.options.bFromPosEndRelative = 1;
+		 } else if(!strcmp((char*)Buf, "fixed-width")) {
+			pTpe->data.field.options.bFixedWidth = 1;
 		 } else if(!strcmp((char*)Buf, "csv")) {
 			if(hasFormat(pTpe)) {
 				errmsg.LogError(0, NO_ERRCODE, "error: can only specify "
@@ -1413,6 +1416,7 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 	int topos = -1;
 	int fieldnum = -1;
 	int fielddelim = 9; /* default is HT (USACSII 9) */
+	int fixedwidth = 0;
 	int re_matchToUse = 0;
 	int re_submatchToUse = 0;
 	int bComplexProcessing = 0;
@@ -1442,6 +1446,9 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 			free(tmpstr);
 		} else if(!strcmp(pblkProperty.descr[i].name, "droplastlf")) {
 			droplastlf = pvals[i].val.d.n;
+			bComplexProcessing = 1;
+		} else if(!strcmp(pblkProperty.descr[i].name, "fixedwidth")) {
+			fixedwidth = pvals[i].val.d.n;
 			bComplexProcessing = 1;
 		} else if(!strcmp(pblkProperty.descr[i].name, "mandatory")) {
 			mandatory = pvals[i].val.d.n;
@@ -1657,6 +1664,7 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 	pTpe->data.field.options.bDropLastLF = droplastlf;
 	pTpe->data.field.options.bSPIffNo1stSP = spifno1stsp;
 	pTpe->data.field.options.bMandatory = mandatory;
+	pTpe->data.field.options.bFixedWidth = fixedwidth;
 	pTpe->data.field.eCaseConv = caseconv;
 	switch(formatType) {
 	case F_NONE:

--- a/template.h
+++ b/template.h
@@ -126,6 +126,7 @@ struct templateEntry {
 				unsigned bJSONfr: 1;		/* format field JSON *field* non escaped (n/v pair) */
 				unsigned bMandatory: 1;		/* mandatory field - emit even if empty */
 				unsigned bFromPosEndRelative: 1;/* is From/To-Pos relative to end of string? */
+				unsigned bFixedWidth: 1;	/* space pad to toChar if string is shorter */
 			} options;		/* options as bit fields */
 		} field;
 	} data;


### PR DESCRIPTION
Pads a string with spaces up to toChar field if string is shorter, if
string is equal then nothing is done and if string is longer then it
gets truncated.

From mailing list patch proposal.
