### PR TITLE
testbench: Added mmpstrucdata valgrind tests into makefile

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -6,6 +6,8 @@ Version 8.13.0 [v8-stable] 2015-09-22
 - bugfix: Parallel build issue "cannot find ../runtime/.libs/librsyslog.a:
   No such file or directory" (#479) fixed.
   Thanks to Thomas D. (Whissi) for the patch.
+- bugfix: Added missing mmpstructdata testfiles into makefile.
+  see also: https://github.com/rsyslog/rsyslog/issues/484
 ------------------------------------------------------------------------------
 Version 8.12.0 [v8-stable] 2015-08-11
 - Harmonize resetConfigVariables values and defaults

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -802,7 +802,10 @@ EXTRA_DIST= \
 	mysql-actq-mt-withpause-vg.sh \
 	testsuites/mysql-actq-mt.conf \
 	mmpstrucdata.sh \
+        mmpstrucdata-vg.sh \
 	testsuites/mmpstrucdata.conf \
+	mmpstrucdata-invalid-vg.sh \
+	testsuites/mmpstrucdata-invalid.conf \
 	libdbi-basic-vg.sh \
 	mmnormalize_variable.sh \
 	mmnormalize_tokenized.sh \


### PR DESCRIPTION
Tests and config files were not included in the makefile,
so they were not added into the release tar.gz file.

closes: https://github.com/rsyslog/rsyslog/issues/484