### PR TITLE
msg object: Added msglock when using $!all-json/$!all-json-plain

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3279,11 +3279,13 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 				bufLen = 2;
 				*pbMustBeFreed = 0;
 			} else {
+				MsgLock(pMsg);
 				if(pProp->id == PROP_CEE_ALL_JSON) {
 					pRes = (uchar*)strdup(RS_json_object_to_json_string_ext(pMsg->json, JSON_C_TO_STRING_SPACED));
 				} else if(pProp->id == PROP_CEE_ALL_JSON_PLAIN) {
 					pRes = (uchar*)strdup(RS_json_object_to_json_string_ext(pMsg->json, JSON_C_TO_STRING_PLAIN));
 				}
+				MsgUnlock(pMsg);
 				*pbMustBeFreed = 1;
 			}
 			break;


### PR DESCRIPTION
Unexpected problems could occur when the msg object was modifed
while json_object_to_json_string_ext function is called.

closes https://github.com/rsyslog/rsyslog/issues/475 and https://github.com/rsyslog/rsyslog/issues/368
