### PR TITLE
Make it possible to customize librdkafka location

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1443,7 +1443,7 @@ AC_ARG_ENABLE(omkafka,
          esac],
         [enable_omkafka=no]
 )
-if test "x$enable_omkafka"; then
+if test "x$enable_omkafka" = "xyes"; then
 	PKG_CHECK_MODULES(LIBRDKAFKA, librdkafka)
 	AC_CHECK_HEADERS([librdkafka/rdkafka.h])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1444,7 +1444,7 @@ AC_ARG_ENABLE(omkafka,
         [enable_omkafka=no]
 )
 if test "x$enable_omkafka"; then
-	#PKG_CHECK_MODULES(LIBRDKAFKA, librdkafka)
+	PKG_CHECK_MODULES(LIBRDKAFKA, librdkafka)
 	AC_CHECK_HEADERS([librdkafka/rdkafka.h])
 fi
 AM_CONDITIONAL(ENABLE_OMKAFKA, test x$enable_omkafka = xyes)

--- a/plugins/omkafka/Makefile.am
+++ b/plugins/omkafka/Makefile.am
@@ -2,7 +2,7 @@ pkglib_LTLIBRARIES = omkafka.la
 
 omkafka_la_SOURCES = omkafka.c
 omkafka_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
-omkafka_la_LDFLAGS = -module -avoid-version -lrdkafka
+omkafka_la_LDFLAGS = -module -avoid-version $(LIBRDKAFKA_LIBS)
 omkafka_la_LIBADD = 
 
 EXTRA_DIST = 


### PR DESCRIPTION
For example, build librdkafka from source and static link.

I've verified the change on CentOS 6.5.  Is there any special reason this was turned off?