### PR TITLE
omelasticsearch: Fix CURL ignoring HTTP errors

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -270,6 +270,8 @@ checkConn(wrkrInstanceData_t *pWrkrData)
 		DBGPRINTF("omelasticsearch: checkConn() curl_easy_init() failed\n");
 		ABORT_FINALIZE(RS_RET_SUSPENDED);
 	}
+	/* Fail on HTTP error */
+	curl_easy_setopt(curl, CURLOPT_FAILONERROR, TRUE);
 	/* Bodypart of request not needed, so set curl opt to nobody and httpget, otherwise lib-curl could sigsegv */
 	curl_easy_setopt(curl, CURLOPT_HTTPGET, TRUE);
 	curl_easy_setopt(curl, CURLOPT_NOBODY, TRUE);
@@ -1033,6 +1035,7 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 		case CURLE_COULDNT_RESOLVE_PROXY:
 		case CURLE_COULDNT_CONNECT:
 		case CURLE_WRITE_ERROR:
+		case CURLE_HTTP_RETURNED_ERROR:
 			STATSCOUNTER_INC(indexHTTPReqFail, mutIndexHTTPReqFail);
 			indexHTTPFail += nmsgs;
 			DBGPRINTF("omelasticsearch: we are suspending ourselfs due "
@@ -1136,6 +1139,8 @@ curlSetup(wrkrInstanceData_t *pWrkrData, instanceData *pData)
 
 	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
 	curl_easy_setopt(handle, CURLOPT_POST, 1);
+
+	curl_easy_setopt(handle, CURLOPT_FAILONERROR, TRUE);
 
 	pWrkrData->curlHandle = handle;
 	pWrkrData->postHeader = header;


### PR DESCRIPTION
By default, CURL doesn't check if the HTTP request to elasticsearch fails. This leads to extra unnecessary processing and can trigger #500.