### PR TITLE
testbench: Fix potential buffer overflow detection

### DIFF
--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -398,7 +398,7 @@ genMsg(char *buf, size_t maxBuf, int *pLenBuf, struct instdata *inst)
 			}
 		} else {
 			if(bRandomizeExtraData)
-				edLen = ((long) rand() + extraDataLen) % extraDataLen + 1;
+				edLen = ((unsigned long) rand() + extraDataLen) % extraDataLen + 1;
 			else
 				edLen = extraDataLen;
 			memset(extraData, 'X', edLen);


### PR DESCRIPTION
On some architectures, calculation of edLen may lead to a
negative value when the value returned by rand() is less
than extraDataLen away from RAND_MAX. The negative value
passed to memset() triggers a glibc error. Forcing the
cast of rand() to be unsigned avoid the return of a negative
value.

Closes: #506

Signed-off-by: Louis Bouchard <louis.bouchard@canonical.com>