### PR TITLE
Fix NULL pointer dereference in imczmq and omczmq

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -302,7 +302,7 @@ static rsRetVal addListener(instanceConf_t* iconf){
 	DBGPRINTF("imczmq: authtype is: %s\n", iconf->authType);
 
 	/* if we are a CURVE server */
-	if (!strcmp(iconf->authType, "CURVESERVER")) {
+	if ((iconf->authType != NULL) && (!strcmp(iconf->authType, "CURVESERVER"))) {
 
 		iconf->is_server = true;
 
@@ -329,7 +329,7 @@ static rsRetVal addListener(instanceConf_t* iconf){
 	}
 
 	/* if we are a CURVE client */
-	if (!strcmp(iconf->authType, "CURVECLIENT")) {
+	if ((iconf->authType != NULL) && (!strcmp(iconf->authType, "CURVECLIENT"))) {
 		DBGPRINTF("imczmq: we are a curve client...\n");
 
 		iconf->is_server = false;

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -136,7 +136,7 @@ static rsRetVal initCZMQ(instanceData* pData) {
 	}
 
 	/* if we are a CURVE server */
-	if (!strcmp(pData->authType, "CURVESERVER")) {
+	if ((pData->authType != NULL) && (!strcmp(pData->authType, "CURVESERVER"))) {
 		DBGPRINTF("omczmq: we are a curve server...\n");
 		
 		is_server = true;
@@ -164,7 +164,7 @@ static rsRetVal initCZMQ(instanceData* pData) {
 	}
 
 	/* if we are a CURVE client */
-	if (!strcmp(pData->authType, "CURVECLIENT")) {
+	if ((pData->authType != NULL) && (!strcmp(pData->authType, "CURVECLIENT"))) {
 		DBGPRINTF("omczmq: we are a curve client...\n");
 
 		is_server = false;


### PR DESCRIPTION
If authtype is not set in the configuration and the pointer is NULL, both plugins crash.