### PR TITLE
(imfile) File truncation detect by comparing current offset and file size on disk

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -520,7 +520,7 @@ strmHandleEOFMonitor(strm_t *pThis)
 	/* Consider EOF reached only when no inode change AND current offset
 	 * matches the current file size on disk.  In other word, inode change
 	 * means file was moved, offset/file size mismatch with same inode
-	 * means file was truncated.
+	 * means file was truncated and also need to be reopened.
 	 */
 	if(statOpen.st_ino == statName.st_ino && pThis->iCurrOffs == statName.st_size) {
 		ABORT_FINALIZE(RS_RET_EOF);

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -490,26 +490,33 @@ finalize_it:
  * If we are monitoring a file, someone may have rotated it. In this case, we
  * also need to close it and reopen it under the same name.
  * rgerhards, 2008-02-13
- * The previous code also did a check for file truncation, in which case the
- * file was considered rewritten. However, this potential border case turned
- * out to be a big trouble spot on busy systems. It caused massive message
- * duplication (I guess stat() can return a too-low number under some
- * circumstances). So starting as of now, we only check the inode number and
- * a file change is detected only if the inode changes. -- rgerhards, 2011-01-10
  */
 static rsRetVal
 strmHandleEOFMonitor(strm_t *pThis)
 {
 	DEFiRet;
+	struct stat statOpen;
 	struct stat statName;
 
 	ISOBJ_TYPE_assert(pThis, strm);
+	/* find inodes of both current descriptor as well as file now in file
+	 * system. If they are different, the file has been rotated (or
+	 * otherwise rewritten). We also check the size, because the inode
+	 * does not change if the file is truncated (this, BTW, is also a case
+	 * where we actually loose log lines, because we can not do anything
+	 * against truncation...). We do NOT rely on the time of last
+	 * modificaton because that may not be available under all
+	 * circumstances. -- rgerhards, 2008-02-13
+	 */
+	if(fstat(pThis->fd, &statOpen) == -1)
+		ABORT_FINALIZE(RS_RET_IO_ERROR);
 	if(stat((char*) pThis->pszCurrFName, &statName) == -1)
 		ABORT_FINALIZE(RS_RET_IO_ERROR);
-	DBGPRINTF("stream checking for file change on '%s', inode %u/%u\n",
-	  pThis->pszCurrFName, (unsigned) pThis->inode,
-	  (unsigned) statName.st_ino);
-	if(pThis->inode == statName.st_ino) {
+	DBGPRINTF("stream checking for file change on '%s', inode %u/%u, size %lld/%lld\n",
+	  pThis->pszCurrFName, (unsigned) statOpen.st_ino,
+	  (unsigned) statName.st_ino,
+	  pThis->iCurrOffs, (long long) statName.st_size);
+	if(statOpen.st_ino == statName.st_ino && pThis->iCurrOffs >= statName.st_size) {
 		ABORT_FINALIZE(RS_RET_EOF);
 	} else {
 		/* we had a file change! */

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -516,7 +516,13 @@ strmHandleEOFMonitor(strm_t *pThis)
 	  pThis->pszCurrFName, (unsigned) statOpen.st_ino,
 	  (unsigned) statName.st_ino,
 	  pThis->iCurrOffs, (long long) statName.st_size);
-	if(statOpen.st_ino == statName.st_ino && pThis->iCurrOffs >= statName.st_size) {
+
+	/* Consider EOF reached only when no inode change AND current offset
+	 * matches the current file size on disk.  In other word, inode change
+	 * means file was moved, offset/file size mismatch with same inode
+	 * means file was truncated.
+	 */
+	if(statOpen.st_ino == statName.st_ino && pThis->iCurrOffs == statName.st_size) {
 		ABORT_FINALIZE(RS_RET_EOF);
 	} else {
 		/* we had a file change! */


### PR DESCRIPTION
My attempt to fix #511.  Suggest to review commits one by one.

Tested manually and also with following command sequence. `cp` will truncate the target file as `open("/tmp/input.log", O_WRONLY|O_TRUNC) = 4`.

```bash
for i in {1..9999}; do echo "message $i" >> /tmp/input.log; done && cp /etc/services /tmp/input.log
```