### PR TITLE
Czmq bind connect

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -360,6 +360,8 @@ static rsRetVal addListener(instanceConf_t* iconf){
 
 	/* if we have a ZMQ_SUB sock, subscribe to topics */
 	if (iconf->sockType == ZMQ_SUB) {
+		iconf->is_server = false;
+
 		char topic[256];
 		while (iconf->topicList) {
 			char *delimiter = strchr(iconf->topicList, ',');
@@ -386,8 +388,8 @@ static rsRetVal addListener(instanceConf_t* iconf){
 		}
 	}
 
-	/* FIXME: currently hard coded to bind */
-	int rc = zsock_attach(pData->sock, (const char*)iconf->sockEndpoints, true);
+	int rc = zsock_attach(pData->sock, (const char*)iconf->sockEndpoints,
+			iconf->is_server);
 	if (rc == -1) {
 		errmsg.LogError(0, NO_ERRCODE, "zsock_attach to %s",
 				iconf->sockEndpoints);

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -193,6 +193,12 @@ static rsRetVal initCZMQ(instanceData* pData) {
 		zsock_set_curve_serverkey (pData->sock, server_key);
 	}
 
+	/* if we are a PUB server */
+	if (pData->sockType == ZMQ_PUB) {
+		DBGPRINTF("omczmq: we are a pub server...\n");
+		is_server = true;
+	}
+
 	/* we default to CONNECT unless told otherwise */
 	int rc = zsock_attach(pData->sock, (const char*)pData->sockEndpoints, is_server);
 	if (rc == -1) {


### PR DESCRIPTION
Some context here: this is a bug, where the pub/sub sockets are not binded/connected as they should be. So a user has to prebend the endpoint string with a ">" for a sub socket or a "@" for a pub socket, otherwise it will not work.