### PR TITLE
bugfix testbench: some tests using imptcp are run if module is disabled

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -11,6 +11,9 @@ Version 8.13.0 [v8-stable] 2015-09-22
 - bugfix: imtcp/TLS hangs on dropped packets
   see also https://github.com/rsyslog/rsyslog/issues/318
   Thanks to github user tinselcity for the patch.
+- bugfix testbench: some tests using imptcp are run if module is disabled
+  Thanks to Michael Biebl for reporting this
+  see also https://github.com/rsyslog/rsyslog/issues/524
 - bugfix omkafka: Fixes a bug not accepting new messages anymore. 
   see also: https://github.com/rsyslog/rsyslog/pull/472
   Thanks to Janmejay Singh

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -117,6 +117,9 @@ TESTS +=  \
 	rscript_ruleset_call.sh \
 	rscript_set_modify.sh \
 	rscript_unaffected_reset.sh \
+	rscript_replace_complex.sh \
+	rscript_wrap2.sh \
+	rscript_wrap3.sh \
 	rs_optimizer_pri.sh \
 	cee_simple.sh \
 	cee_diskqueue.sh \
@@ -177,10 +180,7 @@ TESTS +=  \
 	imptcp_no_octet_counted.sh \
 	imptcp_spframingfix.sh \
 	rscript_random.sh \
-	rscript_replace.sh \
-	rscript_replace_complex.sh \
-	rscript_wrap2.sh \
-	rscript_wrap3.sh
+	rscript_replace.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	imptcp_conndrop-vg.sh
@@ -215,12 +215,14 @@ endif
 endif
 
 if ENABLE_MMNORMALIZE
+if ENABLE_IMPTCP
 TESTS +=  \
 	mmnormalize_variable.sh \
 	mmnormalize_tokenized.sh \
 	mmnormalize_regex_defaulted.sh \
 	mmnormalize_regex_disabled.sh
 
+endif
 if LOGNORM_REGEX_SUPPORTED
 TESTS += \
 	mmnormalize_regex.sh
@@ -228,12 +230,15 @@ endif
 endif
 
 if ENABLE_MMJSONPARSE
+if ENABLE_IMPTCP
 TESTS +=  \
 	mmjsonparse_simple.sh \
 	mmjsonparse_cim.sh \
 	json_array_subscripting.sh \
 	json_array_looping.sh \
-	json_nonarray_looping.sh \
+	json_nonarray_looping.sh
+endif
+TESTS +=  \
 	stop_when_array_has_element.sh
 endif
 

--- a/tests/testsuites/gethostname.conf
+++ b/tests/testsuites/gethostname.conf
@@ -1,7 +1,7 @@
 module(load="../plugins/imudp/.libs/imudp")
 $IncludeConfig diag-common.conf
-module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
 
 $template hostname,"%hostname%"
 local0.* ./HOSTNAME;hostname

--- a/tests/testsuites/rscript_random.conf
+++ b/tests/testsuites/rscript_random.conf
@@ -1,8 +1,8 @@
 $IncludeConfig diag-common.conf
 template(name="outfmt" type="string" string="%$.random_no%\n")
 
-module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
 
 set $.random_no = random(10);
 

--- a/tests/testsuites/rscript_replace_complex.conf
+++ b/tests/testsuites/rscript_replace_complex.conf
@@ -1,8 +1,8 @@
 $IncludeConfig diag-common.conf
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
-module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
 
 set $.replaced_msg = replace($msg, "syslog", "rsyslog");
 set $.replaced_msg = replace($.replaced_msg, "hello", "hello_world");

--- a/tests/testsuites/rscript_wrap2.conf
+++ b/tests/testsuites/rscript_wrap2.conf
@@ -1,8 +1,8 @@
 $IncludeConfig diag-common.conf
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
-module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
 
 set $.replaced_msg = wrap("foo says" & $msg, "*" & "*");
 

--- a/tests/testsuites/rscript_wrap3.conf
+++ b/tests/testsuites/rscript_wrap3.conf
@@ -1,8 +1,8 @@
 $IncludeConfig diag-common.conf
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
-module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
 
 set $.replaced_msg = wrap("foo says" & $msg, "bc" & "def" & "bc", "ES" & "C");
 

--- a/tests/testsuites/stop_when_array_has_element.conf
+++ b/tests/testsuites/stop_when_array_has_element.conf
@@ -2,8 +2,8 @@ $IncludeConfig diag-common.conf
 template(name="foo" type="string" string="%$!foo%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
-module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
 
 action(type="mmjsonparse")
 


### PR DESCRIPTION
Thanks to Michael Biebl for reporting this

see also https://github.com/rsyslog/rsyslog/issues/524