### PR TITLE
rsyslog -> Solr external plugin add batch update via httplib and error handling

### DIFF
--- a/plugins/external/solr/rsyslog_solr.py
+++ b/plugins/external/solr/rsyslog_solr.py
@@ -27,23 +27,30 @@
 
 import sys
 import select
-import pysolr
+import httplib
+import socket
+import time
 
 # skeleton config parameters
 pollPeriod = 0.75 # the number of seconds between polling for new messages
-maxAtOnce = 1024  # max nbr of messages that are processed within one batch
+maxAtOnce = 5000  # max nbr of messages that are processed within one batch
+retryInterval = 5
+numberOfRetries = 10
+errorFile = open("/var/log/rsyslog_solr_oopsies.log", "a")
 
 # App logic global variables
-solrURL = "http://localhost:8983/solr/" # CONFIG: where to connect to?
-solr = "" # handle to solr
+solrServer = "localhost"
+solrPort = 8983
+solrUpdatePath = "/solr/gettingstarted/update"
+solrConnection = "" # HTTP connection to solr
 
 def onInit():
 	""" Do everything that is needed to initialize processing (e.g.
 	    open files, create handles, connect to systems...)
 	"""
-	global solr
-	solr = pysolr.Solr(solrURL)
-
+	global solrConnection
+	solrConnection = httplib.HTTPConnection(solrServer, solrPort)
+	
 
 def onReceive(msgs):
 	"""This is the entry point where actual work needs to be done. It receives
@@ -53,45 +60,52 @@ def onReceive(msgs):
 	   next message will arrive. It may be in a nanosecond from now, but it
 	   may also be in three hours...
 	"""
-	global solr
-	for msg in msgs:
-		# this code can most probably be improved so that multiple
-		# messages are emitted to solr at once... Are you up for a
-		# contribution??? ;)
-		doc = json.loads(line)
-		solr.add([doc])
-
+	solrConnection.request("POST", solrUpdatePath, msgs, {"Content-type": "application/json"})
+	response = solrConnection.getresponse()
+	response.read()  # apparently we have to read the whole reply to reuse the connection
+	if (response.status <> 200):
+		# if there's something wrong with the payload, like a schema mismatch
+		# write batch to error file and move on. Normally there's no point in retrying here
+		errorFile.write("%s\n" % msgs)
 
 def onExit():
 	""" Do everything that is needed to finish processing (e.g.
 	    close files, handles, disconnect from systems...). This is
 	    being called immediately before exiting.
 	"""
-	global solr
-	# looks like we have nothing to do here...
+	solrConnection.close()
+	errorFile.close()
 
-
-"""
--------------------------------------------------------
-This is plumbing that DOES NOT need to be CHANGED
--------------------------------------------------------
-"""
 onInit()
 keepRunning = 1
 while keepRunning == 1:
 	while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
-		msgs = []
+		msgs = "["
 	        msgsInBatch = 0
 		while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
 			line = sys.stdin.readline()
 			if line:
-				msgs.append(line)
+				# append the JSON array used by Solr for updates
+				msgs += line
+				msgs += ","
 			else: # an empty line means stdin has been closed
 				keepRunning = 0
 			msgsInBatch = msgsInBatch + 1
 			if msgsInBatch >= maxAtOnce:
 				break;
 		if len(msgs) > 0:
-			onReceive(msgs)
+			retries = 0
+			while (retries < numberOfRetries):
+				try:
+					# close the JSON array used by Solr for updates
+					onReceive(msgs[:-1] + "]")
+					break
+				except socket.error:
+					# retry if connection failed; it will crash with flames on other exceptions, and you will lose data. But this is something you'd normally see when you first set things up
+					time.sleep(retryInterval)
+				retries += 1
+			# if we failed, we write the failed batch to the error file
+			if (retries == numberOfRetries):
+				errorFile.write("%s\n" % msgs)
 			sys.stdout.flush() # very important, Python buffers far too much!
 onExit()


### PR DESCRIPTION
The previous pysolr approach worked nicely with batches, but it required parsing the JSON input to a dictionary, which we already know is a JSON, and writing it out again into the final string. That was too expensive (~10x more CPU-intensive than rsyslog under load). Also, it had the disadvantage that it raised the same exception when connection failed with when there was something wrong with a single document (so retrying would re-insert all the correct documents N times).

The httplib approach allowed me to retry on socket failures (and write to an error file when the retry count is exceeded) and write to the error file directly when there's a non-200 response code from Solr. Also, the external plugin is now taking onlu ~30% of rsyslog's CPU.

To get an idea of performance, I could max out Solr on my i5 MacBook Air (6K EPS) with ~4% CPU usage from rsyslog and ~1% from rsyslog_solr.py on my i3 Linux laptop. Memory usage was 120MB for rsyslog (queue-dependent of course, I had a 100K messages high watermark on a disk-assisted queue) and 10-15MB on each of the 4 python processes spawned by the queue.workerthreads.