### PR TITLE
re_extract fixed

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3747,7 +3747,7 @@ initFunc_re_match(struct cnffunc *func)
 	regex_t *re;
 	DEFiRet;
 
-	if(func->nParams != 2) {
+	if(func->nParams < 2) {
 		parser_errmsg("rsyslog logic error in line %d of file %s\n",
 			__LINE__, __FILE__);
 		FINALIZE;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -120,6 +120,8 @@ TESTS +=  \
 	rscript_replace_complex.sh \
 	rscript_wrap2.sh \
 	rscript_wrap3.sh \
+	rscript_re_extract.sh \
+	rscript_re_match.sh \
 	rs_optimizer_pri.sh \
 	cee_simple.sh \
 	cee_diskqueue.sh \
@@ -854,6 +856,10 @@ EXTRA_DIST= \
 	testsuites/stop_when_array_has_element.conf \
 	key_dereference_on_uninitialized_variable_space.sh \
 	testsuites/key_dereference_on_uninitialized_variable_space.conf \
+	rscript_re_extract.sh \
+	testsuites/rscript_re_extract.conf \
+	rscript_re_match.sh \
+	testsuites/rscript_re_match.conf \
 	cfg.sh
 
 # TODO: re-enable

--- a/tests/rscript_re_extract.sh
+++ b/tests/rscript_re_extract.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2015-09-29 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_re_extract.sh\]: test re_extract rscript-fn
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_re_extract.conf
+. $srcdir/diag.sh tcpflood -m 1 -I $srcdir/testsuites/date_time_msg
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh content-check "*Number is 19597*"
+. $srcdir/diag.sh exit

--- a/tests/rscript_re_match.sh
+++ b/tests/rscript_re_match.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2015-09-29 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_re_match.sh\]: test re_match rscript-fn
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_re_match.conf
+. $srcdir/diag.sh tcpflood -m 1 -I $srcdir/testsuites/date_time_msg
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh content-check "*Matched*"
+. $srcdir/diag.sh exit

--- a/tests/testsuites/rscript_re_extract.conf
+++ b/tests/testsuites/rscript_re_extract.conf
@@ -1,0 +1,9 @@
+$IncludeConfig diag-common.conf
+template(name="outfmt" type="string" string="*Number is %$.number%*\n")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+set $.number = re_extract($msg, '.* ([0-9]+)$', 0, 1, 'none');
+
+action(type="omfile" file="./rsyslog.out.log" template="outfmt")

--- a/tests/testsuites/rscript_re_match.conf
+++ b/tests/testsuites/rscript_re_match.conf
@@ -1,0 +1,10 @@
+$IncludeConfig diag-common.conf
+template(name="outfmt" type="string" string="*Matched*\n")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+if (re_match($msg, '.* ([0-9]+)$')) then {
+	 action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}
+


### PR DESCRIPTION
It was broken because fn-init was expecting exactly 2 args (which is fine for re_match) but re_extract has 5 args, which fails in init.