### PR TITLE
imudp: Fixed a dbgprintf in processPacket function.

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -417,7 +417,7 @@ processPacket(struct lstn_s *lstn, struct sockaddr_storage *frominetPrev, int *p
 		*pbIsPermitted = 1; /* no check -> everything permitted */
 	}
 
-	DBGPRINTF("recv(%d,%d),acl:%d,msg:%.128s\n", lstn->sock, (int) lenRcvBuf, *pbIsPermitted, rcvBuf);
+	DBGPRINTF("recv(%d,%d),acl:%d,msg:%.*s\n", lstn->sock, (int) lenRcvBuf, *pbIsPermitted, (int)lenRcvBuf, rcvBuf);
 
 	if(*pbIsPermitted != 0)  {
 		/* we now create our own message object and submit it to the queue */


### PR DESCRIPTION
rcvBuf is not terminated with a NULL Byte, so the dbgprintf was
printing the whole buffer.