### PR TITLE
ptcp performance improvements

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -273,7 +273,7 @@ static struct wrkrInfo_s {
 	pthread_cond_t run;
 	struct epoll_event *event; /* event == NULL -> idle */
 	long long unsigned numCalled;	/* how often was this called */
-} wrkrInfo[16];
+} *wrkrInfo;
 static pthread_mutex_t wrkrMut;
 static pthread_cond_t wrkrIdle;
 static int wrkrRunning;
@@ -1368,9 +1368,12 @@ startWorkerPool(void)
 {
 	int i;
 	wrkrRunning = 0;
-	if(runModConf->wrkrMax > 16)
-		runModConf->wrkrMax = 16; /* TODO: make dynamic? */
 	DBGPRINTF("imptcp: starting worker pool, %d workers\n", runModConf->wrkrMax);
+    wrkrInfo = calloc(runModConf->wrkrMax, sizeof(struct wrkrInfo_s));
+    if (wrkrInfo == NULL) {
+        DBGPRINTF("imptcp: worker-info array allocation failed.\n");
+        return;
+    }
 	pthread_mutex_init(&wrkrMut, NULL);
 	pthread_cond_init(&wrkrIdle, NULL);
 	for(i = 0 ; i < runModConf->wrkrMax ; ++i) {
@@ -1398,6 +1401,7 @@ stopWorkerPool(void)
 	}
 	pthread_cond_destroy(&wrkrIdle);
 	pthread_mutex_destroy(&wrkrMut);
+    free(wrkrInfo);
 }
 
 

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1152,8 +1152,6 @@ addSess(ptcplstn_t *pLstn, int sock, prop_t *peerName, prop_t *peerIP)
 	pSess->peerIP = peerIP;
 	pSess->compressionMode = pLstn->pSrv->compressionMode;
 
-	CHKiRet(addEPollSock(epolld_sess, pSess, sock, &pSess->epd));
-
 	/* add to start of server's listener list */
 	pSess->prev = NULL;
 	pthread_mutex_lock(&pSrv->mutSessLst);
@@ -1162,6 +1160,8 @@ addSess(ptcplstn_t *pLstn, int sock, prop_t *peerName, prop_t *peerIP)
 		pSrv->pSess->prev = pSess;
 	pSrv->pSess = pSess;
 	pthread_mutex_unlock(&pSrv->mutSessLst);
+
+	CHKiRet(addEPollSock(epolld_sess, pSess, sock, &pSess->epd));
 
 finalize_it:
 	if(iRet != RS_RET_OK) {

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -997,7 +997,7 @@ addEPollSock(epolld_type_t typ, void *ptr, int sock, epolld_t **pEpd)
 	DEFiRet;
 	epolld_t *epd = NULL;
 
-	CHKmalloc(epd = calloc(sizeof(epolld_t), 1));
+	CHKmalloc(epd = calloc(1, sizeof(epolld_t)));
 	epd->typ = typ;
 	epd->ptr = ptr;
 	*pEpd = epd;
@@ -1414,7 +1414,9 @@ stopWorkerPool(void)
 	int i;
 	DBGPRINTF("imptcp: stoping worker pool\n");
 	for(i = 0 ; i < runModConf->wrkrMax ; ++i) {
+		pthread_mutex_lock(&wrkrMut);
 		pthread_cond_signal(&wrkrInfo[i].run); /* awake wrkr if not running */
+		pthread_mutex_unlock(&wrkrMut);
 		pthread_join(wrkrInfo[i].tid, NULL);
 		DBGPRINTF("imptcp: info: worker %d was called %llu times\n", i, wrkrInfo[i].numCalled);
 		pthread_cond_destroy(&wrkrInfo[i].run);

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -442,6 +442,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_CONF_PARAM_INVLD = -2425,/**< config parameter is invalid */
 	RS_RET_KSI_ERR = -2426,/**< error in KSI subsystem */
 	RS_RET_ERR_LIBLOGNORM = -2427,/**< cannot obtain liblognorm ctx */
+	RS_RET_CONC_CTRL_ERR = -2428,/**< error in lock/unlock/condition/concurrent-modification operation */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */
@@ -465,6 +466,8 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 #else
 #	define CHKiRet(code) if((iRet = code) != RS_RET_OK) goto finalize_it
 #endif
+
+# define CHKiConcCtrl(code) if (code != 0) { iRet = RS_RET_CONC_CTRL_ERR; goto finalize_it; }
 
 /* macro below is to be used if we need our own handling, eg for cleanup */
 #define CHKiRet_Hdlr(code) if((iRet = code) != RS_RET_OK)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -183,6 +183,7 @@ TESTS +=  \
 	imptcp_conndrop.sh \
 	imptcp_no_octet_counted.sh \
 	imptcp_spframingfix.sh \
+	imptcp_nonProcessingPoller.sh \
 	rscript_random.sh \
 	rscript_replace.sh
 if HAVE_VALGRIND

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -184,6 +184,7 @@ TESTS +=  \
 	imptcp_no_octet_counted.sh \
 	imptcp_spframingfix.sh \
 	imptcp_nonProcessingPoller.sh \
+	imptcp_veryLargeOctateCountedMessages.sh \
 	rscript_random.sh \
 	rscript_replace.sh
 if HAVE_VALGRIND
@@ -869,6 +870,9 @@ EXTRA_DIST= \
 	testsuites/lookup_table.conf \
 	testsuites/xlate.lkp_tbl \
 	testsuites/xlate_more.lkp_tbl \
+	imptcp_nonProcessingPoller.sh \
+	imptcp_veryLargeOctateCountedMessages.sh \
+	testsuites/imptcp_nonProcessingPoller.conf \
 	cfg.sh
 
 # TODO: re-enable

--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -127,7 +127,7 @@ int main(int argc, char *argv[])
 				if (bAnticipateTruncation == 1) {
 					if (edLen < strlen(edBuf)) {
 						printf("extra data length specified %d, but actually is %ld in record %d"
-							   " (truncation was anticipated, but payload should have been smaller than data-length, not smaller)\n",
+							   " (truncation was anticipated, but payload should have been smaller than data-length, not larger)\n",
 							   edLen, (long) strlen(edBuf), i);
 						exit(1);
 					}
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
 						if (bAnticipateTruncation == 1) {
 							if (edLen < strlen(edBuf)) {
 								printf("extra data length specified %d, but actually is %ld in record %d"
-									   " (truncation was anticipated, but payload should have been smaller than data-length, not smaller)\n",
+									   " (truncation was anticipated, but payload should have been smaller than data-length, not larger)\n",
 									   edLen, (long) strlen(edBuf), i);
 								exit(1);
 							}

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -103,6 +103,15 @@ case $1 in
 		$valgrind ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &
 		. $srcdir/diag.sh wait-startup $3
 		;;
+   'startup-silent')   # start rsyslogd with default params. $2 is the config file name to use
+   		# returns only after successful startup, $3 is the instance (blank or 2!)
+		if [ ! -f $srcdir/testsuites/$2 ]; then
+		    echo "ERROR: config file '$srcdir/testsuites/$2' not found!"
+		    exit 1
+		fi
+		$valgrind ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 2>/dev/null &
+		. $srcdir/diag.sh wait-startup $3
+		;;
    'startup-vg') # start rsyslogd with default params under valgrind control. $2 is the config file name to use
    		# returns only after successful startup, $3 is the instance (blank or 2!)
 		valgrind --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &

--- a/tests/imptcp_nonProcessingPoller.sh
+++ b/tests/imptcp_nonProcessingPoller.sh
@@ -1,0 +1,13 @@
+# Test imptcp with poller not processing any messages
+# added 2015-10-16 by singh.janmejay
+# This file is part of the rsyslog project, released  under GPLv3
+echo ====================================================================================
+echo TEST: \[imptcp_nonProcessingPoller.sh\]: test imptcp with with poller driven processing disabled
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup imptcp_nonProcessingPoller.conf
+. $srcdir/diag.sh tcpflood -c5 -m20000 -r -d10000 -P129
+sleep 2 # due to large messages, we need this time for the tcp receiver to settle...
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh seq-check 0 19999 -E
+. $srcdir/diag.sh exit

--- a/tests/imptcp_nonProcessingPoller.sh
+++ b/tests/imptcp_nonProcessingPoller.sh
@@ -2,7 +2,7 @@
 # added 2015-10-16 by singh.janmejay
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
-echo TEST: \[imptcp_nonProcessingPoller.sh\]: test imptcp with with poller driven processing disabled
+echo TEST: \[imptcp_nonProcessingPoller.sh\]: test imptcp with poller driven processing disabled
 . $srcdir/diag.sh init
 . $srcdir/diag.sh startup imptcp_nonProcessingPoller.conf
 . $srcdir/diag.sh tcpflood -c1 -m20000 -r -d10000 -P129 -O

--- a/tests/imptcp_veryLargeOctateCountedMessages.sh
+++ b/tests/imptcp_veryLargeOctateCountedMessages.sh
@@ -2,9 +2,9 @@
 # added 2015-10-17 by singh.janmejay
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
-echo TEST: \[imptcp_nonProcessingPoller.sh\]: test imptcp with with poller driven processing disabled
+echo TEST: \[imptcp_veryLargeOctateCountedMessages.sh\]: test imptcp with very large messages while poller driven processing is disabled
 . $srcdir/diag.sh init
-. $srcdir/diag.sh startup imptcp_nonProcessingPoller.conf
+. $srcdir/diag.sh startup-silent imptcp_nonProcessingPoller.conf
 . $srcdir/diag.sh tcpflood -c1 -m20000 -r -d100000 -P129 -O
 sleep 2 # due to large messages, we need this time for the tcp receiver to settle...
 . $srcdir/diag.sh shutdown-when-empty

--- a/tests/imptcp_veryLargeOctateCountedMessages.sh
+++ b/tests/imptcp_veryLargeOctateCountedMessages.sh
@@ -1,13 +1,13 @@
 # Test imptcp with poller not processing any messages
-# added 2015-10-16 by singh.janmejay
+# added 2015-10-17 by singh.janmejay
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
 echo TEST: \[imptcp_nonProcessingPoller.sh\]: test imptcp with with poller driven processing disabled
 . $srcdir/diag.sh init
 . $srcdir/diag.sh startup imptcp_nonProcessingPoller.conf
-. $srcdir/diag.sh tcpflood -c1 -m20000 -r -d10000 -P129 -O
+. $srcdir/diag.sh tcpflood -c1 -m20000 -r -d100000 -P129 -O
 sleep 2 # due to large messages, we need this time for the tcp receiver to settle...
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
-. $srcdir/diag.sh seq-check 0 19999 -E
+. $srcdir/diag.sh seq-check 0 19999 -E -T
 . $srcdir/diag.sh exit

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -471,11 +471,15 @@ int sendMessages(struct instdata *inst)
 	int offsSendBuf = 0;
 	char errStr[1024];
 	int error_number = 0;
+	int show_progress_interval = 100;
 
 	if(!bSilent) {
 		if(dataFile == NULL) {
 			printf("Sending %llu messages.\n", inst->numMsgs);
 			statusText = "messages";
+			if ((inst->numMsgs / 100) > show_progress_interval) {
+				show_progress_interval = inst->numMsgs / 100;
+			}
 		} else {
 			printf("Sending file '%s' %d times.\n", dataFile,
 			       numFileIterations);
@@ -534,7 +538,7 @@ int sendMessages(struct instdata *inst)
 			fflush(stderr);
 			return(1);
 		}
-		if(i % 100 == 0) {
+		if(i % show_progress_interval == 0) {
 			if(bShowProgress)
 				printf("\r%8.8d", i);
 		}

--- a/tests/testsuites/imptcp_nonProcessingPoller.conf
+++ b/tests/testsuites/imptcp_nonProcessingPoller.conf
@@ -1,0 +1,12 @@
+# test with poller-thread-processing disabled
+# singh.janmejay, 2015-10-16
+$MaxMessageSize 10k
+$IncludeConfig diag-common.conf
+template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
+
+module(load="../plugins/imptcp/.libs/imptcp" threads="32" processOnPoller="off")
+input(type="imptcp" port="13514")
+
+if (prifilt("local0.*")) then {
+   action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}


### PR DESCRIPTION
- io-work assignment model made #workers independent (earlier it was O(workers)), better work-starvation management
- fully concurrent poller and io-workers (no waiting for io-workers to be done before next poll)
- better message-content handing when reading inbound messages for octate-counted messages
- removed upper-limit on #workers
- enhanced tcpflood to allow producing octate-counted frames, some improvement in error-reporting
- some aesthetic changes
- created a new config-param (processOnPoller, which defaults to "on" in favor of backward comparability) and when turned off, doesn't dispatch any io-work on poller (leaving it completely free to just poll, which makes a lot of difference in maintaining high-throughput with low-latency). Will send a separate PR for documentation-update.

Note: the race-condition fixed in the last patch is not really an old-bug (it couldn't have affected us unless poller was truly running concurrenly to allow a race with io-workers, which was not the case earlier, so it wasn't an old bug really, it was old code which would become buggy if used in a concurrent poller and io-worker setup).

Will add data from benchmarks in comments.