### PR TITLE
testsuite: imtcp-tls-basic-vg.sh failed on Debian 7 due a bug in valg…

### DIFF
--- a/tests/imtcp-tls-basic-vg.sh
+++ b/tests/imtcp-tls-basic-vg.sh
@@ -7,7 +7,7 @@ echo \[imtcp-tls-basic-vg.sh\]: testing imtcp in TLS mode - basic test
 echo \$DefaultNetstreamDriverCAFile $srcdir/tls-certs/ca.pem     >rsyslog.conf.tlscert
 echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>rsyslog.conf.tlscert
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>rsyslog.conf.tlscert
-. $srcdir/diag.sh startup-vg imtcp-tls-basic.conf
+. $srcdir/diag.sh startup-vg-noleak imtcp-tls-basic.conf
 . $srcdir/diag.sh tcpflood -p13514 -m50000 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown-vg


### PR DESCRIPTION
…rind

The installed version of valgrind seems to have a bug which causes
memory leaks to be detected inside gnutls library.
After research I decided to disable memoryleak checking for
this specific test.

This should also close https://github.com/rsyslog/rsyslog/issues/439
