### PR TITLE
Added pmpanngfw

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -103,6 +103,10 @@ if ENABLE_PMSNARE
 SUBDIRS += contrib/pmsnare
 endif
 
+if ENABLE_PMPANNGFW
+SUBDIRS += contrib/pmpanngfw
+endif
+
 if ENABLE_PMLASTMSG
 SUBDIRS += plugins/pmlastmsg
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -1378,6 +1378,19 @@ AC_ARG_ENABLE(pmsnare,
 AM_CONDITIONAL(ENABLE_PMSNARE, test x$enable_pmsnare = xyes)
 
 
+# settings for pmpanngfw
+AC_ARG_ENABLE(pmpanngfw,
+        [AS_HELP_STRING([--enable-pmpanngfw],[Compiles snare parser module @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_pmpanngfw="yes" ;;
+          no) enable_pmpanngfw="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-pmpanngfw) ;;
+         esac],
+        [enable_pmpanngfw=no]
+)
+AM_CONDITIONAL(ENABLE_PMPANNGFW, test x$enable_pmpanngfw = xyes)
+
+
 # settings for omruleset
 AC_ARG_ENABLE(omruleset,
         [AS_HELP_STRING([--enable-omruleset],[Compiles ruleset forwarding module @<:@default=no@:>@])],
@@ -1708,6 +1721,7 @@ AC_CONFIG_FILES([Makefile \
 		plugins/mmsnmptrapd/Makefile \
 		plugins/pmlastmsg/Makefile \
 		contrib/pmsnare/Makefile \
+    contrib/pmpanngfw/Makefile \
 		contrib/pmaixforwardedfrom/Makefile \
 		contrib/omhiredis/Makefile \
 		contrib/omrabbitmq/Makefile \
@@ -1777,6 +1791,7 @@ echo "    pmcisconames module will be compiled:     $enable_pmcisconames"
 echo "    pmciscoios module will be compiled:       $enable_pmciscoios"
 echo "    pmaixforwardedfrom module w.be compiled:  $enable_pmaixforwardedfrom"
 echo "    pmsnare module will be compiled:          $enable_pmsnare"
+echo "    pmpanngfw module will be compiled:        $enable_pmpanngfw"
 echo
 echo "---{ message modification modules }---"
 echo "    mmnormalize module will be compiled:      $enable_mmnormalize"

--- a/configure.ac
+++ b/configure.ac
@@ -1380,7 +1380,7 @@ AM_CONDITIONAL(ENABLE_PMSNARE, test x$enable_pmsnare = xyes)
 
 # settings for pmpanngfw
 AC_ARG_ENABLE(pmpanngfw,
-        [AS_HELP_STRING([--enable-pmpanngfw],[Compiles snare parser module @<:@default=no@:>@])],
+        [AS_HELP_STRING([--enable-pmpanngfw],[Compiles Palo Alto Networks parser module @<:@default=no@:>@])],
         [case "${enableval}" in
          yes) enable_pmpanngfw="yes" ;;
           no) enable_pmpanngfw="no" ;;

--- a/contrib/pmpanngfw/Makefile.am
+++ b/contrib/pmpanngfw/Makefile.am
@@ -1,0 +1,8 @@
+pkglib_LTLIBRARIES = pmpanngfw.la
+
+pmpanngfw_la_SOURCES = pmpanngfw.c
+pmpanngfw_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) -I ../../tools
+pmpanngfw_la_LDFLAGS = -module -avoid-version
+pmpanngfw_la_LIBADD = 
+
+EXTRA_DIST = 

--- a/contrib/pmpanngfw/README.md
+++ b/contrib/pmpanngfw/README.md
@@ -1,0 +1,87 @@
+# pmpanngfw
+
+Module to detect and transform PAN-OS NGFW logs into a format compatible with mmnormalize
+
+## How it works
+
+Original log:
+
+    Apr 10 02:48:29 1,2012/04/10 02:48:29,001606001116,THREAT,url,1,2012/04/10 02:48:28,##IP##,##IP##,##IP##,##IP##,rule1,counselor,,facebook-    base,vsys1,trust,untrust,ethernet1/2,ethernet1/1,forwardAll,2012/04/10 02:48:28,27555,1,8450,80,0,0,0x208000,tcp,alert,"www.facebook.    com/ajax/pagelet/generic.php/ProfileTimelineSectionPagelet?__a=1&ajaxpipe=1&ajaxpipe_token=AXgw4BUd5yCuD2rQ&data={""profile_id"":603261604,""start"":1333263600,""end"":1335855599,""query_type"":5,""page_index"":1,""section_container_id"":""ucp7d6_26"",""section_pagelet_id"":""pagelet_timeline_recent"",""unit_container_id"":""ucp7d6_25"",""current_scrubber_key"":""recent"",""time_cutoff"":null,""buffer"":1300,""require_click"":false,""num_visible_units"":5,""remove_dupes"":true}&__user=857280013&__adt=3&__att=iframe",(9999),social-networking,informational,client-to-server,0,0x0,192.168.0.0-192.168.255.255,United States,0,text/html
+
+Transformed:
+
+    Apr 10 02:48:29 1<tab>2012/04/10 02:48:29<tab>001606001116<tab>THREAT<tab>url<tab>1<tab>2012/04/10 02:48:28<tab>##IP##<tab>##IP##<tab>##IP##<tab>##IP##<tab>rule1<tab>counselor<tab><tab>facebook-base<tab>vsys1<tab>trust<tab>untrust<tab>ethernet1/2<tab>ethernet1/1<tab>forwardAll  2012/04/10 02:48:28 27555<tab>1<tab>8450<tab>80<tab>0<tab>0x208000<tab>tcp alert<tab>www.facebook.com/ajax/pagelet/generic.php/ProfileTimelineSectionPagelet?__a=1&ajaxpipe=1&ajaxpipe_token=AXgw4BUd5yCuD2rQ&data={"profile_id":603261604,"start":1333263600,"end":1335855599,"query_type":5,"page_index":1,"section_container_id":"ucp7d6_26","section_pagelet_id":"pagelet_timeline_recent","unit_container_id":"ucp7d6_25","current_scrubber_key":"recent","time_cutoff":null,"buffer":1300,"require_click":false,"num_visible_units":5,"remove_dupes":true}&__user=857280013&__adt=3&__att=iframe<tab>(9999)<tab>social-networking<tab>informational<tab>client-to-server<tab>0<tab>0x0<tab>192.168.0.0-192.168.255.255<tab>United States<tab>0<tab>text/html
+
+## How to compile
+
+    $ autoreconf -fvi
+    $ ./configure --enable-pmpanngfw
+    $ cd contrib/pmpanngfw/
+    $ make
+
+The resulting plugin should be found in contrib/pmpanngfw/.libs/
+
+## Example config
+
+    module(load="imtcp")
+    module(load="pmpanngfw")
+    module(load="mmnormalize")
+    module(load="omrabbitmq")
+    
+    template(name="csv" type="list") {
+        property(name="$!src_ip" format="csv")
+        constant(value=",")
+        property(name="$!dest_ip" format="csv")
+        constant(value=",")
+        property(name="$!url")
+        constant(value="\n")
+    }
+    
+    $template alljson,"%$!all-json%\n"
+    
+    template(name="mmeld_json" type="list") {
+        constant(value="{")
+        property(outname="@timestamp" name="timestamp" format="jsonf" dateFormat="rfc3339")
+        constant(value=",")
+        property(outname="@source_host" name="source" format="jsonf")
+        constant(value=",")
+        property(outname="@message" name="msg" format="jsonf")
+        constant(value=",")
+        property(outname="@timegenerated" name="timegenerated" format="jsonf" dateFormat="rfc3339")
+        constant(value=",")
+        property(outname="@timereported" name="timereported" format="jsonf" dateFormat="rfc3339")
+        constant(value=",")
+        property(outname="src_ip" name="$!src_ip" format="jsonf")
+        constant(value=",")
+        property(outname="dest_ip" name="$!dest_ip" format="jsonf")
+        constant(value=",")
+        property(outname="url" name="$!url" format="jsonf")
+        constant(value=",")
+        property(outname="tags" name="$!event.tags" format="jsonf")
+        constant(value="}")
+        constant(value="\n")
+    }
+
+    ruleset(name="pan-ngfw" parser=["rsyslog.panngfw", "rsyslog.rfc5424", "rsyslog.rfc3164"]) {
+        action(type="mmnormalize" rulebase="palo_alto_networks.rb" userawmsg="on")
+        if strlen($!unparsed-data) == 0 then {
+            if $!log_subtype == "url" then set $!url = $!misc;
+            *.* action(type="omrabbitmq" 
+                 host="localhost"
+                 virtual_host="/"
+                 user="guest"
+                 password="guest"
+                 exchange="mmeld-syslog"
+                 routing_key=""
+                 exchange_type="fanout"
+                 template="alljson")
+        }
+        *.* stop
+    }
+    
+    input(type="imtcp" port="13514" ruleset="pan-ngfw")
+
+## mmnormalize rulebase
+
+See https://gist.github.com/jtschichold/87f59b99d98c8eac1da5
+

--- a/contrib/pmpanngfw/pmpanngfw.c
+++ b/contrib/pmpanngfw/pmpanngfw.c
@@ -1,0 +1,297 @@
+/* pmpanngfw.c
+ *
+ * this detects logs sent by Palo Alto Networks NGFW and transforms CSV into tab-separated fields
+ * for handling inside the mmnormalize
+ *
+ * Example: foo,"bar,""baz""",qux becomes foo<TAB>bar,"baz"<TAB>qux
+ *
+ * created 2010-12-13 by Luigi Mori (lmori@paloaltonetworks.com) based on pmsnare
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include "rsyslog.h"
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <ctype.h>
+#include "conf.h"
+#include "syslogd-types.h"
+#include "template.h"
+#include "msg.h"
+#include "module-template.h"
+#include "glbl.h"
+#include "errmsg.h"
+#include "parser.h"
+#include "datetime.h"
+#include "unicode-helper.h"
+#include "typedefs.h"
+
+MODULE_TYPE_PARSER
+MODULE_TYPE_NOKEEP
+PARSER_NAME("rsyslog.panngfw")
+
+/* internal structures
+ */
+DEF_PMOD_STATIC_DATA
+DEFobjCurrIf(errmsg)
+DEFobjCurrIf(glbl)
+DEFobjCurrIf(parser)
+DEFobjCurrIf(datetime)
+
+
+/* static data */
+static int bParseHOSTNAMEandTAG;    /* cache for the equally-named global param - performance enhancement */
+
+typedef struct {
+    uint64 value;
+    uint64 mask;
+} log_type_t;
+
+const log_type_t log_types[] = {
+    { 0x002c544145524854ULL, 0x00FFFFFFFFFFFFFFULL }, /* THREAT, */
+    { 0x2c43494646415254ULL, 0xFFFFFFFFFFFFFFFFULL }, /* TRAFFIC, */
+    { 0x002c4d4554535953ULL, 0x00FFFFFFFFFFFFFFULL }, /* CONFIG */
+    { 0x002c4749464e4f43ULL, 0x00FFFFFFFFFFFFFFULL } /* SYSTEM */
+};
+
+#define NUM_LOG_TYPES (sizeof(log_types)/sizeof(log_type_t))
+
+
+BEGINisCompatibleWithFeature
+CODESTARTisCompatibleWithFeature
+    if(eFeat == sFEATUREAutomaticSanitazion)
+        iRet = RS_RET_OK;
+    if(eFeat == sFEATUREAutomaticPRIParsing)
+        iRet = RS_RET_OK;
+ENDisCompatibleWithFeature
+
+
+
+BEGINparse
+    uchar *p2parse;
+    uchar *p2target;
+    uchar *msgend;
+    int lenMsg, lenDelta;
+    int state;
+    int num_fields = 4;
+    uchar *f3_commas[3];
+    int cur_comma = 0;
+    uint64 log_type;
+    int j;
+CODESTARTparse
+    #define CSV_DELIMITER '\t'
+    #define STATE_FIELD_START 0
+    #define STATE_IN_FIELD 1
+    #define STATE_IN_QUOTE 2
+    #define STATE_IN_QUOTE_QUOTE 3
+
+    state = STATE_FIELD_START;
+
+    dbgprintf("Message will now be parsed by fix Palo Alto Networks NGFW parser.\n");
+    assert(pMsg != NULL);
+    assert(pMsg->pszRawMsg != NULL);
+
+    lenMsg = pMsg->iLenRawMsg - pMsg->offAfterPRI; /* note: offAfterPRI is already the number of PRI chars (do not add one!) */
+    p2parse = pMsg->pszRawMsg + pMsg->offAfterPRI; /* point to start of text, after PRI */
+    msgend = p2parse+lenMsg;
+
+    dbgprintf("pmpanngfw: msg to look at: [%d]'%s'\n", lenMsg, p2parse);
+
+    /* pass the first 3 fields */
+    while(p2parse < msgend) {
+        if (*p2parse == ',') {
+            f3_commas[cur_comma] = p2parse;
+            if (cur_comma == 2) {
+                break;
+            }
+            cur_comma++;
+        }
+        p2parse++;
+    }
+
+    /* check number of fields detected so far */
+    if (cur_comma != 2) {
+        dbgprintf("not a PAN-OS syslog message: first 3 fields not found\n");
+        ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+    }
+
+    /* check msg length */
+    p2parse++;
+    if ((p2parse > msgend) || ((msgend - p2parse) < sizeof(uint64))) {
+        dbgprintf("not a PAN-OS syslog message: too short\n");
+        ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+    }
+
+    /* check log type */
+    log_type = *((uint64 *)p2parse);
+    for(j = 0; j < NUM_LOG_TYPES; j++) {
+        if ((log_type & log_types[j].mask) == log_types[j].value)
+            break;
+    }
+    if (j == NUM_LOG_TYPES) {
+        dbgprintf("not a PAN-OS syslog message, log type: %llx\n", log_type);
+        ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);        
+    }
+
+    /* set the delimiter */
+    *f3_commas[0] = CSV_DELIMITER;
+    *f3_commas[1] = CSV_DELIMITER;
+    *f3_commas[2] = CSV_DELIMITER;
+
+    p2target = p2parse;
+
+    while(p2parse < msgend) {
+        /* dbgprintf("state: %d char: %c p2parse: %16x p2target: %16x\n", state, *p2parse, p2parse, p2target); */
+        switch(state) {
+            case STATE_FIELD_START:
+                switch(*p2parse) {
+                    case '"':
+                        state = STATE_IN_QUOTE;
+                        p2parse++;
+                        break;
+
+                    case ',':
+                        state = STATE_FIELD_START;
+                        *p2target = CSV_DELIMITER;
+                        num_fields++;
+                        p2parse++;
+                        p2target++;
+                        break;
+
+                    default:
+                        state = STATE_IN_FIELD;
+                        *p2target = *p2parse;
+                        p2parse++;
+                        p2target++;
+                }
+                break;
+
+            case STATE_IN_FIELD:
+                switch(*p2parse) {
+                    case ',':
+                        state = STATE_FIELD_START;
+                        *p2target = CSV_DELIMITER;
+                        num_fields++;
+                        p2parse++;
+                        p2target++;
+                        break;
+
+                    default:
+                        *p2target = *p2parse;
+                        p2parse++;
+                        p2target++;
+                }
+                break;
+
+            case STATE_IN_QUOTE:
+                switch(*p2parse) {
+                    case '"':
+                        state = STATE_IN_QUOTE_QUOTE;
+                        p2parse++;
+                        break;
+
+                    default:
+                        *p2target = *p2parse;
+                        p2parse++;
+                        p2target++;
+                }
+                break;
+
+            case STATE_IN_QUOTE_QUOTE:
+                switch(*p2parse) {
+                    case '"':
+                        state = STATE_IN_QUOTE;
+                        *p2target = *p2parse;
+                        p2parse++;
+                        p2target++;
+                        break;
+
+                    case ',':
+                        state = STATE_FIELD_START;
+                        *p2target = CSV_DELIMITER;
+                        num_fields++;
+                        p2parse++;
+                        p2target++;
+                        break;
+
+                    default:
+                        dbgprintf("pmpanngfw: martian char (%d) after quote in quote\n", *p2parse);
+                        ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+                }
+                break;
+
+            default:
+                dbgprintf("how could I have reached this state ?!?\n");
+                ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+        }
+    }
+
+    if(p2parse != p2target) {
+        lenDelta = p2parse - p2target;
+
+        assert(lenDelta >= 2);
+
+        *p2target = 0;
+
+        pMsg->iLenRawMsg -= lenDelta;
+        pMsg->iLenMSG -= lenDelta;
+    }
+
+    lenMsg = p2target - (pMsg->pszRawMsg + pMsg->offAfterPRI);
+
+    DBGPRINTF("pmpanngfw: new message: [%d]'%s'\n", lenMsg, pMsg->pszRawMsg + pMsg->offAfterPRI);
+    DBGPRINTF("pmpanngfw: # fields: %d\n", num_fields);
+
+    ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+
+finalize_it:
+ENDparse
+
+
+BEGINmodExit
+CODESTARTmodExit
+    /* release what we no longer need */
+    objRelease(errmsg, CORE_COMPONENT);
+    objRelease(glbl, CORE_COMPONENT);
+    objRelease(parser, CORE_COMPONENT);
+    objRelease(datetime, CORE_COMPONENT);
+ENDmodExit
+
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_PMOD_QUERIES
+CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES
+ENDqueryEtryPt
+
+
+BEGINmodInit()
+CODESTARTmodInit
+    *ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+CODEmodInit_QueryRegCFSLineHdlr
+    CHKiRet(objUse(glbl, CORE_COMPONENT));
+    CHKiRet(objUse(errmsg, CORE_COMPONENT));
+    CHKiRet(objUse(parser, CORE_COMPONENT));
+    CHKiRet(objUse(datetime, CORE_COMPONENT));
+
+    DBGPRINTF("panngfw parser init called, compiled with version %s\n", VERSION);
+    bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(); /* cache value, is set only during rsyslogd option processing */
+
+
+ENDmodInit
+
+/* vim:set ai:
+ */


### PR DESCRIPTION
Added a module in contrib directory to translate Palo Alto Networks NGFW logs into a format that can be parsed via mmnormalize. The module is based on pmsnare code.

Some details: Palo Alto Networks logs are in CSV format, with comma as separator and double quotes for quoting fields containing a comma. Double quotes inside quoted fields are doubled. Quoted fields are not easily managed via mmnormalize, this module then can be used to translate commas into tabs and quoted fields into plain fields.

Before starting the translation, the module applies a simple heuristic to check if the log is coming from a Palo Alto Networks device.

Sample config in the README.md file.

A script to automatically generate mmnormalize rulebase to extract fields from NGFW logs is available here:
https://gist.github.com/jtschichold/87f59b99d98c8eac1da5

I am obviously fine with ASL 2.0 licensing of this code.