### PR TITLE
add maxoutqsize counter to omkafka

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -52,6 +52,7 @@ DEFobjCurrIf(errmsg)
 DEFobjCurrIf(statsobj)
 
 statsobj_t *kafkaStats;
+int ctrQueueSize;
 STATSCOUNTER_DEF(ctrTopicSubmit, mutCtrTopicSubmit);
 STATSCOUNTER_DEF(ctrKafkaFail, mutCtrKafkaFail);
 STATSCOUNTER_DEF(ctrCacheMiss, mutCtrCacheMiss);
@@ -830,6 +831,7 @@ finalize_it:
 	if(iRet != RS_RET_OK) {
 		iRet = RS_RET_SUSPENDED;
 	}
+	STATSCOUNTER_SETMAX_NOMUT(ctrQueueSize, rd_kafka_outq_len(pData->rk));
 	STATSCOUNTER_INC(ctrTopicSubmit, mutCtrTopicSubmit);
 	RETiRet;
 }
@@ -1055,6 +1057,9 @@ CODEmodInit_QueryRegCFSLineHdlr
 	STATSCOUNTER_INIT(ctrTopicSubmit, mutCtrTopicSubmit);
 	CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"submitted",
 		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrTopicSubmit));
+	ctrQueueSize = 0;
+        CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"maxoutqsize",
+                ctrType_Int, CTR_FLAG_NONE, &ctrQueueSize));
 	STATSCOUNTER_INIT(ctrKafkaFail, mutCtrKafkaFail);
 	CHKiRet(statsobj.AddCounter(kafkaStats, (uchar *)"failures",
 		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrKafkaFail));


### PR DESCRIPTION
librdkafka has its own outqueue. We need a maxoutqsize to help us optimize the confparam `queue.buffering.max.messages`.