### PR TITLE
Address off-by-one issues introduced in f3bd7a2 resulting in extra whitespace in property expansions

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3621,9 +3621,9 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			 */
 			; /*DO NOTHING*/
 		} else {
-			if(iTo > bufLen)  /* iTo is very large, if no to-position is set in the template! */
+			if(iTo >= bufLen)  /* iTo is very large, if no to-position is set in the template! */
 				if (pTpe->data.field.options.bFixedWidth == 0)
-					iTo = bufLen;
+					iTo = bufLen - 1;
 
 			iLen = iTo - iFrom + 1; /* the +1 is for an actual char, NOT \0! */
 			pBufStart = pBuf = MALLOC((iLen + 1) * sizeof(uchar));


### PR DESCRIPTION
Fix issue #576: at the time `iTo` is being set based on `bufLen`, `iFrom` and `iTo` have been readjusted to be zero based instead of one based.  This issue predates f3bd7a2, but that commit then made it insert spaces if `iLen` referenced positions beyond the end of the string, which exposed this older mistake.