### PR TITLE
Possible fix for #575

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -643,6 +643,17 @@ gtlsInitSession(nsd_gtls_t *pThis)
 
 	pThis->sess = session;
 
+#	if HAVE_GNUTLS_CERTIFICATE_SET_RETRIEVE_FUNCTION 
+	/* store a pointer to ourselfs (needed by callback) */
+	gnutls_session_set_ptr(pThis->sess, (void*)pThis);
+	iRet = gtlsLoadOurCertKey(pThis); /* first load .pem files */
+	if(iRet == RS_RET_OK) {
+		gnutls_certificate_set_retrieve_function(xcred, gtlsClientCertCallback);
+	} else if(iRet != RS_RET_CERTLESS) {
+		FINALIZE; /* we have an error case! */
+	}
+#	endif
+
 finalize_it:
 	RETiRet;
 }


### PR DESCRIPTION
The callback given to [gnutls_certificate_set_retrieve_function](https://github.com/csoutherland/rsyslog/blob/6272aa12bcc025cb4ac285dfccae9ecc7418425d/runtime/nsd_gtls.c#651) is expected to set the appropriate server certificate during its execution. When the callback is not specified, it appears that [gnutls loops through the available credentials in order to find an appropriate certificate](https://gitlab.com/gnutls/gnutls/blob/gnutls_2_12_23/lib/auth_cert.c#L2084). Since we appear to be [using the real certificate](https://github.com/csoutherland/rsyslog/blob/6272aa12bcc025cb4ac285dfccae9ecc7418425d/runtime/nsd_gtls.c#1696) for the client side communication as well, it stands to reason that similar code should safely solve this problem. The only caveat is that this depends on my assumption that this is, in fact, the correct key to use.