### PR TITLE
contrib/omczmq and contrib/imczmq improvements

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -703,6 +703,7 @@ CODESTARTfreeCnf
 		lstn_r = lstn;
 		zcert_destroy(&lstn->clientCert);
 		zcert_destroy(&lstn->serverCert);
+        zsock_destroy(&lstn->sock);
 		lstn = lstn_r->next;
 		free(lstn_r);
 	}

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -133,9 +133,10 @@ static struct cnfparamblk actpblk = {
 static rsRetVal initCZMQ(instanceData* pData) {
 	DEFiRet;
 
-	/* Here, we tell CZMQ to not install it's own signal handler,
-	 * as we want to allow rsyslog to handle signals as usual */
-	putenv ("ZSYS_SIGHANDLER=false");
+	/* Turn off CZMQ signal handling */
+	/* ----------------------------- */	
+
+    putenv ("ZSYS_SIGHANDLER=false");
 
 	/* Create the authentication actor */
 	/* ------------------------------ */
@@ -177,8 +178,6 @@ static rsRetVal initCZMQ(instanceData* pData) {
 			ABORT_FINALIZE (RS_RET_SUSPENDED);
 		}
 
-		DBGPRINTF ("omczmq: started beacon actor...\n");
-		
 		zsock_send(pData->beaconActor, "si", "CONFIGURE", pData->beaconport);
 		char *hostname = zstr_recv(pData->beaconActor);
 		
@@ -195,6 +194,9 @@ static rsRetVal initCZMQ(instanceData* pData) {
 
 		zstr_free (&hostname);
 	}
+
+	/* Load certs for auth if auth is used */
+	/* ----------------------------------- */
 
 	if (pData->authType != NULL) {
 

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -47,26 +47,63 @@ DEFobjCurrIf(errmsg)
 static pthread_mutex_t mutDoAct = PTHREAD_MUTEX_INITIALIZER;
 
 typedef struct _instanceData {
-	zactor_t *authActor;
-	zactor_t *beaconActor;
-	zsock_t *sock;
-	zcert_t *clientCert;
-	zcert_t *serverCert;
-	char *sockEndpoints;
-	int sockType;
-	char *authType;
-	char *clientCertPath;
-	char *serverCertPath;
-	uchar *tplName;
-	char *beacon;
-	int beaconport;
-	char *topicList;
+	zactor_t *authActor;	/* reference to a CZMQ auth actor */
+	zactor_t *beaconActor;	/* reference to a CZMQ beacon actor */
+	zsock_t *sock;			/* zeromq socket */
+    bool serverish;			/* whether socket will be a server (bind) or client */
+	zcert_t *clientCert;	/* client curve certificate */
+	zcert_t *serverCert;	/* server curve certificate */
+    zlist_t *topics;        /* publish topics if set */
+
+	char *sockEndpoints;	/* (required) comma delimited list of endpoints */
+	int sockType;			/* (required) the type of our zeromq socket */
+	char *authType;			/* (optional) type of authentication */
+	char *clientCertPath;	/* (optional) path to curve client cert(s) */
+	char *serverCertPath;	/* (optional) path to curve server cert */
+	uchar *tplName;			/* (optional) name of template to use */
+	char *beacon;			/* (optional) content of beacon if beaconing */
+	int beaconport;			/* (optional) port of beacon if beaconing */
+	char *topicList;		/* (optional) topic list */
 } instanceData;
 
 typedef struct wrkrInstanceData {
 	instanceData *pData;
 } wrkrInstanceData_t;
 
+/* -------------------------------------------------------------
+ * Explanation of Options
+ * ---------------------- 
+ * endpoints
+ *		A comma delimited list of endpoints to connect to. Whether the
+ *		endpoint connects or binds is determined by defaults for 
+ *		each socket type.
+ * socktype
+ *		The type of zeromq socket to use; supports PUB, PUSH and DEALER.
+ * beacon
+ *		The beacon is lit! If beacon is set to a value, that value
+ *		will be used to advertise the existence of this endpoint
+ *		over udp multicast beacons.
+ * beaconport
+ *		The port to use for the beacon
+ * authtype
+ *		The authentication type to use - currently only supports
+ *		CURVESERVER and CURVECLIENT.
+ * clientcertpath
+ *		The path to client certificate(s). Must be set if authtype is
+ *		set to CURVE.
+ * servercertpath
+ *		The path to server certificate. Must be set if authtype is
+ *		set to CURVE
+ * template
+ *		The template to use to format outgoing logs. If not set,
+ *		defaults to RSYSLOG_ForwardFormat.
+ * topics
+ *		A comma delimited list of topics to publish messages on.
+ *		If this is set, each message will be sent once per topic
+ *		in the list. Note that ZeroMQ "topics" are simply matches
+ *		against the first bytes in a message, so dynamic topics
+ *		per message can be constructed using templates as well.
+ * ------------------------------------------------------------- */
 static struct cnfparamdescr actpdescr[] = {
 	{ "endpoints", eCmdHdlrGetWord, 1 },
 	{ "socktype", eCmdHdlrGetWord, 1 },
@@ -88,21 +125,28 @@ static struct cnfparamblk actpblk = {
 static rsRetVal initCZMQ(instanceData* pData) {
 	DEFiRet;
 
-	/* tell czmq to not use it's own signal handler */
+	/* Here, we tell CZMQ to not install it's own signal handler,
+	 * as we want to allow rsyslog to handle signals as usual */
 	putenv ("ZSYS_SIGHANDLER=false");
 
-	/* create new auth actor */
-	DBGPRINTF ("omczmq: starting auth actor...\n");
+	/* Create the authentication actor */
+	/* ------------------------------ */
+
 	pData->authActor = zactor_new(zauth, NULL);
+
 	if (!pData->authActor) {
 		errmsg.LogError(0, RS_RET_NO_ERRCODE,
-				"omczmq: could not create auth service");
+				"omczmq: could not create auth actor");
 		ABORT_FINALIZE (RS_RET_NO_ERRCODE);
 	}
 
-	/* create our zeromq socket */
-	DBGPRINTF ("omczmq: creating zeromq socket...\n");
+	DBGPRINTF ("omczmq: auth actor started\n");
+
+	/* Create the zeromq socket */
+	/* ------------------------ */
+
 	pData->sock = zsock_new(pData->sockType);
+
 	if (!pData->sock) {
 		errmsg.LogError(0, RS_RET_NO_ERRCODE,
 				"omczmq: new socket failed for endpoints: %s",
@@ -110,99 +154,112 @@ static rsRetVal initCZMQ(instanceData* pData) {
 		ABORT_FINALIZE(RS_RET_NO_ERRCODE);
 	}
 
-	bool is_server = false;
+	DBGPRINTF ("omczmq: created socket...\n");
 
-	/* if a beacon is set start it */
+	/* Create the beacon actor if configured */
+	/* ------------------------------------- */
+
 	if((pData->beacon != NULL) && (pData->beaconport > 0)) {
-		DBGPRINTF ("omczmq: starting beacon actor...\n");
 
-		/* create the beacon actor, if it fails abort */	
 		pData->beaconActor = zactor_new(zbeacon, NULL);
+
 		if (!pData->beaconActor) {
 			errmsg.LogError(0, RS_RET_NO_ERRCODE,
 					"omczmq: could not create beacon service");
 			ABORT_FINALIZE (RS_RET_NO_ERRCODE);
 		}
 
-		/* configure the beacon and abort if UDP broadcasting ont available */
+		DBGPRINTF ("omczmq: started beacon actor...\n");
+		
 		zsock_send(pData->beaconActor, "si", "CONFIGURE", pData->beaconport);
 		char *hostname = zstr_recv(pData->beaconActor);
+		
 		if (!*hostname) {
 			errmsg.LogError(0, RS_RET_NO_ERRCODE,
 					"omczmq: no UDP broadcasting available");
 			ABORT_FINALIZE (RS_RET_NO_ERRCODE);
 		}
 
-		/* start publishing the beacon */
 		zsock_send(pData->beaconActor, "sbi", "PUBLISH", pData->beacon, strlen(pData->beacon));
+
+		DBGPRINTF ("omczmq: beacon is lit: hostname: '%s', port: '%d'...\n", 
+				hostname, pData->beaconport);
+
+		zstr_free (&hostname);
 	}
 
-	/* if we are a CURVE server */
-	if ((pData->authType != NULL) && (!strcmp(pData->authType, "CURVESERVER"))) {
-		DBGPRINTF("omczmq: we are a curve server...\n");
+	if (pData->authType != NULL) {
+
+		/* CURVESERVER */
+		/* ---------- */
+
+		if (!strcmp(pData->authType, "CURVESERVER")) {
 		
-		is_server = true;
+			zsock_set_zap_domain(pData->sock, "global");
+			zsock_set_curve_server(pData->sock, 1);
 
-		/* set global auth domain */
-		zsock_set_zap_domain(pData->sock, "global");
+			pData->serverCert = zcert_load(pData->serverCertPath);
 
-		/* set that we are a curve server */
-		zsock_set_curve_server(pData->sock, 1);
+			if (!pData->serverCert) {
+				errmsg.LogError(0, NO_ERRCODE, "could not load server cert");
+				ABORT_FINALIZE(RS_RET_ERR);
+			}
 
-		/* get and set our server cert */
-		DBGPRINTF("omczmq: server cert is %s...\n", pData->serverCertPath);
-		pData->serverCert = zcert_load(pData->serverCertPath);
-		if (!pData->serverCert) {
-			errmsg.LogError(0, NO_ERRCODE, "could not load server cert");
-			ABORT_FINALIZE(RS_RET_ERR);
+			zcert_apply(pData->serverCert, pData->sock);
+
+			zstr_sendx(pData->authActor, "CURVE", pData->clientCertPath, NULL);
+			zsock_wait(pData->authActor);
+
+			DBGPRINTF("omczmq: CURVESERVER: serverCertPath: '%s'\n", pData->serverCertPath);
+			DBGPRINTF("omczmq: CURVESERVER: clientCertPath: '%s'\n", pData->clientCertPath);
 		}
 
-		zcert_apply(pData->serverCert, pData->sock);
+		/* CURVECLIENT */
+		/* ----------- */
 
-		/* set allowed clients */
-		DBGPRINTF("omczmq: allowed clients are %s...\n", pData->clientCertPath);
-		zstr_sendx(pData->authActor, "CURVE", pData->clientCertPath, NULL);
-		zsock_wait(pData->authActor);
-	}
+		else if (!strcmp(pData->authType, "CURVECLIENT")) {
 
-	/* if we are a CURVE client */
-	if ((pData->authType != NULL) && (!strcmp(pData->authType, "CURVECLIENT"))) {
-		DBGPRINTF("omczmq: we are a curve client...\n");
+			pData->clientCert = zcert_load(pData->clientCertPath);
+		
+			if (!pData->clientCert) {
+				errmsg.LogError(0, NO_ERRCODE, "could not load client cert");
+				ABORT_FINALIZE(RS_RET_ERR);
+			}
 
-		is_server = false;
+			zcert_apply(pData->clientCert, pData->sock);
 
-		/* get our client cert */
-		pData->clientCert = zcert_load(pData->clientCertPath);
-		if (!pData->clientCert) {
-			errmsg.LogError(0, NO_ERRCODE, "could not load client cert");
-			ABORT_FINALIZE(RS_RET_ERR);
+			pData->serverCert = zcert_load(pData->serverCertPath);
+
+			if (!pData->serverCert) {
+				errmsg.LogError(0, NO_ERRCODE, "could not load server cert");
+				ABORT_FINALIZE(RS_RET_ERR);
+			}
+
+			char *server_key = zcert_public_txt(pData->serverCert);
+			zsock_set_curve_serverkey (pData->sock, server_key);
+
+			DBGPRINTF("omczmq: CURVECLIENT: serverCertPath: '%s'\n", pData->serverCertPath);
+			DBGPRINTF("omczmq: CURVECLIENT: clientCertPath: '%s'\n", pData->clientCertPath);
+			DBGPRINTF("omczmq: CURVECLIENT: server_key: '%s'\n", server_key);
 		}
-
-		/* apply the client cert to the socket */
-		zcert_apply(pData->clientCert, pData->sock);
-
-		/* get the server cert */
-		DBGPRINTF("omczmq: server cert is %s...\n", pData->serverCertPath);
-		pData->serverCert = zcert_load(pData->serverCertPath);
-		if (!pData->serverCert) {
-			errmsg.LogError(0, NO_ERRCODE, "could not load server cert");
-			ABORT_FINALIZE(RS_RET_ERR);
+		else {
+			errmsg.LogError(0, NO_ERRCODE, "unrecognized auth type: '%s'", pData->authType);
+				ABORT_FINALIZE(RS_RET_ERR);
 		}
-
-		/* get the server public key and set it for the socket */
-		char *server_key = zcert_public_txt(pData->serverCert);
-		DBGPRINTF("omczmq: server public key is %s...\n", server_key);
-		zsock_set_curve_serverkey (pData->sock, server_key);
+	}
+	
+	switch (pData->sockType) {
+		case ZMQ_PUB:
+			pData->serverish = true;
+			break;
+		case ZMQ_PUSH:
+		case ZMQ_DEALER:
+		case ZMQ_STREAM:
+			pData->serverish = false;
+			break;
 	}
 
-	/* if we are a PUB server */
-	if (pData->sockType == ZMQ_PUB) {
-		DBGPRINTF("omczmq: we are a pub server...\n");
-		is_server = true;
-	}
-
-	/* we default to CONNECT unless told otherwise */
-	int rc = zsock_attach(pData->sock, (const char*)pData->sockEndpoints, is_server);
+	int rc = zsock_attach(pData->sock, (const char*)pData->sockEndpoints, pData->serverish);
 	if (rc == -1) {
 		errmsg.LogError(0, NO_ERRCODE, "zsock_attach to %s failed",
 				pData->sockEndpoints);
@@ -222,52 +279,27 @@ rsRetVal outputCZMQ(uchar* msg, instanceData* pData) {
 	}
 
 	/* if we have a ZMQ_PUB sock and topics, send with topics */
-	if (pData->sockType == ZMQ_PUB && pData->topicList) {
-		char topic[256], *list = pData->topicList;
-		int rc;
-
-		while (list) {
-			char *delimiter = strchr(list, ',');
-			if (!delimiter) {
-				delimiter = list + strlen (list);
-			}
-
-			if (delimiter - list > 255) {
-				errmsg.LogError(0, NO_ERRCODE,
-						"pData->topicList must be under 256 characters");
-				ABORT_FINALIZE(RS_RET_ERR);
-			}
-
-			memcpy(topic, list, delimiter - list);
-			topic[delimiter - list] = 0;
-
-			/* send the topic */
-			rc = zstr_sendm(pData->sock, topic);
-
-			/* something is very wrong */
+	if (pData->sockType == ZMQ_PUB && pData->topics) {
+		char *topic = zlist_first(pData->topics);
+		while (topic) {
+			int rc = zstr_sendm(pData->sock, topic);
 			if (rc == -1) {
 				errmsg.LogError(0, NO_ERRCODE, "omczmq: send of topic %s failed"
 						": %s", topic, zmq_strerror(errno));
 				ABORT_FINALIZE(RS_RET_ERR);
 			}
 
-			/* send the log line */
 			rc = zstr_send(pData->sock, (char*)msg);
-
-			/* something is very wrong */
 			if (rc == -1) {
 				errmsg.LogError(0, NO_ERRCODE, "omczmq: send of %s failed: %s",
 						msg, zmq_strerror(errno));
 				ABORT_FINALIZE(RS_RET_ERR);
 			}
 
-			if (*delimiter == 0) {
-				break;
-			}
-
-			list = delimiter + 1;
+			topic = zlist_next(pData->topics);
 		}
-	} else {
+	} 
+	else {
 		/* send the log line */
 		int rc = zstr_send(pData->sock, (char*)msg);
 
@@ -286,10 +318,12 @@ static inline void
 setInstParamDefaults(instanceData* pData) {
 	pData->sockEndpoints = NULL;
 	pData->sock = NULL;
+	pData->serverish = false;
 	pData->clientCert = NULL;
 	pData->serverCert = NULL;
 	pData->tplName = NULL;
 	pData->sockType = -1;
+	pData->topics = NULL;
 	pData->authActor = NULL;
 	pData->beaconActor = NULL;
 	pData->authType = NULL;
@@ -324,6 +358,8 @@ ENDdbgPrintInstInfo
 
 BEGINfreeInstance
 CODESTARTfreeInstance
+	if (pData->topics != NULL)
+		zlist_destroy(&pData->topics);
 	zsock_destroy(&pData->sock);
 	zactor_destroy(&pData->authActor);
 	zactor_destroy(&pData->beaconActor);
@@ -375,33 +411,47 @@ CODESTARTnewActInst
 	setInstParamDefaults(pData);
 
 	CODE_STD_STRING_REQUESTnewActInst(1)
+
+	/* handle our configuration arguments
+	* - endpoints - required
+	* - socktype - required
+	* - beacon - optional
+	* - beaconport - required if beacon is set
+	* - authtype - optional and NULL == no auth
+	* - clientcertpath - required if authtype is CURVESERVER or CURVECLIENT
+	* - servercertpath - required if authtype is CURVESERVER or CURVECLIENT
+	* - template - optional defaults to RSYSLOG_ForwardFormat
+	* - topics - optional
+	*/
+
 	for (i = 0; i < actpblk.nParams; ++i) {
 		if (!pvals[i].bUsed) {
 			continue;
 		}
 
-		/* get the socket endpoints to use */
+		/* endpoints */
 		if (!strcmp(actpblk.descr[i].name, "endpoints")) {
 			pData->sockEndpoints = es_str2cstr(pvals[i].val.d.estr, NULL);
 		} 
 
-		/* get the output template to use */
+		/* template */
 		else if (!strcmp(actpblk.descr[i].name, "template")) {
 			pData->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} 
 
-		/* get the socket type */
+		/* socktype */
 		else if (!strcmp(actpblk.descr[i].name, "socktype")){
 			char *stringType = es_str2cstr(pvals[i].val.d.estr, NULL);
 
 			if (!strcmp("PUB", stringType)) {
 				pData->sockType = ZMQ_PUB;
 			}
-
 			else if (!strcmp("PUSH", stringType)) {
 				pData->sockType = ZMQ_PUSH;
 			}
-
+			else if (!strcmp("DEALER", stringType)) {
+				pData->sockType = ZMQ_DEALER;
+			}
 			else {
 				errmsg.LogError(0, RS_RET_CONFIG_ERROR,
 						"omczmq: invalid socktype");
@@ -409,7 +459,7 @@ CODESTARTnewActInst
 			}
 		} 
 
-		/* get the authentication type to use */
+		/* authtype */
 		else if (!strcmp(actpblk.descr[i].name, "authtype")) {
 			pData->authType = es_str2cstr(pvals[i].val.d.estr, NULL);
 
@@ -426,27 +476,27 @@ CODESTARTnewActInst
 			}
 		} 
 
-		/* get client cert argument */
+		/* clientcertpath */
 		else if (!strcmp(actpblk.descr[i].name, "clientcertpath")) {
 			pData->clientCertPath = es_str2cstr(pvals[i].val.d.estr, NULL);
 		}
 
-		/* get server cert argument */
+		/* servercertpath */
 		else if (!strcmp(actpblk.descr[i].name, "servercertpath")) {
 			pData->serverCertPath = es_str2cstr(pvals[i].val.d.estr, NULL);
 		}
 
-		/* get beacon argument */
+		/* beacon */
 		else if (!strcmp(actpblk.descr[i].name, "beacon")) {
 			pData->beacon = es_str2cstr(pvals[i].val.d.estr, NULL);
 		}
 		
-		/* get beacon port */
+		/* beaconport */
 		else if (!strcmp(actpblk.descr[i].name, "beaconport")) {
 			pData->beaconport = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
 		}
 
-		/* get the subscription topics */
+		/* topics */
 		else if(!strcmp(actpblk.descr[i].name, "topics")) {
 			if (pData->sockType != ZMQ_PUB) {
 				errmsg.LogError(0, RS_RET_CONFIG_ERROR,
@@ -454,10 +504,32 @@ CODESTARTnewActInst
 				ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 			}
 
-			pData->topicList = es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->topics = zlist_new();
+
+			char *topics = es_str2cstr(pvals[i].val.d.estr, NULL);
+			char topic[256];
+			while (*topics) {
+				char *delimiter = strchr(topics, ',');
+				if (!delimiter) {
+					delimiter = topics + strlen(topics);
+				}
+				if (delimiter - topics > 255) {
+					errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+						"topics must be under 256 characters");
+					ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+				}
+				memcpy (topic, topics, delimiter - topics);
+				topic[delimiter-topics] = 0;
+				char *current_topic = strdup(topic);
+				zlist_append (pData->topics, current_topic);
+				if (*delimiter == 0) {
+					break;
+				}
+				topics = delimiter + 1;
+			}
 		}
 
-		/* the config has a bad option */
+		/* abort on unrecognized option */
 		else {
 			errmsg.LogError(0, NO_ERRCODE, "omczmq: %s is not a valid option",
 					actpblk.descr[i].name);

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -287,7 +287,6 @@ rsRetVal outputCZMQ(uchar* msg, instanceData* pData) {
 	/* if we have a ZMQ_PUB sock and topics, send once per topic */
 	if (pData->sockType == ZMQ_PUB && pData->topics) {
 		char *topic = zlist_first(pData->topics);
-		zframe_t *msgFrame = zframe_from((char *)msg);
 
 		while (topic) {
 			int rc = zstr_sendm(pData->sock, topic);
@@ -296,16 +295,14 @@ rsRetVal outputCZMQ(uchar* msg, instanceData* pData) {
 				ABORT_FINALIZE(RS_RET_SUSPENDED);
 			}
 
-			rc = zframe_send (&msgFrame, pData->sock, ZFRAME_REUSE);
+			rc = zstr_send(pData->sock, (char*)msg);
 			if (rc != 0) {
 				pData->sendError = true;
-				zframe_destroy(&msgFrame);
 				ABORT_FINALIZE(RS_RET_SUSPENDED);
 			}
 
 			topic = zlist_next(pData->topics);
 		}
-		zframe_destroy(&msgFrame);
 	} 
 	/* otherwise do a normal send */
 	else {

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -264,7 +264,6 @@ static rsRetVal initCZMQ(instanceData* pData) {
 			break;
 		case ZMQ_PUSH:
 		case ZMQ_DEALER:
-		case ZMQ_STREAM:
 			pData->serverish = false;
 			break;
 	}
@@ -475,9 +474,6 @@ CODESTARTnewActInst
 			}
 			else if (!strcmp("DEALER", stringType)) {
 				pData->sockType = ZMQ_DEALER;
-			}
-			else if (!strcmp("STREAM", stringType)) {
-				pData->sockType = ZMQ_STREAM;
 			}
 			else {
 				errmsg.LogError(0, RS_RET_CONFIG_ERROR,


### PR DESCRIPTION
* omczmq - suspend / Retry handling - the output plugin can now recover from some error states due to issues with plugin startup or message sending
* omczmq - refactored topic handling code for ZMQ_PUB output to be a little more efficient
* omczmq - added ability to set a timeout for sends
* omczmq - set topics can be in separate frame (default) or part of message frame (configurable)
* omcmzq - code cleanup
* imczmq - code cleanup
* imczmq - fixed a couple of cases where vars could be used uninitialized
* imczmq - ZMQ_ROUTER support
* imczmq - Fix small memory leak from not freeing sockets  when done with them