### PR TITLE
imjournal: fix off-by-one error in name cmprs

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -234,7 +234,6 @@ readjournal() {
 
 	const void *get;
 	const void *pidget;
-	char *parse;
 	size_t length;
 	size_t pidlength;
 
@@ -335,64 +334,7 @@ readjournal() {
 		/* get length of journal data prefix */
 		prefixlen = ((char *)equal_sign - (char *)get);
 
-		/* translate name fields to lumberjack names */
-		parse = (char *)get;
-
-		switch (*parse)
-		{
-		case '_':
-			++parse;
-			if (*parse == 'P') {
-				if (!strncmp(parse+1, "ID=", 4)) {
-					name = strdup("pid");
-				} else {
-					name = strndup(get, prefixlen);
-				}
-			} else if (*parse == 'G') {
-				if (!strncmp(parse+1, "ID=", 4)) {
-					name = strdup("gid");
-				} else {
-					name = strndup(get, prefixlen);
-				}
-			} else if (*parse == 'U') {
-				if (!strncmp(parse+1, "ID=", 4)) {
-					name = strdup("uid");
-				} else {
-					name = strndup(get, prefixlen);
-				}
-			} else if (*parse == 'E') {
-				if (!strncmp(parse+1, "XE=", 4)) {
-					name = strdup("exe");
-				} else {
-					name = strndup(get, prefixlen);
-				}
-			} else if (*parse == 'C') {
-				parse++;
-				if (*parse == 'O') {
-					if (!strncmp(parse+1, "MM=", 4)) {
-						name = strdup("appname");
-					} else {
-						name = strndup(get, prefixlen);
-					}
-				} else if (*parse == 'M') {
-					if (!strncmp(parse+1, "DLINE=", 7)) {
-						name = strdup("cmd");
-					} else {
-						name = strndup(get, prefixlen);
-					}
-				} else {
-					name = strndup(get, prefixlen);
-				}
-			} else {
-				name = strndup(get, prefixlen);
-			}
-			break;
-
-		default:
-			name = strndup(get, prefixlen);
-			break;
-		}
-
+		name = strndup(get, prefixlen);
 		CHKmalloc(name);
 
 		prefixlen++; /* remove '=' */


### PR DESCRIPTION
Looks like a long standing off-by-one comparison issue with the
invocation of strncmp.  The constant string is only 3 or 6 characters
long, but the comparison length is 4 or 7.