### PR TITLE
omczmq/imcmzq: allow ephemeral client certs

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -353,8 +353,12 @@ static rsRetVal addListener(instanceConf_t* iconf){
 		/* ----------- */
 
 		else if (!strcmp(iconf->authType, "CURVECLIENT")) {
-
-			pData->clientCert = zcert_load(iconf->clientCertPath);
+			if (!strcmp(iconf->clientCertPath, "*")) {
+				pData->clientCert = zcert_new();
+			}
+			else {
+				pData->clientCert = zcert_load(iconf->clientCertPath);
+			}
 			
 			if (!pData->clientCert) {
 				errmsg.LogError(0, NO_ERRCODE, "could not load client cert");

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -228,8 +228,12 @@ static rsRetVal initCZMQ(instanceData* pData) {
 		/* ----------- */
 
 		else if (!strcmp(pData->authType, "CURVECLIENT")) {
-
-			pData->clientCert = zcert_load(pData->clientCertPath);
+			if (!strcmp(pData->clientCertPath, "*")) {
+				pData->clientCert = zcert_new();
+			}
+			else {
+				pData->clientCert = zcert_load(pData->clientCertPath);
+			}
 		
 			if (!pData->clientCert) {
 				errmsg.LogError(0, NO_ERRCODE, "could not load client cert");


### PR DESCRIPTION
This PR allows creation of on demand ephemeral CurveZMQ certs for encryption.
Clients may specify clientcertpath="*" to indicate they want an on demand generated cert.
