### PR TITLE
Add tests for variable name comparison regressions

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -125,6 +125,12 @@ TESTS +=  \
 	rscript_wrap3.sh \
 	rscript_re_extract.sh \
 	rscript_re_match.sh \
+	rscript_eq.sh \
+	rscript_ge.sh \
+	rscript_gt.sh \
+	rscript_le.sh \
+	rscript_lt.sh \
+	rscript_ne.sh \
 	rs_optimizer_pri.sh \
 	cee_simple.sh \
 	cee_diskqueue.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -263,7 +263,8 @@ endif
 TESTS +=  \
 	stop_when_array_has_element.sh \
 	json_null_array.sh \
-	json_null.sh
+	json_null.sh \
+	json_var_cmpr.sh
 endif
 
 if ENABLE_GNUTLS
@@ -906,6 +907,8 @@ EXTRA_DIST= \
 	testsuites/lookup_table.conf \
 	testsuites/xlate.lkp_tbl \
 	testsuites/xlate_more.lkp_tbl \
+	json_var_cmpr.sh \
+	testsuites/json_var_cmpr.conf \
 	cfg.sh
 
 # TODO: re-enable

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -126,11 +126,17 @@ TESTS +=  \
 	rscript_re_extract.sh \
 	rscript_re_match.sh \
 	rscript_eq.sh \
+	rscript_eq_var.sh \
 	rscript_ge.sh \
+	rscript_ge_var.sh \
 	rscript_gt.sh \
+	rscript_gt_var.sh \
 	rscript_le.sh \
+	rscript_le_var.sh \
 	rscript_lt.sh \
+	rscript_lt_var.sh \
 	rscript_ne.sh \
+	rscript_ne_var.sh \
 	rs_optimizer_pri.sh \
 	cee_simple.sh \
 	cee_diskqueue.sh \
@@ -460,16 +466,28 @@ EXTRA_DIST= \
 	testsuites/stop.conf \
 	rscript_le.sh \
 	testsuites/rscript_le.conf \
+	rscript_le_var.sh \
+	testsuites/rscript_le_var.conf \
 	rscript_ge.sh \
 	testsuites/rscript_ge.conf \
+	rscript_ge_var.sh \
+	testsuites/rscript_ge_var.conf \
 	rscript_lt.sh \
 	testsuites/rscript_lt.conf \
+	rscript_lt_var.sh \
+	testsuites/rscript_lt_var.conf \
 	rscript_gt.sh \
 	testsuites/rscript_gt.conf \
+	rscript_gt_var.sh \
+	testsuites/rscript_gt_var.conf \
 	rscript_ne.sh \
 	testsuites/rscript_ne.conf \
+	rscript_ne_var.sh \
+	testsuites/rscript_ne_var.conf \
 	rscript_eq.sh \
 	testsuites/rscript_eq.conf \
+	rscript_eq_var.sh \
+	testsuites/rscript_eq_var.conf \
 	rscript_set_modify.sh \
 	testsuites/rscript_set_modify.conf \
 	testsuites/rscript_unaffected_reset.conf \

--- a/tests/json_var_cmpr.sh
+++ b/tests/json_var_cmpr.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2015-11-24 by portant
+# This file is part of the rsyslog project, released under ASL 2.0
+echo =============================================================================================
+echo \[json_var_case.sh\]: test for referencing local and global variables properly in comparisons
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup json_var_cmpr.conf
+. $srcdir/diag.sh tcpflood -m 1 -M "\"<167>Nov  6 12:34:56 172.0.0.1 test: @cee: { \\\"val\\\": \\\"abc\\\" }\""
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh content-check  "json prop:abc  local prop:def  global prop:ghi"
+. $srcdir/diag.sh exit

--- a/tests/rscript_eq_var.sh
+++ b/tests/rscript_eq_var.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2014-01-17 by rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_eq.sh\]: testing rainerscript EQ statement comparing two variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_eq_var.conf
+. $srcdir/diag.sh injectmsg  0 1
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh seq-check  0 0
+. $srcdir/diag.sh exit

--- a/tests/rscript_ge_var.sh
+++ b/tests/rscript_ge_var.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2014-01-17 by rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_ge.sh\]: testing rainerscript GE statement for two JSON variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_ge_var.conf
+. $srcdir/diag.sh injectmsg  0 1
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh seq-check  0 0
+. $srcdir/diag.sh exit

--- a/tests/rscript_gt_var.sh
+++ b/tests/rscript_gt_var.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2014-01-17 by rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_gt.sh\]: testing rainerscript GT statement for two JSON variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_gt_var.conf
+. $srcdir/diag.sh injectmsg  0 1
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh seq-check  0 0
+. $srcdir/diag.sh exit

--- a/tests/rscript_le_var.sh
+++ b/tests/rscript_le_var.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2014-01-17 by rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_le.sh\]: testing rainerscript LE statement for two JSON variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_le_var.conf
+. $srcdir/diag.sh injectmsg  0 1
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh seq-check  0 0
+. $srcdir/diag.sh exit

--- a/tests/rscript_lt_var.sh
+++ b/tests/rscript_lt_var.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2014-01-17 by rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_lt.sh\]: testing rainerscript LT statement for two JSON variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_lt_var.conf
+. $srcdir/diag.sh injectmsg  0 1
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh seq-check  0 0
+. $srcdir/diag.sh exit

--- a/tests/rscript_ne_var.sh
+++ b/tests/rscript_ne_var.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2014-01-17 by rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[rscript_ne.sh\]: testing rainerscript NE statement for two JSON variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup rscript_ne_var.conf
+. $srcdir/diag.sh injectmsg  0 1
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh seq-check  0 0
+. $srcdir/diag.sh exit

--- a/tests/testsuites/json_var_cmpr.conf
+++ b/tests/testsuites/json_var_cmpr.conf
@@ -1,0 +1,22 @@
+$IncludeConfig diag-common.conf
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+# we must make sure the template contains references to the variables
+template(name="outfmt" type="string" string="json prop:%$!val%  local prop:%$.val%  global prop:%$/val%\n")
+
+action(type="mmjsonparse")
+
+set $.val = "123";
+set $.rval = "123";
+if ($.val == $.rval) then {
+	set $.val = "def";
+}
+set $/val = "123";
+set $/rval = "123";
+if ($/val == $/rval) then {
+	set $/val = "ghi";
+}
+
+action(type="omfile" file="./rsyslog.out.log" template="outfmt")

--- a/tests/testsuites/rscript_eq_var.conf
+++ b/tests/testsuites/rscript_eq_var.conf
@@ -1,0 +1,57 @@
+$IncludeConfig diag-common.conf
+
+template(name="outfmt" type="list") {
+	property(name="$!usr!msgnum")
+	constant(value="\n")
+}
+
+set $!var1 = "value";
+set $!var2 = "value";
+if $!var1 == $!var2 then {
+	set $!var2 = "bad";
+	if $!var1 == $!var2 then {
+		# Failure
+		stop
+	} else {
+		unset $!var1;
+		unset $!var2;
+	}
+} else {
+	# Failure
+	stop
+}
+set $.var1 = "value";
+set $.var2 = "value";
+if $.var1 == $.var2 then {
+	set $.var2 = "bad";
+	if $.var1 == $.var2 then {
+		# Failure
+		stop
+	} else {
+		unset $.var1;
+		unset $.var2;
+	}
+} else {
+	# Failure
+	stop
+}
+set $/var1 = "value";
+set $/var2 = "value";
+if $/var1 == $/var2 then {
+	set $/var2 = "bad";
+	if $/var1 == $/var2 then {
+		# Failure
+		stop
+	} else {
+		unset $/var1;
+		unset $/var2;
+	}
+} else {
+	# Failure
+	stop
+}
+
+if $msg contains 'msgnum' then {
+	set $!usr!msgnum = field($msg, 58, 2);
+	action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}

--- a/tests/testsuites/rscript_ge_var.conf
+++ b/tests/testsuites/rscript_ge_var.conf
@@ -1,0 +1,60 @@
+$IncludeConfig diag-common.conf
+
+template(name="outfmt" type="list") {
+	property(name="$!usr!msgnum")
+	constant(value="\n")
+}
+
+set $!var1 = "42";
+set $!var2 = "42";
+set $!var3 = "41";
+if $!var1 >= $!var2 and $!var1 >= $!var3 then {
+        if $!var3 >= $!var1 then {
+                # Failure
+                stop
+        } else {
+                unset $!var1;
+                unset $!var2;
+                unset $!var3;
+        }
+} else {
+        # Failure
+        stop
+}
+set $.var1 = "42";
+set $.var2 = "42";
+set $.var3 = "41";
+if $.var1 >= $.var2 and $.var1 >= $.var3 then {
+        if $.var3 >= $.var1 then {
+                # Failure
+                stop
+        } else {
+                unset $.var1;
+                unset $.var2;
+                unset $.var3;
+        }
+} else {
+        # Failure
+        stop
+}
+set $/var1 = "42";
+set $/var2 = "42";
+set $/var3 = "41";
+if $/var1 >= $/var2 and $/var1 >= $/var3 then {
+        if $/var3 >= $/var1 then {
+                # Failure
+                stop
+        } else {
+                unset $/var1;
+                unset $/var2;
+                unset $/var3;
+        }
+} else {
+        # Failure
+        stop
+}
+
+if $msg contains 'msgnum' then {
+	set $!usr!msgnum = field($msg, 58, 2);
+	action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}

--- a/tests/testsuites/rscript_gt_var.conf
+++ b/tests/testsuites/rscript_gt_var.conf
@@ -1,0 +1,54 @@
+$IncludeConfig diag-common.conf
+
+template(name="outfmt" type="list") {
+	property(name="$!usr!msgnum")
+	constant(value="\n")
+}
+
+set $!var1 = "43";
+set $!var2 = "42";
+if $!var1 > $!var2 then {
+        if $!var2 > $!var1 then {
+                # Failure
+                stop
+        } else {
+                unset $!var1;
+                unset $!var2;
+        }
+} else {
+        # Failure
+        stop
+}
+set $.var1 = "43";
+set $.var2 = "42";
+if $.var1 > $.var2 then {
+        if $.var2 > $.var1 then {
+                # Failure
+                stop
+        } else {
+                unset $.var1;
+                unset $.var2;
+        }
+} else {
+        # Failure
+        stop
+}
+set $/var1 = "43";
+set $/var2 = "42";
+if $/var1 > $/var2 then {
+        if $/var2 > $/var1 then {
+                # Failure
+                stop
+        } else {
+                unset $/var1;
+                unset $/var2;
+        }
+} else {
+        # Failure
+        stop
+}
+
+if $msg contains 'msgnum' then {
+	set $!usr!msgnum = field($msg, 58, 2);
+	action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}

--- a/tests/testsuites/rscript_le_var.conf
+++ b/tests/testsuites/rscript_le_var.conf
@@ -1,0 +1,60 @@
+$IncludeConfig diag-common.conf
+
+template(name="outfmt" type="list") {
+	property(name="$!usr!msgnum")
+	constant(value="\n")
+}
+
+set $!var1 = "42";
+set $!var2 = "42";
+set $!var3 = "43";
+if $!var1 <= $!var2 and $!var1 <= $!var3 then {
+        if $!var3 <= $!var1 then {
+                # Failure
+                stop
+        } else {
+                unset $!var1;
+                unset $!var2;
+                unset $!var3;
+        }
+} else {
+        # Failure
+        stop
+}
+set $.var1 = "42";
+set $.var2 = "42";
+set $.var3 = "43";
+if $.var1 <= $.var2 and $.var1 <= $.var3 then {
+        if $.var3 <= $.var1 then {
+                # Failure
+                stop
+        } else {
+                unset $.var1;
+                unset $.var2;
+                unset $.var3;
+        }
+} else {
+        # Failure
+        stop
+}
+set $/var1 = "42";
+set $/var2 = "42";
+set $/var3 = "43";
+if $/var1 <= $/var2 and $/var1 <= $/var3 then {
+        if $/var3 <= $/var1 then {
+                # Failure
+                stop
+        } else {
+                unset $/var1;
+                unset $/var2;
+                unset $/var3;
+        }
+} else {
+        # Failure
+        stop
+}
+
+if $msg contains 'msgnum' then {
+	set $!usr!msgnum = field($msg, 58, 2);
+	action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}

--- a/tests/testsuites/rscript_lt_var.conf
+++ b/tests/testsuites/rscript_lt_var.conf
@@ -1,0 +1,54 @@
+$IncludeConfig diag-common.conf
+
+template(name="outfmt" type="list") {
+	property(name="$!usr!msgnum")
+	constant(value="\n")
+}
+
+set $!var1 = "41";
+set $!var2 = "42";
+if $!var1 < $!var2 then {
+        if $!var2 < $!var1 then {
+                # Failure
+                stop
+        } else {
+                unset $!var1;
+                unset $!var2;
+        }
+} else {
+        # Failure
+        stop
+}
+set $.var1 = "41";
+set $.var2 = "42";
+if $.var1 < $.var2 then {
+        if $.var2 < $.var1 then {
+                # Failure
+                stop
+        } else {
+                unset $.var1;
+                unset $.var2;
+        }
+} else {
+        # Failure
+        stop
+}
+set $/var1 = "41";
+set $/var2 = "42";
+if $/var1 < $/var2 then {
+        if $/var2 < $/var1 then {
+                # Failure
+                stop
+        } else {
+                unset $/var1;
+                unset $/var2;
+        }
+} else {
+        # Failure
+        stop
+}
+
+if $msg contains 'msgnum' then {
+	set $!usr!msgnum = field($msg, 58, 2);
+	action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}

--- a/tests/testsuites/rscript_ne_var.conf
+++ b/tests/testsuites/rscript_ne_var.conf
@@ -1,0 +1,60 @@
+$IncludeConfig diag-common.conf
+
+template(name="outfmt" type="list") {
+	property(name="$!usr!msgnum")
+	constant(value="\n")
+}
+
+set $!var1 = "value1";
+set $!var2 = "value2";
+if $!var1 != $!var2 then {
+	set $!var1 = "value";
+	set $!var2 = "value";
+	if $!var1 != $!var2 then {
+		# Failure
+		stop
+	} else {
+		unset $!var1;
+		unset $!var2;
+	}
+} else {
+	# Failure
+	stop
+}
+set $.var1 = "value1";
+set $.var2 = "value2";
+if $.var1 != $.var2 then {
+	set $.var1 = "value";
+	set $.var2 = "value";
+	if $.var1 != $.var2 then {
+		# Failure
+		stop
+	} else {
+		unset $.var1;
+		unset $.var2;
+	}
+} else {
+	# Failure
+	stop
+}
+set $/var1 = "value1";
+set $/var2 = "value2";
+if $/var1 != $/var2 then {
+	set $/var1 = "value";
+	set $/var2 = "value";
+	if $/var1 != $/var2 then {
+		# Failure
+		stop
+	} else {
+		unset $/var1;
+		unset $/var2;
+	}
+} else {
+	# Failure
+	stop
+}
+
+if $msg contains 'msgnum' then {
+	set $!usr!msgnum = field($msg, 58, 2);
+	action(type="omfile" file="./rsyslog.out.log" template="outfmt")
+}


### PR DESCRIPTION
Don't change the first character of the variable name, since we need
that depending on its name space. Instead, determine the proper root
variable string that should be used.

Fixes #617.