### PR TITLE
bugfix: potential race when new action worker is created

### DIFF
--- a/action.c
+++ b/action.c
@@ -306,6 +306,7 @@ rsRetVal actionDestruct(action_t * const pThis)
 		pThis->pMod->freeInstance(pThis->pModData);
 
 	pthread_mutex_destroy(&pThis->mutAction);
+	pthread_mutex_destroy(&pThis->mutWrkrDataTable);
 	d_free(pThis->pszName);
 	d_free(pThis->ppTpl);
 	d_free(pThis->peParamPassing);
@@ -360,6 +361,7 @@ rsRetVal actionConstruct(action_t **ppThis)
 	pThis->tLastOccur = datetime.GetTime(NULL);	/* done once per action on startup only */
 	pThis->iActionNbr = iActionNbr;
 	pthread_mutex_init(&pThis->mutAction, NULL);
+	pthread_mutex_init(&pThis->mutWrkrDataTable, NULL);
 	INIT_ATOMIC_HELPER_MUT(pThis->mutCAS);
 
 	/* indicate we have a new action */
@@ -778,6 +780,7 @@ actionCheckAndCreateWrkrInstance(action_t * const pThis, wti_t * const pWti)
 		
 		/* maintain worker data table -- only needed if wrkrHUP is requested! */
 
+		d_pthread_mutex_lock(&pThis->mutWrkrDataTable);
 		int freeSpot;
 		for(freeSpot = 0 ; freeSpot < pThis->wrkrDataTableSize ; ++freeSpot)
 			if(pThis->wrkrDataTable[freeSpot] == NULL)
@@ -791,6 +794,7 @@ actionCheckAndCreateWrkrInstance(action_t * const pThis, wti_t * const pWti)
 dbgprintf("DDDD: writing data to table spot %d\n", freeSpot);
 		pThis->wrkrDataTable[freeSpot] = pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData;
 		pThis->nWrkr++;
+		d_pthread_mutex_unlock(&pThis->mutWrkrDataTable);
 		DBGPRINTF("wti %p: created action worker instance %d for "
 			  "action %d\n", pWti, pThis->nWrkr, pThis->iActionNbr);
 	}
@@ -1349,6 +1353,7 @@ void
 actionRemoveWorker(action_t *const __restrict__ pAction,
 	void *const __restrict__ actWrkrData)
 {
+	d_pthread_mutex_lock(&pAction->mutWrkrDataTable);
 	pAction->nWrkr--;
 	for(int w = 0 ; w < pAction->wrkrDataTableSize ; ++w) {
 		if(pAction->wrkrDataTable[w] == actWrkrData) {
@@ -1356,6 +1361,7 @@ actionRemoveWorker(action_t *const __restrict__ pAction,
 			break; /* done */
 		}
 	}
+	d_pthread_mutex_unlock(&pAction->mutWrkrDataTable);
 }
 
 
@@ -1377,14 +1383,21 @@ actionCallHUPHdlr(action_t * const pAction)
 	}
 
 	if(pAction->pMod->doHUPWrkr != NULL) {
+		d_pthread_mutex_lock(&pAction->mutWrkrDataTable);
 		for(int i = 0 ; i < pAction->wrkrDataTableSize ; ++i) {
 			dbgprintf("HUP: table entry %d: %p %s\n", i,
 				pAction->wrkrDataTable[i],
 				pAction->wrkrDataTable[i] == NULL ? "[unused]" : "");
 			if(pAction->wrkrDataTable[i] != NULL) {
-				CHKiRet(pAction->pMod->doHUPWrkr(pAction->wrkrDataTable[i]));
+				const rsRetVal localRet
+					= pAction->pMod->doHUPWrkr(pAction->wrkrDataTable[i]);
+				if(localRet != RS_RET_OK) {
+					DBGPRINTF("HUP handler returned error state %d - "
+						  "ignored\n", localRet);
+				}
 			}
 		}
+		d_pthread_mutex_unlock(&pAction->mutWrkrDataTable);
 	}
 
 finalize_it:

--- a/action.h
+++ b/action.h
@@ -74,6 +74,7 @@ struct action_s {
 	uchar *pszName;		/* action name */
 	DEF_ATOMIC_HELPER_MUT(mutCAS)
 	/* for per-worker HUP processing */
+	pthread_mutex_t mutWrkrDataTable; /* protects table structures */
 	void **wrkrDataTable;
 	int wrkrDataTableSize;
 	int nWrkr;


### PR DESCRIPTION
the wrkr instance table was not properly guarded.

This fixes a bug that was never reported, "just" caught by testbench.