### PR TITLE
imzmq: fix Memory leak

### DIFF
--- a/contrib/imzmq3/imzmq3.c
+++ b/contrib/imzmq3/imzmq3.c
@@ -305,6 +305,11 @@ static rsRetVal parseSubscriptions(char* subscribes, sublist** subList){
         DBGPRINTF("'%s'", currentSub->subscribe); 
     }
     DBGPRINTF("\n");
+    
+    if (subscribes) {
+         free(subscribes);
+    }
+    
 finalize_it:
     RETiRet;
 }

--- a/contrib/imzmq3/imzmq3.c
+++ b/contrib/imzmq3/imzmq3.c
@@ -306,10 +306,6 @@ static rsRetVal parseSubscriptions(char* subscribes, sublist** subList){
     }
     DBGPRINTF("\n");
     
-    if (subscribes) {
-         free(subscribes);
-    }
-    
 finalize_it:
     RETiRet;
 }
@@ -479,8 +475,10 @@ static rsRetVal createListener(struct cnfparamvals* pvals) {
         } else if(!strcmp(inppblk.descr[i].name, "rcvHWM")) {
             inst->rcvHWM = (int) pvals[i].val.d.n;
         } else if(!strcmp(inppblk.descr[i].name, "subscribe")) {
-            CHKiRet(parseSubscriptions(es_str2cstr(pvals[i].val.d.estr, NULL), 
-                                       &inst->subscriptions));
+            char *subscribes = es_str2cstr(pvals[i].val.d.estr, NULL);
+            rsRetVal ret = parseSubscriptions(subscribes, &inst->subscriptions);
+            free(subscribes);
+            CHKiRet(ret);
         } else if(!strcmp(inppblk.descr[i].name, "identity")){
             inst->identity = es_str2cstr(pvals[i].val.d.estr, NULL);
         } else if(!strcmp(inppblk.descr[i].name, "sndBuf")) {


### PR DESCRIPTION
here shoud free subscribes , becase   CHKiRet(parseSubscriptions(es_str2cstr(pvals[i].val.d.estr, NULL),  &inst->subscriptions)) have no way to free  
the memory which malloc by es_str2cstr