### PR TITLE
omkafka: fix memory leaks

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -889,6 +889,11 @@ processKafkaParam(char *const param,
 	++val; /* now points to begin of value */
 	CHKmalloc(*name = strdup(param));
 	CHKmalloc(*paramval = strdup(val));
+
+	/* free the memory */
+	if(NULL != param){
+		free(param);
+	}
 finalize_it:
 	RETiRet;
 }


### PR DESCRIPTION
Here param should be freed, because the following func:
 CHKiRet(processKafkaParam(es_str2cstr(pvals[i].val.d.ar->arr[j], NULL),&pData->confParams[j].name,&pData->confParams[j].val)); 
malloc memory with es_str2cstr, but without free.