### PR TITLE
gnutls: fixed memory leak when gtlsRecordRecv returned a failure.

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1576,14 +1576,6 @@ Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf)
 	}
 
 	if(pThis->lenRcvBuf == 0) { /* EOS */
-		*pLenBuf = 0;
-		/* in this case, we also need to free the receive buffer, if we
-		 * allocated one. -- rgerhards, 2008-12-03
-		 */
-		if(pThis->pszRcvBuf != NULL) {
-			free(pThis->pszRcvBuf);
-			pThis->pszRcvBuf = NULL;
-		}
 		ABORT_FINALIZE(RS_RET_CLOSED);
 	}
 
@@ -1600,6 +1592,14 @@ Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf)
 	*pLenBuf = iBytesCopy;
 
 finalize_it:
+	if (iRet != RS_RET_OK) {
+		/* in this case, we also need to free the receive buffer, if we
+		 * allocated one. -- rgerhards, 2008-12-03 -- moved here by alorbach, 2015-12-01
+		 */
+		*pLenBuf = 0;
+		free(pThis->pszRcvBuf);
+		pThis->pszRcvBuf = NULL;
+	}
 	dbgprintf("gtlsRcv return. nsd %p, iRet %d, lenRcvBuf %d, ptrRcvBuf %d\n", pThis, iRet, pThis->lenRcvBuf, pThis->ptrRcvBuf);
 	RETiRet;
 }

--- a/tests/imptcp_conndrop-vg.sh
+++ b/tests/imptcp_conndrop-vg.sh
@@ -7,7 +7,7 @@ echo TEST: \[imptcp_conndrop-vg.sh\]: test imptcp with random connection drops
 . $srcdir/diag.sh startup-vg imptcp_conndrop.conf
 # 100 byte messages to gain more practical data use
 . $srcdir/diag.sh tcpflood -c20 -m50000 -r -d100 -P129 -D
-sleep 4 # due to large messages, we need this time for the tcp receiver to settle...
+sleep 10 # due to large messages, we need this time for the tcp receiver to settle...
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown-vg    # and wait for it to terminate
 . $srcdir/diag.sh check-exit-vg

--- a/tests/imptcp_conndrop.sh
+++ b/tests/imptcp_conndrop.sh
@@ -9,7 +9,7 @@ echo TEST: \[imptcp_conndrop.sh\]: test imptcp with random connection drops
 . $srcdir/diag.sh startup imptcp_conndrop.conf
 # 100 byte messages to gain more practical data use
 . $srcdir/diag.sh tcpflood -c20 -m50000 -r -d100 -P129 -D
-sleep 4 # due to large messages, we need this time for the tcp receiver to settle...
+sleep 10 # due to large messages, we need this time for the tcp receiver to settle...
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown       # and wait for it to terminate
 . $srcdir/diag.sh seq-check 0 49999 -E


### PR DESCRIPTION
When the connection was broken and gtlsRecordRecv returned a
failure, pszRcvBuf was not freed. The code to free pszRcvBuf has
been moved to finalize_it if iRet is not RS_RET_OK.