### PR TITLE
Bury es_str2cstr() calls under explicit Debug test

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -112,7 +112,7 @@ tokenToString(const int token)
 	case CMP_STARTSWITH: tokstr ="CMP_STARTSWITH"; break;
 	case CMP_STARTSWITHI: tokstr ="CMP_STARTSWITHI"; break;
 	case UMINUS: tokstr ="UMINUS"; break;
-	default: snprintf(tokbuf, sizeof(tokbuf), "%c[%d]", token, token); 
+	default: snprintf(tokbuf, sizeof(tokbuf), "%c[%d]", token, token);
 		 tokstr = tokbuf; break;
 	}
 	return tokstr;
@@ -768,7 +768,7 @@ doGetGID(struct nvlst *valnode, struct cnfparamdescr *param,
 	} else {
 		val->val.datatype = 'N';
 		val->val.d.n = resultBuf->gr_gid;
-		dbgprintf("param '%s': uid %d obtained for group '%s'\n",
+		DBGPRINTF("param '%s': uid %d obtained for group '%s'\n",
 		   param->name, (int) resultBuf->gr_gid, cstr);
 		r = 1;
 	}
@@ -795,7 +795,7 @@ doGetUID(struct nvlst *valnode, struct cnfparamdescr *param,
 	} else {
 		val->val.datatype = 'N';
 		val->val.d.n = resultBuf->pw_uid;
-		dbgprintf("param '%s': uid %d obtained for user '%s'\n",
+		DBGPRINTF("param '%s': uid %d obtained for user '%s'\n",
 		   param->name, (int) resultBuf->pw_uid, cstr);
 		r = 1;
 	}
@@ -1001,7 +1001,7 @@ nvlstGetParam(struct nvlst *valnode, struct cnfparamdescr *param,
 		r = 1; /* this *is* valid! */
 		break;
 	default:
-		dbgprintf("error: invalid param type\n");
+		DBGPRINTF("error: invalid param type\n");
 		r = 0;
 		break;
 	}
@@ -1026,7 +1026,7 @@ nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 	struct cnfparamdescr *param;
 
 	if(params->version != CNFPARAMBLK_VERSION) {
-		dbgprintf("nvlstGetParams: invalid param block version "
+		DBGPRINTF("nvlstGetParams: invalid param block version "
 			  "%d, expected %d\n",
 			  params->version, CNFPARAMBLK_VERSION);
 		return NULL;
@@ -1086,7 +1086,7 @@ cnfparamvalsIsSet(struct cnfparamblk *params, struct cnfparamvals *vals)
 	if(vals == NULL)
 		return 0;
 	if(params->version != CNFPARAMBLK_VERSION) {
-		dbgprintf("nvlstGetParams: invalid param block version "
+		DBGPRINTF("nvlstGetParams: invalid param block version "
 			  "%d, expected %d\n",
 			  params->version, CNFPARAMBLK_VERSION);
 		return 0;
@@ -1226,9 +1226,11 @@ var2Number(struct var *r, int *bSuccess)
 	long long n;
 	if(r->datatype == 'S') {
 		n = str2num(r->d.estr, bSuccess);
-char *cc = es_str2cstr(r->d.estr, NULL);
-dbgprintf("JSONorString: string is '%s', num %d\n", cc, (int)n);
-free(cc);
+		if(Debug) {
+			char *cc = es_str2cstr(r->d.estr, NULL);
+			dbgprintf("JSONorString: string is '%s', num %d\n", cc, (int)n);
+			free(cc);
+		}
 	} else {
 		if(r->datatype == 'J') {
 #ifdef HAVE_JSON_OBJECT_NEW_INT64
@@ -1333,7 +1335,7 @@ doExtractFieldByChar(uchar *str, uchar delim, const int matchnbr, uchar **resstr
 			++iCurrFld;
 		}
 	}
-	dbgprintf("field() field requested %d, field found %d\n", matchnbr, iCurrFld);
+	DBGPRINTF("field() field requested %d, field found %d\n", matchnbr, iCurrFld);
 	
 	if(iCurrFld == matchnbr) {
 		/* field found, now extract it */
@@ -1380,7 +1382,7 @@ doExtractFieldByStr(uchar *str, char *delim, const rs_size_t lenDelim, const int
 			++iCurrFld;
 		}
 	}
-	dbgprintf("field() field requested %d, field found %d\n", matchnbr, iCurrFld);
+	DBGPRINTF("field() field requested %d, field found %d\n", matchnbr, iCurrFld);
 	
 	if(iCurrFld == matchnbr) {
 		/* field found, now extract it */
@@ -1444,16 +1446,16 @@ doFunc_re_extract(struct cnffunc *func, struct var *ret, void* usrptr)
 		int iREstat;
 		iREstat = regexp.regexec(func->funcdata, (char*)(str + iOffs),
 					 submatchnbr+1, pmatch, 0);
-		dbgprintf("re_extract: regexec return is %d\n", iREstat);
+		DBGPRINTF("re_extract: regexec return is %d\n", iREstat);
 		if(iREstat == 0) {
 			if(pmatch[0].rm_so == -1) {
-				dbgprintf("oops ... start offset of successful regexec is -1\n");
+				DBGPRINTF("oops ... start offset of successful regexec is -1\n");
 				break;
 			}
 			if(iTry == matchnbr) {
 				bFound = 1;
 			} else {
-				dbgprintf("re_extract: regex found at offset %d, new offset %d, tries %d\n",
+				DBGPRINTF("re_extract: regex found at offset %d, new offset %d, tries %d\n",
 					  iOffs, (int) (iOffs + pmatch[0].rm_eo), iTry);
 				iOffs += pmatch[0].rm_eo;
 				++iTry;
@@ -1462,7 +1464,7 @@ doFunc_re_extract(struct cnffunc *func, struct var *ret, void* usrptr)
 			break;
 		}
 	}
-	dbgprintf("re_extract: regex: end search, found %d\n", bFound);
+	DBGPRINTF("re_extract: regex: end search, found %d\n", bFound);
 	if(!bFound) {
 		bHadNoMatch = 1;
 		goto finalize_it;
@@ -1615,16 +1617,16 @@ doRandomGen(struct var *__restrict__ const sourceVal) {
 	int success = 0;
 	long long max = var2Number(sourceVal, &success);
 	if (! success) {
-		dbgprintf("rainerscript: random(max) didn't get a valid 'max' limit, defaulting random-number value to 0");
+		DBGPRINTF("rainerscript: random(max) didn't get a valid 'max' limit, defaulting random-number value to 0");
 		return 0;
 	}
 	if(max == 0) {
-		dbgprintf("rainerscript: random(max) invalid, 'max' is zero, , defaulting random-number value to 0");
+		DBGPRINTF("rainerscript: random(max) invalid, 'max' is zero, , defaulting random-number value to 0");
 		return 0;
 	}
 	long int x = randomNumber();
 	if (max > MAX_RANDOM_NUMBER) {
-		dbgprintf("rainerscript: desired random-number range [0 - %lld] "
+		DBGPRINTF("rainerscript: desired random-number range [0 - %lld] "
 			"is wider than supported limit of [0 - %d)",
 			max, MAX_RANDOM_NUMBER);
 	}
@@ -1638,7 +1640,6 @@ static inline void
 doFuncCall(struct cnffunc *__restrict__ const func, struct var *__restrict__ const ret,
 	   void *__restrict__ const usrptr)
 {
-	char *fname;
 	char *envvar;
 	int bMustFree;
 	es_str_t *estr;
@@ -1651,7 +1652,7 @@ doFuncCall(struct cnffunc *__restrict__ const func, struct var *__restrict__ con
 	struct funcData_prifilt *pPrifilt;
 	rsRetVal localRet;
 
-	dbgprintf("rainerscript: executing function id %d\n", func->fID);
+	DBGPRINTF("rainerscript: executing function id %d\n", func->fID);
 	switch(func->fID) {
 	case CNFFUNC_STRLEN:
 		if(func->expr[0]->nodetype == 'S') {
@@ -1745,7 +1746,7 @@ doFuncCall(struct cnffunc *__restrict__ const func, struct var *__restrict__ con
 			varFreeMembers(&r[0]);
 		}
 		ret->datatype = 'N';
-		dbgprintf("JSONorString: cnum node type %c result %d\n", func->expr[0]->nodetype, (int) ret->d.n);
+		DBGPRINTF("JSONorString: cnum node type %c result %d\n", func->expr[0]->nodetype, (int) ret->d.n);
 		break;
 	case CNFFUNC_RE_MATCH:
 		cnfexprEval(func->expr[0], &r[0], usrptr);
@@ -1786,7 +1787,7 @@ doFuncCall(struct cnffunc *__restrict__ const func, struct var *__restrict__ con
 			localRet = doExtractFieldByChar((uchar*)str, (char) delim, matchnbr, &resStr);
 		}
 		if(localRet == RS_RET_OK) {
-dbgprintf("JSONorString: return String is '%s'\n", resStr);
+			DBGPRINTF("JSONorString: return String is '%s'\n", resStr);
 			ret->d.estr = es_newStrFromCStr((char*)resStr, strlen((char*)resStr));
 			free(resStr);
 		} else if(localRet == RS_RET_FIELD_NOT_FOUND) {
@@ -1813,7 +1814,7 @@ dbgprintf("JSONorString: return String is '%s'\n", resStr);
 		ret->datatype = 'N';
 		break;
 	case CNFFUNC_LOOKUP:
-dbgprintf("DDDD: executing lookup\n");
+		DBGPRINTF("DDDD: executing lookup\n");
 		ret->datatype = 'S';
 		if(func->funcdata == NULL) {
 			ret->d.estr = es_newStrFromCStr("TABLE-NOT-FOUND", sizeof("TABLE-NOT-FOUND")-1);
@@ -1827,7 +1828,7 @@ dbgprintf("DDDD: executing lookup\n");
 		break;
 	default:
 		if(Debug) {
-			fname = es_str2cstr(func->fname, NULL);
+			char *fname = es_str2cstr(func->fname, NULL);
 			dbgprintf("rainerscript: invalid function id %u (name '%s')\n",
 				  (unsigned) func->fID, fname);
 			free(fname);
@@ -2439,7 +2440,7 @@ cnfexprEval(const struct cnfexpr *__restrict__ const expr, struct var *__restric
 	default:
 		ret->datatype = 'N';
 		ret->d.n = 0ll;
-		dbgprintf("eval error: unknown nodetype %u['%c']\n",
+		DBGPRINTF("eval error: unknown nodetype %u['%c']\n",
 			(unsigned) expr->nodetype, (char) expr->nodetype);
 		break;
 	}
@@ -2993,7 +2994,7 @@ cnfstmtDestruct(struct cnfstmt *stmt)
 		cnfstmtDestructLst(stmt->d.s_propfilt.t_then);
 		break;
 	default:
-		dbgprintf("error: unknown stmt type during destruct %u\n",
+		DBGPRINTF("error: unknown stmt type during destruct %u\n",
 			(unsigned) stmt->nodetype);
 		break;
 	}
@@ -3396,7 +3397,7 @@ cnfexprOptimize(struct cnfexpr *expr)
 	long long ln, rn;
 	struct cnfexpr *exprswap;
 
-	dbgprintf("optimize expr %p, type '%s'\n", expr, tokenToString(expr->nodetype));
+	DBGPRINTF("optimize expr %p, type '%s'\n", expr, tokenToString(expr->nodetype));
 	switch(expr->nodetype) {
 	case '&':
 		constFoldConcat(expr);
@@ -3700,7 +3701,7 @@ cnfstmtOptimize(struct cnfstmt *root)
 			DBGPRINTF("optimizer error: we see a NOP, how come?\n");
 			break;
 		default:
-			dbgprintf("error: unknown stmt type %u during optimizer run\n",
+			DBGPRINTF("error: unknown stmt type %u during optimizer run\n",
 				(unsigned) stmt->nodetype);
 			break;
 		}
@@ -4070,13 +4071,13 @@ cnfDoInclude(char *name)
 		}
 
 		if(S_ISREG(fileInfo.st_mode)) { /* config file */
-			dbgprintf("requested to include config file '%s'\n", cfgFile);
+			DBGPRINTF("requested to include config file '%s'\n", cfgFile);
 			cnfSetLexFile(cfgFile);
 		} else if(S_ISDIR(fileInfo.st_mode)) { /* config directory */
-			dbgprintf("requested to include directory '%s'\n", cfgFile);
+			DBGPRINTF("requested to include directory '%s'\n", cfgFile);
 			cnfDoInclude(cfgFile);
 		} else {
-			dbgprintf("warning: unable to process IncludeConfig directive '%s'\n", cfgFile);
+			DBGPRINTF("warning: unable to process IncludeConfig directive '%s'\n", cfgFile);
 		}
 	}
 

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -143,7 +143,7 @@ CODESTARTfreeInstance
 		for (i = 0; i < pData->iParams; i++) {
 			free(pData->aParams[i]);
 		}
-		free(pData->aParams); 
+		free(pData->aParams);
 	}
 ENDfreeInstance
 
@@ -217,7 +217,7 @@ processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData, msg_t *con
 	int numCharsRead;
 	char *newptr;
 
-dbgprintf("mmexternal: checking prog output, fd %d\n", pWrkrData->fdPipeIn);
+	DBGPRINTF("mmexternal: checking prog output, fd %d\n", pWrkrData->fdPipeIn);
 	numCharsRead = 0;
 	do {
 		if(pWrkrData->maxLenRespBuf < numCharsRead + 256) { /* 256 to permit at least a decent read */
@@ -242,7 +242,7 @@ dbgprintf("mmexternal: checking prog output, fd %d\n", pWrkrData->fdPipeIn);
 			strcpy(pWrkrData->respBuf, "{}\n");
 			numCharsRead = 3;
 		}
-dbgprintf("mmexternal: read state %lld, data '%s'\n", (long long) r, pWrkrData->respBuf);
+		DBGPRINTF("mmexternal: read state %lld, data '%s'\n", (long long) r, pWrkrData->respBuf);
 		if(Debug && r == -1) {
 			DBGPRINTF("mmexternal: error reading from external program: %s\n",
 				   rs_strerror_r(errno, errStr, sizeof(errStr)));
@@ -322,7 +322,7 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdOutErr)
 		 */
 		rs_strerror_r(errno, errStr, sizeof(errStr));
 		DBGPRINTF("mmexternal: failed to execute binary '%s': %s\n",
-			  pWrkrData->pData->szBinary, errStr); 
+			  pWrkrData->pData->szBinary, errStr);
 	}
 	
 	/* we should never reach this point, but if we do, we terminate */
@@ -513,7 +513,7 @@ finalize_it:
 BEGINdoAction
 	instanceData *pData;
 CODESTARTdoAction
-dbgprintf("DDDD:mmexternal processing message\n");
+	DBGPRINTF("DDDD:mmexternal processing message\n");
 	pData = pWrkrData->pData;
 	if(pData->bForceSingleInst)
 		pthread_mutex_lock(&pData->mut);
@@ -527,7 +527,7 @@ dbgprintf("DDDD:mmexternal processing message\n");
 		iRet = RS_RET_SUSPENDED;
 	if(pData->bForceSingleInst)
 		pthread_mutex_unlock(&pData->mut);
-dbgprintf("DDDD:mmexternal DONE processing message\n");
+	DBGPRINTF("DDDD:mmexternal DONE processing message\n");
 ENDdoAction
 
 
@@ -566,8 +566,8 @@ CODESTARTnewActInst
 		if(!pvals[i].bUsed)
 			continue;
 		if(!strcmp(actpblk.descr[i].name, "binary")) {
-			estrBinary = pvals[i].val.d.estr; 
-			estrParams = NULL; 
+			estrBinary = pvals[i].val.d.estr;
+			estrParams = NULL;
 
 			/* Search for space */
 			c = es_getBufAddr(pvals[i].val.d.estr);
@@ -575,18 +575,22 @@ CODESTARTnewActInst
 			while(iCnt < es_strlen(pvals[i].val.d.estr) ) {
 				if (c[iCnt] == ' ') {
 					/* Split binary name from parameters */
-					estrBinary = es_newStrFromSubStr ( pvals[i].val.d.estr, 0, iCnt ); 
-					estrParams = es_newStrFromSubStr ( pvals[i].val.d.estr, iCnt+1, es_strlen(pvals[i].val.d.estr)); 
+					estrBinary = es_newStrFromSubStr ( pvals[i].val.d.estr, 0, iCnt );
+					estrParams = es_newStrFromSubStr ( pvals[i].val.d.estr, iCnt+1, es_strlen(pvals[i].val.d.estr));
 					break;
 				}
 				iCnt++;
 			}	
 			/* Assign binary and params */
 			pData->szBinary = (uchar*)es_str2cstr(estrBinary, NULL);
-			dbgprintf("mmexternal: szBinary = '%s'\n", pData->szBinary); 
+			DBGPRINTF("mmexternal: szBinary = '%s'\n", pData->szBinary);
 			/* Check for Params! */
 			if (estrParams != NULL) {
-				dbgprintf("mmexternal: szParams = '%s'\n", es_str2cstr(estrParams, NULL) ); 
+				if(Debug) {
+					char *params = es_str2cstr(estrParams, NULL);
+					dbgprintf("mmexternal: szParams = '%s'\n", params, NULL);
+					free(params);
+				}
 				
 				/* Count parameters if set */
 				c = es_getBufAddr(estrParams); /* Reset to beginning */
@@ -594,10 +598,10 @@ CODESTARTnewActInst
 				iCnt = 0;
 				while(iCnt < es_strlen(estrParams) ) {
 					if (c[iCnt] == ' ' && c[iCnt-1] != '\\')
-						 pData->iParams++; 
+						 pData->iParams++;
 					iCnt++;
 				}
-				dbgprintf("mmexternal: iParams = '%d'\n", pData->iParams); 
+				DBGPRINTF("mmexternal: iParams = '%d'\n", pData->iParams);
 
 				/* Create argv Array */
 				CHKmalloc(pData->aParams = malloc( (pData->iParams+1) * sizeof(char*))); /* One more for first param */ 
@@ -605,32 +609,32 @@ CODESTARTnewActInst
 				/* Second Loop, create parameter array*/
 				c = es_getBufAddr(estrParams); /* Reset to beginning */
 				iCnt = iStr = iPrm = 0;
-				estrTmp = NULL; 
-				bInQuotes = FALSE; 
+				estrTmp = NULL;
+				bInQuotes = FALSE;
 				/* Set first parameter to binary */
-				pData->aParams[iPrm] = strdup((char*)pData->szBinary); 
-				dbgprintf("mmexternal: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
-				iPrm++; 
+				pData->aParams[iPrm] = strdup((char*)pData->szBinary);
+				DBGPRINTF("mmexternal: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
+				iPrm++;
 				while(iCnt < es_strlen(estrParams) ) {
 					if ( c[iCnt] == ' ' && !bInQuotes ) {
 						/* Copy into Param Array! */
-						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr); 
+						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr);
 					}
 					else if ( iCnt+1 >= es_strlen(estrParams) ) {
 						/* Copy rest of string into Param Array! */
-						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr+1); 
+						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr+1);
 					}
 					else if (c[iCnt] == '"') {
 						/* switch inQuotes Mode */
-						bInQuotes = !bInQuotes; 
+						bInQuotes = !bInQuotes;
 					}
 
 					if ( estrTmp != NULL ) {
-						pData->aParams[iPrm] = es_str2cstr(estrTmp, NULL); 
+						pData->aParams[iPrm] = es_str2cstr(estrTmp, NULL);
 						iStr = iCnt+1; /* Set new start */
-						dbgprintf("mmexternal: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
+						DBGPRINTF("mmexternal: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
 						es_deleteStr( estrTmp );
-						estrTmp = NULL; 
+						estrTmp = NULL;
 						iPrm++;
 					}
 
@@ -638,7 +642,7 @@ CODESTARTnewActInst
 					iCnt++;
 				}
 				/* NULL last parameter! */
-				pData->aParams[iPrm] = NULL; 
+				pData->aParams[iPrm] = NULL;
 
 			}
 		} else if(!strcmp(actpblk.descr[i].name, "output")) {
@@ -660,7 +664,7 @@ CODESTARTnewActInst
 				ABORT_FINALIZE(RS_RET_INVLD_INTERFACE_INPUT);
 			}
 		} else {
-			dbgprintf("mmexternal: program error, non-handled param '%s'\n", actpblk.descr[i].name);
+			DBGPRINTF("mmexternal: program error, non-handled param '%s'\n", actpblk.descr[i].name);
 		}
 	}
 

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -139,7 +139,7 @@ CODESTARTfreeInstance
 		for (i = 0; i < pData->iParams; i++) {
 			free(pData->aParams[i]);
 		}
-		free(pData->aParams); 
+		free(pData->aParams);
 	}
 ENDfreeInstance
 
@@ -170,7 +170,7 @@ writeProgramOutput(wrkrInstanceData_t *__restrict__ const pWrkrData,
 	char errStr[1024];
 	ssize_t r;
 
-dbgprintf("omprog: writeProgramOutput, fd %d\n", pWrkrData->fdOutput);
+	DBGPRINTF("omprog: writeProgramOutput, fd %d\n", pWrkrData->fdOutput);
 	if(pWrkrData->fdOutput == -1) {
 		pWrkrData->fdOutput = open((char*)pWrkrData->pData->outputFileName,
 				       O_WRONLY | O_APPEND | O_CREAT, 0600);
@@ -282,10 +282,10 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdOutErr)
 		 */
 		rs_strerror_r(errno, errStr, sizeof(errStr));
 		DBGPRINTF("omprog: failed to execute binary '%s': %s\n",
-			  pWrkrData->pData->szBinary, errStr); 
+			  pWrkrData->pData->szBinary, errStr);
 		openlog("rsyslogd", 0, LOG_SYSLOG);
 		syslog(LOG_ERR, "omprog: failed to execute binary '%s': %s\n",
-			  pWrkrData->pData->szBinary, errStr); 
+			  pWrkrData->pData->szBinary, errStr);
 	}
 	
 	/* we should never reach this point, but if we do, we terminate */
@@ -512,8 +512,8 @@ CODESTARTnewActInst
 		if(!pvals[i].bUsed)
 			continue;
 		if(!strcmp(actpblk.descr[i].name, "binary")) {
-			estrBinary = pvals[i].val.d.estr; 
-			estrParams = NULL; 
+			estrBinary = pvals[i].val.d.estr;
+			estrParams = NULL;
 
 			/* Search for space */
 			c = es_getBufAddr(pvals[i].val.d.estr);
@@ -521,18 +521,22 @@ CODESTARTnewActInst
 			while(iCnt < es_strlen(pvals[i].val.d.estr) ) {
 				if (c[iCnt] == ' ') {
 					/* Split binary name from parameters */
-					estrBinary = es_newStrFromSubStr ( pvals[i].val.d.estr, 0, iCnt ); 
-					estrParams = es_newStrFromSubStr ( pvals[i].val.d.estr, iCnt+1, es_strlen(pvals[i].val.d.estr)); 
+					estrBinary = es_newStrFromSubStr ( pvals[i].val.d.estr, 0, iCnt );
+					estrParams = es_newStrFromSubStr ( pvals[i].val.d.estr, iCnt+1, es_strlen(pvals[i].val.d.estr));
 					break;
 				}
 				iCnt++;
 			}	
 			/* Assign binary and params */
 			pData->szBinary = (uchar*)es_str2cstr(estrBinary, NULL);
-			dbgprintf("omprog: szBinary = '%s'\n", pData->szBinary); 
+			DBGPRINTF("omprog: szBinary = '%s'\n", pData->szBinary);
 			/* Check for Params! */
 			if (estrParams != NULL) {
-				dbgprintf("omprog: szParams = '%s'\n", es_str2cstr(estrParams, NULL) ); 
+				if(Debug) {
+					char *params = es_str2cstr(estrParams, NULL);
+					dbgprintf("omprog: szParams = '%s'\n", params);
+					free(params);
+				}
 				
 				/* Count parameters if set */
 				c = es_getBufAddr(estrParams); /* Reset to beginning */
@@ -540,10 +544,10 @@ CODESTARTnewActInst
 				iCnt = 0;
 				while(iCnt < es_strlen(estrParams) ) {
 					if (c[iCnt] == ' ' && c[iCnt-1] != '\\')
-						 pData->iParams++; 
+						 pData->iParams++;
 					iCnt++;
 				}
-				dbgprintf("omprog: iParams = '%d'\n", pData->iParams); 
+				DBGPRINTF("omprog: iParams = '%d'\n", pData->iParams);
 
 				/* Create argv Array */
 				CHKmalloc(pData->aParams = malloc( (pData->iParams+1) * sizeof(char*))); /* One more for first param */ 
@@ -551,32 +555,32 @@ CODESTARTnewActInst
 				/* Second Loop, create parameter array*/
 				c = es_getBufAddr(estrParams); /* Reset to beginning */
 				iCnt = iStr = iPrm = 0;
-				estrTmp = NULL; 
-				bInQuotes = FALSE; 
+				estrTmp = NULL;
+				bInQuotes = FALSE;
 				/* Set first parameter to binary */
-				pData->aParams[iPrm] = strdup((char*)pData->szBinary); 
-				dbgprintf("omprog: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
-				iPrm++; 
+				pData->aParams[iPrm] = strdup((char*)pData->szBinary);
+				DBGPRINTF("omprog: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
+				iPrm++;
 				while(iCnt < es_strlen(estrParams) ) {
 					if ( c[iCnt] == ' ' && !bInQuotes ) {
 						/* Copy into Param Array! */
-						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr); 
+						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr);
 					}
 					else if ( iCnt+1 >= es_strlen(estrParams) ) {
 						/* Copy rest of string into Param Array! */
-						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr+1); 
+						estrTmp = es_newStrFromSubStr( estrParams, iStr, iCnt-iStr+1);
 					}
 					else if (c[iCnt] == '"') {
 						/* switch inQuotes Mode */
-						bInQuotes = !bInQuotes; 
+						bInQuotes = !bInQuotes;
 					}
 
 					if ( estrTmp != NULL ) {
-						pData->aParams[iPrm] = es_str2cstr(estrTmp, NULL); 
+						pData->aParams[iPrm] = es_str2cstr(estrTmp, NULL);
 						iStr = iCnt+1; /* Set new start */
-						dbgprintf("omprog: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
+						DBGPRINTF("omprog: Param (%d): '%s'\n", iPrm, pData->aParams[iPrm]);
 						es_deleteStr( estrTmp );
-						estrTmp = NULL; 
+						estrTmp = NULL;
 						iPrm++;
 					}
 
@@ -584,7 +588,7 @@ CODESTARTnewActInst
 					iCnt++;
 				}
 				/* NULL last parameter! */
-				pData->aParams[iPrm] = NULL; 
+				pData->aParams[iPrm] = NULL;
 
 			}
 		} else if(!strcmp(actpblk.descr[i].name, "output")) {
@@ -613,7 +617,7 @@ CODESTARTnewActInst
 		} else if(!strcmp(actpblk.descr[i].name, "template")) {
 			pData->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else {
-			dbgprintf("omprog: program error, non-handled param '%s'\n", actpblk.descr[i].name);
+			DBGPRINTF("omprog: program error, non-handled param '%s'\n", actpblk.descr[i].name);
 		}
 	}
 


### PR DESCRIPTION
In rainerscript.c there was a wayward debug statement emitting a es str,
where the es string was converted to a c-string before printing, and
then freeing the memory. It would seem doing that on the fast path is
unnecessary, so we moved it under an explicit Debug test.

Searching for other uses of es_str2cstr() calls in dbgprintf() calls
(lowercase), which would mean that the memory allocation always occurs
even if the debugging is not enabled, we found two in omprog and
mmexternal.

In the modules that we touched, we switched to use DBGPRINTF() were
possible and logical, to avoid processing any parameters on the fast
path.