### PR TITLE
Add common tokens in tokenToString

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -112,7 +112,19 @@ tokenToString(const int token)
 	case CMP_STARTSWITH: tokstr ="CMP_STARTSWITH"; break;
 	case CMP_STARTSWITHI: tokstr ="CMP_STARTSWITHI"; break;
 	case UMINUS: tokstr ="UMINUS"; break;
-	default: snprintf(tokbuf, sizeof(tokbuf), "%c[%d]", token, token); 
+	case '&': tokstr ="&"; break;
+	case '+': tokstr ="+"; break;
+	case '-': tokstr ="-"; break;
+	case '*': tokstr ="*"; break;
+	case '/': tokstr ="/"; break;
+	case '%': tokstr ="%"; break;
+	case 'M': tokstr ="M"; break;
+	case 'N': tokstr ="N"; break;
+	case 'S': tokstr ="S"; break;
+	case 'V': tokstr ="V"; break;
+	case 'F': tokstr ="F"; break;
+	case 'A': tokstr ="A"; break;
+	default: snprintf(tokbuf, sizeof(tokbuf), "%c[%d]", token, token);
 		 tokstr = tokbuf; break;
 	}
 	return tokstr;


### PR DESCRIPTION
A static buffer is used in tokenToString() when creating a string to
represent an unrecognized token. There are a number of operators and
datatypes that were unrecognized, so this was used often. This change
avoids multiple threads writing over the same string, confusing the
debug output.

Note that this does not solve the problem, as this can still happen if
new datatypes or operators are added in the future, but it does take
care of the common cases known today.