### PR TITLE
Detect librdkafa smartly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1469,7 +1469,14 @@ AC_ARG_ENABLE(omkafka,
         [enable_omkafka=no]
 )
 if test "x$enable_omkafka" = "xyes"; then
-	#PKG_CHECK_MODULES(LIBRDKAFKA, librdkafka)
+	PKG_CHECK_MODULES([LIBRDKAFKA], [librdkafka],, [
+		AC_CHECK_LIB([rdkafka], [rd_kafka_produce], [
+			AC_MSG_WARN([librdkafka is missing but library present, using -lrdkafka])
+			LIBRDKAFKA_LIBS=-lrdkafka
+		], [
+			AC_MSG_ERROR([could not find rdkafka library])
+		])
+	])
 	AC_CHECK_HEADERS([librdkafka/rdkafka.h])
 fi
 AM_CONDITIONAL(ENABLE_OMKAFKA, test x$enable_omkafka = xyes)

--- a/plugins/omkafka/Makefile.am
+++ b/plugins/omkafka/Makefile.am
@@ -2,7 +2,7 @@ pkglib_LTLIBRARIES = omkafka.la
 
 omkafka_la_SOURCES = omkafka.c
 omkafka_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
-omkafka_la_LDFLAGS = -module -avoid-version -lrdkafka #$(LIBRDKAFKA_LIBS)
+omkafka_la_LDFLAGS = -module -avoid-version $(LIBRDKAFKA_LIBS)
 omkafka_la_LIBADD = 
 
 EXTRA_DIST = 


### PR DESCRIPTION
Detect package librdkafka existence first, then check -lrdkafka if
failed (in standard lib dir).

This is an enhanced version based on #502 and fixes #596.

Some test results below.

**Neither of librdkafka package and lib file is present**

```
checking for LIBRDKAFKA... no
checking for rd_kafka_produce in -lrdkafka... no
configure: error: cound not find rdkafka library
```

**Compiled librdkafa from source and installed lib to /usr/lib64/**

```
checking for LIBRDKAFKA... no
checking for rd_kafka_produce in -lrdkafka... yes
configure: WARNING: librdkafka is missing but library present, using -lrdkafka
checking librdkafka/rdkafka.h usability... yes
checking librdkafka/rdkafka.h presence... yes
checking for librdkafka/rdkafka.h... yes
```

**Static linking with With `LIBRDKAFKA_LIBS=/tmp/lib/librdkafka.a`**

```
checking for LIBRDKAFKA... yes
checking librdkafka/rdkafka.h usability... yes
checking librdkafka/rdkafka.h presence... yes
checking for librdkafka/rdkafka.h... yes
```

**Start rsyslog with -dn**

```
yydebug: state 50, reducing by rule 9546.884022679:main thread    : cnf:global:obj: obj: 'module'
9546.884027919:main thread    : nvlst 0x7fc0d0:
9546.884031281:main thread    :         name: 'load', value 'omkafka'
9546.884034889:main thread    : nvlstGetParam: name 'load', type 13, valnode->bUsed 0
9546.884038394:main thread    : modulesProcessCnf params:
9546.884041661:main thread    : load:  'omkafka'
9546.884048329:main thread    : Requested to load module 'omkafka'
9546.884052522:main thread    : loading module '/export/servers/logbook-rsyslog/lib/rsyslog/omkafka.so'
9546.884146908:main thread    : omkafka 8.15.0.master using librdkafka version 0.8.6
9546.884154761:main thread    : module omkafka of type 1 being loaded (keepType=0).
```
