### PR TITLE
Reopen truncated file with opt-in flag 'reopenOnTruncate'

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -522,7 +522,7 @@ openFile(lstn_t *pLstn)
 
 	/* read back in the object */
 	CHKiRet(obj.Deserialize(&pLstn->pStrm, (uchar*) "strm", psSF, NULL, pLstn));
-	pLstn->pStrm->bReopenOnTruncate = pLstn->reopenOnTruncate;
+	CHKiRet(strm.SetbReopenOnTruncate(pLstn->pStrm, pLstn->reopenOnTruncate));
 	DBGPRINTF("imfile: deserialized state file, state file base name '%s', "
 		  "configured base name '%s'\n", pLstn->pStrm->pszFName,
 		  pLstn->pszFileName);

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -112,6 +112,7 @@ typedef struct lstn_s {
 	regex_t end_preg;	/* compiled version of startRegex */
 	uchar *prevLineSegment;	/* previous line segment (in regex mode) */
 	sbool escapeLF;	/* escape LF inside the MSG content? */
+	sbool reopenOnTruncate;
 	sbool addMetadata;
 	ruleset_t *pRuleset;	/* ruleset to bind listener to (use system default if unspecified) */
 	ratelimit_t *ratelimiter;
@@ -146,6 +147,7 @@ struct instanceConf_s {
 	uint8_t readMode;
 	uchar *startRegex;
 	sbool escapeLF;
+	sbool reopenOnTruncate;
 	sbool addMetadata;
 	int maxLinesAtOnce;
 	ruleset_t *pBindRuleset;	/* ruleset to bind listener to (use system default if unspecified) */
@@ -259,6 +261,7 @@ static struct cnfparamdescr inppdescr[] = {
 	{ "readmode", eCmdHdlrInt, 0 },
 	{ "startmsg.regex", eCmdHdlrString, 0 },
 	{ "escapelf", eCmdHdlrBinary, 0 },
+	{ "reopenontruncate", eCmdHdlrBinary, 0 },
 	{ "maxlinesatonce", eCmdHdlrInt, 0 },
 	{ "maxsubmitatonce", eCmdHdlrInt, 0 },
 	{ "removestateondelete", eCmdHdlrBinary, 0 },
@@ -519,6 +522,7 @@ openFile(lstn_t *pLstn)
 
 	/* read back in the object */
 	CHKiRet(obj.Deserialize(&pLstn->pStrm, (uchar*) "strm", psSF, NULL, pLstn));
+	pLstn->pStrm->bReopenOnTruncate = pLstn->reopenOnTruncate;
 	DBGPRINTF("imfile: deserialized state file, state file base name '%s', "
 		  "configured base name '%s'\n", pLstn->pStrm->pszFName,
 		  pLstn->pszFileName);
@@ -645,6 +649,7 @@ createInstance(instanceConf_t **pinst)
 	inst->startRegex = NULL;
 	inst->bRMStateOnDel = 1;
 	inst->escapeLF = 1;
+	inst->reopenOnTruncate = 0;
 	inst->addMetadata = ADD_METADATA_UNSPECIFIED;
 
 	/* node created, let's add to config */
@@ -767,6 +772,7 @@ addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	inst->iPersistStateInterval = cs.iPersistStateInterval;
 	inst->readMode = cs.readMode;
 	inst->escapeLF = 0;
+	inst->reopenOnTruncate = 0;
 	inst->addMetadata = 0;
 	inst->bRMStateOnDel = 0;
 
@@ -874,6 +880,7 @@ lstnDup(lstn_t ** ppExisting, uchar *const __restrict__ newname)
 	pThis->bRMStateOnDel = existing->bRMStateOnDel;
 	pThis->hasWildcard = existing->hasWildcard;
 	pThis->escapeLF = existing->escapeLF;
+	pThis->reopenOnTruncate = existing->reopenOnTruncate;
 	pThis->addMetadata = existing->addMetadata;
 	pThis->pRuleset = existing->pRuleset;
 	pThis->nRecords = 0;
@@ -939,6 +946,7 @@ addListner(instanceConf_t *inst)
 		}
 	pThis->bRMStateOnDel = inst->bRMStateOnDel;
 	pThis->escapeLF = inst->escapeLF;
+	pThis->reopenOnTruncate = inst->reopenOnTruncate;
 	pThis->addMetadata = (inst->addMetadata == ADD_METADATA_UNSPECIFIED) ?
 			       hasWildcard : inst->addMetadata;
 	pThis->pRuleset = inst->pBindRuleset;
@@ -997,6 +1005,8 @@ CODESTARTnewInpInst
 			inst->addMetadata = (sbool) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "escapelf")) {
 			inst->escapeLF = (sbool) pvals[i].val.d.n;
+		} else if(!strcmp(inppblk.descr[i].name, "reopenontruncate")) {
+			inst->reopenOnTruncate = (sbool) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "maxlinesatonce")) {
 			if(   loadModConf->opMode == OPMODE_INOTIFY
 			   && pvals[i].val.d.n > 0) {

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -509,13 +509,17 @@ strmHandleEOFMonitor(strm_t *pThis)
 	DBGPRINTF("stream checking for file change on '%s', inode %u/%u\n",
 	  pThis->pszCurrFName, (unsigned) pThis->inode,
 	  (unsigned) statName.st_ino);
-	if(pThis->inode == statName.st_ino) {
-		ABORT_FINALIZE(RS_RET_EOF);
-	} else {
-		/* we had a file change! */
+
+	/* Inode unchanged but file size on disk is less than current offset
+	 * means file was truncated, we also reopen if 'reopenOnTruncate' is on
+	 */
+	if (pThis->inode != statName.st_ino
+		  || (pThis->bReopenOnTruncate && statName.st_size < pThis->iCurrOffs)) {
 		DBGPRINTF("we had a file change on '%s'\n", pThis->pszCurrFName);
 		CHKiRet(strmCloseFile(pThis));
 		CHKiRet(strmOpenFile(pThis));
+	} else {
+		ABORT_FINALIZE(RS_RET_EOF);
 	}
 
 finalize_it:
@@ -1790,6 +1794,7 @@ DEFpropSetMeth(strm, sType, strmType_t)
 DEFpropSetMeth(strm, iZipLevel, int)
 DEFpropSetMeth(strm, bVeryReliableZip, int)
 DEFpropSetMeth(strm, bSync, int)
+DEFpropSetMeth(strm, bReopenOnTruncate, int)
 DEFpropSetMeth(strm, sIOBufSize, size_t)
 DEFpropSetMeth(strm, iSizeLimit, off_t)
 DEFpropSetMeth(strm, iFlushInterval, int)
@@ -2151,6 +2156,7 @@ CODESTARTobjQueryInterface(strm)
 	pIf->SetiZipLevel = strmSetiZipLevel;
 	pIf->SetbVeryReliableZip = strmSetbVeryReliableZip;
 	pIf->SetbSync = strmSetbSync;
+	pIf->SetbReopenOnTruncate = strmSetbReopenOnTruncate;
 	pIf->SetsIOBufSize = strmSetsIOBufSize;
 	pIf->SetiSizeLimit = strmSetiSizeLimit;
 	pIf->SetiFlushInterval = strmSetiFlushInterval;

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -111,6 +111,7 @@ typedef struct strm_s {
 	/* dynamic properties, valid only during file open, not to be persistet */
 	sbool bDisabled; /* should file no longer be written to? (currently set only if omfile file size limit fails) */
 	sbool bSync;	/* sync this file after every write? */
+	sbool bReopenOnTruncate;
 	size_t sIOBufSize;/* size of IO buffer */
 	uchar *pszDir; /* Directory */
 	int lenDir;
@@ -187,6 +188,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
 	INTERFACEpropSetMeth(strm, sType, strmType_t);
 	INTERFACEpropSetMeth(strm, iZipLevel, int);
 	INTERFACEpropSetMeth(strm, bSync, int);
+	INTERFACEpropSetMeth(strm, bReopenOnTruncate, int);
 	INTERFACEpropSetMeth(strm, sIOBufSize, size_t);
 	INTERFACEpropSetMeth(strm, iSizeLimit, off_t);
 	INTERFACEpropSetMeth(strm, iFlushInterval, int);
@@ -201,8 +203,9 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
 	INTERFACEpropSetMeth(strm, cryprov, cryprov_if_t*);
 	INTERFACEpropSetMeth(strm, cryprovData, void*);
 ENDinterface(strm)
-#define strmCURR_IF_VERSION 10 /* increment whenever you change the interface structure! */
+#define strmCURR_IF_VERSION 11 /* increment whenever you change the interface structure! */
 /* V10, 2013-09-10: added new parameter bEscapeLF, changed mode to uint8_t (rgerhards) */
+/* V11, 2015-12-03: added new parameter bReopenOnTruncate */
 
 static inline int
 strmGetCurrFileNum(strm_t *pStrm) {


### PR DESCRIPTION
Attempt to fix #511.  This is an enhanced version based on https://github.com/rsyslog/rsyslog/pull/514, works fine for us so far.  As discussed before, I added an opt-in flag 'reopenOnTruncate' and default is "off".