### PR TITLE
imfile: Trim line when length of line over specified bytes

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -688,7 +688,7 @@ static rsRetVal strmUnreadChar(strm_t *pThis, uchar c)
  * a line, but following lines that are indented are part of the same log entry
  */
 static rsRetVal
-strmReadLine(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF)
+strmReadLine(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF, uint32_t trimLineOverBytes)
 {
         uchar c;
 	uchar finished;
@@ -716,6 +716,12 @@ strmReadLine(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF)
                 	}
                 	CHKiRet(readCharRet);
         	}
+		if (trimLineOverBytes > 0 && cstrLen(*ppCStr) > trimLineOverBytes) {
+			/* Truncate long line at trimLineOverBytes position */
+			dbgprintf("Truncate long line at %u, mode %d\n", trimLineOverBytes, mode);
+			rsCStrTruncate(*ppCStr, cstrLen(*ppCStr) - trimLineOverBytes);
+			cstrAppendChar(*ppCStr, '\n');
+		}
         	CHKiRet(cstrFinalize(*ppCStr));
 	} else if(mode == 1) {
 		finished=0;
@@ -785,6 +791,12 @@ strmReadLine(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF)
                				CHKiRet(strmReadChar(pThis, &c));
 				}
 			}
+		}
+		if (trimLineOverBytes > 0 && cstrLen(*ppCStr) > trimLineOverBytes) {
+			/* Truncate long line at trimLineOverBytes position */
+			dbgprintf("Truncate long line at %u, mode %d\n", trimLineOverBytes, mode);
+			rsCStrTruncate(*ppCStr, cstrLen(*ppCStr) - trimLineOverBytes);
+			cstrAppendChar(*ppCStr, '\n');
 		}
        		CHKiRet(cstrFinalize(*ppCStr));
 		pThis->bPrevWasNL = 0;

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -192,7 +192,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
 	INTERFACEpropSetMeth(strm, iFlushInterval, int);
 	INTERFACEpropSetMeth(strm, pszSizeLimitCmd, uchar*);
 	/* v6 added */
-	rsRetVal (*ReadLine)(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF);
+	rsRetVal (*ReadLine)(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF, uint32_t trimLineOverBytes);
 	/* v7 added  2012-09-14 */
 	INTERFACEpropSetMeth(strm, bVeryReliableZip, int);
 	/* v8 added  2013-03-21 */
@@ -201,8 +201,9 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
 	INTERFACEpropSetMeth(strm, cryprov, cryprov_if_t*);
 	INTERFACEpropSetMeth(strm, cryprovData, void*);
 ENDinterface(strm)
-#define strmCURR_IF_VERSION 10 /* increment whenever you change the interface structure! */
+#define strmCURR_IF_VERSION 11 /* increment whenever you change the interface structure! */
 /* V10, 2013-09-10: added new parameter bEscapeLF, changed mode to uint8_t (rgerhards) */
+/* V11, 2015-12-11: added new parameter trimLineOverBytes, changed mode to uint32_t (rgerhards) */
 
 static inline int
 strmGetCurrFileNum(strm_t *pStrm) {


### PR DESCRIPTION
Add an opt-in flag 'trimLineOverBytes' to determine if trim line when length of line over specified bytes number. 
Default value of 'trimLineOverBytes' is 0, means never trim line. 
If 'trimLineOverBytes' is positive number, we will truncate the line which length is greater than 'trimLineOverBytes'.