### PR TITLE
Update build steps for RH/CentOS/Fedora

### DIFF
--- a/contrib/mmgrok/README
+++ b/contrib/mmgrok/README
@@ -4,12 +4,18 @@ Using hundreds of grok patterns from logstash-patterns-core.
 
 Build
 
-This plugin requires json-c, glib and grok package. If you use RH/CentOS, please build grok.rpm by yourself as follow:
+This plugin requires json-c, glib and grok package.
 
+If you use RH/CentOS/Fedora, you'll have to build grok rpms by yourself as follow:
+
+    sudo yum install -y yum-utils rpmdevtools
     git clone git@github.com:jordansissel/grok.git
-    rpm -bb grok.spec.template
+    mkdir -p ~/rpmbuild/SPECS/; cp grok/grok.spec.template ~/rpmbuild/SPECS/grok.spec
+    (mkdir -p ~/rpmbuld/SOURCES/; cd ~/rpmbuild/SOURCES/; spectool -g ../SPECS/grok.spec)
+    sudo yum-builddep ~/rpmbuild/SPECS/grok.spec
+    rpmbuild -bb ~/rpmbuild/SPECS/grok.spec
     # use yum command instead of rpm, because grok depends on libevent, pcre, tokyocabinet
-    yum install -y libjson-c-devel glib-devel grok*.rpm
+    sudo yum install -y libjson-c-devel glib-devel ~/rpbuild/RPMS/x86_64/grok*.rpm
 
 Example
 


### PR DESCRIPTION
These are the complete steps needed to build on a RHEL / CentOS / Fedora box (but only verified on a Fedora 21 box).