### PR TITLE
Derive glib-2.0 build flags for mmgrok at config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: c
 
 compiler:
@@ -34,7 +36,7 @@ before_install:
 install:
   - travis_retry sudo apt-get install -qq build-essential automake pkg-config libtool autoconf autotools-dev gdb valgrind libdbi-dev libsnmp-dev libmysqlclient-dev postgresql-client
   - travis_retry sudo apt-get install -qq libestr-dev librelp-dev libjson0-dev zlib1g-dev uuid-dev libgcrypt11-dev liblogging-stdlog-dev bison flex libksi1 libksi1-dev
-  - travis_retry sudo apt-get install -qq python-docutils liblognorm1-dev
+  - travis_retry sudo apt-get install -qq python-docutils liblognorm1-dev libglib2.0 libglib2.0-dev grok libgrok-dev
   - if [ "$CC" == "clang" ]; then travis_retry sudo apt-get install -qq clang; fi
 
 script:
@@ -42,7 +44,7 @@ script:
   # I don't know how to pass two env vars in the include matrix, so
   # I set the second one here via an "if"
   - if [ "$CC" == "clang" ]; then export NO_VALGRIND="--without-valgrind-testbench"; fi
-  - ./configure  --prefix=/opt/rsyslog --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --enable-silent-rules --libdir=/usr/lib64 --docdir=/usr/share/doc/rsyslog --disable-generate-man-pages --enable-testbench --enable-imdiag --enable-imfile --enable-impstats --enable-imptcp --enable-mmanon --enable-mmaudit --enable-mmfields --enable-mmjsonparse --enable-mmpstrucdata --enable-mmsequence --enable-mmutf8fix --enable-mail --enable-omprog --enable-omruleset --enable-omstdout --enable-omuxsock --enable-pmaixforwardedfrom --enable-pmciscoios --enable-pmcisconames --enable-pmlastmsg --enable-pmsnare --enable-libgcrypt --enable-mmnormalize --disable-omudpspoof --enable-relp --disable-snmp --disable-mmsnmptrapd --enable-gnutls --enable-mysql --enable-gt-ksi --enable-libdbi --enable-pgsql --enable-omhttpfs $NO_VALGRIND
+  - ./configure  --prefix=/opt/rsyslog --build=x86_64-pc-linux-gnu --host=x86_64-pc-linux-gnu --mandir=/usr/share/man --infodir=/usr/share/info --datadir=/usr/share --sysconfdir=/etc --localstatedir=/var/lib --disable-dependency-tracking --enable-silent-rules --libdir=/usr/lib64 --docdir=/usr/share/doc/rsyslog --disable-generate-man-pages --enable-testbench --enable-imdiag --enable-imfile --enable-impstats --enable-imptcp --enable-mmanon --enable-mmaudit --enable-mmfields --enable-mmjsonparse --enable-mmpstrucdata --enable-mmsequence --enable-mmutf8fix --enable-mail --enable-omprog --enable-omruleset --enable-omstdout --enable-omuxsock --enable-pmaixforwardedfrom --enable-pmciscoios --enable-pmcisconames --enable-pmlastmsg --enable-pmsnare --enable-libgcrypt --enable-mmnormalize --disable-omudpspoof --enable-relp --disable-snmp --disable-mmsnmptrapd --enable-gnutls --enable-mysql --enable-gt-ksi --enable-libdbi --enable-pgsql --enable-omhttpfs -enable-mmgrok $NO_VALGRIND
   - export USE_AUTO_DEBUG="off" # set to "on" to enable this for travis
   - if [ "x$STAT_AN" == "x" ] ; then make && make check && make distcheck; fi
   #- if [ "x$STAT_AN" == "x" ] ; then cat tests/test-suite.log; fi

--- a/configure.ac
+++ b/configure.ac
@@ -967,7 +967,13 @@ AC_ARG_ENABLE(mmgrok,
         esac],
         [enable_mmgrok=no]
 )
+if test "x$enable_mmgrok" = "xyes"; then
+	GLIB_CFLAGS="$(pkg-config --cflags glib-2.0)"
+	GLIB_LIBS="$(pkg-config --libs glib-2.0)"
+fi
 AM_CONDITIONAL(ENABLE_MMGROK, test x$enable_mmgrok = xyes)
+AC_SUBST(GLIB_CFLAGS)
+AC_SUBST(GLIB_LIBS)
 
 # mmaudit
 AC_ARG_ENABLE(mmaudit,

--- a/contrib/mmgrok/Makefile.am
+++ b/contrib/mmgrok/Makefile.am
@@ -1,8 +1,8 @@
 pkglib_LTLIBRARIES = mmgrok.la
 
 mmgrok_la_SOURCES = mmgrok.c
-mmgrok_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
+mmgrok_la_CPPFLAGS = $(GLIB_CFLAGS) $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
 mmgrok_la_LDFLAGS = -module -avoid-version
-mmgrok_la_LIBADD = -lglib-2.0 -lgrok -ljson-c
+mmgrok_la_LIBADD = $(GLIB_LIBS) -lgrok -ljson-c
 
 EXTRA_DIST = 

--- a/contrib/mmgrok/README
+++ b/contrib/mmgrok/README
@@ -4,7 +4,7 @@ Using hundreds of grok patterns from logstash-patterns-core.
 
 Build
 
-This plugin requires json-c, glib and grok package.
+This plugin requires json-c, glib2, and grok packages.
 
 If you use RH/CentOS/Fedora, you'll have to build grok rpms by yourself as follow:
 
@@ -15,10 +15,7 @@ If you use RH/CentOS/Fedora, you'll have to build grok rpms by yourself as follo
     sudo yum-builddep ~/rpmbuild/SPECS/grok.spec
     rpmbuild -bb ~/rpmbuild/SPECS/grok.spec
     # use yum command instead of rpm, because grok depends on libevent, pcre, tokyocabinet
-    sudo yum install -y libjson-c-devel glib-devel ~/rpbuild/RPMS/x86_64/grok*.rpm
-
-Note: at least on Fedora, when building mmgrok one needs to set CFLAGS to
-include the output of the following: $(pkg-config --cflags glib).
+    sudo yum install -y libjson-c-devel glib2-devel ~/rpbuild/RPMS/x86_64/grok*.rpm
 
 Example
 


### PR DESCRIPTION
Instead of requiring the user to set the proper CFLAGS before invoking
./configure, we add CFLAGS and LIBS values as determined by pkg-config
during configuration setup.

We also update the requirements to be glib-2.0 instead of just plain
glib.

Fixes #680.