### PR TITLE
Remove leading whitespace in front of CPP directives

### DIFF
--- a/contrib/pmpanngfw/pmpanngfw.c
+++ b/contrib/pmpanngfw/pmpanngfw.c
@@ -92,11 +92,11 @@ BEGINparse
     uint64 log_type;
     int j;
 CODESTARTparse
-    #define CSV_DELIMITER '\t'
-    #define STATE_FIELD_START 0
-    #define STATE_IN_FIELD 1
-    #define STATE_IN_QUOTE 2
-    #define STATE_IN_QUOTE_QUOTE 3
+#   define CSV_DELIMITER '\t'
+#   define STATE_FIELD_START 0
+#   define STATE_IN_FIELD 1
+#   define STATE_IN_QUOTE 2
+#   define STATE_IN_QUOTE_QUOTE 3
 
     state = STATE_FIELD_START;
 

--- a/contrib/pmsnare/pmsnare.c
+++ b/contrib/pmsnare/pmsnare.c
@@ -89,7 +89,7 @@ BEGINparse
 	int tablength;
 
 CODESTARTparse
-	#define TabRepresentation "#011"
+#	define TabRepresentation "#011"
 	tablength=sizeof(TabRepresentation);
 	dbgprintf("Message will now be parsed by fix Snare parser.\n");
 	assert(pMsg != NULL);

--- a/grammar/parserif.h
+++ b/grammar/parserif.h
@@ -38,4 +38,4 @@ void cnfDoScript(struct cnfstmt *script);
 void cnfDoCfsysline(char *ln);
 void cnfDoBSDTag(char *ln);
 void cnfDoBSDHost(char *ln);
- #endif
+#endif

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -73,7 +73,7 @@
 	 * simply go ahead and do without them - use mutexes or other things. The
 	 * code needs to be checked against all those cases. -- rgerhards, 2009-01-30
 	 */
-	#include <pthread.h>
+#	include <pthread.h>
 #	define ATOMIC_INC(data, phlpmut)  { \
 		pthread_mutex_lock(phlpmut); \
 		++(*(data)); \

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -48,7 +48,7 @@
 #  include <malloc.h>
 #endif
 #ifdef USE_LIBUUID
-  #include <uuid/uuid.h>
+#  include <uuid/uuid.h>
 #endif
 #include "rsyslog.h"
 #include "srUtils.h"

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1356,9 +1356,9 @@ int *create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbu
 			 * do if we have to.
 			 */
 			if(     (bind(*s, r->ai_addr, r->ai_addrlen) < 0)
-	#		ifndef IPV6_V6ONLY
+#			ifndef IPV6_V6ONLY
 			     && (errno != EADDRINUSE)
-	#		endif
+#			endif
 			   ) {
 				errmsg.LogError(errno, NO_ERRCODE, "bind");
 				close(*s);

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -588,9 +588,9 @@ gtlsGlblInit(void)
 	DEFiRet;
 
 	/* gcry_control must be called first, so that the thread system is correctly set up */
-	#if GNUTLS_VERSION_NUMBER <= 0x020b00
+#	if GNUTLS_VERSION_NUMBER <= 0x020b00
 	gcry_control (GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
-	#endif
+#	endif
 	CHKgnutls(gnutls_global_init());
 	
 	/* X509 stuff */

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -758,9 +758,9 @@ initTLS(void)
 	int r;
 
 	/* order of gcry_control and gnutls_global_init matters! */
-	#if GNUTLS_VERSION_NUMBER <= 0x020b00
+#	if GNUTLS_VERSION_NUMBER <= 0x020b00
 	gcry_control(GCRYCTL_SET_THREAD_CBS, &gcry_threads_pthread);
-	#endif
+#	endif
 	gnutls_global_init();
 	/* set debug mode, if so required by the options */
 	if(tlsLogLevel > 0) {

--- a/tools/rsgtutil.c
+++ b/tools/rsgtutil.c
@@ -31,16 +31,16 @@
 
 #ifdef ENABLEGT
 	/* Guardtime Includes */
-	#include <gt_base.h>
-	#include <gt_http.h>
-	#include "librsgt_common.h"
-	#include "librsgt.h"
+#	include <gt_base.h>
+#	include <gt_http.h>
+#	include "librsgt_common.h"
+#	include "librsgt.h"
 #endif
 #ifdef ENABLEKSI
 	/* KSI Includes */
-	#include <stdint.h>
-	#include "librsgt_common.h"
-	#include "librsksi.h"
+#	include <stdint.h>
+#	include "librsgt_common.h"
+#	include "librsksi.h"
 #endif
 
 typedef unsigned char uchar;

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -610,11 +610,11 @@ rsRetVal createMainQueue(qqueue_t **ppQueue, uchar *pszQueueName, struct nvlst *
 
 	if(lst == NULL) { /* use legacy parameters? */
 		/* ... set some properties ... */
-	#	define setQPROP(func, directive, data) \
+#		define setQPROP(func, directive, data) \
 		CHKiRet_Hdlr(func(*ppQueue, data)) { \
 			errmsg.LogError(0, NO_ERRCODE, "Invalid " #directive ", error %d. Ignored, running with default setting", iRet); \
 		}
-	#	define setQPROPstr(func, directive, data) \
+#		define setQPROPstr(func, directive, data) \
 		CHKiRet_Hdlr(func(*ppQueue, data, (data == NULL)? 0 : strlen((char*) data))) { \
 			errmsg.LogError(0, NO_ERRCODE, "Invalid " #directive ", error %d. Ignored, running with default setting", iRet); \
 		}
@@ -661,8 +661,8 @@ rsRetVal createMainQueue(qqueue_t **ppQueue, uchar *pszQueueName, struct nvlst *
 		setQPROP(qqueueSetiDeqtWinFromHr,  "$MainMsgQueueDequeueTimeBegin", ourConf->globals.mainQ.iMainMsgQueueDeqtWinFromHr);
 		setQPROP(qqueueSetiDeqtWinToHr,    "$MainMsgQueueDequeueTimeEnd", ourConf->globals.mainQ.iMainMsgQueueDeqtWinToHr);
 
-	#	undef setQPROP
-	#	undef setQPROPstr
+#		undef setQPROP
+#		undef setQPROPstr
 	} else { /* use new style config! */
 		qqueueSetDefaultsRulesetQueue(*ppQueue);
 		qqueueApplyCnfParam(*ppQueue, lst);


### PR DESCRIPTION
Seems like the leading whitespace is not a real problem, but noticed it reviewing another patch and thought I'd submit the cleanup for consideration.