### PR TITLE
Fix integer overflow resulting in negative partitions

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -168,8 +168,8 @@ getPartition(instanceData *const __restrict__ pData)
 		return RD_KAFKA_PARTITION_UA;
 	} else {
 		return (pData->fixedPartition == NO_FIXED_PARTITION) ?
-		          ATOMIC_INC_AND_FETCH_int(&pData->currPartition,
-			      &pData->mutCurrPartition) % pData->nPartitions
+		          abs(ATOMIC_INC_AND_FETCH_int(&pData->currPartition,
+			      &pData->mutCurrPartition) % pData->nPartitions)
 			:  pData->fixedPartition;
 	}
 }


### PR DESCRIPTION
If MAX_INT is reached (more likely on 32 bit systems), then the
resulting partition returned, if using the `partitions.number` config
option is used, will be a negative number.

This change will cause imbalance in the partitions once MAX_INT is
reached, but should stabilize again to be evenly distributed.