### PR TITLE
Remove use of sizeof(char) and sizeof(uchar)

### DIFF
--- a/action.c
+++ b/action.c
@@ -387,7 +387,7 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 	}
 	/* generate a friendly name for us action stats */
 	if(pThis->pszName == NULL) {
-		snprintf((char*) pszAName, sizeof(pszAName)/sizeof(uchar), "action %d", pThis->iActionNbr);
+		snprintf((char*) pszAName, sizeof(pszAName), "action %d", pThis->iActionNbr);
 		pThis->pszName = ustrdup(pszAName);
 	}
 
@@ -440,7 +440,7 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 	/* create our queue */
 
 	/* generate a friendly name for the queue */
-	snprintf((char*) pszAName, sizeof(pszAName)/sizeof(uchar), "%s queue",
+	snprintf((char*) pszAName, sizeof(pszAName), "%s queue",
 		 pThis->pszName);
 
 	/* now check if we can run the action in "firehose mode" during stage one of 
@@ -1791,7 +1791,7 @@ addAction(action_t **ppAction, modInfo_t *pMod, void *pModData,
 		if(!(iTplOpts & OMSR_TPL_AS_MSG)) {
 		   	if((pAction->ppTpl[i] =
 				tplFind(ourConf, (char*)pTplName, strlen((char*)pTplName))) == NULL) {
-				snprintf(errMsg, sizeof(errMsg) / sizeof(char),
+				snprintf(errMsg, sizeof(errMsg),
 					 " Could not find template %d '%s' - action disabled",
 					 i, pTplName);
 				errno = 0;

--- a/contrib/imkmsg/imkmsg.c
+++ b/contrib/imkmsg/imkmsg.c
@@ -129,7 +129,7 @@ rsRetVal imkmsgLogIntMsg(syslog_pri_t priority, char *fmt, ...)
 	uchar msgBuf[2048]; /* we use the same size as sysklogd to remain compatible */
 
 	va_start(ap, fmt);
-	vsnprintf((char*)msgBuf, sizeof(msgBuf) / sizeof(char), fmt, ap);
+	vsnprintf((char*)msgBuf, sizeof(msgBuf), fmt, ap);
 	va_end(ap);
 
 	logmsgInternal(NO_ERRCODE, priority, msgBuf, 0);

--- a/contrib/mmgrok/mmgrok.c
+++ b/contrib/mmgrok/mmgrok.c
@@ -218,10 +218,12 @@ msg_to_json(GList *list,instanceData *pData)
     }
     for(;it;it= it->next)
     {
-        char  *key = (char *)malloc(sizeof(char)*((result_t *)it->data)->key_len+1);
-        sprintf(key,"%.*s",((result_t *)it->data)->key_len,((result_t *)it->data)->key);
-	char  *value = (char *)malloc(sizeof(char)*((result_t *)it->data)->value_len+1);
-        sprintf(value,"%.*s", ((result_t*)it->data)->value_len,((result_t*)it->data)->value);	
+	int key_len = ((result_t *)it->data)->key_len;
+        char *key = (char *)malloc(key_len+1);
+        snprintf(key,key_len+1,"%.*s",key_len,((result_t *)it->data)->key);
+	int value_len = ((result_t *)it->data)->value_len;
+	char *value = (char *)malloc(value_len+1);
+        snprintf(value,value_len+1,"%.*s",value_len,((result_t*)it->data)->value);
 	jval = json_object_new_string(value);
 	json_object_object_add(json,key,jval);
 	free(key);

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1357,7 +1357,7 @@ doExtractFieldByChar(uchar *str, uchar delim, const int matchnbr, uchar **resstr
 			    * step back a little not to copy it as part of the field. */
 		/* we got our end pointer, now do the copy */
 		iLen = pFldEnd - pFld + 1; /* the +1 is for an actual char, NOT \0! */
-		CHKmalloc(pBuf = MALLOC((iLen + 1) * sizeof(uchar)));
+		CHKmalloc(pBuf = MALLOC(iLen + 1));
 		/* now copy */
 		memcpy(pBuf, pFld, iLen);
 		pBuf[iLen] = '\0'; /* terminate it */
@@ -1405,7 +1405,7 @@ doExtractFieldByStr(uchar *str, char *delim, const rs_size_t lenDelim, const int
 			iLen = pFldEnd - pFld;
 		}
 		/* we got our end pointer, now do the copy */
-		CHKmalloc(pBuf = MALLOC((iLen + 1) * sizeof(uchar)));
+		CHKmalloc(pBuf = MALLOC(iLen + 1));
 		/* now copy */
 		memcpy(pBuf, pFld, iLen);
 		pBuf[iLen] = '\0'; /* terminate it */

--- a/outchannel.c
+++ b/outchannel.c
@@ -208,7 +208,7 @@ struct outchannel *ochAddLine(char* pName, uchar** ppRestOfConfLine)
 		return NULL;
 	
 	pOch->iLenName = strlen(pName);
-	pOch->pszName = (char*) MALLOC(sizeof(char) * (pOch->iLenName + 1));
+	pOch->pszName = (char*) MALLOC(pOch->iLenName + 1);
 	if(pOch->pszName == NULL) {
 		dbgprintf("ochAddLine could not alloc memory for outchannel name!");
 		pOch->iLenName = 0;

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -207,7 +207,7 @@ doInjectMsg(int iNum, ratelimit_t *ratelimiter)
 	time_t ttGenTime;
 	DEFiRet;
 
-	snprintf((char*)szMsg, sizeof(szMsg)/sizeof(uchar),
+	snprintf((char*)szMsg, sizeof(szMsg),
 		 "<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:%8.8d:", iNum);
 
 	datetime.getCurrTime(&stTime, &ttGenTime);
@@ -241,9 +241,9 @@ injectMsg(uchar *pszCmd, tcps_sess_t *pSess)
 	DEFiRet;
 
 	/* we do not check errors here! */
-	getFirstWord(&pszCmd, wordBuf, sizeof(wordBuf)/sizeof(uchar), TO_LOWERCASE);
+	getFirstWord(&pszCmd, wordBuf, sizeof(wordBuf), TO_LOWERCASE);
 	iFrom = atoi((char*)wordBuf);
-	getFirstWord(&pszCmd, wordBuf, sizeof(wordBuf)/sizeof(uchar), TO_LOWERCASE);
+	getFirstWord(&pszCmd, wordBuf, sizeof(wordBuf), TO_LOWERCASE);
 	nMsgs = atoi((char*)wordBuf);
 	CHKiRet(ratelimitNew(&ratelimit, "imdiag", "injectmsg"));
 
@@ -315,12 +315,12 @@ OnMsgReceived(tcps_sess_t *pSess, uchar *pRcv, int iLenMsg)
 	 * WITHOUT a termination \0 char. So we need to convert it to one
 	 * before proceeding.
 	 */
-	CHKmalloc(pszMsg = MALLOC(sizeof(uchar) * (iLenMsg + 1)));
+	CHKmalloc(pszMsg = MALLOC(iLenMsg + 1));
 	pToFree = pszMsg;
 	memcpy(pszMsg, pRcv, iLenMsg);
 	pszMsg[iLenMsg] = '\0';
 
-	getFirstWord(&pszMsg, cmdBuf, sizeof(cmdBuf)/sizeof(uchar), TO_LOWERCASE);
+	getFirstWord(&pszMsg, cmdBuf, sizeof(cmdBuf), TO_LOWERCASE);
 
 	dbgprintf("imdiag received command '%s'\n", cmdBuf);
 	if(!ustrcmp(cmdBuf, UCHAR_CONSTANT("getmainmsgqueuesize"))) {

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -484,7 +484,7 @@ openFile(lstn_t *pLstn)
 	DBGPRINTF("imfile: trying to open state for '%s', state file '%s'\n",
 		  pLstn->pszFileName, statefn);
 	/* Construct file name */
-	lenSFNam = snprintf((char*)pszSFNam, sizeof(pszSFNam) / sizeof(uchar), "%s/%s",
+	lenSFNam = snprintf((char*)pszSFNam, sizeof(pszSFNam), "%s/%s",
 			     (char*) glbl.GetWorkDir(), (char*)statefn);
 
 	/* check if the file exists */
@@ -1633,7 +1633,7 @@ filesDisplay(); // TODO: remove after initial unstable release(s)
 	          pLstn->pszFileName, ev->wd);
 	if(pLstn->bRMStateOnDel) {
 		statefn = getStateFileName(pLstn, statefile, sizeof(statefile));
-		snprintf((char*)toDel, sizeof(toDel) / sizeof(uchar), "%s/%s",
+		snprintf((char*)toDel, sizeof(toDel), "%s/%s",
 				     glbl.GetWorkDir(), (char*)statefn);
 		bDoRMState = 1;
 	} else {

--- a/plugins/imgssapi/imgssapi.c
+++ b/plugins/imgssapi/imgssapi.c
@@ -435,7 +435,7 @@ OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess)
 		 */
 		char *buf;
 		int ret = 0;
-		CHKmalloc(buf = (char*) MALLOC(sizeof(char) * (glbl.GetMaxLine() + 1)));
+		CHKmalloc(buf = (char*) MALLOC(glbl.GetMaxLine() + 1));
 
                 prop.GetString(pSess->fromHostIP, &pszPeer, &lenPeer);
                 

--- a/plugins/imklog/bsd.c
+++ b/plugins/imklog/bsd.c
@@ -241,7 +241,7 @@ readklog(modConfData_t *pModConf)
 	if((size_t) iMaxLine < sizeof(bufRcv) - 1) {
 		pRcv = bufRcv;
 	} else {
-		if((pRcv = (uchar*) MALLOC(sizeof(uchar) * (iMaxLine + 1))) == NULL) {
+		if((pRcv = (uchar*) MALLOC(iMaxLine + 1)) == NULL) {
 			iMaxLine = sizeof(bufRcv) - 1; /* better this than noting */
 			pRcv = bufRcv;
 		}

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -206,7 +206,7 @@ rsRetVal imklogLogIntMsg(syslog_pri_t priority, char *fmt, ...)
 	uchar msgBuf[2048]; /* we use the same size as sysklogd to remain compatible */
 
 	va_start(ap, fmt);
-	vsnprintf((char*)msgBuf, sizeof(msgBuf) / sizeof(char), fmt, ap);
+	vsnprintf((char*)msgBuf, sizeof(msgBuf), fmt, ap);
 	va_end(ap);
 
 	logmsgInternal(NO_ERRCODE, priority, msgBuf, 0);

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1101,7 +1101,7 @@ addSess(ptcplstn_t *pLstn, int sock, prop_t *peerName, prop_t *peerIP)
 	ptcpsrv_t *pSrv = pLstn->pSrv;
 
 	CHKmalloc(pSess = malloc(sizeof(ptcpsess_t)));
-	CHKmalloc(pSess->pMsg = malloc(iMaxLine * sizeof(uchar)));
+	CHKmalloc(pSess->pMsg = malloc(iMaxLine));
 	pSess->pLstn = pLstn;
 	pSess->sock = sock;
 	pSess->bSuppOctetFram = pLstn->bSuppOctetFram;

--- a/plugins/imsolaris/imsolaris.c
+++ b/plugins/imsolaris/imsolaris.c
@@ -248,7 +248,7 @@ getMsgs(thrdInfo_t *pThrd, int timeout)
 	if((size_t) iMaxLine < sizeof(bufRcv) - 1) {
 		pRcv = bufRcv;
 	} else {
-		CHKmalloc(pRcv = (uchar*) malloc(sizeof(uchar) * (iMaxLine + 1)));
+		CHKmalloc(pRcv = (uchar*) malloc(iMaxLine + 1));
 	}
 
 	 while(pThrd->bShallStop != RSTRUE) {

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -1105,7 +1105,7 @@ BEGINactivateCnf
 CODESTARTactivateCnf
 	/* caching various settings */
 	iMaxLine = glbl.GetMaxLine();
-	lenRcvBuf = (iMaxLine + 1) * sizeof(char);
+	lenRcvBuf = iMaxLine + 1;
 #	ifdef HAVE_RECVMMSG
 	lenRcvBuf *= runModConf->batchSize;
 #	endif

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -1008,7 +1008,7 @@ static rsRetVal readSocket(lstn_t *pLstn)
 	if((size_t) iMaxLine < sizeof(bufRcv) - 1) {
 		pRcv = bufRcv;
 	} else {
-		CHKmalloc(pRcv = (uchar*) MALLOC(sizeof(uchar) * (iMaxLine + 1)));
+		CHKmalloc(pRcv = (uchar*) MALLOC(iMaxLine + 1));
 	}
 
 	memset(&msgh, 0, sizeof(msgh));

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -563,7 +563,7 @@ getSingleRequest(const char* bulkRequest, char** singleRequest ,char **lastLocat
 	if (getSection(req,&req)!=RS_RET_OK)
 			ABORT_FINALIZE(RS_RET_ERR);
 
-    *singleRequest = (char*) calloc (req - start+ 1 + 1,sizeof(char));/* (req - start+ 1 == length of data + 1 for terminal char)*/
+    *singleRequest = (char*) calloc (req - start+ 1 + 1,1);/* (req - start+ 1 == length of data + 1 for terminal char)*/
     if (*singleRequest==NULL) ABORT_FINALIZE(RS_RET_ERR);
     memcpy(*singleRequest,start,req - start);
     *lastLocation=req;

--- a/plugins/omhdfs/omhdfs.c
+++ b/plugins/omhdfs/omhdfs.c
@@ -213,7 +213,7 @@ filePrepare(file_t *pFile)
 	/* file does not exist, create it (and eventually parent directories */
 	if(1) { // check if bCreateDirs
 		len = ustrlen(pFile->name) + 1;
-		CHKmalloc(pszWork = MALLOC(sizeof(uchar) * len));
+		CHKmalloc(pszWork = MALLOC(len));
 		memcpy(pszWork, pFile->name, len);
 		for(p = pszWork+1 ; *p ; p++)
 			if(*p == '/') {

--- a/plugins/omlibdbi/omlibdbi.c
+++ b/plugins/omlibdbi/omlibdbi.c
@@ -229,7 +229,7 @@ reportDBError(instanceData *pData, int bSilent)
 		errmsg.LogError(0, NO_ERRCODE, "unknown DB error occured - could not obtain connection handle");
 	} else { /* we can ask dbi for the error description... */
 		uDBErrno = dbi_conn_error(pData->conn, &pszDbiErr);
-		snprintf(errMsg, sizeof(errMsg)/sizeof(char), "db error (%d): %s\n", uDBErrno, pszDbiErr);
+		snprintf(errMsg, sizeof(errMsg), "db error (%d): %s\n", uDBErrno, pszDbiErr);
 		if(bSilent || uDBErrno == pData->uLastDBErrno)
 			dbgprintf("libdbi, DBError(silent): %s\n", errMsg);
 		else {

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -168,7 +168,7 @@ static void reportDBError(wrkrInstanceData_t *pWrkrData, int bSilent)
 		errmsg.LogError(0, NO_ERRCODE, "unknown DB error occured - could not obtain MySQL handle");
 	} else { /* we can ask mysql for the error description... */
 		uMySQLErrno = mysql_errno(pWrkrData->hmysql);
-		snprintf(errMsg, sizeof(errMsg)/sizeof(char), "db error (%d): %s\n", uMySQLErrno,
+		snprintf(errMsg, sizeof(errMsg), "db error (%d): %s\n", uMySQLErrno,
 			mysql_error(pWrkrData->hmysql));
 		if(bSilent || uMySQLErrno == pWrkrData->uLastMySQLErrno)
 			dbgprintf("mysql, DBError(silent): %s\n", errMsg);
@@ -205,7 +205,7 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 			int err=errno;
 			if(fp==NULL){
 				char msg[512];
-				snprintf(msg,sizeof(msg)/sizeof(char),"Could not open '%s' for reading",pData->configfile);
+				snprintf(msg,sizeof(msg),"Could not open '%s' for reading",pData->configfile);
 				if(bSilent) {
 					char errStr[512];
 					rs_strerror_r(err, errStr, sizeof(errStr));

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -145,7 +145,7 @@ static void reportDBError(instanceData *pData, int bSilent)
 		errmsg.LogError(0, NO_ERRCODE, "unknown DB error occured - could not obtain PgSQL handle");
 	} else { /* we can ask pgsql for the error description... */
 		ePgSQLStatus = PQstatus(pData->f_hpgsql);
-		snprintf(errMsg, sizeof(errMsg)/sizeof(char), "db error (%d): %s\n", ePgSQLStatus,
+		snprintf(errMsg, sizeof(errMsg), "db error (%d): %s\n", ePgSQLStatus,
 				PQerrorMessage(pData->f_hpgsql));
 		if(bSilent || ePgSQLStatus == pData->eLastPgSQLStatus)
 			dbgprintf("pgsql, DBError(silent): %s\n", errMsg);

--- a/runtime/cfsysline.c
+++ b/runtime/cfsysline.c
@@ -319,7 +319,7 @@ static int doParseOnOffOption(uchar **pp)
 	pOptStart = *pp;
 	skipWhiteSpace(pp); /* skip over any whitespace */
 
-	if(getSubString(pp, (char*) szOpt, sizeof(szOpt) / sizeof(uchar), ' ')  != 0) {
+	if(getSubString(pp, (char*) szOpt, sizeof(szOpt), ' ')  != 0) {
 		errmsg.LogError(0, NO_ERRCODE, "Invalid $-configline - could not extract on/off option");
 		return -1;
 	}
@@ -351,7 +351,7 @@ static rsRetVal doGetGID(uchar **pp, rsRetVal (*pSetHdlr)(void*, uid_t), void *p
 	assert(pp != NULL);
 	assert(*pp != NULL);
 
-	if(getSubString(pp, (char*) szName, sizeof(szName) / sizeof(uchar), ' ')  != 0) {
+	if(getSubString(pp, (char*) szName, sizeof(szName), ' ')  != 0) {
 		errmsg.LogError(0, RS_RET_NOT_FOUND, "could not extract group name");
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}
@@ -407,7 +407,7 @@ static rsRetVal doGetUID(uchar **pp, rsRetVal (*pSetHdlr)(void*, uid_t), void *p
 	assert(pp != NULL);
 	assert(*pp != NULL);
 
-	if(getSubString(pp, (char*) szName, sizeof(szName) / sizeof(uchar), ' ')  != 0) {
+	if(getSubString(pp, (char*) szName, sizeof(szName), ' ')  != 0) {
 		errmsg.LogError(0, RS_RET_NOT_FOUND, "could not extract user name");
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}

--- a/runtime/conf.c
+++ b/runtime/conf.c
@@ -107,7 +107,7 @@ doModLoad(uchar **pp, __attribute__((unused)) void* pVal)
 	ASSERT(*pp != NULL);
 
 	skipWhiteSpace(pp); /* skip over any whitespace */
-	if(getSubString(pp, (char*) szName, sizeof(szName) / sizeof(uchar), ' ')  != 0) {
+	if(getSubString(pp, (char*) szName, sizeof(szName), ' ')  != 0) {
 		errmsg.LogError(0, RS_RET_NOT_FOUND, "could not extract module name");
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}
@@ -168,7 +168,7 @@ doNameLine(uchar **pp, void* pVal)
 
 	eDir = (enum eDirective) pVal;	/* this time, it actually is NOT a pointer! */
 
-	if(getSubString(&p, szName, sizeof(szName) / sizeof(char), ',')  != 0) {
+	if(getSubString(&p, szName, sizeof(szName), ',')  != 0) {
 		errmsg.LogError(0, RS_RET_NOT_FOUND, "Invalid config line: could not extract name - line ignored");
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}
@@ -222,7 +222,7 @@ cfsysline(uchar *p)
 
 	ASSERT(p != NULL);
 	errno = 0;
-	if(getSubString(&p, (char*) szCmd, sizeof(szCmd) / sizeof(uchar), ' ')  != 0) {
+	if(getSubString(&p, (char*) szCmd, sizeof(szCmd), ' ')  != 0) {
 		errmsg.LogError(0, RS_RET_NOT_FOUND, "Invalid $-configline - could not extract command - line ignored\n");
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -367,7 +367,7 @@ static void dbgMutLogPrintOne(dbgMutLog_t *pLog)
 			strmutop = "owned";
 			break;
 		default:
-			snprintf(buf, sizeof(buf)/sizeof(char), "unknown state %d - should not happen!", pLog->mutexOp);
+			snprintf(buf, sizeof(buf), "unknown state %d - should not happen!", pLog->mutexOp);
 			strmutop = buf;
 			break;
 	}
@@ -465,7 +465,7 @@ static inline void dbgMutexPreLockLog(pthread_mutex_t *pmut, dbgFuncDB_t *pFuncD
 		pszHolder = "[NONE]";
 	else {
 		dbgGetThrdName(pszHolderThrdName, sizeof(pszHolderThrdName), pHolder->thrd, 1);
-		snprintf(pszBuf, sizeof(pszBuf)/sizeof(char), "%s:%d [%s]", pHolder->pFuncDB->file, pHolder->lockLn, pszHolderThrdName);
+		snprintf(pszBuf, sizeof(pszBuf), "%s:%d [%s]", pHolder->pFuncDB->file, pHolder->lockLn, pszHolderThrdName);
 		pszHolder = pszBuf;
 	}
 
@@ -512,7 +512,7 @@ static inline void dbgMutexPreTryLockLog(pthread_mutex_t *pmut, dbgFuncDB_t *pFu
       pszHolder = "[NONE]";
    else {
       dbgGetThrdName(pszHolderThrdName, sizeof(pszHolderThrdName), pHolder->thrd, 1);
-      snprintf(pszBuf, sizeof(pszBuf)/sizeof(char), "%s:%d [%s]", pHolder->pFuncDB->file, pHolder->lockLn, pszHolderThrdName);
+      snprintf(pszBuf, sizeof(pszBuf), "%s:%d [%s]", pHolder->pFuncDB->file, pHolder->lockLn, pszHolderThrdName);
       pszHolder = pszBuf;
    }
 
@@ -1226,7 +1226,7 @@ dbgGetRTOptNamVal(uchar **ppszOpt, uchar **ppOptName, uchar **ppOptVal)
 
 	/* name - up until '=' or whitespace */
 	i = 0;
-	while(i < (sizeof(optname)/sizeof(uchar) - 1) && *p && *p != '=' && !isspace(*p)) {
+	while(i < (sizeof(optname) - 1) && *p && *p != '=' && !isspace(*p)) {
 		optname[i++] = *p++;
 	}
 
@@ -1237,7 +1237,7 @@ dbgGetRTOptNamVal(uchar **ppszOpt, uchar **ppOptName, uchar **ppOptVal)
 			/* we have a value, get it */
 			++p;
 			i = 0;
-			while(i < (sizeof(optval)/sizeof(uchar) - 1) && *p && !isspace(*p)) {
+			while(i < (sizeof(optval) - 1) && *p && !isspace(*p)) {
 				optval[i++] = *p++;
 			}
 			optval[i] = '\0';

--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -305,7 +305,7 @@ resolveAddr(struct sockaddr_storage *addr, dnscache_entry_t *etry)
 				 * is OK in any way. We do also log the error message. rgerhards, 2007-07-16
 		 		 */
 		 		if(glbl.GetDropMalPTRMsgs() == 1) {
-					snprintf((char*)szErrMsg, sizeof(szErrMsg) / sizeof(uchar),
+					snprintf((char*)szErrMsg, sizeof(szErrMsg),
 						 "Malicious PTR record, message dropped "
 						 "IP = \"%s\" HOST = \"%s\"",
 						 szIP, fqdnBuf);
@@ -320,7 +320,7 @@ resolveAddr(struct sockaddr_storage *addr, dnscache_entry_t *etry)
 				 * (OK, I admit this is more or less impossible, but I am paranoid...)
 				 * rgerhards, 2007-07-16
 				 */
-				snprintf((char*)szErrMsg, sizeof(szErrMsg) / sizeof(uchar),
+				snprintf((char*)szErrMsg, sizeof(szErrMsg),
 					 "Malicious PTR record (message accepted, but used IP "
 					 "instead of PTR name: IP = \"%s\" HOST = \"%s\"",
 					 szIP, fqdnBuf);

--- a/runtime/errmsg.c
+++ b/runtime/errmsg.c
@@ -96,7 +96,7 @@ doLogMsg(const int iErrno, const int iErrCode,  const int severity, const char *
 			snprintf(buf, sizeof(buf), "%s [v%s try http://www.rsyslog.com/e/%d ]", msg, VERSION, iErrCode * -1);
 		}
 	}
-	buf[sizeof(buf)/sizeof(char) - 1] = '\0'; /* just to be on the safe side... */
+	buf[sizeof(buf) - 1] = '\0'; /* just to be on the safe side... */
 	errno = 0;
 	
 	glblErrLogger(severity, iErrCode, (uchar*)buf);
@@ -129,7 +129,7 @@ LogError(const int iErrno, const int iErrCode, const char *fmt, ... )
 		lenBuf--;
 	}
 	va_end(ap);
-	buf[sizeof(buf)/sizeof(char) - 1] = '\0'; /* just to be on the safe side... */
+	buf[sizeof(buf) - 1] = '\0'; /* just to be on the safe side... */
 	
 	doLogMsg(iErrno, iErrCode, LOG_ERR, buf);
 }
@@ -158,7 +158,7 @@ LogMsg(const int iErrno, const int iErrCode, const int severity, const char *fmt
 		lenBuf--;
 	}
 	va_end(ap);
-	buf[sizeof(buf)/sizeof(char) - 1] = '\0'; /* just to be on the safe side... */
+	buf[sizeof(buf) - 1] = '\0'; /* just to be on the safe side... */
 	
 	doLogMsg(iErrno, iErrCode, severity, buf);
 }

--- a/runtime/gss-misc.c
+++ b/runtime/gss-misc.c
@@ -76,7 +76,7 @@ static void display_status_(char *m, OM_uint32 code, int type)
 		} else {
 			char buf[1024];
 			snprintf(buf, sizeof(buf), "GSS-API error %s: %s\n", m, (char *) msg.value);
-			buf[sizeof(buf)/sizeof(char) - 1] = '\0';
+			buf[sizeof(buf) - 1] = '\0';
 			errmsg.LogError(0, NO_ERRCODE, "%s", buf);
 		}
 		if (msg.length != 0)

--- a/runtime/librsgt.c
+++ b/runtime/librsgt.c
@@ -626,7 +626,7 @@ sigblkInit(gtfile gf)
 {
 	if(gf == NULL) goto done;
 	seedIV(gf);
-	memset(gf->roots_valid, 0, sizeof(gf->roots_valid)/sizeof(char));
+	memset(gf->roots_valid, 0, sizeof(gf->roots_valid));
 	gf->nRoots = 0;
 	gf->nRecords = 0;
 	gf->bInBlk = 1;

--- a/runtime/librsksi.c
+++ b/runtime/librsksi.c
@@ -657,7 +657,7 @@ sigblkInitKSI(ksifile ksi)
 {
 	if(ksi == NULL) goto done;
 	seedIVKSI(ksi);
-	memset(ksi->roots_valid, 0, sizeof(ksi->roots_valid)/sizeof(char));
+	memset(ksi->roots_valid, 0, sizeof(ksi->roots_valid));
 	ksi->nRoots = 0;
 	ksi->nRecords = 0;
 	ksi->bInBlk = 1;

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -1129,7 +1129,7 @@ Load(uchar *pModName, sbool bConfLoad, struct nvlst *lst)
 					free(pPathBuf);
 				/* we always alloc enough memory for everything we potentiall need to add */
 				lenPathBuf = PATHBUF_OVERHEAD;
-				CHKmalloc(pPathBuf = malloc(sizeof(uchar)*lenPathBuf));
+				CHKmalloc(pPathBuf = malloc(lenPathBuf));
 			}
 			*pPathBuf = '\0';	/* we do not need to append the path - its already in the module name */
 			iPathLen = 0;
@@ -1152,7 +1152,7 @@ Load(uchar *pModName, sbool bConfLoad, struct nvlst *lst)
 					free(pPathBuf);
 				/* we always alloc enough memory for everything we potentiall need to add */
 				lenPathBuf = iPathLen + PATHBUF_OVERHEAD;
-				CHKmalloc(pPathBuf = malloc(sizeof(uchar)*lenPathBuf));
+				CHKmalloc(pPathBuf = malloc(lenPathBuf));
 			}
 
 			memcpy((char *) pPathBuf, (char *)pModDirCurr, iPathLen);

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2724,15 +2724,19 @@ void MsgSetRawMsgWOSize(msg_t * const pMsg, char* pszRawMsg)
  * The variable pRes must point to a user-supplied buffer of
  * at least 20 characters.
  */
-static void
-textpri(const msg_t *const __restrict__ pMsg, uchar *const __restrict__ pRes)
+static uchar *
+textpri(const msg_t *const __restrict__ pMsg)
 {
-	assert(pRes != NULL);
-	memcpy(pRes, syslog_fac_names[pMsg->iFacility], len_syslog_fac_names[pMsg->iFacility]);
-	pRes[len_syslog_fac_names[pMsg->iFacility]] = '.';
-	memcpy(pRes+len_syslog_fac_names[pMsg->iFacility]+1,
-	       syslog_severity_names[pMsg->iSeverity],
-	       len_syslog_severity_names[pMsg->iSeverity]+1 /* for \0! */);
+	int lenfac = len_syslog_fac_names[pMsg->iFacility];
+	int lensev = len_syslog_severity_names[pMsg->iSeverity];
+	int totlen = lenfac + 1 + lensev + 1;
+	char *pRes = MALLOC(totlen);
+	if(pRes != NULL) {
+		memcpy(pRes, syslog_fac_names[pMsg->iFacility], lenfac);
+		pRes[lenfac] = '.';
+		memcpy(pRes+lenfac+1, syslog_severity_names[pMsg->iSeverity], lensev+1 /* for \0! */);
+	}
+	return pRes;
 }
 
 
@@ -2750,7 +2754,7 @@ static uchar *getNOW(eNOWType eNow, struct syslogTime *t)
 	uchar *pBuf;
 	struct syslogTime tt;
 
-	if((pBuf = (uchar*) MALLOC(sizeof(uchar) * tmpBUFSIZE)) == NULL) {
+	if((pBuf = (uchar*) MALLOC(tmpBUFSIZE)) == NULL) {
 		return NULL;
 	}
 
@@ -3263,10 +3267,10 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			pRes = (uchar*)getPRI(pMsg);
 			break;
 		case PROP_PRI_TEXT:
-			if((pRes = MALLOC(20 * sizeof(uchar))) == NULL)
+			pRes = textpri(pMsg);
+			if(pRes == NULL)
 				RET_OUT_OF_MEMORY;
 			*pbMustBeFreed = 1;
-			textpri(pMsg, pRes);
 			break;
 		case PROP_IUT:
 			pRes = UCHAR_CONSTANT("1"); /* always 1 for syslog messages (a MonitorWare thing;)) */
@@ -3427,7 +3431,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			{
 			struct timespec tp;
 
-			if((pRes = (uchar*) MALLOC(sizeof(uchar) * 32)) == NULL) {
+			if((pRes = (uchar*) MALLOC(32)) == NULL) {
 				RET_OUT_OF_MEMORY;
 			}
  
@@ -3439,7 +3443,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
  
 			*pbMustBeFreed = 1;
 
-			snprintf((char*) pRes, sizeof(uchar) * 32, "%ld", tp.tv_sec);
+			snprintf((char*) pRes, 32, "%ld", tp.tv_sec);
  			}
 
 #			else
@@ -3447,7 +3451,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			{
 			struct sysinfo s_info;
 
-			if((pRes = (uchar*) MALLOC(sizeof(uchar) * 32)) == NULL) {
+			if((pRes = (uchar*) MALLOC(32)) == NULL) {
 				RET_OUT_OF_MEMORY;
 			}
 
@@ -3459,7 +3463,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 
 			*pbMustBeFreed = 1;
 
-			snprintf((char*) pRes, sizeof(uchar) * 32, "%ld", s_info.uptime);
+			snprintf((char*) pRes, 32, "%ld", s_info.uptime);
 			}
 #			endif
 		break;
@@ -3526,7 +3530,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			/* we got our end pointer, now do the copy */
 			/* TODO: code copied from below, this is a candidate for a separate function */
 			iLen = pFldEnd - pFld + 1; /* the +1 is for an actual char, NOT \0! */
-			pBufStart = pBuf = MALLOC((iLen + 1) * sizeof(uchar));
+			pBufStart = pBuf = MALLOC(iLen + 1);
 			if(pBuf == NULL) {
 				if(*pbMustBeFreed == 1)
 					free(pRes);
@@ -3638,7 +3642,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 
 					iLenBuf = pmatch[pTpe->data.field.iSubMatchToUse].rm_eo
 						  - pmatch[pTpe->data.field.iSubMatchToUse].rm_so;
-					pB = MALLOC((iLenBuf + 1) * sizeof(uchar));
+					pB = MALLOC(iLenBuf + 1);
 
 					if (pB == NULL) {
 						if (*pbMustBeFreed == 1)
@@ -3704,7 +3708,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 					iTo = bufLen - 1;
 
 			iLen = iTo - iFrom + 1; /* the +1 is for an actual char, NOT \0! */
-			pBufStart = pBuf = MALLOC((iLen + 1) * sizeof(uchar));
+			pBufStart = pBuf = MALLOC(iLen + 1);
 			if(pBuf == NULL) {
 				if(*pbMustBeFreed == 1)
 					free(pRes);
@@ -3762,7 +3766,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			uchar *pBStart;
 			uchar *pB;
 			uchar *pSrc;
-			pBStart = pB = MALLOC((bufLen + 1) * sizeof(uchar));
+			pBStart = pB = MALLOC(bufLen + 1);
 			if(pB == NULL) {
 				if(*pbMustBeFreed == 1)
 					free(pRes);
@@ -3883,7 +3887,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 				int i;
 
 				iLenBuf += iNumCC * 4;
-				pBStart = pB = MALLOC((iLenBuf + 1) * sizeof(uchar));
+				pBStart = pB = MALLOC(iLenBuf + 1);
 				if(pB == NULL) {
 					if(*pbMustBeFreed == 1)
 						free(pRes);
@@ -4018,7 +4022,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			/* check if we need to obtain a private copy */
 			if(*pbMustBeFreed == 0) {
 				/* ok, original copy, need a private one */
-				pB = MALLOC((iLn + 1) * sizeof(uchar));
+				pB = MALLOC(iLn + 1);
 				if(pB == NULL) {
 					RET_OUT_OF_MEMORY;
 				}
@@ -4046,7 +4050,7 @@ uchar *MsgGetProp(msg_t *__restrict__ const pMsg, struct templateEntry *__restri
 			bufLen = ustrlen(pRes);
 		iBufLen = bufLen;
 		/* the malloc may be optimized, we currently use the worst case... */
-		pBStart = pDst = MALLOC((2 * iBufLen + 3) * sizeof(uchar));
+		pBStart = pDst = MALLOC(2 * iBufLen + 3);
 		if(pDst == NULL) {
 			if(*pbMustBeFreed == 1)
 				free(pRes);

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -1106,7 +1106,7 @@ GetName(obj_t *pThis)
 	ISOBJ_assert(pThis);
 
 	if(pThis->pszName == NULL) {
-		snprintf((char*)szName, sizeof(szName)/sizeof(uchar), "%s %p", objGetClassName(pThis), pThis);
+		snprintf((char*)szName, sizeof(szName), "%s %p", objGetClassName(pThis), pThis);
 		SetName(pThis, szName);
 		/* looks strange, but we NEED to re-check because if there was an
 		 * error in objSetName(), the pointer may still be NULL

--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -346,7 +346,7 @@ static inline rsRetVal uncompressMessage(msg_t *pMsg)
 		 */
 		int ret;
 		iLenDefBuf = glbl.GetMaxLine();
-		CHKmalloc(deflateBuf = MALLOC(sizeof(uchar) * (iLenDefBuf + 1)));
+		CHKmalloc(deflateBuf = MALLOC(iLenDefBuf + 1));
 		ret = uncompress((uchar *) deflateBuf, &iLenDefBuf, (uchar *) pszMsg+1, lenMsg-1);
 		DBGPRINTF("Compressed message uncompressed with status %d, length: new %ld, old %d.\n",
 		        ret, (long) iLenDefBuf, (int) (lenMsg-1));
@@ -476,7 +476,7 @@ SanitizeMsg(msg_t *pMsg)
 	if(maxDest < sizeof(szSanBuf))
 		pDst = szSanBuf;
 	else 
-		CHKmalloc(pDst = MALLOC(sizeof(uchar) * (iMaxLine + 1)));
+		CHKmalloc(pDst = MALLOC(iMaxLine + 1));
 	if(iSrc > 0) {
 		iSrc--; /* go back to where everything is OK */
 		memcpy(pDst, pszMsg, iSrc); /* fast copy known good */

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -412,7 +412,7 @@ StartDA(qqueue_t *pThis)
 	CHKiRet(qqueueConstruct(&pThis->pqDA, QUEUETYPE_DISK , 1, 0, pThis->pConsumer));
 
 	/* give it a name */
-	snprintf((char*) pszDAQName, sizeof(pszDAQName)/sizeof(uchar), "%s[DA]", obj.GetName((obj_t*) pThis));
+	snprintf((char*) pszDAQName, sizeof(pszDAQName), "%s[DA]", obj.GetName((obj_t*) pThis));
 	obj.SetName((obj_t*) pThis->pqDA, pszDAQName);
 
 	/* as the created queue is the same object class, we take the
@@ -2119,7 +2119,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 			/* special handling */
 			pThis->iNumWorkerThreads = 1; /* we need exactly one worker */
 			/* pre-construct file name for .qi file */
-			pThis->lenQIFNam = snprintf((char*)pszQIFNam, sizeof(pszQIFNam) / sizeof(uchar),
+			pThis->lenQIFNam = snprintf((char*)pszQIFNam, sizeof(pszQIFNam),
 				"%s/%s.qi", (char*) pThis->pszSpoolDir, (char*)pThis->pszFilePrefix);
 			pThis->pszQIFNam = ustrdup(pszQIFNam);
 			DBGOPRINT((obj_t*) pThis, ".qi file name is '%s', len %d\n", pThis->pszQIFNam,
@@ -2627,7 +2627,7 @@ qqueueSetFilePrefix(qqueue_t *pThis, uchar *pszPrefix, size_t iLenPrefix)
 	if(pszPrefix == NULL) /* just unset the prefix! */
 		ABORT_FINALIZE(RS_RET_OK);
 
-	if((pThis->pszFilePrefix = MALLOC(sizeof(uchar) * iLenPrefix + 1)) == NULL)
+	if((pThis->pszFilePrefix = MALLOC(iLenPrefix + 1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	memcpy(pThis->pszFilePrefix, pszPrefix, iLenPrefix + 1);
 	pThis->lenFilePrefix = iLenPrefix;

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -513,7 +513,7 @@ static void doDropPrivGid(int iGid)
 		exit(1);
 	}
 	DBGPRINTF("setgid(%d): %d\n", iGid, res);
-	snprintf((char*)szBuf, sizeof(szBuf)/sizeof(uchar), "rsyslogd's groupid changed to %d", iGid);
+	snprintf((char*)szBuf, sizeof(szBuf), "rsyslogd's groupid changed to %d", iGid);
 	logmsgInternal(NO_ERRCODE, LOG_SYSLOG|LOG_INFO, szBuf, 0);
 }
 
@@ -552,7 +552,7 @@ static void doDropPrivUid(int iUid)
 		exit(1);
 	}
 	DBGPRINTF("setuid(%d): %d\n", iUid, res);
-	snprintf((char*)szBuf, sizeof(szBuf)/sizeof(uchar), "rsyslogd's userid changed to %d", iUid);
+	snprintf((char*)szBuf, sizeof(szBuf), "rsyslogd's userid changed to %d", iUid);
 	logmsgInternal(NO_ERRCODE, LOG_SYSLOG|LOG_INFO, szBuf, 0);
 }
 

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -206,7 +206,7 @@ int makeFileParentDirs(const uchar *const szFile, size_t lenFile, mode_t mode,
 	assert(lenFile > 0);
 
         len = lenFile + 1; /* add one for '\0'-byte */
-	if((pszWork = MALLOC(sizeof(uchar) * len)) == NULL)
+	if((pszWork = MALLOC(len)) == NULL)
 		return -1;
         memcpy(pszWork, szFile, len);
         for(p = pszWork+1 ; *p ; p++)
@@ -356,7 +356,7 @@ rsRetVal genFileName(uchar **ppName, uchar *pDirName, size_t lenDirName, uchar *
 	}
 
 	lenName = lenDirName + 1 + lenFName + lenBuf + 1; /* last +1 for \0 char! */
-	if((pName = MALLOC(sizeof(uchar) * lenName)) == NULL)
+	if((pName = MALLOC(lenName)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	
 	/* got memory, now construct string */

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -915,7 +915,7 @@ static rsRetVal strmConstructFinalize(strm_t *pThis)
 			 * to make sure we can write out everything with a SINGLE api call!
 			 * We add another 128 bytes to take care of the gzip header and "all eventualities".
 			 */
-			CHKmalloc(pThis->pZipBuf = (Bytef*) MALLOC(sizeof(uchar) * (pThis->sIOBufSize + 128)));
+			CHKmalloc(pThis->pZipBuf = (Bytef*) MALLOC(pThis->sIOBufSize + 128));
 		}
 	}
 
@@ -947,7 +947,7 @@ static rsRetVal strmConstructFinalize(strm_t *pThis)
 		pthread_cond_init(&pThis->isEmpty, 0);
 		pThis->iCnt = pThis->iEnq = pThis->iDeq = 0;
 		for(i = 0 ; i < STREAM_ASYNC_NUMBUFS ; ++i) {
-			CHKmalloc(pThis->asyncBuf[i].pBuf = (uchar*) MALLOC(sizeof(uchar) * pThis->sIOBufSize));
+			CHKmalloc(pThis->asyncBuf[i].pBuf = (uchar*) MALLOC(pThis->sIOBufSize));
 		}
 		pThis->pIOBuf = pThis->asyncBuf[0].pBuf;
 		pThis->bStopWriter = 0;
@@ -961,7 +961,7 @@ static rsRetVal strmConstructFinalize(strm_t *pThis)
 			DBGPRINTF("ERROR: stream %p cold not create writer thread\n", pThis);
 	} else {
 		/* we work synchronously, so we need to alloc a fixed pIOBuf */
-		CHKmalloc(pThis->pIOBuf = (uchar*) MALLOC(sizeof(uchar) * pThis->sIOBufSize));
+		CHKmalloc(pThis->pIOBuf = (uchar*) MALLOC(pThis->sIOBufSize));
 	}
 
 finalize_it:
@@ -1834,7 +1834,7 @@ strmSetFName(strm_t *pThis, uchar *pszName, size_t iLenName)
 	if(pThis->pszFName != NULL)
 		free(pThis->pszFName);
 
-	if((pThis->pszFName = MALLOC(sizeof(uchar) * (iLenName + 1))) == NULL)
+	if((pThis->pszFName = MALLOC(iLenName + 1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 
 	memcpy(pThis->pszFName, pszName, iLenName + 1); /* always think about the \0! */
@@ -1861,7 +1861,7 @@ strmSetDir(strm_t *pThis, uchar *pszDir, size_t iLenDir)
 	if(iLenDir < 1)
 		ABORT_FINALIZE(RS_RET_FILE_PREFIX_MISSING);
 
-	CHKmalloc(pThis->pszDir = MALLOC(sizeof(uchar) * (iLenDir + 1)));
+	CHKmalloc(pThis->pszDir = MALLOC(iLenDir + 1));
 
 	memcpy(pThis->pszDir, pszDir, iLenDir + 1); /* always think about the \0! */
 	pThis->lenDir = iLenDir;

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -90,7 +90,7 @@ rsRetVal rsCStrConstructFromszStr(cstr_t **ppThis, uchar *sz)
 	CHKiRet(rsCStrConstruct(&pThis));
 
 	pThis->iBufSize = pThis->iStrLen = strlen((char *) sz);
-	if((pThis->pBuf = (uchar*) MALLOC(sizeof(uchar) * pThis->iStrLen)) == NULL) {
+	if((pThis->pBuf = (uchar*) MALLOC(pThis->iStrLen)) == NULL) {
 		RSFREEOBJ(pThis);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
@@ -128,7 +128,7 @@ static rsRetVal rsCStrConstructFromszStrv(cstr_t **ppThis, char *fmt, va_list ap
 
 	pThis->iBufSize = pThis->iStrLen = len;
 	len++; /* account for the \0 written by vsnprintf */
-	if((pThis->pBuf = (uchar*) MALLOC(sizeof(uchar) * len)) == NULL) {
+	if((pThis->pBuf = (uchar*) MALLOC(len)) == NULL) {
 		RSFREEOBJ(pThis);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
@@ -168,7 +168,7 @@ rsRetVal cstrConstructFromESStr(cstr_t **ppThis, es_str_t *str)
 	CHKiRet(rsCStrConstruct(&pThis));
 
 	pThis->iBufSize = pThis->iStrLen = es_strlen(str);
-	if((pThis->pBuf = (uchar*) MALLOC(sizeof(uchar) * pThis->iStrLen)) == NULL) {
+	if((pThis->pBuf = (uchar*) MALLOC(pThis->iStrLen)) == NULL) {
 		RSFREEOBJ(pThis);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
@@ -197,7 +197,7 @@ rsRetVal rsCStrConstructFromCStr(cstr_t **ppThis, cstr_t *pFrom)
 	CHKiRet(rsCStrConstruct(&pThis));
 
 	pThis->iBufSize = pThis->iStrLen = pFrom->iStrLen;
-	if((pThis->pBuf = (uchar*) MALLOC(sizeof(uchar) * pThis->iStrLen)) == NULL) {
+	if((pThis->pBuf = (uchar*) MALLOC(pThis->iStrLen)) == NULL) {
 		RSFREEOBJ(pThis);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
@@ -252,7 +252,7 @@ rsCStrExtendBuf(cstr_t *pThis, size_t iMinNeeded)
 	iNewSize += pThis->iBufSize; /* add current size */
 
 	/* DEV debugging only: dbgprintf("extending string buffer, old %d, new %d\n", pThis->iBufSize, iNewSize); */
-	CHKmalloc(pNewBuf = (uchar*) realloc(pThis->pBuf, iNewSize * sizeof(uchar)));
+	CHKmalloc(pNewBuf = (uchar*) realloc(pThis->pBuf, iNewSize));
 	pThis->iBufSize = iNewSize;
 	pThis->pBuf = pNewBuf;
 
@@ -366,7 +366,7 @@ rsRetVal rsCStrSetSzStr(cstr_t *pThis, uchar *pszNew)
 		pThis->pszBuf = NULL;
 
 		/* now save the new value */
-		if((pThis->pBuf = (uchar*) MALLOC(sizeof(uchar) * pThis->iStrLen)) == NULL) {
+		if((pThis->pBuf = (uchar*) MALLOC(pThis->iStrLen)) == NULL) {
 			RSFREEOBJ(pThis);
 			return RS_RET_OUT_OF_MEMORY;
 		}
@@ -414,7 +414,7 @@ uchar*  rsCStrGetSzStr(cstr_t *pThis)
 	if(pThis->pBuf != NULL)
 		if(pThis->pszBuf == NULL) {
 			/* we do not yet have a usable sz version - so create it... */
-			if((pThis->pszBuf = MALLOC((pThis->iStrLen + 1) * sizeof(uchar))) == NULL) {
+			if((pThis->pszBuf = MALLOC(pThis->iStrLen + 1)) == NULL) {
 				/* TODO: think about what to do - so far, I have no bright
 				 *       idea... rgerhards 2005-09-07
 				 */
@@ -471,7 +471,7 @@ rsRetVal cstrConvSzStrAndDestruct(cstr_t **ppThis, uchar **ppSz, int bRetNULL)
 
 	if(pThis->pBuf == NULL) {
 		if(bRetNULL == 0) {
-			CHKmalloc(pRetBuf = MALLOC(sizeof(uchar)));
+			CHKmalloc(pRetBuf = MALLOC(1));
 			*pRetBuf = '\0';
 		} else {
 			pRetBuf = NULL;

--- a/runtime/tcpclt.c
+++ b/runtime/tcpclt.c
@@ -169,7 +169,7 @@ TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int *pbMustBeFreed)
 			 * I have added this comment so that the logic is not accidently
 			 * changed again. rgerhards, 2005-10-25
 			 */
-			if((buf = MALLOC((len + 2) * sizeof(char))) == NULL) {
+			if((buf = MALLOC(len + 2)) == NULL) {
 				/* extreme mem shortage, try to solve
 				 * as good as we can. No point in calling
 				 * any alarms, they might as well run out
@@ -213,11 +213,11 @@ TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int *pbMustBeFreed)
 		 * comments with "IETF20061218".
 		 * rgerhards, 2006-12-19
 		 */
-		iLenBuf = snprintf(szLenBuf, sizeof(szLenBuf)/sizeof(char), "%d ", (int) len);
+		iLenBuf = snprintf(szLenBuf, sizeof(szLenBuf), "%d ", (int) len);
 		/* IETF20061218 iLenBuf =
-		  snprintf(szLenBuf, sizeof(szLenBuf)/sizeof(char), "%d ", len + iLenBuf);*/
+		  snprintf(szLenBuf, sizeof(szLenBuf), "%d ", len + iLenBuf);*/
 
-		if((buf = MALLOC((len + iLenBuf) * sizeof(char))) == NULL) {
+		if((buf = MALLOC(len + iLenBuf)) == NULL) {
 			/* we are out of memory. This is an extreme situation. We do not
 			 * call any alarm handlers because they most likely run out of mem,
 			 * too. We are brave enough to call debug output, though. Other than

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -70,7 +70,7 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
 		pThis->bAtStrtOfFram = 1; /* indicate frame header expected */
 		pThis->eFraming = TCP_FRAMING_OCTET_STUFFING; /* just make sure... */
 		/* now allocate the message reception buffer */
-		CHKmalloc(pThis->pMsg = (uchar*) MALLOC(sizeof(uchar) * glbl.GetMaxLine() + 1));
+		CHKmalloc(pThis->pMsg = (uchar*) MALLOC(glbl.GetMaxLine() + 1));
 finalize_it:
 ENDobjConstruct(tcps_sess)
 

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -408,7 +408,7 @@ wtiSetDbgHdr(wti_t *pThis, uchar *pszMsg, size_t lenMsg)
 		free(pThis->pszDbgHdr);
 	}
 
-	if((pThis->pszDbgHdr = MALLOC(sizeof(uchar) * lenMsg + 1)) == NULL)
+	if((pThis->pszDbgHdr = MALLOC(lenMsg + 1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 
 	memcpy(pThis->pszDbgHdr, pszMsg, lenMsg + 1); /* always think about the \0! */

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -525,7 +525,7 @@ wtpSetDbgHdr(wtp_t *pThis, uchar *pszMsg, size_t lenMsg)
 		pThis->pszDbgHdr = NULL;
 	}
 
-	if((pThis->pszDbgHdr = MALLOC(sizeof(uchar) * lenMsg + 1)) == NULL)
+	if((pThis->pszDbgHdr = MALLOC(lenMsg + 1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 
 	memcpy(pThis->pszDbgHdr, pszMsg, lenMsg + 1); /* always think about the \0! */

--- a/template.c
+++ b/template.c
@@ -688,7 +688,7 @@ static void doOptions(unsigned char **pp, struct templateEntry *pTpe)
 	while(*p && *p != '%' && *p != ':') {
 		/* outer loop - until end of options */
 		i = 0;
-		while((i < sizeof(Buf) / sizeof(char)) &&
+		while((i < sizeof(Buf)) &&
 		      *p && *p != '%' && *p != ':' && *p != ',') {
 			/* inner loop - until end of ONE option */
 			Buf[i++] = tolower((int)*p);
@@ -1242,7 +1242,7 @@ struct template *tplAddLine(rsconf_t *conf, char* pName, uchar** ppRestOfConfLin
 	
 	DBGPRINTF("tplAddLine processing template '%s'\n", pName);
 	pTpl->iLenName = strlen(pName);
-	pTpl->pszName = (char*) MALLOC(sizeof(char) * (pTpl->iLenName + 1));
+	pTpl->pszName = (char*) MALLOC(pTpl->iLenName + 1);
 	if(pTpl->pszName == NULL) {
 		dbgprintf("tplAddLine could not alloc memory for template name!");
 		pTpl->iLenName = 0;

--- a/tools/pmrfc5424.c
+++ b/tools/pmrfc5424.c
@@ -235,7 +235,7 @@ CODESTARTparse
 	 * message, so we can not run into any troubles. I think this is
 	 * wiser than to use individual buffers.
 	 */
-	CHKmalloc(pBuf = MALLOC(sizeof(uchar) * (lenMsg + 1)));
+	CHKmalloc(pBuf = MALLOC(lenMsg + 1));
 		
 	/* IMPORTANT NOTE:
 	 * Validation is not actually done below nor are any errors handled. I have

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1311,7 +1311,7 @@ initAll(int argc, char **argv)
 
 	if(ourConf->globals.bLogStatusMsgs) {
 		char bufStartUpMsg[512];
-		snprintf(bufStartUpMsg, sizeof(bufStartUpMsg)/sizeof(char),
+		snprintf(bufStartUpMsg, sizeof(bufStartUpMsg),
 			 " [origin software=\"rsyslogd\" " "swVersion=\"" VERSION \
 			 "\" x-pid=\"%d\" x-info=\"http://www.rsyslog.com\"] start",
 			 (int) glblGetOurPid());
@@ -1430,7 +1430,7 @@ doHUP(void)
 	char buf[512];
 
 	if(ourConf->globals.bLogStatusMsgs) {
-		snprintf(buf, sizeof(buf) / sizeof(char),
+		snprintf(buf, sizeof(buf),
 			 " [origin software=\"rsyslogd\" " "swVersion=\"" VERSION
 			 "\" x-pid=\"%d\" x-info=\"http://www.rsyslog.com\"] rsyslogd was HUPed",
 			 (int) glblGetOurPid());
@@ -1564,7 +1564,7 @@ deinitAll(void)
 
 	/* and THEN send the termination log message (see long comment above) */
 	if(bFinished && runConf->globals.bLogStatusMsgs) {
-		(void) snprintf(buf, sizeof(buf) / sizeof(char),
+		(void) snprintf(buf, sizeof(buf),
 		 " [origin software=\"rsyslogd\" " "swVersion=\"" VERSION \
 		 "\" x-pid=\"%d\" x-info=\"http://www.rsyslog.com\"]" " exiting on signal %d.",
 		 (int) glblGetOurPid(), bFinished);

--- a/tools/syncdemo.c
+++ b/tools/syncdemo.c
@@ -329,7 +329,7 @@ dispRuntime(unsigned rt)
 {
 	static char *fmtbuf;
 
-	fmtbuf = malloc(32 * sizeof(char));
+	fmtbuf = malloc(32);
 	snprintf(fmtbuf, 32, "%u.%03.3u",
 		 rt / 1000, rt % 1000);
 	return(fmtbuf);

--- a/tools/syslogd.c
+++ b/tools/syslogd.c
@@ -168,7 +168,7 @@ char **syslogd_crunch_list(char *list)
 	 */
 	count = 0;
 	while ((q=strchr(p, LIST_DELIMITER))) {
-		result[count] = (char *) MALLOC((q - p + 1) * sizeof(char));
+		result[count] = (char *) MALLOC(q - p + 1);
 		if (result[count] == NULL) {
 			printf ("Sorry, can't get enough memory, exiting.\n");
 			exit(0); /* safe exit, because only called during startup */
@@ -179,7 +179,7 @@ char **syslogd_crunch_list(char *list)
 		count++;
 	}
 	if ((result[count] = \
-	     (char *)MALLOC(sizeof(char) * strlen(p) + 1)) == NULL) {
+	     (char *)MALLOC(strlen(p) + 1)) == NULL) {
 		printf ("Sorry, can't get enough memory, exiting.\n");
 		exit(0); /* safe exit, because only called during startup */
 	}


### PR DESCRIPTION
Remove the use `sizeof(char)` or `sizeof(uchar)` in calculations for memory
allocation or string length.  There are no known platforms for which
`sizeof(char)` or `sizeof(uchar)` is not 1, and c99 has defined `sizeof(char)`
to be `1` (section 6.5.3.4 of c99).