### PR TITLE
Enable option use /etc/sysconfig/rsyslog

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -14,8 +14,13 @@ nodist_systemdsystemunit_DATA = \
 CLEANFILES = \
 	rsyslog.service
 
+if ENABLE_RSYSLOG_SYSCONFIG
 %.service: %.service.in
-	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g' $< > $@
+	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g;s,@syslogd_options\@, $$SYSLOGD_OPTIONS,g;s,@syslogd_options_env_file\@,EnvironmentFile=-/etc/sysconfig/rsyslog,g' $< > $@
+else
+%.service: %.service.in
+	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g;s,@syslogd_options\@,,g;/@syslogd_options_env_file\@/d' $< > $@
+endif
 
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -409,6 +409,17 @@ if test "$enable_jemalloc" = "yes"; then
     )
 fi
 
+# support using /etc/sysconfig/rsyslog
+AC_ARG_ENABLE(rsyslog_sysconfig,
+	[AS_HELP_STRING([--enable-rsyslog-sysconfig],[Enable use of etc sysconfig rsyslog @<:@default=no@:>@])],
+	[case "${enableval}" in
+	 yes) enable_rsyslog_sysconfig="yes" ;;
+	  no) enable_rsyslog_sysconfig="no" ;;
+	   *) AC_MSG_ERROR(bad value ${enableval} for --enable-rsyslog-sysconfig) ;;
+	 esac],
+	[enable_rsyslog_sysconfig="no"]
+)
+AM_CONDITIONAL(ENABLE_RSYSLOG_SYSCONFIG, test x$enable_rsyslog_sysconfig = xyes)
 
 # support for unlimited select() syscall
 AC_ARG_ENABLE(unlimited_select,
@@ -1748,7 +1759,7 @@ AC_CONFIG_FILES([Makefile \
 		plugins/mmsnmptrapd/Makefile \
 		plugins/pmlastmsg/Makefile \
 		contrib/pmsnare/Makefile \
-    contrib/pmpanngfw/Makefile \
+		contrib/pmpanngfw/Makefile \
 		contrib/pmaixforwardedfrom/Makefile \
 		contrib/omhiredis/Makefile \
 		contrib/omrabbitmq/Makefile \
@@ -1784,6 +1795,7 @@ echo "    anonymization support enabled:            $enable_mmanon"
 echo "    message counting support enabled:         $enable_mmcount"
 echo "    mmfields enabled:                         $enable_mmfields"
 echo "    liblogging-stdlog support enabled:        $enable_liblogging_stdlog"
+echo "    use /etc/sysconfig/rsyslog                $enable_rsyslog_sysconfig"
 echo
 echo "---{ input plugins }---"
 echo "    Klog functionality enabled:               $enable_klog ($os_type)"

--- a/rsyslog.service.in
+++ b/rsyslog.service.in
@@ -6,7 +6,9 @@ Documentation=http://www.rsyslog.com/doc/
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/rsyslogd -n
+@syslogd_options_env_file@
+ExecStart=@sbindir@/rsyslogd -n@syslogd_options@
+UMask=0066
 StandardOutput=null
 Restart=on-failure
 


### PR DESCRIPTION
Add an option to use `/etc/sysconfig/rsyslog` in the systemd service file.
This lets Fedora drop the patch they are carrying, and is probably
useful for other platforms to consider.