### PR TITLE
Add missing json_null{,_array} tests to dist target

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -861,6 +861,12 @@ EXTRA_DIST= \
 	json_array_looping.sh \
 	json_nonarray_looping.sh \
 	testsuites/json_array_looping.conf \
+	json_null.sh \
+	json_null-vg.sh \
+	testsuites/json_null.conf \
+	json_null_array.sh \
+	json_null_array-vg.sh \
+	testsuites/json_null_array.conf \
 	mmnormalize_regex.sh \
 	testsuites/mmnormalize_regex.conf \
 	testsuites/mmnormalize_regex.rulebase \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -827,7 +827,7 @@ EXTRA_DIST= \
 	mysql-actq-mt-withpause-vg.sh \
 	testsuites/mysql-actq-mt.conf \
 	mmpstrucdata.sh \
-        mmpstrucdata-vg.sh \
+	mmpstrucdata-vg.sh \
 	testsuites/mmpstrucdata.conf \
 	mmpstrucdata-invalid-vg.sh \
 	testsuites/mmpstrucdata-invalid.conf \


### PR DESCRIPTION
These tests were not included in the rsyslog-8.15.0 release tarball.