### PR TITLE
Testbench add var tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,8 +15,6 @@ TESTS +=  \
 	msgvar-concurrency.sh \
 	localvar-concurrency.sh \
 	exec_tpl-concurrency.sh \
-	msgvar-concurrency-array.sh \
-	msgvar-concurrency-array-event.tags.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
 	fac_local7.sh \
@@ -255,6 +253,8 @@ endif
 endif
 
 if ENABLE_MMNORMALIZE
+TESTS += msgvar-concurrency-array.sh \
+	msgvar-concurrency-array-event.tags.sh
 if ENABLE_IMPTCP
 TESTS +=  \
 	mmnormalize_regex_defaulted.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,6 +15,8 @@ TESTS +=  \
 	msgvar-concurrency.sh \
 	localvar-concurrency.sh \
 	exec_tpl-concurrency.sh \
+	msgvar-concurrency-array.sh \
+	msgvar-concurrency-array-event.tags.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
 	fac_local7.sh \
@@ -519,10 +521,18 @@ EXTRA_DIST= \
 	testsuites/stop-msgvar.conf \
 	msgvar-concurrency.sh \
 	testsuites/msgvar-concurrency.conf \
+	msgvar-concurrency-array.sh \
+	testsuites/msgvar-concurrency-array.conf \
+	testsuites/msgvar-concurrency-array.rulebase \
+	msgvar-concurrency-array-event.tags.sh \
+	testsuites/msgvar-concurrency-array-event.tags.conf \
+	testsuites/msgvar-concurrency-array-event.tags.rulebase \
 	localvar-concurrency.sh \
 	testsuites/localvar-concurrency.conf \
 	exec_tpl-concurrency.sh \
 	testsuites/exec_tpl-concurrency.conf \
+	prop-all-json-concurrency.sh \
+	testsuites/prop-all-json-concurrency.conf \
 	global_vars.sh \
 	testsuites/global_vars.conf \
 	rfc5424parser.sh \

--- a/tests/msgvar-concurrency-array-event.tags.sh
+++ b/tests/msgvar-concurrency-array-event.tags.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Test concurrency of message variables
+# Added 2015-11-03 by rgerhards
+# This file is part of the rsyslog project, released  under ASL 2.0
+export TCPFLOOD_EXTRA_OPTS="-M'msg:msg: 1:2, 3:4, 5:6, 7:8 b test'"
+echo ===============================================================================
+echo \[msgvar-concurrency-array-event.tags.sh\]: testing concurrency of local variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup msgvar-concurrency-array-event.tags.conf
+sleep 1
+. $srcdir/diag.sh tcpflood -m500000
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+#. $srcdir/diag.sh seq-check 0 499999
+. $srcdir/diag.sh exit

--- a/tests/prop-all-json-concurrency.sh
+++ b/tests/prop-all-json-concurrency.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Test concurrency of exec_template function with msg variables
+# Added 2015-12-16 by rgerhards
+# This file is part of the rsyslog project, released  under ASL 2.0
+echo ===============================================================================
+echo \[prop-all-json-concurrency.sh\]: testing concurrency of $!all-json variables
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup prop-all-json-concurrency.conf
+sleep 1
+. $srcdir/diag.sh tcpflood -m500000
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh seq-check 0 499999
+. $srcdir/diag.sh exit

--- a/tests/testsuites/exec_tpl-concurrency.conf
+++ b/tests/testsuites/exec_tpl-concurrency.conf
@@ -5,14 +5,15 @@ input(type="imtcp" port="13514")
 
 template(name="interim" type="string" string="%$!tree!here!nbr%")
 template(name="outfmt" type="string" string="%$!interim%\n")
+template(name="all-json" type="string" string="%$!%\n")
 
 if $msg contains "msgnum:" then {
 	set $!tree!here!nbr = field($msg, 58, 2);
-	action(type="omfile" file="rsyslog2.out.log" template="outfmt"
+	action(type="omfile" file="rsyslog2.out.log" template="all-json"
 	       queue.type="linkedList")
 
 	set $!interim = exec_template("interim");
-	set $!tree!here!nbr = "";
+	unset $!tree!here!nbr;
 	action(type="omfile" file="rsyslog.out.log" template="outfmt"
 	       queue.type="fixedArray")
 }

--- a/tests/testsuites/msgvar-concurrency-array-event.tags.conf
+++ b/tests/testsuites/msgvar-concurrency-array-event.tags.conf
@@ -1,0 +1,18 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+template(name="outfmt" type="string" string="%$!%\n")
+
+#action(type="omfile" file="rsyslog2.out.log" template="outfmt" queue.type="linkedList")
+action(type="mmnormalize" ruleBase="testsuites/msgvar-concurrency-array-event.tags.rulebase")
+if $msg contains "msg:" then {
+#	set $!tree!here!nbr = field($msg, 58, 2); # Delimiter = :
+	action(type="omfile" file="rsyslog2.out.log" template="outfmt" queue.type="linkedList")
+	set $!tree!here!save = $!tree!here!nbr;
+	set $!tree!here!nbr = "";
+	set $!tree!here!nbr = $!tree!here!save;
+	action(type="omfile" file="rsyslog.out.log" template="outfmt" queue.type="linkedList")
+}

--- a/tests/testsuites/msgvar-concurrency-array-event.tags.rulebase
+++ b/tests/testsuites/msgvar-concurrency-array-event.tags.rulebase
@@ -1,0 +1,11 @@
+version=2
+rule=tag1,tag1,tag3:msg: %{"name":"numbers", "type":"repeat",
+			"parser":[
+			  {"name":"n1", "type":"number"},
+			  {"type":"literal", "text":":"},
+			  {"name":"n2", "type":"number"}
+			  ],
+			"while":[
+			  {"type":"literal", "text":", "}
+			]
+       		   }% b %w:word%

--- a/tests/testsuites/prop-all-json-concurrency.conf
+++ b/tests/testsuites/prop-all-json-concurrency.conf
@@ -1,0 +1,19 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+template(name="interim" type="string" string="%$!tree!here!nbr%")
+template(name="outfmt" type="string" string="%$.interim%\n")
+template(name="all-json" type="string" string="%$!%\n")
+
+if $msg contains "msgnum:" then {
+	set $!tree!here!nbr = field($msg, 58, 2);
+	action(type="omfile" file="rsyslog2.out.log" template="all-json"
+	       queue.type="linkedList")
+
+	set $.interim = $!all-json;
+	unset $!tree!here!nbr;
+	action(type="omfile" file="rsyslog.out.log" template="outfmt"
+	       queue.type="fixedArray")
+}


### PR DESCRIPTION
Adds tests for concurrent variable access. Some need libfastjson because of a segfault in json-c (https://github.com/json-c/json-c/pull/211).