### PR TITLE
impstats: support broken ElasticSearch JSON implementation

### DIFF
--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -341,6 +341,8 @@ CODESTARTsetModCnf
 			mode = es_str2cstr(pvals[i].val.d.estr, NULL);
 			if(!strcasecmp(mode, "json")) {
 				loadModConf->statsFmt = statsFmt_JSON;
+			} else if(!strcasecmp(mode, "json-elasticsearch")) {
+				loadModConf->statsFmt = statsFmt_JSON_ES;
 			} else if(!strcasecmp(mode, "cee")) {
 				loadModConf->statsFmt = statsFmt_CEE;
 			} else if(!strcasecmp(mode, "legacy")) {

--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -47,6 +47,7 @@ typedef enum statsCtrType_e {
 typedef enum statsFmtType_e {
 	statsFmt_Legacy,
 	statsFmt_JSON,
+	statsFmt_JSON_ES,
 	statsFmt_CEE
 } statsFmtType_t;
 


### PR DESCRIPTION
ES 2.0 no longer supports valid JSON and disallows dots inside names.
This adds a new "json-elasticsearch" format option which replaces
those dots by the bang ("!") character. So "discarded.full" becomes
"discarded!full".

This is a workaroud. A method that will provide more control over
replacemetns will be implemented some time in the future. For
details, see below-quoted issue tracker.

closes https://github.com/rsyslog/rsyslog/issues/713