### PR TITLE
Fix #718 caused by writing to unallocated address

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1764,7 +1764,13 @@ in_processEvent(struct inotify_event *ev)
 				evFileHelper.mask = IN_DELETE; 
 				evFileHelper.cookie = 0; 
 				evFileHelper.len = ev->len; 
-				evFileHelper.name[0] = ev->name[0]; 
+
+				/* XXX: evFileHelper.name is not allocated yet,
+				 * here we keep it untouched as we do not use
+				 * it for now.
+				 *
+				 * evFileHelper.name[0] = ev->name[0];
+				 */
 				in_removeFile(&evFileHelper, etry->dirIdx, pLstn);
 				DBGPRINTF("imfile: IN_MOVED_FROM Event file removed file (wd=%d, name=%s)\n", wd, ev->name);
 			}


### PR DESCRIPTION
`evFileHelper.name` is not allocated and not used at all, in typical
case its address is the same as the local variable `etry` in the same
stack (compiler optimization), assigning to `evFileHelper.name[0]`
actually corrupts the etry data structure and crashes the program.

Here's an example output from gdb session.

```
(gdb) p &evFileHelper.name
$6 = (char (*)[]) 0x7ffff6dfc930
(gdb) p &etry
$7 = (wd_map_t **) 0x7ffff6dfc930
(gdb)
```