### PR TITLE
Handling the condition of inotify instance's failed initialization

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1798,6 +1798,10 @@ do_inotify()
 	CHKiRet(wdmapInit());
 	CHKiRet(dirsInit());
 	ino_fd = inotify_init();
+        if(ino_fd < 0) {
+            errmsg.LogError(1, RS_RET_INOTIFY_INIT_FAILED, "imfile: Init inotify instance failed ");
+            return RS_RET_INOTIFY_INIT_FAILED;
+        }
 	DBGPRINTF("imfile: inotify fd %d\n", ino_fd);
 	in_setupInitialWatches();
 

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -171,6 +171,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_NO_MORE_DATA = -3006,	/**< insufficient data, e.g. end of string during parsing */
 	RS_RET_INVALID_IP = -3007,	/**< invalid ip found where valid was expected */
 	RS_RET_OBJ_CREATION_FAILED = - 3008, /**< the creation of an object failed (no details available) */
+	RS_RET_INOTIFY_INIT_FAILED = - 3009, /**< the initialization of an inotify instance failed (no details available) */
 	RS_RET_PARAM_ERROR = -1000,	/**< invalid parameter in call to function */
 	RS_RET_MISSING_INTERFACE = -1001,/**< interface version mismatch, required missing */
 	RS_RET_INVALID_CORE_INTERFACE = -1002,/**< interface provided by host invalid, can not be used */


### PR DESCRIPTION
### Summary

Seen in v8.14 and reproduced in master code (commit 8e974a3) as well.

The condition of inotify instance is not successfully initialized should be handled.

### Description

Default value for `max_user_instances` and `max_user_watches` are not large enough for high pressure conditions.

**In my real case**, rsyslog are deployed in `docker containers`, and all containers share one host's kernel, so it's easy to hit `max_user_instances` or `max_user_watches`'s limit, it causes initialization for new inotify instance's fail but no message is given, which confuses people meaningless.