### PR TITLE
cleanup: remove dbgprintf's not intended to stay

### DIFF
--- a/action.c
+++ b/action.c
@@ -63,7 +63,7 @@
  * beast.
  * rgerhards, 2011-06-15
  *
- * Copyright 2007-2015 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -791,7 +791,6 @@ actionCheckAndCreateWrkrInstance(action_t * const pThis, wti_t * const pWti)
 				(pThis->wrkrDataTableSize + 1) * sizeof(void*));
 			pThis->wrkrDataTableSize++;
 		}
-dbgprintf("DDDD: writing data to table spot %d\n", freeSpot);
 		pThis->wrkrDataTable[freeSpot] = pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData;
 		pThis->nWrkr++;
 		pthread_mutex_unlock(&pThis->mutWrkrDataTable);

--- a/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
+++ b/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
@@ -83,11 +83,9 @@ CODESTARTparse
 		--lenMsg;
 		++p2parse;
 	}
-dbgprintf("pmaixforwardedfrom: msg to look at: [%d]'%s'\n", lenMsg, p2parse);
 	if((unsigned) lenMsg < 42) {
 		/* too short, can not be "our" message */
                 /* minimum message, 16 character timestamp, 'Message forwarded from ", 1 character name, ': '*/
-dbgprintf("msg too short!\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 
@@ -97,7 +95,7 @@ dbgprintf("msg too short!\n");
         /* if there is the string "Message forwarded from " were the hostname should be */
 	if(strncasecmp((char*) p2parse, OpeningText, sizeof(OpeningText)-1) != 0) {
 		/* wrong opening text */
-dbgprintf("not a AIX message forwarded from mangled log!\n");
+	DBGPRINTF("not a AIX message forwarded from mangled log!\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 	/* bump the message portion up by 23 characters to overwrite the "Message forwarded from " with the hostname */
@@ -113,7 +111,7 @@ dbgprintf("not a AIX message forwarded from mangled log!\n");
 		++p2parse;
 	}
 	if (lenMsg && *p2parse != ':') {
-dbgprintf("not a AIX message forwarded from mangled log but similar enough that the preamble has been removed\n");
+	DBGPRINTF("not a AIX message forwarded from mangled log but similar enough that the preamble has been removed\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 	/* bump the message portion up by one character to overwrite the extra : */

--- a/contrib/pmcisconames/pmcisconames.c
+++ b/contrib/pmcisconames/pmcisconames.c
@@ -82,11 +82,9 @@ CODESTARTparse
 		--lenMsg;
 		++p2parse;
 	}
-dbgprintf("pmcisconames: msg to look at: [%d]'%s'\n", lenMsg, p2parse);
 	if((unsigned) lenMsg < 34) {
 		/* too short, can not be "our" message */
                 /* minimum message, 16 character timestamp, 1 character name, ' : %ASA-1-000000: '*/
-dbgprintf("msg too short!\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 	/* check if the timestamp is a 16 character or 21 character timestamp
@@ -123,7 +121,7 @@ dbgprintf("msg too short!\n");
         /* if the syslog tag is : and the next thing starts with a % assume that this is a mangled cisco log and fix it */
 	if(strncasecmp((char*) p2parse, OpeningText, sizeof(OpeningText)-1) != 0) {
 		/* wrong opening text */
-dbgprintf("not a cisco name mangled log!\n");
+	DBGPRINTF("not a cisco name mangled log!\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 	/* bump the message portion up by two characters to overwrite the extra : */

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1610,13 +1610,6 @@ in_dbg_showEv(struct inotify_event *ev)
 	 }
 }
 
-static void
-filesDisplay(void)
-{
-	lstn_t *pLstn;
-	for(pLstn = runModConf->pRootLstn ; pLstn != NULL ; pLstn = pLstn->next)
-		DBGPRINTF("DDDD: imfile: files: [%p]: '%s'\n", pLstn, pLstn->pszFileName);
-}
 
 /* inotify told us that a file's wd was closed. We now need to remove
  * the file from our internal structures. Remember that a different inode
@@ -1627,7 +1620,6 @@ in_removeFile(const struct inotify_event *const ev,
 	      const int dirIdx,
 	      lstn_t *const __restrict__ pLstn)
 {
-filesDisplay(); // TODO: remove after initial unstable release(s)
 	uchar statefile[MAXFNAME];
 	uchar toDel[MAXFNAME];
 	int bDoRMState;

--- a/plugins/mmaudit/mmaudit.c
+++ b/plugins/mmaudit/mmaudit.c
@@ -190,7 +190,6 @@ audit_parse(uchar *buf, struct json_object **jsonRoot)
 	json_object_object_add(*jsonRoot, "data", json);
 
 	while(*buf) {
-//dbgprintf("audit_parse, buf: '%s'\n", buf);
 		CHKiRet(parseName(&buf, name, sizeof(name)));
 		if(*buf != '=') {
 			ABORT_FINALIZE(RS_RET_ERR);
@@ -199,7 +198,6 @@ audit_parse(uchar *buf, struct json_object **jsonRoot)
 		CHKiRet(parseValue(&buf, val, sizeof(val)));
 		jval = json_object_new_string(val);
 		json_object_object_add(json, name, jval);
-dbgprintf("mmaudit: parsed %s=%s\n", name, val);
 	}
 	
 
@@ -226,7 +224,6 @@ CODESTARTdoAction
 	 */
 	buf = getMSG(pMsg);
 
-dbgprintf("mmaudit: msg is '%s'\n", buf);
 	while(*buf && isspace(*buf)) {
 		++buf;
 	}

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -4,7 +4,7 @@
  * NOTE: read comments in module-template.h for more specifics!
  *
  * Copyright 2011 Nathan Scott.
- * Copyright 2009-2014 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2009-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -155,7 +155,6 @@ ENDcreateInstance
 
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
-dbgprintf("omelasticsearch: createWrkrInstance\n");
 	pWrkrData->restURL = NULL;
 	if(pData->bulkmode) {
 		pWrkrData->batch.currTpl1 = NULL;
@@ -168,7 +167,6 @@ dbgprintf("omelasticsearch: createWrkrInstance\n");
 	}
 	CHKiRet(curlSetup(pWrkrData, pWrkrData->pData));
 finalize_it:
-dbgprintf("DDDD: createWrkrInstance,pData %p/%p, pWrkrData %p\n", pData, pWrkrData->pData, pWrkrData);
 ENDcreateWrkrInstance
 
 BEGINisCompatibleWithFeature
@@ -1074,7 +1072,6 @@ finalize_it:
 
 BEGINbeginTransaction
 CODESTARTbeginTransaction
-dbgprintf("omelasticsearch: beginTransaction, pWrkrData %p, pData %p\n", pWrkrData, pWrkrData->pData);
 	if(!pWrkrData->pData->bulkmode) {
 		FINALIZE;
 	}
@@ -1095,14 +1092,12 @@ CODESTARTdoAction
 		                 ppString, 1));
 	}
 finalize_it:
-dbgprintf("omelasticsearch: result doAction: %d (bulkmode %d)\n", iRet, pWrkrData->pData->bulkmode);
 ENDdoAction
 
 
 BEGINendTransaction
 	char *cstr = NULL;
 CODESTARTendTransaction
-dbgprintf("omelasticsearch: endTransaction init\n");
 	/* End Transaction only if batch data is not empty */
 	if (pWrkrData->batch.data != NULL ) {
 		cstr = es_str2cstr(pWrkrData->batch.data, NULL);
@@ -1113,7 +1108,6 @@ dbgprintf("omelasticsearch: endTransaction init\n");
 		dbgprintf("omelasticsearch: endTransaction, pWrkrData->batch.data is NULL, nothing to send. \n");
 finalize_it:
 	free(cstr);
-dbgprintf("omelasticsearch: endTransaction done with %d\n", iRet);
 ENDendTransaction
 
 /* elasticsearch POST result string ... useful for debugging */

--- a/plugins/omhdfs/omhdfs.c
+++ b/plugins/omhdfs/omhdfs.c
@@ -312,7 +312,6 @@ fileWrite(file_t *pFile, uchar *buf, size_t *lenWrite)
 		}
 	}
 
-dbgprintf("XXXXX: omhdfs writing %u bytes\n", *lenWrite);
 	tSize num_written_bytes = hdfsWrite(pFile->fs, pFile->fh, buf, *lenWrite);
 	if((unsigned) num_written_bytes != *lenWrite) {
 		errmsg.LogError(errno, RS_RET_ERR_HDFS_WRITE,
@@ -371,7 +370,6 @@ addData(instanceData *pData, uchar *buf)
 		memcpy((char*) pData->ioBuf + pData->offsBuf, buf, len);
 		pData->offsBuf += len;
 	} else {
-dbgprintf("XXXXX: not enough room, need to flush\n");
 		CHKiRet(fileWrite(pData->pFile, pData->ioBuf, &pData->offsBuf));
 		if(len >= sizeof(pData->ioBuf)) {
 			CHKiRet(fileWrite(pData->pFile, buf, &len));
@@ -426,7 +424,7 @@ ENDtryResume
 
 BEGINbeginTransaction
 CODESTARTbeginTransaction
-dbgprintf("omhdfs: beginTransaction\n");
+	DBGPRINTF("omhdfs: beginTransaction\n");
 ENDbeginTransaction
 
 
@@ -444,7 +442,7 @@ ENDdoAction
 BEGINendTransaction
 	instanceData *pData = pWrkrData->pData;
 CODESTARTendTransaction
-dbgprintf("omhdfs: endTransaction\n");
+	DBGPRINTF("omhdfs: endTransaction\n");
 	pthread_mutex_lock(&mutDoAct);
 	if(pData->offsBuf != 0) {
 		DBGPRINTF("omhdfs: data unwritten at end of transaction, persisting...\n");

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -287,8 +287,8 @@ getDefaultBSON(msg_t *pMsg)
 
 	/* TODO: move to datetime? Refactor in any case! rgerhards, 2012-03-30 */
 	ts_gen = (gint64) datetime.syslogTime2time_t(&pMsg->tTIMESTAMP) * 1000; /* ms! */
-dbgprintf("ommongodb: ts_gen is %lld\n", (long long) ts_gen);
-dbgprintf("ommongodb: secfrac is %d, precision %d\n",  pMsg->tTIMESTAMP.secfrac, pMsg->tTIMESTAMP.secfracPrecision);
+	DBGPRINTF("ommongodb: ts_gen is %lld\n", (long long) ts_gen);
+	DBGPRINTF("ommongodb: secfrac is %d, precision %d\n",  pMsg->tTIMESTAMP.secfrac, pMsg->tTIMESTAMP.secfracPrecision);
 	if(pMsg->tTIMESTAMP.secfracPrecision > 3) {
 		secfrac = pMsg->tTIMESTAMP.secfrac / i10pow(pMsg->tTIMESTAMP.secfracPrecision - 3);
 	} else if(pMsg->tTIMESTAMP.secfracPrecision < 3) {

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -366,7 +366,6 @@ CODESTARTnewActInst
 			OMSR_RQD_TPL_OPT_SQL));
 	}
 CODE_STD_FINALIZERnewActInst
-dbgprintf("XXXX: added param, iRet %d\n", iRet);
 	cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst
 

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -310,7 +310,6 @@ ENDdoAction
 BEGINendTransaction
 CODESTARTendTransaction
 	iRet = writePgSQL((uchar*) "commit;", pWrkrData->pData); /* TODO: make user-configurable */
-dbgprintf("ompgsql: endTransaction\n");
 ENDendTransaction
 #endif
 

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -16,7 +16,7 @@
  *
  * File begun on 2008-03-13 by RGerhards
  *
- * Copyright 2008-2014 Adiscon GmbH.
+ * Copyright 2008-2016 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -445,7 +445,7 @@ finalize_it:
 
 BEGINbeginTransaction
 CODESTARTbeginTransaction
-dbgprintf("omrelp: beginTransaction\n");
+	DBGPRINTF("omrelp: beginTransaction\n");
 	if(!pWrkrData->bIsConnected) {
 		CHKiRet(doConnect(pWrkrData));
 	}

--- a/plugins/pmlastmsg/pmlastmsg.c
+++ b/plugins/pmlastmsg/pmlastmsg.c
@@ -10,7 +10,7 @@
  *
  * File begun on 2010-07-13 by RGerhards
  *
- * Copyright 2014-2014 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2014-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -91,16 +91,13 @@ CODESTARTparse
 		--lenMsg;
 		++p2parse;
 	}
-dbgprintf("pmlastmsg: msg to look at: [%d]'%s'\n", lenMsg, p2parse);
 	if((unsigned) lenMsg < sizeof(OpeningText)-1 + sizeof(ClosingText)-1 + 1) {
 		/* too short, can not be "our" message */
-dbgprintf("msg too short!\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 
 	if(strncasecmp((char*) p2parse, OpeningText, sizeof(OpeningText)-1) != 0) {
 		/* wrong opening text */
-dbgprintf("wrong opening text!\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 	lenMsg -= sizeof(OpeningText) - 1;
@@ -119,9 +116,6 @@ dbgprintf("wrong opening text!\n");
 
 	if(strncasecmp((char*) p2parse, ClosingText, lenMsg) != 0) {
 		/* wrong closing text */
-dbgprintf("strcasecmp: %d\n", strncasecmp((char*) p2parse, ClosingText, lenMsg));
-dbgprintf("pmlastmsg: closing msg to look at: [%d]'%s', (%s)\n", lenMsg, p2parse, ClosingText);
-dbgprintf("wrong closing text!\n");
 		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -7,7 +7,7 @@
  * of the "old" message code without any modifications. However, it
  * helps to have things at the right place one we go to the meat of it.
  *
- * Copyright 2007-2015 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -2930,7 +2930,6 @@ finalize_it:
 		*pjson = jsonDeepCopy(*pjson);
 	if(mut != NULL)
 		pthread_mutex_unlock(mut);
-dbgprintf("JSONorString: pjson %p, pcstr %p\n", *pjson, *pcstr);
 	RETiRet;
 }
 

--- a/runtime/nsdpoll_ptcp.c
+++ b/runtime/nsdpoll_ptcp.c
@@ -2,7 +2,7 @@
  *
  * An implementation of the nsd epoll() interface for plain tcp sockets.
  * 
- * Copyright 2009 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2009-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -252,12 +252,11 @@ Wait(nsdpoll_t *pNsdpoll, int timeout, int *numEntries, nsd_epworkset_t workset[
 	}
 
 	/* we got valid events, so tell the caller... */
-dbgprintf("epoll returned %d entries\n", nfds);
+	DBGPRINTF("epoll returned %d entries\n", nfds);
 	for(i = 0 ; i < nfds ; ++i) {
 		pOurEvt = (nsdpoll_epollevt_lst_t*) event[i].data.ptr;
 		workset[i].id = pOurEvt->id;
 		workset[i].pUsr = pOurEvt->pUsr;
-dbgprintf("epoll push ppusr[%d]: %p\n", i, pOurEvt->pUsr);
 	}
 	*numEntries = nfds;
 

--- a/runtime/nsdsel_gtls.c
+++ b/runtime/nsdsel_gtls.c
@@ -2,7 +2,7 @@
  *
  * An implementation of the nsd select() interface for GnuTLS.
  * 
- * Copyright (C) 2008-2012 Adiscon GmbH.
+ * Copyright (C) 2008-2016 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -175,7 +175,6 @@ doRetry(nsd_gtls_t *pNsd)
 finalize_it:
 	if(iRet != RS_RET_OK && iRet != RS_RET_CLOSED && iRet != RS_RET_RETRY)
 		pNsd->bAbortConn = 1; /* request abort */
-dbgprintf("XXXXXX: doRetry: iRet %d, pNsd->bAbortConn %d\n", iRet, pNsd->bAbortConn);
 	RETiRet;
 }
 

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -597,8 +597,7 @@ doZipFinish(wrkrInstanceData_t *pWrkrData)
 	if(!pWrkrData->bzInitDone)
 		goto done;
 
-// TODO: can we get this into a single common function?
-dbgprintf("DDDD: in doZipFinish()\n");
+	// TODO: can we get this into a single common function?
 	pWrkrData->zstrm.avail_in = 0;
 	/* run deflate() on buffer until everything has been compressed */
 	do {
@@ -782,14 +781,14 @@ finalize_it:
 
 BEGINtryResume
 CODESTARTtryResume
-	dbgprintf("DDDD: tryResume: pWrkrData %p\n", pWrkrData);
+	dbgprintf("omfwd: tryResume: pWrkrData %p\n", pWrkrData);
 	iRet = doTryResume(pWrkrData);
 ENDtryResume
 
 
 BEGINbeginTransaction
 CODESTARTbeginTransaction
-dbgprintf("omfwd: beginTransaction\n");
+	dbgprintf("omfwd: beginTransaction\n");
 	iRet = doTryResume(pWrkrData);
 ENDbeginTransaction
 
@@ -881,7 +880,6 @@ CODESTARTcommitTransaction
 			FINALIZE;
 	}
 
-dbgprintf("omfwd: endTransaction, offsSndBuf %u, iRet %d\n", pWrkrData->offsSndBuf, iRet);
 	if(pWrkrData->offsSndBuf != 0) {
 		iRet = TCPSendBuf(pWrkrData, pWrkrData->sndBuf, pWrkrData->offsSndBuf, IS_FLUSH);
 		pWrkrData->offsSndBuf = 0;


### PR DESCRIPTION
those starting at column 0 are temporary debug aids during development.
Some of them I intend to keep in for a version or two. Some of them
I tend to forget later. This is a cleanup of those. Most are removed,
some are promoted to be permanently there - now indicated by proper
indention.