### PR TITLE
Trivialfixes

### DIFF
--- a/plugins/mmutf8fix/mmutf8fix.c
+++ b/plugins/mmutf8fix/mmutf8fix.c
@@ -211,6 +211,9 @@ fixInvldMBSeq(instanceData *pData, uchar *msg, int lenMsg, int strtIdx, int *end
 {
 	int i;
 
+	/* startIdx and seqLen always set if bytesLeft is set,
+	   which is required before this function is called */
+	#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 	*endIdx = strtIdx + seqLen;
 	if(*endIdx > lenMsg)
 		*endIdx = lenMsg;
@@ -231,7 +234,9 @@ doUTF8(instanceData *pData, uchar *msg, int lenMsg)
 		c = msg[i];
 		if(bytesLeft) {
 			if((c & 0xc0) != 0x80) {
-				/* sequence invalid, invalidate all bytes */
+				/* sequence invalid, invalidate all bytes
+				   startIdx is always set if bytesLeft is set */
+				#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 				fixInvldMBSeq(pData, msg, lenMsg, strtIdx, &endIdx,
 				              seqLen);
 				i = endIdx - 1;
@@ -242,6 +247,9 @@ doUTF8(instanceData *pData, uchar *msg, int lenMsg)
 				if(bytesLeft == 0) {
 					/* too-large codepoint? */
 					if(codepoint > 0x10FFFF) {
+						/* sequence invalid, invalidate all bytes
+						   startIdx is always set if bytesLeft is set */
+						#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 						fixInvldMBSeq(pData, msg, lenMsg,
 							      strtIdx, &endIdx,
 							      seqLen);

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -666,7 +666,7 @@ parseRequestAndResponseForContext(wrkrInstanceData_t *pWrkrData,cJSON **pReplyRo
 
 			response = cJSON_PrintUnformatted(create);
 
-			if(*response==NULL)
+			if(response==NULL)
 			{
 				free(request);/*as its has been assigned.*/
 				DBGPRINTF("omelasticsearch: Error getting cJSON_PrintUnformatted. Cannot continue\n");

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -560,8 +560,8 @@ static inline rsRetVal
 getSingleRequest(const char* bulkRequest, char** singleRequest ,char **lastLocation)
 {
 	DEFiRet;
-	char *req = bulkRequest;
-	char *start = bulkRequest;
+	const char *req = bulkRequest;
+	const char *start = bulkRequest;
 	if (getSection(req,&req)!=RS_RET_OK)
 		ABORT_FINALIZE(RS_RET_ERR);
 

--- a/plugins/pmciscoios/pmciscoios.c
+++ b/plugins/pmciscoios/pmciscoios.c
@@ -261,6 +261,8 @@ CODESTARTparse2
 
 	/* if we reach this point, we have a wellformed message and can persist the values */
 	MsgSetTAG(pMsg, bufParseTAG, i);
+	/* if bOriginPresent !=0 iHostname gets initialized */
+	#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 	if(pInst->bOriginPresent)
 		MsgSetHOSTNAME(pMsg, bufParseHOSTNAME, iHostname);
 	MsgSetMSGoffs(pMsg, p2parse - pMsg->pszRawMsg);


### PR DESCRIPTION
fix may be uninitialized warning after checking that all codepaths do properly initialize the variables

fixed missing const on variable declarations