### PR TITLE
travis: run testbench under Ubuntu 14.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
        env: STAT_AN="YES", GROK="YES", CFLAGS="-g -O1 -std=c99 -Werror"
        dist: trusty
      - compiler: "gcc"
-       env: BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all"
+       env: BUILD_FROM_TARBALL="YES", GROK="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all"
        dist: trusty
      - compiler: "clang"
        env: CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ matrix:
        dist: trusty
      - compiler: "gcc"
        env: BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute"
+       dist: trusty
      - compiler: "clang"
        env: CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
 
@@ -56,8 +57,8 @@ script:
   - export USE_AUTO_DEBUG="off" # set to "on" to enable this for travis
   - make
   - if [ "x$CHECK" == "xYES" ] ; then make check ; fi
+  - if [ -f tests/test-suite.log ] ; then cat tests/test-suite.log; fi
   - if [ "x$CHECK" == "xYES" ] ; then make distcheck ; fi
-  #- if [ "x$STAT_AN" == "x" ] ; then cat tests/test-suite.log; fi
   - if [ "x$STAT_AN" == "xYES" ] ; then make clean ; fi
   - if [ "x$STAT_AN" == "xYES" ] ; then cd compat; scan-build --status-bugs make && cd .. ; fi
   # we now build those components that we know to need some more work

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
        env: STAT_AN="YES", GROK="YES", CFLAGS="-g -O1 -std=c99 -Werror"
        dist: trusty
      - compiler: "gcc"
-       env: BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute"
+       env: BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all"
        dist: trusty
      - compiler: "clang"
        env: CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,9 +21,49 @@ These are many ways to contribute to the project:
 
 This list is not conclusive. There for sure are many more ways to contribute and if you find one, just let us know. We are very open to new suggestions and like to try out new things.
 
+
+Requirements for patches
+------------------------
+In order to ensure good code quality, after applying the path the code must
+
+- compile cleanly without WARNING messages under both gcc and clang
+- pass clang static analyzer without any report
+
+Note that both warning messages and static analyzer warnings may be false
+positives. We have decided to accept that fate and work around it (e.g. by
+re-arranging the code, etc). Otherwise, we cannot use these useful features.
+
+As a last resort, compiler warnings can be turned off via
+   #pragma diagnostic
+directives. This should really only be done if there is no other known
+way around it. If so, it should be applied to a single function, only and
+not to full source file. Be sure to re-enable the warning after the function
+in question. We have done this in some few cases ourselfs, and if someone
+can fix the root cause, we would appreciate help. But, again, this is a
+last resort which should normally not be used.
+
+For pull requests submitted via github, these two conditions are 
+verified automatically. See the PR for potential failueres. For patches
+submitted otherwise, they will be verified semi-manually.
+
+Also, patches are requested to not break the testbench. Unfortunately, the
+current testbench has some racy tests, which are still useful enough so that
+we do not want to disable them until the root cause has been found. If your
+PR runs into something that you think is not related to your code, just sit
+back and relax. The rsyslog core developer team reviews PRs regularly and
+restarts tests which we know to look racy. If the problem persists, we will
+contact you.
+
+Once all this has passed, a final integration test will be done via buildbot
+on a larger number of platforms. This is a semi-manual process. You will be
+contacted if a problem shows up during it (very unlikely, but occasionally
+happens).
+
 Note to developers
 ------------------
-Please adress pull requests against the master branch. The changes will at first be merged into another branch (master-candidate). There, the changes will be tested and merged into the master branch, should the test succeed.
+Please adress pull requests against the master branch. The changes will at
+first be merged into another branch (master-candidate). There, the
+changes will be tested and merged into the master branch, should the test succeed.
 
 More information is available at:
     http://www.rsyslog.com/how-to-contribute-to-rsyslog/

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -919,7 +919,8 @@ EXTRA_DIST= \
 	testsuites/xlate_more.lkp_tbl \
 	json_var_cmpr.sh \
 	testsuites/json_var_cmpr.conf \
-	cfg.sh
+	cfg.sh \
+	travis/trusty.supp
 
 # TODO: re-enable
 #sndrcv_tls_anon_rebind.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -113,7 +113,7 @@ case $1 in
 		    echo "ERROR: config file '$srcdir/testsuites/$2' not found!"
 		    exit 1
 		fi
-		valgrind --gen-suppressions=all --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &
+		valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &
 		. $srcdir/diag.sh wait-startup $3
 		echo startup-vg still running
 		;;
@@ -126,7 +126,7 @@ case $1 in
 		    echo "ERROR: config file '$srcdir/testsuites/$2' not found!"
 		    exit 1
 		fi
-		valgrind --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=no ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &
+		valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=no ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &
 		. $srcdir/diag.sh wait-startup $3
 		echo startup-vg still running
 		;;

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -113,7 +113,7 @@ case $1 in
 		    echo "ERROR: config file '$srcdir/testsuites/$2' not found!"
 		    exit 1
 		fi
-		valgrind --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &
+		valgrind --gen-suppressions=all --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$srcdir/testsuites/$2 &
 		. $srcdir/diag.sh wait-startup $3
 		echo startup-vg still running
 		;;

--- a/tests/travis/trusty.supp
+++ b/tests/travis/trusty.supp
@@ -1,0 +1,10 @@
+{
+   gnu_libc_memerr
+   Memcheck:Free
+   fun:free
+   fun:__libc_freeres
+   fun:_vgnU_freeres
+   fun:__run_exit_handlers
+   fun:exit
+   fun:(below main)
+}


### PR DESCRIPTION
That's probably also a forward-looking change assuming that travis at some time will drop support for 12.04.

Note that we still use clang on 12.04, and this is intentional.