### PR TITLE
Fix lexer bug affecting hex number literals.

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -139,7 +139,7 @@ int fileno(FILE *stream);
 <EXPR>"startswith"		{ return CMP_STARTSWITH; }
 <EXPR>"startswith_i"		{ return CMP_STARTSWITHI; }
 <EXPR>0[0-7]+ |			/* octal number */
-<EXPR>0x[0-7a-f] |		/* hex number, following rule is dec; strtoll handles all! */
+<EXPR>0x[0-9a-f]+ |		/* hex number, following rule is dec; strtoll handles all! */
 <EXPR>([1-9][0-9]*|0)		{ yylval.n = strtoll(yytext, NULL, 0); return NUMBER; }
 <EXPR>\$[$!./]{0,1}[@a-z][!@a-z0-9\-_\.\[\]]*	{ yylval.s = strdup(yytext+1); return VAR; }
 <EXPR>\'([^'\\]|\\['"\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\'	 {


### PR DESCRIPTION
This fixes a mistake in the lexer rule for hexadecimal number literals that prevented it from recognizing hex numbers containing more than one digit or the digits `8` or `9`.