### PR TITLE
require libfastjson

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_install:
 
 install:
   - travis_retry sudo apt-get install -qq build-essential automake pkg-config libtool autoconf autotools-dev gdb valgrind libdbi-dev libsnmp-dev libmysqlclient-dev postgresql-client faketime
-  - travis_retry sudo apt-get install -qq libestr-dev librelp-dev libjson0-dev zlib1g-dev uuid-dev libgcrypt11-dev liblogging-stdlog-dev bison flex libksi1 libksi1-dev libcurl4-gnutls-dev
+  - travis_retry sudo apt-get install -qq libestr-dev librelp-dev libfastjson-dev zlib1g-dev uuid-dev libgcrypt11-dev liblogging-stdlog-dev bison flex libksi1 libksi1-dev libcurl4-gnutls-dev
   - travis_retry sudo apt-get install -qq python-docutils liblognorm1-dev
   - if [ "$CC" == "clang" ]; then travis_retry sudo apt-get install -qq clang; fi
   - if [ "x$GROK" == "xYES" ]; then travis_retry sudo apt-get install -qq libglib2.0-dev libgrok1 libgrok-dev libtokyocabinet-dev ; fi

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 ------------------------------------------------------------------------------
 Version 8.17.0 [v8-stable] 2016-03-08
+- NEW REQUIREMENT: libfastjson
+  see also: 
 - new feature: dynamic statistics counters
   which may be changed during rule processing
   Thanks to Janmejay Singh for suggesting and implementing this feature
@@ -27,6 +29,9 @@ Version 8.17.0 [v8-stable] 2016-03-08
   Thanks to David Lang for the patch.
 - bugfix rsgtutil: -h command line option did not work
   Thanks to Henri Lakk for the patch.
+- bugfix lexer: hex numbers were not properly represented
+  see: https://github.com/rsyslog/rsyslog/pull/771
+  Thanks to Sam Hanes for the patch.
 ------------------------------------------------------------------------------
 Version 8.16.0 [v8-stable] 2016-01-26
 - rsgtutil: Added extraction support including loglines and hash chains. 

--- a/configure.ac
+++ b/configure.ac
@@ -26,11 +26,7 @@ PKG_PROG_PKG_CONFIG
 
 # modules we require
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
-PKG_CHECK_MODULES([JSON_C], [libfastjson],, [
-	PKG_CHECK_MODULES([JSON_C], [json],, [
-		PKG_CHECK_MODULES([JSON_C], [json-c],,)
-	])
-])
+PKG_CHECK_MODULES([JSON_C], [libfastjson],,)
 
 save_CFLAGS="$CFLAGS"
 save_LIBS="$LIBS"

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -139,7 +139,7 @@ int fileno(FILE *stream);
 <EXPR>"startswith"		{ return CMP_STARTSWITH; }
 <EXPR>"startswith_i"		{ return CMP_STARTSWITHI; }
 <EXPR>0[0-7]+ |			/* octal number */
-<EXPR>0x[0-7a-f] |		/* hex number, following rule is dec; strtoll handles all! */
+<EXPR>0x[0-9a-f]+ |		/* hex number, following rule is dec; strtoll handles all! */
 <EXPR>([1-9][0-9]*|0)		{ yylval.n = strtoll(yytext, NULL, 0); return NUMBER; }
 <EXPR>\$[$!./]{0,1}[@a-z][!@a-z0-9\-_\.\[\]]*	{ yylval.s = strdup(yytext+1); return VAR; }
 <EXPR>\'([^'\\]|\\['"\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\'	 {

--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -1,18 +1,18 @@
 /* lookup.c
  * Support for lookup tables in RainerScript.
  *
- * Copyright 2013 Adiscon GmbH.
+ * Copyright 2013-2016 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *       http://www.apache.org/licenses/LICENSE-2.0
  *       -or-
  *       see COPYING.ASL20 in the source distribution
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -37,6 +37,8 @@
 #include "rsconf.h"
 #include "dirty.h"
 #include "unicode-helper.h"
+
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 
 /* definitions for objects we access */
 DEFobjStaticHelpers


### PR DESCRIPTION
We must make sure all supported platforms (except solaris) build.

Note that Solaris will not build any longer, except when libfastjson is manually installed.

closes https://github.com/rsyslog/rsyslog/issues/717