### PR TITLE
buildbot: add script to build libfastjson on solaris buildbot runs

### DIFF
--- a/tests/solaris/prep-libfastjson.sh
+++ b/tests/solaris/prep-libfastjson.sh
@@ -1,0 +1,15 @@
+# /bin/bash
+set -o xtrace
+PWD_HOME=$PWD
+mkdir local_env
+mkdir local_env/install
+cd local_env
+pwd
+git clone git://github.com/rsyslog/libfastjson
+cd libfastjson
+autoreconf -fvi
+./configure --prefix=$PWD_HOME/local_env/install
+gmake
+gmake install
+pwd
+ls ../install


### PR DESCRIPTION
Solaris does not have libfastjson packages, which we require. So we
add a script for our buildbot tests that builds its own local copy
from libfastjson git. This at least ensures we can run the buildbot
tests again on rsyslog solaris.