### PR TITLE
A CEE cookie shall only be added when using the CEE format

### DIFF
--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -274,7 +274,7 @@ getStatsLineCEE(statsobj_t *pThis, cstr_t **ppcstr, const statsFmtType_t fmt, co
 
 	CHKiRet(cstrConstruct(&pcstr));
 
-	if (fmt == statsFmt_JSON)
+	if (fmt == statsFmt_CEE)
 		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("@cee: "), 6);
 	
 	rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("{"), 1);


### PR DESCRIPTION
I think that the flow is wrong here and that the CEE cookie is currently added, regardless whether you pick json, json-elasticsearch or cee for impstats.