### PR TITLE
The function getopt_long requires colons for flags, if there is a req…

### DIFF
--- a/tools/rsgtutil.c
+++ b/tools/rsgtutil.c
@@ -1701,7 +1701,7 @@ main(int argc, char *argv[])
 	int opt;
 
 	while(1) {
-		opt = getopt_long(argc, argv, "aABcdDeEhkoPstTuvVx", long_options, NULL);
+		opt = getopt_long(argc, argv, "a:ABcdDeE:hk:o:P:stTu:vVx:", long_options, NULL);
 		if(opt == -1)
 			break;
 		switch(opt) {


### PR DESCRIPTION
…uired parameter.