### PR TITLE
gnutls: Fix for issue #732

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1592,8 +1592,9 @@ Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf)
 	*pLenBuf = iBytesCopy;
 
 finalize_it:
-	if (iRet != RS_RET_OK) {
-		/* in this case, we also need to free the receive buffer, if we
+	if (iRet != RS_RET_OK && 
+		iRet != RS_RET_RETRY) {
+		/* We need to free the receive buffer in error error case unless a retry is wanted. , if we
 		 * allocated one. -- rgerhards, 2008-12-03 -- moved here by alorbach, 2015-12-01
 		 */
 		*pLenBuf = 0;


### PR DESCRIPTION
Commit https://github.com/rsyslog/rsyslog/commit/1394e0bec2373e85e003b7320c6d12870424d483
changed how the receive buffer was freed in rcv() call. However Retry handling
was not considered properly. 

Closes https://github.com/rsyslog/rsyslog/issues/732
