### PR TITLE
testbench: temporarily disable dynstats_overflow-vg.sh

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -224,8 +224,8 @@ TESTS +=  \
 if HAVE_VALGRIND
 TESTS +=  \
 	dynstats-vg.sh \
-	dynstats_reset-vg.sh \
-	dynstats_overflow-vg.sh
+	dynstats_reset-vg.sh 
+#	dynstats_overflow-vg.sh
 endif
 endif
 


### PR DESCRIPTION
... because this test fails most of the time on slower machines.
As we know there is an issue, it doesn't make sense to let many
CI builds fail while we work on the timing issue.

see also https://github.com/rsyslog/rsyslog/issues/786