### PR TITLE
AF_UNIX support in imptcp module

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -2082,7 +2082,6 @@ shutdownSrv(ptcpsrv_t *pSrv)
 	ptcplstn_t *pLstn, *lstnDel;
 	ptcpsess_t *pSess, *sessDel;
 
-	//TODO: delete unix socket
 	/* listeners */
 	pLstn = pSrv->pLstn;
 	while(pLstn != NULL) {
@@ -2096,6 +2095,10 @@ shutdownSrv(ptcpsrv_t *pSrv)
 				  lstnDel->rcvdDecompressed);
 		free(lstnDel->epd);
 		free(lstnDel);
+	}
+
+	if (pSrv->bUnixSocket) {
+		unlink((char*) pLstn->pSrv->path);
 	}
 
 	/* sessions */

--- a/tests/imptcp_uds.sh
+++ b/tests/imptcp_uds.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+echo ======================================================================
+echo \[imptcp_uds.sh\]: test imptcp unix domain socket
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup imptcp_uds.conf
+
+LONGLINE="$(printf 'A%.0s' {1..124000})"
+echo "localhost test: $LONGLINE" | nc -U "$srcdir/testbench_socket"
+
+# the sleep below is needed to prevent too-early termination of rsyslogd
+./msleep 100
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+LEN="$(cat "./rsyslog.out.log" | wc -c)"
+if [ "$LEN" -lt "124000" ]; then
+  echo "imptcp_uds.sh failed, should have logged at least 124k characters in a single line"
+  exit 1
+fi;
+. $srcdir/diag.sh exit

--- a/tests/imptcp_uds_unlink.sh
+++ b/tests/imptcp_uds_unlink.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+echo ======================================================================
+echo \[imptcp_uds.sh\]: test imptcp unix domain socket already exists
+
+# First make sure we don't unlink if not asked to
+rm -f "$srcdir/testbench_socket"
+echo "nope" > "$srcdir/testbench_socket"
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup imptcp_uds.conf
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh content-check "imptcp: error while binding unix socket: Address already in use"
+. $srcdir/diag.sh exit
+
+# Now make sure we unlink if asked to
+echo "ok" > "$srcdir/testbench_socket"
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup imptcp_uds_unlink.conf
+
+logger -Tu "$srcdir/testbench_socket" "hello from imptcp uds"
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh content-check "hello from imptcp uds"
+. $srcdir/diag.sh exit

--- a/tests/testsuites/imptcp_uds.conf
+++ b/tests/testsuites/imptcp_uds.conf
@@ -1,0 +1,9 @@
+global(MaxMessageSize="124k")
+
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" path="testbench_socket")
+
+template(name="outfmt" type="string" string="%msg:%\n")
+*.notice	./rsyslog.out.log;outfmt

--- a/tests/testsuites/imptcp_uds_unlink.conf
+++ b/tests/testsuites/imptcp_uds_unlink.conf
@@ -1,0 +1,9 @@
+global(MaxMessageSize="124k")
+
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" path="testbench_socket" unlink="on")
+
+template(name="outfmt" type="string" string="%msg:%\n")
+*.notice	./rsyslog.out.log;outfmt


### PR DESCRIPTION
I need to use SOCK_STREAM AF_UNIX sockets and making imuxsock support it was shaping up to be way more complicated than using something that already deals with sessions. Wanted to get your eyes on this before I wrote up any documentation.

To use it:
```
module(load="imptcp")
input(type="imptcp" path="/path/to/stream.sock")
```

To test it:
```
logger -Tu /path/to/stream.sock "Hello there"
```