### PR TITLE
fixes incorrect formatting of stats when CEE/Json format is used

### DIFF
--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -285,9 +285,9 @@ getStatsLineCEE(statsobj_t *pThis, cstr_t **ppcstr, const statsFmtType_t fmt, co
 	rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("\""), 1);
 	rsCStrAppendStr(pcstr, pThis->name);
 	rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("\""), 1);
-	rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT(","), 1);
 
 	if(pThis->origin != NULL) {
+		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT(","), 1);
 		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("\""), 1);
 		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("origin"), 6);
 		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("\""), 1);
@@ -295,13 +295,12 @@ getStatsLineCEE(statsobj_t *pThis, cstr_t **ppcstr, const statsFmtType_t fmt, co
 		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("\""), 1);
 		rsCStrAppendStr(pcstr, pThis->origin);
 		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("\""), 1);
-		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT(","), 1);
 	}
 
 	/* now add all counters to this line */
 	pthread_mutex_lock(&pThis->mutCtr);
 	for(pCtr = pThis->ctrRoot ; pCtr != NULL ; pCtr = pCtr->next) {
-		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT("\""), 1);
+		rsCStrAppendStrWithLen(pcstr, UCHAR_CONSTANT(",\""), 2);
 		if (fmt == statsFmt_JSON_ES) {
 			/* work-around for broken Elasticsearch JSON implementation:
 			 * we need to replace dots by a different char, we use bang.
@@ -328,14 +327,10 @@ getStatsLineCEE(statsobj_t *pThis, cstr_t **ppcstr, const statsFmtType_t fmt, co
 			rsCStrAppendInt(pcstr, *(pCtr->val.pInt));
 			break;
 		}
-		if (pCtr->next != NULL) {
-			cstrAppendChar(pcstr, ',');
-		} else {
-			cstrAppendChar(pcstr, '}');
-		}
 		resetResettableCtr(pCtr, bResetCtrs);
 	}
 	pthread_mutex_unlock(&pThis->mutCtr);
+	cstrAppendChar(pcstr, '}');
 
 	CHKiRet(cstrFinalize(pcstr));
 	*ppcstr = pcstr;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -243,7 +243,9 @@ TESTS +=  \
 	dynstats_overflow.sh \
 	dynstats_reset.sh \
 	dynstats_ctr_reset.sh \
-	dynstats_nometric.sh
+	dynstats_nometric.sh \
+	no-dynstats-json.sh \
+	no-dynstats.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	dynstats-vg.sh \
@@ -985,6 +987,10 @@ EXTRA_DIST= \
 	testsuites/dynstats_nometric.conf \
 	testsuites/dynstats_overflow.conf \
 	testsuites/dynstats_reset.conf \
+	no-dynstats-json.sh \
+	testsuites/no-dynstats-json.conf \
+	no-dynstats.sh \
+	testsuites/no-dynstats.conf \
 	mmnormalize_variable.sh \
 	mmnormalize_tokenized.sh \
 	testsuites/mmnormalize_variable.conf \

--- a/tests/no-dynstats-json.sh
+++ b/tests/no-dynstats-json.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2016-03-10 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[no-dynstats-json.sh\]: test for verifying stats are reported correctly in json format in absence of any dynstats buckets being configured
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup no-dynstats-json.conf
+. $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh custom-content-check '{"name":"global","origin":"dynstats"}' 'rsyslog.out.stats.log'
+. $srcdir/diag.sh exit

--- a/tests/no-dynstats.sh
+++ b/tests/no-dynstats.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# added 2016-03-10 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[no-dynstats.sh\]: test for verifying stats are reported correctly in legacy format in absence of any dynstats buckets being configured
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup no-dynstats.conf
+. $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh custom-content-check 'global: origin=dynstats' 'rsyslog.out.stats.log'
+. $srcdir/diag.sh exit

--- a/tests/testsuites/no-dynstats-json.conf
+++ b/tests/testsuites/no-dynstats-json.conf
@@ -1,0 +1,9 @@
+$IncludeConfig diag-common.conf
+
+ruleset(name="stats") {
+  action(type="omfile" file="./rsyslog.out.stats.log")
+}
+
+module(load="../plugins/impstats/.libs/impstats" interval="1" severity="7" resetCounters="on" Ruleset="stats" bracketing="on" format="json")
+
+action(type="omfile" file="./rsyslog.out.log")

--- a/tests/testsuites/no-dynstats.conf
+++ b/tests/testsuites/no-dynstats.conf
@@ -1,0 +1,9 @@
+$IncludeConfig diag-common.conf
+
+ruleset(name="stats") {
+  action(type="omfile" file="./rsyslog.out.stats.log")
+}
+
+module(load="../plugins/impstats/.libs/impstats" interval="1" severity="7" resetCounters="on" Ruleset="stats" bracketing="on")
+
+action(type="omfile" file="./rsyslog.out.log")


### PR DESCRIPTION
This happens because we generate stats making assumption that every statsobj will have atleast one counter. This removes that assumption, so we generate valid json regardless of statsobj having counters (and origin field).

Reported here: http://lists.adiscon.net/pipermail/rsyslog/2016-March/042209.html