### PR TITLE
Fix double free in jsonmesg template

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2233,7 +2233,7 @@ msgGetJSONMESG(msg_t *__restrict__ const pMsg)
 	json_object_object_add(json, "uuid", jval);
 #endif
 
-	json_object_object_add(json, "$!", pMsg->json);
+	json_object_object_add(json, "$!", json_object_get(pMsg->json));
 
 	pRes = (uchar*) strdup(json_object_get_string(json));
 	json_object_put(json);


### PR DESCRIPTION
There has to be actual json data in the message (from mmjsonparse,
mmnormalize, imjournal, ...) to trigger the crash. E.g.:

module(load="mmjsonparse")
action(type="mmjsonparse")
template(name="tpl" type="list") {
    property(name="jsonmesg")
}
action(type="omfile" file="/tmp/json.log" template="tpl")
