### PR TITLE
Enable socket bindings before network interface is up

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -214,7 +214,7 @@ createInstance(instanceConf_t **pinst)
 	inst->ratelimitBurst = 10000; /* arbitrary high limit */
 	inst->ratelimitInterval = 0; /* off */
 	inst->rcvbuf = 0;
-	inst->ipfreebind = 2; /* IP_FREEBIND is enabled with warning message */
+	inst->ipfreebind = IPFREEBIND_ENABLED_WITH_LOG;
 	inst->dfltTZ = NULL;
 
 	/* node created, let's add to config */

--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -573,7 +573,7 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 	}
 	DBGPRINTF("%s found, resuming.\n", pData->host);
 	pWrkrData->f_addr = res;
-	pWrkrData->pSockArray = net.create_udp_socket((uchar*)pData->host, NULL, 0, 0);
+	pWrkrData->pSockArray = net.create_udp_socket((uchar*)pData->host, NULL, 0, 0, 0);
 
 finalize_it:
 	if(iRet != RS_RET_OK) {

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1348,6 +1348,9 @@ int *create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbu
 		}
 
 		if(bIsServer) {
+			if (setsockopt(*s, IPPROTO_IP, IP_FREEBIND, &on, sizeof(on)) < 0)
+				dbgprintf("unable to enable free IP bind socket option");
+
 			/* rgerhards, 2007-06-22: if we run on a kernel that does not support
 			 * the IPV6_V6ONLY socket option, we need to use a work-around. On such
 			 * systems the IPv6 socket does also accept IPv4 sockets. So an IPv4

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1361,14 +1361,14 @@ int *create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbu
 			     && (errno != EADDRINUSE)
 	#		endif
 			   ) {
-				if (errno == EADDRNOTAVAIL && ipfreebind) {
+				if (errno == EADDRNOTAVAIL && ipfreebind != IPFREEBIND_DISABLED) {
 					if (setsockopt(*s, IPPROTO_IP, IP_FREEBIND, &on, sizeof(on)) < 0) {
 						errmsg.LogError(errno, NO_ERRCODE, "setsockopt(IP_FREEBIND)");
 					}
 					else if (bind(*s, r->ai_addr, r->ai_addrlen) < 0) {
 						errmsg.LogError(errno, NO_ERRCODE, "bind with IP_FREEBIND");
 					} else {
-						if (ipfreebind > 1)
+						if (ipfreebind >= IPFREEBIND_ENABLED_WITH_LOG)
 							errmsg.LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "bound address %s IP free", hostname);
 						continue;
 					}

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1208,7 +1208,7 @@ void closeUDPListenSockets(int *pSockArr)
  * 1 - server, 0 - client
  * param rcvbuf indicates desired rcvbuf size; 0 means OS default
  */
-int *create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbuf)
+int *create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbuf, int ipfreebind)
 {
         struct addrinfo hints, *res, *r;
         int error, maxs, *s, *socks, on = 1;
@@ -1348,8 +1348,6 @@ int *create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbu
 		}
 
 		if(bIsServer) {
-			if (setsockopt(*s, IPPROTO_IP, IP_FREEBIND, &on, sizeof(on)) < 0)
-				dbgprintf("unable to enable free IP bind socket option");
 
 			/* rgerhards, 2007-06-22: if we run on a kernel that does not support
 			 * the IPV6_V6ONLY socket option, we need to use a work-around. On such
@@ -1363,7 +1361,18 @@ int *create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbu
 			     && (errno != EADDRINUSE)
 	#		endif
 			   ) {
-				errmsg.LogError(errno, NO_ERRCODE, "bind");
+				if (errno == EADDRNOTAVAIL && ipfreebind) {
+					if (setsockopt(*s, IPPROTO_IP, IP_FREEBIND, &on, sizeof(on)) < 0) {
+						errmsg.LogError(errno, NO_ERRCODE, "setsockopt(IP_FREEBIND)");
+					}
+					else if (bind(*s, r->ai_addr, r->ai_addrlen) < 0) {
+						errmsg.LogError(errno, NO_ERRCODE, "bind with IP_FREEBIND");
+					} else {
+						if (ipfreebind > 1)
+							errmsg.LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "bound address %s IP free", hostname);
+						continue;
+					}
+				}
 				close(*s);
 				*s = -1;
 				continue;

--- a/runtime/net.h
+++ b/runtime/net.h
@@ -137,7 +137,7 @@ BEGINinterface(net) /* name must also be changed in ENDinterface macro! */
 	void (*PrintAllowedSenders)(int iListToPrint);
 	void (*clearAllowedSenders)(uchar*);
 	void (*debugListenInfo)(int fd, char *type);
-	int *(*create_udp_socket)(uchar *hostname, uchar *LogPort, int bIsServer, int rcvbuf);
+	int *(*create_udp_socket)(uchar *hostname, uchar *LogPort, int bIsServer, int rcvbuf, int ipfreebind);
 	void (*closeUDPListenSockets)(int *finet);
 	int (*isAllowedSender)(uchar *pszType, struct sockaddr *pFrom, const char *pszFromHost); /* deprecated! */
 	rsRetVal (*getLocalHostname)(uchar**);

--- a/runtime/net.h
+++ b/runtime/net.h
@@ -39,6 +39,11 @@ typedef enum _TCPFRAMINGMODE {
 #define ADDR_NAME 0x01 /* address is hostname wildcard) */
 #define ADDR_PRI6 0x02 /* use IPv6 address prior to IPv4 when resolving */
 
+/* defines for IP_FREEBIND, currently being used in imudp */
+#define IPFREEBIND_DISABLED 0x00 /* don't enable IP_FREEBIND in  sock option */
+#define IPFREEBIND_ENABLED_NO_LOG 0x01 /* enable IP_FREEBIND but no warn on success */
+#define IPFREEBIND_ENABLED_WITH_LOG 0x02 /* enable IP_FREEBIND and warn on success */
+
 #ifdef OS_BSD
 #	ifndef _KERNEL
 #		define s6_addr32 __u6_addr.__u6_addr32

--- a/runtime/net.h
+++ b/runtime/net.h
@@ -39,6 +39,10 @@ typedef enum _TCPFRAMINGMODE {
 #define ADDR_NAME 0x01 /* address is hostname wildcard) */
 #define ADDR_PRI6 0x02 /* use IPv6 address prior to IPv4 when resolving */
 
+/* portability: incase IP_FREEBIND is not defined */
+#ifndef IP_FREEBIND
+#define IP_FREEBIND 0
+#endif
 /* defines for IP_FREEBIND, currently being used in imudp */
 #define IPFREEBIND_DISABLED 0x00 /* don't enable IP_FREEBIND in  sock option */
 #define IPFREEBIND_ENABLED_NO_LOG 0x01 /* enable IP_FREEBIND but no warn on success */

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -760,7 +760,7 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 		pWrkrData->f_addr = res;
 		pWrkrData->bIsConnected = 1;
 		if(pWrkrData->pSockArray == NULL) {
-			pWrkrData->pSockArray = net.create_udp_socket((uchar*)pData->target, NULL, 0, 0);
+			pWrkrData->pSockArray = net.create_udp_socket((uchar*)pData->target, NULL, 0, 0, 0);
 		}
 	} else {
 		CHKiRet(TCPSendInit((void*)pWrkrData));


### PR DESCRIPTION
Allow rsyslog to bind UDP ports even w/out specific interface being up at the moment.
Rather a proof of concept patch (originally by Marius) to open/track discussion of solution.

Alternatively, rsyslog could be ordered after networking, however, that might have some negative side effects. Also IP_FREEBIND is [recommended][1] by systemd documentation.

Cc: @nirmoy

[1]: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/#whatdoesthismeanformeadeveloper