### PR TITLE
fix $PrivDropToGroupID

### DIFF
--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -1107,7 +1107,7 @@ initLegacyConf(void)
 		NULL, &loadConf->globals.uidDropPriv, NULL));
 	CHKiRet(regCfSysLineHdlr((uchar *)"privdroptogroup", 0, eCmdHdlrGID,
 		NULL, &loadConf->globals.gidDropPriv, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"privdroptogroupid", 0, eCmdHdlrGID,
+	CHKiRet(regCfSysLineHdlr((uchar *)"privdroptogroupid", 0, eCmdHdlrInt,
 		NULL, &loadConf->globals.gidDropPriv, NULL));
 	CHKiRet(regCfSysLineHdlr((uchar *)"generateconfiggraph", 0, eCmdHdlrGetWord,
 		NULL, &loadConf->globals.pszConfDAGFile, NULL));


### PR DESCRIPTION
While this was supposed to receive an integer group ID, this did not
work. A group lookup was done instead (just liek with $PrivDropToGroup).

closes https://github.com/rsyslog/rsyslog/issues/889