### PR TITLE
Fsync cursor value to disk

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -385,6 +385,7 @@ persistJournalState () {
 			if (fprintf(sf, "%s", cursor) < 0) {
 				iRet = RS_RET_IO_ERROR;
 			}
+			fsync(fileno(sf));
 			fclose(sf);
 			free(cursor);
 		} else {


### PR DESCRIPTION
Without this change, the imjournal state file contents are not
guaranteed to be on disk.  So the notion of persistence is broken
without this change.