### PR TITLE
Silence unknown statement errors in debug logs

### DIFF
--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -94,6 +94,8 @@ scriptIterateAllActions(struct cnfstmt *root, rsRetVal (*pFunc)(void*, void*), v
 		switch(stmt->nodetype) {
 		case S_NOP:
 		case S_STOP:
+		case S_SET:
+		case S_UNSET:
 		case S_CALL:/* call does not need to do anything - done in called ruleset! */
 			break;
 		case S_ACT:
@@ -108,7 +110,7 @@ scriptIterateAllActions(struct cnfstmt *root, rsRetVal (*pFunc)(void*, void*), v
 				scriptIterateAllActions(stmt->d.s_if.t_else,
 							pFunc, pParam);
 			break;
-        case S_FOREACH:
+		case S_FOREACH:
 			if(stmt->d.s_foreach.body != NULL)
 				scriptIterateAllActions(stmt->d.s_foreach.body,
                                         pFunc, pParam);


### PR DESCRIPTION
When running with debugging enabled, we'll often see the following
error:

    error: unknown stmt type %u during iterateAll

Where "%u" is 4006 or 4007. This patch silences those errors by
adding them to the "ignore" case.