### PR TITLE
imrelp: fix cosmetic memory leak

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -589,6 +589,7 @@ CODESTARTfreeCnf
 		free(inst->pszInputName);
 		free(inst->pristring);
 		free(inst->authmode);
+		prop.Destruct(&inst->pInputName);
 		statsobj.Destruct(&(inst->data.stats));
 		for(i = 0 ; i <  inst->permittedPeers.nmemb ; ++i) {
 			free(inst->permittedPeers.name[i]);


### PR DESCRIPTION
this happens immediately before rsyslog terminates, so it does
not really affect anything. However, it affects the testbench
as memory checkers may report this leak (clang 3.6 address
sanitizer was the first to do).