### PR TITLE
testbench: fix only partially executed test

### DIFF
--- a/tests/daqueue-persist-drvr.sh
+++ b/tests/daqueue-persist-drvr.sh
@@ -19,19 +19,17 @@ echo "*.*     :omtesting:sleep 0 1000" > work-delay.conf
 # inject 10000 msgs, so that DO hit the high watermark
 . $srcdir/diag.sh startup queue-persist.conf
 . $srcdir/diag.sh injectmsg 0 10000
-$srcdir/diag.sh shutdown-immediate
-$srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh shutdown-immediate
+. $srcdir/diag.sh wait-shutdown
 . $srcdir/diag.sh check-mainq-spool
 
 echo "Enter phase 2, rsyslogd restart"
-
-exit
 
 # restart engine and have rest processed
 #remove delay
 echo "#" > work-delay.conf
 . $srcdir/diag.sh startup queue-persist.conf
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
-$srcdir/diag.sh wait-shutdown
-. $srcdir/diag.sh seq-check 0 99999
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh seq-check 0 9999
 . $srcdir/diag.sh exit

--- a/tests/daqueue-persist.sh
+++ b/tests/daqueue-persist.sh
@@ -5,10 +5,13 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo \[daqueue-persist.sh\]: test data persisting at shutdown
-. $srcdir/daqueue-persist-drvr.sh LinkedList
-. $srcdir/daqueue-persist-drvr.sh FixedArray
+echo mode linkedList
+$srcdir/daqueue-persist-drvr.sh LinkedList
+echo mode fixedArray
+$srcdir/daqueue-persist-drvr.sh FixedArray
 # the disk test should not fail, however, the config is extreme and using
 # it more or less is a config error
-. $srcdir/daqueue-persist-drvr.sh Disk
+echo Disk
+$srcdir/daqueue-persist-drvr.sh Disk
 # we do not test Direct mode because this absolute can not work in direct mode
 # (maybe we should do a fail-type of test?)


### PR DESCRIPTION
this is a regression from some month ago, when we changed
the shell calls. Only the first of three tests was executed.