### PR TITLE
omfwd bugfix: keepalive action parameters did not work

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -16,6 +16,7 @@ TESTS +=  \
 	stop-msgvar.sh \
 	glbl-unloadmodules.sh \
 	glbl-invld-param.sh \
+	omfwd-keepalive.sh \
 	msgvar-concurrency.sh \
 	localvar-concurrency.sh \
 	exec_tpl-concurrency.sh \
@@ -600,6 +601,7 @@ EXTRA_DIST= \
 	testsuites/stop-localvar.conf \
 	stop-msgvar.sh \
 	testsuites/stop-msgvar.conf \
+	omfwd-keepalive.sh \
 	msgvar-concurrency.sh \
 	testsuites/msgvar-concurrency.conf \
 	msgvar-concurrency-array.sh \

--- a/tests/omfwd-keepalive.sh
+++ b/tests/omfwd-keepalive.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# addd 2016-03-30 by RGerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+template(name="outfmt" type="list") {
+	property(name="msg")
+	constant(value="\n")
+}
+:msg, contains, "x-pid" stop
+
+action(type="omfile" template="outfmt" file="rsyslog.out.log")
+:msg, contains, "this does not occur" action(type="omfwd"
+	target="10.0.0.1" keepalive="on" keepalive.probes="10"
+	keepalive.time="60" keepalive.interval="10")
+ 
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+echo " msgnum:00000000:" | cmp rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid output generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  exit 1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1023,11 +1023,11 @@ CODESTARTnewActInst
 			pData->iRebindInterval = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "keepalive")) {
 			pData->bKeepAlive = (int) pvals[i].val.d.n;
-		} else if(!strcmp(actpblk.descr[i].name, "keepaliveprobes")) {
+		} else if(!strcmp(actpblk.descr[i].name, "keepalive.probes")) {
 			pData->iKeepAliveProbes = (int) pvals[i].val.d.n;
-		} else if(!strcmp(actpblk.descr[i].name, "keepaliveintvl")) {
+		} else if(!strcmp(actpblk.descr[i].name, "keepalive.interval")) {
 			pData->iKeepAliveIntvl = (int) pvals[i].val.d.n;
-		} else if(!strcmp(actpblk.descr[i].name, "keepalivetime")) {
+		} else if(!strcmp(actpblk.descr[i].name, "keepalive.time")) {
 			pData->iKeepAliveTime = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriver")) {
 			pData->pszStrmDrvr = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
@@ -1102,8 +1102,9 @@ CODESTARTnewActInst
 			}
 			free(cstr);
 		} else {
-			DBGPRINTF("omfwd: program error, non-handled "
-			  "param '%s'\n", actpblk.descr[i].name);
+			errmsg.LogError(0, RS_RET_INTERNAL_ERROR,
+				"omfwd: program error, non-handled parameter '%s'\n",
+				actpblk.descr[i].name);
 		}
 	}
 


### PR DESCRIPTION
due to being inconsistently spelled. This lead to an internal
program error, which unfortunately was only reported to the
debug log.

This patch both fixes the problem and also emits the internal
program error message to the regular log stream (in case a similar
problem re-occurs in the future). A testbench test is also added.

closes https://github.com/rsyslog/rsyslog/issues/916