### PR TITLE
cleanup: remove compatibility checks for old json-c

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,25 +28,6 @@ PKG_PROG_PKG_CONFIG
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
 PKG_CHECK_MODULES([JSON_C], [libfastjson],,)
 
-save_CFLAGS="$CFLAGS"
-save_LIBS="$LIBS"
-
-CFLAGS="$CFLAGS $JSON_C_CFLAGS"
-LIBS="$LIBS $JSON_C_LIBS"
-
-# if int64 is supported, use it
-AC_CHECK_LIB(json-c, json_object_new_object,,)
-AC_CHECK_FUNCS(json_object_new_int64,,)
-
-# look for newer API
-AC_CHECK_FUNCS(json_tokener_error_desc,,)
-AC_CHECK_FUNCS(json_object_object_get_ex,,)
-AC_CHECK_FUNCS(json_object_to_json_string_ext,,)
-AC_CHECK_TYPES([json_bool],,,[[#include <json_object.h>]])
-
-CFLAGS="$save_CFLAGS"
-LIBS="$save_LIBS"
-
 AC_DEFINE_UNQUOTED([PLATFORM_ID], ["${host}"], [platform id for display purposes])
 # we don't mind if we don't have the lsb_release utility. But if we have, it's
 # nice to have the extra information.

--- a/contrib/omhttpfs/omhttpfs.c
+++ b/contrib/omhttpfs/omhttpfs.c
@@ -443,7 +443,7 @@ httpfs_parse_exception(char* buf, int length, httpfs_json_remote_exception* jre)
 		ABORT_FINALIZE(RS_RET_JSON_PARSE_ERR);
     }
 
-    if (!RS_json_object_object_get_ex(json, "RemoteException", &json)) {
+    if (!json_object_object_get_ex(json, "RemoteException", &json)) {
 	ABORT_FINALIZE(RS_RET_JSON_PARSE_ERR);
     }
 
@@ -454,17 +454,17 @@ httpfs_parse_exception(char* buf, int length, httpfs_json_remote_exception* jre)
     const char *str;
     size_t len;
 
-    RS_json_object_object_get_ex(json, "javaClassName", &jobj);
+    json_object_object_get_ex(json, "javaClassName", &jobj);
     str = json_object_get_string(jobj);
     len = strlen(str);
     strncpy(jre->class, str, len);
 
-    RS_json_object_object_get_ex(json, "exception", &jobj);
+    json_object_object_get_ex(json, "exception", &jobj);
     str = json_object_get_string(jobj);
     len = strlen(str);
     strncpy(jre->exception, str, len);
 
-    RS_json_object_object_get_ex(json, "message", &jobj);
+    json_object_object_get_ex(json, "message", &jobj);
     str = json_object_get_string(jobj);
     len = strlen(str);
     strncpy(jre->message, str, len);

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1243,11 +1243,7 @@ var2Number(struct var *r, int *bSuccess)
 		n = str2num(r->d.estr, bSuccess);
 	} else {
 		if(r->datatype == 'J') {
-#ifdef HAVE_JSON_OBJECT_NEW_INT64
 			n = (r->d.json == NULL) ? 0 : json_object_get_int64(r->d.json);
-#else /* HAVE_JSON_OBJECT_NEW_INT64 */
-			n = (r->d.json == NULL) ? 0 : json_object_get_int(r->d.json);
-#endif /* HAVE_JSON_OBJECT_NEW_INT64 */
 		} else {
 			n = r->d.n;
 		}

--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -183,11 +183,7 @@ processJSON(wrkrInstanceData_t *pWrkrData, msg_t *pMsg, char *buf, size_t lenBuf
 
 			err = pWrkrData->tokener->err;
 			if(err != json_tokener_continue)
-#				if HAVE_JSON_TOKENER_ERROR_DESC
-					errMsg = json_tokener_error_desc(err);
-#				else
-					errMsg = json_tokener_errors[err];
-#				endif
+				errMsg = json_tokener_error_desc(err);
 			else
 				errMsg = "Unterminated input";
 		} else if((size_t)pWrkrData->tokener->char_offset < lenBuf)

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -355,11 +355,7 @@ BSONAppendJSONObject(bson *doc, const gchar *name, struct json_object *json)
 	case json_type_int: {
 		int64_t i;
 
-#ifdef HAVE_JSON_OBJECT_NEW_INT64
 		i = json_object_get_int64(json);
-#else /* HAVE_JSON_OBJECT_NEW_INT64 */
-		i = json_object_get_int(json);
-#endif /* HAVE_JSON_OBJECT_NEW_INT64 */
 		if (i >= INT32_MIN && i <= INT32_MAX)
 			return bson_append_int32(doc, name, i);
 		else

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -613,20 +613,6 @@ int rsrtIsInit(void);
 void rsrtSetErrLogger(void (*errLogger)(const int, const int, const uchar*));
 
 
-/* our own support for breaking changes in json-c */
-#ifdef HAVE_JSON_OBJECT_OBJECT_GET_EX
-#	define RS_json_object_object_get_ex(obj, key, retobj) \
-		json_object_object_get_ex((obj), (key), (retobj))
-#else
-#	define RS_json_object_object_get_ex(obj, key, retobj) \
-		(!json_object_is_type(obj, json_type_object) || \
-				(*(retobj) = json_object_object_get((obj), (key))) == NULL) ? FALSE : TRUE
-#endif
-
-#ifndef HAVE_JSON_BOOL
-typedef int json_bool;
-#endif
-
 /* this define below is (later) intended to be used to implement empty
  * structs. TODO: check if compilers supports this and, if not, define
  * a dummy variable. This requires review of where in code empty structs

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -419,11 +419,10 @@ printVersion(void)
 #else
 	printf("\tuuid support:\t\t\t\tNo\n");
 #endif
-#ifdef HAVE_JSON_OBJECT_NEW_INT64
+	/* we keep the following message to so that users don't need
+	 * to wonder.
+	 */
 	printf("\tNumber of Bits in RainerScript integers: 64\n");
-#else
-	printf("\tNumber of Bits in RainerScript integers: 32 (due to too-old json-c lib)\n");
-#endif
 	printf("\nSee http://www.rsyslog.com for more information.\n");
 }
 


### PR DESCRIPTION
as we now use libfastjson, we do no longer need to check for "new"
features, as these are always present in libfastjson (things
like json_object_object_get_ex()).

closes https://github.com/rsyslog/rsyslog/issues/935