### PR TITLE
do not access libfastjson private details

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -42,8 +42,6 @@
 #include <netdb.h>
 #include <libestr.h>
 #include <json.h>
-/* For struct json_object_iter, should not be necessary in future versions */
-#include <json_object_private.h>
 #if HAVE_MALLOC_H
 #  include <malloc.h>
 #endif


### PR DESCRIPTION
this will no longer be supported with 0.99.3 and above and is
also not needed at all

closes https://github.com/rsyslog/rsyslog/issues/944