### PR TITLE
Make privdrop tests more portable and robust

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 ------------------------------------------------------------------------------
 Version 8.18.0 [v8-stable] 2016-04-19
+- testbench: When running privdrop tests testbench tries to drop
+  user to "rsyslog", "syslog" or "daemon" when running as root and
+  you don't explict set RSYSLOG_TESTUSER environment variable.
+  Make sure the unprivileged testuser can write into tests/ dir!
 - templates: add option to convert timestamps to UTC
   closes https://github.com/rsyslog/rsyslog/issues/730
 - omjournal: fix segfault (regression in 8.17.0)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -634,6 +634,7 @@ EXTRA_DIST= \
 	testsuites/global_vars.conf \
 	rfc5424parser.sh \
 	testsuites/rfc5424parser.conf \
+	privdrop_common.sh \
 	privdropuser.sh \
 	privdropuserid.sh \
 	privdropgroup.sh \

--- a/tests/privdrop_common.sh
+++ b/tests/privdrop_common.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# added 2016-04-15 by Thomas D., released under ASL 2.0
+# Several tests need another user/group to test impersonation.
+# This script can be sourced to prevent duplicated code.
+
+# To support <bash-4.2 which don't support "declare -g" we declare
+# the array outside of the function
+declare -A TESTBENCH_TESTUSER
+
+rsyslog_testbench_setup_testuser() {
+	local has_testuser=
+	local testusername=
+	local testgroupname=
+
+	if [ -z "${EUID}" ]; then
+		# Should never happen
+		echo "FATAL ERROR: \$EUID not set!"
+		exit 1
+	fi
+
+	if [ ${EUID} -eq 0 ]; then
+		# Only root is able to become a different user
+
+		local testusers=("rsyslog" "syslog" "daemon")
+
+		if [ -n "${RSYSLOG_TESTUSER}" ]; then
+			# User has specified an username/uid we should use in testbench
+			testusers=("${RSYSLOG_TESTUSER}" ${testusers[@]})
+		fi
+
+		local testuser=
+		for testuser in "${testusers[@]}"; do
+			testusername=$(id --user --name ${testuser} 2>/dev/null)
+			if [ -z "${testusername}" ]; then
+				echo "'id' did not find user \"${testuser}\" ... skipping, trying next user!"
+				continue
+			fi
+
+			testgroupname=$(id --group --name ${testuser} 2>/dev/null)
+			if [ -z "${testgroupname}" ]; then
+				echo "'id' did not find a primary group for \"${testuser}\" ... skipping, trying next user!"
+				continue
+			fi
+
+			has_testuser="${testuser}"
+			break
+		done
+	fi
+
+	if [ -z "${has_testuser}" ]; then
+		testgroupname=$(id --group --name ${EUID} 2>/dev/null)
+		if [ -z "${testgroupname}" ]; then
+			echo "Skipping ... please set RSYSLOG_TESTUSER or make sure the user running the testbench has a primary group!"
+			. $srcdir/diag.sh exit
+		else
+			has_testuser="${EUID}"
+		fi
+	fi
+
+	_rsyslog_testbench_declare_testuser ${has_testuser}
+}
+
+_rsyslog_testbench_declare_testuser() {
+	local testuser=$1
+
+	local testusername=$(id --user --name ${testuser} 2>/dev/null)
+	if [ -z "${testusername}" ]; then
+		# Should never happen
+		echo "FATAL ERROR: Could not get username for user \"${testuser}\"!"
+		exit 1
+	fi
+
+	local testuid=$(id --user ${testuser} 2>/dev/null)
+	if [ -z "${testuid}" ]; then
+		# Should never happen
+		echo "FATAL ERROR: Could not get uid for user \"${testuser}\"!"
+		exit 1
+	fi
+
+	local testgroupname=$(id --group --name ${testuser} 2>/dev/null)
+	if [ -z "${testgroupname}" ]; then
+		# Should never happen
+		echo "FATAL ERROR: Could not get uid of user \"${testuser}\"!"
+		exit 1
+	fi
+
+	local testgid=$(id --group ${testuser} 2>/dev/null)
+	if [ -z "${testgid}" ]; then
+		# Should never happen
+		echo "FATAL ERROR: Could not get primary gid of user \"${testuser}\"!"
+		exit 1
+	fi
+
+	echo "Will use user \"${testusername}\" (#${testuid}) and group \"${testgroupname}\" (#${testgid})"
+
+	TESTBENCH_TESTUSER[username]=${testusername}
+	TESTBENCH_TESTUSER[uid]=${testuid}
+	TESTBENCH_TESTUSER[groupname]=${testgroupname}
+	TESTBENCH_TESTUSER[gid]=${testgid}
+}

--- a/tests/privdropgroup.sh
+++ b/tests/privdropgroup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-# We assume that a group equally named to the user exists
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
 . $srcdir/diag.sh init
-USER_GID=`id -g $USER`
-GROUP=`getent group $USER_GID | cut -d: -f1`
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 global(privdrop.group.keepsupplemental="on")
@@ -13,14 +13,13 @@ template(name="outfmt" type="list") {
 }
 action(type="omfile" template="outfmt" file="rsyslog.out.log")
 '
-. $srcdir/diag.sh add-conf "\$PrivDropToGroup $GROUP"
-
+. $srcdir/diag.sh add-conf "\$PrivDropToGroup ${TESTBENCH_TESTUSER[groupname]}"
 . $srcdir/diag.sh startup
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
-grep "groupid.*$USER_GID" < rsyslog.out.log
+grep "groupid.*${TESTBENCH_TESTUSER[gid]}" < rsyslog.out.log
 if [ ! $? -eq 0 ]; then
-  echo "message indicating drop to gid $USER_GID is missing:"
+  echo "message indicating drop to group \"${TESTBENCH_TESTUSER[groupname]}\" (#${TESTBENCH_TESTUSER[gid]}) is missing:"
   cat rsyslog.out.log
   exit 1
 fi;

--- a/tests/privdropgroupid.sh
+++ b/tests/privdropgroupid.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# We assume that a group equally named to the user exists
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
 . $srcdir/diag.sh init
-USER_GID=`id -g $USER`
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 global(privdrop.group.keepsupplemental="on")
@@ -12,14 +13,13 @@ template(name="outfmt" type="list") {
 }
 action(type="omfile" template="outfmt" file="rsyslog.out.log")
 '
-. $srcdir/diag.sh add-conf "\$PrivDropToGroupID $USER_GID"
-
+. $srcdir/diag.sh add-conf "\$PrivDropToGroupID ${TESTBENCH_TESTUSER[gid]}"
 . $srcdir/diag.sh startup
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
-grep "groupid.*$USER_GID" < rsyslog.out.log
+grep "groupid.*${TESTBENCH_TESTUSER[gid]}" < rsyslog.out.log
 if [ ! $? -eq 0 ]; then
-  echo "message indicating drop to gid $USER_GID is missing:"
+  echo "message indicating drop to gid #${TESTBENCH_TESTUSER[gid]} is missing:"
   cat rsyslog.out.log
   exit 1
 fi;

--- a/tests/privdropuser.sh
+++ b/tests/privdropuser.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# We assume that a group equally named to the user exists
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
 . $srcdir/diag.sh init
-USER_ID=`id -u $USER`
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 template(name="outfmt" type="list") {
@@ -11,14 +12,13 @@ template(name="outfmt" type="list") {
 }
 action(type="omfile" template="outfmt" file="rsyslog.out.log")
 '
-. $srcdir/diag.sh add-conf "\$PrivDropToUser $USER"
-
+. $srcdir/diag.sh add-conf "\$PrivDropToUser ${TESTBENCH_TESTUSER[username]}"
 . $srcdir/diag.sh startup
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
-grep "userid.*$USER_ID" < rsyslog.out.log
+grep "userid.*${TESTBENCH_TESTUSER[uid]}" < rsyslog.out.log
 if [ ! $? -eq 0 ]; then
-  echo "message indicating drop to gid $USER_ID is missing:"
+  echo "message indicating drop to user \"${TESTBENCH_TESTUSER[username]}\" (#${TESTBENCH_TESTUSER[uid]}) is missing:"
   cat rsyslog.out.log
   exit 1
 fi;

--- a/tests/privdropuserid.sh
+++ b/tests/privdropuserid.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
-# We assume that a group equally named to the user exists
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
 . $srcdir/diag.sh init
-USER_ID=`id -u $USER`
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 template(name="outfmt" type="list") {
@@ -11,14 +12,13 @@ template(name="outfmt" type="list") {
 }
 action(type="omfile" template="outfmt" file="rsyslog.out.log")
 '
-. $srcdir/diag.sh add-conf "\$PrivDropToUserID $USER_ID"
-
+. $srcdir/diag.sh add-conf "\$PrivDropToUserID ${TESTBENCH_TESTUSER[uid]}"
 . $srcdir/diag.sh startup
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
-grep "userid.*$USER_ID" < rsyslog.out.log
+grep "userid.*${TESTBENCH_TESTUSER[uid]}" < rsyslog.out.log
 if [ ! $? -eq 0 ]; then
-  echo "message indicating drop to gid $USER_ID is missing:"
+  echo "message indicating drop to uid #${TESTBENCH_TESTUSER[uid]} is missing:"
   cat rsyslog.out.log
   exit 1
 fi;


### PR DESCRIPTION
This is my proposal.

But this fix for issue #927 will uncover a new problem: When we are really testing impersonating another user (which root can only do per default) privdrop tests will fail because the user we drop to probably cannot write to *$SRCDIR/*. So the tests are failing because files like *rsyslog.out.log* or *rsyslogd.started* cannot be created and the test will run into a timeout.

This will be the case when running the testbench as root and for example the user didn't specify a user we should use so that we will fallback to *daemon* user.

Making *tests* world writeable would address this problem but only if the source path is also accessible by the user we will drop to (not guaranteed).

From my current view the right solution would be to create these files in */tmp* (sub dir). This dir could be world writeable and due to the fact that we control the whole path we wouldn't risk that the path isn't accessible.
