### PR TITLE
imfile: fix memory corruption bug when appending @cee

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -469,7 +469,7 @@ static rsRetVal enqLine(lstn_t *const __restrict__ pLstn,
 	if (pLstn->addCeeTag) {
 		size_t msgLen = cstrLen(cstrLine);
 		char *ceeToken = "@cee:";
-		size_t ceeMsgSize = msgLen + strlen(ceeToken);
+		size_t ceeMsgSize = msgLen + strlen(ceeToken) +1;
 		char *ceeMsg;
 		CHKmalloc(ceeMsg = MALLOC(ceeMsgSize));
 		strcpy(ceeMsg, ceeToken);


### PR DESCRIPTION
This PR addresses a possible memory issue when appending @cee prefixes to JSON log lines read via imfile.