### PR TITLE
testbench: Add missing exit calls to {faketime,privdrop}_common.sh

### DIFF
--- a/tests/faketime_common.sh
+++ b/tests/faketime_common.sh
@@ -26,8 +26,9 @@ fi
 
 
 rsyslog_testbench_require_y2k38_support() {
-  if [ -n "${RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE}" ]; then
-    echo "Skipping further tests because system doesn't support year 2038 ..."
-    . $srcdir/diag.sh exit
-  fi
+    if [ -n "${RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE}" ]; then
+        echo "Skipping further tests because system doesn't support year 2038 ..."
+        . $srcdir/diag.sh exit
+        exit 0
+    fi
 }

--- a/tests/privdrop_common.sh
+++ b/tests/privdrop_common.sh
@@ -52,6 +52,7 @@ rsyslog_testbench_setup_testuser() {
 		if [ -z "${testgroupname}" ]; then
 			echo "Skipping ... please set RSYSLOG_TESTUSER or make sure the user running the testbench has a primary group!"
 			. $srcdir/diag.sh exit
+			exit 0
 		else
 			has_testuser="${EUID}"
 		fi


### PR DESCRIPTION
My fault, I misunderstood @rgerhards code comment from https://github.com/rsyslog/rsyslog/pull/875#issuecomment-196260504 when he told me to call `diag.sh exit`.