### PR TITLE
 testbench: Use LD_PRELOAD=libfaketime.so instead of faketime binary 

### DIFF
--- a/tests/faketime_common.sh
+++ b/tests/faketime_common.sh
@@ -26,8 +26,9 @@ fi
 
 
 rsyslog_testbench_require_y2k38_support() {
-  if [ -n "${RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE}" ]; then
-    echo "Skipping further tests because system doesn't support year 2038 ..."
-    . $srcdir/diag.sh exit
-  fi
+    if [ -n "${RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE}" ]; then
+        echo "Skipping further tests because system doesn't support year 2038 ..."
+        . $srcdir/diag.sh exit
+        exit 0
+    fi
 }

--- a/tests/faketime_common.sh
+++ b/tests/faketime_common.sh
@@ -4,26 +4,20 @@
 # faketime is missing or the system isn't year-2038 complaint.
 # This script can be sourced to prevent duplicated code.
 
-if ! hash faketime 2>/dev/null ; then
-    echo "faketime command missing, skipping test"
+faketime_testtime=$(LD_PRELOAD=libfaketime.so FAKETIME="1991-08-25 20:57:08" TZ=GMT date +%s 2>/dev/null)
+if [ ${faketime_testtime} -ne 683153828 ] ; then
+    echo "libfaketime.so missing, skipping test"
     exit 77
 fi
 
-export TZ=UTC+01:00
-
-faketime -f '2016-03-11 16:00:00' date 1>/dev/null 2>&1
-if [ $? -ne 0 ]; then
-    # Safe-guard -- should never happen!
-    echo "faketime command not working as expected. Check faketime binary in path!"
-    exit 1
-fi
-
-faketime '2040-01-01 16:00:00' date 1>/dev/null 2>&1
-if [ $? -ne 0 ]; then
+# GMT-1 (POSIX TIME) is GMT+1 in "Human Time"
+faketime_testtime=$(LD_PRELOAD=libfaketime.so FAKETIME="2040-01-01 16:00:00" TZ=GMT-1 date +%s 2>/dev/null)
+if [ ${faketime_testtime} -eq -1 ]; then
     # System isn't year-2038 compatible
     RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE="yes"
 fi
 
+export LD_PRELOAD=libfaketime.so
 
 rsyslog_testbench_require_y2k38_support() {
     if [ -n "${RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE}" ]; then

--- a/tests/now-utc-casecmp.sh
+++ b/tests/now-utc-casecmp.sh
@@ -19,7 +19,7 @@ template(name="outfmt" type="string"
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file="rsyslog.out.log")
 '
-faketime '2016-01-01 01:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-01-01 01:00:00' $srcdir/diag.sh startup
 # what we send actually is irrelevant, as we just use system properties.
 # but we need to send one message in order to gain output!
 . $srcdir/diag.sh tcpflood -m1

--- a/tests/now-utc-ymd.sh
+++ b/tests/now-utc-ymd.sh
@@ -19,7 +19,7 @@ template(name="outfmt" type="string"
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file="rsyslog.out.log")
 '
-faketime '2016-01-01 01:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-01-01 01:00:00' $srcdir/diag.sh startup
 # what we send actually is irrelevant, as we just use system properties.
 # but we need to send one message in order to gain output!
 . $srcdir/diag.sh tcpflood -m1

--- a/tests/now-utc.sh
+++ b/tests/now-utc.sh
@@ -9,7 +9,7 @@ echo \[now-utc\]: test \$NOW-UTC
 export TZ=TEST-02:00
 
 . $srcdir/diag.sh init
-faketime '2016-01-01 01:00:00' $srcdir/diag.sh startup now-utc.conf
+FAKETIME='2016-01-01 01:00:00' $srcdir/diag.sh startup now-utc.conf
 # what we send actually is irrelevant, as we just use system properties.
 # but we need to send one message in order to gain output!
 . $srcdir/diag.sh tcpflood -m1

--- a/tests/now_family_utc.sh
+++ b/tests/now_family_utc.sh
@@ -9,7 +9,7 @@ echo \[now_family_utc\]: test \$NOW family of system properties
 export TZ=TEST+06:30
 
 . $srcdir/diag.sh init
-faketime '2016-01-01 01:00:00' $srcdir/diag.sh startup now_family_utc.conf
+FAKETIME='2016-01-01 01:00:00' $srcdir/diag.sh startup now_family_utc.conf
 # what we send actually is irrelevant, as we just use system properties.
 # but we need to send one message in order to gain output!
 . $srcdir/diag.sh tcpflood -m1

--- a/tests/privdrop_common.sh
+++ b/tests/privdrop_common.sh
@@ -52,6 +52,7 @@ rsyslog_testbench_setup_testuser() {
 		if [ -z "${testgroupname}" ]; then
 			echo "Skipping ... please set RSYSLOG_TESTUSER or make sure the user running the testbench has a primary group!"
 			. $srcdir/diag.sh exit
+			exit 0
 		else
 			has_testuser="${EUID}"
 		fi

--- a/tests/timegenerated-dateordinal-invld.sh
+++ b/tests/timegenerated-dateordinal-invld.sh
@@ -25,7 +25,7 @@ template(name="outfmt" type="string"
 
 echo "***SUBTEST: check 1800-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '1800-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='1800-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -40,7 +40,7 @@ fi;
 
 echo "***SUBTEST: check 1960-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '1960-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='1960-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -55,7 +55,7 @@ fi;
 
 echo "***SUBTEST: check 2101-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2101-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='2101-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -70,7 +70,7 @@ fi;
 
 echo "***SUBTEST: check 2500-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2500-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='2500-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown

--- a/tests/timegenerated-dateordinal.sh
+++ b/tests/timegenerated-dateordinal.sh
@@ -25,7 +25,7 @@ template(name="outfmt" type="string"
 
 echo "***SUBTEST: check 1970-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '1970-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='1970-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -39,7 +39,7 @@ fi;
 
 echo "***SUBTEST: check 2000-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2000-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2000-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -53,7 +53,7 @@ fi;
 
 echo "***SUBTEST: check 2016-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -67,7 +67,7 @@ fi;
 
 echo "***SUBTEST: check 2016-02-29"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-02-29 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-02-29 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -81,7 +81,7 @@ fi;
 
 echo "***SUBTEST: check 2016-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -95,7 +95,7 @@ fi;
 
 echo "***SUBTEST: check 2016-03-03"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-03-03 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-03-03 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -109,7 +109,7 @@ fi;
 
 echo "***SUBTEST: check 2016-12-31"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-12-31 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-12-31 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -123,7 +123,7 @@ fi;
 
 echo "***SUBTEST: check 2017-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2017-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2017-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -137,7 +137,7 @@ fi;
 
 echo "***SUBTEST: check 2020-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2020-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2020-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -151,7 +151,7 @@ fi;
 
 echo "***SUBTEST: check 2038-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2038-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2038-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -168,7 +168,7 @@ rsyslog_testbench_require_y2k38_support
 
 echo "***SUBTEST: check 2038-12-31"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2038-12-31 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2038-12-31 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -182,7 +182,7 @@ fi;
 
 echo "***SUBTEST: check 2040-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2040-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2040-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -196,7 +196,7 @@ fi;
 
 echo "***SUBTEST: check 2040-12-31"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2040-12-31 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2040-12-31 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -210,7 +210,7 @@ fi;
 
 echo "***SUBTEST: check 2100-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2100-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2100-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown

--- a/tests/timegenerated-utc-legacy.sh
+++ b/tests/timegenerated-utc-legacy.sh
@@ -26,7 +26,7 @@ template(name="outfmt" type="string"
 
 echo "***SUBTEST: check 2016-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown

--- a/tests/timegenerated-utc.sh
+++ b/tests/timegenerated-utc.sh
@@ -28,7 +28,7 @@ template(name="outfmt" type="list") {
 
 echo "***SUBTEST: check 2016-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown

--- a/tests/timegenerated-uxtimestamp-invld.sh
+++ b/tests/timegenerated-uxtimestamp-invld.sh
@@ -25,7 +25,7 @@ template(name="outfmt" type="string"
 
 echo "***SUBTEST: check 1800-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '1800-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='1800-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -40,7 +40,7 @@ fi;
 
 echo "***SUBTEST: check 1960-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '1960-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='1960-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -55,7 +55,7 @@ fi;
 
 echo "***SUBTEST: check 2101-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2101-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='2101-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -70,7 +70,7 @@ fi;
 
 echo "***SUBTEST: check 2500-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2500-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='2500-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown

--- a/tests/timegenerated-uxtimestamp.sh
+++ b/tests/timegenerated-uxtimestamp.sh
@@ -25,7 +25,7 @@ template(name="outfmt" type="string"
 
 echo "***SUBTEST: check 1970-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '1970-01-01 00:00:00' $srcdir/diag.sh startup
+FAKETIME='1970-01-01 00:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -40,7 +40,7 @@ fi;
 
 echo "***SUBTEST: check 2000-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2000-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2000-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -55,7 +55,7 @@ fi;
 
 echo "***SUBTEST: check 2016-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -70,7 +70,7 @@ fi;
 
 echo "***SUBTEST: check 2016-02-29"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-02-29 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-02-29 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -85,7 +85,7 @@ fi;
 
 echo "***SUBTEST: check 2016-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -100,7 +100,7 @@ fi;
 
 echo "***SUBTEST: check 2016-03-03"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-03-03 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-03-03 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -115,7 +115,7 @@ fi;
 
 echo "***SUBTEST: check 2016-12-31"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2016-12-31 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-12-31 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -130,7 +130,7 @@ fi;
 
 echo "***SUBTEST: check 2017-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2017-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2017-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -145,7 +145,7 @@ fi;
 
 echo "***SUBTEST: check 2020-03-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2020-03-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2020-03-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -160,7 +160,7 @@ fi;
 
 echo "***SUBTEST: check 2038-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2038-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2038-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -172,13 +172,11 @@ if [ ! $? -eq 0 ]; then
   exit 1
 fi;
 
-
 rsyslog_testbench_require_y2k38_support
-
 
 echo "***SUBTEST: check 2040-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2040-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2040-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
@@ -193,7 +191,7 @@ fi;
 
 echo "***SUBTEST: check 2100-01-01"
 rm -f rsyslog.out.log	# do cleanup of previous subtest
-faketime -f '2100-01-01 12:00:00' $srcdir/diag.sh startup
+FAKETIME='2100-01-01 12:00:00' $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -m1
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown

--- a/tests/timegenerated-ymd.sh
+++ b/tests/timegenerated-ymd.sh
@@ -19,7 +19,7 @@ template(name="outfmt" type="string"
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file="rsyslog.out.log")
 '
-faketime '2016-01-01 01:00:00' $srcdir/diag.sh startup
+FAKETIME='2016-01-01 01:00:00' $srcdir/diag.sh startup
 # what we send actually is irrelevant, as we just use system properties.
 # but we need to send one message in order to gain output!
 . $srcdir/diag.sh tcpflood -m1


### PR DESCRIPTION
Using `LD_PRELOAD` like suggested in https://github.com/wolfcw/libfaketime/issues/89 seems to be more robust.

Successfully tested against libfaketime-0.9.6 and git master on systems year 2038 compatible and not.

https://github.com/rsyslog/rsyslog/pull/964 should be merged first.