### PR TITLE
Resolves that rsyslog waits after reboot

### DIFF
--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -160,9 +160,10 @@ wtiCancelThrd(wti_t *pThis)
 		DBGOPRINT((obj_t*) pThis, "canceling worker thread\n");
 		pthread_cancel(pThis->thrdID);
 		/* now wait until the thread terminates... */
-		while(wtiGetState(pThis)) {
+		while(!pthread_kill(pThis->thrdID, 0)) {
 			srSleep(0, 10000);
 		}
+	wtiSetState(pThis, 0);
 	}
 
 	RETiRet;


### PR DESCRIPTION
Rsyslog waits after reboot due to endless loop,
because wtiGetState(wti_t *pThis) checks only wti state bIsRunning,
but when the thread is canceling by pthread_cancel,
this flag is not unset so we do need check if the thread
terminated some other way.

The bug appears when we reboot system and Rsyslog has lot of works to do(close tcp connections, save all messages to disk etc.), so some timeouts ran out and Rsyslog needs to cancel threads.

I think it could be harder to reproduce with newer Rsyslog but problem still exists. It's simply reproducible on v7.4.7.

Here is the reproducer:
- Client:
  /etc/rsyslog.d/tcpsender.conf

$ActionQueueFileName tcprule # unique name prefix for spool files
$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
$ActionQueueType Direct   # run asynchronously
$ActionResumeRetryCount -1    # infinite retries if host is dow 
_._ @@192.168.122.1:20000
- Server:
  /etc/rsyslog.conf

$ModLoad imjournal # provides access to the systemd journal
$ModLoad imtcp
$InputTCPServerRun 20000 
$WorkDirectory /var/lib/rsyslog
$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
$IncludeConfig /etc/rsyslog.d/*.conf
$IMJournalStateFile imjournal.state
$IMJournalIgnorePreviousMessages on

_.info;mail.none;authpriv.none;cron.none                /var/log/messages
authpriv._                                              /var/log/secure
mail.\*                                                  -/var/log/maillog
cron.\*                                                  /var/log/cron
_.emerg                                                 :omusrmsg:_
uucp,news.crit                                          /var/log/spooler
local7.\*                                                /var/log/boot.log

Steps to reproduce:
- Server:
  setenforce 0
  systemctl stop firewalld
  systemctl start rsyslog
- Client:

disable selinux permanently
systemctl disable rsyslog

systemctl start rsyslog
while true; do logger "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"; done
# after few seconds ctrl+C

systemctl reboot

If you cannot reproduce, let the while running longer.
Sometimes is good to remove /var/lib/rsyslog/tcprule\* before test.
