### PR TITLE
ommysql and ompgsql should include netdb.h

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -33,6 +33,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <time.h>
+#include <netdb.h>
 #include <mysql.h>
 #include "conf.h"
 #include "syslogd-types.h"

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -39,6 +39,7 @@
 #include <signal.h>
 #include <errno.h>
 #include <time.h>
+#include <netdb.h>
 #include <libpq-fe.h>
 #include "conf.h"
 #include "syslogd-types.h"


### PR DESCRIPTION
MAXHOSTNAMELEN is defined in netdb.h on (at least) SunOS. Fixes build.