### PR TITLE
rsgtutil: Enhanced error return status codes for verify and extract.

### DIFF
--- a/runtime/librsgt.h
+++ b/runtime/librsgt.h
@@ -140,6 +140,9 @@ struct rsgtstatefile {
 #define RSGTE_HASH_CREATE 20 /* error creating a hash */
 #define RSGTE_END_OF_SIG 21 /* unexpected end of signature - more log line exist */
 #define RSGTE_END_OF_LOG 22 /* unexpected end of log file - more signatures exist */
+#define RSGTE_EXTRACT_HASH 23 /* error extracting hashes for record */
+#define RSGTE_CONFIG_ERROR 24 /* Configuration error */
+#define RSGTE_NETWORK_ERROR 25 /* Network error */
 
 /* the following function maps RSGTE_* state to a string - must be updated
  * whenever a new state is added.

--- a/runtime/librsksi.h
+++ b/runtime/librsksi.h
@@ -144,6 +144,8 @@ struct rsksistatefile {
 #define RSGTE_END_OF_SIG 21 /* unexpected end of signature - more log line exist */
 #define RSGTE_END_OF_LOG 22 /* unexpected end of log file - more signatures exist */
 #define RSGTE_EXTRACT_HASH 23 /* error extracting hashes for record */
+#define RSGTE_CONFIG_ERROR 24 /* Configuration error */
+#define RSGTE_NETWORK_ERROR 25 /* Network error */
 
 /* the following function maps RSGTE_* state to a string - must be updated
  * whenever a new state is added.

--- a/tests/ksi-extract-verify-long-vg.sh
+++ b/tests/ksi-extract-verify-long-vg.sh
@@ -17,18 +17,28 @@ echo "running rsgtutil extract command"
 valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsgtutil $RSYSLOG_KSI_DEBUG --extract 4,8,21 --output $srcdir/ksi-export.log --publications-server $RSYSLOG_KSI_BIN $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-long-vg.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-long-vg.sh]: rsgtutil extract failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-long-vg.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 echo "running rsgtutil verify command"
 valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsgtutil $RSYSLOG_KSI_DEBUG --verify --publications-server http://verify.guardtime.com/ksi-publications.bin $srcdir/ksi-export.log
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-long-vg.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-long-vg.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-long-vg.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files

--- a/tests/ksi-extract-verify-long.sh
+++ b/tests/ksi-extract-verify-long.sh
@@ -17,18 +17,28 @@ echo "running rsgtutil extract command"
 ../tools/rsgtutil $RSYSLOG_KSI_DEBUG --extract 4,8,21 --output $srcdir/ksi-export.log --publications-server http://verify.guardtime.com/ksi-publications.bin $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-long.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-long.sh]: rsgtutil extract failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-long.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 echo "running rsgtutil verify command"
 ../tools/rsgtutil $RSYSLOG_KSI_DEBUG --verify --publications-server http://verify.guardtime.com/ksi-publications.bin $srcdir/ksi-export.log
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-long.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-long.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-long.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files

--- a/tests/ksi-extract-verify-short-vg.sh
+++ b/tests/ksi-extract-verify-short-vg.sh
@@ -17,18 +17,28 @@ echo "running rsgtutil extract command"
 valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsgtutil $RSYSLOG_KSI_DEBUG -x 4,8,21 -o $srcdir/ksi-export.log -P http://verify.guardtime.com/ksi-publications.bin $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-short-vg.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-short-vg.sh]: rsgtutil extract failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-short-vg.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 echo "running rsgtutil verify command"
 valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsgtutil $RSYSLOG_KSI_DEBUG -t -P http://verify.guardtime.com/ksi-publications.bin $srcdir/ksi-export.log
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-short-vg.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-short-vg.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-short-vg.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files

--- a/tests/ksi-extract-verify-short.sh
+++ b/tests/ksi-extract-verify-short.sh
@@ -17,18 +17,32 @@ echo "running rsgtutil extract command"
 ../tools/rsgtutil $RSYSLOG_KSI_DEBUG -x 4,8,21 -o $srcdir/ksi-export.log -P http://verify.guardtime.com/ksi-publications.bin $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-short.sh]: rsgtutil extract failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-short.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
+fi
+
 if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-short.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
+	echo "[.sh]: rsgtutil extract failed with error: " $RSYSLOGD_EXIT
 	exit 1;
 fi
 
-echo "running rsgtutil verify command"
-../tools/rsgtutil -t -P http://verify.guardtime.com/ksi-publications.bin $srcdir/ksi-export.log
+echo "running rsgtutil verify command"../tools/rsgtutil -t -P http://verify.guardtime.com/ksi-publications.bin $srcdir/ksi-export.log
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "[ksi-extract-verify-short.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-extract-verify-short.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-extract-verify-short.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files

--- a/tests/ksi-verify-long-vg.sh
+++ b/tests/ksi-verify-long-vg.sh
@@ -17,9 +17,14 @@ echo "running rsgtutil command with long options"
 valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsgtutil $RSYSLOG_KSI_DEBUG --verify --publications-server $RSYSLOG_KSI_BIN $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "rsgtutil returned error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-verify-long-vg.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-verify-long-vg.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files

--- a/tests/ksi-verify-long.sh
+++ b/tests/ksi-verify-long.sh
@@ -16,9 +16,14 @@ echo "running rsgtutil command with long options"
 ../tools/rsgtutil $RSYSLOG_KSI_DEBUG --verify --publications-server $RSYSLOG_KSI_BIN $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "rsgtutil returned error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-verify-long.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-verify-long.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files

--- a/tests/ksi-verify-short-vg.sh
+++ b/tests/ksi-verify-short-vg.sh
@@ -17,9 +17,14 @@ echo "running rsgtutil command with short options"
 valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsgtutil $RSYSLOG_KSI_DEBUG -t -s -P $RSYSLOG_KSI_BIN $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "rsgtutil returned error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-verify-short-vg.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-verify-short-vg.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files

--- a/tests/ksi-verify-short.sh
+++ b/tests/ksi-verify-short.sh
@@ -16,9 +16,14 @@ echo "running rsgtutil command with short options"
 ../tools/rsgtutil $RSYSLOG_KSI_DEBUG -t -P $RSYSLOG_KSI_BIN $srcdir/testsuites/$RSYSLOG_KSI_LOG
 
 RSYSLOGD_EXIT=$?
-if [ "$RSYSLOGD_EXIT" -ne "0" ]; then
-	echo "rsgtutil returned error: " $RSYSLOGD_EXIT
-	exit 1;
+if [ "$RSYSLOGD_EXIT" -ne "0" ]; then	# EX_OK
+	if [ "$RSYSLOGD_EXIT" -eq "69" ]; then	# EX_UNAVAILABLE
+		echo "[ksi-verify-short.sh]: rsgtutil verify failed with service unavailable (does not generate an error)"
+		exit 77;
+	else
+		echo "[ksi-verify-short.sh]: rsgtutil verify failed with error: " $RSYSLOGD_EXIT
+		exit 1;
+	fi 
 fi
 
 # Cleanup temp files


### PR DESCRIPTION
When network connection problems occur during ksi signature check,
a propper return status is used now (EX_UNAVAILABLE).
This tells the tests to set the SKIP return status to the testbench
in order to avoid false test fails.