### PR TITLE
testbench: Fix libefaketime regression

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 ------------------------------------------------------------------------------
 Version 8.19.0 [v8-stable] 2016-05-31
+- testbench: We are now using libfaketime instead of faketime command line
+  tool. Make sure you have installed the library and not just the binary!
 - bugfix: dynstats unusedMetricTtl bug
   Thanks to Janmejay Singh for fixing this.
 - bugfix build system: build was broken on SunOS

--- a/tests/faketime_common.sh
+++ b/tests/faketime_common.sh
@@ -4,20 +4,50 @@
 # faketime is missing or the system isn't year-2038 complaint.
 # This script can be sourced to prevent duplicated code.
 
-faketime_testtime=$(LD_PRELOAD=libfaketime.so FAKETIME="1991-08-25 20:57:08" TZ=GMT date +%s 2>/dev/null)
-if [ ${faketime_testtime} -ne 683153828 ] ; then
-    echo "libfaketime.so missing, skipping test"
-    exit 77
-fi
+rsyslog_testbench_preload_libfaketime() {
+    local missing_requirements=
+    if ! hash find 2>/dev/null ; then
+        missing_requirements="'find' is missing in PATH; Make sure you have findutils/coreutils installed! Skipping test ..."
+    fi
 
-# GMT-1 (POSIX TIME) is GMT+1 in "Human Time"
-faketime_testtime=$(LD_PRELOAD=libfaketime.so FAKETIME="2040-01-01 16:00:00" TZ=GMT-1 date +%s 2>/dev/null)
-if [ ${faketime_testtime} -eq -1 ]; then
-    # System isn't year-2038 compatible
-    RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE="yes"
-fi
+    if ! hash sort 2>/dev/null ; then
+        missing_requirements="'sort' is missing in PATH; Make sure you have coreutils installed! Skipping test ..."
+    fi
 
-export LD_PRELOAD=libfaketime.so
+    if ! hash head 2>/dev/null ; then
+        missing_requirements="'head' is missing in PATH; Make sure you have coreutils installed! Skipping test ..."
+    fi
+
+    if [ -n "${missing_requirements}" ]; then
+        echo ${missing_requirements}
+        exit 77
+    fi
+
+    RSYSLOG_LIBFAKETIME=$(find /usr -name 'libfaketime.so*' -type f | sort --reverse | head --lines 1)
+    if [ -z "${RSYSLOG_LIBFAKETIME}" ]; then
+        echo "Could not determine libfaketime library, skipping test!"
+        exit 77
+    fi
+
+    echo "Testing '${RSYSLOG_LIBFAKETIME}' library ..."
+    local faketime_testtime=$(LD_PRELOAD="${RSYSLOG_LIBFAKETIME}" FAKETIME="1991-08-25 20:57:08" TZ=GMT date +%s 2>/dev/null)
+    if [ ${faketime_testtime} -ne 683153828 ] ; then
+        echo "'${RSYSLOG_LIBFAKETIME}' failed sanity check, skipping test!"
+        exit 77
+    else
+        echo "Test passed! Will use '${RSYSLOG_LIBFAKETIME}' library!"
+        export LD_PRELOAD="${RSYSLOG_LIBFAKETIME}"
+    fi
+
+    # GMT-1 (POSIX TIME) is GMT+1 in "Human Time"
+    faketime_testtime=$(FAKETIME="2040-01-01 16:00:00" TZ=GMT-1 date +%s 2>/dev/null)
+    if [ ${faketime_testtime} -eq -1 ]; then
+        echo "Note: System is not year-2038 compliant"
+        RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE="yes"
+    else
+        echo "Note: System is year-2038 compliant"
+    fi
+}
 
 rsyslog_testbench_require_y2k38_support() {
     if [ -n "${RSYSLOG_TESTBENCH_Y2K38_INCOMPATIBLE}" ]; then
@@ -26,3 +56,5 @@ rsyslog_testbench_require_y2k38_support() {
         exit 0
     fi
 }
+
+rsyslog_testbench_preload_libfaketime


### PR DESCRIPTION
My proposal from https://github.com/rsyslog/rsyslog/issues/992 which uses `find` to keep using `LD_PRELOAD`.