### PR TITLE
core: set default stack size to 4MiB

### DIFF
--- a/runtime/rsyslog.c
+++ b/runtime/rsyslog.c
@@ -35,7 +35,7 @@
  *
  * Module begun 2008-04-16 by Rainer Gerhards
  *
- * Copyright 2008-2014 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -83,9 +83,9 @@
 #include "atomic.h"
 #include "srUtils.h"
 
+pthread_attr_t default_thread_attr;
 #ifdef HAVE_PTHREAD_SETSCHEDPARAM
 struct sched_param default_sched_param;
-pthread_attr_t default_thread_attr;
 int default_thr_sched_policy;
 #endif
 
@@ -145,11 +145,12 @@ rsrtInit(char **ppErrObj, obj_if_t *pObjIF)
 		stdlog_init(0);
 		stdlog_hdl = NULL;
 #endif
+		CHKiRet(pthread_attr_init(&default_thread_attr));
+		pthread_attr_setstacksize(&default_thread_attr, 4096*1024);
 #ifdef HAVE_PTHREAD_SETSCHEDPARAM
 	    	CHKiRet(pthread_getschedparam(pthread_self(),
 			    		      &default_thr_sched_policy,
 					      &default_sched_param));
-		CHKiRet(pthread_attr_init(&default_thread_attr));
 		CHKiRet(pthread_attr_setschedpolicy(&default_thread_attr,
 			    			    default_thr_sched_policy));
 		CHKiRet(pthread_attr_setschedparam(&default_thread_attr,

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -532,9 +532,9 @@ typedef enum rsObjectID rsObjID;
 #define RSFREEOBJ(x) {(x)->OID = OIDrsFreed; free(x);}
 #endif
 
+extern pthread_attr_t default_thread_attr;
 #ifdef HAVE_PTHREAD_SETSCHEDPARAM
 extern struct sched_param default_sched_param;
-extern pthread_attr_t default_thread_attr;
 extern int default_thr_sched_policy;
 #endif
 

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -968,11 +968,7 @@ static rsRetVal strmConstructFinalize(strm_t *pThis)
 		pThis->pIOBuf = pThis->asyncBuf[0].pBuf;
 		pThis->bStopWriter = 0;
 		if(pthread_create(&pThis->writerThreadID,
-#ifdef HAVE_PTHREAD_SETSCHEDPARAM
 			    	  &default_thread_attr,
-#else
-				  NULL,
-#endif
 				  asyncWriterThread, pThis) != 0)
 			DBGPRINTF("ERROR: stream %p cold not create writer thread\n", pThis);
 	} else {

--- a/threads.c
+++ b/threads.c
@@ -235,7 +235,6 @@ static void* thrdStarter(void *arg)
 	ENDfunc
 	pthread_exit(0);
 }
-
 /* Start a new thread and add it to the list of currently
  * executing threads. It is added at the end of the list.
  * rgerhards, 2007-12-14
@@ -253,13 +252,7 @@ rsRetVal thrdCreate(rsRetVal (*thrdMain)(thrdInfo_t*), rsRetVal(*afterRun)(thrdI
 	pThis->pAfterRun = afterRun;
 	pThis->bNeedsCancel = bNeedsCancel;
 	pThis->name = ustrdup(name);
-	pthread_create(&pThis->thrdID,
-#ifdef HAVE_PTHREAD_SETSCHEDPARAM
-			   &default_thread_attr,
-#else
-			   NULL,
-#endif
-			   thrdStarter, pThis);
+	pthread_create(&pThis->thrdID, &default_thread_attr, thrdStarter, pThis);
 	CHKiRet(llAppend(&llThrds, NULL, pThis));
 
 finalize_it:


### PR DESCRIPTION
Note that this is below the usual 10MiB default, but should cause
no issues (output threads already use 4MiB stack size, for example).
This also addresses issues introduced by micro-libc's which only
provide very limited stack space by default.

closes https://github.com/rsyslog/rsyslog/issues/996