### PR TITLE
disable curl signal to avoid race in threads

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -280,6 +280,8 @@ checkConn(wrkrInstanceData_t *pWrkrData)
 	/* Bodypart of request not needed, so set curl opt to nobody and httpget, otherwise lib-curl could sigsegv */
 	curl_easy_setopt(curl, CURLOPT_HTTPGET, TRUE);
 	curl_easy_setopt(curl, CURLOPT_NOBODY, TRUE);
+	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, TRUE);
+
 	/* Only enable for debugging 
 	curl_easy_setopt(curl, CURLOPT_VERBOSE, TRUE); */
 
@@ -1153,6 +1155,7 @@ curlSetup(wrkrInstanceData_t *pWrkrData, instanceData *pData)
 
 	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
 	curl_easy_setopt(handle, CURLOPT_POST, 1);
+	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, TRUE);
 
 	curl_easy_setopt(handle, CURLOPT_FAILONERROR, TRUE);
 


### PR DESCRIPTION
curl use SIGALRM to timeout handling. but it doesn't work in linux
threads and the signal is delivered to an *arbitary* threads which
almost guarantees crashing if a wrong thread picks up the signal.

```
(gdb) bt
 #0  0x00007f8b8859aa6d in addbyter () from libcurl.so.4
 #1  0x00007f8b8859b993 in dprintf_formatf () from libcurl.so.4
 #2  0x00007f8b8859bfd5 in curl_mvsnprintf () from libcurl.so.4
 #3  0x00007f8b8859ac42 in curl_msnprintf () from libcurl.so.4
 #4  0x00007f8b8858bbf6 in Curl_failf () from libcurl.so.4
 #5  0x00007f8b885826ef in Curl_resolv_timeout () from libcurl.so.4
 #6  0x00007f8b88cf2dfd in clock_gettime () from /lib64/libc.so.6
 #7  0x00007f8b6c01b1e0 in ?? ()
 #8  0x00007f8b887d58e8 in Curl_crealloc () from libcurl.so.4
 #9  0x00007f8b6c01a5a0 in ?? ()
 #10 0x00007f8b887d58e8 in Curl_crealloc () from libcurl.so.4
 #11 0x00007f8b6c002860 in ?? ()
 #12 0x000000000000000a in ?? ()
 #13 0x00007f8b6c01b5b0 in ?? ()
 #14 0x00007f8b6c0028c0 in ?? ()
 #15 0x00007f8b6c00c630 in ?? ()
 #16 0x000000000000000a in ?? ()
 #17 0x00007f8b6c0028c0 in ?? ()
 #18 0x0000000000000018 in ?? ()
 #19 0x00007f8b885a5432 in Curl_llist_remove () from libcurl.so.4
 #20 0x0000000004000000 in ?? ()
 #21 <signal handler called>
 #22 0x0000006e0000005b in ?? ()
Cannot access memory at address 0x0
```

References
* https://curl.haxx.se/libcurl/c/threadsafe.html
* https://curl.haxx.se/libcurl/c/CURLOPT_NOSIGNAL.html
* https://www.redhat.com/archives/libvir-list/2012-October/msg00008.html