### PR TITLE
travis: force install of non-OS-standard components

### DIFF
--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -3,11 +3,11 @@ source /etc/lsb-release
 # the following packages are not yet available via travis package
 sudo apt-get install -qq faketime libdbd-mysql libmongo-client-dev
 if [ "x$GROK" == "xYES" ]; then sudo apt-get install -qq libgrok1 libgrok-dev ; fi
-sudo apt-get install -qq libestr-dev librelp-dev libfastjson-dev liblogging-stdlog-dev libksi1 libksi1-dev
-sudo apt-get install -qq python-docutils liblognorm1-dev 
+sudo apt-get install -qq --force-yes libestr-dev librelp-dev libfastjson-dev liblogging-stdlog-dev libksi1 libksi1-dev liblognorm1-dev 
+sudo apt-get install -qq python-docutils
 if [ "$DISTRIB_CODENAME" == "trusty" ]; then sudo apt-get install -qq libhiredis-dev; export HIREDIS_OPT="--enable-omhiredis"; fi
 if [ "$DISTRIB_CODENAME" == "trusty" ]; then sudo apt-get install -qq libsystemd-journal-dev; export JOURNAL_OPT="--enable-imjournal --enable-omjournal"; fi
-sudo apt-get install -qq libqpid-proton3-dev
+sudo apt-get install -qq --force-yes libqpid-proton3-dev
 if [ "$CC" == "clang" ] && [ "$DISTRIB_CODENAME" == "trusty" ]; then CLANG_PKG="clang-3.6"; SCAN_BUILD="scan-build-3.6"; else CLANG_PKG="clang"; SCAN_BUILD="scan-build"; fi
 if [ "$CC" == "clang" ]; then export NO_VALGRIND="--without-valgrind-testbench"; fi
 if [ "$CC" == "clang" ]; then sudo apt-get install -qq $CLANG_PKG ; fi


### PR DESCRIPTION
sometimes the travis build complains about inability to verify
correctness, which is probably related to ongoing build work. This
should solve the issue with PPAs (mostly our own).