### PR TITLE
CStr: reset a previously cached sz string when appending

### DIFF
--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -534,6 +534,15 @@ rsRetVal cstrTrimTrailingWhiteSpace(cstr_t *pThis)
 	if(i != (int) pThis->iStrLen) {
 		pThis->iStrLen = i;
 		pThis->pBuf[pThis->iStrLen] = '\0'; /* we always have this space */
+
+		if(pThis->pszBuf != NULL) {
+			/* in this case, we adjust the psz representation
+			 * by writing a new \0 terminator - this is by far
+			 * the fastest way and outweights the additional memory
+			 * required.
+			 */
+			 pThis->pszBuf[pThis->iStrLen] = '\0';
+		}
 	}
 
 done:	return RS_RET_OK;

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -281,6 +281,10 @@ rsRetVal rsCStrAppendStrWithLen(cstr_t *pThis, const uchar* psz, size_t iStrLen)
 	memcpy(pThis->pBuf + pThis->iStrLen, psz, iStrLen);
 	pThis->iStrLen += iStrLen;
 
+	/* reset any cached sz string */
+	free(pThis->pszBuf);
+	pThis->pszBuf = NULL;
+
 finalize_it:
 	RETiRet;
 }

--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -32,6 +32,7 @@
 #ifndef _STRINGBUF_H_INCLUDED__
 #define _STRINGBUF_H_INCLUDED__ 1
 
+#include <stdlib.h>
 #include <assert.h>
 #include <libestr.h>
 
@@ -82,6 +83,10 @@ static inline rsRetVal cstrAppendChar(cstr_t *pThis, uchar c)
 
 	/* ok, when we reach this, we have sufficient memory */
 	*(pThis->pBuf + pThis->iStrLen++) = c;
+
+	/* reset any cached sz string */
+	free(pThis->pszBuf);
+	pThis->pszBuf = NULL;
 
 finalize_it:
 	return iRet;


### PR DESCRIPTION
When appending to CStr, any previously saved sz string (pszBuf) needs to be reset so it will be re-created the next time a sz string is requested.

Fixes #874.