### PR TITLE
CStr: ensure that rsCStrGetSzStrNoNULL returns the current string

### DIFF
--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -505,7 +505,7 @@ rsRetVal rsCStrTruncate(cstr_t *pThis, size_t nTrunc)
 	
 	pThis->iStrLen -= nTrunc;
 
-	if(pThis->pszBuf != NULL) {
+	if(pThis->pszBuf != NULL && pThis->szStale == 0) {
 		/* in this case, we adjust the psz representation
 		 * by writing a new \0 terminator - this is by far
 		 * the fastest way and outweights the additional memory
@@ -537,6 +537,15 @@ rsRetVal cstrTrimTrailingWhiteSpace(cstr_t *pThis)
 	if(i != (int) pThis->iStrLen) {
 		pThis->iStrLen = i;
 		pThis->pBuf[pThis->iStrLen] = '\0'; /* we always have this space */
+
+		if(pThis->pszBuf != NULL && pThis->szStale == 0) {
+			/* in this case, we adjust the psz representation
+			 * by writing a new \0 terminator - this is by far
+			 * the fastest way and outweights the additional memory
+			 * required.
+			 */
+			 pThis->pszBuf[pThis->iStrLen] = '\0';
+		}
 	}
 
 done:	return RS_RET_OK;

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -69,6 +69,7 @@ rsRetVal cstrConstruct(cstr_t **ppThis)
 	pThis->pszBuf = NULL;
 	pThis->iBufSize = 0;
 	pThis->iStrLen = 0;
+	pThis->szStale = 0;
 	*ppThis = pThis;
 
 finalize_it:
@@ -281,6 +282,9 @@ rsRetVal rsCStrAppendStrWithLen(cstr_t *pThis, const uchar* psz, size_t iStrLen)
 	memcpy(pThis->pBuf + pThis->iStrLen, psz, iStrLen);
 	pThis->iStrLen += iStrLen;
 
+	/* set flag to re-create sz string */
+	pThis->szStale = 1;
+
 finalize_it:
 	RETiRet;
 }
@@ -391,9 +395,9 @@ uchar*  rsCStrGetSzStrNoNULL(cstr_t *pThis)
 		return (uchar*) "";
 
 	if(pThis->pBuf != NULL)
-		if(pThis->pszBuf == NULL) {
+		if(pThis->pszBuf == NULL || pThis->szStale == 1) {
 			/* we do not yet have a usable sz version - so create it... */
-			if((pThis->pszBuf = MALLOC(pThis->iStrLen + 1)) == NULL) {
+		  	if((pThis->pszBuf = (uchar*)realloc(pThis->pszBuf, pThis->iStrLen + 1)) == NULL) {
 				/* TODO: think about what to do - so far, I have no bright
 				 *       idea... rgerhards 2005-09-07
 				 */
@@ -413,6 +417,9 @@ uchar*  rsCStrGetSzStrNoNULL(cstr_t *pThis)
 				}
 				/* write terminator... */
 				pThis->pszBuf[i] = '\0';
+
+				/* reset stale flag */
+				pThis->szStale = 0;
 			}
 		}
 

--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -43,10 +43,11 @@ typedef struct cstr_s
 #ifndef	NDEBUG
 	rsObjID OID;		/**< object ID */
 #endif
-	uchar *pBuf;		/**< pointer to the string buffer, may be NULL if string is empty */
-	uchar *pszBuf;		/**< pointer to the sz version of the string (after it has been created )*/
-	size_t iBufSize;	/**< current maximum size of the string buffer */
-	size_t iStrLen;		/**< length of the string in characters. */
+	uchar  *pBuf;		/**< pointer to the string buffer, may be NULL if string is empty */
+	uchar  *pszBuf;		/**< pointer to the sz version of the string (after it has been created )*/
+	size_t  iBufSize;	/**< current maximum size of the string buffer */
+	size_t  iStrLen;	/**< length of the string in characters. */
+	uint8_t szStale;	/**< flag that indicates that the sz version of the string needs to be re-created */
 } cstr_t;
 
 
@@ -83,6 +84,8 @@ static inline rsRetVal cstrAppendChar(cstr_t *pThis, uchar c)
 	/* ok, when we reach this, we have sufficient memory */
 	*(pThis->pBuf + pThis->iStrLen++) = c;
 
+	/* set flag to re-create sz string */
+	pThis->szStale = 1;
 finalize_it:
 	return iRet;
 }


### PR DESCRIPTION
Fixes #874.This PR replaces PR #1020, where we have had a long discussion about the inner workings of stringbuf, and how if used as in imfile you can end up reading or writing beyond the end of the allocated `pszBuf` string buffer.

I understand that stringbuf has been around a long time and is a central and heavily used component in rsyslog. Judging from the code, I think the original idea was to build strings that would be "finalized" by adding null byte to the end. They would then be read-only? This includes functions like `cstrFinalize`, `cstrGetSzStr` and `cstrGetSzStrNoNULL`. Later I think the design was altered so that the string was allowed to contain null bytes, which most of the functions handle. The most obvious example is `rsCStrGetSzStrNoNULL`, which even replaces null bytes with blanks when creating the sz string. (One could even argue that `cstrGetSzStr` and `cstrGetSzStrNoNULL` are now faulty implementations, since they clearly don't return a "proper" sz string if the string contains null bytes. Is it even useful to talk about finalizing the string?) 

A few methods, e.g. `cstrTrimTrailingWhiteSpace` and `rsCStrTruncate`, seem to combine the two designs. They both do truncation by decreasing `iStrLen`, but then they also insert a null byte in `pBuf`, which is redundant. One of them also inserts a null byte into `pszBuf`, which is OK, but the other one doesn't, which is inconsistent. (In this PR I am addressing the inconsistency, but they could probably be optimized as well.) 

The main purpose of this PR is to make sure that `rsCStrGetSzStrNoNULL` always returns the sz string counterpart of the current string in `pBuf`. `pszBuf` is essentially a cached sz version of the string in `pBuf`, but it can become stale, or out-of-date, when more strings are appended to `pBuf`. My proposed change is to set a flag when that occurs, so that `rsCStrGetSzStrNoNULL` will re-create the sz string in `pszBuf`.

I know you have said that `rsCStrGetSzStrNoNULL` should not be called until the string in `pBuf` is complete. But is this documented anywhere? Such hidden rules are dangerous, because it is so easy to shoot yourself in the foot. It also makes the code harder to write, understand and maintain. As in imfile, where it was not at all obvious that `persistStrmState` was calling `rsCStrGetSzStrNoNULL` several calls down the stack.

Further, I see no reason for such a limitation. I see no reason why stringbuf could not be modified so that `rsCStrGetSzStrNoNULL` can be called at any time and always return the current up-to-date string. It would make the code much more robust and less error prone.