### PR TITLE
support to connect with mysql unix socket on ommysql plugin

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -224,9 +224,9 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 
 		/* check unix socket */
 		if (pData->dbsrv[0] == '/') {
-			strcpy(usock, pData->f_dbsrv);
+			strcpy(usock, pData->dbsrv);
 			usock_p = usock;
-			strcpy(pData->f_dbsrv, "localhost");
+			strcpy(pData->dbsrv, "localhost");
 		}
 
 		if(mysql_real_connect(pWrkrData->hmysql, pData->dbsrv, pData->dbuid,

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -224,7 +224,7 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 		/* check unix socket */
 		if (pData->dbsrv[0] == '/') {
 			size_t pathlen = strlen(pData->dbsrv);
-			memset(pData->dbusock, 0, _DB_MAXFILEAPTH+1)
+			memset(pData->dbusock, 0, _DB_MAXFILEAPTH+1);
 
 				if (pathlen > _DB_MAXFILEAPTH)
 					strncpy(pData->dbusock, pData->dbsrv, _DB_MAXFILEAPTH);

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -229,7 +229,7 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 				if (pathlen > _DB_MAXFILEAPTH)
 					strncpy(pData->dbusock, pData->dbsrv, _DB_MAXFILEAPTH);
 				else
-					strncpy(pData->dbusock, pData->dbsrv);
+					strcpy(pData->dbusock, pData->dbsrv);
 			memset(pData->dbsrv, 0, MAXHOSTNAMELEN+1);
 			strcpy(pData->dbsrv, "localhost");
 		}

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -60,6 +60,7 @@ typedef struct _instanceData {
 	char	dbname[_DB_MAXDBLEN+1];	/* DB name */
 	char	dbuid[_DB_MAXUNAMELEN+1];	/* DB user */
 	char	dbpwd[_DB_MAXPWDLEN+1];	/* DB user's password */
+	char	dbusock[_DB_MAXFILEAPTH+1];	/* DB Unix socket path */
 	uchar   *configfile;			/* MySQL Client Configuration File */
 	uchar   *configsection;		/* MySQL Client Configuration Section */
 	uchar	*tplName;			/* format template to use */
@@ -219,6 +220,20 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 			}
 		}
 		/* Connect to database */
+
+		/* check unix socket */
+		if (pData->dbsrv[0] == '/') {
+			size_t pathlen = strlen(pData->dbsrv);
+			memset(pData->dbusock, 0, _DB_MAXFILEAPTH+1)
+
+				if (pathlen > _DB_MAXFILEAPTH)
+					strncpy(pData->dbusock, pData->dbsrv, _DB_MAXFILEAPTH);
+				else
+					strncpy(pData->dbusock, pData->dbsrv);
+			memset(pData->dbsrv, 0, MAXHOSTNAMELEN+1);
+			strcpy(pData->dbsrv, "localhost");
+		}
+
 		if(mysql_real_connect(pWrkrData->hmysql, pData->dbsrv, pData->dbuid,
 				      pData->dbpwd, pData->dbname, pData->dbsrvPort, NULL, 0) == NULL) {
 			reportDBError(pWrkrData, bSilent);

--- a/runtime/syslogd-types.h
+++ b/runtime/syslogd-types.h
@@ -43,6 +43,7 @@
 #define	_DB_MAXDBLEN	128	/* maximum number of db */
 #define _DB_MAXUNAMELEN	128	/* maximum number of user name */
 #define	_DB_MAXPWDLEN	128 	/* maximum number of user's pass */
+#define	_DB_MAXFILEAPTH	2048	/* maximun size of file path */
 #define _DB_DELAYTIMEONERROR	20	/* If an error occur we stop logging until
 					   a delayed time is over */
 

--- a/runtime/syslogd-types.h
+++ b/runtime/syslogd-types.h
@@ -43,7 +43,7 @@
 #define	_DB_MAXDBLEN	128	/* maximum number of db */
 #define _DB_MAXUNAMELEN	128	/* maximum number of user name */
 #define	_DB_MAXPWDLEN	128 	/* maximum number of user's pass */
-#define	_DB_MAXFILEAPTH	2048	/* maximun size of file path */
+#define	_DB_MAXFILEPATH	2048	/* maximun size of file path */
 #define _DB_DELAYTIMEONERROR	20	/* If an error occur we stop logging until
 					   a delayed time is over */
 


### PR DESCRIPTION
ommysql plugin can't connect with mysql unix socket. This patch is enable to connect with unix socket.

***Expected:***
```syslog
*.* :ommysql:/tmp/mysqld.sock,Syslog,syslogwriter,topsecret
```

