### PR TITLE
CI: add plubming to gather testbench error info in timeout case

### DIFF
--- a/tests/CI/buildbot_cleanup.sh
+++ b/tests/CI/buildbot_cleanup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# This script gathers and sends to stdout all log files created during
+# make check. This is useful if make check is terminated due to timeout,
+# in which case autotools unfortunately does not provide us a way to
+# gather error information.
+ls tests/*.sh.log | xargs cat

--- a/tests/CI/gather_all_logs.sh
+++ b/tests/CI/gather_all_logs.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Some generic cleanup to be done before buildbot processes
+# tests.
+rm -f tests/*.sh.log


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/1036