### PR TITLE
Output Module TCL

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -253,6 +253,11 @@ if ENABLE_OMAMQP1
 SUBDIRS += contrib/omamqp1
 endif
 
+# omtcl
+if ENABLE_OMTCL
+SUBDIRS += contrib/omtcl
+endif
+
 # tests are added as last element, because tests may need different
 # modules that need to be generated first
 SUBDIRS += tests

--- a/configure.ac
+++ b/configure.ac
@@ -1712,6 +1712,27 @@ AM_CONDITIONAL(ENABLE_OMAMQP1, test x$enable_omamqp1 = xyes)
 
 # END AMQP 1.0 PROTOCOL SUPPORT
 
+# TCL SUPPORT
+
+AC_ARG_ENABLE(omtcl,
+        [AS_HELP_STRING([--enable-omtcl],[Compiles omtcl output module @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_omtcl="yes" ;;
+          no) enable_omtcl="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-omtcl) ;;
+         esac],
+        [enable_omtcl=no]
+)
+
+if test "x$enable_omtcl" = "xyes"; then
+	SC_PATH_TCLCONFIG
+	SC_LOAD_TCLCONFIG
+	AC_SUBST(TCL_INCLUDE_SPEC)
+fi
+AM_CONDITIONAL(ENABLE_OMTCL, test x$enable_omtcl = xyes)
+
+# END TCL SUPPORT
+
 # man pages
 AC_CHECKING([if required man pages already exist])
 have_to_generate_man_pages="no"
@@ -1838,6 +1859,7 @@ AC_CONFIG_FILES([Makefile \
 		contrib/pmcisconames/Makefile \
 		contrib/omhttpfs/Makefile \
 		contrib/omamqp1/Makefile \
+		contrib/omtcl/Makefile \
 		tests/Makefile])
 AC_OUTPUT
 
@@ -1888,6 +1910,7 @@ echo "    omczmq module will be compiled:           $enable_omczmq"
 echo "    omrabbitmq module will be compiled:       $enable_omrabbitmq"
 echo "    omhttpfs module will be compiled:         $enable_omhttpfs"
 echo "    omamqp1 module will be compiled:          $enable_omamqp1"
+echo "    omtcl module will be compiled:            $enable_omtcl"
 echo
 echo "---{ parser modules }---"
 echo "    pmlastmsg module will be compiled:        $enable_pmlastmsg"

--- a/contrib/omtcl/Makefile.am
+++ b/contrib/omtcl/Makefile.am
@@ -1,0 +1,8 @@
+pkglib_LTLIBRARIES = omtcl.la
+
+omtcl_la_SOURCES = omtcl.c
+omtcl_la_CPPFLAGS = $(RSRT_CFLAGS) $(TCL_INCLUDE_SPEC)
+omtcl_la_LDFLAGS = -module
+omtcl_la_LIBADD = $(TCL_LIB_SPEC)
+
+EXTRA_DIST =

--- a/contrib/omtcl/omtcl.c
+++ b/contrib/omtcl/omtcl.c
@@ -101,7 +101,7 @@ CODESTARTdoAction
 	objv[0] = pWrkrData->pData->cmdName;
 	objv[1] = Tcl_NewStringObj((char*) ppString[0], -1);
 	if (Tcl_EvalObjv(pWrkrData->pData->interp, 2, objv, 0) != TCL_OK) {
-		iRet = RS_RET_SUSPENDED;
+		iRet = RS_RET_ERR;
 		DBGPRINTF("omtcl: %s", Tcl_GetStringResult(pWrkrData->pData->interp));
 	}
 ENDdoAction

--- a/contrib/omtcl/omtcl.c
+++ b/contrib/omtcl/omtcl.c
@@ -1,0 +1,162 @@
+/* omtcl.c
+ * invoke a tcl procedure for every message
+ *
+ * NOTE: read comments in module-template.h for more specifics!
+ *
+ * File begun on 2016-05-16 by fcr
+ *
+ * Copyright 2016 Francisco Castro <fcr@adinet.com.uy>
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include "rsyslog.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <signal.h>
+#include <errno.h>
+#include <unistd.h>
+#include "conf.h"
+#include "syslogd-types.h"
+#include "srUtils.h"
+#include "template.h"
+#include "module-template.h"
+#include "errmsg.h"
+#include "cfsysline.h"
+#include "tcl.h"
+
+MODULE_TYPE_OUTPUT
+MODULE_TYPE_NOKEEP
+
+DEF_OMOD_STATIC_DATA
+DEFobjCurrIf(errmsg)
+
+typedef struct _instanceData {
+	Tcl_Interp * interp;
+	Tcl_Obj * cmdName;
+} instanceData;
+
+typedef struct wrkrInstanceData {
+	instanceData * pData;
+} wrkrInstanceData_t;
+
+BEGINinitConfVars
+CODESTARTinitConfVars
+ENDinitConfVars
+
+BEGINcreateInstance
+CODESTARTcreateInstance
+	pData->interp = Tcl_CreateInterp();
+	pData->cmdName = NULL;
+ENDcreateInstance
+
+BEGINcreateWrkrInstance
+CODESTARTcreateWrkrInstance
+ENDcreateWrkrInstance
+
+BEGINisCompatibleWithFeature
+CODESTARTisCompatibleWithFeature
+/* not compatible with message reduction */
+ENDisCompatibleWithFeature
+
+BEGINfreeInstance
+CODESTARTfreeInstance
+	if(pData->cmdName != NULL)
+		Tcl_DecrRefCount(pData->cmdName);
+	Tcl_DeleteInterp(pData->interp);
+ENDfreeInstance
+
+BEGINfreeWrkrInstance
+CODESTARTfreeWrkrInstance
+ENDfreeWrkrInstance
+
+BEGINdbgPrintInstInfo
+CODESTARTdbgPrintInstInfo
+ENDdbgPrintInstInfo
+
+BEGINtryResume
+CODESTARTtryResume
+ENDtryResume
+
+BEGINdoAction
+	Tcl_Obj * objv[2];
+CODESTARTdoAction
+	objv[0] = pWrkrData->pData->cmdName;
+	objv[1] = Tcl_NewStringObj((char*) ppString[0], -1);
+	if (Tcl_EvalObjv(pWrkrData->pData->interp, 2, objv, 0) != TCL_OK) {
+		iRet = RS_RET_SUSPENDED;
+		DBGPRINTF("omtcl: %s", Tcl_GetStringResult(pWrkrData->pData->interp));
+	}
+ENDdoAction
+
+BEGINparseSelectorAct
+	char fileName[PATH_MAX+1];
+	char buffer[4096];
+CODESTARTparseSelectorAct
+CODE_STD_STRING_REQUESTparseSelectorAct(1)
+	if(strncmp((char*) p, ":omtcl:", sizeof(":omtcl:") - 1)) {
+		ABORT_FINALIZE(RS_RET_CONFLINE_UNPROCESSED);
+	}
+	p += sizeof(":omtcl:") - 1;
+
+	if(getSubString(&p, fileName, PATH_MAX+1, ',') || getSubString(&p, buffer, 4096, ';') || !strlen(buffer)) {
+		errmsg.LogError(0, RS_RET_INVALID_PARAMS, "Invalid OmTcl parameters");
+		ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+	}
+
+	if (*(p-1) == ';')
+		--p;
+
+	CHKiRet(cflineParseTemplateName(&p, *ppOMSR, 0, 0, (uchar*) "RSYSLOG_FileFormat"));
+
+	CHKiRet(createInstance(&pData));
+	pData->cmdName = Tcl_NewStringObj(buffer, -1);
+	Tcl_IncrRefCount(pData->cmdName);
+
+	// TODO parse arguments: file,procname
+	if (Tcl_EvalFile(pData->interp, fileName) == TCL_ERROR) {
+		errmsg.LogError(0, RS_RET_CONFIG_ERROR, "Loading Tcl script: %s", Tcl_GetStringResult(pData->interp));
+		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+	}
+
+CODE_STD_FINALIZERparseSelectorAct
+ENDparseSelectorAct
+
+BEGINmodExit
+CODESTARTmodExit
+ENDmodExit
+
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_OMOD_QUERIES
+CODEqueryEtryPt_STD_OMOD8_QUERIES
+ENDqueryEtryPt
+
+
+BEGINmodInit()
+CODESTARTmodInit
+INITLegCnfVars
+	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+CODEmodInit_QueryRegCFSLineHdlr
+	DBGPRINTF("omtcl: module compiled with rsyslog version %s.\n", VERSION);
+
+ENDmodInit
+

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -471,6 +471,11 @@ TESTS += \
 endif
 endif
 
+if ENABLE_OMTCL
+TESTS += \
+	 omtcl.sh
+endif
+
 endif # if ENABLE_TESTBENCH
 
 TESTS_ENVIRONMENT = RSYSLOG_MODDIR='$(abs_top_builddir)'/runtime/.libs/
@@ -1232,7 +1237,8 @@ EXTRA_DIST= \
 	testsuites/sndrcv_tls_anon_rebind_rcvr.conf \
 	sndrcv_tls_anon.sh \
 	testsuites/sndrcv_tls_anon_sender.conf \
-	testsuites/sndrcv_tls_anon_rcvr.conf
+	testsuites/sndrcv_tls_anon_rcvr.conf \
+	omtcl.tcl
 
 ourtail_SOURCES = ourtail.c
 msleep_SOURCES = msleep.c

--- a/tests/omtcl.sh
+++ b/tests/omtcl.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+$ModLoad ../contrib/omtcl/.libs/omtcl
+$template tcldict, "message \"%msg:::json%\" fromhost \"%HOSTNAME:::json%\" facility \"%syslogfacility-text%\" priority \"%syslogpriority-text%\" timereported \"%timereported:::date-rfc3339%\" timegenerated \"%timegenerated:::date-rfc3339%\" raw \"%rawmsg:::json%\" tag \"%syslogtag:::json%\""
+*.* :omtcl:omtcl.tcl,doAction;tcldict'
+. $srcdir/diag.sh startup
+echo 'injectmsg litteral <167>Mar  1 01:00:00 172.20.245.8 tag hello world' | \
+	./diagtalker || . $srcdir/diag.sh error-exit $?
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh content-check 'HELLO WORLD'
+cat rsyslog.out.log
+. $srcdir/diag.sh exit

--- a/tests/omtcl.tcl
+++ b/tests/omtcl.tcl
@@ -1,0 +1,10 @@
+proc doAction {msg} {
+  set fd [open "rsyslog.out.log" a]
+  puts $fd "message processed:"
+  foreach {k v} $msg {
+    puts $fd "  $k: <<$v>>"
+  }
+  puts $fd "  uppercase message: <<[string toupper [dict get $msg message]]>>"
+  close $fd
+  fallo
+}

--- a/tests/omtcl.tcl
+++ b/tests/omtcl.tcl
@@ -6,5 +6,4 @@ proc doAction {msg} {
   }
   puts $fd "  uppercase message: <<[string toupper [dict get $msg message]]>>"
   close $fd
-  fallo
 }


### PR DESCRIPTION
An output module that calls a TCL procedure for each message.  This module can be used as an alternative to omshell/ompipe when fast output with custom processing or ad-hoc integration is needed.