### PR TITLE
imrelp: better error codes on unvailablity of TLS options

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -399,9 +399,25 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 		}
 	}
 	relpRet = relpEngineListnerConstructFinalize(pRelpEngine, pSrv);
-	if(relpRet != RELP_RET_OK) {
+	/* re-check error TLS error codes. librelp seems to emit them only
+	 * after finalize in some cases...
+	 */
+	if(relpRet == RELP_RET_ERR_NO_TLS) {
+		errmsg.LogError(0, RS_RET_RELP_NO_TLS,
+				"imrelp: could not activate relp TLS listener, librelp "
+				"does not support it (most probably GnuTLS lib "
+				"is too old)!");
+		ABORT_FINALIZE(RS_RET_RELP_NO_TLS);
+	} else if(relpRet == RELP_RET_ERR_NO_TLS_AUTH) {
+		errmsg.LogError(0, RS_RET_RELP_NO_TLS_AUTH,
+				"imrelp: could not activate relp TLS listener with "
+				"authentication, librelp does not support it "
+				"(most probably GnuTLS lib is too old)! "
+				"Note: anonymous TLS is probably supported.");
+		ABORT_FINALIZE(RS_RET_RELP_NO_TLS_AUTH);
+	} else if(relpRet != RELP_RET_OK) {
 		errmsg.LogError(0, RS_RET_RELP_ERR,
-				"imrelp: could not activate relp listner, code %d", relpRet);
+				"imrelp: could not activate relp listener, code %d", relpRet);
 		ABORT_FINALIZE(RS_RET_RELP_ERR);
 	}
 


### PR DESCRIPTION
librelp seems to emit some TLS error codes not (only) when enabling
TLS, but also when finalizing the listener. We have now duplicated
some checks to make sure the user gets a meaningful message.

closes https://github.com/rsyslog/rsyslog/issues/1019