### PR TITLE
Simplest fix for the omhiredis segfault

### DIFF
--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -232,12 +232,18 @@ ENDdoAction
 BEGINendTransaction
 CODESTARTendTransaction
 	dbgprintf("omhiredis: endTransaction called\n");
+    redisReply* reply;
 	int i;
 	pWrkrData->replies = malloc ( sizeof ( redisReply* ) * pWrkrData->count );
 	for ( i = 0; i < pWrkrData->count; i++ ) {
 		redisGetReply ( pWrkrData->conn, (void *)&pWrkrData->replies[i] );
-		/*  TODO: add error checking here! */
-		freeReplyObject ( pWrkrData->replies[i] );
+        reply = (void *)&pWrkrData->replies[i];
+        if( pWrkrData->conn->err ){
+            dbgprintf("omhiredis: %s\n", pWrkrData->conn->errstr);
+        }
+        else {
+            freeReplyObject(reply);
+        }
 	}
 	free ( pWrkrData->replies );
 ENDendTransaction


### PR DESCRIPTION
This is a brutally simple fix for the omhiredis segfault - if we receive an error from the redis context, we don't try to free the reply object. See https://github.com/redis/hiredis/issues/122 for more info.

I'd like to do a deeper reworking of the module, though, and try to reduce the number of network roundtrips. Comments suggest that the original author had this in mind.

I'm slightly confused by the use of the transaction handlers. Is there a good example of a transactional, batching output module that I can use for inspiration? In particular, what ought I to do if endTransaction fails? How many times should I expect a retry?

Is there a way to introduce a randomised backoff rather than immediately retrying the redis connection?