### PR TITLE
bugfix omfile: handle chown() failure correctly

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -453,6 +453,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_FILE_ALREADY_IN_TABLE = -2431,/**< in imfile: table already contains to be added file */
 	RS_RET_ERR_DROP_PRIV = -2432,/**< error droping privileges */
 	RS_RET_FILE_OPEN_ERROR = -2433, /**< error other than "not found" occured during open() */
+	RS_RET_FILE_CHOWN_ERROR = -2434, /**< error during chown() */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */


### PR DESCRIPTION
If the file creation succeeds, but chown() failed, the file was
still writen, even if the user requested that this should be treated
as a failure case. This is corrected by this commit.

Alos, some refactoring was done to create better error messages.