### PR TITLE
testbench: activate a new relp test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -428,6 +428,7 @@ endif
 if ENABLE_RELP
 TESTS += sndrcv_relp.sh \
          sndrcv_relp_tls.sh \
+         sndrcv_relp_dflt_pt.sh \
 	 imrelp-basic.sh \
 	 imrelp-manyconn.sh
 endif
@@ -888,6 +889,9 @@ EXTRA_DIST= \
 	sndrcv_relp_tls.sh \
 	testsuites/sndrcv_relp_tls_sender.conf \
 	testsuites/sndrcv_relp_tls_rcvr.conf \
+	sndrcv_relp_dflt_pt.sh \
+	testsuites/sndrcv_relp_dflt_pt_rcvr.conf \
+	testsuites/sndrcv_relp_dflt_pt_sender.conf \
 	sndrcv_udp.sh \
 	testsuites/sndrcv_udp_sender.conf \
 	testsuites/sndrcv_udp_rcvr.conf \

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -2,10 +2,17 @@
 # added 2013-12-10 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
+# the first test is redundant, but we keep it when we later make the port
+# configurable.
 if [ `./omrelp_dflt_port` -lt 1024 ]; then
     if [ "$EUID" -ne 0 ]; then
 	echo need to be root to run this test - skipping
         exit 77
     fi
 fi
+if [ `./omrelp_dflt_port` -ne 13515 ]; then
+    echo this test needs configure option --enable-omrelp-default-port=13515 to work
+    exit 77
+fi
+exit
 . $srcdir/sndrcv_drvr.sh sndrcv_relp_dflt_pt 50000


### PR DESCRIPTION
we have improved an existing test file so that it does not require special
configure options to make the testbench succeed.