### PR TITLE
build system: require libfastjson 0.99.3

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,7 +44,7 @@ PKG_PROG_PKG_CONFIG
 
 # modules we require
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
-PKG_CHECK_MODULES([JSON_C], [libfastjson],,)
+PKG_CHECK_MODULES([JSON_C], [libfastjson >= 0.99.3],,)
 
 AC_DEFINE_UNQUOTED([PLATFORM_ID], ["${host}"], [platform id for display purposes])
 # we don't mind if we don't have the lsb_release utility. But if we have, it's


### PR DESCRIPTION
This is because the previous versions have a bug that causes
invalid Unicode encoding for some non US-ASCII characters and
may also segfault (though unlikely) under this condition.