### PR TITLE
Add custom template support for ompgsql

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,10 @@ Version 8.20.0 [v8-stable] 2016-07-12
   to support the new timeout parameter in omrelp.
 - omrelp: add configurable connection timeout
   Thanks to Nathan Brown for implementing this feature.
+- pmrfc3164: add support for slashes in hostname
+  added parameter "permit.slashesinhostname" to support this, off by default
+  [Note that the RFC5424 always supported this, as 5424 is a different
+  standard]
 - bugfix omfile: handle chown() failure correctly
   If the file creation succeeds, but chown() failed, the file was
   still writen, even if the user requested that this should be treated

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,11 @@ Version 8.20.0 [v8-stable] 2016-07-12
 - NEW BUILD REQUIREMENT: librelp, was 1.2.5, now is 1.2.12
   This is only needed if --enable-relp is used. The new version is needed
   to support the new timeout parameter in omrelp.
+- NEW BUILD SUGGESTION: libfastjson 0.99.3
+  while not strictly necessary, previous versions of libfastjson have a bug
+  in unicode processing that can result in non US-ASCII characters to be
+  improperly encoded and may (very unlikely) also cause a segfault.
+  This version will become mandatory in rsyslog 8.20.1.
 - omrelp: add configurable connection timeout
   Thanks to Nathan Brown for implementing this feature.
 - pmrfc3164: add support for slashes in hostname
@@ -41,6 +46,8 @@ Version 8.20.0 [v8-stable] 2016-07-12
   * new tests for core action processing and retry
   * travis tests now also run against all unstable versions of supporting
     libraries. This helps to track interdependency problems early.
+  * new tests for hostname parsing
+  * new tests for RainerScript comparisons
 ------------------------------------------------------------------------------
 Version 8.19.0 [v8-stable] 2016-05-31
 - NEW BUILD REQUIREMENT: autoconf-archive

--- a/configure.ac
+++ b/configure.ac
@@ -888,6 +888,23 @@ AC_ARG_ENABLE(mysql_tests,
 AM_CONDITIONAL(ENABLE_MYSQL_TESTS, test x$enable_mysql_tests = xyes)
 
 
+# capability to enable PostgreSQL testbench tests. This requries that a Syslog database
+# with the default schema (see plugins/ompgsql/createDB.sql) has been created on the
+# local (127.0.0.1) PostgreSQL server and a user "rsyslog" with password "testbench"
+# exists, is able to login with default parameters and has sufficient (read: all)
+# privileges on that database
+AC_ARG_ENABLE(pgsql_tests,
+        [AS_HELP_STRING([--enable-pgsql-tests],[enable PostgreSQL specific tests in testbench @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_pgsql_tests="yes" ;;
+          no) enable_pgsql_tests="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-pgsql-tests) ;;
+         esac],
+        [enable_pgsql_tests=no]
+)
+AM_CONDITIONAL(ENABLE_PGSQL_TESTS, test x$enable_pgsql_tests = xyes)
+
+
 # Mail support (so far we do not need a library, but we need to turn this on and off)
 AC_ARG_ENABLE(mail,
         [AS_HELP_STRING([--enable-mail],[Enable mail support @<:@default=no@:>@])],
@@ -1929,6 +1946,7 @@ echo "---{ debugging support }---"
 echo "    Testbench enabled:                        $enable_testbench"
 echo "    Extended Testbench enabled:               $enable_extended_tests"
 echo "    MySQL Tests enabled:                      $enable_mysql_tests"
+echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"
 echo "    Kafka Tests enabled:                      $enable_kafka_tests"
 echo "    Debug mode enabled:                       $enable_debug"
 echo "    Runtime Instrumentation enabled:          $enable_rtinst"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -264,6 +264,14 @@ TESTS += \
 endif
 endif
 
+if ENABLE_PGSQL
+if ENABLE_PGSQL_TESTS
+TESTS += \
+	pgsql-basic.sh \
+	pgsql-template.sh
+endif
+endif
+
 if ENABLE_MYSQL_TESTS
 TESTS +=  \
 	mysql-basic.sh \

--- a/tests/pgsql-basic.sh
+++ b/tests/pgsql-basic.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under GPLv3
+echo ===============================================================================
+echo \[postgres-basic.sh\]: basic test for postgres output functionality
+. $srcdir/diag.sh init
+psql -h db -U postgres -d Syslog -f testsuites/pgsql-truncate.sql
+
+. $srcdir/diag.sh startup pgsql-basic.conf
+. $srcdir/diag.sh injectmsg  0 5000
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown 
+
+psql -h db -U postgres -d Syslog -f testsuites/pgsql-select-msg.sql -t -A > rsyslog.out.log 
+
+. $srcdir/diag.sh seq-check  0 4999
+. $srcdir/diag.sh exit

--- a/tests/pgsql-template.sh
+++ b/tests/pgsql-template.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under GPLv3
+echo ===============================================================================
+echo \[postgres-basic.sh\]: testing template support for the postgres output
+. $srcdir/diag.sh init
+psql -h db -U postgres -d Syslog -f testsuites/pgsql-truncate.sql
+
+. $srcdir/diag.sh startup pgsql-template.conf
+. $srcdir/diag.sh injectmsg  0 5000
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown 
+
+# we actually put the message in the SysLogTag field, so we know it doesn't use the default
+# template, like in pgsql-basic
+psql -h db -U postgres -d Syslog -f testsuites/pgsql-select-syslogtag.sql -t -A > rsyslog.out.log 
+
+. $srcdir/diag.sh seq-check  0 4999
+. $srcdir/diag.sh exit

--- a/tests/testsuites/pgsql-basic.conf
+++ b/tests/testsuites/pgsql-basic.conf
@@ -1,0 +1,4 @@
+$IncludeConfig diag-common.conf
+
+$ModLoad ../plugins/ompgsql/.libs/ompgsql
+:msg, contains, "msgnum:" :ompgsql:127.0.0.1,Syslog,rsyslog,testbench

--- a/tests/testsuites/pgsql-select-msg.sql
+++ b/tests/testsuites/pgsql-select-msg.sql
@@ -1,0 +1,1 @@
+select substring(Message,9,8) from SystemEvents;

--- a/tests/testsuites/pgsql-select-syslogtag.sql
+++ b/tests/testsuites/pgsql-select-syslogtag.sql
@@ -1,0 +1,1 @@
+select substring(SysLogTag,9,8) from SystemEvents;

--- a/tests/testsuites/pgsql-template.conf
+++ b/tests/testsuites/pgsql-template.conf
@@ -1,0 +1,7 @@
+$IncludeConfig diag-common.conf
+
+# putting the message in the SyslogTag field, so we know the template is actually used
+$template mytemplate,"insert into SystemEvents (SysLogTag) values ('%msg%')",STDSQL
+
+$ModLoad ../plugins/ompgsql/.libs/ompgsql
+:msg, contains, "msgnum:" :ompgsql:127.0.0.1,Syslog,rsyslog,testbench;mytemplate

--- a/tests/testsuites/pgsql-truncate.sql
+++ b/tests/testsuites/pgsql-truncate.sql
@@ -1,0 +1,1 @@
+truncate table SystemEvents;


### PR DESCRIPTION
It seems that for the Postgres output we didn't have template support. It used the ` StdPgSQLFmt` template (with a space in the beginning) no matter what you gave it.

Sorry for the number of commits, I've tried to squash them in one but I only made matters worse :( Please let me know if I need to make any changes at this point.

Configuration sample that worked for me (with the patch):

```
module(load="imuxsock")
module(load="ompgsql")
$template mytemplate,"insert into SystemEvents (Message, Facility, FromHost, Priority, DeviceReportedTime, ReceivedAt, InfoUnitID, SysLogTag) values ('%msg%', %syslogfacility%, '%HOSTNAME%', %syslogpriority%, '%timereported:::date-pgsql%', '%timegenerated:::date-pgsql%', %iut%, '%syslogtag%')",STDSQL
*.* :ompgsql:localhost,Syslog,user,password;mytemplate
```

If no template is specified, StdPgSQLFmt is used still, for backwards compatibility.

I'm planning to add some documentation and a couple of tests, if time permits. 