### PR TITLE
nsd_gtls: Handle chain of certificates

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -767,6 +767,7 @@ if test "x$enable_gnutls" = "xyes"; then
 	AC_DEFINE([ENABLE_GNUTLS], [1], [Indicator that GnuTLS is present])
 	save_libs=$LIBS
 	LIBS="$LIBS $GNUTLS_LIBS"
+	AC_CHECK_FUNCS(gnutls_x509_crt_list_import2,,)
 	AC_CHECK_FUNCS(gnutls_certificate_set_retrieve_function,,)
 	AC_CHECK_FUNCS(gnutls_certificate_type_set_priority,,)
 	LIBS=$save_libs

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -187,7 +187,12 @@ gtlsLoadOurCertKey(nsd_gtls_t *pThis)
 
 	/* try load certificate */
 	CHKiRet(readFile(certFile, &data));
+#if HAVE_GNUTLS_X509_CRT_LIST_IMPORT2
 	CHKgnutls(gnutls_x509_crt_list_import2(&pThis->ourCerts, &pThis->nCerts, &data, GNUTLS_X509_FMT_PEM, GNUTLS_X509_CRT_LIST_IMPORT_FAIL_IF_EXCEED));
+#else
+	gnuRet = gnutls_x509_crt_list_import(pThis->ourCerts, &pThis->nCerts, &data, GNUTLS_X509_FMT_PEM, GNUTLS_X509_CRT_LIST_IMPORT_FAIL_IF_EXCEED);
+	if (gnuRet < 0) CHKgnutls(gnuRet);
+#endif
 	pThis->bOurCertIsInit = 1;
 	free(data.data);
 	data.data = NULL;
@@ -633,7 +638,9 @@ gtlsInitSession(nsd_gtls_t *pThis)
 
 	gnutls_init(&session, GNUTLS_SERVER);
 	pThis->nCerts = NSD_GTLS_MAX_CERTS;
+#if HAVE_GNUTLS_X509_CRT_LIST_IMPORT2
 	pThis->ourCerts = NULL;
+#endif
 	pThis->bHaveSess = 1;
 	pThis->bIsInitiator = 0;
 

--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -25,6 +25,7 @@
 #include "nsd.h"
 
 #define NSD_GTLS_MAX_RCVBUF 8 * 1024 /* max size of buffer for message reception */
+#define NSD_GTLS_MAX_CERTS 0 /* Unlimited number of certificates */
 
 typedef enum {
 	gtlsRtry_None = 0,	/**< no call needs to be retried */
@@ -56,8 +57,9 @@ struct nsd_gtls_s {
 				 * set to 1 and changed to 0 after the first report. It is changed back to 1 after
 				 * one successful authentication. */
 	permittedPeers_t *pPermPeers; /* permitted peers */
-	gnutls_x509_crt_t ourCert;	/**< our certificate, if in client mode (unused in server mode) */
-	gnutls_x509_privkey_t ourKey;	/**< our private key, if in client mode (unused in server mode) */
+	gnutls_x509_crt_t *ourCerts;	/**< our certificates */
+	unsigned int nCerts;	/** How many certificates in ourCerts */
+	gnutls_x509_privkey_t ourKey;	/**< our private key */
 	short	bOurCertIsInit;	/**< 1 if our certificate is initialized and must be deinit on destruction */
 	short	bOurKeyIsInit;	/**< 1 if our private key is initialized and must be deinit on destruction */
 	char *pszRcvBuf;

--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -25,7 +25,11 @@
 #include "nsd.h"
 
 #define NSD_GTLS_MAX_RCVBUF 8 * 1024 /* max size of buffer for message reception */
-#define NSD_GTLS_MAX_CERTS 0 /* Unlimited number of certificates */
+#if HAVE_GNUTLS_X509_CRT_LIST_IMPORT2
+#define NSD_GTLS_MAX_CERTS 0 /* unlimited number of certificates in the chain */
+#else
+#define NSD_GTLS_MAX_CERTS 32 /* maximum number of certificates in the chain */
+#endif
 
 typedef enum {
 	gtlsRtry_None = 0,	/**< no call needs to be retried */
@@ -57,7 +61,11 @@ struct nsd_gtls_s {
 				 * set to 1 and changed to 0 after the first report. It is changed back to 1 after
 				 * one successful authentication. */
 	permittedPeers_t *pPermPeers; /* permitted peers */
+#if HAVE_GNUTLS_X509_CRT_LIST_IMPORT2
 	gnutls_x509_crt_t *ourCerts;	/**< our certificates */
+#else
+	gnutls_x509_crt_t ourCerts[NSD_GTLS_MAX_CERTS];	/**< our certificates */
+#endif
 	unsigned int nCerts;	/** How many certificates in ourCerts */
 	gnutls_x509_privkey_t ourKey;	/**< our private key */
 	short	bOurCertIsInit;	/**< 1 if our certificate is initialized and must be deinit on destruction */


### PR DESCRIPTION
Allow a server to serve a list of certificates. Much public CA now requires a server to serve a chain of certificates up to the root CA.

This allows to use valid public certificates for log-servers.