### PR TITLE
travis: disable forward-compatibility test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,9 @@ matrix:
        dist: trusty
      - compiler: "clang"
        env: CHECK="YES", ESTEST="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
-     - compiler: "clang"
-       dist: trusty
-       env: AD_PPA="v8-devel", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
+     #- compiler: "clang"
+     #  dist: trusty
+     #  env: AD_PPA="v8-devel", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
 
 services:
   - elasticsearch


### PR DESCRIPTION
this needs to be done as the v8-devel PPA is no longer available
see also http://lists.adiscon.net/pipermail/rsyslog/2016-July/043092.html