### PR TITLE
travis: re-enable all new component testing via special pkg repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,9 @@ matrix:
        dist: trusty
      - compiler: "clang"
        env: CHECK="YES", ESTEST="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
-     #- compiler: "clang"
-     #  dist: trusty
-     #  env: AD_PPA="v8-devel", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
+     - compiler: "clang"
+       dist: trusty
+       env: AD_PPA="v8-stable-testing", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
 
 services:
   - elasticsearch


### PR DESCRIPTION
This is an experiment and depends on whether or not we can setup a special PPA for travis use.