### PR TITLE
travis: re-enable forward-compatibility test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,9 +76,9 @@ matrix:
        dist: trusty
      - compiler: "clang"
        env: CHECK="YES", ESTEST="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
-     #- compiler: "clang"
-     #  dist: trusty
-     #  env: AD_PPA="v8-devel", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
+     - compiler: "clang"
+       dist: trusty
+       env: AD_PPA="v8-devel", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
 
 services:
   - elasticsearch

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -3,7 +3,8 @@ source /etc/lsb-release
 # the following packages are not yet available via travis package
 sudo apt-get install -qq faketime libdbd-mysql libmongo-client-dev autoconf-archive
 if [ "x$GROK" == "xYES" ]; then sudo apt-get install -qq libgrok1 libgrok-dev ; fi
-sudo apt-get install -qq --force-yes libestr-dev librelp-dev libfastjson-dev liblogging-stdlog-dev libksi1 libksi1-dev liblognorm1-dev \
+sudo apt-get install -qq --force-yes libestr-dev librelp-dev libfastjson-dev liblogging-stdlog-dev libksi1 libksi1-dev \
+	liblognorm-dev \
 	libcurl4-gnutls-dev
 sudo apt-get install -qq python-docutils
 


### PR DESCRIPTION
the v8-devel PPA is now available again, so we can re-enable testing
with its help