### PR TITLE
make rsyslog log by default to syslog()

### DIFF
--- a/runtime/batch.h
+++ b/runtime/batch.h
@@ -27,6 +27,7 @@
 #define BATCH_H_INCLUDED
 
 #include <string.h>
+#include <stdlib.h>
 #include "msg.h"
 
 /* enum for batch states. Actually, we violate a layer here, in that we assume that a batch is used

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -73,9 +73,9 @@ stdlog_channel_t stdlog_hdl = NULL;	/* handle to be used for stdlog */
 #endif
 
 static struct cnfobj *mainqCnfObj = NULL;/* main queue object, to be used later in startup sequence */
-int bProcessInternalMessages = 1;	/* Should rsyslog itself process internal messages?
+int bProcessInternalMessages = 0;	/* Should rsyslog itself process internal messages?
 					 * 1 - yes
-					 * 0 - send them to libstdlog (e.g. to push to journal)
+					 * 0 - send them to libstdlog (e.g. to push to journal) or syslog()
 					 */
 static uchar *pszWorkDir = NULL;
 #ifdef HAVE_LIBLOGGING_STDLOG
@@ -968,21 +968,12 @@ glblProcessCnf(struct cnfobj *o)
 			continue;
 		if(!strcmp(paramblk.descr[i].name, "processinternalmessages")) {
 			bProcessInternalMessages = (int) cnfparamvals[i].val.d.n;
-#ifndef HAVE_LIBLOGGING_STDLOG
-			if(bProcessInternalMessages != 1) {
-				bProcessInternalMessages = 1;
-				errmsg.LogError(0, RS_RET_ERR, "rsyslog wasn't "
-					"compiled with liblogging-stdlog support. "
-					"The 'ProcessInternalMessages' parameter "
-					"is ignored.\n");
-			}
-#endif
 		} else if(!strcmp(paramblk.descr[i].name, "stdlog.channelspec")) {
 #ifndef HAVE_LIBLOGGING_STDLOG
 			errmsg.LogError(0, RS_RET_ERR, "rsyslog wasn't "
 				"compiled with liblogging-stdlog support. "
 				"The 'stdlog.channelspec' parameter "
-				"is ignored.\n");
+				"is ignored. Note: the syslog API is used instead.\n");
 #else
 			stdlog_chanspec = (uchar*)
 				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -23,6 +23,7 @@
 #define WTI_H_INCLUDED
 
 #include <pthread.h>
+#include <stdlib.h>
 #include "wtp.h"
 #include "obj.h"
 #include "batch.h"

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -93,6 +93,7 @@ case $1 in
 		if [ -e IN_AUTO_DEBUG ]; then
 			export valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
 		fi
+		export RSYSLOG_DFLT_LOG_INTERNAL=1 # testbench needs internal messages logged internally!
 		;;
    'exit')	# cleanup
 		# detect any left-over hanging instance

--- a/tests/inputname.sh
+++ b/tests/inputname.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 echo \[inputname.sh\]: testing $InputTCPServerInputName directive
-$srcdir/killrsyslog.sh # kill rsyslogd if it runs for some reason
+. $srcdir/diag.sh init
+. $srcdir/killrsyslog.sh # kill rsyslogd if it runs for some reason
 . $srcdir/diag.sh generate-HOSTNAME
 
 echo port 12514
@@ -20,3 +21,4 @@ echo port 12516
 if [ "$?" -ne "0" ]; then
   exit 1
 fi
+. $srcdir/diag.sh exit


### PR DESCRIPTION
this enables us to put error messages to systemd journal; which is
especially useful as most distros by default throw away rsyslog
error messages.