### PR TITLE
Fix detection of pthread_setschedparam() on platforms such as FreeBSD

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -316,10 +316,14 @@ AC_CHECK_LIB(
 		 [1],
 		 [Can set thread-name.])])
 
-AC_CHECK_FUNCS(
+AC_SEARCH_LIBS(
     [pthread_setschedparam],
+    [pthread],
     [
       rsyslog_have_pthread_setschedparam=yes
+      AC_DEFINE([HAVE_PTHREAD_SETSCHEDPARAM],
+	[1],
+	[Can set thread scheduling parameters])
     ],
     [
       rsyslog_have_pthread_setschedparam=no


### PR DESCRIPTION
where that symbol is supplied by libpthread.

Previously, config.log was saying:

```
configure:16659: checking for pthread_setschedparam
configure:16659: cc -o conftest -g -O2   conftest.c  >&5
/tmp/conftest-9fd24a.o: In function `main':
/usr/ports/sysutils/rsyslog8/work/rsyslog-8.19.0/conftest.c:149: undefined reference to `pthread_setschedparam'
cc: error: linker command failed with exit code 1 (use -v to see invocation)
configure:16659: $? = 1
```

Note no '-lpthread' flags in that compiler command line.

Switching from AC_CHECK_FUNCS to AC_SEARCH_LIBS allows configure to
test for the presence of that function in that library where necessary.

Without pthread_setschedparam(), syslog traffic received via UDP from
a remote server does not get written out to disk files reliably when
the imudp module is multithreaded.  With it, everything works as
expected.