### PR TITLE
omprog improvement + some general goodness

### DIFF
--- a/action.h
+++ b/action.h
@@ -105,6 +105,7 @@ rsRetVal actionNewInst(struct nvlst *lst, action_t **ppAction);
 rsRetVal actionProcessCnf(struct cnfobj *o);
 void actionCommitAllDirect(wti_t *pWti);
 void actionRemoveWorker(action_t *const pAction, void *const actWrkrData);
+void releaseDoActionParams(action_t * const pAction, wti_t * const pWti, int action_destruct);
 
 /* external data */
 extern int iActionNbr;

--- a/configure.ac
+++ b/configure.ac
@@ -83,6 +83,8 @@ esac
 in_git_src=no
 AS_IF([test -d "$srcdir"/.git && ! test -f  "$srcdir"/.tarball-version], [in_git_src=yes])
 
+AM_CONDITIONAL(OS_LINUX, test x$os_type == xlinux)
+
 AC_DEFINE_UNQUOTED([HOSTENV], "$host", [the host environment, can be queried via a system variable])
 
 # Checks for libraries.

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -275,7 +275,7 @@ injectMsg(uchar *pszCmd, tcps_sess_t *pSess)
 		++pszCmd; /* ignore following space */
 		CHKiRet(doInjectMsg(pszCmd, ratelimit));
 		nMsgs = 1;
-	} else { /* assume 2 args, (from_idx, to_idx) */
+	} else { /* assume 2 args, (from_idx, count) */
 		iFrom = atoi((char*)wordBuf);
 		getFirstWord(&pszCmd, wordBuf, sizeof(wordBuf), TO_LOWERCASE);
 		nMsgs = atoi((char*)wordBuf);

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -467,7 +467,7 @@ writeDataError(instanceData *const pData,
 	struct iovec iov[2];
 	iov[0].iov_base = (void*) json_object_get_string(json);
 	iov[0].iov_len = strlen(iov[0].iov_base);
-	iov[1].iov_base = "\n";
+	iov[1].iov_base = (char *) "\n";
 	iov[1].iov_len = 1;
 
 	/* we must protect the file write do operations due to other wrks & HUP */
@@ -637,6 +637,9 @@ openKafka(instanceData *const __restrict__ pData)
 	rd_kafka_conf_set_opaque(conf, (void *) pData);
 	rd_kafka_conf_set_dr_cb(conf, deliveryCallback);
 	rd_kafka_conf_set_error_cb(conf, errorCallback);
+# if RD_KAFKA_VERSION >= 0x00090001
+	rd_kafka_conf_set_log_cb(conf, kafkaLogger);
+# endif
 
 	char kafkaErrMsg[1024];
 	pData->rk = rd_kafka_new(RD_KAFKA_PRODUCER, conf,
@@ -646,7 +649,9 @@ openKafka(instanceData *const __restrict__ pData)
 			"omkafka: error creating kafka handle: %s\n", kafkaErrMsg);
 		ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
 	}
+# if RD_KAFKA_VERSION < 0x00090001
 	rd_kafka_set_logger(pData->rk, kafkaLogger);
+# endif
 	if((nBrokers = rd_kafka_brokers_add(pData->rk, (char*)pData->brokers)) == 0) {
 		errmsg.LogError(0, RS_RET_KAFKA_NO_VALID_BROKERS,
 			"omkafka: no valid brokers specified: %s\n", pData->brokers);

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -143,11 +143,6 @@ CODESTARTfreeInstance
 	}
 ENDfreeInstance
 
-BEGINfreeWrkrInstance
-CODESTARTfreeWrkrInstance
-ENDfreeWrkrInstance
-
-
 BEGINdbgPrintInstInfo
 CODESTARTdbgPrintInstInfo
 ENDdbgPrintInstInfo
@@ -332,13 +327,14 @@ openPipe(wrkrInstanceData_t *pWrkrData)
 
 	DBGPRINTF("omprog: child has pid %d\n", (int) cpid);
 	if(pWrkrData->pData->outputFileName != NULL) {
-		pWrkrData->fdPipeIn = dup(pipestdout[0]);
+		pWrkrData->fdPipeIn = pipestdout[0];
 		/* we need to set our fd to be non-blocking! */
 		flags = fcntl(pWrkrData->fdPipeIn, F_GETFL);
 		flags |= O_NONBLOCK;
 		fcntl(pWrkrData->fdPipeIn, F_SETFL, flags);
 	} else {
 		pWrkrData->fdPipeIn = -1;
+		close(pipestdout[0]);
 	}
 	close(pipestdin[0]);
 	close(pipestdout[1]);
@@ -398,6 +394,14 @@ cleanup(wrkrInstanceData_t *pWrkrData)
 	RETiRet;
 }
 
+BEGINfreeWrkrInstance
+CODESTARTfreeWrkrInstance
+	if (pWrkrData->bIsRunning) {
+		kill(pWrkrData->pid, SIGTERM);
+		CHKiRet(cleanup(pWrkrData));
+	}
+finalize_it:
+ENDfreeWrkrInstance
 
 /* try to restart the binary when it has stopped.
  */

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -385,8 +385,9 @@ static void * killSubprocessOnTimeout(void *_subpTimeOut_p) {
 	return NULL;
 }
 
-static inline rsRetVal
-setupSubprocessTimeout(subprocess_timeout_desc_t *subpTimeOut, long timeout_ms) {
+static rsRetVal
+setupSubprocessTimeout(subprocess_timeout_desc_t *subpTimeOut, long timeout_ms)
+{
 	int attr_initialized = 0, mutex_initialized = 0, cond_initialized = 0;
 	DEFiRet;
 	CHKiConcCtrl(pthread_attr_init(&subpTimeOut->thd_attr));
@@ -409,8 +410,9 @@ finalize_it:
 	RETiRet;
 }
 
-static inline void
-doForceKillSubprocess(subprocess_timeout_desc_t *subpTimeOut, int do_kill, pid_t pid) {
+static void
+doForceKillSubprocess(subprocess_timeout_desc_t *subpTimeOut, int do_kill, pid_t pid)
+{
     if (pthread_mutex_lock(&subpTimeOut->lock) == 0) {
         subpTimeOut->timeout_armed = 0;
         pthread_cond_signal(&subpTimeOut->cond);

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -606,6 +606,7 @@ setInstParamDefaults(instanceData *pData)
 	pData->outputFileName = NULL;
 	pData->iParams = 0;
 	pData->bForceSingleInst = 0;
+	pData->bSignalOnClose = 0;
 	pData->iHUPForward = NO_HUP_FORWARD;
 }
 

--- a/runtime/librsgt.c
+++ b/runtime/librsgt.c
@@ -254,7 +254,7 @@ rsgtimprintDel(imprint_t *imp)
 }
 
 int
-rsgtInit(char *usragent)
+rsgtInit(const char *usragent)
 {
 	int r = 0;
 	int ret = GT_OK;

--- a/runtime/librsgt.h
+++ b/runtime/librsgt.h
@@ -184,7 +184,7 @@ rsgtSetKeepTreeHashes(gtctx ctx, int val)
 }
 
 int rsgtSetHashFunction(gtctx ctx, char *algName);
-int rsgtInit(char *usragent);
+int rsgtInit(const char *usragent);
 void rsgtExit(void);
 gtctx rsgtCtxNew(void);
 void rsgtsetErrFunc(gtctx ctx, void (*func)(void*, unsigned char *), void *usrptr);

--- a/runtime/rsyslog.c
+++ b/runtime/rsyslog.c
@@ -89,9 +89,6 @@ struct sched_param default_sched_param;
 int default_thr_sched_policy;
 #endif
 
-/* forward definitions */
-static void dfltErrLogger(const int, const int, const uchar *errMsg);
-
 /* globally visible static data - see comment in rsyslog.h for details */
 uchar *glblModPath; /* module load path */
 void (*glblErrLogger)(const int, const int, const uchar*) = dfltErrLogger; /* the error logger to use by the errmsg module */
@@ -106,7 +103,7 @@ static int iRefCount = 0; /* our refcount - it MUST exist only once inside a pro
  * default so that we can log errors during the intial phase, most importantly
  * during initialization. -- rgerhards. 2008-04-17
  */
-static void
+void
 dfltErrLogger(const int severity, const int iErr, const uchar *errMsg)
 {
 	fprintf(stderr, "rsyslog runtime error(%d,%d): %s\n", severity, iErr, errMsg);

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -625,6 +625,8 @@ rsRetVal rsrtExit(void);
 int rsrtIsInit(void);
 void rsrtSetErrLogger(void (*errLogger)(const int, const int, const uchar*));
 
+void dfltErrLogger(const int, const int, const uchar *errMsg);
+
 
 /* this define below is (later) intended to be used to implement empty
  * structs. TODO: check if compilers supports this and, if not, define

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -399,6 +399,8 @@ wtiWorker(wti_t *__restrict__ const pThis)
 				wrkrInfo->p.tx.iparams = NULL;
 				wrkrInfo->p.tx.currIParam = 0;
 				wrkrInfo->p.tx.maxIParams = 0;
+			} else {
+				releaseDoActionParams(pAction, pThis, 1);
 			}
 			wrkrInfo->actWrkrData = NULL; /* re-init for next activation */
 		}

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -4,3 +4,4 @@ tmp
 mangle_qi
 .dep_cache
 .dep_wrk
+.loop_monitor

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -279,6 +279,10 @@ if ENABLE_OMPROG
 TESTS +=  \
 	omprog-cleanup.sh \
 	omprog-cleanup-with-outfile.sh
+if OS_LINUX
+TESTS += \
+	omprog-cleanup-when-unresponsive.sh
+endif
 endif
 
 if ENABLE_OMKAFKA
@@ -979,9 +983,12 @@ EXTRA_DIST= \
 	testsuites/pipeaction.conf \
 	omprog-cleanup.sh \
 	omprog-cleanup-with-outfile.sh \
+  omprog-cleanup-when-unresponsive.sh \
 	testsuites/omprog-cleanup.conf \
 	testsuites/omprog-cleanup-outfile.conf \
+	testsuites/omprog-cleanup-unresponsive.conf \
 	testsuites/omprog-test-bin.sh \
+  testsuites/term-ignoring-script.sh \
 	pipe_noreader.sh \
 	testsuites/pipe_noreader.conf \
 	uxsock_simple.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -283,6 +283,10 @@ if OS_LINUX
 TESTS += \
 	omprog-cleanup-when-unresponsive.sh
 endif
+if HAVE_VALGRIND
+TESTS +=  \
+	omprog-cleanup-vg.sh
+endif
 endif
 
 if ENABLE_OMKAFKA
@@ -982,6 +986,7 @@ EXTRA_DIST= \
 	pipeaction.sh \
 	testsuites/pipeaction.conf \
 	omprog-cleanup.sh \
+	omprog-cleanup-vg.sh \
 	omprog-cleanup-with-outfile.sh \
   omprog-cleanup-when-unresponsive.sh \
 	testsuites/omprog-cleanup.conf \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -286,6 +286,10 @@ endif
 if HAVE_VALGRIND
 TESTS +=  \
 	omprog-cleanup-vg.sh
+if OS_LINUX
+TESTS += \
+	omprog-cleanup-when-unresponsive-vg.sh
+endif
 endif
 endif
 
@@ -988,7 +992,8 @@ EXTRA_DIST= \
 	omprog-cleanup.sh \
 	omprog-cleanup-vg.sh \
 	omprog-cleanup-with-outfile.sh \
-  omprog-cleanup-when-unresponsive.sh \
+	omprog-cleanup-when-unresponsive.sh \
+	omprog-cleanup-when-unresponsive-vg.sh \
 	testsuites/omprog-cleanup.conf \
 	testsuites/omprog-cleanup-outfile.conf \
 	testsuites/omprog-cleanup-unresponsive.conf \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -278,14 +278,18 @@ endif
 if ENABLE_OMPROG
 TESTS +=  \
 	omprog-cleanup.sh \
-	omprog-cleanup-with-outfile.sh
+	omprog-cleanup-with-outfile.sh \
+	omprog-noterm-cleanup.sh \
+	omprog-noterm-default.sh
 if OS_LINUX
 TESTS += \
-	omprog-cleanup-when-unresponsive.sh
+	omprog-cleanup-when-unresponsive.sh \
+	omprog-noterm-unresponsive.sh
 endif
 if HAVE_VALGRIND
 TESTS +=  \
-	omprog-cleanup-vg.sh
+	omprog-cleanup-vg.sh \
+	omprog-noterm-cleanup-vg.sh
 if OS_LINUX
 TESTS += \
 	omprog-cleanup-when-unresponsive-vg.sh
@@ -994,11 +998,19 @@ EXTRA_DIST= \
 	omprog-cleanup-with-outfile.sh \
 	omprog-cleanup-when-unresponsive.sh \
 	omprog-cleanup-when-unresponsive-vg.sh \
+	omprog-noterm-cleanup.sh \
+	omprog-noterm-cleanup-vg.sh \
+	omprog-noterm-default.sh \
+	omprog-noterm-unresponsive.sh \
 	testsuites/omprog-cleanup.conf \
+	testsuites/omprog-noterm.conf \
+	testsuites/omprog-noterm-default.conf \
+	testsuites/omprog-noterm-unresponsive.conf \
+	testsuites/omprog-noterm.sh \
 	testsuites/omprog-cleanup-outfile.conf \
 	testsuites/omprog-cleanup-unresponsive.conf \
 	testsuites/omprog-test-bin.sh \
-  testsuites/term-ignoring-script.sh \
+	testsuites/term-ignoring-script.sh \
 	pipe_noreader.sh \
 	testsuites/pipe_noreader.conf \
 	uxsock_simple.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -275,6 +275,12 @@ TESTS +=  \
 	omjournal-basic-no-template.sh
 endif
 
+if ENABLE_OMPROG
+TESTS +=  \
+	omprog-cleanup.sh \
+	omprog-cleanup-with-outfile.sh
+endif
+
 if ENABLE_OMKAFKA
 if ENABLE_KAFKA_TESTS
 TESTS += \
@@ -971,6 +977,11 @@ EXTRA_DIST= \
 	testsuites/sndrcv_gzip_rcvr.conf \
 	pipeaction.sh \
 	testsuites/pipeaction.conf \
+	omprog-cleanup.sh \
+	omprog-cleanup-with-outfile.sh \
+	testsuites/omprog-cleanup.conf \
+	testsuites/omprog-cleanup-outfile.conf \
+	testsuites/omprog-test-bin.sh \
 	pipe_noreader.sh \
 	testsuites/pipe_noreader.conf \
 	uxsock_simple.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -134,6 +134,9 @@ case $1 in
 		curl localhost:9200/rsyslog_testbench/_search?size=$2 > work
 		python $srcdir/es_response_get_msgnum.py > rsyslog.out.log
 		;;
+   'getpid')
+		pid=$(cat rsyslog$2.pid)
+		;;
    'startup')   # start rsyslogd with default params. $2 is the config file name to use
    		# returns only after successful startup, $3 is the instance (blank or 2!)
 		if [ "x$2" == "x" ]; then
@@ -352,6 +355,18 @@ case $1 in
 		# again, but that's not an issue.
 		rm -f work
 		$RS_SORTCMD -g < rsyslog.out.log > work
+		;;
+   'assert-equal')
+		if [ "x$4" == "x" ]; then
+			tolerance=0
+		else
+			tolerance=$4
+		fi
+		result=$(echo $2 $3 $tolerance | awk 'function abs(v) { return v > 0 ? v : -v } { print (abs($1 - $2) <= $3) ? "PASSED" : "FAILED" }')
+		if [ $result != 'PASSED' ]; then
+				echo "Value '$2' != '$3' (within tolerance of $tolerance)"
+		  . $srcdir/diag.sh error-exit 1
+		fi
 		;;
    'seq-check') # do the usual sequence check to see if everything was properly received. $2 is the instance.
 		rm -f work

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -368,6 +368,13 @@ case $1 in
 		  . $srcdir/diag.sh error-exit 1
 		fi
 		;;
+   'ensure-no-process-exists')
+    ps -ef | grep -v grep | grep -qF "$2"
+    if [ "x$?" == "x0" ]; then
+      echo "assertion failed: process with name-fragment matching '$2' found"
+		  . $srcdir/diag.sh error-exit 1
+    fi
+    ;;
    'seq-check') # do the usual sequence check to see if everything was properly received. $2 is the instance.
 		rm -f work
 		cp rsyslog.out.log work-presort

--- a/tests/omprog-cleanup-vg.sh
+++ b/tests/omprog-cleanup-vg.sh
@@ -14,13 +14,15 @@ sleep 1
 
 old_fd_count=$(lsof -p $pid | wc -l)
 
-for i in $(seq 5 100); do
+for i in $(seq 5 10); do
     pkill -USR1 omprog-test-bin
+    sleep .1
     . $srcdir/diag.sh injectmsg  $i 1
+    sleep .1
 done
-sleep 1
+sleep .5
 
-. $srcdir/diag.sh content-check "msgnum:00000099:"
+. $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
 echo OLD: $old_fd_count NEW: $new_fd_count

--- a/tests/omprog-cleanup-vg.sh
+++ b/tests/omprog-cleanup-vg.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2016-09-20 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-cleanup-vg.sh\]: test for cleanup in omprog with valgrind
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup-vg omprog-cleanup.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 5
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh content-check "msgnum:00000000:"
+. $srcdir/diag.sh getpid
+
+old_fd_count=$(lsof -p $pid | wc -l)
+
+for i in $(seq 5 100); do
+    pkill -USR1 omprog-test-bin
+    . $srcdir/diag.sh injectmsg  $i 1
+done
+sleep 1
+
+. $srcdir/diag.sh content-check "msgnum:00000099:"
+
+new_fd_count=$(lsof -p $pid | wc -l)
+echo OLD: $old_fd_count NEW: $new_fd_count
+. $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh exit

--- a/tests/omprog-cleanup-when-unresponsive-vg.sh
+++ b/tests/omprog-cleanup-when-unresponsive-vg.sh
@@ -17,5 +17,6 @@ echo doing shutdown
 echo wait on shutdown
 . $srcdir/diag.sh wait-shutdown-vg
 . $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh content-check "received SIGTERM, ignoring it" #verify it actually received term
 . $srcdir/diag.sh ensure-no-process-exists term-ignoring-script.sh
 . $srcdir/diag.sh exit

--- a/tests/omprog-cleanup-when-unresponsive-vg.sh
+++ b/tests/omprog-cleanup-when-unresponsive-vg.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# added 2016-09-23 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-cleanup-when-unresponsive-vg.sh\]: test for cleanup in omprog when child-process is not responding with valgrind
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup-vg omprog-cleanup-unresponsive.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 5
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh content-check "msgnum:00000000:"
+. $srcdir/diag.sh getpid
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh ensure-no-process-exists term-ignoring-script.sh
+. $srcdir/diag.sh exit

--- a/tests/omprog-cleanup-when-unresponsive.sh
+++ b/tests/omprog-cleanup-when-unresponsive.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# added 2016-09-17 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-cleanup-when-unresponsive.sh\]: test for cleanup in omprog when child-process is not responding
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-cleanup-unresponsive.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 5
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh content-check "msgnum:00000000:"
+. $srcdir/diag.sh getpid
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh ensure-no-process-exists term-ignoring-script.sh
+. $srcdir/diag.sh exit

--- a/tests/omprog-cleanup-with-outfile.sh
+++ b/tests/omprog-cleanup-with-outfile.sh
@@ -14,17 +14,21 @@ sleep 1
 
 old_fd_count=$(lsof -p $pid | wc -l)
 
-for i in $(seq 5 100); do
+for i in $(seq 5 10); do
     pkill -USR1 omprog-test-bin
+    sleep .1
     . $srcdir/diag.sh injectmsg  $i 1
+    sleep .1
 done
-sleep 1
+sleep .5
 
-. $srcdir/diag.sh content-check "msgnum:00000099:"
+. $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
 echo OLD: $old_fd_count NEW: $new_fd_count
 . $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
+
+cp rsyslog.out.log /tmp/
 
 echo doing shutdown
 . $srcdir/diag.sh shutdown-when-empty

--- a/tests/omprog-cleanup-with-outfile.sh
+++ b/tests/omprog-cleanup-with-outfile.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# added 2016-09-09 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-cleanup-with-outfile.sh\]: test for cleanup in omprog when used with outfile
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-cleanup-outfile.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 5
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh content-check "msgnum:00000000:"
+. $srcdir/diag.sh getpid
+
+old_fd_count=$(lsof -p $pid | wc -l)
+
+for i in $(seq 5 100); do
+    pkill -USR1 omprog-test-bin
+    . $srcdir/diag.sh injectmsg  $i 1
+done
+sleep 1
+
+. $srcdir/diag.sh content-check "msgnum:00000099:"
+
+new_fd_count=$(lsof -p $pid | wc -l)
+echo OLD: $old_fd_count NEW: $new_fd_count
+. $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh exit

--- a/tests/omprog-cleanup.sh
+++ b/tests/omprog-cleanup.sh
@@ -14,13 +14,15 @@ sleep 1
 
 old_fd_count=$(lsof -p $pid | wc -l)
 
-for i in $(seq 5 100); do
+for i in $(seq 5 10); do
     pkill -USR1 omprog-test-bin
+    sleep .1
     . $srcdir/diag.sh injectmsg  $i 1
+    sleep .1
 done
-sleep 1
+sleep .5
 
-. $srcdir/diag.sh content-check "msgnum:00000099:"
+. $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
 echo OLD: $old_fd_count NEW: $new_fd_count

--- a/tests/omprog-cleanup.sh
+++ b/tests/omprog-cleanup.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# added 2016-09-09 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-cleanup.sh\]: test for cleanup in omprog
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-cleanup.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 5
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh content-check "msgnum:00000000:"
+. $srcdir/diag.sh getpid
+
+old_fd_count=$(lsof -p $pid | wc -l)
+
+for i in $(seq 5 100); do
+    pkill -USR1 omprog-test-bin
+    . $srcdir/diag.sh injectmsg  $i 1
+done
+sleep 1
+
+. $srcdir/diag.sh content-check "msgnum:00000099:"
+
+new_fd_count=$(lsof -p $pid | wc -l)
+echo OLD: $old_fd_count NEW: $new_fd_count
+. $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh exit

--- a/tests/omprog-noterm-cleanup-vg.sh
+++ b/tests/omprog-noterm-cleanup-vg.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# added 2016-11-03 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-noterm-cleanup-vg.sh\]: test for cleanup in omprog without SIGTERM with valgrind
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup-vg omprog-noterm.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 5
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh content-check "msgnum:00000000:"
+. $srcdir/diag.sh getpid
+
+old_fd_count=$(lsof -p $pid | wc -l)
+
+for i in $(seq 5 10); do
+    pkill -USR1 omprog-noterm.sh
+    sleep .1
+    . $srcdir/diag.sh injectmsg  $i 1
+    sleep .1
+done
+sleep .5
+
+. $srcdir/diag.sh content-check "msgnum:00000009:"
+
+new_fd_count=$(lsof -p $pid | wc -l)
+echo OLD: $old_fd_count NEW: $new_fd_count
+. $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+sleep 1
+. $srcdir/diag.sh assert-content-missing "received SIGTERM"
+. $srcdir/diag.sh content-check "PROCESS TERMINATED (last msg: Exit due to read-failure)"
+. $srcdir/diag.sh exit

--- a/tests/omprog-noterm-cleanup.sh
+++ b/tests/omprog-noterm-cleanup.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# added 2016-11-03 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-noterm-cleanup.sh\]: test for cleanup in omprog without SIGTERM
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-noterm.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 5
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh content-check "msgnum:00000000:"
+. $srcdir/diag.sh getpid
+
+old_fd_count=$(lsof -p $pid | wc -l)
+
+for i in $(seq 5 10); do
+    set -x
+    pkill -USR1 -f omprog-noterm.sh
+    set +x
+    sleep .1
+    . $srcdir/diag.sh injectmsg  $i 1
+    sleep .5
+done
+sleep .5
+
+. $srcdir/diag.sh content-check "msgnum:00000009:"
+
+new_fd_count=$(lsof -p $pid | wc -l)
+echo OLD: $old_fd_count NEW: $new_fd_count
+. $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+sleep 1
+. $srcdir/diag.sh assert-content-missing "received SIGTERM"
+. $srcdir/diag.sh content-check "PROCESS TERMINATED (last msg: Exit due to read-failure)"
+. $srcdir/diag.sh exit

--- a/tests/omprog-noterm-default.sh
+++ b/tests/omprog-noterm-default.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# added 2016-11-03 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-noterm-default.sh\]: test for cleanup in omprog without SIGTERM with default (off) signalOnClose
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-noterm-default.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 10
+sleep 1
+. $srcdir/diag.sh wait-queueempty
+sleep 1
+. $srcdir/diag.sh content-check "msgnum:00000009:"
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+sleep 1
+. $srcdir/diag.sh assert-content-missing "received SIGTERM"
+. $srcdir/diag.sh content-check "PROCESS TERMINATED (last msg: Exit due to read-failure)"
+. $srcdir/diag.sh exit

--- a/tests/omprog-noterm-default.sh
+++ b/tests/omprog-noterm-default.sh
@@ -2,7 +2,7 @@
 # added 2016-11-03 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
-echo \[omprog-noterm-default.sh\]: test for cleanup in omprog without SIGTERM with default (off) signalOnClose
+echo '[omprog-noterm-default.sh]: test for cleanup in omprog without SIGTERM with default (off) signalOnClose'
 . $srcdir/diag.sh init
 . $srcdir/diag.sh startup omprog-noterm-default.conf
 . $srcdir/diag.sh wait-startup

--- a/tests/omprog-noterm-unresponsive.sh
+++ b/tests/omprog-noterm-unresponsive.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# added 2016-11-03 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[omprog-noterm-unresponsive.sh\]: ensure omprog script is cleanly orphaned when unresponsive if signalOnClose is disabled
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-noterm-unresponsive.conf
+. $srcdir/diag.sh wait-startup
+. $srcdir/diag.sh injectmsg  0 10
+. $srcdir/diag.sh wait-queueempty
+sleep 1
+. $srcdir/diag.sh content-check "msgnum:00000009:"
+
+echo doing shutdown
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown
+. $srcdir/diag.sh wait-shutdown
+sleep 6
+. $srcdir/diag.sh assert-content-missing "received SIGTERM"
+. $srcdir/diag.sh assert-content-missing "PROCESS TERMINATED"
+pkill -USR1 omprog-test-bin
+sleep 1
+. $srcdir/diag.sh content-check "PROCESS TERMINATED"
+. $srcdir/diag.sh exit

--- a/tests/testsuites/omprog-cleanup-outfile.conf
+++ b/tests/testsuites/omprog-cleanup-outfile.conf
@@ -1,0 +1,7 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" output="./rsyslog.omprog.out.log")

--- a/tests/testsuites/omprog-cleanup-outfile.conf
+++ b/tests/testsuites/omprog-cleanup-outfile.conf
@@ -4,4 +4,4 @@ module(load="../plugins/omprog/.libs/omprog")
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" output="./rsyslog.omprog.out.log")
+action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" output="./rsyslog.omprog.out.log" signalOnClose="on")

--- a/tests/testsuites/omprog-cleanup-unresponsive.conf
+++ b/tests/testsuites/omprog-cleanup-unresponsive.conf
@@ -4,5 +4,5 @@ module(load="../plugins/omprog/.libs/omprog")
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(type="omprog" binary="./testsuites/term-ignoring-script.sh" template="outfmt")
+action(type="omprog" binary="./testsuites/term-ignoring-script.sh" template="outfmt" signalOnClose="on")
 

--- a/tests/testsuites/omprog-cleanup-unresponsive.conf
+++ b/tests/testsuites/omprog-cleanup-unresponsive.conf
@@ -1,0 +1,8 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+action(type="omprog" binary="./testsuites/term-ignoring-script.sh" template="outfmt")
+

--- a/tests/testsuites/omprog-cleanup.conf
+++ b/tests/testsuites/omprog-cleanup.conf
@@ -4,5 +4,5 @@ module(load="../plugins/omprog/.libs/omprog")
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt")
+action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" name="omprog_action")
 

--- a/tests/testsuites/omprog-cleanup.conf
+++ b/tests/testsuites/omprog-cleanup.conf
@@ -1,0 +1,8 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt")
+

--- a/tests/testsuites/omprog-noterm-default.conf
+++ b/tests/testsuites/omprog-noterm-default.conf
@@ -4,5 +4,5 @@ module(load="../plugins/omprog/.libs/omprog")
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" name="omprog_action" signalOnClose="on")
+action(type="omprog" binary="./testsuites/omprog-noterm.sh" template="outfmt" name="omprog_action")
 

--- a/tests/testsuites/omprog-noterm-unresponsive.conf
+++ b/tests/testsuites/omprog-noterm-unresponsive.conf
@@ -4,5 +4,5 @@ module(load="../plugins/omprog/.libs/omprog")
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" name="omprog_action" signalOnClose="on")
+action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" name="omprog_action" signalOnClose="off")
 

--- a/tests/testsuites/omprog-noterm.conf
+++ b/tests/testsuites/omprog-noterm.conf
@@ -4,5 +4,5 @@ module(load="../plugins/omprog/.libs/omprog")
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(type="omprog" binary="./testsuites/omprog-test-bin.sh" template="outfmt" name="omprog_action" signalOnClose="on")
+action(type="omprog" binary="./testsuites/omprog-noterm.sh" template="outfmt" name="omprog_action" signalOnClose="off")
 

--- a/tests/testsuites/omprog-noterm.sh
+++ b/tests/testsuites/omprog-noterm.sh
@@ -8,15 +8,20 @@ trap "rm $loop_monitor" SIGUSR1
 
 function print_sigterm_receipt {
     echo 'received SIGTERM' >> $outfile
-    exit
 }
 trap "print_sigterm_receipt" SIGTERM
 
 while [ -e  $loop_monitor ]; do
     read log_line
-    if [ "x$log_line" != "x" ]; then
-	echo $log_line >> $outfile
+    if [ "x$log_line" == "x" ]; then
+	log_line='Exit due to read-failure'
+	rm $loop_monitor
     fi
+    echo $log_line >> $outfile
 done
 
-echo "PROCESS TERMINATED" >> $outfile
+sleep .2 # so we can catch a TERM and log it, in case it comes (negative test for signalOnClose=off)
+
+echo "PROCESS TERMINATED (last msg: $log_line)" >> $outfile
+
+exit 0

--- a/tests/testsuites/omprog-test-bin.sh
+++ b/tests/testsuites/omprog-test-bin.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -x
+
+export loop_monitor=.loop_monitor
+touch $loop_monitor
+
+trap "rm $loop_monitor" SIGUSR1
+
+while [ -e  $loop_monitor ]; do
+    read log_line
+    echo $log_line >> rsyslog.out.log
+done

--- a/tests/testsuites/term-ignoring-script.sh
+++ b/tests/testsuites/term-ignoring-script.sh
@@ -4,11 +4,16 @@ set -x
 
 export loop_monitor=.loop_monitor
 touch $loop_monitor
+outfile=rsyslog.out.log
 
 trap "rm $loop_monitor" SIGUSR1
-trap "echo TERM signal received, ignoring" SIGTERM
+
+function print_sigterm_receipt {
+    echo 'received SIGTERM, ignoring it' >> $outfile
+}
+trap "print_sigterm_receipt" SIGTERM
 
 while [ -e  $loop_monitor ]; do
     read log_line
-    echo $log_line >> rsyslog.out.log
+    echo $log_line >> $outfile
 done

--- a/tests/testsuites/term-ignoring-script.sh
+++ b/tests/testsuites/term-ignoring-script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -x
+
+export loop_monitor=.loop_monitor
+touch $loop_monitor
+
+trap "rm $loop_monitor" SIGUSR1
+trap "echo TERM signal received, ignoring" SIGTERM
+
+while [ -e  $loop_monitor ]; do
+    read log_line
+    echo $log_line >> rsyslog.out.log
+done

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1584,6 +1584,8 @@ deinitAll(void)
 	/* close the inputs */
 	DBGPRINTF("Terminating input threads...\n");
 	glbl.SetGlobalInputTermination();
+	rsrtSetErrLogger(dfltErrLogger);
+	
 	thrdTerminateAll();
 
 	/* and THEN send the termination log message (see long comment above) */

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -705,7 +705,11 @@ startMainQueue(qqueue_t *pQueue)
 void
 rsyslogd_submitErrMsg(const int severity, const int iErr, const uchar *msg)
 {
-	logmsgInternal(iErr, LOG_SYSLOG|(severity & 0x07), msg, 0);
+	if (glbl.GetGlobalInputTermState() == 1) {
+		dfltErrLogger(severity, iErr, msg);
+	} else {
+		logmsgInternal(iErr, LOG_SYSLOG|(severity & 0x07), msg, 0);
+	}
 }
 
 static inline rsRetVal
@@ -1584,7 +1588,6 @@ deinitAll(void)
 	/* close the inputs */
 	DBGPRINTF("Terminating input threads...\n");
 	glbl.SetGlobalInputTermination();
-	rsrtSetErrLogger(dfltErrLogger);
 	
 	thrdTerminateAll();
 

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1534,8 +1534,8 @@ mainloop(void)
 			pid_t child;
 			do {
 				child = waitpid(-1, NULL, WNOHANG);
-				DBGPRINTF("rsyslogd: child %d has terminated\n", child);
-				if (child != -1) {
+				DBGPRINTF("rsyslogd: mainloop waitpid (with-no-hang) returned %d\n", child);
+				if (child != -1 && child != 0) {
 					errmsg.LogError(0, RS_RET_OK, "Child %d has terminated, reaped by main-loop.", child);
 				}
 			} while(child > 0);

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -26,6 +26,7 @@
 
 #include <signal.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include <sys/wait.h>
 #ifdef HAVE_LIBLOGGING_STDLOG
 #  include <liblogging/stdlog.h>
@@ -1530,10 +1531,13 @@ mainloop(void)
 		select(1, NULL, NULL, NULL, &tvSelectTimeout);
 
 		if(bChildDied) {
-			int child;
+			pid_t child;
 			do {
 				child = waitpid(-1, NULL, WNOHANG);
 				DBGPRINTF("rsyslogd: child %d has terminated\n", child);
+				if (child != -1) {
+					errmsg.LogError(0, RS_RET_OK, "Child %d has terminated, reaped by main-loop.", child);
+				}
 			} while(child > 0);
 			bChildDied = 0;
 		}


### PR DESCRIPTION
This includes:
- omprog resource leak fix (fd leak)
- tests for omprog
- omprog got ability to force-kill process if it doesn't die in 5 seconds (linux specific)
- child-process lifecycle debugging aid (in form of logs) (mainLoop and omprog cleanup both log pid at child-death, mainLoop reaping is now visible to user, as opposed to being a mystery, because omprog didn't seem to anticipate it in terms of code)
- errmsg.LogError now switches to dfltErrLogger just before shutdown
- fixed un-freed memory in non-transnational action using string-passing

@rgerhards maintainer edit:
closes #968 
