### PR TITLE
close/reopen file when write fails for specific error codes

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1179,6 +1179,10 @@ doWriteCall(strm_t *pThis, uchar *pBuf, size_t *pLenBuf)
 			DBGPRINTF("log file (%d) write error %d: %s\n", pThis->fd, err, errStr);
 			if(err == EINTR) {
 				/*NO ERROR, just continue */;
+			} else if( !pThis->bIsTTY && ( err == ENOTCONN  || err == EIO )) {
+				/* Failure for network file system, thus file needs to be closed and reopened. */
+				close(pThis->fd);
+				CHKiRet(doPhysOpen(pThis));
 			} else {
 				if(pThis->bIsTTY) {
 					CHKiRet(tryTTYRecover(pThis, err));


### PR DESCRIPTION
Fixes #908. When writing fails for file with error codes ENOTCONN or EIO, then file probably locates in network mounted partition, and thus needs to be closed and reopened.