### PR TITLE
imfile: bugfix: ReopenOnTruncate processing, file open processing

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -486,6 +486,7 @@ endif
 if ENABLE_IMFILE
 TESTS += \
 	imfile-basic.sh \
+	imfile-truncate.sh \
 	imfile-readmode2.sh \
 	imfile-readmode2-with-persists-data-during-stop.sh \
 	imfile-readmode2-with-persists.sh \
@@ -997,6 +998,7 @@ EXTRA_DIST= \
 	imfile-basic.sh \
 	imfile-basic-vg.sh \
 	testsuites/imfile-basic.conf \
+	imfile-truncate.sh \
 	dynfile_invld_async.sh \
 	dynfile_invld_sync.sh \
 	dynfile_cachemiss.sh \

--- a/tests/imfile-truncate.sh
+++ b/tests/imfile-truncate.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# addd 2016-10-06 by RGerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imfile/.libs/imfile")
+
+input(type="imfile"
+      File="./rsyslog.input"
+      Tag="file:"
+      reopenOnTruncate="on"
+     )
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )
+'
+. $srcdir/diag.sh startup
+
+# write the beginning of the file
+echo 'msgnum:0
+msgnum:1' > rsyslog.input
+
+# sleep a little to give rsyslog a chance to begin processing
+sleep 1
+
+# truncate and write some more lines (see https://github.com/rsyslog/rsyslog/issues/1090)
+echo 'msgnum:2
+msgnum:3' > rsyslog.input
+# sleep some more
+sleep 1
+echo 'msgnum:4' >> rsyslog.input
+
+# give it time to finish
+sleep 1
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+. $srcdir/diag.sh seq-check 0 5
+. $srcdir/diag.sh exit

--- a/tests/imfile-truncate.sh
+++ b/tests/imfile-truncate.sh
@@ -30,11 +30,11 @@ msgnum:1' > rsyslog.input
 sleep 1
 
 # truncate and write some more lines (see https://github.com/rsyslog/rsyslog/issues/1090)
-echo 'msgnum:2
-msgnum:3' > rsyslog.input
+echo 'msgnum:2' > rsyslog.input
 # sleep some more
 sleep 1
-echo 'msgnum:4' >> rsyslog.input
+echo 'msgnum:3
+msgnum:4' >> rsyslog.input
 
 # give it time to finish
 sleep 1
@@ -42,5 +42,5 @@ sleep 1
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown
 
-. $srcdir/diag.sh seq-check 0 5
+. $srcdir/diag.sh seq-check 0 4
 . $srcdir/diag.sh exit


### PR DESCRIPTION
This fixes
* ReopenOnTrucate was only honored when a state file existed
  (see https://github.com/rsyslog/rsyslog/issues/1090)
* open processing could run into a loop
  (see https://github.com/rsyslog/rsyslog/issues/1174)

replaces #1091 
