### PR TITLE
fix a couple of compiler warnings that came up for the first time

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -245,7 +245,7 @@ DecodePropFilter(uchar *pline, struct cnfstmt *stmt)
 	/* create parser object starting with line string without leading colon */
 	if((iRet = rsParsConstructFromSz(&pPars, pline+1)) != RS_RET_OK) {
 		parser_errmsg("error %d constructing parser object", iRet);
-		ABORT_FINALIZE(iRet);
+		FINALIZE;
 	}
 
 	/* read property */
@@ -253,7 +253,7 @@ DecodePropFilter(uchar *pline, struct cnfstmt *stmt)
 	if(iRet != RS_RET_OK) {
 		parser_errmsg("error %d parsing filter property", iRet);
 		rsParsDestruct(pPars);
-		ABORT_FINALIZE(iRet);
+		FINALIZE;
 	}
 	CHKiRet(msgPropDescrFill(&stmt->d.s_propfilt.prop, cstrGetSzStrNoNULL(pCSPropName),
 		cstrLen(pCSPropName)));
@@ -263,7 +263,7 @@ DecodePropFilter(uchar *pline, struct cnfstmt *stmt)
 	if(iRet != RS_RET_OK) {
 		parser_errmsg("error %d compare operation property - ignoring selector", iRet);
 		rsParsDestruct(pPars);
-		ABORT_FINALIZE(iRet);
+		FINALIZE;
 	}
 
 	/* we now first check if the condition is to be negated. To do so, we first
@@ -308,7 +308,7 @@ DecodePropFilter(uchar *pline, struct cnfstmt *stmt)
 		if(iRet != RS_RET_OK) {
 			parser_errmsg("error %d compare value property", iRet);
 			rsParsDestruct(pPars);
-			ABORT_FINALIZE(iRet);
+			FINALIZE;
 		}
 	}
 

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -32,7 +32,11 @@
 #include <signal.h>
 #include <stdint.h>
 #include <time.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-attributes"
 #include <mongo.h>
+#pragma GCC diagnostic pop
 #include <json.h>
 
 #include "rsyslog.h"

--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -197,7 +197,7 @@ getDfltTpl(void)
  * is we do not permit this directive after the v2 config system has been used to set
  * the parameter.
  */
-rsRetVal
+static rsRetVal
 setLegacyDfltTpl(void __attribute__((unused)) *pVal, uchar* newVal)
 {
 	DEFiRet;
@@ -355,7 +355,9 @@ ENDdbgPrintInstInfo
  * Note: libnet is not thread-safe, so we need to ensure that only one
  * instance ever is calling libnet code.
  * rgehards, 2007-12-20
- */
+ */ 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
 static inline rsRetVal
 UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, char *msg, size_t len)
 {
@@ -521,6 +523,7 @@ finalize_it:
 	}
 	RETiRet;
 }
+#pragma GCC diagnostic pop
 
 
 /* try to resume connection if it is not ready

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -586,7 +586,7 @@ doModInit(rsRetVal (*modInit)(int, int*, rsRetVal(**)(), rsRetVal(*)(), modInfo_
 
 	if((iRet = moduleConstruct(&pNew)) != RS_RET_OK) {
 		pNew = NULL;
-		ABORT_FINALIZE(iRet);
+		FINALIZE;
 	}
 
 	CHKiRet((*modInit)(CURR_MOD_IF_VERSION, &pNew->iIFVers, &pNew->modQueryEtryPt, queryHostEtryPt, pNew));

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -45,6 +45,7 @@
 #include <sys/stat.h>	 /* required for HP UX */
 #include <time.h>
 #include <errno.h>
+#include <inttypes.h>
 
 #include "rsyslog.h"
 #include "queue.h"
@@ -1676,6 +1677,7 @@ DequeueConsumableElements(qqueue_t *pThis, wti_t *pWti, int *piRemainingQueueSiz
 		}
 		if(rd_fd != -1 && rd_fd == wr_fd && rd_offs == wr_offs) {
 			DBGPRINTF("problem on disk queue '%s': "
+					//"queue size log %d, phys %d, but rd_fd=wr_rd=%d and offs=%lld\n",
 					"queue size log %d, phys %d, but rd_fd=wr_rd=%d and offs=%" PRId64 "\n",
 					obj.GetName((obj_t*) pThis), iQueueSize, pThis->iQueueSize,
 					rd_fd, rd_offs);

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -332,7 +332,8 @@ rsRetVal rsCStrAppendStrf(cstr_t *pThis, const char *fmt, ...)
 	iRet = rsCStrConstructFromszStrv(&pStr, (char*)fmt, ap);
 	va_end(ap);
 
-	CHKiRet(iRet);
+	if(iRet != RS_RET_OK)
+		goto finalize_it;
 
 	iRet = cstrAppendCStr(pThis, pStr);
 	rsCStrDestruct(&pStr);


### PR DESCRIPTION
probably thanks to updated gcc on Fedora; generic code cleanup, not triggered by external event