### PR TITLE
Fix issues with rsyslog internal messages in default mode

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -321,7 +321,7 @@ createInstance(instanceConf_t **pinst)
 	inst->bWritePid = 0;
 	inst->bAnnotate = 0;
 	inst->bParseTrusted = 0;
-	inst->bDiscardOwnMsgs = 1;
+	inst->bDiscardOwnMsgs = bProcessInternalMessages;
 	inst->bUnlink = 1;
 	inst->next = NULL;
 
@@ -1178,7 +1178,10 @@ CODESTARTbeginCnfLoad
 	pModConf->bParseTrusted = 0;
 	pModConf->bParseHost = UNSET;
 	pModConf->bUseSpecialParser = 1;
-	pModConf->bDiscardOwnMsgs = 1;
+	/* if we do not process internal messages, we will see messages
+	 * from ourselves, and so we need to permit this.
+	 */
+	pModConf->bDiscardOwnMsgs = bProcessInternalMessages;
 	pModConf->bUnlink = 1;
 	pModConf->ratelimitIntervalSysSock = DFLT_ratelimitInterval;
 	pModConf->ratelimitBurstSysSock = DFLT_ratelimitBurst;

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1682,7 +1682,8 @@ uchar *getMSG(msg_t * const pM)
 
 
 /* Get PRI value as integer */
-static int getPRIi(msg_t * const pM)
+int
+getPRIi(const msg_t * const pM)
 {
 	syslog_pri_t pri = (pM->iFacility << 3) + (pM->iSeverity);
 	if(pri > 191)

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -3,7 +3,7 @@
  *
  * File begun on 2007-07-13 by RGerhards (extracted from syslogd.c)
  *
- * Copyright 2007-2015 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -191,6 +191,7 @@ uchar *getRcvFrom(msg_t *pM);
 void getTAG(msg_t *pM, uchar **ppBuf, int *piLen);
 const char *getTimeReported(msg_t *pM, enum tplFormatTypes eFmt);
 const char *getPRI(msg_t *pMsg);
+int getPRIi(const msg_t * const pM);
 void getRawMsg(msg_t *pM, uchar **pBuf, int *piLen);
 rsRetVal msgAddJSON(msg_t *pM, uchar *name, struct json_object *json, int force_reset, int sharedReference);
 rsRetVal msgAddMetadata(msg_t *msg, uchar *metaname, uchar *metaval);

--- a/tools/iminternal.c
+++ b/tools/iminternal.c
@@ -6,7 +6,7 @@
  * 
  * File begun on 2007-08-03 by RGerhards
  *
- * Copyright 2007 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -30,7 +30,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <assert.h>
 
 #include "syslogd.h"
 #include "linkedlist.h"
@@ -44,8 +43,6 @@ static linkedList_t llMsgs;
 static rsRetVal iminternalDestruct(iminternal_t *pThis)
 {
 	DEFiRet;
-
-	assert(pThis != NULL);
 
 	if(pThis->pMsg != NULL)
 		msgDestruct(&pThis->pMsg);
@@ -62,8 +59,6 @@ static rsRetVal iminternalConstruct(iminternal_t **ppThis)
 {
 	DEFiRet;
 	iminternal_t *pThis;
-
-	assert(ppThis != NULL);
 
 	if((pThis = (iminternal_t*) calloc(1, sizeof(iminternal_t))) == NULL) {
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
@@ -93,12 +88,8 @@ rsRetVal iminternalAddMsg(msg_t *pMsg)
 	DEFiRet;
 	iminternal_t *pThis;
 
-	assert(pMsg != NULL);
-
 	CHKiRet(iminternalConstruct(&pThis));
-
 	pThis->pMsg = pMsg;
-
 	CHKiRet(llAppend(&llMsgs,  NULL, (void*) pThis));
 
 finalize_it:
@@ -122,8 +113,6 @@ rsRetVal iminternalRemoveMsg(msg_t **ppMsg)
 	iminternal_t *pThis;
 	linkedListCookie_t llCookie = NULL;
 
-	assert(ppMsg != NULL);
-
 	CHKiRet(llGetNextElt(&llMsgs, &llCookie, (void*)&pThis));
 	*ppMsg = pThis->pMsg;
 	pThis->pMsg = NULL; /* we do no longer own it - important for destructor */
@@ -144,8 +133,6 @@ finalize_it:
  */
 rsRetVal iminternalHaveMsgReady(int* pbHaveOne)
 {
-	assert(pbHaveOne != NULL);
-
 	return llGetNumElts(&llMsgs, pbHaveOne);
 }
 
@@ -156,9 +143,7 @@ rsRetVal iminternalHaveMsgReady(int* pbHaveOne)
 rsRetVal modInitIminternal(void)
 {
 	DEFiRet;
-
 	iRet = llInit(&llMsgs, iminternalDestruct, NULL, NULL);
-
 	RETiRet;
 }
 
@@ -172,11 +157,6 @@ rsRetVal modInitIminternal(void)
 rsRetVal modExitIminternal(void)
 {
 	DEFiRet;
-
 	iRet = llDestroy(&llMsgs);
-
 	RETiRet;
 }
-
-/* vim:set ai:
- */


### PR DESCRIPTION
This fixes some issues we have with rsyslog internal message processing when the rsyslog instance emitting those messages is the same that needs to process them.