### PR TITLE
omelasticsearch high availability addressing of ElasticSearch cluster

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -246,7 +246,7 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("omelasticsearch\n");
 	dbgprintf("\ttemplate='%s'\n", pData->tplName);
 	dbgprintf("\tnumServers=%d\n", pData->numServers);
-	dbgprintf("\thealthCheckTimeout=%lun", pData->healthCheckTimeout);
+	dbgprintf("\thealthCheckTimeout=%lu\n", pData->healthCheckTimeout);
 	dbgprintf("\tserverBaseUrls=");
 	for(i = 0 ; i < pData->numServers ; ++i)
 		dbgprintf("%c'%s'", i == 0 ? '[' : ' ', pData->serverBaseUrls[i]);

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -308,8 +308,7 @@ computeBaseUrl(char* serverParam, int defaultPort, sbool useHttps, uchar **baseU
 	else if (strcasestr(serverParam, SCHEME_HTTPS))
 		host = serverParam + strlen(SCHEME_HTTPS);
 	else
-		r = useHttps ?
-			es_addBuf(&urlBuf, SCHEME_HTTPS, sizeof(SCHEME_HTTPS)-1) : 
+		r = useHttps ? es_addBuf(&urlBuf, SCHEME_HTTPS, sizeof(SCHEME_HTTPS)-1) : 
 			es_addBuf(&urlBuf, SCHEME_HTTP, sizeof(SCHEME_HTTP)-1);
 
 	if (r == 0) r = es_addBuf(&urlBuf, serverParam, strlen(serverParam));

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -69,6 +69,7 @@ statsobj_t *indexStats;
 STATSCOUNTER_DEF(indexSubmit, mutIndexSubmit)
 STATSCOUNTER_DEF(indexHTTPFail, mutIndexHTTPFail)
 STATSCOUNTER_DEF(indexHTTPReqFail, mutIndexHTTPReqFail)
+STATSCOUNTER_DEF(checkConnFail, mutCheckConnFail)
 STATSCOUNTER_DEF(indexESFail, mutIndexESFail)
 
 
@@ -83,12 +84,15 @@ STATSCOUNTER_DEF(indexESFail, mutIndexESFail)
  */
 typedef struct curl_slist HEADER;
 typedef struct _instanceData {
-	int port;
+	int defaultPort;
 	int fdErrFile;		/* error file fd or -1 if not open */
 	pthread_mutex_t mutErrFile;
-	uchar *server;
+	uchar **serverBaseUrls;
+	int numServers;
+	long healthCheckTimeout;
 	uchar *uid;
 	uchar *pwd;
+	uchar *authBuf;
 	uchar *searchIndex;
 	uchar *searchType;
 	uchar *parent;
@@ -105,16 +109,18 @@ typedef struct _instanceData {
 	sbool bulkmode;
 	size_t maxbytes;
 	sbool asyncRepl;
-        sbool useHttps;
-        sbool allowUnsignedCerts;
+	sbool useHttps;
+	sbool allowUnsignedCerts;
 } instanceData;
 
 typedef struct wrkrInstanceData {
 	instanceData *pData;
+	int serverIndex;
 	int replyLen;
 	char *reply;
-	CURL	*curlHandle;	/* libcurl session handle */
-	HEADER	*postHeader;	/* json POST request info */
+	CURL	*curlCheckConnHandle;	/* libcurl session handle for checking the server connection */
+	CURL	*curlPostHandle;	/* libcurl session handle for posting data to the server */
+	HEADER	*curlHeader;	/* json POST request info */
 	uchar *restURL;		/* last used URL for error reporting */
 	struct {
 		es_str_t *data;
@@ -127,8 +133,9 @@ typedef struct wrkrInstanceData {
 /* tables for interfacing with the v6 config system */
 /* action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {
-	{ "server", eCmdHdlrGetWord, 0 },
+	{ "server", eCmdHdlrArray, 0 },
 	{ "serverport", eCmdHdlrInt, 0 },
+	{ "healthchecktimeout", eCmdHdlrInt, 0 },
 	{ "uid", eCmdHdlrGetWord, 0 },
 	{ "pwd", eCmdHdlrGetWord, 0 },
 	{ "searchindex", eCmdHdlrGetWord, 0 },
@@ -166,6 +173,10 @@ ENDcreateInstance
 
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
+	pWrkrData->curlHeader = NULL;
+	pWrkrData->curlPostHandle = NULL;
+	pWrkrData->curlCheckConnHandle = NULL;
+	pWrkrData->serverIndex = 0;
 	pWrkrData->restURL = NULL;
 	if(pData->bulkmode) {
 		pWrkrData->batch.currTpl1 = NULL;
@@ -187,13 +198,18 @@ CODESTARTisCompatibleWithFeature
 ENDisCompatibleWithFeature
 
 BEGINfreeInstance
+	int i;
 CODESTARTfreeInstance
 	if(pData->fdErrFile != -1)
 		close(pData->fdErrFile);
 	pthread_mutex_destroy(&pData->mutErrFile);
-	free(pData->server);
+	for(i = 0 ; i < pData->numServers ; ++i)
+		free(pData->serverBaseUrls[i]);
+	free(pData->serverBaseUrls);
 	free(pData->uid);
 	free(pData->pwd);
+	if (pData->authBuf != NULL)
+		free(pData->authBuf);
 	free(pData->searchIndex);
 	free(pData->searchType);
 	free(pData->parent);
@@ -205,24 +221,37 @@ ENDfreeInstance
 
 BEGINfreeWrkrInstance
 CODESTARTfreeWrkrInstance
-	if(pWrkrData->postHeader) {
-		curl_slist_free_all(pWrkrData->postHeader);
-		pWrkrData->postHeader = NULL;
+	if(pWrkrData->curlHeader != NULL) {
+		curl_slist_free_all(pWrkrData->curlHeader);
+		pWrkrData->curlHeader = NULL;
 	}
-	if(pWrkrData->curlHandle) {
-		curl_easy_cleanup(pWrkrData->curlHandle);
-		pWrkrData->curlHandle = NULL;
+	if(pWrkrData->curlCheckConnHandle != NULL) {
+		curl_easy_cleanup(pWrkrData->curlCheckConnHandle);
+		pWrkrData->curlCheckConnHandle = NULL;
 	}
-	free(pWrkrData->restURL);
+	if(pWrkrData->curlPostHandle != NULL) {
+		curl_easy_cleanup(pWrkrData->curlPostHandle);
+		pWrkrData->curlPostHandle = NULL;
+	}
+	if (pWrkrData->restURL != NULL) {
+		free(pWrkrData->restURL);
+		pWrkrData->restURL = NULL;
+	}
 	es_deleteStr(pWrkrData->batch.data);
 ENDfreeWrkrInstance
 
 BEGINdbgPrintInstInfo
+	int i;
 CODESTARTdbgPrintInstInfo
 	dbgprintf("omelasticsearch\n");
 	dbgprintf("\ttemplate='%s'\n", pData->tplName);
-	dbgprintf("\tserver='%s'\n", pData->server);
-	dbgprintf("\tserverport=%d\n", pData->port);
+	dbgprintf("\tnumServers=%d\n", pData->numServers);
+	dbgprintf("\thealthCheckTimeout=%lun", pData->healthCheckTimeout);
+	dbgprintf("\tserverBaseUrls=");
+	for(i = 0 ; i < pData->numServers ; ++i)
+		dbgprintf("%c'%s'", i == 0 ? '[' : ' ', pData->serverBaseUrls[i]);
+	dbgprintf("]\n");
+	dbgprintf("\tdefaultPort=%d\n", pData->defaultPort);
 	dbgprintf("\tuid='%s'\n", pData->uid == NULL ? (uchar*)"(not configured)" : pData->uid);
 	dbgprintf("\tpwd=(%sconfigured)\n", pData->pwd == NULL ? "not " : "");
 	dbgprintf("\tsearch index='%s'\n", pData->searchIndex);
@@ -233,7 +262,7 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("\tdynamic search type=%d\n", pData->dynSrchType);
 	dbgprintf("\tdynamic parent=%d\n", pData->dynParent);
 	dbgprintf("\tasync replication=%d\n", pData->asyncRepl);
-        dbgprintf("\tuse https=%d\n", pData->useHttps);
+	dbgprintf("\tuse https=%d\n", pData->useHttps);
 	dbgprintf("\tbulkmode=%d\n", pData->bulkmode);
 	dbgprintf("\tmaxbytes=%lu\n", pData->maxbytes);
 	dbgprintf("\tallowUnsignedCerts=%d\n", pData->allowUnsignedCerts);
@@ -247,76 +276,119 @@ ENDdbgPrintInstInfo
 
 
 /* Build basic URL part, which includes hostname and port as follows:
- * http://hostname:port/
- * Newly creates an estr for this purpose.
+ * http://hostname:port/ based on a server param
+ * Newly creates a cstr for this purpose.
  */
 static rsRetVal
-setBaseURL(instanceData *pData, es_str_t **url)
+computeBaseUrl(char* serverParam, int defaultPort, sbool useHttps, uchar **baseUrl)
 {
+#	define SCHEME_HTTPS "https://"
+#	define SCHEME_HTTP "http://"
+
 	char portBuf[64];
-	int r;
+	int r = 0;
+	char* host = serverParam;
 	DEFiRet;
 
-	*url = es_newStr(128);
-	snprintf(portBuf, sizeof(portBuf), "%d", pData->port);
-        if (pData->useHttps) {
-  		r = es_addBuf(url, "https://", sizeof("https://")-1);
+	es_str_t *urlBuf = es_newStr(256);
+	if (urlBuf == NULL) {
+		DBGPRINTF("omelasticsearch: failed to allocate es_str urlBuf in computeBaseUrl\n");
+		ABORT_FINALIZE(RS_RET_ERR);
 	}
-	else {
-		r = es_addBuf(url, "http://", sizeof("http://")-1);
+
+	/* Remove a trailing slash if it exists */
+	if (serverParam[strlen(serverParam)-1] == '/')
+		serverParam[strlen(serverParam)-1] = '\0';
+
+	/* Find where the hostname/ip of the server starts. If the scheme is not specified
+	  in the uri, start the buffer with a scheme corresponding to the useHttps parameter.
+	*/
+	if (strcasestr(serverParam, SCHEME_HTTP))
+		host = serverParam + strlen(SCHEME_HTTP);
+	else if (strcasestr(serverParam, SCHEME_HTTPS))
+		host = serverParam + strlen(SCHEME_HTTPS);
+	else
+		r = useHttps ?
+			es_addBuf(&urlBuf, SCHEME_HTTPS, sizeof(SCHEME_HTTPS)-1) : 
+			es_addBuf(&urlBuf, SCHEME_HTTP, sizeof(SCHEME_HTTP)-1);
+
+	if (r == 0) r = es_addBuf(&urlBuf, serverParam, strlen(serverParam));
+	if (r == 0 && !strchr(host, ':')) {
+		snprintf(portBuf, sizeof(portBuf), ":%d", defaultPort);
+		r = es_addBuf(&urlBuf, portBuf, strlen(portBuf));
 	}
-	if(r == 0) r = es_addBuf(url, (char*)pData->server, strlen((char*)pData->server));
-	if(r == 0) r = es_addChar(url, ':');
-	if(r == 0) r = es_addBuf(url, portBuf, strlen(portBuf));
-	if(r == 0) es_addChar(url, '/');
+	if (r == 0) r = es_addChar(&urlBuf, '/');
+	if (r == 0) *baseUrl = (uchar*) es_str2cstr(urlBuf, NULL);
+
+	if (r != 0 || baseUrl == NULL) {
+		DBGPRINTF("omelasticsearch: error occurred computing baseUrl from server %s\n", serverParam);
+		ABORT_FINALIZE(RS_RET_ERR);
+	}
+finalize_it:
+	if (urlBuf) {
+		es_deleteStr(urlBuf);
+	}
 	RETiRet;
 }
 
+static inline void
+incrementServerIndex(wrkrInstanceData_t *pWrkrData)
+{
+	pWrkrData->serverIndex = (pWrkrData->serverIndex + 1) % pWrkrData->pData->numServers;
+}
 
 static rsRetVal
 checkConn(wrkrInstanceData_t *pWrkrData)
 {
-	es_str_t *url;
-	CURL *curl = NULL;
+#	define HEALTH_URI "_cat/health"
+	CURL *curl;
 	CURLcode res;
-	char *cstr;
+	es_str_t *urlBuf;
+	char* healthUrl;
+	char* serverUrl;
+	int i;
+	int r;
 	DEFiRet;
 
-	setBaseURL(pWrkrData->pData, &url);
-	curl = curl_easy_init();
-	if(curl == NULL) {
-		DBGPRINTF("omelasticsearch: checkConn() curl_easy_init() failed\n");
+	curl = pWrkrData->curlCheckConnHandle;
+	urlBuf = es_newStr(256);
+	if (urlBuf == NULL) {
+		DBGPRINTF("omelasticsearch: unable to allocate buffer for health check uri.\n");
 		ABORT_FINALIZE(RS_RET_SUSPENDED);
 	}
-	/* Bodypart of request not needed, so set curl opt to nobody and httpget, otherwise lib-curl could sigsegv */
-	curl_easy_setopt(curl, CURLOPT_HTTPGET, TRUE);
-	curl_easy_setopt(curl, CURLOPT_NOBODY, TRUE);
-	curl_easy_setopt(curl, CURLOPT_NOSIGNAL, TRUE);
-	if(pWrkrData->pData->allowUnsignedCerts)
-		curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, FALSE);
+		
+	for(i = 0; i < pWrkrData->pData->numServers; ++i) {
+		serverUrl = (char*) pWrkrData->pData->serverBaseUrls[pWrkrData->serverIndex];
+		
+		es_emptyStr(urlBuf);
+		r = es_addBuf(&urlBuf, serverUrl, strlen(serverUrl));
+		if(r == 0) r = es_addBuf(&urlBuf, HEALTH_URI, sizeof(HEALTH_URI)-1);
+		if(r == 0) healthUrl = es_str2cstr(urlBuf, NULL);
+		if(r != 0 || healthUrl == NULL) {
+			DBGPRINTF("omelasticsearch: unable to allocate buffer for health check uri.\n");
+			ABORT_FINALIZE(RS_RET_SUSPENDED);
+		}
 
-	/* Only enable for debugging 
-	curl_easy_setopt(curl, CURLOPT_VERBOSE, TRUE); */
+		curl_easy_setopt(curl, CURLOPT_URL, healthUrl);
+		res = curl_easy_perform(curl);
+		free(healthUrl);
 
-	cstr = es_str2cstr(url, NULL);
-	curl_easy_setopt(curl, CURLOPT_URL, cstr);
-	free(cstr);
+		if (res == CURLE_OK) {
+			DBGPRINTF("omelasticsearch: checkConn(%s) completed with success on attempt %d\n", serverUrl, i);
+			ABORT_FINALIZE(RS_RET_OK);
+		}
 
-	pWrkrData->reply = NULL;
-	pWrkrData->replyLen = 0;
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, pWrkrData);
-	res = curl_easy_perform(curl);
-	if(res != CURLE_OK) {
-		DBGPRINTF("omelasticsearch: checkConn() curl_easy_perform() "
-			  "failed: %s\n", curl_easy_strerror(res));
-		ABORT_FINALIZE(RS_RET_SUSPENDED);
+		DBGPRINTF("omelasticsearch: checkConn(%s) failed on attempt %d: %s\n", serverUrl, i, curl_easy_strerror(res));	
+		STATSCOUNTER_INC(checkConnFail, mutCheckConnFail);
+		incrementServerIndex(pWrkrData);
 	}
-	free(pWrkrData->reply);
-	DBGPRINTF("omelasticsearch: checkConn() completed with success\n");
+
+	DBGPRINTF("omelasticsearch: checkConn() failed after %d attempts.\n", i);
+	ABORT_FINALIZE(RS_RET_SUSPENDED);
 
 finalize_it:
-	if(curl != NULL)
-		curl_easy_cleanup(curl);
+	if(urlBuf != NULL)
+		es_deleteStr(urlBuf);
 	RETiRet;
 }
 
@@ -406,21 +478,25 @@ done:	return;
 
 
 static rsRetVal
-setCurlURL(wrkrInstanceData_t *pWrkrData, instanceData *pData, uchar **tpls)
+setPostURL(wrkrInstanceData_t *pWrkrData, instanceData *pData, uchar **tpls)
 {
-	char authBuf[1024];
 	uchar *searchIndex = 0;
 	uchar *searchType;
 	uchar *parent;
 	uchar *bulkId;
+	char* baseUrl;
 	es_str_t *url;
-	int rLocal;
 	int r;
 	DEFiRet;
 	char separator;
 	const int bulkmode = pData->bulkmode;
 
-	setBaseURL(pData, &url);
+	baseUrl = (char*)pData->serverBaseUrls[pWrkrData->serverIndex];
+	url = es_newStrFromCStr(baseUrl, strlen(baseUrl));
+	if (url == NULL) {
+		DBGPRINTF("omelasticsearch: error allocating new estr for POST url.\n");
+		ABORT_FINALIZE(RS_RET_ERR);
+	}
 
 	if(bulkmode) {
 		r = es_addBuf(&url, "_bulk", sizeof("_bulk")-1);
@@ -452,25 +528,16 @@ setCurlURL(wrkrInstanceData_t *pWrkrData, instanceData *pData, uchar **tpls)
 		if(r == 0) es_addBuf(&url, (char*)parent, ustrlen(parent));
 	}
 
-	free(pWrkrData->restURL);
+	if(pWrkrData->restURL != NULL)
+		free(pWrkrData->restURL);
+	
 	pWrkrData->restURL = (uchar*)es_str2cstr(url, NULL);
-	curl_easy_setopt(pWrkrData->curlHandle, CURLOPT_URL, pWrkrData->restURL);
-	es_deleteStr(url);
+	curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_URL, pWrkrData->restURL);
 	DBGPRINTF("omelasticsearch: using REST URL: '%s'\n", pWrkrData->restURL);
 
-	if(pData->uid != NULL) {
-		rLocal = snprintf(authBuf, sizeof(authBuf), "%s:%s", pData->uid,
-			         (pData->pwd == NULL) ? "" : (char*)pData->pwd);
-		if(rLocal < 1) {
-			errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: snprintf failed "
-				"when trying to build auth string (return %d)\n",
-				rLocal);
-			ABORT_FINALIZE(RS_RET_ERR);
-		}
-		curl_easy_setopt(pWrkrData->curlHandle, CURLOPT_USERPWD, authBuf);
-		curl_easy_setopt(pWrkrData->curlHandle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
-	}
 finalize_it:
+	if (url != NULL)
+		es_deleteStr(url);
 	RETiRet;
 }
 
@@ -1084,14 +1151,14 @@ static rsRetVal
 curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls, int nmsgs)
 {
 	CURLcode code;
-	CURL *curl = pWrkrData->curlHandle;
+	CURL *curl = pWrkrData->curlPostHandle;
 	DEFiRet;
 
 	pWrkrData->reply = NULL;
 	pWrkrData->replyLen = 0;
 
-	if(pWrkrData->pData->dynSrchIdx || pWrkrData->pData->dynSrchType || pWrkrData->pData->dynParent)
-		CHKiRet(setCurlURL(pWrkrData, pWrkrData->pData, tpls));
+	CHKiRet(checkConn(pWrkrData));
+	CHKiRet(setPostURL(pWrkrData, pWrkrData->pData, tpls));
 
 	curl_easy_setopt(curl, CURLOPT_WRITEDATA, pWrkrData);
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, (char *)message);
@@ -1118,6 +1185,7 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 
 	CHKiRet(checkResult(pWrkrData, message));
 finalize_it:
+	incrementServerIndex(pWrkrData);
 	free(pWrkrData->reply);
 	RETiRet;
 }
@@ -1206,50 +1274,93 @@ curlResult(void *ptr, size_t size, size_t nmemb, void *userdata)
 	return size*nmemb;
 }
 
-
 static rsRetVal
-curlSetup(wrkrInstanceData_t *pWrkrData, instanceData *pData)
-{
-	HEADER *header;
-	CURL *handle;
+computeAuthHeader(char* uid, char* pwd, uchar** authBuf) {
+	int r;
+	DEFiRet;
+	es_str_t* auth = es_newStr(1024);
 
-	handle = curl_easy_init();
-	if (handle == NULL) {
-		return RS_RET_OBJ_CREATION_FAILED;
+	if (auth == NULL) {
+		DBGPRINTF("omelasticsearch: failed to allocate es_str auth for auth header construction\n");
+		ABORT_FINALIZE(RS_RET_ERR);
 	}
 
-	header = curl_slist_append(NULL, "Content-Type: text/json; charset=utf-8");
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
+	r = es_addBuf(&auth, uid, strlen(uid));
+	if(r == 0) r = es_addChar(&auth, ':');
+	if(r == 0 && pwd != NULL) r = es_addBuf(&auth, pwd, strlen(pwd));
+	if(r == 0) *authBuf = (uchar*) es_str2cstr(auth, NULL);
 
+	if (r != 0 || *authBuf == NULL) {
+		errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: failed to build auth header\n");
+		ABORT_FINALIZE(RS_RET_ERR);
+	}
+
+finalize_it:
+	if (auth != NULL)
+		es_deleteStr(auth);
+	RETiRet;
+}
+
+static void
+curlCheckConnSetup(CURL *handle, HEADER *header, long timeout, sbool allowUnsignedCerts) 
+{
+	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
+	curl_easy_setopt(handle, CURLOPT_NOBODY, TRUE);
+	curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, timeout);
+	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, TRUE);
+
+	if(allowUnsignedCerts)
+		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, FALSE);
+
+	/* Only enable for debugging 
+	curl_easy_setopt(curl, CURLOPT_VERBOSE, TRUE); */
+}
+
+static void
+curlPostSetup(CURL *handle, HEADER *header, uchar* authBuf)
+{
+	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
 	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
 	curl_easy_setopt(handle, CURLOPT_POST, 1);
 	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, TRUE);
 
-	pWrkrData->curlHandle = handle;
-	pWrkrData->postHeader = header;
-
-	if(    pData->bulkmode
-	   || (pData->dynSrchIdx == 0 && pData->dynSrchType == 0 && pData->dynParent == 0)) {
-		/* in this case, we know no tpls are involved in the request-->NULL OK! */
-		setCurlURL(pWrkrData, pData, NULL);
+	if(authBuf != NULL) {
+		curl_easy_setopt(handle, CURLOPT_USERPWD, authBuf);
+		curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
 	}
+}
 
-	if(Debug) {
-		if(pData->dynSrchIdx == 0 && pData->dynSrchType == 0 && pData->dynParent == 0)
-			dbgprintf("omelasticsearch setup, using static REST URL\n");
-		else
-			dbgprintf("omelasticsearch setup, we have a dynamic REST URL\n");
+static rsRetVal
+curlSetup(wrkrInstanceData_t *pWrkrData, instanceData *pData)
+{
+	pWrkrData->curlHeader = curl_slist_append(NULL, "Content-Type: text/json; charset=utf-8");
+	pWrkrData->curlPostHandle = curl_easy_init();
+	if (pWrkrData->curlPostHandle == NULL) {
+		return RS_RET_OBJ_CREATION_FAILED;
 	}
+	curlPostSetup(pWrkrData->curlPostHandle, pWrkrData->curlHeader, pData->authBuf);
+
+	pWrkrData->curlCheckConnHandle = curl_easy_init();
+	if (pWrkrData->curlCheckConnHandle == NULL) {
+		curl_easy_cleanup(pWrkrData->curlPostHandle);
+		pWrkrData->curlPostHandle = NULL;
+		return RS_RET_OBJ_CREATION_FAILED;
+	}
+	curlCheckConnSetup(pWrkrData->curlCheckConnHandle, pWrkrData->curlHeader, 
+		pData->healthCheckTimeout, pData->allowUnsignedCerts);
+
 	return RS_RET_OK;
 }
 
 static void
 setInstParamDefaults(instanceData *pData)
 {
-	pData->server = NULL;
-	pData->port = 9200;
+	pData->serverBaseUrls = NULL;
+	pData->defaultPort = 9200;
+	pData->healthCheckTimeout = 3500;
 	pData->uid = NULL;
 	pData->pwd = NULL;
+	pData->authBuf = NULL;
 	pData->searchIndex = NULL;
 	pData->searchType = NULL;
 	pData->parent = NULL;
@@ -1258,7 +1369,7 @@ setInstParamDefaults(instanceData *pData)
 	pData->dynSrchType = 0;
 	pData->dynParent = 0;
 	pData->asyncRepl = 0;
-        pData->useHttps = 0;
+	pData->useHttps = 0;
 	pData->bulkmode = 0;
 	pData->maxbytes = 104857600; //100 MB Is the default max message size that ships with ElasticSearch
 	pData->allowUnsignedCerts = 0;
@@ -1272,6 +1383,8 @@ setInstParamDefaults(instanceData *pData)
 
 BEGINnewActInst
 	struct cnfparamvals *pvals;
+	char* serverParam = NULL;
+	struct cnfarray* servers = NULL;
 	int i;
 	int iNumTpls;
 CODESTARTnewActInst
@@ -1286,7 +1399,7 @@ CODESTARTnewActInst
 		if(!pvals[i].bUsed)
 			continue;
 		if(!strcmp(actpblk.descr[i].name, "server")) {
-			pData->server = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			servers = pvals[i].val.d.ar;
 		} else if(!strcmp(actpblk.descr[i].name, "errorfile")) {
 			pData->errorFile = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		}else if(!strcmp(actpblk.descr[i].name, "erroronly")) {
@@ -1294,7 +1407,9 @@ CODESTARTnewActInst
 		}else if(!strcmp(actpblk.descr[i].name, "interleaved")) {
 			pData->interleaved = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "serverport")) {
-			pData->port = (int) pvals[i].val.d.n;
+			pData->defaultPort = (int) pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "healthchecktimeout")) {
+			pData->healthCheckTimeout = (long) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "uid")) {
 			pData->uid = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "pwd")) {
@@ -1365,6 +1480,9 @@ CODESTARTnewActInst
 			"name for bulkid template given - action definition invalid");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
+
+	if (pData->uid != NULL)
+		CHKiRet(computeAuthHeader((char*) pData->uid, (char*) pData->pwd, &pData->authBuf));
 
 	iNumTpls = 1;
 	if(pData->dynSrchIdx) ++iNumTpls;
@@ -1451,14 +1569,46 @@ CODESTARTnewActInst
 		}
 	}
 
-	if(pData->server == NULL)
-		pData->server = (uchar*) strdup("localhost");
+	if (servers != NULL) {
+		pData->numServers = servers->nmemb;
+		pData->serverBaseUrls = malloc(servers->nmemb * sizeof(uchar*));
+		if (pData->serverBaseUrls == NULL) {
+			errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
+					"for ElasticSearch server configuration.");
+			ABORT_FINALIZE(RS_RET_ERR);
+		}
+
+		for(i = 0 ; i < servers->nmemb ; ++i) {
+			serverParam = es_str2cstr(servers->arr[i], NULL);
+			if (serverParam == NULL) {
+				errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
+					"for ElasticSearch server configuration.");
+				ABORT_FINALIZE(RS_RET_ERR);
+			}
+			CHKiRet(computeBaseUrl(serverParam, pData->defaultPort, pData->useHttps, pData->serverBaseUrls + i));
+			free(serverParam);
+			serverParam = NULL;
+		}
+	} else {
+		dbgprintf("omelasticsearch: No servers specified, using localhost\n");
+		pData->numServers = 1;
+		pData->serverBaseUrls = malloc(sizeof(uchar*));
+		if (pData->serverBaseUrls == NULL) {
+			errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
+					"for ElasticSearch server configuration.");
+			ABORT_FINALIZE(RS_RET_ERR);
+		}
+		CHKiRet(computeBaseUrl("localhost", pData->defaultPort, pData->useHttps, pData->serverBaseUrls));
+	}
+
 	if(pData->searchIndex == NULL)
 		pData->searchIndex = (uchar*) strdup("system");
 	if(pData->searchType == NULL)
 		pData->searchType = (uchar*) strdup("events");
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);
+	if (serverParam)
+		free(serverParam);
 ENDnewActInst
 
 
@@ -1527,6 +1677,9 @@ CODEmodInit_QueryRegCFSLineHdlr
 	STATSCOUNTER_INIT(indexHTTPReqFail, mutIndexHTTPReqFail);
 	CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"failed.httprequests",
 		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &indexHTTPReqFail));
+	STATSCOUNTER_INIT(checkConnFail, mutCheckConnFail);
+	CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"failed.checkConn",
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &checkConnFail));
 	STATSCOUNTER_INIT(indexESFail, mutIndexESFail);
 	CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"failed.es",
 		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &indexESFail));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -349,6 +349,7 @@ endif
 if ENABLE_ELASTICSEARCH_TESTS
 TESTS +=  \
 	es-basic.sh \
+	es-basic-server.sh \
 	es-basic-ha.sh \
 	es-basic-bulk.sh \
 	es-maxbytes-bulk.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -349,6 +349,7 @@ endif
 if ENABLE_ELASTICSEARCH_TESTS
 TESTS +=  \
 	es-basic.sh \
+	es-basic-ha.sh \
 	es-basic-bulk.sh \
 	es-maxbytes-bulk.sh \
 	es-basic-errfile-empty.sh \

--- a/tests/es-basic-ha.sh
+++ b/tests/es-basic-ha.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[es-basic-ha.sh\]: basic test for elasticsearch high availability functionality
+. $srcdir/diag.sh init
+. $srcdir/diag.sh es-init
+. $srcdir/diag.sh startup es-basic-ha.conf
+. $srcdir/diag.sh injectmsg  0 100
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh es-getdata 100
+. $srcdir/diag.sh seq-check  0 99
+# The configuration makes every other request from message #3 fail checkConn (N/2-1)
+. $srcdir/diag.sh custom-content-check '"failed.checkConn": 49' 'rsyslog.out.stats.log'
+. $srcdir/diag.sh exit

--- a/tests/es-basic-server.sh
+++ b/tests/es-basic-server.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[es-basic-server.sh\]: basic test for elasticsearch functionality with server 
+. $srcdir/diag.sh init
+. $srcdir/diag.sh es-init
+. $srcdir/diag.sh startup es-basic-server.conf
+. $srcdir/diag.sh injectmsg  0 10000
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh es-getdata 10000
+. $srcdir/diag.sh seq-check  0 9999
+. $srcdir/diag.sh exit

--- a/tests/testsuites/es-basic-ha.conf
+++ b/tests/testsuites/es-basic-ha.conf
@@ -1,0 +1,16 @@
+$IncludeConfig diag-common.conf
+
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+
+ruleset(name="stats") {
+  action(type="omfile" file="./rsyslog.out.stats.log")
+}
+module(load="../plugins/impstats/.libs/impstats" interval="1" severity="7" resetCounters="off" Ruleset="stats" bracketing="on" format="json")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+:msg, contains, "msgnum:" action(type="omelasticsearch"
+				 server=["localhost", "http://localhost/", "localhost:9201"]
+				 template="tpl"
+				 searchIndex="rsyslog_testbench")

--- a/tests/testsuites/es-basic-server.conf
+++ b/tests/testsuites/es-basic-server.conf
@@ -1,0 +1,10 @@
+$IncludeConfig diag-common.conf
+
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+:msg, contains, "msgnum:" action(type="omelasticsearch"
+				 server="localhost" 
+				 template="tpl"
+				 searchIndex="rsyslog_testbench")


### PR DESCRIPTION
Resolves #1171 
Changing server parameter to accept an array of servers/uris and port to
defaultPort if not specified on a given uri. Adding dedicated curl handle
for checkConn and refactoring the curl setup a bit, using ES health check
with timeout. Added checkConnFailure stat counting and HA test