### PR TITLE
Lookup table init error check and prifilt init fix

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -4231,6 +4231,7 @@ cnffuncNew_prifilt(int fac)
 		func->fname = es_newStrFromCStr("prifilt", sizeof("prifilt")-1);
 		func->nParams = 0;
 		func->fID = CNFFUNC_PRIFILT;
+		func->destructable_funcdata = 1;
 		((struct funcData_prifilt *)func->funcdata)->pmask[fac] = TABLE_ALLPRI;
 	}
 	return func;

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -484,7 +484,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 #	define CHKiRet(code) if((iRet = code) != RS_RET_OK) goto finalize_it
 #endif
 
-# define CHKiConcCtrl(code) if (code != 0) { iRet = RS_RET_CONC_CTRL_ERR; goto finalize_it; }
+# define CHKiConcCtrl(code) if (code != 0) { iRet = RS_RET_CONC_CTRL_ERR; errno = code; goto finalize_it; }
 
 /* macro below is to be used if we need our own handling, eg for cleanup */
 #define CHKiRet_Hdlr(code) if((iRet = code) != RS_RET_OK)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -230,7 +230,8 @@ TESTS +=  \
 	lookup_table_bad_configs-vg.sh \
 	lookup_table_rscript_reload-vg.sh \
 	lookup_table_rscript_reload_without_stub-vg.sh \
-	multiple_lookup_tables-vg.sh
+	multiple_lookup_tables-vg.sh \
+	fac_local0-vg.sh
 endif # HAVE_VALGRIND
 
 if ENABLE_USERTOOLS
@@ -707,6 +708,7 @@ EXTRA_DIST= \
 	fac_authpriv.sh \
 	testsuites/fac_authpriv.conf \
 	fac_local0.sh \
+	fac_local0-vg.sh \
 	testsuites/fac_local0.conf \
 	fac_local7.sh \
 	testsuites/fac_local7.conf \

--- a/tests/fac_local0-vg.sh
+++ b/tests/fac_local0-vg.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# added 2016-10-14 by janmejay.singh
+
+# This file is part of the rsyslog project, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup-vg fac_local0.conf
+. $srcdir/diag.sh tcpflood -m1000 -P 129
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh seq-check 0 999 
+. $srcdir/diag.sh exit


### PR DESCRIPTION
Primarily fixes towards https://github.com/rsyslog/rsyslog/issues/1071.

The second-issue (funcdata free-at-destruct marker was uninitialized for prifilt) seems fairly unrelated, but since it has been found incidentally on the same thread, hence fixing it in the same PR.