### PR TITLE
Use unsigned to report rcvbuf sizes

### DIFF
--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1216,7 +1216,7 @@ closeUDPListenSockets(int *pSockArr)
  * param rcvbuf indicates desired rcvbuf size; 0 means OS default
  */
 static int *
-create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbuf, int ipfreebind)
+create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, unsigned int rcvbuf, int ipfreebind)
 {
         struct addrinfo hints, *res, *r;
         int error, maxs, *s, *socks, on = 1;

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1221,7 +1221,7 @@ create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbuf, in
         struct addrinfo hints, *res, *r;
         int error, maxs, *s, *socks, on = 1;
 	int sockflags;
-	int actrcvbuf;
+	unsigned int actrcvbuf;
 	socklen_t optlen;
 	char errStr[1024];
 


### PR DESCRIPTION
Just a try to fix #1146 Probably many other int's should be unsigned