### PR TITLE
Use unsigned to report rcvbuf sizes

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -115,7 +115,7 @@ struct instanceConf_s {
 	uchar *dfltTZ;
 	int ratelimitInterval;
 	int ratelimitBurst;
-	int rcvbuf;			/* 0 means: do not set, keep OS default */
+	unsigned int rcvbuf;			/* 0 means: do not set, keep OS default */
 	/*  0 means:  IP_FREEBIND is disabled
 	1 means:  IP_FREEBIND enabled + warning disabled
 	1+ means: IP+FREEBIND enabled + warning enabled */

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1216,12 +1216,12 @@ closeUDPListenSockets(int *pSockArr)
  * param rcvbuf indicates desired rcvbuf size; 0 means OS default
  */
 static int *
-create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, int rcvbuf, int ipfreebind)
+create_udp_socket(uchar *hostname, uchar *pszPort, int bIsServer, unsigned int rcvbuf, int ipfreebind)
 {
         struct addrinfo hints, *res, *r;
         int error, maxs, *s, *socks, on = 1;
 	int sockflags;
-	int actrcvbuf;
+	unsigned int actrcvbuf;
 	socklen_t optlen;
 	char errStr[1024];
 

--- a/runtime/net.h
+++ b/runtime/net.h
@@ -148,7 +148,7 @@ BEGINinterface(net) /* name must also be changed in ENDinterface macro! */
 	void (*PrintAllowedSenders)(int iListToPrint);
 	void (*clearAllowedSenders)(uchar*);
 	void (*debugListenInfo)(int fd, char *type);
-	int *(*create_udp_socket)(uchar *hostname, uchar *LogPort, int bIsServer, int rcvbuf, int ipfreebind);
+	int *(*create_udp_socket)(uchar *hostname, uchar *LogPort, int bIsServer, unsigned int rcvbuf, int ipfreebind);
 	void (*closeUDPListenSockets)(int *finet);
 	int (*isAllowedSender)(uchar *pszType, struct sockaddr *pFrom, const char *pszFromHost); /* deprecated! */
 	rsRetVal (*getLocalHostname)(uchar**);


### PR DESCRIPTION
Just a try to fix #1146 Probably many other int's should be unsigned
