### PR TITLE
Allow the key parameter of Omhiredis to point to a template

### DIFF
--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -40,6 +40,7 @@
 #include "module-template.h"
 #include "errmsg.h"
 #include "cfsysline.h"
+#include "unicode-helper.h"
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP
@@ -53,9 +54,9 @@ DEFobjCurrIf(errmsg)
 #define OMHIREDIS_MODE_QUEUE 1
 #define OMHIREDIS_MODE_PUBLISH 2
 
-/*  our instance data.
- *  this will be accessable 
- *  via pData */
+/* our instance data.
+ * this will be accessable 
+ * via pData */
 typedef struct _instanceData {
 	uchar *server; /* redis server address */
 	int port; /* redis port */
@@ -63,7 +64,8 @@ typedef struct _instanceData {
 	uchar *tplName; /* template name */
 	char *modeDescription; /* mode description */
 	int mode; /* mode constant */
-	char *key; /* key for QUEUE and PUBLISH modes */
+	uchar *key; /* key for QUEUE and PUBLISH modes */
+	sbool dynaKey; /* Should we treat the key as a template? */
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -79,6 +81,7 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "template", eCmdHdlrGetWord, 0 },
 	{ "mode", eCmdHdlrGetWord, 0 },
 	{ "key", eCmdHdlrGetWord, 0 },
+	{ "dynakey", eCmdHdlrBinary, 0 }
 };
 
 static struct cnfparamblk actpblk = {
@@ -102,7 +105,7 @@ CODESTARTisCompatibleWithFeature
 		iRet = RS_RET_OK;
 ENDisCompatibleWithFeature
 
-/*  called when closing */
+/* called when closing */
 static void closeHiredis(wrkrInstanceData_t *pWrkrData)
 {
 	if(pWrkrData->conn != NULL) {
@@ -111,7 +114,7 @@ static void closeHiredis(wrkrInstanceData_t *pWrkrData)
 	}
 }
 
-/*  Free our instance data. */
+/* Free our instance data. */
 BEGINfreeInstance
 CODESTARTfreeInstance
 	if (pData->server != NULL) {
@@ -129,7 +132,7 @@ CODESTARTdbgPrintInstInfo
 	/* nothing special here */
 ENDdbgPrintInstInfo
 
-/*  establish our connection to redis */
+/* establish our connection to redis */
 static rsRetVal initHiredis(wrkrInstanceData_t *pWrkrData, int bSilent)
 {
 	char *server;
@@ -162,40 +165,40 @@ static rsRetVal initHiredis(wrkrInstanceData_t *pWrkrData, int bSilent)
 			pWrkrData->count++;
 		}
 	}
-         
+
 finalize_it:
 	RETiRet;
 }
 
-rsRetVal writeHiredis(uchar *message, wrkrInstanceData_t *pWrkrData)
+rsRetVal writeHiredis(uchar* key, uchar *message, wrkrInstanceData_t *pWrkrData)
 {
 	DEFiRet;
 
-	/*  if we do not have a redis connection, call
-	 *  initHiredis and try to establish one */
+	/* if we do not have a redis connection, call
+	 * initHiredis and try to establish one */
 	if(pWrkrData->conn == NULL)
 		CHKiRet(initHiredis(pWrkrData, 0));
 
-	/*  try to append the command to the pipeline. 
-	 *  REDIS_ERR reply indicates something bad
-	 *  happened, in which case abort. otherwise
-	 *  increase our current pipeline count
-	 *  by 1 and continue. */
+	/* try to append the command to the pipeline. 
+	 * REDIS_ERR reply indicates something bad
+	 * happened, in which case abort. otherwise
+	 * increase our current pipeline count
+	 * by 1 and continue. */
 	int rc;
-    switch(pWrkrData->pData->mode) {
+	switch(pWrkrData->pData->mode) {
 		case OMHIREDIS_MODE_TEMPLATE:
 			rc = redisAppendCommand(pWrkrData->conn, (char*)message);
 			break;
 		case OMHIREDIS_MODE_QUEUE:
-			rc = redisAppendCommand(pWrkrData->conn, "LPUSH %s %s", pWrkrData->pData->key, (char*)message);
+			rc = redisAppendCommand(pWrkrData->conn, "LPUSH %s %s", key, (char*)message);
 			break;
 		case OMHIREDIS_MODE_PUBLISH:
-			rc = redisAppendCommand(pWrkrData->conn, "PUBLISH %s %s", pWrkrData->pData->key, (char*)message);
+			rc = redisAppendCommand(pWrkrData->conn, "PUBLISH %s %s", key, (char*)message);
 			break;
 		default:
 			dbgprintf("omhiredis: mode %d is invalid something is really wrong\n", pWrkrData->pData->mode);
 			ABORT_FINALIZE(RS_RET_ERR);
-    }
+	}
 
 	if (rc == REDIS_ERR) {
 		errmsg.LogError(0, NO_ERRCODE, "omhiredis: %s", pWrkrData->conn->errstr);
@@ -209,65 +212,70 @@ finalize_it:
 	RETiRet;
 }
 
-/*  called when resuming from suspended state.
- *  try to restablish our connection to redis */
+/* called when resuming from suspended state.
+ * try to restablish our connection to redis */
 BEGINtryResume
 CODESTARTtryResume
 	if(pWrkrData->conn == NULL)
 		iRet = initHiredis(pWrkrData, 0);
 ENDtryResume
 
-/*  begin a transaction.
- *  if I decide to use MULTI ... EXEC in the
- *  future, this block should send the
- *  MULTI command to redis. */
+/* begin a transaction.
+ * if I decide to use MULTI ... EXEC in the
+ * future, this block should send the
+ * MULTI command to redis. */
 BEGINbeginTransaction
 CODESTARTbeginTransaction
 	dbgprintf("omhiredis: beginTransaction called\n");
 	pWrkrData->count = 0;
 ENDbeginTransaction
 
-/*  call writeHiredis for this log line,
- *  which appends it as a command to the
- *  current pipeline */
+/* call writeHiredis for this log line,
+ * which appends it as a command to the
+ * current pipeline */
 BEGINdoAction
 CODESTARTdoAction
-	CHKiRet(writeHiredis(ppString[0], pWrkrData));
+	if(pWrkrData->pData->dynaKey) { 
+		CHKiRet(writeHiredis(ppString[1], ppString[0], pWrkrData));
+	}
+	else {
+		CHKiRet(writeHiredis(pWrkrData->pData->key, ppString[0], pWrkrData));
+	}
 	iRet = RS_RET_DEFER_COMMIT;
 finalize_it:
 ENDdoAction
 
-/*  called when we have reached the end of a
- *  batch (queue.dequeuebatchsize).  this
- *  iterates over the replies, putting them
- *  into the pData->replies buffer. we currently
- *  don't really bother to check for errors
- *  which should be fixed */
+/* called when we have reached the end of a
+ * batch (queue.dequeuebatchsize).  this
+ * iterates over the replies, putting them
+ * into the pData->replies buffer. we currently
+ * don't really bother to check for errors
+ * which should be fixed */
 BEGINendTransaction
 CODESTARTendTransaction
 	dbgprintf("omhiredis: endTransaction called\n");
-    redisReply *reply;
+	redisReply *reply;
 	int i;
 	for ( i = 0; i < pWrkrData->count; i++ ) {
 		redisGetReply ( pWrkrData->conn, (void*)&reply);
-        if( pWrkrData->conn->err ){
-            dbgprintf("omhiredis: %s\n", pWrkrData->conn->errstr);
-            closeHiredis(pWrkrData);
-            ABORT_FINALIZE(RS_RET_SUSPENDED);
-        }
-        else {
-            freeReplyObject(reply);
-        }
+		if( pWrkrData->conn->err ){
+			dbgprintf("omhiredis: %s\n", pWrkrData->conn->errstr);
+			closeHiredis(pWrkrData);
+			ABORT_FINALIZE(RS_RET_SUSPENDED);
+		}
+		else {
+			freeReplyObject(reply);
+		}
 	}
 
 finalize_it:
 	RETiRet;
 ENDendTransaction
 
-/*  set defaults. note server is set to NULL 
- *  and is set to a default in initHiredis if 
- *  it is still null when it's called - I should
- *  probable just set the default here instead */
+/* set defaults. note server is set to NULL 
+ * and is set to a default in initHiredis if 
+ * it is still null when it's called - I should
+ * probable just set the default here instead */
 static void
 setInstParamDefaults(instanceData *pData)
 {
@@ -280,13 +288,14 @@ setInstParamDefaults(instanceData *pData)
 	pData->key = NULL;
 }
 
-/*  here is where the work to set up a new instance
- *  is done.  this reads the config options from 
- *  the rsyslog conf and takes appropriate setup
- *  actions. */
+/* here is where the work to set up a new instance
+ * is done.  this reads the config options from 
+ * the rsyslog conf and takes appropriate setup
+ * actions. */
 BEGINnewActInst
 	struct cnfparamvals *pvals;
 	int i;
+	int iNumTpls;
 CODESTARTnewActInst
 	if((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL)
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -294,7 +303,6 @@ CODESTARTnewActInst
 	CHKiRet(createInstance(&pData));
 	setInstParamDefaults(pData);
 
-	CODE_STD_STRING_REQUESTnewActInst(1)
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
@@ -307,6 +315,8 @@ CODESTARTnewActInst
 			pData->serverpassword = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "template")) {
 			pData->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "dynakey")) {
+			pData->dynaKey = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "mode")) {
 			pData->modeDescription = es_str2cstr(pvals[i].val.d.estr, NULL);
 			if (!strcmp(pData->modeDescription, "template")) {
@@ -320,14 +330,14 @@ CODESTARTnewActInst
 				ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 			}
 		} else if(!strcmp(actpblk.descr[i].name, "key")) {
-			pData->key = es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->key = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else {
 			dbgprintf("omhiredis: program error, non-handled "
 				"param '%s'\n", actpblk.descr[i].name);
 		}
 	}
 
-    dbgprintf("omhiredis: checking config sanity\n");
+	dbgprintf("omhiredis: checking config sanity\n");
 
 	/* check config sanity for selected mode */
 	switch(pData->mode) {
@@ -339,9 +349,7 @@ CODESTARTnewActInst
 			}
 			if (pData->tplName == NULL) {
 				dbgprintf("omhiredis: using default RSYSLOG_ForwardFormat template\n");
-				CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)strdup("RSYSLOG_ForwardFormat"), OMSR_NO_RQD_TPL_OPTS));
-			} else {
-				CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)pData->tplName, OMSR_NO_RQD_TPL_OPTS));
+				pData->tplName = (uchar*)"RSYSLOG_ForwardFormat";
 			}
 			break;
 		case OMHIREDIS_MODE_TEMPLATE:
@@ -349,8 +357,20 @@ CODESTARTnewActInst
 				dbgprintf("omhiredis: selected mode requires template\n");
 				ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 			}
-			CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)pData->tplName, OMSR_NO_RQD_TPL_OPTS));
 			break;
+	}
+	
+	iNumTpls = 1;
+
+	if (pData->dynaKey) {
+		iNumTpls = 2;
+	}
+	CODE_STD_STRING_REQUESTnewActInst(iNumTpls);
+
+	CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)pData->tplName, OMSR_NO_RQD_TPL_OPTS));
+
+	if (pData->dynaKey) {
+		CHKiRet(OMSRsetEntry(*ppOMSR, 1, ustrdup(pData->key), OMSR_NO_RQD_TPL_OPTS));
 	}
 
 CODE_STD_FINALIZERnewActInst
@@ -376,8 +396,8 @@ BEGINmodExit
 CODESTARTmodExit
 ENDmodExit
 
-/*  register our plugin entry points
- *  with the rsyslog core engine */
+/* register our plugin entry points
+ * with the rsyslog core engine */
 BEGINqueryEtryPt
 CODESTARTqueryEtryPt
 CODEqueryEtryPt_STD_OMOD_QUERIES
@@ -386,7 +406,7 @@ CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES
 CODEqueryEtryPt_TXIF_OMOD_QUERIES /*  supports transaction interface */ 
 ENDqueryEtryPt
 
-/*  note we do not support rsyslog v5 syntax */
+/* note we do not support rsyslog v5 syntax */
 BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* only supports rsyslog 6 configs */


### PR DESCRIPTION
This PR introduces a new `dynakey` attribute.

If set to `on`, this causes omhiredis to treat the `key` attribute as the name of a template so that you can build a dynamic redis queue name or list key.

Absolutely _no_ warranty of quality or functionality is made here. It took me a while to get the thing to stop throwing Segfaults, so we're a way off production ready.

```
template(name="redis-key" type="list"){
    constant(value="logs-from-")
    property(name="syslogtag")
}


action(
        action.resumeretrycount="-1"
        action.resumeinterval="5"
        queue.maxDiskSpace="1G"
            queue.spoolDirectory="/var/spool/rsyslog"
            queue.filename="plain-docker" 
            queue.size="1000000" 
            queue.type="LinkedList"
            type="omhiredis"
            mode="publish"
        dynakey="on"
            key="redis-key"
            server="localhost"
            template="plain-syslog"
        )
```

```
bob@made-lt051:~|⇒  logger  -p local3.info "hello" -t "world"
bob@made-lt051:~|⇒  logger  -p local3.info "hello" -t "you"  
bob@made-lt051:~|⇒  logger  -p local3.info "hello" -t "badgers"
```

```
1477089483.314670 [0 172.17.0.1:54048] "PUBLISH" "logs-from-world:" "{\"@timestamp\":\"2016-10-21T23:38:03.312192+01:00\",\"host\":\"localhost\",\"severity\":\"info\",\"facility\":\"local3\",\"tag\":\"world:\",\"container\":\"world:\",\"@message\":\" hello\"}"
1477089486.936369 [0 172.17.0.1:54048] "PUBLISH" "logs-from-you:" "{\"@timestamp\":\"2016-10-21T23:38:06.935438+01:00\",\"host\":\"localhost\",\"severity\":\"info\",\"facility\":\"local3\",\"tag\":\"you:\",\"container\":\"you:\",\"@message\":\" hello\"}"
1477089490.932602 [0 172.17.0.1:54048] "PUBLISH" "logs-from-badgers:" "{\"@timestamp\":\"2016-10-21T23:38:10.931619+01:00\",\"host\":\"localhost\",\"severity\":\"info\",\"facility\":\"local3\",\"tag\":\"badgers:\",\"container\":\"badgers:\",\"@message\":\" hello\"}"
```
