### PR TITLE
testbench: add test for empty host name

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -4,6 +4,14 @@ CLEANFILES = \
 # IN_AUTO_DEBUG should be deleted each time make check is run, but
 # there exists no such hook. Se we at least delete it on make clean.
 
+
+pkglib_LTLIBRARIES =
+
+pkglib_LTLIBRARIES += liboverride_gethostname.la
+liboverride_gethostname_la_SOURCES = override_gethostname.c
+liboverride_gethostname_la_CFLAGS =
+liboverride_gethostname_la_LDFLAGS = -avoid-version -shared
+
 # TODO: reenable TESTRUNS = rt_init rscript
 check_PROGRAMS = $(TESTRUNS) ourtail nettester tcpflood chkseq msleep randomgen \
 	diagtalker uxsockrcvr syslog_caller inputfilegen minitcpsrv \
@@ -13,6 +21,7 @@ TESTS = $(TESTRUNS)
 #TESTS = $(TESTRUNS) cfg.sh
 
 TESTS +=  \
+	empty-hostname.sh \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \
 	hostname-with-slash-dflt-invld.sh \
@@ -528,6 +537,7 @@ DISTCLEANFILES=rsyslog.pid
 test_files = testbench.h runtime-dummy.c
 
 EXTRA_DIST= \
+	empty-hostname.sh \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \
 	hostname-with-slash-dflt-invld.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -145,7 +145,7 @@ case $1 in
 		    echo "ERROR: config file '$CONF_FILE' not found!"
 		    exit 1
 		fi
-		$valgrind ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
+		LD_PRELOAD=$RSYSLOG_PRELOAD $valgrind ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
 		. $srcdir/diag.sh wait-startup $3
 		;;
    'startup-silent')   # start rsyslogd with default params. $2 is the config file name to use

--- a/tests/empty-hostname.sh
+++ b/tests/empty-hostname.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+echo ======================================================================
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+action(type="omfile" file="rsyslog.out.log")
+'
+export RSYSLOG_PRELOAD=.libs/liboverride_gethostname.so
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+
+grep " localhost " < rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "expected hostname \"localhost\" not found in logs, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit 1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/faketime_common.sh
+++ b/tests/faketime_common.sh
@@ -36,7 +36,7 @@ rsyslog_testbench_preload_libfaketime() {
         exit 77
     else
         echo "Test passed! Will use '${RSYSLOG_LIBFAKETIME}' library!"
-        export LD_PRELOAD="${RSYSLOG_LIBFAKETIME}"
+        export RSYSLOG_PRELOAD="${RSYSLOG_LIBFAKETIME}"
     fi
 
     # GMT-1 (POSIX TIME) is GMT+1 in "Human Time"

--- a/tests/override_gethostname.c
+++ b/tests/override_gethostname.c
@@ -1,0 +1,18 @@
+//#define _GNU_SOURCE
+//#include <dlfcn.h>
+#include <stdio.h>
+ 
+
+int gethostname(char *name, size_t len)
+{
+	//*name++ = 'i';
+	*name = '\0';
+	return 0;
+}
+ 
+static void __attribute__((constructor))
+my_init(void)
+{
+  printf("loaded\n");
+  //orig_etry = dlsym(RTLD_NEXT, "original_entry_point");
+}


### PR DESCRIPTION
This is a first in a series of tests that mimic specific cases using LD_PRELOAD to override APIs. We still have some issues with the method, and I need to iron them out on the testbench machines.

Note that the new test will fail with a segfault due to #1040 until the fix for this has been merged (which I did not do yet intentionally). This is actually what needs to happen to know the new testbench test (and method) will work.
