### PR TITLE
omelasticsearch: tries to modify constant memory under some circumsta…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,11 @@ matrix:
        env: BUILD_FROM_TARBALL="YES", GROK="YES", KAFKA="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all"
        dist: trusty
      - compiler: "clang"
-       # we run this test without assert() enabled, so that we get "production timing"
-       env: CHECK="YES", ESTEST="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics", CONFIGURE_FLAGS="--disable-debug"
+       env: CHECK="YES", ESTEST="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
      - compiler: "clang"
+       # we run this test without assert() enabled, so that we get "production timing"
        dist: trusty
-       env: AD_PPA="v8-devel", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
+       env: AD_PPA="v8-devel", CHECK="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics", CONFIGURE_FLAGS="--disable-debug"
 
 services:
   - elasticsearch


### PR DESCRIPTION
…nces

Function computeBaseUrl may modify its serverParam parameter, but
this may contain the constant string "localhost". Depending on the
platform, this can lead to a segfault.

Noticed while working on compiler warnings, not seen in practice.

closes https://github.com/rsyslog/rsyslog/issues/1233