### PR TITLE
Removed the use of the deprecated hash function SHA-224.

### DIFF
--- a/runtime/librsksi.c
+++ b/runtime/librsksi.c
@@ -134,8 +134,6 @@ hashOutputLengthOctetsKSI(uint8_t hashID)
 		return 32;
 	case KSI_HASHALG_RIPEMD160: /** The RIPEMD-160 algorithm. */
 		return 20;
-	case KSI_HASHALG_SHA2_224: /** The SHA-224 algorithm. */
-		return 28;
 	case KSI_HASHALG_SHA2_384: /** The SHA-384 algorithm. */
 		return 48;
 	case KSI_HASHALG_SHA2_512: /** The SHA-512 algorithm. */
@@ -164,8 +162,6 @@ hashIdentifierKSI(KSI_HashAlgorithm hashID)
 		return 0x01;
 	case KSI_HASHALG_RIPEMD160: /** The RIPEMD-160 algorithm. */
 		return 0x02;
-	case KSI_HASHALG_SHA2_224: /** The SHA-224 algorithm. */
-		return 0x03;
 	case KSI_HASHALG_SHA2_384: /** The SHA-384 algorithm. */
 		return 0x04;
 	case KSI_HASHALG_SHA2_512: /** The SHA-512 algorithm. */
@@ -194,8 +190,6 @@ hashAlgNameKSI(uint8_t hashID)
 		return "SHA2-256";
 	case KSI_HASHALG_RIPEMD160:
 		return "RIPEMD-160";
-	case KSI_HASHALG_SHA2_224:
-		return "SHA2-224";
 	case KSI_HASHALG_SHA2_384:
 		return "SHA2-384";
 	case KSI_HASHALG_SHA2_512:
@@ -223,8 +217,6 @@ hashID2AlgKSI(uint8_t hashID)
 		return KSI_HASHALG_SHA2_256;
 	case 0x02:
 		return KSI_HASHALG_RIPEMD160;
-	case 0x03:
-		return KSI_HASHALG_SHA2_224;
 	case 0x04:
 		return KSI_HASHALG_SHA2_384;
 	case 0x05:
@@ -803,8 +795,6 @@ rsksiSetHashFunction(rsksictx ctx, char *algName)
 		ctx->hashAlg = KSI_HASHALG_SHA2_256;
 	else if(!strcmp(algName, "RIPEMD-160"))
 		ctx->hashAlg = KSI_HASHALG_RIPEMD160;
-	else if(!strcmp(algName, "SHA2-224"))
-		ctx->hashAlg = KSI_HASHALG_SHA2_224;
 	else if(!strcmp(algName, "SHA2-384"))
 		ctx->hashAlg = KSI_HASHALG_SHA2_384;
 	else if(!strcmp(algName, "SHA2-512"))


### PR DESCRIPTION
The SHA-224 hash algorithm has been removed from the future releases, thus removed the usage of it.