### PR TITLE
Fix an incorrect spelling of `mmgrok`'s README.md

### DIFF
--- a/contrib/mmgrok/README
+++ b/contrib/mmgrok/README
@@ -21,7 +21,7 @@ Example
 
 module(load="mmgrok")
 template(name="tmlp" type="string" string="%$!msg!test%\n")
-action(type="mmgrok" patterndir="path/to/yourpatternsDir" match="%{WORD:test}" soure="msg" target="!msg")
+action(type="mmgrok" patterndir="path/to/yourpatternsDir" match="%{WORD:test}" source="msg" target="!msg")
 action(type="omfile"  file="path/to/file" template="tmlp")
 
 Descrption


### PR DESCRIPTION
This incorrect spelling may confusing people who follows `README.md`'s
instruction.