### PR TITLE
bugfix: abort when persisting object state

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1120,7 +1120,7 @@ static rsRetVal strmCheckNextOutputFile(strm_t *pThis)
 {
 	DEFiRet;
 
-	if(pThis->fd == -1)
+	if(pThis->fd == -1 || pThis->sType != STREAMTYPE_FILE_CIRCULAR)
 		FINALIZE;
 
 	/* wait for output to be empty, so that our counts are correct */


### PR DESCRIPTION
This causes a segfault. It happens whenever an object state larger
than 4095 byte is persisted. Then, incorrectly a try to rollover to
a new state file is tried, which will lead to a division by zero
as the necessary variables for this operation are not set because we
are NOT in circular mode.

This problem can happen wherever state files are written. It has been
experienced with imfile and queue files.

Many thanks to github user mostolog for his help in reproducing the
issue, which was very important to finally nail down this long-standing
bug.

closes https://github.com/rsyslog/rsyslog/issues/1239
closes https://github.com/rsyslog/rsyslog/issues/1162
closes https://github.com/rsyslog/rsyslog/issues/1074