### PR TITLE
Improve KSI signing of the logs

### DIFF
--- a/runtime/librsksi.h
+++ b/runtime/librsksi.h
@@ -146,6 +146,7 @@ struct rsksistatefile {
 #define RSGTE_EXTRACT_HASH 23 /* error extracting hashes for record */
 #define RSGTE_CONFIG_ERROR 24 /* Configuration error */
 #define RSGTE_NETWORK_ERROR 25 /* Network error */
+#define RSGTE_MISS_KSISIG 26 /* KSI signature missing */
 
 const char * RSKSIE2String(int err);
 uint16_t hashOutputLengthOctetsKSI(uint8_t hashID);

--- a/runtime/librsksi.h
+++ b/runtime/librsksi.h
@@ -43,6 +43,7 @@ struct rsksictx_s {
 	uint64_t blockSizeLimit;
 	char *timestamper;
 	void (*errFunc)(void *, unsigned char*);
+	void (*logFunc)(void *, unsigned char*);
 	void *usrptr; /* for error function */
 };
 typedef struct rsksictx_s *rsksictx;
@@ -165,7 +166,8 @@ int rsksiInit(char *usragent);
 void rsksiExit(void);
 rsksictx rsksiCtxNew(void);
 void rsksisetErrFunc(rsksictx ctx, void (*func)(void*, unsigned char *), void *usrptr);
-void reportKSIAPIErr(rsksictx ctx, ksifile ksi, const char *apiname, int ecode); 
+void rsksisetLogFunc(rsksictx ctx, void (*func)(void*, unsigned char *), void *usrptr);
+void reportKSIAPIErr(rsksictx ctx, ksifile ksi, const char *apiname, int ecode);
 ksifile rsksiCtxOpenFile(rsksictx ctx, unsigned char *logfn);
 int rsksifileDestruct(ksifile ksi);
 void rsksiCtxDel(rsksictx ctx);

--- a/runtime/librsksi_read.c
+++ b/runtime/librsksi_read.c
@@ -2028,10 +2028,13 @@ rsksi_extendSig(KSI_Signature *sig, ksifile ksi, tlvrecord_t *rec, ksierrctx_t *
 {
 	KSI_Signature *extended = NULL;
 	uint8_t *der = NULL;
-	size_t lenDer;
+	size_t lenDer = 0;
 	int r, rgt;
 	tlvrecord_t newrec, subrec;
 	uint16_t iRd, iWr;
+
+	if(sig==NULL)
+		goto skip_extention;
 
 	/* Extend Signature now using KSI API*/
 	rgt = KSI_extendSignature(ksi->ctx->ksi_ctx, sig, &extended);
@@ -2049,28 +2052,24 @@ rsksi_extendSig(KSI_Signature *sig, ksifile ksi, tlvrecord_t *rec, ksierrctx_t *
 		goto done;
 	}
 
+skip_extention:
+
 	/* update block_sig tlv record with new extended timestamp */
 	/* we now need to copy all tlv records before the actual der
 	 * encoded part.
 	 */
 	iRd = iWr = 0;
-	// TODO; check tlvtypes at comment places below!
 	CHKr(rsksi_tlvDecodeSUBREC(rec, &iRd, &subrec)); 
-	/* HASH_ALGO */
+	/* REC_NUM */
+	if(subrec.tlvtype!=0x01) {
+		r=RSGTE_INVLTYP;
+		goto done;
+	}
 	COPY_SUBREC_TO_NEWREC
-	CHKr(rsksi_tlvDecodeSUBREC(rec, &iRd, &subrec));
-	/* BLOCK_IV */
-	COPY_SUBREC_TO_NEWREC
-	CHKr(rsksi_tlvDecodeSUBREC(rec, &iRd, &subrec));
-	/* LAST_HASH */
-	COPY_SUBREC_TO_NEWREC
-	CHKr(rsksi_tlvDecodeSUBREC(rec, &iRd, &subrec));
-	/* REC_COUNT */
-	COPY_SUBREC_TO_NEWREC
-	CHKr(rsksi_tlvDecodeSUBREC(rec, &iRd, &subrec));
+
 	/* actual sig! */
 	newrec.data[iWr++] = 0x09 | RSKSI_FLAG_TLV16_RUNTIME;
-	newrec.data[iWr++] = 0x06;
+	newrec.data[iWr++] = 0x05;
 	newrec.data[iWr++] = (lenDer >> 8) & 0xff;
 	newrec.data[iWr++] = lenDer & 0xff;
 	/* now we know how large the new main record is */
@@ -2162,7 +2161,7 @@ verifyBLOCK_SIGKSI(block_sig_t *bs, ksifile ksi, FILE *sigfp, FILE *nsigfp,
 		if(rsksi_read_debug) printf("debug: verifyBLOCK_SIGKSI:\t\t KSI_Signature_verify failed with error: %s (%d)\n", KSI_getErrorString(ksistate), ksistate); 
 		r = RSGTE_INVLD_SIGNATURE;
 		ectx->ksistate = ksistate;
-		goto done;
+		goto skip_ksi;
 	} else {
 		if(rsksi_read_debug) printf("debug: verifyBLOCK_SIGKSI:\t\t KSI_Signature_verify was successfull\n"); 
 	}
@@ -2179,6 +2178,8 @@ verifyBLOCK_SIGKSI(block_sig_t *bs, ksifile ksi, FILE *sigfp, FILE *nsigfp,
 	if(rsksi_read_debug) printf("debug: verifyBLOCK_SIGKSI:\t\t processed without error's\n"); 
 	if(rsksi_read_showVerified)
 		reportVerifySuccess(ectx);
+
+skip_ksi:
 	if(bExtend)
 		if((r = rsksi_extendSig(sig, ksi, &rec, ectx)) != 0) goto done;
 

--- a/runtime/lmsig_ksi.c
+++ b/runtime/lmsig_ksi.c
@@ -65,11 +65,20 @@ errfunc(__attribute__((unused)) void *usrptr, uchar *emsg)
 		"Error: %s", emsg);
 }
 
+static void
+logfunc(__attribute__((unused)) void *usrptr, uchar *emsg)
+{
+	errmsg.LogMsg(0, RS_RET_NO_ERRCODE, LOG_INFO,
+		"KSI Signature Provider: %s", emsg);
+}
+
+
 /* Standard-Constructor
  */
 BEGINobjConstruct(lmsig_ksi)
 	pThis->ctx = rsksiCtxNew();
 	rsksisetErrFunc(pThis->ctx, errfunc, NULL);
+	rsksisetLogFunc(pThis->ctx, logfunc, NULL);
 ENDobjConstruct(lmsig_ksi)
 
 

--- a/runtime/lmsig_ksi.c
+++ b/runtime/lmsig_ksi.c
@@ -62,7 +62,7 @@ static void
 errfunc(__attribute__((unused)) void *usrptr, uchar *emsg)
 {
 	errmsg.LogError(0, RS_RET_SIGPROV_ERR, "KSI Signature Provider"
-		"Error: %s - disabling signatures", emsg);
+		"Error: %s", emsg);
 }
 
 /* Standard-Constructor

--- a/tools/rsgtutil.c
+++ b/tools/rsgtutil.c
@@ -769,6 +769,11 @@ verifyKSI(const char *name, char *errbuf, char *sigfname, char *oldsigfname, cha
 		goto done;
 	}
 
+	if(debug) {
+		KSI_CTX_setLoggerCallback(ksi->ctx->ksi_ctx, KSI_LOG_StreamLogger, stdout);
+		KSI_CTX_setLogLevel(ksi->ctx->ksi_ctx, KSI_LOG_DEBUG);
+	}
+
 	/* Check if we have a logsignature file */
 	if((r = rsksi_chkFileHdr(sigfp, (char*)"LOGSIG11", 0)) == 0) {
 		/* Verify Log signature */
@@ -820,7 +825,7 @@ verifyKSI(const char *name, char *errbuf, char *sigfname, char *oldsigfname, cha
 					r = RSGTE_SUCCESS;
 				}
 				else if(r != RSGTE_SUCCESS) {
-					//fprintf(stderr, "extractKSI:\t\t\t error %d while verifiying BLOCK signature for logline (%d): '%.64s...'\n", r, iLineCurrent, lineRec);
+					fprintf(stderr, "extractKSI:\t\t\t error %d while verifiying BLOCK signature for logline (%d): '%.64s...'\n", r, iLineCurrent, lineRec);
 					goto done;
 				}
 				bInBlock = 0;
@@ -1167,6 +1172,11 @@ extractKSI(const char *name, char *errbuf, char *sigfname, FILE *logfp, FILE *si
 		if (debug) printf("debug: extractKSI:\t\t\t error initializing signature file structures\n");
 		r = RSGTE_IO;
 		goto done;
+	}
+
+	if(debug) {
+		KSI_CTX_setLoggerCallback(ksi->ctx->ksi_ctx, KSI_LOG_StreamLogger, stdout);
+		KSI_CTX_setLogLevel(ksi->ctx->ksi_ctx, KSI_LOG_DEBUG);
 	}
 
 	/* Start extracting process */

--- a/tools/rsgtutil.c
+++ b/tools/rsgtutil.c
@@ -821,11 +821,11 @@ verifyKSI(const char *name, char *errbuf, char *sigfname, char *oldsigfname, cha
 				/* And Verify Block signature */
 				r = verifyBLOCK_SIGKSI(bs, ksi, sigfp, nsigfp, (mode == MD_EXTEND) ? 1 : 0, NULL, &ectx);
 				if(r == RSGTE_MISS_KSISIG) {
-					fprintf(stderr, "\tWARNING: missing KSI signature in block %lu\n", ectx.blkNum);
+					fprintf(stderr, "verifyKSI:\t\t\t WARNING: missing KSI signature in block %lu\n", ectx.blkNum);
 					r = RSGTE_SUCCESS;
 				}
 				else if(r != RSGTE_SUCCESS) {
-					fprintf(stderr, "extractKSI:\t\t\t error %d while verifiying BLOCK signature for logline (%d): '%.64s...'\n", r, iLineCurrent, lineRec);
+					fprintf(stderr, "verifyKSI:\t\t\t error %d while verifiying BLOCK signature in block %lu\n", ectx.blkNum);
 					goto done;
 				}
 				bInBlock = 0;

--- a/tools/rsgtutil.c
+++ b/tools/rsgtutil.c
@@ -814,8 +814,15 @@ verifyKSI(const char *name, char *errbuf, char *sigfname, char *oldsigfname, cha
 				goto done;
 			if(ectx.recNum == bs->recCount) {
 				/* And Verify Block signature */
-				if((r = verifyBLOCK_SIGKSI(bs, ksi, sigfp, nsigfp, (mode == MD_EXTEND) ? 1 : 0, NULL, &ectx)) != 0)
+				r = verifyBLOCK_SIGKSI(bs, ksi, sigfp, nsigfp, (mode == MD_EXTEND) ? 1 : 0, NULL, &ectx);
+				if(r == RSGTE_MISS_KSISIG) {
+					fprintf(stderr, "\tWARNING: missing KSI signature in block %lu\n", ectx.blkNum);
+					r = RSGTE_SUCCESS;
+				}
+				else if(r != RSGTE_SUCCESS) {
+					//fprintf(stderr, "extractKSI:\t\t\t error %d while verifiying BLOCK signature for logline (%d): '%.64s...'\n", r, iLineCurrent, lineRec);
 					goto done;
+				}
 				bInBlock = 0;
 			} else	bInBlock = 1;
 		}
@@ -1366,7 +1373,12 @@ if (debug) printf("debug: extractKSI:\t\t\t line '%d': %.64s...\n", iLineCurrent
 				}
 
 				/* Verify Block signature */
-				if((r = verifyBLOCK_SIGKSI(bs, ksi, sigfp, NULL, 0, ksiRootHash, &ectx)) != RSGTE_SUCCESS) {
+				r = verifyBLOCK_SIGKSI(bs, ksi, sigfp, NULL, 0, ksiRootHash, &ectx);
+				if(r == RSGTE_MISS_KSISIG) {
+					fprintf(stderr, "\tWARNING: missing KSI signature in block %lu\n", ectx.blkNum);
+					r = RSGTE_SUCCESS;
+				}
+				else if(r != RSGTE_SUCCESS) {
 					fprintf(stderr, "extractKSI:\t\t\t error %d while verifiying BLOCK signature for logline (%d): '%.64s...'\n", r, iLineCurrent, lineRec);
 					goto done;
 				}


### PR DESCRIPTION
The following improvements/bugfixes were introduced:

- In case requesting the KSI signing is unsuccessful (no access to gateway, incorrect credentials, etc.) the server will not give up and continue the  log signing. The block are still useful even if lack KSI signature. 
- Added log messages for KSI signing events. 
- Fixed extending of the KSI signature in rsgtutil, added support for new (KSI) signature format and added warning in case the signature is missing. 

Some fixes were also introduced to libksi and this patch should be merged together with the latest patch to libksi (to be sent separately). 

Tested manually.