### PR TITLE
testbench: fix empty-hostname.sh test & change support for empty host…

### DIFF
--- a/tests/empty-hostname.sh
+++ b/tests/empty-hostname.sh
@@ -11,9 +11,9 @@ export RSYSLOG_PRELOAD=.libs/liboverride_gethostname.so
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
 
-grep " localhost " < rsyslog.out.log
+grep " localhost-empty-hostname " < rsyslog.out.log
 if [ ! $? -eq 0 ]; then
-  echo "expected hostname \"localhost\" not found in logs, rsyslog.out.log is:"
+  echo "expected hostname \"localhost-empty-hostname\" not found in logs, rsyslog.out.log is:"
   cat rsyslog.out.log
   . $srcdir/diag.sh error-exit 1
 fi;


### PR DESCRIPTION
…name

If gethostname() returned "", we used "localhost" as mock-up hostname.
However, this caused problems depending on how the local system name was
actually configured.

We have changed the mock.up hostname to "localhost-empty-hostname" now
to clearly indicate the problem. Not only as a side effect, this also
fixes obtaining a different hostname.

closes https://github.com/rsyslog/rsyslog/issues/1268