### PR TITLE
Race condition in wtp

### DIFF
--- a/runtime/wtp.h
+++ b/runtime/wtp.h
@@ -50,6 +50,7 @@ struct wtp_s {
 	rsRetVal (*pConsumer)(void *); /* user-supplied consumer function for dewtpd messages */
 	/* synchronization variables */
 	pthread_mutex_t mutWtp; /* mutex for the wtp's thread management */
+	pthread_cond_t condThrdInitDone; /* signalled when a new thread is ready for work */
 	pthread_cond_t condThrdTrm;/* signalled when threads terminate */
 	/* end sync variables */
 	/* user objects */


### PR DESCRIPTION
The shutdown sequence in wtp relies for its operation on signals and cancelation cleanup handlers. Previously, trying to shutdown a thread that has not yet been properly initialized could lead to a deadlock. This change makes wtpStartWrkr() synchronous in regard to the initialization of the newly created thread.

This issue extends an older one here: #966 