### PR TITLE
Fixing issue #1267: allow lmsig_ksi to configure file persmissions

### DIFF
--- a/runtime/librsksi.h
+++ b/runtime/librsksi.h
@@ -38,6 +38,12 @@ struct rsksictx_s {
 	uint8_t bKeepRecordHashes;
 	uint8_t bKeepTreeHashes;
 	uint64_t blockSizeLimit;
+	uid_t	fileUID;	/* IDs for creation */
+	uid_t	dirUID;
+	gid_t	fileGID;
+	gid_t	dirGID;
+	int fCreateMode; /* mode to use when creating files */
+	int fDirCreateMode; /* mode to use when creating files */
 	char *timestamper;
 	void (*errFunc)(void *, unsigned char*);
 	void (*logFunc)(void *, unsigned char*);
@@ -156,6 +162,14 @@ KSI_HashAlgorithm hashID2AlgKSI(uint8_t hashID);
 #define rsksiSetBlockSizeLimit(ctx, limit) ((ctx)->blockSizeLimit = limit)
 #define rsksiSetKeepRecordHashes(ctx, val) ((ctx)->bKeepRecordHashes = val)
 #define rsksiSetKeepTreeHashes(ctx, val) ((ctx)->bKeepTreeHashes = val)
+#define rsksiSetFileUID(ctx, val) ((ctx)->fileUID = val)	/* IDs for creation */
+#define rsksiSetDirUID(ctx, val) ((ctx)->dirUID = val)
+#define rsksiSetFileGID(ctx, val) ((ctx)->fileGID= val)
+#define rsksiSetDirGID(ctx, val) ((ctx)->dirGID = val)
+#define rsksiSetCreateMode(ctx, val) ((ctx)->fCreateMode= val)
+#define rsksiSetDirCreateMode(ctx, val) ((ctx)->fDirCreateMode = val)
+
+
 
 int rsksiSetAggregator(rsksictx ctx, char *uri, char *loginid, char *key);
 int rsksiSetHashFunction(rsksictx ctx, char *algName);

--- a/runtime/lmsig_ksi.c
+++ b/runtime/lmsig_ksi.c
@@ -49,7 +49,17 @@ static struct cnfparamdescr cnfpdescr[] = {
 	{ "sig.aggregator.key", eCmdHdlrGetWord, CNFPARAM_REQUIRED },
 	{ "sig.block.sizelimit", eCmdHdlrSize, 0 },
 	{ "sig.keeprecordhashes", eCmdHdlrBinary, 0 },
-	{ "sig.keeptreehashes", eCmdHdlrBinary, 0 }
+	{ "sig.keeptreehashes", eCmdHdlrBinary, 0 },
+	{ "dirowner", eCmdHdlrUID, 0 }, /* legacy: dirowner */
+	{ "dirownernum", eCmdHdlrInt, 0 }, /* legacy: dirownernum */
+	{ "dirgroup", eCmdHdlrGID, 0 }, /* legacy: dirgroup */
+	{ "dirgroupnum", eCmdHdlrInt, 0 }, /* legacy: dirgroupnum */
+	{ "fileowner", eCmdHdlrUID, 0 }, /* legacy: fileowner */
+	{ "fileownernum", eCmdHdlrInt, 0 }, /* legacy: fileownernum */
+	{ "filegroup", eCmdHdlrGID, 0 }, /* legacy: filegroup */
+	{ "filegroupnum", eCmdHdlrInt, 0 }, /* legacy: filegroupnum */
+	{ "dircreatemode", eCmdHdlrFileCreateMode, 0 }, /* legacy: dircreatemode */
+	{ "filecreatemode", eCmdHdlrFileCreateMode, 0 } /* legacy: filecreatemode */
 };
 static struct cnfparamblk pblk =
 	{ CNFPARAMBLK_VERSION,
@@ -137,6 +147,26 @@ SetCnfParam(void *pT, struct nvlst *lst)
 			rsksiSetKeepRecordHashes(pThis->ctx, pvals[i].val.d.n);
 		} else if(!strcmp(pblk.descr[i].name, "sig.keeptreehashes")) {
 			rsksiSetKeepTreeHashes(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "dirowner")) {
+			rsksiSetDirUID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "dirownernum")) {
+			rsksiSetDirUID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "dirgroup")) {
+			rsksiSetDirGID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "dirgroupnum")) {
+			rsksiSetDirGID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "fileowner")) {
+			rsksiSetFileUID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "fileownernum")) {
+			rsksiSetFileUID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "filegroup")) {
+			rsksiSetFileGID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "filegroupnum")) {
+			rsksiSetFileGID(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "dircreatemode")) {
+			rsksiSetDirCreateMode(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "filecreatemode")) {
+			rsksiSetCreateMode(pThis->ctx, pvals[i].val.d.n);
 		} else {
 			DBGPRINTF("lmsig_ksi: program error, non-handled "
 			  "param '%s'\n", pblk.descr[i].name);


### PR DESCRIPTION
Enabling lmsig_ksi module to use the same file permissions as omfile. Tested manually. 