### PR TITLE
Imuxsock segfault when stopping rsyslog service

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -1507,6 +1507,11 @@ BEGINafterRun
 	int i;
 CODESTARTafterRun
 	/* do cleanup here */
+        if(startIndexUxLocalSockets == 1 && nfd == 1) {
+                /* No sockets were configured, no cleanup needed. */
+                return RS_RET_OK;
+        }
+
 	/* Close the UNIX sockets. */
        for (i = 0; i < nfd; i++)
 		if (listeners[i].fd != -1)


### PR DESCRIPTION
When imjournal and imuxsock modules are loaded, $OmitLocalLogging is on and the rsyslog service is being stopped, imuxsock wants to close socket on index 0 which leads to segfault in rsyslog and the service stopping ends with failure.