### PR TITLE
testbench: ease testbench debugging by outputting generated conf

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -141,6 +141,8 @@ case $1 in
    		# returns only after successful startup, $3 is the instance (blank or 2!)
 		if [ "x$2" == "x" ]; then
 		    CONF_FILE="testconf.conf"
+		    echo $CONF_FILE is:
+		    cat -n $CONF_FILE
 		else
 		    CONF_FILE="$srcdir/testsuites/$2"
 		fi
@@ -164,6 +166,8 @@ case $1 in
    		# returns only after successful startup, $3 is the instance (blank or 2!)
 		if [ "x$2" == "x" ]; then
 		    CONF_FILE="testconf.conf"
+		    echo $CONF_FILE is:
+		    cat -n $CONF_FILE
 		else
 		    CONF_FILE="$srcdir/testsuites/$2"
 		fi


### PR DESCRIPTION
most importantly, include line numbers, so that rsyslog startup
error messages can be traced to the right line. Due to the framework,
the line number info is otherwise not visible.