### PR TITLE
core: fix bug in module-template macros

### DIFF
--- a/runtime/module-template.h
+++ b/runtime/module-template.h
@@ -385,7 +385,8 @@ finalize_it:\
  */
 #define BEGINnewActInst \
 static rsRetVal newActInst(uchar __attribute__((unused)) *modName, \
-	struct nvlst *lst, void **ppModData, omodStringRequest_t **ppOMSR)\
+	struct nvlst __attribute__((unused)) *lst, void **ppModData, \
+	omodStringRequest_t **ppOMSR)\
 {\
 	DEFiRet;\
 	instanceData *pData = NULL; \


### PR DESCRIPTION
If an om,mm module has no parameters, a macro function parameter is
unused and triggers compile warning (and thus error on -Werror).

closes https://github.com/rsyslog/rsyslog/issues/1293