### PR TITLE
add option "parser.PermitSlashInProgramname"

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -7,7 +7,7 @@
  *
  * Module begun 2008-04-16 by Rainer Gerhards
  *
- * Copyright 2008-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2017 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -119,6 +119,7 @@ int glblReportGoneAwaySenders = 0;
 int glblSenderStatsTimeout = 12 * 60 * 60; /* 12 hr timeout for senders */
 int glblSenderKeepTrack = 0;  /* keep track of known senders? */
 int glblUnloadModules = 1;
+int bPermitSlashInProgramname = 0;
 
 pid_t glbl_ourpid;
 #ifndef HAVE_ATOMIC_BUILTINS
@@ -157,6 +158,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "parser.escapecontrolcharactertab", eCmdHdlrBinary, 0},
 	{ "parser.escapecontrolcharacterscstyle", eCmdHdlrBinary, 0 },
 	{ "parser.parsehostnameandtag", eCmdHdlrBinary, 0 },
+	{ "parser.permitslashinprogramname", eCmdHdlrBinary, 0 },
 	{ "stdlog.channelspec", eCmdHdlrString, 0 },
 	{ "janitor.interval", eCmdHdlrPositiveInt, 0 },
 	{ "senders.reportnew", eCmdHdlrBinary, 0 },
@@ -1142,6 +1144,8 @@ glblDoneLoadCnf(void)
 			bParserEscapeCCCStyle = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "parser.parsehostnameandtag")) {
 			bParseHOSTNAMEandTAG = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "parser.permitslashinprogramname")) {
+			bPermitSlashInProgramname = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "debug.logfile")) {
 			if(pszAltDbgFileName == NULL) {
 				pszAltDbgFileName = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -8,7 +8,7 @@
  * Please note that there currently is no glbl.c file as we do not yet
  * have any implementations.
  *
- * Copyright 2008-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2017 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -41,6 +41,7 @@
 
 extern pid_t glbl_ourpid;
 extern int bProcessInternalMessages;
+extern int bPermitSlashInProgramname;
 #ifdef HAVE_LIBLOGGING_STDLOG
 extern stdlog_channel_t stdlog_hdl;
 #endif

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1517,7 +1517,8 @@ aquireProgramName(smsg_t * const pM)
 	for(  i = 0
 	    ; (i < pM->iLenTAG) && isprint((int) pszTag[i])
 	      && (pszTag[i] != '\0') && (pszTag[i] != ':')
-	      && (pszTag[i] != '[')  && (pszTag[i] != '/')
+	      && (pszTag[i] != '[')
+	      && (bPermitSlashInProgramname || (pszTag[i] != '/'))
 	    ; ++i)
 		; /* just search end of PROGNAME */
 	if(i < CONF_PROGNAME_BUFSIZE) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -22,6 +22,8 @@ TESTS = $(TESTRUNS)
 
 TESTS +=  \
 	empty-hostname.sh \
+	prop-programname.sh \
+	prop-programname-with-slashes.sh \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \
 	hostname-with-slash-dflt-invld.sh \
@@ -757,6 +759,8 @@ EXTRA_DIST= \
 	prop-all-json-concurrency.sh \
 	testsuites/prop-all-json-concurrency.conf \
 	global_vars.sh \
+	prop-programname.sh \
+	prop-programname-with-slashes.sh \
 	testsuites/global_vars.conf \
 	rfc5424parser.sh \
 	testsuites/rfc5424parser.conf \

--- a/tests/prop-programname-with-slashes.sh
+++ b/tests/prop-programname-with-slashes.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# addd 2017-01142 by RGerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+global(parser.PermitSlashInProgramname="on")
+
+template(name="outfmt" type="string" string="%syslogtag%,%programname%\n")
+local0.* action(type="omfile" template="outfmt"
+	        file="rsyslog.out.log")
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m 1 -M "\"<133>2011-03-01T11:22:12Z host tag/with/slashes msgh ...x\""
+. $srcdir/diag.sh tcpflood -m1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+echo "tag/with/slashes,tag/with/slashes" | cmp rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid output generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit 1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/prop-programname.sh
+++ b/tests/prop-programname.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# addd 2017-01142 by RGerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+template(name="outfmt" type="string" string="%syslogtag%,%programname%\n")
+local0.* action(type="omfile" template="outfmt"
+	        file="rsyslog.out.log")
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m 1 -M "\"<133>2011-03-01T11:22:12Z host tag/with/slashes msgh ...x\""
+. $srcdir/diag.sh tcpflood -m1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+echo "tag/with/slashes,tag" | cmp rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid output generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit 1
+fi;
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
The new option permits to have slashes inside the programname
property. This is counter the BSD syslog defintitions, but
sometimes useful (e.g. the journal records path names, which
obviously contain slashes).

closes https://github.com/rsyslog/rsyslog/issues/1365
see also https://github.com/rsyslog/rsyslog/issues/1361