### PR TITLE
For ratelimit checking, added check for time going backwards.

### DIFF
--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -156,8 +156,8 @@ withinRatelimit(ratelimit_t *ratelimit, time_t tt)
 	if(ratelimit->begin == 0)
 		ratelimit->begin = tt;
 
-	/* resume if we go out of time window */
-	if(tt > ratelimit->begin + ratelimit->interval) {
+	/* resume if we go out of time window or if time has gone backwards */
+	if((tt > ratelimit->begin + ratelimit->interval) || (tt < ratelimit->begin) ) {
 		ratelimit->begin = 0;
 		ratelimit->done = 0;
 		tellLostCnt(ratelimit);


### PR DESCRIPTION
Fixes  #1354 . For ratelimit checking, added check for time going backwards. If time goes backwards, then ratelimit begin and done values must be set to zero