### PR TITLE
Imfile multilevelwildcard

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -563,7 +563,8 @@ TESTS += \
 	imfile-persist-state-1.sh \
 	imfile-wildcards.sh \
 	imfile-wildcards-dirs.sh \
-	imfile-wildcards-dirs2.sh
+	imfile-wildcards-dirs2.sh \
+	imfile-wildcards-dirs-multi.sh
 if HAVE_VALGRIND
 TESTS += \
 	imfile-basic-vg.sh \
@@ -1120,6 +1121,7 @@ EXTRA_DIST= \
 	testsuites/imfile-wildcards.conf \
 	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \
+	imfile-wildcards-dirs-multi.sh \
 	testsuites/imfile-wildcards-dirs.conf \
 	dynfile_invld_async.sh \
 	dynfile_invld_sync.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1118,11 +1118,12 @@ EXTRA_DIST= \
 	imfile-persist-state-1.sh \
 	imfile-truncate.sh \
 	imfile-wildcards.sh \
-	testsuites/imfile-wildcards.conf \
 	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \
 	imfile-wildcards-dirs-multi.sh \
+	testsuites/imfile-wildcards.conf \
 	testsuites/imfile-wildcards-dirs.conf \
+	testsuites/imfile-wildcards-dirs-multi.conf \
 	dynfile_invld_async.sh \
 	dynfile_invld_sync.sh \
 	dynfile_cachemiss.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -560,7 +560,10 @@ TESTS += \
 	imfile-endregex-timeout-polling.sh \
 	imfile-endregex-timeout.sh \
 	imfile-endregex-timeout-none.sh \
-	imfile-persist-state-1.sh
+	imfile-persist-state-1.sh \
+	imfile-wildcards.sh \
+	imfile-wildcards-dirs.sh \
+	imfile-wildcards-dirs2.sh
 if HAVE_VALGRIND
 TESTS += \
 	imfile-basic-vg.sh \
@@ -1113,6 +1116,11 @@ EXTRA_DIST= \
 	imfile-endregex-timeout-none.sh \
 	imfile-persist-state-1.sh \
 	imfile-truncate.sh \
+	imfile-wildcards.sh \
+	testsuites/imfile-wildcards.conf \
+	imfile-wildcards-dirs.sh \
+	imfile-wildcards-dirs2.sh \
+	testsuites/imfile-wildcards-dirs.conf \
 	dynfile_invld_async.sh \
 	dynfile_invld_sync.sh \
 	dynfile_cachemiss.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -71,7 +71,8 @@ case $1 in
 		rm -f work rsyslog.out.log rsyslog2.out.log rsyslog.out.log.save # common work files
 		rm -rf test-spool test-logdir stat-file1
 		rm -f rsyslog.out.*.log work-presort rsyslog.pipe
-		rm -f rsyslog.input rsyslog.empty
+		rm -f -r rsyslog.input.*
+		rm -f rsyslog.input rsyslog.empty rsyslog.input.* imfile-state*
 		rm -f testconf.conf HOSTNAME
 		rm -f rsyslog.errorfile tmp.qi
 		rm -f core.* vgcore.*
@@ -116,7 +117,8 @@ case $1 in
 		rm -f work rsyslog.out.log rsyslog2.out.log rsyslog.out.log.save # common work files
 		rm -rf test-spool test-logdir stat-file1
 		rm -f rsyslog.out.*.log rsyslog.random.data work-presort rsyslog.pipe
-		rm -f rsyslog.input rsyslog.conf.tlscert stat-file1 rsyslog.empty
+		rm -f -r rsyslog.input.*
+		rm -f rsyslog.input rsyslog.conf.tlscert stat-file1 rsyslog.empty rsyslog.input.* imfile-state*
 		rm -f testconf.conf
 		rm -f rsyslog.errorfile tmp.qi
 		rm -f HOSTNAME imfile-state:.-rsyslog.input
@@ -414,9 +416,11 @@ case $1 in
 		fi
 		;;
    'content-check-with-count') 
-		count=$(cat rsyslog.out.log | grep -qF "$2" | wc -l)
+		count=$(cat rsyslog.out.log | grep -F "$2" | wc -l)
 		if [ "x$count" == "x$3" ]; then
-		    echo content-check failed, expected $2 to occure $3 times, but found it $count times
+		    echo content-check-with-count success, \"$2\" occured $3 times
+		else
+		    echo content-check-with-count failed, expected \"$2\" to occure $3 times, but found it $count times
 		    . $srcdir/diag.sh error-exit 1
 		fi
 		;;

--- a/tests/imfile-wildcards-dirs-multi.sh
+++ b/tests/imfile-wildcards-dirs-multi.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under GPLv3
+echo [imfile-wildcards-dirs2.sh]
+
+export IMFILEINPUTFILES="10"
+export IMFILEINPUTFILESSTEPS="5"
+export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
+
+. $srcdir/diag.sh init
+# generate input files first. Note that rsyslog processes it as
+# soon as it start up (so the file should exist at that point).
+
+# Start rsyslog now before adding more files
+. $srcdir/diag.sh startup imfile-wildcards-dirs.conf
+# sleep a little to give rsyslog a chance to begin processing
+sleep 1
+
+for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
+do
+	echo "Loop Num $j"
+
+	for i in `seq 1 $IMFILEINPUTFILES`;
+	do
+		mkdir rsyslog.input.dir$i
+		mkdir rsyslog.input.dir$i/dir$i
+		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$i/file.logfile
+	done
+	ls -d rsyslog.input.*
+
+	# Delete all but first!
+	for i in `seq 1 $IMFILEINPUTFILES`;
+	do
+		rm -r rsyslog.input.dir$i
+	done
+done
+
+# sleep a little to give rsyslog a chance for processing
+sleep 1
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL
+. $srcdir/diag.sh exit

--- a/tests/imfile-wildcards-dirs-multi.sh
+++ b/tests/imfile-wildcards-dirs-multi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-echo [imfile-wildcards-dirs2.sh]
+echo [imfile-wildcards-multi.sh]
 
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"
@@ -11,7 +11,7 @@ export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 # soon as it start up (so the file should exist at that point).
 
 # Start rsyslog now before adding more files
-. $srcdir/diag.sh startup imfile-wildcards-dirs.conf
+. $srcdir/diag.sh startup imfile-wildcards-dirs-multi.conf
 # sleep a little to give rsyslog a chance to begin processing
 sleep 1
 
@@ -22,7 +22,9 @@ do
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		mkdir rsyslog.input.dir$i
+		./msleep 25
 		mkdir rsyslog.input.dir$i/dir$i
+		./msleep 25
 		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$i/file.logfile
 	done
 	ls -d rsyslog.input.*

--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under GPLv3
+echo [imfile-wildcards-dirs.sh]
+
+export IMFILEINPUTFILES="10"
+
+. $srcdir/diag.sh init
+# generate input files first. Note that rsyslog processes it as
+# soon as it start up (so the file should exist at that point).
+imfiledirbefore="rsyslog.input.dir1"
+
+# Create first dir and file
+mkdir $imfiledirbefore
+./inputfilegen -m 1 > $imfiledirbefore/file.log
+
+# Start rsyslog now before adding more files
+. $srcdir/diag.sh startup imfile-wildcards-dirs.conf
+# sleep a little to give rsyslog a chance to begin processing
+sleep 1
+
+for i in `seq 2 $IMFILEINPUTFILES`;
+do
+	cp -r $imfiledirbefore rsyslog.input.dir$i
+	imfiledirbefore="rsyslog.input.dir$i"
+done
+ls -d rsyslog.input.*
+
+# sleep a little to give rsyslog a chance for processing
+sleep 1
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILES
+. $srcdir/diag.sh exit

--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -16,6 +16,7 @@ sleep 1
 for i in `seq 1 $IMFILEINPUTFILES`;
 do
 	mkdir rsyslog.input.dir$i
+	./msleep 50
 	./inputfilegen -m 1 > rsyslog.input.dir$i/file.logfile
 done
 ls -d rsyslog.input.*

--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -7,21 +7,16 @@ export IMFILEINPUTFILES="10"
 . $srcdir/diag.sh init
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
-imfiledirbefore="rsyslog.input.dir1"
-
-# Create first dir and file
-mkdir $imfiledirbefore
-./inputfilegen -m 1 > $imfiledirbefore/file.log
 
 # Start rsyslog now before adding more files
 . $srcdir/diag.sh startup imfile-wildcards-dirs.conf
 # sleep a little to give rsyslog a chance to begin processing
 sleep 1
 
-for i in `seq 2 $IMFILEINPUTFILES`;
+for i in `seq 1 $IMFILEINPUTFILES`;
 do
-	cp -r $imfiledirbefore rsyslog.input.dir$i
-	imfiledirbefore="rsyslog.input.dir$i"
+	mkdir rsyslog.input.dir$i
+	./inputfilegen -m 1 > rsyslog.input.dir$i/file.logfile
 done
 ls -d rsyslog.input.*
 

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -9,11 +9,6 @@ export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 . $srcdir/diag.sh init
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
-imfiledirbefore="rsyslog.input.dir1"
-
-# Create first dir and file
-mkdir $imfiledirbefore
-./inputfilegen -m 1 > $imfiledirbefore/file.log
 
 # Start rsyslog now before adding more files
 . $srcdir/diag.sh startup imfile-wildcards-dirs.conf
@@ -24,24 +19,21 @@ for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
 do
 	echo "Loop Num $j"
 
-	for i in `seq 2 $IMFILEINPUTFILES`;
+	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
-		cp -r $imfiledirbefore rsyslog.input.dir$i
-		imfiledirbefore="rsyslog.input.dir$i"
+		mkdir rsyslog.input.dir$i
+		./inputfilegen -m 1 > rsyslog.input.dir$i/file.logfile
 	done
 	ls -d rsyslog.input.*
 
 	# sleep a little to give rsyslog a chance for processing
-	sleep 1
+	sleep 2
 	
 	# Delete all but first!
-	for i in `seq 2 $IMFILEINPUTFILES`;
+	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		rm -r rsyslog.input.dir$i
 	done
-	
-	# Reset to default
-	imfiledirbefore="rsyslog.input.dir1"
 done
 
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under GPLv3
+echo [imfile-wildcards-dirs2.sh]
+
+export IMFILEINPUTFILES="10"
+export IMFILEINPUTFILESSTEPS="5"
+export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
+
+. $srcdir/diag.sh init
+# generate input files first. Note that rsyslog processes it as
+# soon as it start up (so the file should exist at that point).
+imfiledirbefore="rsyslog.input.dir1"
+
+# Create first dir and file
+mkdir $imfiledirbefore
+./inputfilegen -m 1 > $imfiledirbefore/file.log
+
+# Start rsyslog now before adding more files
+. $srcdir/diag.sh startup imfile-wildcards-dirs.conf
+# sleep a little to give rsyslog a chance to begin processing
+sleep 1
+
+for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
+do
+	echo "Loop Num $j"
+
+	for i in `seq 2 $IMFILEINPUTFILES`;
+	do
+		cp -r $imfiledirbefore rsyslog.input.dir$i
+		imfiledirbefore="rsyslog.input.dir$i"
+	done
+	ls -d rsyslog.input.*
+
+	# sleep a little to give rsyslog a chance for processing
+	sleep 1
+	
+	# Delete all but first!
+	for i in `seq 2 $IMFILEINPUTFILES`;
+	do
+		rm -r rsyslog.input.dir$i
+	done
+	
+	# Reset to default
+	imfiledirbefore="rsyslog.input.dir1"
+done
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL
+. $srcdir/diag.sh exit

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -22,6 +22,7 @@ do
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		mkdir rsyslog.input.dir$i
+		./msleep 50
 		./inputfilegen -m 1 > rsyslog.input.dir$i/file.logfile
 	done
 	ls -d rsyslog.input.*

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -25,9 +25,6 @@ do
 		./inputfilegen -m 1 > rsyslog.input.dir$i/file.logfile
 	done
 	ls -d rsyslog.input.*
-
-	# sleep a little to give rsyslog a chance for processing
-	sleep 2
 	
 	# Delete all but first!
 	for i in `seq 1 $IMFILEINPUTFILES`;
@@ -35,6 +32,9 @@ do
 		rm -r rsyslog.input.dir$i
 	done
 done
+
+# sleep a little to give rsyslog a chance for processing
+sleep 1
 
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!

--- a/tests/imfile-wildcards.sh
+++ b/tests/imfile-wildcards.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under GPLv3
+echo [imfile-wildcards.sh]
+
+export IMFILEINPUTFILES="10"
+
+. $srcdir/diag.sh init
+# generate input files first. Note that rsyslog processes it as
+# soon as it start up (so the file should exist at that point).
+
+imfilebefore="rsyslog.input.1"
+./inputfilegen -m 1 > $imfilebefore
+
+# Start rsyslog now before adding more files
+. $srcdir/diag.sh startup imfile-wildcards.conf
+# sleep a little to give rsyslog a chance to begin processing
+sleep 1
+
+for i in `seq 2 $IMFILEINPUTFILES`;
+do
+	cp $imfilebefore rsyslog.input.$i
+	imfilebefore="rsyslog.input.$i"
+done
+ls -l rsyslog.input.*
+
+# sleep a little to give rsyslog a chance for processing
+sleep 1
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILES
+. $srcdir/diag.sh exit

--- a/tests/testsuites/es-bulk-errfile-popul-def-format.conf
+++ b/tests/testsuites/es-bulk-errfile-popul-def-format.conf
@@ -24,6 +24,6 @@ ruleset(name="foo") {
 
 input(type="imfile" File="./inESData.inputfile"
       Tag="foo"
-      StateFile="in_log.state"
+      StateFile="stat-file1"
       Severity="info"
       ruleset="foo")

--- a/tests/testsuites/es-bulk-errfile-popul-def-interleaved.conf
+++ b/tests/testsuites/es-bulk-errfile-popul-def-interleaved.conf
@@ -25,6 +25,6 @@ ruleset(name="foo") {
 
 input(type="imfile" File="./inESData.inputfile"
       Tag="foo"
-      StateFile="in_log.state"
+      StateFile="stat-file1"
       Severity="info"
       ruleset="foo")

--- a/tests/testsuites/es-bulk-errfile-popul-erronly-interleaved.conf
+++ b/tests/testsuites/es-bulk-errfile-popul-erronly-interleaved.conf
@@ -26,6 +26,6 @@ ruleset(name="foo") {
 
 input(type="imfile" File="./inESData.inputfile"
       Tag="foo"
-      StateFile="in_log.state"
+      StateFile="stat-file1"
       Severity="info"
       ruleset="foo")

--- a/tests/testsuites/es-bulk-errfile-popul-erronly.conf
+++ b/tests/testsuites/es-bulk-errfile-popul-erronly.conf
@@ -25,6 +25,6 @@ ruleset(name="foo") {
 
 input(type="imfile" File="./inESData.inputfile"
       Tag="foo"
-      StateFile="in_log.state"
+      StateFile="stat-file1"
       Severity="info"
       ruleset="foo")

--- a/tests/testsuites/imfile-wildcards-dirs-multi.conf
+++ b/tests/testsuites/imfile-wildcards-dirs-multi.conf
@@ -1,0 +1,26 @@
+$IncludeConfig diag-common.conf
+$WorkDirectory test-spool
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./rsyslog.input.*/*/*.logfile"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+)
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )

--- a/tests/testsuites/imfile-wildcards-dirs-multi.conf
+++ b/tests/testsuites/imfile-wildcards-dirs-multi.conf
@@ -10,11 +10,14 @@ input(type="imfile"
 	Tag="file:"
 	Severity="error"
 	Facility="local7"
+	addMetadata="on"
 )
 
 template(name="outfmt" type="list") {
   constant(value="HEADER ")
   property(name="msg" format="json")
+  constant(value="', ")
+  property(name="$!metadata!filename")
   constant(value="\n")
 }
 

--- a/tests/testsuites/imfile-wildcards-dirs.conf
+++ b/tests/testsuites/imfile-wildcards-dirs.conf
@@ -10,11 +10,14 @@ input(type="imfile"
 	Tag="file:"
 	Severity="error"
 	Facility="local7"
+	addMetadata="on"
 )
 
 template(name="outfmt" type="list") {
   constant(value="HEADER ")
   property(name="msg" format="json")
+  constant(value="', ")
+  property(name="$!metadata!filename")
   constant(value="\n")
 }
 

--- a/tests/testsuites/imfile-wildcards-dirs.conf
+++ b/tests/testsuites/imfile-wildcards-dirs.conf
@@ -5,7 +5,7 @@ module(	load="../plugins/imfile/.libs/imfile"
 	PollingInterval="1")
 
 input(type="imfile"
-	File="./rsyslog.input.*/*.log"
+	File="./rsyslog.input.*/*.logfile"
 	Tag="file:"
 	Severity="error"
 	Facility="local7"

--- a/tests/testsuites/imfile-wildcards-dirs.conf
+++ b/tests/testsuites/imfile-wildcards-dirs.conf
@@ -1,4 +1,5 @@
 $IncludeConfig diag-common.conf
+$WorkDirectory test-spool
 
 module(	load="../plugins/imfile/.libs/imfile" 
 	mode="inotify" 

--- a/tests/testsuites/imfile-wildcards-dirs.conf
+++ b/tests/testsuites/imfile-wildcards-dirs.conf
@@ -1,0 +1,25 @@
+$IncludeConfig diag-common.conf
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./rsyslog.input.*/*.log"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+)
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )

--- a/tests/testsuites/imfile-wildcards.conf
+++ b/tests/testsuites/imfile-wildcards.conf
@@ -10,11 +10,14 @@ input(type="imfile"
 	Tag="file:"
 	Severity="error"
 	Facility="local7"
+	addMetadata="on"
 )
 
 template(name="outfmt" type="list") {
   constant(value="HEADER ")
   property(name="msg" format="json")
+  constant(value="', ")
+  property(name="$!metadata!filename")
   constant(value="\n")
 }
 

--- a/tests/testsuites/imfile-wildcards.conf
+++ b/tests/testsuites/imfile-wildcards.conf
@@ -1,0 +1,25 @@
+$IncludeConfig diag-common.conf
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./rsyslog.input.*"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+)
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )

--- a/tests/testsuites/imfile-wildcards.conf
+++ b/tests/testsuites/imfile-wildcards.conf
@@ -1,4 +1,5 @@
 $IncludeConfig diag-common.conf
+$WorkDirectory test-spool
 
 module(	load="../plugins/imfile/.libs/imfile" 
 	mode="inotify" 


### PR DESCRIPTION
Added support for multilevel wildcards (inotify only)
imfile supports now wildcards on multiple levels.
Directories can be dynamically added and removed.
Each directory has its own inotify watch.