### PR TITLE
bugfix: rsyslog loops on freebsd when trying to write /dev/console

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1154,7 +1154,10 @@ tryTTYRecover(strm_t *pThis, int err)
 #ifndef __FreeBSD__
 	if(err == ERR_TTYHUP) {
 #else
-	if(err == ERR_TTYHUP || err == ENXIO) {
+	/* Try to reopen our file descriptor even on errno 6, FreeBSD bug 200429
+	 * Also try on errno 5, FreeBSD bug 211033
+	 */
+	if(err == ERR_TTYHUP || err == ENXIO || err == EIO) {
 #endif /* __FreeBSD__ */
 		close(pThis->fd);
 		CHKiRet(doPhysOpen(pThis));


### PR DESCRIPTION
Rsyslog 8.23.0 loops on FreeBSD when trying to access a (now revoked) /dev/console file descriptor, as per Alexandre's original bug report [1].

The original patch fixes the problem when tryTTYRecover() sees errno 6 ENXIO.

Running FreeBSD 10-stable here and getting errno 5 EIO, same as Xavier gets in his 2016 bug report [2].

New patch [3] includes errno 5 to tryTTYRecover() in runtime/stream.c and fixes the problem for me, on multiple machines.

[1] https://github.com/rsyslog/rsyslog/issues/371
[2] https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=211033
[3] https://bz-attachments.freebsd.org/attachment.cgi?id=178452

closes https://github.com/rsyslog/rsyslog/issues/1351