### PR TITLE
bugfix: str2num mishandling empty strings

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1276,6 +1276,13 @@ str2num(es_str_t *s, int *bSuccess)
 	int64_t num = 0;
 	const uchar *const c = es_getBufAddr(s);
 
+	if(s->lenStr == 0) {
+		DBGPRINTF("rainerscript: str2num: strlen == 0; invalid input (no string)\n");
+		if(bSuccess != NULL) {
+			*bSuccess = 0;
+		}
+		goto done;
+	}
 	if(c[0] == '-') {
 		neg = -1;
 		i = -1;
@@ -1290,6 +1297,7 @@ str2num(es_str_t *s, int *bSuccess)
 	num *= neg;
 	if(bSuccess != NULL)
 		*bSuccess = (i == s->lenStr) ? 1 : 0;
+done:
 	return num;
 }
 

--- a/tests/rscript_num2ipv4.sh
+++ b/tests/rscript_num2ipv4.sh
@@ -22,7 +22,7 @@ set $!ip!e2 = num2ipv4("-123");
 set $!ip!e3 = num2ipv4("1725464567890");
 set $!ip!e4 = num2ipv4("4294967296");
 set $!ip!e5 = num2ipv4("2839.");
-#set $!ip!e6 = num2ipv4("");
+set $!ip!e6 = num2ipv4("");
 
 
 template(name="outfmt" type="string" string="%!ip%\n")
@@ -32,7 +32,7 @@ local4.* action(type="omfile" file="rsyslog.out.log" template="outfmt")
 . $srcdir/diag.sh tcpflood -m1 -y
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
-echo '{ "v1": "0.0.0.0", "v2": "0.0.0.1", "v3": "0.0.1.0", "v4": "0.1.0.0", "v5": "1.0.0.0", "v6": "0.0.0.135", "v7": "1.1.1.1", "v8": "225.33.1.10", "v9": "172.0.0.1", "v10": "255.255.255.255", "e1": "-1", "e2": "-1", "e3": "-1", "e4": "-1", "e5": "-1" }' | cmp rsyslog.out.log
+echo '{ "v1": "0.0.0.0", "v2": "0.0.0.1", "v3": "0.0.1.0", "v4": "0.1.0.0", "v5": "1.0.0.0", "v6": "0.0.0.135", "v7": "1.1.1.1", "v8": "225.33.1.10", "v9": "172.0.0.1", "v10": "255.255.255.255", "e1": "-1", "e2": "-1", "e3": "-1", "e4": "-1", "e5": "-1", "e6": "-1" }' | cmp rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid function output detected, rsyslog.out.log is:"
   cat rsyslog.out.log


### PR DESCRIPTION
If str2num() receives an empty string, misadressing happens.
Under extreme conditions, this theoretically can lead to a segfault.

closes https://github.com/rsyslog/rsyslog/issues/1412