### PR TITLE
Fixed segfault in glblDoneLoadCnf()

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -1076,11 +1076,13 @@ finalize_it:
 /* This processes the "regular" parameters which are to be set after the
  * config has been fully loaded.
  */
-void
+rsRetVal
 glblDoneLoadCnf(void)
 {
 	int i;
 	unsigned char *cstr;
+	DEFiRet;
+	CHKiRet(objUse(net, CORE_COMPONENT));
 
 	qsort(tzinfos, ntzinfos, sizeof(tzinfo_t), qs_arrcmp_tzinfo);
 	DBGPRINTF("Timezone information table (%d entries):\n", ntzinfos);
@@ -1210,7 +1212,7 @@ glblDoneLoadCnf(void)
 		stddbg = -1;
 	}
 
-finalize_it:	return;
+finalize_it:	RETiRet;
 }
 
 

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -125,7 +125,7 @@ void glblProcessCnf(struct cnfobj *o);
 void glblProcessTimezone(struct cnfobj *o);
 void glblProcessMainQCnf(struct cnfobj *o);
 void glblDestructMainqCnfObj(void);
-void glblDoneLoadCnf(void);
+rsRetVal glblDoneLoadCnf(void);
 const uchar * glblGetWorkDirRaw(void);
 tzinfo_t* glblFindTimezoneInfo(char *id);
 int GetGnuTLSLoglevel(void);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -627,11 +627,11 @@ finalize_it:
 /* tell the rsysog core (including ourselfs) that the config load is done and
  * we need to prepare to move over to activate mode.
  */
-static inline void
+static inline rsRetVal
 tellCoreConfigLoadDone(void)
 {
 	DBGPRINTF("telling rsyslog core that config load for %p is done\n", loadConf);
-	glblDoneLoadCnf();
+	return glblDoneLoadCnf();
 }
 
 
@@ -1345,7 +1345,7 @@ ourConf = loadConf; // TODO: remove, once ourConf is gone!
 	DBGPRINTF("Number of actions in this configuration: %d\n", iActionNbr);
 	rulesetOptimizeAll(loadConf);
 
-	tellCoreConfigLoadDone();
+	CHKiRet(tellCoreConfigLoadDone());
 	tellModulesConfigLoadDone();
 
 	tellModulesCheckConfig();


### PR DESCRIPTION
This is caused by uninitialized net static structure in glbl objUse(net)
is not called after start of glbl module.

It looks like it is not possible to use objUse(net) when glbl module
starts. So we call it inside of glblDoneLoadCnf().