### PR TITLE
core: enable internal messages at any time

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -315,6 +315,7 @@ waitMainQEmpty(tcps_sess_t *pSess)
 	DEFiRet;
 
 	while(1) {
+		processImInternal();
 		if(iOverallQueueSize == 0)
 			++nempty;
 		else

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -645,6 +645,7 @@ extern uchar *glblModPath; /* module load path */
 extern void (*glblErrLogger)(const int, const int, const uchar*);
 
 /* some runtime prototypes */
+void processImInternal(void);
 rsRetVal rsrtInit(const char **ppErrObj, obj_if_t *pObjIF);
 rsRetVal rsrtExit(void);
 int rsrtIsInit(void);

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -212,7 +212,7 @@ case $1 in
 		i=0
 		while test ! -f rsyslogd$2.started; do
 			./msleep 100 # wait 100 milliseconds
-			ps -p `cat rsyslog$2.pid`
+			ps -p `cat rsyslog$2.pid` &> /dev/null
 			if [ $? -ne 0 ]
 			then
 			   echo "ABORT! rsyslog pid no longer active during startup!"

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -377,6 +377,11 @@ int openConnections(void)
 				}
 				numConnections = i;
 				printf("continuing with %d connections.\n", numConnections);
+				if(numConnections < 1) {
+					fprintf(stderr, "tcpflood could not open at least one "
+						"connection, error-terminating\n");
+					exit(1);
+				}
 				break;
 			}
 			return 1;

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -885,11 +885,7 @@ logmsgInternalSubmit(const int iErr, const syslog_pri_t pri, const size_t lenMsg
 	pMsg->msgFlags  = flags;
 	msgSetPRI(pMsg, pri);
 
-	if(bHaveMainQueue == 0) { /* not yet in queued mode */
-		iminternalAddMsg(pMsg);
-	} else {
-		logmsgInternal_doWrite(pMsg);
-	}
+	iminternalAddMsg(pMsg);
 finalize_it:
 	RETiRet;
 }
@@ -1095,11 +1091,12 @@ finalize_it:
 
 
 static void
-hdlr_sigttin(void)
+hdlr_sigttin_ou(void)
 {
 	/* this is just a dummy to care for our sigttin input
-	 * module cancel interface. The important point is that
-	 * it actually does *NOTHING*.
+	 * module cancel interface and sigttou internal message
+	 * notificaton/mainloop wakeup mechanism. The important
+	 * point is that it actually does *NOTHING*.
 	 */
 }
 
@@ -1451,7 +1448,8 @@ initAll(int argc, char **argv)
 		hdlr_enable(SIGQUIT, SIG_IGN);
 	}
 	hdlr_enable(SIGTERM, rsyslogdDoDie);
-	hdlr_enable(SIGTTIN, hdlr_sigttin);
+	hdlr_enable(SIGTTIN, hdlr_sigttin_ou);
+	hdlr_enable(SIGTTOU, hdlr_sigttin_ou);
 	hdlr_enable(SIGCHLD, hdlr_sigchld);
 	hdlr_enable(SIGHUP, hdlr_sighup);
 
@@ -1506,7 +1504,7 @@ finalize_it:
  * really help us. TODO: add error messages?
  * rgerhards, 2007-08-03
  */
-static void
+void
 processImInternal(void)
 {
 	smsg_t *pMsg;
@@ -1714,10 +1712,9 @@ mainloop(void)
 	time_t tTime;
 
 	BEGINfunc
-	/* first check if we have any internal messages queued and spit them out. */
-	processImInternal();
 
-	while(!bFinished){
+	do {
+		processImInternal();
 		wait_timeout();
 		if(bChildDied) {
 			pid_t child;
@@ -1745,7 +1742,7 @@ mainloop(void)
 			bHadHUP = 0;
 		}
 
-	}
+	} while(!bFinished); /* end do ... while() */
 	ENDfunc
 }
 
@@ -1794,9 +1791,10 @@ deinitAll(void)
 		errno = 0;
 		logmsgInternal(NO_ERRCODE, LOG_SYSLOG|LOG_INFO, (uchar*)buf, 0);
 	}
-	/* we sleep for 50ms to give the queue a chance to pick up the exit message;
-	 * otherwise we have seen cases where the message did not make it to log
-	 * files, even on idle systems.
+	processImInternal(); /* make sure not-yet written internal messages are processed */
+	/* we sleep a couple of ms to give the queue a chance to pick up the late messages
+	 * (including exit message); otherwise we have seen cases where the message did
+	 * not make it to log files, even on idle systems.
 	 */
 	srSleep(0, 50);
 


### PR DESCRIPTION
previous code could deadlock if internal messages were issued
inside queue processing code, which effectively limited
error-reporting capabilities. This change makes it possible
to call error messages from any part of the code at any time.
This comes at the price of slightly delayed message output.