### PR TITLE
bugfix: rsyslog identifies itself as "liblogging-stdlog" in internal …

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -987,6 +987,8 @@ glblProcessCnf(struct cnfobj *o)
 #else
 			stdlog_chanspec = (uchar*)
 				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			/* we need to re-open with the new channel */
+			stdlog_close(stdlog_hdl);
 			stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG,
 					(char*) stdlog_chanspec);
 #endif

--- a/runtime/rsyslog.c
+++ b/runtime/rsyslog.c
@@ -141,7 +141,7 @@ rsrtInit(const char **ppErrObj, obj_if_t *pObjIF)
 		/* init runtime only if not yet done */
 #ifdef HAVE_LIBLOGGING_STDLOG
 		stdlog_init(0);
-		stdlog_hdl = NULL;
+		stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG, NULL);
 #endif
 		CHKiRet(pthread_attr_init(&default_thread_attr));
 		pthread_attr_setstacksize(&default_thread_attr, 4096*1024);

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1888,5 +1888,8 @@ main(int argc, char **argv)
 
 	mainloop();
 	deinitAll();
+#ifdef HAVE_LIBLOGGING_STDLOG
+	stdlog_close(stdlog_hdl);
+#endif
 	return 0;
 }


### PR DESCRIPTION
…messages

This occured when liblogging-stdlog was used, and was used by default (without
explicit configuration). This is a regression of the new default, which does
not correctly call stdlog_open() in the default case.

closes https://github.com/rsyslog/rsyslog/issues/1442