### PR TITLE
testbench: do not spam testbench log with output from ps command

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -212,7 +212,7 @@ case $1 in
 		i=0
 		while test ! -f rsyslogd$2.started; do
 			./msleep 100 # wait 100 milliseconds
-			ps -p `cat rsyslog$2.pid`
+			ps -p `cat rsyslog$2.pid` &> /dev/null
 			if [ $? -ne 0 ]
 			then
 			   echo "ABORT! rsyslog pid no longer active during startup!"


### PR DESCRIPTION
ps is used when waiting on startup and spams the test log if
rsyslog takes longer to start up (or fails to do so). This
makes the log hard to read.