### PR TITLE
testbench/tcpflood: auto-apply silent option during CI runs

### DIFF
--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1148,6 +1148,11 @@ int main(int argc, char *argv[])
 		}
 	}
 
+	const char *const ci_env = getenv("CI");
+	if(ci_env != NULL && !strcmp(ci_env, "true")) {
+		bSilent = 1;	/* auto-apply silent option during CI runs */
+	}
+
 	if(bStatsRecords && waittime) {
 		fprintf(stderr, "warning: generating performance stats and using a waittime "
 				"is somewhat contradictory!\n");


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/232