### PR TITLE
add new global parameter "umask"

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -174,7 +174,8 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "net.enabledns", eCmdHdlrBinary, 0 },
 	{ "net.permitACLwarning", eCmdHdlrBinary, 0 },
 	{ "environment", eCmdHdlrArray, 0 },
-	{ "processinternalmessages", eCmdHdlrBinary, 0 }
+	{ "processinternalmessages", eCmdHdlrBinary, 0 },
+	{ "umask", eCmdHdlrFileCreateMode, 0 }
 };
 static struct cnfparamblk paramblk =
 	{ CNFPARAMBLK_VERSION,
@@ -1201,6 +1202,8 @@ glblDoneLoadCnf(void)
 				do_setenv(var);
 				free(var);
 			}
+		} else if(!strcmp(paramblk.descr[i].name, "umask")) {
+		        loadConf->globals.umask = (int) cnfparamvals[i].val.d.n;
 		} else {
 			dbgprintf("glblDoneLoadCnf: program error, non-handled "
 			  "param '%s'\n", paramblk.descr[i].name);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,6 +30,7 @@ TESTS +=  \
 	hostname-with-slash-dflt-slash-valid.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
+	glbl-umask.sh \
 	glbl-unloadmodules.sh \
 	glbl-invld-param.sh \
 	glbl_setenv_2_vars.sh \
@@ -605,6 +606,7 @@ EXTRA_DIST= \
 	pmrfc3164-defaultTag.sh \
 	hostname-with-slash-dflt-invld.sh \
 	hostname-with-slash-dflt-slash-valid.sh \
+	glbl-umask.sh \
 	glbl-unloadmodules.sh \
 	glbl-invld-param.sh \
 	glbl_setenv_2_vars.sh \

--- a/tests/glbl-umask.sh
+++ b/tests/glbl-umask.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# addd 2017-03-06 by RGerhards, released under ASL 2.0
+
+# Note: we need to inject a somewhat larger nubmer of messages in order
+# to ensure that we receive some messages in the actual output file,
+# as batching can (validly) cause a larger loss in the non-writable
+# file
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+global(umask="0077")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" {
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")
+}
+'
+. $srcdir/diag.sh startup
+$srcdir/diag.sh injectmsg 0 1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+if [ `ls -l rsyslog.o*|head -c 10 ` != "-rw-------" ]; then
+  echo "invalid file permission (umask), rsyslog.out.log has:"
+  ls -l rsyslog.out.log
+  . $srcdir/diag.sh error-exit 1
+fi;
+. $srcdir/diag.sh exit


### PR DESCRIPTION
This is equivalent to "$umask" and permits to convert that construct
to new-style config format.

closes https://github.com/rsyslog/rsyslog/issues/1382