### PR TITLE
omfwd: add support for network namespaces

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -179,6 +179,7 @@ AC_FUNC_STAT
 AC_FUNC_STRERROR_R
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([flock inotify_init recvmmsg basename alarm clock_gettime gethostbyname gethostname gettimeofday localtime_r memset mkdir regcomp select setsid socket strcasecmp strchr strdup strerror strndup strnlen strrchr strstr strtol strtoul uname ttyname_r getline malloc_trim prctl epoll_create epoll_create1 fdatasync syscall lseek64])
+AC_CHECK_FUNC([setns], [AC_DEFINE([HAVE_SETNS], [1], [Define if setns exists.])])
 AC_CHECK_TYPES([off64_t])
 
 # getifaddrs is in libc (mostly) or in libsocket (eg Solaris 11) or not defined (eg Solaris 10)
@@ -1314,6 +1315,13 @@ AC_ARG_ENABLE(testbench,
          esac],
         [enable_testbench=no]
 )
+
+AC_CHECK_PROG(IP, [ip], [yes], [no])
+if test "x${IP}" = "xno"; then
+	AC_MSG_NOTICE([Will not check network namespace functionality as 'ip' (part of iproute2) is not available.])
+fi
+AM_CONDITIONAL(ENABLE_IP, test "x${IP}" = "xyes")
+
 AM_CONDITIONAL(ENABLE_TESTBENCH, test x$enable_testbench = xyes)
 if test "x$enable_testbench" = "xyes"; then
 	if test "x$enable_imdiag" != "xyes"; then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -237,6 +237,11 @@ TESTS +=  \
 	lookup_table_rscript_reload_without_stub.sh \
 	multiple_lookup_tables.sh
 
+if ENABLE_IP
+TESTS += \
+	tcp_forwarding_ns_tpl.sh
+endif
+
 if HAVE_VALGRIND
 TESTS +=  \
 	rscript_set_memleak-vg.sh \
@@ -708,7 +713,9 @@ EXTRA_DIST= \
 	testsuites/1.omod-if-array \
 	testsuites/1.field1 \
 	tcp_forwarding_tpl.sh \
+	tcp_forwarding_ns_tpl.sh \
 	testsuites/tcp_forwarding_tpl.conf \
+	testsuites/tcp_forwarding_ns_tpl.conf \
 	tcp_forwarding_dflt_tpl.sh \
 	testsuites/tcp_forwarding_dflt_tpl.conf \
 	tcp_forwarding_retries.sh \

--- a/tests/tcp_forwarding_ns_tpl.sh
+++ b/tests/tcp_forwarding_ns_tpl.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# This test tests tcp forwarding in a network namespace with assigned template.
+# To do so, a simple tcp listener service is started in a network namespace.
+# Released under GNU GPLv3+
+echo ===============================================================================
+echo \[tcp_forwarding_ns_tpl.sh\]: test for tcp forwarding in a network namespace with assigned template
+echo This test must be run as root [network namespace creation/change required]
+if [ "$EUID" -ne 0 ]; then
+    exit 77 # Not root, skip this test
+fi
+
+# create the pipe and start a background process that copies data from 
+# it to the "regular" work file
+. $srcdir/diag.sh init
+
+# create network namespace and bring it up
+ip netns add rsyslog_test_ns
+ip netns exec rsyslog_test_ns ip link set dev lo up
+
+# run server in namespace
+ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p13514 -frsyslog.out.log &
+BGPROCESS=$!
+echo background minitcpsrvr process id is $BGPROCESS
+
+# now do the usual run
+. $srcdir/diag.sh startup tcp_forwarding_ns_tpl.conf
+# 10000 messages should be enough
+. $srcdir/diag.sh injectmsg 0 10000
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+# note: minitcpsrvr shuts down automatically if the connection is closed!
+# (we still leave the code here in in case we need it later)
+#echo shutting down minitcpsrv...
+#kill $BGPROCESS
+#wait $BGPROCESS
+#echo background process has terminated, continue test...
+
+# remove network namespace
+ip netns delete rsyslog_test_ns
+
+# and continue the usual checks
+. $srcdir/diag.sh seq-check 0 9999
+. $srcdir/diag.sh exit

--- a/tests/testsuites/tcp_forwarding_ns_tpl.conf
+++ b/tests/testsuites/tcp_forwarding_ns_tpl.conf
@@ -1,0 +1,7 @@
+$IncludeConfig diag-common.conf
+$MainMsgQueueTimeoutShutdown 10000
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then
+	action(type="omfwd" template="outfmt"
+	       target="127.0.0.1" port="13514" protocol="tcp" networknamespace="rsyslog_test_ns")

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -754,13 +754,12 @@ static rsRetVal changeToNs(instanceData *pData)
 #ifdef HAVE_SETNS
 	int iErr;
 	int destinationNs = -1;
-	int originalNamespace = -1;
 	char *nsPath = NULL;
 
 	if(pData->networkNamespace) {
 		/* keep file descriptor of original network namespace */
-		originalNamespace = open("/proc/self/ns/net", O_RDONLY);
-		if (originalNamespace < 0) {
+		pData->originalNamespace = open("/proc/self/ns/net", O_RDONLY);
+		if (pData->originalNamespace < 0) {
 			errmsg.LogError(0, RS_RET_IO_ERROR, "omfwd: could not read /proc/self/ns/net\n");
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
@@ -873,6 +872,7 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 finalize_it:
 	DBGPRINTF("omfwd: doTryResume %s iRet %d\n", pWrkrData->pData->target, iRet);
 	if(iRet != RS_RET_OK) {
+		returnToOriginalNs(pData);
 		if(pWrkrData->f_addr != NULL) {
 			freeaddrinfo(pWrkrData->f_addr);
 			pWrkrData->f_addr = NULL;

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -37,6 +37,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <stdint.h>
+#include <fcntl.h>
 #include <zlib.h>
 #include <pthread.h>
 #include "syslogd.h"
@@ -86,6 +87,8 @@ typedef struct _instanceData {
 	int compressionLevel;	/* 0 - no compression, else level for zlib */
 	char *port;
 	int protocol;
+	char *networkNamespace;
+	int originalNamespace;
 	int iRebindInterval;	/* rebind interval */
 	sbool bKeepAlive;
 	int iKeepAliveIntvl;
@@ -159,6 +162,7 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "device", eCmdHdlrGetWord, 0 },
 	{ "port", eCmdHdlrGetWord, 0 },
 	{ "protocol", eCmdHdlrGetWord, 0 },
+	{ "networknamespace", eCmdHdlrGetWord, 0 },
 	{ "tcp_framing", eCmdHdlrGetWord, 0 },
 	{ "ziplevel", eCmdHdlrInt, 0 },
 	{ "compression.mode", eCmdHdlrGetWord, 0 },
@@ -383,6 +387,7 @@ CODESTARTfreeInstance
 	free(pData->pszStrmDrvr);
 	free(pData->pszStrmDrvrAuthMode);
 	free(pData->port);
+	free(pData->networkNamespace);
 	free(pData->target);
 	free(pData->device);
 	net.DestructPermittedPeers(&pData->pPermPeers);
@@ -740,6 +745,88 @@ finalize_it:
 }
 
 
+/* change to network namespace pData->networkNamespace and keep the file
+ * descriptor to the original namespace.
+ */
+static rsRetVal changeToNs(instanceData *pData)
+{
+	DEFiRet;
+#ifdef HAVE_SETNS
+	int iErr;
+	int destinationNs = -1;
+	int originalNamespace = -1;
+	char *nsPath = NULL;
+
+	if(pData->networkNamespace) {
+		/* keep file descriptor of original network namespace */
+		originalNamespace = open("/proc/self/ns/net", O_RDONLY);
+		if (originalNamespace < 0) {
+			errmsg.LogError(0, RS_RET_IO_ERROR, "omfwd: could not read /proc/self/ns/net\n");
+			ABORT_FINALIZE(RS_RET_IO_ERROR);
+		}
+
+		/* build network namespace path */
+		if (asprintf(&nsPath, "/var/run/netns/%s", pData->networkNamespace) == -1) {
+			errmsg.LogError(0, RS_RET_OUT_OF_MEMORY, "omfwd: asprintf failed\n");
+			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+		}
+
+		/* keep file descriptor of destination network namespace */
+		destinationNs = open(nsPath, 0);
+		if (destinationNs < 0) {
+			errmsg.LogError(0, RS_RET_IO_ERROR, "omfwd: could not change to namespace '%s'\n",
+					pData->networkNamespace);
+			ABORT_FINALIZE(RS_RET_IO_ERROR);
+		}
+
+		/* actually change in the destination network namespace */
+		if((iErr = (setns(destinationNs, CLONE_NEWNET))) != 0) {
+			dbgprintf("could not change to namespace '%s': %d%s\n",
+				  pData->networkNamespace, iErr, gai_strerror(iErr));
+			ABORT_FINALIZE(RS_RET_IO_ERROR);
+		}
+		close(destinationNs);
+		free(nsPath);
+		dbgprintf("omfwd: changed to network namespace '%s'\n", pData->networkNamespace);
+	}
+
+finalize_it:
+#else /* #ifdef HAVE_SETNS */
+		dbgprintf("omfwd: OS does not support network namespaces\n");
+#endif /* #ifdef HAVE_SETNS */
+	RETiRet;
+}
+
+
+/* return to the original network namespace. This should be called after
+ * changeToNs().
+ */
+static rsRetVal returnToOriginalNs(instanceData *pData)
+{
+	DEFiRet;
+#ifdef HAVE_SETNS
+	int iErr;
+
+	/* only in case a network namespace is given and a file descriptor to
+	 * the original namespace exists */
+	if(pData->networkNamespace && pData->originalNamespace >= 0) {
+		/* actually change to the original network namespace */
+		if((iErr = (setns(pData->originalNamespace, CLONE_NEWNET))) != 0) {
+			dbgprintf("could not return to original namespace: %d%s\n",
+				  iErr, gai_strerror(iErr));
+			ABORT_FINALIZE(RS_RET_IO_ERROR);
+		}
+
+		close(pData->originalNamespace);
+		dbgprintf("omfwd: returned to original network namespace\n");
+	}
+
+finalize_it:
+#endif /* #ifdef HAVE_SETNS */
+	RETiRet;
+}
+
+
 /* try to resume connection if it is not ready
  * rgerhards, 2007-08-02
  */
@@ -770,13 +857,17 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 		dbgprintf("%s found, resuming.\n", pData->target);
 		pWrkrData->f_addr = res;
 		if(pWrkrData->pSockArray == NULL) {
+			CHKiRet(changeToNs(pData));
 			pWrkrData->pSockArray = net.create_udp_socket((uchar*)pData->target, NULL, 0, 0, 0, pData->device);
+			CHKiRet(returnToOriginalNs(pData));
 		}
 		if(pWrkrData->pSockArray != NULL) {
 			pWrkrData->bIsConnected = 1;
 		}
 	} else {
+		CHKiRet(changeToNs(pData));
 		CHKiRet(TCPSendInit((void*)pWrkrData));
+		CHKiRet(returnToOriginalNs(pData));
 	}
 
 finalize_it:
@@ -950,6 +1041,8 @@ setInstParamDefaults(instanceData *pData)
 {
 	pData->tplName = NULL;
 	pData->protocol = FORW_UDP;
+	pData->networkNamespace = NULL;
+	pData->originalNamespace = -1;
 	pData->tcp_framing = TCP_FRAMING_OCTET_STUFFING;
 	pData->pszStrmDrvr = NULL;
 	pData->pszStrmDrvrAuthMode = NULL;
@@ -1022,6 +1115,8 @@ CODESTARTnewActInst
 				free(str);
 				ABORT_FINALIZE(RS_RET_INVLD_PROTOCOL);
 			}
+		} else if(!strcmp(actpblk.descr[i].name, "networknamespace")) {
+			pData->networkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "tcp_framing")) {
 			if(!es_strcasebufcmp(pvals[i].val.d.estr, (uchar*)"traditional", 11)) {
 				pData->tcp_framing = TCP_FRAMING_OCTET_STUFFING;
@@ -1255,6 +1350,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 
 	pData->tcp_framing = tcp_framing;
 	pData->port = NULL;
+	pData->networkNamespace = NULL;
 	if(*p == ':') { /* process port */
 		uchar * tmp;
 


### PR DESCRIPTION
Network namespaces are part of the linux kernel since v2.6.24. This
enables forwarding output into a configurable network namespace. E.g.,

action(type="omfwd" networknamespace="my_ns" target="192.168.1.23"
port="10514")

Signed-off-by: Bastian Stender <bst@pengutronix.de>