### PR TITLE
core/file handling: add new error messages

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -315,6 +315,7 @@ waitMainQEmpty(tcps_sess_t *pSess)
 	DEFiRet;
 
 	while(1) {
+		processImInternal();
 		if(iOverallQueueSize == 0)
 			++nempty;
 		else

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -645,6 +645,7 @@ extern uchar *glblModPath; /* module load path */
 extern void (*glblErrLogger)(const int, const int, const uchar*);
 
 /* some runtime prototypes */
+void processImInternal(void);
 rsRetVal rsrtInit(const char **ppErrObj, obj_if_t *pObjIF);
 rsRetVal rsrtExit(void);
 int rsrtIsInit(void);

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -16,7 +16,7 @@
  * it turns out to be problematic. Then, we need to quasi-refcount the number of accesses
  * to the object.
  *
- * Copyright 2008-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2017 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -50,6 +50,9 @@
 #include <errno.h>
 #include <pthread.h>
 #include <poll.h>
+#ifdef HAVE_SYS_PRCTL_H
+#  include <sys/prctl.h>
+#endif
 
 #include "rsyslog.h"
 #include "stringbuf.h"
@@ -61,9 +64,7 @@
 #include "errmsg.h"
 #include "cryprov.h"
 #include "datetime.h"
-#ifdef HAVE_SYS_PRCTL_H
-#  include <sys/prctl.h>
-#endif
+#include "errmsg.h"
 
 /* some platforms do not have large file support :( */
 #ifndef O_LARGEFILE
@@ -164,9 +165,11 @@ resolveFileSizeLimit(strm_t *pThis, uchar *pszCurrFName)
 finalize_it:
 	if(iRet != RS_RET_OK) {
 		if(iRet == RS_RET_SIZELIMITCMD_DIDNT_RESOLVE) {
-			DBGPRINTF("file size limit cmd for file '%s' did no resolve situation\n", pszCurrFName);
+			LogError(0, RS_RET_ERR, "file size limit cmd for file '%s' "
+				"did no resolve situation\n", pszCurrFName);
 		} else {
-			DBGPRINTF("file size limit cmd for file '%s' failed with code %d.\n", pszCurrFName, iRet);
+			LogError(0, RS_RET_ERR, "file size limit cmd for file '%s' "
+				"failed with code %d.\n", pszCurrFName, iRet);
 		}
 		pThis->bDisabled = 1;
 	}
@@ -243,17 +246,14 @@ doPhysOpen(strm_t *pThis)
 	}
 
 	pThis->fd = open((char*)pThis->pszCurrFName, iFlags | O_LARGEFILE, pThis->tOpenMode);
+	const int errno_save = errno; /* dbgprintf can mangle it! */
 	DBGPRINTF("file '%s' opened as #%d with mode %d\n", pThis->pszCurrFName,
 		  pThis->fd, (int) pThis->tOpenMode);
 	if(pThis->fd == -1) {
-		char errStr[1024];
-		int err = errno;
-		rs_strerror_r(err, errStr, sizeof(errStr));
-		DBGOPRINT((obj_t*) pThis, "open error %d, file '%s': %s\n", errno, pThis->pszCurrFName, errStr);
-		if(err == ENOENT)
-			ABORT_FINALIZE(RS_RET_FILE_NOT_FOUND);
-		else
-			ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
+		const rsRetVal errcode = (errno_save == ENOENT)
+			? RS_RET_FILE_NOT_FOUND : RS_RET_FILE_OPEN_ERROR;
+		LogError(errno_save, errcode, "file '%s': open error", pThis->pszCurrFName);
+		ABORT_FINALIZE(errcode);
 	}
 
 	if(pThis->tOperationsMode == STREAMMODE_READ) {
@@ -360,16 +360,9 @@ static rsRetVal strmOpenFile(strm_t *pThis)
 		pThis->iCurrOffs = offset;
 	} else if(pThis->tOperationsMode == STREAMMODE_WRITE) {
 		if(offset != 0) {
-			// TODO: check the exact condition under which this occurs. It
-			// looks OK, seems like the queue code uses a side-effect that makes
-			// this a valid sequence!
-			/*errmsg.LogError(0, 0, "queue '%s', file '%s' opened for non-append write, but "
+			LogError(0, 0, "queue '%s', file '%s' opened for non-append write, but "
 				"already contains %zd bytes\n",
 				obj.GetName((obj_t*) pThis), pThis->pszCurrFName, offset);
-			*/
-			DBGPRINTF("queue '%s', file '%s' opened for non-append write, but "
-				"already contains %lld bytes\n",
-				obj.GetName((obj_t*) pThis), pThis->pszCurrFName, (long long) offset);
 		}
 	}
 
@@ -1208,11 +1201,11 @@ doWriteCall(strm_t *pThis, uchar *pBuf, size_t *pLenBuf)
 #endif /* __FreeBSD__ */
 		iWritten = write(pThis->fd, pWriteBuf, lenBuf);
 		if(iWritten < 0) {
-			char errStr[1024];
-			int err = errno;
+			const int err = errno;
 			iWritten = 0; /* we have written NO bytes! */
-			rs_strerror_r(err, errStr, sizeof(errStr));
-			DBGPRINTF("log file (%d) write error %d: %s\n", pThis->fd, err, errStr);
+			if(err != EINTR) {
+				LogError(err, RS_RET_IO_ERROR, "file '%d' write error", pThis->fd);
+			}
 			if(err == EINTR) {
 				/*NO ERROR, just continue */;
 			} else if( !pThis->bIsTTY && ( err == ENOTCONN  || err == EIO )) {
@@ -1538,7 +1531,7 @@ doZipWrite(strm_t *pThis, uchar *pBuf, size_t lenBuf, const int bFlush)
 {
 	int zRet;	/* zlib return state */
 	DEFiRet;
-	unsigned outavail;
+	unsigned outavail = 0;
 	assert(pThis != NULL);
 	assert(pBuf != NULL);
 
@@ -1550,7 +1543,7 @@ doZipWrite(strm_t *pThis, uchar *pBuf, size_t lenBuf, const int bFlush)
 		/* see note in file header for the params we use with deflateInit2() */
 		zRet = zlibw.DeflateInit2(&pThis->zstrm, pThis->iZipLevel, Z_DEFLATED, 31, 9, Z_DEFAULT_STRATEGY);
 		if(zRet != Z_OK) {
-			DBGPRINTF("error %d returned from zlib/deflateInit2()\n", zRet);
+			LogError(0, RS_RET_ZLIB_ERR, "error %d returned from zlib/deflateInit2()", zRet);
 			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
 		}
 		pThis->bzInitDone = RSTRUE;
@@ -1566,9 +1559,13 @@ doZipWrite(strm_t *pThis, uchar *pBuf, size_t lenBuf, const int bFlush)
 		pThis->zstrm.avail_out = pThis->sIOBufSize;
 		pThis->zstrm.next_out = pThis->pZipBuf;
 		zRet = zlibw.Deflate(&pThis->zstrm, bFlush ? Z_SYNC_FLUSH : Z_NO_FLUSH);    /* no bad return value */
-		outavail =pThis->sIOBufSize - pThis->zstrm.avail_out;
 		DBGPRINTF("after deflate, ret %d, avail_out %d, to write %d\n",
 			zRet, pThis->zstrm.avail_out, outavail);
+		if(zRet != Z_OK) {
+			LogError(0, RS_RET_ZLIB_ERR, "error %d returned from zlib/Deflate()", zRet);
+			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+		}
+		outavail = pThis->sIOBufSize - pThis->zstrm.avail_out;
 		if(outavail != 0) {
 			CHKiRet(strmPhysWrite(pThis, (uchar*)pThis->pZipBuf, outavail));
 		}
@@ -1614,7 +1611,7 @@ doZipFinish(strm_t *pThis)
 finalize_it:
 	zRet = zlibw.DeflateEnd(&pThis->zstrm);
 	if(zRet != Z_OK) {
-		DBGPRINTF("error %d returned from zlib/deflateEnd()\n", zRet);
+		LogError(0, RS_RET_ZLIB_ERR, "error %d returned from zlib/deflateEnd()", zRet);
 	}
 
 	pThis->bzInitDone = 0;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -38,6 +38,7 @@ TESTS +=  \
 	glbl_setenv.sh \
 	invalid_nested_include.sh \
 	omfwd-keepalive.sh \
+	omfile-read-only-errmsg.sh \
 	omfile-read-only.sh \
 	msgvar-concurrency.sh \
 	localvar-concurrency.sh \
@@ -757,6 +758,7 @@ EXTRA_DIST= \
 	stop-msgvar.sh \
 	testsuites/stop-msgvar.conf \
 	omfwd-keepalive.sh \
+	omfile-read-only-errmsg.sh \
 	omfile-read-only.sh \
 	msgvar-concurrency.sh \
 	testsuites/msgvar-concurrency.conf \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -212,7 +212,7 @@ case $1 in
 		i=0
 		while test ! -f rsyslogd$2.started; do
 			./msleep 100 # wait 100 milliseconds
-			ps -p `cat rsyslog$2.pid`
+			ps -p `cat rsyslog$2.pid` &> /dev/null
 			if [ $? -ne 0 ]
 			then
 			   echo "ABORT! rsyslog pid no longer active during startup!"

--- a/tests/omfile-read-only-errmsg.sh
+++ b/tests/omfile-read-only-errmsg.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# addd 2017-03-01 by RGerhards, released under ASL 2.0
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" {
+	action(type="omfile" template="outfmt" file="rsyslog2.out.log")
+}
+
+action(type="omfile" file="rsyslog.out.log")
+'
+touch rsyslog2.out.log
+chmod 0400 rsyslog2.out.log
+ls -l rsyslog.ou*
+. $srcdir/diag.sh startup
+$srcdir/diag.sh injectmsg 0 1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+grep "rsyslog2.out.log.* open error" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+	echo
+	echo "FAIL: expected error message not found. rsyslog.out.log is:"
+	cat rsyslog.out.log
+	. $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -377,6 +377,11 @@ int openConnections(void)
 				}
 				numConnections = i;
 				printf("continuing with %d connections.\n", numConnections);
+				if(numConnections < 1) {
+					fprintf(stderr, "tcpflood could not open at least one "
+						"connection, error-terminating\n");
+					exit(1);
+				}
 				break;
 			}
 			return 1;

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -885,11 +885,7 @@ logmsgInternalSubmit(const int iErr, const syslog_pri_t pri, const size_t lenMsg
 	pMsg->msgFlags  = flags;
 	msgSetPRI(pMsg, pri);
 
-	if(bHaveMainQueue == 0) { /* not yet in queued mode */
-		iminternalAddMsg(pMsg);
-	} else {
-		logmsgInternal_doWrite(pMsg);
-	}
+	iminternalAddMsg(pMsg);
 finalize_it:
 	RETiRet;
 }
@@ -1095,11 +1091,12 @@ finalize_it:
 
 
 static void
-hdlr_sigttin(void)
+hdlr_sigttin_ou(void)
 {
 	/* this is just a dummy to care for our sigttin input
-	 * module cancel interface. The important point is that
-	 * it actually does *NOTHING*.
+	 * module cancel interface and sigttou internal message
+	 * notificaton/mainloop wakeup mechanism. The important
+	 * point is that it actually does *NOTHING*.
 	 */
 }
 
@@ -1451,7 +1448,8 @@ initAll(int argc, char **argv)
 		hdlr_enable(SIGQUIT, SIG_IGN);
 	}
 	hdlr_enable(SIGTERM, rsyslogdDoDie);
-	hdlr_enable(SIGTTIN, hdlr_sigttin);
+	hdlr_enable(SIGTTIN, hdlr_sigttin_ou);
+	hdlr_enable(SIGTTOU, hdlr_sigttin_ou);
 	hdlr_enable(SIGCHLD, hdlr_sigchld);
 	hdlr_enable(SIGHUP, hdlr_sighup);
 
@@ -1506,7 +1504,7 @@ finalize_it:
  * really help us. TODO: add error messages?
  * rgerhards, 2007-08-03
  */
-static void
+void
 processImInternal(void)
 {
 	smsg_t *pMsg;
@@ -1714,10 +1712,9 @@ mainloop(void)
 	time_t tTime;
 
 	BEGINfunc
-	/* first check if we have any internal messages queued and spit them out. */
-	processImInternal();
 
-	while(!bFinished){
+	do {
+		processImInternal();
 		wait_timeout();
 		if(bChildDied) {
 			pid_t child;
@@ -1745,7 +1742,7 @@ mainloop(void)
 			bHadHUP = 0;
 		}
 
-	}
+	} while(!bFinished); /* end do ... while() */
 	ENDfunc
 }
 
@@ -1794,9 +1791,10 @@ deinitAll(void)
 		errno = 0;
 		logmsgInternal(NO_ERRCODE, LOG_SYSLOG|LOG_INFO, (uchar*)buf, 0);
 	}
-	/* we sleep for 50ms to give the queue a chance to pick up the exit message;
-	 * otherwise we have seen cases where the message did not make it to log
-	 * files, even on idle systems.
+	processImInternal(); /* make sure not-yet written internal messages are processed */
+	/* we sleep a couple of ms to give the queue a chance to pick up the late messages
+	 * (including exit message); otherwise we have seen cases where the message did
+	 * not make it to log files, even on idle systems.
 	 */
 	srSleep(0, 50);
 


### PR DESCRIPTION
reissue of #1441 due to rebase problems

Those messages previously went only to the debug log, as due to design limitations inside the error message subsystem they could not be emitted at the related code locations. This has changed now, and so we can improve error reporting.
