### PR TITLE
imczmq: fix 2 regressions introduced in 8.19

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -196,7 +196,7 @@ static rsRetVal addListener(instanceConf_t* iconf){
 #if defined(ZMQ_DISH)
 		case ZMQ_DISH:
 #endif
-			iconf->serverish = true;
+			iconf->serverish = false;
 			break;
 		case ZMQ_PULL:
 #if defined(ZMQ_GATHER)

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -211,6 +211,12 @@ static rsRetVal addListener(instanceConf_t* iconf){
 	}
 
 	if(iconf->topics) {
+		// A zero-length topic means subscribe to everything
+		if(!*iconf->topics && iconf->sockType == ZMQ_SUB) {
+			DBGPRINTF("imczmq: subscribing to all topics\n");
+			zsock_set_subscribe(pData->sock, "");
+		}
+
 		char topic[256];
 		while(*iconf->topics) {
 			char *delimiter = strchr(iconf->topics, ',');


### PR DESCRIPTION
Commit https://github.com/rsyslog/rsyslog/commit/299f5a637f97d2ec064ad3df20fa845ef4b7c7e5 introduced 2 small regressions in the imczmq plugin that I found as we upgrade from 8.18 to 8.24.

Subscribing to every topic (via an empty string in the config) no longer works, and imczmq over a SUB socket no longer connects by default. The fixes for both are very simple.
@taotetek FYI