### PR TITLE
fix new build warnings with gcc6

### DIFF
--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -81,9 +81,10 @@ loadDrvr(netstrms_t *pThis)
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		if(pThis->pDrvrName != NULL)
+		if(pThis->pDrvrName != NULL) {
 			free(pThis->pDrvrName);
 			pThis->pDrvrName = NULL;
+		}
 	}
 	RETiRet;
 }

--- a/runtime/nspoll.c
+++ b/runtime/nspoll.c
@@ -79,9 +79,10 @@ loadDrvr(nspoll_t *pThis)
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		if(pThis->pDrvrName != NULL)
+		if(pThis->pDrvrName != NULL) {
 			free(pThis->pDrvrName);
 			pThis->pDrvrName = NULL;
+		}
 	}
 	RETiRet;
 }

--- a/runtime/nssel.c
+++ b/runtime/nssel.c
@@ -84,9 +84,10 @@ loadDrvr(nssel_t *pThis)
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		if(pThis->pDrvrName != NULL)
+		if(pThis->pDrvrName != NULL) {
 			free(pThis->pDrvrName);
 			pThis->pDrvrName = NULL;
+		}
 	}
 	RETiRet;
 }

--- a/runtime/unlimited_select.h
+++ b/runtime/unlimited_select.h
@@ -35,7 +35,7 @@
 #endif
 
 #ifdef USE_UNLIMITED_SELECT
-void freeFdSet(fd_set *p) {
+static inline void freeFdSet(fd_set *p) {
         free(p);
 }
 #else

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1365,11 +1365,12 @@ initAll(int argc, char **argv)
 					 "configuration parameter instead.\n");
 				glbl.SetParseHOSTNAMEandTAG(0);
 			}
-			if(iHelperUOpt & 0x02)
+			if(iHelperUOpt & 0x02) {
 				fprintf (stderr, "rsyslogd: the -u command line option will go away "
 					 "soon.\n"
 					 "For the 0x02 bit, please use the -C option instead.");
 				bChDirRoot = 0;
+			}
 			break;
 		case 'C':
 			bChDirRoot = 0;


### PR DESCRIPTION
gcc warn you about misleading code indentations and as it turns out, couple has been found here as well