### PR TITLE
improve queue error messages

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -70,7 +70,6 @@
 DEFobjStaticHelpers
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(strm)
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(datetime)
 DEFobjCurrIf(statsobj)
 
@@ -451,7 +450,7 @@ StartDA(qqueue_t *pThis)
 	/* file not found is expected, that means it is no previous QIF available */
 	if(iRet != RS_RET_OK && iRet != RS_RET_FILE_NOT_FOUND) {
 		errno = 0; /* else an errno is shown in errmsg! */
-		errmsg.LogError(errno, iRet, "error starting up disk queue, using pure in-memory mode");
+		LogError(errno, iRet, "error starting up disk queue, using pure in-memory mode");
 		pThis->bIsDA = 0;	/* disable memory mode */
 		FINALIZE; /* something is wrong */
 	}
@@ -742,7 +741,7 @@ queueSwitchToEmergencyMode(qqueue_t *pThis, rsRetVal initiatingError)
 		 */
 	}
 
-	errmsg.LogError(0, initiatingError, "fatal error on disk queue '%s', "
+	LogError(0, initiatingError, "fatal error on disk queue '%s', "
 		"emergency switch to direct mode", obj.GetName((obj_t*) pThis));
 	return RS_RET_ERR_QUEUE_EMERGENCY;
 }
@@ -1992,7 +1991,7 @@ ConsumerReg(qqueue_t *pThis, wti_t *pWti)
 
 	/* report errors, now that we are outside of queue lock */
 	if(skippedMsgs > 0) {
-		errmsg.LogError(0, 0, "problem on disk queue '%s': "
+		LogError(0, 0, "problem on disk queue '%s': "
 				"queue files contain %d messages fewer than specified "
 				"in .qi file -- we lost those messages. That's all we know.",
 				obj.GetName((obj_t*) pThis), skippedMsgs);
@@ -2249,7 +2248,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 
 	if(pThis->iMaxQueueSize < 100
 	   && (pThis->qType == QUEUETYPE_LINKEDLIST || pThis->qType == QUEUETYPE_FIXED_ARRAY)) {
-		errmsg.LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "Note: queue.size=\"%d\" is very "
+		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "Note: queue.size=\"%d\" is very "
 			"low and can lead to unpredictable results. See also "
 			"http://www.rsyslog.com/lower-bound-for-queue-sizes/",
 			pThis->iMaxQueueSize);
@@ -2260,7 +2259,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 	 */
 	goodval = (pThis->iMaxQueueSize / 100) * 60;
 	if(pThis->iHighWtrMrk != -1 && pThis->iHighWtrMrk < goodval) {
-		errmsg.LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": high water mark "
+		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": high water mark "
 				"is set quite low at %d. You should only set it below "
 				"60%% (%d) if you have a good reason for this.",
 				obj.GetName((obj_t*) pThis), pThis->iHighWtrMrk, goodval);
@@ -2269,7 +2268,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 	if(pThis->iNumWorkerThreads > 1) {
 		goodval = (pThis->iMaxQueueSize / 100) * 10;
 		if(pThis->iMinMsgsPerWrkr != -1 && pThis->iMinMsgsPerWrkr < goodval) {
-			errmsg.LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": "
+			LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": "
 					"queue.workerThreadMinimumMessage "
 					"is set quite low at %d. You should only set it below "
 					"10%% (%d) if you have a good reason for this.",
@@ -2278,14 +2277,14 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 	}
 
 	if(pThis->iDiscardMrk > pThis->iMaxQueueSize) {
-		errmsg.LogError(0, RS_RET_PARAM_ERROR, "error: queue \"%s\": "
+		LogError(0, RS_RET_PARAM_ERROR, "error: queue \"%s\": "
 				"queue.discardMark %d is set larger than queue.size",
 				obj.GetName((obj_t*) pThis), pThis->iDiscardMrk);
 	}
 
 	goodval = (pThis->iMaxQueueSize / 100) * 80;
 	if(pThis->iDiscardMrk != -1 && pThis->iDiscardMrk < goodval) {
-		errmsg.LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING,
+		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING,
 				"queue \"%s\": queue.discardMark "
 				"is set quite low at %d. You should only set it below "
 				"80%% (%d) if you have a good reason for this.",
@@ -2294,7 +2293,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 
 	if(pThis->pszFilePrefix != NULL) { /* This means we have a potential DA queue */
 		if(pThis->iFullDlyMrk != -1 && pThis->iFullDlyMrk < pThis->iHighWtrMrk) {
-			errmsg.LogMsg(0, RS_RET_CONF_WRN_FULLDLY_BELOW_HIGHWTR, LOG_WARNING,
+			LogMsg(0, RS_RET_CONF_WRN_FULLDLY_BELOW_HIGHWTR, LOG_WARNING,
 					"queue \"%s\": queue.fullDelayMark "
 					"is set below high water mark. This will result in DA mode "
 					" NOT being activated for full delayable messages",
@@ -3053,7 +3052,7 @@ initCryprov(qqueue_t *pThis, struct nvlst *lst)
 
 	if(snprintf((char*)szDrvrName, sizeof(szDrvrName), "lmcry_%s", pThis->cryprovName)
 		== sizeof(szDrvrName)) {
-		errmsg.LogError(0, RS_RET_ERR, "queue: crypto provider "
+		LogError(0, RS_RET_ERR, "queue: crypto provider "
 				"name is too long: '%s' - encryption disabled",
 				pThis->cryprovName);
 		ABORT_FINALIZE(RS_RET_ERR);
@@ -3068,14 +3067,14 @@ initCryprov(qqueue_t *pThis, struct nvlst *lst)
 	 */
 	if(obj.UseObj(__FILE__, szDrvrName, szDrvrName, (void*) &pThis->cryprov)
 		!= RS_RET_OK) {
-		errmsg.LogError(0, RS_RET_LOAD_ERROR, "queue: could not load "
+		LogError(0, RS_RET_LOAD_ERROR, "queue: could not load "
 				"crypto provider '%s' - encryption disabled",
 				szDrvrName);
 		ABORT_FINALIZE(RS_RET_CRYPROV_ERR);
 	}
 
 	if(pThis->cryprov.Construct(&pThis->cryprovData) != RS_RET_OK) {
-		errmsg.LogError(0, RS_RET_CRYPROV_ERR, "queue: error constructing "
+		LogError(0, RS_RET_CRYPROV_ERR, "queue: error constructing "
 				"crypto provider %s dataset - encryption disabled",
 				szDrvrName);
 		ABORT_FINALIZE(RS_RET_CRYPROV_ERR);
@@ -3178,7 +3177,7 @@ qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst)
 	}
 	if(pThis->qType == QUEUETYPE_DISK) {
 		if(pThis->pszFilePrefix == NULL) {
-			errmsg.LogError(0, RS_RET_QUEUE_DISK_NO_FN, "error on queue '%s', disk mode selected, but "
+			LogError(0, RS_RET_QUEUE_DISK_NO_FN, "error on queue '%s', disk mode selected, but "
 					"no queue file name given; queue type changed to 'linkedList'",
 					obj.GetName((obj_t*) pThis));
 			pThis->qType = QUEUETYPE_LINKEDLIST;
@@ -3186,7 +3185,7 @@ qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst)
 	}
 
 	if(pThis->pszFilePrefix == NULL && pThis->cryprovName != NULL) {
-		errmsg.LogError(0, RS_RET_QUEUE_CRY_DISK_ONLY, "error on queue '%s', crypto provider can "
+		LogError(0, RS_RET_QUEUE_CRY_DISK_ONLY, "error on queue '%s', crypto provider can "
 				"only be set for disk or disk assisted queue - ignored",
 				obj.GetName((obj_t*) pThis));
 		free(pThis->cryprovName);
@@ -3268,7 +3267,6 @@ BEGINObjClassInit(qqueue, 1, OBJ_IS_CORE_MODULE)
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(strm, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
 
 	/* now set our own handlers */

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -64,7 +64,6 @@
 #include "errmsg.h"
 #include "cryprov.h"
 #include "datetime.h"
-#include "errmsg.h"
 
 /* some platforms do not have large file support :( */
 #ifndef O_LARGEFILE


### PR DESCRIPTION
with the recent change that permits us to emit error messages at
(alomost) any time, we can now provide better end-user diagnostics.
This patch generates error message which could previously only be
logged to the debug log.