### PR TITLE
Fixed omsnmp new-config issue

### DIFF
--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -454,6 +454,12 @@ CODESTARTnewActInst
 		}
 	}
 
+	/* Init NetSNMP library and read in MIB database */
+	init_snmp("rsyslog");
+
+	/* Set some defaults in the NetSNMP library */
+	netsnmp_ds_set_int(NETSNMP_DS_LIBRARY_ID, NETSNMP_DS_LIB_DEFAULT_PORT, pData->iPort );
+
 	CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)strdup((pData->tplName == NULL) ? 
 						"RSYSLOG_FileFormat" : (char*)pData->tplName),
 						OMSR_NO_RQD_TPL_OPTS));


### PR DESCRIPTION
When omsnmp was configured via new-config, init_snmp wasn't called.

This config doesn't work.

module(load="omsnmp")
local2.debug action( type="omsnmp"
                    transport="udp"
                    server="localhost"
                    port="162"
                    version="1"
                    community="public"
                    trapoid="ADISCON-MONITORWARE-MIB::syslogtrap"
                    messageoid="ADISCON-MONITORWARE-MIB::syslogMsg"
)
It prints error message:
"rsyslogd-2006: omsnmp_sendsnmp: Adding trap OID failed 'ADISCON-MONITORWARE-MIB::syslogtrap' with error 'Unknown Object Identifier'"

Config worked only without specified MIB-files.


