### PR TITLE
testbench: tcpflood failed to build if RELP support was disabled (2/2)

### DIFF
--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -96,7 +96,9 @@
 #include <string.h>
 #include <netinet/in.h>
 #include <pthread.h>
+#ifdef ENABLE_RELP
 #include <librelp.h>
+#endif
 #include <sys/resource.h>
 #include <sys/time.h>
 #include <errno.h>


### PR DESCRIPTION
The previous commit 73e3b7ab for issue #1426 was incomplete and missed
the librelp.h header include.

Gentoo-Bug: https://bugs.gentoo.org/614424