### PR TITLE
Rate limit proc name

### DIFF
--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -216,7 +216,7 @@ ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRepMsg)
 	 * treshold (the value is >=) are subject to ratelimiting. */
 	if(ratelimit->interval && (pMsg->iSeverity >= ratelimit->severity)) {
         char namebuf[512]; /* 256 for FGDN adn 256 for APPNAME should be enough */
-        snprintf(namebuf, sizeof namebuf, "%s%s", getHOSTNAME(pMsg), getAPPNAME(pMsg, 0));
+        snprintf(namebuf, sizeof namebuf, "%s:%s", getHOSTNAME(pMsg), getAPPNAME(pMsg, 0));
         if(withinRatelimit(ratelimit, pMsg->ttGenTime, namebuf) == 0) {
 			msgDestruct(&pMsg);
 			ABORT_FINALIZE(RS_RET_DISCARDMSG);


### PR DESCRIPTION
This is sort of addition to recently merged changes, first commit addresses real-world use-case finding that hostname and message source are better split by some formatting char (colon seems ok for this purpose) and second commit adds much better source logging for those using imuxsock which does not rely on APPNAME mesage field which is, more often than not, blank. What do you think of this @rgerhards ?