### PR TITLE
Double impstats flush-interval because 1-flush-per-second is not enough tolerance on very slow machines

### DIFF
--- a/tests/dynstats_prevent_premature_eviction.sh
+++ b/tests/dynstats_prevent_premature_eviction.sh
@@ -6,11 +6,11 @@ echo \[dynstats_prevent_premature_eviction.sh\]: test for ensuring metrics are n
 . $srcdir/diag.sh init
 . $srcdir/diag.sh startup dynstats_reset.conf
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
-. $srcdir/diag.sh msleep 800
+. $srcdir/diag.sh msleep 1000
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_1
-. $srcdir/diag.sh msleep 400
+. $srcdir/diag.sh msleep 2000
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_2
-. $srcdir/diag.sh msleep 900
+. $srcdir/diag.sh msleep 2000
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_3
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'

--- a/tests/dynstats_reset-vg.sh
+++ b/tests/dynstats_reset-vg.sh
@@ -7,11 +7,11 @@ echo \[dynstats_reset-vg.sh\]: test for gathering stats with a known-dyn-metrics
 . $srcdir/diag.sh startup-vg dynstats_reset.conf
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_1
-. $srcdir/diag.sh msleep 2100 #one second for unused-metrics to be kept under observation, another for them to be cleared off
+. $srcdir/diag.sh msleep 4100 #two seconds for unused-metrics to be kept under observation, another two them to be cleared off
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_2
-. $srcdir/diag.sh msleep 2100
+. $srcdir/diag.sh msleep 4100
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_3
-. $srcdir/diag.sh msleep 2100
+. $srcdir/diag.sh msleep 4100
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "foo 001 0"
 . $srcdir/diag.sh content-check "bar 002 0"

--- a/tests/dynstats_reset.sh
+++ b/tests/dynstats_reset.sh
@@ -7,11 +7,11 @@ echo \[dynstats_reset.sh\]: test for gathering stats with a known-dyn-metrics re
 . $srcdir/diag.sh startup dynstats_reset.conf
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_1
-. $srcdir/diag.sh msleep 2100
+. $srcdir/diag.sh msleep 4100
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_2
-. $srcdir/diag.sh msleep 2100
+. $srcdir/diag.sh msleep 4100
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_3
-. $srcdir/diag.sh msleep 2100
+. $srcdir/diag.sh msleep 4100
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "foo 001 0"
 . $srcdir/diag.sh content-check "bar 002 0"

--- a/tests/testsuites/dynstats_reset.conf
+++ b/tests/testsuites/dynstats_reset.conf
@@ -4,7 +4,7 @@ ruleset(name="stats") {
   action(type="omfile" file="./rsyslog.out.stats.log")
 }
 
-module(load="../plugins/impstats/.libs/impstats" interval="1" severity="7" resetCounters="on" Ruleset="stats" bracketing="on")
+module(load="../plugins/impstats/.libs/impstats" interval="2" severity="7" resetCounters="on" Ruleset="stats" bracketing="on")
 
 template(name="outfmt" type="string" string="%msg% %$.increment_successful%\n")
 


### PR DESCRIPTION
dynstats_prevent_premature_eviction.sh always fails on Solaris10 sparc buildbot due to this tolerance issue (https://github.com/rsyslog/rsyslog/issues/1519).