### PR TITLE
imtcp: add new parameter discardTruncatedMsg

### DIFF
--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -98,6 +98,7 @@ static struct configSettings_s {
 	int bEmitMsgOnClose;
 	int iAddtlFrameDelim;
 	int bDisableLFDelim;
+	int discardTruncatedMsg;
 	int bUseFlowControl;
 	uchar *pszStrmDrvrAuthMode;
 	uchar *pszInputName;
@@ -129,6 +130,7 @@ struct modConfData_s {
 	int iAddtlFrameDelim; /* addtl frame delimiter, e.g. for netscreen, default none */
 	int bSuppOctetFram;
 	sbool bDisableLFDelim; /* disable standard LF delimiter */
+	sbool discardTruncatedMsg;
 	sbool bUseFlowControl; /* use flow control, what means indicate ourselfs a "light delayable" */
 	sbool bKeepAlive;
 	int iKeepAliveIntvl;
@@ -148,6 +150,7 @@ static modConfData_t *runModConf = NULL;/* modConf ptr to use for the current lo
 static struct cnfparamdescr modpdescr[] = {
 	{ "flowcontrol", eCmdHdlrBinary, 0 },
 	{ "disablelfdelimiter", eCmdHdlrBinary, 0 },
+	{ "discardtruncatedmsg", eCmdHdlrBinary, 0 },
 	{ "octetcountedframing", eCmdHdlrBinary, 0 },
 	{ "notifyonconnectionclose", eCmdHdlrBinary, 0 },
 	{ "addtlframedelimiter", eCmdHdlrNonNegInt, 0 },
@@ -357,6 +360,7 @@ addListner(modConfData_t *modConf, instanceConf_t *inst)
 		CHKiRet(tcpsrv.SetUseFlowControl(pOurTcpsrv, modConf->bUseFlowControl));
 		CHKiRet(tcpsrv.SetAddtlFrameDelim(pOurTcpsrv, modConf->iAddtlFrameDelim));
 		CHKiRet(tcpsrv.SetbDisableLFDelim(pOurTcpsrv, modConf->bDisableLFDelim));
+		CHKiRet(tcpsrv.SetDiscardTruncatedMsg(pOurTcpsrv, modConf->discardTruncatedMsg));
 		CHKiRet(tcpsrv.SetNotificationOnRemoteClose(pOurTcpsrv, modConf->bEmitMsgOnClose));
 		/* now set optional params, but only if they were actually configured */
 		if(modConf->pszStrmDrvrName != NULL) {
@@ -459,6 +463,7 @@ CODESTARTbeginCnfLoad
 	loadModConf->bEmitMsgOnClose = 0;
 	loadModConf->iAddtlFrameDelim = TCPSRV_NO_ADDTL_DELIMITER;
 	loadModConf->bDisableLFDelim = 0;
+	loadModConf->discardTruncatedMsg = 0;
 	loadModConf->pszStrmDrvrName = NULL;
 	loadModConf->pszStrmDrvrAuthMode = NULL;
 	loadModConf->permittedPeers = NULL;
@@ -493,6 +498,8 @@ CODESTARTsetModCnf
 			loadModConf->bUseFlowControl = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "disablelfdelimiter")) {
 			loadModConf->bDisableLFDelim = (int) pvals[i].val.d.n;
+		} else if(!strcmp(modpblk.descr[i].name, "discardtruncatedmsg")) {
+			loadModConf->discardTruncatedMsg = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "octetcountedframing")) {
 			loadModConf->bSuppOctetFram = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "notifyonconnectionclose")) {

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -40,7 +40,8 @@ struct tcps_sess_s {
 	enum {
 		eAtStrtFram,
 		eInOctetCnt,
-		eInMsg
+		eInMsg,
+		eInMsgTruncating
 	} inputState;		/* our current state */
 	int iOctetsRemain;	/* Number of Octets remaining in message */
 	TCPFRAMINGMODE eFraming;

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -968,6 +968,7 @@ BEGINobjConstruct(tcpsrv) /* be sure to specify the object type also in END macr
 	pThis->iLstnMax = TCPLSTN_MAX_DEFAULT;
 	pThis->addtlFrameDelim = TCPSRV_NO_ADDTL_DELIMITER;
 	pThis->bDisableLFDelim = 0;
+	pThis->discardTruncatedMsg = 0;
 	pThis->OnMsgReceive = NULL;
 	pThis->dfltTZ[0] = '\0';
 	pThis->bSPFramingFix = 0;
@@ -1188,6 +1189,19 @@ SetbDisableLFDelim(tcpsrv_t *pThis, int bVal)
 }
 
 
+/* discard the truncated msg part
+ * -- PascalWithopf, 2017-04-20
+ */
+static rsRetVal
+SetDiscardTruncatedMsg(tcpsrv_t *pThis, int discard)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, tcpsrv);
+	pThis->discardTruncatedMsg = discard;
+	RETiRet;
+}
+
+
 /* Set additional framing to use (if any) -- rgerhards, 2008-12-10 */
 static rsRetVal
 SetAddtlFrameDelim(tcpsrv_t *pThis, int iDelim)
@@ -1404,6 +1418,7 @@ CODESTARTobjQueryInterface(tcpsrv)
 	pIf->SetbSPFramingFix = SetbSPFramingFix;
 	pIf->SetAddtlFrameDelim = SetAddtlFrameDelim;
 	pIf->SetbDisableLFDelim = SetbDisableLFDelim;
+	pIf->SetDiscardTruncatedMsg = SetDiscardTruncatedMsg;
 	pIf->SetSessMax = SetSessMax;
 	pIf->SetUseFlowControl = SetUseFlowControl;
 	pIf->SetLstnMax = SetLstnMax;

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -81,6 +81,7 @@ struct tcpsrv_s {
 
 	int addtlFrameDelim;	/**< additional frame delimiter for plain TCP syslog framing (e.g. to handle NetScreen) */
 	int bDisableLFDelim;	/**< if 1, standard LF frame delimiter is disabled (*very dangerous*) */
+	int discardTruncatedMsg;/**< discard msg part that has been truncated*/
 	int ratelimitInterval;
 	int ratelimitBurst;
 	tcps_sess_t **pSessions;/**< array of all of our sessions */
@@ -151,6 +152,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	/* added v9 -- rgerhards, 2010-03-01 */
 	rsRetVal (*SetbDisableLFDelim)(tcpsrv_t*, int);
 	/* added v10 -- rgerhards, 2011-04-01 */
+	rsRetVal (*SetDiscardTruncatedMsg)(tcpsrv_t*, int);
 	rsRetVal (*SetUseFlowControl)(tcpsrv_t*, int);
 	/* added v11 -- rgerhards, 2011-05-09 */
 	rsRetVal (*SetKeepAlive)(tcpsrv_t*, int);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -97,6 +97,7 @@ TESTS +=  \
 	da-mainmsg-q.sh \
 	validation-run.sh \
 	empty-ruleset.sh \
+	imtcp-discard-truncated-msg.sh \
 	imtcp-basic.sh \
 	imtcp-NUL.sh \
 	imtcp-NUL-rawmsg.sh \
@@ -952,6 +953,7 @@ EXTRA_DIST= \
 	testsuites/diskqueue-fsync.conf \
 	empty-ruleset.sh \
 	testsuites/empty-ruleset.conf \
+	imtcp-discard-truncated-msg.sh \
 	imtcp-basic.sh \
 	imtcp-NUL.sh \
 	imtcp-NUL-rawmsg.sh \

--- a/tests/imtcp-discard-truncated-msg.sh
+++ b/tests/imtcp-discard-truncated-msg.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# addd 2016-05-13 by RGerhards, released under ASL 2.0
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+$MaxMessageSize 128
+global(processInternalMessages="on")
+module(load="../plugins/imtcp/.libs/imtcp" discardTruncatedMsg="on")
+input(type="imtcp" port="13514" ruleset="ruleset1")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+ruleset(name="ruleset1") {
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test13 test14 test15 test16\""
+. $srcdir/diag.sh tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long message\""
+. $srcdir/diag.sh tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test13 test14 test15 test16\""
+. $srcdir/diag.sh tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long message\""
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+echo '<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
+<120> 2011-03-01T11:22:12Z host tag: this is a way to long message
+<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
+<120> 2011-03-01T11:22:12Z host tag: this is a way to long message' | cmp rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
Parameter discardTruncatedMsg makes it possible to discard the rest of the message after it has been truncated.
closes https://github.com/rsyslog/rsyslog/issues/745