### PR TITLE
core bugfix: stderr used on shutdown even though it is closed

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -824,7 +824,9 @@ void
 rsyslogd_submitErrMsg(const int severity, const int iErr, const uchar *msg)
 {
 	if (glbl.GetGlobalInputTermState() == 1) {
-		dfltErrLogger(severity, iErr, msg);
+		/* After fork the stderr is unusable (dfltErrLogger uses is internally) */
+		if(!doFork)
+			dfltErrLogger(severity, iErr, msg);
 	} else {
 		logmsgInternal(iErr, LOG_SYSLOG|(severity & 0x07), msg, 0);
 	}


### PR DESCRIPTION
This leads to invalid writes to whatever file is open with file
descriptor 2. The problem only happens during shutdown.

closes https://github.com/rsyslog/rsyslog/issues/1526