### PR TITLE
testbench: invalid init sequence

### DIFF
--- a/tests/mmnormalize_processing_test1.sh
+++ b/tests/mmnormalize_processing_test1.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmnormalize_processing_test2.sh
+++ b/tests/mmnormalize_processing_test2.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmnormalize_processing_test3.sh
+++ b/tests/mmnormalize_processing_test3.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+01:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmnormalize_processing_test4.sh
+++ b/tests/mmnormalize_processing_test4.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST-02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/now-utc-casecmp.sh
+++ b/tests/now-utc-casecmp.sh
@@ -3,12 +3,12 @@
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[now-utc-casecmp\]: test \$year-utc, \$month-utc, \$day-utc
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=TEST-02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/now-utc-ymd.sh
+++ b/tests/now-utc-ymd.sh
@@ -2,13 +2,13 @@
 # test many concurrent tcp connections
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
+. $srcdir/diag.sh init
 echo \[now-utc-ymd\]: test \$year-utc, \$month-utc, \$day-utc
 
 . $srcdir/faketime_common.sh
 
 export TZ=TEST-02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/now-utc.sh
+++ b/tests/now-utc.sh
@@ -3,12 +3,12 @@
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[now-utc\]: test \$NOW-UTC
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=TEST-02:00
 
-. $srcdir/diag.sh init
 FAKETIME='2016-01-01 01:00:00' $srcdir/diag.sh startup now-utc.conf
 # what we send actually is irrelevant, as we just use system properties.
 # but we need to send one message in order to gain output!

--- a/tests/now_family_utc.sh
+++ b/tests/now_family_utc.sh
@@ -3,12 +3,12 @@
 # addd 2016-01-12 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[now_family_utc\]: test \$NOW family of system properties
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+06:30
 
-. $srcdir/diag.sh init
 FAKETIME='2016-01-01 01:00:00' $srcdir/diag.sh startup now_family_utc.conf
 # what we send actually is irrelevant, as we just use system properties.
 # but we need to send one message in order to gain output!

--- a/tests/timegenerated-dateordinal-invld.sh
+++ b/tests/timegenerated-dateordinal-invld.sh
@@ -5,12 +5,12 @@
 # instead provide the defined return value (0)
 # requires faketime
 echo \[timegenerated-dateordinal-invld\]: check invalid dates with ordinal format
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=UTC+00:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/timegenerated-dateordinal.sh
+++ b/tests/timegenerated-dateordinal.sh
@@ -5,12 +5,12 @@
 # from creating additional tests
 # requires faketime
 echo \[timegenerated-dateordinal\]: check valid dates with ordinal format
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=UTC+00:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/timegenerated-utc-legacy.sh
+++ b/tests/timegenerated-utc-legacy.sh
@@ -8,11 +8,11 @@
 # FOR THE SAME REASON, there is NO VALGRIND EQUIVALENT
 # of this test, as valgrind would abort with reports
 # of faketime.
+. $srcdir/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/timegenerated-utc.sh
+++ b/tests/timegenerated-utc.sh
@@ -8,11 +8,11 @@
 # FOR THE SAME REASON, there is NO VALGRIND EQUIVALENT
 # of this test, as valgrind would abort with reports
 # of faketime.
+. $srcdir/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/timegenerated-uxtimestamp-invld.sh
+++ b/tests/timegenerated-uxtimestamp-invld.sh
@@ -5,12 +5,12 @@
 # instead provide the defined return value (0)
 # requires faketime
 echo \[timegenerated-uxtimestamp-invld\]: check invalid dates with uxtimestamp format
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=UTC+00:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/timegenerated-uxtimestamp.sh
+++ b/tests/timegenerated-uxtimestamp.sh
@@ -5,12 +5,12 @@
 # from creating additional tests
 # requires faketime
 echo \[timegenerated-uxtimestamp\]: check valid dates with uxtimestamp format
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=UTC+00:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/timegenerated-ymd.sh
+++ b/tests/timegenerated-ymd.sh
@@ -3,12 +3,12 @@
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[timegenerated-ymd\]: check customized format \(Y-m-d\)
+. $srcdir/diag.sh init
 
 . $srcdir/faketime_common.sh
 
 export TZ=TEST-02:00
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp


### PR DESCRIPTION
this  causes all libfaketime tests to fail, due to unset
environment variable (which is set in init).