### PR TITLE
core bugfix: memory leak when internal messages not processed internally

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -955,8 +955,8 @@ rsRetVal msgDestruct(smsg_t **ppThis)
 	int currCnt;
 #	endif
 CODESTARTobjDestruct(msg)
-	/* DEV Debugging only ! dbgprintf("msgDestruct\t0x%lx,
-	Ref now: %d\n", (unsigned long)pThis, pThis->iRefCount - 1); */
+	/* DEV Debugging only ! dbgprintf("msgDestruct\t0x%lx, "
+		"Ref now: %d\n", (unsigned long)pThis, pThis->iRefCount - 1); */
 #	ifdef HAVE_ATOMIC_BUILTINS
 		currRefCount = ATOMIC_DEC_AND_FETCH(&pThis->iRefCount, NULL);
 #	else

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -250,6 +250,7 @@ endif
 
 if HAVE_VALGRIND
 TESTS +=  \
+	internal-errmsg-memleak.sh \
 	rscript_set_memleak-vg.sh \
 	discard-rptdmsg-vg.sh \
 	discard-allmark-vg.sh \
@@ -625,6 +626,7 @@ DISTCLEANFILES=rsyslog.pid
 test_files = testbench.h runtime-dummy.c
 
 EXTRA_DIST= \
+	internal-errmsg-memleak.sh \
 	empty-hostname.sh \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \

--- a/tests/internal-errmsg-memleak.sh
+++ b/tests/internal-errmsg-memleak.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This tests a memory leak we have seen when processing internal error
+# message with the settings used in this test. We use imfile as it is
+# easist to reproduce this way. Note that we are only interested in
+# whether or not we have a leak, not any other functionality. Most
+# importantly, we do not care if the error message appears or not. This
+# is because it is not so easy to pick it up from the system log and other
+# tests already cover this szenario.
+# add 2017-05-10 by Rainer Gerhards, released under ASL 2.0
+uname
+if [ `uname` = "SunOS" ] ; then # TODO: do we really need this test?
+   echo "Solaris: inotify isn't supported on Solaris"
+   exit 77
+fi
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+global(processInternalMessages="off")
+$RepeatedMsgReduction on # keep this on because many distros have set it
+
+module(load="../plugins/imfile/.libs/imfile") # mode="polling" pollingInterval="1")
+input(type="imfile" File="./rsyslog.input" Tag="tag1" ruleset="ruleset1")
+
+template(name="tmpl1" type="string" string="%msg%\n")
+ruleset(name="ruleset1") {
+	action(type="omfile" file="rsyslog.out.log" template="tmpl1")
+}
+action(type="omfile" file="rsyslog2.out.log")
+'
+. $srcdir/diag.sh startup-vg-waitpid-only
+./msleep 500 # wait a bit so that the error message can be emitted
+. $srcdir/diag.sh shutdown-immediate
+. $srcdir/diag.sh wait-shutdown-vg
+
+. $srcdir/diag.sh exit

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -840,7 +840,7 @@ submitMsgWithDfltRatelimiter(smsg_t *pMsg)
 
 
 static void
-logmsgInternal_doWrite(smsg_t *const __restrict__ pMsg)
+logmsgInternal_doWrite(smsg_t *pMsg)
 {
 	if(bProcessInternalMessages) {
 		ratelimitAddMsg(internalMsg_ratelimiter, NULL, pMsg);
@@ -852,6 +852,8 @@ logmsgInternal_doWrite(smsg_t *const __restrict__ pMsg)
 #		else
 		syslog(pri, "%s", msg);
 #		endif
+		/* we have emitted the message and must destruct it */
+		msgDestruct(&pMsg);
 	}
 }
 


### PR DESCRIPTION
In this case, the message object is not destructed, resulting in a memory leak. Usually, this is no problem due to the low number of internal message, but it can become an issue if a large number of messages is emitted.

closes #1548
closes #1531