### PR TITLE
testbench: enable some more tests on solaris

### DIFF
--- a/tests/imfile-error-not-repeated.sh
+++ b/tests/imfile-error-not-repeated.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # add 2017-04-28 by Pascal Withopf, released under ASL 2.0
-uname
-if [ `uname` = "SunOS" ] ; then
-   echo "Solaris: inotify isn't supported on Solaris"
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '

--- a/tests/internal-errmsg-memleak.sh
+++ b/tests/internal-errmsg-memleak.sh
@@ -7,12 +7,6 @@
 # is because it is not so easy to pick it up from the system log and other
 # tests already cover this szenario.
 # add 2017-05-10 by Rainer Gerhards, released under ASL 2.0
-uname
-if [ `uname` = "SunOS" ] ; then # TODO: do we really need this test?
-   echo "Solaris: inotify isn't supported on Solaris"
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '


### PR DESCRIPTION
I guess they were accidently disabled.