### PR TITLE
Fix format security issue in zmq3 modules

### DIFF
--- a/contrib/imzmq3/imzmq3.c
+++ b/contrib/imzmq3/imzmq3.c
@@ -403,7 +403,7 @@ static rsRetVal createSocket(instanceConf_t* info, void** sock) {
 
     /* Do the bind/connect... */
     if (info->action==ACTION_CONNECT) {
-        rv = zsocket_connect(*sock, info->description);
+        rv = zsocket_connect(*sock, "%s", info->description);
         if (rv == -1) {
             errmsg.LogError(0,
                             RS_RET_INVALID_PARAMS,
@@ -413,7 +413,7 @@ static rsRetVal createSocket(instanceConf_t* info, void** sock) {
         }
         DBGPRINTF("imzmq3: connect for %s successful\n",info->description);
     } else {
-        rv = zsocket_bind(*sock, info->description);
+        rv = zsocket_bind(*sock, "%s", info->description);
         if (rv == -1) {
             errmsg.LogError(0,
                             RS_RET_INVALID_PARAMS,

--- a/contrib/omzmq3/omzmq3.c
+++ b/contrib/omzmq3/omzmq3.c
@@ -242,14 +242,14 @@ static rsRetVal initZMQ(instanceData* pData) {
     if (pData->action == ACTION_BIND) {
         /* bind asserts, so no need to test return val here
            which isn't the greatest api -- oh well */
-        if(-1 == zsocket_bind(pData->socket, (char*)pData->description)) {
+        if(-1 == zsocket_bind(pData->socket, "%s", (char*)pData->description)) {
             errmsg.LogError(0, RS_RET_NO_ERRCODE, "omzmq3: bind failed for %s: %s",
                             pData->description, zmq_strerror(errno));
             ABORT_FINALIZE(RS_RET_NO_ERRCODE);
         }
         DBGPRINTF("omzmq3: bind to %s successful\n",pData->description);
     } else {
-        if(-1 == zsocket_connect(pData->socket, (char*)pData->description)) {
+        if(-1 == zsocket_connect(pData->socket, "%s", (char*)pData->description)) {
             errmsg.LogError(0, RS_RET_NO_ERRCODE, "omzmq3: connect failed for %s: %s", 
                             pData->description, zmq_strerror(errno));
             ABORT_FINALIZE(RS_RET_NO_ERRCODE);


### PR DESCRIPTION
This PR will fix 2 compilation errors when trying to build imzqm3 or omzmq3 module with *-Werror=format-security*:
```
omzmq3.c: In function ‘initZMQ’:
omzmq3.c:245:9: error: format not a string literal and no format arguments [-Werror=format-security]
	if(-1 == zsocket_bind(pData->socket, (char*)pData->description)) {
	^~
omzmq3.c:252:9: error: format not a string literal and no format arguments [-Werror=format-security]
	if(-1 == zsocket_connect(pData->socket, (char*)pData->description)) {
	^~
```
and
```
imzmq3.c: In function ‘createSocket’:
imzmq3.c:406:9: error: format not a string literal and no format arguments [-Werror=format-security]
         rv = zsocket_connect(*sock, info->description);
         ^~
imzmq3.c:416:9: error: format not a string literal and no format arguments [-Werror=format-security]
         rv = zsocket_bind(*sock, info->description);
         ^~
```
