### PR TITLE
Improve librdkafka detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1710,12 +1710,13 @@ fi
 
 # imkafka needs newer library
 if test "x$enable_imkafka" = "xyes"; then
-	PKG_CHECK_MODULES(LIBRDKAFKA, rdkafka >= 0.9.1)
-	AC_CHECK_LIB([rdkafka], [rd_kafka_produce], [
-		AC_MSG_WARN([librdkafka is missing but library present, using -lrdkafka])
-		LIBRDKAFKA_LIBS=-lrdkafka
-	], [
-		AC_MSG_ERROR([could not find rdkafka library])
+	PKG_CHECK_MODULES([LIBRDKAFKA], [rdkafka >= 0.9.1],, [
+		AC_CHECK_LIB([rdkafka], [rd_kafka_produce], [
+			AC_MSG_WARN([librdkafka is missing but library present, using -lrdkafka])
+			LIBRDKAFKA_LIBS=-lrdkafka
+		], [
+			AC_MSG_ERROR([could not find rdkafka library])
+		])
 	])
 	AC_CHECK_HEADERS([librdkafka/rdkafka.h])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -1695,12 +1695,14 @@ AM_CONDITIONAL(ENABLE_KAFKA_TESTS, test x$enable_kafka_tests = xyes)
 
 # omkafka works with older library
 if test "x$enable_omkafka" = "xyes"; then
-	PKG_CHECK_MODULES([LIBRDKAFKA], [librdkafka],, [
-		AC_CHECK_LIB([rdkafka], [rd_kafka_produce], [
-			AC_MSG_WARN([librdkafka is missing but library present, using -lrdkafka])
-			LIBRDKAFKA_LIBS=-lrdkafka
-		], [
-			AC_MSG_ERROR([could not find rdkafka library])
+	PKG_CHECK_MODULES([LIBRDKAFKA], [rdkafka],, [
+		PKG_CHECK_MODULES([LIBRDKAFKA], [librdkafka],, [
+			AC_CHECK_LIB([rdkafka], [rd_kafka_produce], [
+				AC_MSG_WARN([librdkafka is missing but library present, using -lrdkafka])
+				LIBRDKAFKA_LIBS=-lrdkafka
+			], [
+				AC_MSG_ERROR([could not find rdkafka library])
+			])
 		])
 	])
 	AC_CHECK_HEADERS([librdkafka/rdkafka.h])


### PR DESCRIPTION
I was wondering about the message
```
librdkafka is missing but library present, using -lrdkafka
```
so I looked into the code and improved librdkafka detection.