### PR TITLE
mmdblookup bugfix: multiple memory leaks

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -522,6 +522,10 @@ endif
 if ENABLE_MMDBLOOKUP
 TESTS += \
     mmdb.sh
+if HAVE_VALGRIND
+TESTS += \
+    mmdb-vg.sh
+endif
 endif
 
 if ENABLE_GNUTLS
@@ -933,6 +937,7 @@ EXTRA_DIST= \
 	mmdb.rb \
 	test.mmdb \
 	testsuites/mmdb.conf \
+	mmdb-vg.sh \
 	incltest.sh \
 	testsuites/incltest.conf \
 	incltest_dir.sh \
@@ -1480,6 +1485,7 @@ EXTRA_DIST= \
 	imptcp_nonProcessingPoller.sh \
 	imptcp_veryLargeOctateCountedMessages.sh \
 	testsuites/imptcp_nonProcessingPoller.conf \
+	libmaxmindb.supp \
 	travis/trusty.supp \
 	json_var_case.sh \
 	testsuites/json_var_case.conf \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -187,7 +187,9 @@ case $1 in
 		    echo "ERROR: config file '$CONF_FILE' not found!"
 		    exit 1
 		fi
+		set -x
 		valgrind $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=full ../tools/rsyslogd -C -n -irsyslog$3.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
+		set +x
 		. $srcdir/diag.sh wait-startup-pid $3
 		;;
    'startup-vg') # start rsyslogd with default params under valgrind control. $2 is the config file name to use

--- a/tests/libmaxmindb.supp
+++ b/tests/libmaxmindb.supp
@@ -1,0 +1,38 @@
+{
+   libmaxmindb_known_leak_(fixed_in_later_versions)
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:MMDB_open
+   fun:createWrkrInstance
+   fun:actionCheckAndCreateWrkrInstance
+   fun:actionPrepare
+   fun:actionProcessMessage
+   fun:processMsgMain
+   fun:doSubmitToActionQ
+   fun:execAct
+   fun:scriptExec
+   fun:processBatch
+   fun:msgConsumer
+}
+{
+   another_incarnation_of_the_same
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:populate_languages_metadata
+   fun:read_metadata
+   fun:MMDB_open
+   fun:createWrkrInstance
+   fun:actionCheckAndCreateWrkrInstance
+   fun:actionPrepare
+   fun:actionProcessMessage
+   fun:processMsgMain
+   fun:doSubmitToActionQ
+   fun:execAct
+   fun:scriptExec
+   fun:processBatch
+   fun:msgConsumer
+   fun:ConsumerReg
+   fun:wtiWorker
+}

--- a/tests/mmdb-vg.sh
+++ b/tests/mmdb-vg.sh
@@ -1,0 +1,17 @@
+#!/bin/bash 
+# This file is part of the rsyslog project, released under ASL 2.0 
+
+# we libmaxmindb, in packaged versions, has a small cosmetic memory leak,
+# thus we need a supressions file:
+export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="$RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=libmaxmindb.supp"
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup-vg mmdb.conf
+. $srcdir/diag.sh tcpflood -m 100 -j "202.106.0.20\ "
+echo doing shutdown 
+. $srcdir/diag.sh shutdown-when-empty
+echo wait on shutdown 
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh content-check '{ "city": "Beijing" }'
+. $srcdir/diag.sh exit 


### PR DESCRIPTION
There were multiple large memory leaks in mmdblookup, which made
it unusable when used more than lightly.

closes https://github.com/rsyslog/rsyslog/issues/1415