### PR TITLE
bugfix: handling of json "null" objects in regard to msgGetJSONPropJSON

### DIFF
--- a/contrib/mmcount/mmcount.c
+++ b/contrib/mmcount/mmcount.c
@@ -298,6 +298,9 @@ CODESTARTdoAction
 
 	/* key found, so get the value */
 	pszValue = (char*)json_object_get_string(keyjson);
+	if(pszValue == NULL) { /* json null object returns NULL! */
+		pszValue = "";
+	}
 
 	if(pData->pszValue) {
 		/* value also given for count */

--- a/contrib/mmdblookup/mmdblookup.c
+++ b/contrib/mmdblookup/mmdblookup.c
@@ -258,7 +258,7 @@ BEGINdoAction_NoStrings
 	smsg_t *pMsg   = ppMsg[0];
 	struct json_object *json = NULL;
 	struct json_object *keyjson = NULL;
-	char *pszValue;
+	const char *pszValue;
 	instanceData *const pData = pWrkrData->pData;
 	json_object *total_json = NULL;
 	MMDB_entry_data_list_s *entry_data_list = NULL;
@@ -277,6 +277,9 @@ CODESTARTdoAction
 	}
 	/* key found, so get the value */
 	pszValue = (char*)json_object_get_string(keyjson);
+	if(pszValue == NULL) { /* json null object returns NULL! */
+		pszValue = "";
+	}
 
 	int gai_err, mmdb_err;
 	MMDB_lookup_result_s result = MMDB_lookup_string(&pWrkrData->mmdb, pszValue, &gai_err, &mmdb_err);


### PR DESCRIPTION
libfastjson returns NULL for json "null" objects, and callers need
to handle this. This is correctly handled in almost all code path
in rsyslog, and this patch fixes theoretical issues in the remaining
two places. Note, however, that a json null object can not really
occur at those places due to the rest of processing. But we
wanted to include the check anyways.

closes https://github.com/rsyslog/rsyslog/issues/600