### PR TITLE
Ignore NONAME error from getaddrinfo 

### DIFF
--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1188,7 +1188,11 @@ getLocalHostname(uchar **ppName)
 		memset(&flags, 0, sizeof(flags));
 		flags.ai_flags = AI_CANONNAME;
 		int error = getaddrinfo((char*)hnbuf, NULL, &flags, &res);
-		if (error != 0) {
+		if (error != 0 &&
+		    error != EAI_NONAME && error != EAI_AGAIN && error != EAI_FAIL) {
+			/* If we get one of errors above, network is probably
+			 * not working yet, so we fall back to local hostname below
+			 */
 			dbgprintf("getaddrinfo: %s\n", gai_strerror(error));
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}


### PR DESCRIPTION
After digging trough `gethostbyname()` and `getaddrinfo()` glibc sources I found out that for some reason the condition logic was changed in a way that without working DNS, fallback functions fetching local hostname are skipped, so this commits retains this behavior on rsyslog level, thus returning to previous behavior.