### PR TITLE
imfile: multiline timeout does not work after rsyslog restart

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -663,7 +663,6 @@ openFileWithoutStateFile(lstn_t *const __restrict__ pLstn)
 			CHKiRet(strm.SeekCurrOffs(pLstn->pStrm));
 		}
 	}
-	strmSetReadTimeout(pLstn->pStrm, pLstn->readTimeout);
 
 finalize_it:
 	RETiRet;
@@ -683,6 +682,7 @@ openFile(lstn_t *const __restrict__ pLstn)
 	DBGPRINTF("imfile: breopenOnTruncate %d for '%s'\n",
 		pLstn->reopenOnTruncate, pLstn->pszFileName);
 	CHKiRet(strm.SetbReopenOnTruncate(pLstn->pStrm, pLstn->reopenOnTruncate));
+	strmSetReadTimeout(pLstn->pStrm, pLstn->readTimeout);
 
 finalize_it:
 	RETiRet;

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -873,6 +873,9 @@ strmReadMultiLine_isTimedOut(const strm_t *const __restrict__ pThis)
 	/* note: order of evaluation is choosen so that the most inexpensive
 	 * processing flow is used.
 	 */
+	DBGPRINTF("strmReadMultiline_isTimedOut: prevMsgSeg %p, readTimeout %d, "
+		"lastRead %lld\n", pThis->prevMsgSegment, pThis->readTimeout,
+		(long long) pThis->lastRead);
 	return(   (pThis->readTimeout)
 	       && (pThis->prevMsgSegment != NULL)
 	       && (getTime(NULL) > pThis->lastRead + pThis->readTimeout) );
@@ -1013,6 +1016,7 @@ BEGINobjConstruct(strm) /* be sure to specify the object type also in END macro!
 	pThis->bPrevWasNL = 0;
 	pThis->fileNotFoundError = 1;
 	pThis->noRepeatedErrorOutput = 0;
+	pThis->lastRead = getTime(NULL);
 ENDobjConstruct(strm)
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -616,6 +616,8 @@ TESTS += \
 	imfile-endregex-timeout-polling.sh \
 	imfile-endregex-timeout.sh \
 	imfile-endregex-timeout-none.sh \
+	imfile-endregex-timeout-with-shutdown.sh \
+	imfile-endregex-timeout-with-shutdown-polling.sh \
 	imfile-persist-state-1.sh \
 	imfile-wildcards.sh \
 	imfile-wildcards-dirs.sh \
@@ -1215,6 +1217,8 @@ EXTRA_DIST= \
 	imfile-endregex-timeout-polling.sh \
 	imfile-endregex-timeout.sh \
 	imfile-endregex-timeout-none.sh \
+	imfile-endregex-timeout-with-shutdown.sh \
+	imfile-endregex-timeout-with-shutdown-polling.sh \
 	imfile-persist-state-1.sh \
 	imfile-truncate.sh \
 	imfile-wildcards.sh \

--- a/tests/imfile-endregex-timeout-with-shutdown-polling.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown-polling.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+echo ======================================================================
+# Check if inotify header exist
+if [ -n "$(find /usr/include -name 'inotify.h' -print -quit)" ]; then
+	echo [imfile-endregex.sh]
+else
+	exit 77 # no inotify available, skip this test
+fi
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imfile/.libs/imfile"
+	mode="polling"
+	pollingInterval="2"
+      )
+
+input(type="imfile"
+      File="./rsyslog.input"
+      Tag="file:"
+      PersistStateInterval="1"
+      readTimeout="3"
+      startmsg.regex="^[^ ]")
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="\n")
+}
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )
+'
+. $srcdir/diag.sh startup
+
+# we need to sleep a bit between writes to give imfile a chance
+# to pick up the data (IN MULTIPLE ITERATIONS!)
+echo 'msgnum:0
+ msgnum:1' > rsyslog.input
+./msleep 8000
+echo ' msgnum:2
+ msgnum:3' >> rsyslog.input
+
+# we now do a stop and restart of rsyslog. This checks that everything
+# works across restarts.
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh startup
+
+# new data
+echo ' msgnum:4' >> rsyslog.input
+./msleep 8000
+echo ' msgnum:5
+ msgnum:6' >> rsyslog.input
+./msleep 8000
+
+# the next line terminates our test. It is NOT written to the output file,
+# as imfile waits whether or not there is a follow-up line that it needs
+# to combine.
+#echo 'END OF TEST' >> rsyslog.input
+#./msleep 2000
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+
+echo 'HEADER msgnum:0\\n msgnum:1
+HEADER  msgnum:2\\n msgnum:3\\n msgnum:4
+HEADER  msgnum:5\\n msgnum:6' | cmp rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid multiline message generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  exit 1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/imfile-endregex-timeout-with-shutdown.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+echo ======================================================================
+# Check if inotify header exist
+if [ -n "$(find /usr/include -name 'inotify.h' -print -quit)" ]; then
+	echo [imfile-endregex.sh]
+else
+	exit 77 # no inotify available, skip this test
+fi
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imfile/.libs/imfile"
+       timeoutGranularity="1"
+      )
+input(type="imfile"
+      File="./rsyslog.input"
+      Tag="file:"
+      PersistStateInterval="1"
+      readTimeout="3"
+      startmsg.regex="^[^ ]")
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="\n")
+}
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )
+'
+. $srcdir/diag.sh startup
+
+# we need to sleep a bit between writes to give imfile a chance
+# to pick up the data (IN MULTIPLE ITERATIONS!)
+echo 'msgnum:0
+ msgnum:1' > rsyslog.input
+./msleep 8000
+echo ' msgnum:2
+ msgnum:3' >> rsyslog.input
+
+# we now do a stop and restart of rsyslog. This checks that everything
+# works across restarts.
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh startup
+
+# new data
+echo ' msgnum:4' >> rsyslog.input
+./msleep 8000
+echo ' msgnum:5
+ msgnum:6' >> rsyslog.input
+./msleep 8000
+
+# the next line terminates our test. It is NOT written to the output file,
+# as imfile waits whether or not there is a follow-up line that it needs
+# to combine.
+#echo 'END OF TEST' >> rsyslog.input
+#./msleep 2000
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+
+echo 'HEADER msgnum:0\\n msgnum:1
+HEADER  msgnum:2\\n msgnum:3\\n msgnum:4
+HEADER  msgnum:5\\n msgnum:6' | cmp rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid multiline message generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  exit 1
+fi;
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
The timeout feature for multiline reads does not correctly work for files for which a state file existed. This is usually the case for files that had been processed by a previous run and that still exist on the new start. For all other files, especially those monitored by a wildcard and newly created after the rsyslog start, timeout worked as expected.

closes https://github.com/rsyslog/rsyslog/issues/1445
