### PR TITLE
bugfix build system: add libksi only to those binaries that need it

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1306,8 +1306,7 @@ AC_ARG_ENABLE(ksi-ls12,
         [enable_ksi_ls12=no]
 )
 if test "x$enable_ksi_ls12" = "xyes"; then
-	PKG_CHECK_MODULES(GT_KSI, libksi >= 3.13.0)
-	AC_CHECK_LIB([ksi], [KSI_Signature_signAggregatedWithPolicy], [], [AC_MSG_FAILURE([Could not find libksi])])
+	PKG_CHECK_MODULES(GT_KSI_LS12, libksi >= 3.13.0)
 fi
 AM_CONDITIONAL(ENABLE_KSI_LS12, test x$enable_ksi_ls12 = xyes)
 

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -274,7 +274,7 @@ if ENABLE_KSI_LS12
    lmsig_ksi_ls12_la_SOURCES = lmsig_ksi-ls12.c lmsig_ksi-ls12.h lib_ksils12.c \
 			lib_ksils12.h lib_ksi_queue.c lib_ksi_queue.h
    lmsig_ksi_ls12_la_CPPFLAGS = $(RSRT_CFLAGS) $(GT_KSI_LS12_CFLAGS)
-   lmsig_ksi_ls12_la_LDFLAGS = -module -avoid-version
+   lmsig_ksi_ls12_la_LDFLAGS = -module -avoid-version $(GT_KSI_LS12_LIBS)
 endif
 
 update-systemd:


### PR DESCRIPTION
Previously, libksi was added to all binaries when --enable-ksi-ls12
was activated.

closes https://github.com/rsyslog/rsyslog/issues/1600