### PR TITLE
Empty argv

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,13 @@
 Version 8.28.0 [v8-stable] 2017-06-27
 - NEW BUILD REQUIREMENT: librelp 1.2.14 (to build relp components)
   This was necessary because imrelp requires an API introduced in 1.2.14.
+- omkafka: large refactor of kafka subsystem
+  This offers improvements and greatly increases reliablity.
+  Closes https://github.com/rsyslog/rsyslog/issues/1559
+  Closes https://github.com/rsyslog/rsyslog/issues/1584
+  Closes https://github.com/rsyslog/rsyslog/issues/1515
+  Closes https://github.com/rsyslog/rsyslog/issues/1052
+  May fix https://github.com/rsyslog/rsyslog/issues/1230
 - imfile: add capability to truncate oversize messages or split into multiple
   also in this case an error message is emitted. Both of these actions are
   configurable. This also solves memory issues when an endregex does not

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -231,6 +231,7 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdOutErr)
 	sigset_t set;
 	char errStr[1024];
 	char *newenviron[] = { NULL };
+	char *emptyArgv[] = { NULL };
 
 	fclose(stdin);
 	if(dup(fdStdin) == -1) {
@@ -277,6 +278,9 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdOutErr)
 	alarm(0);
 
 	/* finally exec child */
+	if(pWrkrData->pData->aParams==NULL){
+		pWrkrData->pData->aParams=emptyArgv;
+	}
 	iRet = execve((char*)pWrkrData->pData->szBinary, pWrkrData->pData->aParams, newenviron);
 	if(iRet == -1) {
 		/* Note: this will go to stdout of the **child**, so rsyslog will never


### PR DESCRIPTION
One of the users of the FreeBSD rsyslog port (I'm the port maintainer) has reported problems
with the omprog module not generating any output.  He diagnosed this as due to calling 
execve(2) with a NULL second argument -- which is an error on FreeBSD and probably on
other operating systems.

To reproduce:
```
% cat rsyslog.conf
$WorkDirectory /

#$ModLoad imudp
# $UDPServerRun 514
#$ModLoad imtcp
# $InputTCPServerRun 514
#$ModLoad imklog
#$ModLoad imuxsock

module(load="builtin:omfile")
module(load="builtin:ompipe")
#module(load="builtin-shell")
module(load="builtin:omdiscard")
module(load="builtin:omfwd")
module(load="builtin:omusrmsg")
module(load="builtin:pmrfc5424")
module(load="builtin:pmrfc3164")
module(load="builtin:smfile")
module(load="builtin:smtradfile")
module(load="builtin:smfwd")
module(load="builtin:smtradfwd")
module(load="omprog")
module(load="imudp")
module(load="imtcp")
module(load="imuxsock")
$actionomprogbinary /home/matthew/prog

input(type="imtcp" port="514")
input(type="imudp" port="514")


*.*     /var/log/all.log
*.*     :omprog:
```

```
% cat prog 
#!/usr/local/bin/perl
open(FP,">>/tmp/test");
while(<STDIN>){
        print FP $_;
}
close(FP);
``` 

Result is that `prog` doesn't get run and /tmp/test doesn't even get created. 

This PR just defines an array of char* containing only a terminating NULL, and substitutes
that when WrkrData->pData->aParams==NULL

Original patch by 張君天(Chun-Tien Chang) <tcs@kitty.2y.idv.tw>