### PR TITLE
imfile: Added test for dynamic renamed files (wildcard)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -632,7 +632,8 @@ TESTS += \
 	imfile-wildcards.sh \
 	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \
-	imfile-wildcards-dirs-multi.sh
+	imfile-wildcards-dirs-multi.sh \
+	imfile-rename.sh
 if HAVE_VALGRIND
 TESTS += \
 	imfile-basic-vg.sh \
@@ -1237,7 +1238,9 @@ EXTRA_DIST= \
 	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \
 	imfile-wildcards-dirs-multi.sh \
+	imfile-rename.sh \
 	testsuites/imfile-wildcards.conf \
+	testsuites/imfile-wildcards-simple.conf \
 	testsuites/imfile-wildcards-dirs.conf \
 	testsuites/imfile-wildcards-dirs-multi.conf \
 	dynfile_invld_async.sh \

--- a/tests/imfile-rename.sh
+++ b/tests/imfile-rename.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under GPLv3
+export TESTMESSAGES=10000
+export TESTMESSAGESFULL=19999
+
+echo [imfile-rename.sh]
+
+uname
+if [ `uname` = "SunOS" ] ; then
+   echo "Solaris does not support inotify."
+   exit 77
+fi
+
+. $srcdir/diag.sh init
+
+# generate input file first. 
+./inputfilegen -m $TESTMESSAGES > rsyslog.input.1.log
+ls -l rsyslog.input*
+
+. $srcdir/diag.sh startup imfile-wildcards-simple.conf
+
+# sleep a little to give rsyslog a chance to begin processing
+sleep 5
+
+# Move to another filename
+mv rsyslog.input.1.log rsyslog.input.2.log
+
+# generate some more input into moved file 
+./inputfilegen -m $TESTMESSAGES -i $TESTMESSAGES >> rsyslog.input.2.log
+ls -l rsyslog.input*
+
+# sleep a little to give rsyslog a chance to begin processing
+sleep 5
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh seq-check 0 $TESTMESSAGESFULL
+. $srcdir/diag.sh exit

--- a/tests/inputfilegen.c
+++ b/tests/inputfilegen.c
@@ -17,14 +17,18 @@ int main(int argc, char* argv[])
 	int c, i;
 	int space = 0;
 	int nmsgs = DEFMSGS;
+	int nmsgstart = 0;
 	int nchars = NOEXTRADATA;
 	int errflg = 0;
 	char *extradata = NULL;
 
-	while((c=getopt(argc, argv, "pm:d:")) != -1) {
+	while((c=getopt(argc, argv, "pm:i:d:")) != -1) {
 		switch(c) {
 		case 'm':
 			nmsgs = atoi(optarg);
+			break;
+		case 'i':
+			nmsgstart = atoi(optarg);
 			break;
 		case 'd':
 			nchars = atoi(optarg);
@@ -51,7 +55,7 @@ int main(int argc, char* argv[])
 		memset(extradata, 'X', nchars);
 		extradata[nchars] = '\0';
 	}
-	for(i = 0; i < nmsgs; ++i) {
+	for(i = nmsgstart; i < (nmsgs+nmsgstart); ++i) {
 		printf("msgnum:%8.8d:", i);
 		if(space==1) {
 			printf("\n ");

--- a/tests/testsuites/imfile-wildcards-simple.conf
+++ b/tests/testsuites/imfile-wildcards-simple.conf
@@ -1,0 +1,29 @@
+$IncludeConfig diag-common.conf
+$WorkDirectory test-spool
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./rsyslog.input.*.log"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+)
+input(type="imfile"
+	File="/does/not/exist/*.log"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+)
+
+$template outfmt,"%msg:F,58:2%\n"
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )


### PR DESCRIPTION
Added check for IN_MOVED_TO in in_handleDirEvent. Statefilename and
event cookie are saved in IN_MOVE_FROM event in a linkedlist now,
so the statefile can be renamed to a new name in IN_MOVED_TO event.

Closes https://github.com/rsyslog/rsyslog/issues/1417