### PR TITLE
Fix behaviour of PersistStateInterval.  

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -755,7 +755,7 @@ pollFile(lstn_t *pLstn, int *pbHadFileData)
 			*pbHadFileData = 1; /* this is just a flag, so set it and forget it */
 		CHKiRet(enqLine(pLstn, pCStr)); /* process line */
 		rsCStrDestruct(&pCStr); /* discard string (must be done by us!) */
-		if(pLstn->iPersistStateInterval > 0 && pLstn->nRecords++ >= pLstn->iPersistStateInterval) {
+		if(pLstn->iPersistStateInterval > 0 && ++pLstn->nRecords >= pLstn->iPersistStateInterval) {
 			persistStrmState(pLstn);
 			pLstn->nRecords = 0;
 		}


### PR DESCRIPTION
If PersistStateInterval=1, then each log line read should cause the state file to be updated, but this
was not happening because nRecords was being post-increment.