### PR TITLE
core bugfix: segfault after configuration errors

### DIFF
--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1194,8 +1194,9 @@ getLocalHostname(uchar **ppName)
 			/* If we get one of errors above, network is probably
 			 * not working yet, so we fall back to local hostname below
 			 */
-			dbgprintf("getaddrinfo: %s\n", gai_strerror(error));
-			ABORT_FINALIZE(RS_RET_IO_ERROR);
+			LogError(0, RS_RET_ERR, "getaddrinfo failed obtaining local "
+				"hostname - using '%s' instead; error: %s",
+				hnbuf, gai_strerror(error));
 		}
 		if (res != NULL) {
 			/* When AI_CANONNAME is set first member of res linked-list */

--- a/runtime/prop.c
+++ b/runtime/prop.c
@@ -133,7 +133,13 @@ propConstructFinalize(prop_t __attribute__((unused)) *pThis)
  */
 static rsRetVal AddRef(prop_t *pThis)
 {
+	if(pThis == NULL)  {
+		DBGPRINTF("prop/AddRef is passed a NULL ptr - ignoring it "
+			"- further problems may occur\n");
+		FINALIZE;
+	}
 	ATOMIC_INC(&pThis->iRefCount, &pThis->mutRefCount);
+finalize_it:
 	return RS_RET_OK;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -12,6 +12,16 @@ liboverride_gethostname_la_SOURCES = override_gethostname.c
 liboverride_gethostname_la_CFLAGS =
 liboverride_gethostname_la_LDFLAGS = -avoid-version -shared
 
+pkglib_LTLIBRARIES += liboverride_gethostname_nonfqdn.la
+liboverride_gethostname_nonfqdn_la_SOURCES = override_gethostname_nonfqdn.c
+liboverride_gethostname_nonfqdn_la_CFLAGS =
+liboverride_gethostname_nonfqdn_la_LDFLAGS = -avoid-version -shared
+
+pkglib_LTLIBRARIES += liboverride_getaddrinfo.la
+liboverride_getaddrinfo_la_SOURCES = override_getaddrinfo.c
+liboverride_getaddrinfo_la_CFLAGS =
+liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
+
 # TODO: reenable TESTRUNS = rt_init rscript
 check_PROGRAMS = $(TESTRUNS) ourtail nettester tcpflood chkseq msleep randomgen \
 	diagtalker uxsockrcvr syslog_caller inputfilegen minitcpsrv \
@@ -22,6 +32,7 @@ TESTS = $(TESTRUNS)
 
 TESTS +=  \
 	empty-hostname.sh \
+	hostname-getaddrinfo-fail.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
 	hostname-with-slash-pmrfc5424.sh \
@@ -639,6 +650,7 @@ test_files = testbench.h runtime-dummy.c
 EXTRA_DIST= \
 	internal-errmsg-memleak.sh \
 	empty-hostname.sh \
+	hostname-getaddrinfo-fail.sh \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \
 	pmrfc3164-msgFirstSpace.sh \

--- a/tests/hostname-getaddrinfo-fail.sh
+++ b/tests/hostname-getaddrinfo-fail.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This test check what happens if we cannot doe getaddrinfo early
+# in rsyslog startup  (this has caused an error in the past). Even more
+# importantly, it checks that error messages can be issued very early
+# during startup.
+# Note that we use the override of the hostname to ensure we do not
+# accidentely get an acceptable FQDN-type hostname during testing.
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+if [ `uname` = "SunOS" ] ; then
+   echo "Solaris: there seems to be an issue with LD_PRELOAD libraries"
+   exit 77
+fi
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+# note: the listener error on port 13500 is OK! It is caused by plumbing
+# we do not use here in this special case, and we did not want to work
+# very hard to remove that problem (which does not affect the test)
+. $srcdir/diag.sh add-conf '
+action(type="omfile" file="rsyslog.out.log")
+'
+export RSYSLOG_PRELOAD=".libs/liboverride_gethostname_nonfqdn.so:.libs/liboverride_getaddrinfo.so"
+. $srcdir/diag.sh startup
+sleep 1
+. $srcdir/diag.sh shutdown-immediate
+. $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
+
+grep " nonfqdn " < rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "expected hostname \"nonfqdn\" not found in logs, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit 1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/override_getaddrinfo.c
+++ b/tests/override_getaddrinfo.c
@@ -1,0 +1,28 @@
+// we need this for dlsym(): #include <dlfcn.h>
+#include "config.h"
+#include <stdio.h>
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netdb.h>
+
+int getaddrinfo(const char *node __attribute__((unused)),
+	const char *service __attribute__((unused)),
+	const struct addrinfo *hints __attribute__((unused)),
+	struct addrinfo **res __attribute__((unused)))
+{
+	return EAI_MEMORY;
+}
+
+static void __attribute__((constructor))
+my_init(void)
+{
+	/* we currently do not need this entry point, but keep it as
+	 * a "template". It can be used, e.g. to emit some diagnostic
+	 * information:
+	printf("loaded\n");
+	 * or - more importantly - obtain a pointer to the overriden
+	 * API:
+	orig_etry = dlsym(RTLD_NEXT, "original_entry_point");
+	*/
+}

--- a/tests/override_gethostname_nonfqdn.c
+++ b/tests/override_gethostname_nonfqdn.c
@@ -1,0 +1,14 @@
+#include <stdio.h>
+
+int gethostname(char *name, size_t __attribute__((unused)) len)
+{
+	*name++  = 'n';
+	*name++  = 'o';
+	*name++  = 'n';
+	*name++  = 'f';
+	*name++  = 'q';
+	*name++  = 'd';
+	*name++  = 'n';
+	*name++  = '\0';
+	return 0;
+}

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -933,9 +933,11 @@ logmsgInternal(int iErr, const syslog_pri_t pri, const uchar *const msg, int fla
 	 * permits us to process unmodified config files which otherwise contain a
 	 * supressor statement.
 	 */
-	if(((Debug == DEBUG_FULL || !doFork) && ourConf->globals.bErrMsgToStderr) || iConfigVerify) {
+	int emit_to_stderr = (ourConf == NULL) ? 1 : ourConf->globals.bErrMsgToStderr;
+	if(((Debug == DEBUG_FULL || !doFork) && emit_to_stderr) || iConfigVerify) {
 		if(pri2sev(pri) == LOG_ERR)
-			fprintf(stderr, "rsyslogd: %s\n", (bufModMsg == NULL) ? (char*)msg : bufModMsg);
+			fprintf(stderr, "rsyslogd: %s\n",
+				(bufModMsg == NULL) ? (char*)msg : bufModMsg);
 	}
 
 finalize_it:
@@ -1249,18 +1251,17 @@ initAll(int argc, char **argv)
 
 	/* doing some core initializations */
 
-	/* get our host and domain names - we need to do this early as we may emit
-	 * error log messages, which need the correct hostname. -- rgerhards, 2008-04-04
-	 */
-	queryLocalHostname();
-
-	/* initialize the objects */
 	if((iRet = modInitIminternal()) != RS_RET_OK) {
 		fprintf(stderr, "fatal error: could not initialize errbuf object (error code %d).\n",
 			iRet);
 		exit(1); /* "good" exit, leaving at init for fatal error */
 	}
 
+	/* get our host and domain names - we need to do this early as we may emit
+	 * error log messages, which need the correct hostname. -- rgerhards, 2008-04-04
+	 * But we need to have imInternal up first!
+	 */
+	queryLocalHostname();
 
 	/* END core initializations - we now come back to carrying out command line options*/
 


### PR DESCRIPTION
rsyslog will segfault on startup if
a) the local machine's hostname is set to a non-FQDN name
b) the getaddrinfo() system call fails

This scenario is higly unlikely, but may exist especially with provisioned VMs which may not properly be able to do name queries on startup (seen for example on AWS).

This patch fixes the situation and also provides more robustness for very early startup error messages when some of the error-reporting subsystem is not yet properly initialized. Note that under these
circumstances, errors may only show up on stderr.

closes rsyslog#1573