### PR TITLE
imklog: Fix permitnonkernelfacility not working

### DIFF
--- a/plugins/imklog/bsd.c
+++ b/plugins/imklog/bsd.c
@@ -144,13 +144,13 @@ submitSyslog(modConfData_t *pModConf, syslog_pri_t pri, uchar *buf)
 	tp = &tv;
 
 done:
-	Syslog(pri, buf, tp);
+	Syslog(pModConf, pri, buf, tp);
 }
 #else	/* now comes the BSD "code" (just a shim) */
 static void
 submitSyslog(modConfData_t *pModConf, syslog_pri_t pri, uchar *buf)
 {
-	Syslog(pri, buf, NULL);
+	Syslog(pModConf, pri, buf, NULL);
 }
 #endif	/* #ifdef LINUX */
 

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -220,7 +220,7 @@ rsRetVal imklogLogIntMsg(syslog_pri_t priority, const char *fmt, ...)
  * time to use.
  * rgerhards, 2008-04-14
  */
-rsRetVal Syslog(syslog_pri_t priority, uchar *pMsg, struct timeval *tp)
+rsRetVal Syslog(modConfData_t *pModConf, syslog_pri_t priority, uchar *pMsg, struct timeval *tp)
 {
 	syslog_pri_t pri;
 	int bPRISet = 0;
@@ -249,7 +249,7 @@ rsRetVal Syslog(syslog_pri_t priority, uchar *pMsg, struct timeval *tp)
 	/* if we don't get the pri, we use whatever we were supplied */
 
 	/* ignore non-kernel messages if not permitted */
-	if(cs.bPermitNonKernel == 0 && pri2fac(priority) != LOG_KERN)
+	if(pModConf->bPermitNonKernel == 0 && pri2fac(priority) != LOG_KERN)
 		FINALIZE; /* silently ignore */
 
 	iRet = enqMsg((uchar*)pMsg, (uchar*) "kernel:", priority, tp);

--- a/plugins/imklog/imklog.h
+++ b/plugins/imklog/imklog.h
@@ -55,7 +55,7 @@ int klogFacilIntMsg(void);
 
 /* the functions below may be called by the drivers */
 rsRetVal imklogLogIntMsg(syslog_pri_t priority, const char *fmt, ...) __attribute__((format(printf,2, 3)));
-rsRetVal Syslog(syslog_pri_t priority, uchar *msg, struct timeval *tp);
+rsRetVal Syslog(modConfData_t *pModConf, syslog_pri_t priority, uchar *msg, struct timeval *tp);
 
 /* prototypes */
 extern int klog_getMaxLine(void); /* work-around for klog drivers to get configured max line size */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -182,6 +182,7 @@ TESTS +=  \
 	imuxsock_logger_root.sh \
 	imuxsock_traillf_root.sh \
 	imuxsock_ccmiddle_root.sh \
+	imklog_permitnonkernelfacility_root.sh \
 	discard-rptdmsg.sh \
 	discard-allmark.sh \
 	discard.sh \
@@ -1299,6 +1300,7 @@ EXTRA_DIST= \
 	imuxsock_ccmiddle.sh \
 	testsuites/imuxsock_ccmiddle.conf \
 	imuxsock_ccmiddle_root.sh \
+	imklog_permitnonkernelfacility_root.sh \
 	imuxsock_ccmiddle_syssock.sh \
 	testsuites/imuxsock_ccmiddle_root.conf \
 	testsuites/imuxsock_ccmiddle_syssock.conf \

--- a/tests/imklog_permitnonkernelfacility_root.sh
+++ b/tests/imklog_permitnonkernelfacility_root.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2017-07-18 by Pascal Withopf, released under ASL 2.0
+echo \[imklog_permitnonkernelfacility_root.sh\]: test parameter permitnonkernelfacility
+echo This test must be run as root with no other active syslogd
+if [ "$EUID" -ne 0 ]; then
+    exit 77 # Not root, skip this test
+fi
+service rsyslog stop
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imklog/.libs/imklog" permitnonkernelfacility="on")
+
+template(name="outfmt" type="string" string="%msg:57:16%: -%pri%-\n")
+
+:msg, contains, "msgnum" action(type="omfile" template="outfmt" file="rsyslog.out.log")
+'
+. $srcdir/diag.sh startup
+echo "<115>Mar 10 01:00:00 172.20.245.8 tag: msgnum:1" > /dev/kmsg
+echo "<115>Mar 10 01:00:00 172.20.245.8 tag: msgnum:1"
+sleep 2
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+echo 'Mar 10 01:00:00 172.20.245.8 tag: msgnum:1: -115-' | cmp rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+service rsyslog start
+. $srcdir/diag.sh exit


### PR DESCRIPTION
permitnonkernelfacility doesn't work when the new configuration syntax
is used, e.g. 'module(load="imklog" permitnonkernelfacility="on")'.
It does work with the old syntax, e.g. '$KLogPermitNonKernelFacility
on'

This is because the old style config is stored in a static global
struct "cs", while the new style config is passed in as a pointer.
Code in imklog will put old style config entries into the new config
struct, and almost all the code in imklog uses the new config struct
like it should.  Except for a check for bPermitNonKernel in Syslog()
that continued to use the static global that only has old style
configs.

Fix this by passing pModConf down into Syslog() and using that in
place of the static global.

closes https://github.com/rsyslog/rsyslog/issues/477