### PR TITLE
impstats bugfix: impstats does not handle HUP

### DIFF
--- a/runtime/modules.h
+++ b/runtime/modules.h
@@ -203,5 +203,6 @@ rsRetVal modulesProcessCnf(struct cnfobj *o);
 uchar *modGetName(modInfo_t *pThis);
 rsRetVal addModToCnfList(cfgmodules_etry_t **pNew, cfgmodules_etry_t *pLast);
 rsRetVal readyModForCnf(modInfo_t *pThis, cfgmodules_etry_t **ppNew, cfgmodules_etry_t **ppLast);
+void modDoHUP(void);
 
 #endif /* #ifndef MODULES_H_INCLUDED */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -368,6 +368,7 @@ endif
 
 if ENABLE_IMPSTATS
 TESTS +=  \
+	impstats-hup.sh \
 	dynstats.sh \
 	dynstats_overflow.sh \
 	dynstats_reset.sh \
@@ -1372,6 +1373,7 @@ EXTRA_DIST= \
 	dynstats_overflow-vg.sh \
 	dynstats_reset.sh \
 	dynstats_reset-vg.sh \
+	impstats-hup.sh \
 	dynstats.sh \
 	dynstats-vg.sh \
 	dynstats_prevent_premature_eviction.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -483,6 +483,17 @@ case $1 in
 		done
 		echo "dyn-stats reset for bucket ${3} registered"
 		;;
+   'content-check')
+		# this does a content check which permits regex
+		grep "$2" $3
+		if [ "$?" -ne "0" ]; then
+		    echo "----------------------------------------------------------------------"
+		    echo content-check failed to find "'$2'" inside "'$3'"
+		    echo "file contents:"
+		    cat $3
+		    . $srcdir/diag.sh error-exit 1
+		fi
+		;;
    'custom-content-check') 
 		cat $3 | grep -qF "$2"
 		if [ "$?" -ne "0" ]; then

--- a/tests/impstats-hup.sh
+++ b/tests/impstats-hup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# test if HUP works for impstats
+# This file is part of the rsyslog project, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/impstats/.libs/impstats"
+	log.file="./rsyslog.out.log"
+	interval="1" ruleset="stats")
+
+ruleset(name="stats") {
+	stop # nothing to do here
+}
+'
+. $srcdir/diag.sh startup
+./msleep 2000
+mv rsyslog.out.log rsyslog2.out.log
+. $srcdir/diag.sh issue-HUP
+./msleep 2000
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+echo checking pre-HUP file
+. $srcdir/diag.sh content-check 'global: origin=dynstats' rsyslog2.out.log
+echo checking post-HUP file
+. $srcdir/diag.sh content-check 'global: origin=dynstats' rsyslog.out.log
+. $srcdir/diag.sh exit

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1605,6 +1605,7 @@ doHUP(void)
 
 	queryLocalHostname(); /* re-read our name */
 	ruleset.IterateAllActions(ourConf, doHUPActions, NULL);
+	modDoHUP();
 	lookupDoHUP();
 }
 


### PR DESCRIPTION
If the parameter "log.file" is specified, impstats writes its own
log file. However, HUP is not handled for this file, which makes
the functionality unusable with log rotation. It is also counter-
intuitive for users.

This patch enables correct HUP processing. As a sideline, it also
introduces a generic HUP processing framework for non-action type
of loadable modules.

closes https://github.com/rsyslog/rsyslog/issues/1662
closes https://github.com/rsyslog/rsyslog/issues/1663