### PR TITLE
testbench bugfix: hang in tests if omstdout is not present

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1346,13 +1346,6 @@ if test "x${IP}" = "xno"; then
 fi
 AM_CONDITIONAL(ENABLE_IP, test "x${IP}" = "xyes")
 
-AM_CONDITIONAL(ENABLE_TESTBENCH, test x$enable_testbench = xyes)
-if test "x$enable_testbench" = "xyes"; then
-	if test "x$enable_imdiag" != "xyes"; then
-		AC_MSG_ERROR("--enable-testbench requires --enable-imdiag")
-	fi
-fi
-
 
 # valgrind-testbench
 AC_ARG_WITH([valgrind_testbench],
@@ -1482,6 +1475,17 @@ AC_ARG_ENABLE(omstdout,
         [enable_omstdout=no]
 )
 AM_CONDITIONAL(ENABLE_OMSTDOUT, test x$enable_omstdout = xyes)
+
+AM_CONDITIONAL(ENABLE_TESTBENCH, test x$enable_testbench = xyes)
+if test "x$enable_testbench" = "xyes"; then
+	if test "x$enable_imdiag" != "xyes"; then
+		AC_MSG_ERROR("--enable-testbench requires --enable-imdiag")
+	fi
+	if test "x$enable_omstdout" != "xyes"; then
+		AC_MSG_ERROR("--enable-testbench requires --enable-omstdout")
+	fi
+fi
+
 
 # settings for omjournal
 AC_ARG_ENABLE(omjournal,


### PR DESCRIPTION
Many tests depend on omstdout. Given the fact that omstdout
is really only useful for the testbench (at least that's the intent),
we now require --enable-omstdout if --enable-testbench is given.

The alternative would have been to disable all those tests that
need it, which would have lead to considerable less testbench
coverage.

closes https://github.com/rsyslog/rsyslog/issues/1649