### PR TITLE
imfile: Fixed wildcard detection issue on path wildcards

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1053,6 +1053,9 @@ addListner(instanceConf_t *inst)
 	sbool hasWildcard;
 
 	hasWildcard = containsGlobWildcard((char*)inst->pszFileBaseName);
+	DBGPRINTF("imfile: addListner file '%s', wildcard detected: %s\n",
+		  inst->pszFileBaseName, (hasWildcard ? "TRUE" : "FALSE"));
+
 	if(hasWildcard) {
 		if(runModConf->opMode == OPMODE_POLLING) {
 			errmsg.LogError(0, RS_RET_IMFILE_WILDCARD,
@@ -1716,6 +1719,8 @@ in_setupDirWatch(const int dirIdx)
 		memcpy(dirnametrunc, dirs[dirIdx].dirName, dirnamelen); /* Copy mem */
 
 		hasWildcard = containsGlobWildcard(dirnametrunc);
+		DBGPRINTF("imfile: in_setupDirWatch dir '%s', wildcard detected: %s\n",
+			  dirnametrunc, (hasWildcard ? "TRUE" : "FALSE"));
 		if(hasWildcard) {
 			/* Set NULL Byte to FIRST wildcard occurrence */
 			psztmp = strchr(dirnametrunc, '*');
@@ -1928,11 +1933,15 @@ done:	return;
 static void
 in_setupFileWatchStatic(lstn_t *pLstn)
 {
+	sbool hasWildcard;
+
 	DBGPRINTF("imfile: adding file '%s' to configured table\n",
 		  pLstn->pszFileName);
 	dirsAddFile(pLstn, CONFIGURED_FILE);
 
-	if(pLstn->hasWildcard) {
+	/* perform wildcard check on static files manually */
+	hasWildcard = containsGlobWildcard((char*)pLstn->pszFileName);
+	if(hasWildcard) {
 		DBGPRINTF("imfile: file '%s' has wildcard, doing initial "
 			  "expansion\n", pLstn->pszFileName);
 		glob_t files;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -628,6 +628,7 @@ TESTS += \
 	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \
 	imfile-wildcards-dirs-multi.sh \
+	imfile-wildcards-dirs-multi2.sh \
 	imfile-rename.sh
 if HAVE_VALGRIND
 TESTS += \
@@ -1237,11 +1238,13 @@ EXTRA_DIST= \
 	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \
 	imfile-wildcards-dirs-multi.sh \
+	imfile-wildcards-dirs-multi2.sh \
 	imfile-rename.sh \
 	testsuites/imfile-wildcards.conf \
 	testsuites/imfile-wildcards-simple.conf \
 	testsuites/imfile-wildcards-dirs.conf \
 	testsuites/imfile-wildcards-dirs-multi.conf \
+	testsuites/imfile-wildcards-dirs-multi2.conf \
 	dynfile_invld_async.sh \
 	dynfile_invld_sync.sh \
 	dynfile_cachemiss.sh \

--- a/tests/imfile-wildcards-dirs-multi2.sh
+++ b/tests/imfile-wildcards-dirs-multi2.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under GPLv3
+echo [imfile-wildcards-multi2.sh]
+
+uname
+if [ `uname` = "SunOS" ] ; then
+   echo "Solaris does not support inotify."
+   exit 77
+fi
+
+
+export IMFILEINPUTFILES="1"
+export IMFILEINPUTFILESSTEPS="5"
+export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
+
+
+. $srcdir/diag.sh init
+# generate input files first. Note that rsyslog processes it as
+# soon as it start up (so the file should exist at that point).
+
+for i in `seq 1 $IMFILEINPUTFILES`;
+do
+	echo "Make rsyslog.input.dir$i"
+	mkdir rsyslog.input.dir$i
+	./msleep 100
+done
+
+# Start rsyslog now before adding more files
+. $srcdir/diag.sh startup imfile-wildcards-dirs-multi2.conf
+# sleep a little to give rsyslog a chance to begin processing
+sleep 1
+
+for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
+do
+	echo "Loop Num $j"
+	for i in `seq 1 $IMFILEINPUTFILES`;
+	do
+		echo "Make rsyslog.input.dir$i/dir$j/testdir"
+		mkdir rsyslog.input.dir$i/dir$j
+		./msleep 25
+		mkdir rsyslog.input.dir$i/dir$j/testdir
+		./msleep 25
+		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$j/testdir/file.logfile
+	done
+	ls -d rsyslog.input.*
+
+	# Delete all but first!
+	for i in `seq 1 $IMFILEINPUTFILES`;
+	do
+		rm -r rsyslog.input.dir$i/dir$j
+	done
+
+done
+
+# sleep a little to give rsyslog a chance for processing
+sleep 1
+
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
+. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL
+. $srcdir/diag.sh exit

--- a/tests/testsuites/imfile-wildcards-dirs-multi2.conf
+++ b/tests/testsuites/imfile-wildcards-dirs-multi2.conf
@@ -1,0 +1,29 @@
+$IncludeConfig diag-common.conf
+$WorkDirectory test-spool
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./rsyslog.input.dir1/*/testdir/file.logfile"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+)
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="', ")
+  property(name="$!metadata!filename")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )


### PR DESCRIPTION
Wildcards mode was not properly detected when wildcards
were only used in a directory name on startup.
This caused imfile not to create a propper dynamic filewatch.

Closes: https://github.com/rsyslog/rsyslog/issues/1672