### PR TITLE
imtcp: ratelimit based on a key string parameter

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2335,7 +2335,7 @@ msgGetJSONMESG(smsg_t *__restrict__ const pMsg)
 	jval = json_object_new_string((char*)pRes);
 	json_object_object_add(json, "timereported", jval);
 
-	jval = json_object_new_string(getHOSTNAME(pMsg));
+	jval = json_object_new_string(getHOSTNAME(pMsg, 0));
 	json_object_object_add(json, "hostname", jval);
 
 	getTAG(pMsg, &pRes, &bufLen);
@@ -2515,24 +2515,23 @@ int getHOSTNAMELen(smsg_t * const pM)
 }
 
 
-const char *getHOSTNAME(smsg_t * const pM)
+char *getHOSTNAME(smsg_t * const pM, sbool bLockMutex)
 {
+	UNUSED(bLockMutex);
 	if(pM == NULL)
-		return "";
-	else
-		if(pM->pszHOSTNAME == NULL) {
-			resolveDNS(pM);
-			if(pM->rcvFrom.pRcvFrom == NULL) {
-				return "";
-			} else {
-				uchar *psz;
-				int len;
-				prop.GetString(pM->rcvFrom.pRcvFrom, &psz, &len);
-				return (char*) psz;
-			}
+		return (char*) "";
+	if(pM->pszHOSTNAME == NULL) {
+		resolveDNS(pM);
+		if(pM->rcvFrom.pRcvFrom == NULL) {
+			return (char*) "";
 		} else {
-			return (char*) pM->pszHOSTNAME;
+			uchar *psz;
+			int len;
+			prop.GetString(pM->rcvFrom.pRcvFrom, &psz, &len);
+			return (char*) psz;
 		}
+	}
+	return (char*) pM->pszHOSTNAME;
 }
 
 
@@ -3478,7 +3477,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			}
 			break;
 		case PROP_HOSTNAME:
-			pRes = (uchar*)getHOSTNAME(pMsg);
+			pRes = (uchar*)getHOSTNAME(pMsg, 0);
 			bufLen = getHOSTNAMELen(pMsg);
 			break;
 		case PROP_SYSLOGTAG:

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -214,9 +214,11 @@ rsRetVal MsgSetPropsViaJSON(smsg_t *__restrict__ const pMsg, const uchar *__rest
 rsRetVal MsgSetPropsViaJSON_Object(smsg_t *__restrict__ const pMsg, struct json_object *json);
 const uchar* msgGetJSONMESG(smsg_t *__restrict__ const pMsg);
 
+#define UNUSED(x) (void)(x)
+
 /* TODO: remove these five (so far used in action.c) */
 uchar *getMSG(smsg_t *pM);
-const char *getHOSTNAME(smsg_t *pM);
+char *getHOSTNAME(smsg_t *pM, sbool bLockMutex);
 char *getPROCID(smsg_t *pM, sbool bLockMutex);
 char *getAPPNAME(smsg_t *pM, sbool bLockMutex);
 void setMSGLen(smsg_t *pM, int lenMsg);

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -83,7 +83,7 @@ doLastMessageRepeatedNTimes(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep
 	if( ratelimit->pMsg != NULL &&
 	    getMSGLen(pMsg) == getMSGLen(ratelimit->pMsg) &&
 	    !ustrcmp(getMSG(pMsg), getMSG(ratelimit->pMsg)) &&
-	    !strcmp(getHOSTNAME(pMsg), getHOSTNAME(ratelimit->pMsg)) &&
+	    !strcmp(getHOSTNAME(pMsg, 0), getHOSTNAME(ratelimit->pMsg, 0)) &&
 	    !strcmp(getPROCID(pMsg, LOCK_MUTEX), getPROCID(ratelimit->pMsg, LOCK_MUTEX)) &&
 	    !strcmp(getAPPNAME(pMsg, LOCK_MUTEX), getAPPNAME(ratelimit->pMsg, LOCK_MUTEX))) {
 		ratelimit->nsupp++;
@@ -225,7 +225,7 @@ ratelimitMsg(ratelimit_t *__restrict__ const ratelimit, smsg_t *pMsg, smsg_t **p
 	 * treshold (the value is >=) are subject to ratelimiting. */
 	if(ratelimit->interval && (pMsg->iSeverity >= ratelimit->severity)) {
 		char namebuf[512]; /* 256 for FGDN adn 256 for APPNAME should be enough */
-		snprintf(namebuf, sizeof namebuf, "%s:%s", getHOSTNAME(pMsg),
+		snprintf(namebuf, sizeof namebuf, "%s:%s", getHOSTNAME(pMsg, 0),
 			getAPPNAME(pMsg, 0));
 		if(withinRatelimit(ratelimit, pMsg->ttGenTime, namebuf) == 0) {
 			msgDestruct(&pMsg);

--- a/tools/smfile.c
+++ b/tools/smfile.c
@@ -75,7 +75,7 @@ CODESTARTstrgen
 	/* first obtain all strings and their length (if not fixed) */
 	pTimeStamp = (uchar*) getTimeReported(pMsg, tplFmtRFC3339Date);
 	lenTimeStamp = ustrlen(pTimeStamp);
-	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
+	pHOSTNAME = (uchar*) getHOSTNAME(pMsg, 0);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
 	getTAG(pMsg, &pTAG, &lenTAG);
 	pMSG = getMSG(pMsg);

--- a/tools/smfwd.c
+++ b/tools/smfwd.c
@@ -76,7 +76,7 @@ CODESTARTstrgen
 	lenPRI = strlen(pPRI);
 	pTimeStamp = (uchar*) getTimeReported(pMsg, tplFmtRFC3339Date);
 	lenTimeStamp = ustrlen(pTimeStamp);
-	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
+	pHOSTNAME = (uchar*) getHOSTNAME(pMsg, 0);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
 	getTAG(pMsg, &pTAG, &lenTAG);
 	if(lenTAG > 32)

--- a/tools/smtradfile.c
+++ b/tools/smtradfile.c
@@ -70,7 +70,7 @@ BEGINstrgen
 CODESTARTstrgen
 	/* first obtain all strings and their length (if not fixed) */
 	pTimeStamp = (uchar*) getTimeReported(pMsg, tplFmtRFC3164Date);
-	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
+	pHOSTNAME = (uchar*) getHOSTNAME(pMsg, 0);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
 	getTAG(pMsg, &pTAG, &lenTAG);
 	pMSG = getMSG(pMsg);

--- a/tools/smtradfwd.c
+++ b/tools/smtradfwd.c
@@ -74,7 +74,7 @@ CODESTARTstrgen
 	pPRI = getPRI(pMsg);
 	lenPRI = strlen(pPRI);
 	pTimeStamp = (uchar*) getTimeReported(pMsg, tplFmtRFC3164Date);
-	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
+	pHOSTNAME = (uchar*) getHOSTNAME(pMsg, 0);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
 	getTAG(pMsg, &pTAG, &lenTAG);
 	if(lenTAG > 32)


### PR DESCRIPTION
This patch is a small proof of concept as a starting point for discussion.

This would add ratelimit.key parameter, e.g:
 ratelimit.key="procid|appname"
in order to ratelimit on the given key.

The key could be, as in this code,  a given parameter (e.g appname); but ultimately, a combinaison of multiple parameters (example: hostname + application) and allow us to define limits per group. 

the patch is not finished yet but gives an overview of how the code would look like. The same approach could be applied to udp.

How do you feel about it? Do you think this feature would be acceptable?