### PR TITLE
omelasticsearch: avoid 404 during health check

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1297,7 +1297,6 @@ static void
 curlCheckConnSetup(CURL *handle, HEADER *header, long timeout, sbool allowUnsignedCerts)
 {
 	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
-	curl_easy_setopt(handle, CURLOPT_NOBODY, TRUE);
 	curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, timeout);
 	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, TRUE);
 


### PR DESCRIPTION
For http(s), CURLOPT_NOBODY makes libcurl do a HEAD request.
this procudes a "HTTP/1.1 404 Not Found" instead of an expected
"HTTP/1.1 200 OK".
see https://curl.haxx.se/libcurl/c/CURLOPT_NOBODY.html

remove this option to produce a GET request

Fixes: issue #1546