### PR TITLE
omelasticsearch: avoid ES5 warnings while sending json

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1322,10 +1322,17 @@ curlPostSetup(CURL *handle, HEADER *header, uchar* authBuf)
 	}
 }
 
+#define CONTENT_JSON "Content-Type: application/json; charset=utf-8"
+#define CONTENT_JSON_BULK "Content-Type: application/x-ndjson; charset=utf-8"
+
 static rsRetVal
 curlSetup(wrkrInstanceData_t *pWrkrData, instanceData *pData)
 {
-	pWrkrData->curlHeader = curl_slist_append(NULL, "Content-Type: text/json; charset=utf-8");
+	if (pData->bulkmode) {
+		pWrkrData->curlHeader = curl_slist_append(NULL, CONTENT_JSON_BULK);
+	} else {
+		pWrkrData->curlHeader = curl_slist_append(NULL, CONTENT_JSON);
+	}
 	pWrkrData->curlPostHandle = curl_easy_init();
 	if (pWrkrData->curlPostHandle == NULL) {
 		return RS_RET_OBJ_CREATION_FAILED;


### PR DESCRIPTION
ES5 is generating warnings when sending json without the proper header:

$ curl -i -H "Content-Type: text/json" -XGET 'http://elasticsearch5:9200/' -d '{}\n'
HTTP/1.1 200 OK
Warning: 299 Elasticsearch-5.4.3-eed30a8 "Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header." "Wed, 26 Jul 2017 14:33:28 GMT"

no issue on previous version.

this patch correctly sets the header as application/json. It works for all versions (tested on ES2 and ES5)
we also handle the bulkmode where it should be set to application/x-ndjson

Fixes: #1642 