### PR TITLE
omelasticsearch: fixing leak while writing error file

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1039,7 +1039,7 @@ writeDataError(wrkrInstanceData_t *pWrkrData, instanceData *pData, fjson_object 
 			DBGPRINTF("omelasticsearch: error creating file content.\n");
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
-		rendered = (char*)fjson_object_to_json_string(ctx.errRoot);
+		rendered = strdup((char*)fjson_object_to_json_string(ctx.errRoot));
 	}
 
 
@@ -1069,6 +1069,7 @@ writeDataError(wrkrInstanceData_t *pWrkrData, instanceData *pData, fjson_object 
 finalize_it:
 	if(bMutLocked)
 		pthread_mutex_unlock(&pData->mutErrFile);
+	free(rendered);
 	fjson_object_put(ctx.errRoot);
 	RETiRet;
 }


### PR DESCRIPTION
since we switched to libfastjson, the default error function is
duplicating the string from fjson_object_to_json_string in order to free
the fjson object.
we however don't free the duplicated string later.

fix that by adding a free
also add a second duplication for the second case of rendered string;
this makes the code easier to read instead of adding another condition.

Fixes: issue #1668