### PR TITLE
add debug.file and debug.whitelist parameters

### DIFF
--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -823,7 +823,7 @@ sigsegvHdlr(int signum)
  * 2009-05-20 rgerhards
  */
 static void
-do_dbgprint(uchar *pszObjName, char *pszMsg, size_t lenMsg)
+do_dbgprint(uchar *pszObjName, char *pszMsg, const char *pszFileName, size_t lenMsg)
 {
 	static pthread_t ptLastThrdID = 0;
 	static int bWasNL = 0;
@@ -882,6 +882,8 @@ do_dbgprint(uchar *pszObjName, char *pszMsg, size_t lenMsg)
 			lenWriteBuf = snprintf(pszWriteBuf + offsWriteBuf, sizeof(pszWriteBuf) - offsWriteBuf, "%s: ", pszObjName);
 			offsWriteBuf += lenWriteBuf;
 		}
+		lenWriteBuf = snprintf(pszWriteBuf + offsWriteBuf, sizeof(pszWriteBuf) - offsWriteBuf, "%s: ", pszFileName);
+		offsWriteBuf += lenWriteBuf;
 	}
 #endif
 	if(lenMsg > sizeof(pszWriteBuf) - offsWriteBuf) 
@@ -909,7 +911,7 @@ do_dbgprint(uchar *pszObjName, char *pszMsg, size_t lenMsg)
  * contains common code. added 2008-09-26 rgerhards
  */
 static void
-dbgprint(obj_t *pObj, char *pszMsg, size_t lenMsg)
+dbgprint(obj_t *pObj, char *pszMsg, const char *pszFileName, size_t lenMsg)
 {
 	uchar *pszObjName = NULL;
 
@@ -926,7 +928,7 @@ dbgprint(obj_t *pObj, char *pszMsg, size_t lenMsg)
 	pthread_mutex_lock(&mutdbgprint);
 	pthread_cleanup_push(dbgMutexCancelCleanupHdlr, &mutdbgprint);
 
-	do_dbgprint(pszObjName, pszMsg, lenMsg);
+	do_dbgprint(pszObjName, pszMsg, pszFileName, lenMsg);
 
 	pthread_cleanup_pop(1);
 }
@@ -935,6 +937,27 @@ dbgprint(obj_t *pObj, char *pszMsg, size_t lenMsg)
 #pragma GCC diagnostic warning "-Wclobbered"
 #endif 
 
+static int
+checkDbgFile(const char *srcname)
+{
+
+	if(glblDbgFilesNum == 0) {
+		return 1;
+	}
+	if(glblDbgWhitelist) {
+		if(bsearch(srcname, glblDbgFiles, glblDbgFilesNum, sizeof(char*), bs_arrcmp_glblDbgFiles) == NULL) {
+			return 0;
+		} else {
+			return 1;
+		}
+	} else {
+		if(bsearch(srcname, glblDbgFiles, glblDbgFilesNum, sizeof(char*), bs_arrcmp_glblDbgFiles) != NULL) {
+			return 0;
+		} else {
+			return 1;
+		}
+	}
+}
 /* print some debug output when an object is given
  * This is mostly a copy of dbgprintf, but I do not know how to combine it
  * into a single function as we have variable arguments and I don't know how to call
@@ -942,7 +965,7 @@ dbgprint(obj_t *pObj, char *pszMsg, size_t lenMsg)
  * time being. -- rgerhards, 2008-01-29
  */
 void
-dbgoprint(obj_t *pObj, const char *fmt, ...)
+r_dbgoprint( const char *srcname, obj_t *pObj, const char *fmt, ...)
 {
 	va_list ap;
 	char pszWriteBuf[32*1024];
@@ -951,6 +974,10 @@ dbgoprint(obj_t *pObj, const char *fmt, ...)
 	if(!(Debug && debugging_on))
 		return;
 	
+	if(!checkDbgFile(srcname)) {
+		return;
+	}
+
 	/* a quick and very dirty hack to enable us to display just from those objects
 	 * that we are interested in. So far, this must be changed at compile time (and
 	 * chances are great it is commented out while you read it. Later, this shall
@@ -973,23 +1000,28 @@ dbgoprint(obj_t *pObj, const char *fmt, ...)
 		pszWriteBuf[sizeof(pszWriteBuf) - 1] = '\0';
 		lenWriteBuf = sizeof(pszWriteBuf);
 	}
-	dbgprint(pObj, pszWriteBuf, lenWriteBuf);
+	dbgprint(pObj, pszWriteBuf, srcname, lenWriteBuf);
 }
 
 
 /* print some debug output when no object is given
- * WARNING: duplicate code, see dbgoprin above!
+ * WARNING: duplicate code, see dbgoprint above!
  */
 void
-dbgprintf(const char *fmt, ...)
+r_dbgprintf(const char *srcname, const char *fmt, ...)
 {
 	va_list ap;
 	char pszWriteBuf[32*1024];
 	size_t lenWriteBuf;
 
-	if(!(Debug && debugging_on))
+	if(!(Debug && debugging_on)) {
 		return;
-	
+	}
+
+	if(!checkDbgFile(srcname)) {
+		return;
+	}
+
 	va_start(ap, fmt);
 	lenWriteBuf = vsnprintf(pszWriteBuf, sizeof(pszWriteBuf), fmt, ap);
 	va_end(ap);
@@ -1002,7 +1034,7 @@ dbgprintf(const char *fmt, ...)
 		pszWriteBuf[sizeof(pszWriteBuf) - 1] = '\0';
 		lenWriteBuf = sizeof(pszWriteBuf);
 	}
-	dbgprint(NULL, pszWriteBuf, lenWriteBuf);
+	dbgprint(NULL, pszWriteBuf, srcname, lenWriteBuf);
 }
 
 /* handler called when a function is entered. This function creates a new

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -92,8 +92,8 @@ rsRetVal dbgClassExit(void);
 void dbgSetDebugFile(uchar *fn);
 void dbgSetDebugLevel(int level);
 void sigsegvHdlr(int signum);
-void dbgoprint(obj_t *pObj, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
-void dbgprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void r_dbgoprint(const char *srcname, obj_t *pObj, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+void r_dbgprintf(const char *srcname, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 int dbgMutexLock(pthread_mutex_t *pmut, dbgFuncDB_t *pFuncD, int ln, int iStackPtr);
 int dbgMutexTryLock(pthread_mutex_t *pmut, dbgFuncDB_t *pFuncD, int ln, int iStackPtr);
 int dbgMutexUnlock(pthread_mutex_t *pmut, dbgFuncDB_t *pFuncD, int ln, int iStackPtr);
@@ -119,8 +119,10 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #	define DBGPRINTF(...) {}
 #	define DBGOPRINT(...) {}
 #else
-#	define DBGPRINTF(...) if(Debug) { dbgprintf(__VA_ARGS__); }
-#	define DBGOPRINT(...) if(Debug) { dbgoprint(__VA_ARGS__); }
+#	define DBGPRINTF(...) if(Debug) { r_dbgprintf(__FILE__, __VA_ARGS__); }
+#	define DBGOPRINT(...) if(Debug) { r_dbgoprint(__FILE__, __VA_ARGS__); }
+#	define dbgprintf(...) r_dbgprintf(__FILE__, __VA_ARGS__)
+#	define dbgoprint(...) r_dbgoprint(__FILE__, __VA_ARGS__)
 #endif
 #ifdef RTINST
 #define BEGINfunc static dbgFuncDB_t *pdbgFuncDB;

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -118,6 +118,9 @@ extern int glblUnloadModules;
 extern short janitorInterval;
 extern int glblIntMsgRateLimitItv;
 extern int glblIntMsgRateLimitBurst;
+extern char** glblDbgFiles;
+extern size_t glblDbgFilesNum;
+extern int glblDbgWhitelist;
 
 #define glblGetOurPid() glbl_ourpid
 #define glblSetOurPid(pid) { glbl_ourpid = (pid); }
@@ -132,5 +135,6 @@ const uchar * glblGetWorkDirRaw(void);
 tzinfo_t* glblFindTimezoneInfo(char *id);
 int GetGnuTLSLoglevel(void);
 int glblGetMaxLine(void);
+int bs_arrcmp_glblDbgFiles(const void *s1, const void *s2);
 
 #endif /* #ifndef GLBL_H_INCLUDED */

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -626,7 +626,7 @@ struct actWrkrIParams {
 
 /* The following prototype is convenient, even though it may not be the 100%
 correct place.. -- rgerhards 2008-01-07 */
-void dbgprintf(const char *, ...) __attribute__((format(printf, 1, 2)));
+//void dbgprintf(const char *, ...) __attribute__((format(printf, 1, 2)));
 
 
 #include "debug.h"

--- a/tools/rscryutil.c
+++ b/tools/rscryutil.c
@@ -58,7 +58,7 @@ static int optionForce = 0;
  * in order to satisfy the needs of the common code.
  */
 int Debug = 0;
-void dbgprintf(const char *fmt __attribute__((unused)), ...) {};
+void r_dbgprintf(const char *srcname __attribute__((unused)), const char *fmt __attribute__((unused)), ...) {};
 void srSleep(int a __attribute__((unused)), int b __attribute__((unused)));
 /* prototype (avoid compiler warning) */
 void srSleep(int a __attribute__((unused)), int b __attribute__((unused))) {};


### PR DESCRIPTION
add parameters to configure debug-output to only be shown if it is generated by specific files.