### PR TITLE
correct mutex arg in imptcp

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -828,7 +828,7 @@ AcceptConnReq(ptcplstn_t *pLstn, int *newSock, prop_t **peerName, prop_t **peerI
 		LogMsg(0, RS_RET_NO_ERRCODE, LOG_INFO, "imptcp: connection established with host: %s", propGetSzStr(*peerName));
 	}
 
-	STATSCOUNTER_INC(pLstn->ctrSessOpen, pThis->pLstn->mutCtrSessOpen);
+	STATSCOUNTER_INC(pLstn->ctrSessOpen, pLstn->mutCtrSessOpen);
 	*newSock = iNewSock;
 
 finalize_it:
@@ -837,7 +837,7 @@ finalize_it:
 		if(iRet != RS_RET_NO_MORE_DATA && pLstn->pSrv->bEmitMsgOnOpen) {
 			LogError(0, NO_ERRCODE, "imptcp: connection could not be established with host: %s", propGetSzStr(*peerName));
 		}
-		STATSCOUNTER_INC(pLstn->ctrSessOpenErr, pThis->pLstn->mutCtrSessOpenErr);
+		STATSCOUNTER_INC(pLstn->ctrSessOpenErr, pLstn->mutCtrSessOpenErr);
 		/* the close may be redundant, but that doesn't hurt... */
 		if(iNewSock != -1)
 			close(iNewSock);


### PR DESCRIPTION
Remove the 'pThis->' from the second argument to STATSCOUNTER_INC macro.
This only affects architectures without atomic uint64 actions, like aarch64.
Others do not use the mut argument, and it gets compiled out.

Resolves issue #1719.  Thank you @Hoshpak for reporting.