### PR TITLE
omelasticsearch: avoid ES5 warnings while sending json in bulkmode

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1323,16 +1323,11 @@ curlPostSetup(CURL *handle, HEADER *header, uchar* authBuf)
 }
 
 #define CONTENT_JSON "Content-Type: application/json; charset=utf-8"
-#define CONTENT_JSON_BULK "Content-Type: application/x-ndjson; charset=utf-8"
 
 static rsRetVal
 curlSetup(wrkrInstanceData_t *pWrkrData, instanceData *pData)
 {
-	if (pData->bulkmode) {
-		pWrkrData->curlHeader = curl_slist_append(NULL, CONTENT_JSON_BULK);
-	} else {
-		pWrkrData->curlHeader = curl_slist_append(NULL, CONTENT_JSON);
-	}
+	pWrkrData->curlHeader = curl_slist_append(NULL, CONTENT_JSON);
 	pWrkrData->curlPostHandle = curl_easy_init();
 	if (pWrkrData->curlPostHandle == NULL) {
 		return RS_RET_OBJ_CREATION_FAILED;


### PR DESCRIPTION
my original patch attented to fix an deprecation warnings while sending
json related to content type.
I however wanted to improve my commit and support the mentioned x-ndjson
content type in case of bulk mode.
see
https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-bulk.html

However, firstly my patch was wrong, since, in bulk mode, the x-ndjson was
set even for connection checks. Secondly I discovered that ES community
kind of disagree of what is the correct behavior:
 in RFC 6648 the x- prefix is already decided as "deprecated"
see https://github.com/elastic/elasticsearch/issues/25718

So I decided to put only application/json as content type; it is
supported for both simple request or bulk requests containing multiple
json. We can improve it when there is a final decision about it.

Re-Fixes: #1642
Fixes: commit 462be8b2ee4 (omelasticsearch: avoid ES5 warnings while sending json)