### PR TITLE
Fix debugless build

### DIFF
--- a/action.c
+++ b/action.c
@@ -583,7 +583,7 @@ rsRetVal actionSetGlobalResumeInterval(int iNewVal)
  * returned string must not be modified.
  * rgerhards, 2009-05-07
  */
-static uchar *getActStateName(action_t * const pThis, wti_t * const pWti)
+static uchar DL_UNUSED *getActStateName(action_t * const pThis, wti_t * const pWti)
 {
 	switch(getActionState(pWti, pThis)) {
 		case ACT_STATE_RDY:

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -71,7 +71,7 @@ struct cnffunc * cnffuncNew_prifilt(int fac);
  * NOTE: This function MUST be updated if new tokens are defined in the
  *       grammar.
  */
-static const char *
+static const char DL_UNUSED *
 tokenToString(const int token)
 {
 	const char *tokstr;
@@ -2887,10 +2887,11 @@ pmaskPrint(uchar *pmask, int indent)
 	doIndent(indent);
 	dbgprintf("pmask: ");
 	for (i = 0; i <= LOG_NFACILITIES; i++)
-		if (pmask[i] == TABLE_NOPRI)
+		if (pmask[i] == TABLE_NOPRI) {
 			dbgprintf(" X ");
-		else
+		} else {
 			dbgprintf("%2X ", pmask[i]);
+		}
 	dbgprintf("\n");
 }
 
@@ -4621,7 +4622,7 @@ cnfparamGetIdx(struct cnfparamblk *params, const char *name)
 
 
 void
-cstrPrint(const char *text, es_str_t *estr)
+cstrPrint(const char DL_UNUSED *text, es_str_t *estr)
 {
 	char *str;
 	str = es_str2cstr(estr, NULL);

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -176,7 +176,9 @@ writeOutputDebug(wrkrInstanceData_t *__restrict__ const pWrkrData,
 	const char *__restrict__ const buf,
 	const ssize_t lenBuf)
 {
+#ifndef DEBUGLESS
 	char errStr[1024];
+#endif
 	ssize_t r;
 
 	if(pWrkrData->pData->outputFileName == NULL)
@@ -216,7 +218,9 @@ static void
 processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *const pMsg)
 {
 	rsRetVal iRet;
+#ifndef DEBUGLESS
 	char errStr[1024];
+#endif
 	ssize_t r;
 	int numCharsRead;
 	char *newptr;
@@ -388,7 +392,9 @@ cleanup(wrkrInstanceData_t *pWrkrData)
 {
 	int status;
 	int ret;
+#ifndef DEBUGLESS
 	char errStr[1024];
+#endif
 	DEFiRet;
 
 	assert(pWrkrData->bIsRunning == 1);
@@ -452,7 +458,9 @@ callExtProg(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *__restrict
 	int lenWrite;
 	int writeOffset;
 	int i_iov;
+#ifndef DEBUGLESS
 	char errStr[1024];
+#endif
 	struct iovec iov[2];
 	const uchar *inputstr = NULL; /* string to be processed by external program */
 	DEFiRet;

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -118,6 +118,9 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #ifdef DEBUGLESS
 #	define DBGPRINTF(...) {}
 #	define DBGOPRINT(...) {}
+#	define dbgprintf(...) {}
+#   define dbgoprint(...) {}
+#   define DL_UNUSED __attribute__((unused))
 #else
 #	define DBGPRINTF(...) if(Debug) { r_dbgprintf(__FILE__, __VA_ARGS__); }
 #	define DBGOPRINT(...) if(Debug) { r_dbgoprint(__FILE__, __VA_ARGS__); }

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -126,6 +126,7 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #	define DBGOPRINT(...) if(Debug) { r_dbgoprint(__FILE__, __VA_ARGS__); }
 #	define dbgprintf(...) r_dbgprintf(__FILE__, __VA_ARGS__)
 #	define dbgoprint(...) r_dbgoprint(__FILE__, __VA_ARGS__)
+#   define DL_UNUSED
 #endif
 #ifdef RTINST
 #define BEGINfunc static dbgFuncDB_t *pdbgFuncDB;

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -119,14 +119,14 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #	define DBGPRINTF(...) {}
 #	define DBGOPRINT(...) {}
 #	define dbgprintf(...) {}
-#   define dbgoprint(...) {}
-#   define DL_UNUSED __attribute__((unused))
+#	define dbgoprint(...) {}
+#	define DL_UNUSED __attribute__((unused))
 #else
 #	define DBGPRINTF(...) if(Debug) { r_dbgprintf(__FILE__, __VA_ARGS__); }
 #	define DBGOPRINT(...) if(Debug) { r_dbgoprint(__FILE__, __VA_ARGS__); }
 #	define dbgprintf(...) r_dbgprintf(__FILE__, __VA_ARGS__)
 #	define dbgoprint(...) r_dbgoprint(__FILE__, __VA_ARGS__)
-#   define DL_UNUSED
+#	define DL_UNUSED
 #endif
 #ifdef RTINST
 #define BEGINfunc static dbgFuncDB_t *pdbgFuncDB;

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -822,9 +822,9 @@ PrintAllowedSenders(int iListToPrint)
 		dbgprintf("\tNo restrictions set.\n");
 	} else {
 		while(pSender != NULL) {
-			if (F_ISSET(pSender->allowedSender.flags, ADDR_NAME))
+			if (F_ISSET(pSender->allowedSender.flags, ADDR_NAME)) {
 				dbgprintf ("\t%s\n", pSender->allowedSender.addr.HostWildcard);
-			else {
+			} else {
 				if(mygetnameinfo (pSender->allowedSender.addr.NetAddr,
 						     SALEN(pSender->allowedSender.addr.NetAddr),
 						     (char*)szIP, 64, NULL, 0, NI_NUMERICHOST) == 0) {
@@ -1068,8 +1068,10 @@ should_use_so_bsdcompat(void)
 
 	init_done = 1;
 	if (uname(&myutsname) < 0) {
+#ifndef DEBUGLESS
 		char errStr[1024];
 		dbgprintf("uname: %s\r\n", rs_strerror_r(errno, errStr, sizeof(errStr)));
+#endif
 		return 1;
 	}
 	/* Format is <version>.<patchlevel>.<sublevel><extraversion>
@@ -1100,8 +1102,9 @@ should_use_so_bsdcompat(void)
  * a debug aid. rgerhards, 2007-07-02
  */
 static void
-debugListenInfo(int fd, char *type)
+debugListenInfo(int DL_UNUSED fd, char DL_UNUSED *type)
 {
+#ifndef DEBUGLESS
 	const char *szFamily;
 	int port;
 	struct sockaddr_storage sa;
@@ -1132,6 +1135,7 @@ debugListenInfo(int fd, char *type)
 	 * or do any serious error reporting.
 	 */
 	dbgprintf("Listening on syslogd socket %d - could not obtain peer info.\n", fd);
+#endif
 }
 
 
@@ -1267,7 +1271,9 @@ create_udp_socket(uchar *hostname,
 	int actrcvbuf;
 	int actsndbuf;
 	socklen_t optlen;
+#ifndef DEBUGLESS
 	char errStr[1024];
+#endif
 
 	assert(!((pszPort == NULL) && (hostname == NULL)));
         memset(&hints, 0, sizeof(hints));

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -241,7 +241,7 @@ finalize_it:
 
 /* methods */
 
-static const char *
+static const char DL_UNUSED *
 getQueueTypeName(queueType_t t)
 {
 	const char *r;
@@ -267,7 +267,7 @@ getQueueTypeName(queueType_t t)
 }
 
 void
-qqueueDbgPrint(qqueue_t *pThis)
+qqueueDbgPrint(qqueue_t DL_UNUSED *pThis)
 {
 	dbgoprint((obj_t*) pThis, "parameter dump:\n");
 	dbgoprint((obj_t*) pThis, "queue.filename '%s'\n",

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -95,7 +95,7 @@ static rsRetVal strmSeekCurrOffs(strm_t *pThis);
 /* output (current) file name for debug log purposes. Falls back to various
  * levels of impreciseness if more precise name is not known.
  */
-static const char *
+static const char DL_UNUSED *
 getFileDebugName(const strm_t *const pThis)
 {
 	  return (pThis->pszCurrFName == NULL) ?

--- a/runtime/tcpclt.c
+++ b/runtime/tcpclt.c
@@ -80,7 +80,9 @@ CreateSocket(struct addrinfo *addrDest)
 					/* this is normal - will complete later select */
 					return fd;
 				} else {
+#ifndef DEBUGLESS
 					char errStr[1024];
+#endif
 					dbgprintf("create tcp connection failed, reason %s",
 						rs_strerror_r(errno, errStr, sizeof(errStr)));
 				}
@@ -92,7 +94,9 @@ CreateSocket(struct addrinfo *addrDest)
 			close(fd);
 		}
 		else {
+#ifndef DEBUGLESS
 			char errStr[1024];
+#endif
 			dbgprintf("couldn't create send socket, reason %s", rs_strerror_r(errno, errStr, sizeof(errStr)));
 		}		
 		r = r->ai_next;

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -61,7 +61,7 @@ pthread_key_t thrd_wti_key;
 /* get the header for debug messages
  * The caller must NOT free or otherwise modify the returned string!
  */
-static uchar *
+static uchar DL_UNUSED *
 wtiGetDbgHdr(wti_t *pThis)
 {
 	ISOBJ_TYPE_assert(pThis, wti);

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -437,7 +437,9 @@ wtpStartWrkr(wtp_t *pThis)
 {
 	wti_t *pWti;
 	int i;
+#ifndef DEBUGLESS
 	int iState;
+#endif
 	DEFiRet;
 
 	ISOBJ_TYPE_assert(pThis, wtp);
@@ -460,7 +462,10 @@ wtpStartWrkr(wtp_t *pThis)
 
 	pWti = pThis->pWrkr[i];
 	wtiSetState(pWti, WRKTHRD_RUNNING);
-	iState = pthread_create(&(pWti->thrdID), &pThis->attrThrd, wtpWorker, (void*) pWti);
+#ifndef DEBUGLESS
+	iState = 
+#endif
+		pthread_create(&(pWti->thrdID), &pThis->attrThrd, wtpWorker, (void*) pWti);
 	ATOMIC_INC(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd); /* we got one more! */
 
 	DBGPRINTF("%s: started with state %d, num workers now %d\n",

--- a/template.c
+++ b/template.c
@@ -2231,12 +2231,13 @@ void tplPrintList(rsconf_t *conf)
 	pTpl = conf->templates.root;
 	while(pTpl != NULL) {
 		dbgprintf("Template: Name='%s' ", pTpl->pszName == NULL? "NULL" : pTpl->pszName);
-		if(pTpl->optFormatEscape == SQL_ESCAPE)
+		if(pTpl->optFormatEscape == SQL_ESCAPE) {
 			dbgprintf("[SQL-Format (MySQL)] ");
-		else if(pTpl->optFormatEscape == JSON_ESCAPE)
+		} else if(pTpl->optFormatEscape == JSON_ESCAPE) {
 			dbgprintf("[JSON-Escaped Format] ");
-		else if(pTpl->optFormatEscape == STDSQL_ESCAPE)
+		} else if(pTpl->optFormatEscape == STDSQL_ESCAPE) {
 			dbgprintf("[SQL-Format (standard SQL)] ");
+		}
 		if(pTpl->optCaseSensitive)
 			dbgprintf("[Case Sensitive Vars] ");
 		dbgprintf("\n");

--- a/threads.c
+++ b/threads.c
@@ -184,6 +184,12 @@ rsRetVal thrdTerminateAll(void)
 static void* thrdStarter(void *arg)
 {
 	DEFiRet;
+
+#ifdef DEBUGLESS
+	// Silence unused variable warning
+	if (iRet) {}
+#endif
+
 	thrdInfo_t *pThis = (thrdInfo_t*) arg;
 #	if defined(HAVE_PRCTL) && defined(PR_SET_NAME)
 	uchar thrdName[32] = "in:";

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -432,7 +432,9 @@ static rsRetVal UDPSend(wrkrInstanceData_t *__restrict__ const pWrkrData,
 	sbool reInit = RSFALSE;
 	int lasterrno = ENOENT;
 	int lasterr_sock = -1;
+#ifndef DEBUGLESS
 	char errStr[1024];
+#endif
 
 	if(pWrkrData->pData->iRebindInterval && (pWrkrData->nXmit++ % pWrkrData->pData->iRebindInterval == 0)) {
 		dbgprintf("omfwd dropping UDP 'connection' (as configured)\n");

--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -210,7 +210,9 @@ static rsRetVal wallmsg(uchar* pMsg, instanceData *pData)
 	uchar szErr[512];
 	char p[sizeof(_PATH_DEV) + UNAMESZ];
 	register int i;
+#ifndef DEBUGLESS
 	int errnoSave;
+#endif
 	int ttyf;
 	int wrRet;
 	STRUCTUTMP ut;
@@ -267,7 +269,9 @@ static rsRetVal wallmsg(uchar* pMsg, instanceData *pData)
 				wrRet = write(ttyf, pMsg, strlen((char*)pMsg));
 				if(Debug && wrRet == -1) {
 					/* we record the state to the debug log */
+#ifndef DEBUGLESS
 					errnoSave = errno;
+#endif
 					rs_strerror_r(errno, (char*)szErr, sizeof(szErr));
 					dbgprintf("write to terminal '%s' failed with [%d]:%s\n",
 						  p, errnoSave, szErr);

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -482,8 +482,13 @@ static void
 tellChildReady(const int pipefd, const char *const msg)
 {
 	dbgprintf("rsyslogd: child signaling OK\n");
+#ifndef DEBUGLESS
 	const int nWritten = write(pipefd, msg, strlen(msg));
 	dbgprintf("rsyslogd: child signalled OK, nWritten %d\n", (int) nWritten);
+#else
+	// The if() is to silence the "ignoring return value of 'write'" warning.
+	if (write(pipefd, msg, strlen(msg))) {};
+#endif
 	close(pipefd);
 	sleep(1);
 }
@@ -1174,7 +1179,9 @@ initAll(int argc, char **argv)
 	int iHelperUOpt;
 	int bChDirRoot = 1; /* change the current working directory to "/"? */
 	char *arg;	/* for command line option processing */
+#ifndef DEBUGLESS
 	char cwdbuf[128]; /* buffer to obtain/display current working directory */
+#endif
 	int parentPipeFD = 0; /* fd of pipe to parent, if auto-backgrounding */
 	DEFiRet;
 


### PR DESCRIPTION
It seems that using the `--enable-debugless` configure option results in a broken build:

    $ make
    make  all-recursive
    make[1]: Entering directory './rsyslog'
    Making all in compat
    make[2]: Entering directory './rsyslog/compat'
      CC       compat_la-getifaddrs.lo
      CC       compat_la-strndup.lo
      CC       compat_la-solaris_elf_fix.lo
      CCLD     compat.la
    ar: `u' modifier ignored since `D' is the default (see `U')
    make[2]: Leaving directory './rsyslog/compat'
    Making all in runtime
    make[2]: Entering directory './rsyslog/runtime'
      CC       librsyslog_la-rsyslog.lo
    rsyslog.c: In function ‘rsrtInit’:
    rsyslog.c:211:2: error: implicit declaration of function ‘dbgprintf’ [-Werror=implicit-function-declaration]
      dbgprintf("rsyslog runtime initialized, version %s, current users %d\n", VERSION, iRefCount);
      ^
    cc1: some warnings being treated as errors
    Makefile:1161: recipe for target 'librsyslog_la-rsyslog.lo' failed
    make[2]: *** [librsyslog_la-rsyslog.lo] Error 1
    make[2]: Leaving directory './rsyslog/runtime'
    Makefile:818: recipe for target 'all-recursive' failed
    make[1]: *** [all-recursive] Error 1
    make[1]: Leaving directory './rsyslog'
    Makefile:645: recipe for target 'all' failed
    make: *** [all] Error 2

I made the necessary changes to address this, and thought I'd share.