### PR TITLE
core bugfix: race on worker thread termination

### DIFF
--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -416,6 +416,7 @@ wtpWorker(void *arg) /* the arg is actually a wti object, even though we are in 
 
 	wtiWorker(pWti);
 	pthread_cleanup_pop(0);
+        d_pthread_mutex_lock(&pThis->mutWtp);
 	wtpWrkrExecCleanup(pWti);
 
 	ENDfunc
@@ -424,6 +425,7 @@ wtpWorker(void *arg) /* the arg is actually a wti object, even though we are in 
 	 * segfault. So we need to do the broadcast as actually the last action in our processing
 	 */
 	pthread_cond_broadcast(&pThis->condThrdTrm); /* activate anyone waiting on thread shutdown */
+        d_pthread_mutex_unlock(&pThis->mutWtp);
 	pthread_exit(0);
 }
 #if !defined(_AIX)


### PR DESCRIPTION
The testbench got some occasionally failing tests. Review of
them brought up the idea that there is a race during worker
threat termination. Further investigation showed that this
might be a long-standing issue, but so far did not really
surface as the timing was almost always correct. However,
with the new functionality to emit a message on worker
shutdown (v8.29), the timing got more complex and now this
seemed to occasionally surface.

closes #1754