### PR TITLE
core: memory corruption during configuration parsing

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1157,7 +1157,6 @@ CODESTARTnewActInst
 			pData->pszStrmDrvrAuthMode = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriverpermittedpeers")) {
 			uchar *start, *str;
-			uchar save;
 			uchar *p;
 			int lenStr;
 			str = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
@@ -1170,8 +1169,6 @@ CODESTARTnewActInst
 				if(*p == ',') {
 					*p = '\0';
 				}
-				save = *(p+1); /* we always have this, at least the \0 byte at EOS */
-				*(p+1) = '\0';
 				if(*start == '\0') {
 					DBGPRINTF("omfwd: ignoring empty permitted peer\n");
 				} else {
@@ -1181,7 +1178,6 @@ CODESTARTnewActInst
 				start = p+1;
 				if(lenStr)
 					--lenStr;
-				*(p+1) = save;
 			}
 			free(str);
 		} else if(!strcmp(actpblk.descr[i].name, "ziplevel")) {


### PR DESCRIPTION
when omfwd is used with the $streamdriverpermittedpeers legacy
parameter, a memory corruption can occur. This depends on the
length of the provided strings and probably the malloc subsystem.

Once config parsing succeeds, no problem can happen.

Thanks to github user bwdoll for analyzing this bug and providing
a suggested fix (which is almost what this commit includes).

closes https://github.com/rsyslog/rsyslog/issues/1474