### PR TITLE
queue bugfix: file write error message was incorrect

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -367,11 +367,11 @@ static rsRetVal strmOpenFile(strm_t *pThis)
 	CHKiRet(getFileSize(pThis->pszCurrFName, &offset));
 	if(pThis->tOperationsMode == STREAMMODE_WRITE_APPEND) {
 		pThis->iCurrOffs = offset;
-	} else if(pThis->tOperationsMode == STREAMMODE_WRITE) {
+	} else if(pThis->tOperationsMode == STREAMMODE_WRITE_TRUNC) {
 		if(offset != 0) {
-			LogError(0, 0, "queue '%s', file '%s' opened for non-append write, but "
+			LogError(0, 0, "file '%s' opened for truncate write, but "
 				"already contains %zd bytes\n",
-				obj.GetName((obj_t*) pThis), pThis->pszCurrFName, (ssize_t) offset);
+				pThis->pszCurrFName, (ssize_t) offset);
 		}
 	}
 

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -369,9 +369,10 @@ case $1 in
    'check-mainq-spool') # check if mainqueue spool files exist, if not abort (we just check .qi).
 		echo There must exist some files now:
 		ls -l test-spool
+		echo .qi file:
+		cat test-spool/mainq.qi
 		if test ! -f test-spool/mainq.qi; then
 		  echo "error: mainq.qi does not exist where expected to do so!"
-		  ls -l test-spool
 		  . $srcdir/diag.sh error-exit 1
 		fi
 		;;


### PR DESCRIPTION
when a queue was restarted from disk file, it almost always
emitted a message claiming
"file opened for non-append write, but already contains xxx bytes"
This message was wrong and did not indicate a real error condition.
The predicate check was incorrect.

closes https://github.com/rsyslog/rsyslog/issues/170 (kind of)