### PR TITLE
enabling falback to older systemd version without restart-less

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -460,8 +460,10 @@ AC_ARG_ENABLE(imjournal,
         [enable_imjournal="no"]
 )
 if test "x$enable_imjournal" = "xyes"; then
-	PKG_CHECK_MODULES([LIBSYSTEMD_JOURNAL], [libsystemd >= 234] ,, [
-	    PKG_CHECK_MODULES([LIBSYSTEMD_JOURNAL], [libsystemd-journal >= 197])
+	PKG_CHECK_MODULES([LIBSYSTEMD_JOURNAL], [libsystemd >= 234] , [AC_DEFINE(NEW_JOURNAL, 1, [new systemd present])] , [
+	    PKG_CHECK_MODULES([LIBSYSTEMD_JOURNAL], [libsystemd >= 209] , , [
+	        PKG_CHECK_MODULES([LIBSYSTEMD_JOURNAL], [libsystemd-journal >= 197])
+	    ])
 	])
 fi
 AM_CONDITIONAL(ENABLE_IMJOURNAL, test x$enable_imjournal = xyes)


### PR DESCRIPTION
persistent journal switch.

This addresses a point raised in #1747 