### PR TITLE
omfwd bugfix: UDP oversize message not properly handled

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -485,6 +485,7 @@ operation not carried out */
 	RS_RET_DIR_CHOWN_ERROR = -2437, /**< error during chown() */
 	RS_RET_JSON_UNUSABLE = -2438, /**< JSON object is NULL or otherwise unusable */
 	RS_RET_OPERATION_STATUS = -2439, /**< operational status (info) message, no error */
+	RS_RET_UDP_MSGSIZE_TOO_LARGE = -2440, /**< a message is too large to be sent via UDP */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */


### PR DESCRIPTION
When a message larger than supported by the UDP stack is to be sent,
EMSGSIZE is returned, but not specifically handled. That in turn
will lead to action suspension. However, this does not make sense
because messages over the UDP max message size simply cannot be sent.

This patch truncates the message in question and reports an error
message with the condition.

closes https://github.com/rsyslog/rsyslog/issues/1654