### PR TITLE
Support static linking `libmaxminddb` to plugin `mmdblookup`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -21,6 +21,8 @@ if test "$unamestr" = "AIX"; then
 	GNUTLS_CFLAGS="-I/usr/include"
 	RELP_LIBS="-L/usr/lib/ -lrelp"
 	RELP_CFLAGS="-I/usr/include"
+	LIBMAXMINDDB_LIBS="-L/usr/lib/ -lmaxminddb"
+	LIBMAXMINDDB_CFLAGS="-I/usr/include"
 	CC="xlc_r"
 	AC_PREFIX_DEFAULT(/usr)
 	export  ac_cv_func_malloc_0_nonnull=yes

--- a/plugins/mmdblookup/Makefile.am
+++ b/plugins/mmdblookup/Makefile.am
@@ -1,8 +1,6 @@
 pkglib_LTLIBRARIES = mmdblookup.la
 
 mmdblookup_la_SOURCES = mmdblookup.c
-mmdblookup_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
-mmdblookup_la_LDFLAGS = -module -avoid-version -lmaxminddb
-mmdblookup_la_LIBADD = 
-
-EXTRA_DIST = 
+mmdblookup_la_CPPFLAGS = $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(LIBMAXMINDDB_CFLAGS)
+mmdblookup_la_LDFLAGS = -module -avoid-version -l:libmaxminddb.a
+mmdblookup_la_LIBADD =


### PR DESCRIPTION
Update `configure.ac` and `mmdblookup`'s `Makefile.am` to support static link `libmaxminddb`'s static library.