### PR TITLE
TLS errmsg more specific when file can not be read

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -124,12 +124,12 @@ readFile(uchar *pszFile, gnutls_datum_t *pBuf)
 	pBuf->data = NULL;
 
 	if((fd = open((char*)pszFile, O_RDONLY)) == -1) {
-		errmsg.LogError(0, RS_RET_FILE_NOT_FOUND, "can not read file '%s'", pszFile);
+		errmsg.LogError(errno, RS_RET_FILE_NOT_FOUND, "can not read file '%s'", pszFile);
 		ABORT_FINALIZE(RS_RET_FILE_NOT_FOUND);
 	}
 
 	if(fstat(fd, &stat_st) == -1) {
-		errmsg.LogError(0, RS_RET_FILE_NO_STAT, "can not stat file '%s'", pszFile);
+		errmsg.LogError(errno, RS_RET_FILE_NO_STAT, "can not stat file '%s'", pszFile);
 		ABORT_FINALIZE(RS_RET_FILE_NO_STAT);
 	}
 

--- a/tests/tls_error_file_not_found.sh
+++ b/tests/tls_error_file_not_found.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2017-09-21 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+global(
+	defaultNetstreamDriver="gtls"
+	defaultNetstreamDriverKeyFile="tls-certs/nokey.pem"
+	defaultNetstreamDriverCertFile="tls-certs/cert.pem"
+	defaultNetstreamDriverCaFile="tls-certs/ca.pem"
+)
+module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="gtls" StreamDriver.Mode="1" StreamDriver.AuthMode="anon")
+input(type="imtcp" port="13514")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+action(type="omfile" template="outfmt" file="rsyslog.out.log")
+
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+grep "defaultnetstreamdriverkeyfile.*tls-certs/nokey.pem" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected error message from missing input file not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
When a certificate can not be read the error message now contains
more information about what went wrong when trying to read the file.