### PR TITLE
bugfix: rsyslog aborts on startup if certificate files cannot be acce…

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -1129,43 +1129,40 @@ glblDoneLoadCnf(void)
 				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdriverkeyfile")) {
 			free(pszDfltNetstrmDrvrKeyFile);
-			pszDfltNetstrmDrvrKeyFile = (uchar*)
-				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
-			fp = fopen((const char*)pszDfltNetstrmDrvrKeyFile, "r");
+			uchar *const fn = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			fp = fopen((const char*)fn, "r");
 			if(fp == NULL) {
-				char errStr[1024];
-				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
-				"error: certificate file %s couldn't be accessed: %s\n",
-				pszDfltNetstrmDrvrKeyFile, errStr);
+				LogError(errno, RS_RET_NO_FILE_ACCESS,
+					"error: defaultnetstreamdriverkeyfile '%s' "
+					"could not be accessed", fn);
+			} else {
+				fclose(fp);
+				pszDfltNetstrmDrvrKeyFile = fn;
 			}
-			fclose(fp);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercertfile")) {
 			free(pszDfltNetstrmDrvrCertFile);
-			pszDfltNetstrmDrvrCertFile = (uchar*)
-				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
-			fp = fopen((const char*)pszDfltNetstrmDrvrCertFile, "r");
+			uchar *const fn = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			fp = fopen((const char*)fn, "r");
 			if(fp == NULL) {
-				char errStr[1024];
-				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
-				"error: certificate file %s couldn't be accessed: %s\n",
-				pszDfltNetstrmDrvrCertFile, errStr);
+				LogError(errno, RS_RET_NO_FILE_ACCESS,
+					"error: defaultnetstreamdrivercertfile '%s' "
+					"could not be accessed", fn);
+			} else {
+				fclose(fp);
+				pszDfltNetstrmDrvrCertFile = fn;
 			}
-			fclose(fp);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercafile")) {
 			free(pszDfltNetstrmDrvrCAF);
-			pszDfltNetstrmDrvrCAF = (uchar*)
-				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
-			fp = fopen((const char*)pszDfltNetstrmDrvrCAF, "r");
+			uchar *const fn = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			fp = fopen((const char*)fn, "r");
 			if(fp == NULL) {
-				char errStr[1024];
-				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
-				"error: certificate file %s couldn't be accessed: %s\n",
-				pszDfltNetstrmDrvrCAF, errStr);
+				LogError(errno, RS_RET_NO_FILE_ACCESS,
+					"error: defaultnetstreamdrivercafile file '%s' "
+					"could not be accessed", fn);
+			} else {
+				fclose(fp);
+				pszDfltNetstrmDrvrCAF = fn;
 			}
-			fclose(fp);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdriver")) {
 			free(pszDfltNetstrmDrvr);
 			pszDfltNetstrmDrvr = (uchar*)


### PR DESCRIPTION
…ssed

When the global defaults for certificates are set and the certificate
files cannot be accessed, rsyslog aborts. This is caused by a failure
in certificate-file-validity check code. It can only happen right at startup.

Also, the invalid certificate file is still set, causing follow-on problems.

closes https://github.com/rsyslog/rsyslog/issues/1786