### PR TITLE
testbench: Run mmnormalize tests only when mmnormalize module was actually enabled

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -498,7 +498,6 @@ TESTS += msgvar-concurrency-array.sh \
 	mmnormalize_processing_test2.sh \
 	mmnormalize_processing_test3.sh \
 	mmnormalize_processing_test4.sh
-endif
 
 if ENABLE_IMPTCP
 TESTS +=  \
@@ -511,6 +510,7 @@ endif
 if LOGNORM_REGEX_SUPPORTED
 TESTS += \
 	mmnormalize_regex.sh
+endif
 endif
 
 if ENABLE_MMJSONPARSE


### PR DESCRIPTION
This commit fixes a regression caused by commit 835e645b73babf1290b691ef2ef137da206f6eff
and will restore the removed if nesting necessary to run *mmnormalize* tests
only when *mmnormalize* module was actually enabled.

Bug: https://bugs.gentoo.org/631246