### PR TITLE
mmanon: fix fall through warning

### DIFF
--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -455,6 +455,7 @@ isValidHexNum(const uchar *const __restrict__ buf,
 				(*nprocessed)++;
 				return -1;
 			}
+			return cyc;
 		default:
 			return cyc;
 		}


### PR DESCRIPTION
mmanon.c:454:6: warning: this statement may fall through [-Wimplicit-fallthrough=]
    if(cyc == 0) {
      ^
mmanon.c:458:3: note: here
   default:
   ^~~~~~~