### PR TITLE
imptcp: simplify parsing in bind port

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1515,8 +1515,6 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	CHKiRet(createInstance(&inst));
 	if(pNewVal == NULL || *pNewVal == '\0') {
 		errmsg.LogError(0, NO_ERRCODE, "imptcp: port number must be specified, listener ignored");
-	}
-	if((pNewVal == NULL) || (pNewVal == '\0')) {
 		inst->pszBindPort = NULL;
 	} else {
 		CHKmalloc(inst->pszBindPort = ustrdup(pNewVal));


### PR DESCRIPTION
I don't see in which case it could be useful to compare a pointer
a \0 char since we are already comparing it to NULL value just before

imptcp.c: In function ‘addInstance’:
imptcp.c:1519:35: warning: comparison between pointer and zero character constant [-Wpointer-compare]
  if((pNewVal == NULL) || (pNewVal == '\0')) {
                                   ^~
imptcp.c:1519:27: note: did you mean to dereference the pointer?
  if((pNewVal == NULL) || (pNewVal == '\0')) {
                           ^
