### PR TITLE
handle (JSON) variables in case-insensitive way

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,9 +1,12 @@
 ------------------------------------------------------------------------------
 Version 8.30.0 [v8-stable] 2017-10-10
-- NEW BUILD REQUIREMENT
-  when building imjournal, libsystemd-journal >= 234 is now recommended
-  This is to support the imjournal enhancement. Note that it is possible
-  to build with lower version, but this will degrade imjournal functionality.
+- NEW BUILD REQUIREMENTS
+  * libfastjson 0.99.7 is now mandatory
+    the new version is required to support case-insensitive variable
+    comparisons, which are now the default
+  * when building imjournal, libsystemd-journal >= 234 is now recommended
+    This is to support the imjournal enhancement. Note that it is possible
+    to build with lower version, but this will degrade imjournal functionality.
 - imjournal: made switching to persistent journal in runtime possible
   with this patch imjournal can continue logging after switch to
   persistent journal without need to restart rsyslog service

--- a/configure.ac
+++ b/configure.ac
@@ -75,7 +75,7 @@ PKG_PROG_PKG_CONFIG
 # modules we require
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
 
-PKG_CHECK_MODULES([LIBFASTJSON], [libfastjson >= 0.99.3],,)
+PKG_CHECK_MODULES([LIBFASTJSON], [libfastjson >= 0.99.7],,)
 
 AC_DEFINE_UNQUOTED([PLATFORM_ID], ["${host}"], [platform id for display purposes])
 # we don't mind if we don't have the lsb_release utility. But if we have, it's

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -178,6 +178,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "net.aclresolvehostname", eCmdHdlrBinary, 0 },
 	{ "net.enabledns", eCmdHdlrBinary, 0 },
 	{ "net.permitACLwarning", eCmdHdlrBinary, 0 },
+	{ "variables.casesensitive", eCmdHdlrBinary, 0 },
 	{ "environment", eCmdHdlrArray, 0 },
 	{ "processinternalmessages", eCmdHdlrBinary, 0 },
 	{ "umask", eCmdHdlrFileCreateMode, 0 },
@@ -1123,6 +1124,11 @@ glblDoneLoadCnf(void)
 		if(!strcmp(paramblk.descr[i].name, "workdirectory")) {
 			cstr = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 			setWorkDir(NULL, cstr);
+		} else if(!strcmp(paramblk.descr[i].name, "variables.casesensitive")) {
+			const int val = (int) cnfparamvals[i].val.d.n;
+			fjson_global_do_case_sensitive_comparison(val);
+			DBGPRINTF("global/config: set case sensitive variables to %d\n",
+				val);
 		} else if(!strcmp(paramblk.descr[i].name, "localhostname")) {
 			free(LocalHostNameOverride);
 			LocalHostNameOverride = (uchar*)

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -61,6 +61,10 @@ dep_work_dir=$(readlink -f $srcdir/.dep_wrk)
 
 case $1 in
    'init')	$srcdir/killrsyslog.sh # kill rsyslogd if it runs for some reason
+		# for (solaris) load debugging, uncomment next 2 lines:
+		#export LD_DEBUG=all
+		#ldd ../tools/rsyslogd
+
 		if [ -z $RS_SORTCMD ]; then
 			RS_SORTCMD=sort
 		fi  

--- a/tests/solaris/prep-libfastjson.sh
+++ b/tests/solaris/prep-libfastjson.sh
@@ -7,6 +7,7 @@ cd local_env
 pwd
 git clone git://github.com/rsyslog/libfastjson
 cd libfastjson
+git log -2
 autoreconf -fvi
 ./configure --prefix=$PWD_HOME/local_env/install
 gmake

--- a/tests/testsuites/json_var_case.conf
+++ b/tests/testsuites/json_var_case.conf
@@ -1,4 +1,5 @@
 $IncludeConfig diag-common.conf
+global(variables.casesensitive="on")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="13514")

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -35,3 +35,15 @@ if [ "$CC" == "clang" ]; then export NO_VALGRIND="--without-valgrind-testbench";
 if [ "$CC" == "clang" ]; then sudo apt-get install -qq $CLANG_PKG ; fi
 if [ "x$KAFKA" == "xYES" ]; then export ENABLE_KAFKA="--enable-omkafka --enable-imkafka --enable-kafka-tests" ; fi
 if [ "x$DEBUGLESS" == "xYES" ]; then export ENABLE_DEBUGLESS="--enable-debugless" ; fi
+
+#
+# uncomment the following if AND ONLY If you need yet-unreleased packages
+# from the v8-devel repo. Be sure to reset this once the new release has
+# been crafted!
+sudo add-apt-repository ppa:adiscon/v8-devel -y
+sudo apt-get update
+# now come the actual overrides
+sudo apt-get install libfastjson-dev
+#
+
+# end package override code

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1870,11 +1870,10 @@ int
 main(int argc, char **argv)
 {
 #if defined(_AIX)
-	/* AIXPORT : start
-	* SRC support : fd 0 (stdin) must be the SRC socket
-	* startup.  fd 0 is duped to a new descriptor so that stdin can be used
-	* internally by rsyslogd.
-	*/
+	/* SRC support : fd 0 (stdin) must be the SRC socket
+	 * startup.  fd 0 is duped to a new descriptor so that stdin can be used
+	 * internally by rsyslogd.
+	 */
 
 	strncpy(progname,argv[0], sizeof(progname)-1);
 	addrsz = sizeof(srcaddr);
@@ -1883,16 +1882,16 @@ main(int argc, char **argv)
 		src_exists = FALSE;
 	}
 	if (src_exists) 
-		if(dup2(0, SRC_FD) == -1)
-		{
+		if(dup2(0, SRC_FD) == -1) {
 			fprintf(stderr, "%s: dup2 failed exiting now...\n", progname);
 			/* In the unlikely event of dup2 failing we exit */
 			exit(-1);
 		}
 #endif
-	/* AIXPORT : src end */
-	/* use faster hash function inside json lib */
-	json_global_set_string_hash(JSON_C_STR_HASH_PERLLIKE);
+
+	/* disable case-sensitive comparisons in variable subsystem: */
+	fjson_global_do_case_sensitive_comparison(0);
+
 	const char *const log_dflt = getenv("RSYSLOG_DFLT_LOG_INTERNAL");
 	if(log_dflt != NULL && !strcmp(log_dflt, "1"))
 		bProcessInternalMessages = 1;


### PR DESCRIPTION
**NOTE:** *This requires libfastjson 0.99.7, a new version. CI testing will fail as long as the new version is not yet installed on the machines in question. This will probably be the case for at least some days. It is suggested to merge this PR late and after the new libfastjson release.*

The variable system inside rsyslog is JSON based (for easy consumption
of JSON input, the prime source of structured data). In JSON, keys
("variable names") are case-sensitive. This causes constant problems
inside rsyslog configurations. A major nit is that case-insensitivity
option inside templates (even if turned on) does not work with JSON
keys because they of inner workings*1.

It is much more natural to treat keys in a case-INsensitive way (e.g.
"$!Key" and "$!key" are the same). We do not expect any real problems
out of this, as key names only differing in case is highly unlikely.
However, as it is possible we provide a way to enable case-sensitivity
via the global(variables.casesensitve="on") global config object.

Note that the default is to do case-insensitive matches. The reason
is that this is the right thing to do in almost all cases, and we do
not envision any problems at all in existing deployments.

*1 Note: case-insensitivity in rsyslog is achieved by converting all
names to lower case. So that the higher speed of strcmp() can be used.
The template option does actually that, convert the template keys to
lower case. Unfortunately, this does not work with JSON, as JSON keys
are NOT converted to lower case.

closes https://github.com/rsyslog/rsyslog/issues/1805