### PR TITLE
do not call fjson_object_put from jsonMerge

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4692,11 +4692,6 @@ jsonMerge(struct json_object *existing, struct json_object *json)
 			json_object_get(json_object_iter_peek_value(&it)));
 		json_object_iter_next(&it);
 	}
-	/* note: json-c does ref counting. We added all descandants refcounts
-	 * in the loop above. So when we now free(_put) the root object, only
-	 * root gets freed().
-	 */
-	json_object_put(json);
 	RETiRet;
 }
 


### PR DESCRIPTION
MsgSetPropsViaJSON_Object will call fjson_object_put on an ancestor of
the tree seen by jsonMerge.

I don't know if this is the correct way of solving this issue, but this at least lets me get back to working on an external filter rather than trying to figure out why rsyslog keeps segfaulting.

Closes #1822