### PR TITLE
testbench: kill hanging rsyslog instances from past tests

### DIFF
--- a/tests/killrsyslog.sh
+++ b/tests/killrsyslog.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 #check if rsyslog instance exists and, if so, kill it
+echo initial ps
+ps -ef|grep rsyslog
 if [ -e "rsyslog.pid" ]
 then
   echo rsyslog.pid exists, trying to shut down rsyslogd process `cat rsyslog.pid`.
@@ -14,3 +16,5 @@ then
   sleep 1
   rm rsyslog2.pid
 fi
+echo terminal ps
+ps -ef|grep rsyslog

--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -18,6 +18,7 @@ echo "****************************** BEGIN ACTUAL SCRIPT STEP ******************
 source tests/travis/install.sh
 source /etc/lsb-release
 
+tests/killrsyslog.sh
 
 # we turn off leak sanitizer at this time because it reports some
 # pretty irrelevant problems in startup code. In the longer term,


### PR DESCRIPTION
**EXPERIMENTAL: may not make it into release** - depends on if it really works out ;-)

this sometimes happens on buildbot when a previous test instance
was not able to be shut down.