### PR TITLE
travis: remove temporary package override

### DIFF
--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -40,10 +40,10 @@ if [ "x$DEBUGLESS" == "xYES" ]; then export ENABLE_DEBUGLESS="--enable-debugless
 # uncomment the following if AND ONLY If you need yet-unreleased packages
 # from the v8-devel repo. Be sure to reset this once the new release has
 # been crafted!
-sudo add-apt-repository ppa:adiscon/v8-devel -y
-sudo apt-get update
+#sudo add-apt-repository ppa:adiscon/v8-devel -y
+#sudo apt-get update
 # now come the actual overrides
-sudo apt-get install libfastjson-dev
+#sudo apt-get install libfastjson-dev
 #
 
 # end package override code


### PR DESCRIPTION
this was needed while libfastjson 0.99.7 was not released
We just uncomment it so that the override can be easily re-enabled
the next time a similar need arises (what routinely happens)

closes https://github.com/rsyslog/rsyslog/issues/1848