### PR TITLE
core bugfix: potential segfault when shutting down rsyslog

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1336,8 +1336,8 @@ cancelWorkers(qqueue_t *pThis)
  * longer, because we no longer can persist the queue in parallel to waiting
  * on worker timeouts.
  */
-static rsRetVal
-ShutdownWorkers(qqueue_t *pThis)
+rsRetVal
+qqueueShutdownWorkers(qqueue_t *const pThis)
 {
 	DEFiRet;
 
@@ -2653,7 +2653,7 @@ CODESTARTobjDestruct(qqueue)
 		 */
 		if(pThis->qType != QUEUETYPE_DIRECT && !pThis->bEnqOnly && pThis->pqParent == NULL
 		   && pThis->pWtpReg != NULL)
-			ShutdownWorkers(pThis);
+			qqueueShutdownWorkers(pThis);
 
 		if(pThis->bIsDA && getPhysicalQueueSize(pThis) > 0 && pThis->bSaveOnShutdown) {
 			CHKiRet(DoSaveOnShutdown(pThis));

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -207,6 +207,7 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst);
 void qqueueSetDefaultsRulesetQueue(qqueue_t *pThis);
 void qqueueSetDefaultsActionQueue(qqueue_t *pThis);
 void qqueueDbgPrint(qqueue_t *pThis);
+rsRetVal qqueueShutdownWorkers(qqueue_t *pThis);
 
 PROTOTYPEObjClassInit(qqueue);
 PROTOTYPEpropSetMeth(qqueue, iPersistUpdCnt, int);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -226,7 +226,6 @@ freeCnf(rsconf_t *pThis)
 	}
 }
 
-
 /* destructor for the rsconf object */
 PROTOTYPEobjDestruct(rsconf);
 BEGINobjDestruct(rsconf) /* be sure to specify the object type also in END and CODESTART macros! */

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -826,6 +826,19 @@ CODESTARTobjDestruct(ruleset)
 ENDobjDestruct(ruleset)
 
 
+/* helper for Destructor, shut down queue workers */
+DEFFUNC_llExecFunc(doShutdownQueueWorkers)
+{
+	DEFiRet;
+	ruleset_t *const pThis = (ruleset_t*) pData;
+	DBGPRINTF("shutting down queue workers for ruleset %p, name %s, queue %p\n",
+		pThis, pThis->pszName, pThis->pQueue);
+	ISOBJ_TYPE_assert(pThis, ruleset);
+	if(pThis->pQueue != NULL) {
+		qqueueShutdownWorkers(pThis->pQueue);
+	}
+	RETiRet;
+}
 /* destruct ALL rule sets that reside in the system. This must
  * be callable before unloading this module as the module may
  * not be unloaded before unload of the actions is required. This is
@@ -836,6 +849,15 @@ static rsRetVal
 destructAllActions(rsconf_t *conf)
 {
 	DEFiRet;
+
+DBGPRINTF("rulesetDestructAllActions\n");
+	/* we first need to stop all queue workers, else we
+	 * may run into trouble with "call" statements calling
+	 * into then-destroyed rulesets.
+	 * see: https://github.com/rsyslog/rsyslog/issues/1122
+	 */
+DBGPRINTF("RRRRRR: rsconfDestruct - queue shutdown\n");
+	llExecFunc(&(conf->rulesets.llRulesets), doShutdownQueueWorkers, NULL);
 
 	CHKiRet(llDestroy(&(conf->rulesets.llRulesets)));
 	CHKiRet(llInit(&(conf->rulesets.llRulesets), rulesetDestructForLinkedList, rulesetKeyDestruct, strcasecmp));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -48,6 +48,7 @@ TESTS +=  \
 	glbl_setenv_err.sh \
 	glbl_setenv_err_too_long.sh \
 	glbl_setenv.sh \
+	nested-call-shutdown.sh \
 	invalid_nested_include.sh \
 	omfwd-keepalive.sh \
 	omfile-read-only-errmsg.sh \
@@ -701,6 +702,7 @@ EXTRA_DIST= \
 	glbl_setenv_err.sh \
 	glbl_setenv_err_too_long.sh \
 	glbl_setenv.sh \
+	nested-call-shutdown.sh \
 	1.rstest 2.rstest 3.rstest err1.rstest \
 	invalid_nested_include.sh \
 	validation-run.sh \

--- a/tests/nested-call-shutdown.sh
+++ b/tests/nested-call-shutdown.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# addd 2017-10-18 by RGerhards, released under ASL 2.0
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+ruleset(name="rs3" queue.type="linkedList") {
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")
+}
+
+ruleset(name="rs2" queue.type="linkedList") {
+  call rs3
+}
+
+ruleset(name="rs1" queue.type="linkedList") {
+  call rs2
+  :omtesting:sleep 0 1000
+}
+
+if $msg contains "msgnum:" then call rs1
+'
+. $srcdir/diag.sh startup
+#. $srcdir/diag.sh tcpflood -p13514 -m10000
+. $srcdir/diag.sh injectmsg 0 1000
+#. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh shutdown-immediate
+. $srcdir/diag.sh wait-shutdown
+# wo do not check reception - the main point is that we do not abort. The actual
+# message count is unknown (as the point is to shut down while still in processing).
+. $srcdir/diag.sh exit


### PR DESCRIPTION
when rulesets are nested a segfault can occur when shutting down
rsyslog. the reason is that rule sets are destructed in load order,
which means a "later" ruleset may still be active when an "earlier"
one was already destructed. In these cases, a "call" can invalidly
call into the earlier ruleset, which is destructed and so leads to
invalid memory access. If a segfault actually happens depends on the
OS, but it is highly probable.
    
The cure is to split the queue shutdown sequence. In a first step,
all worker threads are terminated and the queue set to enqOnly.
While some are terminated, it is still possible that the others
enqueue messages into the queue (which are then just placed into the
queue, not processed). After this happens, a call can no longer
be issued (as there are no more workers). So then we can destruct
the rulesets in any order.
    
closes https://github.com/rsyslog/rsyslog/issues/1122
