### PR TITLE
omfile: hande file open error via SUSPEND mode

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -51,6 +51,7 @@ TESTS +=  \
 	invalid_nested_include.sh \
 	omfwd-keepalive.sh \
 	omfile-read-only-errmsg.sh \
+	omfile-read-only.sh \
 	omfile_both_files_set.sh \
 	msgvar-concurrency.sh \
 	localvar-concurrency.sh \

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -1062,9 +1062,8 @@ CODESTARTcommitTransaction
 	}
 
 finalize_it:
-	if (pData->bDynamicName &&
-	    (iRet == RS_RET_FILE_OPEN_ERROR || iRet == RS_RET_FILE_NOT_FOUND) )
-		iRet = RS_RET_OK;
+	if(iRet == RS_RET_FILE_OPEN_ERROR || iRet == RS_RET_FILE_NOT_FOUND)
+		iRet = pData->bDynamicName ? RS_RET_OK : RS_RET_SUSPENDED;
 	pthread_mutex_unlock(&pData->mutWrite);
 ENDcommitTransaction
 


### PR DESCRIPTION
For a while, this lead to suspension as the data error was
not detected by the rule engine. This has changed with fixes
in 8.30.0. I asked users what they prefer (and expect) and
everyone meant it should still be handled via suspension. See
github tracker below for more details.

closes https://github.com/rsyslog/rsyslog/issues/1832