### PR TITLE
build: add macro to support new FALLTHROUGH checks in gcc7

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3134,8 +3134,7 @@ cnfstmtPrintOnly(struct cnfstmt *stmt, int indent, sbool subtree)
 		}
 		break;
 	case S_FOREACH:
-		doIndent(indent); dbgprintf("FOREACH %s IN\n",
-									stmt->d.s_foreach.iter->var);
+		doIndent(indent); dbgprintf("FOREACH %s IN\n", stmt->d.s_foreach.iter->var);
 		cnfexprPrint(stmt->d.s_foreach.iter->collection, indent+1);
 		if(subtree) {
 			doIndent(indent); dbgprintf("DO\n");
@@ -3154,9 +3153,10 @@ cnfstmtPrintOnly(struct cnfstmt *stmt, int indent, sbool subtree)
 				  stmt->d.s_unset.varname);
 		break;
     case S_RELOAD_LOOKUP_TABLE:
-		doIndent(indent); dbgprintf("RELOAD_LOOKUP_TABLE table(%s) (stub with '%s' on error)",
-									stmt->d.s_reload_lookup_table.table_name,
-									stmt->d.s_reload_lookup_table.stub_value);
+		doIndent(indent);
+		dbgprintf("RELOAD_LOOKUP_TABLE table(%s) (stub with '%s' on error)",
+			stmt->d.s_reload_lookup_table.table_name,
+			stmt->d.s_reload_lookup_table.stub_value);
 		break;
 	case S_PRIFILT:
 		doIndent(indent); dbgprintf("PRIFILT '%s'\n", stmt->printable);
@@ -3368,13 +3368,13 @@ cnfstmtDestruct(struct cnfstmt *stmt)
 			cstrDestruct(&stmt->d.s_propfilt.pCSCompValue);
 		cnfstmtDestructLst(stmt->d.s_propfilt.t_then);
 		break;
-    case S_RELOAD_LOOKUP_TABLE:
-        if (stmt->d.s_reload_lookup_table.table_name != NULL) {
-			free(stmt->d.s_reload_lookup_table.table_name);
-        }
-        if (stmt->d.s_reload_lookup_table.stub_value != NULL) {
-			free(stmt->d.s_reload_lookup_table.stub_value);
-        }
+	case S_RELOAD_LOOKUP_TABLE:
+		if (stmt->d.s_reload_lookup_table.table_name != NULL) {
+				free(stmt->d.s_reload_lookup_table.table_name);
+		}
+		if (stmt->d.s_reload_lookup_table.stub_value != NULL) {
+				free(stmt->d.s_reload_lookup_table.stub_value);
+		}
 		break;
 	default:
 		DBGPRINTF("error: unknown stmt type during destruct %u\n",

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3375,6 +3375,7 @@ cnfstmtDestruct(struct cnfstmt *stmt)
         if (stmt->d.s_reload_lookup_table.stub_value != NULL) {
 			free(stmt->d.s_reload_lookup_table.stub_value);
         }
+		break;
 	default:
 		DBGPRINTF("error: unknown stmt type during destruct %u\n",
 			(unsigned) stmt->nodetype);
@@ -3476,6 +3477,7 @@ cnfstmtNewReloadLookupTable(struct cnffparamlst *fparams)
 				"failed to allocate memory for lookup-table stub-value\n");
 				failed = 1;
 			}
+			CASE_FALLTHROUGH
 		case 1:
 			param = fparams;
 			if (param->expr->nodetype != 'S') {

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -732,7 +732,9 @@ static void pollFileCancelCleanup(void *pArg)
 
 /* poll a file, need to check file rollover etc. open file if not open */
 #if !defined(_AIX)
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
 #pragma GCC diagnostic ignored "-Wempty-body"
+#pragma GCC diagnostic ignored "-Wclobbered"
 #endif
 static rsRetVal
 pollFile(lstn_t *pLstn, int *pbHadFileData)
@@ -784,6 +786,8 @@ finalize_it:
 }
 #if !defined(_AIX)
 #pragma GCC diagnostic warning "-Wempty-body"
+#pragma GCC diagnostic warning "-Wclobbered"
+#pragma GCC diagnostic warning "-Wunknown-pragmas"
 #endif
 
 

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -324,7 +324,7 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	if(pNewVal == NULL || *pNewVal == '\0') {
 		errmsg.LogError(0, NO_ERRCODE, "imrelp: port number must be specified, listener ignored");
 	}
-	if((pNewVal == NULL) || (pNewVal == '\0')) {
+	if((pNewVal == NULL) || (*pNewVal == '\0')) {
 		inst->pszBindPort = NULL;
 	} else {
 		CHKmalloc(inst->pszBindPort = ustrdup(pNewVal));

--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -455,7 +455,7 @@ isValidHexNum(const uchar *const __restrict__ buf,
 				(*nprocessed)++;
 				return -1;
 			}
-			return cyc;
+			CASE_FALLTHROUGH
 		default:
 			return cyc;
 		}

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -43,6 +43,12 @@ extern int src_exists;
 #endif
 /* src end */
 
+/* define a couple of attributes to improve cross-platform builds */
+#if __GNUC__ > 6
+	#define CASE_FALLTHROUGH __attribute__((fallthrough));
+#else
+	#define CASE_FALLTHROUGH
+#endif
 
 /* ############################################################# *
  * #                 Some constant values                      # *


### PR DESCRIPTION
We add a macro to provide better cross-platform compatibility.
We also intend to do this for other attribues as well.

see also: https://github.com/rsyslog/rsyslog/pull/1798

Note that other PRs will follow to add the new macro where necessary. I just want to get the testbench env going first.

closes https://github.com/rsyslog/rsyslog/issues/1861