### PR TITLE
core: emit error message on abnormal input thread termination

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -50,6 +50,8 @@ extern int src_exists;
 	#define CASE_FALLTHROUGH
 #endif
 
+#define ATTR_NORETURN __attribute__ ((noreturn))
+
 /* ############################################################# *
  * #                 Some constant values                      # *
  * ############################################################# */

--- a/threads.c
+++ b/threads.c
@@ -40,6 +40,7 @@
 #include "linkedlist.h"
 #include "threads.h"
 #include "srUtils.h"
+#include "errmsg.h"
 #include "unicode-helper.h"
 
 /* linked list of currently-known threads */
@@ -181,10 +182,11 @@ rsRetVal thrdTerminateAll(void)
  * function call has just "normal", non-threading semantics.
  * rgerhards, 2007-12-17
  */
-static void* thrdStarter(void *arg)
+static ATTR_NORETURN void*
+thrdStarter(void *const arg)
 {
 	DEFiRet;
-	thrdInfo_t *pThis = (thrdInfo_t*) arg;
+	thrdInfo_t *const pThis = (thrdInfo_t*) arg;
 #	if defined(HAVE_PRCTL) && defined(PR_SET_NAME)
 	uchar thrdName[32] = "in:";
 #	endif
@@ -225,8 +227,12 @@ static void* thrdStarter(void *arg)
 	 */
 	iRet = pThis->pUsrThrdMain(pThis);
 
-	dbgprintf("thrdStarter: usrThrdMain %s - 0x%lx returned with iRet %d, exiting now.\n",
-		  pThis->name, (unsigned long) pThis->thrdID, iRet);
+	if(iRet == RS_RET_OK) {
+		dbgprintf("thrdStarter: usrThrdMain %s - 0x%lx returned with iRet %d, exiting now.\n",
+			  pThis->name, (unsigned long) pThis->thrdID, iRet);
+	} else {
+		LogError(0, iRet, "main thread of %s terminated abnormally", pThis->name);
+	}
 
 	/* signal master control that we exit (we do the mutex lock mostly to
 	 * keep the thread debugger happer, it would not really be necessary with


### PR DESCRIPTION
this in almost all cases indicates a real problem that the user
should be made aware of