### PR TITLE
mmpstrucdata bugfix: formatting error of ']' char

### DIFF
--- a/plugins/mmpstrucdata/mmpstrucdata.c
+++ b/plugins/mmpstrucdata/mmpstrucdata.c
@@ -2,7 +2,7 @@
  * Parse all fields of the message into structured data inside the
  * JSON tree.
  *
- * Copyright 2013 Adiscon GmbH.
+ * Copyright 2013-2017 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -189,7 +189,7 @@ parsePARAM_VALUE(uchar *sdbuf, int lenbuf, int *curridx, uchar *fieldbuf)
 				} else if(sdbuf[i] == '\\') {
 					fieldbuf[j++] = '\\';
 				} else if(sdbuf[i] == ']') {
-					fieldbuf[j++] = '"';
+					fieldbuf[j++] = ']';
 				} else {
 					fieldbuf[j++] = '\\';
 					fieldbuf[j++] = sdbuf[i];


### PR DESCRIPTION
This was invalidly formatted as '"'. Thanks to github user
wu3396 for the error report including the patch idea.

closes https://github.com/rsyslog/rsyslog/issues/1826