### PR TITLE
omelasticsearch bugfix: abort on unavailable ES server

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1254,7 +1254,6 @@ CODESTARTdoAction
 	STATSCOUNTER_INC(indexSubmit, mutIndexSubmit);
 
 	if(pWrkrData->pData->bulkmode) {
-		//DBGPRINTF("Calling computeMessageSize: %p, %p, %p\n", pWrkrData, ppString[0], ppString);
 		const size_t nBytes = computeMessageSize(pWrkrData, ppString[0], ppString);
 
 		/* If max bytes is set and this next message will put us over the limit, submit the current buffer and reset */

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -51,6 +51,7 @@
 #include "statsobj.h"
 #include "cfsysline.h"
 #include "unicode-helper.h"
+#include "obj-types.h"
 
 #ifndef O_LARGEFILE
 #  define O_LARGEFILE 0
@@ -78,6 +79,8 @@ STATSCOUNTER_DEF(indexESFail, mutIndexESFail)
 #	define META_PARENT "\",\"_parent\":\""
 #	define META_ID "\", \"_id\":\""
 #	define META_END  "\"}}\n"
+
+#define WRKR_DATA_TYPE_ES 0xBADF0001
 
 /* REST API for elasticsearch hits this URL:
  * http://<hostName>:<restPort>/<searchIndex>/<searchType>
@@ -113,6 +116,7 @@ typedef struct _instanceData {
 } instanceData;
 
 typedef struct wrkrInstanceData {
+	PTR_ASSERT_DEF
 	instanceData *pData;
 	int serverIndex;
 	int replyLen;
@@ -172,6 +176,7 @@ ENDcreateInstance
 
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
+	PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
 	pWrkrData->curlHeader = NULL;
 	pWrkrData->curlPostHandle = NULL;
 	pWrkrData->curlCheckConnHandle = NULL;
@@ -281,10 +286,10 @@ curlResult(void *ptr, size_t size, size_t nmemb, void *userdata)
 	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t*) userdata;
 	char *buf;
 	size_t newlen;
-
+	PTR_ASSERT_CHK(pWrkrData, WRKR_DATA_TYPE_ES);
 	newlen = pWrkrData->replyLen + size*nmemb;
 	if((buf = realloc(pWrkrData->reply, newlen + 1)) == NULL) {
-		DBGPRINTF("omelasticsearch: realloc failed in curlResult\n");
+		LogError(errno, RS_RET_ERR, "omelasticsearch: realloc failed in curlResult");
 		return 0; /* abort due to failure */
 	}
 	memcpy(buf+pWrkrData->replyLen, p, size*nmemb);
@@ -356,8 +361,13 @@ incrementServerIndex(wrkrInstanceData_t *pWrkrData)
 	pWrkrData->serverIndex = (pWrkrData->serverIndex + 1) % pWrkrData->pData->numServers;
 }
 
-static rsRetVal
-checkConn(wrkrInstanceData_t *pWrkrData)
+
+/* checks if connection to ES can be established; also iterates over
+ * potential servers to support high availability (HA) feature. If it
+ * needs to switch server, will record new one in curl handle.
+ */
+static rsRetVal ATTR_NONNULL()
+checkConn(wrkrInstanceData_t *const pWrkrData)
 {
 #	define HEALTH_URI "_cat/health"
 	CURL *curl;
@@ -369,6 +379,8 @@ checkConn(wrkrInstanceData_t *pWrkrData)
 	int r;
 	DEFiRet;
 
+	pWrkrData->reply = NULL;
+	pWrkrData->replyLen = 0;
 	curl = pWrkrData->curlCheckConnHandle;
 	urlBuf = es_newStr(256);
 	if (urlBuf == NULL) {
@@ -394,21 +406,25 @@ checkConn(wrkrInstanceData_t *pWrkrData)
 		free(healthUrl);
 
 		if (res == CURLE_OK) {
-			DBGPRINTF("omelasticsearch: checkConn(%s) completed with success on attempt %d\n", serverUrl, i);
+			DBGPRINTF("omelasticsearch: checkConn %s completed with success "
+				"on attempt %d\n", serverUrl, i);
 			ABORT_FINALIZE(RS_RET_OK);
 		}
 
-		DBGPRINTF("omelasticsearch: checkConn(%s) failed on attempt %d: %s\n", serverUrl, i, curl_easy_strerror(res));
+		DBGPRINTF("omelasticsearch: checkConn %s failed on attempt %d: %s\n",
+			serverUrl, i, curl_easy_strerror(res));
 		STATSCOUNTER_INC(checkConnFail, mutCheckConnFail);
 		incrementServerIndex(pWrkrData);
 	}
 
-	DBGPRINTF("omelasticsearch: checkConn() failed after %d attempts.\n", i);
+	DBGPRINTF("omelasticsearch: checkConn failed after %d attempts.\n", i);
 	ABORT_FINALIZE(RS_RET_SUSPENDED);
 
 finalize_it:
 	if(urlBuf != NULL)
 		es_deleteStr(urlBuf);
+	free(pWrkrData->reply);
+	pWrkrData->reply = NULL; /* don't leave dangling pointer */
 	RETiRet;
 }
 
@@ -421,13 +437,11 @@ ENDtryResume
 
 
 /* get the current index and type for this message */
-static void
+static void ATTR_NONNULL(1)
 getIndexTypeAndParent(const instanceData *const pData, uchar **const tpls,
 		      uchar **const srchIndex, uchar **const srchType, uchar **const parent,
 		      uchar **const bulkId)
 {
-DBGPRINTF("getIndexTypeAndParent: computeMessageSize: pData->searchIndex %p\n", pData->searchIndex);
-//DBGPRINTF("getIndexTypeAndParent: computeMessageSize: pData->searchIndex %s\n", pData->searchIndex);
 	if(tpls == NULL) {
 		*srchIndex = pData->searchIndex;
 		*parent = pData->parent;
@@ -437,8 +451,6 @@ DBGPRINTF("getIndexTypeAndParent: computeMessageSize: pData->searchIndex %p\n", 
 	}
 
 	if(pData->dynSrchIdx) {
-DBGPRINTF("getIndexTypeAndParent: computeMessageSize: tpls[1] %p\n", tpls[1]);
-//DBGPRINTF("getIndexTypeAndParent: computeMessageSize: tpls[1] %s\n", tpls[1]);
 		*srchIndex = tpls[1];
 		if(pData->dynSrchType) {
 			*srchType = tpls[2];
@@ -498,14 +510,14 @@ DBGPRINTF("getIndexTypeAndParent: computeMessageSize: tpls[1] %p\n", tpls[1]);
 		}
 	}
 done:
-	//assert(srchIndex != NULL);
-	//assert(srchType != NULL);
+	assert(srchIndex != NULL);
+	assert(srchType != NULL);
 	return;
 }
 
 
-static rsRetVal
-setPostURL(wrkrInstanceData_t *pWrkrData, instanceData *pData, uchar **tpls)
+static rsRetVal ATTR_NONNULL(1)
+setPostURL(wrkrInstanceData_t *const pWrkrData, uchar **const tpls)
 {
 	uchar *searchIndex = NULL;
 	uchar *searchType;
@@ -515,6 +527,7 @@ setPostURL(wrkrInstanceData_t *pWrkrData, instanceData *pData, uchar **tpls)
 	es_str_t *url;
 	int r;
 	DEFiRet;
+	instanceData *const pData = pWrkrData->pData;
 	char separator;
 	const int bulkmode = pData->bulkmode;
 
@@ -1169,27 +1182,35 @@ finalize_it:
 	RETiRet;
 }
 
-static void
-initializeBatch(wrkrInstanceData_t *pWrkrData) {
+static void ATTR_NONNULL()
+initializeBatch(wrkrInstanceData_t *pWrkrData)
+{
 	es_emptyStr(pWrkrData->batch.data);
 	pWrkrData->batch.nmemb = 0;
 }
 
-static rsRetVal
-curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls, int nmsgs)
+static rsRetVal ATTR_NONNULL(1, 2)
+curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls, const int nmsgs)
 {
 	CURLcode code;
-	CURL *curl = pWrkrData->curlPostHandle;
+	CURL *const curl = pWrkrData->curlPostHandle;
 	char errbuf[CURL_ERROR_SIZE] = "";
 	DEFiRet;
+
+	PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
 
 	pWrkrData->reply = NULL;
 	pWrkrData->replyLen = 0;
 
-	CHKiRet(checkConn(pWrkrData));
-	CHKiRet(setPostURL(pWrkrData, pWrkrData->pData, tpls));
+	if(pWrkrData->pData->numServers > 1) {
+		/* needs to be called to support ES HA feature */
+		CHKiRet(checkConn(pWrkrData));
+	}
+	CHKiRet(setPostURL(pWrkrData, tpls));
 
-	curl_easy_setopt(curl, CURLOPT_WRITEDATA, pWrkrData);
+	pWrkrData->reply = NULL;
+	pWrkrData->replyLen = 0;
+
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, (char *)message);
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, msglen);
 	curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
@@ -1220,6 +1241,7 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 finalize_it:
 	incrementServerIndex(pWrkrData);
 	free(pWrkrData->reply);
+	pWrkrData->reply = NULL; /* don't leave dangling pointer */
 	RETiRet;
 }
 
@@ -1256,18 +1278,21 @@ CODESTARTdoAction
 	if(pWrkrData->pData->bulkmode) {
 		const size_t nBytes = computeMessageSize(pWrkrData, ppString[0], ppString);
 
-		/* If max bytes is set and this next message will put us over the limit, submit the current buffer and reset */
-		if (pWrkrData->pData->maxbytes > 0 && es_strlen(pWrkrData->batch.data) + nBytes > pWrkrData->pData->maxbytes ) {
-			dbgprintf("omelasticsearch: maxbytes limit reached, submitting partial batch of %d "
-			"elements.\n", pWrkrData->batch.nmemb);
+		/* If max bytes is set and this next message will put us over the limit,
+		* submit the current buffer and reset */
+		if(pWrkrData->pData->maxbytes > 0
+			&& es_strlen(pWrkrData->batch.data) + nBytes > pWrkrData->pData->maxbytes ) {
+			dbgprintf("omelasticsearch: maxbytes limit reached, submitting partial "
+			"batch of %d elements.\n", pWrkrData->batch.nmemb);
 			CHKiRet(submitBatch(pWrkrData));
 			initializeBatch(pWrkrData);
 		}
 		CHKiRet(buildBatch(pWrkrData, ppString[0], ppString));
 
-		/* If there is only one item in the batch, all previous items have been submitted or this is the first item
-		   for this transaction. Return previous committed so that all items leading up to the current (exclusive)
-		   are not replayed should a failure occur anywhere else in the transaction. */
+		/* If there is only one item in the batch, all previous items have been
+	 	 * submitted or this is the first item for this transaction. Return previous
+		 * committed so that all items leading up to the current (exclusive)
+		 * are not replayed should a failure occur anywhere else in the transaction. */
 		iRet = pWrkrData->batch.nmemb == 1 ? RS_RET_PREVIOUS_COMMITTED : RS_RET_DEFER_COMMIT;
 	} else {
 		CHKiRet(curlPost(pWrkrData, ppString[0], strlen((char*)ppString[0]),
@@ -1283,7 +1308,8 @@ CODESTARTendTransaction
 	if (pWrkrData->batch.data != NULL && pWrkrData->batch.nmemb > 0) {
 		CHKiRet(submitBatch(pWrkrData));
 	} else {
-		dbgprintf("omelasticsearch: endTransaction, pWrkrData->batch.data is NULL, nothing to send. \n");
+		dbgprintf("omelasticsearch: endTransaction, pWrkrData->batch.data is NULL, "
+			"nothing to send. \n");
 	}
 finalize_it:
 ENDendTransaction
@@ -1315,28 +1341,36 @@ finalize_it:
 	RETiRet;
 }
 
-static void
-curlCheckConnSetup(CURL *handle, HEADER *header, long timeout, sbool allowUnsignedCerts)
+static void ATTR_NONNULL()
+curlCheckConnSetup(wrkrInstanceData_t *const pWrkrData)
 {
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
-	curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, timeout);
+	PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
+	CURL *const handle = pWrkrData->curlCheckConnHandle;
+	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, pWrkrData->curlHeader);
 	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, TRUE);
+	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
+	curl_easy_setopt(handle, CURLOPT_WRITEDATA, pWrkrData);
 
-	if(allowUnsignedCerts)
+	curl_easy_setopt(handle, CURLOPT_TIMEOUT_MS, pWrkrData->pData->healthCheckTimeout);
+
+	if(pWrkrData->pData->allowUnsignedCerts)
 		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, FALSE);
 
-	if(Debug) {
-		curl_easy_setopt(handle, CURLOPT_VERBOSE, TRUE);
-	}
+	/* uncomment for in-dept debuggung:
+	curl_easy_setopt(handle, CURLOPT_VERBOSE, TRUE); */
 }
 
-static void
-curlPostSetup(CURL *handle, HEADER *header, uchar* authBuf)
+static void ATTR_NONNULL(1)
+curlPostSetup(wrkrInstanceData_t *const pWrkrData, uchar*const  authBuf)
 {
-	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, header);
-	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
-	curl_easy_setopt(handle, CURLOPT_POST, 1);
+	PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
+	CURL *const handle = pWrkrData->curlPostHandle;
+	curl_easy_setopt(handle, CURLOPT_HTTPHEADER, pWrkrData->curlHeader);
 	curl_easy_setopt(handle, CURLOPT_NOSIGNAL, TRUE);
+	curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
+	curl_easy_setopt(handle, CURLOPT_WRITEDATA, pWrkrData);
+
+	curl_easy_setopt(handle, CURLOPT_POST, 1);
 
 	if(authBuf != NULL) {
 		curl_easy_setopt(handle, CURLOPT_USERPWD, authBuf);
@@ -1346,30 +1380,27 @@ curlPostSetup(CURL *handle, HEADER *header, uchar* authBuf)
 
 #define CONTENT_JSON "Content-Type: application/json; charset=utf-8"
 
-static rsRetVal
-curlSetup(wrkrInstanceData_t *pWrkrData, instanceData *pData)
+static rsRetVal ATTR_NONNULL()
+curlSetup(wrkrInstanceData_t *const pWrkrData, instanceData *pData)
 {
+	DEFiRet;
 	pWrkrData->curlHeader = curl_slist_append(NULL, CONTENT_JSON);
-	pWrkrData->curlPostHandle = curl_easy_init();
-	if (pWrkrData->curlPostHandle == NULL) {
-		return RS_RET_OBJ_CREATION_FAILED;
-	}
-	curlPostSetup(pWrkrData->curlPostHandle, pWrkrData->curlHeader, pData->authBuf);
+	CHKmalloc(pWrkrData->curlPostHandle = curl_easy_init());;
+	curlPostSetup(pWrkrData, pData->authBuf);
 
-	pWrkrData->curlCheckConnHandle = curl_easy_init();
-	if (pWrkrData->curlCheckConnHandle == NULL) {
+	CHKmalloc(pWrkrData->curlCheckConnHandle = curl_easy_init());
+	curlCheckConnSetup(pWrkrData);
+
+finalize_it:
+	if(iRet != RS_RET_OK && pWrkrData->curlPostHandle != NULL) {
 		curl_easy_cleanup(pWrkrData->curlPostHandle);
 		pWrkrData->curlPostHandle = NULL;
-		return RS_RET_OBJ_CREATION_FAILED;
 	}
-	curlCheckConnSetup(pWrkrData->curlCheckConnHandle, pWrkrData->curlHeader,
-		pData->healthCheckTimeout, pData->allowUnsignedCerts);
-
-	return RS_RET_OK;
+	RETiRet;
 }
 
-static void
-setInstParamDefaults(instanceData *pData)
+static void ATTR_NONNULL()
+setInstParamDefaults(instanceData *const pData)
 {
 	pData->serverBaseUrls = NULL;
 	pData->defaultPort = 9200;
@@ -1623,8 +1654,6 @@ CODESTARTnewActInst
 		pData->searchIndex = (uchar*) strdup("system");
 	if(pData->searchType == NULL)
 		pData->searchType = (uchar*) strdup("events");
-	//assert(pData->searchIndex != NULL);
-	//assert(pData->searchType != NULL);
 
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);

--- a/runtime/obj-types.h
+++ b/runtime/obj-types.h
@@ -115,10 +115,27 @@ struct obj_s {	/* the dummy struct that each derived class can be casted to */
 		} \
 		ASSERT((unsigned) ((obj_t*)(pObj))->iObjCooCKiE == (unsigned) 0xBADEFEE); \
 		} while(0)
+	/* now the same for pointers to "regular" objects (like wrkrInstanceData) */
+#	define PTR_ASSERT_DEF unsigned int _Assert_type;
+#	define PTR_ASSERT_SET_TYPE(_ptr, _type) _ptr->_Assert_type = _type
+#	define PTR_ASSERT_CHK(_ptr, _type) do { \
+		assert(_ptr != NULL); \
+		if(_ptr->_Assert_type != _type) {\
+			dbgprintf("%s:%d PTR_ASSERT_CHECK failure: invalid pointer type %x, " \
+				"expected %x\n", __FILE__, __LINE__, _ptr->_Assert_type, _type); \
+			fprintf(stderr, "%s:%d PTR_ASSERT_CHECK failure: invalid pointer type %x, " \
+				"expected %x\n", __FILE__, __LINE__, _ptr->_Assert_type, _type); \
+			assert(_ptr->_Assert_type == _type); \
+		} \
+	} while(0)
 #else /* non-debug mode, no checks but much faster */
 #	define BEGINobjInstance obj_t objData
 #	define ISOBJ_TYPE_assert(pObj, objType)
 #	define ISOBJ_assert(pObj)
+
+#	define PTR_ASSERT_DEF
+#	define PTR_ASSERT_SET_TYPE(_ptr, _type)
+#	define PTR_ASSERT_CHK(_ptr, _type)
 #endif
 
 /* a set method for *very simple* object accesses. Note that this does

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -480,6 +480,12 @@ TESTS +=  \
 	es-bulk-errfile-popul-erronly-interleaved.sh \
 	es-bulk-errfile-popul-def-interleaved.sh
 endif
+if HAVE_VALGRIND
+TESTS +=  \
+	es-basic-vg.sh \
+	es-basic-bulk-vg.sh \
+	es-basic-ha-vg.sh
+endif
 endif
 
 if ENABLE_MMPSTRUCDATA
@@ -1077,6 +1083,9 @@ EXTRA_DIST= \
 	testsuites/es-bulk-errfile-popul-erronly-interleaved.conf \
 	es-bulk-errfile-popul-def-interleaved.sh \
 	testsuites/es-bulk-errfile-popul-def-interleaved.conf \
+	es-basic-vg.sh \
+	es-basic-bulk-vg.sh \
+	es-basic-ha-vg.sh \
 	linkedlistqueue.sh \
 	testsuites/linkedlistqueue.conf \
 	da-mainmsg-q.sh \

--- a/tests/es-basic-bulk-vg.sh
+++ b/tests/es-basic-bulk-vg.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[es-basic-bulk\]: basic test for elasticsearch functionality
+. $srcdir/diag.sh init
+. $srcdir/diag.sh es-init
+. $srcdir/diag.sh startup-vg es-basic-bulk.conf
+. $srcdir/diag.sh injectmsg  0 10000
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh es-getdata 10000
+. $srcdir/diag.sh seq-check  0 9999
+. $srcdir/diag.sh exit

--- a/tests/es-basic-ha-vg.sh
+++ b/tests/es-basic-ha-vg.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[es-basic-ha.sh\]: basic test for elasticsearch high availability functionality
+. $srcdir/diag.sh init
+. $srcdir/diag.sh es-init
+. $srcdir/diag.sh startup-vg es-basic-ha.conf
+. $srcdir/diag.sh injectmsg  0 100
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh es-getdata 100
+. $srcdir/diag.sh seq-check  0 99
+# The configuration makes every other request from message #3 fail checkConn (N/2-1)
+. $srcdir/diag.sh custom-content-check '"failed.checkConn": 49' 'rsyslog.out.stats.log'
+. $srcdir/diag.sh exit

--- a/tests/es-basic-vg.sh
+++ b/tests/es-basic-vg.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh es-init
+. $srcdir/diag.sh startup-vg es-basic.conf
+. $srcdir/diag.sh injectmsg  0 10000
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh es-getdata 10000
+. $srcdir/diag.sh seq-check  0 9999
+. $srcdir/diag.sh exit


### PR DESCRIPTION
Depending on the state of unavailability (libcurl return code),
omelasticsearch tries to process a NULL return message, what
leads to a segfault.

This fixes the problem and introduces better error handling and
better error messages.

closes https://github.com/rsyslog/rsyslog/issues/1885