### PR TITLE
imudp: add error msg when listener wasn't created

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -351,6 +351,10 @@ addListner(instanceConf_t *inst)
 				lcnfLast = newlcnfinfo;
 			}
 		}
+	} else {
+		errmsg.LogError(0, NO_ERRCODE, "imudp: Could not create udp listener,"
+				" ignoring port %s bind-address %s.",
+				port, bindAddr);
 	}
 
 finalize_it:

--- a/tests/imudp_error_msg.sh
+++ b/tests/imudp_error_msg.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imudp/.libs/imudp")
+input(type="imudp" port="514" address="128.98.1.12")
+input(type="imudp" port="514" address="128.98.1.12")
+
+template(name="outfmt" type="string" string="-%msg%-\n")
+:syslogtag, contains, "tag" action(type="omfile" template="outfmt"
+			         file="rsyslog2.out.log")
+
+action(type="omfile" template="outfmt" file="rsyslog.out.log")
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+grep "imudp: Could not create udp listener, ignoring port 514 bind-address 128.98.1.12." rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected error message from missing input file not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
When udp listener could not be created, an error message containing the ip-address and port is put out.
closes https://github.com/rsyslog/rsyslog/issues/1899