### PR TITLE
fixes for issues found by coverty scan

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2998,8 +2998,6 @@ getJSONPropVal(smsg_t * const pMsg, msgPropDescr_t *pProp, uchar **pRes, rs_size
 	struct json_object *field;
 	DEFiRet;
 
-	if(*pbMustBeFreed)
-		free(*pRes);
 	*pRes = NULL;
 
 	if(pProp->id == PROP_CEE) {

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -812,11 +812,11 @@ static rsRetVal changeToNs(instanceData *pData)
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
 		close(destinationNs);
-		free(nsPath);
 		dbgprintf("omfwd: changed to network namespace '%s'\n", pData->networkNamespace);
 	}
 
 finalize_it:
+	free(nsPath);
 #else /* #ifdef HAVE_SETNS */
 		dbgprintf("omfwd: OS does not support network namespaces\n");
 #endif /* #ifdef HAVE_SETNS */


### PR DESCRIPTION
due to missing unlock. This could only occur if pstats was set to
CEE-format logging (very uncommon) AND if the system runs out of
memory (in which case other things go pretty bad as well).

found by Coverty scan