### PR TITLE
lookup table bugfix:  potential infinite loop

### DIFF
--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -782,11 +782,10 @@ static rsRetVal
 lookupDoReload(lookup_ref_t *pThis)
 {
 	DEFiRet;
-	CHKiRet(lookupReloadOrStub(pThis, NULL));
-finalize_it:
+	iRet = lookupReloadOrStub(pThis, NULL);
 	if ((iRet != RS_RET_OK) &&
 		(pThis->stub_value_for_reload_failure != NULL)) {
-		CHKiRet(lookupDoStub(pThis, pThis->stub_value_for_reload_failure));
+		iRet = lookupDoStub(pThis, pThis->stub_value_for_reload_failure);
 	}
 	freeStubValueForReloadFailure(pThis);
 	RETiRet;


### PR DESCRIPTION
lookup table could loop if error in lookupDoStub() occurs

also fixes coverty scan CID 185315 (IDENTICAL_BRANCHES due to
CHKiRet() immediately followed by finalize_it)