### PR TITLE
core: double free under OOM condition (extremely unlikely)

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -479,6 +479,7 @@ static void MsgSetRcvFromWithoutAddRef(smsg_t *pThis, prop_t *new)
 static void
 MsgSetRulesetByName(smsg_t * const pMsg, cstr_t *rulesetName)
 {
+	/* coverity[checked_return] */ // KEEP TOGETHER WITH NEXT LINE!
 	rulesetGetRuleset(runConf, &(pMsg->pRuleset), rsCStrGetSzStrNoNULL(rulesetName));
 }
 

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -380,7 +380,7 @@ rsRetVal rsCStrSetSzStr(cstr_t *const __restrict__ pThis,
 		if(newlen > pThis->iBufSize) {
 			uchar *const newbuf = (uchar*) realloc(pThis->pBuf, newlen + 1);
 			if(newbuf == NULL) {
-				RSFREEOBJ(pThis);
+				/* we keep the old value, best we can do */
 				return RS_RET_OUT_OF_MEMORY;
 			}
 			pThis->pBuf = newbuf;


### PR DESCRIPTION
Detected by Coverty scan, can only happen when we run out of
memory, in which case we have a very big problem anyhow.

Double free could happen in lower layer when a property was
freed due to realloc failure. Solution is to continue to use
old value, which also makes sense otherwise.