### PR TITLE
core: potential NULL pointer dereference in config parsing

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -908,6 +908,11 @@ glblProcessTimezone(struct cnfobj *o)
 	int i;
 
 	pvals = nvlstGetParams(o->nvlst, &timezonepblk, NULL);
+	if(pvals == NULL) {
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing timezone "
+				"config parameters");
+		goto done;
+	}
 	if(Debug) {
 		dbgprintf("timezone param blk after glblProcessTimezone:\n");
 		cnfparamsPrint(&timezonepblk, pvals);


### PR DESCRIPTION
This happens if there is a problem with the timezone parameters.
Affects only startup, once started, no problem exists.

Detected by Coverty scan; CID 185414