### PR TITLE
omelasticsearch bugfix: output from libcurl to stdout

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -273,6 +273,26 @@ CODESTARTdbgPrintInstInfo
 ENDdbgPrintInstInfo
 
 
+/* elasticsearch POST result string ... useful for debugging */
+static size_t
+curlResult(void *ptr, size_t size, size_t nmemb, void *userdata)
+{
+	char *p = (char *)ptr;
+	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t*) userdata;
+	char *buf;
+	size_t newlen;
+
+	newlen = pWrkrData->replyLen + size*nmemb;
+	if((buf = realloc(pWrkrData->reply, newlen + 1)) == NULL) {
+		DBGPRINTF("omelasticsearch: realloc failed in curlResult\n");
+		return 0; /* abort due to failure */
+	}
+	memcpy(buf+pWrkrData->replyLen, p, size*nmemb);
+	pWrkrData->replyLen = newlen;
+	pWrkrData->reply = buf;
+	return size*nmemb;
+}
+
 /* Build basic URL part, which includes hostname and port as follows:
  * http://hostname:port/ based on a server param
  * Newly creates a cstr for this purpose.
@@ -369,6 +389,7 @@ checkConn(wrkrInstanceData_t *pWrkrData)
 		}
 
 		curl_easy_setopt(curl, CURLOPT_URL, healthUrl);
+		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, curlResult);
 		res = curl_easy_perform(curl);
 		free(healthUrl);
 
@@ -1250,26 +1271,6 @@ CODESTARTendTransaction
 finalize_it:
 ENDendTransaction
 
-/* elasticsearch POST result string ... useful for debugging */
-static size_t
-curlResult(void *ptr, size_t size, size_t nmemb, void *userdata)
-{
-	char *p = (char *)ptr;
-	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t*) userdata;
-	char *buf;
-	size_t newlen;
-
-	newlen = pWrkrData->replyLen + size*nmemb;
-	if((buf = realloc(pWrkrData->reply, newlen + 1)) == NULL) {
-		DBGPRINTF("omelasticsearch: realloc failed in curlResult\n");
-		return 0; /* abort due to failure */
-	}
-	memcpy(buf+pWrkrData->replyLen, p, size*nmemb);
-	pWrkrData->replyLen = newlen;
-	pWrkrData->reply = buf;
-	return size*nmemb;
-}
-
 static rsRetVal
 computeAuthHeader(char* uid, char* pwd, uchar** authBuf) {
 	int r;
@@ -1307,8 +1308,9 @@ curlCheckConnSetup(CURL *handle, HEADER *header, long timeout, sbool allowUnsign
 	if(allowUnsignedCerts)
 		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, FALSE);
 
-	/* Only enable for debugging
-	curl_easy_setopt(curl, CURLOPT_VERBOSE, TRUE); */
+	if(Debug) {
+		curl_easy_setopt(handle, CURLOPT_VERBOSE, TRUE);
+	}
 }
 
 static void


### PR DESCRIPTION
omelasticsearch made libcurl output messages to stdout. This
commit fixes that. It also automatically enables libcurl verbose
mode during debug runs - it needs to be seen if this is smart or
not (previously, code needed to be commented in).
    
closes https://github.com/rsyslog/rsyslog/issues/1909

