### PR TITLE
omfwd bugfix: ressource leak if namespace could not be set

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -811,12 +811,14 @@ static rsRetVal changeToNs(instanceData *pData)
 				  pData->networkNamespace, gai_strerror(iErr));
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
-		close(destinationNs);
 		dbgprintf("omfwd: changed to network namespace '%s'\n", pData->networkNamespace);
 	}
 
 finalize_it:
 	free(nsPath);
+	if(destinationNs >= 0) {
+		close(destinationNs);
+	}
 #else /* #ifdef HAVE_SETNS */
 		dbgprintf("omfwd: OS does not support network namespaces\n");
 #endif /* #ifdef HAVE_SETNS */


### PR DESCRIPTION
could only happen if namespaces were used

Detected by Coverty scan, CID 185442.