### PR TITLE
aDvens - Proposal for a replacement of ommongodb

### DIFF
--- a/plugins/ommongodb/Makefile.am
+++ b/plugins/ommongodb/Makefile.am
@@ -1,7 +1,7 @@
 pkglib_LTLIBRARIES = ommongodb.la
 ommongodb_la_SOURCES = ommongodb.c
-ommongodb_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(LIBMONGO_CLIENT_CFLAGS)
+ommongodb_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(LIBMONGOC_CFLAGS)
 ommongodb_la_LDFLAGS = -module -avoid-version
-ommongodb_la_LIBADD = $(LIBMONGO_CLIENT_LIBS)
+ommongodb_la_LIBADD = $(LIBMONGOC_LIBS)
 
 EXTRA_DIST = 

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -4,6 +4,10 @@
  * mongodb C interface is crap. Obtain the library here:
  * https://github.com/algernon/libmongo-client
  *
+ * Copyright 2017 Jeremie Jourdin and Hugo Soszynski and aDvens
+ * Remove deprecated libmongo-client and use libmongoc (mongo-c-driver)
+ * This new library handle TLS and replicaset
+ *
  * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
@@ -35,7 +39,8 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-attributes"
-#include <mongo.h>
+#include <mongoc.h>
+#include <bson.h>
 #pragma GCC diagnostic pop
 #include <json.h>
 
@@ -60,16 +65,20 @@ DEFobjCurrIf(errmsg)
 DEFobjCurrIf(datetime)
 
 typedef struct _instanceData {
-	mongo_sync_connection *conn;
 	struct json_tokener *json_tokener; /* only if (tplName != NULL) */
-	uchar *server;
-	int port;
-        uchar *db;
-	uchar *collection;
-	uchar *uid;
-	uchar *pwd;
-	uchar *dbNcoll;
-	uchar *tplName;
+	mongoc_client_t *client;
+   	mongoc_collection_t *collection;
+   	bson_error_t error;
+    	char *server;
+    	char *port;
+    	char *uristr;
+    	char *ssl_ca;
+    	char *ssl_cert;
+    	char *uid;
+    	char *pwd;
+   	char *db;
+   	char *collection_name;
+	char *tplName;
 	int bErrMsgPermitted;	/* only one errmsg permitted per connection */
 } instanceData;
 
@@ -82,11 +91,14 @@ typedef struct wrkrInstanceData {
 /* action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {
 	{ "server", eCmdHdlrGetWord, 0 },
-	{ "serverport", eCmdHdlrInt, 0 },
-	{ "db", eCmdHdlrGetWord, 0 },
-	{ "collection", eCmdHdlrGetWord, 0 },
+	{ "serverport", eCmdHdlrGetWord, 0 },
+	{ "uristr", eCmdHdlrGetWord, 0 },
+	{ "ssl_ca", eCmdHdlrGetWord, 0 },
+	{ "ssl_cert", eCmdHdlrGetWord, 0 },
 	{ "uid", eCmdHdlrGetWord, 0 },
 	{ "pwd", eCmdHdlrGetWord, 0 },
+	{ "db", eCmdHdlrGetWord, 0 },
+	{ "collection", eCmdHdlrGetWord, 0 },
 	{ "template", eCmdHdlrGetWord, 0 }
 };
 static struct cnfparamblk actpblk =
@@ -117,9 +129,13 @@ ENDisCompatibleWithFeature
 
 static void closeMongoDB(instanceData *pData)
 {
-	if(pData->conn != NULL) {
-                mongo_sync_disconnect(pData->conn);
-		pData->conn = NULL;
+	if(pData->client != NULL) {
+		if (pData->collection != NULL) {
+   		    mongoc_collection_destroy (pData->collection);
+		}
+
+   		mongoc_client_destroy (pData->client);
+   		mongoc_cleanup ();
 	}
 }
 
@@ -127,14 +143,18 @@ static void closeMongoDB(instanceData *pData)
 BEGINfreeInstance
 CODESTARTfreeInstance
 	closeMongoDB(pData);
+
 	if (pData->json_tokener != NULL)
 		json_tokener_free(pData->json_tokener);
 	free(pData->server);
-	free(pData->db);
-	free(pData->collection);
+	free(pData->port);
+	free(pData->ssl_ca);
+	free(pData->ssl_cert);
+	free(pData->uristr);
 	free(pData->uid);
 	free(pData->pwd);
-	free(pData->dbNcoll);
+	free(pData->db);
+	free(pData->collection_name);
 	free(pData->tplName);
 ENDfreeInstance
 
@@ -155,20 +175,8 @@ ENDdbgPrintInstInfo
 static void
 reportMongoError(instanceData *pData)
 {
-	char errStr[1024];
-	gchar *err;
-	int eno;
-
 	if(pData->bErrMsgPermitted) {
-		eno = errno;
-		if(mongo_sync_cmd_get_last_error(pData->conn, (gchar*)pData->db, &err) == TRUE) {
-			errmsg.LogError(0, RS_RET_ERR, "ommongodb: error: %s", err);
-		} else {
-			DBGPRINTF("ommongodb: we had an error, but can not obtain specifics, "
-				  "using plain old errno error message generator\n");
-			errmsg.LogError(0, RS_RET_ERR, "ommongodb: error: %s",
-				rs_strerror_r(eno, errStr, sizeof(errStr)));
-		}
+		errmsg.LogError(0, RS_RET_ERR, "ommongodb: error: %s", pData->error.message);
 		pData->bErrMsgPermitted = 0;
 	}
 }
@@ -180,43 +188,25 @@ reportMongoError(instanceData *pData)
  */
 static rsRetVal initMongoDB(instanceData *pData, int bSilent)
 {
-	const char *server;
 	DEFiRet;
 
-	server = (pData->server == NULL) ? "127.0.0.1" : (const char*) pData->server;
-	DBGPRINTF("ommongodb: trying connect to '%s' at port %d\n", server, pData->port);
-
-	pData->conn = mongo_sync_connect(server, pData->port, TRUE);
-	if(pData->conn == NULL) {
+	DBGPRINTF("ommongodb: uristr is '%s'", pData->uristr);
+	mongoc_init ();
+	pData->client = mongoc_client_new (pData->uristr);
+	if (pData->ssl_cert && pData->ssl_ca) {
+		mongoc_ssl_opt_t ssl_opts = { 0 };
+   		ssl_opts.pem_file = pData->ssl_cert;
+   		ssl_opts.ca_file = pData->ssl_ca;
+   		mongoc_client_set_ssl_opts (pData->client, &ssl_opts);
+	}
+	if(pData->client == NULL) {
 		if(!bSilent) {
 			reportMongoError(pData);
 			dbgprintf("ommongodb: can not initialize MongoDB handle");
 		}
                 ABORT_FINALIZE(RS_RET_SUSPENDED);
 	}
-
-	/* perform authentication */
-	if(pData->uid && pData->pwd) {
-
-	  /* require both uid and pwd before attempting authentication */
-	  if(!pData->uid || !pData->pwd) {
-	    dbgprintf("ommongodb: authentication requires uid and pwd attributes set; skipping");
-	  }
-	  else if(!mongo_sync_cmd_authenticate(pData->conn, (const gchar*)pData->db,
-	  	  			(const gchar*)pData->uid, (const gchar*)pData->pwd)) {
-	    if(!bSilent) {
-	      reportMongoError(pData);
-	      dbgprintf("ommongodb: could not authenticate %s against '%s'", pData->uid, pData->db);
-	    }
-
-	    /* no point in continuing with an unauthenticated connection */
-	    closeMongoDB(pData);
-	    ABORT_FINALIZE(RS_RET_SUSPENDED);
-	  }
-	  else {
-	    dbgprintf("ommongodb: authenticated with %s against '%s'", pData->uid, pData->db);
-	  }
-	}
+	pData->collection = mongoc_client_get_collection (pData->client, pData->db, pData->collection_name);
 
 finalize_it:
 	RETiRet;
@@ -262,33 +252,32 @@ i10pow(int exp)
  * a moving target, so we may run out of sync (and stay so to retain
  * backward compatibility, which we consider pretty important).
  */
-static bson *
-getDefaultBSON(smsg_t *pMsg)
+static bson_t *getDefaultBSON(smsg_t *pMsg)
 {
-	bson *doc = NULL;
-	uchar *procid; short unsigned procid_free; rs_size_t procid_len;
-	uchar *tag; short unsigned tag_free; rs_size_t tag_len;
-	uchar *pid; short unsigned pid_free; rs_size_t pid_len;
-	uchar *sys; short unsigned sys_free; rs_size_t sys_len;
-	uchar *msg; short unsigned msg_free; rs_size_t msg_len;
+	bson_t *doc = NULL;
+	char *procid; short unsigned procid_free; rs_size_t procid_len;
+	char *tag; short unsigned tag_free; rs_size_t tag_len;
+	char *pid; short unsigned pid_free; rs_size_t pid_len;
+	char *sys; short unsigned sys_free; rs_size_t sys_len;
+	char *msg; short unsigned msg_free; rs_size_t msg_len;
 	int severity, facil;
-	gint64 ts_gen, ts_rcv; /* timestamps: generated, received */
+	int64 ts_gen, ts_rcv; /* timestamps: generated, received */
 	int secfrac;
 	msgPropDescr_t cProp; /* we use internal implementation knowledge... */
 
 	cProp.id = PROP_PROGRAMNAME;
-	procid = MsgGetProp(pMsg, NULL, &cProp, &procid_len, &procid_free, NULL);
+	procid = (char*)MsgGetProp(pMsg, NULL, &cProp, &procid_len, &procid_free, NULL);
 	cProp.id = PROP_SYSLOGTAG;
-	tag = MsgGetProp(pMsg, NULL, &cProp, &tag_len, &tag_free, NULL);
+	tag = (char*)MsgGetProp(pMsg, NULL, &cProp, &tag_len, &tag_free, NULL);
 	cProp.id = PROP_PROCID;
-	pid = MsgGetProp(pMsg, NULL, &cProp, &pid_len, &pid_free, NULL);
+	pid = (char*)MsgGetProp(pMsg, NULL, &cProp, &pid_len, &pid_free, NULL);
 	cProp.id = PROP_HOSTNAME;
-	sys = MsgGetProp(pMsg, NULL, &cProp, &sys_len, &sys_free, NULL);
+	sys = (char*)MsgGetProp(pMsg, NULL, &cProp, &sys_len, &sys_free, NULL);
 	cProp.id = PROP_MSG;
-	msg = MsgGetProp(pMsg, NULL, &cProp, &msg_len, &msg_free, NULL);
+	msg = (char*)MsgGetProp(pMsg, NULL, &cProp, &msg_len, &msg_free, NULL);
 
 	/* TODO: move to datetime? Refactor in any case! rgerhards, 2012-03-30 */
-	ts_gen = (gint64) datetime.syslogTime2time_t(&pMsg->tTIMESTAMP) * 1000; /* ms! */
+	ts_gen = (int64) datetime.syslogTime2time_t(&pMsg->tTIMESTAMP) * 1000; /* ms! */
 	DBGPRINTF("ommongodb: ts_gen is %lld\n", (long long) ts_gen);
 	DBGPRINTF("ommongodb: secfrac is %d, precision %d\n",  pMsg->tTIMESTAMP.secfrac, pMsg->tTIMESTAMP.secfracPrecision);
 	if(pMsg->tTIMESTAMP.secfracPrecision > 3) {
@@ -299,7 +288,7 @@ getDefaultBSON(smsg_t *pMsg)
 		secfrac = pMsg->tTIMESTAMP.secfrac;
 	}
 	ts_gen += secfrac;
-	ts_rcv = (gint64) datetime.syslogTime2time_t(&pMsg->tRcvdAt) * 1000; /* ms! */
+	ts_rcv = (int64) datetime.syslogTime2time_t(&pMsg->tRcvdAt) * 1000; /* ms! */
 	if(pMsg->tRcvdAt.secfracPrecision > 3) {
 		secfrac = pMsg->tRcvdAt.secfrac / i10pow(pMsg->tRcvdAt.secfracPrecision - 3);
 	} else if(pMsg->tRcvdAt.secfracPrecision < 3) {
@@ -313,17 +302,20 @@ getDefaultBSON(smsg_t *pMsg)
 	severity = pMsg->iSeverity;
 	facil = pMsg->iFacility;
 
-	doc = bson_build(BSON_TYPE_STRING, "sys", sys, sys_len,
-			 BSON_TYPE_UTC_DATETIME, "time", ts_gen,
-			 BSON_TYPE_UTC_DATETIME, "time_rcvd", ts_rcv,
-			 BSON_TYPE_STRING, "msg", msg, msg_len,
-			 BSON_TYPE_INT32, "syslog_fac", facil,
-			 BSON_TYPE_INT32, "syslog_sever", severity,
-			 BSON_TYPE_STRING, "syslog_tag", tag, tag_len,
-			 BSON_TYPE_STRING, "procid", procid, procid_len,
-			 BSON_TYPE_STRING, "pid", pid, pid_len,
-			 BSON_TYPE_STRING, "level", getLumberjackLevel(pMsg->iSeverity), -1,
-			 BSON_TYPE_NONE);
+	doc = bson_new ();
+	bson_oid_t oid;
+   	bson_oid_init (&oid, NULL);
+   	BSON_APPEND_OID (doc, "_id", &oid);
+   	BSON_APPEND_UTF8 (doc, "sys", sys);
+   	BSON_APPEND_DATE_TIME (doc, "time", ts_gen);
+   	BSON_APPEND_DATE_TIME (doc, "time_rcvd", ts_rcv);
+   	BSON_APPEND_UTF8 (doc, "msg", msg);
+   	BSON_APPEND_INT32 (doc, "syslog_fac", facil);
+   	BSON_APPEND_INT32 (doc, "syslog_sever", severity);
+   	BSON_APPEND_UTF8 (doc, "syslog_tag", tag);
+   	BSON_APPEND_UTF8 (doc, "procid", procid);
+   	BSON_APPEND_UTF8 (doc, "pid", pid);
+   	BSON_APPEND_UTF8 (doc, "level", getLumberjackLevel(pMsg->iSeverity));
 
 	if(procid_free) free(procid);
 	if(tag_free) free(tag);
@@ -331,68 +323,77 @@ getDefaultBSON(smsg_t *pMsg)
 	if(sys_free) free(sys);
 	if(msg_free) free(msg);
 
-	if(doc == NULL)
-		return doc;
-	bson_finish(doc);
 	return doc;
 }
 
-static bson *BSONFromJSONArray(struct json_object *json);
-static bson *BSONFromJSONObject(struct json_object *json);
-static gboolean BSONAppendExtendedJSON(bson *doc, const gchar *name, struct json_object *json);
+static bson_t *BSONFromJSONArray(struct json_object *json);
+static bson_t *BSONFromJSONObject(struct json_object *json);
+static int BSONAppendExtendedJSON(bson_t *doc, const char *name, struct json_object *json);
 
 /* Append a BSON variant of json to doc using name.  Return TRUE on success */
-static gboolean
-BSONAppendJSONObject(bson *doc, const gchar *name, struct json_object *json)
+static int
+BSONAppendJSONObject(bson_t *doc, const char *name, struct json_object *json)
 {
+
 	switch(json != NULL ? json_object_get_type(json) : json_type_null) {
+
 	case json_type_null:
-		return bson_append_null(doc, name);
+		return BSON_APPEND_NULL(doc, name);
 	case json_type_boolean:
-		return bson_append_boolean(doc, name,
-					   json_object_get_boolean(json));
+		return BSON_APPEND_BOOL(doc, name, json_object_get_boolean(json));
 	case json_type_double:
-		return bson_append_double(doc, name,
-					  json_object_get_double(json));
+		return BSON_APPEND_DOUBLE(doc, name, json_object_get_double(json));
 	case json_type_int: {
 		int64_t i;
 
 		i = json_object_get_int64(json);
 		if (i >= INT32_MIN && i <= INT32_MAX)
-			return bson_append_int32(doc, name, i);
+			return BSON_APPEND_INT32(doc, name, i);
 		else
-			return bson_append_int64(doc, name, i);
+			return BSON_APPEND_INT64(doc, name, i);
 	}
 	case json_type_object: {
 
 		if (BSONAppendExtendedJSON(doc, name, json) == TRUE)
 		    return TRUE;
 
-		bson *sub;
-		gboolean ok;
+		bson_t *sub;
+		int ok;
 
 		sub = BSONFromJSONObject(json);
 		if (sub == NULL)
 			return FALSE;
-		ok = bson_append_document(doc, name, sub);
-		bson_free(sub);
+		ok = BSON_APPEND_DOCUMENT(doc, name, sub);
+		bson_destroy(sub);
 		return ok;
 	}
 	case json_type_array: {
-		bson *sub;
-		gboolean ok;
+		bson_t *sub;
+		int ok;
 
 		sub = BSONFromJSONArray(json);
 		if (sub == NULL)
 			return FALSE;
-		ok = bson_append_document(doc, name, sub);
-		bson_free(sub);
+		ok = BSON_APPEND_DOCUMENT(doc, name, sub);
+		bson_destroy(sub);
 		return ok;
 	}
-	case json_type_string:
-		return bson_append_string(doc, name,
-					  json_object_get_string(json), -1);
-
+	case json_type_string: {
+		/* Convert text to ISODATE when needed */
+		if (strncmp(name, "date", 5) == 0 || strncmp(name, "time", 5) == 0 ) {
+			struct tm tm;
+			if (strptime(json_object_get_string(json), "%Y-%m-%dT%H:%M:%S:%Z", &tm) != NULL ) {
+				time_t epoch;
+				int64 ts;
+				epoch = mktime(&tm) ;
+				ts = 1000 * (int64) epoch;
+				return BSON_APPEND_DATE_TIME (doc, name, ts);
+			}
+		}
+		else {
+			return BSON_APPEND_UTF8(doc, name, json_object_get_string(json));
+		}
+	}
 	default:
 		return FALSE;
 	}
@@ -405,8 +406,8 @@ BSONAppendJSONObject(bson *doc, const gchar *name, struct json_object *json)
  * to work since quite a while, I do not make any changes now.
  * rgerhards, 2016-04-09
  */
-static gboolean
-BSONAppendExtendedJSON(bson *doc, const gchar *name, struct json_object *json)
+static int
+BSONAppendExtendedJSON(bson_t *doc, const char *name, struct json_object *json)
 {
 	struct json_object_iterator itEnd = json_object_iter_end(json);
 	struct json_object_iterator it = json_object_iter_begin(json);
@@ -415,26 +416,25 @@ BSONAppendExtendedJSON(bson *doc, const gchar *name, struct json_object *json)
 		const char *const key = json_object_iter_peek_name(&it);
 		if (strcmp(key, "$date") == 0) {
 			struct tm tm;
-			gint64 ts;
+			int64 ts;
 			struct json_object *val;
 
 			val = json_object_iter_peek_value(&it);
 			DBGPRINTF("ommongodb: extended json date detected %s", json_object_get_string(val));
 			tm.tm_isdst = -1;
 			strptime(json_object_get_string(val), "%Y-%m-%dT%H:%M:%S%z", &tm);
-			ts = 1000 * (gint64) mktime(&tm);
-			return bson_append_utc_datetime(doc, name, ts);
+			ts = 1000 * (int64) mktime(&tm);
+			return BSON_APPEND_DATE_TIME (doc, name, ts);
 		}
 	}
 	return FALSE;
 }
 
 /* Return a BSON variant of json, which must be a json_type_array */
-static bson *
-BSONFromJSONArray(struct json_object *json)
+static bson_t *BSONFromJSONArray(struct json_object *json)
 {
 	/* Way more than necessary */
-	bson *doc = NULL;
+	bson_t *doc = NULL;
 	size_t i, array_len;
 
 	doc = bson_new();
@@ -447,32 +447,26 @@ BSONFromJSONArray(struct json_object *json)
 
 		if ((size_t)snprintf(buf, sizeof(buf), "%zu", i) >= sizeof(buf))
 			goto error;
-		if (BSONAppendJSONObject(doc, buf,
-					 json_object_array_get_idx(json, i))
-		    == FALSE)
+		if (BSONAppendJSONObject(doc, buf, json_object_array_get_idx(json, i)) == FALSE)
 			goto error;
 	}
-
-	if(bson_finish(doc) == FALSE)
-		goto error;
 
 	return doc;
 
 error:
 	if(doc != NULL)
-		bson_free(doc);
+		bson_destroy(doc);
 	return NULL;
 }
 
 /* Return a BSON variant of json, which must be a json_type_object */
-static bson *
-BSONFromJSONObject(struct json_object *json)
+static bson_t *BSONFromJSONObject(struct json_object *json)
 {
-	bson *doc = NULL;
+	bson_t *doc = NULL;
 
 	doc = bson_new();
 	if(doc == NULL)
-		goto error;
+		return NULL;
 
 	struct json_object_iterator it = json_object_iter_begin(json);
 	struct json_object_iterator itEnd = json_object_iter_end(json);
@@ -483,32 +477,30 @@ BSONFromJSONObject(struct json_object *json)
 		json_object_iter_next(&it);
 	}
 
-	if(bson_finish(doc) == FALSE)
-		goto error;
-
 	return doc;
 
 error:
-	if(doc != NULL)
-		bson_free(doc);
-	return NULL;
+        if(doc != NULL)
+                bson_destroy(doc);
+        return NULL;
+
 }
 
 BEGINtryResume
 CODESTARTtryResume
-	if(pWrkrData->pData->conn == NULL) {
+	if(pWrkrData->pData->client == NULL) {
 		iRet = initMongoDB(pWrkrData->pData, 1);
 	}
 ENDtryResume
 
 BEGINdoAction_NoStrings
-	bson *doc = NULL;
+	bson_t *doc = NULL;
 	instanceData *pData;
 CODESTARTdoAction
 	pthread_mutex_lock(&mutDoAct);
 	pData = pWrkrData->pData;
 	/* see if we are ready to proceed */
-	if(pData->conn == NULL) {
+	if(pData->client == NULL) {
 		CHKiRet(initMongoDB(pData, 0));
 	}
 
@@ -522,7 +514,7 @@ CODESTARTdoAction
 		/* FIXME: is this a correct return code? */
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
-	if(mongo_sync_cmd_insert(pData->conn, (char*)pData->dbNcoll, doc, NULL)) {
+	if (mongoc_collection_insert (pData->collection, MONGOC_INSERT_NONE, doc, NULL, &(pData->error) ) ) {
 		pData->bErrMsgPermitted = 1;
 	} else {
 		dbgprintf("ommongodb: insert error\n");
@@ -535,26 +527,27 @@ CODESTARTdoAction
 finalize_it:
 	pthread_mutex_unlock(&mutDoAct);
 	if(doc != NULL)
-		bson_free(doc);
+		bson_destroy(doc);
 ENDdoAction
 
 
-static void
-setInstParamDefaults(instanceData *pData)
+static void setInstParamDefaults(instanceData *pData)
 {
 	pData->server = NULL;
-	pData->port = 27017;
-	pData->db = NULL;
-	pData->collection= NULL;
+	pData->port = NULL;
+	pData->uristr = NULL;
+	pData->ssl_ca = NULL;
+	pData->ssl_cert = NULL;
 	pData->uid = NULL;
 	pData->pwd = NULL;
+	pData->db = NULL;
+	pData->collection = NULL;
 	pData->tplName = NULL;
 }
 
 BEGINnewActInst
 	struct cnfparamvals *pvals;
 	int i;
-	unsigned lendb, lencoll;
 CODESTARTnewActInst
 	if((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -567,20 +560,26 @@ CODESTARTnewActInst
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
-		if(!strcmp(actpblk.descr[i].name, "server")) {
-			pData->server = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		if(!strcmp(actpblk.descr[i].name, "uristr")) {
+			pData->uristr = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "server")) {
+			pData->server = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "serverport")) {
-			pData->port = (int) pvals[i].val.d.n;
+			pData->port = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "db")) {
-			pData->db = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->db = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "collection")) {
-			pData->collection = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->collection_name = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "ssl_ca")) {
+			pData->ssl_ca = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "ssl_cert")) {
+			pData->ssl_cert = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "uid")) {
-			pData->uid = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->uid = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "pwd")) {
-			pData->pwd = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->pwd = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "template")) {
-			pData->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->tplName = (char*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else {
 			dbgprintf("ommongodb: program error, non-handled "
 			  "param '%s'\n", actpblk.descr[i].name);
@@ -596,21 +595,66 @@ CODESTARTnewActInst
 	}
 
 	if(pData->db == NULL)
-		CHKmalloc(pData->db = (uchar*)strdup("syslog"));
-	if(pData->collection == NULL)
-		 CHKmalloc(pData->collection = (uchar*)strdup("log"));
+		CHKmalloc(pData->db = (char*)strdup("syslog"));
+	if(pData->collection_name == NULL)
+		CHKmalloc(pData->collection_name = (char*)strdup("log"));
 
-	/* we now create a db+collection string as we need to pass this
-	 * into the API and we do not want to generate it each time ;)
-	 * +2 ==> dot as delimiter and \0
+	/*
+	 * If we don't have a uristr, we need to build it
 	 */
-	lendb = strlen((char*)pData->db);
-	lencoll = strlen((char*)pData->collection);
-	CHKmalloc(pData->dbNcoll = malloc(lendb+lencoll+2));
-	memcpy(pData->dbNcoll, pData->db, lendb);
-	pData->dbNcoll[lendb] = '.';
-	/* lencoll+1 => copy \0! */
-	memcpy(pData->dbNcoll+lendb+1, pData->collection, lencoll+1);
+	if(pData->uristr == NULL){
+		char* tmp = NULL;
+		if(pData->server == NULL)
+			CHKmalloc(pData->server = (char*)strdup("127.0.0.1"));
+		if(pData->port == NULL)
+			CHKmalloc(pData->port = (char*)strdup("27017"));
+
+		/* We need to calculate the total length of the connection uri.
+		 * We will let it readable and let gcc do the optimisation for us.
+		 */
+		size_t server = strlen(pData->server);
+		size_t port = strlen(pData->port);
+		size_t uid = 0;
+		size_t pwd = 0;
+		size_t uri_len = strlen("mongodb://") + server + port + 2;
+		if(pData->uid && pData->pwd){
+			uid = strlen(pData->uid);
+			pwd = strlen(pData->pwd);
+			uri_len += uid + pwd + strlen("?authMechanism=PLAIN") + 2;
+		}
+		if(pData->ssl_ca && pData->ssl_cert)
+			uri_len += strlen("?ssl=true"); /* "?ssl=true" & "&ssl=true" are the same size */
+
+		/*
+		 * Formatting string "by hand" is a lot faster on execution than a snprintf for example.
+		 */
+		CHKmalloc(pData->uristr = malloc(uri_len + 1));
+		tmp = stpncpy(pData->uristr, "mongodb://", 10);
+		if(pData->uid && pData->pwd){
+			tmp = stpncpy(tmp, pData->uid, uid);
+			*tmp = ':';
+			++tmp;
+			tmp = stpncpy(tmp, pData->pwd, pwd);
+			*tmp = '@';
+			++tmp;
+		}
+		tmp = stpncpy(tmp, pData->server, server);
+		*tmp = ':';
+		++tmp;
+		tmp = stpncpy(tmp, pData->port, port);
+		*tmp = '/';
+		++tmp;
+		if(pData->uid && pData->pwd)
+			tmp = stpncpy(tmp, "?authMechanism=PLAIN", 20);
+		if(pData->ssl_ca && pData->ssl_cert){
+			if(pData->uid && pData->pwd)
+				tmp = stpncpy(tmp, "&ssl=true", 9);
+			else
+				tmp = stpncpy(tmp, "?ssl=true", 9);
+		}
+		*tmp = '\0';
+	}
+
 
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -549,6 +549,7 @@ BEGINnewActInst
 	struct cnfparamvals *pvals;
 	int i;
 CODESTARTnewActInst
+	dbgprintf("ommongodb: Getting configuration.\n");
 	if((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -556,6 +557,7 @@ CODESTARTnewActInst
 	CHKiRet(createInstance(&pData));
 	setInstParamDefaults(pData);
 
+	dbgprintf("ommongodb: Parsing configuration directives.\n");
 	CODE_STD_STRING_REQUESTnewActInst(1)
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
@@ -602,7 +604,9 @@ CODESTARTnewActInst
 	/*
 	 * If we don't have a uristr, we need to build it
 	 */
+	dbgprintf("ommongodb: Checking the uristr.\n");
 	if(pData->uristr == NULL){
+		dbgprintf("ommongodb: No uristr, building one.\n");
 		char* tmp = NULL;
 		if(pData->server == NULL)
 			CHKmalloc(pData->server = (char*)strdup("127.0.0.1"));
@@ -631,6 +635,7 @@ CODESTARTnewActInst
 		CHKmalloc(pData->uristr = malloc(uri_len + 1));
 		tmp = stpncpy(pData->uristr, "mongodb://", 10);
 		if(pData->uid && pData->pwd){
+			dbgprintf("ommongodb: Adding uid & pwd to uristr.\n");
 			tmp = stpncpy(tmp, pData->uid, uid);
 			*tmp = ':';
 			++tmp;
@@ -638,6 +643,7 @@ CODESTARTnewActInst
 			*tmp = '@';
 			++tmp;
 		}
+		dbgprintf("ommongodb: Adding server & port to uristr.\n");
 		tmp = stpncpy(tmp, pData->server, server);
 		*tmp = ':';
 		++tmp;
@@ -647,6 +653,7 @@ CODESTARTnewActInst
 		if(pData->uid && pData->pwd)
 			tmp = stpncpy(tmp, "?authMechanism=PLAIN", 20);
 		if(pData->ssl_ca && pData->ssl_cert){
+			dbgprintf("ommongodb: Adding ssl to uristr.\n");
 			if(pData->uid && pData->pwd)
 				tmp = stpncpy(tmp, "&ssl=true", 9);
 			else
@@ -654,7 +661,8 @@ CODESTARTnewActInst
 		}
 		*tmp = '\0';
 	}
-
+	dbgprintf("ommongodb: The uristr: %s\n", pData->uristr);
+	dbgprintf("ommongodb: End of the configuration.\n");
 
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);


### PR DESCRIPTION
Hello,

We propose improvements on the existing ommongodb output module. The major improvement is the use of the mongo-c-driver library instead of the deprecated mongo-client library.

New features are :

 - Handle TLS connexion to mongodb
 - Handle MongoDB Replicasets 
 - Added the 'ssl_ca' and 'ssl_cert' directives to configure tls connexion
 - Added 'uristr' directive to configure the connexion uri in the form of 'mongodb://...'

The "uristr" directive overrides the 'uid', 'pwd', 'server' and 'serverport' directives. To create the uri, please refer to the official MongoDB Connection String documentation.

uid, pwd, server and serverport directives are useless now, but still supported in this module, to preserve compatibility with existing configuration.

Feel free to contact us at aDvens if you have any questions: jeremie.jourdin@advens.fr / hugo.soszynski@advens.fr

Regards,

Hugo & Jérémie
