### PR TITLE
cosmetic: ensure strmOpenFile() has opened file when returning RS_RET_OK

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -379,7 +379,9 @@ static rsRetVal strmOpenFile(strm_t *pThis)
 		  (pThis->tOperationsMode == STREAMMODE_READ) ? "READ" : "WRITE", pThis->fd);
 
 finalize_it:
-	if(iRet != RS_RET_OK) {
+	if(iRet == RS_RET_OK) {
+		assert(pThis->fd != -1);
+	} else {
 		if(pThis->pszCurrFName != NULL) {
 			free(pThis->pszCurrFName);
 			pThis->pszCurrFName = NULL; /* just to prevent mis-adressing down the road... */


### PR DESCRIPTION
this tries to fix a potential false positive in Coverity scan. If this does
not work out, we need to explicitely set it to false positive.

CID 185330