### PR TITLE
core/template: fix double free due to 9e3efd4960eb6133c99b0842e5a717b…

### DIFF
--- a/template.c
+++ b/template.c
@@ -178,8 +178,6 @@ tplToString(struct template *__restrict__ const pTpl,
 		if(iLenVal >= (rs_size_t)iparam->lenBuf) /* we reserve one char for the final \0! */
 			CHKiRet(ExtendBuf(iparam, iLenVal + 1));
 		memcpy(iparam->param, pVal, iLenVal+1);
-		if(bMustBeFreed)
-			free(pVal);
 		FINALIZE;
 	}
 	


### PR DESCRIPTION
…a37b5cda1

Fix 9e3efd4960eb6133c99b0842e5a717ba37b5cda1 was incomplete, causing
a double-free.

Detected by Coverity scan, CID 185476