### PR TITLE
imdiag: fix cosmetic race in termination processing

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -316,7 +316,8 @@ waitMainQEmpty(tcps_sess_t *pSess)
 
 	while(1) {
 		processImInternal();
-		if(iOverallQueueSize == 0)
+		const unsigned OverallQueueSize = PREFER_FETCH_32BIT(iOverallQueueSize);
+		if(OverallQueueSize == 0)
 			++nempty;
 		else
 			nempty = 0;
@@ -325,7 +326,7 @@ waitMainQEmpty(tcps_sess_t *pSess)
 		if(iPrint++ % 500 == 0)
 			DBGPRINTF("imdiag sleeping, wait queues drain, "
 				"curr size %d, nempty %d\n",
-				iOverallQueueSize, nempty);
+				OverallQueueSize, nempty);
 		srSleep(0,100000);/* wait a little bit */
 	}
 

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -65,6 +65,7 @@
 	 * sure to use these macros only if that really does not matter!
 	 */
 #	define PREFER_ATOMIC_INC(data) ((void) __sync_fetch_and_add(&(data), 1))
+#	define PREFER_FETCH_32BIT(data) ((unsigned) __sync_fetch_and_and(&(data), 0xffffffff))
 #else
 	/* note that we gained parctical proof that theoretical problems DO occur
 	 * if we do not properly address them. See this blog post for details:
@@ -186,6 +187,7 @@
 #	define DESTROY_ATOMIC_HELPER_MUT(x) pthread_mutex_destroy(&(x));
 
 #	define PREFER_ATOMIC_INC(data) ((void) ++data)
+#	define PREFER_FETCH_32BIT(data) ((unsigned) (data))
 
 #endif
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -305,7 +305,7 @@ qqueueDbgPrint(qqueue_t *pThis)
 static inline int
 getPhysicalQueueSize(qqueue_t *pThis)
 {
-	return pThis->iQueueSize;
+	return (int) PREFER_FETCH_32BIT(pThis->iQueueSize);
 }
 
 


### PR DESCRIPTION
This is not a real problem because imdiag intentionally does multiple
tries to validate predicate validity. However, this is reported in
clang thread sanitizer and so we need to fix it.