### PR TITLE
omstdout: fix theoretical buffer overrun

### DIFF
--- a/plugins/omstdout/omstdout.c
+++ b/plugins/omstdout/omstdout.c
@@ -6,7 +6,7 @@
  *
  * File begun on 2009-03-19 by RGerhards
  *
- * Copyright 2009-2013 Adiscon GmbH.
+ * Copyright 2009-2017 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -136,7 +136,7 @@ CODESTARTdoAction
 		 */
 		iParam = 0;
 		iBuf = 0;
-		while(szParams[iParam] != NULL) {
+		while(szParams[iParam] != NULL && iBuf < (int)sizeof(szBuf)) {
 			if(iParam > 0)
 				szBuf[iBuf++] = ','; /* all but first need a delimiter */
 			iParamVal = 0;


### PR DESCRIPTION
The overrung occurs in code for testing an interface that currently
does not exists, so the overrun can actually never happen. We fixed
it anyhow to keep Coverity scan clean of defects.

Note also that omstdout is a testbench tool not intended for
production.

Detected by Coverity scan, CID 185325