### PR TITLE
rscryutil: fix theroretical file handle leak

### DIFF
--- a/tools/rscryutil.c
+++ b/tools/rscryutil.c
@@ -403,7 +403,7 @@ getRandomKey(void)
 	 * unavailability of /dev/urandom is just a theoretic thing, it
 	 * will always work...).  -- TODO -- rgerhards, 2013-03-06
 	 */
-	if((fd = open("/dev/urandom", O_RDONLY)) > 0) {
+	if((fd = open("/dev/urandom", O_RDONLY)) >= 0) {
 		if(read(fd, cry_key, randomKeyLen)) {}; /* keep compiler happy */
 		close(fd);
 	}


### PR DESCRIPTION
could only happen if file handle 0 was returned, what actuallyy
could not happen, as stdin is kept open by this command line tool.
Still fixing it to get rid of Coverity scan diagnostic.

Detected by Coverity scan, CID 185323