### PR TITLE
omtesting: another try at silencing Coverity scan

### DIFF
--- a/plugins/omtesting/omtesting.c
+++ b/plugins/omtesting/omtesting.c
@@ -177,7 +177,8 @@ static rsRetVal doSleep(instanceData *pData)
 static rsRetVal doRandFail(void)
 {
 	DEFiRet;
-	/* coverity[dc.weak_crypto] -- this is NOT used for security purposes,
+	/* coverity[dc.weak_crypto]
+	 * this is NOT used for security purposes,
 	 * so weak PRNG is OK - rgerhards, 2017-10-30
 	 */
 	if((rand() >> 4) < (RAND_MAX >> 5)) { /* rougly same probability */


### PR DESCRIPTION
If it doesn't work out, we'll disable it via the user interface