### PR TITLE
core/msg: potential race in variable handling

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -293,7 +293,11 @@ openPipe(wrkrInstanceData_t *pWrkrData)
 		/* set our fd to be non-blocking */
 		flags = fcntl(pWrkrData->fdPipeErr, F_GETFL);
 		flags |= O_NONBLOCK;
-		fcntl(pWrkrData->fdPipeErr, F_SETFL, flags);
+		if(fcntl(pWrkrData->fdPipeErr, F_SETFL, flags) == -1) {
+			LogError(errno, RS_RET_ERR, "omprog: set pipe fd to "
+				"nonblocking failed");
+			ABORT_FINALIZE(RS_RET_ERR);
+		}
 	}
 
 	pWrkrData->bIsRunning = 1;

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3069,14 +3069,14 @@ msgGetJSONPropJSONorString(smsg_t * const pMsg, msgPropDescr_t *pProp, struct js
 	*pjson = NULL, *pcstr = NULL;
 
 	if(pProp->id == PROP_CEE) {
+		MsgLock(pMsg);
 		jroot = pMsg->json;
-		MsgLock(pMsg);
 	} else if(pProp->id == PROP_LOCAL_VAR) {
-		jroot = pMsg->localvars;
 		MsgLock(pMsg);
+		jroot = pMsg->localvars;
 	} else if(pProp->id == PROP_GLOBAL_VAR) {
-		jroot = global_var_root;
 		pthread_mutex_lock(&glblVars_lock);
+		jroot = global_var_root;
 	} else {
 		DBGPRINTF("msgGetJSONPropJSONorString; invalid property id %d\n",
 			  pProp->id);
@@ -3127,14 +3127,14 @@ msgGetJSONPropJSON(smsg_t * const pMsg, msgPropDescr_t *pProp, struct json_objec
 	*pjson = NULL;
 
 	if(pProp->id == PROP_CEE) {
+		MsgLock(pMsg);
 		jroot = pMsg->json;
-		MsgLock(pMsg);
 	} else if(pProp->id == PROP_LOCAL_VAR) {
-		jroot = pMsg->localvars;
 		MsgLock(pMsg);
+		jroot = pMsg->localvars;
 	} else if(pProp->id == PROP_GLOBAL_VAR) {
-		jroot = global_var_root;
 		pthread_mutex_lock(&glblVars_lock);
+		jroot = global_var_root;
 	} else {
 		DBGPRINTF("msgGetJSONPropJSON; invalid property id %d\n",
 			  pProp->id);
@@ -4738,19 +4738,19 @@ msgAddJSON(smsg_t * const pM, uchar *name, struct json_object *json, int force_r
 	DEFiRet;
 
 	if(name[0] == '!') {
+		MsgLock(pM);
 		pjroot = &pM->json;
-		MsgLock(pM);
 	} else if(name[0] == '.') {
-		pjroot = &pM->localvars;
 		MsgLock(pM);
+		pjroot = &pM->localvars;
 	} else if (name[0] == '/') { /* globl var */
+		pthread_mutex_lock(&glblVars_lock);
 		pjroot = &global_var_root;
 		if (sharedReference) {
 			given = json;
 			json = jsonDeepCopy(json);
 			json_object_put(given);
 		}
-		pthread_mutex_lock(&glblVars_lock);
 	} else {
 		DBGPRINTF("Passed name %s is unknown kind of variable (It is not CEE, Local or Global variable).", name);
 		ABORT_FINALIZE(RS_RET_INVLD_SETOP);


### PR DESCRIPTION
Root of variable tree is accessed prior to locking access to it.
This introduces a race that may result in various kinds of
misadressing.

Found while reviewing code, no bug report exists.