### PR TITLE
imczmq: remove unallocated and unused pointer

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -278,8 +278,7 @@ static rsRetVal rcvData(void){
 		}
 	}
 
-	zactor_t *authActor;
-	zcert_t *serverCert;
+	zactor_t *authActor = NULL;
 
 	if(runModConf->authenticator == 1) {
 		authActor = zactor_new(zauth, NULL);
@@ -368,7 +367,6 @@ finalize_it:
 	}
 	zlist_destroy(&listenerList);
 	zactor_destroy(&authActor);
-	zcert_destroy(&serverCert);
 	RETiRet;
 }
 


### PR DESCRIPTION
Fix a SIGSEGV in a call to
371: zcert_destroy(&serverCert) called from rcvData().

- remove serverCert as it is only used uninitialized in a call
to zcert_destroy() - this causes a core dump at rsyslogd exit.
- also initialize authActor at definition.

Signed-off-by: Nachiketa Prachanda <nachiketa.prachanda@att.com>