### PR TITLE
Segfault when variable path consists of variables

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3134,6 +3134,9 @@ msgGetJSONPropJSONorString(smsg_t * const pMsg, msgPropDescr_t *pProp, struct js
 		*pjson = *jroot;
 		FINALIZE;
 	}
+	if(*jroot == NULL) {
+		ABORT_FINALIZE(RS_RET_NOT_FOUND);
+	}
 	leaf = jsonPathGetLeaf(pProp->name, pProp->nameLen);
 	CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 1));
 	if(jsonVarExtract(parent, (char*)leaf, pjson) == FALSE) {
@@ -4675,8 +4678,9 @@ jsonPathFindNext(struct json_object *root, uchar *namestart, uchar **name, uchar
 		namebuf[i] = *p;
 	if(i > 0) {
 		namebuf[i] = '\0';
-		if(jsonVarExtract(root, (char*)namebuf, &json) == FALSE)
+		if(jsonVarExtract(root, (char*)namebuf, &json) == FALSE) {
 			json = NULL;
+		}
 	} else
 		json = root;
 	if(json == NULL) {

--- a/tests/check-length-json-property.sh
+++ b/tests/check-length-json-property.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# add 2017-10-30 by PascalWithopf, released under ASL 2.0
+#tests for Segmentation Fault
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+#set $!r = $!var1!var3!var2;
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
When no variables exist and a variable with at least one variable in its path was used, then rsyslog was searching for that non existant variable
Rsyslog now aborts it when no variables exist.
closes https://github.com/rsyslog/rsyslog/issues/1920