### PR TITLE
file stream handler: ensure multiline read is kept valid

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -865,7 +865,12 @@ finalize_it:
 		if(*ppCStr != NULL) {
 			if(cstrLen(*ppCStr) > 0) {
 			/* we may have an empty string in an unsuccesfull poll or after restart! */
-				rsCStrConstructFromCStr(&pThis->prevLineSegment, *ppCStr);
+				if(rsCStrConstructFromCStr(&pThis->prevLineSegment, *ppCStr) != RS_RET_OK) {
+					/* we cannot do anything against this, but we can at least
+					 * ensure we do not have any follow-on errors.
+					 */
+					 pThis->prevLineSegment = NULL;
+				}
 			}
 			cstrDestruct(ppCStr);
 		}


### PR DESCRIPTION
We ensure that the previous line segment is always valid... actually this
was already done with existing code, but Coverity scan did not detect this.
Maybe we now get a control flow issue because we do what already happened
in this case...

CID 185423