### PR TITLE
kafka: Fixed multiple issues found using clang 5.0 analyzer.

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -325,6 +325,8 @@ checkInstance(instanceConf_t *inst)
 
 	/* Set custom configuration parameters */
 	for(int i = 0 ; i < inst->nConfParams ; ++i) {
+		/* Avoid false positives in CLANG */
+		assert( inst->confParams == NULL);
 		DBGPRINTF("imkafka: setting custom configuration parameter: %s:%s\n",
 			inst->confParams[i].name,
 			inst->confParams[i].val);

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -963,6 +963,7 @@ checkFailedMessages(instanceData *const __restrict__ pData)
 	/* Loop through failed messages, reprocess them first! */
 	while (!LIST_EMPTY(&pData->failedmsg_head)) {
 		fmsgEntry = LIST_FIRST(&pData->failedmsg_head);
+		assert(fmsgEntry == NULL); /* Avoids false positives in CLANG*/
 		/* Put back into kafka! */
 		iRet = writeKafka(pData, (uchar*) fmsgEntry->payload, NULL, fmsgEntry->topicname);
 		if(iRet != RS_RET_OK) {
@@ -1053,6 +1054,9 @@ loadFailedMsgs(instanceData *const __restrict__ pData)
 	cstr_t *pCStr = NULL;
 	uchar *puStr;
 	char *pStrTabPos;
+
+	/* Avoid false positives in CLANG */
+	assert(pData->failedMsgFile == NULL);
 
 	/* check if the file exists */
 	if(stat((char*) pData->failedMsgFile, &stat_buf) == -1) {
@@ -1473,7 +1477,7 @@ CODESTARTnewActInst
 	pthread_mutex_unlock(&closeTimeoutMut);
 
 	/* Load failed messages here (If enabled), do NOT check for IRET!*/
-	if (pData->bKeepFailedMessages) {
+	if (pData->bKeepFailedMessages && pData->failedMsgFile != NULL) {
 		loadFailedMsgs(pData);
 	}
 


### PR DESCRIPTION
Added some assert() calls to avoid false positives.