### PR TITLE
kafka: fixed multiple coverity scan issues

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -323,25 +323,26 @@ checkInstance(instanceConf_t *inst)
 	rd_kafka_conf_set_log_cb(inst->conf, kafkaLogger);
 # endif
 
-	/* Set custom configuration parameters */
-	for(int i = 0 ; i < inst->nConfParams ; ++i) {
-		/* Avoid false positives in CLANG */
-		assert( inst->confParams != NULL);
-		DBGPRINTF("imkafka: setting custom configuration parameter: %s:%s\n",
-			inst->confParams[i].name,
-			inst->confParams[i].val);
-		if(rd_kafka_conf_set(inst->conf,
-				     inst->confParams[i].name,
-				     inst->confParams[i].val,
-				     kafkaErrMsg, sizeof(kafkaErrMsg))
-	 	   != RD_KAFKA_CONF_OK) {
-			if(inst->bReportErrs) {
-				errmsg.LogError(0, RS_RET_PARAM_ERROR, "imkafka: error in kafka "
-						"parameter '%s=%s': %s",
-						inst->confParams[i].name,
-						inst->confParams[i].val, kafkaErrMsg);
+	/* Only if confParams is set */
+	if(inst->confParams == NULL) {
+		/* Set custom configuration parameters */
+		for(int i = 0 ; i < inst->nConfParams ; ++i) {
+			DBGPRINTF("imkafka: setting custom configuration parameter: %s:%s\n",
+				inst->confParams[i].name,
+				inst->confParams[i].val);
+			if(rd_kafka_conf_set(inst->conf,
+						 inst->confParams[i].name,
+						 inst->confParams[i].val,
+						 kafkaErrMsg, sizeof(kafkaErrMsg))
+			   != RD_KAFKA_CONF_OK) {
+				if(inst->bReportErrs) {
+					errmsg.LogError(0, RS_RET_PARAM_ERROR, "imkafka: error in kafka "
+							"parameter '%s=%s': %s",
+							inst->confParams[i].name,
+							inst->confParams[i].val, kafkaErrMsg);
+				}
+				ABORT_FINALIZE(RS_RET_PARAM_ERROR);
 			}
-			ABORT_FINALIZE(RS_RET_PARAM_ERROR);
 		}
 	}
 

--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -534,8 +534,8 @@ CODESTARTnewInpInst
 			es_deleteStr(es);
 		} else if(!strcmp(inppblk.descr[i].name, "confparam")) {
 			inst->nConfParams = pvals[i].val.d.ar->nmemb;
-			CHKmalloc(inst->confParams = malloc(sizeof(struct kafka_params)*pvals[i].val.d.ar->nmemb));
-			for(int j = 0; j < pvals[i].val.d.ar->nmemb; j++) {
+			CHKmalloc(inst->confParams = malloc(sizeof(struct kafka_params)*inst->nConfParams));
+			for(int j = 0; j < inst->nConfParams; j++) {
 				char *cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
 				CHKiRet(processKafkaParam(cstr, &inst->confParams[j].name,
 								&inst->confParams[j].val));

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -338,8 +338,7 @@ static rsRetVal
 prepareTopic(instanceData *__restrict__ const pData, const uchar *__restrict__ const newTopicName)
 {
 	DEFiRet;
-	CHKiRet(createTopic(pData, newTopicName, &pData->pTopic));
-finalize_it:
+	iRet = createTopic(pData, newTopicName, &pData->pTopic);
 	if(iRet != RS_RET_OK) {
 		if(pData->pTopic != NULL) {
 			closeTopic(pData);
@@ -1028,7 +1027,7 @@ persistFailedMsgs(instanceData *const __restrict__ pData)
 		DBGPRINTF("omkafka: persistFailedMsgs We do not need to persist failed messages.\n");
 	}
 finalize_it:
-	if(fdMsgFile == -1) {
+	if(fdMsgFile != -1) {
 		close(fdMsgFile);
 	}
 	if(iRet != RS_RET_OK) {
@@ -1123,7 +1122,8 @@ finalize_it:
 		}
 	} else {
 		DBGPRINTF("omkafka: loadFailedMsgs unlinking '%s'\n", (char*)pData->failedMsgFile);
-		if(unlink((char*)pData->failedMsgFile) != 0) {
+		if(	stat((char*) pData->failedMsgFile, &stat_buf) == 0 && /* Delete file if still exists! */
+			unlink((char*)pData->failedMsgFile) != 0) {
 			char errStr[1024];
 			rs_strerror_r(errno, errStr, sizeof(errStr));
 			errmsg.LogError(0, RS_RET_ERR, "omkafka: loadFailedMsgs failed to remove "


### PR DESCRIPTION
CID 185720, 185719 fixed by correcting expression check for MsgFile handle.
CID 185723 fixed by removing CHKiRET
CID 185722 added additional check (stat) for MsgFile before unlink

Fixed 2 clang issues in imkafka as well