### PR TITLE
omprog: added tests for transactions with feedback

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -453,7 +453,10 @@ TESTS +=  \
 	omprog-cleanup-with-outfile.sh \
 	omprog-noterm-cleanup.sh \
 	omprog-noterm-default.sh \
-	omprog-feedback.sh
+	omprog-feedback.sh \
+	omprog-transactions.sh \
+	omprog-transactions-failed-messages.sh \
+	omprog-transactions-failed-commits.sh
 if OS_LINUX
 TESTS += \
 	omprog-cleanup-when-unresponsive.sh \
@@ -1380,6 +1383,9 @@ EXTRA_DIST= \
 	omprog-noterm-default.sh \
 	omprog-noterm-unresponsive.sh \
 	omprog-feedback.sh \
+	omprog-transactions.sh \
+	omprog-transactions-failed-messages.sh \
+	omprog-transactions-failed-commits.sh \
 	omprog-multiparam-vg.sh \
 	testsuites/omprog-cleanup.conf \
 	testsuites/omprog-noterm.conf \
@@ -1392,6 +1398,10 @@ EXTRA_DIST= \
 	testsuites/term-ignoring-script.sh \
 	testsuites/omprog-feedback.conf \
 	testsuites/omprog-feedback-bin.sh \
+	testsuites/omprog-transactions-bin.sh \
+	testsuites/omprog-transactions.conf \
+	testsuites/omprog-transactions-failed-messages.conf \
+	testsuites/omprog-transactions-failed-commits.conf \
 	pipe_noreader.sh \
 	testsuites/pipe_noreader.conf \
 	uxsock_simple.sh \

--- a/tests/omprog-transactions-failed-commits.sh
+++ b/tests/omprog-transactions-failed-commits.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+echo ===============================================================================
+echo '[omprog-transactions-failed-commits.sh]: test omprog with confirmMessages and useTransactions flags enabled, with commit failures'
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-transactions-failed-commits.conf
+. $srcdir/diag.sh wait-startup
+
+. $srcdir/diag.sh injectmsg 0 10
+
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+# Since the transaction boundaries are not deterministic, we cannot check for
+# an exact expected output. We must check the output programmatically.
+
+transaction_state="NONE"
+status_expected=true
+messages_to_commit=()
+messages_processed=()
+line_num=1
+error=
+
+while IFS= read -r line; do
+    if [[ $status_expected == true ]]; then
+        case "$transaction_state" in
+        "NONE")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            ;;
+        "STARTED")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            transaction_state="ACTIVE"
+            ;;
+        "ACTIVE")
+            if [[ "$line" != "<= DEFER_COMMIT" ]]; then
+                error="expecting a DEFER_COMMIT status from script"
+                break
+            fi
+            ;;
+        "COMMITTED")
+            if [[ "$line" == "<= Error: could not commit transaction" ]]; then
+                messages_to_commit=()
+                transaction_state="NONE"
+            else
+                if [[ "$line" != "<= OK" ]]; then
+                    error="expecting an OK status from script"
+                    break
+                fi
+                messages_processed+=("${messages_to_commit[@]}")
+                messages_to_commit=()
+                transaction_state="NONE"
+            fi
+            ;;
+        esac
+        status_expected=false;
+    else
+        if [[ "$line" == "=> BEGIN TRANSACTION" ]]; then
+            if [[ "$transaction_state" != "NONE" ]]; then
+                error="unexpected transaction start"
+                break
+            fi
+            transaction_state="STARTED"
+        elif [[ "$line" == "=> COMMIT TRANSACTION" ]]; then
+            if [[ "$transaction_state" != "ACTIVE" ]]; then
+                error="unexpected transaction commit"
+                break
+            fi
+            transaction_state="COMMITTED"
+        else
+            if [[ "$transaction_state" != "ACTIVE" ]]; then
+                error="unexpected message outside a transaction"
+                break
+            fi
+            if [[ "$line" != "=> msgnum:"* ]]; then
+                error="unexpected message contents"
+                break
+            fi
+            prefix_to_remove="=> "
+            messages_to_commit+=("${line#$prefix_to_remove}")
+        fi
+        status_expected=true;
+    fi
+    let "line_num++"
+done < rsyslog.out.log
+
+if [[ -z "$error" && "$transaction_state" != "NONE" ]]; then
+    error="unexpected end of file (transaction state: $transaction_state)"
+fi
+
+if [[ -n "$error" ]]; then
+    echo "rsyslog.out.log: line $line_num: $error"
+    cat rsyslog.out.log
+    . $srcdir/diag.sh error-exit 1
+fi
+
+# Since the order in which failed messages are retried by rsyslog is not
+# deterministic, we sort the processed messages before checking them.
+IFS=$'\n' messages_sorted=($(sort <<<"${messages_processed[*]}"))
+unset IFS
+
+expected_messages=(
+    "msgnum:00000000:"
+    "msgnum:00000001:"
+    "msgnum:00000002:"
+    "msgnum:00000003:"
+    "msgnum:00000004:"
+    "msgnum:00000005:"
+    "msgnum:00000006:"
+    "msgnum:00000007:"
+    "msgnum:00000008:"
+    "msgnum:00000009:"
+)
+if [[ "${messages_sorted[*]}" != "${expected_messages[*]}" ]]; then
+    echo "unexpected set of processed messages:"
+    printf '%s\n' "${messages_processed[@]}"
+    echo "contents of rsyslog.out.log:"
+    cat rsyslog.out.log
+    . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit

--- a/tests/omprog-transactions-failed-messages.sh
+++ b/tests/omprog-transactions-failed-messages.sh
@@ -1,0 +1,141 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+echo ===============================================================================
+echo '[omprog-transactions-failed-messages.sh]: test omprog with confirmMessages and useTransactions flags enabled, with message failures'
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-transactions-failed-messages.conf
+. $srcdir/diag.sh wait-startup
+
+. $srcdir/diag.sh injectmsg 0 10
+
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+# Since the transaction boundaries are not deterministic, we cannot check for
+# an exact expected output. We must check the output programmatically.
+
+transaction_state="NONE"
+status_expected=true
+messages_to_commit=()
+messages_processed=()
+line_num=1
+error=
+
+while IFS= read -r line; do
+    if [[ $status_expected == true ]]; then
+        case "$transaction_state" in
+        "NONE")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            ;;
+        "STARTED")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            transaction_state="ACTIVE"
+            ;;
+        "ACTIVE")
+            if [[ "$line" == "<= Error: could not process log message" ]]; then
+                #
+                # TODO: Issue #2420: Deferred messages within a transaction are
+                # not retried by rsyslog.
+                # If that's the expected behaviour, what's then the difference
+                # between the RS_RET_OK and the RS_RET_DEFER_COMMIT return codes?
+                # If that's not the expected behaviour, the following lines must
+                # be removed when the bug is solved.
+                #
+                # (START OF CODE THAT WILL POSSIBLY NEED TO BE REMOVED)
+                messages_processed+=("${messages_to_commit[@]}")
+                unset "messages_processed[${#messages_processed[@]}-1]"
+                # (END OF CODE THAT WILL POSSIBLY NEED TO BE REMOVED)
+
+                messages_to_commit=()
+                transaction_state="NONE"
+            elif [[ "$line" != "<= DEFER_COMMIT" ]]; then
+                error="expecting a DEFER_COMMIT status from script"
+                break
+            fi
+            ;;
+        "COMMITTED")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            messages_processed+=("${messages_to_commit[@]}")
+            messages_to_commit=()
+            transaction_state="NONE"
+            ;;
+        esac
+        status_expected=false;
+    else
+        if [[ "$line" == "=> BEGIN TRANSACTION" ]]; then
+            if [[ "$transaction_state" != "NONE" ]]; then
+                error="unexpected transaction start"
+                break
+            fi
+            transaction_state="STARTED"
+        elif [[ "$line" == "=> COMMIT TRANSACTION" ]]; then
+            if [[ "$transaction_state" != "ACTIVE" ]]; then
+                error="unexpected transaction commit"
+                break
+            fi
+            transaction_state="COMMITTED"
+        else
+            if [[ "$transaction_state" != "ACTIVE" ]]; then
+                error="unexpected message outside a transaction"
+                break
+            fi
+            if [[ "$line" != "=> msgnum:"* ]]; then
+                error="unexpected message contents"
+                break
+            fi
+            prefix_to_remove="=> "
+            messages_to_commit+=("${line#$prefix_to_remove}")
+        fi
+        status_expected=true;
+    fi
+    let "line_num++"
+done < rsyslog.out.log
+
+if [[ -z "$error" && "$transaction_state" != "NONE" ]]; then
+    error="unexpected end of file (transaction state: $transaction_state)"
+fi
+
+if [[ -n "$error" ]]; then
+    echo "rsyslog.out.log: line $line_num: $error"
+    cat rsyslog.out.log
+    . $srcdir/diag.sh error-exit 1
+fi
+
+# Since the order in which failed messages are retried by rsyslog is not
+# deterministic, we sort the processed messages before checking them.
+IFS=$'\n' messages_sorted=($(sort <<<"${messages_processed[*]}"))
+unset IFS
+
+expected_messages=(
+    "msgnum:00000000:"
+    "msgnum:00000001:"
+    "msgnum:00000002:"
+    "msgnum:00000003:"
+    "msgnum:00000004:"
+    "msgnum:00000005:"
+    "msgnum:00000006:"
+    "msgnum:00000007:"
+    "msgnum:00000008:"
+    "msgnum:00000009:"
+)
+if [[ "${messages_sorted[*]}" != "${expected_messages[*]}" ]]; then
+    echo "unexpected set of processed messages:"
+    printf '%s\n' "${messages_processed[@]}"
+    echo "contents of rsyslog.out.log:"
+    cat rsyslog.out.log
+    . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit

--- a/tests/omprog-transactions.sh
+++ b/tests/omprog-transactions.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+echo ===============================================================================
+echo '[omprog-transactions.sh]: test omprog with confirmMessages and useTransactions flags enabled'
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-transactions.conf
+. $srcdir/diag.sh wait-startup
+
+. $srcdir/diag.sh injectmsg 0 10
+
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+# Since the transaction boundaries are not deterministic, we cannot check for
+# an exact expected output. We must check the output programmatically.
+
+transaction_state="NONE"
+status_expected=true
+messages_to_commit=()
+messages_processed=()
+line_num=1
+error=
+
+while IFS= read -r line; do
+    if [[ $status_expected == true ]]; then
+        case "$transaction_state" in
+        "NONE")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            ;;
+        "STARTED")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            transaction_state="ACTIVE"
+            ;;
+        "ACTIVE")
+            if [[ "$line" != "<= DEFER_COMMIT" ]]; then
+                error="expecting a DEFER_COMMIT status from script"
+                break
+            fi
+            ;;
+        "COMMITTED")
+            if [[ "$line" != "<= OK" ]]; then
+                error="expecting an OK status from script"
+                break
+            fi
+            messages_processed+=("${messages_to_commit[@]}")
+            messages_to_commit=()
+            transaction_state="NONE"
+            ;;
+        esac
+        status_expected=false;
+    else
+        if [[ "$line" == "=> BEGIN TRANSACTION" ]]; then
+            if [[ "$transaction_state" != "NONE" ]]; then
+                error="unexpected transaction start"
+                break
+            fi
+            transaction_state="STARTED"
+        elif [[ "$line" == "=> COMMIT TRANSACTION" ]]; then
+            if [[ "$transaction_state" != "ACTIVE" ]]; then
+                error="unexpected transaction commit"
+                break
+            fi
+            transaction_state="COMMITTED"
+        else
+            if [[ "$transaction_state" != "ACTIVE" ]]; then
+                error="unexpected message outside a transaction"
+                break
+            fi
+            if [[ "$line" != "=> msgnum:"* ]]; then
+                error="unexpected message contents"
+                break
+            fi
+            prefix_to_remove="=> "
+            messages_to_commit+=("${line#$prefix_to_remove}")
+        fi
+        status_expected=true;
+    fi
+    let "line_num++"
+done < rsyslog.out.log
+
+if [[ -z "$error" && "$transaction_state" != "NONE" ]]; then
+    error="unexpected end of file (transaction state: $transaction_state)"
+fi
+
+if [[ -n "$error" ]]; then
+    echo "rsyslog.out.log: line $line_num: $error"
+    cat rsyslog.out.log
+    . $srcdir/diag.sh error-exit 1
+fi
+
+expected_messages=(
+    "msgnum:00000000:"
+    "msgnum:00000001:"
+    "msgnum:00000002:"
+    "msgnum:00000003:"
+    "msgnum:00000004:"
+    "msgnum:00000005:"
+    "msgnum:00000006:"
+    "msgnum:00000007:"
+    "msgnum:00000008:"
+    "msgnum:00000009:"
+)
+if [[ "${messages_processed[*]}" != "${expected_messages[*]}" ]]; then
+    echo "unexpected set of processed messages:"
+    printf '%s\n' "${messages_processed[@]}"
+    echo "contents of rsyslog.out.log:"
+    cat rsyslog.out.log
+    . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit

--- a/tests/testsuites/omprog-transactions-bin.sh
+++ b/tests/testsuites/omprog-transactions-bin.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+outfile=rsyslog.out.log
+
+status="OK"
+echo "<= $status" >> $outfile
+echo $status
+
+in_transaction=false
+fail_on_commit=false
+retry_count=0
+
+read line
+while [[ -n "$line" ]]; do
+    message=${line//$'\n'}
+    echo "=> $message" >> $outfile
+
+    if [[ "$message" == "BEGIN TRANSACTION" ]]; then
+        in_transaction=true
+        status="OK"
+    elif [[ "$message" == "COMMIT TRANSACTION" ]]; then
+        in_transaction=false
+        if [[ $fail_on_commit == true ]]; then
+            status="Error: could not commit transaction"
+            fail_on_commit=false
+        else
+            status="OK"
+        fi
+    else
+        if [[ $in_transaction == true ]]; then
+            status="DEFER_COMMIT"
+        else
+            # Should not occur
+            status="Error: received a message out of a transaction"
+        fi
+    fi
+
+    # First command line argument ($1) indicates whether to test for negative
+    # cases. If --failed_messages is specified, an error is returned for certain
+    # messages, forcing them to be retried twice. If --failed_commits is
+    # specified, the error is returned when committing the transaction.
+    if [[ "$1" != "" && ($message == *04* || $message == *07*) ]]; then
+        if [[ $retry_count < 2 ]]; then
+            if [[ "$1" == "--failed_commits" ]]; then
+                fail_on_commit=true
+            else
+                status="Error: could not process log message"
+            fi
+            let "retry_count++"
+        else
+            retry_count=0
+        fi
+    fi
+
+    echo "<= $status" >> $outfile
+    echo $status
+    read line
+done
+
+exit 0

--- a/tests/testsuites/omprog-transactions-failed-commits.conf
+++ b/tests/testsuites/omprog-transactions-failed-commits.conf
@@ -1,0 +1,22 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+        binary="./testsuites/omprog-transactions-bin.sh --failed_commits"
+        template="outfmt"
+        name="omprog_action"
+        confirmMessages="on"
+        useTransactions="on"
+        action.resumeRetryCount="10"
+        action.resumeInterval="1"
+        queue.type="LinkedList"
+        queue.workerThreads="1"
+        queue.dequeueBatchSize="6"
+        signalOnClose="off"
+    )
+}

--- a/tests/testsuites/omprog-transactions-failed-messages.conf
+++ b/tests/testsuites/omprog-transactions-failed-messages.conf
@@ -1,0 +1,25 @@
+$IncludeConfig diag-common.conf
+
+#$DebugFile /var/tmp/testlogs/__rsyslog-debug.log
+#$DebugLevel 2
+
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+        binary="./testsuites/omprog-transactions-bin.sh --failed_messages"
+        template="outfmt"
+        name="omprog_action"
+        confirmMessages="on"
+        useTransactions="on"
+        action.resumeRetryCount="10"
+        action.resumeInterval="1"
+        queue.type="LinkedList"
+        queue.workerThreads="1"
+        queue.dequeueBatchSize="6"
+        signalOnClose="off"
+    )
+}

--- a/tests/testsuites/omprog-transactions.conf
+++ b/tests/testsuites/omprog-transactions.conf
@@ -1,0 +1,22 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+        binary="./testsuites/omprog-transactions-bin.sh"
+        template="outfmt"
+        name="omprog_action"
+        confirmMessages="on"
+        useTransactions="on"
+        action.resumeRetryCount="10"
+        action.resumeInterval="1"
+        queue.type="LinkedList"
+        queue.workerThreads="1"
+        queue.dequeueBatchSize="6"
+        signalOnClose="off"
+    )
+}


### PR DESCRIPTION
I have added two automated tests for the feedback feature introduced in #1753. They are still incomplete; consider this as work in progress. I have submitted the PR now because I'm stuck at two issues related to some behavior of the rsyslog core that I don't fully understand.

My doubts are related to how the rsyslog core handles transactions. I have marked them with two "TODO" marks in the code.

1) It seems that deferred messages (confirmed with RS_RET_DEFER_COMMIT) in a transaction are not retried if a later message in the transaction fails (with RS_RET_SUSPENDED). Please see the TODO in "omprog-transactions-feedback.sh". Is this the expected behavior?

2) If a commit fails (endTransaction returns a RS_RET_SUSPENDED), the next transaction hangs at the second message. The debug logs show that the action is correctly resumed, and sent the first message (which the action confirms with DEFER_COMMIT), but then action is no longer called, despite the queue is not empty yet (?). To reproduce this problem, see the TODO in "omprog-feedback-bin.sh"

@rgerhards, it would be great if you could take a careful look at the PR and help me with these two doubts. I have saved the rsyslog debug files for the two cases:
* [rsyslog-debug (deferred messages in failed transaction not retried).log](https://github.com/rsyslog/rsyslog/files/1455955/rsyslog-debug.deferred.messages.in.failed.transaction.not.retried.log)
* [rsyslog-debug (next transaction hangs after failed commit).log](https://github.com/rsyslog/rsyslog/files/1455957/rsyslog-debug.next.transaction.hangs.after.failed.commit.log)

I have carefully reviewed the handling of return codes in omprog.c, and I'm quite sure there isn't any bug there. I would say these behaviors are specific to the rsyslog core, and hence common to all plugins. Regarding the second case, I have tried to find out what's causing the hang by inspecting the code in action.c, but I don't fully understand how the retries are managed when a commit fails (it seems there is special retry code for this case).
