### PR TITLE
core/queue: fix potential race during shutdown

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -48,6 +48,7 @@ Version 8.31.0 [v8-stable] 2017-11-28
   of messages was needed
 - [io]mgssapi: fix build problems (regression from 8.30.0)
 - [io]czmq: fix build problems on some platforms (namely gcc 7, clang 5)
+- tcpsrv bugfix: potential hang during shutdown
 - imczmq bugfix: segfault
   happened in a call to
     371: zcert_destroy(&serverCert) called from rcvData().

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1348,7 +1348,10 @@ qqueueShutdownWorkers(qqueue_t *const pThis)
 
 	CHKiRet(tryShutdownWorkersWithinQueueTimeout(pThis));
 
-	if(getPhysicalQueueSize(pThis) > 0) {
+	pthread_mutex_lock(pThis->mut);
+	const int physQueueSize = getPhysicalQueueSize(pThis);
+	pthread_mutex_unlock(pThis->mut);
+	if(physQueueSize > 0) {
 		CHKiRet(tryShutdownWorkersWithinActionTimeout(pThis));
 	}
 


### PR DESCRIPTION
more or less cosmetic, but pollutes thread debuggers