### PR TITLE
imdiag: blocking pstats did not always work correctly

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -357,12 +357,13 @@ finalize_it:
 }
 
 static void
-imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *ignore_stats,
-						   void __attribute__((unused)) *ignore_ctx) {
+imdiag_statsReadCallback(statsobj_t __attribute__((unused)) *const ignore_stats,
+	void __attribute__((unused)) *const ignore_ctx)
+{
 	long long waitStartTimeMs = currentTimeMills();
 	sem_wait(&statsReportingBlocker);
 	long delta = currentTimeMills() - waitStartTimeMs;
-	if (ATOMIC_DEC_AND_FETCH(&allowOnlyOnce, &mutAllowOnlyOnce) < 0) {
+	if ((int)ATOMIC_DEC_AND_FETCH(&allowOnlyOnce, &mutAllowOnlyOnce) < 0) {
 		sem_post(&statsReportingBlocker);
 	} else {
 		errmsg.LogError(0, RS_RET_OK, "imdiag(stats-read-callback): current stats-reporting "


### PR DESCRIPTION
data type was not correctly re-cast after atomic operation

Also added a couple of code attributes to aid compiler finding bugs.

Detected by Coverity scan, CID 185416