### PR TITLE
travis: run clang static analyzer over ALL files

### DIFF
--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -70,10 +70,4 @@ then
 fi
 
 if [ "x$STAT_AN" == "xYES" ] ; then make clean; CFLAGS="-O2 -std=c99"; ./configure $CONFIG_FLAGS ; fi
-if [ "x$STAT_AN" == "xYES" ] ; then cd compat; $SCAN_BUILD --use-cc $CC --status-bugs make -j && cd .. ; fi
-# we now build those components that we know to need some more work
-# they will not be included in the later static analyzer run. But by
-# explicitely listing the modules which do not work, we automatically
-# get new modules/files covered.
-if [ "x$STAT_AN" == "xYES" ] ; then cd runtime; make - lmnet_la-net.lo libgcry_la-libgcry.lo ; cd .. ;  fi
 if [ "x$STAT_AN" == "xYES" ] ; then $SCAN_BUILD --use-cc $CC --status-bugs make -j ; fi


### PR DESCRIPTION
For historic reasons, it only processed part of the files, what no longer
is necessary (buildbot already covers everything).

closes https://github.com/rsyslog/rsyslog/issues/2005