### PR TITLE
udp socket creation: make IPFREEBIND work

### DIFF
--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1436,8 +1436,7 @@ create_single_udp_socket(int *const s, /* socket */
 					if (ipfreebind >= IPFREEBIND_ENABLED_WITH_LOG)
 						errmsg.LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
 							"bound address %s IP free", hostname);
-					//FINALIZE; TODO: activate this (issue 2040) BUT ensure first
-					// that the option is actually configurable
+					FINALIZE;
 				}
 			}
 			ABORT_FINALIZE(RS_RET_ERR);


### PR DESCRIPTION
... and also solve a socket leak that pre-8.31 occurred when the option
was enabled.

Special thanks to github user amg1127 who analysed the situation and
actually provided the original patch for the issue. Unfortunately, the
existing code base was really bad, and so I needed to do some refactoring
first. My patch here is modelled exactly after amg1127's patch, but
bases on the refactoring.

Full credits for the patch belong to amg1127.

see also https://github.com/rsyslog/rsyslog/pull/2049
closes https://github.com/rsyslog/rsyslog/issues/2040