### PR TITLE
error during config processing: omfile: creating parent directories for file  'File exists'

### DIFF
--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -194,6 +194,10 @@ uchar *srUtilStrDup(uchar *pOld, size_t len)
  * the creation fails in the similar way, we return an error on that second
  * try because otherwise we would potentially run into an endless loop.
  * loop. -- rgerhards, 2010-03-25
+ * The likeliest scenario for a prolonged contest of creating the parent directiories
+ * is within our process space. This can happen with a high probability when two
+ * threads, that want to start logging to files within same directory tree, are
+ * started close to each other. We should fix what we can. -- nipakoo, 2017-11-25
  */
 int makeFileParentDirs(const uchar *const szFile, size_t lenFile, mode_t mode,
 		       uid_t uid, gid_t gid, int bFailOnChownFail)
@@ -203,6 +207,7 @@ int makeFileParentDirs(const uchar *const szFile, size_t lenFile, mode_t mode,
         size_t len;
 	int iTry = 0;
 	int bErr = 0;
+	static pthread_mutex_t mutParentDir = PTHREAD_MUTEX_INITIALIZER;
 
 	assert(szFile != NULL);
 	assert(lenFile > 0);
@@ -216,6 +221,7 @@ int makeFileParentDirs(const uchar *const szFile, size_t lenFile, mode_t mode,
 			/* temporarily terminate string, create dir and go on */
                         *p = '\0';
 			iTry = 0;
+			pthread_mutex_lock(&mutParentDir);
 again:
                         if(access((char*)pszWork, F_OK)) {
                                 if(mkdir((char*)pszWork, mode) == 0) {
@@ -245,9 +251,11 @@ again:
 					int eSave = errno;
 					free(pszWork);
 					errno = eSave;
+					pthread_mutex_unlock(&mutParentDir);
 					return -1;
 				}
 			}
+			pthread_mutex_unlock(&mutParentDir);
                         *p = '/';
                 }
 	free(pszWork);


### PR DESCRIPTION
Add mutex for attempting to create parent directories of a log file. https://github.com/rsyslog/rsyslog/issues/2107