### PR TITLE
Relax time constraints for dynstats elapsed-time dependent tests

### DIFF
--- a/tests/dynstats_prevent_premature_eviction.sh
+++ b/tests/dynstats_prevent_premature_eviction.sh
@@ -15,9 +15,9 @@ echo \[dynstats_prevent_premature_eviction.sh\]: test for ensuring metrics are n
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
 . $srcdir/diag.sh msleep 1000
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_1
-. $srcdir/diag.sh msleep 2000
+. $srcdir/diag.sh msleep 4000
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_2
-. $srcdir/diag.sh msleep 2000
+. $srcdir/diag.sh msleep 4000
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_3
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'

--- a/tests/dynstats_reset-vg.sh
+++ b/tests/dynstats_reset-vg.sh
@@ -14,11 +14,11 @@ echo \[dynstats_reset-vg.sh\]: test for gathering stats with a known-dyn-metrics
 . $srcdir/diag.sh startup-vg dynstats_reset.conf
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_1
-. $srcdir/diag.sh msleep 4100 #two seconds for unused-metrics to be kept under observation, another two them to be cleared off
+. $srcdir/diag.sh msleep 8100 #two seconds for unused-metrics to be kept under observation, another two them to be cleared off
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_2
-. $srcdir/diag.sh msleep 4100
+. $srcdir/diag.sh msleep 8100
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_3
-. $srcdir/diag.sh msleep 4100
+. $srcdir/diag.sh msleep 8100
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "foo 001 0"
 . $srcdir/diag.sh content-check "bar 002 0"

--- a/tests/dynstats_reset.sh
+++ b/tests/dynstats_reset.sh
@@ -14,11 +14,11 @@ echo \[dynstats_reset.sh\]: test for gathering stats with a known-dyn-metrics re
 . $srcdir/diag.sh startup dynstats_reset.conf
 . $srcdir/diag.sh wait-for-stats-flush 'rsyslog.out.stats.log'
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_1
-. $srcdir/diag.sh msleep 4100
+. $srcdir/diag.sh msleep 8100
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_2
-. $srcdir/diag.sh msleep 4100
+. $srcdir/diag.sh msleep 8100
 . $srcdir/diag.sh injectmsg-litteral $srcdir/testsuites/dynstats_input_3
-. $srcdir/diag.sh msleep 4100
+. $srcdir/diag.sh msleep 8100
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "foo 001 0"
 . $srcdir/diag.sh content-check "bar 002 0"

--- a/tests/testsuites/dynstats_reset.conf
+++ b/tests/testsuites/dynstats_reset.conf
@@ -4,7 +4,7 @@ ruleset(name="stats") {
   action(type="omfile" file="./rsyslog.out.stats.log")
 }
 
-module(load="../plugins/impstats/.libs/impstats" interval="2" severity="7" resetCounters="on" Ruleset="stats" bracketing="on")
+module(load="../plugins/impstats/.libs/impstats" interval="4" severity="7" resetCounters="on" Ruleset="stats" bracketing="on")
 
 template(name="outfmt" type="string" string="%msg% %$.increment_successful%\n")
 


### PR DESCRIPTION
Increases tolerance from 1 second to 3 seconds for eviction test (it was 2 seconds unused-ttl with 1 second delay, now its 4 second ttl with 1 second delay, so total 3 seconds of tolerance).