### PR TITLE
fix cancel cleanup handler in directory tree creation code

### DIFF
--- a/runtime/srUtils.h
+++ b/runtime/srUtils.h
@@ -79,8 +79,8 @@ unsigned char *srUtilStrDup(unsigned char *pOld, size_t len);
  * for it.
  * added 2007-07-17 by rgerhards
  */
-int makeFileParentDirs(const uchar *const szFile, size_t lenFile, mode_t mode, uid_t uid, gid_t gid,
-int bFailOnChown);
+int makeFileParentDirs(const uchar *const szFile, const size_t lenFile, const mode_t mode,
+	const uid_t uid, const gid_t gid, const int bFailOnChown);
 int execProg(uchar *program, int bWait, uchar *arg);
 void skipWhiteSpace(uchar **pp);
 rsRetVal genFileName(uchar **ppName, uchar *pDirName, size_t lenDirName, uchar *pFName,


### PR DESCRIPTION
PR #2109 provides a solution for a race in directory creation (if a file
is to be written to a new path). There is a small weakness in that patch
in that it introduces a (very unlikely) potential hang condition during
shutdown.

see also https://github.com/rsyslog/rsyslog/pull/2109