### PR TITLE
rainerscript: bugfix

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1729,7 +1729,7 @@ doRandomGen(struct svar *__restrict__ const sourceVal) {
 static es_str_t*
 lTrim(char *str)
 {
-	int len = strlen(str);
+	const int len = strlen(str);
 	int i;
 	es_str_t *estr = NULL;
 
@@ -1739,9 +1739,7 @@ lTrim(char *str)
 		}
 	}
 
-	if(i != (len - 1)) {
-		estr = es_newStrFromCStr(str + i, strlen(str) - i);
-	}
+	estr = es_newStrFromCStr(str + i, len - i);
 
 	return(estr);
 }
@@ -1753,14 +1751,16 @@ rTrim(char *str)
 	int i;
 	es_str_t *estr = NULL;
 
-	for(i = (len - 1); i > -1; i--) {
+	for(i = (len - 1); i > 0; i--) {
 		if(str[i] != ' ') {
 			break;
 		}
 	}
 
-	if(i != 0) {
+	if(i > 0 || str[0] != ' ') {
 		estr = es_newStrFromCStr(str, (i + 1));
+	} else {
+		estr = es_newStr(1);
 	}
 
 	return(estr);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -316,7 +316,8 @@ TESTS +=  \
 	lookup_table_rscript_reload-vg.sh \
 	lookup_table_rscript_reload_without_stub-vg.sh \
 	multiple_lookup_tables-vg.sh \
-	fac_local0-vg.sh
+	fac_local0-vg.sh \
+	rscript_trim-vg.sh
 endif # HAVE_VALGRIND
 
 if ENABLE_IMJOURNAL
@@ -1592,6 +1593,7 @@ EXTRA_DIST= \
 	lookup_table_rscript_reload_without_stub.sh \
 	lookup_table_rscript_reload-vg.sh \
 	lookup_table_rscript_reload_without_stub-vg.sh \
+	rscript_trim-vg.sh \
 	testsuites/lookup_table.conf \
 	testsuites/lookup_table_no_hup_reload.conf \
 	testsuites/lookup_table_reload_stub.conf \

--- a/tests/rscript_trim-vg.sh
+++ b/tests/rscript_trim-vg.sh
@@ -74,10 +74,11 @@ set $!str!b20 = ltrim(rtrim(" te st "));
 template(name="outfmt" type="string" string="%!str%\n")
 local4.* action(type="omfile" file="rsyslog.out.log" template="outfmt")
 '
-. $srcdir/diag.sh startup
+. $srcdir/diag.sh startup-vg
 . $srcdir/diag.sh tcpflood -m1 -y
 . $srcdir/diag.sh shutdown-when-empty
-. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
 echo '{ "l1": "", "l2": "test", "l3": "test", "l4": "test   ", "l5": "test   ", "l6": "test", "l7": "test ", "l8": "", "l9": "te st", "l10": "te st", "l11": "a", "l12": "a ", "r1": "", "r2": "test", "r3": "   test", "r4": "test", "r5": "   test", "r6": " test", "r7": "test", "r8": "", "r9": "te st", "r10": "te st", "r11": " a", "r12": "a", "b1": "", "b2": "test", "b3": "test", "b4": "te st", "b5": "", "b6": "test", "b7": "test", "b8": "te st", "b9": "test", "b10": "te st", "b11": "test", "b12": "test", "b13": "test", "b14": "te st", "b15": "test", "b16": "te st", "b17": "test", "b18": "test", "b19": "test", "b20": "te st" }' | cmp - rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid function output detected, rsyslog.out.log is:"


### PR DESCRIPTION
fix a bug causing a crash if rtrim or ltrim were called
with a string containing a blank and one single different character.

closes https://github.com/rsyslog/rsyslog/issues/2127