### PR TITLE
cache sin_addr instead of the whole sockaddr structure

### DIFF
--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -79,22 +79,43 @@ static prop_t *staticErrValue;
 static unsigned int
 hash_from_key_fn(void *k) 
 {
-    int len;
-    uchar *rkey = (uchar*) k; /* we treat this as opaque bytes */
-    unsigned hashval = 1;
+	int len = 0;
+	uchar *rkey; /* we treat this as opaque bytes */
+	unsigned hashval = 1;
 
-    len = SALEN((struct sockaddr*)k);
-    while(len--)
-        hashval = hashval * 33 + *rkey++;
+	switch (((struct sockaddr *)k)->sa_family) {
+		case AF_INET:
+			len = sizeof (struct in_addr);
+			rkey = (uchar*) &(((struct sockaddr_in *)k)->sin_addr);
+			break;
+		case AF_INET6:
+			len = sizeof (struct in6_addr);
+			rkey = (uchar*) &(((struct sockaddr_in6 *)k)->sin6_addr);
+			break;
+	}
+	while(len--)
+		hashval = hashval * 33 + *rkey++;
 
-    return hashval;
+	return hashval;
 }
 
 static int
 key_equals_fn(void *key1, void *key2)
 {
-	return (SALEN((struct sockaddr*)key1) == SALEN((struct sockaddr*) key2) 
-		   && !memcmp(key1, key2, SALEN((struct sockaddr*) key1)));
+	int RetVal = 0;
+
+	if (((struct sockaddr *)key1)->sa_family != ((struct sockaddr *)key2)->sa_family)
+		return 0;
+	 switch (((struct sockaddr *)key1)->sa_family) {
+		case AF_INET:
+			RetVal = !memcmp(&((struct sockaddr_in *)key1)->sin_addr, &((struct sockaddr_in *)key2)->sin_addr, sizeof (struct in_addr));
+			break;
+		case AF_INET6:
+			RetVal = !memcmp(&((struct sockaddr_in6 *)key1)->sin6_addr, &((struct sockaddr_in6 *)key2)->sin6_addr, sizeof (struct in6_addr));
+			break;
+	}
+
+	return RetVal;
 }
 
 /* destruct a cache entry.


### PR DESCRIPTION
Description of problem:

It looks like that a hash key which is used to find out already cached dns entry gets incorrectly computed from the whole sockaddr_storage (sockaddr_in/sockaddr_in6) structure including a sin_port (which doesn't have a static value) instead of only an address, thus creating redundant dns cache entries/consuming more space.


How reproducible:

Always.


Steps to Reproduce:

1. Build rsyslog (you have to have CFLAGS containing '-O0 -g' so the follow up gdb script works properly):

~~~
# git clone git@github.com:rsyslog/rsyslog.git
# cd rsyslog
# autoreconf -fvi
# CFLAGS="-O0 -g -pipe -Wall -fpie" ./configure --prefix=/usr/local --disable-static --disable-testbench --disable-liblogging-stdlog --enable-elasticsearch --enable-generate-man-pages  --enable-gnutls  --enable-gssapi-krb5 --enable-imdiag --enable-imfile --enable-imjournal --enable-impstats --enable-imptcp --enable-libdbi --enable-mail --enable-mmanon --enable-mmaudit --enable-mmcount --enable-mmjsonparse --enable-mmnormalize --enable-mmsnmptrapd --enable-mmutf8fix --enable-mysql --enable-omjournal --enable-omprog --enable-omruleset --enable-omstdout --enable-omudpspoof --enable-omuxsock --enable-pgsql --enable-pmaixforwardedfrom --enable-pmcisconames --enable-pmlastmsg  --enable-pmrfc3164sd  --enable-pmsnare  --enable-relp --enable-snmp --enable-unlimited-select --enable-usertools
# make install
~~~

2. Add below into the /etc/rsyslog.conf:

~~~
$ModLoad imudp
$UDPServerRun 514
~~~

3. Run rsylogd:

~~~
# /usr/local/sbin/rsyslogd -nd
~~~

4. Make sure you have gdb & nc utility installed (needed by the below script)

5. Save the below gdb script as rsyslog-gdb-script.txt:

~~~
#set print pretty on
set print elements 4096
set pagination off
set confirm off

define hook-continue
shell echo -n "<141>test[0] testing msg" | nc 127.0.0.1 -u 514
end

hbreak dnscache.c:433 if etry != 0
commands
shell echo "[+] etry:"
p *etry
shell echo "[+] addr:"
p *addr
shell echo "[+] hashtable_search(dnsCache.ht,addr):"
call hashtable_search(dnsCache.ht,addr)
shell echo "[+] *(*(dnscache_entry_t *)$)->fqdn:"
p *(*(dnscache_entry_t *)$)->fqdn
shell echo "[+] hash(dnsCache.ht,addr):"
call hash(dnsCache.ht,addr)
shell echo "[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):"
p (char *) inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr)
shell echo -n "<141>test[0] testing msg" | nc 127.0.0.1 -u 514
end

hbreak dnscache.c:433 if etry == 0
commands
shell echo "[+] addr:"
p *addr
shell echo "[+] hashtable_search(dnsCache.ht,addr):"
call hashtable_search(dnsCache.ht,addr)
shell echo "[+] hash(dnsCache.ht,addr):"
call hash(dnsCache.ht,addr)
shell echo "[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):"
p (char *) inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr)
shell echo -n "<141>test[0] testing msg" | nc 127.0.0.1 -u 514
c
end
shell echo -n "<141>test[0] testing msg" | nc 127.0.0.1 -u 514
c
~~~

5. Attached to rsyslogd with gdb using the above script:

~~~
# gdb -p `pidof rsyslogd` -x rsyslog-gdb-script.txt
~~~


Actual results:

From the below gdb output (cherry picked&cut to make it shorter) we can see that while the client has the same ip address all the time, dnscacheLookup() fails to find it in the cache. Note hash value and sin_port. First mentioned breakpoint hit corresponds to the last breakpoint hit. Everything in between has different hash value & sin_port (emphasized with '<<<==='):

~~~
# gdb -p `pidof rsyslogd` -x rsyslog-gdb-script.txt

... snip ...

Thread 4 "rs:main Q:Reg" hit Breakpoint 2, dnscacheLookup (addr=0x7fef68002dc0, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fef533e6450, ip=0x7fef533e6458) at dnscache.c:433
433                     dbgprintf("dnscache: entry %p found\n", etry);
[+] addr:
$109 = {ss_family = 2, __ss_padding = "\245\036\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$110 = (void *) 0x0
[+] hash(dnsCache.ht,addr):
$111 = 580009756                  <<<===
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$112 = 0x7fef533e75f0 "127.0.0.1" <<<===

Thread 4 "rs:main Q:Reg" hit Breakpoint 2, dnscacheLookup (addr=0x7fef68002850, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fef533e6450, ip=0x7fef533e6458) at dnscache.c:433
433                     dbgprintf("dnscache: entry %p found\n", etry);
[+] addr:
$113 = {ss_family = 2, __ss_padding = "ō\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$114 = (void *) 0x0
[+] hash(dnsCache.ht,addr):
$115 = 157328015                  <<<===
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$116 = 0x7fef533e75f0 "127.0.0.1" <<<===

Thread 4 "rs:main Q:Reg" hit Breakpoint 2, dnscacheLookup (addr=0x7fef68002dc0, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fef533e6450, ip=0x7fef533e6458) at dnscache.c:433
433                     dbgprintf("dnscache: entry %p found\n", etry);
[+] addr:
$117 = {ss_family = 2, __ss_padding = "\317x\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$118 = (void *) 0x0
[+] hash(dnsCache.ht,addr):
$119 = 3143189128                 <<<===
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$120 = 0x7fef533e75f0 "127.0.0.1" <<<===

Thread 4 "rs:main Q:Reg" hit Breakpoint 2, dnscacheLookup (addr=0x7fef68002850, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fef533e6450, ip=0x7fef533e6458) at dnscache.c:433
433                     dbgprintf("dnscache: entry %p found\n", etry);
[+] addr:
$121 = {ss_family = 2, __ss_padding = "Ц\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$122 = (void *) 0x0
[+] hash(dnsCache.ht,addr):
$123 = 1747182104                 <<<===
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$124 = 0x7fef533e75f0 "127.0.0.1" <<<===

Thread 4 "rs:main Q:Reg" hit Breakpoint 2, dnscacheLookup (addr=0x7fef68002dc0, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fef533e6450, ip=0x7fef533e6458) at dnscache.c:433
433                     dbgprintf("dnscache: entry %p found\n", etry);
[+] addr:
$125 = {ss_family = 2, __ss_padding = "\321\305\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$126 = (void *) 0x0
[+] hash(dnsCache.ht,addr):
$127 = 1383972851                 <<<===
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$128 = 0x7fef533e75f0 "127.0.0.1" <<<===

... snip ...

Thread 4 "rs:main Q:Reg" hit Breakpoint 1, dnscacheLookup (addr=0x7fef68002dc0, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fef533e6450, ip=0x7fef533e6458) at dnscache.c:433
433                     dbgprintf("dnscache: entry %p found\n", etry);
[+] etry:
$225 = {addr = {ss_family = 2, __ss_padding = "\245\036\177\000\000\001", '\000' <repeats 17 times>, "$g{\357\177", '\000' <repeats 89 times>, __ss_align = 0}, fqdn = 0x7fef4c00c580, fqdnLowerCase = 0x7fef4c00c5c0, localName = 0x7fef4c00c5c0, ip = 0x7fef4c00c600, next = 0x0, nUsed = 0}
[+] addr:
$226 = {ss_family = 2, __ss_padding = "\245\036\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$227 = (void *) 0x7fef4c00c400
[+] *(*(dnscache_entry_t *)$)->fqdn:
$228 = {objData = {pObjInfo = 0x1de1250, iObjCooCKiE = 195948526, pszName = 0x0}, iRefCount = 1, szVal = {psz = 0x736f686c61636f6c <error: Cannot access memory at address 0x736f686c61636f6c>, sz = "localhost\000\000\000\000\000\000"}, len = 9}
[+] hash(dnsCache.ht,addr):
$229 = 580009756                  <<<===
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$230 = 0x7fef533e75f0 "127.0.0.1" <<<===
(gdb)
~~~


Expected results:

One ip address -> one dns cache entry.


Additional info:

It looks that hash key is incorrectly created from the whole sockaddr_storage (sockaddr_in/sockaddr_in6) structure instead of only the address and creates the key including sin_port which changes almost everytime, thus failing to find already cached entry:

~~~
 76 /* Our hash function.
 77  * TODO: check how well it performs on socket addresses!
 78  */
 79 static unsigned int
 80 hash_from_key_fn(void *k) 
 81 {
 82     int len;
 83     uchar *rkey = (uchar*) k; /* we treat this as opaque bytes */
 84     unsigned hashval = 1;
 85 
 86     len = SALEN((struct sockaddr*)k);
 87     while(len--)
 88         hashval = hashval * 33 + *rkey++;
 89 
 90     return hashval;
 91 }
~~~

Valgrind results:

~~~
==00:02:11:12.210 9444== 50,331,752 bytes in 1 blocks are still reachable in loss record 1,220 of 1,228
==00:02:11:12.210 9444==    at 0x4C28BE3: malloc (vg_replace_malloc.c:299)
==00:02:11:12.210 9444==    by 0x150B67: UnknownInlinedFun (hashtable.c:102)
==00:02:11:12.210 9444==    by 0x150B67: hashtable_insert (hashtable.c:168)
==00:02:11:12.210 9444==    by 0x11E5FE: addEntry (dnscache.c:384)
==00:02:11:12.210 9444==    by 0x11E5FE: dnscacheLookup (dnscache.c:427)
==00:02:11:12.210 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.210 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.210 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.210 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.210 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.210 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.210 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.210 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.210 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.210 9444==    by 0x146EBA: processBatch (ruleset.c:649)
==00:02:11:12.210 9444==    by 0x156583: msgConsumer (rsyslogd.c:695)
==00:02:11:12.210 9444== 
==00:02:11:12.210 9444== 55,849,841 bytes in 2,243,054 blocks are still reachable in loss record 1,221 of 1,228
==00:02:11:12.210 9444==    at 0x4C28BE3: malloc (vg_replace_malloc.c:299)
==00:02:11:12.210 9444==    by 0x147609: SetString (prop.c:87)
==00:02:11:12.210 9444==    by 0x1476EE: CreateStringProp (prop.c:152)
==00:02:11:12.210 9444==    by 0x11E0E2: resolveAddr (dnscache.c:332)
==00:02:11:12.210 9444==    by 0x11E500: addEntry (dnscache.c:374)
==00:02:11:12.210 9444==    by 0x11E500: dnscacheLookup (dnscache.c:427)
==00:02:11:12.210 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.210 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.210 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.210 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.210 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.210 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.210 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.210 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.210 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.210 9444== 
==00:02:11:12.210 9444== 55,849,841 bytes in 2,243,054 blocks are still reachable in loss record 1,222 of 1,228
==00:02:11:12.210 9444==    at 0x4C28BE3: malloc (vg_replace_malloc.c:299)
==00:02:11:12.210 9444==    by 0x147609: SetString (prop.c:87)
==00:02:11:12.211 9444==    by 0x1476EE: CreateStringProp (prop.c:152)
==00:02:11:12.211 9444==    by 0x11E125: resolveAddr (dnscache.c:335)
==00:02:11:12.211 9444==    by 0x11E500: addEntry (dnscache.c:374)
==00:02:11:12.211 9444==    by 0x11E500: dnscacheLookup (dnscache.c:427)
==00:02:11:12.211 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.211 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.211 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.211 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.211 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.211 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.211 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.211 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.211 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.211 9444== 
==00:02:11:12.211 9444== 72,437,920 bytes in 2,263,685 blocks are still reachable in loss record 1,223 of 1,228
==00:02:11:12.211 9444==    at 0x4C28BE3: malloc (vg_replace_malloc.c:299)
==00:02:11:12.211 9444==    by 0x150B1E: hashtable_insert (hashtable.c:170)
==00:02:11:12.211 9444==    by 0x11E5FE: addEntry (dnscache.c:384)
==00:02:11:12.211 9444==    by 0x11E5FE: dnscacheLookup (dnscache.c:427)
==00:02:11:12.211 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.211 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.211 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.211 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.211 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.211 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.211 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.211 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.211 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.211 9444==    by 0x146EBA: processBatch (ruleset.c:649)
==00:02:11:12.211 9444==    by 0x156583: msgConsumer (rsyslogd.c:695)
==00:02:11:12.211 9444== 
==00:02:11:12.211 9444== 107,666,592 bytes in 2,243,054 blocks are still reachable in loss record 1,224 of 1,228
==00:02:11:12.211 9444==    at 0x4C2A975: calloc (vg_replace_malloc.c:711)
==00:02:11:12.211 9444==    by 0x147532: propConstruct (prop.c:56)
==00:02:11:12.211 9444==    by 0x1476A7: CreateStringProp (prop.c:151)
==00:02:11:12.211 9444==    by 0x11E0E2: resolveAddr (dnscache.c:332)
==00:02:11:12.211 9444==    by 0x11E500: addEntry (dnscache.c:374)
==00:02:11:12.211 9444==    by 0x11E500: dnscacheLookup (dnscache.c:427)
==00:02:11:12.211 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.211 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.211 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.211 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.211 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.211 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.211 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.211 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.211 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.211 9444== 
==00:02:11:12.211 9444== 107,666,592 bytes in 2,243,054 blocks are still reachable in loss record 1,225 of 1,228
==00:02:11:12.211 9444==    at 0x4C2A975: calloc (vg_replace_malloc.c:711)
==00:02:11:12.211 9444==    by 0x147532: propConstruct (prop.c:56)
==00:02:11:12.211 9444==    by 0x1476A7: CreateStringProp (prop.c:151)
==00:02:11:12.211 9444==    by 0x11E125: resolveAddr (dnscache.c:335)
==00:02:11:12.211 9444==    by 0x11E500: addEntry (dnscache.c:374)
==00:02:11:12.211 9444==    by 0x11E500: dnscacheLookup (dnscache.c:427)
==00:02:11:12.211 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.211 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.211 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.211 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.211 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.211 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.211 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.211 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.211 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.211 9444== 
==00:02:11:12.211 9444== 107,666,592 bytes in 2,243,054 blocks are still reachable in loss record 1,226 of 1,228
==00:02:11:12.211 9444==    at 0x4C2A975: calloc (vg_replace_malloc.c:711)
==00:02:11:12.211 9444==    by 0x147532: propConstruct (prop.c:56)
==00:02:11:12.211 9444==    by 0x1476A7: CreateStringProp (prop.c:151)
==00:02:11:12.211 9444==    by 0x11DD42: resolveAddr (dnscache.c:349)
==00:02:11:12.211 9444==    by 0x11E500: addEntry (dnscache.c:374)
==00:02:11:12.211 9444==    by 0x11E500: dnscacheLookup (dnscache.c:427)
==00:02:11:12.211 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.211 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.211 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.211 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.211 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.211 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.211 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.211 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.211 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.211 9444== 
==00:02:11:12.211 9444== 289,751,680 bytes in 2,263,685 blocks are still reachable in loss record 1,227 of 1,228
==00:02:11:12.211 9444==    at 0x4C28BE3: malloc (vg_replace_malloc.c:299)
==00:02:11:12.211 9444==    by 0x11E549: addEntry (dnscache.c:379)
==00:02:11:12.211 9444==    by 0x11E549: dnscacheLookup (dnscache.c:427)
==00:02:11:12.211 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.211 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.211 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.211 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.211 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.211 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.211 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.211 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.211 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.211 9444==    by 0x146EBA: processBatch (ruleset.c:649)
==00:02:11:12.211 9444==    by 0x156583: msgConsumer (rsyslogd.c:695)
==00:02:11:12.211 9444==    by 0x142B8E: ConsumerReg (queue.c:2005)
==00:02:11:12.211 9444== 
==00:02:11:12.211 9444== 398,408,560 bytes in 2,263,685 blocks are still reachable in loss record 1,228 of 1,228
==00:02:11:12.211 9444==    at 0x4C28BE3: malloc (vg_replace_malloc.c:299)
==00:02:11:12.211 9444==    by 0x11E4E9: addEntry (dnscache.c:373)
==00:02:11:12.211 9444==    by 0x11E4E9: dnscacheLookup (dnscache.c:427)
==00:02:11:12.211 9444==    by 0x129498: resolveDNS (msg.c:496)
==00:02:11:12.211 9444==    by 0x129501: getRcvFromIP (msg.c:539)
==00:02:11:12.211 9444==    by 0x12B6A1: MsgGetProp (msg.c:3440)
==00:02:11:12.211 9444==    by 0x168657: evalVar (rainerscript.c:1985)
==00:02:11:12.211 9444==    by 0x168657: cnfexprEval (rainerscript.c:2515)
==00:02:11:12.211 9444==    by 0x16A059: doFuncCall (rainerscript.c:1909)
==00:02:11:12.211 9444==    by 0x1681B7: cnfexprEval (rainerscript.c:2551)
==00:02:11:12.211 9444==    by 0x14666B: execSet (ruleset.c:226)
==00:02:11:12.211 9444==    by 0x14666B: scriptExec (ruleset.c:591)
==00:02:11:12.211 9444==    by 0x146EBA: processBatch (ruleset.c:649)
==00:02:11:12.211 9444==    by 0x156583: msgConsumer (rsyslogd.c:695)
==00:02:11:12.211 9444==    by 0x142B8E: ConsumerReg (queue.c:2005)
~~~

To run the provided gdb script after applying the mentioned patch you need to change breakpoints' line numbers to correspond to the changed/shifted source code:

453                     etry = findEntry(addr);
454                     dbgprintf("dnscache: entry %p found\n", etry);

~~~
hbreak dnscache.c:454 if etry != 0

... snip ...

hbreak dnscache.c:454 if etry == 0
~~~

The results after applying the patch - ip address gets found in the cache immediately:

~~~
Thread 4 "rs:main Q:Reg" hit Breakpoint 2, dnscacheLookup (addr=0x7fb208002510, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fb1f711a690, ip=0x7fb1f711a698) at dnscache.c:454
454                     dbgprintf("dnscache: entry %p found\n", etry);
[+] addr:
$1 = {ss_family = 2, __ss_padding = "Ή\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$2 = (void *) 0x0
[+] hash(dnsCache.ht,addr):
$3 = 3121267676
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$4 = 0x7fb1f711b5f0 "127.0.0.1"

Thread 4 "rs:main Q:Reg" hit Breakpoint 1, dnscacheLookup (addr=0x7fb208002810, fqdn=0x0, fqdnLowerCase=0x0, localName=0x7fb1f711a690, ip=0x7fb1f711a698) at dnscache.c:454
454                     dbgprintf("dnscache: entry %p found\n", etry);
[+] etry:
$5 = {addr = {ss_family = 2, __ss_padding = "Ή\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}, fqdn = 0x7fb210003b10, fqdnLowerCase = 0x7fb210003b50, localName = 0x7fb210003b50, ip = 0x7fb210003b90, next = 0x0, nUsed = 0}
[+] addr:
$6 = {ss_family = 2, __ss_padding = "\260\255\177\000\000\001", '\000' <repeats 111 times>, __ss_align = 0}
[+] hashtable_search(dnsCache.ht,addr):
$7 = (void *) 0x7fb210003670
[+] *(*(dnscache_entry_t *)$)->fqdn:
$8 = {objData = {pObjInfo = 0x8af250, iObjCooCKiE = 195948526, pszName = 0x0}, iRefCount = 1, szVal = {psz = 0x736f686c61636f6c <error: Cannot access memory at address 0x736f686c61636f6c>, sz = "localhost\000\000\000\000\000\000"}, len = 9}
[+] hash(dnsCache.ht,addr):
$9 = 3121267676
[+] inet_ntoa((*(struct sockaddr_in *)addr)->sin_addr.s_addr):
$10 = 0x7fb1f711b5f0 "127.0.0.1"
(gdb)
~~~