### PR TITLE
imkafka: Fixed memory leak in msgConsume

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -244,9 +244,16 @@ static void msgConsume (instanceConf_t *inst) {
 					rkmessage->offset,
 					rkmessage->len);
 		enqMsg(inst, rkmessage);
+		/* Destroy message and continue */
 		rd_kafka_message_destroy(rkmessage);
+		rkmessage = NULL;
 	} while(1); /* loop broken inside */
-done:	return;
+done:
+	/* Destroy message in case rkmessage->err was set */
+	if(rkmessage != NULL) {
+		rd_kafka_message_destroy(rkmessage);
+	}
+	return;
 }
 
 

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -5,7 +5,7 @@ export TESTMESSAGES=10000
 export EXTRA_EXITCHECK=dumpkafkalogs
 # supression file needed because of this: 
 # https://github.com/edenhill/librdkafka/issues/1536
-export RS_TEST_VALGRIND_EXTRA_OPTS="--suppressions=librdkafka-bugs.supp"
+# export RS_TEST_VALGRIND_EXTRA_OPTS="--suppressions=librdkafka-bugs.supp"
 . $srcdir/diag.sh download-kafka
 . $srcdir/diag.sh stop-zookeeper
 . $srcdir/diag.sh stop-kafka


### PR DESCRIPTION
When rkmessage->err was set, rkmessage was not proberly destroyed with
rd_kafka_message_destroy.

Closes https://github.com/edenhill/librdkafka/issues/1536