### PR TITLE
imudp bugfix: potential segfault in ratelimiting

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -4,7 +4,7 @@
  * NOTE: read comments in module-template.h to understand how this file
  *       works!
  *
- * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2017 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -331,6 +331,7 @@ addListner(instanceConf_t *inst)
 			CHKiRet(prop.ConstructFinalize(newlcnfinfo->pInputName));
 			ratelimitSetLinuxLike(newlcnfinfo->ratelimiter, inst->ratelimitInterval,
 					      inst->ratelimitBurst);
+			ratelimitSetThreadSafe(newlcnfinfo->ratelimiter);
 			/* support statistics gathering */
 			CHKiRet(statsobj.Construct(&(newlcnfinfo->stats)));
 			CHKiRet(statsobj.SetName(newlcnfinfo->stats, dispname));


### PR DESCRIPTION
The rate-limiter inside imudp was not set to be thread safe, but was
used across multiple threads. This worked in default configuration,
but failed when RepeatedMsgReduction was set to "on".
Note that it in general is a bug to use a rate-limiter in
non-threadsafe mode across multiple threads. This also causes invalid
rate limiting counts in the default case.

closes https://github.com/rsyslog/rsyslog/issues/441
fixes https://github.com/rsyslog/rsyslog/issues/2132