### PR TITLE
testbench: do not run tests that require root permissions by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -343,6 +343,20 @@ fi
 AM_CONDITIONAL(ENABLE_GSSAPI, test x$enable_gssapi_krb5 = xyes)
 
 
+# shall the testbench try to run test that require root permissions?
+# This is uncommon. Test skip if run under non-root, but that pollutes the
+# testbench result. So the default is not to do that.
+AC_ARG_ENABLE(root_tests,
+        [AS_HELP_STRING([--enable-root-tests],[enable root tests in testbench @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_root_tests="yes" ;;
+          no) enable_root_tests="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-root-tests) ;;
+         esac],
+        [enable_root_tests=no]
+)
+AM_CONDITIONAL(ENABLE_ROOT_TESTS, test x$enable_root_tests = xyes)
+
 # multithreading via pthreads
 if test "$os_type" != "solaris"
 then

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -140,7 +140,6 @@ TESTS +=  \
 	sndrcv.sh \
 	sndrcv_failover.sh \
 	sndrcv_gzip.sh \
-	sndrcv_udp.sh \
 	sndrcv_udp_nonstdpt.sh \
 	sndrcv_udp_nonstdpt_v6.sh \
 	imudp_thread_hang.sh \
@@ -195,10 +194,6 @@ TESTS +=  \
 	imuxsock_logger_syssock.sh \
 	imuxsock_traillf_syssock.sh \
 	imuxsock_ccmiddle_syssock.sh \
-	imuxsock_logger_root.sh \
-	imuxsock_traillf_root.sh \
-	imuxsock_ccmiddle_root.sh \
-	imklog_permitnonkernelfacility_root.sh \
 	discard-rptdmsg.sh \
 	discard-allmark.sh \
 	discard.sh \
@@ -284,15 +279,9 @@ TESTS +=  \
 	lookup_table_rscript_reload_without_stub.sh \
 	multiple_lookup_tables.sh
 
-if ENABLE_IP
-TESTS += \
-	tcp_forwarding_ns_tpl.sh
-endif
-
 if HAVE_VALGRIND
 TESTS +=  \
 	mmexternal-SegFault-vg.sh \
-	mmexternal-SegFault-empty-jroot-vg.sh \
 	internal-errmsg-memleak.sh \
 	rscript_set_memleak-vg.sh \
 	no-parser-vg.sh \
@@ -320,6 +309,25 @@ TESTS +=  \
 	fac_local0-vg.sh \
 	rscript_trim-vg.sh
 endif # HAVE_VALGRIND
+
+if ENABLE_ROOT_TESTS
+TESTS +=  \
+	sndrcv_udp.sh \
+	imuxsock_logger_root.sh \
+	imuxsock_traillf_root.sh \
+	imuxsock_ccmiddle_root.sh \
+	imklog_permitnonkernelfacility_root.sh
+if ENABLE_IP
+TESTS += tcp_forwarding_ns_tpl.sh
+endif
+if ENABLE_RELP
+TESTS += sndrcv_relp_dflt_pt.sh
+endif
+if HAVE_VALGRIND
+TESTS +=  \
+	mmexternal-SegFault-empty-jroot-vg.sh
+endif
+endif
 
 if ENABLE_IMJOURNAL
 TESTS +=  \
@@ -635,7 +643,6 @@ endif
 if ENABLE_RELP
 TESTS += sndrcv_relp.sh \
 	 sndrcv_relp_rebind.sh \
-         sndrcv_relp_dflt_pt.sh \
 	 imrelp-basic.sh \
 	 imrelp-manyconn.sh
 if ENABLE_GNUTLS

--- a/tests/imuxsock_traillf.sh
+++ b/tests/imuxsock_traillf.sh
@@ -15,7 +15,11 @@ fi
 . $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
 cmp rsyslog.out.log $srcdir/resultdata/imuxsock_traillf.log
 if [ ! $? -eq 0 ]; then
-  echo "imuxsock_traillf_root.sh failed"
-  exit 1
+  echo "imuxsock_traillf.sh failed"
+  echo contents of rsyslog.out.log:
+  echo \"`cat rsyslog.out.log`\"
+  echo expected:
+  echo \"`cat $srcdir/resultdata/imuxsock_traillf.log`\"
+  . $srcdir/diag.sh error-exit 1
 fi;
 . $srcdir/diag.sh exit

--- a/tests/imuxsock_traillf_syssock.sh
+++ b/tests/imuxsock_traillf_syssock.sh
@@ -25,6 +25,8 @@ if [ ! $? -eq 0 ]; then
   echo "imuxsock_traillf_syssock failed"
   echo contents of rsyslog.out.log:
   echo \"`cat rsyslog.out.log`\"
+  echo expected:
+  echo \"`cat $srcdir/resultdata/imuxsock_traillf.log`\"
   exit 1
 fi;
 . $srcdir/diag.sh exit


### PR DESCRIPTION
Root permissions are uncommon in the CI environmen (requires very special
setup). Test skip if run under non-root, but that pollutes the
testbench result. So the default now is not to do that. The can still be
activated via --enable-root-tests configure switch.

closes https://github.com/rsyslog/rsyslog/issues/2192