### PR TITLE
testbench: provide capability to split testbench

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,11 @@ matrix:
        dist: trusty
      - os: linux
        compiler: "gcc"
-       env: BUILD_FROM_TARBALL="YES", GROK="YES", KAFKA="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all"
+       env: BUILD_FROM_TARBALL="YES", GROK="YES", KAFKA="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench1"
+       dist: trusty
+     - os: linux
+       compiler: "gcc"
+       env: BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2 -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench2"
        dist: trusty
      - os: linux
        compiler: "clang"

--- a/configure.ac
+++ b/configure.ac
@@ -1373,6 +1373,35 @@ AC_ARG_ENABLE(testbench,
         [enable_testbench=no]
 )
 
+# under Travis, we have a ~50 minute max runtime per VM. So we permit to
+# split the testbench in multiple runs, which we can place into different
+# VMs. It's not perfect, but it works...
+AC_ARG_ENABLE(testbench1,
+        [AS_HELP_STRING([--enable-testbench1],[testbench1 enabled @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_testbench1="yes" ;;
+          no) enable_testbench1="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-testbench1) ;;
+         esac],
+        [enable_testbench1=yes]
+)
+
+# under Travis, we have a ~50 minute max runtime per VM. So we permit to
+# split the testbench in multiple runs, which we can place into different
+# VMs. It's not perfect, but it works...
+AC_ARG_ENABLE(testbench2,
+        [AS_HELP_STRING([--enable-testbench2],[testbench2 enabled @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_testbench2="yes" ;;
+          no) enable_testbench2="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-testbench2) ;;
+         esac],
+        [enable_testbench2=yes]
+)
+
+AM_CONDITIONAL(ENABLE_TESTBENCH1, test "x${enable_testbench1}" = "xyes")
+AM_CONDITIONAL(ENABLE_TESTBENCH2, test "x${enable_testbench2}" = "xyes")
+
 AC_CHECK_PROG(IP, [ip], [yes], [no])
 if test "x${IP}" = "xno"; then
 	AC_MSG_NOTICE([Will not check network namespace functionality as 'ip' (part of iproute2) is not available.])
@@ -2263,6 +2292,8 @@ echo "    SNMP support enabled:                     $enable_snmp"
 echo
 echo "---{ debugging support }---"
 echo "    Testbench enabled:                        $enable_testbench"
+echo "    Testbench1 enabled:                       $enable_testbench1"
+echo "    Testbench2 enabled:                       $enable_testbench2"
 echo "    Extended Testbench enabled:               $enable_extended_tests"
 echo "    MySQL Tests enabled:                      $enable_mysql_tests"
 echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,7 +34,10 @@ TESTS = $(TESTRUNS)
 #TESTS = $(TESTRUNS) cfg.sh
 
 TESTS +=  \
-	empty-hostname.sh \
+	empty-hostname.sh 
+
+if ENABLE_TESTBENCH1
+TESTS +=  \
 	hostname-getaddrinfo-fail.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
@@ -209,7 +212,11 @@ TESTS +=  \
 	failover-rptd.sh \
 	failover-no-rptd.sh \
 	failover-no-basic.sh \
-	rcvr_fail_restore.sh \
+	rcvr_fail_restore.sh
+endif
+
+if ENABLE_TESTBENCH2
+TESTS +=  \
 	rscript_contains.sh \
 	rscript_ipv42num.sh \
 	rscript_field.sh \
@@ -284,6 +291,7 @@ TESTS +=  \
 	lookup_table_rscript_reload.sh \
 	lookup_table_rscript_reload_without_stub.sh \
 	multiple_lookup_tables.sh
+endif
 
 if ENABLE_IP
 TESTS += \

--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -70,6 +70,7 @@ $CC -v
 
 if [ "$DISTRIB_CODENAME" != "precise" ]; then AMQP1="--enable-omamqp1"; fi
 export CONFIG_FLAGS="$CONFIGURE_FLAGS \
+	$EXTRA_CONFIGURE \
 	$JOURNAL_OPT \
 	$HIREDIS_OPT \
 	$ENABLE_KAFKA \


### PR DESCRIPTION
This is necessary as we hit the Travis max runtime limit per VM,
so we need to duplicate the tests. This is done via
--enable-testbench1 and --enable-testbench2 which we than use
in different VMs.

This PR also includes updates to the Travis scripts so that we
use the new capability. We have only duplicated Travis VMs where
acutally necessary -- we may need to do more of this in the future.

closes https://github.com/rsyslog/rsyslog/issues/2196