### PR TITLE
cleanup: remove unused runtime instrumentation code

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -616,21 +616,6 @@ AC_ARG_ENABLE(debug_symbols,
 )
 
 
-# runtime instrumentation
-AC_ARG_ENABLE(rtinst,
-        [AS_HELP_STRING([--enable-rtinst],[Enable runtime instrumentation mode @<:@default=no@:>@])],
-        [case "${enableval}" in
-         yes) enable_rtinst="yes" ;;
-          no) enable_rtinst="no" ;;
-           *) AC_MSG_ERROR(bad value ${enableval} for --enable-rtinst) ;;
-         esac],
-        [enable_rtinst="no"]
-)
-if test "$enable_rtinst" = "yes"; then
-        AC_DEFINE(RTINST, 1, [Defined if runtime instrumentation mode is enabled.])
-fi
-
-
 # total debugless: highest performance, but no way at all to enable debug 
 # logging
 AC_ARG_ENABLE(debugless,
@@ -2313,7 +2298,6 @@ echo "    MySQL Tests enabled:                      $enable_mysql_tests"
 echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"
 echo "    Kafka Tests enabled:                      $enable_kafka_tests"
 echo "    Debug mode enabled:                       $enable_debug"
-echo "    Runtime Instrumentation enabled:          $enable_rtinst"
 echo "    (total) debugless mode enabled:           $enable_debugless"
 echo "    Diagnostic tools enabled:                 $enable_diagtools"
 echo "    End-User tools enabled:                   $enable_usertools"

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -636,21 +636,6 @@ dbgFuncDB_t *pFuncDB, int ln, int iStackPtr)
 /* ------------------------- end mutex tracking code ------------------------- */ 
 
 
-/* ------------------------- malloc/free tracking code ------------------------- */ 
-
-/* wrapper for free() */
-void dbgFree(void *pMem, dbgFuncDB_t *pFuncDB, int ln, int iStackPtr)
-{
-	dbgRecordExecLocation(iStackPtr, ln);
-	if(bLogAllocFree) {
-		dbgprintf("%s:%d:%s: free %p\n", pFuncDB->file, ln, pFuncDB->func, (void*) pMem);
-	}
-	free(pMem);
-}
-
-
-/* ------------------------- end malloc/free tracking code ------------------------- */ 
-
 /* ------------------------- thread tracking code ------------------------- */ 
 
 /* get ptr to call stack - if none exists, create a new stack
@@ -1306,20 +1291,6 @@ dbgPrintNameIsInList(const uchar *pName, dbgPrintName_t *pRoot)
 	}
 
 	return bFound;
-}
-
-
-/* this is a special version of malloc that fills the alloced memory with
- * HIGHVALUE, as this helps to identify bugs. -- rgerhards, 2009-10-22
- */
-void *
-dbgmalloc(size_t size)
-{
-	void *pRet;
-	pRet = malloc(size);
-	if(pRet != NULL)
-		memset(pRet, 0xff, size);
-	return pRet;
 }
 
 

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -129,30 +129,14 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #define dbgprintf(...) r_dbgprintf(__FILE__, __VA_ARGS__)
 #define dbgoprint(...) r_dbgoprint(__FILE__, __VA_ARGS__)
 
-#ifdef RTINST
-#define BEGINfunc static dbgFuncDB_t *pdbgFuncDB;
-	int dbgCALLStaCK_POP_POINT = dbgEntrFunc(&pdbgFuncDB, __FILE__, __func__, __LINE__);
-#	define ENDfunc dbgExitFunc(pdbgFuncDB, dbgCALLStaCK_POP_POINT, RS_RET_NO_IRET);
-#	define ENDfuncIRet dbgExitFunc(pdbgFuncDB, dbgCALLStaCK_POP_POINT, iRet);
-#	define ASSERT(x) assert(x)
-#else
-#	define BEGINfunc
-#	define ENDfunc
-#	define ENDfuncIRet
-#	define ASSERT(x)
-#endif
-#ifdef RTINST
-#define RUNLOG dbgSetExecLocation(dbgCALLStaCK_POP_POINT, __LINE__);
-	dbgprintf("%s:%d: %s: log point\n", __FILE__, __LINE__, __func__);
-#define RUNLOG_VAR(fmt, x) dbgSetExecLocation(dbgCALLStaCK_POP_POINT, __LINE__);\
-	 		          dbgprintf("%s:%d: %s: var '%s'[%s]: " fmt "\n", __FILE__, __LINE__, __func__, #x, fmt, x)
-#	define RUNLOG_STR(str)    dbgSetExecLocation(dbgCALLStaCK_POP_POINT, __LINE__);\
-				  dbgprintf("%s:%d: %s: %s\n", __FILE__, __LINE__, __func__, str)
-#else
-#	define RUNLOG
-#	define RUNLOG_VAR(fmt, x)
-#	define RUNLOG_STR(str)
-#endif
+/* things originally introduced for now remove rtinst */
+#define BEGINfunc
+#define ENDfunc
+#define ENDfuncIRet
+#define ASSERT(x) assert(x)
+#define RUNLOG
+#define RUNLOG_VAR(fmt, x)
+#define RUNLOG_STR(str)
 
 #ifdef MEMCHECK
 #	define MALLOC(x) dbgmalloc(x)
@@ -160,28 +144,16 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #	define MALLOC(x) malloc(x)
 #endif
 
-/* mutex operations */
 #define MUTOP_LOCKWAIT		1
 #define MUTOP_LOCK		2
 #define MUTOP_UNLOCK		3
 #define MUTOP_TRYLOCK		4
 
-
-/* debug aides */
-#ifdef RTINST
-#define d_pthread_mutex_lock(x)      dbgMutexLock(x, pdbgFuncDB, __LINE__, dbgCALLStaCK_POP_POINT )
-#define d_pthread_mutex_trylock(x)   dbgMutexTryLock(x, pdbgFuncDB, __LINE__, dbgCALLStaCK_POP_POINT )
-#define d_pthread_mutex_unlock(x)    dbgMutexUnlock(x, pdbgFuncDB, __LINE__, dbgCALLStaCK_POP_POINT )
-#define d_pthread_cond_wait(cond, mut)   dbgCondWait(cond, mut, pdbgFuncDB, __LINE__, dbgCALLStaCK_POP_POINT )
-#define d_pthread_cond_timedwait(cond, mut, to)   dbgCondTimedWait(cond, mut, to, \
-	pdbgFuncDB, __LINE__, dbgCALLStaCK_POP_POINT )
-#define d_free(x)      dbgFree(x, pdbgFuncDB, __LINE__, dbgCALLStaCK_POP_POINT )
-#else
+/* things originally introduced for now removed rtinst */
 #define d_pthread_mutex_lock(x)     pthread_mutex_lock(x)
 #define d_pthread_mutex_trylock(x)  pthread_mutex_trylock(x)
 #define d_pthread_mutex_unlock(x)   pthread_mutex_unlock(x)
 #define d_pthread_cond_wait(cond, mut)   pthread_cond_wait(cond, mut)
 #define d_pthread_cond_timedwait(cond, mut, to)   pthread_cond_timedwait(cond, mut, to)
 #define d_free(x)      free(x)
-#endif
 #endif /* #ifndef DEBUG_H_INCLUDED */


### PR DESCRIPTION
The --enable-rtinst configure switch and associated instrumentation
code dates back to the time pre-(valgrind, address sanitizer, ...).
It has not been actively used by rsyslog developers for years and is
inferior to the new debugging tools.

With this commit, we remove the --enable-rtinst option and do some
mild refactoring of the code itself. As it turned out, fully removing
the debug code requires a bit more of time, and we push this as a
follow-on activity. It's not as urgent as getting us to build
properly under all configure switches.

closes https://github.com/rsyslog/rsyslog/issues/2048