### PR TITLE
build system: enable --unlimited-select by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -554,13 +554,13 @@ fi
 
 # support for unlimited select() syscall
 AC_ARG_ENABLE(unlimited_select,
-        [AS_HELP_STRING([--enable-unlimited-select],[Enable unlimited select() syscall @<:@default=no@:>@])],
+        [AS_HELP_STRING([--enable-unlimited-select],[Enable unlimited select() syscall @<:@default=yes@:>@])],
         [case "${enableval}" in
          yes) enable_unlimited_select="yes" ;;
           no) enable_unlimited_select="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-unlimited-select) ;;
          esac],
-        [enable_unlimited_select="no"]
+        [enable_unlimited_select="yes"]
 )
 if test "$enable_unlimited_select" = "yes"; then
         AC_DEFINE(USE_UNLIMITED_SELECT, 1, [If defined, the select() syscall won't be limited to a particular number of file descriptors.])


### PR DESCRIPTION
This is essential and seems to be often forgotten. We enable it
in the hope that it does not break anything. If so, we need to
re-evaluate the default and situation.

see also https://github.com/rsyslog/rsyslog/issues/1459