### PR TITLE
debug system: output global and imrelp (listener) max message size

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -451,6 +451,7 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 		ABORT_FINALIZE(RS_RET_RELP_ERR);
 	}
 
+	DBGPRINTF("imrelp: max data size %zd\n", inst->maxDataSize);
 	resetConfigVariables(NULL,NULL);
 
 finalize_it:

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1942,6 +1942,7 @@ main(int argc, char **argv)
 	sd_notify(0, "READY=1");
 	dbgprintf("done signaling to systemd that we are ready!\n");
 #endif
+	DBGPRINTF("max message size: %d\n", glblGetMaxLine());
 	DBGPRINTF("----RSYSLOGD INITIALIZED\n");
 
 	mainloop();


### PR DESCRIPTION
Can be useful during debugging.

closes https://github.com/rsyslog/rsyslog/issues/2215