### PR TITLE
pmrfc3164: fix invalid whitespace-skip

### DIFF
--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -197,7 +197,7 @@ CODESTARTparse
 	 * by spaces or tabs followed '{' or '['.
 	 */
 	i = 0;
-	while(i < lenMsg && (p2parse[i] == ' ' || p2parse[i] == ' ')) {
+	while(i < lenMsg && (p2parse[i] == ' ' || p2parse[i] == '\t')) {
 		++i;
 	}
 	if(i < lenMsg && (p2parse[i] == '{' || p2parse[i] == '[')) {


### PR DESCRIPTION
regression from yesterday's commit, deteced by Coverity Scan,
CID 186292