### PR TITLE
imptcp: check if we really got a remote addr on connect

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -806,6 +806,10 @@ AcceptConnReq(ptcplstn_t *const pLstn, int *const newSock, prop_t **peerName, pr
 			    "on listen socket %d", pLstn->sock);
 		ABORT_FINALIZE(RS_RET_ACCEPT_ERR);
 	}
+	if(addrlen == 0) {
+		LogError(errno, RS_RET_ACCEPT_ERR, "AcceptConnReq could not obtain "
+			    "remote peer identification on listen socket %d", pLstn->sock);
+	}
 
 	if(pLstn->pSrv->bKeepAlive)
 		EnableKeepAlive(pLstn, iNewSock);/* we ignore errors, best to do! */


### PR DESCRIPTION
CI testing seems to indicate that we sometimes do not get valid
data, but so far we could not reliably reproduce this. This commit
introduces an additional check which emits an error message in
that case. The hope is that we will see it on further occasions or
get some reports. If that really happens, we should handle it.