### PR TITLE
Fix test so it will run on FreeBSD.

### DIFF
--- a/tests/rscript_format_time.sh
+++ b/tests/rscript_format_time.sh
@@ -1,12 +1,6 @@
 #!/bin/bash
 # Added 2017-10-03 by Stephen Workman, released under ASL 2.0
 
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
@@ -37,7 +31,8 @@ local4.* :omstdout:;outfmt
 
 EXPECTED='{ "rfc3164": "Oct  5 01:10:11", "rfc3339": "2017-10-05T01:10:11Z", "rfc3164Neg": "Mar 29 22:49:49", "rfc3339Neg": "1922-03-29T22:49:49Z", "str1": "2017-10-05T01:10:11Z", "strinv1": "ABC" }'
 
-echo "$EXPECTED" | cmp -b rsyslog.out.log
+# FreeBSD's cmp does not support reading from STDIN
+cmp <(echo "$EXPECTED") rsyslog.out.log
 
 if [[ $? -ne 0 ]]; then
   printf "Invalid function output detected!\n"


### PR DESCRIPTION
FreeBSD's `cmp` program does not read from STDIN.