### PR TITLE
imklog: local host IP was hardcoded to 127.0.0.1

### DIFF
--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -21,7 +21,7 @@
  * To test under Linux:
  * echo test1 > /dev/kmsg
  *
- * Copyright (C) 2008-2016 Adiscon GmbH
+ * Copyright (C) 2008-2017 Adiscon GmbH
  *
  * This file is part of rsyslog.
  *
@@ -400,7 +400,8 @@ ENDfreeCnf
 
 BEGINwillRun
 CODESTARTwillRun
-        iRet = klogWillRunPostPrivDrop(runModConf);
+	pLocalHostIP = glbl.GetLocalHostIP();
+	iRet = klogWillRunPostPrivDrop(runModConf);
 ENDwillRun
 
 
@@ -414,8 +415,6 @@ BEGINmodExit
 CODESTARTmodExit
 	if(pInputName != NULL)
 		prop.Destruct(&pInputName);
-	if(pLocalHostIP != NULL)
-		prop.Destruct(&pLocalHostIP);
 
 	/* release objects we used */
 	objRelease(glbl, CORE_COMPONENT);
@@ -459,11 +458,12 @@ CODEmodInit_QueryRegCFSLineHdlr
 
 	/* we need to create the inputName property (only once during our lifetime) */
 	CHKiRet(prop.CreateStringProp(&pInputName, UCHAR_CONSTANT("imklog"), sizeof("imklog") - 1));
-	CHKiRet(prop.CreateStringProp(&pLocalHostIP, UCHAR_CONSTANT("127.0.0.1"), sizeof("127.0.0.1") - 1));
 
 	/* init legacy config settings */
 	initConfigSettings();
 
+	CHKiRet(omsdRegCFSLineHdlr((uchar *)"klogLocalipif", 0, eCmdHdlrGoneAway,
+			NULL, NULL, STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"debugprintkernelsymbols", 0, eCmdHdlrGoneAway,
 			NULL, NULL, STD_LOADABLE_MODULE_ID));
 	CHKiRet(regCfSysLineHdlr2((uchar *)"klogpath", 0, eCmdHdlrGetWord,
@@ -487,5 +487,3 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler,
 			resetConfigVariables, NULL, STD_LOADABLE_MODULE_ID));
 ENDmodInit
-/* vim:set ai:
- */


### PR DESCRIPTION
This is now taken from the global localHostIP setting, which is used
consistent accross all modules.

Also, the removed (2012?) directive $klogLocalIPIF has been added
again but directly marked as removed. That way, an informative error
message is generated if someone tries to use it.

closes https://github.com/rsyslog/rsyslog/issues/2276