### PR TITLE
testbench: document problems with libfaketime 0.99.7

### DIFF
--- a/KNOWN_ISSUES
+++ b/KNOWN_ISSUES
@@ -1,0 +1,6 @@
+This lists known issue with dependencies and such.
+
+Libfaketime 0.99.7 has a bug that can cause segfaults during testbench
+runs. If you exprience them, either use --disable-libfaketime configure
+switch or go back to an older version.
+see also: https://github.com/rsyslog/rsyslog/issues/2099


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/2099