### PR TITLE
Fix lookup-table unsigned underflow in array-table lookup and empty-table handling across array and sparse-array tables

### DIFF
--- a/runtime/lookup.h
+++ b/runtime/lookup.h
@@ -37,7 +37,7 @@ struct lookup_tables_s {
 };
 
 struct lookup_array_tab_s {
-	int first_key;
+	uint32_t first_key;
 	uchar **interned_val_refs;
 };
 


### PR DESCRIPTION
* uint32 underflow fixed in array-table
* lookup on empty table fixed for array and sparse-array tables
* some trailing whitespaces deleted