### PR TITLE
rsyslogd: add capability to specify that no pid file shall be written

### DIFF
--- a/tools/rsyslogd.8
+++ b/tools/rsyslogd.8
@@ -94,7 +94,8 @@ which is the default.
 .BI "\-i " "pid file"
 Specify an alternative pid file instead of the default one.
 This option must be used if multiple instances of rsyslogd should
-run on a single machine.
+run on a single machine. To disable writing a pid file, use
+the reserved name "NONE" (all upper case!), so "-iNONE".
 .TP
 .B "\-n"
 Avoid auto-backgrounding.  This is needed especially if the


### PR DESCRIPTION
Command line option -iNONE provides this capability. This utilizes the
pre-existing -i option, but uses the special name "NONE" to turn of the
pid file check feature. Turning off is useful for systems where this no
longer is needed (e.g. systemd based).

closes https://github.com/rsyslog/rsyslog/issues/2143