### PR TITLE
testbench: increase default main queue timeouts

### DIFF
--- a/tests/testsuites/diag-common.conf
+++ b/tests/testsuites/diag-common.conf
@@ -13,7 +13,9 @@ $IMDiagServerRun 13500
 $template startupfile,"rsyslogd.started" # trick to use relative path names!
 :syslogtag, contains, "rsyslogd"  ?startupfile
 
-# I have disabled the directive below, so that we see errors in testcase
-# creation. I am not sure why it was present in the first place, so for
-# now I just leave it commented out -- rgerhards, 2011-03-30
-#$ErrorMessagesToStderr off
+# we increase the default timeouts - CI machines tend to be slow and
+# timing out causes cancelation, which results in irrelevant small
+# memory leaks (immediately before termination!). So we do not want
+# these. They make the testbench look instable.
+# Note: tests that need short timeouts need to overwrite them.
+main_queue(queue.timeoutshutdown="5000" queue.queue.timeoutactioncompletion="4500")

--- a/tests/testsuites/diag-common2.conf
+++ b/tests/testsuites/diag-common2.conf
@@ -13,4 +13,9 @@ $IMDiagServerRun 13501
 $template startupfile,"rsyslogd2.started" # trick to use relative path names!
 :syslogtag, contains, "rsyslogd"  ?startupfile
 
-$ErrorMessagesToStderr off
+# we increase the default timeouts - CI machines tend to be slow and
+# timing out causes cancelation, which results in irrelevant small
+# memory leaks (immediately before termination!). So we do not want
+# these. They make the testbench look instable.
+# Note: tests that need short timeouts need to overwrite them.
+main_queue(queue.timeoutshutdown="5000" queue.queue.timeoutactioncompletion="4500")


### PR DESCRIPTION
we increase the default timeouts - CI machines tend to be slow and
timing out causes cancelation, which results in irrelevant small
memory leaks (immediately before termination!). So we do not want
these. They make the testbench look instable.