### PR TITLE
omczmq: change minimum libczmq requirement again

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,7 @@
 ------------------------------------------------------------------------------
 Version 8.32.0 [v8-stable] 2018-01-09
 - NEW BUILD REQUIREMENTs:
-  - libczmq > 4 is now required for omczmq
+  - libczmq >= 3.0.2 is now required for omczmq
     This was actually required for quite some while, but not properly checked
     during configure run. If the lib was older, build failed. Now configure
     detects this and emits the appropiate error message.

--- a/configure.ac
+++ b/configure.ac
@@ -1950,7 +1950,7 @@ AC_ARG_ENABLE(omczmq,
         [enable_omczmq=no]
 )
 if test "x$enable_omczmq" = "xyes"; then
-   PKG_CHECK_MODULES(CZMQ, libczmq >= 4.0.0)
+   PKG_CHECK_MODULES(CZMQ, libczmq >= 3.0.2)
 fi
 AM_CONDITIONAL(ENABLE_OMCZMQ, test x$enable_omczmq = xyes)
 


### PR DESCRIPTION
On Ubuntu 16, we do not have libczmq 4, but omczmq obviously builds
fine with 3.0.2, so this seems to be the actual requirement. If that
works, I'll settle for now as I am finally totally confused on what
happens here. I have asked for help from those in the know, but
if we do not get a definitive answer, it'll stay so that it works
for us -- after all this is a contributed module...

closes https://github.com/rsyslog/rsyslog/issues/872