### PR TITLE
travis: reenable static analyzer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,13 +73,13 @@ matrix:
        dist: trusty
      - os: linux
        compiler: "clang"
-       env: STAT_AN="NOT_OK_YES", GROK="YES", KAFKA="YES", CFLAGS="-g -O2 -std=c99 -W -Wall -Wextra -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -Wno-unused-function"
+       env: STAT_AN="YES", GROK="YES", KAFKA="YES", CFLAGS="-g -O2 -std=c99 -W -Wall -Wextra -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -Wno-unused-function"
        # note: we currently need -Wno-unused-function until we fix inline
        # functions (C99 semantics are really ugly...)
        dist: trusty
      - os: linux
        compiler: "clang"
-       env: MERGE="YES", STAT_AN="NOT_OK_YES", CHECK="YES", GROK="YES", KAFKA="YES", CFLAGS="-g -O2 -std=c99 -W -Wall -Wextra -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -Wno-unused-function"
+       env: MERGE="YES", STAT_AN="YES", CHECK="YES", GROK="YES", KAFKA="YES", CFLAGS="-g -O2 -std=c99 -W -Wall -Wextra -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -Wno-unused-function"
        # note: we currently need -Wno-unused-function until we fix inline
        # functions (C99 semantics are really ugly...)
        dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ matrix:
        dist: trusty
      - os: linux
        compiler: "clang"
-       env: MERGE="YES", STAT_AN="YES", CHECK="YES", GROK="YES", KAFKA="YES", CFLAGS="-g -O2 -std=c99 -W -Wall -Wextra -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -Wno-unused-function"
+       env: MERGE="YES", CHECK="YES", GROK="YES", KAFKA="YES", CFLAGS="-g -O2 -std=c99 -W -Wall -Wextra -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -Wno-unused-function"
        # note: we currently need -Wno-unused-function until we fix inline
        # functions (C99 semantics are really ugly...)
        dist: trusty

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -68,7 +68,7 @@ if [ "$CC" == "clang" ] && [ "$DISTRIB_CODENAME" == "trusty" ]; then sudo add-ap
 sudo bash -c "echo \"deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-5.0 main\" > /etc/apt/sources.list.d/llvm.list" &&\
 wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add - &&\
 sudo apt-get update -yy  &&\
-sudo apt-get install clang-5.0; fi
+sudo apt-get install clang-5.0 clang-tools-5.0; fi
 
 if [ "$CC" == "clang" ] && [ "$DISTRIB_CODENAME" == "trusty" ]; then CLANG_PKG="clang-5.0"; SCAN_BUILD="scan-build-5.0"; else CLANG_PKG="clang"; SCAN_BUILD="scan-build"; fi
 if [ "$CC" == "clang" ]; then export NO_VALGRIND="--without-valgrind-testbench"; fi

--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -10,8 +10,7 @@ echo "CLANG:            $CLANG"
 
 echo "****************************** BEGIN ACTUAL SCRIPT STEP ******************************"
 # check code style. We do this only when DEBUGLESS is enabled,
-# so that we do not do it in each and every run. While once is sufficient,
-# STAT_AN for now gives us sufficient runtime reduction.
+# so that we do not do it in each and every run.
 if [ "x$DEBUGLESS" == "xYES" ] ; then source CI/check_line_length.sh ; fi
 
 source tests/travis/install.sh


### PR DESCRIPTION
LLVM has changed packaging structure, this fix adapts to it. So we
now have scan-build-5.0 again.