### PR TITLE
action bugfix: bHadAutoCommit handled in thread-unsafe way

### DIFF
--- a/action.c
+++ b/action.c
@@ -615,8 +615,8 @@ static rsRetVal getReturnCode(action_t * const pThis, wti_t * const pWti)
 			iRet = RS_RET_OK;
 			break;
 		case ACT_STATE_ITX:
-			if(pThis->bHadAutoCommit) {
-				pThis->bHadAutoCommit = 0; /* auto-reset */
+			if(pWti->actWrkrInfo[pThis->iActionNbr].bHadAutoCommit) {
+				pWti->actWrkrInfo[pThis->iActionNbr].bHadAutoCommit = 0; /* auto-reset */
 				iRet = RS_RET_PREVIOUS_COMMITTED;
 			} else {
 				iRet = RS_RET_DEFER_COMMIT;
@@ -1069,7 +1069,7 @@ handleActionExecResult(action_t *__restrict__ const pThis,
 			break;
 		case RS_RET_PREVIOUS_COMMITTED:
 			/* action state remains the same, but we had a commit. */
-			pThis->bHadAutoCommit = 1;
+			pWti->actWrkrInfo[pThis->iActionNbr].bHadAutoCommit = 1;
 			actionSetActionWorked(pThis, pWti); /* we had a successful call! */
 			break;
 		case RS_RET_DISABLE_ACTION:
@@ -1109,7 +1109,7 @@ actionCallDoAction(action_t *__restrict__ const pThis,
 	DBGPRINTF("entering actionCalldoAction(), state: %s, actionNbr %d\n",
 		  getActStateName(pThis, pWti), pThis->iActionNbr);
 
-	pThis->bHadAutoCommit = 0;
+	pWti->actWrkrInfo[pThis->iActionNbr].bHadAutoCommit = 0;
 	/* for this interface, we need to emulate the old style way
 	 * of parameter passing.
 	 */

--- a/action.h
+++ b/action.h
@@ -47,7 +47,6 @@ struct action_s {
 	/* should all mark msgs be written (not matter how recent the action was executed)? */
 	sbool	bReportSuspension;/* should suspension (and reactivation) of the action reported */
 	sbool	bReportSuspensionCont;
-	sbool	bHadAutoCommit;	/* did an auto-commit happen during doAction()? */
 	sbool	bDisabled;
 	sbool	isTransactional;
 	sbool	bCopyMsg;

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -47,6 +47,7 @@ typedef struct actWrkrInfo {
 	uint16_t uResumeOKinRow;/* number of times in a row that resume said OK with an
 				   immediate failure following */
 	int	iNbrResRtry;	/* number of retries since last suspend */
+	sbool	bHadAutoCommit;	/* did an auto-commit happen during doAction()? */
 	struct {
 		unsigned actState : 3;
 	} flags;


### PR DESCRIPTION
This internal state was improperly handled and most probably caused
(hard to see) issues when action instances were run on multiple worker
threads. It looks like the state variable was forgotten to move over
to worker state when action workers were introduced. This patch
fixes that.

closes https://github.com/rsyslog/rsyslog/issues/2046