### PR TITLE
core/queue: emit better status messages at rsyslog shutdown

### DIFF
--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -1073,8 +1073,8 @@ finalize_it:
  * is returned.
  * rgerhards, 2008-01-30
  */
-static uchar *
-GetName(obj_t *pThis)
+uchar * ATTR_NONNULL()
+objGetName(obj_t *const pThis)
 {
 	uchar *ret;
 	uchar szName[128];
@@ -1349,7 +1349,7 @@ CODESTARTobjQueryInterface(obj)
 	pIf->Deserialize = Deserialize;
 	pIf->DeserializePropBag = DeserializePropBag;
 	pIf->SetName = SetName;
-	pIf->GetName = GetName;
+	pIf->GetName = objGetName;
 finalize_it:
 ENDobjQueryInterface(obj)
 

--- a/runtime/obj.h
+++ b/runtime/obj.h
@@ -124,6 +124,7 @@ rsRetVal (*fFixup)(obj_t*,void*), void *pUsr, rsRetVal (*objConstruct)(), rsRetV
 rsRetVal (*objDeserialize)());
 rsRetVal objDeserializeProperty(var_t *pProp, strm_t *pStrm);
 rsRetVal objDeserializeDummy(obj_t *pObj, strm_t *pStrm);
+uchar *objGetName(obj_t *pThis);
 
 
 /* the following definition is only for "friends" */

--- a/tests/testsuites/threadingmq.conf
+++ b/tests/testsuites/threadingmq.conf
@@ -3,7 +3,8 @@
 # rgerhards, 2009-06-26
 $IncludeConfig diag-common.conf
 
-$MainMsgQueueTimeoutShutdown 100000
+$MainMsgQueueTimeoutShutdown 1
+#$MainMsgQueueTimeoutShutdown 100000
 
 $MainMsgQueueWorkerThreadMinimumMessages 10
 $MainMsgQueueWorkerThreads 5


### PR DESCRIPTION
this helps to diagnose issue - unfortunately we need more
work to ensure that the messages always make it to the user. This
is a start and hopefully useful at least for the testbench, possibly
more.