### PR TITLE
core/cstr: stringbuf.c: cstrGetSzStrNoNULL shall not modify buffer

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1068,6 +1068,7 @@ ENDobjDestruct(msg)
 			msgDestruct(&pNew);\
 			return NULL;\
 		}\
+		cstrFinalize(pNew->pCS##name); \
 	}
 /* Constructs a message object by duplicating another one.
  * Returns NULL if duplication failed. We do not need to lock the
@@ -2183,7 +2184,8 @@ rsRetVal MsgSetAPPNAME(smsg_t *__restrict__ const pMsg, const char* pszAPPNAME)
 		CHKiRet(rsCStrConstruct(&pMsg->pCSAPPNAME));
 	}
 	/* if we reach this point, we have the object */
-	iRet = rsCStrSetSzStr(pMsg->pCSAPPNAME, (uchar*) pszAPPNAME);
+	CHKiRet(rsCStrSetSzStr(pMsg->pCSAPPNAME, (uchar*) pszAPPNAME));
+	cstrFinalize(pMsg->pCSAPPNAME);
 
 finalize_it:
 	RETiRet;

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -761,6 +761,7 @@ strmReadLine(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF,
 
 	/* append previous message to current message if necessary */
 	if(pThis->prevLineSegment != NULL) {
+		cstrFinalize(pThis->prevLineSegment);
 		dbgprintf("readLine: have previous line segment: '%s'\n",
 			rsCStrGetSzStrNoNULL(pThis->prevLineSegment));
 		CHKiRet(cstrAppendCStr(*ppCStr, pThis->prevLineSegment));
@@ -1026,11 +1027,13 @@ finalize_it:
 	}
 	if(iRet == RS_RET_OK) {
 		pThis->strtOffs = pThis->iCurrOffs; /* we are at begin of next line */
+		cstrFinalize(*ppCStr);
 	} else {
 		if(   pThis->readTimeout
 		   && (pThis->prevMsgSegment != NULL)
 		   && (tCurr > pThis->lastRead + pThis->readTimeout)) {
 			if(rsCStrConstructFromCStr(ppCStr, pThis->prevMsgSegment) == RS_RET_OK) {
+				cstrFinalize(*ppCStr);
 				cstrDestruct(&pThis->prevMsgSegment);
 				pThis->lastRead = tCurr;
 				pThis->strtOffs = pThis->iCurrOffs; /* we are at begin of next line */

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -67,6 +67,9 @@ cstrConstruct(cstr_t **const ppThis)
 
 	CHKmalloc(pThis = (cstr_t*) malloc(sizeof(cstr_t)));
 	rsSETOBJTYPE(pThis, OIDrsCStr);
+	#ifndef NDEBUG
+	pThis->isFinalized = 0;
+	#endif
 	pThis->pBuf = NULL;
 	pThis->iBufSize = 0;
 	pThis->iStrLen = 0;
@@ -400,12 +403,8 @@ uchar*
 cstrGetSzStrNoNULL(cstr_t *const __restrict__ pThis)
 {
 	rsCHECKVALIDOBJECT(pThis, OIDrsCStr);
-
-	if(pThis->pBuf == NULL)
-		return (uchar*) "";
-
-	pThis->pBuf[pThis->iStrLen] = '\0'; /* space for this is reserved */
-	return(pThis->pBuf);
+	assert(pThis->isFinalized);
+	return (pThis->pBuf == NULL) ? (uchar*) "" : pThis->pBuf;
 }
 
 
@@ -433,6 +432,7 @@ rsRetVal cstrConvSzStrAndDestruct(cstr_t **ppThis, uchar **ppSz, int bRetNULL)
 
 	assert(ppThis != NULL);
 	pThis = *ppThis;
+	assert(pThis->isFinalized);
 	rsCHECKVALIDOBJECT(pThis, OIDrsCStr);
 	assert(ppSz != NULL);
 	assert(bRetNULL == 0 || bRetNULL == 1);

--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -36,6 +36,7 @@ typedef struct cstr_s
 {	
 #ifndef	NDEBUG
 	rsObjID OID;		/**< object ID */
+	sbool isFinalized;
 #endif
 	uchar *pBuf;		/**< pointer to the string buffer, may be NULL if string is empty */
 	size_t iBufSize;	/**< current maximum size of the string buffer */
@@ -70,10 +71,18 @@ rsRetVal cstrAppendChar(cstr_t *pThis, const uchar c);
  * but before that data is used.
  * rgerhards, 2009-06-16
  */
+#ifdef NDEBUG
 #define cstrFinalize(pThis) { \
 	if((pThis)->iStrLen > 0) \
 		(pThis)->pBuf[(pThis)->iStrLen] = '\0'; /* space is always reserved for this */ \
 }
+#else
+#define cstrFinalize(pThis) { \
+	if((pThis)->iStrLen > 0) \
+		(pThis)->pBuf[(pThis)->iStrLen] = '\0'; /* space is always reserved for this */ \
+	(pThis)->isFinalized = 1; \
+}
+#endif
 
 
 /**

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -114,7 +114,7 @@ case $1 in
 		rm -f rsyslog.input rsyslog.empty rsyslog.input.* imfile-state* omkafka-failed.data
 		rm -f testconf.conf HOSTNAME
 		rm -f rsyslog.errorfile tmp.qi
-		rm -f core.* vgcore.*
+		rm -f core.* vgcore.* core*
 		# Note: rsyslog.action.*.include must NOT be deleted, as it
 		# is used to setup some parameters BEFORE calling init. This
 		# happens in chained test scripts. Delete on exit is fine,
@@ -1034,6 +1034,20 @@ case $1 in
                 # try to gather as much information as possible. That's most important
 		# for systems like Travis-CI where we cannot debug on the machine itself.
 		# our $2 is the to-be-used exit code. if $3 is "stacktrace", call gdb.
+		if [ -e core* ]
+		then
+			echo trying to obtain crash location info
+			echo note: this may not be the correct file, check it
+			CORE=`ls core*`
+			echo "bt" >> gdb.in
+			echo "q" >> gdb.in
+			gdb ../tools/rsyslogd $CORE -batch -x gdb.in
+			CORE=
+			rm gdb.in
+		else
+			echo no core file found, cannot provide additional info
+			ls -l core*
+		fi
 		if [[ "$3" == 'stacktrace' || ( ! -e IN_AUTO_DEBUG &&  "$USE_AUTO_DEBUG" == 'on' ) ]]; then
 			if [ -e core* ]
 			then

--- a/tests/imfile-truncate-line.sh
+++ b/tests/imfile-truncate-line.sh
@@ -56,11 +56,11 @@ HEADER msgnum:2 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\\\n msgnum:3 bbbbb
 HEADER ccccccccccccccccccccccccccccccccccccc\\\\n msgnum:5 dddddddddddddddddddddddddddddddddddddddddddd
 HEADER msgnum:6 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee\\\\n msgnum:7 ffffffffffffffffffffffffffffffffffffffffffff\\\\n msgnum:8 ggggggg
 HEADER ggggggggggggggggggggggggggggggggggggg
-HEADER msgnum:9\n' | cmp -b rsyslog.out.log
+HEADER msgnum:9\n' | cmp -b - rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid multiline message generated, rsyslog.out.log is:"
   cat rsyslog.out.log
-  exit 1
+  . $srcdir/diag.sh error-exit 1
 fi;
 
 grep "imfile error:.*message will be split and processed" rsyslog2.out.log > /dev/null


### PR DESCRIPTION
**RIGHT NOW INCOMPLETE -- but need early access to CI system**

The currently done buffer modification (add of '\0') is bad, especially when
multiple threads access the same string. It is not really an issue that needs
to be urgently fixed, as always the same data is written. However, among others,
it will pollute the thread debugger and as such prevent more elaborate automatted
tests.

closes https://github.com/rsyslog/rsyslog/issues/1993