### PR TITLE
core: improve queue status reporting on shutdown

### DIFF
--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -95,7 +95,7 @@ rsRetVal wtiConstructFinalize(wti_t * const pThis);
 rsRetVal wtiDestruct(wti_t **ppThis);
 rsRetVal wtiWorker(wti_t * const pThis);
 rsRetVal wtiSetDbgHdr(wti_t * const pThis, uchar *pszMsg, size_t lenMsg);
-rsRetVal wtiCancelThrd(wti_t * const pThis);
+rsRetVal wtiCancelThrd(wti_t * const pThis, const uchar *const cancelobj);
 rsRetVal wtiSetAlwaysRunning(wti_t * const pThis);
 rsRetVal wtiSetState(wti_t * const pThis, int bNew);
 rsRetVal wtiWakeupThrd(wti_t * const pThis);

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -286,8 +286,8 @@ wtpShutdownAll(wtp_t *pThis, wtpState_t tShutdownCmd, struct timespec *ptTimeout
 /* Unconditionally cancel all running worker threads.
  * rgerhards, 2008-01-14
  */
-rsRetVal
-wtpCancelAll(wtp_t *pThis)
+rsRetVal ATTR_NONNULL()
+wtpCancelAll(wtp_t *pThis, const uchar *const cancelobj)
 {
 	DEFiRet;
 	int i;
@@ -296,7 +296,7 @@ wtpCancelAll(wtp_t *pThis)
 
 	/* go through all workers and cancel those that are active */
 	for(i = 0 ; i < pThis->iNumWorkerThreads ; ++i) {
-		wtiCancelThrd(pThis->pWrkr[i]);
+		wtiCancelThrd(pThis->pWrkr[i], cancelobj);
 	}
 
 	RETiRet;

--- a/runtime/wtp.h
+++ b/runtime/wtp.h
@@ -84,7 +84,7 @@ rsRetVal wtpProcessThrdChanges(wtp_t *pThis);
 rsRetVal wtpChkStopWrkr(wtp_t *pThis, int bLockUsrMutex);
 rsRetVal wtpSetState(wtp_t *pThis, wtpState_t iNewState);
 rsRetVal wtpWakeupAllWrkr(wtp_t *pThis);
-rsRetVal wtpCancelAll(wtp_t *pThis);
+rsRetVal wtpCancelAll(wtp_t *pThis, const uchar *const cancelobj);
 rsRetVal wtpSetDbgHdr(wtp_t *pThis, uchar *pszMsg, size_t lenMsg);
 rsRetVal wtpShutdownAll(wtp_t *pThis, wtpState_t tShutdownCmd, struct timespec *ptTimeout);
 PROTOTYPEObjClassInit(wtp);


### PR DESCRIPTION
The last commit (yesterday) did not properly convey when we actually
needed to cancel a thread. This commit corrects this and also
provides better information on the actual cancel operation and
some tipps for the user on how to solve it (timeout mentioned).