### PR TITLE
core: pidfile was not deleted upon shutdown

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1914,7 +1914,7 @@ deinitAll(void)
 	dbgClassExit();
 
 	/* NO CODE HERE - dbgClassExit() must be the last thing before exit()! */
-	if(!strcmp(PidFile, NO_PIDFILE)) {
+	if(strcmp(PidFile, NO_PIDFILE)) {
 		unlink(PidFile);
 	}
 }


### PR DESCRIPTION
this is a regeresson from recent commit 159b37afc881, bug was never
released