### PR TITLE
 doFuncReplace(): add tail of src if tail is partially similar to 'replaceWith'

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1636,35 +1636,34 @@ doFuncReplace(struct svar *__restrict__ const operandVal, struct svar *__restric
     uchar *replaceWith = es_getBufAddr(replaceWithStr);
     uint lfind = es_strlen(findStr);
     uint lReplaceWith = es_strlen(replaceWithStr);
-    uint size = 0;
+    uint lSrc = es_strlen(str);
+    uint lDst = 0;
     uchar* src_buff = es_getBufAddr(str);
     uint i, j;
-    for(i = j = 0; i <= es_strlen(str); i++, size++) {
+    for(i = j = 0; i <= lSrc; i++, lDst++) {
         if (j == lfind) {
-            size = size - lfind + lReplaceWith;
+            lDst = lDst - lfind + lReplaceWith;
             j = 0;
         }
-		if (i == es_strlen(str)) break;
+		if (i == lSrc) break;
 		if (src_buff[i] == find[j]) {
 			j++;
 		} else if (j > 0) {
 			i -= (j - 1);
-			size -= (j - 1);
+			lDst -= (j - 1);
 			j = 0;
 		}
     }
-    es_str_t *res = es_newStr(size);
+    es_str_t *res = es_newStr(lDst);
     unsigned char* dest = es_getBufAddr(res);
     uint k, s;
-    for(i = j = k = s = 0; i <= es_strlen(str); i++, s++) {
+    for(i = j = s = 0; i <= lSrc; i++, s++) {
         if (j == lfind) {
-            for (k = 0; k < lReplaceWith; k++) {
-                dest[s - j + k] = replaceWith[k];
-            }
-            s = s - j + lReplaceWith;
+            s -= j;
+            for (k = 0; k < lReplaceWith; k++, s++) dest[s] = replaceWith[k];
             j = 0;
         }
-		if (i == es_strlen(str)) break;
+		if (i == lSrc) break;
 		if (src_buff[i] == find[j]) {
 			j++;
 		} else {
@@ -1676,7 +1675,10 @@ doFuncReplace(struct svar *__restrict__ const operandVal, struct svar *__restric
 			dest[s] = src_buff[i];
 		}
     }
-    res->lenStr = size;
+    if (j > 0) {
+        for (k = 1; k <= j; k++) dest[s - k] = src_buff[i - k];
+    }
+    res->lenStr = lDst;
     if(freeOperand) es_deleteStr(str);
     if(freeFind) es_deleteStr(findStr);
     if(freeReplacement) es_deleteStr(replaceWithStr);

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -504,7 +504,7 @@ objlstAdd(struct objlst *root, struct cnfobj *o)
 {
 	struct objlst *l;
 	struct objlst *newl;
-	
+
 	newl = objlstNew(o);
 	if(root == 0) {
 		root = newl;
@@ -521,7 +521,7 @@ struct cnfstmt*
 scriptAddStmt(struct cnfstmt *root, struct cnfstmt *s)
 {
 	struct cnfstmt *l;
-	
+
 	if(root == NULL) {
 		root = s;
 	} else { /* find last, linear search ok, as only during config phase */
@@ -693,7 +693,7 @@ nvlstChkUnused(struct nvlst *lst)
 		if(!lst->bUsed) {
 			cstr = es_str2cstr(lst->name, NULL);
 			parser_errmsg("parameter '%s' not known -- "
-			  "typo in config file?", 
+			  "typo in config file?",
 			  cstr);
 			free(cstr);
 		}
@@ -1120,7 +1120,7 @@ nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 			  params->version, CNFPARAMBLK_VERSION);
 		return NULL;
 	}
-	
+
 	if(vals == NULL) {
 		bValsWasNULL = 1;
 		if((vals = calloc(params->nParams,
@@ -1164,7 +1164,7 @@ nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 }
 
 
-/* check if at least one cnfparamval is actually set 
+/* check if at least one cnfparamval is actually set
  * returns 1 if so, 0 otherwise
  */
 int
@@ -1428,7 +1428,7 @@ doExtractFieldByChar(uchar *str, uchar delim, const int matchnbr, uchar **resstr
 		}
 	}
 	DBGPRINTF("field() field requested %d, field found %d\n", matchnbr, iCurrFld);
-	
+
 	if(iCurrFld == matchnbr) {
 		/* field found, now extract it */
 		/* first of all, we need to find the end */
@@ -1480,14 +1480,14 @@ doExtractFieldByStr(uchar *str, char *delim, const rs_size_t lenDelim, const int
 		}
 	}
 	DBGPRINTF("field() field requested %d, field found %d\n", matchnbr, iCurrFld);
-	
+
 	if(iCurrFld == matchnbr) {
 		/* field found, now extract it */
 		/* first of all, we need to find the end */
 		pFldEnd = (uchar*) strstr((char*)pFld, delim);
 		if(pFldEnd == NULL) {
 			iLen = strlen((char*) pFld);
-		} else { /* found delmiter!  Note that pFldEnd *is* already on 
+		} else { /* found delmiter!  Note that pFldEnd *is* already on
 			  * the first delmi char, we don't need that. */
 			iLen = pFldEnd - pFld;
 		}
@@ -2062,7 +2062,7 @@ doFunc_is_time(const char *__restrict__ const str,
 			} else if (f == DATE_UNIX) {
 				int result;
 				var2Number(r, &result);
-				
+
 				if (result) {
 					DBGPRINTF("is_time: UNIX format found.\n");
 					ret = 1;
@@ -2400,7 +2400,7 @@ doFuncCall(struct cnffunc *__restrict__ const func, struct svar *__restrict__ co
 		if (sizeof(time_t) == sizeof(int)) {
 			if (unixtime < INT_MIN || unixtime > INT_MAX) {
 				LogMsg(
-					0, RS_RET_VAL_OUT_OF_RANGE, LOG_WARNING, 
+					0, RS_RET_VAL_OUT_OF_RANGE, LOG_WARNING,
 					"Timestamp value %lld is out of range for this system (time_t is "
 					"32bits)!\n", unixtime
 				);
@@ -2430,7 +2430,7 @@ doFuncCall(struct cnffunc *__restrict__ const func, struct svar *__restrict__ co
 
 		varFreeMembers(&r[0]);
 		varFreeMembers(&r[1]);
-		
+
 		break;
 	}
 	case CNFFUNC_PARSE_TIME: {
@@ -3054,7 +3054,7 @@ cnfexprEval(const struct cnfexpr *__restrict__ const expr,
 			cnfexprEval(expr->r, &r, usrptr, pWti);
 			if(var2Number(&r, &convok_r))
 				ret->d.n = 1ll;
-			else 
+			else
 				ret->d.n = 0ll;
 			varFreeMembers(&r);
 		}
@@ -3067,7 +3067,7 @@ cnfexprEval(const struct cnfexpr *__restrict__ const expr,
 			cnfexprEval(expr->r, &r, usrptr, pWti);
 			if(var2Number(&r, &convok_r))
 				ret->d.n = 1ll;
-			else 
+			else
 				ret->d.n = 0ll;
 			varFreeMembers(&r);
 		} else {
@@ -3222,7 +3222,7 @@ cnfexprDestruct(struct cnfexpr *__restrict__ const expr)
 		cnfexprDestruct(expr->l);
 		cnfexprDestruct(expr->r);
 		break;
-	case NOT: 
+	case NOT:
 	case 'M': /* unary */
 		cnfexprDestruct(expr->r);
 		break;
@@ -3447,7 +3447,7 @@ cnfexprPrint(struct cnfexpr *expr, int indent)
 		break;
 	}
 }
-/* print only the given stmt 
+/* print only the given stmt
  * if "subtree" equals 1, the full statement subtree is printed, else
  * really only the statement.
  */
@@ -3939,7 +3939,7 @@ cnfstmtNewAct(struct nvlst *lst)
 	struct cnfstmt* cnfstmt;
 	char namebuf[256];
 	rsRetVal localRet;
-	if((cnfstmt = cnfstmtNew(S_ACT)) == NULL) 
+	if((cnfstmt = cnfstmtNew(S_ACT)) == NULL)
 		goto done;
 	localRet = actionNewInst(lst, &cnfstmt->d.act);
 	if(localRet == RS_RET_OK_WARN) {
@@ -3965,7 +3965,7 @@ cnfstmtNewLegaAct(char *actline)
 {
 	struct cnfstmt* cnfstmt;
 	rsRetVal localRet;
-	if((cnfstmt = cnfstmtNew(S_ACT)) == NULL) 
+	if((cnfstmt = cnfstmtNew(S_ACT)) == NULL)
 		goto done;
 	cnfstmt->printable = (uchar*)strdup((char*)actline);
 	localRet = cflineDoAction(loadConf, (uchar**)&actline, &cnfstmt->d.act);
@@ -3984,7 +3984,7 @@ done:	return cnfstmt;
 
 /* returns 1 if the two expressions are constants, 0 otherwise
  * if both are constants, the expression subtrees are destructed
- * (this is an aid for constant folding optimizing) 
+ * (this is an aid for constant folding optimizing)
  */
 static int
 getConstNumber(struct cnfexpr *expr, long long *l, long long *r)
@@ -4121,7 +4121,7 @@ finalize_it:
 }
 
 /* optimize a comparison with a variable as left-hand operand
- * NOTE: Currently support CMP_EQ, CMP_NE only and code NEEDS 
+ * NOTE: Currently support CMP_EQ, CMP_NE only and code NEEDS
  *       TO BE CHANGED fgr other comparisons!
  */
 static struct cnfexpr*
@@ -4337,7 +4337,7 @@ removeNOPs(struct cnfstmt *root)
 {
 	struct cnfstmt *stmt, *toDel, *prevstmt = NULL;
 	struct cnfstmt *newRoot = NULL;
-	
+
 	if(root == NULL) goto done;
 	stmt = root;
 	while(stmt != NULL) {
@@ -4701,7 +4701,7 @@ initFunc_re_match(struct cnffunc *func)
 	func->funcdata = re;
 
 	regex = es_str2cstr(((struct cnfstringval*) func->expr[1])->estr, NULL);
-	
+
 	if((localRet = objUse(regexp, LM_REGEXP_FILENAME)) == RS_RET_OK) {
 		int errcode;
 		if((errcode = regexp.regcomp(re, (char*) regex, REG_EXTENDED) != 0)) {
@@ -5063,7 +5063,7 @@ cnfparamvalsDestruct(const struct cnfparamvals *paramvals, const struct cnfparam
 	free((void*)paramvals);
 }
 
-/* find the index (or -1!) for a config param by name. This is used to 
+/* find the index (or -1!) for a config param by name. This is used to
  * address the parameter array. Of course, we could use with static
  * indices, but that would create some extra bug potential. So we
  * resort to names. As we do this only during the initial config parsing

--- a/tests/rscript_replace_complex.sh
+++ b/tests/rscript_replace_complex.sh
@@ -9,8 +9,9 @@ echo \[rscript_replace_complex.sh\]: a more complex test for replace script-func
 echo doing shutdown
 . $srcdir/diag.sh shutdown-when-empty
 echo wait on shutdown
-. $srcdir/diag.sh wait-shutdown 
+. $srcdir/diag.sh wait-shutdown
 . $srcdir/diag.sh content-check "try to replace rsyslog and syrsyslog with rrsyslog"
 . $srcdir/diag.sh content-check "try to replace hello_world in hello_worldlo and helhello_world with hello_world_world"
 . $srcdir/diag.sh content-check "try to FBB in FBB_quux and quux_FBB with FBB"
+. $srcdir/diag.sh content-check "in the end of msg; try to not lose as_longer_this_string_as_more_probability_to_catch_the_bu"
 . $srcdir/diag.sh exit

--- a/tests/testsuites/complex_replace_input
+++ b/tests/testsuites/complex_replace_input
@@ -1,3 +1,4 @@
 <167>Mar  6 16:57:54 172.20.245.8 %PIX-7-710005: try to replace syslog and sysyslog with rsyslog
 <167>Mar  6 16:57:54 172.20.245.8 %PIX-7-710005: try to replace hello in hellolo and helhello with hello_world
 <167>Mar  6 16:57:54 172.20.245.8 %PIX-7-710005: try to foo_bar_baz in foo_bar_baz_quux and quux_foo_bar_baz with FBB
+<167>Mar  6 16:57:54 172.20.245.8 %PIX-7-710005: in the end of msg; try to not lose as_longer_this_string_as_more_probability_to_catch_the_bu

--- a/tests/testsuites/rscript_replace_complex.conf
+++ b/tests/testsuites/rscript_replace_complex.conf
@@ -7,5 +7,6 @@ input(type="imtcp" port="13514")
 set $.replaced_msg = replace($msg, "syslog", "rsyslog");
 set $.replaced_msg = replace($.replaced_msg, "hello", "hello_world");
 set $.replaced_msg = replace($.replaced_msg, "foo_bar_baz", "FBB");
+set $.replaced_msg = replace($.replaced_msg, "as_longer_this_string_as_more_probability_to_catch_the_bug", "ss");
 
 action(type="omfile" file="./rsyslog.out.log" template="outfmt")


### PR DESCRIPTION
there is a bug. To catch it just try to use config:
```
template(name="test" type="list") {
    property(name="$!all-json")
}
ruleset(name="test") {
    reset $!xxx=replace($msg, "==1234567890==", "=54321=");
    action(type="omfile" file="tmp/aaa" template="test")
}
*.* call test
```

do two calls 
` logger "A==1234567890=="`
`logger "A==1234567890="`

and see results into `/tmp/aaa`

So I submit a PR to resolve this bug. I have auto-replacement of trailing spaces. Also I have decreased the amount of calculations a bit. And have renamed/added a couple variables to align their names with other.
  