### PR TITLE
build system: enforce use of libfastjson 0.99.8

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -77,7 +77,7 @@ PKG_PROG_PKG_CONFIG
 # modules we require
 PKG_CHECK_MODULES(LIBESTR, libestr >= 0.1.9)
 
-PKG_CHECK_MODULES([LIBFASTJSON], [libfastjson >= 0.99.7],,)
+PKG_CHECK_MODULES([LIBFASTJSON], [libfastjson >= 0.99.8],,)
 
 AC_DEFINE_UNQUOTED([PLATFORM_ID], ["${host}"], [platform id for display purposes])
 # we don't mind if we don't have the lsb_release utility. But if we have, it's


### PR DESCRIPTION
This is now required because 0.99.7 has a bug with pretty serious
consequences for rsyslog.

closes https://github.com/rsyslog/rsyslog/issues/1839
closes https://github.com/rsyslog/rsyslog/issues/2268