### PR TITLE
Report unknown function calls as parser errors

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -4875,6 +4875,7 @@ cnffuncNew(es_str_t *fname, struct cnffparamlst* paramlst)
 	struct cnffparamlst *param, *toDel;
 	unsigned short i;
 	unsigned short nParams;
+	char *cstr;
 
 	/* we first need to find out how many params we have */
 	nParams = 0;
@@ -4888,6 +4889,14 @@ cnffuncNew(es_str_t *fname, struct cnffparamlst* paramlst)
 		func->funcdata = NULL;
 		func->destructable_funcdata = 1;
 		func->fID = funcName2ID(fname, nParams);
+
+		/* parse error if we have an unknown function */
+		if (func->fID == CNFFUNC_INVALID) {
+			cstr = es_str2cstr(fname, NULL);
+			parser_errmsg("Invalid function %s", cstr);
+			free(cstr);
+		}
+
 		/* shuffle params over to array (access speed!) */
 		param = paramlst;
 		for(i = 0 ; i < nParams ; ++i) {


### PR DESCRIPTION
I was using 8.24.0 that came with RHEL 7.4 and tried to use the `ltrim()` function.  It simply returned the value `0`.  Turns out that `ltrim()` didn't exist in 8.24.0, and the warning about that is only printed with debug enabled.  This will now print messages like:
```
rsyslogd: error during parsing file /path/to/rsyslog.conf, on or before line 34: Invalid function ztrim [v8.32.0.master try http://www.rsyslog.com/e/2207 ]
```

*maintainer edit: auto-close existing issue on merge*
closes https://github.com/rsyslog/rsyslog/issues/2187