### PR TITLE
[ci skip] Get more Open Source Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 Rsyslog - what is it?
 =====================
+
+[![Help Contribute to Open Source](https://www.codetriage.com/rsyslog/rsyslog/badges/users.svg)](https://www.codetriage.com/rsyslog/rsyslog)
+
 Rsyslog is a **r**ocket-fast **sys**tem for **log** processing.
 
 It offers high-performance, great security features and a modular design.
@@ -79,7 +82,7 @@ apt-get update && apt-get install -y build-essential pkg-config libestr-dev libf
 
 Aditional packages for other modules:
 ```
-libdbi-dev libmysqlclient-dev postgresql-client libpq-dev libnet-dev librdkafka-dev libgrok-dev libgrok1 libgrok-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev  
+libdbi-dev libmysqlclient-dev postgresql-client libpq-dev libnet-dev librdkafka-dev libgrok-dev libgrok1 libgrok-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev
 ```
 
 For KSI, from the Adiscon PPA:
@@ -142,7 +145,7 @@ Project Philosophy
 We are an open source project in all aspects and very open to outside feedback
 and contribution. We base our work on standards and try to solve all real-world
 needs (of course, we occasionally fail tackling actually all needs ;)). While
-the project is primarily sponsored by Adiscon, technical development is 
+the project is primarily sponsored by Adiscon, technical development is
 independent from company goals and most decisions are solely based on mailing
 list discussion results. There is an active community around rsyslog.
 


### PR DESCRIPTION
[CodeTriage](https://www.codetriage.com/) is an app I have maintained
for the past 4-5 years with the goal of getting people involved in
Open Source projects like this one. The app sends subscribers a random
open issue for them to help "triage". For some languages you can also
suggested areas to add documentation.

The initial approach was inspired by seeing the work of the small
core team spending countless hours asking "what version was
this in" and "can you give us an example app". The idea is to
outsource these small interactions to a huge team of volunteers
and let the core team focus on their work.

I want to add a badge to the README of this project. The idea is to
provide an easy link for people to get started contributing to this
project. A badge indicates the number of people currently subscribed
to help the repo. The color is based off of open issues in the project.

Here are some examples of other projects that have a badge in their
README:

- https://github.com/crystal-lang/crystal
- https://github.com/rails/rails
- https://github.com/codetriage/codetriage

Thanks for building open source software, I would love to help you find some helpers.