### PR TITLE
imfile: Fixed issues not detecting files in directory when wildcards …

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -740,17 +740,17 @@ TESTS += \
 	imfile-endregex-timeout-with-shutdown-polling.sh \
 	imfile-persist-state-1.sh \
 	imfile-wildcards.sh \
+	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \
 	imfile-rename.sh
 
-# we TEMPORARILY disable these tests to permit "normal" CI runs
-# because we know they sometimes fail due to a confirmed bug
-# inside imfile:
-# https://github.com/rsyslog/rsyslog/issues/2271
-# rgerhards, 2017-12-30
-#	imfile-wildcards-dirs.sh \
+# TEMPORARILY disable some imfile tests because refactoring 
+# is needed to get them to work 100% all the time.
+# alorbach, 2018-01-05
 #	imfile-wildcards-dirs-multi.sh \
 #	imfile-wildcards-dirs-multi2.sh \
+#	imfile-wildcards-dirs-multi3.sh \
+#	imfile-wildcards-dirs-multi4.sh \
 #
 
 if HAVE_VALGRIND
@@ -1419,12 +1419,16 @@ EXTRA_DIST= \
 	imfile-wildcards-dirs2.sh \
 	imfile-wildcards-dirs-multi.sh \
 	imfile-wildcards-dirs-multi2.sh \
+	imfile-wildcards-dirs-multi3.sh \
+	imfile-wildcards-dirs-multi4.sh \
 	imfile-rename.sh \
 	testsuites/imfile-wildcards.conf \
 	testsuites/imfile-wildcards-simple.conf \
 	testsuites/imfile-wildcards-dirs.conf \
 	testsuites/imfile-wildcards-dirs-multi.conf \
 	testsuites/imfile-wildcards-dirs-multi2.conf \
+	testsuites/imfile-wildcards-dirs-multi3.conf \
+	testsuites/imfile-wildcards-dirs-multi4.conf \
 	dynfile_invld_async.sh \
 	dynfile_invld_sync.sh \
 	dynfile_cachemiss.sh \

--- a/tests/imfile-wildcards-dirs-multi.sh
+++ b/tests/imfile-wildcards-dirs-multi.sh
@@ -2,17 +2,15 @@
 # This is part of the rsyslog testbench, licensed under GPLv3
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"
-export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
-echo [imfile-wildcards-multi.sh]
-. $srcdir/diag.sh check-inotify
+#export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
+export IMFILECHECKTIMEOUT="5"
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify-only
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
 
 # Start rsyslog now before adding more files
 . $srcdir/diag.sh startup imfile-wildcards-dirs-multi.conf
-# sleep a little to give rsyslog a chance to begin processing
-sleep 1
 
 for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
 do
@@ -21,27 +19,25 @@ do
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		mkdir rsyslog.input.dir$i
-		./msleep 50
 		mkdir rsyslog.input.dir$i/dir$i
-		./msleep 50
 		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$i/file.logfile
-		./msleep 100
 	done
+
 	ls -d rsyslog.input.*
+	
+	# Check correct amount of input files each time
+	let IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $j))
+	. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 
 	# Delete all but first!
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		rm -rf rsyslog.input.dir$i/dir$i/file.logfile
-		./msleep 100
 		rm -rf rsyslog.input.dir$i
 	done
-done
 
-# sleep a little to give rsyslog a chance for processing
-sleep 1
+done
 
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
-. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL
 . $srcdir/diag.sh exit

--- a/tests/imfile-wildcards-dirs-multi3.sh
+++ b/tests/imfile-wildcards-dirs-multi3.sh
@@ -16,7 +16,9 @@ do
 done
 
 # Start rsyslog now before adding more files
-. $srcdir/diag.sh startup imfile-wildcards-dirs-multi2.conf
+. $srcdir/diag.sh startup imfile-wildcards-dirs-multi3.conf
+# sleep a little to give rsyslog a chance to begin processing
+sleep 2
 
 for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
 do
@@ -26,7 +28,8 @@ do
 		echo "Make rsyslog.input.dir$i/dir$j/testdir"
 		mkdir rsyslog.input.dir$i/dir$j
 		mkdir rsyslog.input.dir$i/dir$j/testdir
-		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$j/testdir/file.logfile
+		mkdir rsyslog.input.dir$i/dir$j/testdir/subdir$j
+		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$j/testdir/subdir$j/file.logfile
 	done
 	ls -d rsyslog.input.*
 
@@ -37,8 +40,8 @@ do
 	# Delete all but first!
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
-		rm -rf rsyslog.input.dir$i/dir$j/testdir/file.logfile
-		rm -rr rsyslog.input.dir$i/dir$j
+		rm -rf rsyslog.input.dir$i/dir$j/testdir/subdir$j/file.logfile
+		rm -rf rsyslog.input.dir$i/dir$j
 	done
 done
 

--- a/tests/imfile-wildcards-dirs-multi4.sh
+++ b/tests/imfile-wildcards-dirs-multi4.sh
@@ -9,14 +9,14 @@ export IMFILECHECKTIMEOUT="5"
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
 
+# Start rsyslog now before adding more files
+. $srcdir/diag.sh startup imfile-wildcards-dirs-multi4.conf
+
 for i in `seq 1 $IMFILEINPUTFILES`;
 do
 	echo "Make rsyslog.input.dir$i"
 	mkdir rsyslog.input.dir$i
 done
-
-# Start rsyslog now before adding more files
-. $srcdir/diag.sh startup imfile-wildcards-dirs-multi2.conf
 
 for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
 do
@@ -26,7 +26,10 @@ do
 		echo "Make rsyslog.input.dir$i/dir$j/testdir"
 		mkdir rsyslog.input.dir$i/dir$j
 		mkdir rsyslog.input.dir$i/dir$j/testdir
-		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$j/testdir/file.logfile
+		mkdir rsyslog.input.dir$i/dir$j/testdir/su$j
+		mkdir rsyslog.input.dir$i/dir$j/testdir/su$j/bd$j
+		mkdir rsyslog.input.dir$i/dir$j/testdir/su$j/bd$j/ir$j
+		./inputfilegen -m 1 > rsyslog.input.dir$i/dir$j/testdir/su$j/bd$j/ir$j/file.logfile
 	done
 	ls -d rsyslog.input.*
 
@@ -37,8 +40,8 @@ do
 	# Delete all but first!
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
-		rm -rf rsyslog.input.dir$i/dir$j/testdir/file.logfile
-		rm -rr rsyslog.input.dir$i/dir$j
+		rm -rf rsyslog.input.dir$i/dir$j/testdir/su$j/bd$j/ir$j/file.logfile
+		rm -rf rsyslog.input.dir$i/dir$j
 	done
 done
 

--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -9,20 +9,13 @@ echo [imfile-wildcards-dirs.sh]
 
 # Start rsyslog now before adding more files
 . $srcdir/diag.sh startup imfile-wildcards-dirs.conf
-# sleep a little to give rsyslog a chance to begin processing
-sleep 1
 
 for i in `seq 1 $IMFILEINPUTFILES`;
 do
 	mkdir rsyslog.input.dir$i
 	./inputfilegen -m 1 > rsyslog.input.dir$i/file.logfile
 done
-# wait for imfile to process
-./msleep 250 
 ls -d rsyslog.input.*
-
-# sleep a little to give rsyslog a chance for processing
-sleep 1
 
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -2,10 +2,10 @@
 # This is part of the rsyslog testbench, licensed under GPLv3
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"
-export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
-echo [imfile-wildcards-dirs2.sh]
-. $srcdir/diag.sh check-inotify
+#export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
+export IMFILECHECKTIMEOUT="5"
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify-only
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
 
@@ -21,15 +21,17 @@ do
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		mkdir rsyslog.input.dir$i
-		./msleep 50
 		./inputfilegen -m 1 > rsyslog.input.dir$i/file.logfile
 	done
 	ls -d rsyslog.input.*
+
+	# Check correct amount of input files each time
+	let IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $j))
+	. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 	
 	# Delete all but first!
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
-#		rm -rf rsyslog.input.dir$i/file.logfile
 		rm -rf rsyslog.input.dir$i/
 	done
 done
@@ -39,5 +41,4 @@ sleep 1
 
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!
-. $srcdir/diag.sh content-check-with-count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL
 . $srcdir/diag.sh exit

--- a/tests/imfile-wildcards.sh
+++ b/tests/imfile-wildcards.sh
@@ -12,8 +12,6 @@ imfilebefore="rsyslog.input.1.log"
 
 # Start rsyslog now before adding more files
 . $srcdir/diag.sh startup imfile-wildcards.conf
-# sleep a little to give rsyslog a chance to begin processing
-sleep 1
 
 for i in `seq 2 $IMFILEINPUTFILES`;
 do
@@ -24,9 +22,6 @@ do
 done
 ./inputfilegen -m 3 > rsyslog.input.$((IMFILEINPUTFILES + 1)).log
 ls -l rsyslog.input.*
-
-# sleep a little to give rsyslog a chance for processing
-sleep 1
 
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown	# we need to wait until rsyslogd is finished!

--- a/tests/testsuites/imfile-wildcards-dirs-multi3.conf
+++ b/tests/testsuites/imfile-wildcards-dirs-multi3.conf
@@ -1,0 +1,35 @@
+$IncludeConfig diag-common.conf
+$WorkDirectory test-spool
+
+/* Filter out busy debug output, comment out if needed */
+global(
+	debug.whitelist="off"
+	debug.files=["rainerscript.c", "ratelimit.c", "ruleset.c", "main Q", "msg.c", "../action.c"]
+)
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./rsyslog.input.*/*/testdir/*/file.logfile"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+)
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="', ")
+  property(name="$!metadata!filename")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )

--- a/tests/testsuites/imfile-wildcards-dirs-multi4.conf
+++ b/tests/testsuites/imfile-wildcards-dirs-multi4.conf
@@ -1,0 +1,35 @@
+$IncludeConfig diag-common.conf
+$WorkDirectory test-spool
+
+/* Filter out busy debug output, comment out if needed */
+global(
+	debug.whitelist="off"
+	debug.files=["rainerscript.c", "ratelimit.c", "ruleset.c", "main Q", "msg.c", "../action.c"]
+)
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./rsyslog.input.dir1/*/*/*/*/*/file.logfile"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+)
+
+template(name="outfmt" type="list") {
+  constant(value="HEADER ")
+  property(name="msg" format="json")
+  constant(value="', ")
+  property(name="$!metadata!filename")
+  constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file="rsyslog.out.log"
+   template="outfmt"
+ )


### PR DESCRIPTION
…are used.

When directories and files were created at the same time,
imfile missed the file in some cases (Timing issue).

The handling has been fixed to scan newly created directories ALWAYS for
matching files.

This should fix following issues:
closes https://github.com/rsyslog/rsyslog/issues/2271

However we still have a problem when a directory exist that matches a multilevel wildcard pattern before rsyslog is started. This is discussed here https://github.com/rsyslog/rsyslog/issues/2354

  
  