### PR TITLE
testbench: enable more tests on BSD

### DIFF
--- a/tests/glbl_setenv.sh
+++ b/tests/glbl_setenv.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
@@ -23,7 +16,7 @@ template(name="outfmt" type="string" string="%$!prx%\n")
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
 . $srcdir/diag.sh wait-shutdown    # we need to wait until rsyslogd is finished!
 
-echo 'http://127.0.0.1' | cmp rsyslog.out.log
+echo 'http://127.0.0.1' | cmp - rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid content seen, rsyslog.out.log is:"
   cat rsyslog.out.log

--- a/tests/pmrfc3164-AtSignsInHostname.sh
+++ b/tests/pmrfc3164-AtSignsInHostname.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
@@ -29,7 +22,7 @@ ruleset(name="customparser" parser="custom.rfc3164") {
 echo '-Hostname1-
 -Hostn@me2-
 -Hostname3-
--Hos@name4-' | cmp rsyslog.out.log
+-Hos@name4-' | cmp - rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid response generated, rsyslog.out.log is:"
   cat rsyslog.out.log

--- a/tests/pmrfc3164-AtSignsInHostname_off.sh
+++ b/tests/pmrfc3164-AtSignsInHostname_off.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '

--- a/tests/pmrfc3164-defaultTag.sh
+++ b/tests/pmrfc3164-defaultTag.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
@@ -29,7 +22,7 @@ ruleset(name="customparser" parser="custom.rfc3164") {
 echo '?Hostname1?-?  msgnum:1?
 ?Hostname2?-?   msgnum:2?
 ?Hostname3?-? tag msgnum:3?
-?Hostname4?tag:? msg?' | cmp rsyslog.out.log
+?Hostname4?tag:? msg?' | cmp - rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid response generated, rsyslog.out.log is:"
   cat rsyslog.out.log

--- a/tests/pmrfc3164-msgFirstSpace.sh
+++ b/tests/pmrfc3164-msgFirstSpace.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
@@ -29,7 +22,7 @@ ruleset(name="customparser" parser="custom.rfc3164") {
 echo '-msgnum:1-
 - msgnum:2-
 -msgnum:3-
---' | cmp rsyslog.out.log
+--' | cmp - rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid response generated, rsyslog.out.log is:"
   cat rsyslog.out.log

--- a/tests/pmrfc3164-tagEndingByColon.sh
+++ b/tests/pmrfc3164-tagEndingByColon.sh
@@ -1,12 +1,5 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
@@ -29,7 +22,7 @@ ruleset(name="customparser" parser="custom.rfc3164") {
 . $srcdir/diag.sh wait-shutdown
 echo '-tag1:- msgnum:1-
 -tag2:-  msgnum:2-
--tag5:-msgnum:5-' | cmp rsyslog.out.log
+-tag5:-msgnum:5-' | cmp - rsyslog.out.log
 if [ ! $? -eq 0 ]; then
   echo "invalid response generated, rsyslog.out.log is:"
   cat rsyslog.out.log


### PR DESCRIPTION
These tests have command line tool incompatibilities which are
easy to solve. This doesn't fix all test's issues, but at least
we get some more on board.