### PR TITLE
build system: check for existance of req. header if mmgrok is enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1138,6 +1138,7 @@ AC_ARG_ENABLE(mmgrok,
         [enable_mmgrok=no]
 )
 if test "x$enable_mmgrok" = "xyes"; then
+        AC_CHECK_HEADERS([grok.h])
 	GLIB_CFLAGS="$(pkg-config --cflags glib-2.0)"
 	GLIB_LIBS="$(pkg-config --libs glib-2.0)"
 fi


### PR DESCRIPTION
Else we get a make failure. With this patch, we bail out during
./configure time, which is easier to handle.

Note that a check for libgrok did not work and we did not want to
invest more time for this *contribute* module (aka non-official).

closes https://github.com/rsyslog/rsyslog/issues/871