### PR TITLE
add global config setting shutdown.enable.ctl-c to enable ctl-c

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -127,6 +127,7 @@ int glblIntMsgRateLimitBurst = 500;
 char** glblDbgFiles = NULL;
 size_t glblDbgFilesNum = 0;
 int glblDbgWhitelist = 1;
+int glblPermitCtlC = 0;
 
 pid_t glbl_ourpid;
 #ifndef HAVE_ATOMIC_BUILTINS
@@ -185,6 +186,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "internalmsg.ratelimit.interval", eCmdHdlrPositiveInt, 0 },
 	{ "internalmsg.ratelimit.burst", eCmdHdlrPositiveInt, 0 },
 	{ "errormessagestostderr.maxnumber", eCmdHdlrPositiveInt, 0 },
+	{ "shutdown.enable.ctl-c", eCmdHdlrBinary, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
 	{ "debug.whitelist", eCmdHdlrBinary, 0 }
 };
@@ -1290,6 +1292,8 @@ glblDoneLoadCnf(void)
 		        glblDbgWhitelist = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "umask")) {
 		        loadConf->globals.umask = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "shutdown.enable.ctl-c")) {
+		        glblPermitCtlC = (int) cnfparamvals[i].val.d.n;
 		} else {
 			dbgprintf("glblDoneLoadCnf: program error, non-handled "
 			  "param '%s'\n", paramblk.descr[i].name);

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -121,6 +121,7 @@ extern int glblIntMsgRateLimitBurst;
 extern char** glblDbgFiles;
 extern size_t glblDbgFilesNum;
 extern int glblDbgWhitelist;
+extern int glblPermitCtlC;
 
 #define glblGetOurPid() glbl_ourpid
 #define glblSetOurPid(pid) { glbl_ourpid = (pid); }

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1486,7 +1486,7 @@ initAll(int argc, char **argv)
 
 	hdlr_enable(SIGPIPE, SIG_IGN);
 	hdlr_enable(SIGXFSZ, SIG_IGN);
-	if(Debug) {
+	if(Debug || glblPermitCtlC) {
 		hdlr_enable(SIGUSR1, rsyslogdDebugSwitch);
 		hdlr_enable(SIGINT,  rsyslogdDoDie);
 		hdlr_enable(SIGQUIT, rsyslogdDoDie);


### PR DESCRIPTION
It can be useful to ctl-c out of rsyslog, even if it is started via
-n, especially inside containers.  The new config setting permits
to enable this capability.

closes https://github.com/rsyslog/rsyslog/issues/533