### PR TITLE
action: fix memory leak when errorfile capability is used

### DIFF
--- a/action.c
+++ b/action.c
@@ -1334,6 +1334,7 @@ actionWriteErrorFile(action_t *__restrict__ const pThis, const rsRetVal ret,
 				"action %s: error writing errorFile %s, write returned %lld",
 				pThis->pszName, pThis->pszErrFile, (long long) wrRet);
 		}
+		free(rendered);
 
 		fjson_object_put(etry);
 		etry = NULL;


### PR DESCRIPTION
regression from recent commit c1a601e72f779328994c6c344ef4e7576a57e5c3
Not present in any released code.

Detected by Coverity Scan, CID 186455