### PR TITLE
core: do not write pid file by default if running as pid 1

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -160,7 +160,7 @@ int bFinished = 0;	/* used by termination signal handler, read-only except there
 			 * is either 0 or the number of the signal that requested the
  			 * termination.
 			 */
-const char *PidFile = PATH_PIDFILE;
+const char *PidFile;
 #define NO_PIDFILE "NONE"
 int iConfigVerify = 0;	/* is this just a config verify run? */
 rsconf_t *ourConf = NULL;	/* our config object */
@@ -1342,6 +1342,7 @@ initAll(int argc, char **argv)
 			ConfFile = (uchar*) arg;
 			break;
 		case 'i':		/* pid file name */
+			free((void*)PidFile);
 			PidFile = arg;
 			break;
 		case 'l':
@@ -1951,7 +1952,16 @@ main(int argc, char **argv)
 		fprintf(stderr, "rsyslogd %s: running as pid 1, enabling "
 			"container-specific defaults, press ctl-c to "
 			"terminate rsyslog\n", VERSION);
+		PidFile = strdup("NONE"); /* disables pid file writing */
 		glblPermitCtlC = 1;
+	} else {
+		/* "dynamic defaults" - non-container case */
+		PidFile = strdup(PATH_PIDFILE);
+	}
+	if(PidFile == NULL) {
+		fprintf(stderr, "rsyslogd: could not alloc memory for pid file "
+			"default name - aborting\n");
+		exit(1);
 	}
 
 	/* disable case-sensitive comparisons in variable subsystem: */


### PR DESCRIPTION
This means we run inside a container and writing pid files is unnecessary
and bad practice in this case.