### PR TITLE
fix build warning on Alpine Linux

### DIFF
--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -31,14 +31,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
-#if defined(_AIX) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__DragonFlyBSD__) || defined(__APPLE__)
 #include <sys/wait.h>
-#else
-#include <wait.h>
-#endif
-#ifdef _AIX /* AIXPORT */
-#include <errno.h>
-#endif /* AIXPORT */
 #include <sys/uio.h>
 #include "conf.h"
 #include "syslogd-types.h"

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -36,11 +36,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
-#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <sys/wait.h>
-#else
-#include <wait.h>
-#endif
 #if defined(__linux__) && defined(_GNU_SOURCE)
 #include <sys/syscall.h>
 #include <sys/types.h>

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -29,15 +29,11 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
+#include <errno.h>
 #ifdef HAVE_LIBLOGGING_STDLOG
 #  include <liblogging/stdlog.h>
 #else
 #  include <syslog.h>
-#endif
-#if defined(OS_SOLARIS) || defined(OS_BSD)
-#	include <errno.h>
-#else
-#	include <sys/errno.h>
 #endif
 #ifdef HAVE_LIBSYSTEMD
 #	include <systemd/sd-daemon.h>

--- a/tools/syslogd.c
+++ b/tools/syslogd.c
@@ -57,12 +57,7 @@
 #include <stdarg.h>
 #include <time.h>
 #include <assert.h>
-
-#if defined(OS_SOLARIS) || defined(OS_BSD)
-#	include <errno.h>
-#else
-#	include <sys/errno.h>
-#endif
+#include <errno.h>
 
 #ifdef OS_SOLARIS
 #	include <fcntl.h>


### PR DESCRIPTION
due to old-style header names -- now using the new ones, which are also
supported on the other platforms.