### PR TITLE
omprog: added test for feedback feature (without using transactions)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -30,11 +30,11 @@ check_PROGRAMS = $(TESTRUNS) ourtail nettester tcpflood chkseq msleep randomgen 
 if ENABLE_IMJOURNAL
 check_PROGRAMS += journal_print
 endif
-TESTS = $(TESTRUNS) 
+TESTS = $(TESTRUNS)
 #TESTS = $(TESTRUNS) cfg.sh
 
 TESTS +=  \
-	empty-hostname.sh 
+	empty-hostname.sh
 
 if ENABLE_TESTBENCH1
 TESTS +=  \
@@ -387,7 +387,8 @@ TESTS +=  \
 	omprog-cleanup.sh \
 	omprog-cleanup-with-outfile.sh \
 	omprog-noterm-cleanup.sh \
-	omprog-noterm-default.sh
+	omprog-noterm-default.sh \
+	omprog-feedback.sh
 if OS_LINUX
 TESTS += \
 	omprog-cleanup-when-unresponsive.sh \
@@ -408,7 +409,7 @@ if ENABLE_OMKAFKA
 if ENABLE_IMKAFKA
 if ENABLE_KAFKA_TESTS
 TESTS += \
-	sndrcv_kafka.sh 
+	sndrcv_kafka.sh
 # Tests below need to be stable first!
 #	sndrcv_kafka_multi.sh
 #	sndrcv_kafka_fail.sh
@@ -456,7 +457,7 @@ if HAVE_VALGRIND
 TESTS +=  \
 	mysql-basic-vg.sh \
 	mysql-asyn-vg.sh \
-	mysql-actq-mt-withpause-vg.sh 
+	mysql-actq-mt-withpause-vg.sh
 endif
 if ENABLE_OMLIBDBI
 TESTS +=  \
@@ -534,7 +535,7 @@ TESTS +=  \
 	es-basic-errfile-empty.sh \
 	es-basic-errfile-popul.sh \
 	es-bulk-errfile-empty.sh \
-	es-bulk-errfile-popul.sh 
+	es-bulk-errfile-popul.sh
 if HAVE_VALGRIND
 TESTS += \
 	es-basic-vgthread.sh
@@ -724,7 +725,7 @@ endif
 if ENABLE_EXTENDED_TESTS
 # random.sh is temporarily disabled as it needs some work
 # to rsyslog core to complete in reasonable time
-#TESTS += random.sh 
+#TESTS += random.sh
 endif
 
 if ENABLE_IMFILE
@@ -754,7 +755,7 @@ TESTS += \
 	imfile-wildcards-dirs2.sh \
 	imfile-rename.sh
 
-# TEMPORARILY disable some imfile tests because refactoring 
+# TEMPORARILY disable some imfile tests because refactoring
 # is needed to get them to work 100% all the time.
 # alorbach, 2018-01-05
 #	imfile-wildcards-dirs-multi.sh \
@@ -776,7 +777,7 @@ if ENABLE_OMTCL
 TESTS += \
 	 omtcl.sh
 endif
- 
+
 endif # if ENABLE_TESTBENCH
 
 TESTS_ENVIRONMENT = RSYSLOG_MODDIR='$(abs_top_builddir)'/runtime/.libs/
@@ -1340,6 +1341,7 @@ EXTRA_DIST= \
 	omprog-noterm-cleanup-vg.sh \
 	omprog-noterm-default.sh \
 	omprog-noterm-unresponsive.sh \
+	omprog-feedback.sh \
 	testsuites/omprog-cleanup.conf \
 	testsuites/omprog-noterm.conf \
 	testsuites/omprog-noterm-default.conf \
@@ -1349,6 +1351,8 @@ EXTRA_DIST= \
 	testsuites/omprog-cleanup-unresponsive.conf \
 	testsuites/omprog-test-bin.sh \
 	testsuites/term-ignoring-script.sh \
+	testsuites/omprog-feedback.conf \
+	testsuites/omprog-feedback-bin.sh \
 	pipe_noreader.sh \
 	testsuites/pipe_noreader.conf \
 	uxsock_simple.sh \
@@ -1765,7 +1769,7 @@ EXTRA_DIST= \
 	testsuites/sample.pmsnare_cccstyle \
 	testsuites/sample.pmsnare_ccbackslash \
 	testsuites/sample.pmsnare_modoverride
-	
+
 ourtail_SOURCES = ourtail.c
 msleep_SOURCES = msleep.c
 omrelp_dflt_port_SOURCES = omrelp_dflt_port.c

--- a/tests/omprog-feedback.sh
+++ b/tests/omprog-feedback.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+echo ===============================================================================
+echo '[omprog-feedback.sh]: test omprog with confirmMessages flag enabled'
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh startup omprog-feedback.conf
+. $srcdir/diag.sh wait-startup
+
+. $srcdir/diag.sh injectmsg 0 10
+
+. $srcdir/diag.sh wait-queueempty
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+expected_output="<= OK
+=> msgnum:00000000:
+<= OK
+=> msgnum:00000001:
+<= OK
+=> msgnum:00000002:
+<= OK
+=> msgnum:00000003:
+<= OK
+=> msgnum:00000004:
+<= Error: could not process log message
+=> msgnum:00000004:
+<= Error: could not process log message
+=> msgnum:00000004:
+<= OK
+=> msgnum:00000005:
+<= OK
+=> msgnum:00000006:
+<= OK
+=> msgnum:00000007:
+<= Error: could not process log message
+=> msgnum:00000007:
+<= Error: could not process log message
+=> msgnum:00000007:
+<= OK
+=> msgnum:00000008:
+<= OK
+=> msgnum:00000009:
+<= OK"
+
+written_output=$(<rsyslog.out.log)
+if [[ "x$expected_output" != "x$written_output" ]]; then
+    echo unexpected omprog script output:
+    echo "$written_output"
+    . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit

--- a/tests/testsuites/omprog-feedback-bin.sh
+++ b/tests/testsuites/omprog-feedback-bin.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+outfile=rsyslog.out.log
+
+status="OK"
+echo "<= $status" >> $outfile
+echo $status
+
+retry_count=0
+
+read line
+while [[ "x$line" != "x" ]]; do
+    message=${line//$'\n'}
+    echo "=> $message" >> $outfile
+
+    if [[ $message == *04* || $message == *07* ]]; then
+        if [[ $retry_count < 2 ]]; then
+            status="Error: could not process log message"
+            let "retry_count++"
+        else
+            status="OK"
+            retry_count=0
+        fi
+    else
+        status="OK"
+    fi
+
+    echo "<= $status" >> $outfile
+    echo $status
+    read line
+done
+
+exit 0

--- a/tests/testsuites/omprog-feedback.conf
+++ b/tests/testsuites/omprog-feedback.conf
@@ -1,0 +1,19 @@
+$IncludeConfig diag-common.conf
+
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+        binary="./testsuites/omprog-feedback-bin.sh"
+        template="outfmt"
+        name="omprog_action"
+        confirmMessages="on"
+        useTransactions="off"
+        action.resumeRetryCount="10"
+        action.resumeInterval="1"
+        signalOnClose="off"
+    )
+}


### PR DESCRIPTION
A simple test for the feedback feature implemented in #1753, which didn't have any test yet. This test only checks the 'confirmMessages' flag without the use of transactions.

Note: This PR is based on #1992, but in contrast to that PR, this one is ready to merge. I will rewrite PR #1992 to restrict it to the problematic transaction-related cases.