### PR TITLE
build system: Don't link core against libcurl if explicitly requested

### DIFF
--- a/grammar/Makefile.am
+++ b/grammar/Makefile.am
@@ -12,8 +12,11 @@ libgrammar_la_SOURCES = \
 	parserif.h \
 	grammar.h
 libgrammar_la_CPPFLAGS =  $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-#libgrammar_la_LIBADD = $(CURL_LIBS) $(RSRT_LIBS) $(SOL_LIBS)
-libgrammar_la_LIBADD = $(CURL_LIBS)
+libgrammar_la_LIBADD =
+if ENABLE_LIBCURL
+libgrammar_la_CPPFLAGS += $(CURL_CFLAGS)
+libgrammar_la_LIBADD += $(CURL_LIBS)
+endif
 
 #testdriver_SOURCES = testdriver.c libgrammar.la
 #testdriver_CPPFLAGS =  $(RSRT_CFLAGS)

--- a/plugins/omelasticsearch/Makefile.am
+++ b/plugins/omelasticsearch/Makefile.am
@@ -1,7 +1,7 @@
 pkglib_LTLIBRARIES = omelasticsearch.la
 
 omelasticsearch_la_SOURCES = omelasticsearch.c
-omelasticsearch_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
+omelasticsearch_la_CPPFLAGS = $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(CURL_CFLAGS)
 omelasticsearch_la_LDFLAGS = -module -avoid-version
 omelasticsearch_la_LIBADD =  $(CURL_LIBS) $(LIBM)
 


### PR DESCRIPTION
When using --disable-libcurl, libgrammar should not be linked against
libcurl unconditionally as CURL_LIBS might be set if one of the modules
using libcurl, like elasticsearch, is enabled.

See #2378 