### PR TITLE
build system: remove spurios xOS_LINUX definition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -123,7 +123,6 @@ case "${host}" in
   ;;
 esac
 AM_CONDITIONAL(OS_APPLE, test x$os_type == xapple)
-AM_CONDITIONAL(xOS_LINUX, test x$os_type == xlinux)
 AM_CONDITIONAL(OS_LINUX, test x$os_type == xlinux)
 
 # Running from git source?


### PR DESCRIPTION
This was used nowhere. It most probably was a forgotten left-over
from an experiment.

closes https://github.com/rsyslog/rsyslog/issues/2386