### PR TITLE
core bugfix: string not properly terminated when RFC5424 MSGID is used

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2272,7 +2272,8 @@ rsRetVal MsgSetMSGID(smsg_t * const pMsg, const char* pszMSGID)
 		CHKiRet(rsCStrConstruct(&pMsg->pCSMSGID));
 	}
 	/* if we reach this point, we have the object */
-	iRet = rsCStrSetSzStr(pMsg->pCSMSGID, (uchar*) pszMSGID);
+	CHKiRet(rsCStrSetSzStr(pMsg->pCSMSGID, (uchar*) pszMSGID));
+	cstrFinalize(pMsg->pCSMSGID);
 
 finalize_it:
 	RETiRet;


### PR DESCRIPTION
this can lead to misadressing when the jsonmesg property is used.

closes https://github.com/rsyslog/rsyslog/issues/2396