### PR TITLE
testbench: ensure we have the necessary commands to execute test

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -188,6 +188,14 @@ case $1 in
    'check-url-access')   # check if we can access the URL - will exit 77 when not OK
 		rsyslog_testbench_test_url_access $2
 		;;
+   'check-command-available')   # check if command $2 is available - will exit 77 when not OK
+		command -v $2
+		if [ $? -ne 0 ] ; then
+			echo Testbench requires unavailable command: $2
+			echo skipping this test
+			exit 77
+		fi
+		;;
    'es-init')   # initialize local Elasticsearch *testbench* instance for the next
                 # test. NOTE: do NOT put anything useful on that instance!
 		curl -XDELETE localhost:9200/rsyslog_testbench

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -158,7 +158,6 @@ case $1 in
    'exit')	# cleanup
 		# detect any left-over hanging instance
 		nhanging=0
-		#for pid in $(ps -eo pid,cmd|grep '/tools/[r]syslogd' |sed -e 's/\( *\)\([0-9]*\).*/\2/');
 		for pid in $(ps -eo pid,args|grep '/tools/[r]syslogd' |sed -e 's/\( *\)\([0-9]*\).*/\2/');
 		do
 			echo "ERROR: left-over instance $pid, killing it"

--- a/tests/omprog-cleanup-vg.sh
+++ b/tests/omprog-cleanup-vg.sh
@@ -4,17 +4,9 @@
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-command-available lsof
 
-
-#uname
-#if [ `uname` = "FreeBSD" ] ; then
-   #echo "This test currently does not work on FreeBSD."
-   #exit 77
-#fi
-
 . $srcdir/diag.sh startup-vg omprog-cleanup.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5
-sleep 1
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000000:"
 . $srcdir/diag.sh getpid
@@ -27,17 +19,15 @@ for i in $(seq 5 10); do
     . $srcdir/diag.sh injectmsg  $i 1
     sleep .1
 done
-sleep .5
 
+. $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
 echo OLD: $old_fd_count NEW: $new_fd_count
 . $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
 
-echo doing shutdown
 . $srcdir/diag.sh shutdown-when-empty
-echo wait on shutdown
 . $srcdir/diag.sh wait-shutdown-vg
 . $srcdir/diag.sh check-exit-vg
 . $srcdir/diag.sh exit

--- a/tests/omprog-cleanup-vg.sh
+++ b/tests/omprog-cleanup-vg.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # added 2016-09-20 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
-echo ===============================================================================
-echo \[omprog-cleanup-vg.sh\]: test for cleanup in omprog with valgrind
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available lsof
+
+
+#uname
+#if [ `uname` = "FreeBSD" ] ; then
+   #echo "This test currently does not work on FreeBSD."
+   #exit 77
+#fi
+
 . $srcdir/diag.sh startup-vg omprog-cleanup.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5

--- a/tests/omprog-cleanup-with-outfile.sh
+++ b/tests/omprog-cleanup-with-outfile.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 # added 2016-09-09 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-echo ===============================================================================
-echo \[omprog-cleanup-with-outfile.sh\]: test for cleanup in omprog when used with outfile
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available lsof
 
 uname
-if [ `uname` = "SunOS" ] ; then
-   echo "Solaris: FIX ME"
-   exit 77
-fi
+#if [ `uname` = "SunOS" ] ; then
+#   echo "Solaris: FIX ME"
+#   exit 77
+#fi
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh startup omprog-cleanup-outfile.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5

--- a/tests/omprog-cleanup-with-outfile.sh
+++ b/tests/omprog-cleanup-with-outfile.sh
@@ -4,16 +4,9 @@
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-command-available lsof
 
-uname
-#if [ `uname` = "SunOS" ] ; then
-#   echo "Solaris: FIX ME"
-#   exit 77
-#fi
-
 . $srcdir/diag.sh startup omprog-cleanup-outfile.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5
-sleep 1
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000000:"
 . $srcdir/diag.sh getpid
@@ -26,8 +19,8 @@ for i in $(seq 5 10); do
     . $srcdir/diag.sh injectmsg  $i 1
     sleep .1
 done
-sleep .5
 
+. $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
@@ -36,8 +29,6 @@ echo OLD: $old_fd_count NEW: $new_fd_count
 
 cp rsyslog.out.log /tmp/
 
-echo doing shutdown
 . $srcdir/diag.sh shutdown-when-empty
-echo wait on shutdown
 . $srcdir/diag.sh wait-shutdown
 . $srcdir/diag.sh exit

--- a/tests/omprog-cleanup.sh
+++ b/tests/omprog-cleanup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # added 2016-09-09 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-echo ===============================================================================
-echo \[omprog-cleanup.sh\]: test for cleanup in omprog
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available lsof
 
 uname
 if [ `uname` = "SunOS" ] ; then
@@ -10,7 +10,6 @@ if [ `uname` = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh startup omprog-cleanup.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5

--- a/tests/omprog-cleanup.sh
+++ b/tests/omprog-cleanup.sh
@@ -4,16 +4,9 @@
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-command-available lsof
 
-uname
-if [ `uname` = "SunOS" ] ; then
-   echo "Solaris: FIX ME"
-   exit 77
-fi
-
 . $srcdir/diag.sh startup omprog-cleanup.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5
-sleep 1
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000000:"
 . $srcdir/diag.sh getpid
@@ -26,16 +19,14 @@ for i in $(seq 5 10); do
     . $srcdir/diag.sh injectmsg  $i 1
     sleep .1
 done
-sleep .5
 
+. $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
 echo OLD: $old_fd_count NEW: $new_fd_count
 . $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
 
-echo doing shutdown
 . $srcdir/diag.sh shutdown-when-empty
-echo wait on shutdown
 . $srcdir/diag.sh wait-shutdown
 . $srcdir/diag.sh exit

--- a/tests/omprog-noterm-cleanup-vg.sh
+++ b/tests/omprog-noterm-cleanup-vg.sh
@@ -8,9 +8,9 @@ if [ `uname` = "FreeBSD" ] ; then
    exit 77
 fi
 
-echo ===============================================================================
-echo \[omprog-noterm-cleanup-vg.sh\]: test for cleanup in omprog without SIGTERM with valgrind
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available lsof
+
 . $srcdir/diag.sh startup-vg omprog-noterm.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5

--- a/tests/omprog-noterm-cleanup-vg.sh
+++ b/tests/omprog-noterm-cleanup-vg.sh
@@ -1,20 +1,12 @@
 #!/bin/bash
 # added 2016-11-03 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-command-available lsof
 
 . $srcdir/diag.sh startup-vg omprog-noterm.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5
-sleep 1
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000000:"
 . $srcdir/diag.sh getpid
@@ -27,17 +19,15 @@ for i in $(seq 5 10); do
     . $srcdir/diag.sh injectmsg  $i 1
     sleep .1
 done
-sleep .5
 
+. $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
 echo OLD: $old_fd_count NEW: $new_fd_count
 . $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
 
-echo doing shutdown
 . $srcdir/diag.sh shutdown-when-empty
-echo wait on shutdown
 . $srcdir/diag.sh wait-shutdown-vg
 . $srcdir/diag.sh check-exit-vg
 sleep 1

--- a/tests/omprog-noterm-cleanup.sh
+++ b/tests/omprog-noterm-cleanup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # added 2016-11-03 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-echo ===============================================================================
-echo \[omprog-noterm-cleanup.sh\]: test for cleanup in omprog without SIGTERM
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available lsof
 
 uname
 if [ `uname` = "SunOS" ] ; then
@@ -10,7 +10,6 @@ if [ `uname` = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
 . $srcdir/diag.sh startup omprog-noterm.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5

--- a/tests/omprog-noterm-cleanup.sh
+++ b/tests/omprog-noterm-cleanup.sh
@@ -4,16 +4,9 @@
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-command-available lsof
 
-uname
-if [ `uname` = "SunOS" ] ; then
-   echo "Solaris: FIX ME"
-   exit 77
-fi
-
 . $srcdir/diag.sh startup omprog-noterm.conf
 . $srcdir/diag.sh wait-startup
 . $srcdir/diag.sh injectmsg  0 5
-sleep 1
 . $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000000:"
 . $srcdir/diag.sh getpid
@@ -26,19 +19,17 @@ for i in $(seq 5 10); do
     set +x
     sleep .1
     . $srcdir/diag.sh injectmsg  $i 1
-    sleep .5
+    sleep .1
 done
-sleep .5
 
+. $srcdir/diag.sh wait-queueempty
 . $srcdir/diag.sh content-check "msgnum:00000009:"
 
 new_fd_count=$(lsof -p $pid | wc -l)
 echo OLD: $old_fd_count NEW: $new_fd_count
 . $srcdir/diag.sh assert-equal $old_fd_count $new_fd_count 2
 
-echo doing shutdown
 . $srcdir/diag.sh shutdown-when-empty
-echo wait on shutdown
 . $srcdir/diag.sh wait-shutdown
 sleep 1
 . $srcdir/diag.sh assert-content-missing "received SIGTERM"


### PR DESCRIPTION
this might have caused sporadic failures on platform where "lsof" was
missing.

see also https://github.com/rsyslog/rsyslog/issues/2403