### PR TITLE
config: add ability to use environment variables for config params

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -39,7 +39,39 @@
 }
 
 %{
+#include <libestr.h>
+#include <ctype.h>
 #include "parserif.h"
+
+static es_str_t* ATTR_NONNULL(1)
+expand_backticks(char *const param)
+{
+	const char *val;
+	assert(param != NULL);
+
+	if(strncmp(param, "echo $", sizeof("echo $")-1) != 0) {
+		parser_errmsg("invalid backtick parameter `%s` currently "
+			"only `echo $<var>` is supported - replaced by "
+			"empty string (\"\")", param);
+		val = NULL;
+	} else {
+		size_t i;
+		const size_t len = strlen(param);
+		for(i = len - 1 ; isspace(param[i]) ; --i) {
+			; /* just go down */
+		}
+		if(i > 6 && i < len - 1) {
+			param[i+1] = '\0';
+		}
+		val = getenv(param+6);
+	}
+
+	if(val == NULL) {
+		val = "";
+	}
+
+	return es_newStrFromCStr(val, strlen(val));
+}
 %}
 
 %option noyywrap nodefault case-insensitive yylineno
@@ -174,6 +206,11 @@ int fileno(FILE *stream);
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
 				   return STRING; }
+<EXPR>`([^`\\]|\\['`"\\bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*`	 {
+				   yytext[yyleng-1] = '\0';
+				   unescapeStr((uchar*)yytext+1, yyleng-2);
+				   yylval.estr = expand_backticks(yytext+1);
+				   return STRING; }
 <EXPR>\"([^"\\$]|\\["'\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\" {
 				   yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
@@ -266,6 +303,11 @@ int fileno(FILE *stream);
 				   yytext[yyleng-1] = '\0';
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
+				   return STRING; }
+<INOBJ>`([^`\\]|\\['`?\\abfnrtv]|\\[0-7]{1,3})*` {
+				   yytext[yyleng-1] = '\0';
+				   unescapeStr((uchar*)yytext+1, yyleng-2);
+				   yylval.estr = expand_backticks(yytext+1);
 				   return STRING; }
 				  /*yylval.estr = es_newStrFromBuf(yytext+1, yyleng-2);
 				  return VALUE; }*/

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -313,6 +313,7 @@ void objlstDestruct(struct objlst *lst);
 void objlstPrint(struct objlst *lst);
 struct nvlst* nvlstNewArray(struct cnfarray *ar);
 struct nvlst* nvlstNewStr(es_str_t *value);
+struct nvlst* nvlstNewStrBackticks(es_str_t *const value);
 struct nvlst* nvlstSetName(struct nvlst *lst, es_str_t *name);
 void nvlstDestruct(struct nvlst *lst);
 void nvlstPrint(struct nvlst *lst);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -311,6 +311,7 @@ endif # ENABLE_LIBCURL
 if HAVE_VALGRIND
 TESTS +=  \
 	rscript_parse_json-vg.sh \
+	rscript_backticks-vg.sh \
 	prop-jsonmesg-vg.sh
 endif # HAVE_VALGRIND
 endif # ENABLE_TESTBENCH2
@@ -973,6 +974,7 @@ EXTRA_DIST= \
 	rscript_script_error.sh \
 	rscript_parse_json.sh \
 	rscript_parse_json-vg.sh \
+	rscript_backticks-vg.sh \
 	rscript_previous_action_suspended.sh \
 	rscript_str2num_negative.sh \
 	mmanon_random_32_ipv4.sh \

--- a/tests/rscript_backticks-vg.sh
+++ b/tests/rscript_backticks-vg.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+#module(load="../plugins/imtcp/.libs/imtcp")
+#input(type="imtcp" port="13514")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if `echo $DO_WORK` == "on" and $msg contains "msgnum:" then
+	action(type="omfile" file=`echo $OUTFILE` template="outfmt")
+'
+export DO_WORK=on
+export OUTFILE=rsyslog.out.log
+. $srcdir/diag.sh startup-vg
+. $srcdir/diag.sh injectmsg 0 1000
+#. $srcdir/diag.sh tcpflood -m10
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh seq-check  0 999
+. $srcdir/diag.sh exit


### PR DESCRIPTION
We introduce strings enclosed in backticks, which is along the lines
of what the shell does. However, we currently only support
"echo $VARNAME" -- but this may be extended later on.

closes https://github.com/rsyslog/rsyslog/issues/2416