### PR TITLE
config: add include() script object

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -63,6 +63,7 @@ extern int yyerror(const char*);
 %token <estr> FUNC
 %token <objType> BEGINOBJ
 %token ENDOBJ
+%token BEGIN_INCLUDE
 %token BEGIN_ACTION
 %token BEGIN_PROPERTY
 %token BEGIN_CONSTANT
@@ -135,6 +136,7 @@ conf:	/* empty (to end recursion) */
 	| conf LEGACY_RULESET		{ cnfDoCfsysline($2); }
 	| conf BSD_TAG_SELECTOR		{ cnfDoBSDTag($2); }
 	| conf BSD_HOST_SELECTOR	{ cnfDoBSDHost($2); }
+include:  BEGIN_INCLUDE nvlst ENDOBJ	{ includeProcessCnf($2); }
 obj:	  BEGINOBJ nvlst ENDOBJ 	{ $$ = cnfobjNew($1, $2); }
         | BEGIN_TPL nvlst ENDOBJ	{ $$ = cnfobjNew(CNFOBJ_TPL, $2); }
         | BEGIN_TPL nvlst ENDOBJ '{' propconst '}'
@@ -179,6 +181,7 @@ stmt:	  actlst			{ $$ = $1; }
 	| PRIFILT block			{ $$ = cnfstmtNewPRIFILT($1, $2); }
 	| PROPFILT block		{ $$ = cnfstmtNewPROPFILT($1, $2); }
 	| RELOAD_LOOKUP_TABLE_PROCEDURE '(' fparams ')' { $$ = cnfstmtNewReloadLookupTable($3);}
+	| include			{ $$ = NULL; }
 	| BEGINOBJ			{ $$ = NULL; parser_errmsg("declarative object '%s' not permitted in action block [stmt]", yytext);}
 block:    stmt				{ $$ = $1; }
 	| '{' script '}'		{ $$ = $2; }

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -251,7 +251,7 @@ int fileno(FILE *stream);
   * always the longest match :-(
   */
 <INCL>.|\n
-<INCL>[^ \t\n]+			{ if(cnfDoInclude(yytext) != 0)
+<INCL>[^ \t\n]+			{ if(cnfDoInclude(yytext, 0) != 0)
 					yyterminate();
 				  BEGIN INITIAL; }
 "main_queue"[ \n\t]*"("		{ yylval.objType = CNFOBJ_MAINQ;
@@ -278,6 +278,7 @@ int fileno(FILE *stream);
 				  BEGIN INOBJ; return BEGINOBJ; }
 "dyn_stats"[ \n\t]*"("		{ yylval.objType = CNFOBJ_DYN_STATS;
 				  BEGIN INOBJ; return BEGINOBJ; }
+"include"[ \n\t]*"("		{ BEGIN INOBJ; return BEGIN_INCLUDE; }
 "action"[ \n\t]*"("		{ BEGIN INOBJ; return BEGIN_ACTION; }
 ^[ \t]*:\$?[a-z\-]+[ ]*,[ ]*!?[a-z]+[ ]*,[ ]*\"(\\\"|[^\"])*\"	{
 				  yylval.s = strdup(rmLeadingSpace(yytext));
@@ -369,6 +370,47 @@ cnfParseBuffer(char *buf, unsigned lenBuf)
 done:	return r;
 }
 
+
+/* add config file or text the the stack of config objects to be
+ * processed.
+ * cnfobjname is either the file name or "text" if generated from
+ * text ("text" can also be replaced by something more intelligent
+ * by the caller.
+ * The provided string is freed.
+ */
+int ATTR_NONNULL()
+cnfAddConfigBuffer(es_str_t *const str, const char *const cnfobj_name)
+{
+	struct bufstack *bs;
+	int r = 0;
+	assert(str != NULL);
+	assert(cnfobj_name != NULL);
+
+	if((bs = malloc(sizeof(struct bufstack))) == NULL) {
+		r = 1;
+		goto done;
+	}
+
+	if(currbs != NULL)
+		currbs->lineno = yylineno;
+	bs->prev = currbs;
+	bs->fn = strdup(cnfobj_name);
+	yy_size_t lll = es_strlen(str);
+	bs->bs = yy_scan_buffer((char*)es_getBufAddr(str), lll);
+	bs->estr = str; /* needed so we can free it later */
+	currbs = bs;
+	cnfcurrfn = bs->fn;
+	yylineno = 1;
+	dbgprintf("config parser: pushed config fragment on top of stack: %s\n", cnfobj_name);
+
+done:
+	if(r != 0) {
+		es_deleteStr(str);
+	}
+	return r;
+}
+
+
 /* set a new buffers. Returns 0 on success, 1 on error, 2 on file not exists.
  * note: in case of error, errno must be kept valid!
  */
@@ -376,9 +418,9 @@ int
 cnfSetLexFile(char *fname)
 {
 	es_str_t *str = NULL;
+	struct bufstack *bs;
 	FILE *fp;
 	int r = 0;
-	struct bufstack *bs;
 
 	/* check for invalid recursive include */
 	for(bs = currbs ; bs != NULL ; bs = bs->prev) {
@@ -402,30 +444,9 @@ cnfSetLexFile(char *fname)
 	if(fp != stdin)
 		fclose(fp);
 	
-	/* maintain stack */
-	if((bs = malloc(sizeof(struct bufstack))) == NULL) {
-		r = 1;
-		goto done;
-	}
-
-	if(currbs != NULL)
-		currbs->lineno = yylineno;
-	bs->prev = currbs;
-	bs->fn = strdup(fname == NULL ? "stdin" : fname);
-	yy_size_t lll = es_strlen(str);
-	//bs->bs = yy_scan_buffer((char*)es_getBufAddr(str), (yy_size_t) es_strlen(str));
-	bs->bs = yy_scan_buffer((char*)es_getBufAddr(str), lll);
-	bs->estr = str; /* needed so we can free it later */
-	currbs = bs;
-	cnfcurrfn = bs->fn;
-	yylineno = 1;
-	dbgprintf("config parser: pushed file %s on top of stack\n", fname);
+	r = cnfAddConfigBuffer(str, ((fname == NULL) ? "stdin" : fname));
 
 done:
-	if(r != 0) {
-		if(str != NULL)
-			es_deleteStr(str);
-	}
 	return r;
 }
 

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -41,20 +41,56 @@
 %{
 #include <libestr.h>
 #include <ctype.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
 #include "parserif.h"
+
+/* TODO: move this to a better modules, refactor -- rgerhards, 2018-01-22 */
+static char *
+read_file(const char *const filename)
+{
+	char *content = NULL;
+	int fd;
+	struct stat sb;
+	ssize_t nread;
+	assert(filename != NULL);
+
+	if((fd = open((const char*) filename, O_RDONLY)) == -1) {
+		goto done;
+	}
+
+	if(fstat(fd, &sb) == -1) {
+		goto done;
+	}
+
+	content = malloc(sb.st_size+1);
+	if(content == NULL) {
+		goto done;
+	}
+
+	nread = read(fd, content, sb.st_size);
+	content[nread] = '\0';
+	if(nread != (ssize_t) sb.st_size) {
+		free(content);
+		content = NULL;
+		goto done;
+	}
+
+	close(fd);
+
+done:	return content;
+}
 
 static es_str_t* ATTR_NONNULL(1)
 expand_backticks(char *const param)
 {
-	const char *val;
+	const char *val = NULL;
 	assert(param != NULL);
+	int need_free = 0;
 
-	if(strncmp(param, "echo $", sizeof("echo $")-1) != 0) {
-		parser_errmsg("invalid backtick parameter `%s` currently "
-			"only `echo $<var>` is supported - replaced by "
-			"empty string (\"\")", param);
-		val = NULL;
-	} else {
+	if(strncmp(param, "echo $", sizeof("echo $")-1) == 0) {
 		size_t i;
 		const size_t len = strlen(param);
 		for(i = len - 1 ; isspace(param[i]) ; --i) {
@@ -64,13 +100,24 @@ expand_backticks(char *const param)
 			param[i+1] = '\0';
 		}
 		val = getenv(param+6);
+	} else if(strncmp(param, "cat ", sizeof("cat ")-1) == 0) {
+		val = read_file(param+4);
+		need_free = 1;
 	}
 
 	if(val == NULL) {
+		parser_errmsg("invalid backtick parameter `%s` - replaced by "
+			"empty string (\"\")", param);
 		val = "";
+		need_free = 0;
 	}
 
-	return es_newStrFromCStr(val, strlen(val));
+	es_str_t *const estr = es_newStrFromCStr(val, strlen(val));
+	if(need_free) {
+		free((void*)val);
+	}
+
+	return estr;
 }
 %}
 

--- a/grammar/parserif.h
+++ b/grammar/parserif.h
@@ -39,4 +39,5 @@ void cnfDoScript(struct cnfstmt *script);
 void cnfDoCfsysline(char *ln);
 void cnfDoBSDTag(char *ln);
 void cnfDoBSDHost(char *ln);
+int cnfAddConfigBuffer(es_str_t *const str, const char *const cnfobj_name);
 #endif

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5058,7 +5058,7 @@ cnfDoInclude(const char *const name, const int optional)
 		if(result == GLOB_NOMATCH) {
 	#else
 		result = glob(finalName, GLOB_MARK, NULL, &cfgFiles);
-		if(result == GLOB_NOMATCH && containsGlobWildcard(finalName)) {
+		if(result == GLOB_NOMATCH && containsGlobWildcard((char*)finalName)) {
 	#endif /* HAVE_GLOB_NOMAGIC */
 		goto done;
 	}

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -1,6 +1,6 @@
 /* rsyslog rainerscript definitions
  *
- * Copyright 2011-2016 Rainer Gerhards
+ * Copyright 2011-2018 Rainer Gerhards
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -333,7 +333,7 @@ struct cnfstringval* cnfstringvalNew(es_str_t *estr);
 struct cnfvar* cnfvarNew(char *name);
 struct cnffunc * cnffuncNew(es_str_t *fname, struct cnffparamlst* paramlst);
 struct cnffparamlst * cnffparamlstNew(struct cnfexpr *expr, struct cnffparamlst *next);
-int cnfDoInclude(char *name);
+int cnfDoInclude(const char *name, const int optional);
 int cnfparamGetIdx(struct cnfparamblk *params, const char *name);
 struct cnfparamvals* nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 	       struct cnfparamvals *vals);
@@ -368,6 +368,7 @@ rsRetVal initRainerscript(void);
 void unescapeStr(uchar *s, int len);
 const char * tokenval2str(int tok);
 uchar* var2CString(struct svar *__restrict__ const r, int *__restrict__ const bMustFree);
+void includeProcessCnf(struct nvlst *const lst);
 
 /* debug helper */
 void cstrPrint(const char *text, es_str_t *estr);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -2,7 +2,7 @@
  *
  * Module begun 2011-04-19 by Rainer Gerhards
  *
- * Copyright 2011-2016 Adiscon GmbH.
+ * Copyright 2011-2018 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -426,10 +426,12 @@ yyerror(const char *s)
 	parser_errmsg("%s on token '%s'", s, yytext);
 	return 0;
 }
-void cnfDoObj(struct cnfobj *o)
+void ATTR_NONNULL()
+cnfDoObj(struct cnfobj *const o)
 {
 	int bDestructObj = 1;
 	int bChkUnuse = 1;
+	assert(o != NULL);
 
 	dbgprintf("cnf:global:obj: ");
 	cnfobjPrint(o);

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -686,9 +686,11 @@ GetParserList(rsconf_t *conf, smsg_t *pMsg)
 
 
 /* Add a script block to the current ruleset */
-static void
-addScript(ruleset_t *pThis, struct cnfstmt *script)
+static void ATTR_NONNULL(1)
+addScript(ruleset_t *const pThis, struct cnfstmt *const script)
 {
+	if(script == NULL) /* happens for include() */
+		return;
 	if(pThis->last == NULL)
 		pThis->root = pThis->last = script;
 	else {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -310,6 +310,9 @@ TESTS +=  \
 endif # ENABLE_LIBCURL
 if HAVE_VALGRIND
 TESTS +=  \
+	include-obj-outside-control-flow-vg.sh \
+	include-obj-in-if-vg.sh \
+	include-obj-text-vg.sh \
 	rscript_parse_json-vg.sh \
 	rscript_backticks-vg.sh \
 	prop-jsonmesg-vg.sh
@@ -928,6 +931,9 @@ EXTRA_DIST= \
 	testsuites/diskqueue.conf \
 	arrayqueue.sh \
 	testsuites/arrayqueue.conf \
+	include-obj-outside-control-flow-vg.sh \
+	include-obj-in-if-vg.sh \
+	include-obj-text-vg.sh \
 	rscript_http_request.sh \
 	rscript_http_request-vg.sh \
 	rscript_bare_var_root.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -303,6 +303,7 @@ TESTS +=  \
 	lookup_table_bad_configs.sh \
 	lookup_table_rscript_reload.sh \
 	lookup_table_rscript_reload_without_stub.sh \
+	include-obj-text-from-file.sh \
 	multiple_lookup_tables.sh
 if ENABLE_LIBCURL
 TESTS +=  \
@@ -931,6 +932,7 @@ EXTRA_DIST= \
 	testsuites/diskqueue.conf \
 	arrayqueue.sh \
 	testsuites/arrayqueue.conf \
+	include-obj-text-from-file.sh \
 	include-obj-outside-control-flow-vg.sh \
 	include-obj-in-if-vg.sh \
 	include-obj-text-vg.sh \

--- a/tests/include-obj-in-if-vg.sh
+++ b/tests/include-obj-in-if-vg.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then {
+	include(file="testsuites/include-std-omfile-actio*.conf")
+	continue
+}
+'
+. $srcdir/diag.sh startup-vg
+. $srcdir/diag.sh injectmsg 0 10
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh seq-check 0 9
+. $srcdir/diag.sh exit

--- a/tests/include-obj-outside-control-flow-vg.sh
+++ b/tests/include-obj-outside-control-flow-vg.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if not ($msg contains "msgnum:") then {
+	stop
+}
+
+# Note: the point of this test is to have this include outside of
+# a control flow construct -- this the "strange" if above.
+include(file="testsuites/include-std-omfile-actio*.conf")
+'
+. $srcdir/diag.sh startup-vg
+. $srcdir/diag.sh injectmsg 0 10
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh seq-check 0 9
+. $srcdir/diag.sh exit

--- a/tests/include-obj-text-from-file.sh
+++ b/tests/include-obj-text-from-file.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then {
+	include(text=`cat testsuites/include-std-omfile-action.conf`)
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh injectmsg 0 10
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh seq-check 0 9
+. $srcdir/diag.sh exit

--- a/tests/include-obj-text-vg.sh
+++ b/tests/include-obj-text-vg.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+export CONF_SNIPPET=`cat testsuites/include-std-omfile-action.conf`
+printf "\nThis SNIPPET will be included via env var:\n$CONF_SNIPPET\n\nEND SNIPPET\n"
+. $srcdir/diag.sh add-conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then {
+	include(text=`echo $CONF_SNIPPET`)
+}
+'
+. $srcdir/diag.sh startup-vg
+. $srcdir/diag.sh injectmsg 0 10
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+. $srcdir/diag.sh seq-check 0 9
+. $srcdir/diag.sh exit

--- a/tests/testsuites/include-std-omfile-action.conf
+++ b/tests/testsuites/include-std-omfile-action.conf
@@ -1,0 +1,3 @@
+# this include provides our standard omfile action. It is primarily
+# used for include() tests, but may have other uses as well.
+action(type="omfile" template="outfmt" file="rsyslog.out.log")


### PR DESCRIPTION
This permits to include files (like legacy $IncludeConfig) via a
script object. Needless to say, the script object offers more
features:

- include files can now be
  - required, with rsyslog aborting when not present
  - required, with rsyslog emitting an error message but otherwise
    continuing when not present
  - optional, which means non-present include files will be
    skipped without notice
  This is controlled by the "mode" parameter.
- text can be included form e.g. an environment variable
  --> ex: ```include(text=`echo $ENVVAR`)```

This finally really obsoletes $IncludeConfig.

closes https://github.com/rsyslog/rsyslog/issues/2151