### PR TITLE
Don't write pid file when running under systemd

### DIFF
--- a/rsyslog.service.in
+++ b/rsyslog.service.in
@@ -6,7 +6,7 @@ Documentation=http://www.rsyslog.com/doc/
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/rsyslogd -n
+ExecStart=@sbindir@/rsyslogd -n -iNONE
 StandardOutput=null
 Restart=on-failure
 


### PR DESCRIPTION
systemd does not require a pid file to track the rsyslogd process.
By not writing a pid file, the rsyslog service can be locked down even
further as it no longer needs write access to /var/run.