### PR TITLE
testbench: temporarily disable sndrcv_kafka-vg-rcvr.sh test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -429,8 +429,9 @@ TESTS += \
 #	sndrcv_kafka_failresume.sh
 if HAVE_VALGRIND
 TESTS += \
-	sndrcv_kafka-vg-sender.sh \
 	sndrcv_kafka-vg-rcvr.sh
+# re-enable: (see https://github.com/rsyslog/rsyslog/issues/2434)
+# sndrcv_kafka-vg-sender.sh
 endif
 endif
 endif


### PR DESCRIPTION
This test is known to fail rather frequently. We disable it until
the root cause is solved, because otherwise CI does have too many
false positive failures.

see also https://github.com/rsyslog/rsyslog/issues/2434