### PR TITLE
testbench: do not override default Alpine CFLAGS

### DIFF
--- a/tests/travis/run-alpine.sh
+++ b/tests/travis/run-alpine.sh
@@ -1,5 +1,4 @@
 set -e
-export CFLAGS="-g -Wall -Wextra -O2"
 autoreconf -fvi
 ./configure --prefix=/usr/local $RSYSLOG_CONFIGURE_OPTIONS
 make -j2 check TESTS=""


### PR DESCRIPTION
... as this brought us away from the abuild environment. Most importantly,
-Os was overriden by -O2, which did make a lot of warning go away.