### PR TITLE
dev tools: do not use -ti in docker run

### DIFF
--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -12,4 +12,4 @@ docker run \
 	-e RSYSLOG_CONFIGURE_OPTIONS_EXTRA \
 	-e CC \
 	-e CFLAGS \
-	-v "$RSYSLOG_HOME":/rsyslog -ti $DEV_CONTAINER  $*
+	-v "$RSYSLOG_HOME":/rsyslog $DEV_CONTAINER  $*


### PR DESCRIPTION
this does not properly work when the script is used in
cron jobs