### PR TITLE
omstdout: add new configuration format

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -593,6 +593,11 @@ TESTS +=  \
 	pmnull-withparams.sh
 endif
 
+if ENABLE_OMSTDOUT
+TESTS +=  \
+	omstdout-basic.sh
+endif
+
 if ENABLE_PMNORMALIZE
 TESTS +=  \
 	pmnormalize-basic.sh \
@@ -1119,6 +1124,7 @@ EXTRA_DIST= \
 	mmnormalize_rule_from_array.sh \
 	pmnull-basic.sh \
 	pmnull-withparams.sh \
+	omstdout-basic.sh \
 	testsuites/mmnormalize_processing_tests.rulebase \
 	mmnormalize_processing_test1.sh \
 	mmnormalize_processing_test2.sh \

--- a/tests/omstdout-basic.sh
+++ b/tests/omstdout-basic.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/omstdout/.libs/omstdout")
+input(type="imtcp" port="13514")
+
+template(name="outfmt" type="string" string="-%msg%-\n")
+action(type="omstdout" template="outfmt")
+
+'
+. $srcdir/diag.sh startup > rsyslog.out.log
+. $srcdir/diag.sh tcpflood -m1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdowna
+
+grep "msgnum:00000000:" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
Omstdout can now be configured in the new style
and a parameter for the template was added.

closes https://github.com/rsyslog/rsyslog/issues/2376