### PR TITLE
Fix building with --disable-libcurl

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -36,7 +36,11 @@
 #include <sys/types.h>
 #include <libestr.h>
 #include <time.h>
+
+#ifdef HAVE_LIBCURL
 #include <curl/curl.h>
+#endif
+
 #include "rsyslog.h"
 #include "rainerscript.h"
 #include "conf.h"


### PR DESCRIPTION
We missed the header include in commit d9475f133e3c79875a7c4ccd92038b7123c1f155.

See: https://github.com/rsyslog/rsyslog/issues/2374
Bug: https://bugs.gentoo.org/646262