### PR TITLE
lmsig_ksils12: emit error message if chown() to sig file fails

### DIFF
--- a/runtime/errmsg.h
+++ b/runtime/errmsg.h
@@ -21,7 +21,7 @@
 #ifndef INCLUDED_ERRMSG_H
 #define INCLUDED_ERRMSG_H
 
-#include "errmsg.h"
+#include "obj-types.h"
 
 #define NO_ERRCODE -1
 

--- a/runtime/lib_ksils12.c
+++ b/runtime/lib_ksils12.c
@@ -50,7 +50,6 @@
 #include <fcntl.h>
 #include <stdarg.h>
 #include <limits.h>
-#define MAXFNAME 1024
 
 #include <ksi/ksi.h>
 #include <ksi/tlv_element.h>
@@ -58,6 +57,8 @@
 #include <ksi/net_async.h>
 #include <ksi/net_uri.h>
 #include <ksi/signature_builder.h>
+#include "rsyslog.h"
+#include "errmsg.h"
 #include "lib_ksils12.h"
 #include "lib_ksi_queue.h"
 
@@ -492,6 +493,9 @@ static int mkpath(char* path, mode_t mode, uid_t uid, gid_t gid) {
 		if (mkdir(path, mode) == 0) {
 			if (uid != (uid_t) -1 || gid != (uid_t) -1) {
 				if (chown(path, uid, gid)) {
+					LogError(errno, RS_RET_IO_ERROR,
+						"ksils12 signatures: could not change to "
+						"configured owner - files may be unaccessible");
 				}
 			}
 		}


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/pull/2450