### PR TITLE
cleanup/config: remove redundant lexer rule

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -232,7 +232,6 @@ int fileno(FILE *stream);
 <EXPR>"-" |
 <EXPR>"[" |
 <EXPR>"]" |
-<EXPR>"(" |
 <EXPR>")"			{ return yytext[0]; }
 <EXPR>"=="			{ return CMP_EQ; }
 <EXPR>"<="			{ return CMP_LE; }


### PR DESCRIPTION
This rule was never applied, actually flex even complained about it.
It should not have been there in the first place. The match is actually
done right at the top of the <EXPR> block.