### PR TITLE
fix global parameter name shutdown.enable.ctl-c

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -185,7 +185,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "internalmsg.ratelimit.interval", eCmdHdlrPositiveInt, 0 },
 	{ "internalmsg.ratelimit.burst", eCmdHdlrPositiveInt, 0 },
 	{ "errormessagestostderr.maxnumber", eCmdHdlrPositiveInt, 0 },
-	{ "shutdown.enable.ctl-c", eCmdHdlrBinary, 0 },
+	{ "shutdown.enable.ctlc", eCmdHdlrBinary, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
 	{ "debug.whitelist", eCmdHdlrBinary, 0 }
 };
@@ -1291,7 +1291,7 @@ glblDoneLoadCnf(void)
 		        glblDbgWhitelist = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "umask")) {
 		        loadConf->globals.umask = (int) cnfparamvals[i].val.d.n;
-		} else if(!strcmp(paramblk.descr[i].name, "shutdown.enable.ctl-c")) {
+		} else if(!strcmp(paramblk.descr[i].name, "shutdown.enable.ctlc")) {
 		        glblPermitCtlC = (int) cnfparamvals[i].val.d.n;
 		} else {
 			dbgprintf("glblDoneLoadCnf: program error, non-handled "


### PR DESCRIPTION
the config system actually does not permit "-" inside parameter
names. This has now been changed to "shutdown.enable.ctlc".

closes https://github.com/rsyslog/rsyslog/issues/2482