### PR TITLE
[ommongodb] Adding possibility to ignore some insertion error code

### DIFF
--- a/plugins/ommongodb/README
+++ b/plugins/ommongodb/README
@@ -22,7 +22,7 @@ A very basic example is:
 *.*     action(type="ommongodb" db="logs" collection="syslog")
 
 A more complex example:
-*.*     action(type="ommongodb" uristr="mongodb://vulture:9091,vulture2:9091/?replicaset=Vulture&ssl=true" ssl_cert="/var/db/mongodb/mongod.pem" ssl_ca="/var/db/mongodb/ca.pem" db="logs" collection="syslog")
+*.*     action(type="ommongodb" uristr="mongodb://vulture:9091,vulture2:9091/?replicaset=Vulture&ssl=true" ssl_cert="/var/db/mongodb/mongod.pem" ssl_ca="/var/db/mongodb/ca.pem" db="logs" collection="syslog" allowed_error_codes="11000")
 
 Please see the script clean-mongo-syslog for an example of how to
 purge old records from MongoDB using PyMongo.  It can be run

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -625,7 +625,8 @@ CODESTARTnewActInst
 			if (error_codes != NULL) {
 				tok = strtok_r(error_codes, ", ", &saveptr);
 				while (tok != NULL) {
-					pData->allowed_error_codes[pData->allowed_error_codes_nbr] = (unsigned)atoi(tok);
+					pData->allowed_error_codes[pData->allowed_error_codes_nbr]
+                            = (unsigned)atoi(tok);
 					++(pData->allowed_error_codes_nbr);
 					tok = strtok_r(NULL, ", ", &saveptr);
 				}


### PR DESCRIPTION
Added new configuration (not mandatory) option `allowed_error_codes`.
The directive argument MUST be in the following format (handling a maximum of 256 codes): "11000,...,17,64"

The behavior of ommongodb was for a long time to `ABORT_FINALIZE(RS_RET_SUSPENDED)` on any MongoDB insertion error; keeping this behavior, I wanted to add the possibility to ignore some error code that may be allowed in some (really rare) configuration (*ex. `11000: DuplicateKey` in case of collection containing one or more unique field(s)*).

Hugo.