### PR TITLE
omfile: action now suspends, also with writes. suspend conditions: no…

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -510,6 +510,9 @@ operation not carried out */
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */
 	RS_RET_FIELD_NOT_FOUND = 1002, /**< field() function did not find requested field */
+	// <kortemik>
+	RS_RET_FS_ERR = -2443, /**< file-system error */
+	// </kortemik>
 
 	/* some generic error/status codes */
 	RS_RET_OK = 0,			/**< operation successful */

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -506,13 +506,11 @@ operation not carried out */
 	RS_RET_UDP_MSGSIZE_TOO_LARGE = -2440, /**< a message is too large to be sent via UDP */
 	RS_RET_NON_JSON_PROP = -2441, /**< a non-json property id is provided where a json one is requried */
 	RS_RET_NO_TZ_SET = -2442, /**< system env var TZ is not set (status msg) */
+	RS_RET_FS_ERR = -2443, /**< file-system error */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */
 	RS_RET_FIELD_NOT_FOUND = 1002, /**< field() function did not find requested field */
-	// <kortemik>
-	RS_RET_FS_ERR = -2443, /**< file-system error */
-	// </kortemik>
 
 	/* some generic error/status codes */
 	RS_RET_OK = 0,			/**< operation successful */

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -693,8 +693,9 @@ fsCheck(instanceData *__restrict__ const pData, const uchar *__restrict__ const 
 			LogError(0, iRet, "too few available blocks in %s", path);
 			FINALIZE;
 		}
-	/* there must be enough inodes left  */
-	if (stat.f_favail < 1)
+	/* there must be enough inodes left, one is left for administrative purposes
+	 * check is not done if file system reports 0 total inodes, such as btrfs */
+	if (stat.f_favail < 2 && stat.f_files > 0)
 		{
 			iRet = RS_RET_FS_ERR;
 			LogError(0, iRet, "too few available inodes in %s", path);

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -1138,9 +1138,8 @@ CODESTARTcommitTransaction
 	}
 
 finalize_it:
-
 	if (iRet != RS_RET_OK) {
-		if (runModConf->bDynafileDoNotSuspend == 0) {
+		if (runModConf->bDynafileDoNotSuspend == 0 || !(pData->bDynamicName)) {
 			LogError(0, iRet, "suspending action");
 			iRet = RS_RET_SUSPENDED;
 		}

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -1140,12 +1140,14 @@ CODESTARTcommitTransaction
 finalize_it:
 
 	if (iRet != RS_RET_OK) {
-		LogError(0, iRet, "suspending action");
-		iRet = RS_RET_SUSPENDED;
+		if (runModConf->bDynafileDoNotSuspend == 0) {
+			LogError(0, iRet, "suspending action");
+			iRet = RS_RET_SUSPENDED;
+		}
+		else {
+			LogError(0, iRet, "discarding message");
+		}
 	}
-/* FIXME: what to do with runModConf->bDynafileDoNotSuspend because
- * now it suspends even with non-dynafiles
- */
 	pthread_mutex_unlock(&pData->mutWrite);
 ENDcommitTransaction
 


### PR DESCRIPTION
…t enough inodes, not enough blocks, file-system read-only or output path is not found

this allows omfile to act correctly in case message write retries are intended.

old behaviour should no change as actions default to no retry http://www.rsyslog.com/doc/v8-stable/configuration/actions.html:
```
action.resumeRetryCount integer

[default 0, -1 means eternal]

Sets how often an action is retried before it is considered to have failed. Failed actions discard messages.
```