### PR TITLE
tests/Makefile: Fix EXTRA_DIST and add testsuites/include-std-omfile-action.conf

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1072,7 +1072,7 @@ EXTRA_DIST= \
 	template-pos-from-to-oversize.sh \
 	template-pos-from-to-oversize-lowercase.sh \
 	template-pos-from-to-missing-jsonvar.sh \
-	template-const-jsonf.sh
+	template-const-jsonf.sh \
 	fac_authpriv.sh \
 	testsuites/fac_authpriv.conf \
 	fac_local0.sh \
@@ -1804,7 +1804,8 @@ EXTRA_DIST= \
 	testsuites/sample.pmsnare_ccdefault \
 	testsuites/sample.pmsnare_cccstyle \
 	testsuites/sample.pmsnare_ccbackslash \
-	testsuites/sample.pmsnare_modoverride
+	testsuites/sample.pmsnare_modoverride \
+	testsuites/include-std-omfile-action.conf
 
 ourtail_SOURCES = ourtail.c
 msleep_SOURCES = msleep.c


### PR DESCRIPTION
This commit fixes EXTRA_DIST list which was broken via commit
87f296fd2e667e95f38991a8a7caf84c3458e7c9.

In addition, this commit adds the missing testsuites/include-std-omfile-action.conf file
to EXTRA_DIST.

Fixes: https://github.com/rsyslog/rsyslog/issues/2493