### PR TITLE
coverity: work around expired/invalid scan.coverity.com cert

### DIFF
--- a/tests/travis/run-cron.sh
+++ b/tests/travis/run-cron.sh
@@ -47,6 +47,7 @@ curl --form token=$COVERITY_TOKEN \
   --form file=@rsyslog.tgz \
   --form version="master branch head" \
   --form description="$(git log -1|head -1)" \
+  --insecure \
   https://scan.coverity.com/builds?project=rsyslog%2Frsyslog
 CURL_RESULT=$?
 echo curl returned $CURL_RESULT


### PR DESCRIPTION
DO NOT MERGE THIS AT THE MOMENT

I just found out that the problem is not only the certificate, but Coverity Scan does not work at all since February, 20th. See Coverity's Twitter channel: https://twitter.com/CoverityScan

I hope we get this up again -- Coverity was a very good addition to your toolbox.