### PR TITLE
Changelog: Fix config.enabled parameter name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -40,10 +40,10 @@ Version 8.33.0 [v8-stable] 2018-02-20
   closes https://github.com/rsyslog/rsyslog/issues/2347
 - core/template: add format jsonf to constant template entries
   closes https://github.com/rsyslog/rsyslog/issues/2348
-- config: add ability to disable config parameter ("config.enable")
+- config: add ability to disable config parameter ("config.enabled")
   For auto-generated configs, it is useful to have the ability to disable some
   config constructs even though they may be specified inside the config. This
-  can now be done via the ```config.disable``` parameter, applicable to all
+  can now be done via the ```config.enabled``` parameter, applicable to all
   script objects. If set to ```on``` or not specified, the construct will be
   used, if set to any other value, it will be ignored. This can be used
   together with the backtick functionality to configure enable and disable


### PR DESCRIPTION
Fix two instances of the wrong name.

closes rsyslog/rsyslog#2521

refs rsyslog/rsyslog-doc#614
