### PR TITLE
tests/Makefile: Fix broken TESTS

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -74,7 +74,7 @@ TESTS +=  \
 	template-pos-from-to-oversize.sh \
 	template-pos-from-to-oversize-lowercase.sh \
 	template-pos-from-to-missing-jsonvar.sh \
-	template-const-jsonf.sh
+	template-const-jsonf.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
 	fac_local7.sh \


### PR DESCRIPTION
This patch fixes the list of TESTS, broken by a line without the backslash introduced in Commit 87f296fd2e667e95f38991a8a7caf84c3458e7c9.