### PR TITLE
Add lgtm.yml configuration for analysis on lgtm.com

### DIFF
--- a/.lgtm.yml
+++ b/.lgtm.yml
@@ -1,0 +1,11 @@
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - python-docutils
+    
+    # Enable build with slightly older libfastjson-dev
+    after_prepare:
+        - sed -i -e 's/\[libfastjson >= .*\]/\[libfastjson >= 0.99.4\]/' configure.ac
+        - sed -i -e 's/fjson_global_do_case_sensitive_comparison/\/\/fjson_global_do_case_sensitive_comparison/g' tools/rsyslogd.c
+        - sed -i -e 's/fjson_global_do_case_sensitive_comparison/\/\/fjson_global_do_case_sensitive_comparison/g' runtime/glbl.c


### PR DESCRIPTION
As discussed with @rgerhards: here is a configuration file to enable C/C++ analysis of rsyslog on lgtm.com. Full disclosure: I'm part of the team behind lgtm :smile: 

The build script contains three small patches to configure.ac, tools/rsyslogd.c, and runtime/glbl.c to enable building with an older version of libfastjson-dev. This shouldn't affect the analysis. The build environment on lgtm.com will be upgraded to Ubuntu 18.04 in the next couple of months, so hopefully this small hack won't be needed for long.

Lines 2-5 can also soon be removed from this file; we're looking into why that dependency wasn't detected automatically.

In other words: hopefully these build hints won't be needed any longer in a couple of months' time!