### PR TITLE
stream/bugfix: memory leak on stream open if filename as already gene…

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -353,6 +353,8 @@ static rsRetVal strmOpenFile(strm_t *pThis)
 
 	if(pThis->fd != -1)
 		ABORT_FINALIZE(RS_RET_OK);
+
+	free(pThis->pszCurrFName);
 	pThis->pszCurrFName = NULL; /* used to prevent mem leak in case of error */
 
 	if(pThis->pszFName == NULL)


### PR DESCRIPTION
…rated

this can happen if imfile reads a state file. On each open, memory for the
file name can be lost.

We detected this while working on imfile refactoring, there is no related
bug report. No specific test has been crafted, as the refactored imfile
tests catch it (as soon as they are merged).