### PR TITLE
imfile: emit error on startup if no working directory is set

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -2045,6 +2045,14 @@ ENDendCnfLoad
 BEGINcheckCnf
 	instanceConf_t *inst;
 CODESTARTcheckCnf
+	if(ustrlen(glbl.GetWorkDir()) == 0) {
+		/* this intentionally is an error message */
+		LogError(0, RS_RET_NO_WRKDIR_SET,
+			"imfile: no working directory set, imfile will create "
+			"state files in the current working directory (probably "
+			"the root dir). Use global(workDirectory=\"/some/path\") "
+			"to set the working directory");
+	}
 	for(inst = pModConf->root ; inst != NULL ; inst = inst->next) {
 		std_checkRuleset(pModConf, inst);
 	}

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -580,6 +580,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_RABBITMQ_CONN_ERR = -2447, /**< RabbitMQ Connection error */
 	RS_RET_RABBITMQ_LOGIN_ERR = -2448, /**< RabbitMQ Login error */
 	RS_RET_RABBITMQ_CHANNEL_ERR = -2449, /**< RabbitMQ Connection error */
+	RS_RET_NO_WRKDIR_SET = -2450, /**< working directory not set, but desired by functionality */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */

--- a/tests/imfile-basic.sh
+++ b/tests/imfile-basic.sh
@@ -3,12 +3,16 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50000
 generate_conf
+# NOTE: do NOT set a working directory!
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")
 input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" tag="file:")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+if $msg contains "msgnum:" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+else
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.othermsgs")
 '
 # make sure file exists when rsyslog starts up
 touch $RSYSLOG_DYNNAME.input
@@ -18,4 +22,5 @@ wait_file_lines
 shutdown_when_empty
 wait_shutdown
 seq_check
+content_check "imfile: no working directory set" $RSYSLOG_DYNNAME.othermsgs
 exit_test


### PR DESCRIPTION
When the work directory has not been set or is invalid, state files
are created in the root of the file system. This is neither expected
nor desirable. We now complain loudly about this fact. For backwards
compatibility reasons, we still need to support running imfile in
this case.

closes https://github.com/rsyslog/rsyslog/issues/1296