### PR TITLE
testbench: disable imjournal tests temporarily due to issues

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -428,14 +428,16 @@ TESTS +=  \
 endif
 endif
 
-if ENABLE_IMJOURNAL
-TESTS +=  \
-	imjournal-basic.sh
-if HAVE_VALGRIND
-TESTS +=  \
-	imjournal-basic-vg.sh
-endif
-endif
+# disable temporarily due to issues
+# see: https://github.com/rsyslog/rsyslog/issues/2564
+#if ENABLE_IMJOURNAL
+#TESTS +=  \
+#	imjournal-basic.sh
+#if HAVE_VALGRIND
+#TESTS +=  \
+#	imjournal-basic-vg.sh
+#endif
+#endif
 
 if ENABLE_OMJOURNAL
 TESTS +=  \


### PR DESCRIPTION
So we permit CI to work well while we work on solving the issue.

see: https://github.com/rsyslog/rsyslog/issues/2564