### PR TITLE
Make configuration setting SystemLogRateLimitBurst unsigned int

### DIFF
--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -327,7 +327,7 @@ finalize_it:
 
 /* enable linux-like ratelimiting */
 void
-ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned short interval, unsigned short burst)
+ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned short interval, unsigned burst)
 {
 	ratelimit->interval = interval;
 	ratelimit->burst = burst;

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -25,7 +25,7 @@ struct ratelimit_s {
 	char *name;	/**< rate limiter name, e.g. for user messages */
 	/* support for Linux kernel-type ratelimiting */
 	unsigned short interval;
-	unsigned short burst;
+	unsigned burst;
 	intTiny severity; /**< ratelimit only equal or lower severity levels (eq or higher values) */
 	unsigned done;
 	unsigned missed;
@@ -42,7 +42,7 @@ struct ratelimit_s {
 /* prototypes */
 rsRetVal ratelimitNew(ratelimit_t **ppThis, const char *modname, const char *dynname);
 void ratelimitSetThreadSafe(ratelimit_t *ratelimit);
-void ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned short interval, unsigned short burst);
+void ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned short interval, unsigned burst);
 void ratelimitSetNoTimeCache(ratelimit_t *ratelimit);
 void ratelimitSetSeverity(ratelimit_t *ratelimit, intTiny severity);
 rsRetVal ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep);


### PR DESCRIPTION
rsyslog uses unsigned short for configuration setting
SystemLogRateLimitBurst. Being just 16 bits, unsigned short cannot
hold values bigger than 65535. On our LDAP server rsyslog misbehaved with
SystemLogRateLimitBurst being bigger than 65535. Make it unsigned int to
accept bigger values.