### PR TITLE
testbench: temporarily disable more racy omprog tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -453,28 +453,28 @@ if ENABLE_OMPROG
 #	omprog-cleanup.sh
 #	omprog-noterm-cleanup.sh
 #	omprog-noterm-default.sh
+#	omprog-cleanup-with-outfile.sh
 # linux:
 #	omprog-noterm-unresponsive.sh
 # valgrind:
 #	omprog-noterm-cleanup-vg.sh
+#	omprog-cleanup-vg.sh
 TESTS +=  \
-	omprog-cleanup-with-outfile.sh \
 	omprog-feedback.sh \
 	omprog-transactions.sh \
 	omprog-transactions-failed-messages.sh \
 	omprog-transactions-failed-commits.sh
-if OS_LINUX
-TESTS += \
-	omprog-cleanup-when-unresponsive.sh
-endif
+#if OS_LINUX
+#TESTS += \
+#	omprog-cleanup-when-unresponsive.sh
+#endif
 if HAVE_VALGRIND
 TESTS +=  \
-	omprog-cleanup-vg.sh \
 	omprog-multiparam-vg.sh
-if OS_LINUX
-TESTS += \
-	omprog-cleanup-when-unresponsive-vg.sh
-endif
+#if OS_LINUX
+#TESTS += \
+	#omprog-cleanup-when-unresponsive-vg.sh
+#endif
 endif
 endif
 


### PR DESCRIPTION
I have obviously overlooked some...

see also https://github.com/rsyslog/rsyslog/issues/2403