### PR TITLE
omprog: corrected fd leak with confirmMessages=on

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -273,6 +273,7 @@ openPipe(wrkrInstanceData_t *pWrkrData)
 			pWrkrData->fdPipeErr = pipeStderr[0];
 		}
 		else {
+			close(pipeStderr[0]);
 			pWrkrData->fdPipeErr = -1;
 		}
 	} else if (pWrkrData->pData->outputFileName != NULL) {


### PR DESCRIPTION
There was a fd leak in the feedback feature I added in v8.31.0 (PR #1753). The leak occurred when omprog was used with the `confirmMessages=on` setting and no `output` setting. One fd was leaked every time the external program was started.

I have found this when reviewing the omprog tests. A later PR I'm currently preparing will include a regression test for this case. Meanwhile, the correction should be merged ASAP.