### PR TITLE
fix issues with atomic operations

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -254,7 +254,7 @@ AC_LINK_IFELSE([AC_LANG_PROGRAM(, return __builtin_expect(main != 0, 1))],
 # speeds up processig.
 # note that when automic operations are enabled but not available, they
 # will silently NOT be used!
-AC_ARG_ENABLE(regexp,
+AC_ARG_ENABLE(atomic-operations,
         [AS_HELP_STRING([--enable-atomic-operations],[Enable atomic operation support @<:@default=yes@:>@])],
         [case "${enableval}" in
          yes) enable_atomic_operations="yes" ;;
@@ -2289,6 +2289,7 @@ echo "    liblogging-stdlog support enabled:        $enable_liblogging_stdlog"
 echo "    libsystemd enabled:                       $enable_libsystemd"
 echo "    libcurl enabled:                          $enable_libcurl"
 echo "    kafka static linking enabled:             $enable_kafka_static"
+echo "    atomic operations enabled:                $enable_atomic_operations"
 echo
 echo "---{ input plugins }---"
 echo "    Klog functionality enabled:               $enable_klog ($os_type)"

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -40,6 +40,7 @@
  */
 #ifdef HAVE_ATOMIC_BUILTINS
 #	define ATOMIC_SUB(data, val, phlpmut) __sync_fetch_and_sub(data, val)
+#	define ATOMIC_SUB_unsigned(data, val, phlpmut) __sync_fetch_and_sub(data, val)
 #	define ATOMIC_ADD(data, val) __sync_fetch_and_add(&(data), val)
 #	define ATOMIC_INC(data, phlpmut) ((void) __sync_fetch_and_add(data, 1))
 #	define ATOMIC_INC_AND_FETCH_int(data, phlpmut) __sync_fetch_and_add(data, 1)
@@ -47,6 +48,7 @@
 #	define ATOMIC_DEC(data, phlpmut) ((void) __sync_sub_and_fetch(data, 1))
 #	define ATOMIC_DEC_AND_FETCH(data, phlpmut) __sync_sub_and_fetch(data, 1)
 #	define ATOMIC_FETCH_32BIT(data, phlpmut) ((int) __sync_fetch_and_and(data, 0xffffffff))
+#	define ATOMIC_FETCH_32BIT_unsigned(data, phlpmut) ((int) __sync_fetch_and_and(data, 0xffffffff))
 #	define ATOMIC_STORE_1_TO_32BIT(data) __sync_lock_test_and_set(&(data), 1)
 #	define ATOMIC_STORE_0_TO_INT(data, phlpmut) __sync_fetch_and_and(data, 0)
 #	define ATOMIC_STORE_1_TO_INT(data, phlpmut) __sync_fetch_and_or(data, 1)
@@ -182,8 +184,24 @@
 		return(val);
 	}
 
+	static inline int
+	ATOMIC_FETCH_32BIT_unsigned(unsigned *data, pthread_mutex_t *phlpmut) {
+		int val;
+		pthread_mutex_lock(phlpmut);
+		val = (*data);
+		pthread_mutex_unlock(phlpmut);
+		return(val);
+	}
+
 	static inline void
 	ATOMIC_SUB(int *data, int val, pthread_mutex_t *phlpmut) {
+		pthread_mutex_lock(phlpmut);
+		(*data) -= val;
+		pthread_mutex_unlock(phlpmut);
+	}
+
+	static inline void
+	ATOMIC_SUB_unsigned(unsigned *data, int val, pthread_mutex_t *phlpmut) {
 		pthread_mutex_lock(phlpmut);
 		(*data) -= val;
 		pthread_mutex_unlock(phlpmut);

--- a/runtime/dynstats.c
+++ b/runtime/dynstats.c
@@ -86,7 +86,7 @@ dynstats_destroyCountersIn(dynstats_bucket_t *b, htable *table, dynstats_ctr_t *
 		ctrs_purged++;
 	}
 	STATSCOUNTER_ADD(b->ctrMetricsPurged, b->mutCtrMetricsPurged, ctrs_purged);
-	ATOMIC_SUB(&b->metricCount, ctrs_purged, &b->mutMetricCount);
+	ATOMIC_SUB_unsigned(&b->metricCount, ctrs_purged, &b->mutMetricCount);
 }
 
 static void /* assumes exclusive access to bucket */
@@ -513,7 +513,7 @@ dynstats_addNewCtr(dynstats_bucket_t *b, const uchar* metric, uint8_t doInitialI
 	created = 0;
 	ctr = NULL;
 
-	if ((unsigned) ATOMIC_FETCH_32BIT(&b->metricCount, &b->mutMetricCount) >= b->maxCardinality) {
+	if ((unsigned) ATOMIC_FETCH_32BIT_unsigned(&b->metricCount, &b->mutMetricCount) >= b->maxCardinality) {
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
 	

--- a/tests/imfile-endregex-timeout-with-shutdown-polling.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown-polling.sh
@@ -29,7 +29,7 @@ if $msg contains "msgnum:" then
 # to pick up the data (IN MULTIPLE ITERATIONS!)
 echo 'msgnum:0
  msgnum:1' > rsyslog.input
-./msleep 5000
+./msleep 8000
 echo ' msgnum:2
  msgnum:3' >> rsyslog.input
 
@@ -45,10 +45,10 @@ echo ' msgnum:2
 
 # new data
 echo ' msgnum:4' >> rsyslog.input
-./msleep 5000
+./msleep 8000
 echo ' msgnum:5
  msgnum:6' >> rsyslog.input
-./msleep 5000
+./msleep 8000
 
 # the next line terminates our test. It is NOT written to the output file,
 # as imfile waits whether or not there is a follow-up line that it needs

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -95,7 +95,7 @@ DEFobjCurrIf(statsobj)
  * That should be sufficient (and even than, there would no really bad effect ;)).
  * The variable below is the global counter/clock.
  */
-#if HAVE_ATOMIC_BUILTINS64
+#ifdef HAVE_ATOMIC_BUILTINS64
 static uint64 clockFileAccess = 0;
 #else
 static unsigned clockFileAccess = 0;
@@ -107,7 +107,7 @@ static pthread_mutex_t mutClock;
 static uint64
 getClockFileAccess(void)
 {
-#if HAVE_ATOMIC_BUILTINS64
+#ifdef HAVE_ATOMIC_BUILTINS64
 	return ATOMIC_INC_AND_FETCH_uint64(&clockFileAccess, &mutClock);
 #else
 	return ATOMIC_INC_AND_FETCH_unsigned(&clockFileAccess, &mutClock);


### PR DESCRIPTION
... on platforms that do not support them natively. None of them actually break building except when warning-free compile is enforced.

closes #2612