### PR TITLE
QA: re-enable some compiler warnigs AX_COMPILER_FLAGS disables

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,12 @@ then
 	m4_ifdef([AX_IS_RELEASE], [
 		AX_IS_RELEASE([git-directory])
 		m4_ifdef([AX_COMPILER_FLAGS], [
-			AX_COMPILER_FLAGS()
+			AX_COMPILER_FLAGS(,,,,[-Wunused-parameter -Wmissing-field-initializers])
+			# unfortunately, AX_COMPILER_FLAGS does not provide a way to override
+			# the default -Wno-error=warning" flags. So we do this via sed below.
+			# Note: we *really* want to have this error out during CI testing!
+			# rgerhards, 2018-05-09
+			WARN_CFLAGS="$(echo "$WARN_CFLAGS" | sed s/-Wno-error=/-W/g)"
 		], [
 			CFLAGS="$CFLAGS -W -Wall -Wformat-security -Wshadow -Wcast-align -Wpointer-arith -Wmissing-format-attribute -g"
 			AC_MSG_WARN([missing AX_COMPILER_FLAGS macro, not using it])

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1668,7 +1668,7 @@ static void
 doFunc_exec_template(struct cnffunc *__restrict__ const func,
 	struct svar *__restrict__ const ret,
 	void *const usrptr,
-	wti_t *const __attribute__((unused)) pWti)
+	wti_t *const pWti __attribute__((unused)))
 {
 	smsg_t *const pMsg = (smsg_t*) usrptr;
 	rsRetVal localRet;
@@ -2314,7 +2314,7 @@ static void ATTR_NONNULL()
 doFunct_Prifilt(struct cnffunc *__restrict__ const func,
 	struct svar *__restrict__ const ret,
 	void *__restrict__ const usrptr,
-	wti_t *const __attribute__((unused)) pWti)
+	wti_t *const pWti __attribute__((unused)))
 {
 	struct funcData_prifilt *pPrifilt;
 
@@ -2631,9 +2631,9 @@ doFunct_IsTime(struct cnffunc *__restrict__ const func,
 }
 
 static void ATTR_NONNULL()
-doFunct_ScriptError(struct cnffunc *const __attribute__((unused)) func,
+doFunct_ScriptError(struct cnffunc *const func __attribute__((unused)),
 	struct svar *__restrict__ const ret,
-	void *const __attribute__((unused)) usrptr,
+	void *const usrptr __attribute__((unused)),
 	wti_t *__restrict__ const pWti)
 {
 	ret->datatype = 'N';
@@ -2642,9 +2642,9 @@ doFunct_ScriptError(struct cnffunc *const __attribute__((unused)) func,
 }
 
 static void ATTR_NONNULL()
-doFunct_PreviousActionSuspended(struct cnffunc *const __attribute__((unused)) func,
+doFunct_PreviousActionSuspended(struct cnffunc *const func __attribute__((unused)),
 	struct svar *__restrict__ const ret,
-	void *const __attribute__((unused)) usrptr,
+	void *const usrptr __attribute__((unused)),
 	wti_t *__restrict__ const pWti)
 {
 	ret->datatype = 'N';

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -603,7 +603,7 @@ done:	return;
 }
 #else
 static void ATTR_NONNULL()
-fen_setupWatch(act_obj_t *const __attribute__((unused)) act)
+fen_setupWatch(act_obj_t *const act __attribute__((unused)))
 {
 	DBGPRINTF("fen_setupWatch: DUMMY CALLED - not on Solaris?");
 }

--- a/plugins/imklog/bsd.c
+++ b/plugins/imklog/bsd.c
@@ -7,7 +7,7 @@
  * are very small, and so we use a single driver for both OS's with
  * a little help of conditional compilation.
  *
- * Copyright 2008-2015 Adiscon GmbH
+ * Copyright 2008-2018 Adiscon GmbH
  *
  * This file is part of rsyslog.
  *
@@ -285,7 +285,8 @@ readklog(modConfData_t *pModConf)
 /* to be called in the module's AfterRun entry point
  * rgerhards, 2008-04-09
  */
-rsRetVal klogAfterRun(modConfData_t *pModConf)
+rsRetVal ATTR_NONNULL()
+klogAfterRun(modConfData_t *const pModConf __attribute__((unused)))
 {
         DEFiRet;
 	if(fklog != -1)

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -449,7 +449,7 @@ doForceKillSubprocess(subprocess_timeout_desc_t *subpTimeOut, int do_kill, pid_t
 #endif
 
 static void
-waitForChild(wrkrInstanceData_t *pWrkrData, const long timeout_ms)
+waitForChild(wrkrInstanceData_t *pWrkrData, const long timeout_ms __attribute__((unused)))
 {
 	int status;
 	int ret;

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -307,7 +307,7 @@ dbgFuncDBRemoveMutexLock(dbgFuncDB_t *pFuncDB, pthread_mutex_t *pmut)
  * (what "relevant" means is determinded by various ways)
  */
 void
-dbgOutputTID(char* name)
+dbgOutputTID(char* name __attribute__((unused)))
 {
 #	if defined(HAVE_SYSCALL) && defined(HAVE_SYS_gettid)
 	if(bOutputTidToStderr)

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -4,7 +4,7 @@
  * NOTE: read comments in module-template.h to understand how this file
  *       works!
  *
- * Copyright 2007-2016 Adiscon GmbH.
+ * Copyright 2007-2018 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -777,7 +777,7 @@ finalize_it:
 /* change to network namespace pData->networkNamespace and keep the file
  * descriptor to the original namespace.
  */
-static rsRetVal changeToNs(instanceData *pData)
+static rsRetVal changeToNs(instanceData *const pData __attribute__((unused)))
 {
 	DEFiRet;
 #ifdef HAVE_SETNS
@@ -831,7 +831,7 @@ finalize_it:
 /* return to the original network namespace. This should be called after
  * changeToNs().
  */
-static rsRetVal returnToOriginalNs(instanceData *pData)
+static rsRetVal returnToOriginalNs(instanceData *const pData __attribute__((unused)))
 {
 	DEFiRet;
 #ifdef HAVE_SETNS


### PR DESCRIPTION
We do not know exactly why AX_COMPILER_FLAGS turns these off, but we
consider them useful and would like to have them turned on.

**Note: PR will and must fail** until we have fixed those warnings that sneaked in while the warnings were turned off. Those fixes will be done in separate PRs, then a rebase happens here.