### PR TITLE
remove unnecessary debug output

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5071,7 +5071,6 @@ addMod2List(const int __attribute__((unused)) version, struct scriptFunct *funct
 				functArray[i].fname);
 		}
 	i++;
-	dbgprintf("TTTTTTT: i: %d, name: %s\n", i, functArray[i-1].fname);
 	}
 	newNode->modFcts = functArray;
 

--- a/plugins/fmhttp/fmhttp.c
+++ b/plugins/fmhttp/fmhttp.c
@@ -164,7 +164,6 @@ static struct scriptFunct functions[] = {
 
 BEGINgetFunctArray
 CODESTARTgetFunctArray
-	dbgprintf("TTTTTT: fmhttp\n");
 	*version = 1;
 	*functArray = functions;
 ENDgetFunctArray

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -804,7 +804,6 @@ doModInit(rsRetVal (*modInit)(int, int*, rsRetVal(**)(), rsRetVal(*)(), modInfo_
 			CHKiRet(strgen.ConstructFinalize(pStrgen));
 			break;
 		case eMOD_FUNCTION:
-			dbgprintf("TTTTTT: load function module\n");
 			CHKiRet((*pNew->modQueryEtryPt)((uchar*)"getFunctArray", &pNew->mod.fm.getFunctArray));
 			int version;
 			struct scriptFunct *functArray;


### PR DESCRIPTION
was used while implementing function modules, but were
not removed due to oversight.