### PR TITLE
imrelp: maxDataSize can only be set larger than maxMessageSize

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -488,7 +488,14 @@ CODESTARTnewInpInst
 		} else if(!strcmp(inppblk.descr[i].name, "ruleset")) {
 			inst->pszBindRuleset = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "maxdatasize")) {
-			inst->maxDataSize = (size_t) pvals[i].val.d.n;
+			size_t maxDataSize = (size_t) pvals[i].val.d.n;
+			if(maxDataSize < (size_t)glbl.GetMaxLine()) {
+				errmsg.LogError(0, RS_RET_INVALID_PARAMS, "error: "
+					"maxDataSize is smaller than global parameter "
+					"maxMessageSize - global parameter will be used.");
+			} else {
+				inst->maxDataSize = maxDataSize;
+			}
 		} else if(!strcmp(inppblk.descr[i].name, "keepalive")) {
 			inst->bKeepAlive = (sbool) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "keepalive.probes")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -718,7 +718,8 @@ if ENABLE_RELP
 TESTS += sndrcv_relp.sh \
 	 sndrcv_relp_rebind.sh \
 	 imrelp-basic.sh \
-	 imrelp-manyconn.sh
+	 imrelp-manyconn.sh \
+	 imrelp-maxDataSize-error.sh
 if ENABLE_GNUTLS
 TESTS += \
          sndrcv_relp_tls.sh \
@@ -1364,6 +1365,7 @@ EXTRA_DIST= \
 	testsuites/sndrcv_rcvr.conf \
 	imrelp-basic.sh \
 	imrelp-manyconn.sh \
+	imrelp-maxDataSize-error.sh \
 	sndrcv_relp.sh \
 	testsuites/sndrcv_relp_sender.conf \
 	testsuites/sndrcv_relp_rcvr.conf \

--- a/tests/imrelp-maxDataSize-error.sh
+++ b/tests/imrelp-maxDataSize-error.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# add 2018-04-26 by Pascal Withopf, released under ASL 2.0
+echo [imrelp-maxDataSize-error.sh]
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+
+global(
+	maxMessageSize="300"
+)
+
+input(type="imrelp" port="13514" maxDataSize="250")
+
+action(type="omfile" file="rsyslog.out.log")
+'
+. $srcdir/diag.sh startup
+./msleep 2000
+
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+grep "error: maxDataSize is smaller than global parameter maxMessageSize" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected error message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh exit


### PR DESCRIPTION
maxDataSize specifies the length which will still be accepted
but is larger than the global parameter maxMessageSize.