### PR TITLE
imfile bugfix: statefiles contain invalid JSON

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -2287,7 +2287,7 @@ static rsRetVal ATTR_NONNULL()
 atomicWriteStateFile(const char *fn, const char *content)
 {
 	DEFiRet;
-	const int fd = open(fn, O_CLOEXEC | O_NOCTTY | O_WRONLY | O_CREAT, 0600);
+	const int fd = open(fn, O_CLOEXEC | O_NOCTTY | O_WRONLY | O_CREAT | O_TRUNC, 0600);
 	if(fd < 0) {
 		LogError(errno, RS_RET_IO_ERROR, "imfile: cannot open state file '%s' for "
 			"persisting file state - some data will probably be duplicated "


### PR DESCRIPTION
When imfile rewrites state files, it does not truncate previous
content. If the new content is smaller than the existing one, the
existing part will not be overwritten, resulting in invalid json.
That in turn can lead to some other failures.

closes https://github.com/rsyslog/rsyslog/issues/2662