### PR TITLE
nsdsel_ptcp: replace select() by poll()

### DIFF
--- a/runtime/nsdsel_ptcp.c
+++ b/runtime/nsdsel_ptcp.c
@@ -2,7 +2,7 @@
  *
  * An implementation of the nsd select() interface for plain tcp sockets.
  * 
- * Copyright 2008 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -38,70 +38,61 @@
 #include "nsdsel_ptcp.h"
 #include "unlimited_select.h"
 
+#define FDSET_INCREMENT 1024 /* increment for struct pollfds array allocation */
 /* static data */
 DEFobjStaticHelpers
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 
 
-/* Standard-Constructor
- */
+/* Standard-Constructor */
 BEGINobjConstruct(nsdsel_ptcp) /* be sure to specify the object type also in END macro! */
-	pThis->maxfds = 0;
-#ifdef USE_UNLIMITED_SELECT
-        pThis->pReadfds = calloc(1, glbl.GetFdSetSize());
-        pThis->pWritefds = calloc(1, glbl.GetFdSetSize());
-#else
-	FD_ZERO(&pThis->readfds);
-	FD_ZERO(&pThis->writefds);
-#endif
+	pThis->currfds = 0;
+	pThis->maxfds = FDSET_INCREMENT;
+        CHKmalloc(pThis->fds = calloc(FDSET_INCREMENT, sizeof(struct pollfd)));
+finalize_it:
 ENDobjConstruct(nsdsel_ptcp)
 
 
 /* destructor for the nsdsel_ptcp object */
 BEGINobjDestruct(nsdsel_ptcp) /* be sure to specify the object type also in END and CODESTART macros! */
 CODESTARTobjDestruct(nsdsel_ptcp)
-#ifdef USE_UNLIMITED_SELECT
-	freeFdSet(pThis->pReadfds);
-	freeFdSet(pThis->pWritefds);
-#endif
+	free(pThis->fds);
 ENDobjDestruct(nsdsel_ptcp)
 
 
 /* Add a socket to the select set */
-static rsRetVal
-Add(nsdsel_t *pNsdsel, nsd_t *pNsd, nsdsel_waitOp_t waitOp)
+static rsRetVal ATTR_NONNULL()
+Add(nsdsel_t *const pNsdsel, nsd_t *const pNsd, const nsdsel_waitOp_t waitOp)
 {
 	DEFiRet;
-	nsdsel_ptcp_t *pThis = (nsdsel_ptcp_t*) pNsdsel;
-	nsd_ptcp_t *pSock = (nsd_ptcp_t*) pNsd;
-#ifdef USE_UNLIMITED_SELECT
-        fd_set *pReadfds = pThis->pReadfds;
-        fd_set *pWritefds = pThis->pWritefds;
-#else
-        fd_set *pReadfds = &pThis->readfds;
-        fd_set *pWritefds = &pThis->writefds;
-#endif
-
+	nsdsel_ptcp_t *const pThis = (nsdsel_ptcp_t*) pNsdsel;
+	const nsd_ptcp_t *const pSock = (nsd_ptcp_t*) pNsd;
 	ISOBJ_TYPE_assert(pSock, nsd_ptcp);
 	ISOBJ_TYPE_assert(pThis, nsdsel_ptcp);
 
-	switch(waitOp) {
-		case NSDSEL_RD:
-			FD_SET(pSock->sock, pReadfds);
-			break;
-		case NSDSEL_WR:
-			FD_SET(pSock->sock, pWritefds);
-			break;
-		case NSDSEL_RDWR:
-			FD_SET(pSock->sock, pReadfds);
-			FD_SET(pSock->sock, pWritefds);
-			break;
+	if(pThis->currfds == pThis->maxfds) {
+		struct pollfd *newfds;
+		CHKmalloc(newfds = realloc(pThis->fds,
+			sizeof(struct pollfd) * (pThis->maxfds + FDSET_INCREMENT)));
+		pThis->maxfds += FDSET_INCREMENT;
+		pThis->fds = newfds;
 	}
 
-	if(pSock->sock > pThis->maxfds)
-		pThis->maxfds = pSock->sock;
+	switch(waitOp) {
+		case NSDSEL_RD:
+			pThis->fds[pThis->currfds].events = POLLIN;
+			break;
+		case NSDSEL_WR:
+			pThis->fds[pThis->currfds].events = POLLOUT;
+			break;
+		case NSDSEL_RDWR:
+			pThis->fds[pThis->currfds].events = POLLIN | POLLOUT;
+			break;
+	}
+	pThis->fds[pThis->currfds].fd = pSock->sock;
+	++pThis->currfds;
 
+finalize_it:
 	RETiRet;
 }
 
@@ -109,71 +100,77 @@ Add(nsdsel_t *pNsdsel, nsd_t *pNsd, nsdsel_waitOp_t waitOp)
 /* perform the select()  piNumReady returns how many descriptors are ready for IO 
  * TODO: add timeout!
  */
-static rsRetVal
-Select(nsdsel_t *pNsdsel, int *piNumReady)
+static rsRetVal ATTR_NONNULL()
+Select(nsdsel_t *const pNsdsel, int *const piNumReady)
 {
 	DEFiRet;
-	int i;
 	nsdsel_ptcp_t *pThis = (nsdsel_ptcp_t*) pNsdsel;
-#ifdef USE_UNLIMITED_SELECT
-        fd_set *pReadfds = pThis->pReadfds;
-        fd_set *pWritefds = pThis->pWritefds;
-#else
-        fd_set *pReadfds = &pThis->readfds;
-        fd_set *pWritefds = &pThis->writefds;
-#endif
 
 	ISOBJ_TYPE_assert(pThis, nsdsel_ptcp);
 	assert(piNumReady != NULL);
 
-	if(Debug) { // TODO: debug setting!
-		// TODO: name in dbgprintf!
-		dbgprintf("--------<NSDSEL_PTCP> calling select, active fds (max %d): ", pThis->maxfds);
-		for(i = 0; i <= pThis->maxfds; ++i)
-			if(FD_ISSET(i, pReadfds) || FD_ISSET(i, pWritefds))
-				dbgprintf("%d ", i);
+	assert(pThis->currfds >= 1);
+	if(Debug) {
+		dbgprintf("--------<NSDSEL_PTCP> calling poll, active fds (%d): ", pThis->currfds);
+		for(uint32_t i = 0; i <= pThis->currfds; ++i)
+			dbgprintf("%d ", pThis->fds[i].fd);
 		dbgprintf("\n");
 	}
 
 	/* now do the select */
-	*piNumReady = select(pThis->maxfds+1, pReadfds, pWritefds, NULL, NULL);
+	*piNumReady = poll(pThis->fds, pThis->currfds, -1);
+	if(*piNumReady < 0) {
+		if(errno == EINTR) {
+			DBGPRINTF("nsdsel_ptcp received EINTR\n");
+		} else {
+			LogMsg(errno, RS_RET_POLL_ERR, LOG_WARNING,
+				"ndssel_ptcp: poll system call failed, may cause further troubles");
+		}
+		*piNumReady = 0;
+	}
 
 	RETiRet;
 }
 
 
 /* check if a socket is ready for IO */
-static rsRetVal
-IsReady(nsdsel_t *pNsdsel, nsd_t *pNsd, nsdsel_waitOp_t waitOp, int *pbIsReady)
+static rsRetVal ATTR_NONNULL()
+IsReady(nsdsel_t *const pNsdsel, nsd_t *const pNsd, const nsdsel_waitOp_t waitOp, int *const pbIsReady)
 {
 	DEFiRet;
-	nsdsel_ptcp_t *pThis = (nsdsel_ptcp_t*) pNsdsel;
-	nsd_ptcp_t *pSock = (nsd_ptcp_t*) pNsd;
-#ifdef USE_UNLIMITED_SELECT
-        fd_set *pReadfds = pThis->pReadfds;
-        fd_set *pWritefds = pThis->pWritefds;
-#else
-        fd_set *pReadfds = &pThis->readfds;
-        fd_set *pWritefds = &pThis->writefds;
-#endif
-
+	const nsdsel_ptcp_t *const pThis = (nsdsel_ptcp_t*) pNsdsel;
+	const nsd_ptcp_t *const pSock = (nsd_ptcp_t*) pNsd;
 	ISOBJ_TYPE_assert(pThis, nsdsel_ptcp);
 	ISOBJ_TYPE_assert(pSock, nsd_ptcp);
-	assert(pbIsReady != NULL);
+	const int sock = pSock->sock;
+	// TODO: consider doing a binary search
 
+	uint32_t idx;
+	for(idx = 0 ; idx < pThis->currfds ; ++idx) {
+		if(pThis->fds[idx].fd == sock)
+			break;
+	}
+	if(idx >= pThis->currfds) {
+		LogMsg(0, RS_RET_INTERNAL_ERROR, LOG_ERR,
+			"ndssel_ptcp: could not find socket %d which should be present", sock);
+		ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+	}
+
+	const short revent = pThis->fds[idx].revents;
+	assert(!(revent & POLLNVAL));
 	switch(waitOp) {
 		case NSDSEL_RD:
-			*pbIsReady = FD_ISSET(pSock->sock, pReadfds);
+			*pbIsReady = revent & POLLIN;
 			break;
 		case NSDSEL_WR:
-			*pbIsReady = FD_ISSET(pSock->sock, pWritefds);
+			*pbIsReady = revent & POLLOUT;
 			break;
 		case NSDSEL_RDWR:
-			*pbIsReady =   FD_ISSET(pSock->sock, pReadfds)
-				     | FD_ISSET(pSock->sock, pWritefds);
+			*pbIsReady = revent & (POLLIN | POLLOUT);
 			break;
 	}
 
+finalize_it:
 	RETiRet;
 }
 
@@ -208,7 +205,6 @@ BEGINObjClassExit(nsdsel_ptcp, OBJ_IS_CORE_MODULE) /* CHANGE class also in END M
 CODESTARTObjClassExit(nsdsel_ptcp)
 	/* release objects we no longer need */
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 ENDObjClassExit(nsdsel_ptcp)
 
 
@@ -217,11 +213,5 @@ ENDObjClassExit(nsdsel_ptcp)
  * rgerhards, 2008-02-19
  */
 BEGINObjClassInit(nsdsel_ptcp, 1, OBJ_IS_CORE_MODULE) /* class, version */
-	/* request objects we use */
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-
-	/* set our own handlers */
 ENDObjClassInit(nsdsel_ptcp)
-/* vi:set ai:
- */

--- a/runtime/nsdsel_ptcp.h
+++ b/runtime/nsdsel_ptcp.h
@@ -24,20 +24,16 @@
 #ifndef INCLUDED_NSDSEL_PTCP_H
 #define INCLUDED_NSDSEL_PTCP_H
 
+#include <poll.h>
 #include "nsd.h"
 typedef nsdsel_if_t nsdsel_ptcp_if_t; /* we just *implement* this interface */
 
 /* the nsdsel_ptcp object */
 struct nsdsel_ptcp_s {
-	BEGINobjInstance;	/* Data to implement generic object - MUST be the first data element! */
-	int maxfds;
-#ifdef USE_UNLIMITED_SELECT
-	fd_set *pReadfds;
-	fd_set *pWritefds;
-#else
-	fd_set readfds;
-	fd_set writefds;
-#endif
+	BEGINobjInstance;
+	uint32_t maxfds;
+	uint32_t currfds;
+	struct pollfd *fds;
 };
 
 /* interface is defined in nsd.h, we just implement it! */

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -507,6 +507,7 @@ operation not carried out */
 	RS_RET_NON_JSON_PROP = -2441, /**< a non-json property id is provided where a json one is requried */
 	RS_RET_NO_TZ_SET = -2442, /**< system env var TZ is not set (status msg) */
 	RS_RET_FS_ERR = -2443, /**< file-system error */
+	RS_RET_POLL_ERR = -2444, /**< error in poll() system call */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */

--- a/tests/hostname-getaddrinfo-fail.sh
+++ b/tests/hostname-getaddrinfo-fail.sh
@@ -13,9 +13,6 @@ fi
 
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
-# note: the listener error on port 13500 is OK! It is caused by plumbing
-# we do not use here in this special case, and we did not want to work
-# very hard to remove that problem (which does not affect the test)
 . $srcdir/diag.sh add-conf '
 action(type="omfile" file="rsyslog.out.log")
 '
@@ -32,4 +29,8 @@ if [ ! $? -eq 0 ]; then
   . $srcdir/diag.sh error-exit 1
 fi;
 
+echo EVERYTHING OK - error messages are just as expected!
+echo "note: the listener error on port 13500 is OK! It is caused by plumbing"
+echo "we do not use here in this special case, and we did not want to work"
+echo "very hard to remove that problem (which does not affect the test)"
 . $srcdir/diag.sh exit


### PR DESCRIPTION
**This PR is split off from a larger PR which fails for some reason.** I try to see if the individual patch works, and if so I can apply it immediately as it is pretty useful.

This removes us of problems with fds > 1024. The performance will
probably also increase in most cases.

Note this is not a replacement for the epoll drivers, but a general
stability improvement when epoll() is not available for some reason.

see also https://github.com/rsyslog/rsyslog/issues/2615
closes https://github.com/rsyslog/rsyslog/issues/1728
closes https://github.com/rsyslog/rsyslog/issues/1459