### PR TITLE
cosmetic bugfix: valgrind complain in some error conditions

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -4263,6 +4263,7 @@ cnfstmtNewCall(es_str_t *name)
 	struct cnfstmt* cnfstmt;
 	if((cnfstmt = cnfstmtNew(S_CALL)) != NULL) {
 		cnfstmt->d.s_call.name = name;
+		cnfstmt->d.s_call.ruleset = NULL;
 	}
 	return cnfstmt;
 }


### PR DESCRIPTION
When a "call" script statement was used with a non-existing ruleset AND
debug logginf was active for rainerscript.c, valgrind complained and
one debug message could potentially be incorrect (stating a queue
where non was).

This was caused by not initializing a variable which was probed in
debug mode before it was set. Non-debug mode was not affected.

see also https://github.com/rsyslog/rsyslog/issues/2399#issuecomment-384890873