### PR TITLE
bugfix: rsyslog aborts on startup when specific config errors are made

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1452,6 +1452,13 @@ initAll(int argc, char **argv)
 
 	resetErrMsgsFlag();
 	localRet = rsconf.Load(&ourConf, ConfFile);
+
+	/* check for "hard" errors that needs us to abort in any case */
+	if(   (localRet == RS_RET_CONF_FILE_NOT_FOUND)
+	   || (localRet == RS_RET_NO_ACTIONS) ) {
+		ABORT_FINALIZE(localRet);
+	}
+
 	glbl.GenerateLocalHostNameProperty();
 
 	if(hadErrMsgs()) {


### PR DESCRIPTION
The following errors must be made in rsyslog.conf:
* no action present
* a call statement is used on an undefined ruleset

In this case, rsyslog emits an error message on the missing actions and
then segfaults. Depending on memory layout, it may also continue to run
but do nothing except accepting messages as no action is configured.

This patch make rsyslog properly terminate after the error message. It
is a change in behavior, but there really is no reason why a defunct
instance should be kept running.

closes https://github.com/rsyslog/rsyslog/issues/2399