### PR TITLE
mmgrok: fix potential segfault

### DIFF
--- a/contrib/mmgrok/mmgrok.c
+++ b/contrib/mmgrok/mmgrok.c
@@ -315,18 +315,18 @@ finalize_it:
 static rsRetVal
 MotifyMessage(instanceData *pData)
 {
-    DEFiRet;
-    grok_t  *grok = CreateGrok();
-    char     *msg = strdup(pData->pszSource);
-    char     *line = NULL;
-    line = strtok(msg,"\n");
-    while(line!=NULL)
-    {
-        MotifyLine(line,grok,pData);
-        line = strtok(NULL,"\n");
-    }
-    free(msg);msg=NULL;
-    RETiRet;
+	char *saveptr;
+	DEFiRet;
+	grok_t  *grok = CreateGrok();
+	char     *msg = strdup(pData->pszSource);
+	char     *line = NULL;
+	line = strtok_r(msg, "\n", &saveptr);
+	while(line!=NULL) {
+		MotifyLine(line,grok,pData);
+		line = strtok_r(NULL, "\n", &saveptr);
+	}
+	free(msg);msg=NULL;
+	RETiRet;
 }
 
 


### PR DESCRIPTION
The modules used strtok(), which is not thread-safe. So it will potentially
segfault when multiple instances are spawned (what e.g. happens on busy
systems).

This patch replaces strtok() with its thread-safe counterpart
strtok_r().

see also https://github.com/rsyslog/rsyslog/issues/1359