### PR TITLE
core: consistent handling of oversize input messages

### DIFF
--- a/dirty.h
+++ b/dirty.h
@@ -27,7 +27,7 @@
 #define	DIRTY_H_INCLUDED 1
 
 rsRetVal __attribute__((deprecated)) multiSubmitMsg(multi_submit_t *pMultiSub);
-rsRetVal multiSubmitMsg2(multi_submit_t *pMultiSub); /* friends only! */
+rsRetVal ATTR_NONNULL() multiSubmitMsg2(multi_submit_t *const pMultiSub); /* friends only! */
 rsRetVal submitMsg2(smsg_t *pMsg);
 rsRetVal __attribute__((deprecated)) submitMsg(smsg_t *pMsg);
 rsRetVal multiSubmitFlush(multi_submit_t *pMultiSub);

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1724,8 +1724,12 @@ BEGINsetModCnf
 	int i;
 CODESTARTsetModCnf
 	/* new style config has different default! */
-#if defined(OS_SOLARIS) && defined (HAVE_PORT_SOURCE_FILE) /* use FEN on Solaris! */
-	loadModConf->opMode = OPMODE_FEN;
+#if defined(OS_SOLARIS)
+	#if defined (HAVE_PORT_SOURCE_FILE) /* use FEN on Solaris if available */
+		loadModConf->opMode = OPMODE_FEN;
+	#else
+		loadModConf->opMode = OPMODE_POLLING;
+	#endif
 #else
 	loadModConf->opMode = OPMODE_INOTIFY;
 #endif

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -456,7 +456,7 @@ processPacket(struct lstn_s *lstn, struct sockaddr_storage *frominetPrev, int *p
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		if(pMsg != NULL) {
+		if(pMsg != NULL && iRet != RS_RET_DISCARDMSG) {
 			msgDestruct(&pMsg);
 		}
 	}

--- a/runtime/errmsg.c
+++ b/runtime/errmsg.c
@@ -7,7 +7,7 @@
  * to take further case, as the code now boils to be either my own or, a few lines,
  * of the original BSD-licenses sysklogd code. rgerhards, 2012-01-16
  *
- * Copyright 2008-2013 Adiscon GmbH.
+ * Copyright 2008-2018 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -32,9 +32,15 @@
 #include <stdarg.h>
 #include <errno.h>
 #include <assert.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
 
 #include "rsyslog.h"
 #include "obj.h"
+#include "msg.h"
 #include "errmsg.h"
 #include "srUtils.h"
 #include "stringbuf.h"
@@ -42,10 +48,16 @@
 /* static data */
 DEFobjStaticHelpers
 
+#ifndef O_LARGEFILE
+#define O_LARGEFILE 0
+#endif
+
 static int bHadErrMsgs; /* indicates if we had error messages since reset of this flag
                          * This is used to abort a run if the config is unclean.
 			 */
 
+static int fdOversizeMsgLog = -1;
+static pthread_mutex_t oversizeMsgLogMut = PTHREAD_MUTEX_INITIALIZER;
 
 /* ------------------------------ methods ------------------------------ */
 
@@ -101,6 +113,18 @@ doLogMsg(const int iErrno, const int iErrCode,  const int severity, const char *
 	buf[sizeof(buf) - 1] = '\0'; /* just to be on the safe side... */
 	errno = 0;
 	
+	const int msglen = (int) strlen(buf);
+	if(msglen > glblGetMaxLine()) {
+		/* in extreme cases, our error messages may be longer than the configured
+		 * max message size. If so, we just truncate without further indication, as
+		 * anything else would probably lead to a death loop on error messages.
+		 * Note that we do not split, as we really do not anticipate there is
+		 * much value in supporting extremely short max message sizes - we assume
+		 * it's just a testbench thing. -- rgerhards, 2018-05-11
+		 */
+		 buf[glblGetMaxLine()] = '\0'; /* space must be available! */
+	}
+
 	glblErrLogger(severity, iErrCode, (uchar*)buf);
 
 	if(severity == LOG_ERR)
@@ -166,6 +190,94 @@ LogMsg(const int iErrno, const int iErrCode, const int severity, const char *fmt
 }
 
 
+/* Write an oversize message to the oversize message error log.
+ * We do NOT handle errors during writing that log other than emitting
+ * yet another error message. The reason is that there really is nothing
+ * else that we could do in that case.
+ * rgerhards, 2018-05-03
+ */
+rsRetVal ATTR_NONNULL()
+writeOversizeMessageLog(const smsg_t *const pMsg)
+{
+	struct json_object *json = NULL;
+	char *rendered = NULL;
+	struct json_object *jval;
+	uchar *buf;
+	size_t toWrite;
+	ssize_t wrRet;
+	int dummy;
+	int mutexLocked = 0;
+	DEFiRet;
+	ISOBJ_TYPE_assert(pMsg, msg);
+
+	if(glblGetOversizeMsgErrorFile() == NULL) {
+		FINALIZE;
+	}
+
+	pthread_mutex_lock(&oversizeMsgLogMut);
+	mutexLocked = 1;
+
+	if(fdOversizeMsgLog == -1) {
+		fdOversizeMsgLog = open((char*)glblGetOversizeMsgErrorFile(),
+					O_WRONLY|O_CREAT|O_APPEND|O_LARGEFILE|O_CLOEXEC,
+					S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP);
+		if(fdOversizeMsgLog == -1) {
+			LogError(errno, RS_RET_ERR, "error opening oversize message log file %s",
+				glblGetOversizeMsgErrorFile());
+			FINALIZE;
+		}
+	}
+
+	assert(fdOversizeMsgLog != -1);
+	json = json_object_new_object();
+	if(json == NULL) {
+		FINALIZE;
+	}
+
+	getRawMsg(pMsg, &buf, &dummy);
+	jval = json_object_new_string((char*)buf);
+	json_object_object_add(json, "rawmsg", jval);
+
+	getInputName(pMsg, &buf, &dummy);
+	jval = json_object_new_string((char*)buf);
+	json_object_object_add(json, "input", jval);
+
+	CHKmalloc(rendered = strdup((char*)fjson_object_to_json_string(json)));
+
+	toWrite = strlen(rendered) + 1;
+	/* Note: we overwrite the '\0' terminator with '\n' -- so we avoid
+	 * calling malloc() -- write() does NOT need '\0'!
+	 */
+	rendered[toWrite-1] = '\n'; /* NO LONGER A STRING! */
+	wrRet = write(fdOversizeMsgLog, rendered, toWrite);
+	if(wrRet != (ssize_t) toWrite) {
+		LogError(errno, RS_RET_IO_ERROR,
+			"error writing oversize message log file %s, write returned %lld",
+			glblGetOversizeMsgErrorFile(), (long long) wrRet);
+	}
+
+finalize_it:
+	free(rendered);
+	if(mutexLocked) {
+		pthread_mutex_unlock(&oversizeMsgLogMut);
+	}
+	if(json != NULL) {
+		fjson_object_put(json);
+	}
+	RETiRet;
+}
+
+
+void
+errmsgDoHUP(void)
+{
+	pthread_mutex_lock(&oversizeMsgLogMut);
+	close(fdOversizeMsgLog);
+	fdOversizeMsgLog = -1;
+	pthread_mutex_unlock(&oversizeMsgLogMut);
+}
+
+
 /* queryInterface function
  * rgerhards, 2008-03-05
  */
@@ -201,7 +313,7 @@ ENDObjClassInit(errmsg)
  */
 BEGINObjClassExit(errmsg, OBJ_IS_CORE_MODULE) /* class, version */
 	/* release objects we no longer need */
+	if(fdOversizeMsgLog != -1) {
+		close(fdOversizeMsgLog);
+	}
 ENDObjClassExit(errmsg)
-
-/* vi:set ai:
- */

--- a/runtime/errmsg.h
+++ b/runtime/errmsg.h
@@ -1,6 +1,6 @@
 /* The errmsg object. It is used to emit error message inside rsyslog.
  *
- * Copyright 2008-2013 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -44,10 +44,12 @@ ENDinterface(errmsg)
 
 /* prototypes */
 PROTOTYPEObj(errmsg);
+void errmsgDoHUP(void);
 void resetErrMsgsFlag(void);
 int hadErrMsgs(void);
 void __attribute__((format(printf, 3, 4))) LogError(const int iErrno, const int iErrCode, const char *fmt, ... );
 void __attribute__((format(printf, 4, 5)))
 	LogMsg(const int iErrno, const int iErrCode, const int severity, const char *fmt, ... );
+rsRetVal ATTR_NONNULL() writeOversizeMessageLog(const smsg_t *const pMsg);
 
 #endif /* #ifndef INCLUDED_ERRMSG_H */

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -85,6 +85,9 @@ static uchar *stdlog_chanspec = NULL;
 static int bParseHOSTNAMEandTAG = 1;	/* parser modification (based on startup params!) */
 static int bPreserveFQDN = 0;		/* should FQDNs always be preserved? */
 static int iMaxLine = 8096;		/* maximum length of a syslog message */
+static uchar * oversizeMsgErrorFile = NULL;		/* File where oversize messages are written to */
+static int oversizeMsgInputMode = 0;	/* Mode which oversize messages will be forwarded */
+static int reportOversizeMsg = 1;	/* shall error messages be generated for oversize messages? */
 static int iGnuTLSLoglevel = 0;
 static int iDefPFFamily = PF_UNSPEC;     /* protocol family (IPv4, IPv6 or both) */
 static int bDropMalPTRMsgs = 0;/* Drop messages which have malicious PTR records during DNS lookup */
@@ -157,6 +160,9 @@ static struct cnfparamdescr cnfparamdescr[] = {
         { "defaultnetstreamdrivercertfile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdriver", eCmdHdlrString, 0 },
 	{ "maxmessagesize", eCmdHdlrSize, 0 },
+	{ "oversizemsg.errorfile", eCmdHdlrGetWord, 0 },
+	{ "oversizemsg.report", eCmdHdlrBinary, 0 },
+	{ "oversizemsg.input.mode", eCmdHdlrGetWord, 0 },
 	{ "action.reportsuspension", eCmdHdlrBinary, 0 },
 	{ "action.reportsuspensioncontinuation", eCmdHdlrBinary, 0 },
 	{ "parser.controlcharacterescapeprefix", eCmdHdlrGetChar, 0 },
@@ -219,6 +225,7 @@ glblGetMaxLine(void)
 {
 	return(iMaxLine);
 }
+
 
 int
 GetGnuTLSLoglevel(void)
@@ -418,6 +425,8 @@ setMaxLine(const int64_t iNew)
 	}
 }
 
+
+
 static rsRetVal
 legacySetMaxMessageSize(void __attribute__((unused)) *pVal, int64_t iNew)
 {
@@ -441,6 +450,22 @@ setDebugLevel(void __attribute__((unused)) *pVal, int level)
 	dbgSetDebugLevel(level);
 	dbgprintf("debug level %d set via config file\n", level);
 	dbgprintf("This is rsyslog version " VERSION "\n");
+	RETiRet;
+}
+
+static rsRetVal ATTR_NONNULL()
+setOversizeMsgInputMode(const uchar *const mode)
+{
+	DEFiRet;
+	if(!strcmp((char*)mode, "truncate")) {
+		oversizeMsgInputMode = glblOversizeMsgInputMode_Truncate;
+	} else if(!strcmp((char*)mode, "split")) {
+		oversizeMsgInputMode = glblOversizeMsgInputMode_Split;
+	} else if(!strcmp((char*)mode, "accept")) {
+		oversizeMsgInputMode = glblOversizeMsgInputMode_Accept;
+	} else {
+		oversizeMsgInputMode = glblOversizeMsgInputMode_Truncate;
+	}
 	RETiRet;
 }
 
@@ -550,6 +575,29 @@ done:
 	return(pszRet);
 }
 
+
+/* return the name of the file where oversize messages are written to
+ */
+uchar*
+glblGetOversizeMsgErrorFile(void)
+{
+	return oversizeMsgErrorFile;
+}
+
+
+/* return the mode with which oversize messages will be put forward
+ */
+int
+glblGetOversizeMsgInputMode(void)
+{
+	return oversizeMsgInputMode;
+}
+
+int
+glblReportOversizeMessage(void)
+{
+	return reportOversizeMsg;
+}
 
 /* set our local domain name. Free previous domain, if it was already set.
  */
@@ -799,6 +847,9 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 	pszDfltNetstrmDrvrCertFile = NULL;
 	free(LocalHostNameOverride);
 	LocalHostNameOverride = NULL;
+	free(oversizeMsgErrorFile);
+	oversizeMsgErrorFile = NULL;
+	oversizeMsgInputMode = glblOversizeMsgInputMode_Accept;
 	free(pszWorkDir);
 	pszWorkDir = NULL;
 	bDropMalPTRMsgs = 0;
@@ -806,6 +857,7 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 	iMaxLine = 8192;
 	cCCEscapeChar = '#';
 	bDropTrailingLF = 1;
+	reportOversizeMsg = 1;
 	bEscapeCCOnRcv = 1; /* default is to escape control characters */
 	bSpaceLFOnRcv = 0;
 	bEscape8BitChars = 0; /* default is not to escape control characters */
@@ -1197,6 +1249,15 @@ glblDoneLoadCnf(void)
 			bActionReportSuspensionCont = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "maxmessagesize")) {
 			setMaxLine(cnfparamvals[i].val.d.n);
+		} else if(!strcmp(paramblk.descr[i].name, "oversizemsg.errorfile")) {
+			free(oversizeMsgErrorFile);
+			oversizeMsgErrorFile = (uchar*)es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+		} else if(!strcmp(paramblk.descr[i].name, "oversizemsg.report")) {
+			reportOversizeMsg = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "oversizemsg.input.mode")) {
+			const char *const tmp = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			setOversizeMsgInputMode((uchar*) tmp);
+			free((void*)tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "debug.onshutdown")) {
 			glblDebugOnShutdown = (int) cnfparamvals[i].val.d.n;
 			LogError(0, RS_RET_OK, "debug: onShutdown set to %d", glblDebugOnShutdown);
@@ -1375,6 +1436,7 @@ BEGINObjClassExit(glbl, OBJ_IS_CORE_MODULE) /* class, version */
 	free(LocalDomain);
 	free(LocalHostName);
 	free(LocalHostNameOverride);
+	free(oversizeMsgErrorFile);
 	free(LocalFQDNName);
 	freeTimezoneInfo();
 	objRelease(prop, CORE_COMPONENT);

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -38,6 +38,10 @@
 #include "prop.h"
 
 #define glblGetIOBufSize() 4096 /* size of the IO buffer, e.g. for strm class */
+#define glblOversizeMsgInputMode_Truncate 0
+#define glblOversizeMsgInputMode_Split 1
+#define glblOversizeMsgInputMode_Accept 2
+
 
 extern pid_t glbl_ourpid;
 extern int bProcessInternalMessages;
@@ -147,5 +151,8 @@ tzinfo_t* glblFindTimezoneInfo(char *id);
 int GetGnuTLSLoglevel(void);
 int glblGetMaxLine(void);
 int bs_arrcmp_glblDbgFiles(const void *s1, const void *s2);
+uchar* glblGetOversizeMsgErrorFile(void);
+int glblGetOversizeMsgInputMode(void);
+int glblReportOversizeMessage(void);
 
 #endif /* #ifndef GLBL_H_INCLUDED */

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -526,8 +526,8 @@ finalize_it:
 }
 
 
-static void
-getInputName(smsg_t * const pM, uchar **ppsz, int *plen)
+void
+getInputName(const smsg_t * const pM, uchar **ppsz, int *const plen)
 {
 	BEGINfunc
 	if(pM == NULL || pM->pInputName == NULL) {
@@ -1643,8 +1643,14 @@ static void getUUID(smsg_t * const pM, uchar **pBuf, int *piLen)
 }
 #endif
 
+int ATTR_NONNULL()
+getRawMsgLen(const smsg_t *const pMsg)
+{
+	return (pMsg->pszRawMsg == NULL) ?  0 : pMsg->iLenRawMsg;
+}
+
 void
-getRawMsg(smsg_t * const pM, uchar **pBuf, int *piLen)
+getRawMsg(const smsg_t * const pM, uchar **pBuf, int *piLen)
 {
 	if(pM == NULL) {
 		*pBuf=  UCHAR_CONSTANT("");
@@ -2875,15 +2881,37 @@ finalize_it:
 	RETiRet;
 }
 
+/* truncate the (raw) message to configured max size.
+ * The function makes sure that the stored rawmsg remains
+ * properly terminated by '\0'.
+ */
+void ATTR_NONNULL()
+MsgTruncateToMaxSize(smsg_t *const pThis)
+{
+	ISOBJ_TYPE_assert(pThis, msg);
+	const int maxMsgSize = glblGetMaxLine();
+	assert(pThis->iLenRawMsg > maxMsgSize);
+
+	const int deltaSize = pThis->iLenRawMsg - maxMsgSize;
+	pThis->pszRawMsg[maxMsgSize] = '\0';
+	pThis->iLenRawMsg = maxMsgSize;
+	if(pThis->iLenMSG < deltaSize) {
+		pThis->iLenMSG = 0;
+	} else {
+		pThis->iLenMSG -= deltaSize;
+	}
+}
+
 /* set raw message in message object. Size of message is provided.
  * The function makes sure that the stored rawmsg is properly
  * terminated by '\0'.
  * rgerhards, 2009-06-16
  */
-void MsgSetRawMsg(smsg_t *pThis, const char* pszRawMsg, size_t lenMsg)
+void ATTR_NONNULL()
+MsgSetRawMsg(smsg_t *const pThis, const char*const pszRawMsg, const size_t lenMsg)
 {
+	ISOBJ_TYPE_assert(pThis, msg);
 	int deltaSize;
-	assert(pThis != NULL);
 	if(pThis->pszRawMsg != pThis->szRawMsg)
 		free(pThis->pszRawMsg);
 

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -3,7 +3,7 @@
  *
  * File begun on 2007-07-13 by RGerhards (extracted from syslogd.c)
  *
- * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -195,7 +195,7 @@ void MsgSetHOSTNAME(smsg_t *pMsg, const uchar* pszHOSTNAME, const int lenHOSTNAM
 rsRetVal MsgSetAfterPRIOffs(smsg_t *pMsg, short offs);
 void MsgSetMSGoffs(smsg_t *pMsg, short offs);
 void MsgSetRawMsgWOSize(smsg_t *pMsg, char* pszRawMsg);
-void MsgSetRawMsg(smsg_t *pMsg, const char* pszRawMsg, size_t lenMsg);
+void ATTR_NONNULL() MsgSetRawMsg(smsg_t *const pThis, const char*const pszRawMsg, const size_t lenMsg);
 rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar* pszMSG, int lenMSG);
 uchar *MsgGetProp(smsg_t *pMsg, struct templateEntry *pTpe, msgPropDescr_t *pProp,
 		  rs_size_t *pPropLen, unsigned short *pbMustBeFreed, struct syslogTime *ttNow);
@@ -204,7 +204,9 @@ void getTAG(smsg_t *pM, uchar **ppBuf, int *piLen);
 const char *getTimeReported(smsg_t *pM, enum tplFormatTypes eFmt);
 const char *getPRI(smsg_t *pMsg);
 int getPRIi(const smsg_t * const pM);
-void getRawMsg(smsg_t *pM, uchar **pBuf, int *piLen);
+int ATTR_NONNULL() getRawMsgLen(const smsg_t *const pMsg);
+void getRawMsg(const smsg_t *pM, uchar **pBuf, int *piLen);
+void ATTR_NONNULL() MsgTruncateToMaxSize(smsg_t *const pThis);
 rsRetVal msgAddJSON(smsg_t *pM, uchar *name, struct json_object *json, int force_reset, int sharedReference);
 rsRetVal msgAddMetadata(smsg_t *msg, uchar *metaname, uchar *metaval);
 rsRetVal msgAddMultiMetadata(smsg_t *msg, const uchar **metaname, const uchar **metaval, const int count);
@@ -214,13 +216,13 @@ rsRetVal MsgSetPropsViaJSON(smsg_t *__restrict__ const pMsg, const uchar *__rest
 rsRetVal MsgSetPropsViaJSON_Object(smsg_t *__restrict__ const pMsg, struct json_object *json);
 const uchar* msgGetJSONMESG(smsg_t *__restrict__ const pMsg);
 
-/* TODO: remove these five (so far used in action.c) */
 uchar *getMSG(smsg_t *pM);
 const char *getHOSTNAME(smsg_t *pM);
 char *getPROCID(smsg_t *pM, sbool bLockMutex);
 char *getAPPNAME(smsg_t *pM, sbool bLockMutex);
 void setMSGLen(smsg_t *pM, int lenMsg);
 int getMSGLen(smsg_t *pM);
+void getInputName(const smsg_t * const pM, uchar **ppsz, int *const plen);
 
 int getHOSTNAMELen(smsg_t *pM);
 uchar *getProgramName(smsg_t *pM, sbool bLockMutex);

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -508,6 +508,7 @@ operation not carried out */
 	RS_RET_NO_TZ_SET = -2442, /**< system env var TZ is not set (status msg) */
 	RS_RET_FS_ERR = -2443, /**< file-system error */
 	RS_RET_POLL_ERR = -2444, /**< error in poll() system call */
+	RS_RET_OVERSIZE_MSG = -2445, /**< message is too long (above configured max) */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -385,6 +385,7 @@ TESTS +=  \
 	mmexternal-SegFault-vg.sh \
 	mmexternal-InvldProg-vg.sh \
 	internal-errmsg-memleak-vg.sh \
+	glbl-oversizeMsg-log-vg.sh \
 	rscript_set_memleak-vg.sh \
 	no-parser-vg.sh \
 	discard-rptdmsg-vg.sh \
@@ -725,7 +726,10 @@ TESTS += sndrcv_relp.sh \
 	 imrelp-maxDataSize-error.sh \
 	 imrelp-long-msg.sh \
 	 imrelp-oversizeMode-truncate.sh \
-	 imrelp-oversizeMode-accept.sh
+	 imrelp-oversizeMode-accept.sh \
+	 glbl-oversizeMsg-log.sh \
+	 glbl-oversizeMsg-truncate.sh \
+	 glbl-oversizeMsg-split.sh
 if ENABLE_GNUTLS
 TESTS += \
          sndrcv_relp_tls.sh \
@@ -808,7 +812,8 @@ TESTS += \
 	imfile-wildcards-dirs-multi5-polling.sh \
 	imfile-old-state-file.sh \
 	imfile-rename-while-stopped.sh \
-	imfile-rename.sh
+	imfile-rename.sh \
+	glbl-oversizeMsg-truncate-imfile.sh
 
 if HAVE_VALGRIND
 TESTS += \
@@ -842,6 +847,7 @@ test_files = testbench.h runtime-dummy.c
 
 EXTRA_DIST= \
 	internal-errmsg-memleak-vg.sh \
+	glbl-oversizeMsg-log-vg.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
 	hostname-with-slash-pmrfc5424.sh \
@@ -1377,6 +1383,9 @@ EXTRA_DIST= \
 	imrelp-long-msg.sh \
 	imrelp-oversizeMode-truncate.sh \
 	imrelp-oversizeMode-accept.sh \
+	glbl-oversizeMsg-log.sh \
+	glbl-oversizeMsg-truncate.sh \
+	glbl-oversizeMsg-split.sh \
 	sndrcv_relp.sh \
 	testsuites/sndrcv_relp_sender.conf \
 	testsuites/sndrcv_relp_rcvr.conf \
@@ -1536,6 +1545,7 @@ EXTRA_DIST= \
 	imfile-old-state-file.sh \
 	imfile-rename-while-stopped.sh \
 	imfile-rename.sh \
+	glbl-oversizeMsg-truncate-imfile.sh \
 	testsuites/imfile-wildcards-simple.conf \
 	testsuites/imfile-wildcards-dirs.conf \
 	testsuites/imfile-wildcards-dirs-multi.conf \

--- a/tests/glbl-oversizeMsg-log-vg.sh
+++ b/tests/glbl-oversizeMsg-log-vg.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# add 2018-05-03 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+global(maxMessageSize="230"
+	oversizemsg.errorfile="rsyslog2.out.log")
+
+
+input(type="imrelp" port="13514" maxdatasize="300")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+# TODO: add tcpflood option to specific EXACT test message size!
+. $srcdir/diag.sh startup-vg
+. $srcdir/diag.sh tcpflood -Trelp-plain -p13514 -m1 -d 240
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown-vg
+. $srcdir/diag.sh check-exit-vg
+grep "rawmsg.*<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.*input.*imrelp" rsyslog2.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog2.out.log is:"
+        cat rsyslog2.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tests/glbl-oversizeMsg-log.sh
+++ b/tests/glbl-oversizeMsg-log.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# add 2018-05-03 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+global(maxMessageSize="230"
+	oversizemsg.errorfile="rsyslog2.out.log")
+
+
+input(type="imrelp" port="13514" maxdatasize="300")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+# TODO: add tcpflood option to specific EXACT test message size!
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -Trelp-plain -p13514 -m1 -d 240
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+grep "rawmsg.*<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.*input.*imrelp" rsyslog2.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog2.out.log is:"
+        cat rsyslog2.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tests/glbl-oversizeMsg-split.sh
+++ b/tests/glbl-oversizeMsg-split.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# add 2018-05-03 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+global(maxMessageSize="230"
+	oversizemsg.input.mode="split")
+
+
+input(type="imrelp" port="13514" maxdatasize="300")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+# TODO: add tcpflood option to specific EXACT test message size!
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -Trelp-plain -p13514 -m1 -d 240
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+# We need the ^-sign to symbolize the beginning and the $-sign to symbolize the end
+# because otherwise we won't know if it was truncated at the right length.
+#First part of message is checked
+grep "^<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX$" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+#Split part of message is checked
+grep "^XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX$" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+#Error message is checked
+grep "message too long.*begin of message is:" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tests/glbl-oversizeMsg-truncate-imfile.sh
+++ b/tests/glbl-oversizeMsg-truncate-imfile.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# add 2018-05-02 by PascalWithopf, released under ASL 2.0
+. $srcdir/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+echo '<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX' > rsyslog.input
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imfile/.libs/imfile")
+global(maxMessageSize="230"
+	oversizemsg.input.mode="truncate")
+
+
+input(type="imfile" File="./rsyslog.input" tag="tag:")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
+				 file="rsyslog.out.log")
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown
+
+# We need the ^-sign to symbolize the beginning and the $-sign to symbolize the end
+# because otherwise we won't know if it was truncated at the right length.
+grep "^<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX$" rsyslog.out.log #> /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+grep "message too long.*begin of message is:" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected error message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
+
+. $srcdir/diag.sh exit

--- a/tests/glbl-oversizeMsg-truncate.sh
+++ b/tests/glbl-oversizeMsg-truncate.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# add 2018-04-19 by PascalWithopf, released under ASL 2.0
+# add 2018-05-02 by PascalWithopf, released under ASL 2.0
 . $srcdir/diag.sh init
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
@@ -9,15 +9,16 @@ fi;
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-global(maxMessageSize="150" oversizemsg.input.mode="accept")
+global(maxMessageSize="230")
 
 
-input(type="imrelp" port="13514" maxdatasize="200" oversizeMode="truncate")
+input(type="imrelp" port="13514" maxdatasize="300")
 
-template(name="outfmt" type="string" string="%msg%\n")
-:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+template(name="outfmt" type="string" string="%rawmsg%\n")
+action(type="omfile" template="outfmt"
 				 file="rsyslog.out.log")
 '
+# TODO: add tcpflood option to specific EXACT test message size!
 . $srcdir/diag.sh startup
 . $srcdir/diag.sh tcpflood -Trelp-plain -p13514 -m1 -d 240
 . $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
@@ -25,12 +26,21 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 # We need the ^-sign to symbolize the beginning and the $-sign to symbolize the end
 # because otherwise we won't know if it was truncated at the right length.
-grep "^ msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX$" rsyslog.out.log > /dev/null
+grep "^<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX$" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected message not found. rsyslog.out.log is:"
         cat rsyslog.out.log
         . $srcdir/diag.sh error-exit 1
 fi
+
+grep "message too long.*begin of message is:" rsyslog.out.log > /dev/null
+if [ $? -ne 0 ]; then
+        echo
+        echo "FAIL: expected message not found. rsyslog.out.log is:"
+        cat rsyslog.out.log
+        . $srcdir/diag.sh error-exit 1
+fi
+
 
 . $srcdir/diag.sh exit

--- a/tests/imfile-truncate-line.sh
+++ b/tests/imfile-truncate-line.sh
@@ -10,6 +10,7 @@ echo [imfile-truncate-line.sh]
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $MaxMessageSize 128
+global(oversizemsg.input.mode="accept" oversizemsg.report="on")
 module(load="../plugins/imfile/.libs/imfile")
 input(type="imfile"
       File="./rsyslog.input"

--- a/tests/imptcp-msg-truncation-on-number.sh
+++ b/tests/imptcp-msg-truncation-on-number.sh
@@ -5,7 +5,8 @@
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $MaxMessageSize 128
-global(processInternalMessages="on")
+global(processInternalMessages="on"
+	oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="13514")
 
@@ -18,7 +19,7 @@ action(type="omfile" file="rsyslog.out.log")
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
 
-grep "Framing Error.*change to octet stuffing" rsyslog.out.log > /dev/null
+grep "Framing Error" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected error message from imptcp truncation not found. rsyslog.out.log is:"
@@ -29,7 +30,7 @@ fi
 grep " 9876543210cdefghijklmn test8 test9 test10 test11 test12 test13 test14 test15 kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk tag: testtestets" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
-        echo "FAIL: expected error message from imptcp truncation not found. rsyslog.out.log is:"
+        echo "FAIL: expected message from imptcp truncation not found. rsyslog.out.log is:"
         cat rsyslog.out.log
         . $srcdir/diag.sh error-exit 1
 fi

--- a/tests/imptcp-msg-truncation-on-number2.sh
+++ b/tests/imptcp-msg-truncation-on-number2.sh
@@ -5,7 +5,8 @@
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $MaxMessageSize 128
-global(processInternalMessages="on")
+global(processInternalMessages="on"
+	oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="13514" ruleset="ruleset1")
 

--- a/tests/imptcp-oversize-message-display.sh
+++ b/tests/imptcp-oversize-message-display.sh
@@ -5,7 +5,7 @@
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $MaxMessageSize 128
-global(processInternalMessages="on")
+global(processInternalMessages="on" oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="13514")
 
@@ -17,7 +17,7 @@ action(type="omfile" file="rsyslog.out.log")
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
 
-grep "imptcp:.*150.*\"ghijklmn test8 test9 test10 test\"" rsyslog.out.log > /dev/null
+grep "imptcp: message received.*150 byte larger.*will be split.*\"ghijkl" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected error message from imptcp truncation not found. rsyslog.out.log is:"
@@ -25,7 +25,7 @@ if [ $? -ne 0 ]; then
         . $srcdir/diag.sh error-exit 1
 fi
 
-grep "imptcp:.*22.*\"sstetstetsytetestetste\"" rsyslog.out.log > /dev/null
+grep "imptcp: message received.*22 byte larger.*will be split.*\"sstets" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected error message from imptcp truncation not found. rsyslog.out.log is:"

--- a/tests/imrelp-long-msg.sh
+++ b/tests/imrelp-long-msg.sh
@@ -3,6 +3,7 @@
 . $srcdir/diag.sh init
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
+global(maxMessageSize="214800")
 module(load="../plugins/imrelp/.libs/imrelp")
 input(type="imrelp" port="13514" maxdatasize="214800")
 

--- a/tests/imtcp-msg-truncation-on-number.sh
+++ b/tests/imtcp-msg-truncation-on-number.sh
@@ -5,7 +5,8 @@
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 $MaxMessageSize 128
-global(processInternalMessages="on")
+global(processInternalMessages="on"
+	oversizemsg.input.mode="accept")
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="13514")
 
@@ -17,7 +18,7 @@ action(type="omfile" file="rsyslog.out.log")
 . $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown
 
-grep "Framing Error.*change to octet stuffing" rsyslog.out.log > /dev/null
+grep "Framing Error in received" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
         echo "FAIL: expected error message from imtcp not found. rsyslog.out.log is:"
@@ -28,7 +29,7 @@ fi
 grep "9876543210cdefghijklmn test8 test9 test10 test11 test12 test13 test14 test15 kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk tag: testtestt" rsyslog.out.log > /dev/null
 if [ $? -ne 0 ]; then
         echo
-        echo "FAIL: expected error message from imtcp not found. rsyslog.out.log is:"
+        echo "FAIL: expected date from imtcp not found. rsyslog.out.log is:"
         cat rsyslog.out.log
         . $srcdir/diag.sh error-exit 1
 fi


### PR DESCRIPTION
In the community we frequently discuss handling of oversize messages.
David Lang rightfully suggested to create a central capability inside
rsyslog core to handle them.
    
We need to make a distinction between input and output messages. Also,
input messages frequently need to have some size restrictions done at
a lower layer (e.g. protocol layer) for security reasons. Nevertheless,
we should have a central capability
    
* for cases where it need not be handled at a lower level
* as a safeguard when a module invalidly emits it (imfile is an example,
  see https://github.com/rsyslog/rsyslog/pull/2632 for a try to fix it
  on the module level - we will replace that with the new capability
  described here).
    
The central capability works on message submission, and so cannot be
circumvented. It needs to have at least these capabilities:
    
* truncate message
* split message
  this is of questionable use, but also often requested. In that mode,
  the oversize message content is split into multiple messages. Usually,
  this ends up with message segments where all but the first is lost
  anyhow as the regular filter rules do not match the other fragments.
  As it is requested, we still implemented it.
* report message to a special "oversize message log file" (not via the
   regular engine, as that would obviously cause another oversize message)
    
It is questionable if we should also permit a mode
   
* accept
    
where the oversize message is accepted as-is. This will be part of another
commit if we decide to do so.
    
This commit, as the title says, handles oversize INPUT messages.
    
see also https://github.com/rsyslog/rsyslog/issues/2190
closes https://github.com/rsyslog/rsyslog/issues/2681
closes #498
    
Note: this commit adds global parameter "oversizemsg.errorfile",
which is used to specify the location of the oversize message log file.
