### PR TITLE
remove no longer needed --enable-libcurl configure switch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -495,25 +495,6 @@ if test "$rsyslog_have_pthread_setschedparam" = "yes" -a "$rsyslog_have_sched_h"
 	LIBS=$save_LIBS
 fi
 
-
-# use libcurl?
-AC_ARG_ENABLE(libcurl,
-        [AS_HELP_STRING([--enable-libcurl],[Enable libcurl mode @<:@default=yes@:>@])],
-        [case "${enableval}" in
-          yes) enable_libcurl="yes" ;;
-           no) enable_libcurl="no" ;;
-           *) AC_MSG_ERROR(bad value ${enableval} for --enable-libcurl) ;;
-         esac],
-        [enable_libcurl="yes"]
-)
-if test "$enable_libcurl" = "yes"; then
-	PKG_CHECK_MODULES([CURL], [libcurl], 
-		[ AC_DEFINE(HAVE_LIBCURL, 1, [libcurl present]) ]
-	)
-fi
-
-AM_CONDITIONAL(ENABLE_LIBCURL, test "x${enable_libcurl}" = "xyes")
-
 # klog
 AC_ARG_ENABLE(klog,
         [AS_HELP_STRING([--enable-klog],[Integrated klog functionality @<:@default=yes@:>@])],

--- a/grammar/Makefile.am
+++ b/grammar/Makefile.am
@@ -13,10 +13,6 @@ libgrammar_la_SOURCES = \
 	grammar.h
 libgrammar_la_CPPFLAGS =  $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
 libgrammar_la_LIBADD =
-if ENABLE_LIBCURL
-libgrammar_la_CPPFLAGS += $(CURL_CFLAGS)
-libgrammar_la_LIBADD += $(CURL_LIBS)
-endif
 
 #testdriver_SOURCES = testdriver.c libgrammar.la
 #testdriver_CPPFLAGS =  $(RSRT_CFLAGS)


### PR DESCRIPTION
The --enable-libcurl switch was added to be able to disable libcurl
functionality inside the rsyslog core, see 46f4f43. As libcurl is no
longer used inside the core (due to introducing function modules),
--enable-libcurl needs to be removed.

closes https://github.com/rsyslog/rsyslog/issues/2628