### PR TITLE
testbench: fix race in threadingmqaq test

### DIFF
--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -1452,6 +1452,9 @@ rsRetVal dbgClassInit(void)
 
 	const char *dbgto2stderr = getenv("RSYSLOG_DEBUG_TIMEOUTS_TO_STDERR");
 	dbgTimeoutToStderr = (dbgto2stderr != NULL && !strcmp(dbgto2stderr, "on")) ? 1 : 0;
+	if(dbgTimeoutToStderr) {
+		fprintf(stderr, "rsyslogd: NOTE: RSYSLOG_DEBUG_TIMEOUTS_TO_STDERR activated\n");
+	}
 	dbgGetRuntimeOptions(); /* init debug system from environment */
 	pszAltDbgFileName = getenv("RSYSLOG_DEBUGLOG");
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -2936,8 +2936,9 @@ doEnqSingleObj(qqueue_t *pThis, flowControl_t flowCtlType, smsg_t *pMsg)
 			timeoutComp(&t, pThis->toEnq);
 			const int r = pthread_cond_timedwait(&pThis->notFull, pThis->mut, &t);
 			if(dbgTimeoutToStderr && r != 0) {
-				fprintf(stderr, "%lld: queue timeout, error %d, (ETIMEDOUT is %d) lost message %s\n",
-						(long long) time(NULL), r, ETIMEDOUT, pMsg->pszRawMsg);
+				fprintf(stderr, "%lld: queue timeout(%dms), error %d%s, "
+					"lost message %s\n", (long long) time(NULL), pThis->toEnq,
+					r, ( r == ETIMEDOUT) ? "[ETIMEDOUT]" : "", pMsg->pszRawMsg);
 			}
 			if(r == ETIMEDOUT) {
 				DBGOPRINT((obj_t*) pThis, "doEnqSingleObject: cond timeout, dropping message!\n");

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -42,7 +42,7 @@
 #export RSYSLOG_DEBUGLOG="log"
 TB_TIMEOUT_STARTSTOP=400 # timeout for start/stop rsyslogd in tenths (!) of a second 400 => 40 sec
 # note that 40sec for the startup should be sufficient even on very slow machines. we changed this from 2min on 2017-12-12
-RSYSLOG_DEBUG_TIMEOUTS_TO_STDERR="on"  # we want to know when we loose messages due to timeouts
+export RSYSLOG_DEBUG_TIMEOUTS_TO_STDERR="on"  # we want to know when we loose messages due to timeouts
 
 
 function rsyslog_testbench_test_url_access() {

--- a/tests/testsuites/threadingmqaq.conf
+++ b/tests/testsuites/threadingmqaq.conf
@@ -16,5 +16,6 @@ $OMFileIOBufferSize 256k
 # This time, also run the action queue detached
 $ActionQueueWorkerThreadMinimumMessages 10
 $ActionQueueWorkerThreads 5
+$ActionQueueTimeoutEnqueue 500
 $ActionQueueType LinkedList
 :msg, contains, "msgnum:" ?dynfile;outfmt

--- a/tests/threadingmqaq.sh
+++ b/tests/threadingmqaq.sh
@@ -7,7 +7,6 @@
 # in practice many threading bugs result in an abort rather quickly and these
 # should be covered by this test here.
 # rgerhards, 2009-06-26
-echo \[threadingmqaq.sh\]: main/action queue concurrency
 
 uname
 if [ `uname` = "SunOS" ] ; then


### PR DESCRIPTION
As related testing has show this test sometime fails because
the enq operation on the action queue times out. This is valid,
but causes false positives. The simple (and correct!) solution is
to increase the timeout.