### PR TITLE
mmnormalize: add tests for parsesuccess

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -626,7 +626,10 @@ if ENABLE_MMNORMALIZE
 TESTS += msgvar-concurrency-array.sh \
 	msgvar-concurrency-array-event.tags.sh \
 	mmnormalize_rule_from_string.sh \
-	mmnormalize_rule_from_array.sh
+	mmnormalize_rule_from_array.sh \
+	mmnormalize_parsesuccess_fail.sh \
+	mmnormalize_parsesuccess_fail2.sh \
+	mmnormalize_parsesuccess_ok.sh
 
 if ENABLE_IMPTCP
 TESTS +=  \
@@ -1165,6 +1168,11 @@ EXTRA_DIST= \
 	mmrm1stspace-basic.sh \
 	mmnormalize_rule_from_string.sh \
 	mmnormalize_rule_from_array.sh \
+	mmnormalize_parsesuccess_fail.sh \
+	testsuites/mmnormalize_parsesuccess_fail.sh \
+	mmnormalize_parsesuccess_fail2.sh \
+	testsuites/mmnormalize_parsesuccess_fail2.sh \
+	mmnormalize_parsesuccess_ok.sh \
 	pmnull-basic.sh \
 	pmnull-withparams.sh \
 	omstdout-basic.sh \

--- a/tests/mmnormalize_parsesuccess_fail.sh
+++ b/tests/mmnormalize_parsesuccess_fail.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2018-05-11 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+input(type="imtcp" port="13514" ruleset="tcpinput")
+
+template(name="outfmt" type="string" string="data: %$!data%, parsesuccess: %$!parsesuccess%\n")
+
+ruleset(name="tcpinput") {
+	action(name="main_cee_parser" type="mmnormalize" useRawMsg="off"
+		rulebase="testsuites/mmnormalize_parsesuccess_fail.rulebase")
+	set $!parsesuccess = $parsesuccess;
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")	
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m2 -M "\"message without json\""
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+echo 'data: , parsesuccess: FAIL
+data: , parsesuccess: FAIL' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/mmnormalize_parsesuccess_fail2.sh
+++ b/tests/mmnormalize_parsesuccess_fail2.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2018-05-11 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+input(type="imtcp" port="13514" ruleset="tcpinput")
+
+template(name="outfmt" type="string" string="data: %$!data%, parsesuccess: %$!parsesuccess%\n")
+
+ruleset(name="tcpinput") {
+	action(name="main_cee_parser" type="mmnormalize" useRawMsg="off"
+		rulebase="testsuites/mmnormalize_parsesuccess_fail2.rulebase")
+	set $!parsesuccess = $parsesuccess;
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")	
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m2 -M "\"message without json\""
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+echo 'data: , parsesuccess: FAIL
+data: , parsesuccess: FAIL' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/mmnormalize_parsesuccess_ok.sh
+++ b/tests/mmnormalize_parsesuccess_ok.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# add 2016-11-22 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+input(type="imtcp" port="13514" ruleset="tcpinput")
+
+template(name="outfmt" type="string" string="data: %$!data%, parsesuccess: %$!parsesuccess%\n")
+
+ruleset(name="tcpinput") {
+	action(name="main_cee_parser" type="mmnormalize" useRawMsg="off"
+		rule="rule=:%data:json%")
+	set $!parsesuccess = $parsesuccess;
+	action(type="omfile" template="outfmt" file="rsyslog.out.log")	
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -m2 -M "\"{\\\"field\\\": \\\"data\\\"}\""
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+
+echo 'data: { "field": "data" }, parsesuccess: OK
+data: { "field": "data" }, parsesuccess: OK' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+
+. $srcdir/diag.sh exit

--- a/tests/testsuites/mmnormalize_parsesuccess_fail.rulebase
+++ b/tests/testsuites/mmnormalize_parsesuccess_fail.rulebase
@@ -1,0 +1,1 @@
+rule=:%data:json%

--- a/tests/testsuites/mmnormalize_parsesuccess_fail2.rulebase
+++ b/tests/testsuites/mmnormalize_parsesuccess_fail2.rulebase
@@ -1,0 +1,2 @@
+version=2
+rule=:%data:json%


### PR DESCRIPTION
Parsesuccess always is "OK" when using a rulebase with version 1,
even if it wasn't successfull.
These are tests to reproduce the issue.

See https://github.com/rsyslog/rsyslog/issues/2462