### PR TITLE
pass liblogging cflags when building fmhttp and imfile plugins

### DIFF
--- a/plugins/fmhttp/Makefile.am
+++ b/plugins/fmhttp/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = fmhttp.la
 
 fmhttp_la_SOURCES = fmhttp.c
-fmhttp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(CURL_CFLAGS)
+fmhttp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(CURL_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
 fmhttp_la_LDFLAGS = -module -avoid-version
 fmhttp_la_LIBADD = $(CURL_LIBS)

--- a/plugins/imfile/Makefile.am
+++ b/plugins/imfile/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imfile.la
 
 imfile_la_SOURCES = imfile.c
-imfile_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+imfile_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
 imfile_la_LDFLAGS = -module -avoid-version
 imfile_la_LIBADD = 


### PR DESCRIPTION
Fixes https://github.com/rsyslog/rsyslog/issues/2697.