### PR TITLE
build system: do not use liblogging-stdlog dependency by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1409,13 +1409,13 @@ AM_CONDITIONAL(ENABLE_KSI_LS12, test x$enable_ksi_ls12 = xyes)
 
 # liblogging-stdlog support
 AC_ARG_ENABLE(liblogging-stdlog,
-        [AS_HELP_STRING([--enable-liblogging-stdlog],[Enable liblogging-stdlog support @<:@default=yes@:>@])],
+        [AS_HELP_STRING([--enable-liblogging-stdlog],[Enable liblogging-stdlog support @<:@default=no@:>@])],
         [case "${enableval}" in
          yes) enable_liblogging_stdlog="yes" ;;
           no) enable_liblogging_stdlog="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-liblogging-stdlog) ;;
          esac],
-        [enable_liblogging_stdlog=yes]
+        [enable_liblogging_stdlog=no]
 )
 if test "x$enable_liblogging_stdlog" = "xyes"; then
         PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -859,6 +859,19 @@ logmsgInternal_doWrite(smsg_t *pMsg)
 		const int pri = getPRIi(pMsg);
 		uchar *const msg = getMSG(pMsg);
 #		ifdef HAVE_LIBLOGGING_STDLOG
+		/* the "emit only once" rate limiter is quick and dirty and not
+		 * thread safe. However, that's no problem for the current intend
+		 * and it is not justified to create more robust code for the
+		 * functionality. -- rgerhards, 2018-05-14
+		 */
+		static warnmsg_emitted = 0;
+		if(warnmsg_emitted == 0) {
+			stdlog_log(stdlog_hdl, LOG_WARNING, "%s",
+				"RSYSLOG WARNING: liblogging-stdlog "
+				"functionality will go away soon. For details see "
+				"https://github.com/rsyslog/rsyslog/issues/2706");
+			warnmsg_emitted = 1;
+		}
 		stdlog_log(stdlog_hdl, pri2sev(pri), "%s", (char*)msg);
 #		else
 		syslog(pri, "%s", msg);


### PR DESCRIPTION
Liblogging-stdlog was introduced to provide a broader ability to send rsyslog
internal logs to different sources. However, most distros did not pick up
that capability and so instead we do a regular syslog() call. We assume that
the actual functionality is never used in practice, so we plan to retire it.
That makes building rsyslog from source easier.

The plan is to disable use of liblogging-stdlog by default during
configure. So users (and distros!) can still opt-in to have it enabled if
they desire.

A couple of releases later, we want to completely remove the functionality,
except if there has desire been shown in the meantime which justifies to keep
liblogging-stdlog.

This patch is for disabling liblogging-stdlog by default. We now also
emit a warning message ("liblogging-stdlog will go away") so that users
know what is going on and my react.

closes https://github.com/rsyslog/rsyslog/issues/2705
see also https://github.com/rsyslog/rsyslog/issues/2706