### PR TITLE
core: fix undefined behaviour (unsigned computation may lead to value…

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2915,7 +2915,7 @@ MsgSetRawMsg(smsg_t *const pThis, const char*const pszRawMsg, const size_t lenMs
 	if(pThis->pszRawMsg != pThis->szRawMsg)
 		free(pThis->pszRawMsg);
 
-	deltaSize = lenMsg - pThis->iLenRawMsg;
+	deltaSize = (int) lenMsg - pThis->iLenRawMsg; /* value < 0 in truncation case! */
 	pThis->iLenRawMsg = lenMsg;
 	if(pThis->iLenRawMsg < CONF_RAWMSG_BUFSIZE) {
 		/* small enough: use fixed buffer (faster!) */


### PR DESCRIPTION
… < 0)

This was detected by LLVM UBSAN. On some platforms re-setting the rawmsg
inside the message object could lead to invalid computation due to the
fact the the computation was carried out as unsigned and only then
converted to integer.

No known problem in practice.