### PR TITLE
testbench: Add missing mmkubernetes_test_server.py to EXTRA_DIST

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1901,7 +1901,8 @@ EXTRA_DIST= \
 	pgsql-actq-mt-withpause-vg.sh \
 	../devtools/prep-mysql-db.sh \
 	mmkubernetes-basic.sh \
-	mmkubernetes-basic-vg.sh
+	mmkubernetes-basic-vg.sh \
+	mmkubernetes_test_server.py
 
 ourtail_SOURCES = ourtail.c
 msleep_SOURCES = msleep.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1902,7 +1902,8 @@ EXTRA_DIST= \
 	../devtools/prep-mysql-db.sh \
 	mmkubernetes-basic.sh \
 	mmkubernetes-basic-vg.sh \
-	mmkubernetes_test_server.py
+	mmkubernetes_test_server.py \
+	mmkubernetes-basic.out.json
 
 ourtail_SOURCES = ourtail.c
 msleep_SOURCES = msleep.c


### PR DESCRIPTION
Found a missed file:

```
============================================================================
Testsuite summary for rsyslog 8.35.0
============================================================================
# TOTAL: 399
# PASS:  387
# SKIP:  11
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0


FAIL: mmkubernetes-basic.sh
===========================

------------------------------------------------------------
Test: ./mmkubernetes-basic.sh
------------------------------------------------------------
testbench: TZ env var not set, setting it to UTC
ABORT! Timeout waiting on startup (pid file)
FAIL mmkubernetes-basic.sh (exit status: 1)


$ cat tests/mmk8s_srv.log
/usr/bin/python3.6: can't open file './mmkubernetes_test_server.py': [Errno 2] No such file or directory

$ find /tmp/rsyslog-8.35.0/work/rsyslog-8.35.0/ -name 'mmkubernetes_test*'
-
```