### PR TITLE
lookup table reload: log level from error to info

### DIFF
--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -738,7 +738,7 @@ finalize_it:
 		lookupDestruct(newlu);
 	} else {
 		if (stub_val == NULL) {
-			LogError(0, RS_RET_OK, "lookup table '%s' reloaded from file '%s'",
+			LogMsg(0, RS_RET_OK, LOG_INFO, "lookup table '%s' reloaded from file '%s'",
 					pThis->name, pThis->filename);
 		} else {
 			LogError(0, RS_RET_OK, "lookup table '%s' stubbed with value '%s'",


### PR DESCRIPTION
@rgerhards @davidelang 

Based on discussion, I've attempted to adjust the error level to reflect that the action (reloading the lookup table) is normal/expected and not an actual error condition. No real clue what I'm doing here, so feedback/corrections are much appreciated!

related to rsyslog/rsyslog#2713

