### PR TITLE
mmkubernetes test python must encode response

### DIFF
--- a/tests/mmkubernetes-basic.sh
+++ b/tests/mmkubernetes-basic.sh
@@ -4,7 +4,7 @@
 . $srcdir/diag.sh init
 
 testsrv=mmk8s-test-server
-python ./mmkubernetes_test_server.py 18443 rsyslog${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
+python -u ./mmkubernetes_test_server.py 18443 rsyslog${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
 BGPROCESS=$!
 . $srcdir/diag.sh wait-startup $testsrv
 echo background mmkubernetes_test_server.py process id is $BGPROCESS

--- a/tests/mmkubernetes_test_server.py
+++ b/tests/mmkubernetes_test_server.py
@@ -104,7 +104,7 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
             self.log_error(resp)
         self.send_response(status)
         self.end_headers()
-        self.wfile.write(json.dumps(json.loads(resp), separators=(',',':')))
+        self.wfile.write(json.dumps(json.loads(resp), separators=(',',':')).encode())
 
 port = int(sys.argv[1])
 


### PR DESCRIPTION
https://github.com/rsyslog/rsyslog/issues/2721
Was not working on python3 - must use `encode()` to convert the
string to a `bytes` object.
Also run the server with python -u to make sure we get the log
output from the kubernetes test server.