### PR TITLE
imptcp: experimental multiline support via regex

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -527,6 +527,8 @@ if ENABLE_IMPTCP
 # need to be disabled if we do not have this module
 TESTS +=  \
 	manyptcp.sh \
+	imptcp_framing_regex.sh \
+	imptcp_framing_regex-oversize.sh \
 	imptcp_large.sh \
 	imptcp-connection-msg-disabled.sh \
 	imptcp-connection-msg-received.sh \
@@ -1318,6 +1320,10 @@ EXTRA_DIST= \
 	testsuites/manyptcp.conf \
 	imptcp-NUL.sh \
 	imptcp-NUL-rawmsg.sh \
+	imptcp_framing_regex.sh \
+	testsuites/imptcp_framing_regex.testdata \
+	imptcp_framing_regex-oversize.sh \
+	testsuites/imptcp_framing_regex-oversize.testdata \
 	imptcp_large.sh \
 	imptcp-connection-msg-disabled.sh \
 	imptcp-connection-msg-received.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -688,9 +688,9 @@ case $1 in
 		done
 		echo "dyn-stats reset for bucket ${3} registered"
 		;;
-   'content-check')
+   'content-check-regex')
 		# this does a content check which permits regex
-		grep "$2" $3
+		grep "$2" $3 -q
 		if [ "$?" -ne "0" ]; then
 		    echo "----------------------------------------------------------------------"
 		    echo content-check failed to find "'$2'" inside "'$3'"

--- a/tests/imptcp_framing_regex-oversize.sh
+++ b/tests/imptcp_framing_regex-oversize.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released  under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+$EscapeControlCharactersOnReceive off
+global(maxMessageSize="256")
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="13514" ruleset="remote"
+	framing.delimiter.regex="^<[0-9]{2}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)")
+
+template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")
+ruleset(name="remote") {
+	action(type="omfile" file="rsyslog.out.log" template="outfmt")
+}
+action(type="omfile" file="rsyslog2.out.log")
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -B -I testsuites/imptcp_framing_regex-oversize.testdata
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown       # and wait for it to terminate
+echo 'NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test1
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test xml-ish
+<test/>
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test2
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
+line1
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
+ 1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 2-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 3-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+NEWMSG: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 7-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 8-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+END
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test3
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
+line3
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test4' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+. $srcdir/diag.sh content-check-regex "assuming end of frame" rsyslog2.out.log
+. $srcdir/diag.sh content-check-regex "message too long" rsyslog2.out.log
+. $srcdir/diag.sh exit

--- a/tests/imptcp_framing_regex.sh
+++ b/tests/imptcp_framing_regex.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released  under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+$EscapeControlCharactersOnReceive off
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="13514" ruleset="remote"
+	framing.delimiter.regex="^<[0-9]{2}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)")
+
+template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")
+ruleset(name="remote") {
+	action(type="omfile" file="rsyslog.out.log" template="outfmt")
+}
+'
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh tcpflood -B -I testsuites/imptcp_framing_regex.testdata
+. $srcdir/diag.sh shutdown-when-empty # shut down rsyslogd when done processing messages
+. $srcdir/diag.sh wait-shutdown       # and wait for it to terminate
+echo 'NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test1
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test xml-ish
+<test/>
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test2
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
+line1
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
+ l
+ i
+ n
+
+e2
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test3
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
+line3
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test4' | cmp - rsyslog.out.log
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, rsyslog.out.log is:"
+  cat rsyslog.out.log
+  . $srcdir/diag.sh error-exit  1
+fi;
+. $srcdir/diag.sh exit

--- a/tests/testsuites/imptcp_framing_regex-oversize.testdata
+++ b/tests/testsuites/imptcp_framing_regex-oversize.testdata
@@ -1,0 +1,22 @@
+<33>Mar  1 01:00:00 172.20.245.8 tag test1
+<33>Mar  1 01:00:00 172.20.245.8 tag test xml-ish
+<test/>
+<33>Mar  1 01:00:00 172.20.245.8 tag test2
+<33>Mar  1 01:00:00 172.20.245.8 tag multi
+line1
+<33>Mar  1 01:00:00 172.20.245.8 tag multi
+ 1-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 2-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 3-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 4-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 5-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 6-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 7-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+ 8-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+END
+<33>Mar  1 01:00:00 172.20.245.8 tag test3
+<33>Mar  1 01:00:00 172.20.245.8 tag multi
+line3
+<33>Mar  1 01:00:00 172.20.245.8 tag test4
+<33>Mar  1 01:00:00 172.20.245.8 tag test end
+

--- a/tests/testsuites/imptcp_framing_regex.testdata
+++ b/tests/testsuites/imptcp_framing_regex.testdata
@@ -1,0 +1,18 @@
+<33>Mar  1 01:00:00 172.20.245.8 tag test1
+<33>Mar  1 01:00:00 172.20.245.8 tag test xml-ish
+<test/>
+<33>Mar  1 01:00:00 172.20.245.8 tag test2
+<33>Mar  1 01:00:00 172.20.245.8 tag multi
+line1
+<33>Mar  1 01:00:00 172.20.245.8 tag multi
+ l
+ i
+ n
+
+e2
+<33>Mar  1 01:00:00 172.20.245.8 tag test3
+<33>Mar  1 01:00:00 172.20.245.8 tag multi
+line3
+<33>Mar  1 01:00:00 172.20.245.8 tag test4
+<33>Mar  1 01:00:00 172.20.245.8 tag test end
+


### PR DESCRIPTION
Add support for regex-based framing  for complex multi-line messages (XML in particular), the multiLine method does not work. We now have a capability to specify via a regex when a frame starts (and the previous thus ends).
    
adds imptcp input parameter "framing.delimiter.regex"
