### PR TITLE
omelasticsearch: write op types; bulk rejection retries

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -566,7 +566,8 @@ TESTS +=  \
 	es-basic-errfile-empty.sh \
 	es-basic-errfile-popul.sh \
 	es-bulk-errfile-empty.sh \
-	es-bulk-errfile-popul.sh
+	es-bulk-errfile-popul.sh \
+	es-writeoperation.sh
 if HAVE_VALGRIND
 TESTS += \
 	es-basic-vgthread.sh
@@ -1933,7 +1934,8 @@ EXTRA_DIST= \
 	mmkubernetes-basic.sh \
 	mmkubernetes-basic-vg.sh \
 	mmkubernetes_test_server.py \
-	mmkubernetes-basic.out.json
+	mmkubernetes-basic.out.json \
+	es-writeoperation.sh
 
 ourtail_SOURCES = ourtail.c
 msleep_SOURCES = msleep.c

--- a/tests/README
+++ b/tests/README
@@ -29,6 +29,51 @@ To configure system properties like hostname and firewall, use the
 graphical "yast2" administration tool. Note the ssh-access by default
 is disable in the firewall!
 
+Before running tests
+====================
+make check - this will compile all of the C code used in the tests, as well as
+do any other preparations, and will start running all of the tests.  Ctrl-C to
+stop running all of the tests.
+
+Running all tests
+=================
+make check
+
+Running named tests
+===================
+make testname.sh.log
+
+For example, to run the imfile-basic.sh test, use
+
+make imfile-basic.sh.log
+
+Test output is in imfile-basic.sh.log
+
+To re-run the test, first remove imfile-basic.sh.log then make again
+
+* Using gdb to debug rsyslog during a test run
+
+Edit your test like this:
+
+    . $srcdir/diag.sh startup
+    if [ -n "${USE_GDB:-}" ] ; then
+        echo attach gdb here
+        sleep 54321 || :
+    fi
+
+Run your test in the background:
+
+    USE_GDB=1 make mytest.sh.log &
+
+Tail mytest.sh.log until you see 'attach gdb here'.  The log should also
+tell you what is the rsyslogd pid.
+
+   gdb ../tools/rsyslogd $rsyslogd_pid
+
+Set breakpoints, whatever, then 'continue'
+
+In another window, do ps -ef|grep 54321, then kill that pid
+
 Core Dump Analysis
 ==================
 The testbench contains some limited (yet useful) support for automatically

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -71,8 +71,8 @@ dep_zk_url=http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.10/zookeeper-3.
 dep_zk_cached_file=$dep_cache_dir/zookeeper-3.4.10.tar.gz
 dep_kafka_url=http://www-us.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz
 if [ -z "$ES_DOWNLOAD" ]; then
-	dep_es_url=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.3.tar.gz
-	dep_es_cached_file=$dep_cache_dir/elasticsearch-5.6.3.tar.gz
+	dep_es_url=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz
+	dep_es_cached_file=$dep_cache_dir/elasticsearch-5.6.9.tar.gz
 else
 	dep_es_url="https://artifacts.elastic.co/downloads/elasticsearch/$ES_DOWNLOAD"
 	dep_es_cached_file="$dep_cache_dir/$ES_DOWNLOAD"
@@ -205,7 +205,7 @@ case $1 in
 		;;
    'es-init')   # initialize local Elasticsearch *testbench* instance for the next
                 # test. NOTE: do NOT put anything useful on that instance!
-		curl -XDELETE localhost:9200/rsyslog_testbench
+		curl --silent -XDELETE localhost:${ES_PORT:-9200}/rsyslog_testbench
 		;;
    'es-getdata') # read data from ES to a local file so that we can process
 		if [ "x$3" == "x" ]; then
@@ -217,7 +217,7 @@ case $1 in
    		# it with out regular tooling.
 		# Note: param 2 MUST be number of records to read (ES does
 		# not return the full set unless you tell it explicitely).
-		curl localhost:$es_get_port/rsyslog_testbench/_search?size=$2 > work
+		curl --silent localhost:$es_get_port/rsyslog_testbench/_search?size=$2 > work
 		python $srcdir/es_response_get_msgnum.py > rsyslog.out.log
 		;;
    'getpid')
@@ -934,7 +934,11 @@ case $1 in
 		rm -rf $dep_work_dir/es
 		echo TEST USES ELASTICSEARCH BINARY $dep_es_cached_file
 		(cd $dep_work_dir && tar -zxf $dep_es_cached_file --xform $dep_es_dir_xform_pattern --show-transformed-names) > /dev/null
-		cp $srcdir/testsuites/$dep_work_es_config $dep_work_dir/es/config/elasticsearch.yml
+		if [ -n "${ES_PORT:-}" ] ; then
+			sed "s/^http.port:.*\$/http.port: ${ES_PORT}/" $srcdir/testsuites/$dep_work_es_config > $dep_work_dir/es/config/elasticsearch.yml
+		else
+			cp $srcdir/testsuites/$dep_work_es_config $dep_work_dir/es/config/elasticsearch.yml
+		fi
 
 		if [ ! -d $dep_work_dir/es/data ]; then
 				echo "Creating elastic search directories"
@@ -969,7 +973,7 @@ case $1 in
 		timeseconds=0
 		# Loop until elasticsearch port is reachable or until
 		# timeout is reached!
-		until [ "`curl --silent --show-error --connect-timeout 1 http://localhost:19200 | grep 'rsyslog-testbench'`" != "" ]; do
+		until [ "`curl --silent --show-error --connect-timeout 1 http://localhost:${ES_PORT:-19200} | grep 'rsyslog-testbench'`" != "" ]; do
 			echo "--- waiting for startup: 1 ( $timeseconds ) seconds"
 			./msleep 1000
 			let "timeseconds = $timeseconds + 1"

--- a/tests/es-bulk-retry.sh
+++ b/tests/es-bulk-retry.sh
@@ -1,0 +1,201 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+export ES_PORT=19200
+. $srcdir/diag.sh download-elasticsearch
+. $srcdir/diag.sh stop-elasticsearch
+. $srcdir/diag.sh prepare-elasticsearch
+# change settings to cause bulk rejection errors
+cat >> $dep_work_dir/es/config/elasticsearch.yml <<EOF
+thread_pool.bulk.queue_size: 1
+thread_pool.bulk.size: 1
+EOF
+. $srcdir/diag.sh start-elasticsearch
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+	   log.file="es-stats.log" log.syslog="off" format="cee")
+
+set $.msgnum = field($msg, 58, 2);
+set $.testval = cnum($.msgnum % 2);
+if $.testval == 0 then {
+	# these should be successful
+	set $!msgnum = $.msgnum;
+} else {
+	# these should cause "hard" errors
+	set $!msgnum = "x" & $.msgnum;
+}
+
+template(name="tpl" type="string"
+    string="{\"msgnum\":\"%$!msgnum%\",\"es_msg_id\":\"%$!es_msg_id%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+template(name="id-template" type="string" string="%$!es_msg_id%")
+
+if strlen($!es_msg_id) == 0 then {
+	# NOTE: depends on rsyslog being compiled with --enable-uuid
+	set $!es_msg_id = $uuid;
+}
+
+ruleset(name="error_es") {
+	action(type="omfile" template="RSYSLOG_DebugFormat" file="es-bulk-errors.log")
+}
+
+ruleset(name="try_es") {
+	if strlen($.omes!status) > 0 then {
+		# retry case
+		if ($.omes!status == 200) or ($.omes!status == 201) or (($.omes!status == 409) and ($.omes!writeoperation == "create")) then {
+			stop # successful
+		}
+		if ($.omes!writeoperation == "unknown") or (strlen($.omes!error!type) == 0) or (strlen($.omes!error!reason) == 0) then {
+			call error_es
+			stop
+		}
+		if ($.omes!status == 400) or ($.omes!status < 200) then {
+			call error_es
+			stop
+		}
+		# else fall through to retry operation
+	}
+	action(type="omelasticsearch"
+	       server="127.0.0.1"
+	       serverport="'${ES_PORT:-19200}'"
+	       template="tpl"
+	       writeoperation="create"
+	       bulkid="id-template"
+	       dynbulkid="on"
+	       bulkmode="on"
+	       retryfailures="on"
+	       retryruleset="try_es"
+	       searchType="test-type"
+	       searchIndex="rsyslog_testbench")
+}
+
+if $msg contains "msgnum:" then {
+	call try_es
+}
+
+action(type="omfile" file="rsyslog.out.log")
+'
+rm -f es-bulk-errors.log es-stats.log
+
+curl -s -XPUT localhost:${ES_PORT:-19200}/rsyslog_testbench/ -d '{
+  "mappings": {
+    "test-type": {
+      "properties": {
+        "msgnum": {
+          "type": "integer"
+        }
+      }
+    }
+  }
+}
+' | python -mjson.tool
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+#export RSYSLOG_DEBUGLOG="debug.log"
+if [ "x${USE_VALGRIND:-false}" == "xtrue" ] ; then
+	. $srcdir/diag.sh startup-vg
+else
+	. $srcdir/diag.sh startup
+fi
+if [ -n "${USE_GDB:-}" ] ; then
+	echo attach gdb here
+	sleep 54321 || :
+fi
+numrecords=100
+success=50
+badarg=50
+. $srcdir/diag.sh injectmsg 0 $numrecords
+. $srcdir/diag.sh shutdown-when-empty
+if [ "x${USE_VALGRIND:-false}" == "xtrue" ] ; then
+	. $srcdir/diag.sh wait-shutdown-vg
+	. $srcdir/diag.sh check-exit-vg
+else
+	. $srcdir/diag.sh wait-shutdown
+fi
+. $srcdir/diag.sh es-getdata $numrecords $ES_PORT
+rc=$?
+
+. $srcdir/diag.sh stop-elasticsearch
+. $srcdir/diag.sh cleanup-elasticsearch
+
+cat work | \
+	python -c '
+import sys,json
+records = int(sys.argv[1])
+expectedrecs = {}
+rc = 0
+for ii in xrange(0, records*2, 2):
+	ss = "{:08}".format(ii)
+	expectedrecs[ss] = ss
+for item in json.load(sys.stdin)["hits"]["hits"]:
+	msgnum = item["_source"]["msgnum"]
+	if msgnum in expectedrecs:
+		del expectedrecs[msgnum]
+	else:
+		print "Error: found unexpected msgnum {} in record".format(msgnum)
+		rc = 1
+for item in expectedrecs:
+	print "Error: msgnum {} was missing in Elasticsearch".format(item)
+	rc = 1
+sys.exit(rc)
+' $success || { rc=$?; echo error: did not find expected records in Elasticsearch; }
+
+cat es-stats.log | \
+	python -c '
+import sys,json
+success = int(sys.argv[1])
+badarg = int(sys.argv[2])
+lasthsh = {}
+for line in sys.stdin:
+	jstart = line.find("{")
+	if jstart >= 0:
+		hsh = json.loads(line[jstart:])
+		if hsh["name"] == "omelasticsearch":
+			lasthsh = hsh
+actualsuccess = lasthsh["response.success"]
+actualbadarg = lasthsh["response.badargument"]
+actualrej = lasthsh["response.bulkrejection"]
+actualsubmitted = lasthsh["submitted"]
+assert(actualsuccess == success)
+assert(actualbadarg == badarg)
+assert(actualrej > 0)
+assert(actualsuccess + actualbadarg + actualrej == actualsubmitted)
+' $success $badarg || { rc=$?; echo error: expected responses not found in stats; }
+
+found=0
+for ii in $(seq --format="x%08.f" 1 2 $(expr 2 \* $badarg)) ; do
+	if grep -q '^[$][!]:{.*"msgnum": "'$ii'"' es-bulk-errors.log ; then
+		found=$( expr $found + 1 )
+	else
+		echo error: missing message $ii
+		rc=1
+	fi
+done
+if [ $found -ne $badarg ] ; then
+	echo error: found only $found of $badarg messages in es-bulk-errors.log
+	rc=1
+fi
+if grep -q '^[$][.]:{.*"omes": {' es-bulk-errors.log ; then
+	:
+else
+	echo error: es response info not found in bulk error file
+	rc=1
+fi
+if grep -q '^[$][.]:{.*"status": 400' es-bulk-errors.log ; then
+	:
+else
+	echo error: status 400 not found in bulk error file
+	rc=1
+fi
+
+if [ $rc -eq 0 ] ; then
+	echo tests completed successfully
+else
+	cat rsyslog.out.log
+	. $srcdir/diag.sh error-exit 1 stacktrace
+fi
+
+. $srcdir/diag.sh exit

--- a/tests/es-config-errs.supp
+++ b/tests/es-config-errs.supp
@@ -1,0 +1,11 @@
+{
+   rsyslog does not clean up properly when hitting a config error
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:nvlstNewStr
+   fun:yyparse
+   fun:load
+   fun:initAll
+   fun:main
+}

--- a/tests/es-writeoperation.sh
+++ b/tests/es-writeoperation.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. $srcdir/diag.sh download-elasticsearch
+. $srcdir/diag.sh stop-elasticsearch
+. $srcdir/diag.sh prepare-elasticsearch
+. $srcdir/diag.sh start-elasticsearch
+
+#  Starting actual testbench
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+if $msg contains "msgnum:" then
+	action(type="omelasticsearch"
+	       server="127.0.0.1"
+	       serverport="19200"
+	       template="tpl"
+	       writeoperation="create"
+	       searchIndex="rsyslog_testbench")
+
+action(type="omfile" file="rsyslog.out.log")
+'
+
+# . $srcdir/diag.sh es-init
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh injectmsg  0 1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+if grep -q "omelasticsearch: writeoperation '1' requires bulkid" rsyslog.out.log ; then
+	echo found correct error message
+else
+	echo Error: did not complain about incorrect writeoperation
+	cat rsyslog.out.log
+	. $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+if $msg contains "msgnum:" then
+	action(type="omelasticsearch"
+	       server="127.0.0.1"
+	       serverport="19200"
+	       template="tpl"
+	       writeoperation="unknown"
+	       searchIndex="rsyslog_testbench")
+
+action(type="omfile" file="rsyslog.out.log")
+'
+
+# . $srcdir/diag.sh es-init
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh injectmsg  0 1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+if grep -q "omelasticsearch: invalid value 'unknown' for writeoperation" rsyslog.out.log ; then
+	echo found correct error message
+else
+	echo Error: did not complain about incorrect writeoperation
+	cat rsyslog.out.log
+	. $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh generate-conf
+. $srcdir/diag.sh add-conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+template(name="id-template" type="list") { constant(value="123456789") }
+
+if $msg contains "msgnum:" then
+	action(type="omelasticsearch"
+	       server="127.0.0.1"
+	       serverport="19200"
+	       template="tpl"
+	       writeoperation="create"
+	       bulkid="id-template"
+	       dynbulkid="on"
+	       bulkmode="on"
+	       searchIndex="rsyslog_testbench")
+
+action(type="omfile" file="rsyslog.out.log")
+'
+
+export ES_PORT=19200
+. $srcdir/diag.sh es-init
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+#export RSYSLOG_DEBUGLOG="debug.log"
+. $srcdir/diag.sh startup
+. $srcdir/diag.sh injectmsg  0 1
+. $srcdir/diag.sh shutdown-when-empty
+. $srcdir/diag.sh wait-shutdown
+. $srcdir/diag.sh es-getdata 1 $ES_PORT
+
+cat work | \
+	python -c '
+import sys,json
+hsh = json.load(sys.stdin)
+try:
+	if hsh["hits"]["hits"][0]["_id"] == "123456789":
+		print "good - found expected value"
+		sys.exit(0)
+	print "Error: _id not expected value 123456789:", hsh["hits"]["hits"][0]["_id"]
+	sys.exit(1)
+except ValueError:
+	print "Error: output is not valid:", json.dumps(hsh,indent=2)
+	sys.exit(1)
+'
+
+if [ $? -eq 0 ] ; then
+	echo found correct response
+else
+	cat rsyslog.out.log
+	. $srcdir/diag.sh error-exit 1
+fi
+
+. $srcdir/diag.sh stop-elasticsearch
+. $srcdir/diag.sh cleanup-elasticsearch
+. $srcdir/diag.sh exit


### PR DESCRIPTION
Add support for a 'create' write operation type in addition to
the default 'index'.  Using create allows specifying a unique id
for each record, and allows duplicate document detection.

Add support for checking each record returned in a bulk index
request response.  Allow specifying a ruleset to send each failed
record to.  Add a local variable `omes` which contains the
information in the error response, so that users can control how
to handle responses e.g. retry, or send to an error file.

Add support for response stats - count successes, duplicates, and
different types of failures.

Add testing for bulk index rejections.