### PR TITLE
rsyslog.service.in: create PID file

### DIFF
--- a/rsyslog.service.in
+++ b/rsyslog.service.in
@@ -6,7 +6,7 @@ Documentation=http://www.rsyslog.com/doc/
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/rsyslogd -n -iNONE
+ExecStart=@sbindir@/rsyslogd -n -i/var/run/rsyslogd.pid
 StandardOutput=null
 Restart=on-failure
 


### PR DESCRIPTION
Logrotate scripts use sysv init script with `rotate` option, which expects PID file to be found in /var/run/rsyslogd.pid