### PR TITLE
rsyslog.service.in: move LimitNOFILE to correct section

### DIFF
--- a/rsyslog.service.in
+++ b/rsyslog.service.in
@@ -10,10 +10,10 @@ ExecStart=@sbindir@/rsyslogd -n -iNONE
 StandardOutput=null
 Restart=on-failure
 
-[Install]
-WantedBy=multi-user.target
-Alias=syslog.service
-
 # Increase the default a bit in order to allow many simultaneous
 # files to be monitored, we might need a lot of fds.
 LimitNOFILE=16384
+
+[Install]
+WantedBy=multi-user.target
+Alias=syslog.service


### PR DESCRIPTION
systemd[1]: [/lib/systemd/system/rsyslog.service:19] Unknown lvalue 'LimitNOFILE' in section 'Install'