### PR TITLE
Put LimitNOFILE in the correct section of the systemd service file

### DIFF
--- a/rsyslog.service.in
+++ b/rsyslog.service.in
@@ -10,10 +10,10 @@ ExecStart=@sbindir@/rsyslogd -n -iNONE
 StandardOutput=null
 Restart=on-failure
 
-[Install]
-WantedBy=multi-user.target
-Alias=syslog.service
-
 # Increase the default a bit in order to allow many simultaneous
 # files to be monitored, we might need a lot of fds.
 LimitNOFILE=16384
+
+[Install]
+WantedBy=multi-user.target
+Alias=syslog.service


### PR DESCRIPTION
Noted by log message:
```
usr/lib/systemd/system/rsyslog.service:21: Unknown lvalue 'LimitNOFILE' in section 'Install
```