### PR TITLE
core: misadressing when writing disk queue files

### DIFF
--- a/tests/imfile-basic-vgthread.sh
+++ b/tests/imfile-basic-vgthread.sh
@@ -5,6 +5,12 @@ if [ `uname` = "FreeBSD" ] ; then
    echo "This test currently does not work on FreeBSD."
    exit 77
 fi
+grep "\.el6\." <<< $(uname -a)
+if [ "$?" == "0" ]; then
+	echo "CentOS 6 detected, adding valgrind suppressions"
+	export RS_TEST_VALGRIND_EXTRA_OPTS="--suppressions=imfile-basic-vgthread.supp"
+fi
+
 
 echo [imfile-basic.sh]
 . $srcdir/diag.sh init

--- a/tests/imfile-basic-vgthread.supp
+++ b/tests/imfile-basic-vgthread.supp
@@ -1,0 +1,16 @@
+{
+   CentOS6 valgrind false positive
+   Helgrind:Misc
+   fun:pthread_cond_destroy_WRK
+   fun:pthread_cond_destroy@*
+   fun:qqueueDestruct
+   fun:actionDestruct
+   fun:cnfstmtDestruct
+   fun:cnfstmtDestructLst
+   fun:cnfstmtDestruct
+   fun:cnfstmtDestructLst
+   fun:doDestructCnfStmt
+   fun:llExecFunc
+   fun:destructAllActions
+   fun:main
+}


### PR DESCRIPTION
when writing disk queue files during shutdown, access to freed
memory can occur under these circumstances:

- action A is processing data, but could not complete it
  most importantly, the current in-process batch needs not to
  be totally completed. Most probable cause for this scenario
  is a suspended action in retry mode.
- action A is called from a ruleset RA which
  - does not have a queue assigned
  - where RA is called from a ruleset RO which is bound
    to the input from which the message originated
  - RO must be defined before RA inside the expanded config
- Disk queues (or the disk part of a DA queue) must be utilized
  by A

When re-injecting the unprocessed messages from A into the disk queue, the
name of ruleset RO is accessed (for persisting to disk). However, RO is
already destructed at this point in time.

The patch changes the shutdown processing of rulesets, so that all
shutdown processing is done before any ruleset data is destructed. This
ensures that all data items which potentially need to be accessed
remain valid as long as some part may potentially try to access them.

This follows a the approach used in
   https://github.com/rsyslog/rsyslog/pull/1857
where obviously that part of the problem was not noticed.

see also https://github.com/rsyslog/rsyslog/issues/1122
closes https://github.com/rsyslog/rsyslog/issues/2742

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
