### PR TITLE
use version=2 in mmkubernetes rulebase files

### DIFF
--- a/contrib/mmkubernetes/k8s_container_name.rulebase
+++ b/contrib/mmkubernetes/k8s_container_name.rulebase
@@ -1,2 +1,3 @@
+version=2
 rule=:%k8s_prefix:char-to:_%_%container_name:char-to:.%.%container_hash:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%
 rule=:%k8s_prefix:char-to:_%_%container_name:char-to:_%_%pod_name:char-to:_%_%namespace_name:char-to:_%_%not_used_1:char-to:_%_%not_used_2:rest%

--- a/contrib/mmkubernetes/k8s_filename.rulebase
+++ b/contrib/mmkubernetes/k8s_filename.rulebase
@@ -1,2 +1,3 @@
+version=2
 rule=:/var/log/containers/%pod_name:char-to:.%.%container_hash:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log
 rule=:/var/log/containers/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log


### PR DESCRIPTION
We see memory leaks in liblognorm in older versions of
liblognorm unless we explicitly specify version=2