### PR TITLE
Fixed empty programname if checked before APP-NAME has been properly copied to TAG when receiving using RFC5424 log lines.

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2479,6 +2479,8 @@ tryEmulateTAG(smsg_t * const pM, sbool bLockMutex)
 			bufTAG[sizeof(bufTAG)-1] = '\0'; /* just to make sure... */
 			MsgSetTAG(pM, bufTAG, lenTAG);
 		}
+		/* Signal change in TAG for aquireProgramName */
+		pM->iLenPROGNAME = -1;
 	}
 	if(bLockMutex == LOCK_MUTEX)
 		MsgUnlock(pM);


### PR DESCRIPTION
Fixed empty programname if checked before APP-NAME has been properly copied to TAG when receiving using RFC5424 log lines.

Fixes this:
```
template (name="DynamicMessagesFile" type="string" string="/tmp/d/messages-%programname%.log")
*.info if(programname == "xxx") {
        action(type="omfile" File="/tmp/d/test.log")
    } else {
        action(type="omfile" dynaFile="DynamicMessagesFile")
    }
```

Which would produce a file calles messages-.log because programname is empty when receiving RFC5424 log line.

Fixed by singnalling change in TAG when APP-NAME has been parsed and copied to TAG.
