### PR TITLE
core: fix message loss on target unavailibility during shutdown

### DIFF
--- a/action.c
+++ b/action.c
@@ -1554,8 +1554,15 @@ processBatchMain(void *__restrict__ const pVoid,
 			/* we do not check error state below, because aborting would be
 			 * more harmful than continuing.
 			 */
-			processMsgMain(pAction, pWti, pBatch->pElem[i].pMsg, &ttNow);
-			batchSetElemState(pBatch, i, BATCH_STATE_COMM);
+			rsRetVal localRet = processMsgMain(pAction, pWti, pBatch->pElem[i].pMsg, &ttNow);
+			DBGPRINTF("processBatchMain: i %d, processMsgMain iRet %d\n", i, localRet);
+			if(   localRet == RS_RET_OK
+			   || localRet == RS_RET_DEFER_COMMIT
+			   || localRet == RS_RET_ACTION_FAILED
+			   || localRet == RS_RET_PREVIOUS_COMMITTED ) {
+				batchSetElemState(pBatch, i, BATCH_STATE_COMM);
+				DBGPRINTF("processBatchMain: i %d, COMM state set\n", i);
+			}
 		}
 	}
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1666,6 +1666,7 @@ DeleteProcessedBatch(qqueue_t *pThis, batch_t *pBatch)
 
 	for(i = 0 ; i < pBatch->nElem ; ++i) {
 		pMsg = pBatch->pElem[i].pMsg;
+		DBGPRINTF("DeleteProcessedBatch: etry %d state %d\n", i, pBatch->eltState[i]);
 		if(   pBatch->eltState[i] == BATCH_STATE_RDY
 		   || pBatch->eltState[i] == BATCH_STATE_SUB) {
 			localRet = doEnqSingleObj(pThis, eFLOWCTL_NO_DELAY, MsgAddRef(pMsg));
@@ -1778,6 +1779,8 @@ DequeueConsumableElements(qqueue_t *pThis, wti_t *pWti, int *piRemainingQueueSiz
 	/* it is sufficient to persist only when the bulk of work is done */
 	qqueueChkPersist(pThis, nDequeued+nDiscarded+nDeleted);
 
+	DBGOPRINT((obj_t*) pThis, "dequeued %d consumable elements, szlog %d sz phys %d\n",
+		nDequeued, getLogicalQueueSize(pThis), getPhysicalQueueSize(pThis));
 	pWti->batch.nElem = nDequeued;
 	pWti->batch.nElemDeq = nDequeued + nDiscarded;
 	pWti->batch.deqID = getNextDeqID(pThis);


### PR DESCRIPTION
Triggering condition:
- action queue in disk mode (or DA)
- batch is being processed by failed action in retry mode
- rsyslog is shut down without resuming action

In these cases messages may be lost by not properly writing them
back to the disk queue.

closes https://github.com/rsyslog/rsyslog/issues/2760

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
