### PR TITLE
JSON parsing extension

### DIFF
--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -237,6 +237,7 @@ unsigned short *pbMustBeFreed);
 rsRetVal msgSetJSONFromVar(smsg_t *pMsg, uchar *varname, struct svar *var, int force_reset);
 rsRetVal msgDelJSON(smsg_t *pMsg, uchar *varname);
 rsRetVal jsonFind(struct json_object *jroot, msgPropDescr_t *pProp, struct json_object **jsonres);
+rsRetVal jsonCompact(struct json_object *__restrict__ json);
 
 rsRetVal msgPropDescrFill(msgPropDescr_t *pProp, uchar *name, int nameLen);
 void msgPropDescrDestruct(msgPropDescr_t *pProp);


### PR DESCRIPTION
Hello rsyslog team,
We have a requirement to support extensions for JSON parsing both in rainerscript and mmjsonparse.
(Please see also https://bugzilla.redhat.com/show_bug.cgi?id=1565219)

This PR includes these updates:
- Adding "jsonCompact" to runtime/msg.c.
- Adding parse_json_ex to grammar/rainerscript.c for supporting _compact_.
- Adding parameters variable, alt_variable and _compact_ to mmjsonparse.

The _compact_ indicates removing empty objects from JSON values.

Configuration Examples
1. Configuration to use parse_json_ex to parse json into top level fields in message with compact
```
set $.ret = parse_json_ex($msg, "\$!", "true");
set $.ret = parse_json_ex($!log, "\$!mymessage", "true");
set $! = $!mymessage;
set $!original_raw_json = $!log;
unset $!mymessage;
unset $!log;
```
2. Configuration to use mmjsonparse to parse json into top level fields in message with compact
```
action(type="mmjsonparse" cookie="" compact="on")
action(type="mmjsonparse" cookie="" variable="$!mmlog" container="$!" alt_variable="original_raw_message" compact="on")
```
Please note that this PR depends on the PR #155 in libfastjson.
https://github.com/rsyslog/libfastjson/pull/155

I'd greatly appreciate your reviews and comments.