### PR TITLE
imjournal: journal visibility through additional impstats counters

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -720,7 +720,7 @@ CODESTARTrunInput
 		 */
 		const int e = sd_journal_get_usage(j, (uint64_t *)&statsCounter.diskUsageBytes);
 		if (e < 0) {
-			LogError(e, RS_RET_ERR, "imjournal: sd_get_usage() failed");
+			LogError(-e, RS_RET_ERR, "imjournal: sd_get_usage() failed");
 		}
 
 		if (readjournal() != RS_RET_OK) {

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -718,8 +718,9 @@ CODESTARTrunInput
 		/*
 		 * update journal disk usage before reading the new message.
 		 */
-		if (sd_journal_get_usage(j, (uint64_t *)&statsCounter.diskUsageBytes) < 0) {
-			LogError(0, RS_RET_ERR, "imjournal: sd_get_usage() failed");
+		const int e = sd_journal_get_usage(j, (uint64_t *)&statsCounter.diskUsageBytes);
+		if (e < 0) {
+			LogError(e, RS_RET_ERR, "imjournal: sd_get_usage() failed");
 		}
 
 		if (readjournal() != RS_RET_OK) {

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -309,7 +309,7 @@ readjournal(void)
 	} else {
 		CHKiRet(sanitizeValue(((const char *)get) + 8, length - 8, &message));
 	}
-	STATSCOUNTER_INC(statsCounter.ctrRead, statsCouner.mutCtrRead);
+	STATSCOUNTER_INC(statsCounter.ctrRead, statsCounter.mutCtrRead);
 
 	/* Get message severity ("priority" in journald's terminology) */
 	if (sd_journal_get_data(j, "PRIORITY", &get, &length) >= 0) {


### PR DESCRIPTION
-- Adds impstats counters for messages read from journal, submitted to main queue, and dropped due to rate-limiting
-- Also, adds counters for journal file rotations and disk usage

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
