### PR TITLE
nds_gtls: fix regression that could lead to attack (never released)

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -182,7 +182,6 @@ gtlsLoadOurCertKey(nsd_gtls_t *pThis)
 	gnutls_datum_t data = { NULL, 0 };
 	uchar *keyFile;
 	uchar *certFile;
-	int lenRcvd;
 
 	ISOBJ_TYPE_assert(pThis, nsd_gtls);
 
@@ -202,10 +201,11 @@ gtlsLoadOurCertKey(nsd_gtls_t *pThis)
 
 	/* try load certificate */
 	CHKiRet(readFile(certFile, &data));
-	pThis->nOurCerts=sizeof(pThis->pOurCerts);
-	lenRcvd=gnutls_x509_crt_list_import(pThis->pOurCerts, &pThis->nOurCerts, &data, GNUTLS_X509_FMT_PEM,0);
-	if (lenRcvd<0) {
-		CHKgnutls(lenRcvd);
+	pThis->nOurCerts = sizeof(pThis->pOurCerts) / sizeof(gnutls_x509_crt_t);
+	gnuRet = gnutls_x509_crt_list_import(pThis->pOurCerts, &pThis->nOurCerts,
+		&data, GNUTLS_X509_FMT_PEM,  GNUTLS_X509_CRT_LIST_IMPORT_FAIL_IF_EXCEED);
+	if(gnuRet < 0) {
+		ABORTgnutls;
 	}
 	pThis->bOurCertIsInit = 1;
 	free(data.data);


### PR DESCRIPTION
Commit 7589f42e45888b83f5c2a0d788896d41e6a6a598 introduced support
for loading certificate chains. Unfortunatley the max number of permitted
certificates was miscalculated and so a certificate chain with more than
10 certificates could lead to a buffer overrun. This patch corrects this.

Note that the commit was merged just yesterday and there was no release
with the affected code.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
