### PR TITLE
support mysql unix domain socket

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -77,7 +77,6 @@ typedef struct configSettings_s {
 	int iSrvPort;				/* database server port */
 	uchar *pszMySQLConfigFile;	/* MySQL Client Configuration File */
 	uchar *pszMySQLConfigSection;	/* MySQL Client Configuration Section */ 
-	uchar *pszMySQLSocket;		/* MySQL Socket Path */
 } configSettings_t;
 static configSettings_t cs;
 
@@ -470,7 +469,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 		pData->dbsrvPort = (unsigned) cs.iSrvPort;	/* set configured port */
 		pData->configfile = cs.pszMySQLConfigFile;
 		pData->configsection = cs.pszMySQLConfigSection;
-		pData->socket = cs.pszMySQLSocket;
+		pData->socket = NULL;
 	}
 
 CODE_STD_FINALIZERparseSelectorAct
@@ -505,8 +504,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 	cs.pszMySQLConfigFile = NULL;
 	free(cs.pszMySQLConfigSection);
 	cs.pszMySQLConfigSection = NULL;
-	free(cs.pszMySQLSocket);
-	cs.pszMySQLSocket = NULL;
 	RETiRet;
 }
 
@@ -544,8 +541,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler, resetConfigVariables,
 	NULL, STD_LOADABLE_MODULE_ID));
-	CHKiRet(omsdRegCFSLineHdlr((uchar *)"ommysqlsocket", 0, eCmdHdlrGetWord, NULL, &cs.pszMySQLSocket,
-	STD_LOADABLE_MODULE_ID));
 ENDmodInit
 
 /* vi:set ai:


### PR DESCRIPTION
## Abstract:

This patch is intended to fix problems when using the mysql or mariadb ___binary package___.

If use the ___mysql_real_connect___ api and specify the ___db server___ argument to ___localhost___, the ___mysql_real_connect___ api internally tries to connect using the mysql unix domain socket.

For example, an error will occur under the following conditions:

  1. start mysql daemon with ___--socket=/var/run/mysqld.sock___ option.
  2. Set the ommysql plugin as shown below.

```
    module(load="ommysql")
    action(
        type="ommysql"
        server="localhost"
        serverport="3306"
        db="Syslog"
        uid="rsyslog"
        pwd="blahblah*^^*secret"
        template="stdSQLformat"
    )
```
So, I have added the ___socket___ option to solve this problem.

## Expected:

Adding the ___socket___ option as shown below will not cause an error.

```
    module(load="ommysql")
    action(
        type="ommysql"
        server="localhost"
        serverport="3306"
        socket="/var/run/mysqld.sock"
        db="Syslog"
        uid="rsyslog"
        pwd="blahblah*^^*secret"
        template="stdSQLformat"
    )
```

## Actually result:

If use value of db server as localhost without adding the ___socket___ option, it looks for ___/tmp/mysql.sock___ and can not connect.

```
rsyslogd: db error (2002): Can't connect to local MySQL server through socket '/tmp/mysql.sock' (2)  [v8.24.0]
```