### PR TITLE
core: provide a somewhat better default action name

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,10 @@ Version 8.37.0 [v8-stable] 2018-08-07
   mutex was not properly locked at all times when the async writing buffer
   was flushed
   Thanks to Radovan Sroka for the patch.
+- omelasticsearch: fix build regression
+  Commit 6d4635efbb13907bf651b1a6e5a545effe84d9d9 introduced some compile
+  problems, which were only detected on CentOS6, which unfortunately did
+  not compile omelasticsearch during CI runs
 - imjournal: add journal-specific impstats counters
   these provide some additional insight into journal operations
   Thanks to Abdul Waheed for the patch.

--- a/action.c
+++ b/action.c
@@ -438,7 +438,8 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 	}
 	/* generate a friendly name for us action stats */
 	if(pThis->pszName == NULL) {
-		snprintf((char*) pszAName, sizeof(pszAName), "action %d", pThis->iActionNbr);
+		snprintf((char*) pszAName, sizeof(pszAName), "action-%d-%s",
+			pThis->iActionNbr, pThis->pMod->pszName);
 		pThis->pszName = ustrdup(pszAName);
 	}
 

--- a/tests/stats-json.sh
+++ b/tests/stats-json.sh
@@ -14,4 +14,5 @@ echo wait on shutdown
 . $srcdir/diag.sh wait-shutdown
 . $srcdir/diag.sh custom-content-check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' 'rsyslog.out.stats.log'
 . $srcdir/diag.sh custom-assert-content-missing '@cee' 'rsyslog.out.stats.log'
+cat rsyslog.out.stats.log
 . $srcdir/diag.sh exit


### PR DESCRIPTION
We now inlcude the module name (e.g. "omelasticsearch" or "builtin:omfile")
as part of the name. This is still not perfect, but hopefully a bit
easier to grasp.

see also https://github.com/rsyslog/rsyslog/issues/342

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
