### PR TITLE
Don't link tcpflood against -lgcrypt

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1960,7 +1960,7 @@ tcpflood_LDADD = $(SOL_LIBS) $(PTHREADS_LIBS) $(RELP_LIBS)
 if ENABLE_GNUTLS
 tcpflood_CFLAGS += $(GNUTLS_CFLAGS)
 tcpflood_CPPFLAGS += $(GNUTLS_CFLAGS)
-tcpflood_LDADD += $(GNUTLS_LIBS) -lgcrypt
+tcpflood_LDADD += $(GNUTLS_LIBS)
 endif
 if ENABLE_OPENSSL
 tcpflood_CFLAGS += $(OPENSSL_CFLAGS)


### PR DESCRIPTION
While older GnuTLS versions do use gcrypt, newer version no longer do.

From
https://www.gnutls.org/manual/html_node/Cryptographic-Backend.html

"
Cryptographic library layer

The Cryptographic library layer, currently supports only libnettle.
Older versions of GnuTLS used to support libgcrypt, but it was switched
with nettle mainly for performance reasons and secondary because it is
a simpler library to use. In the future other cryptographic libraries
might be supported as well.
"

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
