### PR TITLE
cleanup: remove no longer needed --enable-memcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -336,7 +336,6 @@ THIS_IS_TEMPORARILY_DISABLED = \
 	--enable-imptcp \
 	--enable-omuxsock \
 	--enable-impstats \
-	--enable-memcheck \
 	--enable-pmaixforwardedfrom \
 	--enable-pmcisconames \
 	--enable-pmsnare \

--- a/configure.ac
+++ b/configure.ac
@@ -704,21 +704,6 @@ if test "$enable_valgrind" = "yes"; then
 fi
 
 
-# memcheck
-AC_ARG_ENABLE(memcheck,
-        [AS_HELP_STRING([--enable-memcheck],[Enable extended memory check support @<:@default=no@:>@])],
-        [case "${enableval}" in
-         yes) enable_memcheck="yes" ;;
-          no) enable_memcheck="no" ;;
-           *) AC_MSG_ERROR(bad value ${enableval} for --enable-memcheck) ;;
-         esac],
-        [enable_memcheck="no"]
-)
-if test "$enable_memcheck" = "yes"; then
-        AC_DEFINE(MEMCHECK, 1, [Defined if memcheck support settings are to be enabled (e.g. prevents dlclose()).])
-fi
-
-
 # compile diagnostic tools (small helpers usually not needed)
 AC_ARG_ENABLE(diagtools,
         [AS_HELP_STRING([--enable-diagtools],[Enable diagnostic tools @<:@default=no@:>@])],

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -105,7 +105,6 @@ void dbgExitFunc(dbgFuncDB_t *pFuncDB, int iStackPtrRestore, int iRet);
 void dbgSetExecLocation(int iStackPtr, int line);
 void dbgSetThrdName(uchar *pszName);
 void dbgPrintAllDebugInfo(void);
-void *dbgmalloc(size_t size);
 void dbgOutputTID(char* name);
 int dbgGetDbglogFd(void);
 
@@ -139,11 +138,8 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #define RUNLOG_VAR(fmt, x)
 #define RUNLOG_STR(str)
 
-#ifdef MEMCHECK
-#	define MALLOC(x) dbgmalloc(x)
-#else
-#	define MALLOC(x) malloc(x)
-#endif
+/* this macro is needed to support old, no longer used --enable-memcheck setting (now we use ASAN/valgrind!) */
+#define MALLOC(x) malloc(x)
 
 #define MUTOP_LOCKWAIT		1
 #define MUTOP_LOCK		2


### PR DESCRIPTION
veeeeery old testing capability, no longer functional but
causes build to fail if enabled. Replaced by ASAN/valgrind.

Issue detected while testing some other CI settings.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
