### PR TITLE
add global directive "abortOnUncleanConfig"

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -186,6 +186,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "net.aclresolvehostname", eCmdHdlrBinary, 0 },
 	{ "net.enabledns", eCmdHdlrBinary, 0 },
 	{ "net.permitACLwarning", eCmdHdlrBinary, 0 },
+	{ "abortonuncleanconfig", eCmdHdlrBinary, 0 },
 	{ "variables.casesensitive", eCmdHdlrBinary, 0 },
 	{ "environment", eCmdHdlrArray, 0 },
 	{ "processinternalmessages", eCmdHdlrBinary, 0 },
@@ -1332,6 +1333,8 @@ glblDoneLoadCnf(void)
 		        setDisableDNS(!((int) cnfparamvals[i].val.d.n));
 		} else if(!strcmp(paramblk.descr[i].name, "net.permitwarning")) {
 		        setOption_DisallowWarning(!((int) cnfparamvals[i].val.d.n));
+		} else if(!strcmp(paramblk.descr[i].name, "abortonuncleanconfig")) {
+		        loadConf->globals.bAbortOnUncleanConfig = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "internalmsg.ratelimit.burst")) {
 		        glblIntMsgRateLimitBurst = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "internalmsg.ratelimit.interval")) {

--- a/tests/abort-uncleancfg-badcfg-check.sh
+++ b/tests/abort-uncleancfg-badcfg-check.sh
@@ -2,14 +2,12 @@
 # Copyright 2015-01-29 by Tim Eifler
 # This file is part of the rsyslog project, released  under ASL 2.0
 # The configuration test should fail because of the invalid config file.
-echo ===============================================================================
-echo \[abort-uncleancfg-badcfg.sh\]: testing abort on unclean configuration
-echo "testing a bad Configuration verification run"
 . $srcdir/diag.sh init
 ../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/abort-uncleancfg-badcfg.conf -M../runtime/.libs:../.libs
 if [ $? == 0 ]; then
    echo "Error: config check should fail"
-   exit 1 
+   . $srcdir/diag.sh error-exit 1
 fi
+printf "unclean config lead to exit, as expected - OK\n"
 . $srcdir/diag.sh exit
 

--- a/tests/testsuites/abort-uncleancfg-badcfg.conf
+++ b/tests/testsuites/abort-uncleancfg-badcfg.conf
@@ -1,6 +1,6 @@
 $IncludeConfig diag-common.conf
 
-$AbortOnUncleanConfig on
+global(AbortOnUncleanConfig="on")
 
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1552,10 +1552,11 @@ initAll(int argc, char **argv)
 
 	if(hadErrMsgs()) {
 		if(loadConf->globals.bAbortOnUncleanConfig) {
-			fprintf(stderr, "rsyslogd: $AbortOnUncleanConfig is set, and config is not clean.\n"
-					"Check error log for details, fix errors and restart. As a last\n"
-					"resort, you may want to remove $AbortOnUncleanConfig to permit a\n"
-					"startup with a dirty config.\n");
+			fprintf(stderr, "rsyslogd: global(AbortOnUncleanConfig=\"on\") is set, and "
+				"config is not clean.\n"
+				"Check error log for details, fix errors and restart. As a last\n"
+				"resort, you may want to use global(AbortOnUncleanConfig=\"off\") \n"
+				"to permit a startup with a dirty config.\n");
 			exit(2);
 		}
 		if(iConfigVerify) {


### PR DESCRIPTION
This provides a new-style alternative to $AbortOnUncleanConfig.
Note that a testbench test was changed to the new syntax. Adding
an additional test did not look useful, as the testbench still
sufficiently tests old and new method.

closes https://github.com/rsyslog/rsyslog/issues/2744

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
