### PR TITLE
check for null fp before fclose

### DIFF
--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -737,8 +737,10 @@ CODESTARTcreateWrkrInstance
 			free(token);
 			token = NULL;
 		}
-		fclose(fp);
-		fp = NULL;
+		if (fp) {
+			fclose(fp);
+			fp = NULL;
+		}
 	}
 	if (tokenHdr) {
 		hdr = curl_slist_append(hdr, tokenHdr);


### PR DESCRIPTION
check for null fp before `fclose(fp)`
fixes https://github.com/rsyslog/rsyslog/issues/2804