### PR TITLE
travis: remove "merge master" test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,14 +84,6 @@ matrix:
        env: RUN="run.sh",BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench2"
        dist: trusty
 
-     - os: linux
-       compiler: "clang"
-       services:
-         - mysql
-         - postgresql
-       env: RUN="run.sh",MERGE="YES", CHECK="YES", GROK="YES", KAFKA="YES", CFLAGS="-g -O2"
-       dist: trusty
-
      - os: osx
        compiler: "clang"
        env: RUN="run-osx.sh", CFLAGS="-g"

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ matrix:
      - os: linux
        compiler: "clang"
        services:
-         - elasticsearch
          - mysql
          - postgresql
        env: RUN="run.sh",CHECK="YES", ESTEST="YES", CFLAGS="-g -O1 -fsanitize=address -fno-color-diagnostics"
@@ -54,7 +53,6 @@ matrix:
        compiler: "clang"
        dist: trusty
        services:
-         - elasticsearch
          - mysql
          - postgresql
        env: RUN="run.sh",CFLAGS="-fsanitize=undefined,nullability,unsigned-integer-overflow -fno-sanitize-recover=undefined,nullability,unsigned-integer-overflow -g -O3 -fno-omit-frame-pointer -fno-color-diagnostics", UBSAN_OPTIONS="print_stacktrace=1", CHECK="YES", ESTEST="YES", KAFKA="YES"


### PR DESCRIPTION
We originally merged master into the PR. At that time, github did not
(reliably?) provide a merged code basis. This is now the case, so the
test is kind of unnecessary. It only did some good if master was updated
after PR submission but before Travis started the test. This is pretty
unlikely, so we remove that test - which also is a relief in regard
to Travis runtime.

see also https://github.com/rsyslog/rsyslog/issues/2800

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
