### PR TITLE
more explicit error msg with message modification mod on queue

### DIFF
--- a/action.c
+++ b/action.c
@@ -575,7 +575,9 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 	if(pThis->bUsesMsgPassingMode && pThis->pQueue->qType != QUEUETYPE_DIRECT) {
 		parser_warnmsg("module %s with message passing mode uses "
 			"non-direct queue. This most probably leads to undesired "
-			"results", (char*)modGetName(pThis->pMod));
+			"results. For message modificaton modules (mm*), this means "
+			"that they will have no effect - "
+			"see https://www.rsyslog.com/mm-no-queue/", (char*)modGetName(pThis->pMod));
 	}
 	
 	/* and now reset the queue params (see comment in its function header!) */
@@ -2055,8 +2057,6 @@ addAction(action_t **ppAction, modInfo_t *pMod, void *pModData,
 
 	CHKiRet(actionConstructFinalize(pAction, lst));
 	
-	/* TODO: if we exit here, we have a (quite acceptable...) memory leak */
-
 	*ppAction = pAction; /* finally store the action pointer */
 
 finalize_it:


### PR DESCRIPTION
Message modification modules do not work if used with a non-direct queue.
We now make this more explicit in the config parsing error message.

closes https://github.com/rsyslog/rsyslog/issues/1323

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
