### PR TITLE
build system: do not disable testbench tests via --disable-liblogging…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1425,12 +1425,17 @@ AC_ARG_ENABLE(liblogging-stdlog,
         [enable_liblogging_stdlog=no]
 )
 if test "x$enable_liblogging_stdlog" = "xyes"; then
-        PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
+	PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
 		AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.])
-        )
+	)
 fi
 AM_CONDITIONAL(ENABLE_LIBLOGGING_STDLOG, test x$enable_liblogging_stdlog = xyes)
 
+# we use liblogging-stdlog inside the testbench, which is why we need to check for it in any case
+PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
+	AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.]),
+	[AC_MSG_NOTICE([liblogging-stdlog not found, parts of the testbench will not run])]
+)
 
 # RFC 3195 support
 AC_ARG_ENABLE(rfc3195,

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -69,7 +69,7 @@ DEFobjCurrIf(net)
  * class...
  */
 int glblDebugOnShutdown = 0;	/* start debug log when we are shut down */
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 stdlog_channel_t stdlog_hdl = NULL;	/* handle to be used for stdlog */
 #endif
 
@@ -79,7 +79,7 @@ int bProcessInternalMessages = 0;	/* Should rsyslog itself process internal mess
 					 * 0 - send them to libstdlog (e.g. to push to journal) or syslog()
 					 */
 static uchar *pszWorkDir = NULL;
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 static uchar *stdlog_chanspec = NULL;
 #endif
 static int bParseHOSTNAMEandTAG = 1;	/* parser modification (based on startup params!) */
@@ -1061,7 +1061,7 @@ glblProcessCnf(struct cnfobj *o)
 		} else if(!strcmp(paramblk.descr[i].name, "internal.developeronly.options")) {
 		        glblDevOptions = (uint64_t) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "stdlog.channelspec")) {
-#ifndef HAVE_LIBLOGGING_STDLOG
+#ifndef ENABLE_LIBLOGGING_STDLOG
 			LogError(0, RS_RET_ERR, "rsyslog wasn't "
 				"compiled with liblogging-stdlog support. "
 				"The 'stdlog.channelspec' parameter "

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -31,7 +31,7 @@
 #define GLBL_H_INCLUDED
 
 #include <sys/types.h>
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 #include <liblogging/stdlog.h>
 #endif
 #include "rainerscript.h"
@@ -46,7 +46,7 @@
 extern pid_t glbl_ourpid;
 extern int bProcessInternalMessages;
 extern int bPermitSlashInProgramname;
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 extern stdlog_channel_t stdlog_hdl;
 #endif
 

--- a/runtime/rsyslog.c
+++ b/runtime/rsyslog.c
@@ -59,7 +59,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 #include <liblogging/stdlog.h>
 #endif
 
@@ -139,7 +139,7 @@ rsrtInit(const char **ppErrObj, obj_if_t *pObjIF)
 	if(iRefCount == 0) {
 		seedRandomNumber();
 		/* init runtime only if not yet done */
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 		stdlog_init(0);
 		stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG, NULL);
 #endif

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -30,7 +30,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <errno.h>
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 #  include <liblogging/stdlog.h>
 #else
 #  include <syslog.h>
@@ -858,7 +858,7 @@ logmsgInternal_doWrite(smsg_t *pMsg)
 	} else {
 		const int pri = getPRIi(pMsg);
 		uchar *const msg = getMSG(pMsg);
-#		ifdef HAVE_LIBLOGGING_STDLOG
+#		ifdef ENABLE_LIBLOGGING_STDLOG
 		/* the "emit only once" rate limiter is quick and dirty and not
 		 * thread safe. However, that's no problem for the current intend
 		 * and it is not justified to create more robust code for the
@@ -2082,7 +2082,7 @@ main(int argc, char **argv)
 
 	mainloop();
 	deinitAll();
-#ifdef HAVE_LIBLOGGING_STDLOG
+#ifdef ENABLE_LIBLOGGING_STDLOG
 	stdlog_close(stdlog_hdl);
 #endif
 	return 0;


### PR DESCRIPTION
…-stdlog

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
