### PR TITLE
default rules use container_name_and_id; include rulebase files in dist

### DIFF
--- a/contrib/mmkubernetes/Makefile.am
+++ b/contrib/mmkubernetes/Makefile.am
@@ -4,3 +4,5 @@ mmkubernetes_la_SOURCES = mmkubernetes.c
 mmkubernetes_la_CPPFLAGS = $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(CURL_CFLAGS) $(LIBLOGNORM_CFLAGS)
 mmkubernetes_la_LDFLAGS = -module -avoid-version
 mmkubernetes_la_LIBADD = $(CURL_LIBS) $(LIBLOGNORM_LIBS)
+
+EXTRA_DIST = k8s_filename.rulebase k8s_container_name.rulebase

--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -77,9 +77,9 @@ DEFobjCurrIf(regexp)
  */
 #define DFLT_FILENAME_LNRULES "rule=:/var/log/containers/%pod_name:char-to:.%."\
 	"%container_hash:char-to:_%_"\
-	"%namespace_name:char-to:_%_%container_name:char-to:-%-%container_id:char-to:.%.log\n"\
+	"%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log\n"\
 	"rule=:/var/log/containers/%pod_name:char-to:_%_"\
-	"%namespace_name:char-to:_%_%container_name:char-to:-%-%container_id:char-to:.%.log"
+	"%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"
 #define DFLT_FILENAME_RULEBASE "/etc/rsyslog.d/k8s_filename.rulebase"
 /* original from fluentd plugin:
  *   '^(?<name_prefix>[^_]+)_(?<container_name>[^\._]+)\


### PR DESCRIPTION
Change the default filename rules to use container_name_and_id
Include the rulebase files in the dist / source tarball