### PR TITLE
impstats: emit warning if log.syslog="off" and ruleset name given

### DIFF
--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -1,7 +1,7 @@
 /* impstats.c
  * A module to periodically output statistics gathered by rsyslog.
  *
- * Copyright 2010-2017 Adiscon GmbH.
+ * Copyright 2010-2018 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -50,6 +50,7 @@
 #include "statsobj.h"
 #include "prop.h"
 #include "ruleset.h"
+#include "parserif.h"
 
 
 MODULE_TYPE_INPUT
@@ -407,6 +408,14 @@ CODESTARTsetModCnf
 			dbgprintf("impstats: program error, non-handled "
 			  "param '%s' in beginCnfLoad\n", modpblk.descr[i].name);
 		}
+	}
+
+	if(loadModConf->pszBindRuleset != NULL && loadModConf->bLogToSyslog == 0) {
+		parser_warnmsg("impstats: log.syslog set to \"off\" but ruleset specified - with "
+			"these settings, the ruleset will never be used, because regular syslog "
+			"processing is turned off - ruleset parameter is ignored");
+		free(loadModConf->pszBindRuleset);
+		loadModConf->pszBindRuleset = NULL;
 	}
 
 	loadModConf->configSetViaV2Method = 1;


### PR DESCRIPTION
With this config, "ruleset" is silently ignored, what probably is
not obvious to a user.

closes https://github.com/rsyslog/rsyslog/issues/2821

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
