### PR TITLE
imsolaris: use new errmsg interface

### DIFF
--- a/plugins/imsolaris/imsolaris.c
+++ b/plugins/imsolaris/imsolaris.c
@@ -94,7 +94,6 @@ MODULE_CNFNAME("imsolaris")
 
 /* Module static data */
 DEF_IMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(prop)
 
@@ -117,7 +116,7 @@ static char *LogName = NULL;	/* the log socket name TODO: make configurable! */
 void
 imsolaris_logerror(int err, char *errStr)
 {
-	errmsg.LogError(err, RS_RET_ERR_DOOR, "%s", errStr);
+	LogError(err, RS_RET_ERR_DOOR, "%s", errStr);
 }
 
 
@@ -143,13 +142,13 @@ tryRecover(void)
 		iRet = sun_openklog((LogName == NULL) ? PATH_LOG : LogName);
 		if(iRet == RS_RET_OK) {
 			if(tryNum > 1) {		
-				errmsg.LogError(0, iRet, "failure on system log socket recovered.");
+				LogError(0, iRet, "failure on system log socket recovered.");
 			}	
 			break;
 		}	
 		/* failure, so sleep a bit. We wait try*10 ms, with a max of 15 seconds */
 		if(tryNum == 1) {		
-			errmsg.LogError(0, iRet, "failure on system log socket, trying to recover...");
+			LogError(0, iRet, "failure on system log socket, trying to recover...");
 		}	
 		waitusecs = tryNum * 10000;
 		waitsecs = waitusecs / 1000000;
@@ -199,7 +198,7 @@ readLog(int fd, uchar *pRcv, int iMaxLine)
 			int en = errno;
 			rs_strerror_r(errno, errStr, sizeof(errStr));
 			DBGPRINTF("imsolaris: stream input error on fd %d: %s.\n", fd, errStr);
-			errmsg.LogError(en, NO_ERRCODE, "imsolaris: stream input error: %s", errStr);
+			LogError(en, NO_ERRCODE, "imsolaris: stream input error: %s", errStr);
 			tryRecover();
 		}	
 	} else {
@@ -274,7 +273,7 @@ getMsgs(thrdInfo_t *pThrd, int timeout)
 					int en = errno;
 					rs_strerror_r(en, errStr, sizeof(errStr));
 					DBGPRINTF("imsolaris: poll error: %d = %s.\n", errno, errStr);
-					errmsg.LogError(en, NO_ERRCODE, "imsolaris: poll error: %s",
+					LogError(en, NO_ERRCODE, "imsolaris: poll error: %s",
 							errStr);
 				}
 				continue;
@@ -365,7 +364,7 @@ CODESTARTwillRun
 
 	iRet = sun_openklog((LogName == NULL) ? PATH_LOG : LogName);
 	if(iRet != RS_RET_OK) {
-		errmsg.LogError(0, iRet, "error opening system log socket");
+		LogError(0, iRet, "error opening system log socket");
 	}
 finalize_it:
 ENDwillRun
@@ -384,7 +383,6 @@ BEGINmodExit
 CODESTARTmodExit
 	sun_delete_doorfiles();
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
 ENDmodExit
 
@@ -413,7 +411,6 @@ BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/issues/1684

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
