### PR TITLE
Travis: reduce distcheck tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,16 +71,16 @@ matrix:
        services:
          - mysql
          - postgresql
-       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", GROK="YES", KAFKA="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench1"
+       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", GROK="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench2"
        dist: trusty
 
-     - os: linux
-       compiler: "gcc"
-       services:
-         - mysql
-         - postgresql
-       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench2"
-       dist: trusty
+#     - os: linux
+#       compiler: "gcc"
+#       services:
+#         - mysql
+#         - postgresql
+#       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench2"
+#       dist: trusty
 
      - os: osx
        compiler: "clang"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -217,13 +217,13 @@ TESTS +=  \
 	timegenerated-utc-legacy.sh \
 	timereported-utc.sh \
 	timereported-utc-legacy.sh
+endif
 if ENABLE_MMNORMALIZE
 TESTS += \
 	mmnormalize_processing_test1.sh \
 	mmnormalize_processing_test2.sh \
 	mmnormalize_processing_test3.sh \
 	mmnormalize_processing_test4.sh
-endif
 endif
 
 if ENABLE_PGSQL
@@ -262,7 +262,7 @@ TESTS +=  \
 	mysql-asyn-vg.sh \
 	mysql-actq-mt-withpause-vg.sh
 endif
-if ENABLE_OMLIBDBI
+if ENABLE_OMLIBDBI # we piggy-back on MYSQL_TESTS as we need the same environment
 TESTS +=  \
 	libdbi-basic.sh \
 	libdbi-asyn.sh
@@ -273,7 +273,7 @@ endif
 endif
 endif
 
-endif #  ENABLE_TESTBENCH2
+endif #  ENABLE_TESTBENCH1
 
 if ENABLE_TESTBENCH2
 TESTS +=  \


### PR DESCRIPTION
this has been moved to the buildbot infrastructure, where we
do not have the strong runtime limitations. We still need to
run db-related (mysql, ...) distcheck tests as this is not yet
supported in the containers we use on buildbot.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
