### PR TITLE
imkmsg bugfix: build warnings on some platforms

### DIFF
--- a/contrib/imkmsg/imkmsg.c
+++ b/contrib/imkmsg/imkmsg.c
@@ -113,7 +113,7 @@ enqMsg(uchar *msg, uchar* pszTag, syslog_pri_t pri, struct timeval *tp, struct j
 	MsgSetTAG(pMsg, pszTag, ustrlen(pszTag));
 	msgSetPRI(pMsg, pri);
 	pMsg->json = json;
-	CHKiRet(submitMsg(pMsg));
+	CHKiRet(submitMsg2(pMsg));
 
 finalize_it:
 	RETiRet;
@@ -123,7 +123,7 @@ finalize_it:
 /* log an imkmsg-internal message
  * rgerhards, 2008-04-14
  */
-rsRetVal imkmsgLogIntMsg(syslog_pri_t priority, char *fmt, ...)
+rsRetVal imkmsgLogIntMsg(syslog_pri_t priority, const char *fmt, ...)
 {
 	DEFiRet;
 	va_list ap;

--- a/contrib/imkmsg/imkmsg.h
+++ b/contrib/imkmsg/imkmsg.h
@@ -48,8 +48,9 @@ rsRetVal klogAfterRun(modConfData_t *pModConf);
 int klogFacilIntMsg();
 
 /* the functions below may be called by the drivers */
-rsRetVal imkmsgLogIntMsg(syslog_pri_t priority, char *fmt, ...) __attribute__((format(printf,2, 3)));
+rsRetVal imkmsgLogIntMsg(syslog_pri_t priority, const char *fmt, ...) __attribute__((format(printf,2, 3)));
 rsRetVal Syslog(syslog_pri_t priority, uchar *msg, struct timeval *tp, struct json_object *json);
+int klogFacilIntMsg(void);
 
 /* prototypes */
 extern int klog_getMaxLine(void); /* work-around for klog drivers to get configured max line size */

--- a/contrib/imkmsg/kmsg.c
+++ b/contrib/imkmsg/kmsg.c
@@ -156,7 +156,7 @@ submitSyslog(uchar *buf)
 /* open the kernel log - will be called inside the willRun() imkmsg entry point
  */
 rsRetVal
-klogWillRunPrePrivDrop(modConfData_t *pModConf)
+klogWillRunPrePrivDrop(modConfData_t __attribute__((unused)) *pModConf)
 {
 	char errmsg[2048];
 	DEFiRet;
@@ -175,7 +175,7 @@ finalize_it:
 /* make sure the kernel log is readable after dropping privileges
  */
 rsRetVal
-klogWillRunPostPrivDrop(modConfData_t *pModConf)
+klogWillRunPostPrivDrop(modConfData_t __attribute__((unused)) *pModConf)
 {
 	char errmsg[2048];
 	int r;

--- a/tests/hostname-getaddrinfo-fail.sh
+++ b/tests/hostname-getaddrinfo-fail.sh
@@ -13,7 +13,8 @@ if [ `uname` = "SunOS" ] ; then
 fi
 if [ `uname` = "FreeBSD" ] ; then
    echo "FreeBSD: temporarily disabled until we know what is wrong"
-   #exit 77
+   echo "see https://github.com/rsyslog/rsyslog/issues/2833"
+   exit 77
 fi
 
 . $srcdir/diag.sh init


### PR DESCRIPTION
nothing serious, but still breaks CI. Also, we want as-clean-as-possible code

closes https://github.com/rsyslog/rsyslog/issues/2830

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
