### PR TITLE
testbench: fix tests that look awfully wrong

### DIFF
--- a/tests/arrayqueue.sh
+++ b/tests/arrayqueue.sh
@@ -2,18 +2,12 @@
 # Test for fixedArray queue mode
 # added 2009-05-20 by rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
-echo ===============================================================================
-echo \[arrayqueue.sh\]: testing queue fixedArray queue mode
 . $srcdir/diag.sh init
 . $srcdir/diag.sh startup arrayqueue.conf
 
 # 40000 messages should be enough
 . $srcdir/diag.sh injectmsg  0 40000
-
-# terminate *now* (don't wait for queue to drain!)
-kill `cat rsyslog.pid`
-
-# now wait until rsyslog.pid is gone (and the process finished)
+. $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown 
 . $srcdir/diag.sh seq-check 0 39999
 . $srcdir/diag.sh exit

--- a/tests/linkedlistqueue.sh
+++ b/tests/linkedlistqueue.sh
@@ -2,17 +2,10 @@
 # Test for Linkedlist queue mode
 # added 2009-05-20 by rgerhards
 # This file is part of the rsyslog project, released  under GPLv3
-echo \[linkedlistqueue.sh\]: testing queue Linkedlist queue mode
 . $srcdir/diag.sh init
 . $srcdir/diag.sh startup linkedlistqueue.conf
-
-# 40000 messages should be enough
 . $srcdir/diag.sh injectmsg  0 40000
-
-# terminate *now* (don't wait for queue to drain)
-kill `cat rsyslog.pid`
-
-# now wait until rsyslog.pid is gone (and the process finished)
+. $srcdir/diag.sh shutdown-when-empty
 . $srcdir/diag.sh wait-shutdown 
 . $srcdir/diag.sh seq-check 0 39999
 . $srcdir/diag.sh exit


### PR DESCRIPTION
These tests indicated they terminate rsyslog forcefully without
drainging the queues, but then checked if they were drained (all
messages processed). That does not make sense, and I cannot
envison why I wrote this in the first place. So I assume some
copy&paste problem was the root of that.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
