### PR TITLE
imrelp: add support for seting address to bind to (#894)

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -80,6 +80,7 @@ static configSettings_t cs;
 
 struct instanceConf_s {
 	uchar *pszBindPort;		/* port to bind to */
+	uchar *pszBindAddr;		/* address to bind to */
 	uchar *pszBindRuleset;		/* name of ruleset to bind to */
 	uchar *pszInputName;		/* value for inputname property */
 	prop_t *pInputName;		/* InputName in property format for fast access */
@@ -141,6 +142,7 @@ static struct cnfparamblk modpblk =
 /* input instance parameters */
 static struct cnfparamdescr inppdescr[] = {
 	{ "port", eCmdHdlrString, CNFPARAM_REQUIRED },
+	{ "address", eCmdHdlrString, 0 },
 	{ "name", eCmdHdlrString, 0 },
 	{ "ruleset", eCmdHdlrString, 0 },
 	{ "keepalive", eCmdHdlrBinary, 0 },
@@ -272,6 +274,7 @@ createInstance(instanceConf_t **pinst)
 	inst->next = NULL;
 
 	inst->pszBindPort = NULL;
+	inst->pszBindAddr = NULL;
 	inst->pszBindRuleset = NULL;
 	inst->pszInputName = NULL;
 	inst->pBindRuleset = NULL;
@@ -380,6 +383,7 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 
 	CHKiRet(relpEngineListnerConstruct(pRelpEngine, &pSrv));
 	CHKiRet(relpSrvSetLstnPort(pSrv, inst->pszBindPort));
+	CHKiRet(relpSrvSetLstnAddr(pSrv, inst->pszBindAddr));
 	CHKiRet(relpSrvSetMaxDataSize(pSrv, inst->maxDataSize));
 
 #ifdef HAVE_RELPSRVSETOVERSIZEMODE
@@ -501,6 +505,8 @@ CODESTARTnewInpInst
 			continue;
 		if(!strcmp(inppblk.descr[i].name, "port")) {
 			inst->pszBindPort = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "address")) {
+			inst->pszBindAddr = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "name")) {
 			inst->pszInputName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "ruleset")) {
@@ -741,6 +747,9 @@ BEGINfreeCnf
 CODESTARTfreeCnf
 	for(inst = pModConf->root ; inst != NULL ; ) {
 		free(inst->pszBindPort);
+		if (inst->pszBindAddr != NULL) {
+			free(inst->pszBindAddr);
+		}
 		free(inst->pszBindRuleset);
 		free(inst->pszInputName);
 		free(inst->pristring);


### PR DESCRIPTION
This adds a new optional `address` parameter to `imrelp` inputs in order
to specify an address to bind to.

Based on support added by rsyslog/librelp@96eb5be (rsyslog/librelp#90).