### PR TITLE
core: do not abort startup on problems setting scheduling policy

### DIFF
--- a/runtime/rsyslog.c
+++ b/runtime/rsyslog.c
@@ -135,6 +135,8 @@ rsRetVal
 rsrtInit(const char **ppErrObj, obj_if_t *pObjIF)
 {
 	DEFiRet;
+	int ret;
+	char errstr[1024];
 
 	if(iRefCount == 0) {
 		seedRandomNumber();
@@ -143,23 +145,48 @@ rsrtInit(const char **ppErrObj, obj_if_t *pObjIF)
 		stdlog_init(0);
 		stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG, NULL);
 #endif
-		CHKiRet(pthread_attr_init(&default_thread_attr));
+		ret = pthread_attr_init(&default_thread_attr);
+		if(ret != 0) {
+			rs_strerror_r(ret, errstr, sizeof(errstr));
+			fprintf(stderr, "rsyslogd: pthread_attr_init failed during "
+				"startup - can not continue. Error was %s\n", errstr);
+			exit(1);
+		}
 		pthread_attr_setstacksize(&default_thread_attr, 4096*1024);
 #ifdef HAVE_PTHREAD_SETSCHEDPARAM
-	    	CHKiRet(pthread_getschedparam(pthread_self(),
-			    		      &default_thr_sched_policy,
-					      &default_sched_param));
+		ret = pthread_getschedparam(pthread_self(), &default_thr_sched_policy,
+			&default_sched_param);
+		if(ret != 0) {
+			rs_strerror_r(ret, errstr, sizeof(errstr));
+			fprintf(stderr, "rsyslogd: pthread_getschedparam failed during "
+				"startup - ignoring. Error was %s\n", errstr);
+			default_thr_sched_policy = 0; /* should be default on all platforms */
+		}
 #if defined (_AIX)
                 pthread_attr_setstacksize(&default_thread_attr, 4096*512);
 #endif
 
 
-		CHKiRet(pthread_attr_setschedpolicy(&default_thread_attr,
-			    			    default_thr_sched_policy));
-		CHKiRet(pthread_attr_setschedparam(&default_thread_attr,
-			    			   &default_sched_param));
-		CHKiRet(pthread_attr_setinheritsched(&default_thread_attr,
-			    			     PTHREAD_EXPLICIT_SCHED));
+		ret = pthread_attr_setschedpolicy(&default_thread_attr, default_thr_sched_policy);
+		if(ret != 0) {
+			rs_strerror_r(ret, errstr, sizeof(errstr));
+			fprintf(stderr, "rsyslogd: pthread_attr_setschedpolicy failed during "
+				"startup - tried to set priority %d, now using default "
+				"priority instead. Error was: %s\n",
+				default_thr_sched_policy, errstr);
+		}
+		ret = pthread_attr_setschedparam(&default_thread_attr, &default_sched_param);
+		if(ret != 0) {
+			rs_strerror_r(ret, errstr, sizeof(errstr));
+			fprintf(stderr, "rsyslogd: pthread_attr_setschedparam failed during "
+				"startup - ignored Error was: %s\n", errstr);
+		}
+		ret = pthread_attr_setinheritsched(&default_thread_attr, PTHREAD_EXPLICIT_SCHED);
+		if(ret != 0) {
+			rs_strerror_r(ret, errstr, sizeof(errstr));
+			fprintf(stderr, "rsyslogd: pthread_attr_setinheritsched failed during "
+				"startup - ignoring. Error was: %s\n", errstr);
+		}
 #endif
 		if(ppErrObj != NULL) *ppErrObj = "obj";
 		CHKiRet(objClassInit(NULL)); /* *THIS* *MUST* always be the first class initilizer being called! */


### PR DESCRIPTION
rsyslog creates a default scheduling policy on startup. This code
invalidly used CHKiRet (our exception handler) to check pthreads
return codes, what this macro cannot do. This lead to hard to
diagnose startup problems in cases where there were problems
setting the scheduling defaults (e.g. when rsyslog is set to run
at idle priority). Even more so, this blocked startup altogether,
which is not the right thing to do. Actually, this can be considered
a regression from commit 7742b21. That commit was 8 years ago, so
in general this cannot be a big issues ;-)

The code now emits proper error messages (to stderr, as at this point
no other output is available as it is during the initial state of
rsyslog initialization) and continues the startup.

closes https://github.com/rsyslog/rsyslog/issues/2855

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
