### PR TITLE
testbench: kubernetes test cannot recover from failure

### DIFF
--- a/tests/CI/kill_all_kubernetes_test_server.sh
+++ b/tests/CI/kill_all_kubernetes_test_server.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# This script shall be executed before the real CI run to make sure
+# the environment is "clean enough". It is not necessary in containers,
+# where we usually get a fresh container for each run.
+echo clean all instances of ./mmkubernetes_test_server.py that might still be running
+ps -ef | grep '[0-9] python .*\./mmkubernetes_test_server.py'
+for pid in $(ps -eo pid,cmd|grep '[0-9] python .*\./mmkubernetes_test_server.py' |sed -e 's/\( *\)\([0-9]*\).*/\2/');
+do
+	echo "killing pid $pid"
+	kill -9 $pid
+done

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -365,7 +365,8 @@ case $1 in
 			let "i++"
 			if test $i -gt $TB_TIMEOUT_STARTSTOP
 			then
-			   echo "ABORT! Timeout waiting on startup (pid file)"
+			   ps -f
+			   echo "ABORT! Timeout waiting on startup (pid file rsyslog$2.pid)"
 			   . $srcdir/diag.sh error-exit 1
 			fi
 		done

--- a/tests/glbl-oversizeMsg-truncate-imfile.sh
+++ b/tests/glbl-oversizeMsg-truncate-imfile.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # add 2018-05-02 by PascalWithopf, released under ASL 2.0
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
   echo "imrelp parameter oversizeMode not available. Test stopped"

--- a/tests/imrelp-manyconn.sh
+++ b/tests/imrelp-manyconn.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 # adddd 2016-06-08 by RGerhards, released under ASL 2.0
 . $srcdir/diag.sh init
+
+ldd ../plugins/imrelp/.libs/imrelpuname
+if [ `uname` = "FreeBSD" ] ; then
+   echo "This test currently does not work on FreeBSD."
+   exit 77
+fi
+
 . $srcdir/diag.sh generate-conf
 . $srcdir/diag.sh add-conf '
 module(load="../plugins/imrelp/.libs/imrelp")

--- a/tests/mmkubernetes-basic-vg.sh
+++ b/tests/mmkubernetes-basic-vg.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
 # added 2018-04-06 by richm, released under ASL 2.0
+#
+# Note: on buidbot VMs (where there is no environment cleanup), the
+# kubernetes test server may be kept running if the script aborts or
+# is aborted (buildbot master failure!) for some reason. As such we
+# execute it under "timeout" control, which ensure it always is
+# terminated. It's not a 100% great method, but hopefully does the
+# trick. -- rgerhards, 2018-07-21
 #export RSYSLOG_DEBUG="debug"
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available timeout
 
 testsrv=mmk8s-test-server
-python ./mmkubernetes_test_server.py 18443 rsyslog${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
+timeout 3m python ./mmkubernetes_test_server.py 18443 rsyslog${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
 BGPROCESS=$!
 . $srcdir/diag.sh wait-startup $testsrv
 echo background mmkubernetes_test_server.py process id is $BGPROCESS

--- a/tests/mmkubernetes-basic.sh
+++ b/tests/mmkubernetes-basic.sh
@@ -1,10 +1,19 @@
 #!/bin/bash
 # added 2018-04-06 by richm, released under ASL 2.0
+#
+# Note: on buidbot VMs (where there is no environment cleanup), the
+# kubernetes test server may be kept running if the script aborts or
+# is aborted (buildbot master failure!) for some reason. As such we
+# execute it under "timeout" control, which ensure it always is
+# terminated. It's not a 100% great method, but hopefully does the
+# trick. -- rgerhards, 2018-07-21
 #export RSYSLOG_DEBUG="debug"
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available timeout
 
 testsrv=mmk8s-test-server
-python -u ./mmkubernetes_test_server.py 18443 rsyslog${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
+echo starting kubernetes \"emulator\"
+timeout 3m python -u ./mmkubernetes_test_server.py 18443 rsyslog${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
 BGPROCESS=$!
 . $srcdir/diag.sh wait-startup $testsrv
 echo background mmkubernetes_test_server.py process id is $BGPROCESS


### PR DESCRIPTION
when the test is aborted it is currently not possible to recover the hanging instance, forcing all future tries on that machine to hang until either reboot or manual intervention.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
