### PR TITLE
core: replace errmsg object calling conventions

### DIFF
--- a/contrib/imkmsg/imkmsg.c
+++ b/contrib/imkmsg/imkmsg.c
@@ -59,7 +59,6 @@ DEFobjCurrIf(datetime)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(prop)
 DEFobjCurrIf(net)
-DEFobjCurrIf(errmsg)
 
 /* config settings */
 typedef struct configSettings_s {
@@ -247,7 +246,6 @@ CODESTARTmodExit
 	objRelease(net, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -272,7 +270,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 	CHKiRet(objUse(net, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
 	/* we need to create the inputName property (only once during our lifetime) */
 	CHKiRet(prop.CreateStringProp(&pInputName, UCHAR_CONSTANT("imkmsg"), sizeof("imkmsg") - 1));

--- a/contrib/mmcount/mmcount.c
+++ b/contrib/mmcount/mmcount.c
@@ -49,7 +49,6 @@ MODULE_TYPE_NOKEEP
 MODULE_CNFNAME("mmcount")
 
 
-DEFobjCurrIf(errmsg);
 DEF_OMOD_STATIC_DATA
 
 /* config variables */
@@ -331,7 +330,6 @@ NO_LEGACY_CONF_parseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -350,5 +348,4 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	DBGPRINTF("mmcount: module compiled with rsyslog version %s.\n", VERSION);
-	iRet = objUse(errmsg, CORE_COMPONENT);
 ENDmodInit

--- a/contrib/mmgrok/mmgrok.c
+++ b/contrib/mmgrok/mmgrok.c
@@ -29,7 +29,6 @@ MODULE_CNFNAME("mmgrok");
         
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unused)) *pVal);
 
-DEFobjCurrIf(errmsg);
 DEF_OMOD_STATIC_DATA
 
 typedef struct result_s{
@@ -372,7 +371,6 @@ ENDparseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -416,7 +414,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 		ABORT_FINALIZE(RS_RET_NO_MSG_PASSING);
 	}
 
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler,
 				    resetConfigVariables, NULL, STD_LOADABLE_MODULE_ID));

--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -61,7 +61,6 @@ MODULE_TYPE_OUTPUT /* this is technically an output plugin */
 MODULE_TYPE_KEEP /* releasing the module would cause a leak through libcurl */
 MODULE_CNFNAME("mmkubernetes")
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(regexp)
 
 #define HAVE_LOADSAMPLESFROMSTRING 1
@@ -248,7 +247,7 @@ static int init_annotationmatch(annotation_match_t *match, struct cnfarray *ar) 
 			char errMsg[512];
 			regexp.regerror(rexret, &match->regexps[jj], errMsg, sizeof(errMsg));
 			iRet = RS_RET_CONFIG_ERROR;
-			errmsg.LogError(0, iRet,
+			LogError(0, iRet,
 					"error: could not compile annotation_match string [%s]"
 					" into an extended regexp - %d: %s\n",
 					match->patterns[jj], rexret, errMsg);
@@ -432,7 +431,7 @@ static void
 errCallBack(void __attribute__((unused)) *cookie, const char *msg,
 	    size_t __attribute__((unused)) lenMsg)
 {
-	errmsg.LogError(0, RS_RET_ERR_LIBLOGNORM, "liblognorm error: %s", msg);
+	LogError(0, RS_RET_ERR_LIBLOGNORM, "liblognorm error: %s", msg);
 }
 
 static rsRetVal
@@ -446,7 +445,7 @@ set_lnctx(ln_ctx *ctxln, char *instRules, uchar *instRulebase, char *modRules, u
 	if(instRules) {
 #if HAVE_LOADSAMPLESFROMSTRING == 1
 		if(ln_loadSamplesFromString(*ctxln, instRules) !=0) {
-			errmsg.LogError(0, RS_RET_NO_RULEBASE, "error: normalization rules '%s' "
+			LogError(0, RS_RET_NO_RULEBASE, "error: normalization rules '%s' "
 					"could not be loaded", instRules);
 			ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_SAMPDB_LOAD);
 		}
@@ -455,14 +454,14 @@ set_lnctx(ln_ctx *ctxln, char *instRules, uchar *instRulebase, char *modRules, u
 #endif
 	} else if(instRulebase) {
 		if(ln_loadSamples(*ctxln, (char*) instRulebase) != 0) {
-			errmsg.LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
+			LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
 					"could not be loaded", instRulebase);
 			ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_SAMPDB_LOAD);
 		}
 	} else if(modRules) {
 #if HAVE_LOADSAMPLESFROMSTRING == 1
 		if(ln_loadSamplesFromString(*ctxln, modRules) !=0) {
-			errmsg.LogError(0, RS_RET_NO_RULEBASE, "error: normalization rules '%s' "
+			LogError(0, RS_RET_NO_RULEBASE, "error: normalization rules '%s' "
 					"could not be loaded", modRules);
 			ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_SAMPDB_LOAD);
 		}
@@ -471,7 +470,7 @@ set_lnctx(ln_ctx *ctxln, char *instRules, uchar *instRulebase, char *modRules, u
 #endif
 	} else if(modRulebase) {
 		if(ln_loadSamples(*ctxln, (char*) modRulebase) != 0) {
-			errmsg.LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
+			LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
 					"could not be loaded", modRulebase);
 			ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_SAMPDB_LOAD);
 		}
@@ -499,7 +498,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "mmkubernetes: "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "mmkubernetes: "
 			"error processing module config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -532,7 +531,7 @@ CODESTARTsetModCnf
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: certificate file %s couldn't be accessed: %s\n",
 						loadModConf->caCertFile, errStr);
 				ABORT_FINALIZE(iRet);
@@ -552,7 +551,7 @@ CODESTARTsetModCnf
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: token file %s couldn't be accessed: %s\n",
 						loadModConf->tokenFile, errStr);
 				ABORT_FINALIZE(iRet);
@@ -581,7 +580,7 @@ CODESTARTsetModCnf
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: filenamerulebase file %s couldn't be accessed: %s\n",
 						loadModConf->fnRulebase, errStr);
 				ABORT_FINALIZE(iRet);
@@ -601,7 +600,7 @@ CODESTARTsetModCnf
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: containerrulebase file %s couldn't be accessed: %s\n",
 						loadModConf->contRulebase, errStr);
 				ABORT_FINALIZE(iRet);
@@ -617,12 +616,12 @@ CODESTARTsetModCnf
 
 #if HAVE_LOADSAMPLESFROMSTRING == 1
 	if (loadModConf->fnRules && loadModConf->fnRulebase) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 				"mmkubernetes: only 1 of filenamerules or filenamerulebase may be used");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 	if (loadModConf->contRules && loadModConf->contRulebase) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 				"mmkubernetes: only 1 of containerrules or containerrulebase may be used");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
@@ -820,7 +819,7 @@ CODESTARTnewActInst
 
 	pvals = nvlstGetParams(lst, &actpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "mmkubernetes: "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "mmkubernetes: "
 			"error processing config parameters [action(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -862,7 +861,7 @@ CODESTARTnewActInst
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: certificate file %s couldn't be accessed: %s\n",
 						pData->caCertFile, errStr);
 				ABORT_FINALIZE(iRet);
@@ -882,7 +881,7 @@ CODESTARTnewActInst
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: token file %s couldn't be accessed: %s\n",
 						pData->tokenFile, errStr);
 				ABORT_FINALIZE(iRet);
@@ -911,7 +910,7 @@ CODESTARTnewActInst
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: filenamerulebase file %s couldn't be accessed: %s\n",
 						pData->fnRulebase, errStr);
 				ABORT_FINALIZE(iRet);
@@ -931,7 +930,7 @@ CODESTARTnewActInst
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
 				iRet = RS_RET_NO_FILE_ACCESS;
-				errmsg.LogError(0, iRet,
+				LogError(0, iRet,
 						"error: containerrulebase file %s couldn't be accessed: %s\n",
 						pData->contRulebase, errStr);
 				ABORT_FINALIZE(iRet);
@@ -947,12 +946,12 @@ CODESTARTnewActInst
 
 #if HAVE_LOADSAMPLESFROMSTRING == 1
 	if (pData->fnRules && pData->fnRulebase) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 		    "mmkubernetes: only 1 of filenamerules or filenamerulebase may be used");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 	if (pData->contRules && pData->contRulebase) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 			"mmkubernetes: only 1 of containerrules or containerrulebase may be used");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
@@ -1024,7 +1023,7 @@ BEGINparseSelectorAct
 CODESTARTparseSelectorAct
 CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	if(strncmp((char *) p, ":mmkubernetes:", sizeof(":mmkubernetes:") - 1)) {
-		errmsg.LogError(0, RS_RET_LEGA_ACT_NOT_SUPPORTED,
+		LogError(0, RS_RET_LEGA_ACT_NOT_SUPPORTED,
 			"mmkubernetes supports only v6+ config format, use: "
 			"action(type=\"mmkubernetes\" ...)");
 	}
@@ -1192,47 +1191,47 @@ queryKB(wrkrInstanceData_t *pWrkrData, char *url, struct json_object **rply)
 	if(ccode != CURLE_OK)
 		ABORT_FINALIZE(RS_RET_ERR);
 	if(CURLE_OK != (ccode = curl_easy_perform(pWrkrData->curlCtx))) {
-		errmsg.LogMsg(0, RS_RET_ERR, LOG_ERR,
+		LogMsg(0, RS_RET_ERR, LOG_ERR,
 			      "mmkubernetes: failed to connect to [%s] - %d:%s\n",
 			      url, ccode, curl_easy_strerror(ccode));
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	if(CURLE_OK != (ccode = curl_easy_getinfo(pWrkrData->curlCtx,
 					CURLINFO_RESPONSE_CODE, &resp_code))) {
-		errmsg.LogMsg(0, RS_RET_ERR, LOG_ERR,
+		LogMsg(0, RS_RET_ERR, LOG_ERR,
 			      "mmkubernetes: could not get response code from query to [%s] - %d:%s\n",
 			      url, ccode, curl_easy_strerror(ccode));
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	if(resp_code == 401) {
-		errmsg.LogMsg(0, RS_RET_ERR, LOG_ERR,
+		LogMsg(0, RS_RET_ERR, LOG_ERR,
 			      "mmkubernetes: Unauthorized: not allowed to view url - "
 			      "check token/auth credentials [%s]\n",
 			      url);
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	if(resp_code == 403) {
-		errmsg.LogMsg(0, RS_RET_ERR, LOG_ERR,
+		LogMsg(0, RS_RET_ERR, LOG_ERR,
 			      "mmkubernetes: Forbidden: no access - "
 			      "check permissions to view url [%s]\n",
 			      url);
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	if(resp_code == 404) {
-		errmsg.LogMsg(0, RS_RET_ERR, LOG_ERR,
+		LogMsg(0, RS_RET_ERR, LOG_ERR,
 			      "mmkubernetes: Not Found: the resource does not exist at url [%s]\n",
 			      url);
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	if(resp_code == 429) {
-		errmsg.LogMsg(0, RS_RET_ERR, LOG_ERR,
+		LogMsg(0, RS_RET_ERR, LOG_ERR,
 			      "mmkubernetes: Too Many Requests: the server is too heavily loaded "
 			      "to provide the data for the requested url [%s]\n",
 			      url);
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	if(resp_code != 200) {
-		errmsg.LogMsg(0, RS_RET_ERR, LOG_ERR,
+		LogMsg(0, RS_RET_ERR, LOG_ERR,
 			      "mmkubernetes: server returned unexpected code [%ld] for url [%s]\n",
 			      resp_code, url);
 		ABORT_FINALIZE(RS_RET_ERR);
@@ -1245,7 +1244,7 @@ queryKB(wrkrInstanceData_t *pWrkrData, char *url, struct json_object **rply)
 	if(!json_object_is_type(jo, json_type_object)) {
 		json_object_put(jo);
 		jo = NULL;
-		errmsg.LogMsg(0, RS_RET_JSON_PARSE_ERR, LOG_INFO,
+		LogMsg(0, RS_RET_JSON_PARSE_ERR, LOG_INFO,
 			      "mmkubernetes: unable to parse string as JSON:[%.*s]\n",
 			      (int)pWrkrData->curlRplyLen, pWrkrData->curlRply);
 		ABORT_FINALIZE(RS_RET_JSON_PARSE_ERR);
@@ -1345,7 +1344,7 @@ CODESTARTdoAction
 				add_ns_metadata = 1;
 			} else {
 				/* namespace with no metadata??? */
-				errmsg.LogMsg(0, RS_RET_ERR, LOG_INFO,
+				LogMsg(0, RS_RET_ERR, LOG_INFO,
 					      "mmkubernetes: namespace [%s] has no metadata!\n", ns);
 				jNsMeta = NULL;
 			}
@@ -1452,7 +1451,6 @@ CODESTARTmodExit
 	curl_global_cleanup();
 
 	objRelease(regexp, LM_REGEXP_FILENAME);
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -1471,7 +1469,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	DBGPRINTF("mmkubernetes: module compiled with rsyslog version %s.\n", VERSION);
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(regexp, LM_REGEXP_FILENAME));
 
 	/* CURL_GLOBAL_ALL initializes more than is needed but the

--- a/contrib/omamqp1/omamqp1.c
+++ b/contrib/omamqp1/omamqp1.c
@@ -72,7 +72,6 @@ MODULE_CNFNAME("omamqp1")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 
 
 /* Settings for the action */
@@ -321,7 +320,7 @@ CODESTARTnewActInst
             char *u = es_str2cstr(pvals[i].val.d.estr, NULL);
             cs->url = pn_url_parse(u);
             if (!cs->url) {
-                errmsg.LogError(0, RS_RET_CONF_PARSE_ERROR, "omamqp1: Invalid host URL configured: '%s'", u);
+                LogError(0, RS_RET_CONF_PARSE_ERROR, "omamqp1: Invalid host URL configured: '%s'", u);
                 free(u);
                 ABORT_FINALIZE(RS_RET_CONF_PARSE_ERROR);
             }
@@ -371,8 +370,6 @@ NO_LEGACY_CONF_parseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-    CHKiRet(objRelease(errmsg, CORE_COMPONENT));
-finalize_it:
 ENDmodExit
 
 
@@ -392,7 +389,6 @@ CODESTARTmodInit
     *ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current
                                                 interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-    CHKiRet(objUse(errmsg, CORE_COMPONENT));
     INITChkCoreFeature(bCoreSupportsBatching, CORE_FEATURE_BATCHING);
     DBGPRINTF("omamqp1: module compiled with rsyslog version %s.\n", VERSION);
     DBGPRINTF("omamqp1: %susing transactional output interface.\n", bCoreSupportsBatching ? "" : "not ");
@@ -905,7 +901,7 @@ static rsRetVal _launch_protocol_thread(instanceData *pData)
             return RS_RET_OK;
         }
     } while (rc == EAGAIN);
-    errmsg.LogError(0, RS_RET_SYS_ERR, "omamqp1: thread create failed: %d", rc);
+    LogError(0, RS_RET_SYS_ERR, "omamqp1: thread create failed: %d", rc);
     return RS_RET_SYS_ERR;
 }
 

--- a/contrib/omfile-hardened/omfile-hardened.c
+++ b/contrib/omfile-hardened/omfile-hardened.c
@@ -84,7 +84,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(strm)
 DEFobjCurrIf(statsobj)
@@ -1581,7 +1580,6 @@ ENDdoHUP
 BEGINmodExit
 CODESTARTmodExit
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(strm, CORE_COMPONENT);
 	objRelease(statsobj, CORE_COMPONENT);
 	DESTROY_ATOMIC_HELPER_MUT(mutClock);
@@ -1604,7 +1602,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 INITLegCnfVars
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(strm, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
 

--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -48,7 +48,6 @@ MODULE_CNFNAME("omhiredis")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 
 #define OMHIREDIS_MODE_TEMPLATE 0
 #define OMHIREDIS_MODE_QUEUE 1
@@ -151,7 +150,7 @@ static rsRetVal initHiredis(wrkrInstanceData_t *pWrkrData, int bSilent)
 			timeout);
 	if (pWrkrData->conn->err) {
 		if(!bSilent)
-			errmsg.LogError(0, RS_RET_SUSPENDED,
+			LogError(0, RS_RET_SUSPENDED,
 				"can not initialize redis handle");
 		ABORT_FINALIZE(RS_RET_SUSPENDED);
 	}
@@ -161,7 +160,7 @@ static rsRetVal initHiredis(wrkrInstanceData_t *pWrkrData, int bSilent)
 		int rc;
 		rc = redisAppendCommand(pWrkrData->conn, "AUTH %s", serverpasswd);
 		if (rc == REDIS_ERR) {
-			errmsg.LogError(0, NO_ERRCODE, "omhiredis: %s", pWrkrData->conn->errstr);
+			LogError(0, NO_ERRCODE, "omhiredis: %s", pWrkrData->conn->errstr);
 			ABORT_FINALIZE(RS_RET_ERR);
 		} else {
 			pWrkrData->count++;
@@ -206,7 +205,7 @@ static rsRetVal writeHiredis(uchar* key, uchar *message, wrkrInstanceData_t *pWr
 	}
 
 	if (rc == REDIS_ERR) {
-		errmsg.LogError(0, NO_ERRCODE, "omhiredis: %s", pWrkrData->conn->errstr);
+		LogError(0, NO_ERRCODE, "omhiredis: %s", pWrkrData->conn->errstr);
 		dbgprintf("omhiredis: %s\n", pWrkrData->conn->errstr);
 		ABORT_FINALIZE(RS_RET_ERR);
 	} else {
@@ -407,10 +406,9 @@ BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* only supports rsyslog 6 configs */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	INITChkCoreFeature(bCoreSupportsBatching, CORE_FEATURE_BATCHING);
 	if (!bCoreSupportsBatching) {
-		errmsg.LogError(0, NO_ERRCODE, "omhiredis: rsyslog core does not support batching - abort");
+		LogError(0, NO_ERRCODE, "omhiredis: rsyslog core does not support batching - abort");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	DBGPRINTF("omhiredis: module compiled with rsyslog version %s.\n", VERSION);

--- a/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
+++ b/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
@@ -47,7 +47,6 @@ PARSER_NAME("rsyslog.aixforwardedfrom")
 /* internal structures
  */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -144,7 +143,6 @@ ENDparse
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -163,7 +161,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/contrib/pmcisconames/pmcisconames.c
+++ b/contrib/pmcisconames/pmcisconames.c
@@ -48,7 +48,6 @@ PARSER_NAME("rsyslog.cisconames")
 /* internal structures
  */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -148,7 +147,6 @@ ENDparse
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -167,7 +165,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/contrib/pmpanngfw/pmpanngfw.c
+++ b/contrib/pmpanngfw/pmpanngfw.c
@@ -46,7 +46,6 @@ PARSER_NAME("rsyslog.panngfw")
 /* internal structures
  */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -265,7 +264,6 @@ ENDparse
 BEGINmodExit
 CODESTARTmodExit
     /* release what we no longer need */
-    objRelease(errmsg, CORE_COMPONENT);
     objRelease(glbl, CORE_COMPONENT);
     objRelease(parser, CORE_COMPONENT);
     objRelease(datetime, CORE_COMPONENT);
@@ -284,7 +282,6 @@ CODESTARTmodInit
     *ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
     CHKiRet(objUse(glbl, CORE_COMPONENT));
-    CHKiRet(objUse(errmsg, CORE_COMPONENT));
     CHKiRet(objUse(parser, CORE_COMPONENT));
     CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/contrib/pmsnare/pmsnare.c
+++ b/contrib/pmsnare/pmsnare.c
@@ -68,7 +68,6 @@ MODULE_CNFNAME("pmsnare")
 /* internal structures
  */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -413,7 +412,6 @@ ENDparse2
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -433,7 +431,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/plugins/im3195/im3195.c
+++ b/plugins/im3195/im3195.c
@@ -55,7 +55,6 @@ MODULE_TYPE_NOKEEP
 
 /* Module static data */
 DEF_IMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(prop)
 
 /* configuration settings */
@@ -137,7 +136,7 @@ CODESTARTrunInput
 		 * return after SIGUSR1.
 		 */
 		if((iRet = (rsRetVal) srAPIRunListener(pAPI)) != RS_RET_OK) {
-			errmsg.LogError(0, NO_ERRCODE, "error %d running liblogging listener - im3195 "
+			LogError(0, NO_ERRCODE, "error %d running liblogging listener - im3195 "
 				"is defunct", iRet);
 			FINALIZE; /* this causes im3195 to become defunct; TODO: recovery handling */
 		}
@@ -149,17 +148,17 @@ ENDrunInput
 BEGINwillRun
 CODESTARTwillRun
 	if((pAPI = srAPIInitLib()) == NULL) {
-		errmsg.LogError(0, NO_ERRCODE, "error initializing liblogging - im3195 is defunct");
+		LogError(0, NO_ERRCODE, "error initializing liblogging - im3195 is defunct");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 
 	if((iRet = (rsRetVal) srAPISetOption(pAPI, srOPTION_BEEP_LISTENPORT, listenPort)) != RS_RET_OK) {
-		errmsg.LogError(0, NO_ERRCODE, "error %d setting liblogging listen port - im3195 is defunct", iRet);
+		LogError(0, NO_ERRCODE, "error %d setting liblogging listen port - im3195 is defunct", iRet);
 		FINALIZE;
 	}
 
 	if((iRet = (rsRetVal) srAPISetupListener(pAPI, OnReceive)) != RS_RET_OK) {
-		errmsg.LogError(0, NO_ERRCODE, "error %d setting up liblogging listener - im3195 is defunct", iRet);
+		LogError(0, NO_ERRCODE, "error %d setting up liblogging listener - im3195 is defunct", iRet);
 		FINALIZE;
 	}
 
@@ -181,7 +180,6 @@ CODESTARTmodExit
 	if(pInputName != NULL)
 		prop.Destruct(&pInputName);
 	/* release objects we used */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
 ENDmodExit
 
@@ -202,7 +200,6 @@ BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"input3195listenport", 0, eCmdHdlrInt, NULL, &listenPort,

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -74,7 +74,6 @@ DEFobjCurrIf(datetime)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(prop)
 DEFobjCurrIf(net)
-DEFobjCurrIf(errmsg)
 
 /* config settings */
 typedef struct configSettings_s {
@@ -322,7 +321,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -442,7 +441,6 @@ CODESTARTmodExit
 	objRelease(net, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -475,7 +473,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 	CHKiRet(objUse(net, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
 	/* we need to create the inputName property (only once during our lifetime) */
 	CHKiRet(prop.CreateStringProp(&pInputName, UCHAR_CONSTANT("imklog"), sizeof("imklog") - 1));

--- a/plugins/immark/immark.c
+++ b/plugins/immark/immark.c
@@ -54,7 +54,6 @@ MODULE_CNFNAME("immark")
 /* Module static data */
 DEF_IMOD_STATIC_DATA
 DEFobjCurrIf(glbl)
-DEFobjCurrIf(errmsg)
 
 static int iMarkMessagePeriod = DEFAULT_MARK_PERIOD;
 struct modConfData_s {
@@ -107,7 +106,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -149,7 +148,7 @@ ENDendCnfLoad
 BEGINcheckCnf
 CODESTARTcheckCnf
 	if(pModConf->iMarkMessagePeriod == 0) {
-		errmsg.LogError(0, NO_ERRCODE, "immark: mark message period must not be 0, can not run");
+		LogError(0, NO_ERRCODE, "immark: mark message period must not be 0, can not run");
 		ABORT_FINALIZE(RS_RET_NO_RUN);	/* we can not run with this error */
 	}
 finalize_it:
@@ -205,7 +204,6 @@ ENDwillRun
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -228,7 +226,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
 	/* legacy config handlers */
 	CHKiRet(regCfSysLineHdlr2((uchar *)"markmessageperiod", 0, eCmdHdlrInt, NULL,

--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -67,7 +67,6 @@ DEF_IMOD_STATIC_DATA
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(prop)
 DEFobjCurrIf(statsobj)
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(ruleset)
 
 typedef struct configSettings_s {
@@ -142,7 +141,6 @@ CODESTARTmodExit
 	/* release objects we used */
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(statsobj, CORE_COMPONENT);
 	objRelease(ruleset, CORE_COMPONENT);
 ENDmodExit
@@ -360,7 +358,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -398,7 +396,7 @@ CODESTARTsetModCnf
 			} else if(!strcasecmp(mode, "legacy")) {
 				loadModConf->statsFmt = statsFmt_Legacy;
 			} else {
-				errmsg.LogError(0, RS_RET_ERR, "impstats: invalid format %s",
+				LogError(0, RS_RET_ERR, "impstats: invalid format %s",
 						mode);
 			}
 			free(mode);
@@ -460,7 +458,7 @@ checkRuleset(modConfData_t *modConf)
 
 	localRet = ruleset.GetRuleset(modConf->pConf, &pRuleset, modConf->pszBindRuleset);
 	if(localRet == RS_RET_NOT_FOUND) {
-		errmsg.LogError(0, NO_ERRCODE, "impstats: ruleset '%s' not found - "
+		LogError(0, NO_ERRCODE, "impstats: ruleset '%s' not found - "
 				"using default ruleset instead", modConf->pszBindRuleset);
 	}
 	CHKiRet(localRet);
@@ -493,7 +491,7 @@ ENDdoHUP
 BEGINcheckCnf
 CODESTARTcheckCnf
 	if(pModConf->iStatsInterval == 0) {
-		errmsg.LogError(0, NO_ERRCODE, "impstats: stats interval zero not permitted, using "
+		LogError(0, NO_ERRCODE, "impstats: stats interval zero not permitted, using "
 				"default of %d seconds", DEFAULT_STATS_PERIOD);
 		pModConf->iStatsInterval = DEFAULT_STATS_PERIOD;
 	}
@@ -510,7 +508,7 @@ CODESTARTactivateCnf
 		  runModConf->logfile == NULL ? "deactivated" : (char*)runModConf->logfile);
 	localRet = statsobj.EnableStats();
 	if(localRet != RS_RET_OK) {
-		errmsg.LogError(0, localRet, "impstats: error enabling statistics gathering");
+		LogError(0, localRet, "impstats: error enabling statistics gathering");
 		ABORT_FINALIZE(RS_RET_NO_RUN);
 	}
 	/* initialize our own counters */
@@ -542,7 +540,7 @@ CODESTARTactivateCnf
 	CHKiRet(statsobj.ConstructFinalize(statsobj_resources));
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		errmsg.LogError(0, iRet, "impstats: error activating module");
+		LogError(0, iRet, "impstats: error activating module");
 		iRet = RS_RET_NO_RUN;
 	}
 ENDactivateCnf
@@ -611,7 +609,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	initConfigSettings();
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 	/* the pstatsinverval is an alias to support a previous screwed-up syntax... */

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -89,7 +89,6 @@ DEFobjCurrIf(glbl)
 DEFobjCurrIf(net)
 DEFobjCurrIf(prop)
 DEFobjCurrIf(datetime)
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(ruleset)
 DEFobjCurrIf(statsobj)
 
@@ -433,7 +432,7 @@ static rsRetVal startupUXSrv(ptcpsrv_t *pSrv) {
 
 	sock = socket(AF_UNIX, SOCK_STREAM, 0);
 	if(sock < 0) {
-		errmsg.LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: error creating unix socket");
+		LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: error creating unix socket");
 		ABORT_FINALIZE(RS_RET_ERR_CRE_AFUX);
 	}
 
@@ -451,30 +450,30 @@ static rsRetVal startupUXSrv(ptcpsrv_t *pSrv) {
 	}
 
 	if (sockflags == -1) {
-		errmsg.LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: error setting fcntl(O_NONBLOCK) on unix socket");
+		LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: error setting fcntl(O_NONBLOCK) on unix socket");
 		ABORT_FINALIZE(RS_RET_ERR_CRE_AFUX);
 	}
 
 	if (bind(sock, (struct sockaddr *)&local, SUN_LEN(&local)) < 0) {
-		errmsg.LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: error while binding unix socket");
+		LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: error while binding unix socket");
 		ABORT_FINALIZE(RS_RET_ERR_CRE_AFUX);
 	}
 
 	if (listen(sock, pSrv->socketBacklog) < 0) {
-		errmsg.LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: unix socket listen error");
+		LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: unix socket listen error");
 		ABORT_FINALIZE(RS_RET_ERR_CRE_AFUX);
 	}
 
 	if(chown(local.sun_path, pSrv->fileUID, pSrv->fileGID) != 0) {
 		if(pSrv->bFailOnPerms) {
-			errmsg.LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: unix socket chown error");
+			LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: unix socket chown error");
 			ABORT_FINALIZE(RS_RET_ERR_CRE_AFUX);
 		}
 	}
 
 	if(chmod(local.sun_path, pSrv->fCreateMode) != 0) {
 		if(pSrv->bFailOnPerms) {
-			errmsg.LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: unix socket chmod error");
+			LogError(errno, RS_RET_ERR_CRE_AFUX, "imptcp: unix socket chmod error");
 			ABORT_FINALIZE(RS_RET_ERR_CRE_AFUX);
 		}
 	}
@@ -590,7 +589,7 @@ startupSrv(ptcpsrv_t *pSrv)
 		if(net.should_use_so_bsdcompat()) {
 			if (setsockopt(sock, SOL_SOCKET, SO_BSDCOMPAT,
 					(char *) &on, sizeof(on)) < 0) {
-				errmsg.LogError(errno, NO_ERRCODE, "TCP setsockopt(BSDCOMPAT)");
+				LogError(errno, NO_ERRCODE, "TCP setsockopt(BSDCOMPAT)");
                                 close(sock);
 				sock = -1;
 				continue;
@@ -763,7 +762,7 @@ EnableKeepAlive(ptcplstn_t *pLstn, int sock)
 	ret = -1;
 #	endif
 	if(ret < 0) {
-		errmsg.LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive probes - ignored");
+		LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive probes - ignored");
 	}
 
 #	if defined(TCP_KEEPCNT)
@@ -778,7 +777,7 @@ EnableKeepAlive(ptcplstn_t *pLstn, int sock)
 	ret = -1;
 #	endif
 	if(ret < 0) {
-		errmsg.LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive time - ignored");
+		LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive time - ignored");
 	}
 
 #	if defined(TCP_KEEPCNT)
@@ -793,7 +792,7 @@ EnableKeepAlive(ptcplstn_t *pLstn, int sock)
 	ret = -1;
 #	endif
 	if(ret < 0) {
-		errmsg.LogError(errno, NO_ERRCODE, "imptcp cannot set keepalive intvl - ignored");
+		LogError(errno, NO_ERRCODE, "imptcp cannot set keepalive intvl - ignored");
 	}
 
 	dbgprintf("KEEPALIVE enabled for socket %d\n", sock);
@@ -1039,13 +1038,13 @@ processDataRcvd(ptcpsess_t *const __restrict__ pThis,
 			prop.GetString(pThis->peerName, &propPeerName, &lenPeerName);
 			prop.GetString(pThis->peerIP, &propPeerIP, &lenPeerIP);
 			if(c != ' ') {
-				errmsg.LogError(0, NO_ERRCODE, "Framing Error in received TCP message "
+				LogError(0, NO_ERRCODE, "Framing Error in received TCP message "
 						"from peer: (hostname) %s, (ip) %s: delimiter is not "
 						"SP but has ASCII value %d.", propPeerName, propPeerIP, c);
 			}
 			if(pThis->iOctetsRemain < 1) {
 				/* TODO: handle the case where the octet count is 0! */
-				errmsg.LogError(0, NO_ERRCODE, "Framing Error in received TCP message"
+				LogError(0, NO_ERRCODE, "Framing Error in received TCP message"
 						" from peer: (hostname) %s, (ip) %s: invalid octet count %d.",
 						propPeerName, propPeerIP, pThis->iOctetsRemain);
 				pThis->eFraming = TCP_FRAMING_OCTET_STUFFING;
@@ -1055,13 +1054,13 @@ processDataRcvd(ptcpsess_t *const __restrict__ pThis,
 				 */
 				DBGPRINTF("truncating message with %d octets - max msg size is %d\n",
 					  pThis->iOctetsRemain, iMaxLine);
-				errmsg.LogError(0, NO_ERRCODE, "received oversize message from peer: "
+				LogError(0, NO_ERRCODE, "received oversize message from peer: "
 						"(hostname) %s, (ip) %s: size is %d bytes, max msg "
 						"size is %d, truncating...", propPeerName, propPeerIP,
 						pThis->iOctetsRemain, iMaxLine);
 			}
 			if(pThis->iOctetsRemain > pThis->pLstn->pSrv->maxFrameSize) {
-				errmsg.LogError(0, NO_ERRCODE, "Framing Error in received TCP message "
+				LogError(0, NO_ERRCODE, "Framing Error in received TCP message "
 						"from peer: (hostname) %s, (ip) %s: frame too large: %d, "
 						"change to octet stuffing", propPeerName, propPeerIP,
 						pThis->iOctetsRemain);
@@ -1321,7 +1320,7 @@ addEPollSock(epolld_type_t typ, void *ptr, int sock, epolld_t **pEpd)
 	if(epoll_ctl(epollfd, EPOLL_CTL_ADD, sock, &(epd->ev)) != 0) {
 		char errStr[1024];
 		int eno = errno;
-		errmsg.LogError(0, RS_RET_EPOLL_CTL_FAILED, "os error (%d) during epoll ADD: %s",
+		LogError(0, RS_RET_EPOLL_CTL_FAILED, "os error (%d) during epoll ADD: %s",
 			        eno, rs_strerror_r(eno, errStr, sizeof(errStr)));
 		ABORT_FINALIZE(RS_RET_EPOLL_CTL_FAILED);
 	}
@@ -1331,7 +1330,7 @@ addEPollSock(epolld_type_t typ, void *ptr, int sock, epolld_t **pEpd)
 finalize_it:
 	if(iRet != RS_RET_OK) {
 		if (epd != NULL) {
-			errmsg.LogError(0, RS_RET_INTERNAL_ERROR, "error: could not initialize mutex for ptcp "
+			LogError(0, RS_RET_INTERNAL_ERROR, "error: could not initialize mutex for ptcp "
 			"connection for socket: %d", sock);
 		}
 		free(epd);
@@ -1725,7 +1724,7 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		errmsg.LogError(0, NO_ERRCODE, "error %d trying to add listener", iRet);
+		LogError(0, NO_ERRCODE, "error %d trying to add listener", iRet);
 		if(pSrv != NULL) {
 			destructSrv(pSrv);
 		}
@@ -1876,7 +1875,7 @@ sessActivity(ptcpsess_t *pSess, int *continue_polling)
 			}
 			*continue_polling = 0;
 			if(bEmitOnClose) {
-				errmsg.LogError(0, RS_RET_PEER_CLOSED_CONN, "imptcp session %d closed by "
+				LogError(0, RS_RET_PEER_CLOSED_CONN, "imptcp session %d closed by "
 					  	"remote peer %s.", remsock, peerName);
 			}
 			CHKiRet(closeSess(pSess)); /* close may emit more messages in strmzip mode! */
@@ -1914,7 +1913,7 @@ processWorkItem(epolld_t *epd)
 		sessActivity((ptcpsess_t *) epd->ptr, &continue_polling);
 		break;
 	default:
-		errmsg.LogError(0, RS_RET_INTERNAL_ERROR,
+		LogError(0, RS_RET_INTERNAL_ERROR,
 						"error: invalid epolld_type_t %d after epoll", epd->typ);
 		break;
 	}
@@ -1957,7 +1956,7 @@ destroyIoQ(void)
 	while (!STAILQ_EMPTY(&io_q.q)) {
 		n = STAILQ_FIRST(&io_q.q);
 		STAILQ_REMOVE_HEAD(&io_q.q, link);
-		errmsg.LogError(0, RS_RET_INTERNAL_ERROR, "imptcp: discarded enqueued io-work to allow shutdown "
+		LogError(0, RS_RET_INTERNAL_ERROR, "imptcp: discarded enqueued io-work to allow shutdown "
 								"- ignored");
 		free(n);
 	}
@@ -1999,7 +1998,7 @@ enqueueIoWork(epolld_t *epd, int dispatchInlineIfQueueFull) {
 finalize_it:
 	if (iRet != RS_RET_OK) {
 		if (n == NULL) {
-			errmsg.LogError(0, iRet, "imptcp: couldn't allocate memory to enqueue io-request - ignored");
+			LogError(0, iRet, "imptcp: couldn't allocate memory to enqueue io-request - ignored");
 		}
 	}
 	RETiRet;
@@ -2223,7 +2222,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "imptcp: error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "imptcp: error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -2278,7 +2277,7 @@ ENDendCnfLoad
 static inline void
 std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *inst)
 {
-	errmsg.LogError(0, NO_ERRCODE, "imptcp: ruleset '%s' for port %s not found - "
+	LogError(0, NO_ERRCODE, "imptcp: ruleset '%s' for port %s not found - "
 			"using default ruleset instead", inst->pszBindRuleset,
 			inst->pszBindPort);
 }
@@ -2302,7 +2301,7 @@ CODESTARTactivateCnfPrePrivDrop
 		addListner(pModConf, inst);
 	}
 	if(pSrvRoot == NULL) {
-		errmsg.LogError(0, RS_RET_NO_LSTN_DEFINED, "imptcp: no ptcp server defined, module can not run.");
+		LogError(0, RS_RET_NO_LSTN_DEFINED, "imptcp: no ptcp server defined, module can not run.");
 		ABORT_FINALIZE(RS_RET_NO_RUN);
 	}
 
@@ -2321,7 +2320,7 @@ CODESTARTactivateCnfPrePrivDrop
 	}
 
 	if(epollfd < 0) {
-		errmsg.LogError(0, RS_RET_EPOLL_CR_FAILED, "error: epoll_create() failed");
+		LogError(0, RS_RET_EPOLL_CR_FAILED, "error: epoll_create() failed");
 		ABORT_FINALIZE(RS_RET_NO_RUN);
 	}
 
@@ -2453,7 +2452,6 @@ CODESTARTmodExit
 	objRelease(prop, CORE_COMPONENT);
 	objRelease(net, LM_NET_FILENAME);
 	objRelease(datetime, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(ruleset, CORE_COMPONENT);
 ENDmodExit
 
@@ -2506,7 +2504,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 	CHKiRet(objUse(net, LM_NET_FILENAME));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -59,7 +59,6 @@ MODULE_CNFNAME("imrelp")
 DEF_IMOD_STATIC_DATA
 DEFobjCurrIf(net)
 DEFobjCurrIf(prop)
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(ruleset)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(statsobj)
@@ -199,7 +198,7 @@ static void
 onErr(void *pUsr, char *objinfo, char* errmesg, __attribute__((unused)) relpRetVal errcode)
 {
 	instanceConf_t *inst = (instanceConf_t*) pUsr;
-	errmsg.LogError(0, RS_RET_RELP_AUTH_FAIL, "imrelp[%s]: error '%s', object "
+	LogError(0, RS_RET_RELP_AUTH_FAIL, "imrelp[%s]: error '%s', object "
 			" '%s' - input may not work as intended",
 			inst->pszBindPort, errmesg, objinfo);
 }
@@ -207,7 +206,7 @@ onErr(void *pUsr, char *objinfo, char* errmesg, __attribute__((unused)) relpRetV
 static void
 onGenericErr(char *objinfo, char* errmesg, __attribute__((unused)) relpRetVal errcode)
 {
-	errmsg.LogError(0, RS_RET_RELP_ERR, "imrelp: librelp error '%s', object "
+	LogError(0, RS_RET_RELP_ERR, "imrelp: librelp error '%s', object "
 			" '%s' - input may not work as intended", errmesg, objinfo);
 }
 
@@ -215,7 +214,7 @@ static void
 onAuthErr(void *pUsr, char *authinfo, char* errmesg, __attribute__((unused)) relpRetVal errcode)
 {
 	instanceConf_t *inst = (instanceConf_t*) pUsr;
-	errmsg.LogError(0, RS_RET_RELP_AUTH_FAIL, "imrelp[%s]: authentication error '%s', peer "
+	LogError(0, RS_RET_RELP_AUTH_FAIL, "imrelp[%s]: authentication error '%s', peer "
 			"is '%s'", inst->pszBindPort, errmesg, authinfo);
 }
 
@@ -312,7 +311,7 @@ finalize_it:
 static inline void
 std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *inst)
 {
-	errmsg.LogError(0, NO_ERRCODE, "imrelp[%s]: ruleset '%s' not found - "
+	LogError(0, NO_ERRCODE, "imrelp[%s]: ruleset '%s' not found - "
 			"using default ruleset instead",
 			inst->pszBindPort, inst->pszBindRuleset);
 }
@@ -331,7 +330,7 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	CHKiRet(createInstance(&inst));
 
 	if(pNewVal == NULL || *pNewVal == '\0') {
-		errmsg.LogError(0, NO_ERRCODE, "imrelp: port number must be specified, listener ignored");
+		LogError(0, NO_ERRCODE, "imrelp: port number must be specified, listener ignored");
 	}
 	if((pNewVal == NULL) || (*pNewVal == '\0')) {
 		inst->pszBindPort = NULL;
@@ -407,20 +406,20 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 	if(inst->bEnableTLS) {
 		relpRet = relpSrvEnableTLS2(pSrv);
 		if(relpRet == RELP_RET_ERR_NO_TLS) {
-			errmsg.LogError(0, RS_RET_RELP_NO_TLS,
+			LogError(0, RS_RET_RELP_NO_TLS,
 					"imrelp: could not activate relp TLS, librelp "
 					"does not support it (most probably GnuTLS lib "
 					"is too old)!");
 			ABORT_FINALIZE(RS_RET_RELP_NO_TLS);
 		} else if(relpRet == RELP_RET_ERR_NO_TLS_AUTH) {
-			errmsg.LogError(0, RS_RET_RELP_NO_TLS_AUTH,
+			LogError(0, RS_RET_RELP_NO_TLS_AUTH,
 					"imrelp: could not activate relp TLS with "
 					"authentication, librelp does not support it "
 					"(most probably GnuTLS lib is too old)! "
 					"Note: anonymous TLS is probably supported.");
 			ABORT_FINALIZE(RS_RET_RELP_NO_TLS_AUTH);
 		} else if(relpRet != RELP_RET_OK) {
-			errmsg.LogError(0, RS_RET_RELP_ERR,
+			LogError(0, RS_RET_RELP_ERR,
 					"imrelp: could not activate relp TLS, code %d", relpRet);
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 		}
@@ -432,7 +431,7 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 		}
 		relpSrvSetGnuTLSPriString(pSrv, (char*)inst->pristring);
 		if(relpSrvSetAuthMode(pSrv, (char*)inst->authmode) != RELP_RET_OK) {
-			errmsg.LogError(0, RS_RET_RELP_ERR,
+			LogError(0, RS_RET_RELP_ERR,
 					"imrelp: invalid auth mode '%s'", inst->authmode);
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 		}
@@ -451,20 +450,20 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 	 * after finalize in some cases...
 	 */
 	if(relpRet == RELP_RET_ERR_NO_TLS) {
-		errmsg.LogError(0, RS_RET_RELP_NO_TLS,
+		LogError(0, RS_RET_RELP_NO_TLS,
 				"imrelp: could not activate relp TLS listener, librelp "
 				"does not support it (most probably GnuTLS lib "
 				"is too old)!");
 		ABORT_FINALIZE(RS_RET_RELP_NO_TLS);
 	} else if(relpRet == RELP_RET_ERR_NO_TLS_AUTH) {
-		errmsg.LogError(0, RS_RET_RELP_NO_TLS_AUTH,
+		LogError(0, RS_RET_RELP_NO_TLS_AUTH,
 				"imrelp: could not activate relp TLS listener with "
 				"authentication, librelp does not support it "
 				"(most probably GnuTLS lib is too old)! "
 				"Note: anonymous TLS is probably supported.");
 		ABORT_FINALIZE(RS_RET_RELP_NO_TLS_AUTH);
 	} else if(relpRet != RELP_RET_OK) {
-		errmsg.LogError(0, RS_RET_RELP_ERR,
+		LogError(0, RS_RET_RELP_ERR,
 				"imrelp: could not activate relp listener, code %d", relpRet);
 		ABORT_FINALIZE(RS_RET_RELP_ERR);
 	}
@@ -549,7 +548,7 @@ CODESTARTnewInpInst
 			if(fp == NULL) {
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 				"error: certificate file %s couldn't be accessed: %s\n",
 				inst->caCertFile, errStr);
 			} else {
@@ -561,7 +560,7 @@ CODESTARTnewInpInst
 			if(fp == NULL) {
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 				"error: certificate file %s couldn't be accessed: %s\n",
 				inst->myCertFile, errStr);
 			} else {
@@ -573,7 +572,7 @@ CODESTARTnewInpInst
 			if(fp == NULL) {
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 				"error: certificate file %s couldn't be accessed: %s\n",
 				inst->myPrivKeyFile, errStr);
 			} else {
@@ -636,7 +635,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -675,7 +674,7 @@ CODESTARTendCnfLoad
 		}
 	} else {
 		if((cs.pszBindRuleset != NULL) && (cs.pszBindRuleset[0] != '\0')) {
-			errmsg.LogError(0, RS_RET_DUP_PARAM, "imrelp: ruleset "
+			LogError(0, RS_RET_DUP_PARAM, "imrelp: ruleset "
 					"set via legacy directive ignored");
 		}
 	}
@@ -704,7 +703,7 @@ CODESTARTcheckCnf
 		}
 		maxMessageSize = (size_t)glbl.GetMaxLine();
 		if(inst->maxDataSize < maxMessageSize) {
-			errmsg.LogError(0, RS_RET_INVALID_PARAMS, "error: "
+			LogError(0, RS_RET_INVALID_PARAMS, "error: "
 					"maxDataSize (%zu) is smaller than global parameter "
 					"maxMessageSize (%zu) - global parameter will be used.",
 					inst->maxDataSize, maxMessageSize);
@@ -724,7 +723,7 @@ CODESTARTactivateCnfPrePrivDrop
 		addListner(pModConf, inst);
 	}
 	if(pRelpEngine == NULL) {
-		errmsg.LogError(0, RS_RET_NO_LSTN_DEFINED, "imrelp: no RELP listener defined, module can not run.");
+		LogError(0, RS_RET_NO_LSTN_DEFINED, "imrelp: no RELP listener defined, module can not run.");
 		ABORT_FINALIZE(RS_RET_NO_RUN);
 	}
 finalize_it:
@@ -818,7 +817,6 @@ CODESTARTmodExit
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
 	objRelease(net, LM_NET_FILENAME);
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -857,7 +855,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	/* request objects we use */
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(net, LM_NET_FILENAME));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -74,7 +74,6 @@ DEFobjCurrIf(tcpsrv)
 DEFobjCurrIf(tcps_sess)
 DEFobjCurrIf(net)
 DEFobjCurrIf(netstrm)
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(ruleset)
 
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unused)) *pVal);
@@ -391,7 +390,7 @@ addListner(modConfData_t *modConf, instanceConf_t *inst)
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		errmsg.LogError(0, NO_ERRCODE, "imtcp: error %d trying to add listener", iRet);
+		LogError(0, NO_ERRCODE, "imtcp: error %d trying to add listener", iRet);
 	}
 	RETiRet;
 }
@@ -406,7 +405,7 @@ CODESTARTnewInpInst
 
 	pvals = nvlstGetParams(lst, &inppblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS,
+		LogError(0, RS_RET_MISSING_CNFPARAMS,
 			        "imtcp: required parameter are missing\n");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -487,7 +486,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "imtcp: error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "imtcp: error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -517,7 +516,7 @@ CODESTARTsetModCnf
 			if(max <= 200000000) {
 				loadModConf->maxFrameSize = max;
 			} else {
-				errmsg.LogError(0, RS_RET_PARAM_ERROR, "imtcp: invalid value for 'maxFrameSize' "
+				LogError(0, RS_RET_PARAM_ERROR, "imtcp: invalid value for 'maxFrameSize' "
 						"parameter given is %d, max is 200000000", max);
 				ABORT_FINALIZE(RS_RET_PARAM_ERROR);
 			}
@@ -597,7 +596,7 @@ ENDendCnfLoad
 static inline void
 std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *inst)
 {
-	errmsg.LogError(0, NO_ERRCODE, "imtcp: ruleset '%s' for port %s not found - "
+	LogError(0, NO_ERRCODE, "imtcp: ruleset '%s' for port %s not found - "
 			"using default ruleset instead", inst->pszBindRuleset,
 			inst->pszBindPort);
 }
@@ -611,7 +610,7 @@ CODESTARTcheckCnf
 			inst->bSuppOctetFram = pModConf->bSuppOctetFram;
 	}
 	if(pModConf->root == NULL) {
-		errmsg.LogError(0, RS_RET_NO_LISTNERS , "imtcp: module loaded, but "
+		LogError(0, RS_RET_NO_LISTNERS , "imtcp: module loaded, but "
 				"no listeners defined - no input will be gathered");
 		iRet = RS_RET_NO_LISTNERS;
 	}
@@ -708,7 +707,6 @@ CODESTARTmodExit
 	objRelease(netstrm, LM_NETSTRMS_FILENAME);
 	objRelease(tcps_sess, LM_TCPSRV_FILENAME);
 	objRelease(tcpsrv, LM_TCPSRV_FILENAME);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(ruleset, CORE_COMPONENT);
 ENDmodExit
 
@@ -759,7 +757,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(netstrm, LM_NETSTRMS_FILENAME));
 	CHKiRet(objUse(tcps_sess, LM_TCPSRV_FILENAME));
 	CHKiRet(objUse(tcpsrv, LM_TCPSRV_FILENAME));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 
 	/* register config file handlers */

--- a/plugins/mmaudit/mmaudit.c
+++ b/plugins/mmaudit/mmaudit.c
@@ -57,7 +57,6 @@ MODULE_TYPE_NOKEEP
 
 
 /* static data */
-DEFobjCurrIf(errmsg);
 
 /* internal structures
  */
@@ -302,7 +301,6 @@ ENDparseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -342,7 +340,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 		ABORT_FINALIZE(RS_RET_NO_MSG_PASSING);
 	}
 
-	iRet = objUse(errmsg, CORE_COMPONENT);
 ENDmodInit
 
 /* vi:set ai:

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -49,7 +49,6 @@ MODULE_CNFNAME("mmexternal")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 
 typedef struct _instanceData {
 	uchar *szBinary;	/* name of binary to call */
@@ -249,7 +248,7 @@ processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *co
 	pWrkrData->respBuf[numCharsRead-1] = '\0';
 	iRet = MsgSetPropsViaJSON(pMsg, (uchar*)pWrkrData->respBuf);
 	if(iRet != RS_RET_OK) {
-		errmsg.LogError(0, iRet, "mmexternal: invalid reply '%s' from program '%s'",
+		LogError(0, iRet, "mmexternal: invalid reply '%s' from program '%s'",
 				pWrkrData->respBuf, pWrkrData->pData->szBinary);
 	}
 
@@ -399,10 +398,10 @@ cleanup(wrkrInstanceData_t *pWrkrData)
 		DBGPRINTF("mmexternal: waitpid status return for program '%s': %2.2x\n",
 			  pWrkrData->pData->szBinary, status);
 		if(WIFEXITED(status)) {
-			errmsg.LogError(0, NO_ERRCODE, "program '%s' exited normally, state %d",
+			LogError(0, NO_ERRCODE, "program '%s' exited normally, state %d",
 					pWrkrData->pData->szBinary, WEXITSTATUS(status));
 		} else if(WIFSIGNALED(status)) {
-			errmsg.LogError(0, NO_ERRCODE, "program '%s' terminated by signal %d.",
+			LogError(0, NO_ERRCODE, "program '%s' terminated by signal %d.",
 					pWrkrData->pData->szBinary, WTERMSIG(status));
 		}
 	}
@@ -577,7 +576,7 @@ CODESTARTnewActInst
 			else if(!strcmp(cstr, "fulljson"))
 				pData->inputProp = INPUT_JSON;
 			else {
-				errmsg.LogError(0, RS_RET_INVLD_INTERFACE_INPUT,
+				LogError(0, RS_RET_INVLD_INTERFACE_INPUT,
 					"mmexternal: invalid interface.input parameter '%s'",
 					cstr);
 				ABORT_FINALIZE(RS_RET_INVLD_INTERFACE_INPUT);
@@ -602,7 +601,6 @@ BEGINmodExit
 CODESTARTmodExit
 	free(cs.szBinary);
 	cs.szBinary = NULL;
-	iRet = objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -619,6 +617,5 @@ CODESTARTmodInit
 INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 CODEmodInit_QueryRegCFSLineHdlr
 ENDmodInit

--- a/plugins/mmfields/mmfields.c
+++ b/plugins/mmfields/mmfields.c
@@ -43,7 +43,6 @@ MODULE_TYPE_NOKEEP
 MODULE_CNFNAME("mmfields")
 
 
-DEFobjCurrIf(errmsg)
 DEF_OMOD_STATIC_DATA
 
 /* config variables */
@@ -255,7 +254,6 @@ NO_LEGACY_CONF_parseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -274,5 +272,4 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	DBGPRINTF("mmfields: module compiled with rsyslog version %s.\n", VERSION);
-	iRet = objUse(errmsg, CORE_COMPONENT);
 ENDmodInit

--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -52,7 +52,6 @@ MODULE_CNFNAME("mmjsonparse")
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unused)) *pVal);
 
 /* static data */
-DEFobjCurrIf(errmsg);
 
 /* internal structures
  */
@@ -128,7 +127,7 @@ BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
 	pWrkrData->tokener = json_tokener_new();
 	if(pWrkrData->tokener == NULL) {
-		errmsg.LogError(0, RS_RET_ERR, "error: could not create json "
+		LogError(0, RS_RET_ERR, "error: could not create json "
 				"tokener, cannot activate instance");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
@@ -343,7 +342,6 @@ ENDparseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -395,7 +393,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 		ABORT_FINALIZE(RS_RET_NO_MSG_PASSING);
 	}
 
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler,
 				    resetConfigVariables, NULL, STD_LOADABLE_MODULE_ID));

--- a/plugins/mmpstrucdata/mmpstrucdata.c
+++ b/plugins/mmpstrucdata/mmpstrucdata.c
@@ -45,7 +45,6 @@ MODULE_TYPE_NOKEEP
 MODULE_CNFNAME("mmpstrucdata")
 
 
-DEFobjCurrIf(errmsg);
 DEF_OMOD_STATIC_DATA
 
 /* config variables */
@@ -379,7 +378,6 @@ ENDdoAction
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -398,5 +396,4 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	DBGPRINTF("mmpstrucdata: module compiled with rsyslog version %s.\n", VERSION);
-	iRet = objUse(errmsg, CORE_COMPONENT);
 ENDmodInit

--- a/plugins/mmrm1stspace/mmrm1stspace.c
+++ b/plugins/mmrm1stspace/mmrm1stspace.c
@@ -42,7 +42,6 @@ MODULE_TYPE_NOKEEP
 MODULE_CNFNAME("mmrm1stspace")
 
 
-DEFobjCurrIf(errmsg);
 DEF_OMOD_STATIC_DATA
 
 /* config variables */
@@ -156,7 +155,6 @@ ENDdoAction
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -177,5 +175,4 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	DBGPRINTF("mmrm1stspace: module compiled with rsyslog version %s.\n", VERSION);
-	iRet = objUse(errmsg, CORE_COMPONENT);
 ENDmodInit

--- a/plugins/mmsnmptrapd/mmsnmptrapd.c
+++ b/plugins/mmsnmptrapd/mmsnmptrapd.c
@@ -54,7 +54,6 @@ MODULE_CNFNAME("mmsnmptrapd")
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unused)) *pVal);
 
 /* static data */
-DEFobjCurrIf(errmsg);
 
 /* internal structures
  */
@@ -286,7 +285,7 @@ buildSeverityMapping(instanceData *const pData)
 			FINALIZE;
 		}
 		if(getSubstring(&mapping, ',', pszSevCode, sizeof(pszSevCode)) == 0) {
-			errmsg.LogError(0, RS_RET_ERR, "error: invalid severity mapping, cannot "
+			LogError(0, RS_RET_ERR, "error: invalid severity mapping, cannot "
 					"extract code. given: '%s'\n", cs.pszSeverityMapping);
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
@@ -294,7 +293,7 @@ buildSeverityMapping(instanceData *const pData)
 		if(!isNumeric(pszSevCode))
 			sevCode = -1;
 		if(sevCode < 0 || sevCode > 7) {
-			errmsg.LogError(0, RS_RET_ERR, "error: severity code %d outside of valid "
+			LogError(0, RS_RET_ERR, "error: severity code %d outside of valid "
 					"range 0..7 (was string '%s')\n", sevCode, pszSevCode);
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
@@ -368,7 +367,6 @@ ENDparseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -423,7 +421,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 		ABORT_FINALIZE(RS_RET_NO_MSG_PASSING);
 	}
 
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
 	/* TODO: config vars ininit can be replaced by commented-out code above in v6 */
 	cs.pszTagName = NULL;

--- a/plugins/mmutf8fix/mmutf8fix.c
+++ b/plugins/mmutf8fix/mmutf8fix.c
@@ -47,7 +47,6 @@ MODULE_TYPE_NOKEEP
 MODULE_CNFNAME("mmutf8fix")
 
 
-DEFobjCurrIf(errmsg);
 DEF_OMOD_STATIC_DATA
 
 /* define operation modes we have */
@@ -165,7 +164,7 @@ CODESTARTnewActInst
 				pData->mode = MODE_CC;
 			} else {
 				char *cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
-				errmsg.LogError(0, RS_RET_INVLD_MODE,
+				LogError(0, RS_RET_INVLD_MODE,
 					"mmutf8fix: invalid mode '%s' - ignored",
 					cstr);
 				free(cstr);
@@ -311,7 +310,6 @@ NO_LEGACY_CONF_parseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -329,5 +327,4 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	DBGPRINTF("mmutf8fix: module compiled with rsyslog version %s.\n", VERSION);
-	iRet = objUse(errmsg, CORE_COMPONENT);
 ENDmodInit

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -65,7 +65,6 @@ MODULE_CNFNAME("omelasticsearch")
 
 /* internal structures */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(statsobj)
 DEFobjCurrIf(prop)
 DEFobjCurrIf(ruleset)
@@ -1592,7 +1591,7 @@ computeAuthHeader(char* uid, char* pwd, uchar** authBuf) {
 	if(r == 0) *authBuf = (uchar*) es_str2cstr(auth, NULL);
 
 	if (r != 0 || *authBuf == NULL) {
-		errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: failed to build auth header\n");
+		LogError(0, RS_RET_ERR, "omelasticsearch: failed to build auth header\n");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 
@@ -1776,7 +1775,7 @@ CODESTARTnewActInst
 			fp = fopen((const char*)pData->caCertFile, "r");
 			if(fp == NULL) {
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 						"error: 'tls.cacert' file %s couldn't be accessed: %s\n",
 						pData->caCertFile, errStr);
 			} else {
@@ -1787,7 +1786,7 @@ CODESTARTnewActInst
 			fp = fopen((const char*)pData->myCertFile, "r");
 			if(fp == NULL) {
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 						"error: 'tls.mycert' file %s couldn't be accessed: %s\n",
 						pData->myCertFile, errStr);
 			} else {
@@ -1798,7 +1797,7 @@ CODESTARTnewActInst
 			fp = fopen((const char*)pData->myPrivKeyFile, "r");
 			if(fp == NULL) {
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 						"error: 'tls.myprivkey' file %s couldn't be accessed: %s\n",
 						pData->myPrivKeyFile, errStr);
 			} else {
@@ -1811,7 +1810,7 @@ CODESTARTnewActInst
 			} else if (writeop && !strcmp(writeop, "index")) {
 				pData->writeOperation = ES_WRITE_INDEX;
 			} else if (writeop) {
-				errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+				LogError(0, RS_RET_CONFIG_ERROR,
 					"omelasticsearch: invalid value '%s' for writeoperation: "
 					"must be one of 'index' or 'create' - using default value 'index'", writeop);
 				pData->writeOperation = ES_WRITE_INDEX;
@@ -1832,37 +1831,37 @@ CODESTARTnewActInst
 	}
 
 	if(pData->pwd != NULL && pData->uid == NULL) {
-		errmsg.LogError(0, RS_RET_UID_MISSING,
+		LogError(0, RS_RET_UID_MISSING,
 			"omelasticsearch: password is provided, but no uid "
 			"- action definition invalid");
 		ABORT_FINALIZE(RS_RET_UID_MISSING);
 	}
 	if(pData->dynSrchIdx && pData->searchIndex == NULL) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 			"omelasticsearch: requested dynamic search index, but no "
 			"name for index template given - action definition invalid");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 	if(pData->dynSrchType && pData->searchType == NULL) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 			"omelasticsearch: requested dynamic search type, but no "
 			"name for type template given - action definition invalid");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 	if(pData->dynParent && pData->parent == NULL) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 			"omelasticsearch: requested dynamic parent, but no "
 			"name for parent template given - action definition invalid");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 	if(pData->dynBulkId && pData->bulkId == NULL) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 			"omelasticsearch: requested dynamic bulkid, but no "
 			"name for bulkid template given - action definition invalid");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 	if(pData->dynPipelineName && pData->pipelineName == NULL) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 			"omelasticsearch: requested dynamic pipeline name, but no "
 			"name for pipelineName template given - action definition invalid");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
@@ -1921,7 +1920,7 @@ CODESTARTnewActInst
 		pData->numServers = servers->nmemb;
 		pData->serverBaseUrls = malloc(servers->nmemb * sizeof(uchar*));
 		if (pData->serverBaseUrls == NULL) {
-			errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
+			LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
 					"for ElasticSearch server configuration.");
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
@@ -1929,7 +1928,7 @@ CODESTARTnewActInst
 		for(i = 0 ; i < servers->nmemb ; ++i) {
 			serverParam = es_str2cstr(servers->arr[i], NULL);
 			if (serverParam == NULL) {
-				errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
+				LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
 					"for ElasticSearch server configuration.");
 				ABORT_FINALIZE(RS_RET_ERR);
 			}
@@ -1949,7 +1948,7 @@ CODESTARTnewActInst
 		pData->numServers = 1;
 		pData->serverBaseUrls = malloc(sizeof(uchar*));
 		if (pData->serverBaseUrls == NULL) {
-			errmsg.LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
+			LogError(0, RS_RET_ERR, "omelasticsearch: unable to allocate buffer "
 					"for ElasticSearch server configuration.");
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
@@ -1962,7 +1961,7 @@ CODESTARTnewActInst
 		pData->searchType = (uchar*) strdup("events");
 
 	if ((pData->writeOperation != ES_WRITE_INDEX) && (pData->bulkId == NULL)) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR,
+		LogError(0, RS_RET_CONFIG_ERROR,
 			"omelasticsearch: writeoperation '%d' requires bulkid", pData->writeOperation);
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
@@ -2012,7 +2011,7 @@ CODESTARTcheckCnf
 		if (inst->retryRulesetName) {
 			localRet = ruleset.GetRuleset(pModConf->pConf, &pRuleset, inst->retryRulesetName);
 			if(localRet == RS_RET_NOT_FOUND) {
-				errmsg.LogError(0, localRet, "omelasticsearch: retryruleset '%s' not found - "
+				LogError(0, localRet, "omelasticsearch: retryruleset '%s' not found - "
 						"no retry ruleset will be used", inst->retryRulesetName);
 			} else {
 				inst->retryRuleset = pRuleset;
@@ -2047,7 +2046,6 @@ CODESTARTmodExit
 		prop.Destruct(&pInputName);
 	curl_global_cleanup();
 	statsobj.Destruct(&indexStats);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(statsobj, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
 	objRelease(ruleset, CORE_COMPONENT);
@@ -2071,13 +2069,12 @@ BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 
 	if (curl_global_init(CURL_GLOBAL_ALL) != 0) {
-		errmsg.LogError(0, RS_RET_OBJ_CREATION_FAILED, "CURL fail. -elasticsearch indexing disabled");
+		LogError(0, RS_RET_OBJ_CREATION_FAILED, "CURL fail. -elasticsearch indexing disabled");
 		ABORT_FINALIZE(RS_RET_OBJ_CREATION_FAILED);
 	}
 

--- a/plugins/omgssapi/omgssapi.c
+++ b/plugins/omgssapi/omgssapi.c
@@ -64,7 +64,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(gssutil)
 DEFobjCurrIf(tcpclt)
@@ -288,7 +287,7 @@ finalize_it:
 	RETiRet;
 
  fail:
-	errmsg.LogError(0, RS_RET_GSS_SENDINIT_ERROR, "GSS-API Context initialization failed\n");
+	LogError(0, RS_RET_GSS_SENDINIT_ERROR, "GSS-API Context initialization failed\n");
 	gss_release_name(&min_stat, &target_name);
 	gss_release_buffer(&min_stat, &out_tok);
 	if (*context != GSS_C_NO_CONTEXT) {
@@ -536,7 +535,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 					++p; /* eat */
 					pData->compressionLevel = iLevel;
 				} else {
-					errmsg.LogError(0, NO_ERRCODE, "Invalid compression level '%c' specified in "
+					LogError(0, NO_ERRCODE, "Invalid compression level '%c' specified in "
 						 "forwardig action - NOT turning on compression.",
 						 *p);
 				}
@@ -545,7 +544,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 				/* no further options settable */
 				tcp_framing = TCP_FRAMING_OCTET_COUNTING;
 			} else { /* invalid option! Just skip it... */
-				errmsg.LogError(0, NO_ERRCODE, "Invalid option %c in forwarding action - "
+				LogError(0, NO_ERRCODE, "Invalid option %c in forwarding action - "
 					"ignoring.", *p);
 				++p; /* eat invalid option */
 			}
@@ -562,7 +561,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 			/* we probably have end of string - leave it for the rest
 			 * of the code to handle it (but warn the user)
 			 */
-			errmsg.LogError(0, NO_ERRCODE, "Option block not terminated in gssapi forward action.");
+			LogError(0, NO_ERRCODE, "Option block not terminated in gssapi forward action.");
 	}
 	/* extract the host first (we do a trick - we replace the ';' or ':' with a '\0')
 	 * now skip to port and then template name. rgerhards 2005-07-06
@@ -580,7 +579,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 			/* SKIP AND COUNT */;
 		pData->port = MALLOC(i + 1);
 		if(pData->port == NULL) {
-			errmsg.LogError(0, NO_ERRCODE, "Could not get memory to store syslog forwarding port, "
+			LogError(0, NO_ERRCODE, "Could not get memory to store syslog forwarding port, "
 				 "using default port, results may not be what you intend\n");
 			/* we leave f_forw.port set to NULL, this is then handled by
 			 * getFwdSyslogPt().
@@ -599,7 +598,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 			if(bErr == 0) { /* only 1 error msg! */
 				bErr = 1;
 				errno = 0;
-				errmsg.LogError(0, NO_ERRCODE, "invalid selector line (port), probably not doing "
+				LogError(0, NO_ERRCODE, "invalid selector line (port), probably not doing "
 					 "what was intended");
 			}
 		}
@@ -651,7 +650,6 @@ ENDparseSelectorAct
 BEGINmodExit
 CODESTARTmodExit
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(gssutil, LM_GSSUTIL_FILENAME);
 	objRelease(tcpclt, LM_TCPCLT_FILENAME);
 
@@ -681,7 +679,7 @@ static rsRetVal setGSSMode(void __attribute__((unused)) *pVal, uchar *mode)
 		cs.gss_mode = GSSMODE_ENC;
 		dbgprintf("GSS-API gssmode set to GSSMODE_ENC\n");
 	} else {
-		errmsg.LogError(0, RS_RET_INVALID_PARAMS, "unknown gssmode parameter: %s", (char *) mode);
+		LogError(0, RS_RET_INVALID_PARAMS, "unknown gssmode parameter: %s", (char *) mode);
 		iRet = RS_RET_INVALID_PARAMS;
 	}
 	free(mode);
@@ -705,7 +703,6 @@ BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(gssutil, LM_GSSUTIL_FILENAME));
 	CHKiRet(objUse(tcpclt, LM_TCPCLT_FILENAME));

--- a/plugins/omhdfs/omhdfs.c
+++ b/plugins/omhdfs/omhdfs.c
@@ -61,7 +61,6 @@ MODULE_TYPE_NOKEEP
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 
 /* global data */
 static struct hashtable *files;		/* holds all file objects that we know */
@@ -314,7 +313,7 @@ fileWrite(file_t *pFile, uchar *buf, size_t *lenWrite)
 
 	tSize num_written_bytes = hdfsWrite(pFile->fs, pFile->fh, buf, *lenWrite);
 	if((unsigned) num_written_bytes != *lenWrite) {
-		errmsg.LogError(errno, RS_RET_ERR_HDFS_WRITE,
+		LogError(errno, RS_RET_ERR_HDFS_WRITE,
 			        "omhdfs: failed to write %s, expected %lu bytes, "
 			        "written %lu\n", pFile->name, (unsigned long) *lenWrite,
 				(unsigned long) num_written_bytes);
@@ -471,7 +470,7 @@ CODESTARTparseSelectorAct
 				       (cs.dfltTplName == NULL) ? (uchar*)"RSYSLOG_FileFormat" : cs.dfltTplName));
 
 	if(cs.fileName == NULL) {
-		errmsg.LogError(0, RS_RET_ERR_HDFS_OPEN, "omhdfs: no file name specified, can not continue");
+		LogError(0, RS_RET_ERR_HDFS_OPEN, "omhdfs: no file name specified, can not continue");
 		ABORT_FINALIZE(RS_RET_FILE_NOT_SPECIFIED);
 	}
 
@@ -486,7 +485,7 @@ CODESTARTparseSelectorAct
 		pFile->hdfsPort = cs.hdfsPort;
 		fileOpen(pFile);
 		if(pFile->fh == NULL){
-			errmsg.LogError(0, RS_RET_ERR_HDFS_OPEN, "omhdfs: failed to open %s - "
+			LogError(0, RS_RET_ERR_HDFS_OPEN, "omhdfs: failed to open %s - "
 				    	"retrying later", pFile->name);
 			iRet = RS_RET_SUSPENDED;
 		}
@@ -538,7 +537,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 	if(files != NULL)
 		hashtable_destroy(files, 1); /* 1 => free all values automatically */
 ENDmodExit
@@ -558,7 +556,6 @@ BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKmalloc(files = create_hashtable(20, hash_from_string, key_equals_string,
 			                   fileObjDestruct4Hashtable));
 

--- a/plugins/omjournal/omjournal.c
+++ b/plugins/omjournal/omjournal.c
@@ -52,7 +52,6 @@ MODULE_TYPE_NOKEEP
 MODULE_CNFNAME("omjournal")
 
 
-DEFobjCurrIf(errmsg);
 DEF_OMOD_STATIC_DATA
 
 /* config variables */
@@ -301,7 +300,6 @@ ENDdoAction
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -322,5 +320,4 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
 	DBGPRINTF("omjournal: module compiled with rsyslog version %s.\n", VERSION);
-	iRet = objUse(errmsg, CORE_COMPONENT);
 ENDmodInit

--- a/plugins/ommail/ommail.c
+++ b/plugins/ommail/ommail.c
@@ -60,7 +60,6 @@ MODULE_CNFNAME("ommail")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(datetime)
 
@@ -794,11 +793,11 @@ CODESTARTparseSelectorAct
 	/* TODO: check strdup() result */
 
 	if(cs.pszFrom == NULL) {
-		errmsg.LogError(0, RS_RET_MAIL_NO_FROM, "no sender address given - specify $ActionMailFrom");
+		LogError(0, RS_RET_MAIL_NO_FROM, "no sender address given - specify $ActionMailFrom");
 		ABORT_FINALIZE(RS_RET_MAIL_NO_FROM);
 	}
 	if(cs.lstRcpt == NULL) {
-		errmsg.LogError(0, RS_RET_MAIL_NO_TO, "no recipient address given - specify $ActionMailTo");
+		LogError(0, RS_RET_MAIL_NO_TO, "no recipient address given - specify $ActionMailTo");
 		ABORT_FINALIZE(RS_RET_MAIL_NO_TO);
 	}
 
@@ -852,7 +851,6 @@ CODESTARTmodExit
 	/* release what we no longer need */
 	objRelease(datetime, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -882,7 +880,6 @@ INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	/* tell which objects we need */
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -69,7 +69,6 @@ MODULE_CNFNAME("ommongodb")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(datetime)
 
 typedef struct _instanceData {
@@ -187,7 +186,7 @@ static void
 reportMongoError(instanceData *pData)
 {
 	if(pData->bErrMsgPermitted) {
-		errmsg.LogError(0, RS_RET_ERR, "ommongodb: error: %s", pData->error.message);
+		LogError(0, RS_RET_ERR, "ommongodb: error: %s", pData->error.message);
 		pData->bErrMsgPermitted = 0;
 	}
 }
@@ -721,7 +720,6 @@ NO_LEGACY_CONF_parseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
 ENDmodExit
 
@@ -741,7 +739,6 @@ BEGINmodInit()
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 	INITChkCoreFeature(bCoreSupportsBatching, CORE_FEATURE_BATCHING);
 	DBGPRINTF("ommongodb: module compiled with rsyslog version %s.\n", VERSION);

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -54,7 +54,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 
 typedef struct _instanceData {
 	char	dbsrv[MAXHOSTNAMELEN+1];	/* IP or hostname of DB server*/ 
@@ -201,7 +200,7 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 	pData = pWrkrData->pData;
 	pWrkrData->hmysql = mysql_init(NULL);
 	if(pWrkrData->hmysql == NULL) {
-		errmsg.LogError(0, RS_RET_SUSPENDED, "can not initialize MySQL handle");
+		LogError(0, RS_RET_SUSPENDED, "can not initialize MySQL handle");
 		iRet = RS_RET_SUSPENDED;
 	} else { /* we could get the handle, now on with work... */
 		mysql_options(pWrkrData->hmysql,MYSQL_READ_DEFAULT_GROUP,
@@ -218,7 +217,7 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 					rs_strerror_r(err, errStr, sizeof(errStr));
 					dbgprintf("mysql configuration error(%d): %s - %s\n",err,msg,errStr);
 				} else
-					errmsg.LogError(err,NO_ERRCODE,"mysql configuration error: %s\n",msg);
+					LogError(err,NO_ERRCODE,"mysql configuration error: %s\n",msg);
 			} else {
 				fclose(fp);
 				mysql_options(pWrkrData->hmysql,MYSQL_READ_DEFAULT_FILE,pData->configfile);
@@ -488,7 +487,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	 * Retries make no sense. 
 	 */
 	if (iMySQLPropErr) { 
-		errmsg.LogError(0, RS_RET_INVALID_PARAMS, "Trouble with MySQL connection properties. "
+		LogError(0, RS_RET_INVALID_PARAMS, "Trouble with MySQL connection properties. "
 				"-MySQL logging disabled");
 		ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
 	} else {
@@ -538,10 +537,9 @@ CODESTARTmodInit
 INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	INITChkCoreFeature(bCoreSupportsBatching, CORE_FEATURE_BATCHING);
 	if(!bCoreSupportsBatching) {	
-		errmsg.LogError(0, NO_ERRCODE, "ommysql: rsyslog core too old");
+		LogError(0, NO_ERRCODE, "ommysql: rsyslog core too old");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 
@@ -553,7 +551,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	   mysql_server_init(0, NULL, NULL)
 #	endif
 	                                   ) {
-		errmsg.LogError(0, NO_ERRCODE, "ommysql: intializing mysql client failed, plugin "
+		LogError(0, NO_ERRCODE, "ommysql: intializing mysql client failed, plugin "
 		                "can not run");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -57,7 +57,6 @@ MODULE_CNFNAME("ompgsql")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 
 typedef struct _instanceData {
 	char            srv[MAXHOSTNAMELEN+1];   /* IP or hostname of DB server*/ 
@@ -169,7 +168,7 @@ static void reportDBError(wrkrInstanceData_t *pWrkrData, int bSilent)
 	/* output log message */
 	errno = 0;
 	if (pWrkrData->f_hpgsql == NULL) {
-		errmsg.LogError(0, NO_ERRCODE, "unknown DB error occured - could not obtain PgSQL handle");
+		LogError(0, NO_ERRCODE, "unknown DB error occured - could not obtain PgSQL handle");
 	} else { /* we can ask pgsql for the error description... */
 		ePgSQLStatus = PQstatus(pWrkrData->f_hpgsql);
 		snprintf(errMsg, sizeof(errMsg), "db error (%d): %s\n", ePgSQLStatus,
@@ -178,7 +177,7 @@ static void reportDBError(wrkrInstanceData_t *pWrkrData, int bSilent)
 			dbgprintf("pgsql, DBError(silent): %s\n", errMsg);
 		else {
 			pWrkrData->eLastPgSQLStatus = ePgSQLStatus;
-			errmsg.LogError(0, NO_ERRCODE, "%s", errMsg);
+			LogError(0, NO_ERRCODE, "%s", errMsg);
 		}
 	}
 
@@ -507,7 +506,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	 * Retries make no sense. 
 	 */
 	if (iPgSQLPropErr) {
-		errmsg.LogError(0, RS_RET_INVALID_PARAMS, "Trouble with PgSQL connection properties. "
+		LogError(0, RS_RET_INVALID_PARAMS, "Trouble with PgSQL connection properties. "
 				"-PgSQL logging disabled");
 		ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
 	}
@@ -534,10 +533,9 @@ CODESTARTmodInit
 INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	INITChkCoreFeature(bCoreSupportsBatching, CORE_FEATURE_BATCHING);
 	if (!bCoreSupportsBatching) {
-		errmsg.LogError(0, NO_ERRCODE, "ompgsql: rsyslog core too old");
+		LogError(0, NO_ERRCODE, "ompgsql: rsyslog core too old");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 ENDmodInit

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -65,7 +65,6 @@ MODULE_CNFNAME("omrelp")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 
 #define DFLT_ENABLE_TLS 0
@@ -183,7 +182,7 @@ static void
 onErr(void *pUsr, char *objinfo, char* errmesg, __attribute__((unused)) relpRetVal errcode)
 {
 	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t*) pUsr;
-	errmsg.LogError(0, RS_RET_RELP_AUTH_FAIL, "omrelp[%s:%s]: error '%s', object "
+	LogError(0, RS_RET_RELP_AUTH_FAIL, "omrelp[%s:%s]: error '%s', object "
 			" '%s' - action may not work as intended",
 			pWrkrData->pData->target, pWrkrData->pData->port, errmesg, objinfo);
 }
@@ -191,7 +190,7 @@ onErr(void *pUsr, char *objinfo, char* errmesg, __attribute__((unused)) relpRetV
 static void
 onGenericErr(char *objinfo, char* errmesg, __attribute__((unused)) relpRetVal errcode)
 {
-	errmsg.LogError(0, RS_RET_RELP_ERR, "omrelp: librelp error '%s', object "
+	LogError(0, RS_RET_RELP_ERR, "omrelp: librelp error '%s', object "
 			"'%s' - action may not work as intended",
 			errmesg, objinfo);
 }
@@ -200,7 +199,7 @@ static void
 onAuthErr(void *pUsr, char *authinfo, char* errmesg, __attribute__((unused)) relpRetVal errcode)
 {
 	instanceData *pData = ((wrkrInstanceData_t*) pUsr)->pData;
-	errmsg.LogError(0, RS_RET_RELP_AUTH_FAIL, "omrelp[%s:%s]: authentication error '%s', peer "
+	LogError(0, RS_RET_RELP_AUTH_FAIL, "omrelp[%s:%s]: authentication error '%s', peer "
 			"is '%s' - DISABLING action", pData->target, pData->port, errmesg, authinfo);
 	pData->bHadAuthFail = 1;
 }
@@ -234,7 +233,7 @@ doCreateRelpClient(wrkrInstanceData_t *pWrkrData)
 		if(relpCltSetGnuTLSPriString(pWrkrData->pRelpClt, (char*) pData->pristring) != RELP_RET_OK)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 		if(relpCltSetAuthMode(pWrkrData->pRelpClt, (char*) pData->authmode) != RELP_RET_OK) {
-			errmsg.LogError(0, RS_RET_RELP_ERR,
+			LogError(0, RS_RET_RELP_ERR,
 					"omrelp: invalid auth mode '%s'\n", pData->authmode);
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 		}
@@ -376,7 +375,7 @@ CODESTARTnewActInst
 			if(fp == NULL) {
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 				"error: certificate file %s couldn't be accessed: %s\n",
 				pData->caCertFile, errStr);
 			} else {
@@ -388,7 +387,7 @@ CODESTARTnewActInst
 			if(fp == NULL) {
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 				"error: certificate file %s couldn't be accessed: %s\n",
 				pData->myCertFile, errStr);
 			} else {
@@ -400,7 +399,7 @@ CODESTARTnewActInst
 			if(fp == NULL) {
 				char errStr[1024];
 				rs_strerror_r(errno, errStr, sizeof(errStr));
-				errmsg.LogError(0, RS_RET_NO_FILE_ACCESS,
+				LogError(0, RS_RET_NO_FILE_ACCESS,
 				"error: certificate file %s couldn't be accessed: %s\n",
 				pData->myPrivKeyFile, errStr);
 			} else {
@@ -411,7 +410,7 @@ CODESTARTnewActInst
 			if(!strcmp(authMode, "name") || !strcmp(authMode, "fingerprint")) {
 				pData->authmode = (uchar*)authMode;
 			} else {
-				errmsg.LogError(0, RS_RET_INVALID_PARAMS,
+				LogError(0, RS_RET_INVALID_PARAMS,
 						"omrelp error: invalid authmode: %s\n",
 						authMode);
 			}
@@ -478,12 +477,12 @@ doConnect(wrkrInstanceData_t *const pWrkrData)
 	if(iRet == RELP_RET_OK) {
 		pWrkrData->bIsConnected = 1;
 	} else if(iRet == RELP_RET_ERR_NO_TLS) {
-		errmsg.LogError(0, iRet, "omrelp: Could not connect, librelp does NOT "
+		LogError(0, iRet, "omrelp: Could not connect, librelp does NOT "
 				"does not support TLS (most probably GnuTLS lib "
 				"is too old)!");
 		FINALIZE;
 	} else if(iRet == RELP_RET_ERR_NO_TLS_AUTH) {
-		errmsg.LogError(0, iRet,
+		LogError(0, iRet,
 				"omrelp: could not activate relp TLS with "
 				"authentication, librelp does not support it "
 				"(most probably GnuTLS lib is too old)! "
@@ -626,7 +625,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 			/* SKIP AND COUNT */;
 		pData->port = MALLOC(i + 1);
 		if(pData->port == NULL) {
-			errmsg.LogError(0, NO_ERRCODE, "Could not get memory to store relp port, "
+			LogError(0, NO_ERRCODE, "Could not get memory to store relp port, "
 				 "using default port, results may not be what you intend\n");
 			/* we leave f_forw.port set to NULL, this is then handled by getRelpPt() */
 		} else {
@@ -642,7 +641,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 			if(bErr == 0) { /* only 1 error msg! */
 				bErr = 1;
 				errno = 0;
-				errmsg.LogError(0, NO_ERRCODE, "invalid selector line (port), probably not doing "
+				LogError(0, NO_ERRCODE, "invalid selector line (port), probably not doing "
 					 "what was intended");
 			}
 		}
@@ -670,7 +669,6 @@ CODESTARTmodExit
 
 	/* release what we no longer need */
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -699,6 +697,5 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(relpEngineSetEnableCmd(pRelpEngine, (uchar*) "syslog", eRelpCmdState_Required));
 
 	/* tell which objects we need */
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 ENDmodInit

--- a/plugins/omruleset/omruleset.c
+++ b/plugins/omruleset/omruleset.c
@@ -55,7 +55,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 
 /* static data */
 DEFobjCurrIf(ruleset);
-DEFobjCurrIf(errmsg);
 
 /* internal structures
  */
@@ -151,7 +150,7 @@ setRuleset(void __attribute__((unused)) *pVal, uchar *pszName)
 
 	localRet = ruleset.GetRuleset(ourConf, &cs.pRuleset, pszName);
 	if(localRet == RS_RET_NOT_FOUND) {
-		errmsg.LogError(0, RS_RET_RULESET_NOT_FOUND, "error: ruleset '%s' not found - ignored", pszName);
+		LogError(0, RS_RET_RULESET_NOT_FOUND, "error: ruleset '%s' not found - ignored", pszName);
 	}
 	CHKiRet(localRet);
 	cs.pszRulesetName = pszName; /* save for later display purposes */
@@ -174,7 +173,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	}
 
 	if(cs.pRuleset == NULL) {
-		errmsg.LogError(0, RS_RET_NO_RULESET, "error: no ruleset was specified, use "
+		LogError(0, RS_RET_NO_RULESET, "error: no ruleset was specified, use "
 				"$ActionOmrulesetRulesetName directive first!");
 		ABORT_FINALIZE(RS_RET_NO_RULESET);
 	}
@@ -183,7 +182,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	p += sizeof(":omruleset:") - 1; /* eat indicator sequence  (-1 because of '\0'!) */
 	CHKiRet(createInstance(&pData));
 
-	errmsg.LogMsg(0, RS_RET_DEPRECATED, LOG_WARNING,
+	LogMsg(0, RS_RET_DEPRECATED, LOG_WARNING,
 			"warning: omruleset is deprecated, consider "
 			"using the 'call' statement instead");
 
@@ -208,7 +207,6 @@ ENDparseSelectorAct
 BEGINmodExit
 CODESTARTmodExit
 	free(cs.pszRulesetName);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(ruleset, CORE_COMPONENT);
 ENDmodExit
 
@@ -261,9 +259,8 @@ CODEmodInit_QueryRegCFSLineHdlr
 	}
 
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
-	errmsg.LogMsg(0, RS_RET_DEPRECATED, LOG_WARNING,
+	LogMsg(0, RS_RET_DEPRECATED, LOG_WARNING,
 			"warning: omruleset is deprecated, consider "
 			"using the 'call' statement instead");
 

--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -50,7 +50,6 @@ MODULE_CNFNAME("omsnmp")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 
 /* Default static snmp OID's */
 /*unused 
@@ -237,7 +236,7 @@ omsnmp_initSession(wrkrInstanceData_t *pWrkrData)
 
 	pWrkrData->snmpsession = snmp_open(&session);
 	if (pWrkrData->snmpsession == NULL) {
-		errmsg.LogError(0, RS_RET_SUSPENDED, "omsnmp_initSession: snmp_open to host '%s' on Port '%d' "
+		LogError(0, RS_RET_SUSPENDED, "omsnmp_initSession: snmp_open to host '%s' on Port '%d' "
 		"failed\n", pData->szTarget, pData->iPort);
 		/* Stay suspended */
 		iRet = RS_RET_SUSPENDED;
@@ -279,7 +278,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 		if(!snmp_parse_oid(pData->szEnterpriseOID == NULL ? "1.3.6.1.4.1.3.1.1" :
 			(char*)pData->szEnterpriseOID, enterpriseoid, &enterpriseoidlen )) {
 			strErr = snmp_api_errstring(snmp_errno);
-			errmsg.LogError(0, RS_RET_DISABLE_ACTION, "omsnmp_sendsnmp: Parsing EnterpriseOID "
+			LogError(0, RS_RET_DISABLE_ACTION, "omsnmp_sendsnmp: Parsing EnterpriseOID "
 					"failed '%s' with error '%s' \n", pData->szSyslogMessageOID, strErr);
 			ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
 		}
@@ -316,7 +315,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 			pData->szSnmpTrapOID == NULL ?  "1.3.6.1.4.1.19406.1.2.1" : (char*) pData->szSnmpTrapOID
 			) != 0) {
 			strErr = snmp_api_errstring(snmp_errno);
-			errmsg.LogError(0, RS_RET_DISABLE_ACTION, "omsnmp_sendsnmp: Adding trap OID failed '%s' "
+			LogError(0, RS_RET_DISABLE_ACTION, "omsnmp_sendsnmp: Adding trap OID failed '%s' "
 			"with error '%s' \n", pData->szSnmpTrapOID, strErr);
 			ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
 		}
@@ -332,13 +331,13 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 		int iErrCode = snmp_add_var(pdu, oidSyslogMessage, oLen, 's', (char*) psz);
 		if (iErrCode) {
 			const char *str = snmp_api_errstring(iErrCode);
-			errmsg.LogError(0, RS_RET_DISABLE_ACTION,  "omsnmp_sendsnmp: Invalid SyslogMessage OID, "
+			LogError(0, RS_RET_DISABLE_ACTION,  "omsnmp_sendsnmp: Invalid SyslogMessage OID, "
 			"error code '%d' - '%s'\n", iErrCode, str );
 			ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
 		}
 	} else {
 		strErr = snmp_api_errstring(snmp_errno);
-		errmsg.LogError(0, RS_RET_DISABLE_ACTION, "omsnmp_sendsnmp: Parsing SyslogMessageOID failed '%s' "
+		LogError(0, RS_RET_DISABLE_ACTION, "omsnmp_sendsnmp: Parsing SyslogMessageOID failed '%s' "
 		"with error '%s' \n", pData->szSyslogMessageOID, strErr);
 
 		ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
@@ -350,7 +349,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 	{
 		/* Debug Output! */
 		int iErrorCode = pWrkrData->snmpsession->s_snmp_errno;
-		errmsg.LogError(0, RS_RET_SUSPENDED,  "omsnmp_sendsnmp: snmp_send failed error '%d', "
+		LogError(0, RS_RET_SUSPENDED,  "omsnmp_sendsnmp: snmp_send failed error '%d', "
 		"Description='%s'\n", iErrorCode*(-1), api_errors[iErrorCode*(-1)]);
 
 		/* Clear Session */
@@ -572,7 +571,6 @@ CODESTARTmodExit
 	free(cs.pszSyslogMessageOID);
 
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -590,7 +588,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	initConfVars();
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmptransport", 0, eCmdHdlrGetWord, NULL, &cs.pszTransport,
 	STD_LOADABLE_MODULE_ID));

--- a/plugins/omstdout/omstdout.c
+++ b/plugins/omstdout/omstdout.c
@@ -49,7 +49,6 @@ MODULE_CNFNAME("omstdout")
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unused)) *pVal);
 
 /* static data */
-DEFobjCurrIf(errmsg);
 
 /* internal structures
  */
@@ -246,7 +245,7 @@ CODESTARTnewActInst
 	bDestructPValsOnExit = 0;
 	pvals = nvlstGetParams(lst, &actpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "omstdout: error reading "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "omstdout: error reading "
 				"config parameters");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -311,7 +310,6 @@ ENDparseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -364,7 +362,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 		CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionomstdoutarrayinterface", 0, eCmdHdlrBinary, NULL,
 			                   &cs.bUseArrayInterface, STD_LOADABLE_MODULE_ID));
 	}
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionomstdoutensurelfending", 0, eCmdHdlrBinary, NULL,
 				   &cs.bEnsureLFEnding, STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler,

--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -85,7 +85,6 @@ MODULE_CNFNAME("omudpspoof")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(net)
 
@@ -204,7 +203,7 @@ setLegacyDfltTpl(void __attribute__((unused)) *pVal, uchar* newVal)
 
 	if(loadModConf != NULL && loadModConf->tplName != NULL) {
 		free(newVal);
-		errmsg.LogError(0, RS_RET_ERR, "omudpspoof default template already set via module "
+		LogError(0, RS_RET_ERR, "omudpspoof default template already set via module "
 			"global parameter - can no longer be changed");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
@@ -255,7 +254,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -271,7 +270,7 @@ CODESTARTsetModCnf
 		if(!strcmp(modpblk.descr[i].name, "template")) {
 			loadModConf->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 			if(cs.tplName != NULL) {
-				errmsg.LogError(0, RS_RET_DUP_PARAM, "omudpspoof: warning: default template "
+				LogError(0, RS_RET_DUP_PARAM, "omudpspoof: warning: default template "
 						"was already set via legacy directive - may lead to inconsistent "
 						"results.");
 			}
@@ -556,7 +555,7 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 
 		if(pWrkrData->libnet_handle == NULL) {
 			if(pData->bReportLibnetInitErr) {
-				errmsg.LogError(0, RS_RET_ERR_LIBNET_INIT, "omudpsoof: error "
+				LogError(0, RS_RET_ERR_LIBNET_INIT, "omudpsoof: error "
 				                "initializing libnet - are you running as root?");
 				pData->bReportLibnetInitErr = 0;
 			}
@@ -643,7 +642,7 @@ CODESTARTnewActInst
 
 	pvals = nvlstGetParams(lst, &actpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "omudpspoof: mandatory "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "omudpspoof: mandatory "
 		                "parameters missing");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -707,7 +706,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(2)
 						    : cs.pszSourceNameTemplate;
 
 	if(cs.pszTargetHost == NULL) {
-		errmsg.LogError(0, NO_ERRCODE, "No $ActionOMUDPSpoofTargetHost given, can not continue "
+		LogError(0, NO_ERRCODE, "No $ActionOMUDPSpoofTargetHost given, can not continue "
 			"with this action.");
 		ABORT_FINALIZE(RS_RET_HOST_NOT_SPECIFIED);
 	}
@@ -750,7 +749,6 @@ CODESTARTmodExit
 	/* destroy the libnet state needed for forged UDP sources */
 	pthread_mutex_destroy(&mutLibnet);
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(net, LM_NET_FILENAME);
 	freeConfigVars();
@@ -786,7 +784,6 @@ INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(net,LM_NET_FILENAME));
 
 	pthread_mutex_init(&mutLibnet, NULL);

--- a/plugins/omuxsock/omuxsock.c
+++ b/plugins/omuxsock/omuxsock.c
@@ -51,7 +51,6 @@ MODULE_CNFNAME("omuxsock")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 
 #define INVLD_SOCK -1
@@ -133,7 +132,7 @@ setLegacyDfltTpl(void __attribute__((unused)) *pVal, uchar* newVal)
 
 	if(loadModConf != NULL && loadModConf->tplName != NULL) {
 		free(newVal);
-		errmsg.LogError(0, RS_RET_ERR, "omuxsock default template already set via module "
+		LogError(0, RS_RET_ERR, "omuxsock default template already set via module "
 			"global parameter - can no longer be changed");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
@@ -171,7 +170,7 @@ BEGINsetModCnf
 CODESTARTsetModCnf
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
 	if(pvals == NULL) {
-		errmsg.LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing module "
 				"config parameters [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
@@ -187,7 +186,7 @@ CODESTARTsetModCnf
 		if(!strcmp(modpblk.descr[i].name, "template")) {
 			loadModConf->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 			if(cs.tplName != NULL) {
-				errmsg.LogError(0, RS_RET_DUP_PARAM, "omuxsock: default template "
+				LogError(0, RS_RET_DUP_PARAM, "omuxsock: default template "
 						"was already set via legacy directive - may lead to inconsistent "
 						"results.");
 			}
@@ -385,7 +384,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	CHKiRet(cflineParseTemplateName(&p, *ppOMSR, 0, 0, getDfltTpl()));
 	
 	if(cs.sockName == NULL) {
-		errmsg.LogError(0, RS_RET_NO_SOCK_CONFIGURED, "No output socket configured for omuxsock\n");
+		LogError(0, RS_RET_NO_SOCK_CONFIGURED, "No output socket configured for omuxsock\n");
 		ABORT_FINALIZE(RS_RET_NO_SOCK_CONFIGURED);
 	}
 
@@ -412,7 +411,6 @@ freeConfigVars(void)
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 
 	freeConfigVars();
@@ -444,7 +442,6 @@ INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
 	CHKiRet(regCfSysLineHdlr((uchar *)"omuxsockdefaulttemplate", 0, eCmdHdlrGetWord, setLegacyDfltTpl,
 		NULL, NULL));

--- a/plugins/pmciscoios/pmciscoios.c
+++ b/plugins/pmciscoios/pmciscoios.c
@@ -46,7 +46,6 @@ MODULE_CNFNAME("pmciscoios")
 
 /* internal structures */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -270,7 +269,6 @@ ENDparse2
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -289,7 +287,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/plugins/pmlastmsg/pmlastmsg.c
+++ b/plugins/pmlastmsg/pmlastmsg.c
@@ -52,7 +52,6 @@ PARSER_NAME("rsyslog.lastline")
 /* internal structures
  */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -137,7 +136,6 @@ ENDparse
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -156,7 +154,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/plugins/pmnormalize/pmnormalize.c
+++ b/plugins/pmnormalize/pmnormalize.c
@@ -48,7 +48,6 @@ MODULE_CNFNAME("pmnormalize")
 
 /* internal structures */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -105,7 +104,7 @@ static void
 errCallBack(void __attribute__((unused)) *cookie, const char *msg,
 	    size_t __attribute__((unused)) lenMsg)
 {
-	errmsg.LogError(0, RS_RET_ERR_LIBLOGNORM, "liblognorm error: %s", msg);
+	LogError(0, RS_RET_ERR_LIBLOGNORM, "liblognorm error: %s", msg);
 }
 
 /* to be called to build the liblognorm part of the instance ONCE ALL PARAMETERS ARE CORRECT
@@ -116,7 +115,7 @@ buildInstance(instanceConf_t *inst)
 {
 	DEFiRet;
 	if((inst->ctxln = ln_initCtx()) == NULL) {
-		errmsg.LogError(0, RS_RET_ERR_LIBLOGNORM_INIT, "error: could not initialize "
+		LogError(0, RS_RET_ERR_LIBLOGNORM_INIT, "error: could not initialize "
 				"liblognorm ctx, cannot activate action");
 		ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_INIT);
 	}
@@ -124,7 +123,7 @@ buildInstance(instanceConf_t *inst)
 
 	if(inst->rule != NULL && inst->rulebase == NULL) {
 		if(ln_loadSamplesFromString(inst->ctxln, inst->rule) !=0) {
-			errmsg.LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
+			LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
 					"could not be loaded cannot activate action", inst->rulebase);
 			ln_exitCtx(inst->ctxln);
 			ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_SAMPDB_LOAD);
@@ -133,7 +132,7 @@ buildInstance(instanceConf_t *inst)
 		inst->rule = NULL;
 	} else if(inst->rulebase != NULL && inst->rule == NULL) {
 		if(ln_loadSamples(inst->ctxln, (char*) inst->rulebase) != 0) {
-			errmsg.LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
+			LogError(0, RS_RET_NO_RULEBASE, "error: normalization rulebase '%s' "
 					"could not be loaded cannot activate action", inst->rulebase);
 			ln_exitCtx(inst->ctxln);
 			ABORT_FINALIZE(RS_RET_ERR_LIBLOGNORM_SAMPDB_LOAD);
@@ -193,11 +192,11 @@ CODESTARTnewParserInst
                 }
 	}
 	if(!inst->rulebase && !inst->rule) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR, "pmnormalize: rulebase needed. "
+		LogError(0, RS_RET_CONFIG_ERROR, "pmnormalize: rulebase needed. "
 				"Use option rulebase or rule.");
 	}
 	if(inst->rulebase && inst->rule) {
-		errmsg.LogError(0, RS_RET_CONFIG_ERROR, "pmnormalize: only one rulebase "
+		LogError(0, RS_RET_CONFIG_ERROR, "pmnormalize: only one rulebase "
 				"possible, rulebase can't be used with rule");
 	}
 
@@ -226,7 +225,7 @@ CODESTARTparse2
 	if(r != 0) {
 		DBGPRINTF("error %d during ln_normalize\n", r);
 		if(pInst->undefPropErr) {
-			errmsg.LogError(0, RS_RET_ERR, "error %d during ln_normalize; "
+			LogError(0, RS_RET_ERR, "error %d during ln_normalize; "
 					"json: %s\n", r, fjson_object_to_json_string(json));
 		}
 	} else {
@@ -239,7 +238,6 @@ ENDparse2
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -258,7 +256,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/plugins/pmnull/pmnull.c
+++ b/plugins/pmnull/pmnull.c
@@ -46,7 +46,6 @@ MODULE_CNFNAME("pmnull")
 
 /* internal structures */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -163,7 +162,6 @@ ENDparse2
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -182,7 +180,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -43,7 +43,6 @@ MODULE_TYPE_NOKEEP
 
 /* static data */
 DEFobjStaticHelpers
-//DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(netstrm)
 

--- a/runtime/prop.c
+++ b/runtime/prop.c
@@ -242,7 +242,6 @@ ENDobjQueryInterface(prop)
  * rgerhards, 2009-04-06
  */
 BEGINObjClassExit(prop, OBJ_IS_CORE_MODULE) /* class, version */
-//	objRelease(errmsg, CORE_COMPONENT);
 ENDObjClassExit(prop)
 
 
@@ -252,7 +251,6 @@ ENDObjClassExit(prop)
  */
 BEGINObjClassInit(prop, 1, OBJ_IS_CORE_MODULE) /* class, version */
 	/* request objects we use */
-//	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 
 	/* set our own handlers */
 	OBJSetMethodHandler(objMethod_DEBUGPRINT, propDebugPrint);

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -37,7 +37,6 @@
 
 /* definitions for objects we access */
 DEFobjStaticHelpers
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(datetime)
 DEFobjCurrIf(parser)
@@ -398,7 +397,6 @@ ratelimitModExit(void)
 {
 	objRelease(datetime, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 }
 
@@ -409,7 +407,6 @@ ratelimitModInit(void)
 	CHKiRet(objGetObjInterface(&obj));
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 finalize_it:
 	RETiRet;

--- a/runtime/strgen.c
+++ b/runtime/strgen.c
@@ -43,7 +43,6 @@
 /* definitions for objects we access */
 DEFobjStaticHelpers
 DEFobjCurrIf(glbl)
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(ruleset)
 
 /* static data */
@@ -262,7 +261,6 @@ destroyMasterStrgenList(void)
 BEGINObjClassExit(strgen, OBJ_IS_CORE_MODULE) /* class, version */
 	destroyMasterStrgenList();
 	objRelease(glbl, CORE_COMPONENT);
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(ruleset, CORE_COMPONENT);
 ENDObjClassExit(strgen)
 
@@ -274,7 +272,6 @@ ENDObjClassExit(strgen)
 BEGINObjClassInit(strgen, 1, OBJ_IS_CORE_MODULE) /* class, version */
 	/* request objects we use */
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 	InitStrgenList(&pStrgenLstRoot);
 ENDObjClassInit(strgen)

--- a/runtime/strms_sess.c
+++ b/runtime/strms_sess.c
@@ -46,7 +46,6 @@
 DEFobjStaticHelpers
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(prop)
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(netstrm)
 DEFobjCurrIf(datetime)
 
@@ -273,7 +272,6 @@ ENDobjQueryInterface(strms_sess)
 BEGINObjClassExit(strms_sess, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in END MACRO! */
 CODESTARTObjClassExit(strms_sess)
 	/* release objects we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(netstrm, LM_NETSTRMS_FILENAME);
 	objRelease(datetime, CORE_COMPONENT);
 ENDObjClassExit(strms_sess)
@@ -285,7 +283,6 @@ ENDObjClassExit(strms_sess)
  */
 BEGINObjClassInit(strms_sess, 1, OBJ_IS_CORE_MODULE) /* class, version - CHANGE class also in END MACRO! */
 	/* request objects we use */
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(netstrm, LM_NETSTRMS_FILENAME));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 	CHKiRet(objUse(prop, CORE_COMPONENT));

--- a/tools/omdiscard.c
+++ b/tools/omdiscard.c
@@ -43,7 +43,6 @@ MODULE_TYPE_NOKEEP
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg);
 
 typedef struct _instanceData {
 	EMPTY_STRUCT
@@ -110,7 +109,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(0)
 
 	if(*p == '~') {
 		dbgprintf("discard\n");
-		errmsg.LogMsg(0, RS_RET_DEPRECATED, LOG_WARNING,
+		LogMsg(0, RS_RET_DEPRECATED, LOG_WARNING,
 			"warning: ~ action is deprecated, consider "
 			"using the 'stop' statement instead");
 	} else {
@@ -139,7 +138,6 @@ ENDparseSelectorAct
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -154,7 +152,6 @@ BEGINmodInit(Discard)
 CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 ENDmodInit
 /*
  * vi:set ai:

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -82,7 +82,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(strm)
 DEFobjCurrIf(statsobj)
 
@@ -1519,7 +1518,6 @@ ENDdoHUP
 
 BEGINmodExit
 CODESTARTmodExit
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(strm, CORE_COMPONENT);
 	objRelease(statsobj, CORE_COMPONENT);
 	DESTROY_ATOMIC_HELPER_MUT(mutClock);
@@ -1542,7 +1540,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 INITLegCnfVars
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(strm, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
 

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -65,7 +65,6 @@ MODULE_CNFNAME("omfwd")
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(net)
 DEFobjCurrIf(netstrms)
@@ -1509,7 +1508,6 @@ freeConfigVars(void)
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(net, LM_NET_FILENAME);
 	objRelease(netstrm, LM_NETSTRMS_FILENAME);
@@ -1556,7 +1554,6 @@ INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(net,LM_NET_FILENAME));
 
 	CHKiRet(regCfSysLineHdlr((uchar *)"actionforwarddefaulttemplate", 0, eCmdHdlrGetWord,

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -50,7 +50,6 @@ MODULE_CNFNAME("pmrfc3164")
 /* internal structures
  */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -386,7 +385,6 @@ ENDparse2
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -406,7 +404,6 @@ CODESTARTmodInit
 	/* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 

--- a/tools/pmrfc5424.c
+++ b/tools/pmrfc5424.c
@@ -51,7 +51,6 @@ PARSER_NAME("rsyslog.rfc5424")
 /* internal structures
  */
 DEF_PMOD_STATIC_DATA
-DEFobjCurrIf(errmsg)
 DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(datetime)
@@ -303,7 +302,6 @@ ENDparse
 BEGINmodExit
 CODESTARTmodExit
 	/* release what we no longer need */
-	objRelease(errmsg, CORE_COMPONENT);
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(datetime, CORE_COMPONENT);
@@ -322,7 +320,6 @@ CODESTARTmodInit
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	CHKiRet(objUse(errmsg, CORE_COMPONENT));
 	CHKiRet(objUse(parser, CORE_COMPONENT));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 


### PR DESCRIPTION
old interface still needs to be removed to fully finish
refactoring of this component.

see also https://github.com/rsyslog/rsyslog/issues/1684

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
