### PR TITLE
add --enable-default-tests ./configure option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
        services:
          - mysql
          - postgresql
-       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", GROK="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench2"
+       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", GROK="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-default-tests --disable-elasticsearch --disable-impstats --disable-imfile --disable-imptcp --disable-gnutls -disable-openssl --disable-relp --disable-pmsnare --disable-pmlastmsg"
        dist: trusty
 
 #     - os: linux
@@ -79,7 +79,7 @@ matrix:
 #       services:
 #         - mysql
 #         - postgresql
-#       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-testbench2"
+#       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=travis/trusty.supp --gen-suppressions=all", EXTRA_CONFIGURE="--disable-default-tests"
 #       dist: trusty
 
      - os: osx

--- a/configure.ac
+++ b/configure.ac
@@ -1470,7 +1470,7 @@ AC_ARG_ENABLE(testbench,
 # on some platforms. This provides the ability to turn it off. In the
 # longer term, we should consider writing our own replacement.
 AC_ARG_ENABLE(libfaketime,
-        [AS_HELP_STRING([--enable-libfaketime],[testbench1 enabled @<:@default=no@:>@])],
+        [AS_HELP_STRING([--enable-libfaketime],[libfaketime enabled @<:@default=no@:>@])],
         [case "${enableval}" in
          yes) enable_libfaketime="yes" ;;
           no) enable_libfaketime="no" ;;
@@ -1478,36 +1478,24 @@ AC_ARG_ENABLE(libfaketime,
          esac],
         [enable_libfaketime=no]
 )
-
-# under Travis, we have a ~50 minute max runtime per VM. So we permit to
-# split the testbench in multiple runs, which we can place into different
-# VMs. It's not perfect, but it works...
-AC_ARG_ENABLE(testbench1,
-        [AS_HELP_STRING([--enable-testbench1],[testbench1 enabled @<:@default=yes@:>@])],
-        [case "${enableval}" in
-         yes) enable_testbench1="yes" ;;
-          no) enable_testbench1="no" ;;
-           *) AC_MSG_ERROR(bad value ${enableval} for --enable-testbench1) ;;
-         esac],
-        [enable_testbench1=yes]
-)
 AM_CONDITIONAL(ENABLE_LIBFAKETIME, test "x${enable_libfaketime}" = "xyes")
 
-# under Travis, we have a ~50 minute max runtime per VM. So we permit to
-# split the testbench in multiple runs, which we can place into different
-# VMs. It's not perfect, but it works...
-AC_ARG_ENABLE(testbench2,
-        [AS_HELP_STRING([--enable-testbench2],[testbench2 enabled @<:@default=yes@:>@])],
+# this permits to control the "default tests" in testbench runs. These
+# are those tests that do not need a special configure option. There are
+# some situations where we really want to turn them of so that we can
+# run tests only for a specific component (e.g. ElasticSearch).
+# This also enables us to do some parallel testing even while the
+# testbench is not yet able to support make -j check
+AC_ARG_ENABLE(default-tests,
+        [AS_HELP_STRING([--enable-default-tests],[default-tests enabled @<:@default=yes@:>@])],
         [case "${enableval}" in
-         yes) enable_testbench2="yes" ;;
-          no) enable_testbench2="no" ;;
-           *) AC_MSG_ERROR(bad value ${enableval} for --enable-testbench2) ;;
+         yes) enable_default_tests="yes" ;;
+          no) enable_default_tests="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-default-tests) ;;
          esac],
-        [enable_testbench2=yes]
+        [enable_default_tests=yes]
 )
-
-AM_CONDITIONAL(ENABLE_TESTBENCH1, test "x${enable_testbench1}" = "xyes")
-AM_CONDITIONAL(ENABLE_TESTBENCH2, test "x${enable_testbench2}" = "xyes")
+AM_CONDITIONAL(ENABLE_DEFAULT_TESTS, test "x${enable_default_tests}" = "xyes")
 
 AC_CHECK_PROG(IP, [ip], [yes], [no])
 if test "x${IP}" = "xno"; then
@@ -2446,8 +2434,7 @@ echo
 echo "---{ debugging support }---"
 echo "    distcheck workaround enabled:             $enable_distcheck_workaround"
 echo "    Testbench enabled:                        $enable_testbench"
-echo "    Testbench1 enabled:                       $enable_testbench1"
-echo "    Testbench2 enabled:                       $enable_testbench2"
+echo "    Default tests enabled:                    $enable_default_tests"
 echo "    Testbench libfaketime tests enabled:      $enable_libfaketime"
 echo "    Extended Testbench enabled:               $enable_extended_tests"
 echo "    MySQL Tests enabled:                      $enable_mysql_tests"
@@ -2458,6 +2445,5 @@ echo "    Debug mode enabled:                       $enable_debug"
 echo "    (total) debugless mode enabled:           $enable_debugless"
 echo "    Diagnostic tools enabled:                 $enable_diagtools"
 echo "    End-User tools enabled:                   $enable_usertools"
-echo "    Enhanced memory checking enabled:         $enable_memcheck"
 echo "    Valgrind support settings enabled:        $enable_valgrind"
 echo

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -34,11 +34,9 @@ endif
 TESTS = $(TESTRUNS)
 #TESTS = $(TESTRUNS) cfg.sh
 
+if ENABLE_DEFAULT_TESTS
 TESTS +=  \
-	empty-hostname.sh
-
-if ENABLE_TESTBENCH1
-TESTS +=  \
+	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
@@ -201,83 +199,7 @@ TESTS +=  \
 	failover-rptd.sh \
 	failover-no-rptd.sh \
 	failover-no-basic.sh \
-	rcvr_fail_restore.sh
-if ENABLE_LIBFAKETIME
-TESTS +=  \
-	now_family_utc.sh \
-	now-utc.sh \
-	now-utc-ymd.sh \
-	now-utc-casecmp.sh \
-	timegenerated-ymd.sh \
-	timegenerated-uxtimestamp.sh \
-	timegenerated-uxtimestamp-invld.sh \
-	timegenerated-dateordinal.sh \
-	timegenerated-dateordinal-invld.sh \
-	timegenerated-utc.sh \
-	timegenerated-utc-legacy.sh \
-	timereported-utc.sh \
-	timereported-utc-legacy.sh
-# now come faketime tests that utilize mmnormalize - aka "no endif here"
-if ENABLE_MMNORMALIZE
-TESTS += \
-	mmnormalize_processing_test1.sh \
-	mmnormalize_processing_test2.sh \
-	mmnormalize_processing_test3.sh \
-	mmnormalize_processing_test4.sh
-endif
-endif
-
-if ENABLE_PGSQL
-if ENABLE_PGSQL_TESTS
-TESTS += \
-	pgsql-basic.sh \
-	pgsql-basic-cnf6.sh \
-	pgsql-basic-threads-cnf6.sh \
-	pgsql-template.sh \
-	pgsql-template-cnf6.sh \
-	pgsql-actq-mt-withpause.sh \
-	pgsql-template-threads-cnf6.sh
-if HAVE_VALGRIND
-TESTS += \
-	pgsql-basic-vg.sh \
-	pgsql-template-vg.sh \
-	pgsql-basic-cnf6-vg.sh \
-	pgsql-template-cnf6-vg.sh \
-	pgsql-actq-mt-withpause-vg.sh
-endif
-endif
-endif
-
-if ENABLE_MYSQL_TESTS
-TESTS +=  \
-	mysql-basic.sh \
-	mysql-basic-cnf6.sh \
-	mysql-asyn.sh \
-	mysql-actq-mt.sh \
-	mysql-actq-mt-withpause.sh \
-	action-tx-single-processing.sh \
-	action-tx-errfile.sh
-if HAVE_VALGRIND
-TESTS +=  \
-	mysql-basic-vg.sh \
-	mysql-asyn-vg.sh \
-	mysql-actq-mt-withpause-vg.sh
-endif
-if ENABLE_OMLIBDBI # we piggy-back on MYSQL_TESTS as we need the same environment
-TESTS +=  \
-	libdbi-basic.sh \
-	libdbi-asyn.sh
-if HAVE_VALGRIND
-TESTS +=  \
-	libdbi-basic-vg.sh
-endif
-endif
-endif
-
-endif #  ENABLE_TESTBENCH1
-
-if ENABLE_TESTBENCH2
-TESTS +=  \
+	rcvr_fail_restore.sh \
 	rscript_contains.sh \
 	rscript_bare_var_root.sh \
 	rscript_bare_var_root-empty.sh \
@@ -364,10 +286,6 @@ TESTS +=  \
 	lookup_table_rscript_reload_without_stub.sh \
 	include-obj-text-from-file.sh \
 	multiple_lookup_tables.sh
-if ENABLE_FMHTTP
-TESTS +=  \
-	rscript_http_request.sh
-endif # ENABLE_FMHTTP
 if HAVE_VALGRIND
 TESTS +=  \
 	include-obj-outside-control-flow-vg.sh \
@@ -376,13 +294,7 @@ TESTS +=  \
 	rscript_parse_json-vg.sh \
 	rscript_backticks-vg.sh \
 	rscript-config_enable-off-vg.sh \
-	prop-jsonmesg-vg.sh
-endif # HAVE_VALGRIND
-
-endif # ENABLE_TESTBENCH2
-
-if HAVE_VALGRIND
-TESTS +=  \
+	prop-jsonmesg-vg.sh \
 	mmexternal-SegFault-vg.sh \
 	mmexternal-InvldProg-vg.sh \
 	internal-errmsg-memleak-vg.sh \
@@ -412,12 +324,90 @@ TESTS +=  \
 	multiple_lookup_tables-vg.sh \
 	fac_local0-vg.sh \
 	rscript_trim-vg.sh
+endif # HAVE_VALGRIND
+endif # ENABLE_DEFAULT_TESTS
+
+if ENABLE_LIBFAKETIME
+TESTS +=  \
+	now_family_utc.sh \
+	now-utc.sh \
+	now-utc-ymd.sh \
+	now-utc-casecmp.sh \
+	timegenerated-ymd.sh \
+	timegenerated-uxtimestamp.sh \
+	timegenerated-uxtimestamp-invld.sh \
+	timegenerated-dateordinal.sh \
+	timegenerated-dateordinal-invld.sh \
+	timegenerated-utc.sh \
+	timegenerated-utc-legacy.sh \
+	timereported-utc.sh \
+	timereported-utc-legacy.sh
+# now come faketime tests that utilize mmnormalize - aka "no endif here"
+if ENABLE_MMNORMALIZE
+TESTS += \
+	mmnormalize_processing_test1.sh \
+	mmnormalize_processing_test2.sh \
+	mmnormalize_processing_test3.sh \
+	mmnormalize_processing_test4.sh
+endif
+endif
+
+if ENABLE_PGSQL
+if ENABLE_PGSQL_TESTS
+TESTS += \
+	pgsql-basic.sh \
+	pgsql-basic-cnf6.sh \
+	pgsql-basic-threads-cnf6.sh \
+	pgsql-template.sh \
+	pgsql-template-cnf6.sh \
+	pgsql-actq-mt-withpause.sh \
+	pgsql-template-threads-cnf6.sh
+if HAVE_VALGRIND
+TESTS += \
+	pgsql-basic-vg.sh \
+	pgsql-template-vg.sh \
+	pgsql-basic-cnf6-vg.sh \
+	pgsql-template-cnf6-vg.sh \
+	pgsql-actq-mt-withpause-vg.sh
+endif
+endif
+endif
+
+if ENABLE_MYSQL_TESTS
+TESTS +=  \
+	mysql-basic.sh \
+	mysql-basic-cnf6.sh \
+	mysql-asyn.sh \
+	mysql-actq-mt.sh \
+	mysql-actq-mt-withpause.sh \
+	action-tx-single-processing.sh \
+	action-tx-errfile.sh
+if HAVE_VALGRIND
+TESTS +=  \
+	mysql-basic-vg.sh \
+	mysql-asyn-vg.sh \
+	mysql-actq-mt-withpause-vg.sh
+endif
+if ENABLE_OMLIBDBI # we piggy-back on MYSQL_TESTS as we need the same environment
+TESTS +=  \
+	libdbi-basic.sh \
+	libdbi-asyn.sh
+if HAVE_VALGRIND
+TESTS +=  \
+	libdbi-basic-vg.sh
+endif
+endif
+endif #  MYSQL_TESTS
 
 if ENABLE_FMHTTP
 TESTS +=  \
+	rscript_http_request.sh
+if HAVE_VALGRIND
+TESTS +=  \
 	rscript_http_request-vg.sh
-endif # ENABLE_FMHTTP
 endif # HAVE_VALGRIND
+endif # ENABLE_FMHTTP
+
 
 if ENABLE_ROOT_TESTS
 TESTS +=  \


### PR DESCRIPTION
This permits to control the "default tests" in testbench runs. These
are those tests that do not need a special configure option. There are
some situations where we really want to turn them of so that we can
run tests only for a specific component (e.g. ElasticSearch).

This commit also removes the --enable-testbench[12] configure switches,
which were introduced just to work-around travis runtime restrictions.
With the new CI setup and new options we could reduce the Travis runtime
dramatically and so we do not need them any longer.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
