### PR TITLE
mmkubernetes: stops working with non-kubernetes container names

### DIFF
--- a/tests/mmkubernetes-basic-vg.sh
+++ b/tests/mmkubernetes-basic-vg.sh
@@ -37,6 +37,12 @@ action(type="mmjsonparse" cookie="")
 action(type="mmkubernetes")
 action(type="omfile" file="rsyslog.out.log" template="mmk8s_template")
 '
+cat > pod-error1.log <<EOF
+{"log":"not in right format","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z"}
+EOF
+cat > pod-error2.log <<EOF
+{"message":"not in right format","CONTAINER_NAME":"not in right format","CONTAINER_ID_FULL":"id3"}
+EOF
 cat > pod-name1_namespace-name1_container-name1-id1.log <<EOF
 {"log":"{\"type\":\"response\",\"@timestamp\":\"2018-04-06T17:26:34Z\",\"tags\":[],\"pid\":75,\"method\":\"head\",\"statusCode\":200,\"req\":{\"url\":\"/\",\"method\":\"head\",\"headers\":{\"user-agent\":\"curl/7.29.0\",\"host\":\"localhost:5601\",\"accept\":\"*/*\"},\"remoteAddress\":\"127.0.0.1\",\"userAgent\":\"127.0.0.1\"},\"res\":{\"statusCode\":200,\"responseTime\":1,\"contentLength\":9},\"message\":\"HEAD1 / 200 1ms - 9.0B\"}\n","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z"}
 EOF
@@ -48,6 +54,9 @@ cat > pod-name3.log <<EOF
 EOF
 cat > pod-name4.log <<EOF
 {"message":"a message from container 4","CONTAINER_NAME":"some-prefix_container-name4_pod-name4_namespace-name4_unused4_unused44","CONTAINER_ID_FULL":"id4"}
+EOF
+cat > pod-name5.log <<EOF
+{"message":"a message from container 5","CONTAINER_NAME":"some-prefix_container-name5_pod-name5.with.dot.in.pod.name_namespace-name5_unused5_unused55","CONTAINER_ID_FULL":"id5"}
 EOF
 rm -f imfile-state\:*
 startup_vg_noleak

--- a/tests/mmkubernetes-basic.out.json
+++ b/tests/mmkubernetes-basic.out.json
@@ -107,4 +107,33 @@
   "docker": {
     "container_id": "id3"
   }
+},
+{
+  "message": "a message from container 5",
+  "CONTAINER_NAME": "some-prefix_container-name5_pod-name5.with.dot.in.pod.name_namespace-name5_unused5_unused55",
+  "CONTAINER_ID_FULL": "id5",
+  "kubernetes": {
+    "namespace_id": "namespace-name5-id",
+    "namespace_labels": {
+      "label_1_key": "label 1 value",
+      "label_with_empty_value": "",
+      "label_2_key": "label 2 value"
+    },
+    "creation_timestamp": "2018-04-09T21:56:39Z",
+    "pod_id": "pod-name5.with.dot.in.pod.name-id",
+    "labels": {
+      "custom_label": "pod-name5.with.dot.in.pod.name-label-value",
+      "deploymentconfig": "pod-name5.with.dot.in.pod.name-dc",
+      "component": "pod-name5.with.dot.in.pod.name-component",
+      "label_with_empty_value": "",
+      "deployment": "pod-name5.with.dot.in.pod.name-deployment"
+    },
+    "pod_name": "pod-name5.with.dot.in.pod.name",
+    "namespace_name": "namespace-name5",
+    "container_name": "container-name5",
+    "master_url": "http://localhost:18443"
+  },
+  "docker": {
+    "container_id": "id5"
+  }
 }]

--- a/tests/mmkubernetes-basic.sh
+++ b/tests/mmkubernetes-basic.sh
@@ -38,6 +38,12 @@ action(type="mmjsonparse" cookie="")
 action(type="mmkubernetes")
 action(type="omfile" file="rsyslog.out.log" template="mmk8s_template")
 '
+cat > pod-error1.log <<EOF
+{"log":"not in right format","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z"}
+EOF
+cat > pod-error2.log <<EOF
+{"message":"not in right format","CONTAINER_NAME":"not in right format","CONTAINER_ID_FULL":"id3"}
+EOF
 cat > pod-name1_namespace-name1_container-name1-id1.log <<EOF
 {"log":"{\"type\":\"response\",\"@timestamp\":\"2018-04-06T17:26:34Z\",\"tags\":[],\"pid\":75,\"method\":\"head\",\"statusCode\":200,\"req\":{\"url\":\"/\",\"method\":\"head\",\"headers\":{\"user-agent\":\"curl/7.29.0\",\"host\":\"localhost:5601\",\"accept\":\"*/*\"},\"remoteAddress\":\"127.0.0.1\",\"userAgent\":\"127.0.0.1\"},\"res\":{\"statusCode\":200,\"responseTime\":1,\"contentLength\":9},\"message\":\"HEAD1 / 200 1ms - 9.0B\"}\n","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z"}
 EOF
@@ -49,6 +55,9 @@ cat > pod-name3.log <<EOF
 EOF
 cat > pod-name4.log <<EOF
 {"message":"a message from container 4","CONTAINER_NAME":"some-prefix_container-name4_pod-name4_namespace-name4_unused4_unused44","CONTAINER_ID_FULL":"id4"}
+EOF
+cat > pod-name5.log <<EOF
+{"message":"a message from container 5","CONTAINER_NAME":"some-prefix_container-name5_pod-name5.with.dot.in.pod.name_namespace-name5_unused5_unused55","CONTAINER_ID_FULL":"id5"}
 EOF
 rm -f imfile-state\:*
 startup


### PR DESCRIPTION
When mmkubernetes encounters a record with a CONTAINER_NAME field,
but the value does not match the rulebase, mmkubernetes returns
an error, and mmkubernetes does not do any further processing
of any records.
The fix is to check the return value of ln_normalize to see if
it is a "hard" error or a "does not match" error.
This also adds a test for pod names with dots in them.


<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->