### PR TITLE
fix race in parallel builds

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -202,7 +202,7 @@ if ENABLE_LIBGCRYPT
    libgcry_la_SOURCES = libgcry.c libgcry_common.c libgcry.h
    libgcry_la_CPPFLAGS = $(RSRT_CFLAGS) $(LIBGCRYPT_CFLAGS)
    pkglib_LTLIBRARIES += lmcry_gcry.la
-   lmcry_gcry_la_DEPENDENCIES = librsyslog.la
+   lmcry_gcry_la_DEPENDENCIES = librsyslog.la libgcry.la
    lmcry_gcry_la_SOURCES = lmcry_gcry.c lmcry_gcry.h
    lmcry_gcry_la_CPPFLAGS = $(RSRT_CFLAGS) $(LIBGCRYPT_CFLAGS)
    lmcry_gcry_la_LDFLAGS = -module -avoid-version \


### PR DESCRIPTION
If libgcry.la is built later than lmcry_gcry.la, there is a failure:
[snip]
|../aarch64-wrs-linux-libtool  --tag=CC   --mode=link aarch64-wrs-linux-gcc
-o lmcry_gcry.la lmcry_gcry_la-lmcry_gcry.lo libgcry.la -lgcrypt
|aarch64-wrs-linux-libtool:   error: cannot find the library 'libgcry.la'
or unhandled argument 'libgcry.la'
|Makefile:1049: recipe for target 'lmcry_gcry.la' failed
|make[2]: *** [lmcry_gcry.la] Error 1
[snip]

The LIBADD of lmcry_gcry.la contains libgcry.la, we should also add libgcry.la
to lmcry_gcry.la's DEPENDENCIES.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
