### PR TITLE
travis: reduce runtime on "distcheck" commit

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -312,8 +312,19 @@ DISTCHECK_CONFIGURE_FLAGS=
 DISTCHECK_CONFIGURE_FLAGS+= \
 	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir) \
 	--enable-silent-rules \
-	--enable-diagtools \
+	--enable-rsyslogd \
+	--enable-omstdout \
 	--enable-imdiag \
+	--enable-testbench \
+	--enable-valgrind
+# currently not supported in make distcheck:
+# --enable-mysql-tests
+# --enable-pgsql-tests 
+# --enable-extended-tests --> should probably never be enabled due to runtime
+
+if ENABLE_DEFAULT_TESTS
+DISTCHECK_CONFIGURE_FLAGS+= \
+	--enable-diagtools \
 	--enable-impstats \
 	--enable-imptcp \
 	--enable-klog \
@@ -328,9 +339,7 @@ DISTCHECK_CONFIGURE_FLAGS+= \
 	--enable-mmrm1stspace \
 	--enable-mmsequence \
 	--enable-mmutf8fix \
-	--enable-omprog \
 	--enable-omruleset \
-	--enable-omstdout \
 	--enable-omuxsock \
 	--enable-pmaixforwardedfrom \
 	--enable-pmciscoios \
@@ -338,14 +347,13 @@ DISTCHECK_CONFIGURE_FLAGS+= \
 	--enable-pmlastmsg \
 	--enable-pmnull \
 	--enable-pmsnare \
-	--enable-rsyslogd \
-	--enable-usertools \
-	--enable-testbench \
-	--enable-valgrind
-# currently not supported in make distcheck:
-# --enable-mysql-tests
-# --enable-pgsql-tests 
-# --enable-extended-tests --> should probably never be enabled due to runtime
+	--enable-usertools
+
+endif  # if ENABLE_DEFAULT_TESTS
+
+if ENABLE_OMPROG
+DISTCHECK_CONFIGURE_FLAGS+= --enable-omprog 
+endif
 
 # Note: [io]mzmq3 cannot be built any longer, according to Brian Knox they require an
 # outdated version of the client lib. So we do not bother any longer about them.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -29,7 +29,6 @@ check_PROGRAMS = $(TESTRUNS) ourtail tcpflood chkseq msleep randomgen \
 	mangle_qi \
 	have_relpSrvSetOversizeMode
 TESTS = $(TESTRUNS)
-#TESTS = $(TESTRUNS) cfg.sh
 
 if ENABLE_DEFAULT_TESTS
 TESTS +=  \
@@ -283,6 +282,22 @@ TESTS +=  \
 	lookup_table_rscript_reload_without_stub.sh \
 	include-obj-text-from-file.sh \
 	multiple_lookup_tables.sh
+	parsertest-parse1.sh \
+	parsertest-parse1-udp.sh \
+	parsertest-parse2.sh \
+	parsertest-parse2-udp.sh \
+	parsertest-parse_8bit_escape.sh \
+	parsertest-parse_8bit_escape-udp.sh \
+	parsertest-parse3.sh \
+	parsertest-parse3-udp.sh \
+	parsertest-parse_invld_regex.sh \
+	parsertest-parse_invld_regex-udp.sh \
+	parsertest-parse-3164-buggyday.sh \
+	parsertest-parse-3164-buggyday-udp.sh \
+	parsertest-parse-nodate.sh \
+	parsertest-parse-nodate-udp.sh \
+	parsertest-snare_ccoff_udp.sh \
+	parsertest-snare_ccoff_udp2.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	include-obj-outside-control-flow-vg.sh \
@@ -320,6 +335,9 @@ TESTS +=  \
 	lookup_table_rscript_reload_without_stub-vg.sh \
 	multiple_lookup_tables-vg.sh \
 	fac_local0-vg.sh \
+	badqi.sh \
+	threadingmq.sh \
+	threadingmqaq.sh \
 	rscript_trim-vg.sh
 endif # HAVE_VALGRIND
 endif # ENABLE_DEFAULT_TESTS
@@ -755,11 +773,6 @@ TESTS += \
 	sndrcv_omudpspoof_nonstdpt.sh
 endif
 
-if ENABLE_OMSTDOUT
-TESTS += \
-	threadingmq.sh \
-	threadingmqaq.sh \
-	badqi.sh
 #disabled as array-passing mode is no longer supported:	omod-if-array.sh 
 #	omod-if-array.sh 
 #	omod-if-array-udp.sh 
@@ -770,22 +783,6 @@ TESTS += \
 	tabescape_off.sh \
 	tabescape_off-udp.sh \
 	inputname-imtcp.sh \
-	parsertest-parse1.sh \
-	parsertest-parse1-udp.sh \
-	parsertest-parse2.sh \
-	parsertest-parse2-udp.sh \
-	parsertest-parse_8bit_escape.sh \
-	parsertest-parse_8bit_escape-udp.sh \
-	parsertest-parse3.sh \
-	parsertest-parse3-udp.sh \
-	parsertest-parse_invld_regex.sh \
-	parsertest-parse_invld_regex-udp.sh \
-	parsertest-parse-3164-buggyday.sh \
-	parsertest-parse-3164-buggyday-udp.sh \
-	parsertest-parse-nodate.sh \
-	parsertest-parse-nodate-udp.sh \
-	parsertest-snare_ccoff_udp.sh \
-	parsertest-snare_ccoff_udp2.sh \
 	fieldtest.sh \
 	fieldtest-udp.sh \
 	proprepltest-nolimittag-udp.sh \
@@ -803,7 +800,6 @@ TESTS += \
 	timestamp-subseconds-udp.sh \
 	timestamp-subseconds.sh
 
-endif
 endif
 
 if ENABLE_OMRULESET

--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -49,6 +49,54 @@ if [ "x$BUILD_FROM_TARBALL" == "xYES" ]; then
 	tar xzf ../rsyslog.tar.gz
 	ls -ld rsyslog*
 	cd rsyslog*
+	export JOURNAL_OPT=
+	export DEFAULT_CONFIG_FLAGS="--disable-fmhttp"
+	echo "============================== DONE unpacking =============================="
+else
+	export DEFAULT_CONFIG_FLAGS="
+	--enable-imfile \
+	--enable-impstats \
+	--enable-mmrm1stspace \
+	--enable-imptcp \
+	--enable-mmanon \
+	--enable-mmaudit \
+	--enable-mmfields \
+	--enable-mmjsonparse \
+	--enable-mmpstrucdata \
+	--enable-mmsequence \
+	--enable-mmutf8fix \
+	--enable-mail \
+	--enable-omprog \
+	--enable-omruleset \
+	--enable-omuxsock \
+	--enable-pmaixforwardedfrom \
+	--enable-pmciscoios \
+	--enable-pmcisconames \
+	--enable-pmlastmsg \
+	--enable-pmsnare \
+	--enable-libgcrypt \
+	--enable-mmnormalize \
+	--enable-omudpspoof \
+	--enable-relp --enable-omrelp-default-port=13515 \
+	--enable-snmp \
+	--enable-mmsnmptrapd \
+	--enable-gnutls \
+	--enable-openssl \
+	--enable-gt-ksi \
+	--enable-libdbi \
+	--enable-omhttpfs \
+	--enable-elasticsearch \
+	--enable-ommongodb \
+	--enable-omtcl \
+	--enable-mmdblookup \
+	--enable-mmcount \
+	--enable-gssapi-krb5 \
+	--enable-omhiredis \
+	--enable-imczmq --enable-omczmq \
+	--enable-usertools \
+	--enable-pmnull \
+	--enable-pmnormalize \
+	"
 fi
 pwd
 autoreconf --force --verbose --install
@@ -69,56 +117,19 @@ export CONFIG_FLAGS="$CONFIGURE_FLAGS \
 	$GROK \
 	$ES_TEST_CONFIGURE_OPT \
 	$AMQP1 \
+	$DEFAULT_CONFIG_FLAGS \
 	--disable-generate-man-pages \
-	--enable-distcheck-workaround \
-	--enable-testbench \
-	--enable-imdiag \
-	--enable-imfile \
-	--enable-impstats \
-	--enable-mmrm1stspace \
-	--enable-imptcp \
-	--enable-mmanon \
-	--enable-mmaudit \
-	--enable-mmfields \
-	--enable-mmjsonparse \
-	--enable-mmpstrucdata \
-	--enable-mmsequence \
-	--enable-mmutf8fix \
-	--enable-mail \
-	--enable-omprog \
-	--enable-omruleset \
-	--enable-omstdout \
-	--enable-omuxsock \
-	--enable-pmaixforwardedfrom \
-	--enable-pmciscoios \
-	--enable-pmcisconames \
-	--enable-pmlastmsg \
-	--enable-pmsnare \
-	--enable-libgcrypt \
-	--enable-mmnormalize \
-	--enable-omudpspoof \
-	--enable-relp --enable-omrelp-default-port=13515 \
-	--enable-snmp \
-	--enable-mmsnmptrapd \
-	--enable-gnutls \
-	--enable-openssl \
-	--enable-mysql --enable-mysql-tests \
-	--enable-gt-ksi \
-	--enable-libdbi \
-	--enable-pgsql --enable-pgsql-tests \
-	--enable-omhttpfs \
-	--enable-elasticsearch \
 	--enable-valgrind \
-	--enable-ommongodb \
-	--enable-omtcl \
-	--enable-mmdblookup \
-	--enable-mmcount \
-	--enable-gssapi-krb5 \
-	--enable-omhiredis \
-	--enable-imczmq --enable-omczmq \
-	--enable-usertools \
-	--enable-pmnull \
-	--enable-pmnormalize"
+	--enable-testbench \
+	--enable-omstdout \
+	--enable-imdiag \
+	--enable-pgsql --enable-pgsql-tests \
+	--enable-mysql --enable-mysql-tests"
+
+
+echo "============================== flags set =============================="
+env | grep CONFIG
+echo "============================== flags end =============================="
 # Note: [io]mzmq3 cannot be built any longer, according to Brian Knox they require an
 # outdated version of the client lib. So we do not bother any longer about them.
 ./configure  $CONFIG_FLAGS
@@ -142,7 +153,7 @@ then
     fi
     set -e # now errors are no longer permited, again
     echo now running \"make distcheck\"
-    make distcheck
+    #make distcheck
 fi
 
 if [ "x$STAT_AN" == "xYES" ] ; then make clean; CFLAGS="-O2"; ./configure $CONFIG_FLAGS ; fi


### PR DESCRIPTION
We run only some distcheck test that we cannot yet run inside
the containers on travis. This reduces the amount of redundant
work done, speeding up Travis runtime.

Any missing checks are still detected by buildbot part of CI.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
