### PR TITLE
write all header metadata to omes for retries

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -589,7 +589,8 @@ TESTS +=  \
 	es-writeoperation.sh
 if ENABLE_IMPSTATS
 TESTS +=  \
-	es-basic-ha.sh
+	es-basic-ha.sh \
+	es-bulk-retry.sh
 endif
 if ENABLE_IMFILE
 TESTS +=  \
@@ -1285,6 +1286,7 @@ EXTRA_DIST= \
 	es-basic-bulk-vg.sh \
 	es-basic-ha-vg.sh \
 	es-maxbytes-bulk.sh \
+	es-bulk-retry.sh \
 	linkedlistqueue.sh \
 	testsuites/linkedlistqueue.conf \
 	da-mainmsg-q.sh \


### PR DESCRIPTION
Write all of the original request metadata fields to `$.omes` for
the retry, if present.  This may include all of the following:
_index, _type, _id, _parent, pipeline
This is in addition to the fields from the response.  If the same
field name exists in the request metadata and the response, the
field from the request will be used, in order to facilitate
retrying the exact same request.