### PR TITLE
add PARSE_HOSTNAME for imkafka to support host name parsing.

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -176,7 +176,7 @@ DBGPRINTF("imkafka: enqMsg: Msg: %.*s\n", (int)rkmessage->len, (char *)rkmessage
 	MsgSetRawMsg(pMsg, (char*)rkmessage->payload, (int)rkmessage->len);
 	MsgSetFlowControlType(pMsg, eFLOWCTL_LIGHT_DELAY);
 	MsgSetRuleset(pMsg, inst->pBindRuleset);
-	pMsg->msgFlags  = NEEDS_PARSING; // | PARSE_HOSTNAME;
+	pMsg->msgFlags  = NEEDS_PARSING | PARSE_HOSTNAME;
 	/* Optional Fields */
 	if (rkmessage->key_len) {
 		DBGPRINTF("imkafka: enqMsg: Key: %.*s\n", (int)rkmessage->key_len, (char *)rkmessage->key);

--- a/plugins/mmkv/Makefile.am
+++ b/plugins/mmkv/Makefile.am
@@ -1,0 +1,8 @@
+pkglib_LTLIBRARIES = mmkv.la
+
+mmkv_la_SOURCES = mmkv.c
+mmkv_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
+mmkv_la_LDFLAGS = -module -avoid-version
+mmkv_la_LIBADD = 
+
+EXTRA_DIST = 

--- a/plugins/mmkv/mmkv.c
+++ b/plugins/mmkv/mmkv.c
@@ -1,0 +1,319 @@
+/* mmkv.c
+ * Parse all fields of the message into structured data inside the
+ * JSON tree.
+ *
+ * Copyright 2013 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include "rsyslog.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <signal.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdint.h>
+#include "conf.h"
+#include "syslogd-types.h"
+#include "srUtils.h"
+#include "template.h"
+#include "module-template.h"
+#include "errmsg.h"
+
+MODULE_TYPE_OUTPUT
+MODULE_TYPE_NOKEEP
+MODULE_CNFNAME("mmkv")
+
+
+DEFobjCurrIf(errmsg)
+DEF_OMOD_STATIC_DATA
+
+/* config variables */
+
+/* define operation modes we have */
+#define SIMPLE_MODE 0	 /* just overwrite */
+#define REWRITE_MODE 1	 /* rewrite IP address, canoninized */
+typedef struct _instanceData {
+	char prefix;
+	char fieldsplit;
+	char valuesplit;
+	uchar *jsonRoot;	/**< container where to store fields */	
+	msgPropDescr_t *varDescr;/**< name of variable to use */
+} instanceData;
+
+typedef struct wrkrInstanceData {
+	instanceData *pData;
+} wrkrInstanceData_t;
+
+struct modConfData_s {
+	rsconf_t *pConf;	/* our overall config object */
+};
+static modConfData_t *loadModConf = NULL;/* modConf ptr to use for the current load process */
+static modConfData_t *runModConf = NULL;/* modConf ptr to use for the current exec process */
+
+
+/* tables for interfacing with the v6 config system */
+/* action (instance) parameters */
+static struct cnfparamdescr actpdescr[] = {
+	{ "prefix", eCmdHdlrGetChar, 0 },
+	{ "fieldsplit", eCmdHdlrGetChar, 0 },
+	{ "valuesplit", eCmdHdlrGetChar, 0 },	
+	{ "variable", eCmdHdlrGetWord, 0 },
+	{ "jsonroot", eCmdHdlrString, 0 }
+};
+static struct cnfparamblk actpblk =
+	{ CNFPARAMBLK_VERSION,
+	  sizeof(actpdescr)/sizeof(struct cnfparamdescr),
+	  actpdescr
+	};
+
+BEGINbeginCnfLoad
+CODESTARTbeginCnfLoad
+	loadModConf = pModConf;
+	pModConf->pConf = pConf;
+ENDbeginCnfLoad
+
+BEGINendCnfLoad
+CODESTARTendCnfLoad
+ENDendCnfLoad
+
+BEGINcheckCnf
+CODESTARTcheckCnf
+ENDcheckCnf
+
+BEGINactivateCnf
+CODESTARTactivateCnf
+	runModConf = pModConf;
+ENDactivateCnf
+
+BEGINfreeCnf
+CODESTARTfreeCnf
+ENDfreeCnf
+
+
+BEGINcreateInstance
+CODESTARTcreateInstance
+ENDcreateInstance
+
+BEGINcreateWrkrInstance
+CODESTARTcreateWrkrInstance
+ENDcreateWrkrInstance
+
+
+BEGINisCompatibleWithFeature
+CODESTARTisCompatibleWithFeature
+ENDisCompatibleWithFeature
+
+
+BEGINfreeInstance
+CODESTARTfreeInstance
+	free(pData->jsonRoot);
+	msgPropDescrDestruct(pData->varDescr);
+	free(pData->varDescr);
+ENDfreeInstance
+
+BEGINfreeWrkrInstance
+CODESTARTfreeWrkrInstance
+ENDfreeWrkrInstance
+
+
+static inline void
+setInstParamDefaults(instanceData *pData)
+{
+	pData->prefix = '\0';
+	pData->fieldsplit = '&';
+	pData->valuesplit = '=';
+	pData->jsonRoot = NULL;	
+	pData->varDescr = NULL;
+}
+
+BEGINnewActInst
+	struct cnfparamvals *pvals;
+	int i;	
+	char *varName = NULL;
+CODESTARTnewActInst
+	DBGPRINTF("newActInst (mmkv)\n");
+	if((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
+		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+	}
+
+	CODE_STD_STRING_REQUESTnewActInst(1)
+	CHKiRet(OMSRsetEntry(*ppOMSR, 0, NULL, OMSR_TPL_AS_MSG));
+	CHKiRet(createInstance(&pData));
+	setInstParamDefaults(pData);
+
+	for(i = 0 ; i < actpblk.nParams ; ++i) {
+		if(!pvals[i].bUsed)
+			continue;
+
+		
+		if(!strcmp(actpblk.descr[i].name, "prefix")) {
+			pData->prefix = es_getBufAddr(pvals[i].val.d.estr)[0];
+		} else if(!strcmp(actpblk.descr[i].name, "fieldsplit")) {
+			pData->fieldsplit = es_getBufAddr(pvals[i].val.d.estr)[0];
+		} else if(!strcmp(actpblk.descr[i].name, "valuesplit")) {
+			pData->valuesplit = es_getBufAddr(pvals[i].val.d.estr)[0];
+		} else if(!strcmp(actpblk.descr[i].name, "variable")) {
+			varName = es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "jsonroot")) {
+			pData->jsonRoot = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else {
+			dbgprintf("mmkv: program error, non-handled "
+			  "param '%s'\n", actpblk.descr[i].name);
+		}
+	}
+	if (varName) {
+		CHKmalloc(pData->varDescr = MALLOC(sizeof(msgPropDescr_t)));
+		CHKiRet(msgPropDescrFill(pData->varDescr, (uchar*) varName, strlen(varName)));
+		
+		free(varName);
+		varName = NULL;
+	}
+	if(pData->jsonRoot == NULL) {
+		CHKmalloc(pData->jsonRoot = (uchar*) strdup("!"));
+	}
+
+CODE_STD_FINALIZERnewActInst
+	cnfparamvalsDestruct(pvals, &actpblk);
+ENDnewActInst
+
+
+BEGINdbgPrintInstInfo
+CODESTARTdbgPrintInstInfo
+dbgprintf("\tvariable='%s'\n", pData->varDescr->name);
+ENDdbgPrintInstInfo
+
+
+BEGINtryResume
+CODESTARTtryResume
+ENDtryResume
+
+
+static rsRetVal
+extractField(instanceData *pData, uchar *msgtext, int lenMsg, int *curridx, uchar *fieldbuf, uchar **valuebuf)
+{
+	int i, j;
+	DEFiRet;
+	i = *curridx;
+	j = 0;
+	
+	while(i < lenMsg && msgtext[i] != pData->valuesplit) {
+		fieldbuf[j++] = msgtext[i++];		
+	}
+	fieldbuf[j] = '\0';
+
+	i++;j++;
+	*valuebuf = fieldbuf + j;
+	while(i < lenMsg && msgtext[i] != pData->fieldsplit) {
+		fieldbuf[j++] = msgtext[i++];		
+	}
+	
+	fieldbuf[j] = '\0';
+	if(i < lenMsg)
+		++i;
+	*curridx = i;
+
+	RETiRet;
+}
+
+
+static rsRetVal
+parse_fields(instanceData *pData, smsg_t *pMsg, uchar *msgtext, int lenMsg)
+{
+	uchar fieldbuf[32*1024];
+	struct json_object *json;
+	struct json_object *jval;
+	uchar *buf;
+	uchar *valuebuf;
+	int currIdx = 0;
+	DEFiRet;
+
+	if(lenMsg < (int) sizeof(fieldbuf)) {
+		buf = fieldbuf;
+	} else {
+		CHKmalloc(buf = malloc(lenMsg+1));
+	}
+
+	json =  json_object_new_object();
+	if(json == NULL) {
+		ABORT_FINALIZE(RS_RET_ERR);
+	}
+	while(currIdx < lenMsg) {
+		CHKiRet(extractField(pData, msgtext, lenMsg, &currIdx, buf, &valuebuf));
+		DBGPRINTF("mmkv: %s:'%s'\n", buf, valuebuf);
+		if (pData->prefix == '\0' || pData->prefix == buf[0]) {
+			jval = json_object_new_string((char*)valuebuf);
+			json_object_object_add(json, (char*)buf, jval);
+		}
+	}
+ 	msgAddJSON(pMsg, pData->jsonRoot, json, 0, 0);
+finalize_it:
+	if(buf != fieldbuf)
+		free(buf);
+	RETiRet;
+}
+
+
+BEGINdoAction_NoStrings
+	smsg_t **ppMsg = (smsg_t **) pMsgData;
+	smsg_t *pMsg = ppMsg[0];
+	uchar *msg;
+	int lenMsg;
+	unsigned short freeBuf = 0;
+CODESTARTdoAction
+	if (pWrkrData->pData->varDescr) {
+		msg = MsgGetProp(pMsg, NULL, pWrkrData->pData->varDescr, &lenMsg, &freeBuf, NULL);
+	} else {	
+		msg = getMSG(pMsg);		
+		lenMsg = getMSGLen(pMsg);
+	}
+
+	iRet = parse_fields(pWrkrData->pData, pMsg, msg, lenMsg);
+ENDdoAction
+
+
+NO_LEGACY_CONF_parseSelectorAct
+
+
+BEGINmodExit
+CODESTARTmodExit
+	objRelease(errmsg, CORE_COMPONENT);
+ENDmodExit
+
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_OMOD_QUERIES
+CODEqueryEtryPt_STD_OMOD8_QUERIES
+CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES
+CODEqueryEtryPt_STD_CONF2_QUERIES
+ENDqueryEtryPt
+
+
+
+BEGINmodInit()
+CODESTARTmodInit
+	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+CODEmodInit_QueryRegCFSLineHdlr
+	DBGPRINTF("mmkv: module compiled with rsyslog version %s.\n", VERSION);
+	iRet = objUse(errmsg, CORE_COMPONENT);
+ENDmodInit
+


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
Uncommenting the flag to support hostname parsing for imkafka.