### PR TITLE
testbench: move some cleanup to "make clean" target

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,21 @@
 if ENABLE_TESTBENCH
-CLEANFILES = \
+
+CLEANFILES=\
+	*_*.conf \
+	rsyslogd.started work-*.conf rsyslog.random.data \
+	rsyslogd2.started work-*.conf rsyslog*.pid.save xlate*.lkp_tbl \
+	log log* \
+	work \
+	rsyslog_*.out.* \
+	rsyslog2_*.out.* \
+	test-spool test-logdir stat-file1 \
+	rsyslog.pipe rsyslog.input.* \
+	rsyslog.input rsyslog.empty rsyslog.input.* imfile-state* omkafka-failed.data \
+	rsyslog.input-symlink.log rsyslog-link.*.log targets \
+	HOSTNAME \
+	rsyslog.errorfile tmp.qi nocert
+
+CLEANFILES+= \
 	IN_AUTO_DEBUG
 # IN_AUTO_DEBUG should be deleted each time make check is run, but
 # there exists no such hook. Se we at least delete it on make clean.

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -511,7 +511,7 @@ case $1 in
 		rm -f rsyslogd.started work-*.conf rsyslog.random.data
 		rm -f rsyslogd2.started work-*.conf rsyslog*.pid.save xlate*.lkp_tbl
 		rm -f log log* # RSyslog debug output 
-		rm -f work rsyslog.out.* ${RSYSLOG2_OUT_LOG} # common work files
+		rm -f work rsyslog*.out.*
 		rm -rf test-spool test-logdir stat-file1
 		rm -f rsyslog.pipe rsyslog.input.*
 		rm -f rsyslog.input rsyslog.empty rsyslog.input.* imfile-state* omkafka-failed.data


### PR DESCRIPTION
**NOTE: before merge, buildbot VMs should also be changed to call ```make clean``` upon each start of processing.**

To support parallel testbench runs, we need to have dynamic work files.
So deleting work files on each test does not work, especially as we can
no longer assume they are "left-overs" from a failed. tes - they may
actulally (and quite likely) belong to tests that run in parallel.

So the proper solution is to do via "make clean".

closes https://github.com/rsyslog/rsyslog/pull/2916 (which it replaces)

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
