### PR TITLE
testbench: support dynamic pidfile naming

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1809,7 +1809,6 @@ EXTRA_DIST= \
 	rscript_wrap3.sh \
 	testsuites/rscript_wrap3.conf \
 	testsuites/wrap3_input\
-	testsuites/gethostname.conf \
 	json_array_subscripting.sh \
 	testsuites/json_array_subscripting.conf \
 	testsuites/json_array_input \

--- a/tests/daqueue-dirty-shutdown.sh
+++ b/tests/daqueue-dirty-shutdown.sh
@@ -19,7 +19,6 @@
 # Then, we check that at a minimum the .qi file exists.
 # Copyright (C) 2016 by Rainer Gerhards
 # Released under ASL 2.0
-echo ===============================================================================
 
 #uncomment the following if you want a log for step 1 of this test
 #export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
@@ -54,6 +53,8 @@ ls test-spool
 
 . $srcdir/diag.sh kill-immediate   # do not give it sufficient time to shutdown
 wait_shutdown
+rm -f $RSYSLOG_PIDBASE.pid # as we kill, rsyslog does not itself cleanup the pid file
+
 echo spool files after kill:
 ls test-spool
 

--- a/tests/hostname-with-slash-dflt-invld.sh
+++ b/tests/hostname-with-slash-dflt-invld.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # addd 2016-07-11 by RGerhards, released under ASL 2.0
-
 . $srcdir/diag.sh init
-. $srcdir/diag.sh generate-HOSTNAME
+setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
@@ -16,13 +15,13 @@ echo '<167>Mar  6 16:57:54 hostname1/hostname2 test: msgnum:0' > rsyslog.input
 tcpflood -B -I rsyslog.input
 shutdown_when_empty
 wait_shutdown
-cmp HOSTNAME $RSYSLOG_OUT_LOG
+printf "%s" "$RS_HOSTNAME" | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid hostname generated, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG
   echo
   echo "expected was:"
-  cat HOSTNAME
+  printf "%s\n" "$RS_HOSTNAME"
   echo
   error_exit 1
 fi;

--- a/tests/imjournal-basic-vg.sh
+++ b/tests/imjournal-basic-vg.sh
@@ -19,8 +19,17 @@ action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup_vg
 TESTMSG="TestBenCH-RSYSLog imjournal This is a test message - $(date +%s)"
+
 ./journal_print "$TESTMSG"
-if [ $? -ne 0 ]; then
+journal_write_state=$?
+
+# we must not terminate the test until we have terminated rsyslog
+./msleep 500
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown_vg
+. $srcdir/diag.sh check-exit-vg
+
+if [ $journal_write_state -ne 0 ]; then
         echo "SKIP: failed to put test into journal."
         exit 77
 fi
@@ -29,10 +38,7 @@ if [ $? -ne 0 ]; then
         echo "SKIP: cannot read journal."
         exit 77
 fi
-./msleep 500
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown_vg
-. $srcdir/diag.sh check-exit-vg
+
 cat $RSYSLOG_OUT_LOG | fgrep -qF "$TESTMSG"
 if [ $? -ne 0 ]; then
   echo "FAIL:  $RSYSLOG_OUT_LOG content (tail -n200):"

--- a/tests/mmkubernetes-basic.sh
+++ b/tests/mmkubernetes-basic.sh
@@ -10,14 +10,6 @@
 #export RSYSLOG_DEBUG="debug"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-command-available timeout
-
-testsrv=mmk8s-test-server
-echo starting kubernetes \"emulator\"
-timeout 3m python -u ./mmkubernetes_test_server.py 18443 rsyslog${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
-BGPROCESS=$!
-. $srcdir/diag.sh wait-startup $testsrv
-echo background mmkubernetes_test_server.py process id is $BGPROCESS
-
 pwd=$( pwd )
 generate_conf
 add_conf '
@@ -38,6 +30,14 @@ action(type="mmjsonparse" cookie="")
 action(type="mmkubernetes")
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="mmk8s_template")
 '
+
+testsrv=mmk8s-test-server
+echo starting kubernetes \"emulator\"
+timeout 3m python -u ./mmkubernetes_test_server.py 18443 ${RSYSLOG_PIDBASE}${testsrv}.pid rsyslogd${testsrv}.started > mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+. $srcdir/diag.sh wait-startup $testsrv
+echo background mmkubernetes_test_server.py process id is $BGPROCESS
+
 cat > pod-error1.log <<EOF
 {"log":"not in right format","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z"}
 EOF
@@ -66,7 +66,7 @@ shutdown_when_empty
 wait_shutdown
 
 kill $BGPROCESS
-. $srcdir/diag.sh wait-pid-termination rsyslog${testsrv}.pid
+. $srcdir/diag.sh wait-pid-termination ${RSYSLOG_PIDBASE}${testsrv}.pid
 cat mmk8s_srv.log
 
 # for each record in mmkubernetes-basic.out.json, see if the matching

--- a/tests/testsuites/gethostname.conf
+++ b/tests/testsuites/gethostname.conf
@@ -1,7 +1,0 @@
-module(load="../plugins/imudp/.libs/imudp")
-$IncludeConfig diag-common.conf
-module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
-
-$template hostname,"%hostname%"
-local0.* ./HOSTNAME;hostname


### PR DESCRIPTION
required for parallel test execution

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
