### PR TITLE
core/regex: emit error message when hashtable entry could not be inse…

### DIFF
--- a/runtime/regexp.c
+++ b/runtime/regexp.c
@@ -149,7 +149,11 @@ static perthread_regex_t *get_perthread_regex(const regex_t *preg) {
 
 		if (uncomp) {
 			entry = create_perthread_regex(preg, uncomp);
-			hashtable_insert(perthread_regexs, (void *)entry, entry);
+			if(!hashtable_insert(perthread_regexs, (void *)entry, entry)) {
+				LogError(0, RS_RET_INTERNAL_ERROR,
+					"error trying to insert thread-regexp into hash-table - things "
+					"will not work 100%% correctly (mostly probably out of memory issue)");
+			}
 		}
 	}
 	if (entry) {


### PR DESCRIPTION
…rted

detected by Coverity Scan, CID 190890

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
