### PR TITLE
fix imkafka can't parse hostname

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -92,6 +92,7 @@ struct instanceConf_s {
 	rd_kafka_topic_conf_t *topic_conf;
 	int partition;
 	int bIsSubscribed;
+	int nMsgParsingFlags;
 
 	struct instanceConf_s *next;
 };
@@ -130,6 +131,7 @@ static struct cnfparamdescr inppdescr[] = {
 	{ "confparam", eCmdHdlrArray, 0 },
 	{ "consumergroup", eCmdHdlrString, 0},
 	{ "ruleset", eCmdHdlrString, 0 },
+	{ "parsehostname", eCmdHdlrBinary, 0 },
 };
 static struct cnfparamblk inppblk =
 	{ CNFPARAMBLK_VERSION,
@@ -176,7 +178,7 @@ DBGPRINTF("imkafka: enqMsg: Msg: %.*s\n", (int)rkmessage->len, (char *)rkmessage
 	MsgSetRawMsg(pMsg, (char*)rkmessage->payload, (int)rkmessage->len);
 	MsgSetFlowControlType(pMsg, eFLOWCTL_LIGHT_DELAY);
 	MsgSetRuleset(pMsg, inst->pBindRuleset);
-	pMsg->msgFlags  = NEEDS_PARSING; // | PARSE_HOSTNAME;
+	pMsg->msgFlags  = inst->nMsgParsingFlags;
 	/* Optional Fields */
 	if (rkmessage->key_len) {
 		DBGPRINTF("imkafka: enqMsg: Key: %.*s\n", (int)rkmessage->key_len, (char *)rkmessage->key);
@@ -279,6 +281,7 @@ createInstance(instanceConf_t **pinst)
 	inst->confParams = NULL;
 	inst->pBindRuleset = NULL;
 	inst->bReportErrs = 1; /* Fixed for now */
+	inst->nMsgParsingFlags = NEEDS_PARSING;
 	inst->bIsConnected = 0;
 	inst->bIsSubscribed = 0;
 	/* Kafka objects */
@@ -555,6 +558,12 @@ CODESTARTnewInpInst
 			inst->consumergroup = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "ruleset")) {
 			inst->pszBindRuleset = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "parsehostname")) {
+			if (pvals[i].val.d.n) {
+				inst->nMsgParsingFlags = NEEDS_PARSING | PARSE_HOSTNAME;
+			} else {
+				inst->nMsgParsingFlags = NEEDS_PARSING;
+			}
 		} else {
 			dbgprintf("imkafka: program error, non-handled "
 			  "param '%s'\n", inppblk.descr[i].name);


### PR DESCRIPTION
Fix imkafka can't parse hostname.
Add a option named "ParseHostName"(default is off) in imkafka, to maintain compatibility.
When ParseHostName = "on", a correct $hostname would be parsed.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
