### PR TITLE
testbench: use new kafka/zookeeper versions, fixed/added tests.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -507,11 +507,12 @@ if ENABLE_OMKAFKA
 if ENABLE_IMKAFKA
 if ENABLE_KAFKA_TESTS
 TESTS += \
-	sndrcv_kafka.sh
+	sndrcv_kafka.sh \
+	sndrcv_kafka_multi_topics.sh
 # Tests below need to be stable first!
-#	sndrcv_kafka_multi.sh
-#	sndrcv_kafka_fail.sh
+#	sndrcv_kafka_fail.sh \
 #	sndrcv_kafka_failresume.sh
+#	sndrcv_kafka_multi.sh
 if HAVE_VALGRIND
 TESTS += \
 	sndrcv_kafka-vg-rcvr.sh
@@ -521,6 +522,7 @@ endif
 endif
 endif
 endif
+
 if ENABLE_IMPSTATS
 TESTS +=  \
 	impstats-hup.sh \
@@ -1538,11 +1540,8 @@ EXTRA_DIST= \
 	mysql-actq-mt-withpause.sh \
 	mysql-actq-mt-withpause-vg.sh \
 	sndrcv_kafka.sh \
-	sndrcv_kafka-vg-sender.sh \
+	sndrcv_kafka_multi_topics.sh \
 	sndrcv_kafka-vg-rcvr.sh \
-	sndrcv_kafka_multi.sh \
-	sndrcv_kafka_fail.sh \
-	sndrcv_kafka_failresume.sh \
 	testsuites/kafka-server.properties \
 	testsuites/kafka-server.dep_wrk1.properties \
 	testsuites/kafka-server.dep_wrk2.properties \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -460,16 +460,19 @@ python -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsocknam
 
 #START: ext kafka config
 dep_cache_dir=$(readlink -f .dep_cache)
-dep_zk_url=http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.10/zookeeper-3.4.10.tar.gz
-dep_zk_cached_file=$dep_cache_dir/zookeeper-3.4.10.tar.gz
-dep_kafka_url=http://www-us.apache.org/dist/kafka/0.10.2.1/kafka_2.12-0.10.2.1.tgz
+dep_zk_url=http://www-us.apache.org/dist/zookeeper/zookeeper-3.4.13/zookeeper-3.4.13.tar.gz
+dep_zk_cached_file=$dep_cache_dir/zookeeper-3.4.13.tar.gz
+#	dep_kafka_url=http://www-us.apache.org/dist/kafka/0.10.2.2/kafka_2.12-0.10.2.2.tgz
+#	dep_kafka_cached_file=$dep_cache_dir/kafka_2.12-0.10.2.2.tgz
+dep_kafka_url=http://www-us.apache.org/dist/kafka/2.0.0/kafka_2.12-2.0.0.tgz
+dep_kafka_cached_file=$dep_cache_dir/kafka_2.12-2.0.0.tgz
+
 if [ -z "$ES_DOWNLOAD" ]; then
 	export ES_DOWNLOAD=elasticsearch-5.6.9.tar.gz
 fi
 dep_es_cached_file="$dep_cache_dir/$ES_DOWNLOAD"
 
 # kafaka (including Zookeeper)
-dep_kafka_cached_file=$dep_cache_dir/kafka_2.12-0.10.2.1.tgz
 dep_kafka_dir_xform_pattern='s#^[^/]\+#kafka#g'
 dep_zk_dir_xform_pattern='s#^[^/]\+#zk#g'
 dep_es_dir_xform_pattern='s#^[^/]\+#es#g'

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -2,9 +2,12 @@
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 export TESTMESSAGES=100000
+export TESTMESSAGESFULL=100000
 # enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
 # too much
-export EXTRA_EXITCHECK=dumpkafkalogs
+# export EXTRA_EXITCHECK=dumpkafkalogs
+echo ===============================================================================
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Create kafka/zookeeper instance and static topic
 . $srcdir/diag.sh download-kafka
 . $srcdir/diag.sh stop-zookeeper
 . $srcdir/diag.sh stop-kafka
@@ -12,12 +15,14 @@ export EXTRA_EXITCHECK=dumpkafkalogs
 . $srcdir/diag.sh start-kafka
 . $srcdir/diag.sh create-kafka-topic 'static' '.dep_wrk' '22181'
 
-echo Give Kafka some time to process topic create ...
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo Starting receiver instance [omkafka]
-export RSYSLOG_DEBUGLOG="log"
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Init Testbench 
 . $srcdir/diag.sh init
+
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Starting receiver instance [omkafka]
+export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
 module(load="../plugins/imkafka/.libs/imkafka")
@@ -27,7 +32,8 @@ input(	type="imkafka"
 	broker="localhost:29092" 
 	consumergroup="default"
 	confParam=[ "compression.codec=none",
-		"socket.timeout.ms=1000",
+		"socket.timeout.ms=5000",
+		"reconnect.backoff.jitter.ms=1000",
 		"socket.keepalive.enable=true"]
 	)
 
@@ -40,7 +46,7 @@ if ($msg contains "msgnum:") then {
 startup_vg
 . $srcdir/diag.sh wait-startup
 
-echo Starting sender instance [imkafka]
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Starting sender instance [imkafka]
 export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
@@ -52,53 +58,57 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(	name="kafka-fwd" 
+local4.* action(	name="kafka-fwd" 
 	type="omkafka" 
 	topic="static" 
 	broker="localhost:29092" 
 	template="outfmt" 
 	confParam=[	"compression.codec=none",
-			"socket.timeout.ms=1000",
+			"socket.timeout.ms=10000",
 			"socket.keepalive.enable=true",
 			"reconnect.backoff.jitter.ms=1000",
 			"queue.buffering.max.messages=20000",
+			"enable.auto.commit=true",
 			"message.send.max.retries=1"]
-	topicConfParam=["message.timeout.ms=1000"]
+	topicConfParam=["message.timeout.ms=10000"]
 	partitions.auto="on"
+	closeTimeout="30000"
 	resubmitOnFailure="on"
 	keepFailedMessages="on"
 	failedMsgFile="omkafka-failed.data"
 	action.resumeInterval="2"
-	action.resumeRetryCount="10"
+	action.resumeRetryCount="-1"
 	queue.saveonshutdown="on"
 	)
 ' 2
 startup 2
 . $srcdir/diag.sh wait-startup 2
 
-echo Inject messages into rsyslog sender instance  
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Inject messages into rsyslog sender instance  
 tcpflood -m$TESTMESSAGES -i1
 
-echo Sleep to give rsyslog instances time to process data ...
-sleep 5
+#echo \[sndrcv_kafka-vg-rcvr.sh\]: Sleep to give rsyslog instances time to process data ...
+#sleep 5
 
-echo Stopping sender instance [imkafka]
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Stopping sender instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown 2
 
-echo Sleep to give rsyslog receiver time to receive data ...
-sleep 5
+#echo \[sndrcv_kafka-vg-rcvr.sh\]: Sleep to give rsyslog receiver time to receive data ...
+#sleep 20
 
-echo Stopping receiver instance [omkafka]
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Stopping receiver instance [omkafka]
 shutdown_when_empty
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg
 
 # Do the final sequence check
-seq_check 1 $TESTMESSAGES -d
+seq_check 1 $TESTMESSAGESFULL -d
 
-echo stop kafka instance
+echo \[sndrcv_kafka-vg-rcvr.sh\]: delete kafka topics 
 . $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
+
+echo \[sndrcv_kafka-vg-rcvr.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=1000
-export TESTMESSAGESFULL=1000
+export TESTMESSAGES=100000
+export TESTMESSAGESFULL=100000
 # enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
 # too much
 #export EXTRA_EXITCHECK=dumpkafkalogs
@@ -18,34 +18,12 @@ echo \[sndrcv_kafka.sh\]: Create kafka/zookeeper instance and static topic
 echo \[sndrcv_kafka.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka.sh\]: Starting receiver instance [imkafka]
-export RSYSLOG_DEBUGLOG="log"
+echo \[sndrcv_kafka.sh\]: Init Testbench 
 . $srcdir/diag.sh init
+
+# --- Create/Start omkafka sender config 
+export RSYSLOG_DEBUGLOG="log"
 generate_conf
-add_conf '
-module(load="../plugins/imkafka/.libs/imkafka")
-/* Polls messages from kafka server!*/
-input(	type="imkafka" 
-	topic="static" 
-	broker="localhost:29092" 
-	consumergroup="default"
-	confParam=[ "compression.codec=none",
-		"socket.timeout.ms=1000",
-		"socket.keepalive.enable=true"]
-	)
-
-template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-
-if ($msg contains "msgnum:") then {
-	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
-}
-'
-startup 
-. $srcdir/diag.sh wait-startup
-
-echo \[sndrcv_kafka.sh\]: Starting sender instance [omkafka]
-export RSYSLOG_DEBUGLOG="log2"
-generate_conf 2
 add_conf '
 main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
 
@@ -55,52 +33,85 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(	name="kafka-fwd" 
+local4.* action(	name="kafka-fwd" 
 	type="omkafka" 
 	topic="static" 
 	broker="localhost:29092" 
 	template="outfmt" 
 	confParam=[	"compression.codec=none",
-			"socket.timeout.ms=1000",
+			"socket.timeout.ms=10000",
 			"socket.keepalive.enable=true",
 			"reconnect.backoff.jitter.ms=1000",
 			"queue.buffering.max.messages=20000",
+			"enable.auto.commit=true",
 			"message.send.max.retries=1"]
-	topicConfParam=["message.timeout.ms=1000"]
+	topicConfParam=["message.timeout.ms=10000"]
 	partitions.auto="on"
+	closeTimeout="30000"
 	resubmitOnFailure="on"
 	keepFailedMessages="on"
 	failedMsgFile="omkafka-failed.data"
-	action.resumeInterval="2"
-	action.resumeRetryCount="10"
+	action.resumeInterval="1"
+	action.resumeRetryCount="-1"
 	queue.saveonshutdown="on"
 	)
-' 2
-startup 2
-. $srcdir/diag.sh wait-startup 2
+'
+
+echo \[sndrcv_kafka.sh\]: Starting sender instance [omkafka]
+startup
+. $srcdir/diag.sh wait-startup
+# --- 
 
 echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance  
 tcpflood -m$TESTMESSAGES -i1
 
-echo \[sndrcv_kafka.sh\]: Sleep to give rsyslog instances time to process data ...
-sleep 5
+# --- Create/Start imkafka receiver config 
+export RSYSLOG_DEBUGLOG="log2"
+generate_conf 2
+add_conf '
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server!*/
+input(	type="imkafka" 
+	topic="static" 
+	broker="localhost:29092" 
+	consumergroup="default"
+	confParam=[ "compression.codec=none",
+		"socket.timeout.ms=10000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if ($msg contains "msgnum:") then {
+	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
+}
+' 2
+
+echo \[sndrcv_kafka.sh\]: Starting receiver instance [imkafka]
+startup 2
+. $srcdir/diag.sh wait-startup 2
+# --- 
+
+#echo \[sndrcv_kafka.sh\]: Sleep to give rsyslog instances time to process data ...
+#sleep 20
 
 echo \[sndrcv_kafka.sh\]: Stopping sender instance [omkafka]
-shutdown_when_empty 2
-wait_shutdown 2
-
-echo \[sndrcv_kafka.sh\]: Sleep to give rsyslog receiver time to receive data ...
-sleep 5
-
-echo \[sndrcv_kafka.sh\]: Stopping receiver instance [imkafka]
 shutdown_when_empty
 wait_shutdown
+
+echo \[sndrcv_kafka.sh\]: Stopping receiver instance [imkafka]
+shutdown_when_empty 2
+wait_shutdown 2
 
 # Do the final sequence check
 seq_check 1 $TESTMESSAGESFULL -d
 
-echo \[sndrcv_kafka_fail.sh\]: stop kafka instance
+echo \[sndrcv_kafka.sh\]: delete kafka topics 
 . $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
+
+echo \[sndrcv_kafka.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -2,8 +2,9 @@
 # added 2017-05-18 by alorbach
 #	This test only tests what happens when kafka cluster fails
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=1000
-export TESTMESSAGESFULL=2000
+export TESTMESSAGES=10000
+export TESTMESSAGES2=10001
+export TESTMESSAGESFULL=10000
 
 echo ===============================================================================
 echo \[sndrcv_kafka_fail.sh\]: Create kafka/zookeeper instance and static topic
@@ -17,12 +18,13 @@ echo \[sndrcv_kafka_fail.sh\]: Create kafka/zookeeper instance and static topic
 echo \[sndrcv_kafka_fail.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
+echo \[sndrcv_kafka_fail.sh\]: Init Testbench 
+. $srcdir/diag.sh init
+
 echo \[sndrcv_kafka_fail.sh\]: Stopping kafka cluster instance 
 . $srcdir/diag.sh stop-kafka
 
-echo \[sndrcv_kafka_fail.sh\]: Starting receiver instance [omkafka]
-export RSYSLOG_DEBUGLOG="log"
-. $srcdir/diag.sh init
+# --- Create omkafka receiver config 
 generate_conf
 add_conf '
 module(load="../plugins/imkafka/.libs/imkafka")
@@ -32,7 +34,7 @@ input(	type="imkafka"
 	broker="localhost:29092" 
 	consumergroup="default"
 	confParam=[ "compression.codec=none",
-		"socket.timeout.ms=1000",
+		"socket.timeout.ms=5000",
 		"socket.keepalive.enable=true"]
 	)
 
@@ -42,14 +44,17 @@ if ($msg contains "msgnum:") then {
 	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
 }
 '
+
+echo \[sndrcv_kafka_fail.sh\]: Starting receiver instance [omkafka]
+export RSYSLOG_DEBUGLOG="log"
 startup
 . $srcdir/diag.sh wait-startup
+# --- 
 
-echo \[sndrcv_kafka_fail.sh\]: Starting sender instance [imkafka]
-export RSYSLOG_DEBUGLOG="log2"
+# --- Create omkafka sender config 
 generate_conf 2
 add_conf '
-main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
+main_queue(queue.timeoutactioncompletion="5000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
@@ -57,29 +62,35 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(	name="kafka-fwd" 
+local4.* action(	name="kafka-fwd" 
 	type="omkafka" 
 	topic="static" 
 	broker="localhost:29092" 
 	template="outfmt" 
 	confParam=[	"compression.codec=none",
-			"socket.timeout.ms=1000",
+			"socket.timeout.ms=5000",
 			"socket.keepalive.enable=true",
 			"reconnect.backoff.jitter.ms=1000",
 			"queue.buffering.max.messages=20000",
+			"enable.auto.commit=true",
 			"message.send.max.retries=1"]
-	topicConfParam=["message.timeout.ms=1000"]
+	topicConfParam=["message.timeout.ms=5000"]
 	partitions.auto="on"
+	closeTimeout="30000"
 	resubmitOnFailure="on"
 	keepFailedMessages="on"
 	failedMsgFile="omkafka-failed.data"
 	action.resumeInterval="2"
-	action.resumeRetryCount="10"
+	action.resumeRetryCount="-1"
 	queue.saveonshutdown="on"
 	)
 ' 2
+
+echo \[sndrcv_kafka_fail.sh\]: Starting sender instance [imkafka]
+export RSYSLOG_DEBUGLOG="log2"
 startup 2
 . $srcdir/diag.sh wait-startup 2
+# --- 
 
 echo \[sndrcv_kafka_fail.sh\]: Inject messages into rsyslog sender instance  
 tcpflood -m$TESTMESSAGES -i1
@@ -91,7 +102,7 @@ echo \[sndrcv_kafka_fail.sh\]: Sleep to give rsyslog instances time to process d
 sleep 5
 
 echo \[sndrcv_kafka_fail.sh\]: Inject messages into rsyslog sender instance  
-tcpflood -m$TESTMESSAGES -i1001
+tcpflood -m$TESTMESSAGES -i$TESTMESSAGES2
 
 echo \[sndrcv_kafka_fail.sh\]: Sleep to give rsyslog sender time to send data ...
 sleep 5
@@ -100,19 +111,24 @@ echo \[sndrcv_kafka_fail.sh\]: Stopping sender instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown 2
 
-echo \[sndrcv_kafka_fail.sh\]: Sleep to give rsyslog receiver time to receive data ...
-sleep 5
+#echo \[sndrcv_kafka_fail.sh\]: Sleep to give rsyslog receiver time to receive data ...
+#sleep 20
 
 echo \[sndrcv_kafka_fail.sh\]: Stopping receiver instance [omkafka]
 shutdown_when_empty
 wait_shutdown
 
 # Do the final sequence check
-seq_check 1 $TESTMESSAGESFULL -d
+seq_check2 1 $TESTMESSAGESFULL -d
+
+echo \[sndrcv_kafka_fail.sh\]: delete kafka topics 
+. $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
 
 echo \[sndrcv_kafka_fail.sh\]: stop kafka instance
-. $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case
 . $srcdir/diag.sh stop-zookeeper
+
+echo success
+exit_test

--- a/tests/sndrcv_kafka_multi_topics.sh
+++ b/tests/sndrcv_kafka_multi_topics.sh
@@ -1,0 +1,157 @@
+#!/bin/bash
+# added 2018-08-13 by alorbach
+# This file is part of the rsyslog project, released under ASL 2.0
+export TESTMESSAGES=5000
+export TESTMESSAGESFULL=10000
+# enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
+# too much
+#export EXTRA_EXITCHECK=dumpkafkalogs
+echo ===============================================================================
+echo \[sndrcv_kafka_multi_topics.sh\]: Create kafka/zookeeper instance and static topic
+. $srcdir/diag.sh download-kafka
+. $srcdir/diag.sh stop-zookeeper
+. $srcdir/diag.sh stop-kafka
+. $srcdir/diag.sh start-zookeeper
+. $srcdir/diag.sh start-kafka
+. $srcdir/diag.sh create-kafka-topic 'static1' '.dep_wrk' '22181'
+. $srcdir/diag.sh create-kafka-topic 'static2' '.dep_wrk' '22181'
+
+echo \[sndrcv_kafka_multi_topics.sh\]: Give Kafka some time to process topic create ...
+sleep 5
+
+echo \[sndrcv_kafka_fail.sh\]: Init Testbench 
+. $srcdir/diag.sh init
+
+# --- Create omkafka sender config 
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/omkafka/.libs/omkafka")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514")	/* this port for tcpflood! */
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+local4.* action(	name="kafka-fwd" 
+	type="omkafka" 
+	topic="static1" 
+	broker="localhost:29092" 
+	template="outfmt" 
+	confParam=[	"compression.codec=none",
+			"socket.timeout.ms=10000",
+			"socket.keepalive.enable=true",
+			"reconnect.backoff.jitter.ms=1000",
+			"queue.buffering.max.messages=20000",
+			"enable.auto.commit=true",
+			"message.send.max.retries=1"]
+	topicConfParam=["message.timeout.ms=10000"]
+	partitions.auto="on"
+	closeTimeout="30000"
+	resubmitOnFailure="on"
+	keepFailedMessages="on"
+	failedMsgFile="omkafka-failed1.data"
+	action.resumeInterval="2"
+	action.resumeRetryCount="-1"
+	queue.saveonshutdown="on"
+	)
+local4.* action(	name="kafka-fwd" 
+	type="omkafka" 
+	topic="static2" 
+	broker="localhost:29092" 
+	template="outfmt" 
+	confParam=[	"compression.codec=none",
+			"socket.timeout.ms=10000",
+			"socket.keepalive.enable=true",
+			"reconnect.backoff.jitter.ms=1000",
+			"queue.buffering.max.messages=20000",
+			"enable.auto.commit=true",
+			"message.send.max.retries=1"]
+	topicConfParam=["message.timeout.ms=10000"]
+	partitions.auto="on"
+	closeTimeout="30000"
+	resubmitOnFailure="on"
+	keepFailedMessages="on"
+	failedMsgFile="omkafka-failed2.data"
+	action.resumeInterval="2"
+	action.resumeRetryCount="-1"
+	queue.saveonshutdown="on"
+	)
+' 
+
+echo \[sndrcv_kafka_multi_topics.sh\]: Starting sender instance [omkafka]
+export RSYSLOG_DEBUGLOG="log"
+startup
+. $srcdir/diag.sh wait-startup
+# --- 
+
+
+# --- Create omkafka sender config 
+generate_conf 2
+add_conf '
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server!*/
+input(	type="imkafka" 
+	topic="static1" 
+	broker="localhost:29092" 
+	consumergroup="default1"
+	confParam=[ "compression.codec=none",
+		"socket.timeout.ms=10000",
+		"enable.partition.eof=false",
+		"reconnect.backoff.jitter.ms=1000",
+		"socket.keepalive.enable=true"]
+	)
+input(	type="imkafka" 
+	topic="static2" 
+	broker="localhost:29092" 
+	consumergroup="default2"
+	confParam=[ "compression.codec=none",
+		"socket.timeout.ms=10000",
+		"enable.partition.eof=false",
+		"reconnect.backoff.jitter.ms=1000",
+		"socket.keepalive.enable=true"]
+	)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if ($msg contains "msgnum:") then {
+	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
+}
+' 2
+
+echo \[sndrcv_kafka_multi_topics.sh\]: Starting receiver instance [imkafka]
+export RSYSLOG_DEBUGLOG="log2"
+startup 2
+. $srcdir/diag.sh wait-startup 2
+# --- 
+
+echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance  
+tcpflood -m$TESTMESSAGES -i1
+
+#echo \[sndrcv_kafka.sh\]: Sleep to give rsyslog instances time to process data ...
+sleep 5
+
+echo \[sndrcv_kafka.sh\]: Stopping sender instance [omkafka]
+shutdown_when_empty 2
+wait_shutdown 2
+
+echo \[sndrcv_kafka.sh\]: Stopping receiver instance [imkafka]
+shutdown_when_empty
+wait_shutdown
+
+# Do the final sequence check
+seq_check 1 $TESTMESSAGES -d
+. $srcdir/diag.sh content-check-with-count "000" $TESTMESSAGESFULL
+
+echo \[sndrcv_kafka.sh\]: delete kafka topics 
+. $srcdir/diag.sh delete-kafka-topic 'static1' '.dep_wrk' '22181'
+. $srcdir/diag.sh delete-kafka-topic 'static2' '.dep_wrk' '22181'
+
+echo \[sndrcv_kafka.sh\]: stop kafka instance
+. $srcdir/diag.sh stop-kafka
+
+# STOP ZOOKEEPER in any case
+. $srcdir/diag.sh stop-zookeeper
+
+echo success
+exit_test

--- a/tests/testsuites/kafka-server.dep_wrk1.properties
+++ b/tests/testsuites/kafka-server.dep_wrk1.properties
@@ -18,10 +18,11 @@ leader.imbalance.per.broker.percentage=10
 log.segment.bytes=10485760
 log.cleaner.enable=true 
 log.cleanup.policy=delete
+log.retention.hours=1
 log.dirs=kafka-logs
 log.flush.interval.messages=1000
 log.flush.interval.ms=1000
-log.flush.scheduler.interval.ms=2000
+log.flush.scheduler.interval.ms=1000
 log.index.interval.bytes=4096
 log.index.size.max.bytes=10485760
 log.message.timestamp.type=CreateTime
@@ -32,10 +33,8 @@ message.max.bytes=1000000
 
 num.network.threads=2
 num.io.threads=2
-#num.partitions=1
 num.partitions=100
 num.recovery.threads.per.data.dir=1
-
 num.replica.fetchers=1
 min.insync.replicas=2
 
@@ -44,7 +43,7 @@ socket.request.max.bytes=104857600
 socket.send.buffer.bytes=102400
 
 offsets.storage=kafka
-offsets.topic.num.partitions=1
+offsets.topic.num.partitions=50
 offsets.topic.replication.factor=3
 
 replica.fetch.max.bytes=1048576
@@ -52,16 +51,16 @@ replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
-replica.socket.timeout.ms=30000
+replica.socket.timeout.ms=5000
 
 unclean.leader.election.enable=false
 queued.max.requests=500
 
-#zookeeper.connect=zoo1.internal:22181,zoo2.internal:22181,zoo3.internal:22181
-#zookeeper.connection.timeout.ms=6000
 zookeeper.connect=localhost:22181/kafka,localhost:22182/kafka,localhost:22183/kafka
-zookeeper.connection.timeout.ms=6000
-zookeeper.session.timeout.ms=6000
+zookeeper.connection.timeout.ms=10000
+zookeeper.session.timeout.ms=5000
 zookeeper.sync.time.ms=2000
 
 group.id="default"
+
+heartbeat.interval.ms=1000

--- a/tests/testsuites/kafka-server.dep_wrk2.properties
+++ b/tests/testsuites/kafka-server.dep_wrk2.properties
@@ -18,10 +18,11 @@ leader.imbalance.per.broker.percentage=10
 log.segment.bytes=10485760
 log.cleaner.enable=true 
 log.cleanup.policy=delete
+log.retention.hours=1
 log.dirs=kafka-logs
 log.flush.interval.messages=1000
 log.flush.interval.ms=1000
-log.flush.scheduler.interval.ms=2000
+log.flush.scheduler.interval.ms=1000
 log.index.interval.bytes=4096
 log.index.size.max.bytes=10485760
 log.message.timestamp.type=CreateTime
@@ -32,10 +33,8 @@ message.max.bytes=1000000
 
 num.network.threads=2
 num.io.threads=2
-#num.partitions=1
 num.partitions=100
 num.recovery.threads.per.data.dir=1
-
 num.replica.fetchers=1
 min.insync.replicas=2
 
@@ -52,16 +51,16 @@ replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
-replica.socket.timeout.ms=30000
+replica.socket.timeout.ms=5000
 
 unclean.leader.election.enable=false
 queued.max.requests=500
 
-#zookeeper.connect=zoo1.internal:22181,zoo2.internal:22181,zoo3.internal:22181
-#zookeeper.connection.timeout.ms=6000
 zookeeper.connect=localhost:22181/kafka,localhost:22182/kafka,localhost:22183/kafka
-zookeeper.connection.timeout.ms=6000
-zookeeper.session.timeout.ms=6000
+zookeeper.connection.timeout.ms=10000
+zookeeper.session.timeout.ms=5000
 zookeeper.sync.time.ms=2000
 
 group.id="default"
+
+heartbeat.interval.ms=1000

--- a/tests/testsuites/kafka-server.dep_wrk3.properties
+++ b/tests/testsuites/kafka-server.dep_wrk3.properties
@@ -18,10 +18,11 @@ leader.imbalance.per.broker.percentage=10
 log.segment.bytes=10485760
 log.cleaner.enable=true 
 log.cleanup.policy=delete
+log.retention.hours=1
 log.dirs=kafka-logs
 log.flush.interval.messages=1000
 log.flush.interval.ms=1000
-log.flush.scheduler.interval.ms=2000
+log.flush.scheduler.interval.ms=1000
 log.index.interval.bytes=4096
 log.index.size.max.bytes=10485760
 log.message.timestamp.type=CreateTime
@@ -32,10 +33,8 @@ message.max.bytes=1000000
 
 num.network.threads=2
 num.io.threads=2
-#num.partitions=1
 num.partitions=100
 num.recovery.threads.per.data.dir=1
-
 num.replica.fetchers=1
 min.insync.replicas=2
 
@@ -52,16 +51,16 @@ replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
-replica.socket.timeout.ms=30000
+replica.socket.timeout.ms=5000
 
 unclean.leader.election.enable=false
 queued.max.requests=500
 
-#zookeeper.connect=zoo1.internal:22181,zoo2.internal:22181,zoo3.internal:22181
-#zookeeper.connection.timeout.ms=6000
 zookeeper.connect=localhost:22181/kafka,localhost:22182/kafka,localhost:22183/kafka
-zookeeper.connection.timeout.ms=6000
-zookeeper.session.timeout.ms=6000
+zookeeper.connection.timeout.ms=10000
+zookeeper.session.timeout.ms=5000
 zookeeper.sync.time.ms=2000
 
 group.id="default"
+
+heartbeat.interval.ms=1000

--- a/tests/testsuites/kafka-server.properties
+++ b/tests/testsuites/kafka-server.properties
@@ -3,28 +3,26 @@ listeners=PLAINTEXT://:29092
 
 auto.create.topics.enable=true
 auto.leader.rebalance.enable=true
-background.threads=10
+background.threads=2
 compression.type=producer
 controlled.shutdown.enable=true
+default.replication.factor=1
 
 delete.topic.enable=true
-dual.commit.enabled=false
+dual.commit.enabled=true
 
-leader.imbalance.check.interval.seconds=300
+leader.imbalance.check.interval.seconds=10
 leader.imbalance.per.broker.percentage=10
 
-num.partitions=1
-num.recovery.threads.per.data.dir=1
-
-#10 MB is sufficient for testing
-log.segment.bytes=10485760
-log.cleaner.enable=true 
+#100 MB is sufficient for testing
+log.segment.bytes=536870912
+log.cleaner.enable=false
 log.cleanup.policy=delete
 log.retention.hours=1
 log.dirs=kafka-logs
-log.flush.interval.messages=20000
-log.flush.interval.ms=10000
-log.flush.scheduler.interval.ms=2000
+log.flush.interval.messages=1000
+log.flush.interval.ms=1000
+log.flush.scheduler.interval.ms=1000
 log.index.interval.bytes=4096
 log.index.size.max.bytes=10485760
 log.message.timestamp.type=CreateTime
@@ -33,33 +31,37 @@ log.retention.hours=168
 log.roll.hours=168
 message.max.bytes=1000000
 
-num.network.threads=3
-num.io.threads=8
-num.partitions=100
+num.network.threads=2
+num.io.threads=2
+num.partitions=1
 num.recovery.threads.per.data.dir=1
-num.replica.fetchers=4
+num.replica.fetchers=1
+min.insync.replicas=1
 
 socket.receive.buffer.bytes=102400
 socket.request.max.bytes=104857600
 socket.send.buffer.bytes=102400
 
 offsets.storage=kafka
-offsets.topic.num.partitions=50
+offsets.topic.num.partitions=1
 #offsets.topic.replication.factor=3
+transaction.state.log.num.partitions=1
 
 replica.fetch.max.bytes=1048576
 replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
-replica.socket.timeout.ms=30000
+replica.socket.timeout.ms=5000
 
 unclean.leader.election.enable=false
-queued.max.requests=500
+queued.max.requests=10000
 
 zookeeper.connect=localhost:22181/kafka
-zookeeper.connection.timeout.ms=6000
-zookeeper.session.timeout.ms=6000
-zookeeper.sync.time.ms=2000
+zookeeper.connection.timeout.ms=10000
+zookeeper.session.timeout.ms=5000
+zookeeper.sync.time.ms=5000
 
 group.id="default"
+
+heartbeat.interval.ms=1000


### PR DESCRIPTION
Fixed test configurations (socket timeouts, settings and so on)
Switched testbench to newer kafka/zookeeper versions.
Added new test for multiple imkafka instances.
Renabled sndrcv_kafka_fail.sh testcase.

