### PR TITLE
testbench: replace hardcoded port 13514

### DIFF
--- a/tests/CI/buildbot_cleanup.sh
+++ b/tests/CI/buildbot_cleanup.sh
@@ -4,3 +4,13 @@
 # in which case autotools unfortunately does not provide us a way to
 # gather error information.
 rm -f tests/*.sh.log
+
+# cleanup of hanging instances from previous runs
+# practice has shown this is pretty useful!
+for pid in $(ps -eo pid,args|grep '/tools/[r]syslogd ' |sed -e 's/\( *\)\([0-9]*\).*/\2/');
+do
+	echo "ERROR: left-over previous instance $pid, killing it"
+	ps -fp $pid
+	pwd
+	kill -9 $pid
+done

--- a/tests/abort-uncleancfg-goodcfg.sh
+++ b/tests/abort-uncleancfg-goodcfg.sh
@@ -11,7 +11,7 @@ $AbortOnUncleanConfig on
 
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/arrayqueue.sh
+++ b/tests/arrayqueue.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 # set spool locations and switch queue to disk-only mode
 $MainMsgQueueType FixedArray

--- a/tests/asynwr_deadlock.sh
+++ b/tests/asynwr_deadlock.sh
@@ -12,7 +12,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 

--- a/tests/asynwr_deadlock2.sh
+++ b/tests/asynwr_deadlock2.sh
@@ -50,18 +50,16 @@
 # we hit all failure conditions.
 #
 # added 2010-03-17 by Rgerhards
-# This file is part of the rsyslog project, released  under GPLv3
-echo =================================================================================
-echo TEST: \[asynwr_deadlock2.sh\]: a case known to have caused a deadlock in the past
+# This file is part of the rsyslog project, released under ASL 2.0
 . $srcdir/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:3%,%msg:F,58:4%,%msg:F,58:5%\n"
-$template dynfile,"rsyslog.out.%msg:F,58:2%.log" # use multiple dynafiles
+$template dynfile,"'$RSYSLOG_DYNNAME'.%msg:F,58:2%.log" # use multiple dynafiles
 
 $OMFileFlushOnTXEnd on
 $OMFileFlushInterval 10
@@ -77,10 +75,9 @@ startup
 # send 20000 messages, each close to 2K (non-randomized!), so that we can fill
 # the buffers and hopefully run into the "deadlock".
 tcpflood -m20000 -d1800 -P129 -i1 -f5
-# the sleep below is needed to prevent too-early termination of the tcp listener
-sleep 1
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown       # and wait for it to terminate
-cat rsyslog.out.*.log > $RSYSLOG_OUT_LOG
+shutdown_when_empty
+wait_shutdown
+cat $RSYSLOG_DYNNAME.*.log > $RSYSLOG_OUT_LOG
 seq_check 1 20000 -E
+rm -f $RSYSLOG_DYNNAME.*.log
 exit_test

--- a/tests/asynwr_deadlock4.sh
+++ b/tests/asynwr_deadlock4.sh
@@ -16,7 +16,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:3%,%msg:F,58:4%,%msg:F,58:5%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # use multiple dynafiles

--- a/tests/asynwr_deadlock_2.sh
+++ b/tests/asynwr_deadlock_2.sh
@@ -12,7 +12,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 

--- a/tests/asynwr_simple.sh
+++ b/tests/asynwr_simple.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/asynwr_simple_2.sh
+++ b/tests/asynwr_simple_2.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/asynwr_small.sh
+++ b/tests/asynwr_small.sh
@@ -19,7 +19,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/asynwr_timeout.sh
+++ b/tests/asynwr_timeout.sh
@@ -12,7 +12,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/asynwr_timeout_2.sh
+++ b/tests/asynwr_timeout_2.sh
@@ -12,7 +12,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/asynwr_tinybuf.sh
+++ b/tests/asynwr_tinybuf.sh
@@ -13,7 +13,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/badqi.sh
+++ b/tests/badqi.sh
@@ -12,7 +12,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/complex1.sh
+++ b/tests/complex1.sh
@@ -3,9 +3,7 @@
 #
 # added 2010-03-16 by Rgerhards
 #
-# This file is part of the rsyslog project, released  under GPLv3
-echo ====================================================================================
-echo TEST: \[complex1.sh\]: complex test with gzip and multiple action queues
+# This file is part of the rsyslog project, released under ASL 2.0
 
 uname
 if [ `uname` = "SunOS" ] ; then
@@ -14,6 +12,8 @@ if [ `uname` = "SunOS" ] ; then
 fi
 
 . $srcdir/diag.sh init
+export RSYSLOG_PORT2="$(get_free_port)"
+export RSYSLOG_PORT3="$(get_free_port)"
 generate_conf
 add_conf '
 $MaxMessageSize 10k
@@ -45,13 +45,13 @@ $DynaFileCacheSize 4
 $omfileFlushInterval 1
 *.* ?dynfile;outfmt
 # listener
-$InputTCPServerInputName 13514
+$InputTCPServerInputName '$TCPFLOOD_PORT'
 $InputTCPServerBindRuleset R13514
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 
 ## RULESET with listener
-$Ruleset R13515
+$Ruleset R_PORT2
 # queue params:
 $ActionQueueTimeoutShutdown 60000
 $ActionQueueTimeoutEnqueue 5000
@@ -69,14 +69,14 @@ $DynaFileCacheSize 4
 $omfileFlushInterval 1
 *.* ?dynfile;outfmt
 # listener
-$InputTCPServerInputName 13515
-$InputTCPServerBindRuleset R13515
-$InputTCPServerRun 13515
+$InputTCPServerInputName '$RSYSLOG_PORT2'
+$InputTCPServerBindRuleset R_PORT2
+$InputTCPServerRun '$RSYSLOG_PORT2'
 
 
 
 ## RULESET with listener
-$Ruleset R13516
+$Ruleset R_PORT3
 # queue params:
 $ActionQueueTimeoutShutdown 60000
 $ActionQueueTimeoutEnqueue 5000
@@ -94,17 +94,17 @@ $DynaFileCacheSize 4
 $omfileFlushInterval 1
 *.* ?dynfile;outfmt
 # listener
-$InputTCPServerInputName 13516
-$InputTCPServerBindRuleset R13516
-$InputTCPServerRun 13516
+$InputTCPServerInputName '$RSYSLOG_PORT3'
+$InputTCPServerBindRuleset R_PORT3
+$InputTCPServerRun '$RSYSLOG_PORT3'
 '
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="log"
 startup
 # send 40,000 messages of 400 bytes plus header max, via three dest ports
+export TCPFLOOD_PORT="$TCPFLOOD_PORT:$RSYSLOG_PORT2:$RSYSLOG_PORT3"
 tcpflood -m40000 -rd400 -P129 -f5 -n3 -c15 -i1
-sleep 4 # due to large messages, we need this time for the tcp receiver to settle...
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate
 ls rsyslog.out.*.log

--- a/tests/compresssp-stringtpl.sh
+++ b/tests/compresssp-stringtpl.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:::compressSPACE%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/compresssp.sh
+++ b/tests/compresssp.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="list") {
 	property(name="msg" compressSpace="on")

--- a/tests/da-mainmsg-q.sh
+++ b/tests/da-mainmsg-q.sh
@@ -15,7 +15,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 # set spool locations and switch queue to disk assisted mode
 $WorkDirectory test-spool
@@ -34,7 +34,7 @@ template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to
 startup
 
 # part1: send first 50 messages (in memory, only)
-#tcpflood 127.0.0.1 13514 1 50
+#tcpflood 127.0.0.1 '$TCPFLOOD_PORT' 1 50
 . $srcdir/diag.sh injectmsg 0 50
 . $srcdir/diag.sh wait-queueempty # let queue drain for this test case
 

--- a/tests/daqueue-invld-qi.sh
+++ b/tests/daqueue-invld-qi.sh
@@ -13,7 +13,7 @@ add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 1
 $MainMsgQueueSaveOnShutdown on
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ModLoad ../plugins/omtesting/.libs/omtesting
 

--- a/tests/daqueue-persist-drvr.sh
+++ b/tests/daqueue-persist-drvr.sh
@@ -13,7 +13,7 @@ add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 1
 $MainMsgQueueSaveOnShutdown on
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ModLoad ../plugins/omtesting/.libs/omtesting
 

--- a/tests/discard-allmark-vg.sh
+++ b/tests/discard-allmark-vg.sh
@@ -14,7 +14,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ActionWriteAllMarkMessages on
 

--- a/tests/discard-allmark.sh
+++ b/tests/discard-allmark.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ActionWriteAllMarkMessages on
 

--- a/tests/discard-rptdmsg-vg.sh
+++ b/tests/discard-rptdmsg-vg.sh
@@ -14,7 +14,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $RepeatedMsgReduction on
 

--- a/tests/discard-rptdmsg.sh
+++ b/tests/discard-rptdmsg.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $RepeatedMsgReduction on
 

--- a/tests/discard.sh
+++ b/tests/discard.sh
@@ -12,7 +12,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 :msg, contains, "00000001" ~
 

--- a/tests/diskq-rfc5424.sh
+++ b/tests/diskq-rfc5424.sh
@@ -17,7 +17,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="rs")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
 
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/diskqueue-fsync.sh
+++ b/tests/diskqueue-fsync.sh
@@ -18,7 +18,7 @@ fi
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 # set spool locations and switch queue to disk-only mode
 $WorkDirectory test-spool

--- a/tests/diskqueue-full.sh
+++ b/tests/diskqueue-full.sh
@@ -15,7 +15,7 @@ main_queue(queue.filename="mainq" queue.maxDiskSpace="4m"
 )
 
 module(load="../plugins/imtcp/.libs/imtcp")
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/diskqueue.sh
+++ b/tests/diskqueue.sh
@@ -16,7 +16,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 # set spool locations and switch queue to disk-only mode
 $WorkDirectory test-spool

--- a/tests/dynfile_cachemiss.sh
+++ b/tests/dynfile_cachemiss.sh
@@ -13,7 +13,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:3%\n"
 $template dynfile,"%msg:F,58:2%.log" # complete name is in message

--- a/tests/dynfile_invalid2.sh
+++ b/tests/dynfile_invalid2.sh
@@ -13,7 +13,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:3%\n"
 $template dynfile,"%msg:F,58:2%.log" # complete name is in message

--- a/tests/empty-prop-comparison.sh
+++ b/tests/empty-prop-comparison.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 set $!doOutput = "";

--- a/tests/empty-ruleset.sh
+++ b/tests/empty-ruleset.sh
@@ -1,16 +1,15 @@
 #!/bin/bash
 # Copyright 2014-11-20 by Rainer Gerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
-echo ===============================================================================
-echo \[empty-ruleset.sh\]: testing empty ruleset
 . $srcdir/diag.sh init
+export TCPFLOOD_PORT2="$(get_free_port)"
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 $MainMsgQueueTimeoutShutdown 10000
 
-input(type="imtcp" port="13514" ruleset="real")
-input(type="imtcp" port="13515" ruleset="empty")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="real")
+input(type="imtcp" port="'$TCPFLOOD_PORT2'" ruleset="empty")
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
@@ -23,9 +22,9 @@ ruleset(name="real") {
 }
 '
 startup
-tcpflood -p13515 -m5000 -i0 # these should NOT show up
-tcpflood -p13514 -m10000 -i5000
-tcpflood -p13515 -m500 -i15000 # these should NOT show up
+tcpflood -p$TCPFLOOD_PORT2 -m5000 -i0 # these should NOT show up
+tcpflood -p$TCPFLOOD_PORT -m10000 -i5000
+tcpflood -p$TCPFLOOD_PORT2 -m500 -i15000 # these should NOT show up
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 5000 14999

--- a/tests/exec_tpl-concurrency.sh
+++ b/tests/exec_tpl-concurrency.sh
@@ -15,7 +15,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="interim" type="string" string="%$!tree!here!nbr%")
 template(name="outfmt" type="string" string="%$!interim%\n")

--- a/tests/execonlyonce.sh
+++ b/tests/execonlyonce.sh
@@ -14,7 +14,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/fac_authpriv.sh
+++ b/tests/fac_authpriv.sh
@@ -7,7 +7,7 @@
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 authpriv.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_ftp.sh
+++ b/tests/fac_ftp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 ftp.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_invld1.sh
+++ b/tests/fac_invld1.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_invld2.sh
+++ b/tests/fac_invld2.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_invld3.sh
+++ b/tests/fac_invld3.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_invld4_rfc5424.sh
+++ b/tests/fac_invld4_rfc5424.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_local0-vg.sh
+++ b/tests/fac_local0-vg.sh
@@ -13,7 +13,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if $syslogfacility-text == "local0" then

--- a/tests/fac_local0.sh
+++ b/tests/fac_local0.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if $syslogfacility-text == "local0" then

--- a/tests/fac_local7.sh
+++ b/tests/fac_local7.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if $syslogfacility-text == "local7" then

--- a/tests/fac_mail.sh
+++ b/tests/fac_mail.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 mail.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_news.sh
+++ b/tests/fac_news.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if prifilt("news.*") then

--- a/tests/fac_ntp.sh
+++ b/tests/fac_ntp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 ntp.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_uucp.sh
+++ b/tests/fac_uucp.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 uucp.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/failover-double.sh
+++ b/tests/failover-double.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
-# This file is part of the rsyslog project, released under GPLv3
-echo ===============================================================================
-echo \[failover-double.sh\]: test for double failover functionality
+# This file is part of the rsyslog project, released under ASL 2.0
 . $srcdir/diag.sh init
+export DEAD_PORT="$(get_free_port)"
 generate_conf
 add_conf '
 $template outfmt,"%msg:F,58:2%\n"
 
-:msg, contains, "msgnum:" @@127.0.0.1:13516
+:msg, contains, "msgnum:" @@127.0.0.1:'$DEAD_PORT'
 $ActionExecOnlyWhenPreviousIsSuspended on
 &	@@127.0.0.1:1234
 &	./'"${RSYSLOG_OUT_LOG}"';outfmt
@@ -15,9 +14,7 @@ $ActionExecOnlyWhenPreviousIsSuspended off
 '
 startup
 . $srcdir/diag.sh injectmsg  0 5000
-echo doing shutdown
 shutdown_when_empty
-echo wait on shutdown
 wait_shutdown 
 seq_check  0 4999
 exit_test

--- a/tests/fieldtest-udp.sh
+++ b/tests/fieldtest-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg:F,32:2%\n")
 

--- a/tests/fieldtest.sh
+++ b/tests/fieldtest.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg:F,32:2%\n")
 

--- a/tests/glbl-oversizeMsg-log-vg.sh
+++ b/tests/glbl-oversizeMsg-log-vg.sh
@@ -13,7 +13,7 @@ global(maxMessageSize="230"
 	oversizemsg.errorfile=`echo $RSYSLOG2_OUT_LOG`)
 
 
-input(type="imrelp" port="13514" maxdatasize="300")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="300")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 action(type="omfile" template="outfmt"
@@ -21,7 +21,7 @@ action(type="omfile" template="outfmt"
 '
 # TODO: add tcpflood option to specific EXACT test message size!
 startup_vg
-tcpflood -Trelp-plain -p13514 -m1 -d 240
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 240
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg

--- a/tests/glbl-oversizeMsg-log.sh
+++ b/tests/glbl-oversizeMsg-log.sh
@@ -13,7 +13,7 @@ global(maxMessageSize="230"
 	oversizemsg.errorfile=`echo $RSYSLOG2_OUT_LOG`)
 
 
-input(type="imrelp" port="13514" maxdatasize="300")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="300")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 action(type="omfile" template="outfmt"
@@ -21,7 +21,7 @@ action(type="omfile" template="outfmt"
 '
 # TODO: add tcpflood option to specific EXACT test message size!
 startup
-tcpflood -Trelp-plain -p13514 -m1 -d 240
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 240
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 

--- a/tests/glbl-oversizeMsg-split.sh
+++ b/tests/glbl-oversizeMsg-split.sh
@@ -13,7 +13,7 @@ global(maxMessageSize="230"
 	oversizemsg.input.mode="split")
 
 
-input(type="imrelp" port="13514" maxdatasize="300")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="300")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 action(type="omfile" template="outfmt"
@@ -21,7 +21,7 @@ action(type="omfile" template="outfmt"
 '
 # TODO: add tcpflood option to specific EXACT test message size!
 startup
-tcpflood -Trelp-plain -p13514 -m1 -d 240
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 240
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 

--- a/tests/glbl-oversizeMsg-truncate.sh
+++ b/tests/glbl-oversizeMsg-truncate.sh
@@ -12,7 +12,7 @@ module(load="../plugins/imrelp/.libs/imrelp")
 global(maxMessageSize="230")
 
 
-input(type="imrelp" port="13514" maxdatasize="300")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="300")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 action(type="omfile" template="outfmt"
@@ -20,7 +20,7 @@ action(type="omfile" template="outfmt"
 '
 # TODO: add tcpflood option to specific EXACT test message size!
 startup
-tcpflood -Trelp-plain -p13514 -m1 -d 240
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 240
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 

--- a/tests/global_vars.sh
+++ b/tests/global_vars.sh
@@ -10,7 +10,7 @@ add_conf '
 $MainMsgQueueTimeoutShutdown 10000
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%$/msgnum%\n")
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) /* trick to use relative path names! */

--- a/tests/gzipwr_flushInterval.sh
+++ b/tests/gzipwr_flushInterval.sh
@@ -11,7 +11,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%\n")

--- a/tests/gzipwr_flushOnTXEnd.sh
+++ b/tests/gzipwr_flushOnTXEnd.sh
@@ -11,7 +11,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%\n")

--- a/tests/gzipwr_large.sh
+++ b/tests/gzipwr_large.sh
@@ -14,7 +14,7 @@ $MaxMessageSize 10k
 
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/gzipwr_large_dynfile.sh
+++ b/tests/gzipwr_large_dynfile.sh
@@ -24,7 +24,7 @@ $MaxMessageSize 10k
 
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:3%,%msg:F,58:4%,%msg:F,58:5%\n"
 $template dynfile,"rsyslog.out.%msg:F,58:2%.log" # use multiple dynafiles

--- a/tests/gzipwr_rscript.sh
+++ b/tests/gzipwr_rscript.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/hostname-with-slash-dflt-invld.sh
+++ b/tests/hostname-with-slash-dflt-invld.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%hostname%") # no LF, as HOSTNAME file also does not have it!
 
 local4.debug action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)

--- a/tests/hostname-with-slash-dflt-slash-valid.sh
+++ b/tests/hostname-with-slash-dflt-slash-valid.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%hostname%\n")
 
 # note: we use the default parser chain, which includes RFC5424 and that parser

--- a/tests/hostname-with-slash-pmrfc3164.sh
+++ b/tests/hostname-with-slash-pmrfc3164.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%hostname%\n")
 
 parser(name="pmrfc3164.hostname_with_slashes" type="pmrfc3164" permit.slashesinhostname="on")

--- a/tests/hostname-with-slash-pmrfc5424.sh
+++ b/tests/hostname-with-slash-pmrfc5424.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%hostname%\n")
 
 $rulesetparser rsyslog.rfc5424

--- a/tests/imptcp-NUL-rawmsg.sh
+++ b/tests/imptcp-NUL-rawmsg.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imptcp-NUL.sh
+++ b/tests/imptcp-NUL.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imptcp-buffer-overflow.sh
+++ b/tests/imptcp-buffer-overflow.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp-connection-msg-disabled.sh
+++ b/tests/imptcp-connection-msg-disabled.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 :msg, contains, "msgnum:" {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)

--- a/tests/imptcp-connection-msg-received.sh
+++ b/tests/imptcp-connection-msg-received.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" notifyonconnectionclose="on" notifyonconnectionopen="on")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" notifyonconnectionclose="on" notifyonconnectionopen="on")
 
 :msg, contains, "msgnum:" {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)

--- a/tests/imptcp-custom-delimiter.sh
+++ b/tests/imptcp-custom-delimiter.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" AddtlFrameDelimiter="13")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" AddtlFrameDelimiter="13")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp-discard-truncated-msg.sh
+++ b/tests/imptcp-discard-truncated-msg.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="ruleset1" discardTruncatedMsg="on")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1" discardTruncatedMsg="on")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {

--- a/tests/imptcp-maxFrameSize-parameter.sh
+++ b/tests/imptcp-maxFrameSize-parameter.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 12800
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" maxframesize="100")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" maxframesize="100")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp-msg-truncation-on-number.sh
+++ b/tests/imptcp-msg-truncation-on-number.sh
@@ -8,7 +8,7 @@ $MaxMessageSize 128
 global(processInternalMessages="on"
 	oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp-msg-truncation-on-number2.sh
+++ b/tests/imptcp-msg-truncation-on-number2.sh
@@ -8,7 +8,7 @@ $MaxMessageSize 128
 global(processInternalMessages="on"
 	oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="ruleset1")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="templ1" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {

--- a/tests/imptcp-oversize-message-display.sh
+++ b/tests/imptcp-oversize-message-display.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on" oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp_addtlframedelim.sh
+++ b/tests/imptcp_addtlframedelim.sh
@@ -8,7 +8,7 @@ add_conf '
 $ModLoad ../plugins/imptcp/.libs/imptcp
 $MainMsgQueueTimeoutShutdown 10000
 $InputPTCPServerAddtlFrameDelimiter 0
-$InputPTCPServerRun 13514
+$InputPTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 $OMFileFlushOnTXEnd off

--- a/tests/imptcp_conndrop-vg.sh
+++ b/tests/imptcp_conndrop-vg.sh
@@ -10,7 +10,7 @@ $MaxMessageSize 10k
 
 $ModLoad ../plugins/imptcp/.libs/imptcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputPTCPServerRun 13514
+$InputPTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/imptcp_conndrop.sh
+++ b/tests/imptcp_conndrop.sh
@@ -12,7 +12,7 @@ $MaxMessageSize 10k
 
 $ModLoad ../plugins/imptcp/.libs/imptcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputPTCPServerRun 13514
+$InputPTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/imptcp_framing_regex-oversize.sh
+++ b/tests/imptcp_framing_regex-oversize.sh
@@ -6,7 +6,7 @@ add_conf '
 $EscapeControlCharactersOnReceive off
 global(maxMessageSize="256")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="remote"
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote"
 	framing.delimiter.regex="^<[0-9]{2}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)")
 
 template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")

--- a/tests/imptcp_framing_regex.sh
+++ b/tests/imptcp_framing_regex.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 $EscapeControlCharactersOnReceive off
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="remote"
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote"
 	framing.delimiter.regex="^<[0-9]{2}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)")
 
 template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")

--- a/tests/imptcp_large.sh
+++ b/tests/imptcp_large.sh
@@ -12,7 +12,7 @@ $MaxMessageSize 10k
 
 $ModLoad ../plugins/imptcp/.libs/imptcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputPTCPServerRun 13514
+$InputPTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/imptcp_multi_line.sh
+++ b/tests/imptcp_multi_line.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="remote" multiline="on")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote" multiline="on")
 
 template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")
 ruleset(name="remote") {

--- a/tests/imptcp_no_octet_counted.sh
+++ b/tests/imptcp_no_octet_counted.sh
@@ -6,7 +6,7 @@ echo TEST: \[imptcp_no_octet_counted.sh\]: test imptcp with octet counted framin
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="remote" supportOctetCountedFraming="off")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote" supportOctetCountedFraming="off")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="remote") {

--- a/tests/imptcp_nonProcessingPoller.sh
+++ b/tests/imptcp_nonProcessingPoller.sh
@@ -11,7 +11,7 @@ $MaxMessageSize 10k
 template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp" threads="32" processOnPoller="off")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 if (prifilt("local0.*")) then {
    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/imptcp_spframingfix.sh
+++ b/tests/imptcp_spframingfix.sh
@@ -6,7 +6,7 @@ echo TEST: \[imptcp_spframingfix.sh\]: test imptcp in regard to Cisco ASA framin
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="remote" framingfix.cisco.asa="on")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote" framingfix.cisco.asa="on")
 
 template(name="outfmt" type="string" string="%rawmsg:6:7%\n")
 ruleset(name="remote") {

--- a/tests/imptcp_veryLargeOctateCountedMessages.sh
+++ b/tests/imptcp_veryLargeOctateCountedMessages.sh
@@ -9,7 +9,7 @@ add_conf '$MaxMessageSize 10k
 template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp" threads="32" processOnPoller="off")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 if (prifilt("local0.*")) then {
    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")

--- a/tests/imrelp-basic.sh
+++ b/tests/imrelp-basic.sh
@@ -4,14 +4,14 @@
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="13514")
+input(type="imrelp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -Trelp-plain -p13514 -m10000
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 9999

--- a/tests/imrelp-long-msg.sh
+++ b/tests/imrelp-long-msg.sh
@@ -5,14 +5,14 @@ generate_conf
 add_conf '
 global(maxMessageSize="214800")
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="13514" maxdatasize="214800")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="214800")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 				 file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -Trelp-plain -p13514 -m2 -d 204800
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m2 -d 204800
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 1

--- a/tests/imrelp-manyconn.sh
+++ b/tests/imrelp-manyconn.sh
@@ -10,14 +10,14 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="13514")
+input(type="imrelp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -Trelp-plain -c-2000 -p13514 -m100000
+tcpflood -Trelp-plain -c-2000 -p'$TCPFLOOD_PORT' -m100000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 99999

--- a/tests/imrelp-maxDataSize-error.sh
+++ b/tests/imrelp-maxDataSize-error.sh
@@ -10,7 +10,7 @@ global(
 	maxMessageSize="300"
 )
 
-input(type="imrelp" port="13514" maxDataSize="250")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxDataSize="250")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '

--- a/tests/imrelp-oversizeMode-accept.sh
+++ b/tests/imrelp-oversizeMode-accept.sh
@@ -9,14 +9,14 @@ fi;
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="13514" maxdatasize="200" oversizeMode="accept")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="200" oversizeMode="accept")
 
 template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 				 file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -Trelp-plain -p13514 -m1 -d 240
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 240
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 

--- a/tests/imrelp-oversizeMode-truncate.sh
+++ b/tests/imrelp-oversizeMode-truncate.sh
@@ -12,14 +12,14 @@ module(load="../plugins/imrelp/.libs/imrelp")
 global(maxMessageSize="150" oversizemsg.input.mode="accept")
 
 
-input(type="imrelp" port="13514" maxdatasize="200" oversizeMode="truncate")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="200" oversizeMode="truncate")
 
 template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 				 file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -Trelp-plain -p13514 -m1 -d 240
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 240
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 

--- a/tests/imtcp-NUL-rawmsg.sh
+++ b/tests/imtcp-NUL-rawmsg.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imtcp-NUL.sh
+++ b/tests/imtcp-NUL.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imtcp-basic.sh
+++ b/tests/imtcp-basic.sh
@@ -5,14 +5,14 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -p13514 -m10000
+tcpflood -p'$TCPFLOOD_PORT' -m10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 9999

--- a/tests/imtcp-discard-truncated-msg.sh
+++ b/tests/imtcp-discard-truncated-msg.sh
@@ -6,7 +6,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imtcp/.libs/imtcp" discardTruncatedMsg="on")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {

--- a/tests/imtcp-maxFrameSize.sh
+++ b/tests/imtcp-maxFrameSize.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 global(processInternalMessages="on")
 module(load="../plugins/imtcp/.libs/imtcp" maxFrameSize="100")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '

--- a/tests/imtcp-msg-truncation-on-number.sh
+++ b/tests/imtcp-msg-truncation-on-number.sh
@@ -8,7 +8,7 @@ $MaxMessageSize 128
 global(processInternalMessages="on"
 	oversizemsg.input.mode="accept")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '

--- a/tests/imtcp-msg-truncation-on-number2.sh
+++ b/tests/imtcp-msg-truncation-on-number2.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="templ1" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {

--- a/tests/imtcp-multiport.sh
+++ b/tests/imtcp-multiport.sh
@@ -2,78 +2,27 @@
 # Test for multiple ports in imtcp
 # This test checks if multiple tcp listener ports are correctly
 # handled by imtcp
-#
-# NOTE: this test must (and can) be enhanced when we merge in the
-#       upgraded tcpflood program
-#
 # added 2009-05-22 by Rgerhards
-# This file is part of the rsyslog project, released  under GPLv3
-echo ===============================================================================
-echo \[imtcp-multiport.sh\]: testing imtcp multiple listeners
+# This file is part of the rsyslog project, released under ASL 2.0
 . $srcdir/diag.sh init
+export TCPFLOOD_PORT2="$(get_free_port)"
+export TCPFLOOD_PORT3="$(get_free_port)"
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
-$InputTCPServerRun 13515
-$InputTCPServerRun 13516
+$InputTCPServerRun '$TCPFLOOD_PORT'
+$InputTCPServerRun '$TCPFLOOD_PORT2'
+$InputTCPServerRun '$TCPFLOOD_PORT3'
 
 $template outfmt,"%msg:F,58:2%\n"
-template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
-:msg, contains, "msgnum:" ?dynfile;outfmt
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-tcpflood -p13514 -m10000
+tcpflood -p'$TCPFLOOD_PORT' -m10000
+tcpflood -p'$TCPFLOOD_PORT2' -i10000 -m10000
+tcpflood -p'$TCPFLOOD_PORT3' -i20000 -m10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
-seq_check 0 9999
-exit_test
-#
-#
-# ### now complete new cycle with other port ###
-#
-#
-. $srcdir/diag.sh init
-generate_conf
-add_conf '
-$ModLoad ../plugins/imtcp/.libs/imtcp
-$MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
-$InputTCPServerRun 13515
-$InputTCPServerRun 13516
-
-$template outfmt,"%msg:F,58:2%\n"
-template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
-:msg, contains, "msgnum:" ?dynfile;outfmt
-'
-startup
-tcpflood -p13515 -m10000
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown
-seq_check 0 9999
-exit_test
-#
-#
-# ### now complete new cycle with other port ###
-#
-#
-. $srcdir/diag.sh init
-generate_conf
-add_conf '
-$ModLoad ../plugins/imtcp/.libs/imtcp
-$MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
-$InputTCPServerRun 13515
-$InputTCPServerRun 13516
-
-$template outfmt,"%msg:F,58:2%\n"
-template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
-:msg, contains, "msgnum:" ?dynfile;outfmt
-'
-startup
-tcpflood -p13516 -m10000
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown
-seq_check 0 9999
+seq_check 0 29999
 exit_test

--- a/tests/imtcp-tls-basic-vg.sh
+++ b/tests/imtcp-tls-basic-vg.sh
@@ -22,7 +22,7 @@ $DefaultNetstreamDriver gtls
 $IncludeConfig rsyslog.conf.tlscert
 $InputTCPServerStreamDriverMode 1
 $InputTCPServerStreamDriverAuthMode anon
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 $OMFileFlushOnTXEnd off
@@ -35,7 +35,7 @@ echo \$DefaultNetstreamDriverCAFile $srcdir/tls-certs/ca.pem     >rsyslog.conf.t
 echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>rsyslog.conf.tlscert
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>rsyslog.conf.tlscert
 startup_vg_noleak
-tcpflood -p13514 -m10000 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg

--- a/tests/imtcp-tls-basic.sh
+++ b/tests/imtcp-tls-basic.sh
@@ -15,7 +15,7 @@ $DefaultNetstreamDriver gtls
 $IncludeConfig rsyslog.conf.tlscert
 $InputTCPServerStreamDriverMode 1
 $InputTCPServerStreamDriverAuthMode anon
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 $OMFileFlushOnTXEnd off
@@ -28,7 +28,7 @@ echo \$DefaultNetstreamDriverCAFile $srcdir/tls-certs/ca.pem     >rsyslog.conf.t
 echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>rsyslog.conf.tlscert
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>rsyslog.conf.tlscert
 startup
-tcpflood -p13514 -m50000 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p'$TCPFLOOD_PORT' -m50000 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 49999

--- a/tests/imtcp-tls-ossl-basic-vg.sh
+++ b/tests/imtcp-tls-ossl-basic-vg.sh
@@ -16,7 +16,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 input(	type="imtcp"
-	port="13514" )
+	port="'$TCPFLOOD_PORT'" )
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(	type="omfile" 
@@ -25,7 +25,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 # Begin actuall testcase
 startup_vg_noleak
-tcpflood -p13514 -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg

--- a/tests/imtcp-tls-ossl-basic.sh
+++ b/tests/imtcp-tls-ossl-basic.sh
@@ -16,7 +16,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 input(	type="imtcp"
-	port="13514" )
+	port="'$TCPFLOOD_PORT'" )
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(	type="omfile" 
@@ -25,7 +25,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 # Begin actuall testcase
 startup
-tcpflood -p13514 -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 9999

--- a/tests/imtcp-tls-ossl-x509fingerprint.sh
+++ b/tests/imtcp-tls-ossl-x509fingerprint.sh
@@ -18,7 +18,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	PermittedPeer=["SHA1:5C:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3"]
 	)
 input(	type="imtcp"
-	port="13514" )
+	port="'$TCPFLOOD_PORT'" )
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(	type="omfile" 
@@ -27,7 +27,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 # Begin actuall testcase
 startup
-tcpflood -p13514 -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem 
+tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem 
 # -L5
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown

--- a/tests/imtcp-tls-ossl-x509name.sh
+++ b/tests/imtcp-tls-ossl-x509name.sh
@@ -18,7 +18,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	PermittedPeer=["/CN=rsyslog-client/OU=Adiscon GmbH/O=Adiscon GmbH/L=Grossrinderfeld/ST=BW/C=DE/DC=rsyslog.com","rsyslog.com"]
 	)
 input(	type="imtcp"
-	port="13514" )
+	port="'$TCPFLOOD_PORT'" )
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(	type="omfile" 
@@ -27,7 +27,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 # Begin actuall testcase
 startup
-tcpflood -p13514 -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 9999

--- a/tests/imtcp-tls-ossl-x509valid.sh
+++ b/tests/imtcp-tls-ossl-x509valid.sh
@@ -16,7 +16,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="x509/certvalid" )
 input(	type="imtcp"
-	port="13514" )
+	port="'$TCPFLOOD_PORT'" )
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(	type="omfile" 
@@ -25,7 +25,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 '
 # Begin actuall testcase
 startup
-tcpflood -p13514 -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 9999

--- a/tests/imtcp_conndrop.sh
+++ b/tests/imtcp_conndrop.sh
@@ -19,7 +19,7 @@ $MaxMessageSize 10k
 
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/imtcp_conndrop_tls-vg.sh
+++ b/tests/imtcp_conndrop_tls-vg.sh
@@ -25,7 +25,7 @@ $DefaultNetstreamDriver gtls
 $IncludeConfig rsyslog.conf.tlscert
 $InputTCPServerStreamDriverMode 1
 $InputTCPServerStreamDriverAuthMode anon
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
@@ -39,7 +39,7 @@ echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>rsyslog.conf.
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>rsyslog.conf.tlscert
 startup_vg
 # 100 byte messages to gain more practical data use
-tcpflood -c20 -p13514 -m10000 -r -d100 -P129 -D -l0.995 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -c20 -p'$TCPFLOOD_PORT' -m10000 -r -d100 -P129 -D -l0.995 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 sleep 5 # due to large messages, we need this time for the tcp receiver to settle...
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate

--- a/tests/imtcp_conndrop_tls.sh
+++ b/tests/imtcp_conndrop_tls.sh
@@ -18,7 +18,7 @@ $DefaultNetstreamDriver gtls
 $IncludeConfig rsyslog.conf.tlscert
 $InputTCPServerStreamDriverMode 1
 $InputTCPServerStreamDriverAuthMode anon
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
@@ -32,7 +32,7 @@ echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>rsyslog.conf.
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>rsyslog.conf.tlscert
 startup
 # 100 byte messages to gain more practical data use
-tcpflood -c20 -p13514 -m50000 -r -d100 -P129 -D -l0.995 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -c20 -p'$TCPFLOOD_PORT' -m50000 -r -d100 -P129 -D -l0.995 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 sleep 5 # due to large messages, we need this time for the tcp receiver to settle...
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate

--- a/tests/imtcp_incomplete_frame_at_end.sh
+++ b/tests/imtcp_incomplete_frame_at_end.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="list") {
 	property(name="msg")

--- a/tests/imtcp_no_octet_counted.sh
+++ b/tests/imtcp_no_octet_counted.sh
@@ -6,7 +6,7 @@ echo TEST: \[imtcp_no_octet_counted.sh\]: test imtcp with octet counted framing 
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="remote" supportOctetCountedFraming="off")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="remote" supportOctetCountedFraming="off")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="remote") {

--- a/tests/imtcp_spframingfix.sh
+++ b/tests/imtcp_spframingfix.sh
@@ -6,7 +6,7 @@ echo TEST: \[imptcp_spframingfix.sh\]: test imptcp in regard to Cisco ASA framin
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="remote" framingfix.cisco.asa="on")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="remote" framingfix.cisco.asa="on")
 
 template(name="outfmt" type="string" string="%rawmsg:6:7%\n")
 ruleset(name="remote") {

--- a/tests/json_array_looping-vg.sh
+++ b/tests/json_array_looping-vg.sh
@@ -20,7 +20,7 @@ template(name="quux" type="string" string="quux: %$.quux%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_array_looping.sh
+++ b/tests/json_array_looping.sh
@@ -13,7 +13,7 @@ template(name="quux" type="string" string="quux: %$.quux%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_array_subscripting.sh
+++ b/tests/json_array_subscripting.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="msg: %$!foo[1]% | %$.quux% | %$.cor
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 set $.quux = $!foo[2];

--- a/tests/json_nonarray_looping.sh
+++ b/tests/json_nonarray_looping.sh
@@ -13,7 +13,7 @@ template(name="quux" type="string" string="quux: %$.quux%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_null-vg.sh
+++ b/tests/json_null-vg.sh
@@ -17,7 +17,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # we must make sure the template contains a reference to the 
 # data item with null value

--- a/tests/json_null.sh
+++ b/tests/json_null.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # we must make sure the template contains a reference to the 
 # data item with null value

--- a/tests/json_null_array-vg.sh
+++ b/tests/json_null_array-vg.sh
@@ -15,7 +15,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%$.data%\n")
 

--- a/tests/json_null_array.sh
+++ b/tests/json_null_array.sh
@@ -8,7 +8,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%$.data%\n")
 

--- a/tests/json_object_looping-vg.sh
+++ b/tests/json_object_looping-vg.sh
@@ -21,7 +21,7 @@ template(name="modified" type="string" string="new: %$!foo!str4% deleted: %$!foo
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_object_looping.sh
+++ b/tests/json_object_looping.sh
@@ -14,7 +14,7 @@ template(name="modified" type="string" string="new: %$!foo!str4% deleted: %$!foo
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_object_suicide_in_loop-vg.sh
+++ b/tests/json_object_suicide_in_loop-vg.sh
@@ -21,7 +21,7 @@ add_conf '\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_var_case.sh
+++ b/tests/json_var_case.sh
@@ -9,7 +9,7 @@ add_conf '
 global(variables.casesensitive="on")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # we must make sure the template contains references to the variables
 template(name="outfmt" type="string" string="abc:%$!abc% ABC:%$!ABC% aBc:%$!aBc% _abc:%$!_abc% _ABC:%$!_ABC% _aBc:%$!_aBc%\n" option.casesensitive="on")

--- a/tests/json_var_cmpr.sh
+++ b/tests/json_var_cmpr.sh
@@ -8,7 +8,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # we must make sure the template contains references to the variables
 template(name="outfmt" type="string" string="json prop:%$!val%  local prop:%$.val%  global prop:%$/val%\n")

--- a/tests/key_dereference_on_uninitialized_variable_space.sh
+++ b/tests/key_dereference_on_uninitialized_variable_space.sh
@@ -17,7 +17,7 @@ ruleset(name="echo") {
   action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="corge")
 }
 
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 call echo
 '

--- a/tests/linkedlistqueue.sh
+++ b/tests/linkedlistqueue.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ErrorMessagesToStderr off
 

--- a/tests/localvar-concurrency.sh
+++ b/tests/localvar-concurrency.sh
@@ -15,7 +15,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%$.tree!here!nbr%\n")
 

--- a/tests/manyptcp.sh
+++ b/tests/manyptcp.sh
@@ -8,7 +8,7 @@ add_conf '
 $ModLoad ../plugins/imptcp/.libs/imptcp
 $MainMsgQueueTimeoutShutdown 10000
 $MaxOpenFiles 2000
-$InputPTCPServerRun 13514
+$InputPTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/manytcp-too-few-tls-vg.sh
+++ b/tests/manytcp-too-few-tls-vg.sh
@@ -24,7 +24,7 @@ global(
 
 $InputTCPServerStreamDriverMode 1
 $InputTCPServerStreamDriverAuthMode anon
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/manytcp.sh
+++ b/tests/manytcp.sh
@@ -22,7 +22,7 @@ $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
 $MaxOpenFiles 2000
 $InputTCPMaxSessions 1100
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/mmanon_both_modes_compatible.sh
+++ b/tests/mmanon_both_modes_compatible.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.enable="on" ipv4.mode="zero" ipv4.bits="32" ipv6.bits="128" ipv6.anonmode="zero" ipv6.enable="on")

--- a/tests/mmanon_random_128_ipv6.sh
+++ b/tests/mmanon_random_128_ipv6.sh
@@ -4,11 +4,11 @@
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
-template(name="filename" type="string" string="rsyslog.out.%syslogtag%.log")
+template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}.'%syslogtag%.log")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.anonmode="random" ipv6.bits="128" ipv6.enable="on")
@@ -25,40 +25,41 @@ tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 file1 33:45:DDD::4
 
 shutdown_when_empty
 wait_shutdown
-echo ' 33:45:DDD::4' | cmp - rsyslog.out.file1.log >/dev/null
+echo ' 33:45:DDD::4' | cmp - ${RSYSLOG_DYNNAME}.file1.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file1.log is:"
-  cat rsyslog.out.file1.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file1.log is:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
   error_exit  1
 fi;
 
-echo ' ::' | cmp - rsyslog.out.file2.log >/dev/null
+echo ' ::' | cmp - ${RSYSLOG_DYNNAME}.file2.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file2.log is:"
-  cat rsyslog.out.file2.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file2.log is:"
+  cat ${RSYSLOG_DYNNAME}.file2.log
   error_exit  1
 fi;
 
-echo ' 72:8374:adc7:47FF::43:0:1AFE' | cmp - rsyslog.out.file3.log  >/dev/null
+echo ' 72:8374:adc7:47FF::43:0:1AFE' | cmp - ${RSYSLOG_DYNNAME}.file3.log  >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file3.log is:"
-  cat rsyslog.out.file3.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file3.log is:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
   error_exit  1
 fi;
 
-echo ' FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF' | cmp - rsyslog.out.file4.log >/dev/null
+echo ' FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF' | cmp - ${RSYSLOG_DYNNAME}.file4.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file4.log is:"
-  cat rsyslog.out.file4.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file4.log is:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file3.log rsyslog.out.file5.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file3.log ${RSYSLOG_DYNNAME}.file5.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-addresses generated, rsyslog.out.file3.log and rsyslog.out.file5.log are:"
-  cat rsyslog.out.file3.log
-  cat rsyslog.out.file5.log
+  echo "invalidly equal ip-addresses generated, ${RSYSLOG_DYNNAME}.file3.log and ${RSYSLOG_DYNNAME}.file5.log are:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
+  cat ${RSYSLOG_DYNNAME}.file5.log
   error_exit  1
 fi;
 
+rm -f ${RSYSLOG_DYNNAME}.*.log
 exit_test

--- a/tests/mmanon_random_32_ipv4.sh
+++ b/tests/mmanon_random_32_ipv4.sh
@@ -4,11 +4,11 @@
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
-template(name="filename" type="string" string="rsyslog.out.%syslogtag%.log")
+template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}'.%syslogtag%.log")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.mode="random" ipv4.bits="32")
@@ -25,40 +25,41 @@ tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 file1 1.1.1.8
 
 shutdown_when_empty
 wait_shutdown
-echo ' 1.1.1.8' | cmp - rsyslog.out.file1.log >/dev/null
+echo ' 1.1.1.8' | cmp - ${RSYSLOG_DYNNAME}.file1.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file1.log is:"
-  cat rsyslog.out.file1.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file1.log is:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
   error_exit  1
 fi;
 
-echo ' 0.0.0.0' | cmp - rsyslog.out.file2.log >/dev/null
+echo ' 0.0.0.0' | cmp - ${RSYSLOG_DYNNAME}.file2.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file2.log is:"
-  cat rsyslog.out.file2.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file2.log is:"
+  cat ${RSYSLOG_DYNNAME}.file2.log
   error_exit  1
 fi;
 
-echo ' 172.0.234.255' | cmp - rsyslog.out.file3.log  >/dev/null
+echo ' 172.0.234.255' | cmp - ${RSYSLOG_DYNNAME}.file3.log  >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file3.log is:"
-  cat rsyslog.out.file3.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file3.log is:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
   error_exit  1
 fi;
 
-echo ' 111.1.1.8.' | cmp - rsyslog.out.file4.log >/dev/null
+echo ' 111.1.1.8.' | cmp - ${RSYSLOG_DYNNAME}.file4.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file4.log is:"
-  cat rsyslog.out.file4.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file4.log is:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file3.log rsyslog.out.file5.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file3.log ${RSYSLOG_DYNNAME}.file5.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-addresses generated, rsyslog.out.file3.log and rsyslog.out.file5.log are:"
-  cat rsyslog.out.file3.log
-  cat rsyslog.out.file5.log
+  echo "invalidly equal ip-addresses generated, ${RSYSLOG_DYNNAME}.file3.log and ${RSYSLOG_DYNNAME}.file5.log are:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
+  cat ${RSYSLOG_DYNNAME}.file5.log
   error_exit  1
 fi;
 
+rm -f ${RSYSLOG_DYNNAME}.*.log
 exit_test

--- a/tests/mmanon_random_cons_128_ipembedded.sh
+++ b/tests/mmanon_random_cons_128_ipembedded.sh
@@ -4,11 +4,11 @@
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
-template(name="filename" type="string" string="rsyslog.out.%syslogtag%.log")
+template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}'.%syslogtag%.log")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.enable="off" ipv4.enable="off" embeddedipv4.anonmode="random-consistent" embeddedipv4.bits="128")
@@ -26,56 +26,57 @@ tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 file1 33:45:DDD::4.123.123.
 
 shutdown_when_empty
 wait_shutdown
-echo ' 33:45:DDD::4' | cmp - rsyslog.out.file1.log >/dev/null
+echo ' 33:45:DDD::4' | cmp - ${RSYSLOG_DYNNAME}.file1.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file1.log is:"
-  cat rsyslog.out.file1.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file1.log is:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
   error_exit  1
 fi;
 
-echo ' ::' | cmp - rsyslog.out.file2.log >/dev/null
+echo ' ::' | cmp - ${RSYSLOG_DYNNAME}.file2.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file2.log is:"
-  cat rsyslog.out.file2.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file2.log is:"
+  cat ${RSYSLOG_DYNNAME}.file2.log
   error_exit  1
 fi;
 
-echo ' 72:8374:adc7:47FF::43:0:1AFE' | cmp - rsyslog.out.file3.log  >/dev/null
+echo ' 72:8374:adc7:47FF::43:0:1AFE' | cmp - ${RSYSLOG_DYNNAME}.file3.log  >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file3.log is:"
-  cat rsyslog.out.file3.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file3.log is:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
   error_exit  1
 fi;
 
-echo ' FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF' | cmp - rsyslog.out.file4.log >/dev/null
+echo ' FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF' | cmp - ${RSYSLOG_DYNNAME}.file4.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file4.log is:"
-  cat rsyslog.out.file4.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file4.log is:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file3.log rsyslog.out.file5.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file3.log ${RSYSLOG_DYNNAME}.file5.log >/dev/null
 if [ ! $? -eq 0 ]; then
-  echo "invalidly unequal ip-addresses generated, rsyslog.out.file3.log and rsyslog.out.file5.log are:"
-  cat rsyslog.out.file3.log
-  cat rsyslog.out.file5.log
+  echo "invalidly unequal ip-addresses generated, ${RSYSLOG_DYNNAME}.file3.log and ${RSYSLOG_DYNNAME}.file5.log are:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
+  cat ${RSYSLOG_DYNNAME}.file5.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file2.log rsyslog.out.file6.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file2.log ${RSYSLOG_DYNNAME}.file6.log >/dev/null
 if [ ! $? -eq 0 ]; then
-  echo "invalidly unequal ip-addresses generated, rsyslog.out.file1.log and rsyslog.out.file6.log are:"
-  cat rsyslog.out.file1.log
-  cat rsyslog.out.file6.log
+  echo "invalidly unequal ip-addresses generated, ${RSYSLOG_DYNNAME}.file1.log and ${RSYSLOG_DYNNAME}.file6.log are:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
+  cat ${RSYSLOG_DYNNAME}.file6.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file4.log rsyslog.out.file5.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file4.log ${RSYSLOG_DYNNAME}.file5.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-addresses generated, rsyslog.out.file4.log and rsyslog.out.file5.log are:"
-  cat rsyslog.out.file4.log
-  cat rsyslog.out.file5.log
+  echo "invalidly equal ip-addresses generated, ${RSYSLOG_DYNNAME}.file4.log and ${RSYSLOG_DYNNAME}.file5.log are:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
+  cat ${RSYSLOG_DYNNAME}.file5.log
   error_exit  1
 fi;
 
+rm -f ${RSYSLOG_DYNNAME}.*.log
 exit_test

--- a/tests/mmanon_random_cons_128_ipv6.sh
+++ b/tests/mmanon_random_cons_128_ipv6.sh
@@ -4,11 +4,11 @@
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
-template(name="filename" type="string" string="rsyslog.out.%syslogtag%.log")
+template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}'.%syslogtag%.log")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.anonmode="random-consistent" ipv6.bits="128")
@@ -26,56 +26,57 @@ tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 file1 33:45:DDD::4
 
 shutdown_when_empty
 wait_shutdown
-echo ' 33:45:DDD::4' | cmp - rsyslog.out.file1.log >/dev/null
+echo ' 33:45:DDD::4' | cmp - ${RSYSLOG_DYNNAME}.file1.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file1.log is:"
-  cat rsyslog.out.file1.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file1.log is:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
   error_exit  1
 fi;
 
-echo ' ::' | cmp - rsyslog.out.file2.log >/dev/null
+echo ' ::' | cmp - ${RSYSLOG_DYNNAME}.file2.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file2.log is:"
-  cat rsyslog.out.file2.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file2.log is:"
+  cat ${RSYSLOG_DYNNAME}.file2.log
   error_exit  1
 fi;
 
-echo ' 72:8374:adc7:47FF::43:0:1AFE' | cmp - rsyslog.out.file3.log  >/dev/null
+echo ' 72:8374:adc7:47FF::43:0:1AFE' | cmp - ${RSYSLOG_DYNNAME}.file3.log  >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file3.log is:"
-  cat rsyslog.out.file3.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file3.log is:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
   error_exit  1
 fi;
 
-echo ' FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF' | cmp - rsyslog.out.file4.log >/dev/null
+echo ' FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF' | cmp - ${RSYSLOG_DYNNAME}.file4.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file4.log is:"
-  cat rsyslog.out.file4.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file4.log is:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file3.log rsyslog.out.file5.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file3.log ${RSYSLOG_DYNNAME}.file5.log >/dev/null
 if [ ! $? -eq 0 ]; then
-  echo "invalidly unequal ip-addresses generated, rsyslog.out.file3.log and rsyslog.out.file5.log are:"
-  cat rsyslog.out.file3.log
-  cat rsyslog.out.file5.log
+  echo "invalidly unequal ip-addresses generated, ${RSYSLOG_DYNNAME}.file3.log and ${RSYSLOG_DYNNAME}.file5.log are:"
+  cat ${RSYSLOG_DYNNAME}.file3.log
+  cat ${RSYSLOG_DYNNAME}.file5.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file2.log rsyslog.out.file6.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file2.log ${RSYSLOG_DYNNAME}.file6.log >/dev/null
 if [ ! $? -eq 0 ]; then
-  echo "invalidly unequal ip-addresses generated, rsyslog.out.file1.log and rsyslog.out.file6.log are:"
-  cat rsyslog.out.file1.log
-  cat rsyslog.out.file6.log
+  echo "invalidly unequal ip-addresses generated, ${RSYSLOG_DYNNAME}.file1.log and ${RSYSLOG_DYNNAME}.file6.log are:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
+  cat ${RSYSLOG_DYNNAME}.file6.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file4.log rsyslog.out.file5.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file4.log ${RSYSLOG_DYNNAME}.file5.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-addresses generated, rsyslog.out.file4.log and rsyslog.out.file5.log are:"
-  cat rsyslog.out.file4.log
-  cat rsyslog.out.file5.log
+  echo "invalidly equal ip-addresses generated, ${RSYSLOG_DYNNAME}.file4.log and ${RSYSLOG_DYNNAME}.file5.log are:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
+  cat ${RSYSLOG_DYNNAME}.file5.log
   error_exit  1
 fi;
 
+rm -f ${RSYSLOG_DYNNAME}.*.log
 exit_test

--- a/tests/mmanon_random_cons_32_ipv4.sh
+++ b/tests/mmanon_random_cons_32_ipv4.sh
@@ -4,11 +4,11 @@
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
-template(name="filename" type="string" string="rsyslog.out.%syslogtag%.log")
+template(name="filename" type="string" string="'$RSYSLOG_DYNNAME'.%syslogtag%.log")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.mode="random-consistent" ipv4.bits="32")
@@ -28,64 +28,65 @@ tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 file1 1.1.1.8
 
 shutdown_when_empty
 wait_shutdown
-echo ' 1.1.1.8' | cmp - rsyslog.out.file1.log >/dev/null
+echo ' 1.1.1.8' | cmp - ${RSYSLOG_DYNNAME}.file1.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file1.log is:"
-  cat rsyslog.out.file1.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file1.log is:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
   error_exit  1
 fi;
 
-echo ' 0.0.0.0' | cmp - rsyslog.out.file2.log >/dev/null
+echo ' 0.0.0.0' | cmp - ${RSYSLOG_DYNNAME}.file2.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file2.log is:"
-  cat rsyslog.out.file2.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file2.log is:"
+  cat ${RSYSLOG_DYNNAME}.file2.log
   error_exit  1
 fi;
 
-echo ' 172.0.234.255' | cmp - rsyslog.out.file4.log  >/dev/null
+echo ' 172.0.234.255' | cmp - ${RSYSLOG_DYNNAME}.file4.log  >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file4.log is:"
-  cat rsyslog.out.file4.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file4.log is:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
   error_exit  1
 fi;
 
-echo ' 111.1.1.8.' | cmp - rsyslog.out.file7.log >/dev/null
+echo ' 111.1.1.8.' | cmp - ${RSYSLOG_DYNNAME}.file7.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-address generated, rsyslog.out.file7.log is:"
-  cat rsyslog.out.file7.log
+  echo "invalidly equal ip-address generated, ${RSYSLOG_DYNNAME}.file7.log is:"
+  cat ${RSYSLOG_DYNNAME}.file7.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file1.log rsyslog.out.file6.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file1.log ${RSYSLOG_DYNNAME}.file6.log >/dev/null
 if [ ! $? -eq 0 ]; then
-  echo "invalidly unequal ip-addresses generated, rsyslog.out.file1.log and rsyslog.out.file6.log are:"
-  cat rsyslog.out.file1.log
-  cat rsyslog.out.file6.log
+  echo "invalidly unequal ip-addresses generated, ${RSYSLOG_DYNNAME}.file1.log and ${RSYSLOG_DYNNAME}.file6.log are:"
+  cat ${RSYSLOG_DYNNAME}.file1.log
+  cat ${RSYSLOG_DYNNAME}.file6.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file6.log rsyslog.out.file8.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file6.log ${RSYSLOG_DYNNAME}.file8.log >/dev/null
 if [ ! $? -eq 0 ]; then
-  echo "invalidly unequal ip-addresses generated, rsyslog.out.file6.log and rsyslog.out.file8.log are:"
-  cat rsyslog.out.file6.log
-  cat rsyslog.out.file8.log
+  echo "invalidly unequal ip-addresses generated, ${RSYSLOG_DYNNAME}.file6.log and ${RSYSLOG_DYNNAME}.file8.log are:"
+  cat ${RSYSLOG_DYNNAME}.file6.log
+  cat ${RSYSLOG_DYNNAME}.file8.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file2.log rsyslog.out.file3.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file2.log ${RSYSLOG_DYNNAME}.file3.log >/dev/null
 if [ ! $? -eq 0 ]; then
-  echo "invalidly unequal ip-addresses generated, rsyslog.out.file2.log and rsyslog.out.file3.log are:"
-  cat rsyslog.out.file2.log
-  cat rsyslog.out.file3.log
+  echo "invalidly unequal ip-addresses generated, ${RSYSLOG_DYNNAME}.file2.log and ${RSYSLOG_DYNNAME}.file3.log are:"
+  cat ${RSYSLOG_DYNNAME}.file2.log
+  cat ${RSYSLOG_DYNNAME}.file3.log
   error_exit  1
 fi;
 
-cmp rsyslog.out.file4.log rsyslog.out.file5.log >/dev/null
+cmp ${RSYSLOG_DYNNAME}.file4.log ${RSYSLOG_DYNNAME}.file5.log >/dev/null
 if [ ! $? -eq 1 ]; then
-  echo "invalidly equal ip-addresses generated, rsyslog.out.file4.log and rsyslog.out.file5.log are:"
-  cat rsyslog.out.file4.log
-  cat rsyslog.out.file5.log
+  echo "invalidly equal ip-addresses generated, ${RSYSLOG_DYNNAME}.file4.log and ${RSYSLOG_DYNNAME}.file5.log are:"
+  cat ${RSYSLOG_DYNNAME}.file4.log
+  cat ${RSYSLOG_DYNNAME}.file5.log
   error_exit  1
 fi;
 
+rm -f ${RSYSLOG_DYNNAME}.*.log
 exit_test

--- a/tests/mmanon_recognize_ipembedded.sh
+++ b/tests/mmanon_recognize_ipembedded.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.enable="off" ipv6.enable="off" embeddedipv4.bits="128" embeddedipv4.anonmode="zero")

--- a/tests/mmanon_recognize_ipv4.sh
+++ b/tests/mmanon_recognize_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" mode="zero" ipv4.bits="32")

--- a/tests/mmanon_recognize_ipv6.sh
+++ b/tests/mmanon_recognize_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.enable="off" ipv6.enable="on" ipv6.bits="128" ipv6.anonmode="zero")

--- a/tests/mmanon_simple_12_ipv4.sh
+++ b/tests/mmanon_simple_12_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="12" ipv4.mode="simple")

--- a/tests/mmanon_simple_33_ipv4.sh
+++ b/tests/mmanon_simple_33_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="33" ipv4.mode="simple" ipv4.replacechar="*")

--- a/tests/mmanon_simple_8_ipv4.sh
+++ b/tests/mmanon_simple_8_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="8" ipv4.mode="simple")

--- a/tests/mmanon_zero_128_ipv6.sh
+++ b/tests/mmanon_zero_128_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.bits="129" ipv6.anonmode="zero")

--- a/tests/mmanon_zero_12_ipv4.sh
+++ b/tests/mmanon_zero_12_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="12")

--- a/tests/mmanon_zero_33_ipv4.sh
+++ b/tests/mmanon_zero_33_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="33")

--- a/tests/mmanon_zero_50_ipv6.sh
+++ b/tests/mmanon_zero_50_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.bits="50" ipv6.anonmode="zero")

--- a/tests/mmanon_zero_64_ipv6.sh
+++ b/tests/mmanon_zero_64_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.bits="64" ipv6.anonmode="zero")

--- a/tests/mmanon_zero_8_ipv4.sh
+++ b/tests/mmanon_zero_8_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="8")

--- a/tests/mmanon_zero_96_ipv6.sh
+++ b/tests/mmanon_zero_96_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="testing")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon")

--- a/tests/mmdb-container-empty.sh
+++ b/tests/mmdb-container-empty.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%$!src_geoip%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup" container="!")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="testing")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmdb-container.sh
+++ b/tests/mmdb-container.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%$!mmdb_root%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup" container="!mmdb_root")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="testing")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmdb-multilevel-vg.sh
+++ b/tests/mmdb-multilevel-vg.sh
@@ -13,7 +13,7 @@ template(name="outfmt" type="string" string="%$!iplocation%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="testing")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmdb-vg.sh
+++ b/tests/mmdb-vg.sh
@@ -13,7 +13,7 @@ template(name="outfmt" type="string" string="%$!iplocation%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="testing")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmdb.sh
+++ b/tests/mmdb.sh
@@ -14,7 +14,7 @@ template(name="outfmt" type="string" string="%$!iplocation%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514" ruleset="testing")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmexternal-InvldProg-vg.sh
+++ b/tests/mmexternal-InvldProg-vg.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmexternal/.libs/mmexternal")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 set $!x = "a";
 
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmexternal-SegFault-empty-jroot-vg.sh
+++ b/tests/mmexternal-SegFault-empty-jroot-vg.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmexternal/.libs/mmexternal")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="-%$!%-\n")
 

--- a/tests/mmexternal-SegFault-vg.sh
+++ b/tests/mmexternal-SegFault-vg.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmexternal/.libs/mmexternal")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 set $!x = "a";
 
 template(name="outfmt" type="string" string="-%$!%-\n")

--- a/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
+++ b/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse" cookie="")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse-w-o-cookie.sh
+++ b/tests/mmjsonparse-w-o-cookie.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse" cookie="")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_cim.sh
+++ b/tests/mmjsonparse_cim.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$!cim!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse" cookie="@cim:" container="!cim")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_cim2.sh
+++ b/tests/mmjsonparse_cim2.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$!cim!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse" cookie="@cim:" container="$!cim")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_localvar.sh
+++ b/tests/mmjsonparse_localvar.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$.msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse" cookie="@cim:" container="$.")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_simple.sh
+++ b/tests/mmjsonparse_simple.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 if $parsesuccess == "OK" then {

--- a/tests/mmnormalize_processing_test1.sh
+++ b/tests/mmnormalize_processing_test1.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_processing_test2.sh
+++ b/tests/mmnormalize_processing_test2.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_processing_test3.sh
+++ b/tests/mmnormalize_processing_test3.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_processing_test4.sh
+++ b/tests/mmnormalize_processing_test4.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_regex.sh
+++ b/tests/mmnormalize_regex.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize" allowRegex="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")

--- a/tests/mmnormalize_regex_defaulted.sh
+++ b/tests/mmnormalize_regex_defaulted.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")

--- a/tests/mmnormalize_regex_disabled.sh
+++ b/tests/mmnormalize_regex_disabled.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize" allowRegex="off")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")

--- a/tests/mmnormalize_rule_from_array.sh
+++ b/tests/mmnormalize_rule_from_array.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 
-input(type="imtcp" port="13514" ruleset="norm")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="norm")
 
 template(name="outfmt" type="string" string="%hostname% %syslogtag%\n")
 

--- a/tests/mmnormalize_rule_from_string.sh
+++ b/tests/mmnormalize_rule_from_string.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 
-input(type="imtcp" port="13514" ruleset="norm")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="norm")
 
 template(name="outfmt" type="string" string="%hostname% %syslogtag%\n")
 

--- a/tests/mmnormalize_tokenized.sh
+++ b/tests/mmnormalize_tokenized.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_tokenized.rulebase`)
 if ( $!only_ips != "" ) then {

--- a/tests/mmnormalize_variable.sh
+++ b/tests/mmnormalize_variable.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="h:%$!hr% m:%$!min% s:%$!sec%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 template(name="time_fragment" type="list") {
   property(name="msg" regex.Expression="[0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]+" regex.Type="ERE" regex.Match="0")

--- a/tests/mmpstrucdata-case.sh
+++ b/tests/mmpstrucdata-case.sh
@@ -11,7 +11,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 
 template(name="outfmt" type="string" string="SD:%$!RFC5424-SD%\n")
 
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmpstrucdata" sd_name.lowercase="off")
 

--- a/tests/mmpstrucdata-invalid-vg.sh
+++ b/tests/mmpstrucdata-invalid-vg.sh
@@ -18,7 +18,7 @@ add_conf '
 module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
 module(load="../plugins/imtcp/.libs/imtcp")
 
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmpstrucdata")
 if $msg contains "msgnum" then

--- a/tests/mmpstrucdata-vg.sh
+++ b/tests/mmpstrucdata-vg.sh
@@ -18,7 +18,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 
 template(name="outfmt" type="string" string="%$!rfc5424-sd!tcpflood@32473!msgnum%\n")
 
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmpstrucdata")
 if $msg contains "msgnum" then

--- a/tests/mmpstrucdata.sh
+++ b/tests/mmpstrucdata.sh
@@ -11,7 +11,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 
 template(name="outfmt" type="string" string="%$!rfc5424-sd!tcpflood@32473!msgnum%\n")
 
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmpstrucdata")
 if $msg contains "msgnum" then

--- a/tests/mmrm1stspace-basic.sh
+++ b/tests/mmrm1stspace-basic.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 module(load="../plugins/mmrm1stspace/.libs/mmrm1stspace")
 template(name="outfmt" type="string" string="-%msg%-\n")

--- a/tests/msgvar-concurrency-array-event.tags.sh
+++ b/tests/msgvar-concurrency-array-event.tags.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%$!%\n")
 

--- a/tests/msgvar-concurrency-array.sh
+++ b/tests/msgvar-concurrency-array.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%$!%\n")
 

--- a/tests/msgvar-concurrency.sh
+++ b/tests/msgvar-concurrency.sh
@@ -2,9 +2,6 @@
 # Test concurrency of message variables
 # Added 2015-11-03 by rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
-echo ===============================================================================
-echo \[msgvar-concurrency.sh\]: testing concurrency of local variables
-
 uname
 if [ `uname` = "SunOS" ] ; then
    echo "This test currently does not work on all flavors of Solaris."
@@ -15,7 +12,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%$!tree!here!nbr%\n")
 
@@ -31,9 +28,8 @@ if $msg contains "msgnum:" then {
 }
 '
 startup
-sleep 1
 tcpflood -m500000
-shutdown_when_empty # shut down rsyslogd when done processing messages
+shutdown_when_empty
 wait_shutdown
 seq_check 0 499999
 exit_test

--- a/tests/nested-call-shutdown.sh
+++ b/tests/nested-call-shutdown.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
@@ -26,7 +26,7 @@ ruleset(name="rs1" queue.type="linkedList") {
 if $msg contains "msgnum:" then call rs1
 '
 startup
-#tcpflood -p13514 -m10000
+#tcpflood -p'$TCPFLOOD_PORT' -m10000
 . $srcdir/diag.sh injectmsg 0 1000
 . $srcdir/diag.sh shutdown-immediate
 wait_shutdown

--- a/tests/no-parser-errmsg.sh
+++ b/tests/no-parser-errmsg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
 template(name="test" type="string" string="tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 ruleset(name="ruleset" parser="rsyslog.rfc5424") {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG` template="test")

--- a/tests/no-parser-vg.sh
+++ b/tests/no-parser-vg.sh
@@ -11,7 +11,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
 ruleset(name="ruleset" parser="rsyslog.rfc5424") {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)
 }

--- a/tests/now-utc-casecmp.sh
+++ b/tests/now-utc-casecmp.sh
@@ -12,7 +12,7 @@ export TZ=TEST-02:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%$Now%:%$Year%-%$Month%-%$Day%,%$Now-utc%:%$Year-utc%-%$Month-utc%-%$Day-utc%\n")

--- a/tests/now-utc-ymd.sh
+++ b/tests/now-utc-ymd.sh
@@ -12,7 +12,7 @@ export TZ=TEST-02:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%$year%-%$month%-%$day%,%$year-utc%-%$month-utc%-%$day-utc%\n")

--- a/tests/now-utc.sh
+++ b/tests/now-utc.sh
@@ -7,7 +7,7 @@ echo \[now-utc\]: test \$NOW-UTC
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%$now%,%$now-utc%\n")

--- a/tests/now_family_utc.sh
+++ b/tests/now_family_utc.sh
@@ -7,7 +7,7 @@ echo \[now_family_utc\]: test \$NOW family of system properties
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%$hour%:%$minute%,%$hour-utc%:%$minute-utc%\n")

--- a/tests/omfile-read-only-errmsg.sh
+++ b/tests/omfile-read-only-errmsg.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" {

--- a/tests/omfile-read-only.sh
+++ b/tests/omfile-read-only.sh
@@ -11,7 +11,7 @@ messages=20000 # how many messages to inject?
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" {

--- a/tests/omfile_both_files_set.sh
+++ b/tests/omfile_both_files_set.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="dynafile" type="string" string=`echo $RSYSLOG_OUT_LOG`)
 template(name="outfmt" type="string" string="-%msg%-\n")

--- a/tests/omfwd-keepalive.sh
+++ b/tests/omfwd-keepalive.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="list") {
 	property(name="msg")

--- a/tests/omjournal-basic-no-template.sh
+++ b/tests/omjournal-basic-no-template.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omjournal/.libs/omjournal")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="omjournal")
 '

--- a/tests/omjournal-basic-template.sh
+++ b/tests/omjournal-basic-template.sh
@@ -8,7 +8,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omjournal/.libs/omjournal")
 
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg%")
 action(type="omjournal" template="outfmt")

--- a/tests/omod-if-array-udp.sh
+++ b/tests/omod-if-array-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%%timestamp%%hostname%%programname%%syslogtag%\n")
 

--- a/tests/omod-if-array.sh
+++ b/tests/omod-if-array.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%%timestamp%%hostname%%programname%%syslogtag%\n")
 

--- a/tests/omruleset-queue.sh
+++ b/tests/omruleset-queue.sh
@@ -21,7 +21,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/omruleset/.libs/omruleset
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ruleset rsinclude
 # create ruleset main queue with default parameters

--- a/tests/omruleset.sh
+++ b/tests/omruleset.sh
@@ -17,7 +17,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/omruleset/.libs/omruleset
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ruleset rsinclude
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/omstdout-basic.sh
+++ b/tests/omstdout-basic.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="-%msg%-\n")
 action(type="omstdout" template="outfmt")

--- a/tests/parsertest-parse-3164-buggyday-udp.sh
+++ b/tests/parsertest-parse-3164-buggyday-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%timestamp:::date-rfc3164-buggyday%,%hostname%,%programname%,%syslogtag%,%msg%\n")

--- a/tests/parsertest-parse-3164-buggyday.sh
+++ b/tests/parsertest-parse-3164-buggyday.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%timestamp:::date-rfc3164-buggyday%,%hostname%,%programname%,%syslogtag%,%msg%\n")

--- a/tests/parsertest-parse-nodate-udp.sh
+++ b/tests/parsertest-parse-nodate-udp.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%hostname%,%programname%,%syslogtag%,%msg%\n")
 

--- a/tests/parsertest-parse-nodate.sh
+++ b/tests/parsertest-parse-nodate.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%hostname%,%programname%,%syslogtag%,%msg%\n")
 

--- a/tests/parsertest-parse1-udp.sh
+++ b/tests/parsertest-parse1-udp.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/parsertest-parse1.sh
+++ b/tests/parsertest-parse1.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%timestamp%,%hostname%,%programname%,%syslogtag%,%msg%\n")
 

--- a/tests/parsertest-parse2-udp.sh
+++ b/tests/parsertest-parse2-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/parsertest-parse2.sh
+++ b/tests/parsertest-parse2.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/parsertest-parse3-udp.sh
+++ b/tests/parsertest-parse3-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%timereported:1:19:date-rfc3339,csv%, %hostname:::csv%, %programname:::csv%, %syslogtag:R,ERE,0,BLANK:[0-9]+--end:csv%, %syslogseverity:::csv%, %msg:::drop-last-lf,csv%\n")

--- a/tests/parsertest-parse3.sh
+++ b/tests/parsertest-parse3.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%timereported:1:19:date-rfc3339,csv%, %hostname:::csv%, %programname:::csv%, %syslogtag:R,ERE,0,BLANK:[0-9]+--end:csv%, %syslogseverity:::csv%, %msg:::drop-last-lf,csv%\n")

--- a/tests/parsertest-parse_8bit_escape-udp.sh
+++ b/tests/parsertest-parse_8bit_escape-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 $Escape8BitCharactersOnReceive on
 

--- a/tests/parsertest-parse_8bit_escape.sh
+++ b/tests/parsertest-parse_8bit_escape.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 $Escape8BitCharactersOnReceive on
 

--- a/tests/parsertest-parse_invld_regex-udp.sh
+++ b/tests/parsertest-parse_invld_regex-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%timereported:1:19:date-rfc3339,csv%, %hostname:::csv%, %programname:::csv%, %syslogtag:R,ERE,0,BLANK:[0-9+--end:csv%, %syslogseverity:::csv%, %msg:::drop-last-lf,csv%\n")

--- a/tests/parsertest-parse_invld_regex.sh
+++ b/tests/parsertest-parse_invld_regex.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%timereported:1:19:date-rfc3339,csv%, %hostname:::csv%, %programname:::csv%, %syslogtag:R,ERE,0,BLANK:[0-9+--end:csv%, %syslogseverity:::csv%, %msg:::drop-last-lf,csv%\n")

--- a/tests/parsertest-snare_ccoff_udp.sh
+++ b/tests/parsertest-snare_ccoff_udp.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 $EscapeControlCharactersOnReceive off
 

--- a/tests/parsertest-snare_ccoff_udp2.sh
+++ b/tests/parsertest-snare_ccoff_udp2.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 $EscapeControlCharactersOnReceive off
 

--- a/tests/pipe_noreader.sh
+++ b/tests/pipe_noreader.sh
@@ -23,7 +23,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" |./rsyslog.pipe

--- a/tests/pmlastmsg-udp.sh
+++ b/tests/pmlastmsg-udp.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/pmlastmsg/.libs/pmlastmsg")
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/pmlastmsg.sh
+++ b/tests/pmlastmsg.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/pmlastmsg/.libs/pmlastmsg")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/pmnormalize-basic.sh
+++ b/tests/pmnormalize-basic.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")
 
-input(type="imtcp" port="13514" ruleset="ruleset")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
 parser(name="custom.pmnormalize" type="pmnormalize" rulebase=`echo $srcdir/testsuites/pmnormalize_basic.rulebase`)
 
 template(name="test" type="string" string="host: %hostname%, ip: %fromhost-ip%, tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")

--- a/tests/pmnormalize-rule.sh
+++ b/tests/pmnormalize-rule.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")
 
-input(type="imtcp" port="13514" ruleset="ruleset")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
 parser(name="custom.pmnormalize" type="pmnormalize" rule=["rule=:<%pri:number%> %fromhost-ip:ipv4% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%", "rule=:<%pri:number%> %hostname:word% %fromhost-ip:ipv4% %syslogtag:char-to:\\x3a%: %msg:rest%"])
 
 template(name="test" type="string" string="host: %hostname%, ip: %fromhost-ip%, tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")

--- a/tests/pmnull-basic.sh
+++ b/tests/pmnull-basic.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnull/.libs/pmnull")
-input(type="imtcp" port="13514" ruleset="ruleset")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
 parser(name="custom.pmnull.withOrigin" type="pmnull")
 template(name="test" type="string" string="tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 ruleset(name="ruleset" parser=["custom.pmnull.withOrigin", "rsyslog.pmnull"]) {

--- a/tests/pmnull-withparams.sh
+++ b/tests/pmnull-withparams.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnull/.libs/pmnull")
-input(type="imtcp" port="13514" ruleset="ruleset")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
 parser(name="custom.pmnull" type="pmnull" tag="mytag" syslogfacility="3" syslogseverity="1")
 template(name="test" type="string" string="tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 ruleset(name="ruleset" parser=["custom.pmnull", "rsyslog.pmnull"]) {

--- a/tests/pmrfc3164-AtSignsInHostname.sh
+++ b/tests/pmrfc3164-AtSignsInHostname.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="customparser")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" permit.AtSignsInHostname="on")
 template(name="outfmt" type="string" string="-%hostname%-\n")
 

--- a/tests/pmrfc3164-AtSignsInHostname_off.sh
+++ b/tests/pmrfc3164-AtSignsInHostname_off.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="customparser")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" permit.AtSignsInHostname="off")
 template(name="outfmt" type="string" string="-%hostname%-%syslogtag%-%msg%-\n")
 

--- a/tests/pmrfc3164-defaultTag.sh
+++ b/tests/pmrfc3164-defaultTag.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="customparser")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" permit.AtSignsInHostname="off" force.tagEndingByColon="on")
 template(name="outfmt" type="string" string="?%hostname%?%syslogtag%?%msg%?\n")
 

--- a/tests/pmrfc3164-json.sh
+++ b/tests/pmrfc3164-json.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="rs")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
 template(name="outfmt" type="string" string="%msg%---%rawmsg%\n")
 
 ruleset(name="rs") {

--- a/tests/pmrfc3164-msgFirstSpace.sh
+++ b/tests/pmrfc3164-msgFirstSpace.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="customparser")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" remove.msgFirstSpace="on")
 template(name="outfmt" type="string" string="-%msg%-\n")
 

--- a/tests/pmrfc3164-tagEndingByColon.sh
+++ b/tests/pmrfc3164-tagEndingByColon.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="customparser")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" force.tagEndingByColon="on")
 template(name="outfmt" type="string" string="-%syslogtag%-%msg%-\n")
 

--- a/tests/pmsnare-ccbackslash-udp.sh
+++ b/tests/pmsnare-ccbackslash-udp.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost"
        parser.escapeControlCharactersCStyle="on")

--- a/tests/pmsnare-ccbackslash.sh
+++ b/tests/pmsnare-ccbackslash.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost"
        parser.escapeControlCharactersCStyle="on")

--- a/tests/pmsnare-cccstyle-udp.sh
+++ b/tests/pmsnare-cccstyle-udp.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(parser.escapeControlCharactersCStyle="on")
 

--- a/tests/pmsnare-cccstyle.sh
+++ b/tests/pmsnare-cccstyle.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 $EscapeControlCharactersOnReceive on
 global(
 	parser.escapeControlCharactersCStyle="on"

--- a/tests/pmsnare-ccdefault-udp.sh
+++ b/tests/pmsnare-ccdefault-udp.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-ccdefault.sh
+++ b/tests/pmsnare-ccdefault.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-ccoff-udp.sh
+++ b/tests/pmsnare-ccoff-udp.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-ccoff.sh
+++ b/tests/pmsnare-ccoff.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-default-udp.sh
+++ b/tests/pmsnare-default-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-default.sh
+++ b/tests/pmsnare-default.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-modoverride-udp.sh
+++ b/tests/pmsnare-modoverride-udp.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(
 	parser.escapeControlCharactersOnReceive="off"

--- a/tests/pmsnare-modoverride.sh
+++ b/tests/pmsnare-modoverride.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 global(
 	parser.escapeControlCharactersOnReceive="off"

--- a/tests/prop-all-json-concurrency.sh
+++ b/tests/prop-all-json-concurrency.sh
@@ -8,7 +8,7 @@ echo \[prop-all-json-concurrency.sh\]: testing concurrency of $!all-json variabl
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="interim" type="string" string="%$!tree!here!nbr%")
 template(name="outfmt" type="string" string="%$.interim%\n")

--- a/tests/prop-jsonmesg-vg.sh
+++ b/tests/prop-jsonmesg-vg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="list"){
     property(name="jsonmesg")

--- a/tests/prop-programname-with-slashes.sh
+++ b/tests/prop-programname-with-slashes.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 global(parser.PermitSlashInProgramname="on")
 
 template(name="outfmt" type="string" string="%syslogtag%,%programname%\n")

--- a/tests/prop-programname.sh
+++ b/tests/prop-programname.sh
@@ -11,7 +11,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%syslogtag%,%programname%\n")
 local0.* action(type="omfile" template="outfmt"

--- a/tests/proprepltest-nolimittag-udp.sh
+++ b/tests/proprepltest-nolimittag-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="+%syslogtag%+\n")
 

--- a/tests/proprepltest-nolimittag.sh
+++ b/tests/proprepltest-nolimittag.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="+%syslogtag%+\n")
 

--- a/tests/proprepltest-rfctag-udp.sh
+++ b/tests/proprepltest-rfctag-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="+%syslogtag:1:32%+\n")
 

--- a/tests/proprepltest-rfctag.sh
+++ b/tests/proprepltest-rfctag.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="+%syslogtag:1:32%+\n")
 

--- a/tests/queue-persist-drvr.sh
+++ b/tests/queue-persist-drvr.sh
@@ -13,7 +13,7 @@ add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 1
 $MainMsgQueueSaveOnShutdown on
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ModLoad ../plugins/omtesting/.libs/omtesting
 

--- a/tests/random.sh
+++ b/tests/random.sh
@@ -15,7 +15,7 @@ $ErrorMessagesToStderr off
 
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%rawmsg%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/rawmsg-after-pri.sh
+++ b/tests/rawmsg-after-pri.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(type="string" name="outfmt" string="%rawmsg-after-pri%\n")
 if $syslogfacility-text == "local0" then

--- a/tests/relp_tls_certificate_not_found.sh
+++ b/tests/relp_tls_certificate_not_found.sh
@@ -6,8 +6,8 @@ add_conf '
 
 module(load="../plugins/omrelp/.libs/omrelp")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 ruleset(name="ruleset") {
 	action(type="omrelp" target="127.0.0.1" port="10514" tls="on" tls.authMode="name" tls.caCert="tls-certs/ca.pem" tls.myCert="tls-certs/fake-cert.pem" tls.myPrivKey="tls-certs/fake-key.pem" tls.permittedPeer=["rsyslog-test-root-ca"])

--- a/tests/rfc5424parser.sh
+++ b/tests/rfc5424parser.sh
@@ -10,7 +10,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 if $msg contains "msgnum" then
 	action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)

--- a/tests/rs-cnum.sh
+++ b/tests/rs-cnum.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!var = cnum(15*3);
 

--- a/tests/rs-int2hex.sh
+++ b/tests/rs-int2hex.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!var = int2hex(61);
 set $!var2 = int2hex(-13);

--- a/tests/rs-substring.sh
+++ b/tests/rs-substring.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!var = substring($msg, 3, 2);
 

--- a/tests/rs_optimizer_pri.sh
+++ b/tests/rs_optimizer_pri.sh
@@ -13,7 +13,7 @@ add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 if $syslogfacility-text == "local4" then
 	action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)

--- a/tests/rscript_bare_var_root-empty.sh
+++ b/tests/rscript_bare_var_root-empty.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 template(name="outfmt" type="string" string="empty-%$!%-\n")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="rs")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
 
 ruleset(name="rs") {
 	set $. = $!;

--- a/tests/rscript_bare_var_root.sh
+++ b/tests/rscript_bare_var_root.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!%\n")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="rs")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
 
 ruleset(name="rs") {
 	set $!a = "TEST1";

--- a/tests/rscript_format_time.sh
+++ b/tests/rscript_format_time.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # $DebugLevel 2
 

--- a/tests/rscript_hash32-vg.sh
+++ b/tests/rscript_hash32-vg.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.hash_no_1 = hash32("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash32mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_hash32.sh
+++ b/tests/rscript_hash32.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.hash_no_1 = hash32("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash32mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_hash64-vg.sh
+++ b/tests/rscript_hash64-vg.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.hash_no_1 = hash64("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash64mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_hash64.sh
+++ b/tests/rscript_hash64.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.hash_no_1 = hash64("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash64mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_http_request-vg.sh
+++ b/tests/rscript_http_request-vg.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/fmhttp/.libs/fmhttp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # for debugging the test itself:
 #template(name="outfmt" type="string" string="%$!%:  :%$.%:  %rawmsg%\n")

--- a/tests/rscript_http_request.sh
+++ b/tests/rscript_http_request.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/fmhttp/.libs/fmhttp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # for debugging the test itself:
 #template(name="outfmt" type="string" string="%$!%:  :%$.%:  %rawmsg%\n")

--- a/tests/rscript_int2Hex.sh
+++ b/tests/rscript_int2Hex.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!ip!v0 = int2hex("");
 set $!ip!v1 = int2hex("0");

--- a/tests/rscript_ipv42num.sh
+++ b/tests/rscript_ipv42num.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!ip!v1 = ip42num("0.0.0.0");
 set $!ip!v2 = ip42num("0.0.0.1");

--- a/tests/rscript_is_time.sh
+++ b/tests/rscript_is_time.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # $DebugLevel 2
 

--- a/tests/rscript_num2ipv4.sh
+++ b/tests/rscript_num2ipv4.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/fmhttp/.libs/fmhttp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!ip!v0 = num2ipv4("");
 set $!ip!v1 = num2ipv4("0");

--- a/tests/rscript_parse_json-vg.sh
+++ b/tests/rscript_parse_json-vg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%$!%\n")
 
 local4.* {

--- a/tests/rscript_parse_json.sh
+++ b/tests/rscript_parse_json.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%$!%\n")
 
 local4.* {

--- a/tests/rscript_parse_time.sh
+++ b/tests/rscript_parse_time.sh
@@ -67,7 +67,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 # $DebugLevel 2
 

--- a/tests/rscript_previous_action_suspended.sh
+++ b/tests/rscript_previous_action_suspended.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omtesting/.libs/omtesting")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 ruleset(name="output_writer") {

--- a/tests/rscript_random.sh
+++ b/tests/rscript_random.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.random_no%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.random_no = random(10);
 

--- a/tests/rscript_re_extract.sh
+++ b/tests/rscript_re_extract.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="*Number is %$.number%*\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")'
+input(type="imtcp" port="'$TCPFLOOD_PORT'")'
 add_conf "
 set \$.number = re_extract(\$msg, '.* ([0-9]+)$', 0, 1, 'none');"
 add_conf '

--- a/tests/rscript_re_match.sh
+++ b/tests/rscript_re_match.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="*Matched*\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")'
+input(type="imtcp" port="'$TCPFLOOD_PORT'")'
 add_conf "
 if (re_match(\$msg, '.* ([0-9]+)$')) then {"
 add_conf '

--- a/tests/rscript_replace.sh
+++ b/tests/rscript_replace.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="13514")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
 
 template(name="date_time" type="list") {
   property(name="msg" regex.Expression="Thu .+ 2014" regex.Type="ERE" regex.Match="0")

--- a/tests/rscript_replace_complex.sh
+++ b/tests/rscript_replace_complex.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.replaced_msg = replace($msg, "syslog", "rsyslog");
 set $.replaced_msg = replace($.replaced_msg, "hello", "hello_world");

--- a/tests/rscript_script_error.sh
+++ b/tests/rscript_script_error.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="string" string="%$!%\n")
 
 local4.* {

--- a/tests/rscript_set_memleak-vg.sh
+++ b/tests/rscript_set_memleak-vg.sh
@@ -15,7 +15,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="rcvr")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rcvr")
 
 template(name="json" type="string" string="%$!%\n")
 template(name="ts" type="string" string="%timestamp:::date-rfc3339%")

--- a/tests/rscript_str2num_empty.sh
+++ b/tests/rscript_str2num_empty.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!ip!v1 = 1+"";
 

--- a/tests/rscript_str2num_negative.sh
+++ b/tests/rscript_str2num_negative.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.n = "-1";
 set $!ip!v1 = 1 + $.n;

--- a/tests/rscript_substring.sh
+++ b/tests/rscript_substring.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!str!var1 = substring("", 0, 0);
 set $!str!var2 = substring("test", 0, 4);

--- a/tests/rscript_trim-vg.sh
+++ b/tests/rscript_trim-vg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!str!l1 = ltrim("");
 set $!str!l2 = ltrim("test");

--- a/tests/rscript_trim.sh
+++ b/tests/rscript_trim.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $!str!l1 = ltrim("");
 set $!str!l2 = ltrim("test");

--- a/tests/rscript_wrap2.sh
+++ b/tests/rscript_wrap2.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.replaced_msg = wrap("foo says" & $msg, "*" & "*");
 

--- a/tests/rscript_wrap3.sh
+++ b/tests/rscript_wrap3.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 set $.replaced_msg = wrap("foo says" & $msg, "bc" & "def" & "bc", "ES" & "C");
 

--- a/tests/rsf_getenv.sh
+++ b/tests/rsf_getenv.sh
@@ -13,7 +13,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 # set spool locations and switch queue to disk-only mode
 $WorkDirectory test-spool

--- a/tests/rulesetmultiqueue-v6.sh
+++ b/tests/rulesetmultiqueue-v6.sh
@@ -5,10 +5,7 @@
 # use some custom code as the test driver framework does not (yet?)
 # support multi-output-file operations.
 # added 2013-11-14 by Rgerhards
-# This file is part of the rsyslog project, released  under GPLv3
-echo ===============================================================================
-echo \[rulesetmultiqueu.sh\]: testing multiple queues via rulesets
-
+# This file is part of the rsyslog project, released  under ASL 2.0
 uname
 if [ `uname` = "SunOS" ] ; then
    echo "This test currently does not work on all flavors of Solaris."
@@ -16,6 +13,8 @@ if [ `uname` = "SunOS" ] ; then
 fi
 
 . $srcdir/diag.sh init
+export RSYSLOG_PORT2="$(get_free_port)"
+export RSYSLOG_PORT3="$(get_free_port)"
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
@@ -25,40 +24,40 @@ $MainMsgQueueTimeoutShutdown 10000
 $template outfmt,"%msg:F,58:2%\n"
 
 # create the individual rulesets
-$template dynfile1,"rsyslog.out1.log" # trick to use relative path names!
+$template dynfile1,"'$RSYSLOG_OUT_LOG'1.log" # trick to use relative path names!
 ruleset(name="file1" queue.type="linkedList") {
 	:msg, contains, "msgnum:" ?dynfile1;outfmt
 }
 
-$template dynfile2,"rsyslog.out2.log" # trick to use relative path names!
+$template dynfile2,"'$RSYSLOG_OUT_LOG'2.log" # trick to use relative path names!
 ruleset(name="file2" queue.type="linkedList") {
 	:msg, contains, "msgnum:" ?dynfile2;outfmt
 }
 
-$template dynfile3,"rsyslog.out3.log" # trick to use relative path names!
+$template dynfile3,"'$RSYSLOG_OUT_LOG'3.log" # trick to use relative path names!
 ruleset(name="file3" queue.type="linkedList") {
 	:msg, contains, "msgnum:" ?dynfile3;outfmt
 }
 
 # start listeners and bind them to rulesets
 $InputTCPServerBindRuleset file1
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $InputTCPServerBindRuleset file2
-$InputTCPServerRun 13515
+$InputTCPServerRun '$RSYSLOG_PORT2'
 
 $InputTCPServerBindRuleset file3
-$InputTCPServerRun 13516
+$InputTCPServerRun '$RSYSLOG_PORT3'
 '
-rm -f rsyslog.out1.log rsyslog.out2.log rsyslog.out3.log
+rm -f ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log
 startup
 . $srcdir/diag.sh wait-startup
 # now fill the three files (a bit sequentially, but they should
 # still get their share of concurrency - to increase the chance
 # we use three connections per set).
-tcpflood -c3 -p13514 -m20000 -i0
-tcpflood -c3 -p13515 -m20000 -i20000
-tcpflood -c3 -p13516 -m20000 -i40000
+tcpflood -c3 -p'$TCPFLOOD_PORT' -m20000 -i0
+tcpflood -c3 -p'$RSYSLOG_PORT2' -m20000 -i20000
+tcpflood -c3 -p'$RSYSLOG_PORT3' -m20000 -i40000
 
 # in this version of the imdiag, we do not have the capability to poll
 # all queues for emptyness. So we do a sleep in the hopes that this will
@@ -69,7 +68,7 @@ shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 # now consolidate all logs into a single one so that we can use the
 # regular check logic
-cat rsyslog.out1.log rsyslog.out2.log rsyslog.out3.log > $RSYSLOG_OUT_LOG
+cat ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log > $RSYSLOG_OUT_LOG
 seq_check 0 59999
-rm -f rsyslog.out1.log rsyslog.out2.log rsyslog.out3.log
+rm -f ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log
 exit_test

--- a/tests/rulesetmultiqueue.sh
+++ b/tests/rulesetmultiqueue.sh
@@ -5,10 +5,7 @@
 # use some custom code as the test driver framework does not (yet?)
 # support multi-output-file operations.
 # added 2009-10-30 by Rgerhards
-# This file is part of the rsyslog project, released  under GPLv3
-echo ===============================================================================
-echo \[rulesetmultiqueu.sh\]: testing multiple queues via rulesets
-
+# This file is part of the rsyslog project, released  under ASL 2.0
 uname
 if [ `uname` = "SunOS" ] ; then
    echo "This test currently does not work on all flavors of Solaris."
@@ -16,6 +13,8 @@ if [ `uname` = "SunOS" ] ; then
 fi
 
 . $srcdir/diag.sh init
+export RSYSLOG_PORT2="$(get_free_port)"
+export RSYSLOG_PORT3="$(get_free_port)"
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
@@ -27,49 +26,48 @@ $template outfmt,"%msg:F,58:2%\n"
 # create the individual rulesets
 $ruleset file1
 $RulesetCreateMainQueue on
-$template dynfile1,"rsyslog.out1.log" # trick to use relative path names!
+$template dynfile1,"'$RSYSLOG_OUT_LOG'1.log" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile1;outfmt
 
 $ruleset file2
 $RulesetCreateMainQueue on
-$template dynfile2,"rsyslog.out2.log" # trick to use relative path names!
+$template dynfile2,"'$RSYSLOG_OUT_LOG'2.log" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile2;outfmt
 
 $ruleset file3
 $RulesetCreateMainQueue on
-$template dynfile3,"rsyslog.out3.log" # trick to use relative path names!
+$template dynfile3,"'$RSYSLOG_OUT_LOG'3.log" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile3;outfmt
 
 # start listeners and bind them to rulesets
 $InputTCPServerBindRuleset file1
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $InputTCPServerBindRuleset file2
-$InputTCPServerRun 13515
+$InputTCPServerRun '$RSYSLOG_PORT2'
 
 $InputTCPServerBindRuleset file3
-$InputTCPServerRun 13516
+$InputTCPServerRun '$RSYSLOG_PORT3'
 '
-rm -f rsyslog.out1.log rsyslog.out2.log rsyslog.out3.log
+rm -f ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log
 startup
 . $srcdir/diag.sh wait-startup
 # now fill the three files (a bit sequentially, but they should
 # still get their share of concurrency - to increase the chance
 # we use three connections per set).
-tcpflood -c3 -p13514 -m20000 -i0
-tcpflood -c3 -p13515 -m20000 -i20000
-tcpflood -c3 -p13516 -m20000 -i40000
+tcpflood -c3 -p'$TCPFLOOD_PORT' -m20000 -i0
+tcpflood -c3 -p'$RSYSLOG_PORT2' -m20000 -i20000
+tcpflood -c3 -p'$RSYSLOG_PORT3' -m20000 -i40000
 
 # in this version of the imdiag, we do not have the capability to poll
 # all queues for emptyness. So we do a sleep in the hopes that this will
 # sufficiently drain the queues. This is race, but the best we currently
 # can do... - rgerhards, 2009-11-05
-sleep 2 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 # now consolidate all logs into a single one so that we can use the
 # regular check logic
-cat rsyslog.out1.log rsyslog.out2.log rsyslog.out3.log > $RSYSLOG_OUT_LOG
+cat ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log > $RSYSLOG_OUT_LOG
 seq_check 0 59999
-rm -f rsyslog.out1.log rsyslog.out2.log rsyslog.out3.log
+rm -f ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log
 exit_test

--- a/tests/sndrcv_gzip.sh
+++ b/tests/sndrcv_gzip.sh
@@ -2,18 +2,17 @@
 # This test is similar to tcpsndrcv, but it forwards messages in
 # zlib-compressed format (our own syslog extension).
 # rgerhards, 2009-11-11
-# This file is part of the rsyslog project, released  under GPLv3
-echo ===============================================================================
-echo \[sndrcv_gzip.sh\]: testing sending and receiving via tcp in zlib mode
+# This file is part of the rsyslog project, released under ASL 2.0
 . $srcdir/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
+export RCVR_PORT="$(get_free_port)"
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 # then SENDER sends to this port (not tcpflood!)
-$InputTCPServerRun 13515
+$InputTCPServerRun '$RCVR_PORT'
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
@@ -21,14 +20,15 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 '
 startup
 . $srcdir/diag.sh wait-startup
+
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
-*.*	@@127.0.0.1:13515
+*.*	@@127.0.0.1:'$RCVR_PORT'
 ' 2
 startup 2
 . $srcdir/diag.sh wait-startup 2
@@ -37,7 +37,6 @@ startup 2
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
 tcpflood -m50000 -i1
-sleep 5 # make sure all data is received in input buffers
 # shut down sender when everything is sent, receiver continues to run concurrently
 # may be needed by TLS (once we do it): sleep 60
 shutdown_when_empty 2

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -48,7 +48,7 @@ main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")	/* this port for tcpflood! */
+input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/sndrcv_kafka-vg-sender.sh
+++ b/tests/sndrcv_kafka-vg-sender.sh
@@ -48,7 +48,7 @@ main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")	/* this port for tcpflood! */
+input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -51,7 +51,7 @@ main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")	/* this port for tcpflood! */
+input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -53,7 +53,7 @@ main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")	/* this port for tcpflood! */
+input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -52,7 +52,7 @@ main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")	/* this port for tcpflood! */
+input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/sndrcv_kafka_multi.sh
+++ b/tests/sndrcv_kafka_multi.sh
@@ -52,7 +52,7 @@ generate_conf 2
 add_conf '
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" Ruleset="omkafka")	/* this port for tcpflood! */
+input(type="imtcp" port="'$TCPFLOOD_PORT'" Ruleset="omkafka")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/sndrcv_omudpspoof.sh
+++ b/tests/sndrcv_omudpspoof.sh
@@ -37,7 +37,7 @@ generate_conf 2
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 # this listener is for message generation by the test framework!
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ModLoad ../plugins/omudpspoof/.libs/omudpspoof
 $template spoofaddr,"127.0.0.1"

--- a/tests/sndrcv_omudpspoof_nonstdpt.sh
+++ b/tests/sndrcv_omudpspoof_nonstdpt.sh
@@ -37,7 +37,7 @@ generate_conf 2
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 # this listener is for message generation by the test framework!
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $ModLoad ../plugins/omudpspoof/.libs/omudpspoof
 $template spoofaddr,"127.0.0.1"

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # added 2013-12-10 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-echo ===============================================================================
 # the first test is redundant, but we keep it when we later make the port
 # configurable.
 if [ `./omrelp_dflt_port` -lt 1024 ]; then
@@ -10,6 +9,7 @@ if [ `./omrelp_dflt_port` -lt 1024 ]; then
         exit 77
     fi
 fi
+
 if [ `./omrelp_dflt_port` -ne 13515 ]; then
     echo this test needs configure option --enable-omrelp-default-port=13515 to work
     exit 77

--- a/tests/stop-localvar.sh
+++ b/tests/stop-localvar.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.nbr%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 if $msg contains "msgnum:" then {
 	set $.nbr = field($msg, 58, 2);

--- a/tests/stop-msgvar.sh
+++ b/tests/stop-msgvar.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$!nbr%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 if $msg contains "msgnum:" then {
 	set $!nbr = field($msg, 58, 2);

--- a/tests/stop.sh
+++ b/tests/stop.sh
@@ -7,7 +7,7 @@ echo \[stop.sh\]: testing stop statement
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 if $msg contains "00000001" then
 	stop

--- a/tests/stop_when_array_has_element.sh
+++ b/tests/stop_when_array_has_element.sh
@@ -10,7 +10,7 @@ template(name="foo" type="string" string="%$!foo%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 action(type="mmjsonparse")
 

--- a/tests/tabescape_dflt-udp.sh
+++ b/tests/tabescape_dflt-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/tabescape_dflt.sh
+++ b/tests/tabescape_dflt.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/tabescape_off-udp.sh
+++ b/tests/tabescape_off-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514" ruleset="ruleset1")
+input(type="imudp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 $ErrorMessagesToStderr off
 $EscapeControlCharacterTab off

--- a/tests/tabescape_off.sh
+++ b/tests/tabescape_off.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514" ruleset="ruleset1")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
 $ErrorMessagesToStderr off
 $EscapeControlCharacterTab off

--- a/tests/tcp-msgreduc-vg.sh
+++ b/tests/tcp-msgreduc-vg.sh
@@ -15,7 +15,7 @@ echo \[tcp-msgreduc-vg.sh\]: testing msg reduction via UDP
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 $RepeatedMsgReduction on
 
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/tcp_forwarding_dflt_tpl.sh
+++ b/tests/tcp_forwarding_dflt_tpl.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # This test tests tcp forwarding with assigned default template.
 # added 2015-05-30 by rgerhards. Released under ASL 2.0
-echo ======================================================================================
-echo \[tcp_forwarding_dflt_tpl.sh\]: test for tcp forwarding with assigned default template
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
@@ -17,9 +15,9 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 module(load="builtin:omfwd" template="outfmt")
 
 if $msg contains "msgnum:" then
-	action(type="omfwd" target="127.0.0.1" port="13514" protocol="tcp")
+	action(type="omfwd" target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp")
 '
-./minitcpsrv -t127.0.0.1 -p13514 -f $RSYSLOG_OUT_LOG &
+./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
 BGPROCESS=$!
 echo background minitcpsrv process id is $BGPROCESS
 

--- a/tests/tcp_forwarding_ns_tpl.sh
+++ b/tests/tcp_forwarding_ns_tpl.sh
@@ -19,14 +19,14 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 if $msg contains "msgnum:" then
 	action(type="omfwd" template="outfmt"
-	       target="127.0.0.1" port="13514" protocol="tcp" networknamespace="rsyslog_test_ns")
+	       target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp" networknamespace="rsyslog_test_ns")
 '
 # create network namespace and bring it up
 ip netns add rsyslog_test_ns
 ip netns exec rsyslog_test_ns ip link set dev lo up
 
 # run server in namespace
-ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p13514 -f $RSYSLOG_OUT_LOG &
+ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p'$TCPFLOOD_PORT' -f $RSYSLOG_OUT_LOG &
 BGPROCESS=$!
 echo background minitcpsrvr process id is $BGPROCESS
 

--- a/tests/tcp_forwarding_retries.sh
+++ b/tests/tcp_forwarding_retries.sh
@@ -13,14 +13,14 @@ add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" {
 	action(type="omfwd"
-	       target="127.0.0.1" port="13514" protocol="TCP"
+	       target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="TCP"
 	       action.resumeRetryCount="10"
 	       template="outfmt")
 }
 '
 
 # we start a small receiver process
-./minitcpsrv -t127.0.0.1 -p13514 -f $RSYSLOG_OUT_LOG -s4 &
+./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG -s4 &
 BGPROCESS=$!
 echo background minitcpsrvr process id is $BGPROCESS
 

--- a/tests/tcp_forwarding_tpl.sh
+++ b/tests/tcp_forwarding_tpl.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 # This test tests tcp forwarding with assigned template. To do so, a simple
 # tcp listener service is started.
-# added 2012-10-30 by Rgerhards. Released under GNU GPLv3+
-echo ===============================================================================
-echo \[tcp_forwarding_tpl.sh\]: test for tcp forwarding with assigned template
+# added 2012-10-30 by Rgerhards. Released under ASL 2.0
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
@@ -15,9 +13,9 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 if $msg contains "msgnum:" then
 	action(type="omfwd" template="outfmt"
-	       target="127.0.0.1" port="13514" protocol="tcp")
+	       target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp")
 '
-./minitcpsrv -t127.0.0.1 -p13514 -f $RSYSLOG_OUT_LOG &
+./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
 BGPROCESS=$!
 echo background minitcpsrvr process id is $BGPROCESS
 

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -3,8 +3,8 @@
  *
  * Params
  * -t	target address (default 127.0.0.1)
- * -p	target port (default 13514)
- * -n	number of target ports (targets are in range -p..(-p+-n-1)
+ * -p	target port(s) (default 13514), multiple via port1:port2:port3...
+ * -n	number of target ports (all target ports must be given in -p!)
  *      Note -c must also be set to at LEAST the number of -n!
  * -c	number of connections (default 1), use negative number
  *      to set a "soft limit": if tcpflood cannot open the
@@ -161,7 +161,7 @@ char *test_rs_strerror_r(int errnum, char *buf, size_t buflen) {
 
 static char *targetIP = "127.0.0.1";
 static char *msgPRI = "167";
-static int targetPort = 13514;
+static int targetPort[5] = {13514};
 static int numTargetPorts = 1;
 static int verbose = 0;
 static int dynFileIDs = 0;
@@ -280,7 +280,7 @@ setupUDP(void)
 
 	memset((char *) &udpRcvr, 0, sizeof(udpRcvr));
 	udpRcvr.sin_family = AF_INET;
-	udpRcvr.sin_port = htons(targetPort);
+	udpRcvr.sin_port = htons(targetPort[0]);
 	if(inet_aton(targetIP, &udpRcvr.sin_addr)==0) {
 		fprintf(stderr, "inet_aton() failed\n");
 		return(1);
@@ -303,9 +303,9 @@ int openConn(int *fd, const int connIdx)
 	/* randomize port if required */
 	if(numTargetPorts > 1) {
 		rnd = rand(); /* easier if we need value for debug messages ;) */
-		port = targetPort + (rnd % numTargetPorts);
+		port = targetPort[(rnd % numTargetPorts)];
 	} else {
-		port = targetPort;
+		port = targetPort[0];
 	}
 	if(transport == TP_RELP_PLAIN) {
 		#ifdef ENABLE_RELP
@@ -341,7 +341,7 @@ int openConn(int *fd, const int connIdx)
 			} else {
 				if(retries++ == 50) {
 					perror("connect()");
-					fprintf(stderr, "connect() failed\n");
+					fprintf(stderr, "connect(%d) failed\n", port);
 					return(1);
 				} else {
 					usleep(100000); /* ms = 1000 us! */
@@ -1394,6 +1394,29 @@ static int sendTLS(int __attribute__((unused)) i, char __attribute__((unused)) *
 static void closeTLSSess(int __attribute__((unused)) i) {}
 #	endif
 
+static void
+setTargetPorts(const char *const port_arg)
+{
+	int i = 0;
+
+	char *saveptr;
+	char *ports = strdup(port_arg);
+	printf("ports: %s\n", ports);
+	char *port = strtok_r(ports, ":", &saveptr);
+	while(port != NULL) {
+		if(i == sizeof(targetPort)/sizeof(int)) {
+			fprintf(stderr, "too many ports specified, max %d\n",
+				(int) (sizeof(targetPort)/sizeof(int)));
+			exit(1);
+		}
+		targetPort[i] = atoi(port);
+		i++;
+		port = strtok_r(NULL, ":", &saveptr);
+	}
+	free(ports);
+}
+
+
 /* Run the test.
  * rgerhards, 2009-04-03
  */
@@ -1423,7 +1446,7 @@ int main(int argc, char *argv[])
 				break;
 		case 't':	targetIP = optarg;
 				break;
-		case 'p':	targetPort = atoi(optarg);
+		case 'p':	setTargetPorts(optarg);
 				break;
 		case 'n':	numTargetPorts = atoi(optarg);
 				break;

--- a/tests/template-pos-from-to-lowercase.sh
+++ b/tests/template-pos-from-to-lowercase.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:9:16:lowercase%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/template-pos-from-to-missing-jsonvar.sh
+++ b/tests/template-pos-from-to-missing-jsonvar.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="-%$!non!existing!var:109:116:%-\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/template-pos-from-to-oversize-lowercase.sh
+++ b/tests/template-pos-from-to-oversize-lowercase.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="-%msg:109:116:lowercase%-\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/template-pos-from-to-oversize.sh
+++ b/tests/template-pos-from-to-oversize.sh
@@ -7,7 +7,7 @@ echo "*** string template ****"
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="-%msg:109:116:%-\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
@@ -31,7 +31,7 @@ rm  $RSYSLOG_OUT_LOG # cleanup previous run
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 template(name="outfmt" type="list") {
 	constant(value="-")
 	property(name="msg" position.from="109" position.to="116")

--- a/tests/template-pos-from-to.sh
+++ b/tests/template-pos-from-to.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:9:16:%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/timegenerated-dateordinal-invld.sh
+++ b/tests/timegenerated-dateordinal-invld.sh
@@ -14,7 +14,7 @@ export TZ=UTC+00:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timegenerated:::date-ordinal%\n")

--- a/tests/timegenerated-dateordinal.sh
+++ b/tests/timegenerated-dateordinal.sh
@@ -14,7 +14,7 @@ export TZ=UTC+00:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timegenerated:::date-ordinal%\n")

--- a/tests/timegenerated-utc-legacy.sh
+++ b/tests/timegenerated-utc-legacy.sh
@@ -16,7 +16,7 @@ export TZ=TEST+02:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timegenerated:::date-utc%\n")

--- a/tests/timegenerated-utc.sh
+++ b/tests/timegenerated-utc.sh
@@ -16,7 +16,7 @@ export TZ=TEST+02:00
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="list") {
 	property(name="timegenerated" date.inUTC="on")

--- a/tests/timegenerated-uxtimestamp-invld.sh
+++ b/tests/timegenerated-uxtimestamp-invld.sh
@@ -14,7 +14,7 @@ export TZ=UTC+00:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timegenerated:::date-unixtimestamp%\n")

--- a/tests/timegenerated-uxtimestamp.sh
+++ b/tests/timegenerated-uxtimestamp.sh
@@ -14,7 +14,7 @@ export TZ=UTC+00:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timegenerated:::date-unixtimestamp%\n")

--- a/tests/timegenerated-ymd.sh
+++ b/tests/timegenerated-ymd.sh
@@ -12,7 +12,7 @@ export TZ=TEST-02:00
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timegenerated:::date-year%-%timegenerated:::date-month%-%timegenerated:::date-day%\n")

--- a/tests/timereported-utc-legacy.sh
+++ b/tests/timereported-utc-legacy.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timereported:::date-rfc3339,date-utc%\n")

--- a/tests/timereported-utc-vg.sh
+++ b/tests/timereported-utc-vg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 template(name="outfmt" type="string"
 	 string="%timereported:::date-rfc3339,date-utc%\n")

--- a/tests/timereported-utc.sh
+++ b/tests/timereported-utc.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="list") {
 	property(name="timereported" dateformat="rfc3339" date.inUTC="on")

--- a/tests/timestamp-3164-udp.sh
+++ b/tests/timestamp-3164-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-rfc3164%\n")
 

--- a/tests/timestamp-3164.sh
+++ b/tests/timestamp-3164.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-rfc3164%\n")
 

--- a/tests/timestamp-3339-udp.sh
+++ b/tests/timestamp-3339-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-rfc3339%\n")
 

--- a/tests/timestamp-3339.sh
+++ b/tests/timestamp-3339.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-rfc3339%\n")
 

--- a/tests/timestamp-mysql-udp.sh
+++ b/tests/timestamp-mysql-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-mysql%\n")
 

--- a/tests/timestamp-mysql.sh
+++ b/tests/timestamp-mysql.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-mysql%\n")
 

--- a/tests/timestamp-pgsql-udp.sh
+++ b/tests/timestamp-pgsql-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-pgsql%\n")
 

--- a/tests/timestamp-pgsql.sh
+++ b/tests/timestamp-pgsql.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-pgsql%\n")
 

--- a/tests/timestamp-subseconds-udp.sh
+++ b/tests/timestamp-subseconds-udp.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="13514")
+input(type="imudp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-subseconds%\n")
 

--- a/tests/timestamp-subseconds.sh
+++ b/tests/timestamp-subseconds.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%timestamp:::date-subseconds%\n")
 

--- a/tests/tls-check-for-certificate.sh
+++ b/tests/tls-check-for-certificate.sh
@@ -10,7 +10,7 @@ global(
 	defaultNetstreamDriverCaFile="tls-certs/ca.pem"
 )
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="gtls" StreamDriver.Mode="1" StreamDriver.AuthMode="anon")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 

--- a/tests/tls_error_file_not_found.sh
+++ b/tests/tls_error_file_not_found.sh
@@ -10,7 +10,7 @@ global(
 	defaultNetstreamDriverCaFile="tls-certs/ca.pem"
 )
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="gtls" StreamDriver.Mode="1" StreamDriver.AuthMode="anon")
-input(type="imtcp" port="13514")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 

--- a/tests/udp-msgreduc-orgmsg-vg.sh
+++ b/tests/udp-msgreduc-orgmsg-vg.sh
@@ -15,7 +15,7 @@ echo \[udp-msgreduc-orgmsg-vg.sh\]: testing msg reduction via udp, with org mess
 generate_conf
 add_conf '
 $ModLoad ../plugins/imudp/.libs/imudp
-$UDPServerRun 13514
+$UDPServerRun '$TCPFLOOD_PORT'
 $RepeatedMsgReduction on
 $RepeatedMsgContainsOriginalMsg on
 

--- a/tests/udp-msgreduc-vg.sh
+++ b/tests/udp-msgreduc-vg.sh
@@ -15,7 +15,7 @@ echo \[udp-msgreduc-vg.sh\]: testing imtcp multiple listeners
 generate_conf
 add_conf '
 $ModLoad ../plugins/imudp/.libs/imudp
-$UDPServerRun 13514
+$UDPServerRun '$TCPFLOOD_PORT'
 $RepeatedMsgReduction on
 
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/wr_large.sh
+++ b/tests/wr_large.sh
@@ -13,7 +13,7 @@ $MaxMessageSize 10k
 
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun 13514
+$InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!


### PR DESCRIPTION
part of the effort to make parallel testing possible

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
