### PR TITLE
omprog: remove "hideEnvironment" parameter as this is a bugfix

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -68,7 +68,6 @@ typedef struct _instanceData {
 	uchar *szTemplateName;	/* assigned output template */
 	int bConfirmMessages;	/* does the program provide feedback via stdout? */
 	int bUseTransactions;	/* send begin/end transaction marks to program? */
-	int bUseNULLEnvironment;	/* use an empty environment (vs. rsyslog's)? */
 	uchar *szBeginTransactionMark;	/* mark message for begin transaction */
 	uchar *szCommitTransactionMark;	/* mark message for commit transaction */
 	int bForceSingleInst;	/* only a single wrkr instance of program permitted? */
@@ -99,7 +98,6 @@ static configSettings_t cs;
 /* action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {
 	{ "binary", eCmdHdlrString, CNFPARAM_REQUIRED },
-	{ "hideEnvironment", eCmdHdlrBinary, 0 },
 	{ "confirmMessages", eCmdHdlrBinary, 0 },
 	{ "useTransactions", eCmdHdlrBinary, 0 },
 	{ "beginTransactionMark", eCmdHdlrString, 0 },
@@ -129,7 +127,6 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdout, int fdStder
 	struct sigaction sigAct;
 	sigset_t set;
 	char errStr[1024];
-	char *newenviron[] = { NULL };
 
 	if(dup2(fdStdin, STDIN_FILENO) == -1) {
 		DBGPRINTF("omprog: dup() stdin failed\n");
@@ -202,8 +199,7 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdout, int fdStder
 	alarm(0);
 
 	/* finally exec child */
-	iRet = execve((char*)pWrkrData->pData->szBinary, pWrkrData->pData->aParams,
-		(pWrkrData->pData->bUseNULLEnvironment) ? newenviron : environ);
+	iRet = execve((char*)pWrkrData->pData->szBinary, pWrkrData->pData->aParams, environ);
 	if(iRet == -1) {
 		/* Note: this will go to stdout of the **child**, so rsyslog will never
 		 * see it except when stdout is captured. If we use the plugin interface,
@@ -794,7 +790,6 @@ setInstParamDefaults(instanceData *pData)
 	pData->iParams = 0;
 	pData->bConfirmMessages = 0;
 	pData->bUseTransactions = 0;
-	pData->bUseNULLEnvironment = 1;
 	pData->szBeginTransactionMark = NULL;
 	pData->szCommitTransactionMark = NULL;
 	pData->bForceSingleInst = 0;
@@ -839,8 +834,6 @@ CODESTARTnewActInst
 		if(!strcmp(actpblk.descr[i].name, "binary")) {
 			CHKiRet(split_binary_parameters(&pData->szBinary, &pData->aParams, &pData->iParams,
 				pvals[i].val.d.estr));
-		} else if(!strcmp(actpblk.descr[i].name, "hideEnvironment")) {
-			pData->bUseNULLEnvironment = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "confirmMessages")) {
 			pData->bConfirmMessages = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "useTransactions")) {

--- a/tests/omprog-close-unresponsive-noterm.sh
+++ b/tests/omprog-close-unresponsive-noterm.sh
@@ -22,7 +22,6 @@ main_queue(
         binary=`echo $srcdir/testsuites/omprog-close-unresponsive-bin.sh`
         template="outfmt"
         name="omprog_action"
-	hideEnvironment="off"
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"  # facilitates sync with the child process
         signalOnClose="off"

--- a/tests/omprog-close-unresponsive.sh
+++ b/tests/omprog-close-unresponsive.sh
@@ -21,7 +21,6 @@ main_queue(
         type="omprog"
         binary=`echo $srcdir/testsuites/omprog-close-unresponsive-bin.sh`
         template="outfmt"
-	hideEnvironment="off"
         name="omprog_action"
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"  # facilitates sync with the child process

--- a/tests/omprog-defaults.sh
+++ b/tests/omprog-defaults.sh
@@ -29,7 +29,6 @@ template(name="outfmt" type="string" string="%msg%\n")
 	binary=`echo $srcdir/testsuites/omprog-defaults-bin.sh param1 param2 param3`
         template="outfmt"
         name="omprog_action"
-	hideEnvironment="off"
     )
 }
 '

--- a/tests/omprog-feedback.sh
+++ b/tests/omprog-feedback.sh
@@ -19,7 +19,6 @@ template(name="outfmt" type="string" string="%msg%\n")
         template="outfmt"
         name="omprog_action"
         queue.type="Direct"  # the default; facilitates sync with the child process
-	hideEnvironment="off"
         confirmMessages="on"
         useTransactions="off"
         action.resumeRetryCount="10"

--- a/tests/omprog-restart-terminated-outfile.sh
+++ b/tests/omprog-restart-terminated-outfile.sh
@@ -18,7 +18,6 @@ template(name="outfmt" type="string" string="%msg%\n")
         binary=`echo $srcdir/testsuites/omprog-restart-terminated-bin.sh`
         template="outfmt"
         name="omprog_action"
-	hideEnvironment="off"
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"  # facilitates sync with the child process
         action.resumeRetryCount="10"

--- a/tests/omprog-restart-terminated.sh
+++ b/tests/omprog-restart-terminated.sh
@@ -21,7 +21,6 @@ template(name="outfmt" type="string" string="%msg%\n")
         binary=`echo $srcdir/testsuites/omprog-restart-terminated-bin.sh`
         template="outfmt"
         name="omprog_action"
-	hideEnvironment="off"
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"  # facilitates sync with the child process
         action.resumeRetryCount="10"

--- a/tests/omprog-transactions-failed-commits.sh
+++ b/tests/omprog-transactions-failed-commits.sh
@@ -18,7 +18,6 @@ template(name="outfmt" type="string" string="%msg%\n")
         binary=`echo $srcdir/testsuites/omprog-transactions-bin.sh --failed_commits`
         template="outfmt"
         name="omprog_action"
-	hideEnvironment="off"
         queue.type="Direct"  # the default; facilitates sync with the child process
         queue.dequeueBatchSize="6"
         confirmMessages="on"

--- a/tests/omprog-transactions-failed-messages.sh
+++ b/tests/omprog-transactions-failed-messages.sh
@@ -18,7 +18,6 @@ template(name="outfmt" type="string" string="%msg%\n")
         binary=`echo $srcdir/testsuites/omprog-transactions-bin.sh --failed_messages`
         template="outfmt"
         name="omprog_action"
-	hideEnvironment="off"
         queue.type="Direct"  # the default; facilitates sync with the child process
         queue.dequeueBatchSize="6"
         confirmMessages="on"

--- a/tests/omprog-transactions.sh
+++ b/tests/omprog-transactions.sh
@@ -18,7 +18,6 @@ template(name="outfmt" type="string" string="%msg%\n")
         binary=`echo $srcdir/testsuites/omprog-transactions-bin.sh`
         template="outfmt"
         name="omprog_action"
-	hideEnvironment="off"
         queue.type="Direct"  # the default; facilitates sync with the child process
         queue.dequeueBatchSize="6"
         confirmMessages="on"


### PR DESCRIPTION
discussion confirmed that not passing environment to called program
should be considered a bug and consequently no parameter to control
this behaviour is needed. I just added that parameter to be able
to carry on with testbench work, and this commit removes it. The
param was never part of any official relase.

closes https://github.com/rsyslog/rsyslog/issues/2921

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
