### PR TITLE
omprog: improve child process output capture/redirection

### DIFF
--- a/plugins/external/skeletons/python/plugin-with-feedback.py
+++ b/plugins/external/skeletons/python/plugin-with-feedback.py
@@ -6,6 +6,7 @@ To integrate a plugin based on this skeleton with rsyslog, configure an
 'omprog' action like the following:
     action(type="omprog"
         binary="/usr/bin/myplugin.py"
+        output="/var/log/myplugin.log"
         confirmMessages="on"
         ...)
 
@@ -61,20 +62,12 @@ def onInit():
     # Apart from processing the logs received from rsyslog, you want your plugin
     # to be able to report its own logs in some way. This will facilitate
     # diagnosing problems and debugging your code. Here we set up the standard
-    # Python logging system to output the logs to stderr.
+    # Python logging system to output the logs to stderr. In the rsyslog
+    # configuration, you can configure the 'omprog' action to capture the stderr
+    # of your plugin by specifying the action's "output" parameter.
     logging.basicConfig(stream=sys.stderr,
                         level=logging.WARNING,
                         format='%(asctime)s %(levelname)s %(message)s')
-
-    # In the rsyslog configuration, you can configure the 'omprog' action to
-    # capture the stderr of your plugin by specifying the action's "output"
-    # parameter. However, note that this parameter is intended for debugging
-    # purposes and cannot be used on a permanent basis (in particular, it will
-    # not work well if rsyslog decides to launch multiple instances of your
-    # plugin, since this would cause concurrent writes to the output file).
-    # As an alternative to logging to stderr, you can log to a per-process
-    # file, as shown here:
-    # logging.basicConfig(filename="myplugin-{}.log".format(os.getpid()), ...)
 
     # This is an example of a debug log. (Note that for debug logs to be
     # emitted you must set 'level' to logging.DEBUG above.)

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -59,7 +59,23 @@ DEF_OMOD_STATIC_DATA
 #define NO_HUP_FORWARD -1	/* indicates that HUP should NOT be forwarded */
 #define DEFAULT_CLOSE_TIMEOUT_MS 5000
 #define READLINE_BUFFER_SIZE 1024
+#define OUTPUT_CAPTURE_BUFFER_SIZE 4096
 #define MAX_FD_TO_CLOSE 65535
+
+typedef struct outputCaptureCtx {
+	uchar *szFileName;		/* name of file to write the program output to, or NULL */
+	mode_t fCreateMode;		/* output file creation permissions */
+	int bIsRunning;			/* is the output-capture thread running? (if 0, next fields are meaningless) */
+	pthread_t thrdID;		/* ID of the output-capture thread */
+	int fdPipe[2];			/* pipe for capturing the output of the child processes */
+	int fdFile;				/* fd of the output file (-1 if it could not be opened) */
+	int bFileErr;			/* file open error occurred? (to avoid reporting too many errors) */
+	int bReadErr;			/* read error occurred? (to avoid reporting too many errors) */
+	int bWriteErr;			/* write error occurred? (to avoid reporting too many errors) */
+	pthread_mutex_t mutWrite;	/* mutex for reopening the output file on HUP while being written */
+	pthread_mutex_t mutTerm;	/* mutex for signaling the termination of the thread */
+	pthread_cond_t condTerm;	/* condition for signaling the termination of the thread */
+} outputCaptureCtx_t;
 
 typedef struct _instanceData {
 	uchar *szBinary;		/* name of external program to call */
@@ -75,17 +91,15 @@ typedef struct _instanceData {
 	int bSignalOnClose;		/* should send SIGTERM to program before closing pipe? */
 	long lCloseTimeout;		/* how long to wait for program to terminate after closing pipe (ms) */
 	int bKillUnresponsive;	/* should send SIGKILL if closeTimeout is reached? */
-	uchar *szOutputFileName;	/* name of file to write the program output to, or NULL */
-	pthread_mutex_t mut;	/* make sure only one instance is active */
+	outputCaptureCtx_t outputCaptureCtx;	/* settings and state for the output capture thread */
+	pthread_mutex_t mut;	/* make sure only one instance is active (buggy! - see #2813) */
 } instanceData;
 
 typedef struct wrkrInstanceData {
 	instanceData *pData;
 	pid_t pid;			/* pid of currently running child process */
 	int fdPipeOut;		/* fd for sending messages to the program */
-	int fdPipeIn;		/* fd for receiving status messages from the program */
-	int fdPipeErr;		/* fd for receiving error output from the program */
-	int fdOutputFile;	/* fd to write the program output to (-1 if to discard) */
+	int fdPipeIn;		/* fd for receiving status messages from the program, or -1 */
 	int bIsRunning;		/* is program currently running? 0-no, 1-yes */
 } wrkrInstanceData_t;
 
@@ -102,13 +116,14 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "useTransactions", eCmdHdlrBinary, 0 },
 	{ "beginTransactionMark", eCmdHdlrString, 0 },
 	{ "commitTransactionMark", eCmdHdlrString, 0 },
-	{ "output", eCmdHdlrString, 0 },
 	{ "forcesingleinstance", eCmdHdlrBinary, 0 },
 	{ "hup.signal", eCmdHdlrGetWord, 0 },
 	{ "template", eCmdHdlrGetWord, 0 },
 	{ "signalOnClose", eCmdHdlrBinary, 0 },
 	{ "closeTimeout", eCmdHdlrInt, 0 },
-	{ "killUnresponsive", eCmdHdlrBinary, 0 }
+	{ "killUnresponsive", eCmdHdlrBinary, 0 },
+	{ "output", eCmdHdlrString, 0 },
+	{ "fileCreateMode", eCmdHdlrFileCreateMode, 0 }
 };
 
 static struct cnfparamblk actpblk =
@@ -117,53 +132,52 @@ static struct cnfparamblk actpblk =
 	  actpdescr
 	};
 
-/* execute the child process (must be called in child context
- * after fork).
+/* execute the external program (must be called in child context after fork).
  */
 static __attribute__((noreturn)) void
-execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdout, int fdStderr)
+execBinary(const instanceData *pData, int fdStdin, int fdStdout)
 {
-	int i, maxFd, iRet;
+	int fdOutput, maxFd, fd, sigNum;
 	struct sigaction sigAct;
-	sigset_t set;
+	sigset_t sigSet;
 	char errStr[1024];
 
 	if(dup2(fdStdin, STDIN_FILENO) == -1) {
-		DBGPRINTF("omprog: dup() stdin failed\n");
-		/* do some more error handling here? Maybe if the module
-		 * gets some more widespread use...
-		 */
+		goto failed;
 	}
 
-	if(pWrkrData->pData->bConfirmMessages) {
-		/* send message confirmations via stdout */
-		if(dup2(fdStdout, STDOUT_FILENO) == -1) {
-			DBGPRINTF("omprog: dup() stdout failed\n");
-		}
-		/* redirect stderr to the output file, if specified */
-		if (pWrkrData->pData->szOutputFileName != NULL) {
-			if(dup2(fdStderr, STDERR_FILENO) == -1) {
-				DBGPRINTF("omprog: dup() stderr failed\n");
-			}
-		} else {
-			close(fdStderr);
-		}
-	} else if (pWrkrData->pData->szOutputFileName != NULL) {
-		/* redirect both stdout and stderr to the output file */
-		if(dup2(fdStderr, STDOUT_FILENO) == -1) {
-			DBGPRINTF("omprog: dup() stdout failed\n");
-		}
-		if(dup2(fdStderr, STDERR_FILENO) == -1) {
-			DBGPRINTF("omprog: dup() stderr failed\n");
-		}
-		close(fdStdout);
+	if(pData->outputCaptureCtx.bIsRunning) {
+		fdOutput = pData->outputCaptureCtx.fdPipe[1];
 	} else {
-		/* no need to send data to parent via stdout or stderr */
-		close(fdStdout);
-		close(fdStderr);
+		fdOutput = open("/dev/null", O_WRONLY);
+		if(fdOutput == -1) {
+			goto failed;
+		}
 	}
 
-	/* close all file handles the child process doesn't need.
+	if(fdStdout != -1) {
+		/* confirmMessages enabled: redirect stdout to parent via pipe. After
+		 * this point, anything written to the child's stdout will be treated
+		 * by omprog as initialization feedback (see startChild). This
+		 * includes debug messages (DBGPRINTF) when in debug mode. So we
+		 * cannot use DBGPRINTF from this point on, except for error cases.
+		 */
+		if(dup2(fdStdout, STDOUT_FILENO) == -1) {
+			goto failed;
+		}
+	} else {
+		/* confirmMessages disabled: redirect stdout to file or /dev/null */
+		if(dup2(fdOutput, STDOUT_FILENO) == -1) {
+			goto failed;
+		}
+	}
+
+	/* redirect stderr to file or /dev/null */
+	if(dup2(fdOutput, STDERR_FILENO) == -1) {
+		goto failed;
+	}
+
+	/* close the file handles the child process doesn't need (all above STDERR).
 	 * The following way is simple and portable, though not perfect.
 	 * See https://stackoverflow.com/a/918469 for alternatives.
 	 */
@@ -176,16 +190,16 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdout, int fdStder
 		maxFd -= 10;
 	}
 #	endif
-	for(i = STDERR_FILENO + 1 ; i <= maxFd ; ++i) {
-		close(i);
+	for(fd = STDERR_FILENO + 1 ; fd <= maxFd ; ++fd) {
+		close(fd);
 	}
 
 	/* reset signal handlers to default */
 	memset(&sigAct, 0, sizeof(sigAct));
 	sigemptyset(&sigAct.sa_mask);
 	sigAct.sa_handler = SIG_DFL;
-	for(i = 1 ; i < NSIG ; ++i) {
-		sigaction(i, &sigAct, NULL);
+	for(sigNum = 1 ; sigNum < NSIG ; ++sigNum) {
+		sigaction(sigNum, &sigAct, NULL);
 	}
 
 	/* we need to block SIGINT, otherwise our program is cancelled when we are
@@ -193,27 +207,25 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdout, int fdStder
 	 */
 	sigAct.sa_handler = SIG_IGN;
 	sigaction(SIGINT, &sigAct, NULL);
-	sigemptyset(&set);
-	sigprocmask(SIG_SETMASK, &set, NULL);
+	sigemptyset(&sigSet);
+	sigprocmask(SIG_SETMASK, &sigSet, NULL);
 
 	alarm(0);
 
-	/* finally exec child */
-	iRet = execve((char*)pWrkrData->pData->szBinary, pWrkrData->pData->aParams, environ);
-	if(iRet == -1) {
-		/* Note: this will go to stdout of the **child**, so rsyslog will never
-		 * see it except when stdout is captured. If we use the plugin interface,
-		 * we can use this to convey a proper status back!
-		 */
-		rs_strerror_r(errno, errStr, sizeof(errStr));
-		DBGPRINTF("omprog: failed to execute program '%s': %s\n",
-			  pWrkrData->pData->szBinary, errStr);
-		openlog("rsyslogd", 0, LOG_SYSLOG);
-		syslog(LOG_ERR, "omprog: failed to execute program '%s': %s\n",
-			  pWrkrData->pData->szBinary, errStr);
-	}
+	/* finally exec program */
+	execve((char*)pData->szBinary, pData->aParams, environ);
 
-	/* we should never reach this point, but if we do, we terminate */
+failed:
+	/* an error occurred: log it and exit the child process. We use the
+	 * 'syslog' system call to log the error (we cannot use LogMsg/LogError,
+	 * since these functions add directly to the rsyslog input queue).
+	 */
+	rs_strerror_r(errno, errStr, sizeof(errStr));
+	DBGPRINTF("omprog: failed to execute program '%s': %s\n",
+			pData->szBinary, errStr);
+	openlog("rsyslogd", 0, LOG_SYSLOG);
+	syslog(LOG_ERR, "omprog: failed to execute program '%s': %s\n",
+			pData->szBinary, errStr);
 	exit(1);
 }
 
@@ -223,153 +235,70 @@ execBinary(wrkrInstanceData_t *pWrkrData, int fdStdin, int fdStdout, int fdStder
 static rsRetVal
 openPipe(wrkrInstanceData_t *pWrkrData)
 {
-	int pipeStdin[2];
-	int pipeStdout[2];
-	int pipeStderr[2];
+	int pipeStdin[2] = { -1, -1 };
+	int pipeStdout[2] = { -1, -1 };
 	pid_t cpid;
-	int flags;
 	DEFiRet;
 
+	/* open a pipe to send messages to the program */
 	if(pipe(pipeStdin) == -1) {
 		ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
 	}
-	if(pipe(pipeStdout) == -1) {
-		close(pipeStdin[0]); close(pipeStdin[1]);
-		ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
-	}
-	if(pipe(pipeStderr) == -1) {
-		close(pipeStdin[0]); close(pipeStdin[1]);
-		close(pipeStdout[0]); close(pipeStdout[1]);
+
+	/* if the 'confirmMessages' setting is enabled, open a pipe to receive
+	   message confirmations from the program */
+	if(pWrkrData->pData->bConfirmMessages && pipe(pipeStdout) == -1) {
 		ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
 	}
 
 	DBGPRINTF("omprog: executing program '%s' with '%d' parameters\n",
-		  pWrkrData->pData->szBinary, pWrkrData->pData->iParams);
-
-	/* final sanity check */
-	assert(pWrkrData->pData->szBinary != NULL);
-	assert(pWrkrData->pData->aParams != NULL);
-
-	/* NO OUTPUT AFTER FORK! */
+			pWrkrData->pData->szBinary, pWrkrData->pData->iParams);
 
 	cpid = fork();
 	if(cpid == -1) {
 		ABORT_FINALIZE(RS_RET_ERR_FORK);
 	}
-	pWrkrData->pid = cpid;
 
-	if(cpid == 0) {
-		/* we are now the child, just exec the binary. */
-		close(pipeStdin[1]); /* close those pipe "ports" that */
-		close(pipeStdout[0]); /* ... we don't need */
-		close(pipeStderr[0]);
-		execBinary(pWrkrData, pipeStdin[0], pipeStdout[1], pipeStderr[1]);
-		/*NO CODE HERE - WILL NEVER BE REACHED!*/
+	if(cpid == 0) {  /* we are now the child process: execute the program */
+		/* close the pipe ends that the child doesn't need */
+		close(pipeStdin[1]);
+		if(pipeStdout[0] != -1) {
+			close(pipeStdout[0]);
+		}
+
+		execBinary(pWrkrData->pData, pipeStdin[0], pipeStdout[1]);
+		/* NO CODE HERE - WILL NEVER BE REACHED! */
 	}
 
 	DBGPRINTF("omprog: child has pid %d\n", (int) cpid);
 
+	/* close the pipe ends that the parent doesn't need */
 	close(pipeStdin[0]);
-	close(pipeStdout[1]);
-	close(pipeStderr[1]);
+	if(pipeStdout[1] != -1) {
+		close(pipeStdout[1]);
+	}
 
 	/* we'll send messages to the program via fdPipeOut */
 	pWrkrData->fdPipeOut = pipeStdin[1];
 
-	if(pWrkrData->pData->bConfirmMessages) {
-		/* we'll receive message confirmations via fdPipeIn */
-		pWrkrData->fdPipeIn = pipeStdout[0];
-		/* we'll capture stderr to the output file, if specified */
-		if (pWrkrData->pData->szOutputFileName != NULL) {
-			pWrkrData->fdPipeErr = pipeStderr[0];
-		}
-		else {
-			close(pipeStderr[0]);
-			pWrkrData->fdPipeErr = -1;
-		}
-	} else if (pWrkrData->pData->szOutputFileName != NULL) {
-		/* we'll capture both stdout and stderr via fdPipeErr */
-		close(pipeStdout[0]);
-		pWrkrData->fdPipeIn = -1;
-		pWrkrData->fdPipeErr = pipeStderr[0];
-	} else {
-		/* no need to read the program stdout or stderr */
-		close(pipeStdout[0]);
-		close(pipeStderr[0]);
-		pWrkrData->fdPipeIn = -1;
-		pWrkrData->fdPipeErr = -1;
-	}
+	/* we'll receive message confirmations via fdPipeIn */
+	pWrkrData->fdPipeIn = pipeStdout[0];
 
-	if(pWrkrData->fdPipeErr != -1) {
-		/* set our fd to be non-blocking */
-		flags = fcntl(pWrkrData->fdPipeErr, F_GETFL);
-		flags |= O_NONBLOCK;
-		if(fcntl(pWrkrData->fdPipeErr, F_SETFL, flags) == -1) {
-			LogError(errno, RS_RET_ERR, "omprog: set pipe fd to "
-				"nonblocking failed");
-			ABORT_FINALIZE(RS_RET_ERR);
-		}
-	}
-
+	pWrkrData->pid = cpid;
 	pWrkrData->bIsRunning = 1;
+
 finalize_it:
+	if(iRet != RS_RET_OK) {
+		if(pipeStdin[0] != -1) {
+			close(pipeStdin[0]);
+			close(pipeStdin[1]);
+		}
+		if(pipeStdout[0] != -1) {
+			close(pipeStdout[0]);
+			close(pipeStdout[1]);
+		}
+	}
 	RETiRet;
-}
-
-/* As this is assume to be a debug function, we only make
- * best effort to write the message but do *not* try very
- * hard to handle errors. -- rgerhards, 2014-01-16
- */
-static void
-writeProgramOutput(wrkrInstanceData_t *__restrict__ const pWrkrData,
-	const char *__restrict__ const buf,
-	const ssize_t lenBuf)
-{
-	char errStr[1024];
-	ssize_t r;
-
-	if(pWrkrData->fdOutputFile == -1) {
-		pWrkrData->fdOutputFile = open((char*)pWrkrData->pData->szOutputFileName,
-				       O_WRONLY | O_APPEND | O_CREAT, 0600);
-		if(pWrkrData->fdOutputFile == -1) {
-			DBGPRINTF("omprog: error opening output file %s: %s\n",
-				   pWrkrData->pData->szOutputFileName,
-				   rs_strerror_r(errno, errStr, sizeof(errStr)));
-			goto done;
-		}
-	}
-
-	r = write(pWrkrData->fdOutputFile, buf, (size_t) lenBuf);
-	if(r != lenBuf) {
-		DBGPRINTF("omprog: problem writing output file %s: bytes "
-			  "requested %lld, written %lld, msg: %s\n",
-			   pWrkrData->pData->szOutputFileName, (long long) lenBuf, (long long) r,
-			   rs_strerror_r(errno, errStr, sizeof(errStr)));
-	}
-done:	return;
-}
-
-/* check output of the executed program
- * If configured to care about the output, we check if there is some and,
- * if so, properly handle it.
- */
-static void
-checkProgramOutput(wrkrInstanceData_t *__restrict__ const pWrkrData)
-{
-	char buf[4096];
-	ssize_t r;
-
-	if(pWrkrData->fdPipeErr == -1)
-		goto done;
-
-	do {
-		r = read(pWrkrData->fdPipeErr, buf, sizeof(buf));
-		if(r > 0) {
-			writeProgramOutput(pWrkrData, buf, r);
-		}
-	} while(r > 0);
-
-done:	return;
 }
 
 static void
@@ -430,18 +359,8 @@ waitForChild(wrkrInstanceData_t *pWrkrData)
 static void
 cleanupChild(wrkrInstanceData_t *pWrkrData)
 {
-	assert(pWrkrData->bIsRunning == 1);
+	assert(pWrkrData->bIsRunning);
 
-	checkProgramOutput(pWrkrData);  /* try to catch any late messages */
-
-	if(pWrkrData->fdOutputFile != -1) {
-		close(pWrkrData->fdOutputFile);
-		pWrkrData->fdOutputFile = -1;
-	}
-	if(pWrkrData->fdPipeErr != -1) {
-		close(pWrkrData->fdPipeErr);
-		pWrkrData->fdPipeErr = -1;
-	}
 	if(pWrkrData->fdPipeIn != -1) {
 		close(pWrkrData->fdPipeIn);
 		pWrkrData->fdPipeIn = -1;
@@ -463,7 +382,7 @@ cleanupChild(wrkrInstanceData_t *pWrkrData)
 static void
 terminateChild(wrkrInstanceData_t *pWrkrData)
 {
-	assert(pWrkrData->bIsRunning == 1);
+	assert(pWrkrData->bIsRunning);
 
 	if (pWrkrData->pData->bSignalOnClose) {
 		kill(pWrkrData->pid, SIGTERM);
@@ -489,24 +408,21 @@ writePipe(wrkrInstanceData_t *pWrkrData, uchar *szMsg)
 	len = strlen((char*)szMsg);
 
 	do {
-		checkProgramOutput(pWrkrData);
 		written = write(pWrkrData->fdPipeOut, ((char*)szMsg) + offset, len - offset);
 		if(written == -1) {
 			if(errno == EPIPE) {
 				DBGPRINTF("omprog: program '%s' terminated, will be restarted\n",
-					  pWrkrData->pData->szBinary);
+						pWrkrData->pData->szBinary);
 				/* force restart in tryResume() */
 				cleanupChild(pWrkrData);
 			} else {
 				DBGPRINTF("omprog: error %d writing to pipe: %s\n", errno,
-					   rs_strerror_r(errno, errStr, sizeof(errStr)));
+						rs_strerror_r(errno, errStr, sizeof(errStr)));
 			}
 			ABORT_FINALIZE(RS_RET_SUSPENDED);
 		}
 		offset += written;
 	} while(offset < len);
-
-	checkProgramOutput(pWrkrData);
 
 finalize_it:
 	RETiRet;
@@ -515,9 +431,10 @@ finalize_it:
 /* Reads a line from a blocking pipe, using the unistd.h read() function.
  * Returns the line as a null-terminated string in *lineptr, not including
  * the \n or \r\n terminator.
- * On success, returns the line length.
+ * On success, returns the line length (>= 0).
  * On error, returns -1 and sets errno.
- * On EOF, returns -1 and sets errno to EPIPE.
+ * On EOF, returns -1 and sets errno to EPIPE (if EOF is read in the middle of
+ * a line, discards the read characters).
  * On success, the caller is responsible for freeing the returned line buffer.
  */
 static ssize_t
@@ -592,8 +509,7 @@ lineToStatusCode(wrkrInstanceData_t *pWrkrData, const char* line)
 		iRet = RS_RET_PREVIOUS_COMMITTED;
 	} else {
 		/* anything else is considered a recoverable error */
-		DBGPRINTF("omprog: program '%s' returned: %s\n",
-			  pWrkrData->pData->szBinary, line);
+		DBGPRINTF("omprog: program '%s' returned: %s\n", pWrkrData->pData->szBinary, line);
 		iRet = RS_RET_SUSPENDED;
 	}
 	RETiRet;
@@ -602,7 +518,7 @@ lineToStatusCode(wrkrInstanceData_t *pWrkrData, const char* line)
 static rsRetVal
 readPipe(wrkrInstanceData_t *pWrkrData)
 {
-	char *line;
+	char *line = NULL;
 	ssize_t lineLen;
 	char errStr[1024];
 	DEFiRet;
@@ -611,7 +527,7 @@ readPipe(wrkrInstanceData_t *pWrkrData)
 	if (lineLen == -1) {
 		if (errno == EPIPE) {
 			DBGPRINTF("omprog: program '%s' terminated, will be restarted\n",
-				  pWrkrData->pData->szBinary);
+					pWrkrData->pData->szBinary);
 			/* force restart in tryResume() */
 			cleanupChild(pWrkrData);
 		} else {
@@ -621,9 +537,10 @@ readPipe(wrkrInstanceData_t *pWrkrData)
 		ABORT_FINALIZE(RS_RET_SUSPENDED);
 	}
 
-	iRet = lineToStatusCode(pWrkrData, line);
-	free(line);
+	CHKiRet(lineToStatusCode(pWrkrData, line));
+
 finalize_it:
+	free(line);
 	RETiRet;
 }
 
@@ -632,7 +549,7 @@ startChild(wrkrInstanceData_t *pWrkrData)
 {
 	DEFiRet;
 
-	assert(pWrkrData->bIsRunning == 0);
+	assert(!pWrkrData->bIsRunning);
 
 	CHKiRet(openPipe(pWrkrData));
 
@@ -647,6 +564,213 @@ finalize_it:
 		terminateChild(pWrkrData);
 	}
 	RETiRet;
+}
+
+static void
+writeOutputToFile(outputCaptureCtx_t *pCtx, char *buf, ssize_t len)
+{
+	ssize_t written;
+	ssize_t offset = 0;
+
+	assert(pCtx->bIsRunning);
+	pthread_mutex_lock(&pCtx->mutWrite);
+
+	if(pCtx->fdFile == -1) {
+		if(pCtx->bFileErr) {  /* discarding output because file couldn't be opened */
+			return;
+		}
+
+		pCtx->fdFile = open((char*)pCtx->szFileName, O_WRONLY | O_APPEND | O_CREAT,
+				pCtx->fCreateMode);
+		if(pCtx->fdFile == -1) {
+			LogError(errno, RS_RET_NO_FILE_ACCESS, "omprog: error opening output file %s; "
+					"output from program will be discarded", pCtx->szFileName);
+			pCtx->bFileErr = 1;  /* avoid reporting too many errors */
+			return;
+		}
+	}
+
+	do {
+		written = write(pCtx->fdFile, buf + offset, len - offset);
+		if(written == -1) {
+			if(errno == EINTR) {
+				continue;  /* call interrupted: retry write */
+			}
+
+			if(!pCtx->bWriteErr) {
+				LogError(errno, RS_RET_SYS_ERR, "omprog: error writing to output file "
+						"(subsequent errors will not be reported)");
+				pCtx->bWriteErr = 1;  /* avoid reporting too many errors */
+			}
+			break;
+		}
+
+		if(pCtx->bWriteErr) {
+			LogMsg(0, NO_ERRCODE, LOG_WARNING, "omprog: resumed writing to output file");
+			pCtx->bWriteErr = 0;
+		}
+
+		offset += written;
+	} while(offset < len);
+
+	pthread_mutex_unlock(&pCtx->mutWrite);
+}
+
+static void
+closeOutputFile(outputCaptureCtx_t *pCtx)
+{
+	assert(pCtx->bIsRunning);
+	DBGPRINTF("omprog: reopening output file upon reception of HUP signal\n");
+	pthread_mutex_lock(&pCtx->mutWrite);
+
+	if(pCtx->fdFile != -1) {
+		close(pCtx->fdFile);
+		pCtx->fdFile = -1;
+	}
+	pCtx->bFileErr = 0;  /* if there was an error opening the file, we'll retry */
+
+	pthread_mutex_unlock(&pCtx->mutWrite);
+}
+
+/* This code runs in a dedicated thread. Captures the output of the child processes
+ * through a shared pipe (one reader and multiple writers), and writes the output
+ * to a file. The lines concurrently emmitted to stdout/stderr by the child processes
+ * will not appear intermingled in the output file if 1) the lines are short enough
+ * (less than PIPE_BUF bytes long: 4KB on Linux, and 512 bytes or more on other
+ * POSIX systems), and 2) the program outputs each line using a single 'write'
+ * syscall (line buffering mode). When a HUP signal is received, the output file is
+ * reopened (this provides support for external rotation of the file).
+ */
+static void *
+captureOutput(void *_pCtx) {
+	outputCaptureCtx_t *pCtx = (outputCaptureCtx_t *)_pCtx;
+	sigset_t sigSet;
+	char readBuf[OUTPUT_CAPTURE_BUFFER_SIZE];
+	ssize_t lenRead;
+
+	DBGPRINTF("omprog: starting output capture thread\n");
+
+	/* block signals for this thread (otherwise shutdown hangs on FreeBSD) */
+	sigfillset(&sigSet);
+	pthread_sigmask(SIG_SETMASK, &sigSet, NULL);
+
+	for(;;) {
+		lenRead = read(pCtx->fdPipe[0], readBuf, sizeof(readBuf));
+		if(lenRead == -1) {
+			if(errno == EINTR) {
+				continue;  /* call interrupted: retry read */
+			}
+
+			if(!pCtx->bReadErr) {
+				LogError(errno, RS_RET_SYS_ERR, "omprog: error capturing output from program "
+						"(subsequent errors will not be reported)");
+				pCtx->bReadErr = 1;  /* avoid reporting too many errors */
+			}
+			continue;  /* continue with next line */
+		}
+
+		if(lenRead == 0) {
+			break;  /* all write ends of pipe closed: exit loop and terminate thread */
+		}
+
+		if(pCtx->bReadErr) {
+			LogMsg(0, NO_ERRCODE, LOG_WARNING, "omprog: resumed capturing output from program");
+			pCtx->bReadErr = 0;
+		}
+
+		writeOutputToFile(pCtx, readBuf, lenRead);
+	}
+
+	DBGPRINTF("omprog: all output-capture pipe ends closed, terminating output capture thread\n");
+	pthread_mutex_lock(&pCtx->mutTerm);
+	pCtx->bIsRunning = 0;
+	pthread_cond_signal(&pCtx->condTerm);
+	pthread_mutex_unlock(&pCtx->mutTerm);
+	return NULL;
+}
+
+static rsRetVal
+startOutputCapture(outputCaptureCtx_t *pCtx)
+{
+	int pip[2] = { -1, -1 };
+	DEFiRet;
+
+	assert(!pCtx->bIsRunning);
+
+	/* open a (single) pipe to capture output from (all) child processes */
+	if(pipe(pip) == -1) {
+		ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
+	}
+
+	pCtx->fdPipe[0] = pip[0];
+	pCtx->fdPipe[1] = pip[1];
+	pCtx->fdFile = -1;
+	pCtx->bFileErr = 0;
+	pCtx->bReadErr = 0;
+	pCtx->bWriteErr = 0;
+	CHKiConcCtrl(pthread_mutex_init(&pCtx->mutWrite, NULL));
+	CHKiConcCtrl(pthread_mutex_init(&pCtx->mutTerm, NULL));
+	CHKiConcCtrl(pthread_cond_init(&pCtx->condTerm, NULL));
+
+	/* start a thread to read lines from the pipe and write them to the output file */
+	CHKiConcCtrl(pthread_create(&pCtx->thrdID, NULL, captureOutput, (void *)pCtx));
+
+	pCtx->bIsRunning = 1;
+
+finalize_it:
+	if(iRet != RS_RET_OK && pip[0] != -1) {
+		close(pip[0]);
+		close(pip[1]);
+	}
+	RETiRet;
+}
+
+static void
+endOutputCapture(outputCaptureCtx_t *pCtx, long timeoutMs)
+{
+	struct timespec ts;
+	int bTimedOut;
+
+	assert(pCtx->bIsRunning);
+
+	/* close our write end of the output-capture pipe */
+	close(pCtx->fdPipe[1]);
+
+	/* the output capture thread will now terminate because there are no more
+	 * writers attached to the output-capture pipe. However, if a child becomes
+	 * unresponsive without closing its pipe end (assuming killUnresponsive=off),
+	 * we would wait forever. To avoid this, we wait for the thread to terminate
+	 * during a maximum timeout (we reuse the 'closeTimeout' setting for this).
+	 */
+	timeoutComp(&ts, timeoutMs);
+	pthread_mutex_lock(&pCtx->mutTerm);
+	bTimedOut = 0;
+	while(pCtx->bIsRunning && !bTimedOut) {
+		if(pthread_cond_timedwait(&pCtx->condTerm, &pCtx->mutTerm, &ts) == ETIMEDOUT) {
+			bTimedOut = 1;
+		}
+	}
+	pthread_mutex_unlock(&pCtx->mutTerm);
+
+	if(bTimedOut) {
+		LogMsg(0, NO_ERRCODE, LOG_WARNING, "omprog: forcing termination of output capture "
+				"thread because of unresponsive child process");
+		pthread_cancel(pCtx->thrdID);
+		pCtx->bIsRunning = 0;
+	}
+
+	pthread_join(pCtx->thrdID, NULL);
+	pthread_cond_destroy(&pCtx->condTerm);
+	pthread_mutex_destroy(&pCtx->mutTerm);
+	pthread_mutex_destroy(&pCtx->mutWrite);
+
+	/* close the read end of the output-capture pipe */
+	close(pCtx->fdPipe[0]);
+
+	/* close the output file (if it could be opened) */
+	if(pCtx->fdFile != -1) {
+		close(pCtx->fdFile);
+	}
 }
 
 
@@ -664,10 +788,9 @@ ENDcreateInstance
 
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
+	pWrkrData->pid = -1;
 	pWrkrData->fdPipeOut = -1;
 	pWrkrData->fdPipeIn = -1;
-	pWrkrData->fdPipeErr = -1;
-	pWrkrData->fdOutputFile = -1;
 	pWrkrData->bIsRunning = 0;
 
 	iRet = startChild(pWrkrData);
@@ -676,8 +799,9 @@ ENDcreateWrkrInstance
 
 BEGINisCompatibleWithFeature
 CODESTARTisCompatibleWithFeature
-	if(eFeat == sFEATURERepeatedMsgReduction)
+	if(eFeat == sFEATURERepeatedMsgReduction) {
 		iRet = RS_RET_OK;
+	}
 ENDisCompatibleWithFeature
 
 
@@ -765,11 +889,15 @@ BEGINfreeInstance
 CODESTARTfreeInstance
 	pthread_mutex_destroy(&pData->mut);
 
+	if(pData->outputCaptureCtx.bIsRunning) {
+		endOutputCapture(&pData->outputCaptureCtx, pData->lCloseTimeout);
+	}
+
 	free(pData->szBinary);
 	free(pData->szTemplateName);
 	free(pData->szBeginTransactionMark);
 	free(pData->szCommitTransactionMark);
-	free(pData->szOutputFileName);
+	free(pData->outputCaptureCtx.szFileName);
 
 	if(pData->aParams != NULL) {
 		for (i = 0; i < pData->iParams; i++) {
@@ -796,9 +924,10 @@ setInstParamDefaults(instanceData *pData)
 	pData->bSignalOnClose = 0;
 	pData->lCloseTimeout = DEFAULT_CLOSE_TIMEOUT_MS;
 	pData->bKillUnresponsive = -1;
-	pData->szOutputFileName = NULL;
+	pData->outputCaptureCtx.szFileName = NULL;
+	pData->outputCaptureCtx.fCreateMode = 0600;
+	pData->outputCaptureCtx.bIsRunning = 0;
 }
-
 
 static void
 setInstParamCalcDefaults(instanceData *pData)
@@ -841,8 +970,6 @@ CODESTARTnewActInst
 			pData->szBeginTransactionMark = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "commitTransactionMark")) {
 			pData->szCommitTransactionMark = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
-		} else if(!strcmp(actpblk.descr[i].name, "output")) {
-			pData->szOutputFileName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "forcesingleinstance")) {
 			pData->bForceSingleInst = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "signalOnClose")) {
@@ -871,6 +998,10 @@ CODESTARTnewActInst
 			free((void*)sig);
 		} else if(!strcmp(actpblk.descr[i].name, "template")) {
 			pData->szTemplateName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "output")) {
+			pData->outputCaptureCtx.szFileName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "fileCreateMode")) {
+			pData->outputCaptureCtx.fCreateMode = (mode_t) pvals[i].val.d.n;
 		} else {
 			DBGPRINTF("omprog: program error, non-handled param '%s'\n", actpblk.descr[i].name);
 		}
@@ -880,6 +1011,11 @@ CODESTARTnewActInst
 	CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)strdup((pData->szTemplateName == NULL) ?
 						"RSYSLOG_FileFormat" : (char*)pData->szTemplateName),
 						OMSR_NO_RQD_TPL_OPTS));
+	
+	if(pData->outputCaptureCtx.szFileName != NULL) {
+		CHKiRet(startOutputCapture(&pData->outputCaptureCtx));
+	}
+
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst
@@ -918,12 +1054,21 @@ CODE_STD_FINALIZERparseSelectorAct
 ENDparseSelectorAct
 
 
+BEGINdoHUP
+CODESTARTdoHUP
+	if(pData->outputCaptureCtx.bIsRunning) {
+		closeOutputFile(&pData->outputCaptureCtx);
+	}
+ENDdoHUP
+
+
 BEGINdoHUPWrkr
 CODESTARTdoHUPWrkr
 	DBGPRINTF("omprog: processing HUP for work instance %p, pid %d, forward: %d\n",
-		pWrkrData, (int) pWrkrData->pid, pWrkrData->pData->iHUPForward);
-	if(pWrkrData->pData->iHUPForward != NO_HUP_FORWARD)
+			pWrkrData, (int) pWrkrData->pid, pWrkrData->pData->iHUPForward);
+	if(pWrkrData->pData->iHUPForward != NO_HUP_FORWARD) {
 		kill(pWrkrData->pid, pWrkrData->pData->iHUPForward);
+	}
 ENDdoHUPWrkr
 
 
@@ -940,6 +1085,7 @@ CODEqueryEtryPt_STD_OMOD_QUERIES
 CODEqueryEtryPt_STD_OMOD8_QUERIES
 CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES
 CODEqueryEtryPt_TXIF_OMOD_QUERIES /* we support the transactional interface */
+CODEqueryEtryPt_doHUP
 CODEqueryEtryPt_doHUPWrkr
 ENDqueryEtryPt
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -573,6 +573,8 @@ endif #if ENABLE_JOURNAL_TESTS
 if ENABLE_OMPROG
 TESTS +=  \
 	omprog-defaults.sh \
+	omprog-output-capture.sh \
+	omprog-output-capture-mt.sh \
 	omprog-feedback.sh \
 	omprog-close-unresponsive.sh \
 	omprog-close-unresponsive-noterm.sh \
@@ -584,6 +586,7 @@ TESTS +=  \
 if HAVE_VALGRIND
 TESTS +=  \
 	omprog-defaults-vg.sh \
+	omprog-output-capture-vg.sh \
 	omprog-feedback-vg.sh \
 	omprog-close-unresponsive-vg.sh \
 	omprog-restart-terminated-vg.sh \
@@ -1433,6 +1436,9 @@ EXTRA_DIST= \
 	pipeaction.sh \
 	omprog-defaults.sh \
 	omprog-defaults-vg.sh \
+	omprog-output-capture.sh \
+	omprog-output-capture-mt.sh \
+	omprog-output-capture-vg.sh \
 	omprog-feedback.sh \
 	omprog-feedback-vg.sh \
 	omprog-close-unresponsive.sh \
@@ -1446,6 +1452,8 @@ EXTRA_DIST= \
 	omprog-transactions-failed-messages.sh \
 	omprog-transactions-failed-commits.sh \
 	testsuites/omprog-defaults-bin.sh \
+	testsuites/omprog-output-capture-bin.sh \
+	testsuites/omprog-output-capture-mt-bin.py \
 	testsuites/omprog-feedback-bin.sh \
 	testsuites/omprog-close-unresponsive-bin.sh \
 	testsuites/omprog-restart-terminated-bin.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -480,7 +480,7 @@ function exit_test() {
 	rm -f tmp.qi nocert
 	rm -fr $RSYSLOG_DYNNAME*  # delete all of our dynamic files
 	unset TCPFLOOD_EXTRA_OPTS
-	printf "Test SUCCESFULL\n"
+	printf "Test SUCCESFUL\n"
 	echo  -------------------------------------------------------------------------------
 }
 
@@ -828,7 +828,7 @@ case $1 in
 		if [ "$?" -ne "0" ]; then
 		    echo FAIL: content-cmp failed
 		    echo EXPECTED:
-		    echo $2
+		    echo "$2"
 		    echo ACTUAL:
 		    cat ${RSYSLOG_OUT_LOG}
 		    error_exit 1

--- a/tests/omprog-close-unresponsive-noterm.sh
+++ b/tests/omprog-close-unresponsive-noterm.sh
@@ -33,12 +33,11 @@ main_queue(
 cp -f $srcdir/testsuites/omprog-close-unresponsive-bin.sh $RSYSLOG_DYNNAME.omprog-close-unresponsive-bin.sh
 startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown
 . $srcdir/diag.sh ensure-no-process-exists $RSYSLOG_DYNNAME.omprog-close-unresponsive-bin.sh
 
-expected_output="Starting
+EXPECTED="Starting
 Received msgnum:00000000:
 Received msgnum:00000001:
 Received msgnum:00000002:
@@ -51,11 +50,6 @@ Received msgnum:00000008:
 Received msgnum:00000009:
 Terminating unresponsively"
 
-written_output=$(<$RSYSLOG_OUT_LOG)
-if [[ "$expected_output" != "$written_output" ]]; then
-    echo unexpected omprog script output:
-    echo "$written_output"
-    error_exit 1
-fi
+. $srcdir/diag.sh content-cmp "$EXPECTED"
 
 exit_test

--- a/tests/omprog-close-unresponsive-vg.sh
+++ b/tests/omprog-close-unresponsive-vg.sh
@@ -31,9 +31,7 @@ main_queue(
 }
 '
 startup_vg
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg

--- a/tests/omprog-close-unresponsive.sh
+++ b/tests/omprog-close-unresponsive.sh
@@ -32,14 +32,12 @@ main_queue(
 '
 cp -f $srcdir/testsuites/omprog-close-unresponsive-bin.sh $RSYSLOG_DYNNAME.omprog-close-unresponsive-bin.sh
 startup
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown
 . $srcdir/diag.sh ensure-no-process-exists $RSYSLOG_DYNNAME.omprog-close-unresponsive-bin.sh
 
-expected_output="Starting
+EXPECTED="Starting
 Received msgnum:00000000:
 Received msgnum:00000001:
 Received msgnum:00000002:
@@ -53,11 +51,6 @@ Received msgnum:00000009:
 Received SIGTERM
 Terminating unresponsively"
 
-written_output=$(<$RSYSLOG_OUT_LOG)
-if [[ "$expected_output" != "$written_output" ]]; then
-    echo unexpected omprog script output:
-    echo "$written_output"
-    error_exit 1
-fi
+. $srcdir/diag.sh content-cmp "$EXPECTED"
 
 exit_test

--- a/tests/omprog-defaults.sh
+++ b/tests/omprog-defaults.sh
@@ -26,20 +26,18 @@ template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" {
     action(
         type="omprog"
-	binary=`echo $srcdir/testsuites/omprog-defaults-bin.sh param1 param2 param3`
+	    binary=`echo $srcdir/testsuites/omprog-defaults-bin.sh p1 p2 p3`
         template="outfmt"
         name="omprog_action"
     )
 }
 '
 startup
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown
 
-expected_output="Starting with parameters: param1 param2 param3
+EXPECTED="Starting with parameters: p1 p2 p3
 Received msgnum:00000000:
 Received msgnum:00000001:
 Received msgnum:00000002:
@@ -52,11 +50,6 @@ Received msgnum:00000008:
 Received msgnum:00000009:
 Terminating normally"
 
-written_output=$(<$RSYSLOG_OUT_LOG)
-if [[ "$expected_output" != "$written_output" ]]; then
-    echo unexpected omprog script output:
-    echo "$written_output"
-    error_exit 1
-fi
+cmp_exact $RSYSLOG_OUT_LOG
 
 exit_test

--- a/tests/omprog-feedback-vg.sh
+++ b/tests/omprog-feedback-vg.sh
@@ -18,18 +18,15 @@ template(name="outfmt" type="string" string="%msg%\n")
         binary=`echo $srcdir/testsuites/omprog-feedback-bin.sh`
         template="outfmt"
         name="omprog_action"
-        queue.type="Direct"  # the default; facilitates sync with the child process
+        queue.type="Direct"
         confirmMessages="on"
         useTransactions="off"
-        action.resumeRetryCount="10"
         action.resumeInterval="1"
     )
 }
 '
 startup_vg
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg

--- a/tests/omprog-feedback.sh
+++ b/tests/omprog-feedback.sh
@@ -21,19 +21,18 @@ template(name="outfmt" type="string" string="%msg%\n")
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"
         useTransactions="off"
-        action.resumeRetryCount="10"
-        action.resumeInterval="1"
+        action.resumeInterval="1"  # retry interval: 1 second
+#       action.resumeRetryCount="0" # the default; no need to increase since
+                                    # the action resumes immediately
     )
 }
 '
 startup
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown
 
-expected_output="<= OK
+EXPECTED="<= OK
 => msgnum:00000000:
 <= OK
 => msgnum:00000001:
@@ -63,11 +62,6 @@ expected_output="<= OK
 => msgnum:00000009:
 <= OK"
 
-written_output=$(<$RSYSLOG_OUT_LOG)
-if [[ "$expected_output" != "$written_output" ]]; then
-    echo unexpected omprog script output:
-    echo "$written_output"
-    error_exit 1
-fi
+cmp_exact $RSYSLOG_OUT_LOG
 
 exit_test

--- a/tests/omprog-output-capture-mt.sh
+++ b/tests/omprog-output-capture-mt.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+# Similar to the 'omprog-output-capture.sh' test, with multiple worker
+# threads on high load. Checks that the lines concurrently emmitted to
+# stdout/stderr by the various program instances are not intermingled in
+# the output file (i.e., are captured atomically by omprog) when 1) the
+# lines are less than PIPE_BUF bytes long and 2) the program writes the
+# lines in line-buffered mode. In this test, the 'stdbuf' utility of GNU
+# Coreutils is used to force line buffering in a Python program (see
+# 'omprog-output-capture-mt-bin.py' for alternatives).
+
+uname
+if [ `uname` = "SunOS" ] ; then
+   echo "This test currently does not work on all flavors of Solaris (problems with Python?)."
+   exit 77
+fi
+
+NUMBER_OF_MESSAGES=20000   # number of logs to send
+
+if [[ "$(uname)" == "Linux" ]]; then
+    LINE_LENGTH=4095   # 4KB minus 1 byte (for the newline char)
+else
+    LINE_LENGTH=511   # 512 minus 1 byte (for the newline char)
+fi
+
+export command_line="/usr/bin/stdbuf -oL -eL $srcdir/testsuites/omprog-output-capture-mt-bin.py $LINE_LENGTH"
+
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-command-available stdbuf
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/omprog/.libs/omprog")
+
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+main_queue(
+    queue.timeoutShutdown="60000"  # long shutdown timeout for the main queue
+)
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+        binary=`echo $command_line`
+        template="outfmt"
+        name="omprog_action"
+        queue.type="LinkedList"  # use a dedicated queue
+        queue.workerThreads="10"  # ...with many workers
+        queue.timeoutShutdown="60000"  # ...and a long shutdown timeout
+        closeTimeout="10000"  # wait enough for program to terminate
+        output=`echo $RSYSLOG_OUT_LOG`
+        fileCreateMode="0644"
+    )
+}
+'
+startup
+tcpflood -m$NUMBER_OF_MESSAGES
+
+# Issue some HUP signals to cause the output file to be reopened during
+# writing (not a complete test of this feature, but at least we check it
+# doesn't break the output).
+. $srcdir/diag.sh issue-HUP
+./msleep 1000
+. $srcdir/diag.sh issue-HUP
+./msleep 1000
+. $srcdir/diag.sh issue-HUP
+
+shutdown_when_empty
+wait_shutdown
+
+line_num=0
+while IFS= read -r line; do
+    let "line_num++"
+    if [[ ${#line} != $LINE_LENGTH ]]; then
+        echo "intermingled line in captured output: line: $line_num, length: ${#line} (expected: $LINE_LENGTH)"
+        echo "$line"
+        error_exit 1
+    fi
+done < $RSYSLOG_OUT_LOG
+
+if (( $line_num != $(($NUMBER_OF_MESSAGES * 2)) )); then
+    echo "unexpected number of lines in captured output: $line_num (expected: $(($NUMBER_OF_MESSAGES * 2)))"
+    error_exit 1
+fi
+
+exit_test

--- a/tests/omprog-output-capture-vg.sh
+++ b/tests/omprog-output-capture-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 
-# Same test than 'omprog-defaults.sh', but checking for memory
+# Same test than 'omprog-output-capture.sh', but checking for memory
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
 
@@ -15,14 +15,15 @@ template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" {
     action(
         type="omprog"
-	binary=`echo $srcdir/testsuites/omprog-defaults-bin.sh param1 param2 param3`
+	    binary=`echo $srcdir/testsuites/omprog-output-capture-bin.sh`
         template="outfmt"
         name="omprog_action"
+        output=`echo $RSYSLOG_OUT_LOG`
     )
 }
 '
 startup_vg
-injectmsg 0 10
+. $srcdir/diag.sh injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg

--- a/tests/omprog-output-capture.sh
+++ b/tests/omprog-output-capture.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+# This test tests the 'output' setting of omprog when the feedback
+# feature is not used (confirmMessages=off).
+
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+	    binary=`echo $srcdir/testsuites/omprog-output-capture-bin.sh`
+        template="outfmt"
+        name="omprog_action"
+        output=`echo $RSYSLOG_OUT_LOG`
+        fileCreateMode="0644"  # default is 0600
+    )
+}
+'
+startup
+. $srcdir/diag.sh injectmsg 0 10
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED="[stdout] Starting
+[stderr] Starting
+[stdout] Received msgnum:00000000:
+[stderr] Received msgnum:00000000:
+[stdout] Received msgnum:00000001:
+[stderr] Received msgnum:00000001:
+[stdout] Received msgnum:00000002:
+[stderr] Received msgnum:00000002:
+[stdout] Received msgnum:00000003:
+[stderr] Received msgnum:00000003:
+[stdout] Received msgnum:00000004:
+[stderr] Received msgnum:00000004:
+[stdout] Received msgnum:00000005:
+[stderr] Received msgnum:00000005:
+[stdout] Received msgnum:00000006:
+[stderr] Received msgnum:00000006:
+[stdout] Received msgnum:00000007:
+[stderr] Received msgnum:00000007:
+[stdout] Received msgnum:00000008:
+[stderr] Received msgnum:00000008:
+[stdout] Received msgnum:00000009:
+[stderr] Received msgnum:00000009:
+[stdout] Terminating normally
+[stderr] Terminating normally"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+exit_test

--- a/tests/omprog-restart-terminated-outfile.sh
+++ b/tests/omprog-restart-terminated-outfile.sh
@@ -1,18 +1,12 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 
-# Similar to the 'omprog-restart-terminated.sh' test, using the 'outfile'
-# parameter. The use of this parameter has implications on the file
-# descriptors handled by omprog.
+# Similar to the 'omprog-restart-terminated.sh' test, using the 'output'
+# parameter. Checks that no file descriptors are leaked across restarts
+# of the program when stderr is being captured to a file.
+
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-command-available lsof
-
-uname -a
-if [ `uname` = "SunOS" ] ; then
-   echo "This test currently does not work on all flavors of Solaris"
-   echo "looks like a problem with signal delivery to the script"
-   exit 77
-fi
 
 generate_conf
 add_conf '
@@ -28,20 +22,30 @@ template(name="outfmt" type="string" string="%msg%\n")
         name="omprog_action"
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"  # facilitates sync with the child process
-        action.resumeRetryCount="10"
+        action.resumeRetryCount="3"
         action.resumeInterval="1"
         action.reportSuspensionContinuation="on"
         signalOnClose="off"
-        output="./rsyslog.omprog.out.log"
+        output=`echo $RSYSLOG2_OUT_LOG`
     )
 }
 '
 
-# we need a test-specifc program name, as we use it inside the process table
-cp -f $srcdir/testsuites/omprog-restart-terminated-bin.sh $RSYSLOG_DYNNAME.omprog-restart-terminated-bin.sh 
+# we need a test-specific program name, as we use it inside the process table
+cp -f $srcdir/testsuites/omprog-restart-terminated-bin.sh $RSYSLOG_DYNNAME.omprog-restart-terminated-bin.sh
+
+# On Solaris 10, the output of ps is truncated for long process names; use /usr/ucb/ps instead:
+if [[ `uname` = "SunOS" && `uname -r` = "5.10" ]]; then
+    function get_child_pid {
+        echo $(/usr/ucb/ps -awwx | grep "[o]mprog-restart-terminated-bin.sh" | awk '{ print $1 }')
+    }
+else
+    function get_child_pid {
+        echo $(ps -ef | grep "[o]mprog-restart-terminated-bin.sh" | awk '{ print $2 }')
+    }
+fi
 
 startup
-. $srcdir/diag.sh wait-startup
 injectmsg 0 1
 . $srcdir/diag.sh wait-queueempty
 
@@ -52,23 +56,23 @@ injectmsg 1 1
 injectmsg 2 1
 . $srcdir/diag.sh wait-queueempty
 
-pkill -USR1 -f $RSYSLOG_DYNNAME.omprog-restart-terminated-bin.sh
-sleep 1 # ensure signal is delivered on (very) slow machines
+kill -s USR1 $(get_child_pid)
+./msleep 100
 
 injectmsg 3 1
 injectmsg 4 1
 . $srcdir/diag.sh wait-queueempty
 
-pkill -TERM -f $RSYSLOG_DYNNAME.omprog-restart-terminated-bin.sh
-sleep 1 # ensure signal is delivered on (very) slow machines
+kill -s TERM $(get_child_pid)
+./msleep 100
 
 injectmsg 5 1
 injectmsg 6 1
 injectmsg 7 1
 . $srcdir/diag.sh wait-queueempty
 
-pkill -USR1 -f $RSYSLOG_DYNNAME.omprog-restart-terminated-bin.sh
-sleep 1 # ensure signal is delivered on (very) slow machines
+kill -s USR1 $(get_child_pid)
+./msleep 100
 
 injectmsg 8 1
 injectmsg 9 1
@@ -104,11 +108,34 @@ Terminating normally"
 
 cmp_exact $RSYSLOG_OUT_LOG
 
+EXPECTED="[stderr] Starting
+[stderr] Received msgnum:00000000:
+[stderr] Received msgnum:00000001:
+[stderr] Received msgnum:00000002:
+[stderr] Received SIGUSR1, will terminate after the next message
+[stderr] Received msgnum:00000003:
+[stderr] Terminating without confirming the last message
+[stderr] Starting
+[stderr] Received msgnum:00000003:
+[stderr] Received msgnum:00000004:
+[stderr] Received SIGTERM, terminating
+[stderr] Starting
+[stderr] Received msgnum:00000005:
+[stderr] Received msgnum:00000006:
+[stderr] Received msgnum:00000007:
+[stderr] Received SIGUSR1, will terminate after the next message
+[stderr] Received msgnum:00000008:
+[stderr] Terminating without confirming the last message
+[stderr] Starting
+[stderr] Received msgnum:00000008:
+[stderr] Received msgnum:00000009:
+[stderr] Terminating normally"
+
+cmp_exact $RSYSLOG2_OUT_LOG
+
 if [[ "$start_fd_count" != "$end_fd_count" ]]; then
     echo "file descriptor leak: started with $start_fd_count open files, ended with $end_fd_count"
     error_exit 1
 fi
-
-cat -n $RSYSLOG_OUT_LOG # 2018-08-29 debug, remove when no longer needed
 
 exit_test

--- a/tests/omprog-restart-terminated-vg.sh
+++ b/tests/omprog-restart-terminated-vg.sh
@@ -4,15 +4,8 @@
 # Same test than 'omprog-restart-terminated.sh', but checking for memory
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
+
 . $srcdir/diag.sh init
-
-uname -a
-if [ `uname` = "SunOS" ] ; then
-   echo "This test currently does not work on all flavors of Solaris"
-   echo "looks like a problem with signal delivery to the script"
-   exit 77
-fi
-
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")
@@ -22,48 +15,59 @@ template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" {
     action(
         type="omprog"
-        binary=`echo $srcdir/testsuites/omprog-restart-terminated-bin.sh`
+        binary="'$RSYSLOG_DYNNAME'.omprog-restart-terminated-bin.sh"
         template="outfmt"
         name="omprog_action"
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"  # facilitates sync with the child process
-        action.resumeRetryCount="10"
+        action.resumeRetryCount="3"
         action.resumeInterval="1"
         action.reportSuspensionContinuation="on"
         signalOnClose="off"
     )
 }
 '
-startup_vg
-. $srcdir/diag.sh wait-startup
-injectmsg 0 1
-. $srcdir/diag.sh wait-queueempty
 
+# we need a test-specific program name, as we use it inside the process table
+cp -f $srcdir/testsuites/omprog-restart-terminated-bin.sh $RSYSLOG_DYNNAME.omprog-restart-terminated-bin.sh
+
+# On Solaris 10, the output of ps is truncated for long process names; use /usr/ucb/ps instead:
+if [[ `uname` = "SunOS" && `uname -r` = "5.10" ]]; then
+    function get_child_pid {
+        echo $(/usr/ucb/ps -awwx | grep "[o]mprog-restart-terminated-bin.sh" | awk '{ print $1 }')
+    }
+else
+    function get_child_pid {
+        echo $(ps -ef | grep "[o]mprog-restart-terminated-bin.sh" | awk '{ print $2 }')
+    }
+fi
+
+startup_vg
+injectmsg 0 1
 injectmsg 1 1
 injectmsg 2 1
 . $srcdir/diag.sh wait-queueempty
 
-pkill -USR1 -f omprog-restart-terminated-bin.sh
-sleep 1 # ensure signal is delivered on (very) slow machines
+kill -s USR1 $(get_child_pid)
+./msleep 100
 
 injectmsg 3 1
 injectmsg 4 1
 . $srcdir/diag.sh wait-queueempty
 
-pkill -TERM -f omprog-restart-terminated-bin.sh
-sleep 1 # ensure signal is delivered on (very) slow machines
+kill -s TERM $(get_child_pid)
+./msleep 100
 
 injectmsg 5 1
 injectmsg 6 1
 injectmsg 7 1
 . $srcdir/diag.sh wait-queueempty
 
-pkill -USR1 -f omprog-restart-terminated-bin.sh
-sleep 1 # ensure signal is delivered on (very) slow machines
+kill -s USR1 $(get_child_pid)
+./msleep 100
 
 injectmsg 8 1
 injectmsg 9 1
-. $srcdir/diag.sh wait-queueempty
 
 shutdown_when_empty
 wait_shutdown_vg

--- a/tests/omprog-transactions-failed-commits.sh
+++ b/tests/omprog-transactions-failed-commits.sh
@@ -6,6 +6,16 @@
 # transaction commits.
 
 . $srcdir/diag.sh init
+
+uname
+if [ `uname` = "SunOS" ] ; then
+    # On Solaris, this test causes rsyslog to hang. This is presumably due
+    # to issue #2356 in the rsyslog core, which doesn't seem completely
+    # corrected. TODO: re-enable this test when the issue is corrected.
+    echo "Solaris: FIX ME"
+    exit 77
+fi
+
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")
@@ -27,20 +37,8 @@ template(name="outfmt" type="string" string="%msg%\n")
     )
 }
 '
-
-uname
-if [ `uname` = "SunOS" ] ; then
-    # On Solaris, this test causes rsyslog to hang. This is presumably due
-    # to issue #2356 in the rsyslog core, which doesn't seem completely
-    # corrected. TODO: re-enable this test when the issue is corrected.
-    echo "Solaris: FIX ME"
-    exit 77
-fi
-
 startup
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/omprog-transactions-failed-messages.sh
+++ b/tests/omprog-transactions-failed-messages.sh
@@ -28,9 +28,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 }
 '
 startup
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/omprog-transactions-vg.sh
+++ b/tests/omprog-transactions-vg.sh
@@ -30,9 +30,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 }
 '
 startup_vg
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown_vg
 . $srcdir/diag.sh check-exit-vg

--- a/tests/omprog-transactions.sh
+++ b/tests/omprog-transactions.sh
@@ -30,9 +30,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 }
 '
 startup
-. $srcdir/diag.sh wait-startup
 injectmsg 0 10
-. $srcdir/diag.sh wait-queueempty
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/testsuites/omprog-feedback-bin.sh
+++ b/tests/testsuites/omprog-feedback-bin.sh
@@ -9,7 +9,7 @@ echo $status
 retry_count=0
 
 read line
-while [[ "x$line" != "x" ]]; do
+while [[ -n "$line" ]]; do
     message=${line//$'\n'}
     echo "=> $message" >> $outfile
 

--- a/tests/testsuites/omprog-output-capture-bin.sh
+++ b/tests/testsuites/omprog-output-capture-bin.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+echo "[stdout] Starting"
+>&2 echo "[stderr] Starting"
+
+read log_line
+while [[ -n "$log_line" ]]; do
+    echo "[stdout] Received $log_line"
+    >&2 echo "[stderr] Received $log_line"
+    read log_line
+done
+
+echo "[stdout] Terminating normally"
+>&2 echo "[stderr] Terminating normally"
+
+exit 0

--- a/tests/testsuites/omprog-output-capture-mt-bin.py
+++ b/tests/testsuites/omprog-output-capture-mt-bin.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import sys
+import os
+import logging
+
+lineLength = int(sys.argv[1])
+linePrefix = "[{0:09d}] ".format(os.getpid())
+
+logLine = sys.stdin.readline()
+while logLine:
+    logLine = logLine.strip()
+    numRepeats = lineLength / len(logLine)
+    lineToStdout = (linePrefix + "[stdout] " + logLine*numRepeats)[:lineLength]
+    lineToStderr = (linePrefix + "[stderr] " + logLine*numRepeats)[:lineLength]
+
+    # Write to stdout without flushing. Since stdout is block-buffered when redirected to a pipe,
+    # and multiple processes are writing to the pipe, this will cause intermingled lines in the
+    # output file. However, we avoid this by executing this script with 'stdbuf -oL' (see the
+    # test code), which forces line buffering for stdout. We could alternatively call
+    # sys.stdout.flush() after the write (this also causes a single 'write' syscall, since the
+    # size of the block buffer is generally greater than PIPE_BUF).
+    sys.stdout.write(lineToStdout + "\n")
+
+    # Write to stderr using two writes. Since stderr is unbuffered, each write will be written
+    # immediately to the pipe, and this will cause intermingled lines in the output file.
+    # However, we avoid this by executing this script with 'stdbuf -eL', which forces line
+    # buffering for stderr. We could alternatively do a single write.
+    sys.stderr.write(lineToStderr)
+    sys.stderr.write("\n")
+
+    # Note: In future versions of Python3, stderr will possibly be line buffered (see
+    # https://bugs.python.org/issue13601).
+    # Note: When writing to stderr using the Python logging module, it seems that line
+    # buffering is also used (although this could depend on the Python version).
+
+    logLine = sys.stdin.readline()

--- a/tests/testsuites/omprog-restart-terminated-bin.sh
+++ b/tests/testsuites/omprog-restart-terminated-bin.sh
@@ -5,17 +5,22 @@ terminate=false
 
 function handle_sigusr1 {
     echo "Received SIGUSR1, will terminate after the next message" >> $outfile
+    >&2 echo "[stderr] Received SIGUSR1, will terminate after the next message"
     terminate=true
 }
 trap "handle_sigusr1" SIGUSR1
 
 function handle_sigterm {
     echo "Received SIGTERM, terminating" >> $outfile
+    >&2 echo "[stderr] Received SIGTERM, terminating"
     exit 1
 }
 trap "handle_sigterm" SIGTERM
 
 echo "Starting" >> $outfile
+
+# Write also to stderr (useful for testing the 'output' setting)
+>&2 echo "[stderr] Starting"
 
 # Tell rsyslog we are ready to start processing messages
 echo "OK"
@@ -23,10 +28,12 @@ echo "OK"
 read log_line
 while [[ -n "$log_line" ]]; do
     echo "Received $log_line" >> $outfile
+    >&2 echo "[stderr] Received $log_line"
 
     if [[ $terminate == true ]]; then
         # Terminate prematurely by closing pipe, without confirming the message
         echo "Terminating without confirming the last message" >> $outfile
+        >&2 echo "[stderr] Terminating without confirming the last message"
         exit 1
     fi
 
@@ -37,4 +44,6 @@ while [[ -n "$log_line" ]]; do
 done
 
 echo "Terminating normally" >> $outfile
+>&2 echo "[stderr] Terminating normally"
+
 exit 0


### PR DESCRIPTION
Capture program output using a pipe shared with all child processes,
and write to the file using a dedicated thread. Ensures lines emitted
by the child processes will not be intermingled in the output file if
the lines are less than PIPE_BUF chars long and are written in line-
buffered mode.

Reopen output file on HUP, to support external rotation of the file.

New setting 'fileCreateMode' as in omfile.

With these improvements the 'output' setting should now be usable for
production (it was originally intended only for debugging).

Redirect stdout/stderr of child process to /dev/null when not captured.
Closes #2787

Minor: simplify some test code: 'wait-startup' not needed after
'startup', 'wait-queueempty' not needed before 'shutdown_when_empty'.