### PR TITLE
omprog: fix invalid memory access on partial writes to pipe

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -480,19 +480,18 @@ terminateChild(wrkrInstanceData_t *pWrkrData)
 static rsRetVal
 writePipe(wrkrInstanceData_t *pWrkrData, uchar *szMsg)
 {
-	int lenWritten;
-	int lenWrite;
-	int writeOffset;
+	ssize_t len;
+	ssize_t written;
+	ssize_t offset = 0;
 	char errStr[1024];
 	DEFiRet;
 
-	lenWrite = strlen((char*)szMsg);
-	writeOffset = 0;
+	len = strlen((char*)szMsg);
 
 	do {
 		checkProgramOutput(pWrkrData);
-		lenWritten = write(pWrkrData->fdPipeOut, ((char*)szMsg)+writeOffset, lenWrite);
-		if(lenWritten == -1) {
+		written = write(pWrkrData->fdPipeOut, ((char*)szMsg) + offset, len - offset);
+		if(written == -1) {
 			if(errno == EPIPE) {
 				DBGPRINTF("omprog: program '%s' terminated, will be restarted\n",
 					  pWrkrData->pData->szBinary);
@@ -504,8 +503,8 @@ writePipe(wrkrInstanceData_t *pWrkrData, uchar *szMsg)
 			}
 			ABORT_FINALIZE(RS_RET_SUSPENDED);
 		}
-		writeOffset += lenWritten;
-	} while(lenWritten != lenWrite);
+		offset += written;
+	} while(offset < len);
 
 	checkProgramOutput(pWrkrData);
 


### PR DESCRIPTION
When sending logs to the program, in case of a partial write to the pipe, invalid data was sent, or an invalid memory access could occur. (A partial write can occur if the syscall is interrupted or the pipe is full.)

I have incidentally found this bug through code inspection (I have not reproduced it). It affects all versions to date.

Ideally there should be a test case for this, but I'm not sure how it could be implemented functionally (?).

Note: the changes from "int" to "ssize_t" are not related to the bug. Just a minor refactor.