### PR TITLE
omfile: implement file-id, used in state file

### DIFF
--- a/plugins/imfile/Makefile.am
+++ b/plugins/imfile/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imfile.la
 
-imfile_la_SOURCES = imfile.c
+imfile_la_SOURCES = imfile.c siphash.c
 imfile_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
 imfile_la_LDFLAGS = -module -avoid-version
 imfile_la_LIBADD = 

--- a/plugins/imfile/siphash.c
+++ b/plugins/imfile/siphash.c
@@ -1,0 +1,185 @@
+/* SipHash reference C implementation
+ *
+ * Copyright (c) 2012-2016 Jean-Philippe Aumasson
+ * <jeanphilippe.aumasson@gmail.com>
+ * Copyright (c) 2012-2014 Daniel J. Bernstein <djb@cr.yp.to>
+ *
+ * Slightly adapted by rsyslog in regard to build system and code style
+ * check.
+ *
+ * To the extent possible under law, the author(s) have dedicated all copyright
+ * and related and neighboring rights to this software to the public domain
+ * worldwide. This software is distributed without any warranty.
+ *
+ * You should have received a copy of the CC0 Public Domain Dedication along
+ * with
+ * this software. If not, see
+ * <http://creativecommons.org/publicdomain/zero/1.0/>.
+ *
+ * For details on siphash see https://131002.net/siphash/
+ */
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* default: SipHash-2-4 */
+#define cROUNDS 2
+#define dROUNDS 4
+
+#define ROTL(x, b) (uint64_t)(((x) << (b)) | ((x) >> (64 - (b))))
+
+#define U32TO8_LE(p, v)                                                        \
+	(p)[0] = (uint8_t)((v));                                                   \
+	(p)[1] = (uint8_t)((v) >> 8);                                              \
+	(p)[2] = (uint8_t)((v) >> 16);                                             \
+	(p)[3] = (uint8_t)((v) >> 24);
+
+#define U64TO8_LE(p, v)                                                        \
+	U32TO8_LE((p), (uint32_t)((v)));                                           \
+	U32TO8_LE((p) + 4, (uint32_t)((v) >> 32));
+
+#define U8TO64_LE(p)                                                           \
+	(((uint64_t)((p)[0])) | ((uint64_t)((p)[1]) << 8) |                        \
+	((uint64_t)((p)[2]) << 16) | ((uint64_t)((p)[3]) << 24) |                 \
+	((uint64_t)((p)[4]) << 32) | ((uint64_t)((p)[5]) << 40) |                 \
+	((uint64_t)((p)[6]) << 48) | ((uint64_t)((p)[7]) << 56))
+
+#define SIPROUND                                                               \
+	do {                                                                       \
+		v0 += v1;                                                              \
+		v1 = ROTL(v1, 13);                                                     \
+		v1 ^= v0;                                                              \
+		v0 = ROTL(v0, 32);                                                     \
+		v2 += v3;                                                              \
+		v3 = ROTL(v3, 16);                                                     \
+		v3 ^= v2;                                                              \
+		v0 += v3;                                                              \
+		v3 = ROTL(v3, 21);                                                     \
+		v3 ^= v0;                                                              \
+		v2 += v1;                                                              \
+		v1 = ROTL(v1, 17);                                                     \
+		v1 ^= v2;                                                              \
+		v2 = ROTL(v2, 32);                                                     \
+	} while (0)
+
+#ifdef DEBUG
+#define TRACE                                                                  \
+	do {                                                                       \
+		printf("(%3d) v0 %08x %08x\n", (int)inlen, (uint32_t)(v0 >> 32),       \
+		       (uint32_t)v0);                                                  \
+		printf("(%3d) v1 %08x %08x\n", (int)inlen, (uint32_t)(v1 >> 32),       \
+		       (uint32_t)v1);                                                  \
+		printf("(%3d) v2 %08x %08x\n", (int)inlen, (uint32_t)(v2 >> 32),       \
+		       (uint32_t)v2);                                                  \
+		printf("(%3d) v3 %08x %08x\n", (int)inlen, (uint32_t)(v3 >> 32),       \
+		       (uint32_t)v3);                                                  \
+	} while (0)
+#else
+#define TRACE
+#endif
+
+extern int rs_siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
+	uint8_t *out, const size_t outlen); /* avoid compiler warning */
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Wunknown-attributes"
+#endif
+int
+#if defined(__clang__)
+__attribute__((no_sanitize("unsigned-integer-overflow")))
+#endif
+rs_siphash(const uint8_t *in, const size_t inlen, const uint8_t *k,
+	uint8_t *out, const size_t outlen) {
+
+	uint64_t v0 = 0x736f6d6570736575ULL;
+	uint64_t v1 = 0x646f72616e646f6dULL;
+	uint64_t v2 = 0x6c7967656e657261ULL;
+	uint64_t v3 = 0x7465646279746573ULL;
+	uint64_t k0 = U8TO64_LE(k);
+	uint64_t k1 = U8TO64_LE(k + 8);
+	uint64_t m;
+	int i;
+	const uint8_t *end = in + inlen - (inlen % sizeof(uint64_t));
+	const int left = inlen & 7;
+	uint64_t b = ((uint64_t)inlen) << 56;
+	assert((outlen == 8) || (outlen == 16));
+	v3 ^= k1;
+	v2 ^= k0;
+	v1 ^= k1;
+	v0 ^= k0;
+
+	if (outlen == 16)
+	v1 ^= 0xee;
+
+	for (; in != end; in += 8) {
+		m = U8TO64_LE(in);
+		v3 ^= m;
+
+		TRACE;
+		for (i = 0; i < cROUNDS; ++i)
+		    SIPROUND;
+
+		v0 ^= m;
+	}
+
+	switch (left) {
+	case 7:
+		b |= ((uint64_t)in[6]) << 48;
+		/*FALLTHROUGH*/
+	case 6:
+		b |= ((uint64_t)in[5]) << 40;
+		/*FALLTHROUGH*/
+	case 5:
+		b |= ((uint64_t)in[4]) << 32;
+		/*FALLTHROUGH*/
+	case 4:
+		b |= ((uint64_t)in[3]) << 24;
+		/*FALLTHROUGH*/
+	case 3:
+		b |= ((uint64_t)in[2]) << 16;
+		/*FALLTHROUGH*/
+	case 2:
+		b |= ((uint64_t)in[1]) << 8;
+		/*FALLTHROUGH*/
+	case 1:
+		b |= ((uint64_t)in[0]);
+		break;
+	case 0:
+	default:
+		break;
+	}
+
+	v3 ^= b;
+
+	TRACE;
+	for (i = 0; i < cROUNDS; ++i)
+		SIPROUND;
+
+	v0 ^= b;
+
+	if (outlen == 16)
+		v2 ^= 0xee;
+	else
+		v2 ^= 0xff;
+
+	TRACE;
+	for (i = 0; i < dROUNDS; ++i)
+		SIPROUND;
+
+	b = v0 ^ v1 ^ v2 ^ v3;
+	U64TO8_LE(out, b);
+
+	if (outlen == 8)
+		return 0;
+
+	v1 ^= 0xdd;
+
+	TRACE;
+	for (i = 0; i < dROUNDS; ++i)
+		SIPROUND;
+
+	b = v0 ^ v1 ^ v2 ^ v3;
+	U64TO8_LE(out + 8, b);
+
+	return 0;
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -925,6 +925,7 @@ TESTS += \
 	imfile-rename.sh \
 	imfile-symlink.sh \
 	imfile-symlink-multi.sh \
+	imfile-growing-file-id.sh \
 	glbl-oversizeMsg-truncate-imfile.sh
 
 if HAVE_VALGRIND
@@ -1479,6 +1480,7 @@ EXTRA_DIST= \
 	imfile-rename.sh \
 	imfile-symlink.sh \
 	imfile-symlink-multi.sh \
+	imfile-growing-file-id.sh \
 	glbl-oversizeMsg-truncate-imfile.sh \
 	dynfile_invld_async.sh \
 	dynfile_invld_sync.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -382,7 +382,6 @@ function error_exit() {
 # $4... are just to have the abilit to pass in more options...
 # add -v to chkseq if you need more verbose output
 function seq_check() {
-	echo RSYSLOG_OUT_LOG: $RSYSLOG_OUT_LOG
 	$RS_SORTCMD -g < ${RSYSLOG_OUT_LOG} | ./chkseq -s$1 -e$2 $3 $4 $5 $6 $7
 	if [ "$?" -ne "0" ]; then
 		echo "sequence error detected in $RSYSLOG_OUT_LOG"
@@ -460,6 +459,7 @@ function exit_test() {
 	rm -f imfile-state:.-rsyslog.input
 	rm -f $RSYSLOG_DYNNAME*  # delete all of our dynamic files
 	unset TCPFLOOD_EXTRA_OPTS
+	printf "Test SUCCESFULL\n"
 	echo  -------------------------------------------------------------------------------
 }
 

--- a/tests/imfile-growing-file-id.sh
+++ b/tests/imfile-growing-file-id.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
+export TESTMESSAGES=10000
+export RETRIES=10
+export TESTMESSAGESFULL=19999
+echo [imfile-rename.sh]
+. $srcdir/diag.sh check-inotify-only
+generate_conf
+add_conf '
+global(workDirectory="test-spool")
+module(load="../plugins/imfile/.libs/imfile" mode="inotify" PollingInterval="1")
+
+/* Filter out busy debug output */
+global( debug.whitelist="off"
+	debug.files=["rainerscript.c", "ratelimit.c", "ruleset.c", "main Q", "msg.c", "../action.c"])
+
+input(type="imfile" File="./rsyslog.input"
+	Tag="file:" Severity="error" Facility="local7" addMetadata="on")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "msgnum:" then
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+
+# generate small input file - state file must be inode only
+./inputfilegen -m 1 > rsyslog.input
+ls -li rsyslog.input
+
+echo "STEP 1 - small input"
+startup
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown	# we need to wait until rsyslogd is finished!
+
+echo "STEP 2 - still small input"
+# add a bit to input file, but state file must still be inode only
+./inputfilegen -m 1 -i1 >> rsyslog.input
+ls -li rsyslog.input*
+if [ $(ls test-spool/* | wc -l) -ne 1 ]; then
+	echo FAIL: more than one state file in work directory:
+	ls -l test-spool
+	error_exit 1
+fi
+
+startup
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown	# we need to wait until rsyslogd is finished!
+
+echo "STEP 3 - larger input, hash shall be used"
+./inputfilegen -m 998 TESTMESSAGES -i 2 >> rsyslog.input
+ls -li rsyslog.input*
+echo ls test-spool:
+ls -l test-spool
+
+startup
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown	# we need to wait until rsyslogd is finished!
+
+if [ $(ls test-spool/* | wc -l) -ne 1 ]; then
+	echo FAIL: more than one state file in work directory:
+	ls -l test-spool
+	error_exit 1
+fi
+
+
+echo "STEP 4 - append to larger input, hash state file must now be found"
+./inputfilegen -m 1000 TESTMESSAGES -i 1000 >> rsyslog.input
+ls -li rsyslog.input*
+echo ls test-spool:
+ls -l test-spool
+
+startup
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown	# we need to wait until rsyslogd is finished!
+
+if [ $(ls test-spool/* | wc -l) -ne 1 ]; then
+	echo FAIL: more than one state file in work directory:
+	ls -l test-spool
+	error_exit 1
+fi
+
+seq_check 0 1999
+exit_test

--- a/tests/imfile-persist-state-1.sh
+++ b/tests/imfile-persist-state-1.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 # added 2016-11-02 by rgerhards
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-echo [imfile-persist-state-1.sh]
-. $srcdir/diag.sh check-inotify
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '
 global(workDirectory="test-spool")


### PR DESCRIPTION
This ensures that files with the same inodes are not accidently treated
as equal, at least within the limits of the file id hash (see doc for
details).

closes https://github.com/rsyslog/rsyslog/issues/2530

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
