### PR TITLE
testbench: add program to get system time

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -45,7 +45,8 @@ check_PROGRAMS = $(TESTRUNS) ourtail tcpflood chkseq msleep randomgen \
 	diagtalker uxsockrcvr syslog_caller inputfilegen minitcpsrv \
 	omrelp_dflt_port \
 	mangle_qi \
-	have_relpSrvSetOversizeMode
+	have_relpSrvSetOversizeMode \
+	test_id
 if ENABLE_IMJOURNAL
 check_PROGRAMS += journal_print
 endif
@@ -1739,6 +1740,7 @@ omrelp_dflt_port_SOURCES = omrelp_dflt_port.c
 mangle_qi_SOURCES = mangle_qi.c
 chkseq_SOURCES = chkseq.c
 have_relpSrvSetOversizeMode = have_relpSrvSetOversizeMode.c
+test_id_SOURCES = test_id.c
 
 uxsockrcvr_SOURCES = uxsockrcvr.c
 uxsockrcvr_LDADD = $(SOL_LIBS)

--- a/tests/test_id.c
+++ b/tests/test_id.c
@@ -1,0 +1,16 @@
+#include <stdlib.h>
+#include <sys/time.h>
+#include <stdio.h>
+#include <time.h>
+
+int main()
+{
+	struct timeval tv;
+	struct timezone tz;
+	struct tm *tm;
+	gettimeofday(&tv, &tz);
+	tm = localtime(&tv.tv_sec);
+	printf("%02d:%02d:%02d:%06ld", tm->tm_hour, tm->tm_min, tm->tm_sec, tv.tv_usec);
+
+	return 0;
+}


### PR DESCRIPTION
The new program test_id puts out the system time
up to microseconds.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
