### PR TITLE
omrelp: permit new authmode certvalid

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -863,8 +863,10 @@ TESTS += sndrcv_relp.sh \
 if ENABLE_GNUTLS
 TESTS += \
          sndrcv_relp_tls.sh \
+         sndrcv_relp_tls_certvalid.sh \
          sndrcv_relp_tls_prio.sh \
-         relp_tls_certificate_not_found.sh
+         relp_tls_certificate_not_found.sh \
+	 omrelp_wrong_authmode.sh
 endif
 endif
 
@@ -1443,7 +1445,9 @@ EXTRA_DIST= \
 	sndrcv_relp_rebind.sh \
 	sndrcv_relp_tls_prio.sh \
 	sndrcv_relp_tls.sh \
+        sndrcv_relp_tls_certvalid.sh \
 	relp_tls_certificate_not_found.sh \
+	omrelp_wrong_authmode.sh \
 	sndrcv_relp_dflt_pt.sh \
 	sndrcv_udp.sh \
 	imudp_thread_hang.sh \

--- a/tests/omrelp_wrong_authmode.sh
+++ b/tests/omrelp_wrong_authmode.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# add 2018-09-13 by Pascal Withopf, released under ASL 2.0
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="13514" ruleset="ruleset")
+
+ruleset(name="ruleset") {
+	action(type="omrelp" target="127.0.0.1" port="10514" tls="on" tls.authMode="INVALID_AUTH_MODE" tls.caCert="tls-certs/ca.pem" tls.myCert="tls-certs/cert.pem" tls.myPrivKey="tls-certs/key.pem" tls.permittedPeer=["rsyslog-test-root-ca"])
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+
+grep "omrelp.* invalid auth.*mode .*INVALID_AUTH_MODE" $RSYSLOG_OUT_LOG > /dev/null
+if [ $? -ne 0 ]; then
+        echo "FAIL: expected error message from missing input file not found. $RSYSLOG_OUT_LOG is:"
+        cat -n $RSYSLOG_OUT_LOG
+        error_exit 1
+fi
+
+exit_test

--- a/tests/sndrcv_relp_tls_certvalid.sh
+++ b/tests/sndrcv_relp_tls_certvalid.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# added 2018-09-13 by PascalWithopf
+# This file is part of the rsyslog project, released under ASL 2.0
+. $srcdir/diag.sh init
+# uncomment for debugging support:
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="log"
+
+generate_conf
+export PORT_RCVR="$(get_free_port)"
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+# then SENDER sends to this port (not tcpflood!)
+input(type="imrelp" port="'$PORT_RCVR'" tls="on"
+		tls.cacert="tls-certs/ca.pem"
+		tls.mycert="tls-certs/cert.pem"
+		tls.myprivkey="tls-certs/key.pem"
+		tls.authmode="certvalid"
+		tls.permittedpeer="rsyslog")
+
+$template outfmt,"%msg:F,58:2%\n"
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+export RSYSLOG_DEBUGLOG="log2"
+#valgrind="valgrind"
+generate_conf 2
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp")
+
+:msg, contains, "msgnum:" action(type="omrelp"
+		target="127.0.0.1" port="'$PORT_RCVR'" tls="on"
+		tls.cacert="tls-certs/ca.pem"
+		tls.mycert="tls-certs/cert.pem"
+		tls.myprivkey="tls-certs/key.pem"
+		tls.authmode="certvalid"
+		tls.permittedpeer="rsyslog")
+action(type="omfile" file="'$RSYSLOG_DYNNAME.errmsgs'")
+' 2
+startup 2
+
+grep "omrelp error: invalid authmode" $RSYSLOG_DYNNAME.errmsgs > /dev/null
+if [ $? -eq 0 ]; then
+        echo "SKIP: librelp does not support "certvalid" auth mode"
+	# mini-cleanup to not leave dangling processes
+	. $srcdir/diag.sh shutdown-immediate 2
+	. $srcdir/diag.sh shutdown-immediate
+	rm $RSYSLOG_DYNNAME* &> /dev/null
+	exit 77
+fi
+
+# now inject the messages into instance 2. It will connect to instance 1,
+# and that instance will record the data.
+injectmsg 1 50000
+
+# shut down sender
+shutdown_when_empty 2
+wait_shutdown 2
+# now it is time to stop the receiver as well
+shutdown_when_empty
+wait_shutdown
+
+seq_check 1 50000
+exit_test


### PR DESCRIPTION
The new authmode certvalid for relp is now permitted in omrelp.
Test was also added.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
