### PR TITLE
testbench: disable journal tests by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1677,6 +1677,22 @@ if test "x$enable_omjournal" = "xyes"; then
 fi
 AM_CONDITIONAL(ENABLE_OMJOURNAL, test x$enable_omjournal = xyes)
 
+# capability to enable journal testbench tests. They have very special requirements,
+# so it does not make sense to have them run by default.
+# Also note that as of now, they have a pretty high rate of false positives due
+# to bugs in the journal.
+# see also https://github.com/rsyslog/rsyslog/issues/2931#issuecomment-416914707
+AC_ARG_ENABLE(journal_tests,
+        [AS_HELP_STRING([--enable-journal-tests],[enable systemd journal specific tests in testbench @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_journal_tests="yes" ;;
+          no) enable_journal_tests="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-journal-tests) ;;
+         esac],
+        [enable_journal_tests=no]
+)
+AM_CONDITIONAL(ENABLE_JOURNAL_TESTS, test x$enable_journal_tests = xyes)
+
 
 # settings for pmlastmsg
 AC_ARG_ENABLE(pmlastmsg,
@@ -2443,6 +2459,7 @@ echo "    MySQL Tests enabled:                      $enable_mysql_tests"
 echo "    Elasticsearch Tests:                      $enable_elasticsearch_tests"
 echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"
 echo "    Kafka Tests enabled:                      $enable_kafka_tests"
+echo "    systemd journal tests enabled:            $enable_journal_tests"
 echo "    Debug mode enabled:                       $enable_debug"
 echo "    (total) debugless mode enabled:           $enable_debugless"
 echo "    Diagnostic tools enabled:                 $enable_diagtools"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -545,6 +545,7 @@ TESTS +=  \
 endif
 endif
 
+if ENABLE_JOURNAL_TESTS
 if ENABLE_IMJOURNAL
 TESTS +=  \
 	imjournal-basic.sh \
@@ -562,6 +563,7 @@ TESTS +=  \
 	omjournal-basic-template.sh \
 	omjournal-basic-no-template.sh
 endif
+endif #if ENABLE_JOURNAL_TESTS
 
 if ENABLE_OMPROG
 TESTS +=  \


### PR DESCRIPTION
They have very special requirements, so it does not make sense to have
them run by default. Also note that as of now, they have a pretty high
rate of false positives due to bugs in the journal.

see also https://github.com/rsyslog/rsyslog/issues/2931#issuecomment-416914707

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
