### PR TITLE
testbench: short test id and make more reliable

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,13 +8,12 @@ CLEANFILES=\
 	rsyslog*.pid.save xlate*.lkp_tbl \
 	log log* \
 	work \
-	rsyslog_*.out.* \
-	rsyslog2_*.out.* \
 	test-spool test-logdir stat-file1 \
 	rsyslog.pipe rsyslog.input.* \
 	rsyslog.input rsyslog.input.* imfile-state* omkafka-failed.data \
 	rsyslog.input-symlink.log rsyslog-link.*.log targets \
 	HOSTNAME \
+	rstb_* \
 	tmp.qi nocert
 
 CLEANFILES+= \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -99,11 +99,10 @@ function generate_conf() {
 	new_port="$(get_free_port)"
 	if [ "$1" == "" ]; then
 		export IMDIAG_PORT=$new_port
-		export RSYSLOG_DYNNAME="rsyslog_$(basename $0)_${new_port}"
 		export TESTCONF_NM="${RSYSLOG_DYNNAME}_" # this basename is also used by instance 2!
 		export RSYSLOG_OUT_LOG="${RSYSLOG_DYNNAME}.out.log"
 		export RSYSLOG2_OUT_LOG="${RSYSLOG_DYNNAME}_2.out.log"
-		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}_" # also used by instance 2!
+		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!
 		mkdir $RSYSLOG_DYNNAME.spool
 	else
 		export IMDIAG_PORT2=$new_port
@@ -548,13 +547,17 @@ case $1 in
 		# some default names (later to be set in other parts, once we support fully
 		# parallel tests)
 		export RSYSLOG_DFLT_LOG_INTERNAL=1 # testbench needs internal messages logged internally!
-		export RSYSLOG2_OUT_LOG=rsyslog2.out.log
-		export RSYSLOG_OUT_LOG=rsyslog.out.log
+		export RSYSLOG2_OUT_LOG=rsyslog2.out.log # TODO: remove
+		export RSYSLOG_OUT_LOG=rsyslog.out.log # TODO: remove
 		export RSYSLOG_PIDBASE="rsyslog" # TODO: remove
-		export RSYSLOG_DYNNAME="rsyslog" # TODO: remove
+		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))"
 		export IMDIAG_PORT=13500
 		export IMDIAG_PORT2=13501
 		export TCPFLOOD_PORT=13514
+
+		# we create one file with the test name, so that we know what was
+		# left over if "make distcheck" complains
+		touch $RSYSLOG_DYNNAME-$(basename $0).test_id
 
 		if [ -z $RS_SORTCMD ]; then
 			RS_SORTCMD=sort

--- a/tests/es-writeoperation.sh
+++ b/tests/es-writeoperation.sh
@@ -25,7 +25,6 @@ if $msg contains "msgnum:" then
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '
 
-# . $srcdir/diag.sh es-init
 startup
 injectmsg  0 1
 shutdown_when_empty
@@ -38,7 +37,6 @@ else
 	error_exit 1
 fi
 
-. $srcdir/diag.sh init
 generate_conf
 add_conf '
 template(name="tpl" type="string"
@@ -57,7 +55,6 @@ if $msg contains "msgnum:" then
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '
 
-# . $srcdir/diag.sh es-init
 startup
 injectmsg  0 1
 shutdown_when_empty
@@ -70,7 +67,6 @@ else
 	error_exit 1
 fi
 
-. $srcdir/diag.sh init
 generate_conf
 add_conf '
 template(name="tpl" type="string"

--- a/tests/omprog-restart-terminated-outfile.sh
+++ b/tests/omprog-restart-terminated-outfile.sh
@@ -109,6 +109,4 @@ if [[ "$start_fd_count" != "$end_fd_count" ]]; then
     error_exit 1
 fi
 
-cat -n $RSYSLOG_OUT_LOG # 2018-08-29 debug, remove when no longer needed
-
 exit_test

--- a/tests/sndrcv_gzip.sh
+++ b/tests/sndrcv_gzip.sh
@@ -48,3 +48,4 @@ wait_shutdown
 # may be needed by TLS (once we do it): sleep 60
 # do the final check
 seq_check 1 50000 $3
+exit_test

--- a/tests/test_id.c
+++ b/tests/test_id.c
@@ -3,14 +3,37 @@
 #include <stdio.h>
 #include <time.h>
 
-int main()
+/* one provided by Aaaron Wiebe based on perl's hashing algorithm
+ * (so probably pretty generic). Not for excessively large strings!
+ */
+#if defined(__clang__)
+#pragma GCC diagnostic ignored "-Wunknown-attributes"
+#endif
+static unsigned __attribute__((nonnull(1))) int
+#if defined(__clang__)
+__attribute__((no_sanitize("unsigned-integer-overflow")))
+#endif
+hash_from_string(void *k)
+{
+	char *rkey = (char*) k;
+	unsigned hashval = 1;
+
+	while (*rkey)
+		hashval = hashval * 33 + *rkey++;
+
+	return hashval;
+}
+
+int main(int argc, char *argv[])
 {
 	struct timeval tv;
 	struct timezone tz;
-	struct tm *tm;
 	gettimeofday(&tv, &tz);
-	tm = localtime(&tv.tv_sec);
-	printf("%02d:%02d:%02d:%06ld", tm->tm_hour, tm->tm_min, tm->tm_sec, tv.tv_usec);
+	if(argc != 2) {
+		fprintf(stderr, "usage: test_id test-file-name\n");
+		exit(1);
+	}
+	printf("%06ld_%04.4x", tv.tv_usec, hash_from_string(argv[1]));
 
 	return 0;
 }


### PR DESCRIPTION
The RSYSLOG_DYNNAME used to make test file unique was very long,
which potentially causes issues with some test scenarios.
see also: https://github.com/rsyslog/rsyslog/pull/2945#issuecomment-417078768

Also, the dynamic port determination method we currently use
is not 100% reliable. That port number was used inside the DYNNAME
and thus was not necessarily unique. This has now changed to the
current time in microseconds plus a hash of the test file name. This
should be sufficiently unique. If still not, we can now simply
extend the test_id program (e.g. read /dev/urandom).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
