### PR TITLE
lstnPortFileName: abort when file can't be opened

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -628,8 +628,9 @@ startupSrv(ptcpsrv_t *pSrv)
 						"error while trying to get socket");
 			}
 			if((fp = fopen((const char*)pSrv->pszLstnPortFileName, "w+")) == NULL) {
-				LogError(errno, NO_ERRCODE, "imptcp: ListenPortFileName: "
+				LogError(errno, RS_RET_IO_ERROR, "imptcp: ListenPortFileName: "
 						"error while trying to open file");
+				ABORT_FINALIZE(RS_RET_IO_ERROR);
 			}
 			if(isIPv6) {
 				fprintf(fp, "%d", ntohs((((struct sockaddr_in6*)r->ai_addr)->sin6_port)));

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -539,8 +539,9 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 						"error while trying to get socket");
 			}
 			if((fp = fopen((const char*)pszLstnPortFileName, "w+")) == NULL) {
-				LogError(errno, NO_ERRCODE, "nsd_ptcp: ListenPortFileName: "
+				LogError(errno, RS_RET_IO_ERROR, "nsd_ptcp: ListenPortFileName: "
 						"error while trying to open file");
+				ABORT_FINALIZE(RS_RET_IO_ERROR);
 			}
 			if(isIPv6) {
 				fprintf(fp, "%d", ntohs((((struct sockaddr_in6*)r->ai_addr)->sin6_port)));


### PR DESCRIPTION
Until now it was tried to write to the file even
if it couldn't be opened. Now the process is aborted.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
