### PR TITLE
tcpflood: fix segfauls on some platforms (e.g. AIX)

### DIFF
--- a/action.c
+++ b/action.c
@@ -83,7 +83,6 @@
  * A copy of the GPL can be found in the file "COPYING" in this distribution.
  */
 #include "config.h"
-#include "rsyslog.h"
 #include <stdio.h>
 #include <assert.h>
 #include <stdarg.h>
@@ -101,6 +100,7 @@
 #endif
 #include <json.h>
 
+#include "rsyslog.h"
 #include "dirty.h"
 #include "template.h"
 #include "action.h"

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -31,8 +31,6 @@
 %top{
 #ifndef __clang_analyzer__ /* this is not really our code */
 #include "config.h"
-#include "rsyslog.h"
-#include "srUtils.h"
 #if !defined(_AIX)
 #pragma GCC diagnostic ignored "-Wsign-compare"
 #pragma GCC diagnostic ignored "-Wmissing-noreturn"
@@ -46,6 +44,8 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include "rsyslog.h"
+#include "srUtils.h"
 #include "parserif.h"
 
 /* TODO: move this to a better modules, refactor -- rgerhards, 2018-01-22 */

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -29,7 +29,6 @@
 #define _XPG4_2
 #endif
 #include "config.h"
-#include "rsyslog.h"
 #include <stdlib.h>
 #include <stdio.h>
 #include <ctype.h>
@@ -45,6 +44,7 @@
 #ifdef HAVE_LIBSYSTEMD
 #	include <systemd/sd-daemon.h>
 #endif
+#include "rsyslog.h"
 #include "dirty.h"
 #include "cfsysline.h"
 #include "unicode-helper.h"

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -2,7 +2,7 @@
  * This core plugin is an interface module to message modification
  * modules written in languages other than C.
  *
- * Copyright 2014-2017 by Rainer Gerhards
+ * Copyright 2014-2018 by Rainer Gerhards
  *
  * This file is part of rsyslog.
  *
@@ -21,7 +21,6 @@
  * limitations under the License.
  */
 #include "config.h"
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -33,6 +32,7 @@
 #include <fcntl.h>
 #include <sys/wait.h>
 #include <sys/uio.h>
+#include "rsyslog.h"
 #include "conf.h"
 #include "syslogd-types.h"
 #include "srUtils.h"

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -11,7 +11,7 @@
  *
  * File begun on 2007-07-22 by RGerhards
  *
- * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -32,8 +32,6 @@
  * A copy of the LGPL can be found in the file "COPYING.LESSER" in this distribution.
  */
 #include "config.h"
-#include "rsyslog.h"
-#include "rainerscript.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -55,6 +53,8 @@
 #	define PATH_MAX MAXPATHLEN
 #endif
 
+#include "rsyslog.h"
+#include "rainerscript.h"
 #include "cfsysline.h"
 #include "rsconf.h"
 #include "modules.h"

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -12,7 +12,7 @@
  * long term, but it is good to have it out of syslogd.c. Maybe this here is
  * an interim location ;)
  *
- * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -32,7 +32,6 @@
  */
 #include "config.h"
 
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -53,6 +52,7 @@
 #include <sys/types.h>
 #include <arpa/inet.h>
 
+#include "rsyslog.h"
 #include "syslogd-types.h"
 #include "module-template.h"
 #include "parse.h"

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -2,7 +2,7 @@
  *
  * An implementation of the nsd interface for plain tcp sockets.
  *
- * Copyright 2007-2017 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -24,7 +24,6 @@
  */
 #include "config.h"
 
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -39,6 +38,7 @@
 #include <unistd.h>
 #include <netinet/tcp.h>
 
+#include "rsyslog.h"
 #include "syslogd-types.h"
 #include "module-template.h"
 #include "parse.h"

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -133,6 +133,7 @@ extern int src_exists;
 /* make sure we uses consistent macros, no matter what the
  * platform gives us.
  */
+#undef LOG_NFACILITIES /* may be system defined, override */
 #define LOG_NFACILITIES 24+1 /* plus one for our special "invld" facility! */
 #define LOG_MAXPRI 191	/* highest supported valid PRI value --> RFC3164, RFC5424 */
 #undef LOG_MAKEPRI

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -7,7 +7,7 @@
  * \date    2003-09-09
  *          Coding begun.
  *
- * Copyright 2003-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2003-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -29,7 +29,6 @@
  */
 #include "config.h"
 
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -43,6 +42,8 @@
 #include <ctype.h>
 #include <inttypes.h>
 #include <fcntl.h>
+
+#include "rsyslog.h"
 #include "srUtils.h"
 #include "obj.h"
 #include "errmsg.h"

--- a/runtime/tcpclt.c
+++ b/runtime/tcpclt.c
@@ -3,7 +3,7 @@
  * This is the implementation of TCP-based syslog clients (the counterpart
  * of the tcpsrv class).
  *
- * Copyright 2007-2012 Adiscon GmbH.
+ * Copyright 2007-2018 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -22,7 +22,6 @@
  * limitations under the License.
  */
 #include "config.h"
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -37,6 +36,7 @@
 #if HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
+#include "rsyslog.h"
 #include "dirty.h"
 #include "syslogd-types.h"
 #include "net.h"

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -150,7 +150,6 @@ char *test_rs_strerror_r(int errnum, char *buf, size_t buflen) {
 	return buf;
 }
 
-#define EXIT_FAILURE 1
 #define INVALID_SOCKET -1
 /* Name of input file, must match $IncludeConfig in test suite .conf files */
 #define NETTEST_INPUT_CONF_FILE "nettest.input.conf"
@@ -765,6 +764,7 @@ prepareGenerators()
 	int i;
 	long long msgsThrd;
 	long long starting = 0;
+	pthread_attr_t thrd_attr;
 
 	if(runMultithreaded) {
 		bSilent = 1;
@@ -772,6 +772,9 @@ prepareGenerators()
 	} else {
 		numThrds = 1;
 	}
+
+	pthread_attr_init(&thrd_attr);
+	pthread_attr_setstacksize(&thrd_attr, 4096*1024);
 
 	runningThreads = 0;
 	doRun = 0;
@@ -790,7 +793,7 @@ prepareGenerators()
 		instarray[i].numMsgs = msgsThrd;
 		instarray[i].numSent = 0;
 		instarray[i].idx = i;
-		pthread_create(&(instarray[i].thread), NULL, thrdStarter, instarray + i);
+		pthread_create(&(instarray[i].thread), &thrd_attr, thrdStarter, instarray + i);
 		/*printf("started thread %x\n", (unsigned) instarray[i].thread);*/
 		starting += msgsThrd;
 	}

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -36,7 +36,6 @@
  * limitations under the License.
  */
 #include "config.h"
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -53,7 +52,7 @@
 #	include <pthread.h>
 #endif
 
-
+#include "rsyslog.h"
 #include "conf.h"
 #include "syslogd-types.h"
 #include "srUtils.h"

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -23,7 +23,6 @@
  * limitations under the License.
  */
 #include "config.h"
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -40,6 +39,7 @@
 #include <fcntl.h>
 #include <zlib.h>
 #include <pthread.h>
+#include "rsyslog.h"
 #include "syslogd.h"
 #include "conf.h"
 #include "syslogd-types.h"

--- a/tools/ompipe.c
+++ b/tools/ompipe.c
@@ -12,7 +12,7 @@
  * NOTE: read comments in module-template.h to understand how this pipe
  *       works!
  *
- * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -31,7 +31,6 @@
  * limitations under the License.
  */
 #include "config.h"
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -44,6 +43,7 @@
 #include <unistd.h>
 #include <sys/file.h>
 
+#include "rsyslog.h"
 #include "syslogd.h"
 #include "syslogd-types.h"
 #include "srUtils.h"

--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -27,7 +27,6 @@
  * limitations under the License.
  */
 #include "config.h"
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -57,6 +56,7 @@
 #if HAVE_PATHS_H
 #include <paths.h>
 #endif
+#include "rsyslog.h"
 #include "srUtils.h"
 #include "stringbuf.h"
 #include "syslogd-types.h"

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -22,7 +22,6 @@
  * limitations under the License.
  */
 #include "config.h"
-#include "rsyslog.h"
 
 #include <signal.h>
 #include <stdlib.h>
@@ -39,6 +38,7 @@
 #	include <systemd/sd-daemon.h>
 #endif
 
+#include "rsyslog.h"
 #include "wti.h"
 #include "ratelimit.h"
 #include "parser.h"
@@ -1838,9 +1838,10 @@ wait_timeout(void)
 			if (errno != EINTR)
 			{
 				fprintf(stderr,"%s: ERROR: '%d' recvfrom\n", progname,errno);
-				exit(1);
-			} else  /* punt on short read */
-				continue;
+				exit(1); //TODO: this needs to be handled gracefully
+			} else { /* punt on short read */
+				return;
+			}
 
 			switch(srcpacket.subreq.action)
 			{


### PR DESCRIPTION
The default stack size on some platforms is insufficient, so we
need to explicitely set it.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
