### PR TITLE
testbench: Added new kafka tests using kafkacat for better debugging.

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -324,7 +324,8 @@ checkInstance(instanceConf_t *const inst)
 	/* enable kafka debug output */
 	if(rd_kafka_conf_set(inst->conf, "debug", RD_KAFKA_DEBUG_CONTEXTS,
 		kafkaErrMsg, sizeof(kafkaErrMsg)) != RD_KAFKA_CONF_OK) {
-		ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+		LogError(0, RS_RET_KAFKA_ERROR, "imkafka: error setting kafka debug option: %s\n", kafkaErrMsg);
+		/* DO NOT ABORT IN THIS CASE! */
 	}
 #	endif
 
@@ -339,8 +340,12 @@ checkInstance(instanceConf_t *const inst)
 			inst->confParams[i].val,
 			kafkaErrMsg, sizeof(kafkaErrMsg)) != RD_KAFKA_CONF_OK) {
 			if(inst->bReportErrs) {
-				LogError(0, RS_RET_PARAM_ERROR, "imkafka: error in kafka "
+				LogError(0, RS_RET_PARAM_ERROR, "error setting custom configuration "
 					"parameter '%s=%s': %s",
+					inst->confParams[i].name,
+					inst->confParams[i].val, kafkaErrMsg);
+			} else {
+				DBGPRINTF("imkafka: error setting custom configuration parameter '%s=%s': %s",
 					inst->confParams[i].name,
 					inst->confParams[i].val, kafkaErrMsg);
 			}
@@ -814,5 +819,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
-	DBGPRINTF("imkafka: version %s initializing\n", VERSION);
+	DBGPRINTF("imkafka %s using librdkafka version %s, 0x%x\n",
+		VERSION, rd_kafka_version_str(), rd_kafka_version());
+
 ENDmodInit

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -368,6 +368,10 @@ rd_kafka_topic_t** topic) {
 					"topic conf parameter '%s=%s': %s",
 					pData->topicConfParams[i].name,
 					pData->topicConfParams[i].val, errstr);
+			} else {
+				DBGPRINTF("omkafka: setting custom topic configuration parameter '%s=%s': %s",
+					pData->topicConfParams[i].name,
+					pData->topicConfParams[i].val, errstr);
 			}
 			ABORT_FINALIZE(RS_RET_PARAM_ERROR);
 		}
@@ -1101,8 +1105,7 @@ openKafka(instanceData *const __restrict__ pData)
 	/* main conf */
 	rd_kafka_conf_t *const conf = rd_kafka_conf_new();
 	if(conf == NULL) {
-		LogError(0, RS_RET_KAFKA_ERROR,
-			"omkafka: error creating kafka conf obj: %s\n",
+		LogError(0, RS_RET_KAFKA_ERROR, "omkafka: error creating kafka conf obj: %s\n",
 			rd_kafka_err2str(rd_kafka_last_error()));
 		ABORT_FINALIZE(RS_RET_KAFKA_ERROR);
 	}
@@ -1111,7 +1114,8 @@ openKafka(instanceData *const __restrict__ pData)
 	/* enable kafka debug output */
 	if(rd_kafka_conf_set(conf, "debug", RD_KAFKA_DEBUG_CONTEXTS,
 		errstr, sizeof(errstr)) != RD_KAFKA_CONF_OK) {
-		ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+		LogError(0, RS_RET_KAFKA_ERROR, "omkafka: error setting kafka debug option: %s\n", errstr);
+		/* DO NOT ABORT IN THIS CASE! */
 	}
 #endif
 
@@ -1123,8 +1127,12 @@ openKafka(instanceData *const __restrict__ pData)
 			pData->confParams[i].val, errstr, sizeof(errstr))
 	 	   != RD_KAFKA_CONF_OK) {
 			if(pData->bReportErrs) {
-				LogError(0, RS_RET_PARAM_ERROR, "error in kafka "
+				LogError(0, RS_RET_PARAM_ERROR, "error setting custom configuration "
 					"parameter '%s=%s': %s",
+					pData->confParams[i].name,
+					pData->confParams[i].val, errstr);
+			} else {
+				DBGPRINTF("omkafka: error setting custom configuration parameter '%s=%s': %s",
 					pData->confParams[i].name,
 					pData->confParams[i].val, errstr);
 			}

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -646,7 +646,7 @@ writeKafka(instanceData *const pData, uchar *const msg,
 #if RD_KAFKA_VERSION >= 0x00090400
 	if (msgTimestamp == NULL) {
 		/* Resubmitted items don't have a timestamp */
-		ttMsgTimestamp = time(NULL);
+		ttMsgTimestamp = 0;
 	} else {
 		ttMsgTimestamp = atoi((char*)msgTimestamp); /* Convert timestamp into int */
 		ttMsgTimestamp *= 1000; /* Timestamp in Milliseconds for kafka */
@@ -661,8 +661,10 @@ writeKafka(instanceData *const pData, uchar *const msg,
 						RD_KAFKA_V_VALUE(msg, strlen((char*)msg)),
 						RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
 						RD_KAFKA_V_TIMESTAMP(ttMsgTimestamp),
+						RD_KAFKA_V_KEY(NULL, 0),
 						RD_KAFKA_V_END);
 	} else {
+		DBGPRINTF("omkafka: rd_kafka_producev key=%s\n", pData->key);
 		msg_kafka_response = rd_kafka_producev(pData->rk,
 						RD_KAFKA_V_RKT(rkt),
 						RD_KAFKA_V_PARTITION(partition),

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -597,12 +597,14 @@ if ENABLE_OMKAFKA
 if ENABLE_IMKAFKA
 if ENABLE_KAFKA_TESTS
 TESTS += \
+	omkafka.sh \
+	imkafka.sh \
 	sndrcv_kafka.sh \
+	sndrcv_kafka_multi.sh
 	sndrcv_kafka_multi_topics.sh
 # Tests below need to be stable first!
 #	sndrcv_kafka_fail.sh \
 #	sndrcv_kafka_failresume.sh
-#	sndrcv_kafka_multi.sh
 if HAVE_VALGRIND
 TESTS += \
 	sndrcv_kafka-vg-rcvr.sh
@@ -1585,6 +1587,8 @@ EXTRA_DIST= \
 	mysql-actq-mt.sh \
 	mysql-actq-mt-withpause.sh \
 	mysql-actq-mt-withpause-vg.sh \
+	omkafka.sh \
+	imkafka.sh \
 	sndrcv_kafka.sh \
 	sndrcv_kafka_multi_topics.sh \
 	sndrcv_kafka-vg-rcvr.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -600,11 +600,12 @@ TESTS += \
 	omkafka.sh \
 	imkafka.sh \
 	sndrcv_kafka.sh \
-	sndrcv_kafka_multi.sh
 	sndrcv_kafka_multi_topics.sh
 # Tests below need to be stable first!
 #	sndrcv_kafka_fail.sh \
-#	sndrcv_kafka_failresume.sh
+#	sndrcv_kafka_failresume.sh \
+# needs properly to much mempory on arm devices!
+#	sndrcv_kafka_multi.sh
 if HAVE_VALGRIND
 TESTS += \
 	sndrcv_kafka-vg-rcvr.sh

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -109,6 +109,8 @@ local0.* ./'${RSYSLOG_DYNNAME}'.HOSTNAME;hostname
 
 
 # begin a new testconfig
+#	2018-09-07:	Incremented inputs.timeout.shutdown to 60000 because kafka tests may not be 
+#			finished under stress otherwise
 # $1 is the instance id, if given
 function generate_conf() {
 	export TCPFLOOD_PORT="$(get_free_port)"
@@ -120,7 +122,7 @@ function generate_conf() {
 		mkdir $RSYSLOG_DYNNAME.spool
 	fi
 	echo 'module(load="../plugins/imdiag/.libs/imdiag")
-global(inputs.timeout.shutdown="10000")
+global(inputs.timeout.shutdown="60000")
 $IMDiagListenPortFileName '$RSYSLOG_DYNNAME.imdiag$1.port'
 $IMDiagServerRun 0
 

--- a/tests/imkafka.sh
+++ b/tests/imkafka.sh
@@ -7,6 +7,12 @@ export TESTMESSAGESFULL=$TESTMESSAGES
 # Generate random topic name
 export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
+echo \[imkafka.sh\]: Init Testbench 
+. $srcdir/diag.sh init
+
+# Check for kafkacat
+check_command_available kafkacat
+
 # enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
 # too much
 #export EXTRA_EXITCHECK=dumpkafkalogs
@@ -22,9 +28,6 @@ echo \[imkafka.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
 
 echo \[imkafka.sh\]: Give Kafka some time to process topic create ...
 sleep 5
-
-echo \[imkafka.sh\]: Init Testbench 
-. $srcdir/diag.sh init
 
 # --- Create imkafka receiver config
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/imkafka.sh
+++ b/tests/imkafka.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# added 2018-08-29 by alorbach
+# This file is part of the rsyslog project, released under ASL 2.0
+export TESTMESSAGES=100000
+export TESTMESSAGESFULL=$TESTMESSAGES
+
+# Generate random topic name
+export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+
+# enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
+# too much
+#export EXTRA_EXITCHECK=dumpkafkalogs
+echo ===============================================================================
+echo \[imkafka.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
+. $srcdir/diag.sh download-kafka
+. $srcdir/diag.sh stop-zookeeper
+. $srcdir/diag.sh stop-kafka
+. $srcdir/diag.sh start-zookeeper
+. $srcdir/diag.sh start-kafka
+# create new topic
+. $srcdir/diag.sh create-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
+
+echo \[imkafka.sh\]: Give Kafka some time to process topic create ...
+sleep 5
+
+echo \[imkafka.sh\]: Init Testbench 
+. $srcdir/diag.sh init
+
+# --- Create imkafka receiver config
+export RSYSLOG_DEBUGLOG="log"
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server!*/
+input(	type="imkafka" 
+	topic="'$RANDTOPIC'" 
+	broker="localhost:29092" 
+	consumergroup="default"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if ($msg contains "msgnum:") then {
+	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
+}
+'
+# --- 
+
+# --- Start imkafka receiver config
+echo \[imkafka.sh\]: Starting receiver instance [imkafka]
+startup
+# --- 
+
+# --- Fill Kafka Server with messages
+# Can properly be done in a better way?!
+for i in {00000001..00100000}
+do
+	echo " msgnum:$i" >> $RSYSLOG_OUT_LOG.in
+done
+
+echo \[imkafka.sh\]: Inject messages into kafka
+cat $RSYSLOG_OUT_LOG.in | kafkacat -P -b localhost:29092 -t $RANDTOPIC
+# --- 
+
+echo \[imkafka.sh\]: Give imkafka some time to start...
+sleep 5
+
+echo \[imkafka.sh\]: Stopping sender instance [omkafka]
+shutdown_when_empty
+wait_shutdown
+
+# Delete topic to remove old traces before
+. $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
+
+echo \[imkafka.sh\]: stop kafka instance
+. $srcdir/diag.sh stop-kafka
+
+# STOP ZOOKEEPER in any case
+. $srcdir/diag.sh stop-zookeeper
+
+# Do the final sequence check
+seq_check 1 $TESTMESSAGESFULL -d
+
+echo success
+exit_test

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=50000
+export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 
 # Generate random topic name
 export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+
+echo \[omkafka.sh\]: Init Testbench 
+. $srcdir/diag.sh init
+
+# Check for kafkacat
+check_command_available kafkacat
 
 # enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
 # too much
@@ -22,9 +28,6 @@ echo \[omkafka.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
 
 echo \[omkafka.sh\]: Give Kafka some time to process topic create ...
 sleep 5
-
-echo \[omkafka.sh\]: Init Testbench 
-. $srcdir/diag.sh init
 
 # --- Create/Start omkafka sender config 
 export RSYSLOG_DEBUGLOG="log"
@@ -79,8 +82,8 @@ kafkacat -b localhost:29092 -e -C -o beginning -t $RANDTOPIC -f '%p@%o:%k:%s' > 
 # Delete topic to remove old traces before
 # . $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
 
-# Dump Kafka log
-# uncomment if needed . $srcdir/diag.sh dump-kafka-serverlog
+# Dump Kafka log | uncomment if needed
+# . $srcdir/diag.sh dump-kafka-serverlog
 
 echo \[omkafka.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=100000
-export TESTMESSAGESFULL=100000
+export TESTMESSAGES=50000
+export TESTMESSAGESFULL=$TESTMESSAGES
 
 # Generate random topic name
 export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
@@ -11,7 +11,7 @@ export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1
 # too much
 #export EXTRA_EXITCHECK=dumpkafkalogs
 echo ===============================================================================
-echo \[sndrcv_kafka.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
+echo \[omkafka.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
 . $srcdir/diag.sh download-kafka
 . $srcdir/diag.sh stop-zookeeper
 . $srcdir/diag.sh stop-kafka
@@ -20,13 +20,13 @@ echo \[sndrcv_kafka.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
 # create new topic
 . $srcdir/diag.sh create-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
 
-echo \[sndrcv_kafka.sh\]: Give Kafka some time to process topic create ...
+echo \[omkafka.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka.sh\]: Init Testbench
+echo \[omkafka.sh\]: Init Testbench 
 . $srcdir/diag.sh init
 
-# --- Create/Start omkafka sender config
+# --- Create/Start omkafka sender config 
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
@@ -36,13 +36,13 @@ module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
-template(name="outfmt" type="string" string="%msg%\n")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
-local4.* action(	name="kafka-fwd"
-	type="omkafka"
-	topic="'$RANDTOPIC'"
-	broker="localhost:29092"
-	template="outfmt"
+local4.* action(	name="kafka-fwd" 
+	type="omkafka" 
+	topic="'$RANDTOPIC'" 
+	broker="localhost:29092" 
+	template="outfmt" 
 	confParam=[	"compression.codec=none",
 			"socket.timeout.ms=10000",
 			"socket.keepalive.enable=true",
@@ -62,56 +62,27 @@ local4.* action(	name="kafka-fwd"
 	)
 '
 
-echo \[sndrcv_kafka.sh\]: Starting sender instance [omkafka]
+echo \[omkafka.sh\]: Starting sender instance [omkafka]
 startup
-# ---
+# --- 
 
-echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance
+echo \[omkafka.sh\]: Inject messages into rsyslog sender instance  
 tcpflood -m$TESTMESSAGES -i1
 
-# --- Create/Start imkafka receiver config
-export RSYSLOG_DEBUGLOG="log2"
-generate_conf 2
-add_conf '
-main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-
-module(load="../plugins/imkafka/.libs/imkafka")
-/* Polls messages from kafka server!*/
-input(	type="imkafka"
-	topic="'$RANDTOPIC'"
-	broker="localhost:29092"
-	consumergroup="default"
-	confParam=[ "compression.codec=none",
-		"session.timeout.ms=10000",
-		"socket.timeout.ms=5000",
-		"socket.keepalive.enable=true",
-		"reconnect.backoff.jitter.ms=1000",
-		"enable.partition.eof=false" ]
-	)
-
-template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-
-if ($msg contains "msgnum:") then {
-	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
-}
-' 2
-
-echo \[sndrcv_kafka.sh\]: Starting receiver instance [imkafka]
-startup 2
-# ---
-
-echo \[sndrcv_kafka.sh\]: Stopping sender instance [omkafka]
+echo \[omkafka.sh\]: Stopping sender instance [omkafka]
 shutdown_when_empty
 wait_shutdown
 
-echo \[sndrcv_kafka.sh\]: Stopping receiver instance [imkafka]
-shutdown_when_empty 2
-wait_shutdown 2
+kafkacat -b localhost:29092 -e -C -o beginning -t $RANDTOPIC -f '%s'> $RSYSLOG_OUT_LOG
+kafkacat -b localhost:29092 -e -C -o beginning -t $RANDTOPIC -f '%p@%o:%k:%s' > $RSYSLOG_OUT_LOG.extra
 
 # Delete topic to remove old traces before
-. $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
+# . $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
 
-echo \[sndrcv_kafka.sh\]: stop kafka instance
+# Dump Kafka log
+# uncomment if needed . $srcdir/diag.sh dump-kafka-serverlog
+
+echo \[omkafka.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -18,7 +18,7 @@ echo \[sndrcv_kafka-vg-rcvr.sh\]: Create kafka/zookeeper instance and static top
 echo \[sndrcv_kafka-vg-rcvr.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Init Testbench 
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Init Testbench
 . $srcdir/diag.sh init
 
 echo \[sndrcv_kafka-vg-rcvr.sh\]: Starting receiver instance [omkafka]
@@ -27,9 +27,9 @@ generate_conf
 add_conf '
 module(load="../plugins/imkafka/.libs/imkafka")
 /* Polls messages from kafka server!*/
-input(	type="imkafka" 
-	topic="static" 
-	broker="localhost:29092" 
+input(	type="imkafka"
+	topic="static"
+	broker="localhost:29092"
 	consumergroup="default"
 	confParam=[ "compression.codec=none",
 		"socket.timeout.ms=5000",
@@ -57,11 +57,11 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-local4.* action(	name="kafka-fwd" 
-	type="omkafka" 
-	topic="static" 
-	broker="localhost:29092" 
-	template="outfmt" 
+local4.* action(	name="kafka-fwd"
+	type="omkafka"
+	topic="static"
+	broker="localhost:29092"
+	template="outfmt"
 	confParam=[	"compression.codec=none",
 			"socket.timeout.ms=10000",
 			"socket.keepalive.enable=true",
@@ -82,7 +82,7 @@ local4.* action(	name="kafka-fwd"
 ' 2
 startup 2
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Inject messages into rsyslog sender instance  
+echo \[sndrcv_kafka-vg-rcvr.sh\]: Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i1
 
 #echo \[sndrcv_kafka-vg-rcvr.sh\]: Sleep to give rsyslog instances time to process data ...
@@ -103,7 +103,7 @@ check_exit_vg
 # Do the final sequence check
 seq_check 1 $TESTMESSAGESFULL -d
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: delete kafka topics 
+echo \[sndrcv_kafka-vg-rcvr.sh\]: delete kafka topics
 . $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
 
 echo \[sndrcv_kafka-vg-rcvr.sh\]: stop kafka instance

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -7,21 +7,23 @@ export TESTMESSAGESFULL=100000
 # too much
 # export EXTRA_EXITCHECK=dumpkafkalogs
 echo ===============================================================================
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Create kafka/zookeeper instance and static topic
+echo Check and Stop previous instances of kafka/zookeeper 
 . $srcdir/diag.sh download-kafka
 . $srcdir/diag.sh stop-zookeeper
 . $srcdir/diag.sh stop-kafka
+
+echo Init Testbench
+. $srcdir/diag.sh init
+
+echo Create kafka/zookeeper instance and topics
 . $srcdir/diag.sh start-zookeeper
 . $srcdir/diag.sh start-kafka
 . $srcdir/diag.sh create-kafka-topic 'static' '.dep_wrk' '22181'
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Give Kafka some time to process topic create ...
+echo Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Init Testbench
-. $srcdir/diag.sh init
-
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Starting receiver instance [omkafka]
+echo Starting receiver instance [omkafka]
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
@@ -45,7 +47,7 @@ if ($msg contains "msgnum:") then {
 '
 startup_vg
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Starting sender instance [imkafka]
+echo Starting sender instance [imkafka]
 export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
@@ -74,28 +76,28 @@ local4.* action(	name="kafka-fwd"
 	closeTimeout="30000"
 	resubmitOnFailure="on"
 	keepFailedMessages="on"
-	failedMsgFile="omkafka-failed.data"
+	failedMsgFile="'$RSYSLOG_OUT_LOG'-failed-'$RANDTOPIC'.data"
 	action.resumeInterval="2"
-	action.resumeRetryCount="-1"
+	action.resumeRetryCount="10"
 	queue.saveonshutdown="on"
 	)
 ' 2
 startup 2
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Inject messages into rsyslog sender instance
+echo Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i1
 
-#echo \[sndrcv_kafka-vg-rcvr.sh\]: Sleep to give rsyslog instances time to process data ...
+#echo Sleep to give rsyslog instances time to process data ...
 #sleep 5
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Stopping sender instance [imkafka]
+echo Stopping sender instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown 2
 
-#echo \[sndrcv_kafka-vg-rcvr.sh\]: Sleep to give rsyslog receiver time to receive data ...
+#echo Sleep to give rsyslog receiver time to receive data ...
 #sleep 20
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: Stopping receiver instance [omkafka]
+echo Stopping receiver instance [omkafka]
 shutdown_when_empty
 wait_shutdown_vg
 check_exit_vg
@@ -103,10 +105,10 @@ check_exit_vg
 # Do the final sequence check
 seq_check 1 $TESTMESSAGESFULL -d
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: delete kafka topics
+echo delete kafka topics
 . $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
 
-echo \[sndrcv_kafka-vg-rcvr.sh\]: stop kafka instance
+echo stop kafka instance
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case

--- a/tests/sndrcv_kafka-vg-sender.sh
+++ b/tests/sndrcv_kafka-vg-sender.sh
@@ -16,7 +16,7 @@ export TESTMESSAGESFULL=1000
 echo \[sndrcv_kafka-vg-sender.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka-vg-sender.sh\]: Init Testbench 
+echo \[sndrcv_kafka-vg-sender.sh\]: Init Testbench
 . $srcdir/diag.sh init
 
 echo \[sndrcv_kafka-vg-sender.sh\]: Starting receiver instance [omkafka]
@@ -25,9 +25,9 @@ generate_conf
 add_conf '
 module(load="../plugins/imkafka/.libs/imkafka")
 /* Polls messages from kafka server!*/
-input(	type="imkafka" 
-	topic="static" 
-	broker="localhost:29092" 
+input(	type="imkafka"
+	topic="static"
+	broker="localhost:29092"
 	consumergroup="default"
 	confParam=[ "compression.codec=none",
 		"socket.timeout.ms=5000",
@@ -54,11 +54,11 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(	name="kafka-fwd" 
-	type="omkafka" 
-	topic="static" 
-	broker="localhost:29092" 
-	template="outfmt" 
+action(	name="kafka-fwd"
+	type="omkafka"
+	topic="static"
+	broker="localhost:29092"
+	template="outfmt"
 	confParam=[	"compression.codec=none",
 			"socket.timeout.ms=5000",
 			"socket.keepalive.enable=true",
@@ -77,7 +77,7 @@ action(	name="kafka-fwd"
 ' 2
 startup_vg 2
 
-echo \[sndrcv_kafka-vg-sender.sh\]: Inject messages into rsyslog sender instance  
+echo \[sndrcv_kafka-vg-sender.sh\]: Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i1
 
 echo \[sndrcv_kafka-vg-sender.sh\]: Sleep to give rsyslog instances time to process data ...
@@ -95,7 +95,7 @@ echo \[sndrcv_kafka-vg-sender.sh\]: Stopping receiver instance [omkafka]
 shutdown_when_empty
 wait_shutdown
 
-echo \[sndrcv_kafka-vg-sender.sh\]: delete kafka topics 
+echo \[sndrcv_kafka-vg-sender.sh\]: delete kafka topics
 . $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
 
 # Do the final sequence check

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -9,7 +9,7 @@ export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1
 
 # enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
 # too much
-#export EXTRA_EXITCHECK=dumpkafkalogs
+# export EXTRA_EXITCHECK=dumpkafkalogs
 echo ===============================================================================
 echo \[sndrcv_kafka.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
 . $srcdir/diag.sh download-kafka
@@ -110,6 +110,9 @@ wait_shutdown 2
 
 # Delete topic to remove old traces before
 . $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
+
+# Dump Kafka log | uncomment if needed
+. $srcdir/diag.sh dump-kafka-serverlog
 
 echo \[sndrcv_kafka.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -66,6 +66,8 @@ echo \[sndrcv_kafka.sh\]: Starting sender instance [omkafka]
 startup
 # ---
 
+# Injection messages now before starting receiver, simply because omkafka will take some time and
+# there is no reason to wait for the receiver to startup first. 
 echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i1
 
@@ -112,7 +114,7 @@ wait_shutdown 2
 . $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
 
 # Dump Kafka log | uncomment if needed
-. $srcdir/diag.sh dump-kafka-serverlog
+# . $srcdir/diag.sh dump-kafka-serverlog
 
 echo \[sndrcv_kafka.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -2,40 +2,49 @@
 # added 2017-05-18 by alorbach
 #	This test only tests what happens when kafka cluster fails
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=10000
-export TESTMESSAGES2=10001
-export TESTMESSAGESFULL=10000
+export TESTMESSAGES=50000
+export TESTMESSAGES2=50001
+export TESTMESSAGESFULL=100000
+
+# Generate random topic name
+export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
 echo ===============================================================================
-echo \[sndrcv_kafka_fail.sh\]: Create kafka/zookeeper instance and static topic
+echo \[sndrcv_kafka_fail.sh\]: Create kafka/zookeeper instance and $RANDTOPIC topic
 . $srcdir/diag.sh download-kafka
 . $srcdir/diag.sh stop-zookeeper
 . $srcdir/diag.sh stop-kafka
 . $srcdir/diag.sh start-zookeeper
 . $srcdir/diag.sh start-kafka
-. $srcdir/diag.sh create-kafka-topic 'static' '.dep_wrk' '22181'
+. $srcdir/diag.sh create-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
 
 echo \[sndrcv_kafka_fail.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka_fail.sh\]: Init Testbench 
+echo \[sndrcv_kafka_fail.sh\]: Init Testbench
 . $srcdir/diag.sh init
 
-echo \[sndrcv_kafka_fail.sh\]: Stopping kafka cluster instance 
+echo \[sndrcv_kafka_fail.sh\]: Stopping kafka cluster instance
 . $srcdir/diag.sh stop-kafka
 
-# --- Create omkafka receiver config 
+# --- Create imkafka receiver config
+export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
 module(load="../plugins/imkafka/.libs/imkafka")
 /* Polls messages from kafka server!*/
-input(	type="imkafka" 
-	topic="static" 
-	broker="localhost:29092" 
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker="localhost:29092"
 	consumergroup="default"
 	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
 		"socket.timeout.ms=5000",
-		"socket.keepalive.enable=true"]
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
 	)
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
@@ -45,15 +54,15 @@ if ($msg contains "msgnum:") then {
 }
 '
 
-echo \[sndrcv_kafka_fail.sh\]: Starting receiver instance [omkafka]
-export RSYSLOG_DEBUGLOG="log"
+echo \[sndrcv_kafka_fail.sh\]: Starting receiver instance [imkafka]
 startup
-# --- 
+# ---
 
-# --- Create omkafka sender config 
+# --- Create omkafka sender config
+export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
-main_queue(queue.timeoutactioncompletion="5000" queue.timeoutshutdown="60000")
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
@@ -61,45 +70,44 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-local4.* action(	name="kafka-fwd" 
-	type="omkafka" 
-	topic="static" 
-	broker="localhost:29092" 
-	template="outfmt" 
+local4.* action(	name="kafka-fwd"
+	type="omkafka"
+	topic="'$RANDTOPIC'"
+	broker="localhost:29092"
+	template="outfmt"
 	confParam=[	"compression.codec=none",
-			"socket.timeout.ms=5000",
+			"socket.timeout.ms=10000",
 			"socket.keepalive.enable=true",
 			"reconnect.backoff.jitter.ms=1000",
 			"queue.buffering.max.messages=20000",
 			"enable.auto.commit=true",
 			"message.send.max.retries=1"]
-	topicConfParam=["message.timeout.ms=5000"]
+	topicConfParam=["message.timeout.ms=10000"]
 	partitions.auto="on"
-	closeTimeout="30000"
+	closeTimeout="60000"
 	resubmitOnFailure="on"
 	keepFailedMessages="on"
 	failedMsgFile="omkafka-failed.data"
 	action.resumeInterval="2"
-	action.resumeRetryCount="-1"
+	action.resumeRetryCount="2"
 	queue.saveonshutdown="on"
 	)
 ' 2
 
-echo \[sndrcv_kafka_fail.sh\]: Starting sender instance [imkafka]
-export RSYSLOG_DEBUGLOG="log2"
+echo \[sndrcv_kafka_fail.sh\]: Starting sender instance [omkafka]
 startup 2
-# --- 
+# ---
 
-echo \[sndrcv_kafka_fail.sh\]: Inject messages into rsyslog sender instance  
+echo \[sndrcv_kafka_fail.sh\]: Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i1
 
-echo \[sndrcv_kafka_fail.sh\]: Starting kafka cluster instance 
+echo \[sndrcv_kafka_fail.sh\]: Starting kafka cluster instance
 . $srcdir/diag.sh start-kafka
 
 echo \[sndrcv_kafka_fail.sh\]: Sleep to give rsyslog instances time to process data ...
 sleep 5
 
-echo \[sndrcv_kafka_fail.sh\]: Inject messages into rsyslog sender instance  
+echo \[sndrcv_kafka_fail.sh\]: Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i$TESTMESSAGES2
 
 echo \[sndrcv_kafka_fail.sh\]: Sleep to give rsyslog sender time to send data ...
@@ -109,24 +117,21 @@ echo \[sndrcv_kafka_fail.sh\]: Stopping sender instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown 2
 
-#echo \[sndrcv_kafka_fail.sh\]: Sleep to give rsyslog receiver time to receive data ...
-#sleep 20
-
 echo \[sndrcv_kafka_fail.sh\]: Stopping receiver instance [omkafka]
 shutdown_when_empty
 wait_shutdown
 
-# Do the final sequence check
-seq_check2 1 $TESTMESSAGESFULL -d
-
-echo \[sndrcv_kafka_fail.sh\]: delete kafka topics 
-. $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
+echo \[sndrcv_kafka_fail.sh\]: delete kafka topics
+. $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
 
 echo \[sndrcv_kafka_fail.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case
 . $srcdir/diag.sh stop-zookeeper
+
+# Do the final sequence check
+seq_check2 1 $TESTMESSAGESFULL -d
 
 echo success
 exit_test

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -89,7 +89,6 @@ action(	name="kafka-fwd"
 echo \[sndrcv_kafka_failresume.sh\]: Starting sender instance [imkafka]
 startup 2
 # ---
->>>>>>> testbench: Added new kafka tests using kafkacat for better debugging.
 
 echo \[sndrcv_kafka_failresume.sh\]: Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i1

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -2,8 +2,11 @@
 # added 2017-06-06 by alorbach
 #	This tests the keepFailedMessages feature in omkafka
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=1000
-export TESTMESSAGESFULL=1000
+export TESTMESSAGES=50000
+export TESTMESSAGESFULL=50000
+
+# Generate random topic name
+export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
 echo ===============================================================================
 echo \[sndrcv_kafka_failresume.sh\]: Create kafka/zookeeper instance and static topic
@@ -12,26 +15,30 @@ echo \[sndrcv_kafka_failresume.sh\]: Create kafka/zookeeper instance and static 
 . $srcdir/diag.sh stop-kafka
 . $srcdir/diag.sh start-zookeeper
 . $srcdir/diag.sh start-kafka
-. $srcdir/diag.sh create-kafka-topic 'static' '.dep_wrk' '22181'
+. $srcdir/diag.sh create-kafka-topic $RANDTOPIC '.dep_wrk' '22181'
 
 echo \[sndrcv_kafka_failresume.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka_failresume.sh\]: Init Testbench 
+echo \[sndrcv_kafka_failresume.sh\]: Init Testbench
 . $srcdir/diag.sh init
 
-# --- Create omkafka receiver config 
+# --- Create omkafka receiver config
+export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
 module(load="../plugins/imkafka/.libs/imkafka")
 /* Polls messages from kafka server!*/
-input(	type="imkafka" 
-	topic="static" 
-	broker="localhost:29092" 
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker="localhost:29092"
 	consumergroup="default"
 	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
 		"socket.timeout.ms=5000",
-		"socket.keepalive.enable=true"]
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
 	)
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
@@ -40,9 +47,13 @@ if ($msg contains "msgnum:") then {
 	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
 }
 '
-# --- 
 
-# --- Create omkafka sender config 
+echo \[sndrcv_kafka_failresume.sh\]: Starting receiver instance [omkafka]
+startup
+# ---
+
+# --- Create omkafka sender config
+export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
 main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
@@ -53,11 +64,11 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-action(	name="kafka-fwd" 
-	type="omkafka" 
-	topic="static" 
-	broker="localhost:29092" 
-	template="outfmt" 
+action(	name="kafka-fwd"
+	type="omkafka"
+	topic="'$RANDTOPIC'"
+	broker="localhost:29092"
+	template="outfmt"
 	confParam=[	"compression.codec=none",
 			"socket.timeout.ms=5000",
 			"socket.keepalive.enable=true",
@@ -74,27 +85,23 @@ action(	name="kafka-fwd"
 	queue.saveonshutdown="on"
 	)
 ' 2
-# ---
 
 echo \[sndrcv_kafka_failresume.sh\]: Starting sender instance [imkafka]
-export RSYSLOG_DEBUGLOG="log"
 startup 2
+# ---
+>>>>>>> testbench: Added new kafka tests using kafkacat for better debugging.
 
-echo \[sndrcv_kafka_failresume.sh\]: Starting receiver instance [omkafka]
-export RSYSLOG_DEBUGLOG="log2"
-startup
-
-echo \[sndrcv_kafka_failresume.sh\]: Inject messages into rsyslog sender instance  
+echo \[sndrcv_kafka_failresume.sh\]: Inject messages into rsyslog sender instance
 tcpflood -m$TESTMESSAGES -i1
 
-echo \[sndrcv_kafka_failresume.sh\]: Stopping kafka cluster instance 
+echo \[sndrcv_kafka_failresume.sh\]: Stopping kafka cluster instance
 . $srcdir/diag.sh stop-kafka
 
 echo \[sndrcv_kafka_failresume.sh\]: Stopping sender instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown 2
 
-echo \[sndrcv_kafka_failresume.sh\]: Starting kafka cluster instance 
+echo \[sndrcv_kafka_failresume.sh\]: Starting kafka cluster instance
 . $srcdir/diag.sh start-kafka
 
 echo \[sndrcv_kafka_failresume.sh\]: Sleep to give rsyslog instances time to process data ...
@@ -111,24 +118,21 @@ echo \[sndrcv_kafka_failresume.sh\]: Stopping sender instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown 2
 
-echo \[sndrcv_kafka_failresume.sh\]: Sleep to give rsyslog receiver time to receive data ...
-sleep 20
-
 echo \[sndrcv_kafka_failresume.sh\]: Stopping receiver instance [omkafka]
 shutdown_when_empty
 wait_shutdown
 
-echo \[sndrcv_kafka_failresume.sh\]: delete kafka topics 
+echo \[sndrcv_kafka_failresume.sh\]: delete kafka topics
 . $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk' '22181'
-
-# Do the final sequence check
-seq_check 1 $TESTMESSAGESFULL
 
 echo \[sndrcv_kafka_failresume.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case
 . $srcdir/diag.sh stop-zookeeper
+
+# Do the final sequence check
+seq_check 1 $TESTMESSAGESFULL
 
 echo success
 exit_test

--- a/tests/sndrcv_kafka_multi.sh
+++ b/tests/sndrcv_kafka_multi.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 # added 2017-05-08 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=1000
-export TESTMESSAGESFULL=1000
+export TESTMESSAGES=100000
+export TESTMESSAGESFULL=100000
+
+# Generate random topic name
+export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
 
 echo ===============================================================================
 echo \[sndrcv_kafka_multi.sh\]: Create multiple kafka/zookeeper instances and static topic
@@ -19,37 +22,20 @@ echo \[sndrcv_kafka_multi.sh\]: Create multiple kafka/zookeeper instances and st
 . $srcdir/diag.sh start-kafka '.dep_wrk1'
 . $srcdir/diag.sh start-kafka '.dep_wrk2'
 . $srcdir/diag.sh start-kafka '.dep_wrk3'
-. $srcdir/diag.sh create-kafka-topic 'static' '.dep_wrk1' '22181'
+. $srcdir/diag.sh create-kafka-topic $RANDTOPIC '.dep_wrk1' '22181'
 
+echo \[sndrcv_kafka_multi.sh\]: Give Kafka some time to process topic create ...
+sleep 5
+
+echo \[sndrcv_kafka_multi.sh\]: Init Testbench
 . $srcdir/diag.sh init
 
-# --- Create omkafka receiver config 
+# --- Create omkafka sender config
+export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
-module(load="../plugins/imkafka/.libs/imkafka")
-/* Polls messages from kafka server!*/
-input(	type="imkafka" 
-	topic="static" 
-	broker=["localhost:29092", "localhost:29093", "localhost:29094"] 
-#	broker="localhost:29092" 
-	consumergroup="default"
-	confParam=[ "compression.codec=none",
-		"socket.timeout.ms=5000",
-		"enable.partition.eof=false",
-		"socket.keepalive.enable=true"]
-	)	
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
 
-template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-
-if ($msg contains "msgnum:") then {
-	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
-}
-'
-# --- 
-
-# --- Create omkafka sender config 
-generate_conf 2
-add_conf '
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="'$TCPFLOOD_PORT'" Ruleset="omkafka")	/* this port for tcpflood! */
@@ -57,53 +43,66 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'" Ruleset="omkafka")	/* this port for t
 template(name="outfmt" type="string" string="%msg%\n")
 
 ruleset(name="omkafka") {
-	action( type="omkafka" 
-		name="kafka-fwd" 
-		broker=["localhost:29092", "localhost:29093", "localhost:29094"] 
-		topic="static" 
-		template="outfmt" 
+	action( type="omkafka"
+		name="kafka-fwd"
+		broker=["localhost:29092", "localhost:29093", "localhost:29094"]
+		topic="'$RANDTOPIC'"
+		template="outfmt"
 		confParam=[	"compression.codec=none",
 				"socket.timeout.ms=5000",
 				"socket.keepalive.enable=true",
 				"reconnect.backoff.jitter.ms=1000",
-				"queue.buffering.max.messages=20000",
+				"queue.buffering.max.messages=10000",
 				"message.send.max.retries=1"]
 		partitions.auto="on"
 		partitions.scheme="random"
+		closeTimeout="60000"
 		queue.size="1000000"
 		queue.type="LinkedList"
 		action.repeatedmsgcontainsoriginalmsg="off"
-		action.resumeRetryCount="-1"
+		action.resumeInterval="1"
+		action.resumeRetryCount="2"
 		action.reportSuspension="on"
 		action.reportSuspensionContinuation="on" )
-
 }
 
-ruleset(name="omkafka1") {
-	action(name="kafka-fwd" type="omkafka" topic="static" broker="localhost:29092" template="outfmt" partitions.auto="on")
-}
-ruleset(name="omkafka2") {
-	action(name="kafka-fwd" type="omkafka" topic="static" broker="localhost:29093" template="outfmt" partitions.auto="on")
-}
-ruleset(name="omkafka3") {
-	action(name="kafka-fwd" type="omkafka" topic="static" broker="localhost:29094" template="outfmt" partitions.auto="on")
-}
-' 2
-# --- 
+'
 
 echo \[sndrcv_kafka_multi.sh\]: Starting sender instance [omkafka]
-export RSYSLOG_DEBUGLOG="log"
 startup
 
 # now inject the messages into instance 2. It will connect to instance 1, and that instance will record the data.
 tcpflood -m$TESTMESSAGES -i1
 
-echo \[sndrcv_kafka_multi.sh\]: Starting receiver instance [imkafka]
+# --- Create omkafka receiver config
 export RSYSLOG_DEBUGLOG="log2"
-startup 2
+generate_conf 2
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
 
-#echo \[sndrcv_kafka_multi.sh\]: Sleep to give rsyslog instances time to process data ...
-#sleep 20 
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server!*/
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker=["localhost:29092", "localhost:29093", "localhost:29094"]
+	consumergroup="default"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)	
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if ($msg contains "msgnum:") then {
+	action( type="omfile" file=`echo '$RSYSLOG_OUT_LOG'` template="outfmt" )
+}
+' 2
+
+echo \[sndrcv_kafka_multi.sh\]: Starting receiver instance [imkafka]
+startup 2
 
 echo \[sndrcv_kafka_multi.sh\]: Stopping sender instance [omkafka]
 shutdown_when_empty
@@ -113,11 +112,8 @@ echo \[sndrcv_kafka_multi.sh\]: Stopping receiver instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown 2
 
-echo \[sndrcv_kafka_multi.sh\]: delete kafka topics 
-. $srcdir/diag.sh delete-kafka-topic 'static' '.dep_wrk1' '22181'
-
-# Do the final sequence check
-seq_check 1 $TESTMESSAGESFULL -d
+echo \[sndrcv_kafka_multi.sh\]: delete kafka topics
+. $srcdir/diag.sh delete-kafka-topic $RANDTOPIC '.dep_wrk1' '22181'
 
 echo \[sndrcv_kafka.sh\]: stop kafka instances
 . $srcdir/diag.sh stop-kafka '.dep_wrk1'
@@ -126,6 +122,9 @@ echo \[sndrcv_kafka.sh\]: stop kafka instances
 . $srcdir/diag.sh stop-zookeeper '.dep_wrk1'
 . $srcdir/diag.sh stop-zookeeper '.dep_wrk2'
 . $srcdir/diag.sh stop-zookeeper '.dep_wrk3'
+
+# Do the final sequence check
+seq_check 1 $TESTMESSAGESFULL -d
 
 echo success
 exit_test

--- a/tests/sndrcv_kafka_multi_topics.sh
+++ b/tests/sndrcv_kafka_multi_topics.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 # added 2018-08-13 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-export TESTMESSAGES=5000
-export TESTMESSAGESFULL=10000
+export TESTMESSAGES=50000
+export TESTMESSAGESFULL=100000
+
+# Generate random topic name
+export RANDTOPIC1=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC2=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+
 # enable the EXTRA_EXITCHECK only if really needed - otherwise spams the test log
 # too much
 #export EXTRA_EXITCHECK=dumpkafkalogs
@@ -13,98 +18,105 @@ echo \[sndrcv_kafka_multi_topics.sh\]: Create kafka/zookeeper instance and stati
 . $srcdir/diag.sh stop-kafka
 . $srcdir/diag.sh start-zookeeper
 . $srcdir/diag.sh start-kafka
-. $srcdir/diag.sh create-kafka-topic 'static1' '.dep_wrk' '22181'
-. $srcdir/diag.sh create-kafka-topic 'static2' '.dep_wrk' '22181'
+. $srcdir/diag.sh create-kafka-topic $RANDTOPIC1 '.dep_wrk' '22181'
+. $srcdir/diag.sh create-kafka-topic $RANDTOPIC2 '.dep_wrk' '22181'
 
 echo \[sndrcv_kafka_multi_topics.sh\]: Give Kafka some time to process topic create ...
 sleep 5
 
-echo \[sndrcv_kafka_fail.sh\]: Init Testbench 
+echo \[sndrcv_kafka_fail.sh\]: Init Testbench
 . $srcdir/diag.sh init
 
-# --- Create omkafka sender config 
+# --- Create omkafka sender config
+export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
-main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="13514")	/* this port for tcpflood! */
+input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 
-local4.* action(	name="kafka-fwd" 
-	type="omkafka" 
-	topic="static1" 
-	broker="localhost:29092" 
-	template="outfmt" 
+local4.* action(	name="kafka-fwd"
+	type="omkafka"
+	topic="'$RANDTOPIC1'"
+	broker="localhost:29092"
+	template="outfmt"
 	confParam=[	"compression.codec=none",
 			"socket.timeout.ms=10000",
 			"socket.keepalive.enable=true",
 			"reconnect.backoff.jitter.ms=1000",
-			"queue.buffering.max.messages=20000",
+			"queue.buffering.max.messages=10000",
 			"enable.auto.commit=true",
 			"message.send.max.retries=1"]
 	topicConfParam=["message.timeout.ms=10000"]
 	partitions.auto="on"
-	closeTimeout="30000"
+	closeTimeout="60000"
 	resubmitOnFailure="on"
 	keepFailedMessages="on"
 	failedMsgFile="omkafka-failed1.data"
-	action.resumeInterval="2"
-	action.resumeRetryCount="-1"
+	action.resumeInterval="1"
+	action.resumeRetryCount="2"
 	queue.saveonshutdown="on"
 	)
-local4.* action(	name="kafka-fwd" 
-	type="omkafka" 
-	topic="static2" 
-	broker="localhost:29092" 
-	template="outfmt" 
+local4.* action(	name="kafka-fwd"
+	type="omkafka"
+	topic="'$RANDTOPIC2'"
+	broker="localhost:29092"
+	template="outfmt"
 	confParam=[	"compression.codec=none",
 			"socket.timeout.ms=10000",
 			"socket.keepalive.enable=true",
 			"reconnect.backoff.jitter.ms=1000",
-			"queue.buffering.max.messages=20000",
+			"queue.buffering.max.messages=10000",
 			"enable.auto.commit=true",
 			"message.send.max.retries=1"]
 	topicConfParam=["message.timeout.ms=10000"]
 	partitions.auto="on"
-	closeTimeout="30000"
+	closeTimeout="60000"
 	resubmitOnFailure="on"
 	keepFailedMessages="on"
 	failedMsgFile="omkafka-failed2.data"
-	action.resumeInterval="2"
-	action.resumeRetryCount="-1"
+	action.resumeInterval="1"
+	action.resumeRetryCount="2"
 	queue.saveonshutdown="on"
 	)
-' 
+'
 
 echo \[sndrcv_kafka_multi_topics.sh\]: Starting sender instance [omkafka]
-export RSYSLOG_DEBUGLOG="log"
 startup
-# --- 
+# ---
 
+echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance
+tcpflood -m$TESTMESSAGES -i1
 
-# --- Create omkafka sender config 
+# --- Create omkafka receiver config
+export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
 module(load="../plugins/imkafka/.libs/imkafka")
 /* Polls messages from kafka server!*/
-input(	type="imkafka" 
-	topic="static1" 
-	broker="localhost:29092" 
+input(	type="imkafka"
+	topic="'$RANDTOPIC1'"
+	broker="localhost:29092"
 	consumergroup="default1"
 	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
 		"socket.timeout.ms=10000",
 		"enable.partition.eof=false",
 		"reconnect.backoff.jitter.ms=1000",
 		"socket.keepalive.enable=true"]
 	)
-input(	type="imkafka" 
-	topic="static2" 
-	broker="localhost:29092" 
+input(	type="imkafka"
+	topic="'$RANDTOPIC2'"
+	broker="localhost:29092"
 	consumergroup="default2"
 	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
 		"socket.timeout.ms=10000",
 		"enable.partition.eof=false",
 		"reconnect.backoff.jitter.ms=1000",
@@ -119,37 +131,30 @@ if ($msg contains "msgnum:") then {
 ' 2
 
 echo \[sndrcv_kafka_multi_topics.sh\]: Starting receiver instance [imkafka]
-export RSYSLOG_DEBUGLOG="log2"
 startup 2
-# --- 
+# ---
 
-echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance  
-tcpflood -m$TESTMESSAGES -i1
-
-#echo \[sndrcv_kafka.sh\]: Sleep to give rsyslog instances time to process data ...
-sleep 5
-
-echo \[sndrcv_kafka.sh\]: Stopping sender instance [omkafka]
-shutdown_when_empty 2
-wait_shutdown 2
-
-echo \[sndrcv_kafka.sh\]: Stopping receiver instance [imkafka]
+echo \[sndrcv_kafka.sh\]: Stopping sender  instance [omkafka]
 shutdown_when_empty
 wait_shutdown
 
-# Do the final sequence check
-seq_check 1 $TESTMESSAGES -d
-content_check_with_count "000" $TESTMESSAGESFULL
+echo \[sndrcv_kafka.sh\]: Stopping receiver instance [imkafka]
+shutdown_when_empty 2
+wait_shutdown 2
 
-echo \[sndrcv_kafka.sh\]: delete kafka topics 
-. $srcdir/diag.sh delete-kafka-topic 'static1' '.dep_wrk' '22181'
-. $srcdir/diag.sh delete-kafka-topic 'static2' '.dep_wrk' '22181'
+echo \[sndrcv_kafka.sh\]: delete kafka topics
+. $srcdir/diag.sh delete-kafka-topic $RANDTOPIC1 '.dep_wrk' '22181'
+. $srcdir/diag.sh delete-kafka-topic $RANDTOPIC2 '.dep_wrk' '22181'
 
 echo \[sndrcv_kafka.sh\]: stop kafka instance
 . $srcdir/diag.sh stop-kafka
 
 # STOP ZOOKEEPER in any case
 . $srcdir/diag.sh stop-zookeeper
+
+# Do the final sequence check
+seq_check 1 $TESTMESSAGES -d
+content_check_with_count "000" $TESTMESSAGESFULL
 
 echo success
 exit_test

--- a/tests/testsuites/kafka-server.dep_wrk1.properties
+++ b/tests/testsuites/kafka-server.dep_wrk1.properties
@@ -1,12 +1,12 @@
 broker.id=1
-listeners=PLAINTEXT://:29092
+listeners=plaintext://localhost:29092
 
 auto.create.topics.enable=true
 auto.leader.rebalance.enable=true
 background.threads=2
 compression.type=producer
 controlled.shutdown.enable=true
-default.replication.factor=3
+default.replication.factor=1
 
 delete.topic.enable=true
 dual.commit.enabled=false
@@ -14,52 +14,54 @@ dual.commit.enabled=false
 leader.imbalance.check.interval.seconds=10
 leader.imbalance.per.broker.percentage=10
 
-#10 MB is sufficient for testing
-log.segment.bytes=10485760
-log.cleaner.enable=true 
+#100 MB is sufficient for testing
+log.segment.bytes=104857600
+log.cleaner.enable=false
 log.cleanup.policy=delete
-log.retention.hours=1
 log.dirs=kafka-logs
-log.flush.interval.messages=1000
-log.flush.interval.ms=1000
-log.flush.scheduler.interval.ms=1000
+log.flush.interval.messages=10000
+log.flush.interval.ms=10000
+log.flush.scheduler.interval.ms=10000
 log.index.interval.bytes=4096
-log.index.size.max.bytes=10485760
+log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
+log.retention.bytes=104857600
 log.retention.hours=168 
 log.roll.hours=168
 message.max.bytes=1000000
 
 num.network.threads=2
 num.io.threads=2
-num.partitions=100
+num.partitions=2
 num.recovery.threads.per.data.dir=1
 num.replica.fetchers=1
-min.insync.replicas=2
+min.insync.replicas=1
 
 socket.receive.buffer.bytes=102400
-socket.request.max.bytes=104857600
+socket.request.max.bytes=10485760
 socket.send.buffer.bytes=102400
 
 offsets.storage=kafka
-offsets.topic.num.partitions=50
+offsets.topic.num.partitions=1
 offsets.topic.replication.factor=3
+transaction.state.log.num.partitions=1
 
-replica.fetch.max.bytes=1048576
+replica.fetch.max.bytes=10485760
 replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
 replica.socket.timeout.ms=5000
 
-unclean.leader.election.enable=false
-queued.max.requests=500
+# Allow unclean leader election!
+unclean.leader.election.enable=true
+queued.max.requests=10000
 
 zookeeper.connect=localhost:22181/kafka,localhost:22182/kafka,localhost:22183/kafka
 zookeeper.connection.timeout.ms=10000
 zookeeper.session.timeout.ms=5000
-zookeeper.sync.time.ms=2000
+zookeeper.sync.time.ms=5000
 
 group.id="default"
 

--- a/tests/testsuites/kafka-server.dep_wrk1.properties
+++ b/tests/testsuites/kafka-server.dep_wrk1.properties
@@ -27,7 +27,7 @@ log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
 log.retention.bytes=104857600
-log.retention.hours=168 
+log.retention.hours=5000
 log.roll.hours=168
 message.max.bytes=1000000
 

--- a/tests/testsuites/kafka-server.dep_wrk2.properties
+++ b/tests/testsuites/kafka-server.dep_wrk2.properties
@@ -27,7 +27,7 @@ log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
 log.retention.bytes=104857600
-log.retention.hours=168 
+log.retention.hours=5000
 log.roll.hours=168
 message.max.bytes=1000000
 

--- a/tests/testsuites/kafka-server.dep_wrk2.properties
+++ b/tests/testsuites/kafka-server.dep_wrk2.properties
@@ -1,12 +1,12 @@
 broker.id=2
-listeners=PLAINTEXT://:29093
+listeners=plaintext://localhost:29093
 
 auto.create.topics.enable=true
 auto.leader.rebalance.enable=true
 background.threads=2
 compression.type=producer
 controlled.shutdown.enable=true
-default.replication.factor=3
+default.replication.factor=1
 
 delete.topic.enable=true
 dual.commit.enabled=false
@@ -14,52 +14,54 @@ dual.commit.enabled=false
 leader.imbalance.check.interval.seconds=10
 leader.imbalance.per.broker.percentage=10
 
-#10 MB is sufficient for testing
-log.segment.bytes=10485760
-log.cleaner.enable=true 
+#100 MB is sufficient for testing
+log.segment.bytes=104857600
+log.cleaner.enable=false
 log.cleanup.policy=delete
-log.retention.hours=1
 log.dirs=kafka-logs
-log.flush.interval.messages=1000
-log.flush.interval.ms=1000
-log.flush.scheduler.interval.ms=1000
+log.flush.interval.messages=10000
+log.flush.interval.ms=10000
+log.flush.scheduler.interval.ms=10000
 log.index.interval.bytes=4096
-log.index.size.max.bytes=10485760
+log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
+log.retention.bytes=104857600
 log.retention.hours=168 
 log.roll.hours=168
 message.max.bytes=1000000
 
 num.network.threads=2
 num.io.threads=2
-num.partitions=100
+num.partitions=2
 num.recovery.threads.per.data.dir=1
 num.replica.fetchers=1
-min.insync.replicas=2
+min.insync.replicas=1
 
 socket.receive.buffer.bytes=102400
-socket.request.max.bytes=104857600
+socket.request.max.bytes=10485760
 socket.send.buffer.bytes=102400
 
 offsets.storage=kafka
 offsets.topic.num.partitions=1
 offsets.topic.replication.factor=3
+transaction.state.log.num.partitions=1
 
-replica.fetch.max.bytes=1048576
+replica.fetch.max.bytes=10485760
 replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
 replica.socket.timeout.ms=5000
 
-unclean.leader.election.enable=false
-queued.max.requests=500
+# Allow unclean leader election!
+unclean.leader.election.enable=true
+queued.max.requests=10000
 
 zookeeper.connect=localhost:22181/kafka,localhost:22182/kafka,localhost:22183/kafka
 zookeeper.connection.timeout.ms=10000
 zookeeper.session.timeout.ms=5000
-zookeeper.sync.time.ms=2000
+zookeeper.sync.time.ms=5000
 
 group.id="default"
 

--- a/tests/testsuites/kafka-server.dep_wrk3.properties
+++ b/tests/testsuites/kafka-server.dep_wrk3.properties
@@ -27,7 +27,7 @@ log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
 log.retention.bytes=104857600
-log.retention.hours=168 
+log.retention.hours=5000
 log.roll.hours=168
 message.max.bytes=1000000
 

--- a/tests/testsuites/kafka-server.dep_wrk3.properties
+++ b/tests/testsuites/kafka-server.dep_wrk3.properties
@@ -1,12 +1,12 @@
 broker.id=3
-listeners=PLAINTEXT://:29094
+listeners=plaintext://localhost:29094
 
 auto.create.topics.enable=true
 auto.leader.rebalance.enable=true
 background.threads=2
 compression.type=producer
 controlled.shutdown.enable=true
-default.replication.factor=3
+default.replication.factor=1
 
 delete.topic.enable=true
 dual.commit.enabled=false
@@ -14,52 +14,54 @@ dual.commit.enabled=false
 leader.imbalance.check.interval.seconds=10
 leader.imbalance.per.broker.percentage=10
 
-#10 MB is sufficient for testing
-log.segment.bytes=10485760
-log.cleaner.enable=true 
+#100 MB is sufficient for testing
+log.segment.bytes=104857600
+log.cleaner.enable=false
 log.cleanup.policy=delete
-log.retention.hours=1
 log.dirs=kafka-logs
-log.flush.interval.messages=1000
-log.flush.interval.ms=1000
-log.flush.scheduler.interval.ms=1000
+log.flush.interval.messages=10000
+log.flush.interval.ms=10000
+log.flush.scheduler.interval.ms=10000
 log.index.interval.bytes=4096
-log.index.size.max.bytes=10485760
+log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
+log.retention.bytes=104857600
 log.retention.hours=168 
 log.roll.hours=168
 message.max.bytes=1000000
 
 num.network.threads=2
 num.io.threads=2
-num.partitions=100
+num.partitions=2
 num.recovery.threads.per.data.dir=1
 num.replica.fetchers=1
-min.insync.replicas=2
+min.insync.replicas=1
 
 socket.receive.buffer.bytes=102400
-socket.request.max.bytes=104857600
+socket.request.max.bytes=10485760
 socket.send.buffer.bytes=102400
 
 offsets.storage=kafka
 offsets.topic.num.partitions=1
 offsets.topic.replication.factor=3
+transaction.state.log.num.partitions=1
 
-replica.fetch.max.bytes=1048576
+replica.fetch.max.bytes=10485760
 replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
 replica.socket.timeout.ms=5000
 
-unclean.leader.election.enable=false
-queued.max.requests=500
+# Allow unclean leader election!
+unclean.leader.election.enable=true
+queued.max.requests=10000
 
 zookeeper.connect=localhost:22181/kafka,localhost:22182/kafka,localhost:22183/kafka
 zookeeper.connection.timeout.ms=10000
 zookeeper.session.timeout.ms=5000
-zookeeper.sync.time.ms=2000
+zookeeper.sync.time.ms=5000
 
 group.id="default"
 

--- a/tests/testsuites/kafka-server.properties
+++ b/tests/testsuites/kafka-server.properties
@@ -1,5 +1,5 @@
 broker.id=0
-listeners=PLAINTEXT://:29092
+listeners=plaintext://localhost:29092
 
 auto.create.topics.enable=true
 auto.leader.rebalance.enable=true
@@ -9,52 +9,53 @@ controlled.shutdown.enable=true
 default.replication.factor=1
 
 delete.topic.enable=true
-dual.commit.enabled=true
+dual.commit.enabled=false
 
 leader.imbalance.check.interval.seconds=10
 leader.imbalance.per.broker.percentage=10
 
 #100 MB is sufficient for testing
-log.segment.bytes=536870912
+log.segment.bytes=104857600
 log.cleaner.enable=false
 log.cleanup.policy=delete
-log.retention.hours=1
 log.dirs=kafka-logs
-log.flush.interval.messages=1000
-log.flush.interval.ms=1000
-log.flush.scheduler.interval.ms=1000
+log.flush.interval.messages=10000
+log.flush.interval.ms=10000
+log.flush.scheduler.interval.ms=10000
 log.index.interval.bytes=4096
-log.index.size.max.bytes=10485760
+log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
+log.retention.bytes=104857600
 log.retention.hours=168 
 log.roll.hours=168
 message.max.bytes=1000000
 
 num.network.threads=2
 num.io.threads=2
-num.partitions=1
+num.partitions=2
 num.recovery.threads.per.data.dir=1
 num.replica.fetchers=1
 min.insync.replicas=1
 
 socket.receive.buffer.bytes=102400
-socket.request.max.bytes=104857600
+socket.request.max.bytes=10485760
 socket.send.buffer.bytes=102400
 
 offsets.storage=kafka
-offsets.topic.num.partitions=1
-#offsets.topic.replication.factor=3
-transaction.state.log.num.partitions=1
+offsets.topic.num.partitions=2
+offsets.topic.replication.factor=1
+transaction.state.log.num.partitions=2
 
-replica.fetch.max.bytes=1048576
+replica.fetch.max.bytes=10485760
 replica.fetch.wait.max.ms=500
 replica.high.watermark.checkpoint.interval.ms=5000
 replica.lag.time.max.ms=10000
 replica.socket.receive.buffer.bytes=65536
 replica.socket.timeout.ms=5000
 
-unclean.leader.election.enable=false
+# Allow unclean leader election!
+unclean.leader.election.enable=true
 queued.max.requests=10000
 
 zookeeper.connect=localhost:22181/kafka

--- a/tests/testsuites/kafka-server.properties
+++ b/tests/testsuites/kafka-server.properties
@@ -27,7 +27,7 @@ log.index.size.max.bytes=104857600
 log.message.timestamp.type=CreateTime
 log.retention.check.interval.ms=300000
 log.retention.bytes=104857600
-log.retention.hours=168 
+log.retention.hours=5000
 log.roll.hours=168
 message.max.bytes=1000000
 

--- a/tests/testsuites/zoo.dep_wrk1.cfg
+++ b/tests/testsuites/zoo.dep_wrk1.cfg
@@ -1,20 +1,5 @@
-#---  Do we need this for the test? 
-#server.1=localhost:2889:3888
-#server.2=localhost:3889:4888
-#server.3=localhost:4889:5888
-#--- 
-
-# The number of milliseconds of each tick
-tickTime=2000
-# The number of ticks that the initial
-# synchronization phase can take
-initLimit=10
-# The number of ticks that can pass between
-# sending a request and getting an acknowledgement
-syncLimit=5
-# the directory where the snapshot is stored.
-# do not use /tmp for storage, /tmp here is just
-# example sakes.
+tickTime=1000
+initLimit=5
+syncLimit=2
 dataDir=zk_data_dir
-# the port at which the clients will connect
 clientPort=22181

--- a/tests/testsuites/zoo.dep_wrk2.cfg
+++ b/tests/testsuites/zoo.dep_wrk2.cfg
@@ -1,20 +1,5 @@
-#---  Do we need this for the test? 
-#server.1=localhost:2889:3888
-#server.2=localhost:3889:4888
-#server.3=localhost:4889:5888
-#--- 
-
-# The number of milliseconds of each tick
-tickTime=2000
-# The number of ticks that the initial
-# synchronization phase can take
-initLimit=10
-# The number of ticks that can pass between
-# sending a request and getting an acknowledgement
-syncLimit=5
-# the directory where the snapshot is stored.
-# do not use /tmp for storage, /tmp here is just
-# example sakes.
+tickTime=1000
+initLimit=5
+syncLimit=2
 dataDir=zk_data_dir
-# the port at which the clients will connect
 clientPort=22182

--- a/tests/testsuites/zoo.dep_wrk3.cfg
+++ b/tests/testsuites/zoo.dep_wrk3.cfg
@@ -1,20 +1,5 @@
-#---  Do we need this for the test? 
-#server.1=localhost:2889:3888
-#server.2=localhost:3889:4888
-#server.3=localhost:4889:5888
-#--- 
-
-# The number of milliseconds of each tick
-tickTime=2000
-# The number of ticks that the initial
-# synchronization phase can take
-initLimit=10
-# The number of ticks that can pass between
-# sending a request and getting an acknowledgement
-syncLimit=5
-# the directory where the snapshot is stored.
-# do not use /tmp for storage, /tmp here is just
-# example sakes.
+tickTime=1000
+initLimit=5
+syncLimit=2
 dataDir=zk_data_dir
-# the port at which the clients will connect
 clientPort=22183

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -52,7 +52,8 @@ fi
 
 # As travis has no xenial images, we always need to install librdkafka from source
 if [ "x$KAFKA" == "xYES" ]; then 
-	sudo apt-get install -qq liblz4-dev
+	sudo apt-get install -qq liblz4-dev 
+	# For kafka testbench, "kafkacat" package is needed!
 	git clone https://github.com/edenhill/librdkafka > /dev/null
 	(unset CFLAGS; cd librdkafka ; ./configure --prefix=/usr --CFLAGS="-g" > /dev/null ; make -j2  > /dev/null ; sudo make install > /dev/null)
 	rm -rf librdkafka # get rid of source, e.g. for line length check


### PR DESCRIPTION
Omkafka: 
- Fixed minor issue in omkafka producing wrong kafka timestamps when msgTimestamp was NULL. 
- Setting RD_KAFKA_V_KEY(NULL, 0) in rd_kafka_producev now when KEY is not configured. 
- Fixed minor issue when rsyslog is compiled with --enable-debug and librdkafka is to old. 

Testbench: 
- Using latest kafka server version again.
- Fixed server configuration issues holding the kafka tests back from working. 
- Fixed some config issues in all sndrcv kafka tests. 
- Generating dynamically kafka topics now for each kafka test.
- Testmessages back to 100000 working stable now with log.retention.hours=5000.
- Renabled kafka_multi test which runs a test on 3 kafka/zookeeper instances.

