### PR TITLE
WiP: Fix errant error message when dynafile param needed

### DIFF
--- a/contrib/omfile-hardened/omfile-hardened.c
+++ b/contrib/omfile-hardened/omfile-hardened.c
@@ -1398,7 +1398,7 @@ CODESTARTnewActInst
 
 	if(pData->fname == NULL) {
 		parser_errmsg("omfile: either the \"file\" or "
-				"\"dynfile\" parameter must be given");
+				"\"dynafile\" parameter must be given");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
 

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -1323,7 +1323,7 @@ CODESTARTnewActInst
 
 	if(pData->fname == NULL || *pData->fname == '\0') {
 		parser_errmsg("omfile: either the \"file\" or "
-				"\"dynfile\" parameter must be given");
+				"\"dynafile\" parameter must be given");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
 
@@ -1335,7 +1335,7 @@ CODESTARTnewActInst
 		}
 	}
 	if(allWhiteSpace) {
-		parser_errmsg("omfile: \"file\" or \"dynfile\" parameter "
+		parser_errmsg("omfile: \"file\" or \"dynafile\" parameter "
 			"consist only of whitespace - this is not permitted");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1140,7 +1140,7 @@ CODESTARTnewActInst
 	pvals = nvlstGetParams(lst, &actpblk, NULL);
 	if(pvals == NULL) {
 		LogError(0, RS_RET_MISSING_CNFPARAMS, "omfwd: either the \"file\" or "
-				"\"dynfile\" parameter must be given");
+				"\"dynafile\" parameter must be given");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
 


### PR DESCRIPTION
Per issue [2975](https://github.com/rsyslog/rsyslog/issues/2975)

Compiled successfully under Ubuntu 16.04, but that's about it.

Dirt simple changes. Not much to see here.

I can't even say with 100% certainty I got everything, as I'm not that familiar with rsyslog... but I did do a search and these were the ones I found. Clearly there are other instances of *dynfile* that aren't malicious. I tried to err on the side of changing as little as possible.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
