### PR TITLE
omprog: add feedback timeout and keep-alive feature

### DIFF
--- a/plugins/external/INTERFACE.md
+++ b/plugins/external/INTERFACE.md
@@ -46,9 +46,9 @@ If the plugin writes a line to stdout containing anything else (for example,
 the string `Error: could not connect to the database` followed by a LF), rsyslog
 will consider that the plugin has not been able to process the message. The
 message will be retried later, according to the retry settings configured for
-the `omprog` action (e.g. the `action.resumeInterval` setting). When debugging
-is enabled in rsyslog, the line returned by the plugin will be included in the
-debug logs.
+the `omprog` action (in particular, the `action.resumeInterval` setting). If the
+`reportFailures` flag is set to `on`, rsyslog will also log the returned error
+line.
 
 If the plugin terminates, the message is also considered as non-processed.
 The plugin will later be restarted, and the message retried, according to the
@@ -57,7 +57,10 @@ configured retry settings.
 When starting the plugin, if `confirmMessages` is `on`, rsyslog will also wait
 for the plugin to confirm its initialization. The plugin must write an `OK` line
 to stdout just after starting. If it writes anything else or terminates, rsyslog
-will consider the plugin initialization has failed, and will try to restart it later.
+will consider the plugin initialization has failed, and will try to restart it
+later. It is recommended to ensure that the program is really ready to start
+receiving messages before emitting this first confirmation (for example, by
+checking that a destination database is accessible).
 
 Example of exchanged messages
 -----------------------------
@@ -79,6 +82,53 @@ terminated by a LF (\n).
 Note that the first `OK` does not confirm any message, but that the plugin has
 correctly started and is ready to receive messages. When the plugin receives
 an end-of-file (EOF), it must silently terminate.
+
+Confirmation timeout
+--------------------
+The plugin must confirm each message before a timeout of 10 seconds. A different
+timeout can be configured using the `confirmTimeout` setting. If the plugin does
+not return anything to rsyslog before this timeout, rsyslog will restart the
+program, and retry the message.
+
+It is important that the `confirmTimeout` be adjusted to an appropriate value for
+your plugin, since a too low timeout can cause duplicate processing of messages
+(if rsyslog decides that the plugin has gone unresponsive when it really hasn't).
+In case of doubt, consider either a) setting a rather high timeout (but note that
+this can go against the _fail fast_ pattern), b) enabling the `signalOnClose`
+and/or `killUnresponsive` flags in the configuration, to ensure that the plugin
+will stop its processing if rsyslog decides to restart it, or c) using keep-alive
+feedback as explained below.
+
+Keep-alive feedback
+-------------------
+The plugin can also provide _keep-alive feedback_ to rsyslog. This allows the
+plugin to exceed the `confirmTimeout` for certain messages requiring a long-
+running processing (for example, attempting to reconnect to a database after a
+temporary loss of connection), without having to increase too much the configured
+timeout in anticipation of those peak latencies.
+
+To provide keep-alive feedback, the plugin must periodically write a dot (`.`)
+to stdout, without ending the line. Each dot must be written before the timeout
+is reached (rsyslog will restart the timeout after receiving each dot). Once the
+plugin completes the processing of the message, it must write the `OK` word (or
+an error message) as usual, followed by a line feed. rsyslog will ignore all
+leading dots when processing the received line.
+
+The following sequence illustrates the use of the keep-alive feedback:
+
+    <= OK
+    => log message 1
+    <= OK
+    => log message 2
+    <= .......OK
+    => log message 3
+    <= ..OK
+    => log message 4
+    <= ...OK
+
+The plugin can also provide keep-alive feedback during its initialization, before
+emitting the first `OK`. This can be useful to give enough time to the plugin to
+complete its initialization checks.
 
 Writing to stderr
 -----------------

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -575,6 +575,8 @@ TESTS +=  \
 	omprog-output-capture.sh \
 	omprog-output-capture-mt.sh \
 	omprog-feedback.sh \
+	omprog-feedback-mt.sh \
+	omprog-feedback-timeout.sh \
 	omprog-close-unresponsive.sh \
 	omprog-close-unresponsive-noterm.sh \
 	omprog-restart-terminated.sh \
@@ -1439,7 +1441,9 @@ EXTRA_DIST= \
 	omprog-output-capture-mt.sh \
 	omprog-output-capture-vg.sh \
 	omprog-feedback.sh \
+	omprog-feedback-mt.sh \
 	omprog-feedback-vg.sh \
+	omprog-feedback-timeout.sh \
 	omprog-close-unresponsive.sh \
 	omprog-close-unresponsive-vg.sh \
 	omprog-close-unresponsive-noterm.sh \
@@ -1454,6 +1458,8 @@ EXTRA_DIST= \
 	testsuites/omprog-output-capture-bin.sh \
 	testsuites/omprog-output-capture-mt-bin.py \
 	testsuites/omprog-feedback-bin.sh \
+	testsuites/omprog-feedback-mt-bin.sh \
+	testsuites/omprog-feedback-timeout-bin.sh \
 	testsuites/omprog-close-unresponsive-bin.sh \
 	testsuites/omprog-restart-terminated-bin.sh \
 	testsuites/omprog-transactions-bin.sh \

--- a/tests/omprog-feedback-mt.sh
+++ b/tests/omprog-feedback-mt.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+# Similar to the 'omprog-feedback.sh' test, with multiple worker threads
+# on high load, and a given error rate (percentage of failed messages, i.e.
+# confirmed as failed by the program). Note: the action retry interval
+# (1 second) causes a very low throughput; we need to set a very low error
+# rate to avoid the test lasting too much.
+
+NUMBER_OF_MESSAGES=10000  # number of logs to send
+ERROR_RATE_PERCENT=1      # percentage of logs to be retried
+
+export command_line=`echo $srcdir/testsuites/omprog-feedback-mt-bin.sh $ERROR_RATE_PERCENT`
+
+. $srcdir/diag.sh init
+
+uname
+if [ `uname` = "SunOS" ] ; then
+    # On Solaris, this test causes rsyslog to hang. This is presumably due
+    # to issue #2356 in the rsyslog core, which doesn't seem completely
+    # corrected. TODO: re-enable this test when the issue is corrected.
+    echo "Solaris: FIX ME"
+    exit 77
+fi
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/omprog/.libs/omprog")
+
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+main_queue(
+    queue.timeoutShutdown="30000"  # long shutdown timeout for the main queue
+)
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+        binary=`echo $command_line`
+        template="outfmt"
+        name="omprog_action"
+        confirmMessages="on"
+        queue.type="LinkedList"  # use a dedicated queue
+        queue.workerThreads="10"  # ...with multiple workers
+        queue.size="10000"  # ...high capacity (default is 1000)
+        queue.timeoutShutdown="30000"  # ...and a long shutdown timeout
+        action.resumeInterval="1"  # retry interval: 1 second
+    )
+}
+'
+startup
+tcpflood -m$NUMBER_OF_MESSAGES
+shutdown_when_empty
+wait_shutdown
+
+# Note: we use awk here to remove leading spaces returned by wc on FreeBSD
+line_count=$(wc -l < ${RSYSLOG_OUT_LOG} | awk '{print $1}')
+if [[ $line_count != $NUMBER_OF_MESSAGES ]]; then
+    echo "unexpected line count in omprog script output: $line_count (expected: $NUMBER_OF_MESSAGES)"
+    error_exit 1
+fi
+
+exit_test

--- a/tests/omprog-feedback-timeout.sh
+++ b/tests/omprog-feedback-timeout.sh
@@ -2,8 +2,9 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 
 # This test tests the feedback feature of omprog (confirmMessages=on),
-# by checking that omprog re-sends to the external program the messages
-# it has failed to process.
+# by checking that omprog restarts the program if it does not send the
+# feedback before the configured 'confirmTimeout'. Also tests the
+# keep-alive feature.
 
 . $srcdir/diag.sh init
 generate_conf
@@ -15,15 +16,13 @@ template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" {
     action(
         type="omprog"
-        binary=`echo $srcdir/testsuites/omprog-feedback-bin.sh`
+        binary=`echo $srcdir/testsuites/omprog-feedback-timeout-bin.sh`
         template="outfmt"
         name="omprog_action"
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"
+        confirmTimeout="2000"  # 2 seconds
         reportFailures="on"
-        action.resumeInterval="1"  # retry interval: 1 second
-#       action.resumeRetryCount="0" # the default; no need to increase since
-                                    # the action resumes immediately
     )
 }
 '
@@ -32,7 +31,8 @@ injectmsg 0 10
 shutdown_when_empty
 wait_shutdown
 
-EXPECTED="<= OK
+EXPECTED="Starting
+<= OK
 => msgnum:00000000:
 <= OK
 => msgnum:00000001:
@@ -42,9 +42,9 @@ EXPECTED="<= OK
 => msgnum:00000003:
 <= OK
 => msgnum:00000004:
-<= Error: could not process log message
-=> msgnum:00000004:
-<= Error: could not process log message
+<= (timeout)
+Starting
+<= OK
 => msgnum:00000004:
 <= OK
 => msgnum:00000005:
@@ -52,11 +52,7 @@ EXPECTED="<= OK
 => msgnum:00000006:
 <= OK
 => msgnum:00000007:
-<= Error: could not process log message
-=> msgnum:00000007:
-<= Error: could not process log message
-=> msgnum:00000007:
-<= OK
+<= ........OK
 => msgnum:00000008:
 <= OK
 => msgnum:00000009:

--- a/tests/omprog-feedback-vg.sh
+++ b/tests/omprog-feedback-vg.sh
@@ -20,7 +20,6 @@ template(name="outfmt" type="string" string="%msg%\n")
         name="omprog_action"
         queue.type="Direct"
         confirmMessages="on"
-        useTransactions="off"
         action.resumeInterval="1"
     )
 }

--- a/tests/testsuites/omprog-feedback-bin.sh
+++ b/tests/testsuites/omprog-feedback-bin.sh
@@ -4,7 +4,7 @@ outfile=$RSYSLOG_OUT_LOG
 
 status="OK"
 echo "<= $status" >> $outfile
-echo $status
+echo "$status"
 
 retry_count=0
 
@@ -26,7 +26,7 @@ while [[ -n "$line" ]]; do
     fi
 
     echo "<= $status" >> $outfile
-    echo $status
+    echo "$status"
     read line
 done
 

--- a/tests/testsuites/omprog-feedback-mt-bin.sh
+++ b/tests/testsuites/omprog-feedback-mt-bin.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+outfile=$RSYSLOG_OUT_LOG
+
+status="OK"
+echo $status
+
+retried=false
+
+read line
+while [[ -n "$line" ]]; do
+    message=${line//$'\n'}
+
+    if [[ $((RANDOM % 100)) < $1 ]]; then
+        status="Error: could not process log message"
+        retried=true
+    else
+        if [[ $retried == true ]]; then
+            echo "=> $message (retried)" >> $outfile
+            retried=false
+        else
+            echo "=> $message" >> $outfile
+        fi
+        status="OK"
+    fi
+
+    echo $status
+    read line
+done
+
+exit 0

--- a/tests/testsuites/omprog-feedback-timeout-bin.sh
+++ b/tests/testsuites/omprog-feedback-timeout-bin.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+outfile=$RSYSLOG_OUT_LOG
+
+echo "Starting" >> $outfile
+echo "<= OK" >> $outfile
+echo "OK"
+
+just_started=true
+
+read line
+while [[ -n "$line" ]]; do
+    message=${line//$'\n'}
+    echo "=> $message" >> $outfile
+
+    if [[ $message == *02* ]]; then
+        # Test partial reads from pipe
+        echo "<= OK" >> $outfile
+        printf 'O'
+        printf 'K'
+        printf '\n'
+    elif [[ $message == *04* ]]; then
+        if [[ $just_started == false ]]; then
+            # Force a restart due to 'confirmTimeout' (2 seconds) exceeded
+            echo "<= (timeout)" >> $outfile
+            ./msleep 10000
+        else
+            # When the message is retried (just after restart), confirm it correctly
+            echo "<= OK" >> $outfile
+            echo "OK"
+        fi
+    elif [[ $message == *07* ]]; then
+        # Test keep-alive feature for long-running processing (more than 2 seconds)
+        echo "<= ........OK" >> $outfile
+        for i in {1..8}; do
+            ./msleep 500
+            printf '.'
+        done
+        printf 'OK\n'
+    else
+        echo "<= OK" >> $outfile
+        echo "OK"
+    fi
+
+    just_started=false
+    read line
+done
+
+exit 0


### PR DESCRIPTION
Restart the program if it does not respond within timeout.
New setting 'confirmTimeout' (default 10 seconds).

Allow the program to provide keep-alive feedback when a
message requires long-running processing.

Improve efficiency when reading feedback line (use buffer).

Retry interrupted writes/reads to/from pipe.

New setting 'reportFailures' for reporting error messages
from the program.

Report child termination when writing to pipe.

Minor refactor: renamed writePipe function to sendMessage,
renamed readPipe to readStatus.