### PR TITLE
testbench: use a reliable dynamic imdiag port

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -536,7 +536,7 @@ static rsRetVal addTCPListener(void __attribute__((unused)) *pVal, uchar *pNewVa
 	CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, pszInputName == NULL ?
 						UCHAR_CONSTANT("imdiag") : pszInputName));
 	CHKiRet(tcpsrv.SetOrigin(pOurTcpsrv, (uchar*)"imdiag"));
-	/* we support octect-cuunted frame (constant 1 below) */
+	/* we support octect-counted frame (constant 1 below) */
 	tcpsrv.configureTCPListen(pOurTcpsrv, pNewVal, 1, NULL);
 
 finalize_it:
@@ -700,7 +700,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 				   NULL, &iTCPSessMax, STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiagserverstreamdrivermode"), 0,
 				   eCmdHdlrInt, NULL, &iStrmDrvrMode, STD_LOADABLE_MODULE_ID));
-	CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("listenportfilename"), 0,
+	CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiaglistenportfilename"), 0,
 				   eCmdHdlrGetWord, NULL, &pszLstnPortFileName, STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiagserverstreamdriverauthmode"), 0,
 				   eCmdHdlrGetWord, NULL, &pszStrmDrvrAuthMode, STD_LOADABLE_MODULE_ID));

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -424,6 +424,7 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 	int sock = -1;
 	int numSocks;
 	int sockflags;
+	int port_override = 0; /* if dyn port (0): use this for actually bound port */
 	struct addrinfo hints, *res = NULL, *r;
 
 	ISOBJ_TYPE_assert(pNS, netstrms);
@@ -451,6 +452,13 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 
 	numSocks = 0;   /* num of sockets counter at start of array */
 	for(r = res; r != NULL ; r = r->ai_next) {
+		if(port_override != 0) {
+			if(r->ai_family == AF_INET6) {
+				((struct sockaddr_in6*)r->ai_addr)->sin6_port = port_override;
+			} else {
+				((struct sockaddr_in*)r->ai_addr)->sin_port = port_override;
+			}
+		}
 		sock = socket(r->ai_family, r->ai_socktype, r->ai_protocol);
 		if(sock < 0) {
 			if(!(r->ai_family == PF_INET6 && errno == EAFNOSUPPORT)) {
@@ -462,18 +470,18 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 			continue;
 		}
 
-#ifdef IPV6_V6ONLY
-		if(r->ai_family == AF_INET6) {
-			isIPv6 = 1;
-			int iOn = 1;
-			if(setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
-			      (char *)&iOn, sizeof (iOn)) < 0) {
-				close(sock);
-				sock = -1;
-				continue;
+		#ifdef IPV6_V6ONLY
+			if(r->ai_family == AF_INET6) {
+				isIPv6 = 1;
+				int iOn = 1;
+				if(setsockopt(sock, IPPROTO_IPV6, IPV6_V6ONLY,
+				      (char *)&iOn, sizeof (iOn)) < 0) {
+					close(sock);
+					sock = -1;
+					continue;
+				}
 			}
-		}
-#endif
+		#endif
 		if(setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, (char *) &on, sizeof(on)) < 0 ) {
 			dbgprintf("error %d setting tcp socket option\n", errno);
 			close(sock);
@@ -496,31 +504,25 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 			continue;
 		}
 
-
 		/* We need to enable BSD compatibility. Otherwise an attacker
 		 * could flood our log files by sending us tons of ICMP errors.
 		 */
-/* AIXPORT : SO_BSDCOMPAT socket option is depricated , and its usage has been discontinued
- * on most unixes, AIX does not support this option , hence remove the call.
- */
-#if !defined(_AIX)
-#ifndef BSD
-		if(net.should_use_so_bsdcompat()) {
-			if (setsockopt(sock, SOL_SOCKET, SO_BSDCOMPAT,
-					(char *) &on, sizeof(on)) < 0) {
-				LogError(errno, NO_ERRCODE, "TCP setsockopt(BSDCOMPAT)");
-				close(sock);
-				sock = -1;
-				continue;
+		#if !defined(_AIX) && !defined(BSD)
+			if(net.should_use_so_bsdcompat()) {
+				if (setsockopt(sock, SOL_SOCKET, SO_BSDCOMPAT,
+						(char *) &on, sizeof(on)) < 0) {
+					LogError(errno, NO_ERRCODE, "TCP setsockopt(BSDCOMPAT)");
+					close(sock);
+					sock = -1;
+					continue;
+				}
 			}
-		}
-#endif
-#endif
+		#endif
 
 	        if( (bind(sock, r->ai_addr, r->ai_addrlen) < 0)
-#ifndef IPV6_V6ONLY
-		     && (errno != EADDRINUSE)
-#endif
+			#ifndef IPV6_V6ONLY
+			&& (errno != EADDRINUSE)
+			#endif
 	           ) {
 			/* TODO: check if *we* bound the socket - else we *have* an error! */
 			char errStr[1024];
@@ -532,26 +534,40 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 			continue;
 		}
 
-		if(pszLstnPortFileName != NULL) {
-			FILE *fp;
+		/* if we bind to dynamic port (port 0 given), we will do so consistently. Thus
+		 * once we got a dynamic port, we will keep it and use it for other protocols
+		 * as well. As of my understanding, this should always work as the OS does not
+		 * pick a port that is used by some protocol (well, at least this looks very
+		 * unlikely...). If our asusmption is wrong, we should iterate until we find a
+		 * combination that works - it is very unusual to have the same service listen
+		 * on differnt ports on IPv4 and IPv6.
+		 */
+		const int currport = (isIPv6) ?
+			(((struct sockaddr_in6*)r->ai_addr)->sin6_port) :
+			(((struct sockaddr_in*)r->ai_addr)->sin_port) ;
+		if(currport == 0) {
 			if(getsockname(sock, r->ai_addr, &r->ai_addrlen) == -1) {
 				LogError(errno, NO_ERRCODE, "nsd_ptcp: ListenPortFileName: getsockname:"
 						"error while trying to get socket");
 			}
-			if((fp = fopen((const char*)pszLstnPortFileName, "w+")) == NULL) {
-				LogError(errno, RS_RET_IO_ERROR, "nsd_ptcp: ListenPortFileName: "
-						"error while trying to open file");
-				ABORT_FINALIZE(RS_RET_IO_ERROR);
+			port_override = (isIPv6) ?
+				(((struct sockaddr_in6*)r->ai_addr)->sin6_port) :
+				(((struct sockaddr_in*)r->ai_addr)->sin_port) ;
+			if(pszLstnPortFileName != NULL) {
+				FILE *fp;
+				if((fp = fopen((const char*)pszLstnPortFileName, "w+")) == NULL) {
+					LogError(errno, RS_RET_IO_ERROR, "nsd_ptcp: ListenPortFileName: "
+							"error while trying to open file");
+					ABORT_FINALIZE(RS_RET_IO_ERROR);
+				}
+				if(isIPv6) {
+					fprintf(fp, "%d", ntohs((((struct sockaddr_in6*)r->ai_addr)->sin6_port)));
+				} else {
+					fprintf(fp, "%d", ntohs((((struct sockaddr_in*)r->ai_addr)->sin_port)));
+				}
+				fclose(fp);
 			}
-			if(isIPv6) {
-				fprintf(fp, "%d", ntohs((((struct sockaddr_in6*)r->ai_addr)->sin6_port)));
-			} else {
-				fprintf(fp, "%d", ntohs((((struct sockaddr_in*)r->ai_addr)->sin_port)));
-			}
-			fclose(fp);
 		}
-
-
 
 		if(listen(sock, iSessMax / 10 + 5) < 0) {
 			/* If the listen fails, it most probably fails because we ask

--- a/tests/array_lookup_table-vg.sh
+++ b/tests/array_lookup_table-vg.sh
@@ -46,7 +46,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check "msgnum:00000000: quux"
 content_check "msgnum:00000001: quux"
 content_check "msgnum:00000002: foo_latest"

--- a/tests/array_lookup_table_misuse-vg.sh
+++ b/tests/array_lookup_table_misuse-vg.sh
@@ -46,7 +46,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check "msgnum:00000000: foo_new"
 content_check "msgnum:00000001: bar_new"
 content_check "msgnum:00000002: baz"

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -112,26 +112,21 @@ local0.* ./'${RSYSLOG_DYNNAME}'.HOSTNAME;hostname
 # $1 is the instance id, if given
 function generate_conf() {
 	export TCPFLOOD_PORT="$(get_free_port)"
-	new_port="$(get_free_port)"
 	if [ "$1" == "" ]; then
-		export IMDIAG_PORT=$new_port
 		export TESTCONF_NM="${RSYSLOG_DYNNAME}_" # this basename is also used by instance 2!
 		export RSYSLOG_OUT_LOG="${RSYSLOG_DYNNAME}.out.log"
 		export RSYSLOG2_OUT_LOG="${RSYSLOG_DYNNAME}_2.out.log"
 		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!
 		mkdir $RSYSLOG_DYNNAME.spool
-	else
-		export IMDIAG_PORT2=$new_port
 	fi
-	echo imdiag running on port $new_port
-	echo "module(load=\"../plugins/imdiag/.libs/imdiag\")
-global(inputs.timeout.shutdown=\"10000\")
-\$IMDiagServerRun $new_port
+	echo 'module(load="../plugins/imdiag/.libs/imdiag")
+global(inputs.timeout.shutdown="10000")
+$IMDiagListenPortFileName '$RSYSLOG_DYNNAME.imdiag$1.port'
+$IMDiagServerRun 0
 
-:syslogtag, contains, \"rsyslogd\"  ./${RSYSLOG_DYNNAME}$1.started
-###### end of testbench instrumentation part, test conf follows:" > ${TESTCONF_NM}$1.conf
+:syslogtag, contains, "rsyslogd"  ./'${RSYSLOG_DYNNAME}$1'.started
+###### end of testbench instrumentation part, test conf follows:' > ${TESTCONF_NM}$1.conf
 }
-
 
 # add more data to config file. Note: generate_conf must have been called
 # $1 is config fragment, $2 the instance id, if given
@@ -209,6 +204,13 @@ function wait_startup_pid() {
 	echo "$1.pid found, pid  `cat $1.pid`"
 }
 
+# special version of wait_startup_pid() for rsyslog startup
+function wait_rsyslog_startup_pid() {
+	wait_startup_pid $RSYSLOG_PIDBASE$1
+	eval export IMDIAG_PORT$1=$(cat $RSYSLOG_DYNNAME.imdiag$1.port)
+	eval PORT=$IMDIAG_PORT$1
+	echo "imdiag$1 port: $PORT"
+}
 
 # wait for startup of an arbitrary process
 # $1 - pid file name
@@ -238,7 +240,7 @@ function wait_process_startup() {
 
 # wait for rsyslogd startup ($1 is the instance)
 function wait_startup() {
-	wait_startup_pid $RSYSLOG_PIDBASE$2
+	wait_rsyslog_startup_pid $1
 	i=0
 	while test ! -f ${RSYSLOG_DYNNAME}$1.started; do
 		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
@@ -286,7 +288,7 @@ function startup_vg_waitpid_only() {
 	    exit 1
 	fi
 	LD_PRELOAD=$RSYSLOG_PRELOAD valgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/known_issues.supp --gen-suppressions=all --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=$RS_TESTBENCH_LEAK_CHECK ../tools/rsyslogd -C -n -i$RSYSLOG_PIDBASE$2.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
-	wait_startup_pid $RSYSLOG_PIDBASE$2
+	wait_rsyslog_startup_pid $1
 }
 
 # start rsyslogd with default params under valgrind control. $1 is the config file name to use
@@ -311,7 +313,7 @@ function startup_vg_noleak() {
 function startup_vgthread_waitpid_only() {
 	startup_common "$1" "$2"
 	valgrind --tool=helgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 --suppressions=$srcdir/linux_localtime_r.supp --gen-suppressions=all ../tools/rsyslogd -C -n -i$RSYSLOG_PIDBASE$2.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
-	wait_startup_pid $RSYSLOG_PIDBASE$2
+	wait_rsyslog_startup_pid $2
 }
 
 # start rsyslogd with default params under valgrind thread debugger control.

--- a/tests/diagtalker.c
+++ b/tests/diagtalker.c
@@ -1,7 +1,7 @@
 /* A yet very simple tool to talk to imdiag (this replaces the
  * previous Java implementation in order to get fewer dependencies).
  *
- * Copyright 2010,2011 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2010-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -64,16 +64,16 @@ int openConn(int *fd)
 		} else {
 			if(retries++ == 50) {
 				perror("connect()");
-				fprintf(stderr, "connect() failed\n");
+				fprintf(stderr, "[%d] connect() failed\n", port);
 				exit(1);
 			} else {
-				fprintf(stderr, "connect failed, retrying...\n");
+				fprintf(stderr, "[%d] connect failed, retrying...\n", port);
 				usleep(100000); /* ms = 1000 us! */
 			}
 		}
 	}
 	if(retries > 0) {
-		fprintf(stderr, "connection established.\n");
+		fprintf(stderr, "[%d] connection established.\n", port);
 	}
 
 	*fd = sock;

--- a/tests/discard-allmark-vg.sh
+++ b/tests/discard-allmark-vg.sh
@@ -30,6 +30,6 @@ tcpflood -m10 -i1
 ./msleep 1500
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 2 10
 exit_test

--- a/tests/discard-rptdmsg-vg.sh
+++ b/tests/discard-rptdmsg-vg.sh
@@ -30,6 +30,6 @@ tcpflood -m10 -i1
 ./msleep 1500
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 2 10
 exit_test

--- a/tests/dynstats-json-vg.sh
+++ b/tests/dynstats-json-vg.sh
@@ -41,7 +41,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 custom_content_check '{ "name": "global", "origin": "dynstats", "values": { "stats_one.ops_overflow": 0, "stats_one.new_metric_add": 1, "stats_one.no_metric": 0, "stats_one.metrics_purged": 0, "stats_one.ops_ignored": 0, "stats_one.purge_triggered": 0, "stats_two.ops_overflow": 0, "stats_two.new_metric_add": 1, "stats_two.no_metric": 0, "stats_two.metrics_purged": 0, "stats_two.ops_ignored": 0, "stats_two.purge_triggered": 0 } }' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_content_check '{ "name": "stats_one", "origin": "dynstats.bucket", "values": { "foo": 1 } }' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_content_check '{ "name": "stats_two", "origin": "dynstats.bucket", "values": { "foo": 1 } }' "${RSYSLOG_DYNNAME}.out.stats.log"

--- a/tests/dynstats-vg.sh
+++ b/tests/dynstats-vg.sh
@@ -44,7 +44,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 custom_content_check 'bar=1' "${RSYSLOG_DYNNAME}.out.stats.log"
 . $srcdir/diag.sh first-column-sum-check 's/.*foo=\([0-9]\+\)/\1/g' 'foo=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
 . $srcdir/diag.sh first-column-sum-check 's/.*bar=\([0-9]\+\)/\1/g' 'bar=' "${RSYSLOG_DYNNAME}.out.stats.log" 1

--- a/tests/dynstats_overflow-vg.sh
+++ b/tests/dynstats_overflow-vg.sh
@@ -101,7 +101,7 @@ content_check "corge 018 0"
 
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 . $srcdir/diag.sh first-column-sum-check 's/.*metrics_purged=\([0-9]\+\)/\1/g' 'metrics_purged=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
 

--- a/tests/dynstats_prevent_premature_eviction-vg.sh
+++ b/tests/dynstats_prevent_premature_eviction-vg.sh
@@ -50,7 +50,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
  # because dyn-accumulators for existing metrics were posted-to under a second, they should not have been evicted
 custom_content_check 'baz=2' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_content_check 'bar=1' "${RSYSLOG_DYNNAME}.out.stats.log"

--- a/tests/dynstats_reset-vg.sh
+++ b/tests/dynstats_reset-vg.sh
@@ -52,7 +52,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
  # because dyn-metrics would be reset before it can accumulate and report high counts, sleep between msg-injection ensures that
 . $srcdir/diag.sh custom-assert-content-missing 'baz=2' "${RSYSLOG_DYNNAME}.out.stats.log"
 . $srcdir/diag.sh custom-assert-content-missing 'foo=2' "${RSYSLOG_DYNNAME}.out.stats.log"

--- a/tests/es-basic-vg.sh
+++ b/tests/es-basic-vg.sh
@@ -27,7 +27,7 @@ startup_vg
 injectmsg  0 10000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 . $srcdir/diag.sh es-getdata 10000 19200
 . $srcdir/diag.sh stop-elasticsearch
 seq_check  0 9999

--- a/tests/es-basic-vgthread.sh
+++ b/tests/es-basic-vgthread.sh
@@ -27,7 +27,7 @@ startup_vgthread
 injectmsg  0 10000
 shutdown_when_empty
 wait_shutdown_vg 
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 . $srcdir/diag.sh es-getdata 10000 $ES_PORT
 seq_check  0 9999
 . $srcdir/diag.sh stop-elasticsearch

--- a/tests/es-bulk-retry.sh
+++ b/tests/es-bulk-retry.sh
@@ -111,7 +111,7 @@ injectmsg 0 $numrecords
 shutdown_when_empty
 if [ "x${USE_VALGRIND:-false}" == "xtrue" ] ; then
 	wait_shutdown_vg
-	. $srcdir/diag.sh check_exit_vg
+	check_exit_vg
 else
 	wait_shutdown
 fi

--- a/tests/fac_local0-vg.sh
+++ b/tests/fac_local0-vg.sh
@@ -23,6 +23,6 @@ startup_vg
 tcpflood -m1000 -P 129
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 999 
 exit_test

--- a/tests/failover-basic-vg.sh
+++ b/tests/failover-basic-vg.sh
@@ -24,6 +24,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check  0 4999
 exit_test

--- a/tests/failover-no-basic-vg.sh
+++ b/tests/failover-no-basic-vg.sh
@@ -25,7 +25,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # now we need our custom logic to see if the result file is empty
 # (what it should be!)
 cmp $RSYSLOG_OUT_LOG /dev/null

--- a/tests/failover-no-rptd-vg.sh
+++ b/tests/failover-no-rptd-vg.sh
@@ -1,14 +1,6 @@
 #!/bin/bash
+# rptd test for failover functionality - no failover
 # This file is part of the rsyslog project, released under GPLv3
-
-uname
-if [ `uname` = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
-echo ===============================================================================
-echo \[failover-no-rptd.sh\]: rptd test for failover functionality - no failover
 . $srcdir/diag.sh init
 generate_conf
 add_conf '
@@ -21,17 +13,14 @@ $ActionExecOnlyWhenPreviousIsSuspended on
 '
 startup_vg
 injectmsg  0 5000
-echo doing shutdown
 shutdown_when_empty
-echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # now we need our custom logic to see if the result file is empty
 # (what it should be!)
-cmp $RSYSLOG_OUT_LOG /dev/null
-if [ $? -eq 1 ]
-then
+if [ -f $RSYSLOG_OUT_LOG -a "$(cat $RSYSLOG_OUT_LOG)" != "" ]; then
 	echo "ERROR, output file not empty"
-	exit 1
+	cat -n "$RSYSLOG_OUT_LOG"
+	error_exit 1
 fi
 exit_test

--- a/tests/failover-rptd-vg.sh
+++ b/tests/failover-rptd-vg.sh
@@ -26,6 +26,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check  0 4999
 exit_test

--- a/tests/glbl-oversizeMsg-log-vg.sh
+++ b/tests/glbl-oversizeMsg-log-vg.sh
@@ -24,7 +24,7 @@ startup_vg
 tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 240
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 grep "rawmsg.*<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:240:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.*input.*imrelp" ${RSYSLOG2_OUT_LOG} > /dev/null
 if [ $? -ne 0 ]; then
         echo

--- a/tests/imfile-basic-vg.sh
+++ b/tests/imfile-basic-vg.sh
@@ -32,6 +32,6 @@ startup_vg
 sleep 1
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 49999
 exit_test

--- a/tests/imfile-basic-vgthread.sh
+++ b/tests/imfile-basic-vgthread.sh
@@ -36,7 +36,7 @@ ls -l $RSYSLOG_DYNNAME.input
 startup_vgthread
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 seq_check 0 49999
 exit_test

--- a/tests/imfile-endregex-vg.sh
+++ b/tests/imfile-endregex-vg.sh
@@ -52,7 +52,7 @@ sleep 1
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg    # we need to wait until rsyslogd is finished!
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 # give it time to write the output file
 sleep 1

--- a/tests/imfile-readmode0-vg.sh
+++ b/tests/imfile-readmode0-vg.sh
@@ -32,7 +32,7 @@ printf '\nmsgnum:5' >> $RSYSLOG_DYNNAME.input # this one shouldn't be written to
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg    # we need to wait until rsyslogd is finished!
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 ## check if we have the correct number of messages
 NUMLINES=$(grep -c HEADER  $RSYSLOG_OUT_LOG 2>/dev/null)

--- a/tests/imfile-readmode2-vg.sh
+++ b/tests/imfile-readmode2-vg.sh
@@ -52,7 +52,7 @@ sleep 1
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg    # we need to wait until rsyslogd is finished!
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 # give it time to write the output file
 sleep 1

--- a/tests/imjournal-basic-vg.sh
+++ b/tests/imjournal-basic-vg.sh
@@ -27,7 +27,7 @@ journal_write_state=$?
 ./msleep 500
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 if [ $journal_write_state -ne 0 ]; then
         echo "SKIP: failed to put test into journal."

--- a/tests/imptcp_conndrop-vg.sh
+++ b/tests/imptcp_conndrop-vg.sh
@@ -25,6 +25,6 @@ tcpflood -c20 -m50000 -r -d100 -P129 -D
 sleep 10 # due to large messages, we need this time for the tcp receiver to settle...
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg    # and wait for it to terminate
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 49999 -E
 exit_test

--- a/tests/imtcp-tls-basic-vg.sh
+++ b/tests/imtcp-tls-basic-vg.sh
@@ -36,6 +36,6 @@ startup_vg_noleak
 tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 9999
 exit_test

--- a/tests/imtcp-tls-ossl-basic-vg.sh
+++ b/tests/imtcp-tls-ossl-basic-vg.sh
@@ -28,6 +28,6 @@ startup_vg_noleak
 tcpflood -p'$TCPFLOOD_PORT' -m10000 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 9999
 exit_test

--- a/tests/include-obj-in-if-vg.sh
+++ b/tests/include-obj-in-if-vg.sh
@@ -17,6 +17,6 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 9
 exit_test

--- a/tests/include-obj-outside-control-flow-vg.sh
+++ b/tests/include-obj-outside-control-flow-vg.sh
@@ -18,6 +18,6 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 9
 exit_test

--- a/tests/include-obj-text-vg.sh
+++ b/tests/include-obj-text-vg.sh
@@ -16,6 +16,6 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 9
 exit_test

--- a/tests/json_array_looping-vg.sh
+++ b/tests/json_array_looping-vg.sh
@@ -48,7 +48,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check 'quux: abc0'
 content_check 'quux: def1'
 content_check 'quux: ghi2'

--- a/tests/json_object_looping-vg.sh
+++ b/tests/json_object_looping-vg.sh
@@ -57,7 +57,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check 'quux: { "key": "str1", "value": "abc0" }'
 content_check 'quux: { "key": "str2", "value": "def1", "random_key": "str2" }'
 content_check 'quux: { "key": "str3", "value": "ghi2" }'

--- a/tests/json_object_suicide_in_loop-vg.sh
+++ b/tests/json_object_suicide_in_loop-vg.sh
@@ -42,7 +42,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check 'quux: { "key": "str1", "value": "abc0" }'
 content_check 'quux: { "key": "str2", "value": "def1", "random_key": "str2" }'
 content_check 'quux: { "key": "str3", "value": "ghi2" }'

--- a/tests/libdbi-basic-vg.sh
+++ b/tests/libdbi-basic-vg.sh
@@ -20,7 +20,7 @@ startup_vg_noleak
 injectmsg  0 5000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # note "-s" is requried to suppress the select "field header"
 mysql -s --user=rsyslog --password=testbench < testsuites/mysql-select-msg.sql > $RSYSLOG_OUT_LOG
 seq_check  0 4999

--- a/tests/lookup_table-vg.sh
+++ b/tests/lookup_table-vg.sh
@@ -44,7 +44,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check "msgnum:00000000: foo_latest"
 content_check "msgnum:00000001: quux"
 content_check "msgnum:00000002: baz_latest"

--- a/tests/lookup_table_bad_configs-vg.sh
+++ b/tests/lookup_table_bad_configs-vg.sh
@@ -166,5 +166,5 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/lookup_table_no_hup_reload-vg.sh
+++ b/tests/lookup_table_no_hup_reload-vg.sh
@@ -36,7 +36,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 . $srcdir/diag.sh assert-content-missing "foo_new"
 . $srcdir/diag.sh assert-content-missing "bar_new"
 . $srcdir/diag.sh assert-content-missing "baz"

--- a/tests/lookup_table_rscript_reload-vg.sh
+++ b/tests/lookup_table_rscript_reload-vg.sh
@@ -51,7 +51,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check "msgnum:00000000: foo_latest"
 content_check "msgnum:00000001: quux"
 content_check "msgnum:00000002: baz_latest"

--- a/tests/lookup_table_rscript_reload_without_stub-vg.sh
+++ b/tests/lookup_table_rscript_reload_without_stub-vg.sh
@@ -51,7 +51,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check_with_count "msgnum:00000000: foo_latest" 2
 content_check_with_count "msgnum:00000001: quux" 2
 content_check_with_count "msgnum:00000002: baz_latest" 1

--- a/tests/manytcp-too-few-tls-vg.sh
+++ b/tests/manytcp-too-few-tls-vg.sh
@@ -37,7 +37,7 @@ tcpflood -c1000 -m40000
 sleep 1
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg	# we need to wait until rsyslogd is finished!
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # we do not do a seq check, as of the design of this test some messages
 # will be lost. So there is no point in checking if all were received. The
 # point is that we look at the valgrind result, to make sure we do not

--- a/tests/mmdb-multilevel-vg.sh
+++ b/tests/mmdb-multilevel-vg.sh
@@ -27,6 +27,6 @@ startup_vg
 tcpflood -m 100 -j "202.106.0.20\ "
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check '{ "city_name": "Beijing" }'
 exit_test 

--- a/tests/mmdb-vg.sh
+++ b/tests/mmdb-vg.sh
@@ -24,6 +24,6 @@ startup_vg
 tcpflood -m 100 -j "202.106.0.20\ "
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check '{ "city": "Beijing" }'
 exit_test 

--- a/tests/mmexternal-InvldProg-vg.sh
+++ b/tests/mmexternal-InvldProg-vg.sh
@@ -21,7 +21,7 @@ tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag:msgnum:1\""
 ./msleep 500 # let the fork happen and report back!
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 grep 'failed to execute'  $RSYSLOG_OUT_LOG > /dev/null
 if [ $? -ne 0 ]; then

--- a/tests/mmexternal-SegFault-empty-jroot-vg.sh
+++ b/tests/mmexternal-SegFault-empty-jroot-vg.sh
@@ -20,7 +20,7 @@ startup_vg
 tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag:msgnum:1\""
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 echo '-{ "sometag": "somevalue" }-' | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then

--- a/tests/mmexternal-SegFault-vg.sh
+++ b/tests/mmexternal-SegFault-vg.sh
@@ -23,7 +23,7 @@ startup_vg
 tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag:msgnum:1\""
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 echo '-{ "x": "a", "sometag": "somevalue" }-' | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then

--- a/tests/mmkubernetes-basic-vg.sh
+++ b/tests/mmkubernetes-basic-vg.sh
@@ -64,7 +64,7 @@ startup_vg_noleak
 sleep 10 || :
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 kill $BGPROCESS
 . $srcdir/diag.sh wait-pid-termination ${RSYSLOG_PIDBASE}${testsrv}.pid

--- a/tests/mmpstrucdata-case.sh
+++ b/tests/mmpstrucdata-case.sh
@@ -25,7 +25,6 @@ if [ `uname` = "FreeBSD" ] ; then
 fi
 
 startup
-wait_startup
 tcpflood -m100 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 eventID=\\\"1011\\\"] valid structured data\""
 shutdown_when_empty
 wait_shutdown

--- a/tests/mmpstrucdata-invalid-vg.sh
+++ b/tests/mmpstrucdata-invalid-vg.sh
@@ -25,7 +25,6 @@ if $msg contains "msgnum" then
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup_vg
-wait_startup
 # we use different message counts as this hopefully aids us
 # in finding which sample is leaking. For this, check the number
 # of blocks lost and see what set they match.

--- a/tests/mmpstrucdata-invalid-vg.sh
+++ b/tests/mmpstrucdata-invalid-vg.sh
@@ -34,5 +34,5 @@ tcpflood -m300 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpfl
 tcpflood -m400 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 = ] invalid structured data!\""
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/mmpstrucdata-vg.sh
+++ b/tests/mmpstrucdata-vg.sh
@@ -29,6 +29,6 @@ sleep 1
 tcpflood -m100 -y
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 99
 exit_test

--- a/tests/multiple_lookup_tables-vg.sh
+++ b/tests/multiple_lookup_tables-vg.sh
@@ -48,7 +48,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check "msgnum:00000000: 0_foo_new 1_foo_new"
 content_check "msgnum:00000001: 0_bar_new 1_bar_new"
 content_check "msgnum:00000002: 0_baz 1_baz"

--- a/tests/mysql-actq-mt-withpause-vg.sh
+++ b/tests/mysql-actq-mt-withpause-vg.sh
@@ -31,7 +31,7 @@ echo waiting for worker threads to timeout
 injectmsg  100000 50000
 shutdown_when_empty
 wait_shutdown_vg 
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # note "-s" is requried to suppress the select "field header"
 mysql -s --user=rsyslog --password=testbench < testsuites/mysql-select-msg.sql > $RSYSLOG_OUT_LOG
 seq_check  0 149999

--- a/tests/mysql-asyn-vg.sh
+++ b/tests/mysql-asyn-vg.sh
@@ -15,7 +15,7 @@ startup_vg
 injectmsg  0 50000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # note "-s" is requried to suppress the select "field header"
 mysql -s --user=rsyslog --password=testbench < testsuites/mysql-select-msg.sql > $RSYSLOG_OUT_LOG
 seq_check  0 49999

--- a/tests/mysql-basic-vg.sh
+++ b/tests/mysql-basic-vg.sh
@@ -13,7 +13,7 @@ startup_vg
 injectmsg  0 5000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # note "-s" is requried to suppress the select "field header"
 mysql -s --user=rsyslog --password=testbench < testsuites/mysql-select-msg.sql > $RSYSLOG_OUT_LOG
 seq_check  0 4999

--- a/tests/omprog-close-unresponsive-vg.sh
+++ b/tests/omprog-close-unresponsive-vg.sh
@@ -34,5 +34,5 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/omprog-defaults-vg.sh
+++ b/tests/omprog-defaults-vg.sh
@@ -25,5 +25,5 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/omprog-feedback-vg.sh
+++ b/tests/omprog-feedback-vg.sh
@@ -29,5 +29,5 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/omprog-output-capture-vg.sh
+++ b/tests/omprog-output-capture-vg.sh
@@ -26,5 +26,5 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/omprog-restart-terminated-vg.sh
+++ b/tests/omprog-restart-terminated-vg.sh
@@ -71,5 +71,5 @@ injectmsg 9 1
 
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/omprog-transactions-vg.sh
+++ b/tests/omprog-transactions-vg.sh
@@ -33,5 +33,5 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/pgsql-actq-mt-withpause-vg.sh
+++ b/tests/pgsql-actq-mt-withpause-vg.sh
@@ -30,7 +30,7 @@ echo waiting for worker threads to timeout
 injectmsg  100000 50000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 psql -h localhost -U postgres -d syslogtest -f testsuites/pgsql-select-msg.sql -t -A > $RSYSLOG_OUT_LOG
 seq_check  0 149999

--- a/tests/pgsql-basic-cnf6-vg.sh
+++ b/tests/pgsql-basic-cnf6-vg.sh
@@ -16,7 +16,7 @@ startup_vg
 injectmsg  0 5000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 psql -h localhost -U postgres -d syslogtest -f testsuites/pgsql-select-msg.sql -t -A > $RSYSLOG_OUT_LOG
 seq_check  0 4999

--- a/tests/pgsql-basic-vg.sh
+++ b/tests/pgsql-basic-vg.sh
@@ -14,7 +14,7 @@ startup_vg
 injectmsg  0 5000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 psql -h localhost -U postgres -d syslogtest -f testsuites/pgsql-select-msg.sql -t -A > $RSYSLOG_OUT_LOG
 seq_check  0 4999

--- a/tests/pgsql-template-cnf6-vg.sh
+++ b/tests/pgsql-template-cnf6-vg.sh
@@ -24,7 +24,7 @@ startup_vg
 injectmsg  0 5000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 # we actually put the message in the SysLogTag field, so we know it doesn't use the default
 # template, like in pgsql-basic

--- a/tests/pgsql-template-vg.sh
+++ b/tests/pgsql-template-vg.sh
@@ -19,7 +19,7 @@ startup_vg
 injectmsg  0 5000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 psql -h localhost -U postgres -d syslogtest -f testsuites/pgsql-select-syslogtag.sql -t -A > $RSYSLOG_OUT_LOG
 seq_check  0 4999

--- a/tests/pmnormalize-rule-vg.sh
+++ b/tests/pmnormalize-rule-vg.sh
@@ -21,7 +21,7 @@ tcpflood -m1 -M "\"<112> 255.255.255.255 debian tag2: this is a test message\""
 tcpflood -m1 -M "\"<177> centos 192.168.0.9 tag3: this is a test message\""
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 echo 'host: ubuntu, ip: 127.0.0.1, tag: tag1, pri: 189, syslogfacility: 23, syslogseverity: 5 msg: this is a test message
 host: debian, ip: 255.255.255.255, tag: tag2, pri: 112, syslogfacility: 14, syslogseverity: 0 msg: this is a test message
 host: centos, ip: 192.168.0.9, tag: tag3, pri: 177, syslogfacility: 22, syslogseverity: 1 msg: this is a test message' | cmp - $RSYSLOG_OUT_LOG

--- a/tests/prop-jsonmesg-vg.sh
+++ b/tests/prop-jsonmesg-vg.sh
@@ -17,7 +17,7 @@ startup_vg
 tcpflood -m1 -y
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 export EXPECTED='"msg": "msgnum:00000000:", '
 . $srcdir/diag.sh grep-check
 exit_test

--- a/tests/rscript-config_enable-off-vg.sh
+++ b/tests/rscript-config_enable-off-vg.sh
@@ -17,6 +17,6 @@ startup_vg
 injectmsg 0 10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check 0 9
 exit_test

--- a/tests/rscript_field-vg.sh
+++ b/tests/rscript_field-vg.sh
@@ -29,6 +29,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 seq_check  0 4999
 exit_test

--- a/tests/rscript_hash32-vg.sh
+++ b/tests/rscript_hash32-vg.sh
@@ -23,6 +23,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 . $srcdir/diag.sh content-pattern-check "^\(746581550 -  50\|3889673532 -  32\)$"
 exit_test

--- a/tests/rscript_hash64-vg.sh
+++ b/tests/rscript_hash64-vg.sh
@@ -23,6 +23,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 . $srcdir/diag.sh content-pattern-check "^\(-2574714428477944902 -  14\|-50452361579464591 -  25\)$"
 exit_test

--- a/tests/rscript_http_request-vg.sh
+++ b/tests/rscript_http_request-vg.sh
@@ -22,7 +22,7 @@ startup_vg
 tcpflood -m10
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 echo '{ "reply": "msgnum:00000000:" }
 { "reply": "msgnum:00000001:" }
 { "reply": "msgnum:00000002:" }

--- a/tests/rscript_parse_json-vg.sh
+++ b/tests/rscript_parse_json-vg.sh
@@ -17,7 +17,7 @@ startup_vg
 tcpflood -m1
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 # Our fixed and calculated expected results
 EXPECTED='{ "parsed": { "c1": "data" } }'

--- a/tests/rscript_set_memleak-vg.sh
+++ b/tests/rscript_set_memleak-vg.sh
@@ -36,7 +36,7 @@ startup_vg
 tcpflood -m5000
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 # note: we check only the valgrind result, we are not really interested
 # in the output data (non-standard format in any way...)
 exit_test

--- a/tests/rscript_trim-vg.sh
+++ b/tests/rscript_trim-vg.sh
@@ -78,7 +78,7 @@ startup_vg
 tcpflood -m1 -y
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 echo '{ "l1": "", "l2": "test", "l3": "test", "l4": "test   ", "l5": "test   ", "l6": "test", "l7": "test ", "l8": "", "l9": "te st", "l10": "te st", "l11": "a", "l12": "a ", "r1": "", "r2": "test", "r3": "   test", "r4": "test", "r5": "   test", "r6": " test", "r7": "test", "r8": "", "r9": "te st", "r10": "te st", "r11": " a", "r12": "a", "b1": "", "b2": "test", "b3": "test", "b4": "te st", "b5": "", "b6": "test", "b7": "test", "b8": "te st", "b9": "test", "b10": "te st", "b11": "test", "b12": "test", "b13": "test", "b14": "te st", "b15": "test", "b16": "te st", "b17": "test", "b18": "test", "b19": "test", "b20": "te st" }' | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid function output detected, $RSYSLOG_OUT_LOG is:"

--- a/tests/rulesetmultiqueue-v6.sh
+++ b/tests/rulesetmultiqueue-v6.sh
@@ -51,7 +51,6 @@ $InputTCPServerRun '$RSYSLOG_PORT3'
 '
 rm -f ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log
 startup
-wait_startup
 # now fill the three files (a bit sequentially, but they should
 # still get their share of concurrency - to increase the chance
 # we use three connections per set).

--- a/tests/rulesetmultiqueue.sh
+++ b/tests/rulesetmultiqueue.sh
@@ -51,7 +51,6 @@ $InputTCPServerRun '$RSYSLOG_PORT3'
 '
 rm -f ${RSYSLOG_OUT_LOG}1.log ${RSYSLOG_OUT_LOG}2.log ${RSYSLOG_OUT_LOG}3.log
 startup
-wait_startup
 # now fill the three files (a bit sequentially, but they should
 # still get their share of concurrency - to increase the chance
 # we use three connections per set).

--- a/tests/sndrcv.sh
+++ b/tests/sndrcv.sh
@@ -25,7 +25,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -38,7 +37,6 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")
 action(type="omfwd" target="127.0.0.1" protocol="tcp" port="'$PORT_RCVR'")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_drvr_noexit.sh
+++ b/tests/sndrcv_drvr_noexit.sh
@@ -29,11 +29,9 @@
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 startup $1_rcvr.conf 
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 startup $1_sender.conf 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_failover.sh
+++ b/tests/sndrcv_failover.sh
@@ -26,7 +26,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -43,7 +42,6 @@ $ActionExecOnlyWhenPreviousIsSuspended on
 $ActionExecOnlyWhenPreviousIsSuspended off
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_gzip.sh
+++ b/tests/sndrcv_gzip.sh
@@ -19,7 +19,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
@@ -31,7 +30,6 @@ $InputTCPServerRun '$TCPFLOOD_PORT'
 *.*	@@127.0.0.1:'$RCVR_PORT'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -44,7 +44,6 @@ if ($msg contains "msgnum:") then {
 }
 '
 startup_vg
-wait_startup
 
 echo \[sndrcv_kafka-vg-rcvr.sh\]: Starting sender instance [imkafka]
 export RSYSLOG_DEBUGLOG="log2"
@@ -82,7 +81,6 @@ local4.* action(	name="kafka-fwd"
 	)
 ' 2
 startup 2
-wait_startup 2
 
 echo \[sndrcv_kafka-vg-rcvr.sh\]: Inject messages into rsyslog sender instance  
 tcpflood -m$TESTMESSAGES -i1

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -98,7 +98,7 @@ wait_shutdown 2
 echo \[sndrcv_kafka-vg-rcvr.sh\]: Stopping receiver instance [omkafka]
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 
 # Do the final sequence check
 seq_check 1 $TESTMESSAGESFULL -d

--- a/tests/sndrcv_kafka-vg-sender.sh
+++ b/tests/sndrcv_kafka-vg-sender.sh
@@ -41,7 +41,6 @@ if ($msg contains "msgnum:") then {
 }
 '
 startup
-wait_startup
 
 echo \[sndrcv_kafka-vg-sender.sh\]: Starting sender instance [imkafka]
 export RSYSLOG_DEBUGLOG="log2"
@@ -77,7 +76,6 @@ action(	name="kafka-fwd"
 	)
 ' 2
 startup_vg 2
-wait_startup 2
 
 echo \[sndrcv_kafka-vg-sender.sh\]: Inject messages into rsyslog sender instance  
 tcpflood -m$TESTMESSAGES -i1

--- a/tests/sndrcv_kafka-vg-sender.sh
+++ b/tests/sndrcv_kafka-vg-sender.sh
@@ -86,7 +86,7 @@ sleep 5
 echo \[sndrcv_kafka-vg-sender.sh\]: Stopping sender instance [imkafka]
 shutdown_when_empty 2
 wait_shutdown_vg 2
-. $srcdir/diag.sh check_exit_vg 2
+check_exit_vg 2
 
 echo \[sndrcv_kafka-vg-sender.sh\]: Sleep to give rsyslog receiver time to receive data ...
 sleep 20

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -59,7 +59,6 @@ local4.* action(	name="kafka-fwd"
 
 echo \[sndrcv_kafka.sh\]: Starting sender instance [omkafka]
 startup
-wait_startup
 # --- 
 
 echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance  
@@ -91,7 +90,6 @@ if ($msg contains "msgnum:") then {
 
 echo \[sndrcv_kafka.sh\]: Starting receiver instance [imkafka]
 startup 2
-wait_startup 2
 # --- 
 
 #echo \[sndrcv_kafka.sh\]: Sleep to give rsyslog instances time to process data ...

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -48,7 +48,6 @@ if ($msg contains "msgnum:") then {
 echo \[sndrcv_kafka_fail.sh\]: Starting receiver instance [omkafka]
 export RSYSLOG_DEBUGLOG="log"
 startup
-wait_startup
 # --- 
 
 # --- Create omkafka sender config 
@@ -89,7 +88,6 @@ local4.* action(	name="kafka-fwd"
 echo \[sndrcv_kafka_fail.sh\]: Starting sender instance [imkafka]
 export RSYSLOG_DEBUGLOG="log2"
 startup 2
-wait_startup 2
 # --- 
 
 echo \[sndrcv_kafka_fail.sh\]: Inject messages into rsyslog sender instance  

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -79,12 +79,10 @@ action(	name="kafka-fwd"
 echo \[sndrcv_kafka_failresume.sh\]: Starting sender instance [imkafka]
 export RSYSLOG_DEBUGLOG="log"
 startup 2
-wait_startup 2
 
 echo \[sndrcv_kafka_failresume.sh\]: Starting receiver instance [omkafka]
 export RSYSLOG_DEBUGLOG="log2"
 startup
-wait_startup
 
 echo \[sndrcv_kafka_failresume.sh\]: Inject messages into rsyslog sender instance  
 tcpflood -m$TESTMESSAGES -i1
@@ -105,7 +103,6 @@ sleep 5
 echo \[sndrcv_kafka_failresume.sh\]: Starting sender instance [imkafka]
 export RSYSLOG_DEBUGLOG="log3"
 startup 2
-wait_startup 2
 
 echo \[sndrcv_kafka_failresume.sh\]: Sleep to give rsyslog sender time to send data ...
 sleep 5

--- a/tests/sndrcv_kafka_multi.sh
+++ b/tests/sndrcv_kafka_multi.sh
@@ -94,7 +94,6 @@ ruleset(name="omkafka3") {
 echo \[sndrcv_kafka_multi.sh\]: Starting sender instance [omkafka]
 export RSYSLOG_DEBUGLOG="log"
 startup
-wait_startup
 
 # now inject the messages into instance 2. It will connect to instance 1, and that instance will record the data.
 tcpflood -m$TESTMESSAGES -i1
@@ -102,7 +101,6 @@ tcpflood -m$TESTMESSAGES -i1
 echo \[sndrcv_kafka_multi.sh\]: Starting receiver instance [imkafka]
 export RSYSLOG_DEBUGLOG="log2"
 startup 2
-wait_startup 2
 
 #echo \[sndrcv_kafka_multi.sh\]: Sleep to give rsyslog instances time to process data ...
 #sleep 20 

--- a/tests/sndrcv_kafka_multi_topics.sh
+++ b/tests/sndrcv_kafka_multi_topics.sh
@@ -82,7 +82,6 @@ local4.* action(	name="kafka-fwd"
 echo \[sndrcv_kafka_multi_topics.sh\]: Starting sender instance [omkafka]
 export RSYSLOG_DEBUGLOG="log"
 startup
-wait_startup
 # --- 
 
 
@@ -122,7 +121,6 @@ if ($msg contains "msgnum:") then {
 echo \[sndrcv_kafka_multi_topics.sh\]: Starting receiver instance [imkafka]
 export RSYSLOG_DEBUGLOG="log2"
 startup 2
-wait_startup 2
 # --- 
 
 echo \[sndrcv_kafka.sh\]: Inject messages into rsyslog sender instance  

--- a/tests/sndrcv_omudpspoof.sh
+++ b/tests/sndrcv_omudpspoof.sh
@@ -30,7 +30,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'"
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -50,7 +49,6 @@ $ActionOMUDPSpoofSourcePortEnd 514
 *.*	:omudpspoof:
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_omudpspoof_nonstdpt.sh
+++ b/tests/sndrcv_omudpspoof_nonstdpt.sh
@@ -30,7 +30,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'"
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -51,7 +50,6 @@ $ActionOMUDPSpoofSourcePortEnd 514
 *.*	:omudpspoof:
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_relp.sh
+++ b/tests/sndrcv_relp.sh
@@ -19,7 +19,6 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-wait_startup
 printf "#### RECEIVER STARTED\n\n"
 
 ########## sender ##########
@@ -34,7 +33,6 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 action(type="omrelp" name="omrelp" target="127.0.0.1" port="'$PORT_RCVR'")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 printf "#### SENDER STARTED\n\n"
 

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -32,7 +32,6 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -45,7 +44,6 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 action(type="omrelp" protocol="tcp" target="127.0.0.1" port="'$PORT_RCVR'")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_relp_rebind.sh
+++ b/tests/sndrcv_relp_rebind.sh
@@ -19,7 +19,6 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -36,7 +35,6 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 action(type="omrelp" protocol="tcp" target="127.0.0.1" port="'$PORT_RCVR'" rebindinterval="1")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_relp_tls.sh
+++ b/tests/sndrcv_relp_tls.sh
@@ -18,7 +18,6 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -31,7 +30,6 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 action(type="omrelp" target="127.0.0.1" port="'$PORT_RCVR'" tls="on")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_relp_tls_prio.sh
+++ b/tests/sndrcv_relp_tls_prio.sh
@@ -20,7 +20,6 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -33,7 +32,6 @@ input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 action(type="omrelp" target="127.0.0.1" port="'$PORT_RCVR'" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_anon_hostname.sh
+++ b/tests/sndrcv_tls_anon_hostname.sh
@@ -31,7 +31,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -54,7 +53,6 @@ $ActionSendStreamDriverAuthMode anon
 *.*	@@localhost:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_anon_ipv4.sh
+++ b/tests/sndrcv_tls_anon_ipv4.sh
@@ -31,7 +31,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -55,7 +54,6 @@ $ActionSendStreamDriverAuthMode anon
 *.*	@@127.0.0.1:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_anon_ipv6.sh
+++ b/tests/sndrcv_tls_anon_ipv6.sh
@@ -31,7 +31,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -53,7 +52,6 @@ $ActionSendStreamDriverAuthMode anon
 *.*	@@[::1]:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_anon_rebind.sh
+++ b/tests/sndrcv_tls_anon_rebind.sh
@@ -31,7 +31,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -55,7 +54,6 @@ $ActionSendTCPRebindInterval 50
 *.*	@@127.0.0.1:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_ossl_anon_ipv4.sh
+++ b/tests/sndrcv_tls_ossl_anon_ipv4.sh
@@ -34,7 +34,6 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 					file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -57,7 +56,6 @@ $ActionSendStreamDriverAuthMode anon
 *.*	@@127.0.0.1:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_ossl_anon_ipv6.sh
+++ b/tests/sndrcv_tls_ossl_anon_ipv6.sh
@@ -35,7 +35,6 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 					file="'$RSYSLOG_OUT_LOG'")
 '
 startup 
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -61,7 +60,6 @@ $ActionSendStreamDriverAuthMode anon
 *.*	@@[::1]:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_ossl_anon_rebind.sh
+++ b/tests/sndrcv_tls_ossl_anon_rebind.sh
@@ -35,7 +35,6 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 					file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -63,7 +62,6 @@ $ActionSendTCPRebindInterval 100
 *.*	@@127.0.0.1:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_tls_priorityString.sh
+++ b/tests/sndrcv_tls_priorityString.sh
@@ -31,7 +31,6 @@ if $msg contains "msgnum" then {
 }
 '
 startup 
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -53,7 +52,6 @@ action(type="omfwd" Target="127.0.0.1" port="'$PORT_RCVR'" Protocol="tcp" stream
 	gnutlsprioritystring="NORMAL:-MD5")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_udp.sh
+++ b/tests/sndrcv_udp.sh
@@ -30,7 +30,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -43,7 +42,6 @@ $InputTCPServerRun '$TCPFLOOD_PORT'
 *.*	@127.0.0.1:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_udp_nonstdpt.sh
+++ b/tests/sndrcv_udp_nonstdpt.sh
@@ -27,7 +27,6 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -40,7 +39,6 @@ $InputTCPServerRun '$TCPFLOOD_PORT'
 *.*	@127.0.0.1:'$PORT_RCVR'
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sndrcv_udp_nonstdpt_v6.sh
+++ b/tests/sndrcv_udp_nonstdpt_v6.sh
@@ -20,7 +20,6 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup
-wait_startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -35,7 +34,6 @@ action(type="omfwd"
        protocol="udp" udp.sendDelay="1")
 ' 2
 startup 2
-wait_startup 2
 # may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,

--- a/tests/sparse_array_lookup_table-vg.sh
+++ b/tests/sparse_array_lookup_table-vg.sh
@@ -54,7 +54,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check "msgnum:00000000: quux"
 content_check "msgnum:00000001: quux"
 content_check "msgnum:00000002: foo_latest"

--- a/tests/stats-cee-vg.sh
+++ b/tests/stats-cee-vg.sh
@@ -31,6 +31,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 custom_content_check '@cee: { "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/stats-json-vg.sh
+++ b/tests/stats-json-vg.sh
@@ -31,7 +31,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
 . $srcdir/diag.sh custom-assert-content-missing '@cee' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/tcp-msgreduc-vg.sh
+++ b/tests/tcp-msgreduc-vg.sh
@@ -22,7 +22,6 @@ $template outfmt,"%msg:F,58:2%\n"
 *.*       action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup_vg
-wait_startup
 tcpflood -t 127.0.0.1 -m 4 -r -M "\"<133>2011-03-01T11:22:12Z host tag msgh ...\""
 tcpflood -t 127.0.0.1 -m 1 -r -M "\"<133>2011-03-01T11:22:12Z host tag msgh ...x\""
 # we need to give rsyslog a little time to settle the receiver

--- a/tests/tcp-msgreduc-vg.sh
+++ b/tests/tcp-msgreduc-vg.sh
@@ -28,5 +28,5 @@ tcpflood -t 127.0.0.1 -m 1 -r -M "\"<133>2011-03-01T11:22:12Z host tag msgh ...x
 ./msleep 1500
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 exit_test

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1404,7 +1404,6 @@ setTargetPorts(const char *const port_arg)
 
 	char *saveptr;
 	char *ports = strdup(port_arg);
-	printf("ports: %s\n", ports);
 	char *port = strtok_r(ports, ":", &saveptr);
 	while(port != NULL) {
 		if(i == sizeof(targetPort)/sizeof(int)) {

--- a/tests/udp-msgreduc-orgmsg-vg.sh
+++ b/tests/udp-msgreduc-orgmsg-vg.sh
@@ -23,7 +23,6 @@ $template outfmt,"%msg:F,58:2%\n"
 *.*       action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup_vg
-wait_startup
 tcpflood -t 127.0.0.1 -m 4 -r -Tudp -M "\"<133>2011-03-01T11:22:12Z host tag msgh ...\""
 tcpflood -t 127.0.0.1 -m 1 -r -Tudp -M "\"<133>2011-03-01T11:22:12Z host tag msgh ...x\""
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/udp-msgreduc-vg.sh
+++ b/tests/udp-msgreduc-vg.sh
@@ -23,7 +23,6 @@ $template outfmt,"%msg:F,58:2%\n"
 #:msg, contains, "msgnum:" action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup_vg
-wait_startup
 tcpflood -t 127.0.0.1 -m 4 -r -Tudp -M "\"<133>2011-03-01T11:22:12Z host tag msgh ...\""
 tcpflood -t 127.0.0.1 -m 1 -r -Tudp -M "\"<133>2011-03-01T11:22:12Z host tag msgh ...x\""
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/unused_lookup_table-vg.sh
+++ b/tests/unused_lookup_table-vg.sh
@@ -24,7 +24,7 @@ startup_vg
 injectmsg  0 1
 shutdown_when_empty
 wait_shutdown_vg
-. $srcdir/diag.sh check_exit_vg
+check_exit_vg
 content_check "msgnum:00000000:"
 exit_test
 


### PR DESCRIPTION
this also requires changes to some tooling. Most importantly, imdiag
now "officially" needs IPv4. The testbench actually always needed that,
but it was not plainly visible.

Also removing some left-over debug output.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
