### PR TITLE
provide better error information if gone-away config directive is used

### DIFF
--- a/runtime/cfsysline.c
+++ b/runtime/cfsysline.c
@@ -25,7 +25,6 @@
  */
 #include "config.h"
 
-#include "rsyslog.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
@@ -35,12 +34,14 @@
 #include <pwd.h>
 #include <grp.h>
 
+#include "rsyslog.h"
 #include "cfsysline.h"
 #include "obj.h"
 #include "conf.h"
 #include "errmsg.h"
 #include "srUtils.h"
 #include "unicode-helper.h"
+#include "parserif.h"
 
 
 /* static data */
@@ -605,7 +606,7 @@ doGoneAway(__attribute__((unused)) uchar **pp,
 	   __attribute__((unused)) rsRetVal (*pSetHdlr)(void*, int),
 	   __attribute__((unused)) void *pVal)
 {
-	LogError(0, RS_RET_CMD_GONE_AWAY, "config directive is no longer supported -- ignored");
+	parser_warnmsg("config directive is no longer supported -- ignored");
 	return RS_RET_CMD_GONE_AWAY;
 }
 

--- a/tests/conf-directive-gone-away.sh
+++ b/tests/conf-directive-gone-away.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# addd 2018-09-04 by RGerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+$optimizeForUniprocessor
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown
+content_check "config directive is no longer supported"
+exit_test


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/2880

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
