### PR TITLE
queue.c: add error if queue file can't be accessed

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -782,9 +782,9 @@ qqueueTryLoadPersistedInfo(qqueue_t *pThis)
 	if(stat((char*) pThis->pszQIFNam, &stat_buf) == -1) {
 		if(errno == ENOENT) {
 			DBGOPRINT((obj_t*) pThis, "clean startup, no .qi file found\n");
-			ABORT_FINALIZE(RS_RET_FILE_NOT_FOUND);
 		} else {
-			DBGOPRINT((obj_t*) pThis, "error %d trying to access .qi file\n", errno);
+			LogError(errno, RS_RET_IO_ERROR, "queue: %s: error %d could not access .qi file",
+					obj.GetName((obj_t*) pThis), errno);
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
 	}


### PR DESCRIPTION
When having a disk-assisted queue without permission
to write to the specified queue file an error will
be put out.

closes https://github.com/rsyslog/rsyslog/issues/323

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
