### PR TITLE
build system: fix platform linker options detection

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -43,23 +43,20 @@ rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAG
 # potentially incomplete build, a problem we had several times...)
 rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la ../compat/compat.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS) $(HASH_XXHASH_LIBS)
 
-# if you know how to do an "if AIX os OS_APPLE" or an elseif chain, let me now!
-#rsyslogd_LDFLAGS = -export-dynamic \
-#	-Wl,$(top_builddir)/runtime/.libs/librsyslog.a
-#if OS_LINUX
+# Note: do NOT indent the if chain - it will not work!
+if OS_LINUX
 rsyslogd_LDFLAGS = -export-dynamic \
 	#-Wl,--whole-archive,$(top_builddir)/runtime/.libs/librsyslog.a,--no-whole-archive
-#endif
+else
 if OS_APPLE
 rsyslogd_LDFLAGS = -export-dynamic \
 	-Wl,$(top_builddir)/runtime/.libs/librsyslog.a
-endif
+else
 if OS_AIX
 rsyslogd_LDFLAGS = -export-dynamic -bexpall -bE:strippedsymbols.exp
-#else
-#rsyslogd_LDFLAGS = -export-dynamic \
-	#-Wl,--whole-archive,$(top_builddir)/runtime/.libs/librsyslog.a,--no-whole-archive
-endif
+endif # if OS_AIX
+endif # if OS_APPLE
+endif # if OS_LINUX
 
 EXTRA_DIST = $(man_MANS) \
 	rscryutil.rst \


### PR DESCRIPTION
most importantly, it did not work for AIX, which resulted in problems
starting up rsyslog

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
