### PR TITLE
testbench: make imrelp tests faster and avoid imtcp

### DIFF
--- a/tests/sndrcv_relp.sh
+++ b/tests/sndrcv_relp.sh
@@ -23,12 +23,9 @@ printf "#### RECEIVER STARTED\n\n"
 
 ########## sender ##########
 #export RSYSLOG_DEBUGLOG="log2"
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 generate_conf 2
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
-module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 action(type="omrelp" name="omrelp" target="127.0.0.1" port="'$PORT_RCVR'")
 ' 2
@@ -38,17 +35,13 @@ printf "#### SENDER STARTED\n\n"
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-tcpflood -m50000 -i1
-#sleep 5 # make sure all data is received in input buffers
+injectmsg 1 50000
+
 shutdown_when_empty 2
 wait_shutdown 2
 # now it is time to stop the receiver as well
 shutdown_when_empty
 wait_shutdown
 
-# may be needed by TLS (once we do it): sleep 60
-# do the final check
 seq_check 1 50000
-
-unset PORT_RCVR # TODO: move to exit_test()?
 exit_test

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -38,8 +38,6 @@ generate_conf 2
 export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
-module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 action(type="omrelp" protocol="tcp" target="127.0.0.1" port="'$PORT_RCVR'")
 ' 2
@@ -48,19 +46,14 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-tcpflood -m50000 -i1
-sleep 5 # make sure all data is received in input buffers
-# shut down sender when everything is sent, receiver continues to run concurrently
-# may be needed by TLS (once we do it): sleep 60
+injectmsg 1 50000
+
+# shut down sender
 shutdown_when_empty 2
 wait_shutdown 2
 # now it is time to stop the receiver as well
 shutdown_when_empty
 wait_shutdown
 
-# may be needed by TLS (once we do it): sleep 60
-# do the final check
 seq_check 1 50000
-
-unset PORT_RCVR # TODO: move to exit_test()?
 exit_test

--- a/tests/sndrcv_relp_tls_prio.sh
+++ b/tests/sndrcv_relp_tls_prio.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 # added 2013-12-10 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-echo ===============================================================================
-echo \[sndrcv_relp_tls_prio.sh\]: testing sending and receiving via relp with TLS enabled and priority string set
+. $srcdir/diag.sh init
+echo testing sending and receiving via relp with TLS enabled and priority string set
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
@@ -23,32 +22,23 @@ startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
-module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")	/* this port for tcpflood! */
 
 action(type="omrelp" target="127.0.0.1" port="'$PORT_RCVR'" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
 ' 2
 startup 2
-# may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-tcpflood -m50000 -i1
-sleep 5 # make sure all data is received in input buffers
-# shut down sender when everything is sent, receiver continues to run concurrently
-# may be needed by TLS (once we do it): sleep 60
+injectmsg 1 50000
+
+# shut down sender
 shutdown_when_empty 2
 wait_shutdown 2
 # now it is time to stop the receiver as well
 shutdown_when_empty
 wait_shutdown
 
-# may be needed by TLS (once we do it): sleep 60
-# do the final check
 seq_check 1 50000
-
-unset PORT_RCVR # TODO: move to exit_test()?
 exit_test


### PR DESCRIPTION
imtcp was primarily used for historical reasons and is actually
to inferior method of injection messages for such cases

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
