### PR TITLE
pmnormalize: fix memory leak

### DIFF
--- a/plugins/pmnormalize/pmnormalize.c
+++ b/plugins/pmnormalize/pmnormalize.c
@@ -3,7 +3,7 @@
  *
  * File begun on 2017-03-03 by Pascal Withopf.
  *
- * Copyright 2014-2017 Adiscon GmbH.
+ * Copyright 2014-2018 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -81,7 +81,6 @@ CODESTARTisCompatibleWithFeature
 		iRet = RS_RET_OK;
 ENDisCompatibleWithFeature
 
-
 /* create input instance, set default parameters, and
  * add it to the list of instances.
  */
@@ -94,6 +93,7 @@ createInstance(instanceConf_t **pinst)
 	inst->undefPropErr = 0;
 	inst->rulebase = NULL;
 	inst->rule = NULL;
+	inst->ctxln = NULL;
 	*pinst = inst;
 finalize_it:
 	RETiRet;
@@ -146,6 +146,9 @@ finalize_it:
 BEGINfreeParserInst
 CODESTARTfreeParserInst
 	dbgprintf("pmnormalize: free parser instance %p\n", pInst);
+	if(pInst->ctxln != NULL) {
+		ln_exitCtx(pInst->ctxln);
+	}
 ENDfreeParserInst
 
 
@@ -185,6 +188,8 @@ CODESTARTnewParserInst
 				CHKiRet(es_addChar(&rules, '\n'));
 			}
 			inst->rule = (char*)es_str2cstr(rules, NULL);
+			if(rules != NULL)
+				es_deleteStr(rules);
 		} else {
 			LogError(0, RS_RET_INTERNAL_ERROR ,
 				"pmnormalize: program error, non-handled param '%s'",

--- a/tests/pmnormalize-rule-vg.sh
+++ b/tests/pmnormalize-rule-vg.sh
@@ -6,29 +6,28 @@ add_conf 'module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")
 
 input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
-parser(name="custom.pmnormalize" type="pmnormalize" rule=["rule=:<%pri:number%> %fromhost-ip:ipv4% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%", "rule=:<%pri:number%> %hostname:word% %fromhost-ip:ipv4% %syslogtag:char-to:\\x3a%: %msg:rest%"])
+parser(name="custom.pmnormalize" type="pmnormalize" rule=[
+	"rule=:<%pri:number%> %fromhost-ip:ipv4% %fromhost:word% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%",
+	"rule=:<%pri:number%> %fromhost:word% %hostname:word% %fromhost-ip:ipv4% %syslogtag:char-to:\\x3a%: %msg:rest%"
+	])
 
-template(name="test" type="string" string="host: %hostname%, ip: %fromhost-ip%, tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
+template(name="test" type="string" string="host: %hostname%, fromhost: %fromhost%, ip: %fromhost-ip%, tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 
 ruleset(name="ruleset" parser="custom.pmnormalize") {
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="test")
 }
 '
-startup_vg_noleak
+startup_vg
 
-tcpflood -m1 -M "\"<189> 127.0.0.1 ubuntu tag1: this is a test message\""
-tcpflood -m1 -M "\"<112> 255.255.255.255 debian tag2: this is a test message\""
-tcpflood -m1 -M "\"<177> centos 192.168.0.9 tag3: this is a test message\""
+tcpflood -m1 -M "\"<189> 127.0.0.1 ubuntu ubuntu tag1: this is a test message\""
+tcpflood -m1 -M "\"<112> 255.255.255.255 debian debian tag2: this is a test message\""
+tcpflood -m1 -M "\"<177> centos centos 192.168.0.9 tag3: this is a test message\""
 shutdown_when_empty
 wait_shutdown_vg
 check_exit_vg
-echo 'host: ubuntu, ip: 127.0.0.1, tag: tag1, pri: 189, syslogfacility: 23, syslogseverity: 5 msg: this is a test message
-host: debian, ip: 255.255.255.255, tag: tag2, pri: 112, syslogfacility: 14, syslogseverity: 0 msg: this is a test message
-host: centos, ip: 192.168.0.9, tag: tag3, pri: 177, syslogfacility: 22, syslogseverity: 1 msg: this is a test message' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
 
+EXPECTED='host: ubuntu, fromhost: ubuntu, ip: 127.0.0.1, tag: tag1, pri: 189, syslogfacility: 23, syslogseverity: 5 msg: this is a test message
+host: debian, fromhost: debian, ip: 255.255.255.255, tag: tag2, pri: 112, syslogfacility: 14, syslogseverity: 0 msg: this is a test message
+host: centos, fromhost: centos, ip: 192.168.0.9, tag: tag3, pri: 177, syslogfacility: 22, syslogseverity: 1 msg: this is a test message'
+cmp_exact $RSYSLOG_OUT_LOG
 exit_test


### PR DESCRIPTION
While parsing the message the reference count of the
json objects is incremented but was never decremented.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
