### PR TITLE
imrelp: do not fail build if librelp does not have relpSrvSetLstnAddr

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1403,6 +1403,8 @@ if test "x$enable_relp" = "xyes"; then
 
         AC_CHECK_FUNC([relpSrvSetOversizeMode],
                       [AC_DEFINE([HAVE_RELPSRVSETOVERSIZEMODE], [1], [Define if relpSrvSetOversizeMode exists.])])
+        AC_CHECK_FUNC([relpSrvSetLstnAddr],
+                      [AC_DEFINE([HAVE_RELPSRVSETLSTNADDR], [1], [Define if relpSrvSetLstnAddr exists.])])
 
         CFLAGS="$save_CFLAGS"
         LIBS="$save_LIBS"

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -381,9 +381,11 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 	}
 
 	CHKiRet(relpEngineListnerConstruct(pRelpEngine, &pSrv));
-	CHKiRet(relpSrvSetLstnPort(pSrv, inst->pszBindPort));
-	CHKiRet(relpSrvSetLstnAddr(pSrv, inst->pszBindAddr));
 	CHKiRet(relpSrvSetMaxDataSize(pSrv, inst->maxDataSize));
+	CHKiRet(relpSrvSetLstnPort(pSrv, inst->pszBindPort));
+	#if defined(HAVE_RELPSRVSETLSTNADDR)
+		CHKiRet(relpSrvSetLstnAddr(pSrv, inst->pszBindAddr));
+	#endif
 
 #ifdef HAVE_RELPSRVSETOVERSIZEMODE
 	CHKiRet(relpSrvSetOversizeMode(pSrv, inst->oversizeMode));
@@ -505,7 +507,13 @@ CODESTARTnewInpInst
 		if(!strcmp(inppblk.descr[i].name, "port")) {
 			inst->pszBindPort = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "address")) {
-			inst->pszBindAddr = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			#if defined(HAVE_RELPSRVSETLSTNADDR)
+				inst->pszBindAddr = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			#else
+				parser_errmsg("imrelp: librelp does not support input parameter 'address'; "
+					"it probably is too old (1.2.16 should be fine); ignoring setting now, "
+					"listening on all interfaces");
+			#endif
 		} else if(!strcmp(inppblk.descr[i].name, "name")) {
 			inst->pszInputName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "ruleset")) {


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/2938

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
