### PR TITLE
testbench: fixed imfile parallel issues

### DIFF
--- a/tests/imfile-endmsg.regex-with-example.sh
+++ b/tests/imfile-endmsg.regex-with-example.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # This test tests imfile endmsg.regex.
-export IMFILECHECKTIMEOUT="20"
-export IMFILELASTINPUTLINES="6"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify
+export IMFILECHECKTIMEOUT="20"
+export IMFILELASTINPUTLINES="6"
+
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endmsg.regex-with-example.sh
+++ b/tests/imfile-endmsg.regex-with-example.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # This test tests imfile endmsg.regex.
-echo ======================================================================
-echo [imfile-endmsg.regex.sh]
-. $srcdir/diag.sh check-inotify
+export IMFILECHECKTIMEOUT="20"
+export IMFILELASTINPUTLINES="6"
 . $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")
@@ -105,6 +105,8 @@ echo '{"time":"date", "stream":"stdout", "log":"msgnum:6\n"}' >> $RSYSLOG_DYNNAM
 echo 'date stdout P msgnum:7' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:7"}' >> $RSYSLOG_DYNNAME.json.input
 
+content_check_with_count "$RSYSLOG_DYNNAME" $IMFILELASTINPUTLINES $IMFILECHECKTIMEOUT
+
 shutdown_when_empty # shut down rsyslogd when done processing messages
 if [ "x${USE_VALGRIND:-false}" == "xtrue" ] ; then
 	wait_shutdown_vg
@@ -121,8 +123,8 @@ sleep 1
 NUMLINES=$(wc -l $RSYSLOG_OUT_LOG | awk '{print $1}' 2>/dev/null)
 
 rc=0
-if [ ! $NUMLINES -eq 6 ]; then
-  echo "ERROR: expecting 6 lines, got $NUMLINES"
+if [ ! $NUMLINES -eq $IMFILELASTINPUTLINES ]; then
+  echo "ERROR: expecting $IMFILELASTINPUTLINES lines, got $NUMLINES"
   rc=1
 fi
 

--- a/tests/imfile-endregex-timeout-with-shutdown-polling.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown-polling.sh
@@ -2,6 +2,7 @@
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . $srcdir/diag.sh init
 export IMFILECHECKTIMEOUT="20"
+
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile" mode="polling" pollingInterval="1")

--- a/tests/imfile-endregex-timeout-with-shutdown-polling.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown-polling.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . $srcdir/diag.sh init
+export IMFILECHECKTIMEOUT="20"
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile" mode="polling" pollingInterval="1")
@@ -28,8 +29,9 @@ startup
 # we need to sleep a bit between writes to give imfile a chance
 # to pick up the data (IN MULTIPLE ITERATIONS!)
 echo 'msgnum:0
- msgnum:1' > $RSYSLOG_DYNNAME.input
-./msleep 8000
+ msgnum:1' > $RSYSLOG_DYNNAME.input	 
+content_check_with_count 'msgnum:0
+ msgnum:1' 1 $IMFILECHECKTIMEOUT
 echo ' msgnum:2
  msgnum:3' >> $RSYSLOG_DYNNAME.input
 
@@ -45,27 +47,15 @@ startup
 
 # new data
 echo ' msgnum:4' >> $RSYSLOG_DYNNAME.input
-./msleep 8000
+content_check_with_count 'msgnum:2
+ msgnum:3
+ msgnum:4' 1 $IMFILECHECKTIMEOUT
+
 echo ' msgnum:5
  msgnum:6' >> $RSYSLOG_DYNNAME.input
-./msleep 8000
-
-# the next line terminates our test. It is NOT written to the output file,
-# as imfile waits whether or not there is a follow-up line that it needs
-# to combine.
-#echo 'END OF TEST' >> $RSYSLOG_DYNNAME.input
-#./msleep 2000
+content_check_with_count 'msgnum:5
+ msgnum:6' 1 $IMFILECHECKTIMEOUT
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown    # we need to wait until rsyslogd is finished!
-
-printf 'HEADER msgnum:0\\\\n msgnum:1
-HEADER  msgnum:2\\\\n msgnum:3\\\\n msgnum:4
-HEADER  msgnum:5\\\\n msgnum:6\n' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid multiline message generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit 1
-fi;
-
 exit_test

--- a/tests/imfile-endregex-timeout-with-shutdown.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+export IMFILECHECKTIMEOUT="30"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify-only
 generate_conf
@@ -24,7 +25,8 @@ startup
 # to pick up the data (IN MULTIPLE ITERATIONS!)
 echo 'msgnum:0
  msgnum:1' > $RSYSLOG_DYNNAME.input
-./msleep 8000
+content_check_with_count "msgnum:0
+ msgnum:1" 1 $IMFILECHECKTIMEOUT
 echo ' msgnum:2
  msgnum:3' >> $RSYSLOG_DYNNAME.input
 
@@ -36,22 +38,21 @@ startup
 
 # new data
 echo ' msgnum:4' >> $RSYSLOG_DYNNAME.input
-./msleep 8000
+content_check_with_count "msgnum:2
+ msgnum:3
+ msgnum:4" 1 $IMFILECHECKTIMEOUT
+
 echo ' msgnum:5
  msgnum:6' >> $RSYSLOG_DYNNAME.input
-./msleep 8000
+content_check_with_count "msgnum:5
+ msgnum:6" 1 $IMFILECHECKTIMEOUT
+
 
 # the next line terminates our test. It is NOT written to the output file,
 # as imfile waits whether or not there is a follow-up line that it needs
 # to combine.
-#echo 'END OF TEST' >> $RSYSLOG_DYNNAME.input
-#./msleep 2000
+echo 'END OF TEST' >> $RSYSLOG_DYNNAME.input
 
 shutdown_when_empty
 wait_shutdown
-
-EXPECTED='HEADER msgnum:0\\n msgnum:1
-HEADER  msgnum:2\\n msgnum:3\\n msgnum:4
-HEADER  msgnum:5\\n msgnum:6'
-cmp_exact $RSYSLOG_OUT_LOG
 exit_test

--- a/tests/imfile-endregex-timeout-with-shutdown.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-export IMFILECHECKTIMEOUT="30"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify-only
+export IMFILECHECKTIMEOUT="30"
+
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile" timeoutGranularity="1")

--- a/tests/imfile-endregex-timeout.sh
+++ b/tests/imfile-endregex-timeout.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+export IMFILECHECKTIMEOUT="30"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify-only
 generate_conf
@@ -24,19 +25,19 @@ startup
 # to pick up the data (IN MULTIPLE ITERATIONS!)
 echo 'msgnum:0
  msgnum:1' > $RSYSLOG_DYNNAME.input
-./msleep 10000
+content_check_with_count "msgnum:0
+ msgnum:1" 1 $IMFILECHECKTIMEOUT
+
 echo ' msgnum:2
  msgnum:3' >> $RSYSLOG_DYNNAME.input
+content_check_with_count "msgnum:2
+ msgnum:3" 1 $IMFILECHECKTIMEOUT
+
 # the next line terminates our test. It is NOT written to the output file,
 # as imfile waits whether or not there is a follow-up line that it needs
 # to combine.
 echo 'END OF TEST' >> $RSYSLOG_DYNNAME.input
-./msleep 2000
 
 shutdown_when_empty
 wait_shutdown
-
-EXPECTED='HEADER msgnum:0\\n msgnum:1
-HEADER  msgnum:2\\n msgnum:3' 
-cmp_exact $RSYSLOG_OUT_LOG
 exit_test

--- a/tests/imfile-endregex-timeout.sh
+++ b/tests/imfile-endregex-timeout.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-export IMFILECHECKTIMEOUT="30"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify-only
+export IMFILECHECKTIMEOUT="30"
+
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile" timeoutGranularity="1")

--- a/tests/imfile-freshStartTail2.sh
+++ b/tests/imfile-freshStartTail2.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # add 2018-05-17 by Pascal Withopf, released under ASL 2.0
-export IMFILECHECKTIMEOUT="60"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify
+export IMFILECHECKTIMEOUT="60"
+
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-freshStartTail2.sh
+++ b/tests/imfile-freshStartTail2.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # add 2018-05-17 by Pascal Withopf, released under ASL 2.0
+export IMFILECHECKTIMEOUT="60"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
@@ -17,13 +18,11 @@ template(name="outfmt" type="string" string="%msg%\n")
 startup
 
 echo '{ "id": "jinqiao1"}' > $RSYSLOG_DYNNAME.input.a
-./msleep 2000
+content_check_with_count '{ "id": "jinqiao1"}' 1 $IMFILECHECKTIMEOUT
+
 echo '{ "id": "jinqiao2"}' >> $RSYSLOG_DYNNAME.input.a
+content_check_with_count '{ "id": "jinqiao2"}' 1 $IMFILECHECKTIMEOUT
 
 shutdown_when_empty
 wait_shutdown
-
-EXPECTED='{ "id": "jinqiao1"}
-{ "id": "jinqiao2"}'
-cmp_exact $RSYSLOG_OUT_LOG
 exit_test

--- a/tests/imfile-rename.sh
+++ b/tests/imfile-rename.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
 export TESTMESSAGES=10000
-export RETRIES=10
+export RETRIES=50
 export TESTMESSAGESFULL=19999
 echo [imfile-rename.sh]
 . $srcdir/diag.sh check-inotify-only

--- a/tests/imfile-rename.sh
+++ b/tests/imfile-rename.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh check-inotify-only
+. $srcdir/diag.sh init
 export TESTMESSAGES=10000
 export RETRIES=50
 export TESTMESSAGESFULL=19999
-echo [imfile-rename.sh]
-. $srcdir/diag.sh check-inotify-only
-. $srcdir/diag.sh init
+
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-symlink.sh
+++ b/tests/imfile-symlink.sh
@@ -4,11 +4,12 @@
 # are recorded with correct corresponding metadata (name of symlink 
 # matching configuration).
 # This is part of the rsyslog testbench, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify
 export IMFILEINPUTFILES="10"
 export IMFILELASTINPUTLINES="3"
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
-. $srcdir/diag.sh check-inotify
+
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
 generate_conf

--- a/tests/imfile-symlink.sh
+++ b/tests/imfile-symlink.sh
@@ -5,6 +5,8 @@
 # matching configuration).
 # This is part of the rsyslog testbench, released under ASL 2.0
 export IMFILEINPUTFILES="10"
+export IMFILELASTINPUTLINES="3"
+export IMFILECHECKTIMEOUT="20"
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify
 # generate input files first. Note that rsyslog processes it as
@@ -49,28 +51,16 @@ do
 	# Wait little for correct timing
 	./msleep 50
 done
-./inputfilegen -m 3 > $RSYSLOG_DYNNAME.input.$((IMFILEINPUTFILES + 1)).log
+
+# Content check with timeout
+content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILES $IMFILECHECKTIMEOUT
+
+./inputfilegen -m $IMFILELASTINPUTLINES > $RSYSLOG_DYNNAME.input.$((IMFILEINPUTFILES + 1)).log
 ls -l $RSYSLOG_DYNNAME.input.* rsyslog-link.* $RSYSLOG_DYNNAME.targets
+
+# Content check with timeout
+content_check_with_count "input.11.log" $IMFILELASTINPUTLINES $IMFILECHECKTIMEOUT
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown        # we need to wait until rsyslogd is finished!
-
-sort ${RSYSLOG_OUT_LOG} > ${RSYSLOG_OUT_LOG}.sorted
-
-echo HEADER msgnum:00000000:, filename: ./$RSYSLOG_DYNNAME.input-symlink.log, fileoffset: 0 >$RSYSLOG_DYNNAME.expected
-for i in `seq 2 $IMFILEINPUTFILES` ; do
-	echo HEADER msgnum:00000000:, filename: ./$RSYSLOG_DYNNAME.input.${i}.log, fileoffset: 0 >>$RSYSLOG_DYNNAME.expected
-done
-echo HEADER msgnum:00000000:, filename: ./$RSYSLOG_DYNNAME.input.11.log, fileoffset: 0 >>$RSYSLOG_DYNNAME.expected
-echo HEADER msgnum:00000001:, filename: ./$RSYSLOG_DYNNAME.input.11.log, fileoffset: 17 >>$RSYSLOG_DYNNAME.expected
-echo HEADER msgnum:00000002:, filename: ./$RSYSLOG_DYNNAME.input.11.log, fileoffset: 34 >>$RSYSLOG_DYNNAME.expected
-sort < $RSYSLOG_DYNNAME.expected | cmp - ${RSYSLOG_OUT_LOG}.sorted
-if [ ! $? -eq 0 ]; then
-  echo "invalid output generated, ${RSYSLOG_OUT_LOG} is:"
-  cat -n $RSYSLOG_OUT_LOG
-  echo "EXPECTED:"
-  cat -n $RSYSLOG_DYNNAME.expected
-  error_exit 1
-fi;
-
 exit_test

--- a/tests/imfile-wildcards-dirs-multi.sh
+++ b/tests/imfile-wildcards-dirs-multi.sh
@@ -59,6 +59,7 @@ do
 	do
 		mkdir $RSYSLOG_DYNNAME.input.dir$i
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$i
+		touch $RSYSLOG_DYNNAME.input.dir$i/dir$i/file.logfile
 		./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/dir$i/file.logfile
 	done
 
@@ -72,9 +73,14 @@ do
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/dir$i/file.logfile
+		rm -rf $RSYSLOG_DYNNAME.input.dir$i/dir$i/
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i
 	done
 
+	# Helps in testbench parallel mode. 
+	#	Otherwise sometimes directories are not marked deleted in imfile before they get created again.
+	#	This is properly a real issue in imfile when FILE IO is high. 
+	./msleep 1000
 done
 
 shutdown_when_empty

--- a/tests/imfile-wildcards-dirs-multi.sh
+++ b/tests/imfile-wildcards-dirs-multi.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify-only
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
-. $srcdir/diag.sh check-inotify-only
+
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-wildcards-dirs-multi2.sh
+++ b/tests/imfile-wildcards-dirs-multi2.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
+
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-wildcards-dirs-multi2.sh
+++ b/tests/imfile-wildcards-dirs-multi2.sh
@@ -62,6 +62,7 @@ do
 		echo "Make $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir"
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir
+		touch $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/file.logfile
 		./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/file.logfile
 	done
 	ls -d $RSYSLOG_DYNNAME.input.*
@@ -76,6 +77,11 @@ do
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/file.logfile
 		rm -rr $RSYSLOG_DYNNAME.input.dir$i/dir$j
 	done
+
+	# Helps in testbench parallel mode. 
+	#	Otherwise sometimes directories are not marked deleted in imfile before they get created again.
+	#	This is properly a real issue in imfile when FILE IO is high. 
+	./msleep 1000
 done
 
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/imfile-wildcards-dirs-multi3.sh
+++ b/tests/imfile-wildcards-dirs-multi3.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
+
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-wildcards-dirs-multi3.sh
+++ b/tests/imfile-wildcards-dirs-multi3.sh
@@ -3,7 +3,7 @@
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
-export IMFILECHECKTIMEOUT="10"
+export IMFILECHECKTIMEOUT="20"
 . $srcdir/diag.sh init
 generate_conf
 add_conf '
@@ -66,6 +66,7 @@ do
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/subdir$j
+		touch $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/subdir$j/file.logfile
 		./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/subdir$j/file.logfile
 		ls -l $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/subdir$j/file.logfile
 	done
@@ -81,6 +82,11 @@ do
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/subdir$j/file.logfile
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/dir$j
 	done
+
+	# Helps in testbench parallel mode. 
+	#	Otherwise sometimes directories are not marked deleted in imfile before they get created again.
+	#	This is properly a real issue in imfile when FILE IO is high. 
+	./msleep 1000
 done
 
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/imfile-wildcards-dirs-multi4.sh
+++ b/tests/imfile-wildcards-dirs-multi4.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
+
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-wildcards-dirs-multi4.sh
+++ b/tests/imfile-wildcards-dirs-multi4.sh
@@ -66,6 +66,7 @@ do
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/su$j
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/su$j/bd$j
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/su$j/bd$j/ir$j
+		touch $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/su$j/bd$j/ir$j/file.logfile
 		./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/su$j/bd$j/ir$j/file.logfile
 	done
 	ls -d $RSYSLOG_DYNNAME.input.*
@@ -80,6 +81,11 @@ do
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/dir$j/testdir/su$j/bd$j/ir$j/file.logfile
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/dir$j
 	done
+
+	# Helps in testbench parallel mode. 
+	#	Otherwise sometimes directories are not marked deleted in imfile before they get created again.
+	#	This is properly a real issue in imfile when FILE IO is high. 
+	./msleep 1000
 done
 
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/imfile-wildcards-dirs-multi5-polling.sh
+++ b/tests/imfile-wildcards-dirs-multi5-polling.sh
@@ -3,7 +3,7 @@
 export IMFILEINPUTFILES="8" #"8"
 export IMFILEINPUTFILESSTEPS="5" #"5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
-export IMFILECHECKTIMEOUT="5"
+export IMFILECHECKTIMEOUT="20"
 . $srcdir/diag.sh init
 #. $srcdir/diag.sh check-inotify-only
 # generate input files first. Note that rsyslog processes it as
@@ -54,6 +54,7 @@ do
 	do
 		mkdir $RSYSLOG_DYNNAME.input.dir$i
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$i
+		touch $RSYSLOG_DYNNAME.input.dir$i/dir$i/file.logfile
 		./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/dir$i/file.logfile
 	done
 

--- a/tests/imfile-wildcards-dirs-multi5-polling.sh
+++ b/tests/imfile-wildcards-dirs-multi5-polling.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
+#. $srcdir/diag.sh check-inotify-only
 export IMFILEINPUTFILES="8" #"8"
 export IMFILEINPUTFILESSTEPS="5" #"5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
-#. $srcdir/diag.sh check-inotify-only
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
 

--- a/tests/imfile-wildcards-dirs-multi5.sh
+++ b/tests/imfile-wildcards-dirs-multi5.sh
@@ -53,6 +53,7 @@ do
 	do
 		mkdir $RSYSLOG_DYNNAME.input.dir$i
 		mkdir $RSYSLOG_DYNNAME.input.dir$i/dir$i
+		touch $RSYSLOG_DYNNAME.input.dir$i/dir$i/file.logfile
 		./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/dir$i/file.logfile
 	done
 
@@ -73,6 +74,10 @@ do
 		rm -vrf $RSYSLOG_DYNNAME.input.dir$i
 	done
 
+	# Helps in testbench parallel mode. 
+	#	Otherwise sometimes directories are not marked deleted in imfile before they get created again.
+	#	This is properly a real issue in imfile when FILE IO is high. 
+	./msleep 1000
 done
 
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/imfile-wildcards-dirs-multi5.sh
+++ b/tests/imfile-wildcards-dirs-multi5.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
 export IMFILEINPUTFILES="8" #"8"
 export IMFILEINPUTFILESSTEPS="5" #"5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
 

--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
 export IMFILEINPUTFILES="10"
+export IMFILECHECKTIMEOUT="20"
 echo [imfile-wildcards-dirs.sh]
 . $srcdir/diag.sh check-inotify
 . $srcdir/diag.sh init
@@ -50,11 +51,19 @@ startup
 for i in `seq 1 $IMFILEINPUTFILES`;
 do
 	mkdir $RSYSLOG_DYNNAME.input.dir$i
+	touch $RSYSLOG_DYNNAME.input.dir$i/file.logfile
 	./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/file.logfile
 done
 ls -d $RSYSLOG_DYNNAME.input.*
 
+# Content check with timeout
+content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILES $IMFILECHECKTIMEOUT
+
+for i in `seq 1 $IMFILEINPUTFILES`;
+do
+	rm -rf $RSYSLOG_DYNNAME.input.dir$i/
+done
+
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown	# we need to wait until rsyslogd is finished!
-content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILES
 exit_test

--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-export IMFILEINPUTFILES="10"
-export IMFILECHECKTIMEOUT="20"
-echo [imfile-wildcards-dirs.sh]
 . $srcdir/diag.sh check-inotify
 . $srcdir/diag.sh init
+export IMFILEINPUTFILES="10"
+export IMFILECHECKTIMEOUT="20"
+
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -3,7 +3,7 @@
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
-export IMFILECHECKTIMEOUT="5"
+export IMFILECHECKTIMEOUT="20"
 . $srcdir/diag.sh init
 generate_conf
 add_conf '
@@ -58,6 +58,7 @@ do
 	for i in `seq 1 $IMFILEINPUTFILES`;
 	do
 		mkdir $RSYSLOG_DYNNAME.input.dir$i
+		touch $RSYSLOG_DYNNAME.input.dir$i/file.logfile
 		./inputfilegen -m 1 > $RSYSLOG_DYNNAME.input.dir$i/file.logfile
 	done
 	ls -d $RSYSLOG_DYNNAME.input.*
@@ -71,6 +72,11 @@ do
 	do
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/
 	done
+	
+	# Helps in testbench parallel mode. 
+	#	Otherwise sometimes directories are not marked deleted in imfile before they get created again.
+	#	This is properly a real issue in imfile when FILE IO is high. 
+	./msleep 1000
 done
 
 # sleep a little to give rsyslog a chance for processing

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="20"
-. $srcdir/diag.sh init
+
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-wildcards.sh
+++ b/tests/imfile-wildcards.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify
 export IMFILEINPUTFILES="10"
 export IMFILELASTINPUTLINES="3"
 export IMFILECHECKTIMEOUT="20"
 
-. $srcdir/diag.sh init
-. $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '
 # comment out if you need more debug info:
@@ -37,16 +37,17 @@ if $msg contains "msgnum:" then
 # generate input files first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
 
-imfilebefore=$RSYSLOG_DYNNAME.input.1.log
+imfilebefore=$RSYSLOG_DYNNAME.input.01.log
 ./inputfilegen -m 1 > $imfilebefore
 
 # Start rsyslog now before adding more files
 startup
 
-for i in `seq 2 $IMFILEINPUTFILES`;
+for i in $(seq 2 $IMFILEINPUTFILES);
 do
-	cp $imfilebefore $RSYSLOG_DYNNAME.input.$i.log
-	imfilebefore=$RSYSLOG_DYNNAME.input.$i.log
+	filnbr=$(printf "%2.2d" $i)
+	cp $imfilebefore $RSYSLOG_DYNNAME.input.$filnbr.log
+	imfilebefore=$RSYSLOG_DYNNAME.input.$filnbr.log
 done
 
 # Content check with timeout
@@ -61,4 +62,28 @@ content_check_with_count "input.11.log" $IMFILELASTINPUTLINES $IMFILECHECKTIMEOU
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown	# we need to wait until rsyslogd is finished!
+
+# Sort Output file now, and compare full file content
+presort
+
+printf 'HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.01.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.02.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.03.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.04.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.05.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.06.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.07.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.08.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.09.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.10.log, fileoffset: 0
+HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.11.log, fileoffset: 0
+HEADER msgnum:00000001:, filename: ./'$RSYSLOG_DYNNAME'.input.11.log, fileoffset: 17
+HEADER msgnum:00000002:, filename: ./'$RSYSLOG_DYNNAME'.input.11.log, fileoffset: 34\n' | cmp - $RSYSLOG_DYNNAME.presort
+if [ ! $? -eq 0 ]; then
+	echo "FAIL: invalid output generated, $RSYSLOG_DYNNAME.presort is:"
+	echo "File contents:"
+	cat -n $RSYSLOG_DYNNAME.presort
+	error_exit 1
+fi;
+
 exit_test

--- a/tests/imfile-wildcards.sh
+++ b/tests/imfile-wildcards.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
 export IMFILEINPUTFILES="10"
+export IMFILELASTINPUTLINES="3"
+export IMFILECHECKTIMEOUT="20"
+
 . $srcdir/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
@@ -44,32 +47,18 @@ for i in `seq 2 $IMFILEINPUTFILES`;
 do
 	cp $imfilebefore $RSYSLOG_DYNNAME.input.$i.log
 	imfilebefore=$RSYSLOG_DYNNAME.input.$i.log
-	# Wait little for correct timing
-	./msleep 50
 done
-./inputfilegen -m 3 > $RSYSLOG_DYNNAME.input.$((IMFILEINPUTFILES + 1)).log
+
+# Content check with timeout
+content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILES $IMFILECHECKTIMEOUT
+
+# Add some extra lines to the last log
+./inputfilegen -m $IMFILELASTINPUTLINES > $RSYSLOG_DYNNAME.input.$((IMFILEINPUTFILES + 1)).log
 ls -l $RSYSLOG_DYNNAME.input.*
+
+# Content check with timeout
+content_check_with_count "input.11.log" $IMFILELASTINPUTLINES $IMFILECHECKTIMEOUT
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown	# we need to wait until rsyslogd is finished!
-
-printf 'HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.1.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.2.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.3.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.4.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.5.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.6.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.7.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.8.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.9.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.10.log, fileoffset: 0
-HEADER msgnum:00000000:, filename: ./'$RSYSLOG_DYNNAME'.input.11.log, fileoffset: 0
-HEADER msgnum:00000001:, filename: ./'$RSYSLOG_DYNNAME'.input.11.log, fileoffset: 17
-HEADER msgnum:00000002:, filename: ./'$RSYSLOG_DYNNAME'.input.11.log, fileoffset: 34\n' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid output generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  exit 1
-fi;
-
 exit_test


### PR DESCRIPTION
- Fixed timing issues in some imfile wildcard/regex tests
- Added touch command in imfile wildcard tests to make sure directories exist before files are created in it if IO is under stress. 
- changed content checking in some tests to use "content_check_with_count" with check timeouts instead of using fixed sleeptimes. 
