### PR TITLE
imfile: improve truncation detection

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -221,9 +221,9 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	/* begin regular error codes */
 	RS_RET_NOT_IMPLEMENTED = -7,	/**< implementation is missing (probably internal error or lazyness ;)) */
 	RS_RET_OUT_OF_MEMORY = -6,	/**< memory allocation failed */
-	RS_RET_PROVIDED_BUFFER_TOO_SMALL = -50,
-/*< the caller provided a buffer, but the called function sees the size of this buffer is too small -
-operation not carried out */
+	RS_RET_PROVIDED_BUFFER_TOO_SMALL = -50, /*< the caller provided a buffer, but the called function sees
+						  the size of this buffer is too small - operation not carried out */
+	RS_RET_FILE_TRUNCATED = -51,	/**< (input) file was truncated, not an error but a status */
 	RS_RET_TRUE = -3,		/**< to indicate a true state (can be used as TRUE, legacy) */
 	RS_RET_FALSE = -2,		/**< to indicate a false state (can be used as FALSE, legacy) */
 	RS_RET_NO_IRET = -8,	/**< This is a trick for the debuging system - it means no iRet is provided  */

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -583,9 +583,9 @@ strmHandleEOFMonitor(strm_t *pThis)
 	ISOBJ_TYPE_assert(pThis, strm);
 	if(stat((char*) pThis->pszCurrFName, &statName) == -1)
 		ABORT_FINALIZE(RS_RET_IO_ERROR);
-	DBGPRINTF("stream checking for file change on '%s', inode %u/%u\n",
-	  pThis->pszCurrFName, (unsigned) pThis->inode,
-	  (unsigned) statName.st_ino);
+	DBGPRINTF("stream checking for file change on '%s', inode %u/%u size %llu/%llu\n",
+		pThis->pszCurrFName, (unsigned) pThis->inode, (unsigned) statName.st_ino,
+		(long long unsigned) pThis->iCurrOffs, (long long unsigned) statName.st_size);
 
 	/* Inode unchanged but file size on disk is less than current offset
 	 * means file was truncated, we also reopen if 'reopenOnTruncate' is on

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -124,6 +124,7 @@ typedef struct strm_s {
 	ino_t inode;	/* current inode for files being monitored (undefined else) */
 	uchar *pszCurrFName; /* name of current file (if open) */
 	uchar *pIOBuf;	/* the iobuffer currently in use to gather data */
+	char *pIOBuf_truncation; /* iobuffer used during trucation detection block re-reads */
 	size_t iBufPtrMax;	/* current max Ptr in Buffer (if partial read!) */
 	size_t iBufPtr;	/* pointer into current buffer */
 	int iUngetC;	/* char set via UngetChar() call or -1 if none set */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -947,6 +947,7 @@ TESTS += \
 	imfile-fileNotFoundError-parameter.sh \
 	imfile-error-not-repeated.sh \
 	imfile-truncate.sh \
+	imfile-truncate-multiple.sh \
 	imfile-readmode2.sh \
 	imfile-readmode2-polling.sh \
 	imfile-readmode2-with-persists-data-during-stop.sh \
@@ -1553,6 +1554,7 @@ EXTRA_DIST= \
 	imfile-freshStartTail2.sh \
 	imfile-freshStartTail3.sh \
 	imfile-truncate.sh \
+	imfile-truncate-multiple.sh \
 	imfile-wildcards.sh \
 	imfile-wildcards-dirs.sh \
 	imfile-wildcards-dirs2.sh \

--- a/tests/imfile-truncate-multiple.sh
+++ b/tests/imfile-truncate-multiple.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# this test checks truncation mode, and does so with multiple truncations of
+# the input file.
+# It also needs a larger load, which shall be sufficient to do begin of file
+# checks as well as should support file id hash generation.
+# addd 2016-10-06 by RGerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+. $srcdir/diag.sh check-inotify
+export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+export RSYSLOG_DEBUGLOG="log"
+generate_conf
+add_conf '
+module(load="../plugins/imfile/.libs/imfile" pollingInterval="1")
+
+input(type="imfile" File="'./$RSYSLOG_DYNNAME'.input" Tag="file:" reopenOnTruncate="on")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "msgnum:" then
+	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+
+# write the beginning of the file
+NUMMSG=1000
+./inputfilegen -m 1000 -i0 > $RSYSLOG_DYNNAME.input
+ls -li $RSYSLOG_DYNNAME.input
+inode=$(ls -i $RSYSLOG_DYNNAME.input | awk '{ print $1;}' )
+echo inode $inode
+
+startup
+
+for i in {0..50}; do
+	# check that previous msg injection worked
+	wait_queueempty
+	echo nbr of lines: $(wc -l $RSYSLOG_OUT_LOG)
+	seq_check 0 $((NUMMSG - 1))
+
+	# begin new inject cycle
+	generate_msgs=$(( i * 50))
+	echo generating $NUMMSG .. $((NUMMSG + generate_msgs -1))
+	./inputfilegen -m$generate_msgs -i$NUMMSG > $RSYSLOG_DYNNAME.input
+	let NUMMSG=NUMMSG+generate_msgs
+	if [  $inode -ne $(ls -i $RSYSLOG_DYNNAME.input | awk '{ print $1;}' ) ]; then
+		echo FAIL testbench did not keep same inode number, expected $inode
+		ls -li $RSYSLOG_DYNNAME.input
+		exit 100
+	fi
+done
+
+echo generated $NUMMSG messages
+
+shutdown_when_empty
+wait_shutdown
+
+seq_check 0 $((NUMMSG - 1))
+exit_test


### PR DESCRIPTION
previously, truncation was only detected at end of file. Especially with
busy files that could cause loss of data and possibly also stall imfile
reading. The new code now also checks during each read. Obviously, there
is some additional overhead associated with that, but this is unavoidable.

It still is highly recommended NOT to turn on "reopenOnTruncate" in imfile.
Note that there are also inherant reliability issues. There is no way to
"fix" these, as they are caused by races between the process(es) who truncate
and rsyslog reading the file. But with the new code, the "problem window"
should be much smaller and, more importantly, imfile should not stall.

see also https://github.com/rsyslog/rsyslog/issues/1605
possibly replaces #3011
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
