### PR TITLE
omprog: document 'useTransactions' flag as experimental

### DIFF
--- a/plugins/external/INTERFACE.md
+++ b/plugins/external/INTERFACE.md
@@ -176,6 +176,11 @@ _transactions_), instead of individually. For a general explanation on how
 rsyslog handles the batching of messages, see
 http://www.rsyslog.com/doc/v8-stable/development/dev_oplugins.html.
 
+_**Warning:**
+This feature is currently **experimental**. It could change in future releases
+without keeping backwards compatibility with existing configurations or the
+interface described below._
+
 How to process the messages in batches (transactions)
 -----------------------------------------------------
 To enable transactions, set the `useTransactions` flag to `on` in the `omprog`


### PR DESCRIPTION
The rsyslog module interface was not designed to support modules that
can act both as transactional and non-transactional according to
a configuration parameter. The old transaction interface (incidentally)
supports this, but it is not supported by the new transaction interface.

Therefore a future change is envisaged regarding this feature, that will
likely break backwards compatibility.