### PR TITLE
bugfix imfile: segfault in ratelimiter

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -915,9 +915,6 @@ act_obj_destroy(act_obj_t *const act, const int is_deleted)
 			}
 		}
 	}
-	if(act->ratelimiter != NULL) {
-		ratelimitDestruct(act->ratelimiter);
-	}
 	if(act->pStrm != NULL) {
 		const instanceConf_t *const inst = act->edge->instarr[0];// TODO: same file, multiple instances?
 		pollFile(act); /* get any left-over data */
@@ -933,6 +930,9 @@ act_obj_destroy(act_obj_t *const act, const int is_deleted)
 			DBGPRINTF("act_obj_destroy: deleting state file %s\n", statefn);
 			unlink((char*)statefn);
 		}
+	}
+	if(act->ratelimiter != NULL) {
+		ratelimitDestruct(act->ratelimiter);
 	}
 	#ifdef HAVE_INOTIFY_INIT
 	if(act->wd != -1) {
@@ -1525,7 +1525,7 @@ pollFileReal(act_obj_t *act, cstr_t **pCStr)
 	int nProcessed = 0;
 	regex_t *start_preg = NULL, *end_preg = NULL;
 
-	DBGPRINTF("pollFileReal enter, pStrm %p, name '%s'\n", act->pStrm, act->name);
+	DBGPRINTF("pollFileReal enter, act %p, pStrm %p, name '%s'\n", act, act->pStrm, act->name);
 	DBGPRINTF("pollFileReal enter, edge %p\n", act->edge);
 	DBGPRINTF("pollFileReal enter, edge->instarr %p\n", act->edge->instarr);
 


### PR DESCRIPTION
imfile crashes inside rate limit processing, often when log
files are rotated. However, this could occur in any case where
the monitored files was closed by imfile, it rotation is just
the most probable cause for this (moving the file to another
directory or deleting it also can trigger the same issue, for
example). The root cause was invalid sequence of operations.

closes https://github.com/rsyslog/rsyslog/issues/3021

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
