### PR TITLE
testbench: add simple omsnmp test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -344,6 +344,10 @@ TESTS +=  \
 endif # HAVE_VALGRIND
 endif # ENABLE_DEFAULT_TESTS
 
+if ENABLE_SNMP
+TESTS +=  \
+	omsnmp_errmsg_no_params.sh
+endif # if ENABLE_SNMP
 
 if ENABLE_MAIL
 TESTS +=  \
@@ -1182,6 +1186,7 @@ EXTRA_DIST= \
 	rs-cnum.sh \
 	rs-int2hex.sh \
 	rs-substring.sh \
+	omsnmp_errmsg_no_params.sh \
 	ommail_errmsg_no_params.sh \
 	mmanon_random_32_ipv4.sh \
 	mmanon_random_cons_32_ipv4.sh \

--- a/tests/omsnmp_errmsg_no_params.sh
+++ b/tests/omsnmp_errmsg_no_params.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# add 2018-09-25 by Jan Gerhards, released under ASL 2.0
+
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+
+module(load="../plugins/omsnmp/.libs/omsnmp")
+
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="omsnmp")
+'
+
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "parameter 'server' required but not specified"
+
+exit_test


### PR DESCRIPTION
currently only checks if module is loaded and checks for
required parameters correctly

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
