### PR TITLE
testbench: re-enable test sndrcv_relp_dflt_pt.sh

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -545,9 +545,6 @@ TESTS +=  \
 if ENABLE_IP
 TESTS += tcp_forwarding_ns_tpl.sh
 endif
-if ENABLE_RELP
-TESTS += sndrcv_relp_dflt_pt.sh
-endif
 if HAVE_VALGRIND
 TESTS +=  \
 	mmexternal-SegFault-empty-jroot-vg.sh
@@ -861,6 +858,7 @@ TESTS += sndrcv_relp.sh \
 	 imrelp-long-msg.sh \
 	 imrelp-oversizeMode-truncate.sh \
 	 imrelp-oversizeMode-accept.sh \
+	 sndrcv_relp_dflt_pt.sh \
 	 glbl-oversizeMsg-log.sh \
 	 glbl-oversizeMsg-truncate.sh \
 	 glbl-oversizeMsg-split.sh

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -1,32 +1,28 @@
 #!/bin/bash
+# this checks if omrelp works with the default port
+# Note: imrelp requires the port, so we cannot and must not
+# check the "default port"
 # added 2013-12-10 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-# the first test is redundant, but we keep it when we later make the port
-# configurable.
-if [ `./omrelp_dflt_port` -lt 1024 ]; then
+. $srcdir/diag.sh init
+relp_port=$(./omrelp_dflt_port)
+if [ $relp_port -lt 1024 ]; then
     if [ "$EUID" -ne 0 ]; then
+	echo relp default port $relp_port is priviledged
 	echo need to be root to run this test - skipping
         exit 77
     fi
 fi
 
-if [ `./omrelp_dflt_port` -ne 13515 ]; then
-    echo this test needs configure option --enable-omrelp-default-port=13515 to work
-    exit 77
-fi
-exit
-
 # uncomment for debugging support:
-. $srcdir/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)
-input(type="imrelp" port="'$PORT_RCVR'")
+input(type="imrelp" port="'$relp_port'")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
@@ -39,10 +35,9 @@ export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
 
-action(type="omrelp" protocol="tcp" target="127.0.0.1" port="'$PORT_RCVR'")
+action(type="omrelp" target="127.0.0.1")
 ' 2
 startup 2
-# may be needed by TLS (once we do it): sleep 30
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.


### PR DESCRIPTION
Test was originally only executed when root tests were enabled,
which routinely was not the case. There was not even a hard reason
to handle it that way. Also, the test had a couple of defects which
have also been fixed.

closes https://github.com/rsyslog/rsyslog/issues/3064

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
