### PR TITLE
QA: add test for queue.cry.keyprogram parameter

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -136,6 +136,7 @@ TESTS +=  \
 	imtcp_incomplete_frame_at_end.sh \
 	queue-encryption-disk.sh \
 	queue-encryption-disk_keyfile.sh \
+	queue-encryption-disk_keyprog.sh \
 	queue-encryption-da.sh \
 	daqueue-persist.sh \
 	daqueue-invld-qi.sh \
@@ -1435,6 +1436,7 @@ EXTRA_DIST= \
 	rcvr_fail_restore.sh \
 	queue-encryption-disk.sh \
 	queue-encryption-disk_keyfile.sh \
+	queue-encryption-disk_keyprog.sh \
 	queue-encryption-da.sh \
 	daqueue-dirty-shutdown.sh \
 	daqueue-invld-qi.sh \

--- a/tests/queue-encryption-disk_keyprog.sh
+++ b/tests/queue-encryption-disk_keyprog.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# addd 2018-10-01 by RGerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.filename="mainq"
+	queue.type="disk"
+	queue.maxDiskSpace="4m"
+	queue.maxfilesize="1m"
+	queue.timeoutenqueue="300000"
+	queue.lowwatermark="5000"
+
+	queue.cry.provider="gcry"
+	queue.cry.keyprogram="./'$RSYSLOG_DYNNAME.keyprogram'"
+	queue.saveonshutdown="on"
+)
+
+template(name="outfmt" type="string"
+	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
+
+:omtesting:sleep 0 5000
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+echo '#!/bin/bash
+echo RSYSLOG-KEY-PROVIDER:0
+echo 16
+echo "1234567890123456"' >> $RSYSLOG_DYNNAME.keyprogram
+chmod +x $RSYSLOG_DYNNAME.keyprogram
+startup
+injectmsg 0 1000
+shutdown_immediate
+wait_shutdown
+echo INFO: queue files in ${RSYSLOG_DYNNAME}.spool:
+ls -l ${RSYSLOG_DYNNAME}.spool
+check_not_present "msgnum:0000" ${RSYSLOG_DYNNAME}.spool/mainq.0*
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
