### PR TITLE
poll() loop. fix mismatch between sock list and pollvector index

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -899,13 +899,15 @@ rcvMainLoop(struct wrkrInfo_s *const __restrict__ pWrkr)
 		i = 0;
 		for(lstn = lcnfRoot ; nfds && lstn != NULL ; lstn = lstn->next) {
 			assert(i < nfd);
-			if(glbl.GetGlobalInputTermState() == 1)
-				ABORT_FINALIZE(RS_RET_FORCE_TERM); /* terminate input! */
-			if(pollfds[i].revents & POLLIN) {
-		       		processSocket(pWrkr, lstn, &frominetPrev, &bIsPermitted);
-				--nfds;
+			if(lstn->sock != -1) {
+				if(glbl.GetGlobalInputTermState() == 1)
+					ABORT_FINALIZE(RS_RET_FORCE_TERM); /* terminate input! */
+				if(pollfds[i].revents & POLLIN) {
+					processSocket(pWrkr, lstn, &frominetPrev, &bIsPermitted);
+					--nfds;
+				}
+				++i;
 			}
-			++i;
 	       }
 	       /* end of a run, back to loop for next recv() */
 	}


### PR DESCRIPTION
There is a mismatch between how the pollfds fd-array is created and how it is read when processing a poll() result.
At creation time the code currently skips lstn->sock if it is -1. This is not done when processing the poll event.
A possibility is also to skip these checks altogether since poll() should ignore fds that have value -1.
