### PR TITLE
imrelp: Fixed issue with oldstyle configuration caused by commit:

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -346,6 +346,8 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 		CHKmalloc(inst->pszBindRuleset = ustrdup(cs.pszBindRuleset));
 	}
 	inst->pBindRuleset = NULL;
+
+	inst->bEnableLstn = -1; /* all ok, ready to start up */
 finalize_it:
 	free(pNewVal);
 	RETiRet;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -861,6 +861,7 @@ if ENABLE_RELP
 TESTS += sndrcv_relp.sh \
 	 sndrcv_relp_rebind.sh \
 	 imrelp-basic.sh \
+	 imrelp-basic-oldstyle.sh \
 	 imrelp-manyconn.sh \
 	 imrelp-maxDataSize-error.sh \
 	 imrelp-long-msg.sh \
@@ -1451,6 +1452,7 @@ EXTRA_DIST= \
 	sndrcv_failover.sh \
 	sndrcv.sh \
 	imrelp-basic.sh \
+	imrelp-basic-oldstyle.sh \
 	imrelp-manyconn.sh \
 	imrelp-maxDataSize-error.sh \
 	imrelp-long-msg.sh \

--- a/tests/imrelp-basic-oldstyle.sh
+++ b/tests/imrelp-basic-oldstyle.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# addd 2018-10-09 by Alorbach, released under ASL 2.0
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+
+$ModLoad ../plugins/imrelp/.libs/imrelp # Old Style module loading
+$inputrelpserverrun '$TCPFLOOD_PORT' 
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m10000
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown
+seq_check 0 9999
+exit_test


### PR DESCRIPTION
imrelp: Fixed issue with oldstyle configuration caused by commit:
https://github.com/rsyslog/rsyslog/commit/32b71daa8aadb8f16fe0ca2945e54d593f47a824
    
Fixed by setting bEnableLstn in addInstance().
Closes https://github.com/rsyslog/rsyslog/issues/3106
