### PR TITLE
gcry crypto driver: small memleak

### DIFF
--- a/runtime/libgcry.c
+++ b/runtime/libgcry.c
@@ -463,6 +463,7 @@ void
 rsgcryCtxDel(gcryctx ctx)
 {
 	if(ctx != NULL) {
+		free(ctx->key);
 		free(ctx);
 	}
 }

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -457,11 +457,13 @@ StartDA(qqueue_t *pThis)
 		pThis->pqDA->useCryprov = pThis->useCryprov;
 		pThis->pqDA->cryprov = pThis->cryprov;
 		pThis->pqDA->cryprovData = pThis->cryprovData;
+		pThis->pqDA->cryprovName = pThis->cryprovName;
 		pThis->pqDA->cryprovNameFull = pThis->cryprovNameFull;
 		/* reset memory queue parameters */
 		pThis->useCryprov = 0;
 		/* pThis->cryprov cannot and need not be reset, is structure */
 		pThis->cryprovData = NULL;
+		pThis->cryprovName = NULL;
 		pThis->cryprovNameFull = NULL;
 	}
 


### PR DESCRIPTION
If a crypto key is specified directly via the key="" parameter,
the storage for that key is not freed, causing a small memleak.
Note that the problem occurs only once per context, so this
should not cause real issues. Even more so, as specifying a
key directly is meant only for testing purposes and is strongly
discouraged for production use.

Detected by internal testing, no actual fail case known.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
