### PR TITLE
fix useless use of cat

### DIFF
--- a/tests/imjournal-basic-vg.sh
+++ b/tests/imjournal-basic-vg.sh
@@ -39,7 +39,7 @@ if [ $? -ne 0 ]; then
         exit 77
 fi
 
-cat $RSYSLOG_OUT_LOG | fgrep -qF "$TESTMSG"
+fgrep -qF "$TESTMSG" < $RSYSLOG_OUT_LOG
 if [ $? -ne 0 ]; then
   echo "FAIL:  $RSYSLOG_OUT_LOG content (tail -n200):"
   tail -n200 $RSYSLOG_OUT_LOG

--- a/tests/imjournal-statefile.sh
+++ b/tests/imjournal-statefile.sh
@@ -38,7 +38,7 @@ startup
 ./msleep 500
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
-COUNT= cat $RSYSLOG_OUT_LOG | fgrep "$TESTMSG" | wc -l
+COUNT= fgrep "$TESTMSG" < $RSYSLOG_OUT_LOG | wc -l
 if [ $COUNT -ne 1 ]; then
   echo "FAIL: message found $COUNT times (expected 1)"
   echo " $RSYSLOG_OUT_LOG content (tail -n200):"

--- a/tests/imkafka-vg.sh
+++ b/tests/imkafka-vg.sh
@@ -10,7 +10,7 @@ export TESTMESSAGES=10000
 export TESTMESSAGESFULL=$TESTMESSAGES
 
 # Generate random topic name
-export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/imkafka.sh
+++ b/tests/imkafka.sh
@@ -10,7 +10,7 @@ export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 
 # Generate random topic name
-export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/imkafka_multi_many.sh
+++ b/tests/imkafka_multi_many.sh
@@ -10,7 +10,7 @@ export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/imkafka_multi_single.sh
+++ b/tests/imkafka_multi_single.sh
@@ -10,7 +10,7 @@ export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -11,7 +11,7 @@ export TESTMESSAGES2=50001
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -10,7 +10,7 @@ export TESTMESSAGES=50000
 export TESTMESSAGESFULL=50000
 
 # Generate random topic name
-export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_kafka_multi.sh
+++ b/tests/sndrcv_kafka_multi.sh
@@ -9,7 +9,7 @@ export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 8 | head -n 1)
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs


### PR DESCRIPTION
more or less cosmetic here, but anyhow...

detected by shellcheck

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
