### PR TITLE
bugfix core: potential hang on rsyslog termination

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -12,7 +12,7 @@
  * function names - this makes it really hard to read and does not provide much
  * benefit, at least I (now) think so...
  *
- * Copyright 2008-2017 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -480,7 +480,10 @@ wtpStartWrkr(wtp_t *pThis)
 	 */
 	do {
 		d_pthread_cond_wait(&pThis->condThrdInitDone, &pThis->mutWtp);
-	} while(wtiGetState(pWti) != WRKTHRD_RUNNING);
+	} while((iState = wtiGetState(pWti)) == WRKTHRD_INITIALIZING);
+	DBGPRINTF("%s: new worker finished initialization with state %d, num workers now %d\n",
+		wtpGetDbgHdr(pThis), iState,
+		ATOMIC_FETCH_32BIT(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd));
 
 finalize_it:
 	d_pthread_mutex_unlock(&pThis->mutWtp);

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -552,6 +552,7 @@ function wait_shutdown() {
 		   echo "manual cleanup."
 		   echo "TRYING TO capture status via gdb from hanging process"
 		   gdb ../tools/rsyslogd <<< "attach $out_pid
+set pagination off
 inf thr
 thread apply all bt
 quit"


### PR DESCRIPTION
The root cause was a deadlock during worker startup. This could
happen for example when a DA queue needed to persist data during
shutdown.

Fail condition:
* startup request for a new worker
* initialization of that worker
* immediate detection that the worker can or must shutdown
* main thread waiting for worker running state, which it skips,
  and so the main thread hangs inside a loop

closes https://github.com/rsyslog/rsyslog/issues/3094

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
