### PR TITLE
mmutf8fix: add test for no error

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -353,6 +353,11 @@ TESTS +=  \
 	omsnmp_errmsg_no_params.sh
 endif # if ENABLE_SNMP
 
+if ENABLE_MMUTF8FIX
+TESTS +=  \
+	mmutf8fix_no_error.sh
+endif # if ENABLE_MAIL
+
 if ENABLE_MAIL
 TESTS +=  \
 	ommail_errmsg_no_params.sh
@@ -1191,6 +1196,7 @@ EXTRA_DIST= \
 	rs-substring.sh \
 	omsnmp_errmsg_no_params.sh \
 	ommail_errmsg_no_params.sh \
+	mmutf8fix_no_error.sh \
 	mmanon_random_32_ipv4.sh \
 	mmanon_random_cons_32_ipv4.sh \
 	mmanon_recognize_ipv4.sh \

--- a/tests/mmutf8fix_no_error.sh
+++ b/tests/mmutf8fix_no_error.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# add 2018-10-10 by Jan Gerhards, released under ASL 2.0
+
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+
+module(load="../plugins/mmutf8fix/.libs/mmutf8fix")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+
+ruleset(name="testing") {
+	action(type="mmutf8fix")
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}'
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag: this is a test message
+<129>Mar 10 01:00:00 172.20.245.8 tag: special characters: ??%%,,..
+<129>Mar 10 01:00:00 172.20.245.8 tag: numbers: 1234567890\""
+
+shutdown_when_empty
+wait_shutdown
+echo ' this is a test message
+ special characters: ??%%,,..
+ numbers: 1234567890' | cmp - $RSYSLOG_OUT_LOG
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
+  cat $RSYSLOG_OUT_LOG
+  error_exit  1
+fi;
+
+exit_test


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/3070

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
