### PR TITLE
add test for msleep usage message

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,6 +55,7 @@ if ENABLE_DEFAULT_TESTS
 TESTS +=  \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
+	msleep_usage_output.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
 	hostname-with-slash-pmrfc5424.sh \
@@ -1198,6 +1199,7 @@ EXTRA_DIST= \
 	omsnmp_errmsg_no_params.sh \
 	ommail_errmsg_no_params.sh \
 	mmutf8fix_no_error.sh \
+	msleep_usage_output.sh \
 	mmanon_random_32_ipv4.sh \
 	mmanon_random_cons_32_ipv4.sh \
 	mmanon_recognize_ipv4.sh \

--- a/tests/msleep_usage_output.sh
+++ b/tests/msleep_usage_output.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# add 2016-11-22 by Jan Gerhards, released under ASL 2.0
+
+. $srcdir/diag.sh init
+
+./msleep &> $RSYSLOG_DYNNAME.output
+grep "usage: msleep" $RSYSLOG_DYNNAME.output 
+
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated"
+  error_exit  1
+fi;
+
+exit_test


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/issues/3072

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
