### PR TITLE
bugfix core msg: potential deadlock (and rsyslog hang)

### DIFF
--- a/plugins/mmsnmptrapd/mmsnmptrapd.c
+++ b/plugins/mmsnmptrapd/mmsnmptrapd.c
@@ -238,7 +238,7 @@ BEGINdoAction_NoStrings
 	instanceData *pData;
 CODESTARTdoAction
 	pData = pWrkrData->pData;
-	getTAG(pMsg, &pszTag, &lenTAG);
+	getTAG(pMsg, &pszTag, &lenTAG, LOCK_MUTEX);
 	if(strncmp((char*)pszTag, (char*)pData->pszTagID, pData->lenTagID)) {
 		DBGPRINTF("tag '%s' not matching, mmsnmptrapd ignoring this message\n",
 			  pszTag);

--- a/plugins/omjournal/omjournal.c
+++ b/plugins/omjournal/omjournal.c
@@ -258,7 +258,7 @@ send_non_template_message(smsg_t *const __restrict__ pMsg)
 	int sev;
 
 	MsgGetSeverity(pMsg, &sev);
-	getTAG(pMsg, &tag, &lenTag);
+	getTAG(pMsg, &tag, &lenTag, LOCK_MUTEX);
 	/* we can use more properties here, but let's see if there
 	* is some real user interest. We can always add later...
 	*/

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2348,7 +2348,7 @@ msgGetJSONMESG(smsg_t *__restrict__ const pMsg)
 	jval = json_object_new_string(getHOSTNAME(pMsg));
 	json_object_object_add(json, "hostname", jval);
 
-	getTAG(pMsg, &pRes, &bufLen);
+	getTAG(pMsg, &pRes, &bufLen, LOCK_MUTEX);
 	jval = json_object_new_string((char*)pRes);
 	json_object_object_add(json, "syslogtag", jval);
 
@@ -2456,8 +2456,8 @@ void MsgSetTAG(smsg_t *__restrict__ const pMsg, const uchar* pszBuf, const size_
  * if there is a TAG and, if not, if it can emulate it.
  * rgerhards, 2005-11-24
  */
-static void
-tryEmulateTAG(smsg_t * const pM, sbool bLockMutex)
+static void ATTR_NONNULL(1)
+tryEmulateTAG(smsg_t *const pM, const sbool bLockMutex)
 {
 	size_t lenTAG;
 	uchar bufTAG[CONF_TAG_MAXSIZE];
@@ -2491,15 +2491,15 @@ tryEmulateTAG(smsg_t * const pM, sbool bLockMutex)
 }
 
 
-void
-getTAG(smsg_t * const pM, uchar **ppBuf, int *piLen)
+void ATTR_NONNULL(2,3)
+getTAG(smsg_t * const pM, uchar **const ppBuf, int *const piLen, const sbool bLockMutex)
 {
 	if(pM == NULL) {
 		*ppBuf = UCHAR_CONSTANT("");
 		*piLen = 0;
 	} else {
 		if(pM->iLenTAG == 0)
-			tryEmulateTAG(pM, LOCK_MUTEX);
+			tryEmulateTAG(pM, bLockMutex);
 		if(pM->iLenTAG == 0) {
 			*ppBuf = UCHAR_CONSTANT("");
 			*piLen = 0;
@@ -2600,13 +2600,14 @@ MsgGetStructuredData(smsg_t * const pM, uchar **pBuf, rs_size_t *len)
 /* get the "programname" as sz string
  * rgerhards, 2005-10-19
  */
-uchar *getProgramName(smsg_t * const pM, sbool bLockMutex)
+uchar * ATTR_NONNULL(1)
+getProgramName(smsg_t *const pM, const sbool bLockMutex)
 {
 	if(pM->iLenPROGNAME == -1) {
 		if(pM->iLenTAG == 0) {
 			uchar *pRes;
 			rs_size_t bufLen = -1;
-			getTAG(pM, &pRes, &bufLen);
+			getTAG(pM, &pRes, &bufLen, bLockMutex);
 		}
 
 		if(bLockMutex == LOCK_MUTEX) {
@@ -2629,7 +2630,8 @@ uchar *getProgramName(smsg_t * const pM, sbool bLockMutex)
  * now would like to send out the same one via syslog-protocol.
  * MUST be called with the Msg Lock locked!
  */
-static void tryEmulateAPPNAME(smsg_t * const pM)
+static void ATTR_NONNULL(1)
+tryEmulateAPPNAME(smsg_t *const pM, const sbool bLockMutex)
 {
 	assert(pM != NULL);
 	if(pM->pCSAPPNAME != NULL)
@@ -2637,7 +2639,7 @@ static void tryEmulateAPPNAME(smsg_t * const pM)
 
 	if(msgGetProtocolVersion(pM) == 0) {
 		/* only then it makes sense to emulate */
-		MsgSetAPPNAME(pM, (char*)getProgramName(pM, MUTEX_ALREADY_LOCKED));
+		MsgSetAPPNAME(pM, (char*)getProgramName(pM, bLockMutex));
 	}
 }
 
@@ -2647,7 +2649,8 @@ static void tryEmulateAPPNAME(smsg_t * const pM)
  * This must be called WITHOUT the message lock being held.
  * rgerhards, 2009-06-26
  */
-static void prepareAPPNAME(smsg_t * const pM, sbool bLockMutex)
+static void ATTR_NONNULL(1)
+prepareAPPNAME(smsg_t *const pM, const sbool bLockMutex)
 {
 	if(pM->pCSAPPNAME == NULL) {
 		if(bLockMutex == LOCK_MUTEX)
@@ -2655,7 +2658,7 @@ static void prepareAPPNAME(smsg_t * const pM, sbool bLockMutex)
 
 		/* re-query as things might have changed during locking */
 		if(pM->pCSAPPNAME == NULL)
-			tryEmulateAPPNAME(pM);
+			tryEmulateAPPNAME(pM, MUTEX_ALREADY_LOCKED);
 
 		if(bLockMutex == LOCK_MUTEX)
 			MsgUnlock(pM);
@@ -3522,7 +3525,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			bufLen = getHOSTNAMELen(pMsg);
 			break;
 		case PROP_SYSLOGTAG:
-			getTAG(pMsg, &pRes, &bufLen);
+			getTAG(pMsg, &pRes, &bufLen, LOCK_MUTEX);
 			break;
 		case PROP_RAWMSG:
 			getRawMsg(pMsg, &pRes, &bufLen);

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -202,7 +202,7 @@ rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar* pszMSG, int lenMSG);
 uchar *MsgGetProp(smsg_t *pMsg, struct templateEntry *pTpe, msgPropDescr_t *pProp,
 		  rs_size_t *pPropLen, unsigned short *pbMustBeFreed, struct syslogTime *ttNow);
 uchar *getRcvFrom(smsg_t *pM);
-void getTAG(smsg_t *pM, uchar **ppBuf, int *piLen);
+void getTAG(smsg_t *pM, uchar **ppBuf, int *piLen, sbool);
 const char *getTimeReported(smsg_t *pM, enum tplFormatTypes eFmt);
 const char *getPRI(smsg_t *pMsg);
 int getPRIi(const smsg_t * const pM);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -150,6 +150,7 @@ TESTS +=  \
 	rulesetmultiqueue-v6.sh \
 	manytcp.sh \
 	rsf_getenv.sh \
+	msg-deadlock-headerless-noappname.sh \
 	imtcp_conndrop.sh \
 	imtcp_addtlframedelim.sh \
 	imtcp_no_octet_counted.sh \
@@ -1418,6 +1419,7 @@ EXTRA_DIST= \
 	testsuites/spframingfix.testdata \
 	imtcp_spframingfix.sh \
 	imptcp_spframingfix.sh \
+	msg-deadlock-headerless-noappname.sh \
 	imtcp_conndrop.sh \
 	imtcp_conndrop_tls.sh \
 	imtcp_conndrop_tls-vg.sh \

--- a/tests/msg-deadlock-headerless-noappname.sh
+++ b/tests/msg-deadlock-headerless-noappname.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# this checks against a situation where a deadlock was caused in
+# practice.
+# added 2018-10-17 by Jan Gerhards, released under ASL 2.0
+. $srcdir/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="input")
+
+ruleset(name="input") {
+    set $!tag = $app-name;
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+startup
+tcpflood -p $TCPFLOOD_PORT -M "[2018-10-16 09:59:13] ping pong"
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown
+exit_test

--- a/tools/smfile.c
+++ b/tools/smfile.c
@@ -77,7 +77,7 @@ CODESTARTstrgen
 	lenTimeStamp = ustrlen(pTimeStamp);
 	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
-	getTAG(pMsg, &pTAG, &lenTAG);
+	getTAG(pMsg, &pTAG, &lenTAG, LOCK_MUTEX);
 	pMSG = getMSG(pMsg);
 	lenMSG = getMSGLen(pMsg);
 

--- a/tools/smfwd.c
+++ b/tools/smfwd.c
@@ -78,7 +78,7 @@ CODESTARTstrgen
 	lenTimeStamp = ustrlen(pTimeStamp);
 	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
-	getTAG(pMsg, &pTAG, &lenTAG);
+	getTAG(pMsg, &pTAG, &lenTAG, LOCK_MUTEX);
 	if(lenTAG > 32)
 		lenTAG = 32; /* for forwarding, a max of 32 chars is permitted (RFC!) */
 	pMSG = getMSG(pMsg);

--- a/tools/smtradfile.c
+++ b/tools/smtradfile.c
@@ -72,7 +72,7 @@ CODESTARTstrgen
 	pTimeStamp = (uchar*) getTimeReported(pMsg, tplFmtRFC3164Date);
 	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
-	getTAG(pMsg, &pTAG, &lenTAG);
+	getTAG(pMsg, &pTAG, &lenTAG, LOCK_MUTEX);
 	pMSG = getMSG(pMsg);
 	lenMSG = getMSGLen(pMsg);
 

--- a/tools/smtradfwd.c
+++ b/tools/smtradfwd.c
@@ -76,7 +76,7 @@ CODESTARTstrgen
 	pTimeStamp = (uchar*) getTimeReported(pMsg, tplFmtRFC3164Date);
 	pHOSTNAME = (uchar*) getHOSTNAME(pMsg);
 	lenHOSTNAME = getHOSTNAMELen(pMsg);
-	getTAG(pMsg, &pTAG, &lenTAG);
+	getTAG(pMsg, &pTAG, &lenTAG, LOCK_MUTEX);
 	if(lenTAG > 32)
 		lenTAG = 32; /* for forwarding, a max of 32 chars is permitted (RFC!) */
 	pMSG = getMSG(pMsg);


### PR DESCRIPTION
can happen e.g. with headerless messages when app-name
property is used

closes https://github.com/rsyslog/rsyslog/issues/3135

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
