### PR TITLE
testbench: do no longer output netstat on failed test

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -679,12 +679,12 @@ function error_exit() {
 		RSYSLOG_DEBUG=$RSYSLOG_DEBUG_SAVE
 		rm IN_AUTO_DEBUG
 	fi
-	# output listening ports as a temporay debug measure (2018-09-08 rgerhards)
-	if [ $(uname) == "Linux" ]; then
-		netstat -tlp
-	else
-		netstat
-	fi
+	# output listening ports as a temporay debug measure (2018-09-08 rgerhards), now disables, but not yet removed (2018-10-22)
+	#if [ $(uname) == "Linux" ]; then
+	#	netstat -tlp
+	#else
+	#	netstat
+	#fi
 
 	# Extended debug output for dependencies started by testbench
 	if [[ "$EXTRA_EXITCHECK" == 'dumpkafkalogs' ]]; then


### PR DESCRIPTION
it looks like we have solved the issue that we wanted to debug
with this - still leave it commented out if problems resurface

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
