### PR TITLE
queue bugfix: invalid error message on queue startup

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -799,6 +799,7 @@ qqueueTryLoadPersistedInfo(qqueue_t *pThis)
 	if(stat((char*) pThis->pszQIFNam, &stat_buf) == -1) {
 		if(errno == ENOENT) {
 			DBGOPRINT((obj_t*) pThis, "clean startup, no .qi file found\n");
+			ABORT_FINALIZE(RS_RET_FILE_NOT_FOUND);
 		} else {
 			LogError(errno, RS_RET_IO_ERROR, "queue: %s: error %d could not access .qi file",
 					obj.GetName((obj_t*) pThis), errno);

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -283,8 +283,8 @@ doPhysOpen(strm_t *pThis)
 	DBGPRINTF("file '%s' opened as #%d with mode %d\n", pThis->pszCurrFName,
 		  pThis->fd, (int) pThis->tOpenMode);
 	if(pThis->fd == -1) {
-		const rsRetVal errcode = (errno_save == ENOENT)
-			? RS_RET_FILE_NOT_FOUND : RS_RET_FILE_OPEN_ERROR;
+		const rsRetVal errcode = (errno_save == ENOENT) ? RS_RET_FILE_NOT_FOUND
+			: RS_RET_FILE_OPEN_ERROR;
 		if(pThis->fileNotFoundError) {
 			if(pThis->noRepeatedErrorOutput == 0) {
 				LogError(errno_save, errcode, "file '%s': open error", pThis->pszCurrFName);

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -167,7 +167,7 @@ typedef struct strm_s {
 	cstr_t *prevLineSegment; /* for ReadLine, previous, unprocessed part of file */
 	cstr_t *prevMsgSegment; /* for ReadMultiLine, previous, yet unprocessed part of msg */
 	int64 strtOffs;		/* start offset in file for current line/msg */
-	int fileNotFoundError;
+	int fileNotFoundError;	/* boolean; if set, report file not found errors, else silently ignore */
 	int noRepeatedErrorOutput; /* if a file is missing the Error is only given once */
 	int ignoringMsg;
 } strm_t;

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -471,7 +471,6 @@ function custom_content_check() {
 # check that given content $1 is not present in file $2 (default: RSYSLOG_OUTLOG)
 # regular expressions may be used
 function check_not_present() {
-
 	if [ "$2" == "" ]; then
 		file=$RSYSLOG_OUT_LOG
 	else
@@ -481,9 +480,9 @@ function check_not_present() {
 	if [ "$?" -eq "0" ]; then
 		echo FAIL: check_not present found
 		echo $1
-		echo inside file $file
-		echo sample:
-		grep "$1" < "$file" | head -10 | cat -n
+		echo inside file $file of $(wc -l < $file) lines
+		echo samples:
+		cat -n "$file" | grep "$1" | head -10
 		error_exit 1
 	fi
 }


### PR DESCRIPTION
due to some old regression (commit not exactly identified, but for
sure a regression, 9 years ago it was correct) an error message
is emitted when no .qi file exists on startup of the queue, which
is a normal condition.

Actually, the code should not have tried to open the .qi file in
the first place because it detected that it did not exist. That
(necessary) shortcut had been removed a while ago.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
