### PR TITLE
fix bad bash coding style and disable shellcheck false positives

### DIFF
--- a/.shellcheck.yaml
+++ b/.shellcheck.yaml
@@ -1,5 +1,12 @@
 ignored:
   - SC2181 # we need support for old Solaris 10
+  - SC2016 # shellcheck does not properly understand our intent, the issue
+           # is raised e.g. here in config file creation:
+	   #  binary="'$RSYSLOG_DYNNAME'.omprog-restart-terminated-bin.sh"
+	   # we cannot explicitely permit this on each occurence.
 
   # things we do not (currently) care about
+  - SC2046
   - SC2086
+  - SC2155
+  - SC2164

--- a/tests/abort-uncleancfg-badcfg-check.sh
+++ b/tests/abort-uncleancfg-badcfg-check.sh
@@ -2,7 +2,7 @@
 # Copyright 2015-01-29 by Tim Eifler
 # This file is part of the rsyslog project, released  under ASL 2.0
 # The configuration test should fail because of the invalid config file.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/abort-uncleancfg-badcfg.conf -M../runtime/.libs:../.libs
 if [ $? == 0 ]; then
    echo "Error: config check should fail"

--- a/tests/abort-uncleancfg-badcfg-check_1.sh
+++ b/tests/abort-uncleancfg-badcfg-check_1.sh
@@ -5,7 +5,7 @@
 echo ===============================================================================
 echo \[abort-uncleancfg-badcfg_1.sh\]: testing abort on unclean configuration
 echo "testing a bad Configuration verification run"
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/abort-uncleancfg-badcfg_1.conf -M../runtime/.libs:../.libs
 if [ $? == 0 ]; then
    echo "Error: config check should fail"

--- a/tests/abort-uncleancfg-goodcfg-check.sh
+++ b/tests/abort-uncleancfg-goodcfg-check.sh
@@ -2,7 +2,7 @@
 # Copyright 2015-01-29 by Tim Eifler
 # This file is part of the rsyslog project, released  under ASL 2.0
 # The configuration test should pass because of the good config file.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 echo "testing a good Configuration verification run"
 ../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/abort-uncleancfg-goodcfg.conf -M../runtime/.libs:../.libs
 if [ $? -ne 0 ]; then

--- a/tests/abort-uncleancfg-goodcfg.sh
+++ b/tests/abort-uncleancfg-goodcfg.sh
@@ -4,7 +4,7 @@
 echo ===============================================================================
 echo \[abort-uncleancfg-goodcfg.sh\]: testing abort on unclean configuration
 echo "testing a good Configuration verification run"
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $AbortOnUncleanConfig on

--- a/tests/action-tx-errfile.sh
+++ b/tests/action-tx-errfile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 mysql --user=rsyslog --password=testbench < testsuites/mysql-truncate.sql
 generate_conf
 add_conf '

--- a/tests/action-tx-single-processing.sh
+++ b/tests/action-tx-single-processing.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 mysql --user=rsyslog --password=testbench < testsuites/mysql-truncate.sql
 generate_conf
 add_conf '

--- a/tests/array_lookup_table-vg.sh
+++ b/tests/array_lookup_table-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[array_lookup_table-vg.sh\]: test cleanup for array lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate_array.lkp_tbl")

--- a/tests/array_lookup_table.sh
+++ b/tests/array_lookup_table.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[array_lookup_table.sh\]: test for array lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate_array.lkp_tbl")

--- a/tests/array_lookup_table_misuse-vg.sh
+++ b/tests/array_lookup_table_misuse-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[array_lookup_table-vg.sh\]: test cleanup for array lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate_array.lkp_tbl")

--- a/tests/arrayqueue.sh
+++ b/tests/arrayqueue.sh
@@ -2,7 +2,7 @@
 # Test for fixedArray queue mode
 # added 2009-05-20 by rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_deadlock.sh
+++ b/tests/asynwr_deadlock.sh
@@ -7,7 +7,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ================================================================================
 echo TEST: \[asynwr_deadlock.sh\]: a case known to have caused a deadlock in the past
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_deadlock2.sh
+++ b/tests/asynwr_deadlock2.sh
@@ -51,7 +51,7 @@
 #
 # added 2010-03-17 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_deadlock4.sh
+++ b/tests/asynwr_deadlock4.sh
@@ -9,7 +9,7 @@
 #
 # added 2010-03-18 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_deadlock_2.sh
+++ b/tests/asynwr_deadlock_2.sh
@@ -7,7 +7,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ================================================================================
 echo TEST: \[asynwr_deadlock_2.sh\]: a case known to have caused a deadlock in the past
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_simple.sh
+++ b/tests/asynwr_simple.sh
@@ -5,7 +5,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo TEST: \[asynwr_simple.sh\]: simple test for async file writing
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_simple_2.sh
+++ b/tests/asynwr_simple_2.sh
@@ -5,7 +5,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo TEST: \[asynwr_simple_2.sh\]: simple test for async file writing
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_small.sh
+++ b/tests/asynwr_small.sh
@@ -14,7 +14,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo TEST: \[asynwr_small.sh\]: test for async file writing for few messages
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_timeout.sh
+++ b/tests/asynwr_timeout.sh
@@ -5,7 +5,7 @@
 #
 # added 2010-03-09 by Rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_timeout_2.sh
+++ b/tests/asynwr_timeout_2.sh
@@ -7,7 +7,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo TEST: \[asynwr_timeout.sh\]: test async file writing timeout writes
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/asynwr_tinybuf.sh
+++ b/tests/asynwr_tinybuf.sh
@@ -8,7 +8,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo TEST: \[asynwr_tinybuf.sh\]: test async file writing with 1-byte buffer
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/badqi.sh
+++ b/tests/badqi.sh
@@ -7,7 +7,7 @@
 # uncomment for debugging support:
 echo ===============================================================================
 echo \[badqi.sh\]: test startup with invalid .qi file
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/cee_diskqueue.sh
+++ b/tests/cee_diskqueue.sh
@@ -11,7 +11,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(workDirectory="/tmp")

--- a/tests/cee_simple.sh
+++ b/tests/cee_simple.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[cee_simple.sh\]: basic CEE property test
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!usr!msg:F,58:2%\n")

--- a/tests/check-length-json-property.sh
+++ b/tests/check-length-json-property.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2017-10-30 by PascalWithopf, released under ASL 2.0
 #tests for Segmentation Fault
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 #set $!r = $!var1!var3!var2;

--- a/tests/complex1.sh
+++ b/tests/complex1.sh
@@ -4,7 +4,7 @@
 # added 2010-03-16 by Rgerhards
 #
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 skip_platform "SunOS"  "This test currently does not work on all flavors of Solaris."
 export RSYSLOG_PORT2="$(get_free_port)"
 export RSYSLOG_PORT3="$(get_free_port)"

--- a/tests/compresssp-stringtpl.sh
+++ b/tests/compresssp-stringtpl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-03-22 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/compresssp.sh
+++ b/tests/compresssp.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-03-22 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/conf-directive-gone-away.sh
+++ b/tests/conf-directive-gone-away.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-09-04 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $optimizeForUniprocessor

--- a/tests/da-mainmsg-q.sh
+++ b/tests/da-mainmsg-q.sh
@@ -10,7 +10,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo "[da-mainmsg-q.sh]: testing main message queue in DA mode (going to disk)"
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/daqueue-dirty-shutdown.sh
+++ b/tests/daqueue-dirty-shutdown.sh
@@ -24,7 +24,7 @@
 #export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 #export RSYSLOG_DEBUGLOG="log"
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")

--- a/tests/daqueue-invld-qi.sh
+++ b/tests/daqueue-invld-qi.sh
@@ -7,7 +7,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/daqueue-persist-drvr.sh
+++ b/tests/daqueue-persist-drvr.sh
@@ -6,7 +6,7 @@
 # added 2009-05-27 by Rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/dircreate_dflt.sh
+++ b/tests/dircreate_dflt.sh
@@ -4,7 +4,7 @@
 # in any case, so we do not need to add any extra new test dir.
 # added 2009-11-30 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # set spool locations and switch queue to disk-only mode

--- a/tests/dircreate_off.sh
+++ b/tests/dircreate_off.sh
@@ -4,7 +4,7 @@
 # in any case, so we do not need to add any extra new test dir.
 # added 2009-11-30 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # set spool locations and switch queue to disk-only mode

--- a/tests/discard-allmark-vg.sh
+++ b/tests/discard-allmark-vg.sh
@@ -9,7 +9,7 @@ fi
 
 echo ===============================================================================
 echo \[discard-allmark.sh\]: testing discard-allmark functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/discard-allmark.sh
+++ b/tests/discard-allmark.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo \[discard-allmark.sh\]: testing discard-allmark functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/discard-rptdmsg-vg.sh
+++ b/tests/discard-rptdmsg-vg.sh
@@ -9,7 +9,7 @@ fi
 
 echo ===============================================================================
 echo \[discard-rptdmsg.sh\]: testing discard-rptdmsg functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/discard-rptdmsg.sh
+++ b/tests/discard-rptdmsg.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo \[discard-rptdmsg.sh\]: testing discard-rptdmsg functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/discard.sh
+++ b/tests/discard.sh
@@ -7,7 +7,7 @@
 # uncomment for debugging support:
 echo ===============================================================================
 echo \[discard.sh\]: testing discard functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/diskq-rfc5424.sh
+++ b/tests/diskq-rfc5424.sh
@@ -13,7 +13,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/diskqueue-fsync.sh
+++ b/tests/diskqueue-fsync.sh
@@ -14,7 +14,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/diskqueue-full.sh
+++ b/tests/diskqueue-full.sh
@@ -2,7 +2,7 @@
 # checks that nothing bad happens if a DA (disk) queue runs out
 # of configured disk space
 # addd 2017-02-07 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 generate_conf
 add_conf '

--- a/tests/diskqueue.sh
+++ b/tests/diskqueue.sh
@@ -5,7 +5,7 @@
 # memory to disk mode for DA queues.
 # added 2009-04-17 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/dynfile_invalid2.sh
+++ b/tests/dynfile_invalid2.sh
@@ -6,7 +6,7 @@
 # added 2010-03-22 by Rgerhards
 #
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/dynfile_invld_async.sh
+++ b/tests/dynfile_invld_async.sh
@@ -6,7 +6,7 @@
 # added 2010-03-09 by Rgerhards
 #
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/dynfile_invld_sync.sh
+++ b/tests/dynfile_invld_sync.sh
@@ -6,7 +6,7 @@
 # added 2010-03-09 by Rgerhards
 #
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/dynstats-json-vg.sh
+++ b/tests/dynstats-json-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats-json-vg.sh\]: test for verifying stats are reported correctly in json format with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 dyn_stats(name="stats_one")

--- a/tests/dynstats-json.sh
+++ b/tests/dynstats-json.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[dynstats-json.sh\]: test for verifying stats are reported correctly in json format
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 dyn_stats(name="stats_one")

--- a/tests/dynstats-vg.sh
+++ b/tests/dynstats-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats-vg.sh\]: test for gathering stats over dynamic metric names with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/dynstats.sh
+++ b/tests/dynstats.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2015-11-10 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/dynstats_ctr_reset.sh
+++ b/tests/dynstats_ctr_reset.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats_ctr_reset.sh\]: test to ensure correctness of stats-ctr reset
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/dynstats_nometric.sh
+++ b/tests/dynstats_nometric.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats_nometric.sh\]: test for dyn-stats meta-metric behavior with zero-length metric name
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/dynstats_overflow-vg.sh
+++ b/tests/dynstats_overflow-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats_overflow-vg.sh\]: test for gathering stats when metrics exceed provisioned capacity
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/dynstats_overflow.sh
+++ b/tests/dynstats_overflow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2015-11-13 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/dynstats_prevent_premature_eviction-vg.sh
+++ b/tests/dynstats_prevent_premature_eviction-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats_prevent_premature_eviction-vg.sh\]: test for ensuring metrics are not evicted before unused-ttl with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/dynstats_prevent_premature_eviction.sh
+++ b/tests/dynstats_prevent_premature_eviction.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats_prevent_premature_eviction.sh\]: test for ensuring metrics are not evicted before unused-ttl
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/dynstats_reset-vg.sh
+++ b/tests/dynstats_reset-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats_reset-vg.sh\]: test for gathering stats with a known-dyn-metrics reset in-between
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/dynstats_reset.sh
+++ b/tests/dynstats_reset.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2015-11-13 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/dynstats_reset_without_pstats_reset.sh
+++ b/tests/dynstats_reset_without_pstats_reset.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[dynstats_reset_without_pstats_reset.sh\]: test to ensure correctness of stats-ctr reset when pstats reset is turned off
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/empty-hostname.sh
+++ b/tests/empty-hostname.sh
@@ -8,7 +8,7 @@
 # hardcoded default of "localhost-empty-hostname" is used.
 # Note that the test may fail if the library is not properly preloaded.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 skip_platform "AIX" "we cannot preload required dummy lib"
 generate_conf
 add_conf '

--- a/tests/empty-prop-comparison.sh
+++ b/tests/empty-prop-comparison.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-07-08 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/empty-ruleset.sh
+++ b/tests/empty-ruleset.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright 2014-11-20 by Rainer Gerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export TCPFLOOD_PORT2="$(get_free_port)"
 generate_conf
 add_conf '

--- a/tests/es-basic-abort.sh
+++ b/tests/es-basic-abort.sh
@@ -8,7 +8,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 
 #  Starting actual testbench
 # TODO: move up,
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="tpl" type="string"

--- a/tests/es-basic-bulk-vg.sh
+++ b/tests/es-basic-bulk-vg.sh
@@ -7,7 +7,7 @@ export ES_PORT=19200
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-basic-bulk.sh
+++ b/tests/es-basic-bulk.sh
@@ -7,7 +7,7 @@ export ES_PORT=19200
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-basic-errfile-empty.sh
+++ b/tests/es-basic-errfile-empty.sh
@@ -7,7 +7,7 @@ export ES_PORT=19200
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-basic-errfile-popul.sh
+++ b/tests/es-basic-errfile-popul.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 curl -H 'Content-Type: application/json' -XPUT localhost:19200/rsyslog_testbench/ -d '{
   "mappings": {

--- a/tests/es-basic-es6.0.sh
+++ b/tests/es-basic-es6.0.sh
@@ -7,7 +7,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh start-elasticsearch
 
 #  Starting actual testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="tpl" type="string"

--- a/tests/es-basic-ha-vg.sh
+++ b/tests/es-basic-ha-vg.sh
@@ -7,7 +7,7 @@ export ES_PORT=19200
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-basic-ha.sh
+++ b/tests/es-basic-ha.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-basic-server.sh
+++ b/tests/es-basic-server.sh
@@ -7,7 +7,7 @@ export ES_PORT=19200
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="tpl" type="string"

--- a/tests/es-basic-vg.sh
+++ b/tests/es-basic-vg.sh
@@ -7,7 +7,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh start-elasticsearch
 
 #  Starting actual testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-basic-vgthread.sh
+++ b/tests/es-basic-vgthread.sh
@@ -7,7 +7,7 @@ export ES_PORT=19200
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-basic.sh
+++ b/tests/es-basic.sh
@@ -7,7 +7,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh start-elasticsearch
 
 #  Starting actual testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-bulk-errfile-empty.sh
+++ b/tests/es-bulk-errfile-empty.sh
@@ -7,7 +7,7 @@ export ES_PORT=19200
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-bulk-errfile-popul-def-format.sh
+++ b/tests/es-bulk-errfile-popul-def-format.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 echo '{ "name" : "foo" }
 {"name": bar"}

--- a/tests/es-bulk-errfile-popul-def-interleaved.sh
+++ b/tests/es-bulk-errfile-popul-def-interleaved.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 echo '{ "name" : "foo" }
 {"name": bar"}

--- a/tests/es-bulk-errfile-popul-erronly-interleaved.sh
+++ b/tests/es-bulk-errfile-popul-erronly-interleaved.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 echo '{ "name" : "foo" }
 {"name": bar"}

--- a/tests/es-bulk-errfile-popul-erronly.sh
+++ b/tests/es-bulk-errfile-popul-erronly.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 echo '{ "name" : "foo" }
 {"name": bar"}

--- a/tests/es-bulk-errfile-popul.sh
+++ b/tests/es-bulk-errfile-popul.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 curl -H 'Content-Type: application/json' -XPUT localhost:19200/rsyslog_testbench/ -d '{
   "mappings": {

--- a/tests/es-bulk-retry.sh
+++ b/tests/es-bulk-retry.sh
@@ -11,7 +11,7 @@ thread_pool.bulk.size: 1
 EOF
 . $srcdir/diag.sh start-elasticsearch
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/impstats/.libs/impstats" interval="1"

--- a/tests/es-maxbytes-bulk.sh
+++ b/tests/es-maxbytes-bulk.sh
@@ -6,7 +6,7 @@ export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 . $srcdir/diag.sh prepare-elasticsearch
 . $srcdir/diag.sh start-elasticsearch
  
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh es-init
 generate_conf
 add_conf '

--- a/tests/es-writeoperation.sh
+++ b/tests/es-writeoperation.sh
@@ -6,7 +6,7 @@
 . $srcdir/diag.sh start-elasticsearch
 
 #  Starting actual testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="tpl" type="string"

--- a/tests/exec_tpl-concurrency.sh
+++ b/tests/exec_tpl-concurrency.sh
@@ -11,7 +11,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/execonlyonce.sh
+++ b/tests/execonlyonce.sh
@@ -9,7 +9,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo \[execonlyonce.sh\]: test for the $ActionExecOnlyOnceEveryInterval directive
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/execonlywhenprevsuspended-nonsusp-queue.sh
+++ b/tests/execonlywhenprevsuspended-nonsusp-queue.sh
@@ -5,7 +5,7 @@
 echo =====================================================================================
 echo \[execonlywhenprevsuspended-nonsusp-queue\]: test execonly...suspended functionality with non-suspended action and queue
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 main_queue(queue.workerthreads="1") 

--- a/tests/execonlywhenprevsuspended-nonsusp.sh
+++ b/tests/execonlywhenprevsuspended-nonsusp.sh
@@ -5,7 +5,7 @@
 echo =====================================================================================
 echo \[execonlywhenprevsuspended-nonsusp\]: test execonly...suspended functionality with non-suspended action
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 main_queue(queue.workerthreads="1") 

--- a/tests/execonlywhenprevsuspended-queue.sh
+++ b/tests/execonlywhenprevsuspended-queue.sh
@@ -9,7 +9,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 main_queue(queue.workerthreads="1") 

--- a/tests/execonlywhenprevsuspended.sh
+++ b/tests/execonlywhenprevsuspended.sh
@@ -5,7 +5,7 @@
 # rgerhards, 2010-06-23
 echo =====================================================================================
 echo \[execonlywhenprevsuspended.sh\]: test execonly...suspended functionality simple case
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 main_queue(queue.workerthreads="1") 

--- a/tests/execonlywhenprevsuspended2.sh
+++ b/tests/execonlywhenprevsuspended2.sh
@@ -6,7 +6,7 @@
 # rgerhards, 2010-06-23
 echo ===============================================================================
 echo \[execonlywhenprevsuspended2.sh\]: test execonly...suspended functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # omtesting provides the ability to cause "SUSPENDED" action state

--- a/tests/execonlywhenprevsuspended3.sh
+++ b/tests/execonlywhenprevsuspended3.sh
@@ -6,7 +6,7 @@
 # rgerhards, 2010-06-24
 echo ===============================================================================
 echo \[execonlywhenprevsuspended3.sh\]: test execonly...suspended functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # omtesting provides the ability to cause "SUSPENDED" action state

--- a/tests/execonlywhenprevsuspended4.sh
+++ b/tests/execonlywhenprevsuspended4.sh
@@ -4,7 +4,7 @@
 # rgerhards, 2010-06-24
 echo ===============================================================================
 echo \[execonlywhenprevsuspended4.sh\]: test execonly..suspended multi backup action
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # omtesting provides the ability to cause "SUSPENDED" action state

--- a/tests/execonlywhenprevsuspended_multiwrkr.sh
+++ b/tests/execonlywhenprevsuspended_multiwrkr.sh
@@ -2,7 +2,7 @@
 # rgerhards, 2013-12-05
 echo =====================================================================================
 echo \[execonlywhenprevsuspended_multiwrkr.sh\]: test execonly...suspended functionality multiworker case
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # omtesting provides the ability to cause "SUSPENDED" action state

--- a/tests/fac_authpriv.sh
+++ b/tests/fac_authpriv.sh
@@ -3,7 +3,7 @@
 # added 2014-09-16 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/fac_ftp.sh
+++ b/tests/fac_ftp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/fac_invld1.sh
+++ b/tests/fac_invld1.sh
@@ -2,7 +2,7 @@
 # added 2014-10-01 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_invld2.sh
+++ b/tests/fac_invld2.sh
@@ -2,7 +2,7 @@
 # added 2014-10-01 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_invld3.sh
+++ b/tests/fac_invld3.sh
@@ -2,7 +2,7 @@
 # added 2014-10-01 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_invld4_rfc5424.sh
+++ b/tests/fac_invld4_rfc5424.sh
@@ -2,7 +2,7 @@
 # added 2014-10-01 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_local0-vg.sh
+++ b/tests/fac_local0-vg.sh
@@ -9,7 +9,7 @@ if [ $(uname) = "FreeBSD" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_local0.sh
+++ b/tests/fac_local0.sh
@@ -2,7 +2,7 @@
 # added 2014-09-17 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_local7.sh
+++ b/tests/fac_local7.sh
@@ -2,7 +2,7 @@
 # added 2014-09-24 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_mail.sh
+++ b/tests/fac_mail.sh
@@ -2,7 +2,7 @@
 # added 2014-09-17 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_news.sh
+++ b/tests/fac_news.sh
@@ -2,7 +2,7 @@
 # added 2014-09-17 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/fac_ntp.sh
+++ b/tests/fac_ntp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/fac_uucp.sh
+++ b/tests/fac_uucp.sh
@@ -2,7 +2,7 @@
 # added 2014-09-17 by Rgerhards
 
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/failover-async.sh
+++ b/tests/failover-async.sh
@@ -9,7 +9,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/failover-basic-vg.sh
+++ b/tests/failover-basic-vg.sh
@@ -9,7 +9,7 @@ fi
 
 echo ===============================================================================
 echo \[failover-basic.sh\]: basic test for failover functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/failover-basic.sh
+++ b/tests/failover-basic.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[failover-basic.sh\]: basic test for failover functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/failover-double.sh
+++ b/tests/failover-double.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export DEAD_PORT=4  # a port unassigned by IANA and very unlikely to be used
 generate_conf
 add_conf '

--- a/tests/failover-no-basic-vg.sh
+++ b/tests/failover-no-basic-vg.sh
@@ -9,7 +9,7 @@ fi
 
 echo ===============================================================================
 echo \[failover-no-basic.sh\]: basic test for failover functionality - no failover
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $RepeatedMsgReduction off

--- a/tests/failover-no-basic.sh
+++ b/tests/failover-no-basic.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[failover-no-basic.sh\]: basic test for failover functionality - no failover
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $RepeatedMsgReduction off

--- a/tests/failover-no-rptd-vg.sh
+++ b/tests/failover-no-rptd-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # rptd test for failover functionality - no failover
 # This file is part of the rsyslog project, released under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $RepeatedMsgReduction on

--- a/tests/failover-no-rptd.sh
+++ b/tests/failover-no-rptd.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[failover-no-rptd.sh\]: rptd test for failover functionality - no failover
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $RepeatedMsgReduction on

--- a/tests/failover-rptd-vg.sh
+++ b/tests/failover-rptd-vg.sh
@@ -9,7 +9,7 @@ fi
 
 echo ===============================================================================
 echo \[failover-rptd.sh\]: rptd test for failover functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $RepeatedMsgReduction on

--- a/tests/failover-rptd.sh
+++ b/tests/failover-rptd.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[failover-rptd.sh\]: rptd test for failover functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $RepeatedMsgReduction on

--- a/tests/fieldtest-udp.sh
+++ b/tests/fieldtest-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/fieldtest.sh
+++ b/tests/fieldtest.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/glbl-invld-param.sh
+++ b/tests/glbl-invld-param.sh
@@ -3,7 +3,7 @@
 # once had this problem)
 # addd 2016-03-03 by RGerhards, released under ASL 2.0
 echo \[glbl-invld-param\]: 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(invalid="off")

--- a/tests/glbl-oversizeMsg-log-vg.sh
+++ b/tests/glbl-oversizeMsg-log-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-03 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
   echo "imrelp parameter oversizeMode not available. Test stopped"

--- a/tests/glbl-oversizeMsg-log.sh
+++ b/tests/glbl-oversizeMsg-log.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-03 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
   echo "imrelp parameter oversizeMode not available. Test stopped"

--- a/tests/glbl-oversizeMsg-split.sh
+++ b/tests/glbl-oversizeMsg-split.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-03 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
   echo "imrelp parameter oversizeMode not available. Test stopped"

--- a/tests/glbl-oversizeMsg-truncate-imfile.sh
+++ b/tests/glbl-oversizeMsg-truncate-imfile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-02 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then

--- a/tests/glbl-oversizeMsg-truncate.sh
+++ b/tests/glbl-oversizeMsg-truncate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-02 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
   echo "imrelp parameter oversizeMode not available. Test stopped"

--- a/tests/glbl-umask.sh
+++ b/tests/glbl-umask.sh
@@ -6,7 +6,7 @@
 # as batching can (validly) cause a larger loss in the non-writable
 # file
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(umask="0077")

--- a/tests/glbl-unloadmodules.sh
+++ b/tests/glbl-unloadmodules.sh
@@ -3,7 +3,7 @@
 # reliably deduce from the outside if it really worked.
 # addd 2016-03-03 by RGerhards, released under ASL 2.0
 echo \[glbl-unloadmodules\]: 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(debug.unloadModules="off")

--- a/tests/glbl_setenv.sh
+++ b/tests/glbl_setenv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(environment="http_proxy=http://127.0.0.1")

--- a/tests/glbl_setenv_2_vars.sh
+++ b/tests/glbl_setenv_2_vars.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(environment=["http_proxy=http://127.0.0.1", "SECOND=OK OK"])

--- a/tests/glbl_setenv_err.sh
+++ b/tests/glbl_setenv_err.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # env var is missing equal sign and MUST trigger parsing error!

--- a/tests/glbl_setenv_err_too_long.sh
+++ b/tests/glbl_setenv_err_too_long.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # name is 400 chars long --> too long

--- a/tests/global_vars.sh
+++ b/tests/global_vars.sh
@@ -4,7 +4,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 echo ===============================================================================
 echo \[global_vars.sh\]: testing global variable support
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 10000

--- a/tests/gzipwr_flushInterval.sh
+++ b/tests/gzipwr_flushInterval.sh
@@ -7,7 +7,7 @@ if [ $(uname) = "FreeBSD" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/gzipwr_flushOnTXEnd.sh
+++ b/tests/gzipwr_flushOnTXEnd.sh
@@ -7,7 +7,7 @@ if [ $(uname) = "FreeBSD" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/gzipwr_large.sh
+++ b/tests/gzipwr_large.sh
@@ -5,7 +5,7 @@
 # added 2010-03-10 by Rgerhards
 #
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/gzipwr_large_dynfile.sh
+++ b/tests/gzipwr_large_dynfile.sh
@@ -15,7 +15,7 @@
 # added 2010-03-10 by Rgerhards
 #
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/gzipwr_rscript.sh
+++ b/tests/gzipwr_rscript.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/hostname-getaddrinfo-fail.sh
+++ b/tests/hostname-getaddrinfo-fail.sh
@@ -13,7 +13,7 @@
 # the simplest way forward.
 #
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 skip_platform "AIX" "we cannot preload required dummy lib"
 skip_platform "SunOS" "there seems to be an issue with LD_PRELOAD libraries"
 skip_platform "FreeBSD" "temporarily disabled until we know what is wrong, \

--- a/tests/hostname-with-slash-dflt-invld.sh
+++ b/tests/hostname-with-slash-dflt-invld.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-07-11 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/hostname-with-slash-dflt-slash-valid.sh
+++ b/tests/hostname-with-slash-dflt-slash-valid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-07-11 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/hostname-with-slash-pmrfc3164.sh
+++ b/tests/hostname-with-slash-pmrfc3164.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-07-11 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/hostname-with-slash-pmrfc5424.sh
+++ b/tests/hostname-with-slash-pmrfc5424.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-07-11 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/imfile-basic-vg.sh
+++ b/tests/imfile-basic-vg.sh
@@ -8,7 +8,7 @@ if [ $(uname) = "FreeBSD" ] ; then
 fi
 
 echo [imfile-basic.sh]
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imfile/.libs/imfile

--- a/tests/imfile-basic-vgthread.sh
+++ b/tests/imfile-basic-vgthread.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 uname
 if [ $(uname) = "FreeBSD" ] ; then
    echo "This test currently does not work on FreeBSD."

--- a/tests/imfile-basic.sh
+++ b/tests/imfile-basic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
 echo [imfile-basic.sh]
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imfile/.libs/imfile

--- a/tests/imfile-discard-truncated-line.sh
+++ b/tests/imfile-discard-truncated-line.sh
@@ -6,7 +6,7 @@ echo ======================================================================
 # Check if inotify header exist
 echo [imfile-discard-truncated-line.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imfile-endmsg.regex-vg.sh
+++ b/tests/imfile-endmsg.regex-vg.sh
@@ -5,7 +5,7 @@ USE_VALGRIND=true
 echo ======================================================================
 echo [imfile-endmsg.regex.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endmsg.regex-with-example-vg.sh
+++ b/tests/imfile-endmsg.regex-with-example-vg.sh
@@ -5,7 +5,7 @@ USE_VALGRIND=true
 echo ======================================================================
 echo [imfile-endmsg.regex.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endmsg.regex-with-example.sh
+++ b/tests/imfile-endmsg.regex-with-example.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # This test tests imfile endmsg.regex.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILECHECKTIMEOUT="20"
 export IMFILELASTINPUTLINES="6"

--- a/tests/imfile-endmsg.regex.sh
+++ b/tests/imfile-endmsg.regex.sh
@@ -4,7 +4,7 @@
 echo ======================================================================
 echo [imfile-endmsg.regex.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endregex-save-lf-persist.sh
+++ b/tests/imfile-endregex-save-lf-persist.sh
@@ -3,7 +3,7 @@
 echo ======================================================================
 echo [imfile-endregex-save-lf-persist.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endregex-save-lf.sh
+++ b/tests/imfile-endregex-save-lf.sh
@@ -5,7 +5,7 @@
 echo ======================================================================
 echo [imfile-endregex-save-lf.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endregex-timeout-none-polling.sh
+++ b/tests/imfile-endregex-timeout-none-polling.sh
@@ -6,7 +6,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile"

--- a/tests/imfile-endregex-timeout-none.sh
+++ b/tests/imfile-endregex-timeout-none.sh
@@ -3,7 +3,7 @@
 echo ======================================================================
 echo [imfile-endregex-timeout-none.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endregex-timeout-polling.sh
+++ b/tests/imfile-endregex-timeout-polling.sh
@@ -7,7 +7,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile"

--- a/tests/imfile-endregex-timeout-with-shutdown-polling.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown-polling.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILECHECKTIMEOUT="20"
 
 generate_conf

--- a/tests/imfile-endregex-timeout-with-shutdown.sh
+++ b/tests/imfile-endregex-timeout-with-shutdown.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify-only
 export IMFILECHECKTIMEOUT="30"
 

--- a/tests/imfile-endregex-timeout.sh
+++ b/tests/imfile-endregex-timeout.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify-only
 export IMFILECHECKTIMEOUT="30"
 

--- a/tests/imfile-endregex-vg.sh
+++ b/tests/imfile-endregex-vg.sh
@@ -9,7 +9,7 @@ fi
 
 echo ======================================================================
 echo [imfile-endregex.sh]
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endregex.sh
+++ b/tests/imfile-endregex.sh
@@ -5,7 +5,7 @@
 echo ======================================================================
 echo [imfile-endregex.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-error-not-repeated.sh
+++ b/tests/imfile-error-not-repeated.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2017-04-28 by Pascal Withopf, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile" mode="polling" pollingInterval="1")

--- a/tests/imfile-file-not-found-error.sh
+++ b/tests/imfile-file-not-found-error.sh
@@ -2,7 +2,7 @@
 # add 2017-04-28 by Pascal Withopf, released under ASL 2.0
 echo [imfile-file-not-found-error.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-fileNotFoundError-parameter.sh
+++ b/tests/imfile-fileNotFoundError-parameter.sh
@@ -2,7 +2,7 @@
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
 echo [imfile-file-not-found-error.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-freshStartTail1.sh
+++ b/tests/imfile-freshStartTail1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-17 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '

--- a/tests/imfile-freshStartTail2.sh
+++ b/tests/imfile-freshStartTail2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-17 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILECHECKTIMEOUT="60"
 

--- a/tests/imfile-freshStartTail3.sh
+++ b/tests/imfile-freshStartTail3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-05-17 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '

--- a/tests/imfile-growing-file-id.sh
+++ b/tests/imfile-growing-file-id.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify-only
 generate_conf
 add_conf '

--- a/tests/imfile-logrotate.sh
+++ b/tests/imfile-logrotate.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . $srcdir/diag.sh check-inotify-only
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available logrotate
 
 export TESTMESSAGES=10000

--- a/tests/imfile-old-state-file.sh
+++ b/tests/imfile-old-state-file.sh
@@ -7,7 +7,7 @@
 # exactly what shall happen.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # added 2018-03-29 by rgerhards
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '

--- a/tests/imfile-persist-state-1.sh
+++ b/tests/imfile-persist-state-1.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2016-11-02 by rgerhards
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '

--- a/tests/imfile-readmode0-vg.sh
+++ b/tests/imfile-readmode0-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Tests for processing of partial lines in read mode 0
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-readmode2-polling.sh
+++ b/tests/imfile-readmode2-polling.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global( debug.whitelist="on"

--- a/tests/imfile-readmode2-vg.sh
+++ b/tests/imfile-readmode2-vg.sh
@@ -9,7 +9,7 @@ fi
 
 echo ======================================================================
 echo [imfile-readmode2-vg.sh]
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-readmode2-with-persists-data-during-stop.sh
+++ b/tests/imfile-readmode2-with-persists-data-during-stop.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")

--- a/tests/imfile-readmode2-with-persists.sh
+++ b/tests/imfile-readmode2-with-persists.sh
@@ -3,7 +3,7 @@
 echo ======================================================================
 echo [imfile-readmode2-with-persists.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")

--- a/tests/imfile-readmode2.sh
+++ b/tests/imfile-readmode2.sh
@@ -3,7 +3,7 @@
 #export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction stdout"
 #export RSYSLOG_DEBUGLOG="log"
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '

--- a/tests/imfile-rename-while-stopped.sh
+++ b/tests/imfile-rename-while-stopped.sh
@@ -5,7 +5,7 @@ export RETRIES=10
 export TESTMESSAGESFULL=19999
 echo [imfile-rename.sh]
 . $srcdir/diag.sh check-inotify-only
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imfile-rename.sh
+++ b/tests/imfile-rename.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
 . $srcdir/diag.sh check-inotify-only
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export TESTMESSAGES=10000
 export RETRIES=50
 export TESTMESSAGESFULL=19999

--- a/tests/imfile-symlink-multi.sh
+++ b/tests/imfile-symlink-multi.sh
@@ -3,7 +3,7 @@
 # to single file and checks that message is reported once for each symlink
 # with correct corresponding metadata.
 # This is part of the rsyslog testbench, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILEINPUTFILES="10"
 

--- a/tests/imfile-symlink.sh
+++ b/tests/imfile-symlink.sh
@@ -4,7 +4,7 @@
 # are recorded with correct corresponding metadata (name of symlink 
 # matching configuration).
 # This is part of the rsyslog testbench, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILEINPUTFILES="10"
 export IMFILELASTINPUTLINES="3"

--- a/tests/imfile-truncate-line.sh
+++ b/tests/imfile-truncate-line.sh
@@ -6,7 +6,7 @@ echo ======================================================================
 # Check if inotify header exist
 echo [imfile-truncate-line.sh]
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imfile-truncate-multiple.sh
+++ b/tests/imfile-truncate-multiple.sh
@@ -4,7 +4,7 @@
 # It also needs a larger load, which shall be sufficient to do begin of file
 # checks as well as should support file id hash generation.
 # addd 2016-10-06 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/imfile-truncate.sh
+++ b/tests/imfile-truncate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-10-06 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 generate_conf
 add_conf '

--- a/tests/imfile-wildcards-dirs-multi.sh
+++ b/tests/imfile-wildcards-dirs-multi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify-only
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"

--- a/tests/imfile-wildcards-dirs-multi2.sh
+++ b/tests/imfile-wildcards-dirs-multi2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))

--- a/tests/imfile-wildcards-dirs-multi3.sh
+++ b/tests/imfile-wildcards-dirs-multi3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))

--- a/tests/imfile-wildcards-dirs-multi4.sh
+++ b/tests/imfile-wildcards-dirs-multi4.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))

--- a/tests/imfile-wildcards-dirs-multi5-polling.sh
+++ b/tests/imfile-wildcards-dirs-multi5-polling.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="8"
 export IMFILEINPUTFILESSTEPS="5"
 export IMFILECHECKTIMEOUT="5"

--- a/tests/imfile-wildcards-dirs-multi5.sh
+++ b/tests/imfile-wildcards-dirs-multi5.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="8" #"8"
 export IMFILEINPUTFILESSTEPS="5" #"5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))

--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
 . $srcdir/diag.sh check-inotify
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="10"
 export IMFILECHECKTIMEOUT="20"
 

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="10"
 export IMFILEINPUTFILESSTEPS="5"
 #export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))

--- a/tests/imfile-wildcards.sh
+++ b/tests/imfile-wildcards.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILEINPUTFILES="10"
 export IMFILELASTINPUTLINES="3"

--- a/tests/imjournal-basic-vg.sh
+++ b/tests/imjournal-basic-vg.sh
@@ -7,7 +7,7 @@
 # sometimes happen in some environments.
 # addd 2017-10-25 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh require-journalctl
 generate_conf
 add_conf '

--- a/tests/imjournal-basic.sh
+++ b/tests/imjournal-basic.sh
@@ -7,7 +7,7 @@
 # sometimes happen in some environments.
 # addd 2017-10-25 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh require-journalctl
 generate_conf
 add_conf '

--- a/tests/imjournal-statefile.sh
+++ b/tests/imjournal-statefile.sh
@@ -7,7 +7,7 @@
 # sometimes happen in some environments.
 # addd 2017-10-25 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh require-journalctl
 generate_conf
 add_conf '

--- a/tests/imkafka-vg.sh
+++ b/tests/imkafka-vg.sh
@@ -2,7 +2,7 @@
 # added 2018-08-29 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
 # *** ==============================================================================

--- a/tests/imkafka.sh
+++ b/tests/imkafka.sh
@@ -2,7 +2,7 @@
 # added 2018-08-29 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
 # *** ==============================================================================

--- a/tests/imkafka_multi_many.sh
+++ b/tests/imkafka_multi_many.sh
@@ -2,7 +2,7 @@
 # added 2018-08-29 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
 # *** ==============================================================================

--- a/tests/imkafka_multi_single.sh
+++ b/tests/imkafka_multi_single.sh
@@ -2,7 +2,7 @@
 # added 2018-08-29 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
 # *** ==============================================================================

--- a/tests/imklog_permitnonkernelfacility_root.sh
+++ b/tests/imklog_permitnonkernelfacility_root.sh
@@ -6,7 +6,7 @@ if [ "$EUID" -ne 0 ]; then
     exit 77 # Not root, skip this test
 fi
 service rsyslog stop
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imklog/.libs/imklog" permitnonkernelfacility="on")

--- a/tests/impstats-hup.sh
+++ b/tests/impstats-hup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # test if HUP works for impstats
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/impstats/.libs/impstats"

--- a/tests/imptcp-NUL-rawmsg.sh
+++ b/tests/imptcp-NUL-rawmsg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")

--- a/tests/imptcp-NUL.sh
+++ b/tests/imptcp-NUL.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")

--- a/tests/imptcp-buffer-overflow.sh
+++ b/tests/imptcp-buffer-overflow.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imptcp-connection-msg-disabled.sh
+++ b/tests/imptcp-connection-msg-disabled.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-31 by Pascal Withopf, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")

--- a/tests/imptcp-connection-msg-received.sh
+++ b/tests/imptcp-connection-msg-received.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-31 by Pascal Withopf, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")

--- a/tests/imptcp-custom-delimiter.sh
+++ b/tests/imptcp-custom-delimiter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imptcp-discard-truncated-msg.sh
+++ b/tests/imptcp-discard-truncated-msg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imptcp-maxFrameSize-parameter.sh
+++ b/tests/imptcp-maxFrameSize-parameter.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 12800

--- a/tests/imptcp-msg-truncation-on-number.sh
+++ b/tests/imptcp-msg-truncation-on-number.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imptcp-msg-truncation-on-number2.sh
+++ b/tests/imptcp-msg-truncation-on-number2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imptcp-oversize-message-display.sh
+++ b/tests/imptcp-oversize-message-display.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imptcp_addtlframedelim.sh
+++ b/tests/imptcp_addtlframedelim.sh
@@ -2,7 +2,7 @@
 # added 2010-08-11 by Rgerhards
 #
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imptcp/.libs/imptcp

--- a/tests/imptcp_conndrop-vg.sh
+++ b/tests/imptcp_conndrop-vg.sh
@@ -3,7 +3,7 @@
 # Copyright (C) 2014 Rainer Gerhards -- 2014-11-14
 echo ====================================================================================
 echo TEST: \[imptcp_conndrop-vg.sh\]: test imptcp with random connection drops
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/imptcp_conndrop.sh
+++ b/tests/imptcp_conndrop.sh
@@ -5,7 +5,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
 echo TEST: \[imptcp_conndrop.sh\]: test imptcp with random connection drops
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/imptcp_framing_regex-oversize.sh
+++ b/tests/imptcp_framing_regex-oversize.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $EscapeControlCharactersOnReceive off

--- a/tests/imptcp_framing_regex.sh
+++ b/tests/imptcp_framing_regex.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $EscapeControlCharactersOnReceive off

--- a/tests/imptcp_large.sh
+++ b/tests/imptcp_large.sh
@@ -5,7 +5,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
 echo TEST: \[imptcp_large.sh\]: test imptcp with large-size messages
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/imptcp_multi_line.sh
+++ b/tests/imptcp_multi_line.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")

--- a/tests/imptcp_no_octet_counted.sh
+++ b/tests/imptcp_no_octet_counted.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
 echo TEST: \[imptcp_no_octet_counted.sh\]: test imptcp with octet counted framing disabled
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")

--- a/tests/imptcp_nonProcessingPoller.sh
+++ b/tests/imptcp_nonProcessingPoller.sh
@@ -4,7 +4,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
 echo TEST: \[imptcp_nonProcessingPoller.sh\]: test imptcp with poller driven processing disabled
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/imptcp_spframingfix.sh
+++ b/tests/imptcp_spframingfix.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 echo ====================================================================================
 echo TEST: \[imptcp_spframingfix.sh\]: test imptcp in regard to Cisco ASA framing fix
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")

--- a/tests/imptcp_uds.sh
+++ b/tests/imptcp_uds.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo ======================================================================
 echo \[imptcp_uds.sh\]: test imptcp unix domain socket
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(MaxMessageSize="124k")

--- a/tests/imptcp_uds_unlink.sh
+++ b/tests/imptcp_uds_unlink.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # First make sure we don't unlink if not asked to
 rm -f "$srcdir/testbench_socket"
 echo "nope" > "$srcdir/testbench_socket"
@@ -24,7 +24,7 @@ exit_test
 # Now make sure we unlink if asked to
 echo "ok" > "$srcdir/testbench_socket"
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(MaxMessageSize="124k")

--- a/tests/imptcp_veryLargeOctateCountedMessages.sh
+++ b/tests/imptcp_veryLargeOctateCountedMessages.sh
@@ -3,7 +3,7 @@
 # test imptcp with very large messages while poller driven processing is disabled
 # added 2015-10-17 by singh.janmejay
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '$MaxMessageSize 10k
 template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/imrelp-basic-oldstyle.sh
+++ b/tests/imrelp-basic-oldstyle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-10-09 by Alorbach, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 

--- a/tests/imrelp-basic.sh
+++ b/tests/imrelp-basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")

--- a/tests/imrelp-long-msg.sh
+++ b/tests/imrelp-long-msg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # adddd 2018-04-16 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(maxMessageSize="214800")

--- a/tests/imrelp-manyconn.sh
+++ b/tests/imrelp-manyconn.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # adddd 2016-06-08 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 uname
 if [ $(uname) = "FreeBSD" ] ; then
    echo "This test currently does not work on FreeBSD."

--- a/tests/imrelp-maxDataSize-error.sh
+++ b/tests/imrelp-maxDataSize-error.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2018-04-26 by Pascal Withopf, released under ASL 2.0
 echo [imrelp-maxDataSize-error.sh]
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")

--- a/tests/imrelp-missing-privkey.sh
+++ b/tests/imrelp-missing-privkey.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-06-05 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")

--- a/tests/imrelp-oversizeMode-accept.sh
+++ b/tests/imrelp-oversizeMode-accept.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-25 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
   echo "imrelp parameter oversizeMode not available. Test stopped"

--- a/tests/imrelp-oversizeMode-truncate.sh
+++ b/tests/imrelp-oversizeMode-truncate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-19 by PascalWithopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ./have_relpSrvSetOversizeMode
 if [ $? -eq 1 ]; then
   echo "imrelp parameter oversizeMode not available. Test stopped"

--- a/tests/imtcp-NUL-rawmsg.sh
+++ b/tests/imtcp-NUL-rawmsg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/imtcp-NUL.sh
+++ b/tests/imtcp-NUL.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/imtcp-basic.sh
+++ b/tests/imtcp-basic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/imtcp-discard-truncated-msg.sh
+++ b/tests/imtcp-discard-truncated-msg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imtcp-maxFrameSize.sh
+++ b/tests/imtcp-maxFrameSize.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(processInternalMessages="on")

--- a/tests/imtcp-msg-truncation-on-number.sh
+++ b/tests/imtcp-msg-truncation-on-number.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imtcp-msg-truncation-on-number2.sh
+++ b/tests/imtcp-msg-truncation-on-number2.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 128

--- a/tests/imtcp-multiport.sh
+++ b/tests/imtcp-multiport.sh
@@ -4,7 +4,7 @@
 # handled by imtcp
 # added 2009-05-22 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export TCPFLOOD_PORT2="$(get_free_port)"
 export TCPFLOOD_PORT3="$(get_free_port)"
 generate_conf

--- a/tests/imtcp-tls-basic-vg.sh
+++ b/tests/imtcp-tls-basic-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2011-02-28 by Rgerhards
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/imtcp-tls-basic.sh
+++ b/tests/imtcp-tls-basic.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ===============================================================================
 echo \[imtcp-tls-basic.sh\]: testing imtcp in TLS mode - basic test
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/imtcp-tls-ossl-basic-vg.sh
+++ b/tests/imtcp-tls-ossl-basic-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imtcp-tls-ossl-basic.sh
+++ b/tests/imtcp-tls-ossl-basic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imtcp-tls-ossl-x509fingerprint.sh
+++ b/tests/imtcp-tls-ossl-x509fingerprint.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imtcp-tls-ossl-x509name.sh
+++ b/tests/imtcp-tls-ossl-x509name.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imtcp-tls-ossl-x509valid.sh
+++ b/tests/imtcp-tls-ossl-x509valid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imtcp_addtlframedelim.sh
+++ b/tests/imtcp_addtlframedelim.sh
@@ -5,7 +5,7 @@
 # NOTE: we intentionally use obsolete legacy style so that we can check
 # that it still works. DO NOT CONVERT/REMOVE! -- rgerhards, 2018-08-01
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export PORT_TCP="$(get_free_port)"
 generate_conf
 # be careful: bash expansion is used below --> you need to escape!

--- a/tests/imtcp_conndrop.sh
+++ b/tests/imtcp_conndrop.sh
@@ -12,7 +12,7 @@ fi
 
 echo ====================================================================================
 echo TEST: \[imtcp_conndrop.sh\]: test imtcp with random connection drops
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/imtcp_conndrop_tls-vg.sh
+++ b/tests/imtcp_conndrop_tls-vg.sh
@@ -3,7 +3,7 @@
 # added 2011-06-09 by Rgerhards
 #
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/imtcp_conndrop_tls.sh
+++ b/tests/imtcp_conndrop_tls.sh
@@ -3,7 +3,7 @@
 # added 2011-06-09 by Rgerhards
 #
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/imtcp_incomplete_frame_at_end.sh
+++ b/tests/imtcp_incomplete_frame_at_end.sh
@@ -2,7 +2,7 @@
 # Copyright (C) 2016 by Rainer Gerhardds
 # This file is part of the rsyslog project, released  under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/imtcp_no_octet_counted.sh
+++ b/tests/imtcp_no_octet_counted.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 echo ====================================================================================
 echo TEST: \[imtcp_no_octet_counted.sh\]: test imtcp with octet counted framing disabled
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/imtcp_spframingfix.sh
+++ b/tests/imtcp_spframingfix.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 echo ====================================================================================
 echo TEST: \[imptcp_spframingfix.sh\]: test imptcp in regard to Cisco ASA framing fix
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/imudp_error_msg.sh
+++ b/tests/imudp_error_msg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/imudp_thread_hang.sh
+++ b/tests/imudp_thread_hang.sh
@@ -5,7 +5,7 @@
 # not properly terminated.
 # Copyright 2014 by Rainer Gerhards, licensed under ASL 2.0
 echo \[imudp_thread_hang\]: a situation where imudp caused a hang
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool

--- a/tests/imuxsock_ccmiddle.sh
+++ b/tests/imuxsock_ccmiddle.sh
@@ -6,7 +6,7 @@ if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/imuxsock_ccmiddle_root.sh
+++ b/tests/imuxsock_ccmiddle_root.sh
@@ -12,7 +12,7 @@ if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imuxsock/.libs/imuxsock

--- a/tests/imuxsock_ccmiddle_syssock.sh
+++ b/tests/imuxsock_ccmiddle_syssock.sh
@@ -13,7 +13,7 @@ if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock"

--- a/tests/imuxsock_hostname.sh
+++ b/tests/imuxsock_hostname.sh
@@ -6,7 +6,7 @@ if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(localHostName="rsyslog-testbench-hostname")

--- a/tests/imuxsock_logger.sh
+++ b/tests/imuxsock_logger.sh
@@ -12,7 +12,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/imuxsock_logger_err.sh
+++ b/tests/imuxsock_logger_err.sh
@@ -2,7 +2,7 @@
 # this is primarily a safeguard to ensure the imuxsock tests basically work
 # added 2014-12-04 by Rainer Gerhards, licensed under ASL 2.0
 echo \[imuxsock_logger.sh\]: test imuxsock
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/imuxsock_logger_parserchain.sh
+++ b/tests/imuxsock_logger_parserchain.sh
@@ -16,7 +16,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/imuxsock_logger_root.sh
+++ b/tests/imuxsock_logger_root.sh
@@ -6,7 +6,7 @@ echo This test must be run as root with no other active syslogd
 if [ "$EUID" -ne 0 ]; then
     exit 77 # Not root, skip this test
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imuxsock/.libs/imuxsock

--- a/tests/imuxsock_logger_ruleset.sh
+++ b/tests/imuxsock_logger_ruleset.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # rgerhards, 2016-02-02 released under ASL 2.0
 echo \[imuxsock_logger_ruleset.sh\]: test imuxsock with ruleset definition
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/imuxsock_logger_ruleset_ratelimit.sh
+++ b/tests/imuxsock_logger_ruleset_ratelimit.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # rgerhards, 2016-02-18 released under ASL 2.0
 echo \[imuxsock_logger_ruleset_ratelimit.sh\]: test imuxsock with ruleset definition
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/imuxsock_logger_syssock.sh
+++ b/tests/imuxsock_logger_syssock.sh
@@ -16,7 +16,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock"

--- a/tests/imuxsock_traillf.sh
+++ b/tests/imuxsock_traillf.sh
@@ -5,7 +5,7 @@ if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/imuxsock_traillf_root.sh
+++ b/tests/imuxsock_traillf_root.sh
@@ -12,7 +12,7 @@ if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imuxsock/.libs/imuxsock

--- a/tests/imuxsock_traillf_syssock.sh
+++ b/tests/imuxsock_traillf_syssock.sh
@@ -12,7 +12,7 @@ if [ $no_liblogging_stdlog -ne 0 ];then
   echo "liblogging-stdlog not available - skipping test"
   exit 77
 fi
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock"

--- a/tests/incltest.sh
+++ b/tests/incltest.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf "\$IncludeConfig ${srcdir}/testsuites/incltest.d/include.conf
 "

--- a/tests/incltest_dir.sh
+++ b/tests/incltest_dir.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 env|grep src
 echo ac_top_srcdir: $ac_top_srcdir

--- a/tests/incltest_dir_empty_wildcard.sh
+++ b/tests/incltest_dir_empty_wildcard.sh
@@ -2,7 +2,7 @@
 # This test checks if an empty includeConfig directory causes problems. It
 # should not, as this is a valid situation that by default exists on many
 # distros.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf "\$IncludeConfig ${srcdir}/testsuites/incltest.d/*.conf-not-there
 "

--- a/tests/incltest_dir_wildcard.sh
+++ b/tests/incltest_dir_wildcard.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf "include(file=\"${srcdir}/testsuites/incltest.d/*.conf\")
 "

--- a/tests/include-obj-in-if-vg.sh
+++ b/tests/include-obj-in-if-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/include-obj-outside-control-flow-vg.sh
+++ b/tests/include-obj-outside-control-flow-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/include-obj-text-from-file.sh
+++ b/tests/include-obj-text-from-file.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/include-obj-text-vg.sh
+++ b/tests/include-obj-text-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 INCLFILE="${srcdir}/testsuites/include-std-omfile-action.conf"
 export CONF_SNIPPET=`cat $INCLFILE`

--- a/tests/inputname-imtcp.sh
+++ b/tests/inputname-imtcp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/internal-errmsg-memleak-vg.sh
+++ b/tests/internal-errmsg-memleak-vg.sh
@@ -14,7 +14,7 @@ if [ $(uname) = "FreeBSD" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(processInternalMessages="off")

--- a/tests/invalid_nested_include.sh
+++ b/tests/invalid_nested_include.sh
@@ -2,7 +2,7 @@
 # Note: this test tests if we die when recursively include the same
 # file ever again. This is a user error, but we should detect it.
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 echo '$IncludeConfig '${RSYSLOG_DYNNAME}'work-nested.conf
 ' > ${RSYSLOG_DYNNAME}work-nested.conf

--- a/tests/json_array_looping-vg.sh
+++ b/tests/json_array_looping-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[json_array_looping-vg.sh\]: basic test for looping over json array with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="garply" type="string" string="garply: %$.garply%\n")

--- a/tests/json_array_looping.sh
+++ b/tests/json_array_looping.sh
@@ -2,7 +2,7 @@
 # added 2014-11-11 by singh.janmejay
 # basic test for looping over json array
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="garply" type="string" string="garply: %$.garply%\n")

--- a/tests/json_array_subscripting.sh
+++ b/tests/json_array_subscripting.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[json_array_subscripting.sh\]: basic test for json array subscripting
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="msg: %$!foo[1]% | %$.quux% | %$.corge% | %$.grault% | %$!foo[3]!bar[1]!baz%\n")

--- a/tests/json_nonarray_looping.sh
+++ b/tests/json_nonarray_looping.sh
@@ -2,7 +2,7 @@
 # added 2015-03-02 by singh.janmejay
 # test to assert attempt to iterate upon a non-array json-object fails gracefully
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="garply" type="string" string="garply: %$.garply%\n")

--- a/tests/json_null-vg.sh
+++ b/tests/json_null-vg.sh
@@ -12,7 +12,7 @@ fi
 
 echo ===============================================================================
 echo \[json_null.sh\]: test for json containung \"null\" value
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")

--- a/tests/json_null.sh
+++ b/tests/json_null.sh
@@ -5,7 +5,7 @@
 # not actually check the output
 echo ===============================================================================
 echo \[json_null.sh\]: test for json containung \"null\" value
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")

--- a/tests/json_null_array-vg.sh
+++ b/tests/json_null_array-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[json_null_array.sh\]: test for json containung \"null\" value
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")

--- a/tests/json_null_array.sh
+++ b/tests/json_null_array.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[json_null_array.sh\]: test for json containung \"null\" value
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")

--- a/tests/json_object_looping-vg.sh
+++ b/tests/json_object_looping-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[json_object_looping-vg.sh\]: basic test for looping over json object / associative-array with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="garply" type="string" string="garply: %$.garply%\n")

--- a/tests/json_object_looping.sh
+++ b/tests/json_object_looping.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[json_object_looping.sh\]: basic test for looping over json object / associative-array
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="garply" type="string" string="garply: %$.garply%\n")

--- a/tests/json_object_suicide_in_loop-vg.sh
+++ b/tests/json_object_suicide_in_loop-vg.sh
@@ -2,7 +2,7 @@
 # basic test for looping over json object and unsetting it while inside the loop-body
 # added 2016-03-31 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/json_var_case.sh
+++ b/tests/json_var_case.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===========================================================================================
 echo \[json_var_case.sh\]: test for JSON upper and lower case variables, and leading underscores
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(variables.casesensitive="on")

--- a/tests/json_var_cmpr.sh
+++ b/tests/json_var_cmpr.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo =============================================================================================
 echo \[json_var_case.sh\]: test for referencing local and global variables properly in comparisons
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")

--- a/tests/key_dereference_on_uninitialized_variable_space.sh
+++ b/tests/key_dereference_on_uninitialized_variable_space.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[key_dereference_on_uninitialized_variable_space.sh\]: test to dereference key from a not-yet-created cee or local json-object
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="corge" type="string" string="cee:%$!%\n")

--- a/tests/ksi-verify-long.sh
+++ b/tests/ksi-verify-long.sh
@@ -10,7 +10,7 @@ RSYSLOG_KSI_DEBUG="--show-verified"
 RSYSLOG_KSI_LOG="ksi-sample.log"
 
 echo \[ksi-verify-long.sh\]: testing rsgtutil verify function - long options
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 echo "running rsgtutil command with long options"
 ../tools/rsgtutil $RSYSLOG_KSI_DEBUG --verify --publications-server $RSYSLOG_KSI_BIN $srcdir/testsuites/$RSYSLOG_KSI_LOG

--- a/tests/ksi-verify-short.sh
+++ b/tests/ksi-verify-short.sh
@@ -10,7 +10,7 @@ RSYSLOG_KSI_DEBUG="-s"
 RSYSLOG_KSI_LOG="ksi-sample.log"
 
 echo \[ksi-verify-short.sh\]: testing rsgtutil verify function - short options
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 echo "running rsgtutil command with short options"
 ../tools/rsgtutil $RSYSLOG_KSI_DEBUG -t -P $RSYSLOG_KSI_BIN $srcdir/testsuites/$RSYSLOG_KSI_LOG

--- a/tests/libdbi-asyn.sh
+++ b/tests/libdbi-asyn.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[libdbi-asyn.sh\]: asyn test for libdbi functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/omlibdbi/.libs/omlibdbi

--- a/tests/libdbi-basic-vg.sh
+++ b/tests/libdbi-basic-vg.sh
@@ -4,7 +4,7 @@
 # itself seems to have a memory leak
 echo ===============================================================================
 echo \[libdbi-basic.sh\]: basic test for libdbi-basic functionality via mysql
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/omlibdbi/.libs/omlibdbi

--- a/tests/libdbi-basic.sh
+++ b/tests/libdbi-basic.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[libdbi-basic.sh\]: basic test for libdbi-basic functionality via mysql
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/omlibdbi/.libs/omlibdbi

--- a/tests/linkedlistqueue.sh
+++ b/tests/linkedlistqueue.sh
@@ -2,7 +2,7 @@
 # Test for Linkedlist queue mode
 # added 2009-05-20 by rgerhards
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/lmsig_ksi_ls12.sh
+++ b/tests/lmsig_ksi_ls12.sh
@@ -3,7 +3,7 @@ echo \[lmsig_ksi_ls12.sh\]: test ksi_ls12
 
 rm -rf $srcdir/ksitest
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/localvar-concurrency.sh
+++ b/tests/localvar-concurrency.sh
@@ -11,7 +11,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/lookup_table-vg.sh
+++ b/tests/lookup_table-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table-vg.sh\]: test for clean destory of lookup-table, when lookup-fn is used
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl" reloadOnHUP="on")

--- a/tests/lookup_table.sh
+++ b/tests/lookup_table.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table.sh\]: test for lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl" reloadOnHUP="on")

--- a/tests/lookup_table_bad_configs-vg.sh
+++ b/tests/lookup_table_bad_configs-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table_bad_configs.sh\]: test for sparse-array lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl")

--- a/tests/lookup_table_bad_configs.sh
+++ b/tests/lookup_table_bad_configs.sh
@@ -2,7 +2,7 @@
 # added 2015-12-02 by singh.janmejay
 # test for sparse-array lookup-table and HUP based reloading of it
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 uname
 if [ $(uname) = "FreeBSD" ] ; then
    echo "This test currently does not work on FreeBSD."

--- a/tests/lookup_table_no_hup_reload-vg.sh
+++ b/tests/lookup_table_no_hup_reload-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table_no_hup_reload-vg.sh\]: test for lookup-table with HUP based reloading disabled with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl" reloadOnHUP="off")

--- a/tests/lookup_table_no_hup_reload.sh
+++ b/tests/lookup_table_no_hup_reload.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table_no_hup_reload.sh\]: test for lookup-table with HUP based reloading disabled
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl" reloadOnHUP="off")

--- a/tests/lookup_table_rscript_reload-vg.sh
+++ b/tests/lookup_table_rscript_reload-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table_rscript_reload-vg.sh\]: test for lookup-table reload by rscript-fn with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl")

--- a/tests/lookup_table_rscript_reload.sh
+++ b/tests/lookup_table_rscript_reload.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table_rscript_reload.sh\]: test for lookup-table reload by rscript-fn
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl")

--- a/tests/lookup_table_rscript_reload_without_stub-vg.sh
+++ b/tests/lookup_table_rscript_reload_without_stub-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table_rscript_reload_without_stub-vg.sh\]: test for lookup-table reload by rscript-stmt without stub-value with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl")

--- a/tests/lookup_table_rscript_reload_without_stub.sh
+++ b/tests/lookup_table_rscript_reload_without_stub.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[lookup_table_rscript_reload_without_stub.sh\]: test for lookup-table reload by rscript-stmt without stub
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl")

--- a/tests/manyptcp.sh
+++ b/tests/manyptcp.sh
@@ -2,7 +2,7 @@
 # test many concurrent tcp connections
 echo ====================================================================================
 echo TEST: \[manyptcp.sh\]: test imptcp with large connection count
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imptcp/.libs/imptcp

--- a/tests/manytcp-too-few-tls-vg.sh
+++ b/tests/manytcp-too-few-tls-vg.sh
@@ -8,7 +8,7 @@ if [ $(uname) = "FreeBSD" ] ; then
 fi
 
 echo \[manytcp-too-few-tls.sh\]: test concurrent tcp connections
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/manytcp.sh
+++ b/tests/manytcp.sh
@@ -15,7 +15,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/mmanon_both_modes_compatible.sh
+++ b/tests/mmanon_both_modes_compatible.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_random_128_ipv6.sh
+++ b/tests/mmanon_random_128_ipv6.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_random_32_ipv4.sh
+++ b/tests/mmanon_random_32_ipv4.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_random_cons_128_ipembedded.sh
+++ b/tests/mmanon_random_cons_128_ipembedded.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_random_cons_128_ipv6.sh
+++ b/tests/mmanon_random_cons_128_ipv6.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_random_cons_32_ipv4.sh
+++ b/tests/mmanon_random_cons_32_ipv4.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_recognize_ipembedded.sh
+++ b/tests/mmanon_recognize_ipembedded.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_recognize_ipv4.sh
+++ b/tests/mmanon_recognize_ipv4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_recognize_ipv6.sh
+++ b/tests/mmanon_recognize_ipv6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_simple_12_ipv4.sh
+++ b/tests/mmanon_simple_12_ipv4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_simple_33_ipv4.sh
+++ b/tests/mmanon_simple_33_ipv4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_simple_8_ipv4.sh
+++ b/tests/mmanon_simple_8_ipv4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_zero_128_ipv6.sh
+++ b/tests/mmanon_zero_128_ipv6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_zero_12_ipv4.sh
+++ b/tests/mmanon_zero_12_ipv4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_zero_33_ipv4.sh
+++ b/tests/mmanon_zero_33_ipv4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_zero_50_ipv6.sh
+++ b/tests/mmanon_zero_50_ipv6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_zero_64_ipv6.sh
+++ b/tests/mmanon_zero_64_ipv6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_zero_8_ipv4.sh
+++ b/tests/mmanon_zero_8_ipv4.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_zero_96_ipv6.sh
+++ b/tests/mmanon_zero_96_ipv6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmdb-container-empty.sh
+++ b/tests/mmdb-container-empty.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!src_geoip%\n")

--- a/tests/mmdb-container.sh
+++ b/tests/mmdb-container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!mmdb_root%\n")

--- a/tests/mmdb-multilevel-vg.sh
+++ b/tests/mmdb-multilevel-vg.sh
@@ -5,7 +5,7 @@
 # thus we need a supressions file:
 export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="$RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/libmaxmindb.supp"
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!iplocation%\n")

--- a/tests/mmdb-vg.sh
+++ b/tests/mmdb-vg.sh
@@ -5,7 +5,7 @@
 # thus we need a supressions file:
 export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="$RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/libmaxmindb.supp"
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!iplocation%\n")

--- a/tests/mmdb.sh
+++ b/tests/mmdb.sh
@@ -6,7 +6,7 @@ echo \[mmdb.sh\]: test for mmdb
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="log"
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!iplocation%\n")

--- a/tests/mmexternal-InvldProg-vg.sh
+++ b/tests/mmexternal-InvldProg-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-12-29 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmexternal-SegFault-empty-jroot-vg.sh
+++ b/tests/mmexternal-SegFault-empty-jroot-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2017-11-06 by PascalWithopf, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmexternal-SegFault-vg.sh
+++ b/tests/mmexternal-SegFault-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2017-11-06 by PascalWithopf, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmjsonparse-invalid-containerName.sh
+++ b/tests/mmjsonparse-invalid-containerName.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-13 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/impstats/.libs/impstats" interval="300"

--- a/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
+++ b/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-03-22 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!msgnum%\n")

--- a/tests/mmjsonparse-w-o-cookie.sh
+++ b/tests/mmjsonparse-w-o-cookie.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-03-22 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!msgnum%\n")

--- a/tests/mmjsonparse_cim.sh
+++ b/tests/mmjsonparse_cim.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mmjsonparse_cim.sh\]: basic test for mmjsonparse module with "cim" cookie
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!cim!msgnum%\n")

--- a/tests/mmjsonparse_cim2.sh
+++ b/tests/mmjsonparse_cim2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-16 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!cim!msgnum%\n")

--- a/tests/mmjsonparse_localvar.sh
+++ b/tests/mmjsonparse_localvar.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-04-16 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.msgnum%\n")

--- a/tests/mmjsonparse_simple.sh
+++ b/tests/mmjsonparse_simple.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mmjsonparse_simple.sh\]: basic test for mmjsonparse module with defaults
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!msgnum%\n")

--- a/tests/mmkubernetes-basic-vg.sh
+++ b/tests/mmkubernetes-basic-vg.sh
@@ -9,7 +9,7 @@
 # trick. -- rgerhards, 2018-07-21
 #export RSYSLOG_DEBUG="debug"
 USE_VALGRIND=true
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available timeout
 pwd=$( pwd )
 k8s_srv_port=$( get_free_port )

--- a/tests/mmkubernetes-basic.sh
+++ b/tests/mmkubernetes-basic.sh
@@ -9,7 +9,7 @@
 # trick. -- rgerhards, 2018-07-21
 #export RSYSLOG_DEBUG="debug"
 USE_VALGRIND=false
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available timeout
 pwd=$( pwd )
 k8s_srv_port=$( get_free_port )

--- a/tests/mmnormalize_processing_test1.sh
+++ b/tests/mmnormalize_processing_test1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00

--- a/tests/mmnormalize_processing_test2.sh
+++ b/tests/mmnormalize_processing_test2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00

--- a/tests/mmnormalize_processing_test3.sh
+++ b/tests/mmnormalize_processing_test3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+01:00

--- a/tests/mmnormalize_processing_test4.sh
+++ b/tests/mmnormalize_processing_test4.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST-02:00

--- a/tests/mmnormalize_regex.sh
+++ b/tests/mmnormalize_regex.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mmnormalize_regex.sh\]: test for mmnormalize regex field_type
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="hosts_and_ports" type="string" string="host and port list: %$!hps%\n")

--- a/tests/mmnormalize_regex_defaulted.sh
+++ b/tests/mmnormalize_regex_defaulted.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mmnormalize_regex_defaulted.sh\]: test for mmnormalize regex field_type, with allow_regex defaulted
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="hosts_and_ports" type="string" string="host and port list: %$!hps%\n")

--- a/tests/mmnormalize_regex_disabled.sh
+++ b/tests/mmnormalize_regex_disabled.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mmnormalize_regex_disabled.sh\]: test for mmnormalize regex field_type with allow_regex disabled
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="hosts_and_ports" type="string" string="host and port list: %$!hps%\n")

--- a/tests/mmnormalize_rule_from_array.sh
+++ b/tests/mmnormalize_rule_from_array.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmnormalize_rule_from_string.sh
+++ b/tests/mmnormalize_rule_from_string.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmnormalize_tokenized.sh
+++ b/tests/mmnormalize_tokenized.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mmnormalize_tokenized.sh\]: test for mmnormalize tokenized field_type
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="ips" type="string" string="%$.ips%\n")

--- a/tests/mmnormalize_variable.sh
+++ b/tests/mmnormalize_variable.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mmnormalize_variable.sh\]: basic test for mmnormalize module variable-support
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="h:%$!hr% m:%$!min% s:%$!sec%\n")

--- a/tests/mmpstrucdata-case.sh
+++ b/tests/mmpstrucdata-case.sh
@@ -3,7 +3,7 @@
 # correctly parsed.
 # This file is part of the rsyslog project, released  under ASL 2.0
 # rgerhards, 2015-04-30
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")

--- a/tests/mmpstrucdata-invalid-vg.sh
+++ b/tests/mmpstrucdata-invalid-vg.sh
@@ -12,7 +12,7 @@ fi
 
 echo ===============================================================================
 echo \[mmpstrucdata-invalid.sh\]: testing mmpstrucdata with invalid SD
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")

--- a/tests/mmpstrucdata-vg.sh
+++ b/tests/mmpstrucdata-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[mmpstrucdata.sh\]: testing mmpstrucdata
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")

--- a/tests/mmpstrucdata.sh
+++ b/tests/mmpstrucdata.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released  under ASL 2.0
 # rgerhards, 2013-11-22
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")

--- a/tests/mmrm1stspace-basic.sh
+++ b/tests/mmrm1stspace-basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/mmutf8fix_no_error.sh
+++ b/tests/mmutf8fix_no_error.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2018-10-10 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/msg-deadlock-headerless-noappname.sh
+++ b/tests/msg-deadlock-headerless-noappname.sh
@@ -2,7 +2,7 @@
 # this checks against a situation where a deadlock was caused in
 # practice.
 # added 2018-10-17 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/msgdup.sh
+++ b/tests/msgdup.sh
@@ -15,7 +15,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")

--- a/tests/msgvar-concurrency-array-event.tags.sh
+++ b/tests/msgvar-concurrency-array-event.tags.sh
@@ -5,7 +5,7 @@
 export TCPFLOOD_EXTRA_OPTS="-M'msg:msg: 1:2, 3:4, 5:6, 7:8 b test'"
 echo ===============================================================================
 echo \[msgvar-concurrency-array-event.tags.sh\]: testing concurrency of local variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmnormalize/.libs/mmnormalize")

--- a/tests/msgvar-concurrency-array.sh
+++ b/tests/msgvar-concurrency-array.sh
@@ -5,7 +5,7 @@
 export TCPFLOOD_EXTRA_OPTS="-M'msg:msg: 1:2, 3:4, 5:6, 7:8 b test'"
 echo ===============================================================================
 echo \[msgvar-concurrency-array.sh\]: testing concurrency of local variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/mmnormalize/.libs/mmnormalize")

--- a/tests/msgvar-concurrency.sh
+++ b/tests/msgvar-concurrency.sh
@@ -8,7 +8,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/msleep_usage_output.sh
+++ b/tests/msleep_usage_output.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 ./msleep &> $RSYSLOG_DYNNAME.output
 grep "usage: msleep" $RSYSLOG_DYNNAME.output 

--- a/tests/multiple_lookup_tables-vg.sh
+++ b/tests/multiple_lookup_tables-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[multiple_lookup_table-vg.sh\]: test for multiple lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate_0" file="xlate.lkp_tbl")

--- a/tests/multiple_lookup_tables.sh
+++ b/tests/multiple_lookup_tables.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[multiple_lookup_table.sh\]: test for multiple lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate_0" file="xlate.lkp_tbl")

--- a/tests/mysql-actq-mt-withpause-extended.sh
+++ b/tests/mysql-actq-mt-withpause-extended.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mysql-act-mt.sh\]: test for mysql with multithread actionq
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/ommysql/.libs/ommysql")

--- a/tests/mysql-actq-mt-withpause-vg.sh
+++ b/tests/mysql-actq-mt-withpause-vg.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mysql-act-mt.sh\]: test for mysql with multithread actionq
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/ommysql/.libs/ommysql")

--- a/tests/mysql-actq-mt-withpause.sh
+++ b/tests/mysql-actq-mt-withpause.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mysql-act-mt.sh\]: test for mysql with multithread actionq
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/ommysql/.libs/ommysql")

--- a/tests/mysql-actq-mt.sh
+++ b/tests/mysql-actq-mt.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[mysql-act-mt.sh\]: test for mysql with multithread actionq
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/ommysql/.libs/ommysql")

--- a/tests/mysql-asyn-vg.sh
+++ b/tests/mysql-asyn-vg.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[mysql-asyn.sh\]: asyn test for mysql functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql

--- a/tests/mysql-asyn.sh
+++ b/tests/mysql-asyn.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[mysql-asyn.sh\]: asyn test for mysql functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql

--- a/tests/mysql-basic-cnf6.sh
+++ b/tests/mysql-basic-cnf6.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[mysql-basic.sh\]: basic test for mysql-basic functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql

--- a/tests/mysql-basic-vg.sh
+++ b/tests/mysql-basic-vg.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[mysql-basic-vg.sh\]: basic test for mysql-basic functionality/valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql

--- a/tests/mysql-basic.sh
+++ b/tests/mysql-basic.sh
@@ -2,7 +2,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[mysql-basic.sh\]: basic test for mysql-basic functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql

--- a/tests/nested-call-shutdown.sh
+++ b/tests/nested-call-shutdown.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-10-18 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")

--- a/tests/no-dynstats-json.sh
+++ b/tests/no-dynstats-json.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[no-dynstats-json.sh\]: test for verifying stats are reported correctly in json format in absence of any dynstats buckets being configured
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/no-dynstats.sh
+++ b/tests/no-dynstats.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[no-dynstats.sh\]: test for verifying stats are reported correctly in legacy format in absence of any dynstats buckets being configured
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/no-parser-errmsg.sh
+++ b/tests/no-parser-errmsg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-03-06 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/no-parser-vg.sh
+++ b/tests/no-parser-vg.sh
@@ -7,7 +7,7 @@ if [ $(uname) = "FreeBSD" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/now-utc-casecmp.sh
+++ b/tests/now-utc-casecmp.sh
@@ -3,7 +3,7 @@
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[now-utc-casecmp\]: test \$year-utc, \$month-utc, \$day-utc
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 . $srcdir/faketime_common.sh
 

--- a/tests/now-utc-ymd.sh
+++ b/tests/now-utc-ymd.sh
@@ -2,7 +2,7 @@
 # test many concurrent tcp connections
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 echo \[now-utc-ymd\]: test \$year-utc, \$month-utc, \$day-utc
 
 . $srcdir/faketime_common.sh

--- a/tests/now-utc.sh
+++ b/tests/now-utc.sh
@@ -3,7 +3,7 @@
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[now-utc\]: test \$NOW-UTC
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/now_family_utc.sh
+++ b/tests/now_family_utc.sh
@@ -3,7 +3,7 @@
 # addd 2016-01-12 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[now_family_utc\]: test \$NOW family of system properties
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/omfile-null-filename.sh
+++ b/tests/omfile-null-filename.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # check that omfile does not segfault when filename is given but empty.
 # addd 2018-04-03 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 action(type="omfile" file="")

--- a/tests/omfile-read-only-errmsg.sh
+++ b/tests/omfile-read-only-errmsg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-03-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/omfile-read-only.sh
+++ b/tests/omfile-read-only.sh
@@ -7,7 +7,7 @@ messages=20000 # how many messages to inject?
 # as batching can (validly) cause a larger loss in the non-writable
 # file
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/omfile-whitespace-filename.sh
+++ b/tests/omfile-whitespace-filename.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-04-03 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 action(type="omfile" file=" ")

--- a/tests/omfile_both_files_set.sh
+++ b/tests/omfile_both_files_set.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/omfwd-keepalive.sh
+++ b/tests/omfwd-keepalive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-03-30 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/omjournal-abort-no-template.sh
+++ b/tests/omjournal-abort-no-template.sh
@@ -5,7 +5,7 @@
 # not abort when trying to use omjournal. Not high tech,
 # but better than nothing.
 # addd 2016-03-16 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omjournal/.libs/omjournal")

--- a/tests/omjournal-abort-template.sh
+++ b/tests/omjournal-abort-template.sh
@@ -5,7 +5,7 @@
 # not abort when trying to use omjournal. Not high tech,
 # but better than nothing.
 # addd 2016-03-16 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omjournal/.libs/omjournal")

--- a/tests/omjournal-basic-no-template.sh
+++ b/tests/omjournal-basic-no-template.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # a basic test for omjournal.
 # addd 2016-03-18 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh require-journalctl
 generate_conf
 add_conf '

--- a/tests/omjournal-basic-template.sh
+++ b/tests/omjournal-basic-template.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # a very basic test for omjournal.
 # addd 2016-03-18 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh require-journalctl
 generate_conf
 add_conf '

--- a/tests/omkafka-vg.sh
+++ b/tests/omkafka-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
 # *** ==============================================================================

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
 # *** ==============================================================================

--- a/tests/ommail_errmsg_no_params.sh
+++ b/tests/ommail_errmsg_no_params.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2018-09-25 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/omod-if-array-udp.sh
+++ b/tests/omod-if-array-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/omod-if-array.sh
+++ b/tests/omod-if-array.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/omprog-close-unresponsive-noterm.sh
+++ b/tests/omprog-close-unresponsive-noterm.sh
@@ -4,7 +4,7 @@
 # This test checks that omprog does NOT send a TERM signal to the
 # external program when signalOnClose=off, closes the pipe, and kills
 # the unresponsive child if killUnresponsive=on.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-close-unresponsive-vg.sh
+++ b/tests/omprog-close-unresponsive-vg.sh
@@ -5,7 +5,7 @@
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-close-unresponsive.sh
+++ b/tests/omprog-close-unresponsive.sh
@@ -5,7 +5,7 @@
 # program when signalOnClose=on, closes the pipe, and kills the
 # child if unresponsive.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-defaults-vg.sh
+++ b/tests/omprog-defaults-vg.sh
@@ -5,7 +5,7 @@
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-defaults.sh
+++ b/tests/omprog-defaults.sh
@@ -16,7 +16,7 @@
 # (default value of closeTimeout), which should be sufficient for the
 # program to write its output.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-feedback-mt.sh
+++ b/tests/omprog-feedback-mt.sh
@@ -12,7 +12,7 @@ ERROR_RATE_PERCENT=1      # percentage of logs to be retried
 
 export command_line=`echo $srcdir/testsuites/omprog-feedback-mt-bin.sh $ERROR_RATE_PERCENT`
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "SunOS" ] ; then

--- a/tests/omprog-feedback-timeout.sh
+++ b/tests/omprog-feedback-timeout.sh
@@ -6,7 +6,7 @@
 # feedback before the configured 'confirmTimeout'. Also tests the
 # keep-alive feature.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-feedback-vg.sh
+++ b/tests/omprog-feedback-vg.sh
@@ -5,7 +5,7 @@
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-feedback.sh
+++ b/tests/omprog-feedback.sh
@@ -5,7 +5,7 @@
 # by checking that omprog re-sends to the external program the messages
 # it has failed to process.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-output-capture-mt.sh
+++ b/tests/omprog-output-capture-mt.sh
@@ -9,7 +9,7 @@
 # lines in line-buffered mode. In this test, the 'stdbuf' utility of GNU
 # Coreutils is used to force line buffering in a Python program (see
 # 'omprog-output-capture-mt-bin.py' for alternatives).
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 uname
 if [ $(uname) = "SunOS" ] ; then
    echo "This test currently does not work on all flavors of Solaris (problems with Python?)."

--- a/tests/omprog-output-capture-vg.sh
+++ b/tests/omprog-output-capture-vg.sh
@@ -5,7 +5,7 @@
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-output-capture.sh
+++ b/tests/omprog-output-capture.sh
@@ -3,7 +3,7 @@
 
 # This test tests the 'output' setting of omprog when the feedback
 # feature is not used (confirmMessages=off).
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-restart-terminated-outfile.sh
+++ b/tests/omprog-restart-terminated-outfile.sh
@@ -5,7 +5,7 @@
 # parameter. Checks that no file descriptors are leaked across restarts
 # of the program when stderr is being captured to a file.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available lsof
 
 generate_conf

--- a/tests/omprog-restart-terminated-vg.sh
+++ b/tests/omprog-restart-terminated-vg.sh
@@ -5,7 +5,7 @@
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-restart-terminated.sh
+++ b/tests/omprog-restart-terminated.sh
@@ -7,7 +7,7 @@
 # omprog is going to write to the pipe (to send a message to the
 # program), and when omprog is going to read from the pipe (when it
 # is expecting the program to confirm the last message).
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 check_command_available lsof
 
 generate_conf

--- a/tests/omprog-single-instance-outfile.sh
+++ b/tests/omprog-single-instance-outfile.sh
@@ -7,7 +7,7 @@
 
 NUMBER_OF_MESSAGES=10000  # number of logs to send
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "SunOS" ] ; then

--- a/tests/omprog-single-instance-vg.sh
+++ b/tests/omprog-single-instance-vg.sh
@@ -7,7 +7,7 @@
 
 NUMBER_OF_MESSAGES=10000  # number of logs to send
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "SunOS" ] ; then

--- a/tests/omprog-single-instance.sh
+++ b/tests/omprog-single-instance.sh
@@ -7,7 +7,7 @@
 
 NUMBER_OF_MESSAGES=10000  # number of logs to send
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "SunOS" ] ; then

--- a/tests/omprog-transactions-failed-commits.sh
+++ b/tests/omprog-transactions-failed-commits.sh
@@ -5,7 +5,7 @@
 # parameters, with the external program returning an error on certain
 # transaction commits.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "SunOS" ] ; then

--- a/tests/omprog-transactions-failed-messages.sh
+++ b/tests/omprog-transactions-failed-messages.sh
@@ -5,7 +5,7 @@
 # parameters, with the external program returning an error on certain
 # messages.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-transactions-vg.sh
+++ b/tests/omprog-transactions-vg.sh
@@ -5,7 +5,7 @@
 # problems using valgrind. Note it is not necessary to repeat the
 # rest of checks (this simplifies the maintenance of the tests).
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omprog-transactions.sh
+++ b/tests/omprog-transactions.sh
@@ -5,7 +5,7 @@
 # parameters, with the external program successfully confirming all messages
 # and transactions.
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omprog/.libs/omprog")

--- a/tests/omrelp_wrong_authmode.sh
+++ b/tests/omrelp_wrong_authmode.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-09-13 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")

--- a/tests/omruleset-queue.sh
+++ b/tests/omruleset-queue.sh
@@ -16,7 +16,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/omruleset/.libs/omruleset

--- a/tests/omruleset.sh
+++ b/tests/omruleset.sh
@@ -12,7 +12,7 @@
 # This file is part of the rsyslog project, released under GPLv3
 echo ===============================================================================
 echo \[omruleset.sh\]: basic test for omruleset functionality
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/omruleset/.libs/omruleset

--- a/tests/omsnmp_errmsg_no_params.sh
+++ b/tests/omsnmp_errmsg_no_params.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2018-09-25 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/omstdout-basic.sh
+++ b/tests/omstdout-basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/omtcl.sh
+++ b/tests/omtcl.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../contrib/omtcl/.libs/omtcl

--- a/tests/parsertest-parse-3164-buggyday-udp.sh
+++ b/tests/parsertest-parse-3164-buggyday-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/parsertest-parse-3164-buggyday.sh
+++ b/tests/parsertest-parse-3164-buggyday.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/parsertest-parse-nodate-udp.sh
+++ b/tests/parsertest-parse-nodate-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/parsertest-parse-nodate.sh
+++ b/tests/parsertest-parse-nodate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/parsertest-parse1-udp.sh
+++ b/tests/parsertest-parse1-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/parsertest-parse1.sh
+++ b/tests/parsertest-parse1.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/parsertest-parse2-udp.sh
+++ b/tests/parsertest-parse2-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/parsertest-parse2.sh
+++ b/tests/parsertest-parse2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/parsertest-parse3-udp.sh
+++ b/tests/parsertest-parse3-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/parsertest-parse3.sh
+++ b/tests/parsertest-parse3.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/parsertest-parse_8bit_escape-udp.sh
+++ b/tests/parsertest-parse_8bit_escape-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-28 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/parsertest-parse_8bit_escape.sh
+++ b/tests/parsertest-parse_8bit_escape.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-28 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/parsertest-parse_invld_regex-udp.sh
+++ b/tests/parsertest-parse_invld_regex-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-28 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/parsertest-parse_invld_regex.sh
+++ b/tests/parsertest-parse_invld_regex.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-28 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/parsertest-snare_ccoff_udp.sh
+++ b/tests/parsertest-snare_ccoff_udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/parsertest-snare_ccoff_udp2.sh
+++ b/tests/parsertest-snare_ccoff_udp2.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/pgsql-actq-mt-withpause-vg.sh
+++ b/tests/pgsql-actq-mt-withpause-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-actq-mt-withpause.sh
+++ b/tests/pgsql-actq-mt-withpause.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-basic-cnf6-vg.sh
+++ b/tests/pgsql-basic-cnf6-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-basic-cnf6.sh
+++ b/tests/pgsql-basic-cnf6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-basic-threads-cnf6.sh
+++ b/tests/pgsql-basic-threads-cnf6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-basic-vg.sh
+++ b/tests/pgsql-basic-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-basic.sh
+++ b/tests/pgsql-basic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-template-cnf6-vg.sh
+++ b/tests/pgsql-template-cnf6-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-template-cnf6.sh
+++ b/tests/pgsql-template-cnf6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f ${srcdir}/testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-template-threads-cnf6.sh
+++ b/tests/pgsql-template-threads-cnf6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-template-vg.sh
+++ b/tests/pgsql-template-vg.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pgsql-template.sh
+++ b/tests/pgsql-template.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under GPLv3
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
 

--- a/tests/pipe_noreader.sh
+++ b/tests/pipe_noreader.sh
@@ -16,7 +16,7 @@
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/pipeaction.sh
+++ b/tests/pipeaction.sh
@@ -15,7 +15,7 @@ fi
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 10000

--- a/tests/pmlastmsg-udp.sh
+++ b/tests/pmlastmsg-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/pmlastmsg/.libs/pmlastmsg")

--- a/tests/pmlastmsg.sh
+++ b/tests/pmlastmsg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/pmlastmsg/.libs/pmlastmsg")

--- a/tests/pmnormalize-basic.sh
+++ b/tests/pmnormalize-basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-12-08 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmnormalize-rule-vg.sh
+++ b/tests/pmnormalize-rule-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-06-12 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf 'module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")

--- a/tests/pmnormalize-rule.sh
+++ b/tests/pmnormalize-rule.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-06-12 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmnull-basic.sh
+++ b/tests/pmnull-basic.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-12-07 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmnull-withparams.sh
+++ b/tests/pmnull-withparams.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-12-08 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmrfc3164-AtSignsInHostname.sh
+++ b/tests/pmrfc3164-AtSignsInHostname.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmrfc3164-AtSignsInHostname_off.sh
+++ b/tests/pmrfc3164-AtSignsInHostname_off.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmrfc3164-defaultTag.sh
+++ b/tests/pmrfc3164-defaultTag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmrfc3164-json.sh
+++ b/tests/pmrfc3164-json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-12-12 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmrfc3164-msgFirstSpace.sh
+++ b/tests/pmrfc3164-msgFirstSpace.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmrfc3164-tagEndingByColon.sh
+++ b/tests/pmrfc3164-tagEndingByColon.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2016-11-22 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmsnare-ccbackslash-udp.sh
+++ b/tests/pmsnare-ccbackslash-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")

--- a/tests/pmsnare-ccbackslash.sh
+++ b/tests/pmsnare-ccbackslash.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/pmsnare-cccstyle-udp.sh
+++ b/tests/pmsnare-cccstyle-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/pmsnare-cccstyle.sh
+++ b/tests/pmsnare-cccstyle.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 setvar_RS_HOSTNAME
 generate_conf
 add_conf '

--- a/tests/pmsnare-ccdefault-udp.sh
+++ b/tests/pmsnare-ccdefault-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")

--- a/tests/pmsnare-ccdefault.sh
+++ b/tests/pmsnare-ccdefault.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")

--- a/tests/pmsnare-ccoff-udp.sh
+++ b/tests/pmsnare-ccoff-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")

--- a/tests/pmsnare-ccoff.sh
+++ b/tests/pmsnare-ccoff.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")

--- a/tests/pmsnare-default-udp.sh
+++ b/tests/pmsnare-default-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/pmsnare-default.sh
+++ b/tests/pmsnare-default.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/pmsnare-modoverride-udp.sh
+++ b/tests/pmsnare-modoverride-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")

--- a/tests/pmsnare-modoverride.sh
+++ b/tests/pmsnare-modoverride.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")

--- a/tests/privdropgroup.sh
+++ b/tests/privdropgroup.sh
@@ -10,7 +10,7 @@ fi
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(privdrop.group.keepsupplemental="on")

--- a/tests/privdropgroupid.sh
+++ b/tests/privdropgroupid.sh
@@ -3,7 +3,7 @@
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(privdrop.group.keepsupplemental="on")

--- a/tests/privdropuser.sh
+++ b/tests/privdropuser.sh
@@ -10,7 +10,7 @@ fi
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/privdropuserid.sh
+++ b/tests/privdropuserid.sh
@@ -10,7 +10,7 @@ fi
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/prop-all-json-concurrency.sh
+++ b/tests/prop-all-json-concurrency.sh
@@ -4,7 +4,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 echo ===============================================================================
 echo \[prop-all-json-concurrency.sh\]: testing concurrency of $!all-json variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/prop-jsonmesg-vg.sh
+++ b/tests/prop-jsonmesg-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Added 2018-01-17 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/prop-programname-with-slashes.sh
+++ b/tests/prop-programname-with-slashes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2017-01142 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/prop-programname.sh
+++ b/tests/prop-programname.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2017-01142 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/proprepltest-nolimittag-udp.sh
+++ b/tests/proprepltest-nolimittag-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/proprepltest-nolimittag.sh
+++ b/tests/proprepltest-nolimittag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/proprepltest-rfctag-udp.sh
+++ b/tests/proprepltest-rfctag-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/proprepltest-rfctag.sh
+++ b/tests/proprepltest-rfctag.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/queue-encryption-da.sh
+++ b/tests/queue-encryption-da.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-09-28 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")

--- a/tests/queue-encryption-disk.sh
+++ b/tests/queue-encryption-disk.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-09-28 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")

--- a/tests/queue-encryption-disk_keyfile.sh
+++ b/tests/queue-encryption-disk_keyfile.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-09-30 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")

--- a/tests/queue-encryption-disk_keyprog.sh
+++ b/tests/queue-encryption-disk_keyprog.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2018-10-01 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")

--- a/tests/queue-persist-drvr.sh
+++ b/tests/queue-persist-drvr.sh
@@ -7,7 +7,7 @@
 # This file is part of the rsyslog project, released  under GPLv3
 # uncomment for debugging support:
 echo testing memory queue persisting to disk, mode $1
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/random.sh
+++ b/tests/random.sh
@@ -3,7 +3,7 @@
 #
 # added 2010-04-01 by Rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 # The random data will generate TCP framing error messages. We will

--- a/tests/rawmsg-after-pri.sh
+++ b/tests/rawmsg-after-pri.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rcvr_fail_restore.sh
+++ b/tests/rcvr_fail_restore.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Copyright (C) 2011 by Rainer Gerhards
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/relp_tls_certificate_not_found.sh
+++ b/tests/relp_tls_certificate_not_found.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-09-21 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 

--- a/tests/rfc5424parser.sh
+++ b/tests/rfc5424parser.sh
@@ -3,7 +3,7 @@
 # rgerhards, 2013-11-22
 echo ===============================================================================
 echo \[rfc5424parser.sh\]: testing mmpstrucdata
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rs-cnum.sh
+++ b/tests/rs-cnum.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-04 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rs-int2hex.sh
+++ b/tests/rs-int2hex.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-04 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rs-substring.sh
+++ b/tests/rs-substring.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-04 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rs_optimizer_pri.sh
+++ b/tests/rs_optimizer_pri.sh
@@ -7,7 +7,7 @@
 # rgerhards, 2013-11-20
 echo ===============================================================================
 echo \[rs_optimizer_pri.sh\]: testing RainerScript PRI optimizer
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/rscript-config_enable-off-vg.sh
+++ b/tests/rscript-config_enable-off-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export DO_STOP=off
 generate_conf
 add_conf '

--- a/tests/rscript-config_enable-on.sh
+++ b/tests/rscript-config_enable-on.sh
@@ -3,7 +3,7 @@
 # in all testbench tests and does not need its individual test
 # (actually it is here tested via template() and action() as well...
 # added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export DO_STOP=on
 generate_conf
 add_conf '

--- a/tests/rscript_backticks-vg.sh
+++ b/tests/rscript_backticks-vg.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/rscript_bare_var_root-empty.sh
+++ b/tests/rscript_bare_var_root-empty.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2018-01-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="empty-%$!%-\n")

--- a/tests/rscript_bare_var_root.sh
+++ b/tests/rscript_bare_var_root.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2018-01-01 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!%\n")

--- a/tests/rscript_contains.sh
+++ b/tests/rscript_contains.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2012-09-14 by rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/rscript_eq.sh
+++ b/tests/rscript_eq.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_eq.sh\]: testing rainerscript EQ statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_eq_var.sh
+++ b/tests/rscript_eq_var.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_eq.sh\]: testing rainerscript EQ statement comparing two variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_field-vg.sh
+++ b/tests/rscript_field-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[rscript_field-vg.sh\]: testing rainerscript field\(\) function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_field.sh
+++ b/tests/rscript_field.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_field.sh\]: testing rainerscript field\(\) function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_format_time.sh
+++ b/tests/rscript_format_time.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Added 2017-10-03 by Stephen Workman, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_ge.sh
+++ b/tests/rscript_ge.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_ge.sh\]: testing rainerscript GE statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_ge_var.sh
+++ b/tests/rscript_ge_var.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_ge.sh\]: testing rainerscript GE statement for two JSON variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_gt.sh
+++ b/tests/rscript_gt.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_gt.sh\]: testing rainerscript GT statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_gt_var.sh
+++ b/tests/rscript_gt_var.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_gt.sh\]: testing rainerscript GT statement for two JSON variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_hash32-vg.sh
+++ b/tests/rscript_hash32-vg.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \rscript_hash32.sh\]: test for hash32 and hash64mod script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")

--- a/tests/rscript_hash32.sh
+++ b/tests/rscript_hash32.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \rscript_hash32.sh\]: test for hash32 and hash64mod script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")

--- a/tests/rscript_hash64-vg.sh
+++ b/tests/rscript_hash64-vg.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \rscript_hash64.sh\]: test for hash64 and hash64mod script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")

--- a/tests/rscript_hash64.sh
+++ b/tests/rscript_hash64.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \rscript_hash64.sh\]: test for hash64 and hash64mod script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")

--- a/tests/rscript_http_request-vg.sh
+++ b/tests/rscript_http_request-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-12-01 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 rsyslog_testbench_test_url_access http://testbench.rsyslog.com/testbench/echo-get.php
 generate_conf
 add_conf '

--- a/tests/rscript_http_request.sh
+++ b/tests/rscript_http_request.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-12-01 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 rsyslog_testbench_test_url_access http://testbench.rsyslog.com/testbench/echo-get.php
 generate_conf
 add_conf '

--- a/tests/rscript_int2Hex.sh
+++ b/tests/rscript_int2Hex.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-02-09 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_ipv42num.sh
+++ b/tests/rscript_ipv42num.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-02-09 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_is_time.sh
+++ b/tests/rscript_is_time.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Added 2017-12-16 by Stephen Workman, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_le.sh
+++ b/tests/rscript_le.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_le.sh\]: testing rainerscript LE statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_le_var.sh
+++ b/tests/rscript_le_var.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_le.sh\]: testing rainerscript LE statement for two JSON variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_lt.sh
+++ b/tests/rscript_lt.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_lt.sh\]: testing rainerscript LT statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_lt_var.sh
+++ b/tests/rscript_lt_var.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_lt.sh\]: testing rainerscript LT statement for two JSON variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_ne.sh
+++ b/tests/rscript_ne.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_ne.sh\]: testing rainerscript NE statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_ne_var.sh
+++ b/tests/rscript_ne_var.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_ne.sh\]: testing rainerscript NE statement for two JSON variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_num2ipv4.sh
+++ b/tests/rscript_num2ipv4.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-02-09 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_optimizer1.sh
+++ b/tests/rscript_optimizer1.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_optimizer1.sh\]: testing rainerscript optimizer
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_parse_json-vg.sh
+++ b/tests/rscript_parse_json-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Added 2017-12-09 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_parse_json.sh
+++ b/tests/rscript_parse_json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Added 2017-12-09 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_parse_time.sh
+++ b/tests/rscript_parse_time.sh
@@ -62,7 +62,7 @@ rfc3164_11_r=$($getts "$rfc3164_11")
 rfc3164_12="Dec 25 20:00:00"
 rfc3164_12_r=$($getts "$rfc3164_12")
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_previous_action_suspended.sh
+++ b/tests/rscript_previous_action_suspended.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Added 2017-12-09 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_prifilt.sh
+++ b/tests/rscript_prifilt.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_prifilt.sh\]: testing rainerscript prifield\(\) function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_random.sh
+++ b/tests/rscript_random.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_random.sh\]: test for random-number-generator script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.random_no%\n")

--- a/tests/rscript_re_extract.sh
+++ b/tests/rscript_re_extract.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_re_extract.sh\]: test re_extract rscript-fn
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="*Number is %$.number%*\n")

--- a/tests/rscript_re_match.sh
+++ b/tests/rscript_re_match.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_re_match.sh\]: test re_match rscript-fn
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="*Matched*\n")

--- a/tests/rscript_replace.sh
+++ b/tests/rscript_replace.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_replace.sh\]: test for replace script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")

--- a/tests/rscript_replace_complex.sh
+++ b/tests/rscript_replace_complex.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_replace_complex.sh\]: a more complex test for replace script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")

--- a/tests/rscript_ruleset_call.sh
+++ b/tests/rscript_ruleset_call.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_ruleset_call.sh\]: testing rainerscript ruleset\(\) and call statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_ruleset_call_indirect-basic.sh
+++ b/tests/rscript_ruleset_call_indirect-basic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2016-12-11 by rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_ruleset_call_indirect-invld.sh
+++ b/tests/rscript_ruleset_call_indirect-invld.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2016-12-11 by rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_ruleset_call_indirect-var.sh
+++ b/tests/rscript_ruleset_call_indirect-var.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2016-12-11 by rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_script_error.sh
+++ b/tests/rscript_script_error.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Added 2017-12-09 by Rainer Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_set_memleak-vg.sh
+++ b/tests/rscript_set_memleak-vg.sh
@@ -11,7 +11,7 @@ if [ $(uname) = "FreeBSD" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_set_modify.sh
+++ b/tests/rscript_set_modify.sh
@@ -4,7 +4,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_set_modify.sh\]: testing set twice
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_set_unset_invalid_var.sh
+++ b/tests/rscript_set_unset_invalid_var.sh
@@ -2,7 +2,7 @@
 # Check that invalid variable names are detected.
 # Copyright 2017-01-24 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="json" type="string" string="%$!%\n")

--- a/tests/rscript_stop.sh
+++ b/tests/rscript_stop.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_stop.sh\]: testing rainerscript STOP statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_stop2.sh
+++ b/tests/rscript_stop2.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_stop2.sh\]: testing rainerscript STOP statement, alternate method
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_str2num_empty.sh
+++ b/tests/rscript_str2num_empty.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-02-09 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_str2num_negative.sh
+++ b/tests/rscript_str2num_negative.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-02-09 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_substring.sh
+++ b/tests/rscript_substring.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-12-10 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_trim-vg.sh
+++ b/tests/rscript_trim-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-08-14 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_trim.sh
+++ b/tests/rscript_trim.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-08-14 by Jan Gerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/rscript_unaffected_reset.sh
+++ b/tests/rscript_unaffected_reset.sh
@@ -5,7 +5,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_unaffected_reset.sh\]: testing set/reset
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/rscript_wrap2.sh
+++ b/tests/rscript_wrap2.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_wrap2.sh\]: a test for wrap\(2\) script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")

--- a/tests/rscript_wrap3.sh
+++ b/tests/rscript_wrap3.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[rscript_wrap3.sh\]: a test for wrap\(3\) script-function
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")

--- a/tests/rsf_getenv.sh
+++ b/tests/rsf_getenv.sh
@@ -8,7 +8,7 @@
 echo ===============================================================================
 echo \[rsf_getenv.sh\]: testing RainerScript getenv\(\) function
 export MSGNUM="msgnum:"
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/rulesetmultiqueue-v6.sh
+++ b/tests/rulesetmultiqueue-v6.sh
@@ -12,7 +12,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export RSYSLOG_PORT2="$(get_free_port)"
 export RSYSLOG_PORT3="$(get_free_port)"
 generate_conf

--- a/tests/rulesetmultiqueue.sh
+++ b/tests/rulesetmultiqueue.sh
@@ -12,7 +12,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 export RSYSLOG_PORT2="$(get_free_port)"
 export RSYSLOG_PORT3="$(get_free_port)"
 generate_conf

--- a/tests/sndrcv.sh
+++ b/tests/sndrcv.sh
@@ -9,7 +9,7 @@ echo ===========================================================================
 echo \[sndrcv.sh\]: testing sending and receiving via tcp
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_drvr_noexit.sh
+++ b/tests/sndrcv_drvr_noexit.sh
@@ -24,7 +24,7 @@
 # added 2009-11-11 by Rgerhards
 # This file is part of the rsyslog project, released  under GPLv3
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_failover.sh
+++ b/tests/sndrcv_failover.sh
@@ -7,7 +7,7 @@
 # location to the conf file.
 # added 2011-06-20 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 # uncomment for debugging support:
 # start up the instances

--- a/tests/sndrcv_gzip.sh
+++ b/tests/sndrcv_gzip.sh
@@ -3,7 +3,7 @@
 # zlib-compressed format (our own syslog extension).
 # rgerhards, 2009-11-11
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -13,7 +13,7 @@ echo Check and Stop previous instances of kafka/zookeeper
 . $srcdir/diag.sh stop-kafka
 
 echo Init Testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 echo Create kafka/zookeeper instance and topics
 . $srcdir/diag.sh start-zookeeper

--- a/tests/sndrcv_kafka-vg-sender.sh
+++ b/tests/sndrcv_kafka-vg-sender.sh
@@ -12,7 +12,7 @@ echo Check and Stop previous instances of kafka/zookeeper
 . $srcdir/diag.sh stop-kafka
 
 echo Init Testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 echo Create kafka/zookeeper instance and topics
 . $srcdir/diag.sh start-zookeeper

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 #echo Test very unstable, thus skipping
 #echo see https://github.com/rsyslog/rsyslog/issues/3057
 #exit 77

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -3,7 +3,7 @@
 #	This test only tests what happens when kafka cluster fails
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 # *** ==============================================================================
 export TESTMESSAGES=50000

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -3,7 +3,7 @@
 #	This tests the keepFailedMessages feature in omkafka
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 # *** ==============================================================================
 export TESTMESSAGES=50000

--- a/tests/sndrcv_kafka_multi.sh
+++ b/tests/sndrcv_kafka_multi.sh
@@ -2,7 +2,7 @@
 # added 2017-05-08 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 # *** ==============================================================================
 export TESTMESSAGES=100000

--- a/tests/sndrcv_kafka_multi_topics.sh
+++ b/tests/sndrcv_kafka_multi_topics.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2018-08-13 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 export TESTMESSAGES=50000
 export TESTMESSAGESFULL=100000

--- a/tests/sndrcv_omudpspoof.sh
+++ b/tests/sndrcv_omudpspoof.sh
@@ -15,7 +15,7 @@ fi
 export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_omudpspoof_nonstdpt.sh
+++ b/tests/sndrcv_omudpspoof_nonstdpt.sh
@@ -15,7 +15,7 @@ fi
 export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_relp.sh
+++ b/tests/sndrcv_relp.sh
@@ -4,7 +4,7 @@
 #. $srcdir/sndrcv_drvr.sh sndrcv_relp 50000
 
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ########## receiver ##########
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -4,7 +4,7 @@
 # check the "default port"
 # added 2013-12-10 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 relp_port=$(./omrelp_dflt_port)
 if [ $relp_port -lt 1024 ]; then
     if [ "$EUID" -ne 0 ]; then

--- a/tests/sndrcv_relp_rebind.sh
+++ b/tests/sndrcv_relp_rebind.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2017-09-29 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 echo testing sending and receiving via relp w/ rebind interval
 # uncomment for debugging support:
 # start up the instances

--- a/tests/sndrcv_relp_tls.sh
+++ b/tests/sndrcv_relp_tls.sh
@@ -3,7 +3,7 @@
 # testing sending and receiving via relp with TLS enabled
 # This file is part of the rsyslog project, released under ASL 2.0
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_relp_tls_certvalid.sh
+++ b/tests/sndrcv_relp_tls_certvalid.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2018-09-13 by PascalWithopf
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_relp_tls_prio.sh
+++ b/tests/sndrcv_relp_tls_prio.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # added 2013-12-10 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 echo testing sending and receiving via relp with TLS enabled and priority string set
 
 # uncomment for debugging support:

--- a/tests/sndrcv_tls_anon_hostname.sh
+++ b/tests/sndrcv_tls_anon_hostname.sh
@@ -5,7 +5,7 @@ echo ===========================================================================
 echo \[sndrcv_tls_anon_hostname.sh\]: testing sending and receiving via TLS with anon auth using hostname SNI
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_tls_anon_ipv4.sh
+++ b/tests/sndrcv_tls_anon_ipv4.sh
@@ -5,7 +5,7 @@ echo ===========================================================================
 echo \[sndrcv_tls_anon_ipv4.sh\]: testing sending and receiving via TLS with anon auth using bare ipv4, no SNI
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_tls_anon_ipv6.sh
+++ b/tests/sndrcv_tls_anon_ipv6.sh
@@ -5,7 +5,7 @@ echo ===========================================================================
 echo \[sndrcv_tls_anon_ipv6.sh\]: testing sending and receiving via TLS with anon auth using bare ipv6, no SNI
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_tls_anon_rebind.sh
+++ b/tests/sndrcv_tls_anon_rebind.sh
@@ -2,7 +2,7 @@
 # testing sending and receiving via TLS with anon auth and rebind
 # rgerhards, 2011-04-04
 # This file is part of the rsyslog project, released  under GPLv3
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # uncomment for debugging support:
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"

--- a/tests/sndrcv_tls_ossl_anon_ipv4.sh
+++ b/tests/sndrcv_tls_ossl_anon_ipv4.sh
@@ -5,7 +5,7 @@ echo ===========================================================================
 echo \[sndrcv_tls_ossl_anon_ipv4.sh\]: testing sending and receiving via TLS with anon auth using bare ipv4, no SNI
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_tls_ossl_anon_ipv6.sh
+++ b/tests/sndrcv_tls_ossl_anon_ipv6.sh
@@ -6,7 +6,7 @@ echo \[sndrcv_tls_ossl_anon_ipv6.sh\]: testing sending and receiving via TLS wit
 . $srcdir/diag.sh check-ipv6-available
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_tls_ossl_anon_rebind.sh
+++ b/tests/sndrcv_tls_ossl_anon_rebind.sh
@@ -6,7 +6,7 @@ echo \[sndrcv_tls_ossl_anon_rebind.sh\]: testing sending and receiving via TLS w
 #valgrind="valgrind"
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_tls_priorityString.sh
+++ b/tests/sndrcv_tls_priorityString.sh
@@ -6,7 +6,7 @@ echo \[sndrcv_tls_priorityString.sh\]: testing sending and receiving via TLS wit
 echo NOTE: When this test fails, it could be due to the priorityString being outdated!
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_udp.sh
+++ b/tests/sndrcv_udp.sh
@@ -14,7 +14,7 @@ fi
 export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_udp_nonstdpt.sh
+++ b/tests/sndrcv_udp_nonstdpt.sh
@@ -11,7 +11,7 @@ echo \[sndrcv_udp_nonstdpt.sh\]: testing sending and receiving via udp
 export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sndrcv_udp_nonstdpt_v6.sh
+++ b/tests/sndrcv_udp_nonstdpt_v6.sh
@@ -5,7 +5,7 @@ echo ===========================================================================
 echo \[sndrcv_udp_nonstdpt_v6.sh\]: testing sending and receiving via udp
 
 # uncomment for debugging support:
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"

--- a/tests/sparse_array_lookup_table-vg.sh
+++ b/tests/sparse_array_lookup_table-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[sparse_array_lookup_table.sh\]: test for sparse-array lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate_array.lkp_tbl")

--- a/tests/sparse_array_lookup_table.sh
+++ b/tests/sparse_array_lookup_table.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[sparse_array_lookup_table.sh\]: test for sparse-array lookup-table and HUP based reloading of it
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate_array.lkp_tbl")

--- a/tests/stats-cee-vg.sh
+++ b/tests/stats-cee-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[stats-cee-vg.sh\]: test for verifying stats are reported correctly cee format with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/stats-cee.sh
+++ b/tests/stats-cee.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[stats-cee.sh\]: test for verifying stats are reported correctly cee format
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/stats-json-es.sh
+++ b/tests/stats-json-es.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[stats-json-es.sh\]: test for verifying stats are reported correctly json-elasticsearch format
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/stats-json-vg.sh
+++ b/tests/stats-json-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[stats-json-vg.sh\]: test for verifying stats are reported correctly json format with valgrind
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/stats-json.sh
+++ b/tests/stats-json.sh
@@ -2,7 +2,7 @@
 # added 2016-03-30 by singh.janmejay
 # test for verifying stats are reported correctly json format
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 ruleset(name="stats") {

--- a/tests/stop-localvar.sh
+++ b/tests/stop-localvar.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 echo ===============================================================================
 echo \[stop-localvar.sh\]: testing stop statement together with local variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$.nbr%\n")

--- a/tests/stop-msgvar.sh
+++ b/tests/stop-msgvar.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 echo ===============================================================================
 echo \[stop-msgvar.sh\]: testing stop statement together with message variables
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!nbr%\n")

--- a/tests/stop.sh
+++ b/tests/stop.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 echo ===============================================================================
 echo \[stop.sh\]: testing stop statement
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/stop_when_array_has_element.sh
+++ b/tests/stop_when_array_has_element.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo ===============================================================================
 echo \[stop_when_array_has_element.sh\]: loop detecting presense of an element and stopping ruleset execution
-. $srcdir/diag.sh init stop_when_array_has_element.sh
+. ${srcdir:=.}/diag.sh init stop_when_array_has_element.sh
 generate_conf
 add_conf '
 template(name="foo" type="string" string="%$!foo%\n")

--- a/tests/tabescape_dflt-udp.sh
+++ b/tests/tabescape_dflt-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/tabescape_dflt.sh
+++ b/tests/tabescape_dflt.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/tabescape_off-udp.sh
+++ b/tests/tabescape_off-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/tabescape_off.sh
+++ b/tests/tabescape_off.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-29 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/tcp-msgreduc-vg.sh
+++ b/tests/tcp-msgreduc-vg.sh
@@ -11,7 +11,7 @@ fi
 
 echo ===============================================================================
 echo \[tcp-msgreduc-vg.sh\]: testing msg reduction via UDP
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/tcp_forwarding_dflt_tpl.sh
+++ b/tests/tcp_forwarding_dflt_tpl.sh
@@ -4,7 +4,7 @@
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 10000

--- a/tests/tcp_forwarding_ns_tpl.sh
+++ b/tests/tcp_forwarding_ns_tpl.sh
@@ -11,7 +11,7 @@ fi
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 10000

--- a/tests/tcp_forwarding_retries.sh
+++ b/tests/tcp_forwarding_retries.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2016-06-21 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 messages=20000 # how many messages to inject?
 # Note: we need to inject a somewhat larger nubmer of messages in order

--- a/tests/tcp_forwarding_tpl.sh
+++ b/tests/tcp_forwarding_tpl.sh
@@ -5,7 +5,7 @@
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 10000

--- a/tests/tcpflood_wrong_option_output.sh
+++ b/tests/tcpflood_wrong_option_output.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 ./tcpflood -t &> $RSYSLOG_DYNNAME.output
 grep "invalid option" $RSYSLOG_DYNNAME.output 

--- a/tests/template-const-jsonf.sh
+++ b/tests/template-const-jsonf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-02-10 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {

--- a/tests/template-json.sh
+++ b/tests/template-json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 set $!backslash = "a \\ \"b\" c / d"; # '/' must not be escaped!

--- a/tests/template-pos-from-to-lowercase.sh
+++ b/tests/template-pos-from-to-lowercase.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # test many concurrent tcp connections
 # addd 2016-03-28 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/template-pos-from-to-missing-jsonvar.sh
+++ b/tests/template-pos-from-to-missing-jsonvar.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-03-28 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/template-pos-from-to-oversize-lowercase.sh
+++ b/tests/template-pos-from-to-oversize-lowercase.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-03-28 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/template-pos-from-to-oversize.sh
+++ b/tests/template-pos-from-to-oversize.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # addd 2016-03-28 by RGerhards, released under ASL 2.0
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 echo "*** string template ****"
 generate_conf

--- a/tests/template-pos-from-to.sh
+++ b/tests/template-pos-from-to.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # test many concurrent tcp connections
 # addd 2016-03-28 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/template-pure-json.sh
+++ b/tests/template-pure-json.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # added 2018-02-10 by Rainer Gerhards; Released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list" option.jsonf="on") {

--- a/tests/threadingmq.sh
+++ b/tests/threadingmq.sh
@@ -8,7 +8,7 @@
 # should be covered by this test here.
 # rgerhards, 2009-06-26
 echo \[threadingmq.sh\]: main queue concurrency
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 1

--- a/tests/threadingmqaq.sh
+++ b/tests/threadingmqaq.sh
@@ -14,7 +14,7 @@ if [ $(uname) = "SunOS" ] ; then
    exit 77
 fi
 
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 10000

--- a/tests/timegenerated-dateordinal-invld.sh
+++ b/tests/timegenerated-dateordinal-invld.sh
@@ -5,7 +5,7 @@
 # instead provide the defined return value (0)
 # requires faketime
 echo \[timegenerated-dateordinal-invld\]: check invalid dates with ordinal format
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 . $srcdir/faketime_common.sh
 

--- a/tests/timegenerated-dateordinal.sh
+++ b/tests/timegenerated-dateordinal.sh
@@ -5,7 +5,7 @@
 # from creating additional tests
 # requires faketime
 echo \[timegenerated-dateordinal\]: check valid dates with ordinal format
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 . $srcdir/faketime_common.sh
 

--- a/tests/timegenerated-utc-legacy.sh
+++ b/tests/timegenerated-utc-legacy.sh
@@ -8,7 +8,7 @@
 # FOR THE SAME REASON, there is NO VALGRIND EQUIVALENT
 # of this test, as valgrind would abort with reports
 # of faketime.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00

--- a/tests/timegenerated-utc.sh
+++ b/tests/timegenerated-utc.sh
@@ -8,7 +8,7 @@
 # FOR THE SAME REASON, there is NO VALGRIND EQUIVALENT
 # of this test, as valgrind would abort with reports
 # of faketime.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 . $srcdir/faketime_common.sh
 
 export TZ=TEST+02:00

--- a/tests/timegenerated-uxtimestamp-invld.sh
+++ b/tests/timegenerated-uxtimestamp-invld.sh
@@ -5,7 +5,7 @@
 # instead provide the defined return value (0)
 # requires faketime
 echo \[timegenerated-uxtimestamp-invld\]: check invalid dates with uxtimestamp format
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 . $srcdir/faketime_common.sh
 

--- a/tests/timegenerated-uxtimestamp.sh
+++ b/tests/timegenerated-uxtimestamp.sh
@@ -5,7 +5,7 @@
 # from creating additional tests
 # requires faketime
 echo \[timegenerated-uxtimestamp\]: check valid dates with uxtimestamp format
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 . $srcdir/faketime_common.sh
 

--- a/tests/timegenerated-ymd.sh
+++ b/tests/timegenerated-ymd.sh
@@ -3,7 +3,7 @@
 # addd 2016-02-23 by RGerhards, released under ASL 2.0
 # requires faketime
 echo \[timegenerated-ymd\]: check customized format \(Y-m-d\)
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 . $srcdir/faketime_common.sh
 

--- a/tests/timereported-utc-legacy.sh
+++ b/tests/timereported-utc-legacy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-03-22 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/timereported-utc-vg.sh
+++ b/tests/timereported-utc-vg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-03-22 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/timereported-utc.sh
+++ b/tests/timereported-utc.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # addd 2016-03-22 by RGerhards, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/timestamp-3164-udp.sh
+++ b/tests/timestamp-3164-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/timestamp-3164.sh
+++ b/tests/timestamp-3164.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/timestamp-3339-udp.sh
+++ b/tests/timestamp-3339-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/timestamp-3339.sh
+++ b/tests/timestamp-3339.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/timestamp-mysql-udp.sh
+++ b/tests/timestamp-mysql-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/timestamp-mysql.sh
+++ b/tests/timestamp-mysql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/timestamp-pgsql-udp.sh
+++ b/tests/timestamp-pgsql-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/timestamp-pgsql.sh
+++ b/tests/timestamp-pgsql.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-27 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/timestamp-subseconds-udp.sh
+++ b/tests/timestamp-subseconds-udp.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")

--- a/tests/timestamp-subseconds.sh
+++ b/tests/timestamp-subseconds.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-06-25 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/tls-check-for-certificate.sh
+++ b/tests/tls-check-for-certificate.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-05-05 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(

--- a/tests/tls_error_file_not_found.sh
+++ b/tests/tls_error_file_not_found.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2017-09-21 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(

--- a/tests/udp-msgreduc-orgmsg-vg.sh
+++ b/tests/udp-msgreduc-orgmsg-vg.sh
@@ -11,7 +11,7 @@ fi
 
 echo ===============================================================================
 echo \[udp-msgreduc-orgmsg-vg.sh\]: testing msg reduction via udp, with org message
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imudp/.libs/imudp

--- a/tests/udp-msgreduc-vg.sh
+++ b/tests/udp-msgreduc-vg.sh
@@ -11,7 +11,7 @@ fi
 
 echo ===============================================================================
 echo \[udp-msgreduc-vg.sh\]: testing imtcp multiple listeners
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $ModLoad ../plugins/imudp/.libs/imudp

--- a/tests/unused_lookup_table-vg.sh
+++ b/tests/unused_lookup_table-vg.sh
@@ -10,7 +10,7 @@ fi
 
 echo ===============================================================================
 echo \[unused_lookup_table.sh\]: test for ensuring clean destruction of lookup-table even when it is never used
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="xlate.lkp_tbl")

--- a/tests/uxsock_simple.sh
+++ b/tests/uxsock_simple.sh
@@ -3,7 +3,7 @@
 # all data to an output file, then a rsyslog instance is started which generates
 # messages and sends them to the unix socket. Datagram sockets are being used.
 # added 2010-08-06 by Rgerhards
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then

--- a/tests/variable_leading_underscore.sh
+++ b/tests/variable_leading_underscore.sh
@@ -3,7 +3,7 @@
 # This file is part of the rsyslog project, released  under ASL 2.0
 # The configuration test should pass because we now support leading
 # underscores in variable names.
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 ../tools/rsyslogd  -C -N1 -f$srcdir/testsuites/variable_leading_underscore.conf -M../runtime/.libs:../.libs
 if [ $? -ne 0 ]; then
    echo "Error: config check fail"

--- a/tests/wr_large_async.sh
+++ b/tests/wr_large_async.sh
@@ -5,7 +5,7 @@
 # added 2010-03-10 by Rgerhards
 #
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/wr_large_sync.sh
+++ b/tests/wr_large_sync.sh
@@ -5,7 +5,7 @@
 # added 2010-03-10 by Rgerhards
 #
 # This file is part of the rsyslog project, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $MaxMessageSize 10k

--- a/tests/wtpShutdownAll-assertionFailure.sh
+++ b/tests/wtpShutdownAll-assertionFailure.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # add 2018-04-19 by Pascal Withopf, released under ASL 2.0
-. $srcdir/diag.sh init
+. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 $AbortOnUncleanConfig on


### PR DESCRIPTION
Also now permit interactivly running tests without explicitly setting
$srcdir. This now works if we are inside ./tests and fails, as before,
when we are in a different directory.

Detected by shellcheck via CodeFactor.io

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
