### PR TITLE
CodeCov: fix typo in file exclusion

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -6,7 +6,7 @@ coverage:
   range: 50..75
   # the next 2 lines few hopefully help us avoid CI fail due to slightly
   # different execution pathes (if not, remove) -- rgerhards, 2018-10-12
-  precision: 0
+  precision: 1
   round: up
 
 ignore:
@@ -22,5 +22,5 @@ ignore:
   # that would require a service registration
   # see also: https://github.com/rsyslog/rsyslog/issues/3073
   - "runtime/lib_ksi_queue.c"
-  - "runtime/lib_ksil212.c"
+  - "runtime/lib_ksils12.c"
   - "runtime/lmsig_ksi-ls12.c"


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
