### PR TITLE
testbench: cleanup bash codestyle

### DIFF
--- a/tests/imfile-wildcards-dirs.sh
+++ b/tests/imfile-wildcards-dirs.sh
@@ -59,7 +59,7 @@ ls -d $RSYSLOG_DYNNAME.input.*
 # Content check with timeout
 content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILES $IMFILECHECKTIMEOUT
 
-for i in `seq 1 $IMFILEINPUTFILES`;
+for i in $(seq 1 $IMFILEINPUTFILES);
 do
 	rm -rf $RSYSLOG_DYNNAME.input.dir$i/
 done

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -52,11 +52,11 @@ startup
 # sleep a little to give rsyslog a chance to begin processing
 sleep 1
 
-for j in `seq 1 $IMFILEINPUTFILESSTEPS`;
+for j in $(seq 1 $IMFILEINPUTFILESSTEPS);
 do
 	echo "Loop Num $j"
 
-	for i in `seq 1 $IMFILEINPUTFILES`;
+	for i in $(seq 1 $IMFILEINPUTFILES);
 	do
 		mkdir $RSYSLOG_DYNNAME.input.dir$i
 		touch $RSYSLOG_DYNNAME.input.dir$i/file.logfile
@@ -69,7 +69,7 @@ do
 	content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 	
 	# Delete all but first!
-	for i in `seq 1 $IMFILEINPUTFILES`;
+	for i in $(seq 1 $IMFILEINPUTFILES);
 	do
 		rm -rf $RSYSLOG_DYNNAME.input.dir$i/
 	done

--- a/tests/timegenerated-dateordinal-invld.sh
+++ b/tests/timegenerated-dateordinal-invld.sh
@@ -33,7 +33,7 @@ echo "001" | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid timestamps generated, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG
-  date -d @`cat $RSYSLOG_OUT_LOG`
+  date -d @$(cat $RSYSLOG_OUT_LOG)
   exit 1
 fi;
 
@@ -48,7 +48,7 @@ echo "001" | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid timestamps generated, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG
-  date -d @`cat $RSYSLOG_OUT_LOG`
+  date -d @$(cat $RSYSLOG_OUT_LOG)
   exit 1
 fi;
 
@@ -63,7 +63,7 @@ echo "001" | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid timestamps generated, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG
-  date -d @`cat $RSYSLOG_OUT_LOG`
+  date -d @$(cat $RSYSLOG_OUT_LOG)
   exit 1
 fi;
 
@@ -78,7 +78,7 @@ echo "001" | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid timestamps generated, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG
-  date -d @`cat $RSYSLOG_OUT_LOG`
+  date -d @$(cat $RSYSLOG_OUT_LOG)
   exit 1
 fi;
 


### PR DESCRIPTION
detected by shellcheck

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
