### PR TITLE
bugfix tcpflood testing tool: improper parameter validation

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -55,7 +55,6 @@ if ENABLE_DEFAULT_TESTS
 TESTS +=  \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
-	tcpflood_wrong_option_output.sh \
 	msleep_usage_output.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
@@ -309,6 +308,7 @@ TESTS +=  \
 	parsertest-snare_ccoff_udp2.sh
 if HAVE_VALGRIND
 TESTS +=  \
+	tcpflood_wrong_option_output.sh \
 	include-obj-outside-control-flow-vg.sh \
 	include-obj-in-if-vg.sh \
 	include-obj-text-vg.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -452,7 +452,7 @@ function get_mainqueuesize() {
 # grep for (partial) content. $1 is the content to check for, $2 the file to check
 function content_check() {
 	file=${2:-$RSYSLOG_OUT_LOG}
-	grep -qF "$1" < "$file"
+	grep -qF -- "$1" < "$file"
 	if [ "$?" -ne "0" ]; then
 	    printf '\n============================================================\n'
 	    printf 'FILE "%s" content:\n' "$file"

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1610,6 +1610,11 @@ int main(int argc, char *argv[])
 	}
 
 	if(transport == TP_TLS) {
+		if(tlsKeyFile == NULL || tlsCertFile == NULL) {
+			printf("error: transport TLS is specified (-Ttls), -z and -Z must also "
+				"be specified\n");
+			exit(1);
+		}
 		initTLS();
 	} else if(transport == TP_RELP_PLAIN) {
 		#ifdef ENABLE_RELP

--- a/tests/tcpflood_wrong_option_output.sh
+++ b/tests/tcpflood_wrong_option_output.sh
@@ -1,14 +1,18 @@
 #!/bin/bash
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
-
 . ${srcdir:=.}/diag.sh init
 
-./tcpflood -t &> $RSYSLOG_DYNNAME.output
-grep "invalid option" $RSYSLOG_DYNNAME.output 
+options=-t
+./tcpflood $options &> $RSYSLOG_OUT_LOG
+content_check 'invalid option'
 
-if [ ! $? -eq 0 ]; then
-  echo "invalid response generated"
-  error_exit  1
-fi;
+options=-Ttls
+valgrind --error-exitcode=10 ./tcpflood $options &> $RSYSLOG_OUT_LOG
+if [ $? -eq 10 ]; then
+	cat "$RSYSLOG_OUT_LOG"
+	printf 'FAIL: valgrind failed with options: %s\n' "$options"
+	error_exit 1
+fi
+content_check '-z and -Z must also be specified'
 
 exit_test


### PR DESCRIPTION
tool may abort when TLS transport is specified by mandatory parameters
are not specified

closes https://github.com/rsyslog/rsyslog/issues/3176

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
