### PR TITLE
testbench: introduce concept of "unreliable" tests

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -29,6 +29,12 @@
 #		only be set specifically if there is good need to do so, e.g. if
 #		a test needs to timeout.
 #
+#
+# EXIT STATES
+# 0 - ok
+# 1 - FAIL
+# 77 - SKIP
+# 100 - Testbench failure
 
 # environment variables:
 # USE_AUTO_DEBUG "on" --> enables automatic debugging, anything else
@@ -96,6 +102,25 @@ function skip_platform() {
 		exit 77
 	fi
 
+}
+
+
+# set special tests status. States ($1) are:
+# unreliable -- as the name says, test does not work reliably; $2 must be github issue URL
+#               depending on CI configuration, "unreliable" tests are skipped and not failed
+#               or not executed at all. Test reports may also be amended to github issue.
+function test_status() {
+	if [ "$1" == "unreliable" ]; then
+		if [ "$2" == "" ]; then
+			printf 'TESTBENCH_ERROR: github issue URL must be given\n'
+			error_exit 100
+		fi
+		export TEST_STATUS="$1"
+		export TEST_GITHUB_ISSUE="$2"
+	else
+		printf 'TESTBENCH_ERROR: test_status "%s" unknown\n' "$1"
+		error_exit 100
+	fi
 }
 
 
@@ -654,7 +679,6 @@ function check_exit_vg(){
 # for systems like Travis-CI where we cannot debug on the machine itself.
 # our $1 is the to-be-used exit code. if $2 is "stacktrace", call gdb.
 function error_exit() {
-	#env
 	if [ -e core* ]
 	then
 		echo trying to obtain crash location info
@@ -724,9 +748,15 @@ function error_exit() {
 		error_stats
 	fi
 
-	# we need to do some minimal cleanup so that "make distcheck" does not
-	# complain too much
-	exit $1
+	if [ "$TEST_STATUS" == "unreliable" ] && [ "$1" -ne 100 ]; then
+		# TODO: log github issue
+		printf 'Test flagged as unreliable, exiting with 77 (skip). Original\n'
+		printf 'exit code was %d\n' $1
+		printf 'GitHub ISSUE: %s\n' "$TEST_GITHUB_ISSUE"
+		exit 77
+	else
+		exit $1
+	fi
 }
 
 # Helper function to call Adiscon test error script

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -2,6 +2,7 @@
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+test_status unreliable 'https://github.com/rsyslog/rsyslog/issues/3197'
 check_command_available kafkacat
 
 export TESTMESSAGES=100000


### PR DESCRIPTION
This permits to flag some tests as being unreliable. If done so, CI
can treat them specially. This is meant to get rid of time-consuming
issues with known problematic tests, but still retain the ability to
gather trouble-shooting information. Later commits may extend the
functionality.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
