### PR TITLE
testbench: improve kafka test stability

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -14,6 +14,7 @@ CLEANFILES=\
 	rsyslog.input-symlink.log rsyslog-link.*.log targets \
 	HOSTNAME \
 	rstb_* \
+	zookeeper.pid \
 	tmp.qi nocert
 
 CLEANFILES+= \

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -26,6 +26,10 @@ create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
+# impstats in order to gain insight into error cases
+module(load="../plugins/impstats/.libs/impstats"
+	log.file="'$RSYSLOG_DYNNAME.pstats'"
+	interval="1" log.syslog="off")
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
 $imdiagInjectDelayMode full
 
@@ -92,7 +96,10 @@ while [ $timecounter -lt $timeoutend ]; do
 			error_exit 1
 		else
 			echo wait-file-lines not yet there, currently $count lines
+printf 'pstats data:\n'
+cat $RSYSLOG_DYNNAME.pstats
 			printf '\n'
+
 			$TESTTOOL_DIR/msleep 1000
 		fi
 	fi


### PR DESCRIPTION
zookeeper startup was not actually checked, it was just hoped
that it started within 2 seconds (sleep). On busy systems, this
may be too short, thus results in an improper start and thus can
result in follow-on problems during the test.

We have now corrected it so that we wait until we see a pid. It's
still questionable if this is sufficient to conclude zookeeper is
really ready for processing. But let's take one step after the
other.

see also https://github.com/rsyslog/rsyslog/issues/3057

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
