### PR TITLE
testbench: keep kafka/zookeeper running between tests

### DIFF
--- a/tests/CI/buildbot_cleanup.sh
+++ b/tests/CI/buildbot_cleanup.sh
@@ -3,7 +3,8 @@
 # make check. This is useful if make check is terminated due to timeout,
 # in which case autotools unfortunately does not provide us a way to
 # gather error information.
-rm -f tests/*.sh.log
+rm -f tests/*.sh.log zookeeper.pid
+rm -rf rstb_*
 
 # cleanup of hanging instances from previous runs
 # practice has shown this is pretty useful!
@@ -23,7 +24,7 @@ do
 	kill -9 $pid || exit 0
 done
 
-# now the same for mmkubernetes_test_server
+# now the same for kafaka
 for pid in $(ps -eo pid,args|grep '[k]afka' |sed -e 's/\( *\)\([0-9]*\).*/\2/');
 do
 	echo "ERROR: left-over previous instance $pid, killing it"
@@ -31,7 +32,7 @@ do
 	kill -9 $pid || exit 0
 done
 
-# now the same for mmkubernetes_test_server
+# now the same for zookeeper
 for pid in $(ps -eo pid,args|grep '[z]ookeeper' |sed -e 's/\( *\)\([0-9]*\).*/\2/');
 do
 	echo "ERROR: left-over previous instance $pid, killing it"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -625,11 +625,11 @@ if ENABLE_KAFKA_TESTS
 TESTS += \
 	omkafka.sh \
 	imkafka.sh \
-	imkafka-hang-on-no-kafka.sh \
-	imkafka-hang-other-action-on-no-kafka.sh \
 	imkafka-backgrounded.sh \
 	imkafka-config-err-ruleset.sh \
 	imkafka-config-err-param.sh \
+	imkafka-hang-on-no-kafka.sh \
+	imkafka-hang-other-action-on-no-kafka.sh \
 	imkafka_multi_single.sh \
 	sndrcv_kafka.sh \
 	sndrcv_kafka_multi_topics.sh

--- a/tests/imkafka-backgrounded.sh
+++ b/tests/imkafka-backgrounded.sh
@@ -3,6 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
+export KEEP_KAFKA_RUNNING="YES"
 
 export TESTMESSAGES=100000
 export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)

--- a/tests/imkafka-config-err-param.sh
+++ b/tests/imkafka-config-err-param.sh
@@ -3,6 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
+export KEEP_KAFKA_RUNNING="YES"
 
 export TESTMESSAGES=1000
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.

--- a/tests/imkafka-config-err-ruleset.sh
+++ b/tests/imkafka-config-err-ruleset.sh
@@ -3,6 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
+export KEEP_KAFKA_RUNNING="YES"
 
 export TESTMESSAGES=100000
 export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)

--- a/tests/imkafka-vg.sh
+++ b/tests/imkafka-vg.sh
@@ -5,6 +5,7 @@ echo Init Testbench
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
+export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.

--- a/tests/imkafka.sh
+++ b/tests/imkafka.sh
@@ -4,6 +4,7 @@
 echo Init Testbench
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
+export KEEP_KAFKA_RUNNING="YES"
 
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES

--- a/tests/imkafka_multi_single.sh
+++ b/tests/imkafka_multi_single.sh
@@ -3,6 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
+export KEEP_KAFKA_RUNNING="YES"
 
 export TESTMESSAGES=100000
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.

--- a/tests/omkafka-vg.sh
+++ b/tests/omkafka-vg.sh
@@ -4,7 +4,7 @@
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 
-# *** ==============================================================================
+export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=10000
 export TESTMESSAGESFULL=$TESTMESSAGES
 

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -5,6 +5,7 @@
 test_status unreliable 'https://github.com/rsyslog/rsyslog/issues/3197'
 check_command_available kafkacat
 
+export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -2,11 +2,7 @@
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-#echo Test very unstable, thus skipping
-#echo see https://github.com/rsyslog/rsyslog/issues/3057
-#exit 77
-
-# *** ==============================================================================
+export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
 
@@ -16,19 +12,15 @@ export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
-echo ===============================================================================
-echo Check and Stop previous instances of kafka/zookeeper 
+
 download_kafka
 stop_zookeeper
 stop_kafka
-
-echo Create kafka/zookeeper instance and topics
 start_zookeeper
 start_kafka
-# create new topic
+
 create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
 
-# --- Create/Start omkafka sender config
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
@@ -119,7 +111,6 @@ kafka_wait_group_coordinator
 shutdown_when_empty 2
 wait_shutdown 2
 
-# Delete topic to remove old traces before
 delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
 
 # Dump Kafka log | uncomment if needed


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
