### PR TITLE
bugfix tcpflood: invalid type in calloc (openssl mode)

### DIFF
--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -210,7 +210,6 @@ static gnutls_certificate_credentials_t tlscred;
 /* Main OpenSSL CTX pointer */
 static SSL_CTX *ctx;
 static SSL **sslArray;
-// static DH *pDH;
 #endif
 
 /* variables for managing multi-threaded operations */
@@ -369,7 +368,7 @@ int openConnections(void)
 	if(bShowProgress)
 		if(write(1, "      open connections", sizeof("      open connections")-1)){}
 #	if defined(ENABLE_OPENSSL)
-	sslArray = calloc(numConnections, sizeof(sslArray));
+	sslArray = calloc(numConnections, sizeof(SSL *));
 #	elif defined(ENABLE_GNUTLS)
 	sessArray = calloc(numConnections, sizeof(gnutls_session_t));
 #	endif


### PR DESCRIPTION
It is unlikley that this has caused a real issue, as long as pointers
are all of the same size (what is highly probable).

detected by cppcheck via Codacy.com

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
