### PR TITLE
testbench: stabilize imptcp_large test

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1554,7 +1554,7 @@ case $1 in
 		;;
    'wait-file-lines') 
 		# $2 filename, $3 expected nbr of lines, $4 nbr of tries
-		timeoutend=${4:-1}
+		timeoutend=${4:-200}
 		timecounter=0
 
 		while [  $timecounter -lt $timeoutend ]; do

--- a/tests/imptcp_large.sh
+++ b/tests/imptcp_large.sh
@@ -1,31 +1,25 @@
 #!/bin/bash
 # Test imptcp with large messages
 # added 2010-08-10 by Rgerhards
-#
-# This file is part of the rsyslog project, released  under GPLv3
-echo ====================================================================================
-echo TEST: \[imptcp_large.sh\]: test imptcp with large-size messages
+# This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
-$MaxMessageSize 10k
+global(maxMessageSize="10k")
+template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 
-$ModLoad ../plugins/imptcp/.libs/imptcp
-$MainMsgQueueTimeoutShutdown 10000
-$InputPTCPServerRun '$TCPFLOOD_PORT'
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
-$template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
-template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
-$OMFileFlushOnTXEnd off
-$OMFileFlushInterval 2
-$OMFileIOBufferSize 256k
-local0.* ?dynfile;outfmt
+ruleset(name="testing") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
 '
 startup
-# send 4000 messages of 10.000bytes plus header max, randomized
-tcpflood -c5 -m20000 -r -d10000 -P129
-sleep 2 # due to large messages, we need this time for the tcp receiver to settle...
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown       # and wait for it to terminate
+# send messages of 10.000bytes plus header max, randomized
+tcpflood -c5 -m20000 -r -d10000
+. $srcdir/diag.sh wait-file-lines $RSYSLOG_OUT_LOG 20000
+shutdown_when_empty
+wait_shutdown
 seq_check 0 19999 -E
 exit_test


### PR DESCRIPTION
... and also fix some issue in test setup. This means the test has been
rewritten and now also support current script syntax. Bufferred i/o was
probably only used because of where it was copied from, and it was used
in a way that does not seem correct (iotimeout was set, but background
writing not activated).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
