### PR TITLE
testbench: add self-test for kafka subsystem

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -624,6 +624,7 @@ if ENABLE_OMKAFKA
 if ENABLE_IMKAFKA
 if ENABLE_KAFKA_TESTS
 TESTS += \
+	kafka-selftest.sh \
 	omkafka.sh \
 	imkafka.sh \
 	imkafka-backgrounded.sh \
@@ -1672,6 +1673,7 @@ EXTRA_DIST= \
 	mysql-actq-mt.sh \
 	mysql-actq-mt-withpause.sh \
 	mysql-actq-mt-withpause-vg.sh \
+	kafka-selftest.sh \
 	omkafka.sh \
 	omkafka-vg.sh \
 	imkafka-hang-on-no-kafka.sh \

--- a/tests/kafka-selftest.sh
+++ b/tests/kafka-selftest.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# added 2018-10-26 by Rainer Gerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available kafkacat
+export KEEP_KAFKA_RUNNING="YES"
+
+export TESTMESSAGES=100000
+
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
+
+# Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
+#export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+printf 'injecting messages via kafkacat\n'
+injectmsg_kafkacat
+
+# experimental: wait until kafkacat receives everything
+
+timeoutend=10
+timecounter=0
+
+printf 'receiving messages via kafkacat\n'
+while [ $timecounter -lt $timeoutend ]; do
+	(( timecounter++ ))
+
+	kafkacat -b localhost:29092 -e -C -o beginning -t $RANDTOPIC -f '%s\n' > $RSYSLOG_OUT_LOG
+	count=$(wc -l < ${RSYSLOG_OUT_LOG})
+	if [ $count -eq $TESTMESSAGES ]; then
+		printf '**** wait-kafka-lines success, have %d lines ****\n\n' "$TESTMESSAGES"
+		break
+	else
+		if [ "x$timecounter" == "x$timeoutend" ]; then
+			echo wait-kafka-lines failed, expected $TESTMESSAGES got $count
+			error_exit 1
+		else
+			echo wait-file-lines not yet there, currently $count lines
+			printf '\n'
+			$TESTTOOL_DIR/msleep 1000
+		fi
+	fi
+done
+unset count
+
+#end experimental
+
+delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+sed -i 's/ msgnum://' "$RSYSLOG_OUT_LOG"
+seq_check 1 $TESTMESSAGES -d
+
+exit_test


### PR DESCRIPTION
We can now check if kafka's own tools also fail.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
