### PR TITLE
cleanup: remove commented-out code

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -707,9 +707,6 @@ act_obj_add(fs_edge_t *const edge, const char *const name, const int is_file,
 	}
 	act->next = edge->active;
 	edge->active = act;
-//dbgprintf("printout of fs tree after act_obj_add for '%s'\n", name);
-//fs_node_print(runModConf->conf_tree, 0);
-//dbg_wdmapPrint("wdmap after act_obj_add");
 finalize_it:
 	if(iRet != RS_RET_OK) {
 		if(act != NULL) {
@@ -1017,9 +1014,6 @@ act_obj_unlink(act_obj_t *act)
 	}
 	act_obj_destroy(act, 1);
 	act = NULL;
-//dbgprintf("printout of fs tree post unlink\n");
-//fs_node_print(runModConf->conf_tree, 0);
-//dbg_wdmapPrint("wdmap after");
 }
 
 static void
@@ -2430,7 +2424,6 @@ do_fen(void)
 			if(act->edge->is_file) {
 				pollFile(act);
 			} else {
-				// curr: fs_node_walk(act->edge->parent, poll_tree);
 				fs_node_walk(act->edge->node, poll_tree);
 			}
 		}

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -48,7 +48,7 @@
  *
  * File begun on 2008-01-04 by RGerhards
  *
- * Copyright 2008-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -956,39 +956,6 @@ finalize_it:
 	}
 
 
-	RETiRet;
-}
-
-/* This is a dummy deserializer, to be used for the delete queue reader
- * specifically. This is kind of a hack, but also to be replace (hopefully) soon
- * by totally different code. So let's make it as simple as possible...
- * rgerhards, 2012-11-06
- */
-rsRetVal
-objDeserializeDummy(obj_t __attribute__((unused)) *pObj, strm_t *pStrm)
-{
-	DEFiRet;
-	var_t *pVar = NULL;
-
-	CHKiRet(var.Construct(&pVar));
-	CHKiRet(var.ConstructFinalize(pVar));
-
-	iRet = objDeserializeProperty(pVar, pStrm);
-	while(iRet == RS_RET_OK) {
-		/* this loop does actually NOGHTING but read the file... */
-		/* re-init var object - TODO: method of var! */
-		rsCStrDestruct(&pVar->pcsName); /* no longer needed */
-		if(pVar->varType == VARTYPE_STR) {
-			if(pVar->val.pStr != NULL)
-				rsCStrDestruct(&pVar->val.pStr);
-		}
-		iRet = objDeserializeProperty(pVar, pStrm);
-	}
-finalize_it:
-	if(iRet == RS_RET_NO_PROPLINE)
-		iRet = RS_RET_OK; /* NO_PROPLINE is OK and a kind of EOF! */
-	if(pVar != NULL)
-		var.Destruct(&pVar);
 	RETiRet;
 }
 

--- a/runtime/obj.h
+++ b/runtime/obj.h
@@ -21,7 +21,7 @@
  *
  * pThis always references to a pointer of the object.
  *
- * Copyright 2008-2012 Adiscon GmbH.
+ * Copyright 2008-2018 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -123,7 +123,6 @@ rsRetVal objDeserializeWithMethods(void *ppObj, uchar *pszTypeExpected, int lenT
 rsRetVal (*fFixup)(obj_t*,void*), void *pUsr, rsRetVal (*objConstruct)(), rsRetVal (*objConstructFinalize)(),
 rsRetVal (*objDeserialize)());
 rsRetVal objDeserializeProperty(var_t *pProp, strm_t *pStrm);
-rsRetVal objDeserializeDummy(obj_t *pObj, strm_t *pStrm);
 uchar *objGetName(obj_t *pThis);
 
 


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
