### PR TITLE
cleanup: remove no longer needed --enable-rtinst code

### DIFF
--- a/action.c
+++ b/action.c
@@ -316,7 +316,7 @@ actionResetQueueParams(void)
 
 	cs.glbliActionResumeRetryCount = 0;		/* I guess it is smart to reset this one, too */
 
-	d_free(cs.pszActionQFName);
+	free(cs.pszActionQFName);
 	cs.pszActionQFName = NULL;			/* prefix for the main message queue file */
 
 	RETiRet;
@@ -329,7 +329,7 @@ actionResetQueueParams(void)
 rsRetVal actionDestruct(action_t * const pThis)
 {
 	DEFiRet;
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	if(!strcmp((char*)modGetName(pThis->pMod), "builtin:omdiscard")) {
 		/* discard actions will be optimized out */
@@ -355,13 +355,13 @@ rsRetVal actionDestruct(action_t * const pThis)
 	pthread_mutex_destroy(&pThis->mutAction);
 	pthread_mutex_destroy(&pThis->mutWrkrDataTable);
 	free((void*)pThis->pszErrFile);
-	d_free(pThis->pszName);
-	d_free(pThis->ppTpl);
-	d_free(pThis->peParamPassing);
-	d_free(pThis->wrkrDataTable);
+	free(pThis->pszName);
+	free(pThis->ppTpl);
+	free(pThis->peParamPassing);
+	free(pThis->wrkrDataTable);
 
 finalize_it:
-	d_free(pThis);
+	free(pThis);
 	RETiRet;
 }
 
@@ -389,7 +389,7 @@ rsRetVal actionConstruct(action_t **ppThis)
 	DEFiRet;
 	action_t *pThis;
 
-	ASSERT(ppThis != NULL);
+	assert(ppThis != NULL);
 	
 	CHKmalloc(pThis = (action_t*) calloc(1, sizeof(action_t)));
 	pThis->iResumeInterval = 30;
@@ -785,7 +785,7 @@ actionDoRetry(action_t * const pThis, wti_t * const pWti)
 	int bTreatOKasSusp;
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	iRetries = 0;
 	while((*pWti->pbShutdownImmediate == 0) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
@@ -1602,7 +1602,7 @@ actionCallHUPHdlr(action_t * const pAction)
 {
 	DEFiRet;
 
-	ASSERT(pAction != NULL);
+	assert(pAction != NULL);
 	DBGPRINTF("Action %p checks HUP hdlr, act level: %p, wrkr level %p\n",
 		pAction, pAction->pMod->doHUP, pAction->pMod->doHUPWrkr);
 
@@ -1657,7 +1657,7 @@ static rsRetVal setActionQueType(void __attribute__((unused)) *pVal, uchar *pszT
 		LogError(0, RS_RET_INVALID_PARAMS, "unknown actionqueue parameter: %s", (char *) pszType);
 		iRet = RS_RET_INVALID_PARAMS;
 	}
-	d_free(pszType); /* no longer needed */
+	free(pszType); /* no longer needed */
 
 	RETiRet;
 }
@@ -1826,7 +1826,6 @@ DEFFUNC_llExecFunc(doActivateActions)
 {
 	rsRetVal localRet;
 	action_t * const pThis = (action_t*) pData;
-	BEGINfunc
 	localRet = qqueueStart(pThis->pQueue);
 	if(localRet != RS_RET_OK) {
 		LogError(0, localRet, "error starting up action queue");
@@ -1838,7 +1837,6 @@ DEFFUNC_llExecFunc(doActivateActions)
 	}
 	DBGPRINTF("Action %s[%p]: queue %p started\n", modGetName(pThis->pMod),
 		  pThis, pThis->pQueue);
-	ENDfunc
 	return RS_RET_OK; /* we ignore errors, we can not do anything either way */
 }
 

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -117,7 +117,7 @@ static void setDefaults(instanceConf_t* iconf) {
 static rsRetVal createInstance(instanceConf_t** pinst) {
 	DEFiRet;
 	instanceConf_t* inst;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	
 	setDefaults(inst);
 	
@@ -138,7 +138,7 @@ static rsRetVal addListener(instanceConf_t* iconf){
 	
 	DBGPRINTF("imczmq: addListener called..\n");
 	struct listener_t* pData = NULL;
-	CHKmalloc(pData=(struct listener_t*)MALLOC(sizeof(struct listener_t)));
+	CHKmalloc(pData=(struct listener_t*)malloc(sizeof(struct listener_t)));
 	pData->ruleset = iconf->pBindRuleset;
 
 	pData->sock = zsock_new(iconf->sockType);

--- a/contrib/imzmq3/imzmq3.c
+++ b/contrib/imzmq3/imzmq3.c
@@ -279,7 +279,7 @@ static rsRetVal parseSubscriptions(char* subscribes, sublist** subList){
 	DEFiRet;
 
 	/* create empty list */
-	CHKmalloc(*subList = (sublist*)MALLOC(sizeof(sublist)));
+	CHKmalloc(*subList = (sublist*)malloc(sizeof(sublist)));
 	head = *subList;
 	head->next = NULL;
 	head->subscribe=NULL;
@@ -288,7 +288,7 @@ static rsRetVal parseSubscriptions(char* subscribes, sublist** subList){
 	if(tok) {
 	    head->subscribe=strdup(tok);
 	    for(tok=strtok(NULL, ","); tok!=NULL;tok=strtok(NULL, ",")) {
-	        CHKmalloc(currentSub->next = (sublist*)MALLOC(sizeof(sublist)));
+	        CHKmalloc(currentSub->next = (sublist*)malloc(sizeof(sublist)));
 	        currentSub=currentSub->next;
 	        currentSub->subscribe=strdup(tok);
 	        currentSub->next=NULL;
@@ -435,7 +435,7 @@ static rsRetVal createSocket(instanceConf_t* info, void** sock) {
 static rsRetVal createInstance(instanceConf_t** pinst) {
 	DEFiRet;
 	instanceConf_t* inst;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 
 	/* set defaults into new instance config struct */
 	setDefaults(inst);
@@ -527,7 +527,7 @@ static rsRetVal addListener(instanceConf_t* inst){
 	CHKiRet(createSocket(inst, &sock));
 
 	/* now create new lstn_s struct */
-	CHKmalloc(newcnfinfo=(struct lstn_s*)MALLOC(sizeof(struct lstn_s)));
+	CHKmalloc(newcnfinfo=(struct lstn_s*)malloc(sizeof(struct lstn_s)));
 	newcnfinfo->next = NULL;
 	newcnfinfo->sock = sock;
 	newcnfinfo->pRuleset = inst->pBindRuleset;
@@ -607,10 +607,10 @@ static rsRetVal rcv_loop(thrdInfo_t* pThrd){
 	/* make arrays of pollitems, pollerdata so they are easy to delete later */
 
 	/* create the poll items*/
-	CHKmalloc(items = (zmq_pollitem_t*)MALLOC(sizeof(zmq_pollitem_t)*n_items));
+	CHKmalloc(items = (zmq_pollitem_t*)malloc(sizeof(zmq_pollitem_t)*n_items));
 
 	/* create poller data (stuff to pass into the zmq closure called when we get a message)*/
-	CHKmalloc(pollerData = (poller_data*)MALLOC(sizeof(poller_data)*n_items));
+	CHKmalloc(pollerData = (poller_data*)malloc(sizeof(poller_data)*n_items));
 
 	/* loop through and initialize the poll items and poller_data arrays...*/
 	for(i=0, current = lcnfRoot; current != NULL; current = current->next, i++) {

--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -966,7 +966,7 @@ CODESTARTnewActInst
 		} else if(!strcmp(actpblk.descr[i].name, "srcmetadatapath")) {
 			msgPropDescrDestruct(pData->srcMetadataDescr);
 			free(pData->srcMetadataDescr);
-			CHKmalloc(pData->srcMetadataDescr = MALLOC(sizeof(msgPropDescr_t)));
+			CHKmalloc(pData->srcMetadataDescr = malloc(sizeof(msgPropDescr_t)));
 			srcMetadataPath = es_str2cstr(pvals[i].val.d.estr, NULL);
 			CHKiRet(msgPropDescrFill(pData->srcMetadataDescr, (uchar *)srcMetadataPath,
 				strlen(srcMetadataPath)));
@@ -1119,7 +1119,7 @@ CODESTARTnewActInst
 		}
 	}
 	if(pData->srcMetadataDescr == NULL) {
-		CHKmalloc(pData->srcMetadataDescr = MALLOC(sizeof(msgPropDescr_t)));
+		CHKmalloc(pData->srcMetadataDescr = malloc(sizeof(msgPropDescr_t)));
 		CHKiRet(msgPropDescrFill(pData->srcMetadataDescr, loadModConf->srcMetadataPath,
 			strlen((char *)loadModConf->srcMetadataPath)));
 	}
@@ -1143,10 +1143,10 @@ CODESTARTnewActInst
 	if(pData->de_dot_separator)
 		pData->de_dot_separator_len = strlen((const char *)pData->de_dot_separator);
 
-	CHKmalloc(pData->contNameDescr = MALLOC(sizeof(msgPropDescr_t)));
+	CHKmalloc(pData->contNameDescr = malloc(sizeof(msgPropDescr_t)));
 	CHKiRet(msgPropDescrFill(pData->contNameDescr, (uchar*) DFLT_CONTAINER_NAME,
 			strlen(DFLT_CONTAINER_NAME)));
-	CHKmalloc(pData->contIdFullDescr = MALLOC(sizeof(msgPropDescr_t)));
+	CHKmalloc(pData->contIdFullDescr = malloc(sizeof(msgPropDescr_t)));
 	CHKiRet(msgPropDescrFill(pData->contIdFullDescr, (uchar*) DFLT_CONTAINER_ID_FULL,
 			strlen(DFLT_CONTAINER_NAME)));
 

--- a/contrib/omfile-hardened/omfile-hardened.c
+++ b/contrib/omfile-hardened/omfile-hardened.c
@@ -457,14 +457,14 @@ finalize_it:
  * as the index of the to-be-deleted entry. This index may
  * point to an unallocated entry, in whcih case the
  * function immediately returns. Parameter bFreeEntry is 1
- * if the entry should be d_free()ed and 0 if not.
+ * if the entry should be free()ed and 0 if not.
  */
 static rsRetVal
 dynaFileDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, const int bFreeEntry)
 {
 	dynaFileCacheEntry **pCache = pData->dynCache;
 	DEFiRet;
-	ASSERT(pCache != NULL);
+	assert(pCache != NULL);
 
 	if(pCache[iEntry] == NULL)
 		FINALIZE;
@@ -473,7 +473,7 @@ dynaFileDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, 
 		pCache[iEntry]->pName == NULL ? UCHAR_CONSTANT("[OPEN FAILED]") : pCache[iEntry]->pName);
 
 	if(pCache[iEntry]->pName != NULL) {
-		d_free(pCache[iEntry]->pName);
+		free(pCache[iEntry]->pName);
 		pCache[iEntry]->pName = NULL;
 	}
 
@@ -486,7 +486,7 @@ dynaFileDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, 
 	}
 
 	if(bFreeEntry) {
-		d_free(pCache[iEntry]);
+		free(pCache[iEntry]);
 		pCache[iEntry] = NULL;
 	}
 
@@ -503,14 +503,12 @@ static void
 dynaFileFreeCacheEntries(instanceData *__restrict__ const pData)
 {
 	register uint i;
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 
-	BEGINfunc;
 	for(i = 0 ; i < pData->iCurrCacheSize ; ++i) {
 		dynaFileDelCacheEntry(pData, i, 1);
 	}
 	pData->iCurrElt = -1; /* invalidate current element */
-	ENDfunc;
 }
 
 
@@ -518,13 +516,11 @@ dynaFileFreeCacheEntries(instanceData *__restrict__ const pData)
  */
 static void dynaFileFreeCache(instanceData *__restrict__ const pData)
 {
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 
-	BEGINfunc;
 	dynaFileFreeCacheEntries(pData);
 	if(pData->dynCache != NULL)
-		d_free(pData->dynCache);
-	ENDfunc;
+		free(pData->dynCache);
 }
 
 
@@ -737,8 +733,8 @@ prepareDynFile(instanceData *__restrict__ const pData, const uchar *__restrict__
 	dynaFileCacheEntry **pCache;
 	DEFiRet;
 
-	ASSERT(pData != NULL);
-	ASSERT(newFileName != NULL);
+	assert(pData != NULL);
+	assert(newFileName != NULL);
 
 	pCache = pData->dynCache;
 
@@ -859,8 +855,8 @@ static  rsRetVal
 doWrite(instanceData *__restrict__ const pData, uchar *__restrict__ const pszBuf, const int lenBuf)
 {
 	DEFiRet;
-	ASSERT(pData != NULL);
-	ASSERT(pszBuf != NULL);
+	assert(pData != NULL);
+	assert(pszBuf != NULL);
 
 	DBGPRINTF("omfile: write to stream, pData->pStrm %p, lenBuf %d, strt data %.128s\n",
 		  pData->pStrm, lenBuf, pszBuf);

--- a/contrib/pmsnare/pmsnare.c
+++ b/contrib/pmsnare/pmsnare.c
@@ -114,13 +114,13 @@ struct instanceConf_s {
 static rsRetVal createInstance(instanceConf_t **pinst) {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 	*pinst = inst;
 	
 	/*  Add to list of instances. */
 	if(modInstances == NULL) {
-		CHKmalloc(modInstances = MALLOC(sizeof(modInstances_t)));
+		CHKmalloc(modInstances = malloc(sizeof(modInstances_t)));
 		modInstances->tail = modInstances->root = NULL;
 	}
 	if (modInstances->tail == NULL) {

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -256,7 +256,7 @@ DecodePropFilter(uchar *pline, struct cnfstmt *stmt)
 	int iOffset; /* for compare operations */
 	DEFiRet;
 
-	ASSERT(pline != NULL);
+	assert(pline != NULL);
 
 	DBGPRINTF("Decoding property-based filter '%s'\n", pline);
 
@@ -1514,7 +1514,7 @@ doExtractFieldByChar(uchar *str, uchar delim, const int matchnbr, uchar **resstr
 		allocLen += (3 - (iLen % 4));
 		/*older versions of valgrind have a problem with strlen inspecting 4-bytes at a time*/
 #		endif
-		CHKmalloc(pBuf = MALLOC(allocLen));
+		CHKmalloc(pBuf = malloc(allocLen));
 		/* now copy */
 		memcpy(pBuf, pFld, iLen);
 		pBuf[iLen] = '\0'; /* terminate it */
@@ -1562,7 +1562,7 @@ doExtractFieldByStr(uchar *str, char *delim, const rs_size_t lenDelim, const int
 			iLen = pFldEnd - pFld;
 		}
 		/* we got our end pointer, now do the copy */
-		CHKmalloc(pBuf = MALLOC(iLen + 1));
+		CHKmalloc(pBuf = malloc(iLen + 1));
 		/* now copy */
 		memcpy(pBuf, pFld, iLen);
 		pBuf[iLen] = '\0'; /* terminate it */

--- a/outchannel.c
+++ b/outchannel.c
@@ -208,7 +208,7 @@ struct outchannel *ochAddLine(char* pName, uchar** ppRestOfConfLine)
 		return NULL;
 	
 	pOch->iLenName = strlen(pName);
-	pOch->pszName = (char*) MALLOC(pOch->iLenName + 1);
+	pOch->pszName = (char*) malloc(pOch->iLenName + 1);
 	if(pOch->pszName == NULL) {
 		dbgprintf("ochAddLine could not alloc memory for outchannel name!");
 		pOch->iLenName = 0;

--- a/parse.c
+++ b/parse.c
@@ -429,7 +429,7 @@ rsRetVal parsAddrWithBits(rsParsObj *pThis, struct NetAddr **pIP, int *pBits)
 
 		switch(getaddrinfo ((char*)pszIP+1, NULL, &hints, &res)) {
 		case 0:
-			(*pIP)->addr.NetAddr = MALLOC (res->ai_addrlen);
+			(*pIP)->addr.NetAddr = malloc (res->ai_addrlen);
 			memcpy ((*pIP)->addr.NetAddr, res->ai_addr, res->ai_addrlen);
 			freeaddrinfo (res);
 			break;
@@ -465,7 +465,7 @@ rsRetVal parsAddrWithBits(rsParsObj *pThis, struct NetAddr **pIP, int *pBits)
 
 		switch(getaddrinfo ((char*)pszIP, NULL, &hints, &res)) {
 		case 0:
-			(*pIP)->addr.NetAddr = MALLOC (res->ai_addrlen);
+			(*pIP)->addr.NetAddr = malloc (res->ai_addrlen);
 			memcpy ((*pIP)->addr.NetAddr, res->ai_addr, res->ai_addrlen);
 			freeaddrinfo (res);
 			break;

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -478,7 +478,7 @@ OnMsgReceived(tcps_sess_t *const pSess, uchar *const pRcv, const int iLenMsg)
 	 * WITHOUT a termination \0 char. So we need to convert it to one
 	 * before proceeding.
 	 */
-	CHKmalloc(pszMsg = MALLOC(iLenMsg + 1));
+	CHKmalloc(pszMsg = malloc(iLenMsg + 1));
 	pToFree = pszMsg;
 	memcpy(pszMsg, pRcv, iLenMsg);
 	pszMsg[iLenMsg] = '\0';

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -695,7 +695,7 @@ act_obj_add(fs_edge_t *const edge, const char *const name, const int is_file,
 	if(is_file && !is_symlink) {
 		const instanceConf_t *const inst = edge->instarr[0];// TODO: same file, multiple instances?
 		CHKiRet(ratelimitNew(&act->ratelimiter, "imfile", name));
-		CHKmalloc(act->multiSub.ppMsgs = MALLOC(inst->nMultiSub * sizeof(smsg_t *)));
+		CHKmalloc(act->multiSub.ppMsgs = malloc(inst->nMultiSub * sizeof(smsg_t *)));
 		act->multiSub.maxElem = inst->nMultiSub;
 		act->multiSub.nElem = 0;
 		pollFile(act);
@@ -1274,7 +1274,7 @@ enqLine(act_obj_t *const act,
 		/* Make sure we account for terminating null byte */
 		size_t ceeMsgSize = msgLen + CONST_LEN_CEE_COOKIE + 1;
 		char *ceeMsg;
-		CHKmalloc(ceeMsg = MALLOC(ceeMsgSize));
+		CHKmalloc(ceeMsg = malloc(ceeMsgSize));
 		strcpy(ceeMsg, CONST_CEE_COOKIE);
 		strcat(ceeMsg, (char*)rsCStrGetSzStrNoNULL(cstrLine));
 		MsgSetRawMsg(pMsg, ceeMsg, ceeMsgSize);
@@ -1486,11 +1486,9 @@ finalize_it:
  */
 static void pollFileCancelCleanup(void *pArg)
 {
-	BEGINfunc;
 	cstr_t **ppCStr = (cstr_t**) pArg;
 	if(*ppCStr != NULL)
 		rsCStrDestruct(ppCStr);
-	ENDfunc;
 }
 
 
@@ -1574,7 +1572,7 @@ createInstance(instanceConf_t **const pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 	inst->pBindRuleset = NULL;
 

--- a/plugins/imgssapi/imgssapi.c
+++ b/plugins/imgssapi/imgssapi.c
@@ -182,7 +182,6 @@ isPermittedHost(struct sockaddr *addr, char *fromHostFQDN, void *pUsrSrv, void*p
 	gss_sess_t *pGSess;
 	char allowedMethods = 0;
 
-	BEGINfunc
 	assert(pUsrSrv != NULL);
 	pGSrv = (gsssrv_t*) pUsrSrv;
 	pGSess = (gss_sess_t*) pUsrSess;
@@ -195,7 +194,6 @@ isPermittedHost(struct sockaddr *addr, char *fromHostFQDN, void *pUsrSrv, void*p
 		allowedMethods |= ALLOWEDMETHOD_GSS;
 	if(allowedMethods && pGSess != NULL)
 		pGSess->allowedMethods = allowedMethods;
-	ENDfunc
 	return allowedMethods;
 }
 
@@ -436,7 +434,7 @@ OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess)
 	if(allowedMethods & ALLOWEDMETHOD_GSS) {
 		int ret = 0;
 		const size_t bufsize = glbl.GetMaxLine();
-		CHKmalloc(buf = (char*) MALLOC(bufsize + 1));
+		CHKmalloc(buf = (char*) malloc(bufsize + 1));
 
 		prop.GetString(pSess->fromHostIP, &pszPeer, &lenPeer);
 

--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -280,7 +280,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 
 	inst->brokers = NULL;

--- a/plugins/imklog/bsd.c
+++ b/plugins/imklog/bsd.c
@@ -240,7 +240,7 @@ readklog(modConfData_t *pModConf)
 	if((size_t) iMaxLine < sizeof(bufRcv) - 1) {
 		pRcv = bufRcv;
 	} else {
-		if((pRcv = (uchar*) MALLOC(iMaxLine + 1)) == NULL) {
+		if((pRcv = (uchar*) malloc(iMaxLine + 1)) == NULL) {
 			iMaxLine = sizeof(bufRcv) - 1; /* better this than noting */
 			pRcv = bufRcv;
 		}

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1586,7 +1586,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 
 	inst->pszBindPort = NULL;

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -269,7 +269,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 
 	inst->pszBindPort = NULL;

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -279,7 +279,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 	inst->pszBindRuleset = NULL;
 	inst->pszInputName = NULL;

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -205,7 +205,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 	inst->pBindRuleset = NULL;
 
@@ -1174,11 +1174,11 @@ CODESTARTactivateCnf
 	DBGPRINTF("imudp: config params iMaxLine %d, lenRcvBuf %d\n", iMaxLine, lenRcvBuf);
 	for(i = 0 ; i < runModConf->wrkrMax ; ++i) {
 #		ifdef HAVE_RECVMMSG
-		CHKmalloc(wrkrInfo[i].recvmsg_iov = MALLOC(runModConf->batchSize * sizeof(struct iovec)));
-		CHKmalloc(wrkrInfo[i].recvmsg_mmh = MALLOC(runModConf->batchSize * sizeof(struct mmsghdr)));
-		CHKmalloc(wrkrInfo[i].frominet = MALLOC(runModConf->batchSize * sizeof(struct sockaddr_storage)));
+		CHKmalloc(wrkrInfo[i].recvmsg_iov = malloc(runModConf->batchSize * sizeof(struct iovec)));
+		CHKmalloc(wrkrInfo[i].recvmsg_mmh = malloc(runModConf->batchSize * sizeof(struct mmsghdr)));
+		CHKmalloc(wrkrInfo[i].frominet = malloc(runModConf->batchSize * sizeof(struct sockaddr_storage)));
 #		endif
-		CHKmalloc(wrkrInfo[i].pRcvBuf = MALLOC(lenRcvBuf));
+		CHKmalloc(wrkrInfo[i].pRcvBuf = malloc(lenRcvBuf));
 		wrkrInfo[i].id = i;
 	}
 finalize_it:

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -314,7 +314,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->sockName = NULL;
 	inst->pLogHostName = NULL;
 	inst->pszBindRuleset = NULL;
@@ -1077,7 +1077,7 @@ static rsRetVal readSocket(lstn_t *pLstn)
 	if((size_t) iMaxLine < sizeof(bufRcv) - 1) {
 		pRcv = bufRcv;
 	} else {
-		CHKmalloc(pRcv = (uchar*) MALLOC(iMaxLine + 1));
+		CHKmalloc(pRcv = (uchar*) malloc(iMaxLine + 1));
 	}
 
 	memset(&msgh, 0, sizeof(msgh));

--- a/plugins/mmnormalize/mmnormalize.c
+++ b/plugins/mmnormalize/mmnormalize.c
@@ -402,7 +402,7 @@ CODESTARTnewActInst
 			                "mmnormalize: 'variable' param can't be used with 'useRawMsg'. "
 			                "Ignoring 'variable', will use raw message.");
 		} else {
-			CHKmalloc(pData->varDescr = MALLOC(sizeof(msgPropDescr_t)));
+			CHKmalloc(pData->varDescr = malloc(sizeof(msgPropDescr_t)));
 			CHKiRet(msgPropDescrFill(pData->varDescr, (uchar*) varName, strlen(varName)));
 		}
 		free(varName);

--- a/plugins/mmsnmptrapd/mmsnmptrapd.c
+++ b/plugins/mmsnmptrapd/mmsnmptrapd.c
@@ -297,7 +297,7 @@ buildSeverityMapping(instanceData *const pData)
 					"range 0..7 (was string '%s')\n", sevCode, pszSevCode);
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
-		CHKmalloc(node = MALLOC(sizeof(struct severMap_s)));
+		CHKmalloc(node = malloc(sizeof(struct severMap_s)));
 		CHKmalloc(node->name = ustrdup(pszSev));
 		node->code = sevCode;
 		/* we enqueue at the top, so the two lines below do all we need! */
@@ -343,11 +343,11 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	} else {
 		int lenTag = ustrlen(cs.pszTagName);
 		/* new tag value (with colon at the end) */
-		CHKmalloc(pData->pszTagName = MALLOC(lenTag + 2));
+		CHKmalloc(pData->pszTagName = malloc(lenTag + 2));
 		memcpy(pData->pszTagName, cs.pszTagName, lenTag);
 		memcpy(pData->pszTagName+lenTag, ":", 2);
 		/* tag ID for comparisions */
-		CHKmalloc(pData->pszTagID = MALLOC(lenTag + 2));
+		CHKmalloc(pData->pszTagID = malloc(lenTag + 2));
 		memcpy(pData->pszTagID, cs.pszTagName, lenTag);
 		memcpy(pData->pszTagID+lenTag, "/", 2);
 		free(cs.pszTagName); /* no longer needed */

--- a/plugins/omgssapi/omgssapi.c
+++ b/plugins/omgssapi/omgssapi.c
@@ -211,7 +211,7 @@ static rsRetVal TCPSendGSSInit(void *pvData)
 
 	base = (cs.gss_base_service_name == NULL) ? "host" : cs.gss_base_service_name;
 	out_tok.length = strlen(pData->f_hname) + strlen(base) + 2;
-	CHKmalloc(out_tok.value = MALLOC(out_tok.length));
+	CHKmalloc(out_tok.value = malloc(out_tok.length));
 	strcpy(out_tok.value, base);
 	strcat(out_tok.value, "@");
 	strcat(out_tok.value, pData->f_hname);
@@ -435,7 +435,7 @@ CODESTARTdoAction
 			uLong srcLen = l;
 			int ret;
 			/* TODO: optimize malloc sequence? -- rgerhards, 2008-09-02 */
-			CHKmalloc(out = (Bytef*) MALLOC(iMaxLine + iMaxLine/100 + 12));
+			CHKmalloc(out = (Bytef*) malloc(iMaxLine + iMaxLine/100 + 12));
 			out[0] = 'z';
 			out[1] = '\0';
 			ret = compress2((Bytef*) out+1, &destLen, (Bytef*) psz,
@@ -577,7 +577,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 		tmp = ++p;
 		for(i=0 ; *p && isdigit((int) *p) ; ++p, ++i)
 			/* SKIP AND COUNT */;
-		pData->port = MALLOC(i + 1);
+		pData->port = malloc(i + 1);
 		if(pData->port == NULL) {
 			LogError(0, NO_ERRCODE, "Could not get memory to store syslog forwarding port, "
 				 "using default port, results may not be what you intend\n");

--- a/plugins/omhdfs/omhdfs.c
+++ b/plugins/omhdfs/omhdfs.c
@@ -212,7 +212,7 @@ filePrepare(file_t *pFile)
 	/* file does not exist, create it (and eventually parent directories */
 	if(1) { // check if bCreateDirs
 		len = ustrlen(pFile->name) + 1;
-		CHKmalloc(pszWork = MALLOC(len));
+		CHKmalloc(pszWork = malloc(len));
 		memcpy(pszWork, pFile->name, len);
 		for(p = pszWork+1 ; *p ; p++)
 			if(*p == '/') {

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -234,7 +234,7 @@ getPartition(instanceData *const __restrict__ pData)
 
 /* must always be called with appropriate locks taken */
 static void
-d_free_topic(rd_kafka_topic_t **topic)
+free_topic(rd_kafka_topic_t **topic)
 {
 	if (*topic != NULL) {
 		DBGPRINTF("omkafka: closing topic %s\n", rd_kafka_topic_name(*topic));
@@ -280,7 +280,7 @@ failedmsg_entry_construct(const char *const msg, const size_t msglen, const char
 static void
 closeTopic(instanceData *__restrict__ const pData)
 {
-	d_free_topic(&pData->pTopic);
+	free_topic(&pData->pTopic);
 }
 
 /* these dynaTopic* functions are only slightly modified versions of those found in omfile.c.
@@ -295,7 +295,7 @@ dynaTopicDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry,
 {
 	dynaTopicCacheEntry **pCache = pData->dynCache;
 	DEFiRet;
-	ASSERT(pCache != NULL);
+	assert(pCache != NULL);
 
 	if(pCache[iEntry] == NULL)
 		FINALIZE;
@@ -305,7 +305,7 @@ dynaTopicDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry,
 		pCache[iEntry]->pName == NULL ? UCHAR_CONSTANT("[OPEN FAILED]") : pCache[iEntry]->pName);
 
 	if(pCache[iEntry]->pName != NULL) {
-		d_free(pCache[iEntry]->pName);
+		free(pCache[iEntry]->pName);
 		pCache[iEntry]->pName = NULL;
 	}
 
@@ -313,7 +313,7 @@ dynaTopicDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry,
 
 	if(bFreeEntry) {
 		pthread_rwlock_destroy(&pCache[iEntry]->lock);
-		d_free(pCache[iEntry]);
+		free(pCache[iEntry]);
 		pCache[iEntry] = NULL;
 	}
 
@@ -326,16 +326,14 @@ static void
 dynaTopicFreeCacheEntries(instanceData *__restrict__ const pData)
 {
 	register int i;
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 
-	BEGINfunc;
 	pthread_mutex_lock(&pData->mutDynCache);
 	for(i = 0 ; i < pData->iCurrCacheSize ; ++i) {
 		dynaTopicDelCacheEntry(pData, i, 1);
 	}
 	pData->iCurrElt = -1; /* invalidate current element */
 	pthread_mutex_unlock(&pData->mutDynCache);
-	ENDfunc;
 }
 
 /* create the topic object */
@@ -423,8 +421,8 @@ prepareDynTopic(instanceData *__restrict__ const pData, const uchar *__restrict_
 	dynaTopicCacheEntry *entry = NULL;
 	rd_kafka_topic_t *tmpTopic = NULL;
 	DEFiRet;
-	ASSERT(pData != NULL);
-	ASSERT(newTopicName != NULL);
+	assert(pData != NULL);
+	assert(newTopicName != NULL);
 
 	pCache = pData->dynCache;
 	/* first check, if we still have the current topic */
@@ -503,7 +501,7 @@ prepareDynTopic(instanceData *__restrict__ const pData, const uchar *__restrict_
 	}
 
 	if((pCache[iFirstFree]->pName = ustrdup(newTopicName)) == NULL) {
-		d_free_topic(&tmpTopic);
+		free_topic(&tmpTopic);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
 	pCache[iFirstFree]->pTopic = tmpTopic;
@@ -1453,7 +1451,7 @@ CODESTARTfreeInstance
 	pthread_rwlock_wrlock(&pData->rkLock);
 	closeKafka(pData);
 	if(pData->dynaTopic && pData->dynCache != NULL) {
-		d_free(pData->dynCache);
+		free(pData->dynCache);
 		pData->dynCache = NULL;
 	}
 	/* Persist failed messages */

--- a/plugins/omlibdbi/omlibdbi.c
+++ b/plugins/omlibdbi/omlibdbi.c
@@ -182,7 +182,7 @@ ENDisCompatibleWithFeature
  */
 static void closeConn(instanceData *pData)
 {
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 	if(pData->conn != NULL) {	/* just to be on the safe side... */
 		dbi_conn_close(pData->conn);
 		pData->conn = NULL;
@@ -220,8 +220,7 @@ reportDBError(instanceData *pData, int bSilent)
 	char errMsg[1024];
 	const char *pszDbiErr;
 
-	BEGINfunc
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 
 	/* output log message */
 	errno = 0;
@@ -238,7 +237,6 @@ reportDBError(instanceData *pData, int bSilent)
 		}
 	}
 
-	ENDfunc
 }
 
 
@@ -249,8 +247,8 @@ static rsRetVal initConn(instanceData *pData, int bSilent)
 	DEFiRet;
 	int iDrvrsLoaded;
 
-	ASSERT(pData != NULL);
-	ASSERT(pData->conn == NULL);
+	assert(pData != NULL);
+	assert(pData->conn == NULL);
 
 	if(bDbiInitialized == 0) {
 		/* we need to init libdbi first */
@@ -327,8 +325,8 @@ writeDB(const uchar *psz, instanceData *const __restrict__ pData)
 	DEFiRet;
 	dbi_result dbiRes = NULL;
 
-	ASSERT(psz != NULL);
-	ASSERT(pData != NULL);
+	assert(psz != NULL);
+	assert(pData != NULL);
 
 	/* see if we are ready to proceed */
 	if(pData->conn == NULL) {

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -196,7 +196,7 @@ static rsRetVal initMySQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 	instanceData *pData;
 	DEFiRet;
 
-	ASSERT(pWrkrData->hmysql == NULL);
+	assert(pWrkrData->hmysql == NULL);
 	pData = pWrkrData->pData;
 	pWrkrData->hmysql = mysql_init(NULL);
 	if(pWrkrData->hmysql == NULL) {

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -627,7 +627,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 		tmp = ++p;
 		for(i=0 ; *p && isdigit((int) *p) ; ++p, ++i)
 			/* SKIP AND COUNT */;
-		pData->port = MALLOC(i + 1);
+		pData->port = malloc(i + 1);
 		if(pData->port == NULL) {
 			LogError(0, NO_ERRCODE, "Could not get memory to store relp port, "
 				 "using default port, results may not be what you intend\n");

--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -262,7 +262,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 	}
 	
 	/* String should not be NULL */
-	ASSERT(psz != NULL);
+	assert(psz != NULL);
 	dbgprintf( "omsnmp_sendsnmp: ENTER - Syslogmessage = '%s'\n", (char*)psz);
 
 	/* If SNMP Version1 is configured !*/
@@ -277,7 +277,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 					"failed '%s' with error '%s' \n", pData->szSyslogMessageOID, strErr);
 			ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
 		}
-		CHKmalloc(pdu->enterprise = (oid *) MALLOC(enterpriseoidlen * sizeof(oid)));
+		CHKmalloc(pdu->enterprise = (oid *) malloc(enterpriseoidlen * sizeof(oid)));
 		memcpy(pdu->enterprise, enterpriseoid, enterpriseoidlen * sizeof(oid));
 		pdu->enterprise_length = enterpriseoidlen;
 

--- a/plugins/pmciscoios/pmciscoios.c
+++ b/plugins/pmciscoios/pmciscoios.c
@@ -84,7 +84,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->bOriginPresent = 0;
 	inst->bXrPresent = 0;
 	*pinst = inst;

--- a/plugins/pmnormalize/pmnormalize.c
+++ b/plugins/pmnormalize/pmnormalize.c
@@ -89,7 +89,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->undefPropErr = 0;
 	inst->rulebase = NULL;
 	inst->rule = NULL;

--- a/plugins/pmnull/pmnull.c
+++ b/plugins/pmnull/pmnull.c
@@ -86,7 +86,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->tag = NULL;
 	*pinst = inst;
 finalize_it:

--- a/runtime/cfsysline.c
+++ b/runtime/cfsysline.c
@@ -477,9 +477,9 @@ getWord(uchar **pp, cstr_t **ppStrB)
 	DEFiRet;
 	uchar *p;
 
-	ASSERT(pp != NULL);
-	ASSERT(*pp != NULL);
-	ASSERT(ppStrB != NULL);
+	assert(pp != NULL);
+	assert(*pp != NULL);
+	assert(ppStrB != NULL);
 
 	CHKiRet(cstrConstruct(ppStrB));
 
@@ -521,8 +521,8 @@ static rsRetVal doGetWord(uchar **pp, rsRetVal (*pSetHdlr)(void*, uchar*), void 
 	cstr_t *pStrB = NULL;
 	uchar *pNewVal;
 
-	ASSERT(pp != NULL);
-	ASSERT(*pp != NULL);
+	assert(pp != NULL);
+	assert(*pp != NULL);
 
 	CHKiRet(getWord(pp, &pStrB));
 	CHKiRet(cstrConvSzStrAndDestruct(&pStrB, &pNewVal, 0));
@@ -565,8 +565,8 @@ doSyslogName(uchar **pp, rsRetVal (*pSetHdlr)(void*, int),
 	cstr_t *pStrB;
 	int iNewVal;
 
-	ASSERT(pp != NULL);
-	ASSERT(*pp != NULL);
+	assert(pp != NULL);
+	assert(*pp != NULL);
 
 	CHKiRet(getWord(pp, &pStrB)); /* get word */
 	iNewVal = decodeSyslogName(cstrGetSzStrNoNULL(pStrB), pNameTable);
@@ -630,7 +630,7 @@ doSeverity(uchar **pp, rsRetVal (*pSetHdlr)(void*, int), void *pVal)
  */
 static rsRetVal cslchDestruct(void *pThis)
 {
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 	free(pThis);
 	
 	return RS_RET_OK;

--- a/runtime/conf.c
+++ b/runtime/conf.c
@@ -102,8 +102,8 @@ doModLoad(uchar **pp, __attribute__((unused)) void* pVal)
 	uchar szName[512];
 	uchar *pModName;
 
-	ASSERT(pp != NULL);
-	ASSERT(*pp != NULL);
+	assert(pp != NULL);
+	assert(*pp != NULL);
 
 	skipWhiteSpace(pp); /* skip over any whitespace */
 	if(getSubString(pp, (char*) szName, sizeof(szName), ' ')  != 0) {
@@ -161,9 +161,9 @@ doNameLine(uchar **pp, void* pVal)
 	enum eDirective eDir;
 	char szName[128];
 
-	ASSERT(pp != NULL);
+	assert(pp != NULL);
 	p = *pp;
-	ASSERT(p != NULL);
+	assert(p != NULL);
 
 	eDir = (enum eDirective) pVal;	/* this time, it actually is NOT a pointer! */
 
@@ -219,7 +219,7 @@ cfsysline(uchar *p)
 	DEFiRet;
 	uchar szCmd[64];
 
-	ASSERT(p != NULL);
+	assert(p != NULL);
 	errno = 0;
 	if(getSubString(&p, (char*) szCmd, sizeof(szCmd), ' ')  != 0) {
 		LogError(0, RS_RET_NOT_FOUND, "Invalid $-configline "
@@ -264,9 +264,9 @@ rsRetVal cflineParseTemplateName(uchar** pp, omodStringRequest_t *pOMSR, int iEn
 	cstr_t *pStrB = NULL;
 	DEFiRet;
 
-	ASSERT(pp != NULL);
-	ASSERT(*pp != NULL);
-	ASSERT(pOMSR != NULL);
+	assert(pp != NULL);
+	assert(*pp != NULL);
+	assert(pOMSR != NULL);
 
 	p =*pp;
 	/* a template must follow - search it and complain, if not found */
@@ -329,7 +329,7 @@ cflineParseFileName(uchar* p, uchar *pFileName, omodStringRequest_t *pOMSR, int 
 	int i;
 	DEFiRet;
 
-	ASSERT(pOMSR != NULL);
+	assert(pOMSR != NULL);
 
 	pName = pFileName;
 	i = 1; /* we start at 1 so that we reseve space for the '\0'! */
@@ -360,7 +360,7 @@ rsRetVal DecodePRIFilter(uchar *pline, uchar pmask[])
 	uchar xbuf[200];
 	DEFiRet;
 
-	ASSERT(pline != NULL);
+	assert(pline != NULL);
 
 	dbgprintf("Decoding traditional PRI filter '%s'\n", pline);
 
@@ -502,8 +502,8 @@ rsRetVal cflineDoAction(rsconf_t *conf, uchar **p, action_t **ppAction)
 	void *pModData;
 	DEFiRet;
 
-	ASSERT(p != NULL);
-	ASSERT(ppAction != NULL);
+	assert(p != NULL);
+	assert(ppAction != NULL);
 
 	/* loop through all modules and see if one picks up the line */
 	node = module.GetNxtCnfType(conf, NULL, eMOD_OUT);

--- a/runtime/datetime.c
+++ b/runtime/datetime.c
@@ -936,7 +936,6 @@ formatTimestamp3339(struct syslogTime *ts, char* pBuf)
 	int secfrac;
 	short digit;
 
-	BEGINfunc
 	assert(ts != NULL);
 	assert(pBuf != NULL);
 
@@ -994,7 +993,6 @@ formatTimestamp3339(struct syslogTime *ts, char* pBuf)
 
 	pBuf[iBuf] = '\0';
 
-	ENDfunc
 	return iBuf;
 }
 

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -1,8 +1,6 @@
 /* debug.c
  *
- * This file proides debug and run time error analysis support. Some of the
- * settings are very performance intense and my be turned off during a release
- * build.
+ * This file proides debug support.
  *
  * File begun on 2008-01-22 by RGerhards
  *
@@ -63,139 +61,14 @@ DEFobjCurrIf(obj)
 int Debug = DEBUG_OFF;		/* debug flag  - read-only after startup */
 int debugging_on = 0;	 /* read-only, except on sig USR1 */
 int dbgTimeoutToStderr = 0;
-static int bLogFuncFlow = 0; /* shall the function entry and exit be logged to the debug log? */
-static int bLogAllocFree = 0; /* shall calls to (m/c)alloc and free be logged to the debug log? */
-static int bPrintFuncDBOnExit = 0; /* shall the function entry and exit be logged to the debug log? */
-static int bPrintMutexAction = 0; /* shall mutex calls be printed to the debug log? */
 static int bPrintTime = 1;	/* print a timestamp together with debug message */
-static int bPrintAllDebugOnExit = 0;
-static int bAbortTrace = 1;	/* print a trace after SIGABRT or SIGSEGV */
 static int bOutputTidToStderr = 0;/* output TID to stderr on thread creation */
 char *pszAltDbgFileName = NULL; /* if set, debug output is *also* sent to here */
 int altdbg = -1;	/* and the handle for alternate debug output */
 int stddbg = 1; /* the handle for regular debug output, set to stdout if not forking, -1 otherwise */
 static uint64_t dummy_errcount = 0; /* just to avoid some static analyzer complaints */
+static pthread_key_t keyThrdName;
 
-/* list of files/objects that should be printed */
-typedef struct dbgPrintName_s {
-	uchar *pName;
-	struct dbgPrintName_s *pNext;
-} dbgPrintName_t;
-
-
-/* forward definitions */
-static void dbgGetThrdName(char *pszBuf, size_t lenBuf, pthread_t thrd, int bIncludeNumID);
-static dbgThrdInfo_t *dbgGetThrdInfo(void);
-
-
-/* This lists are single-linked and members are added at the top */
-static dbgPrintName_t *printNameFileRoot = NULL;
-
-
-/* list of all known FuncDBs. We use a special list, because it must only be single-linked. As
- * functions never disappear, we only need to add elements when we see a new one and never need
- * to remove anything. For this, we simply add at the top, which saves us a Last pointer. The goal
- * is to use as few memory as possible.
- */
-typedef struct dbgFuncDBListEntry_s {
-	dbgFuncDB_t *pFuncDB;
-	struct dbgFuncDBListEntry_s *pNext;
-} dbgFuncDBListEntry_t;
-dbgFuncDBListEntry_t *pFuncDBListRoot;
-
-static pthread_mutex_t mutFuncDBList;
-
-typedef struct dbgMutLog_s {
-	struct dbgMutLog_s *pNext;
-	struct dbgMutLog_s *pPrev;
-	pthread_mutex_t *mut;
-	pthread_t thrd;
-	dbgFuncDB_t *pFuncDB;
-	int lockLn;	/* the actual line where the mutex was locked */
-	short mutexOp;
-} dbgMutLog_t;
-
-
-static dbgThrdInfo_t *dbgCallStackListRoot = NULL;
-static dbgThrdInfo_t *dbgCallStackListLast = NULL;
-static pthread_mutex_t mutCallStack;
-
-static pthread_mutex_t mutdbgprint;
-
-static pthread_key_t keyCallStack;
-
-
-/* we do not have templates, so we use some macros to create linked list handlers
- * for the several types
- * DLL means "doubly linked list"
- * rgerhards, 2008-01-23
- */
-#define DLL_Del(type, pThis) \
-	if(pThis->pPrev != NULL) \
-		pThis->pPrev->pNext = pThis->pNext; \
-	if(pThis->pNext != NULL) \
-		pThis->pNext->pPrev = pThis->pPrev; \
-	if(pThis == dbg##type##ListRoot) \
-		dbg##type##ListRoot = pThis->pNext; \
-	if(pThis == dbg##type##ListLast) \
-		dbg##type##ListLast = pThis->pPrev; \
-	free(pThis);
-
-#define DLL_Add(type, pThis) \
-		if(dbg##type##ListRoot == NULL) { \
-			dbg##type##ListRoot = pThis; \
-			dbg##type##ListLast = pThis; \
-		} else { \
-			pThis->pPrev = dbg##type##ListLast; \
-			dbg##type##ListLast->pNext = pThis; \
-			dbg##type##ListLast = pThis; \
-		}
-
-/* we need to do our own mutex cancel cleanup handler as it shall not
- * be subject to the debugging instrumentation (that would probably run us
- * into an infinite loop
- */
-static void dbgMutexCancelCleanupHdlr(void *pmut)
-{
-	pthread_mutex_unlock((pthread_mutex_t*) pmut);
-}
-
-
-/* ------------------------- mutex tracking code ------------------------- */
-
-/* ------------------------- FuncDB utility functions ------------------------- */
-
-#define SIZE_FUNCDB_MUTEX_TABLE(pFuncDB) ((int) (sizeof(pFuncDB->mutInfo) / sizeof(dbgFuncDBmutInfoEntry_t)))
-
-/* print a FuncDB
- */
-static void dbgFuncDBPrint(dbgFuncDB_t *pFuncDB)
-{
-	assert(pFuncDB != NULL);
-	assert(pFuncDB->magic == dbgFUNCDB_MAGIC);
-	/* make output suitable for sorting on invocation count */
-	dbgprintf("%10.10ld times called: %s:%d:%s\n", pFuncDB->nTimesCalled, pFuncDB->file, pFuncDB->line,
-		pFuncDB->func);
-}
-
-
-/* print all funcdb entries
- */
-static void dbgFuncDBPrintAll(void)
-{
-	dbgFuncDBListEntry_t *pFuncDBList;
-	int nFuncs = 0;
-
-	for(pFuncDBList = pFuncDBListRoot ; pFuncDBList != NULL ; pFuncDBList = pFuncDBList->pNext) {
-		dbgFuncDBPrint(pFuncDBList->pFuncDB);
-		nFuncs++;
-	}
-
-	dbgprintf("%d unique functions called\n", nFuncs);
-}
-
-
-/* ------------------------- END FuncDB utility functions ------------------------- */
 
 /* output the current thread ID to "relevant" places
  * (what "relevant" means is determinded by various ways)
@@ -213,152 +86,47 @@ dbgOutputTID(char* name __attribute__((unused)))
 }
 
 
-/* ------------------------- end mutex tracking code ------------------------- */
-
-
-/* ------------------------- thread tracking code ------------------------- */
-
-/* get ptr to call stack - if none exists, create a new stack
- */
-static dbgThrdInfo_t *dbgGetThrdInfo(void)
-{
-	dbgThrdInfo_t *pThrd;
-
-	pthread_mutex_lock(&mutCallStack);
-	if((pThrd = pthread_getspecific(keyCallStack)) == NULL) {
-		/* construct object */
-		if((pThrd = calloc(1, sizeof(dbgThrdInfo_t))) != NULL) {
-			pThrd->thrd = pthread_self();
-			(void) pthread_setspecific(keyCallStack, pThrd);
-			DLL_Add(CallStack, pThrd);
-		}
-	}
-	pthread_mutex_unlock(&mutCallStack);
-	return pThrd;
-}
-
-
-
-/* find a specific thread ID. It must be present, else something is wrong
- */
-static dbgThrdInfo_t *
-dbgFindThrd(pthread_t thrd)
-{
-	dbgThrdInfo_t *pThrd;
-
-	for(pThrd = dbgCallStackListRoot ; pThrd != NULL ; pThrd = pThrd->pNext) {
-		if(pThrd->thrd == thrd)
-			break;
-	}
-	return pThrd;
-}
-
-
 /* build a string with the thread name. If none is set, the thread ID is
- * used instead. Caller must provide buffer space. If bIncludeNumID is set
- * to 1, the numerical ID is always included.
+ * used instead. Caller must provide buffer space. 
  * rgerhards 2008-01-23
  */
-static void dbgGetThrdName(char *pszBuf, size_t lenBuf, pthread_t thrd, int bIncludeNumID)
+static void ATTR_NONNULL()
+dbgGetThrdName(char *const pszBuf, const size_t lenBuf, const pthread_t thrdID) 
 {
-	dbgThrdInfo_t *pThrd;
-
 	assert(pszBuf != NULL);
 
-	pThrd = dbgFindThrd(thrd);
-
-	if(pThrd == 0 || pThrd->pszThrdName == NULL) {
-		/* no thread name, use numeric value  */
-		snprintf(pszBuf, lenBuf, "%lx", (long) thrd);
+	const char *const thrdName = pthread_getspecific(keyThrdName);
+	if(thrdName == NULL) {
+		snprintf(pszBuf, lenBuf, "%lx", (long) thrdID);
 	} else {
-		if(bIncludeNumID) {
-			snprintf(pszBuf, lenBuf, "%-15s (%lx)", pThrd->pszThrdName, (long) thrd);
-		} else {
-			snprintf(pszBuf, lenBuf, "%-15s", pThrd->pszThrdName);
-		}
+		snprintf(pszBuf, lenBuf, "%-15s", thrdName);
 	}
 }
 
 
-/* set a name for the current thread. The caller provided string is duplicated.
- * Note: we must lock the "dbgprint" mutex, because dbgprint() uses the thread
- * name and we could get a race (and abort) in cases where both are executed in
- * parallel and we free or incompletely-copy the string.
- */
+/* set a name for the current thread */
 void dbgSetThrdName(uchar *pszName)
 {
-	pthread_mutex_lock(&mutdbgprint);
-	dbgThrdInfo_t *pThrd = dbgGetThrdInfo();
-	if(pThrd->pszThrdName != NULL)
-		free(pThrd->pszThrdName);
-	pThrd->pszThrdName = strdup((char*)pszName);
-	pthread_mutex_unlock(&mutdbgprint);
+	(void) pthread_setspecific(keyThrdName, strdup((char*) pszName));
 }
 
 
-/* destructor for a call stack object */
-static void dbgCallStackDestruct(void *arg)
+/* destructor for thread name (called by pthreads!) */
+static void dbgThrdNameDestruct(void *arg)
 {
-	dbgThrdInfo_t *pThrd = (dbgThrdInfo_t*) arg;
-
-	dbgprintf("destructor for debug call stack %p called\n", pThrd);
-	if(pThrd->pszThrdName != NULL) {
-		free(pThrd->pszThrdName);
-	}
-
-	pthread_mutex_lock(&mutCallStack);
-	DLL_Del(CallStack, pThrd);
-	pthread_mutex_unlock(&mutCallStack);
+	free(arg);
 }
 
 
-/* print a thread's call stack
+/* write the debug message. This is a helper to dbgprintf and dbgoprint which
+ * contains common code. added 2008-09-26 rgerhards
+ * Note: We need to split the function due to the bad nature of POSIX
+ * cancel cleanup handlers.
  */
-static void dbgCallStackPrint(dbgThrdInfo_t *pThrd)
+static void DBGL_UNUSED
+dbgprint(obj_t *pObj, char *pszMsg, const char *pszFileName, const size_t lenMsg)
 {
-	int i;
-	char pszThrdName[64];
-
-	pthread_mutex_lock(&mutCallStack);
-	dbgGetThrdName(pszThrdName, sizeof(pszThrdName), pThrd->thrd, 1);
-	dbgprintf("\n");
-	dbgprintf("Recorded Call Order for Thread '%s':\n", pszThrdName);
-	for(i = 0 ; i < pThrd->stackPtr ; i++) {
-		dbgprintf("%d: %s:%d:%s:\n", i, pThrd->callStack[i]->file, pThrd->lastLine[i],
-			pThrd->callStack[i]->func);
-	}
-	dbgprintf("maximum number of nested calls for this thread: %d.\n", pThrd->stackPtrMax);
-	dbgprintf("NOTE: not all calls may have been recorded, code does not currently guarantee that!\n");
-	pthread_mutex_unlock(&mutCallStack);
-}
-
-/* print all threads call stacks
- */
-static void dbgCallStackPrintAll(void)
-{
-	dbgThrdInfo_t *pThrd;
-	/* stack info */
-	for(pThrd = dbgCallStackListRoot ; pThrd != NULL ; pThrd = pThrd->pNext) {
-		dbgCallStackPrint(pThrd);
-	}
-}
-
-static
-void dbgPrintAllDebugInfo(void)
-{
-	dbgCallStackPrintAll();
-	if(bPrintFuncDBOnExit)
-		dbgFuncDBPrintAll();
-}
-
-
-/* actually write the debug message. This is a separate fuction because the cleanup_push/_pop
- * interface otherwise is unsafe to use (generates compiler warnings at least).
- * 2009-05-20 rgerhards
- */
-static void
-do_dbgprint(uchar *pszObjName, char *pszMsg, const char *pszFileName, size_t lenMsg)
-{
+	uchar *pszObjName = NULL;
 	static pthread_t ptLastThrdID = 0;
 	static int bWasNL = 0;
 	char pszThrdName[64]; /* 64 is to be on the safe side, anything over 20 is bad... */
@@ -371,7 +139,10 @@ do_dbgprint(uchar *pszObjName, char *pszMsg, const char *pszFileName, size_t len
 	struct timeval tv;
 #	endif
 
-#if 1
+	if(pObj != NULL) {
+		pszObjName = obj.GetName(pObj);
+	}
+
 	/* The bWasNL handler does not really work. It works if no thread
 	 * switching occurs during non-NL messages. Else, things are messed
 	 * up. Anyhow, it works well enough to provide useful help during
@@ -389,10 +160,7 @@ do_dbgprint(uchar *pszObjName, char *pszMsg, const char *pszFileName, size_t len
 		ptLastThrdID = pthread_self();
 	}
 
-	/* do not cache the thread name, as the caller might have changed it
-	 * TODO: optimized, invalidate cache when new name is set
-	 */
-	dbgGetThrdName(pszThrdName, sizeof(pszThrdName), ptLastThrdID, 0);
+	dbgGetThrdName(pszThrdName, sizeof(pszThrdName), ptLastThrdID);
 
 	if(bWasNL) {
 		if(bPrintTime) {
@@ -422,7 +190,6 @@ do_dbgprint(uchar *pszObjName, char *pszMsg, const char *pszFileName, size_t len
 			"%s: ", pszFileName);
 		offsWriteBuf += lenWriteBuf;
 	}
-#endif
 	if(lenMsg > sizeof(pszWriteBuf) - offsWriteBuf)
 		lenCopy = sizeof(pszWriteBuf) - offsWriteBuf;
 	else
@@ -447,42 +214,10 @@ do_dbgprint(uchar *pszObjName, char *pszMsg, const char *pszFileName, size_t len
 	bWasNL = (pszMsg[lenMsg - 1] == '\n') ? 1 : 0;
 }
 
-static void
-dbgprintfWithCancelHdlr(uchar *const pszObjName, char *pszMsg,
-	const char *pszFileName, const size_t lenMsg)
-{
-	pthread_mutex_lock(&mutdbgprint);
-	pthread_cleanup_push(dbgMutexCancelCleanupHdlr, &mutdbgprint);
-	do_dbgprint(pszObjName, pszMsg, pszFileName, lenMsg);
-	pthread_cleanup_pop(1);
-}
-/* write the debug message. This is a helper to dbgprintf and dbgoprint which
- * contains common code. added 2008-09-26 rgerhards
- * Note: We need to split the function due to the bad nature of POSIX
- * cancel cleanup handlers.
- */
-static void DBGL_UNUSED
-dbgprint(obj_t *pObj, char *pszMsg, const char *pszFileName, const size_t lenMsg)
-{
-	uchar *pszObjName = NULL;
-
-	/* we must get the object name before we lock the mutex, because the object
-	 * potentially calls back into us. If we locked the mutex, we would deadlock
-	 * ourselfs. On the other hand, the GetName call needs not to be protected, as
-	 * this thread has a valid reference. If such an object is deleted by another
-	 * thread, we are in much more trouble than just for dbgprint(). -- rgerhards, 2008-09-26
-	 */
-	if(pObj != NULL) {
-		pszObjName = obj.GetName(pObj);
-	}
-
-	dbgprintfWithCancelHdlr(pszObjName, pszMsg, pszFileName, lenMsg);
-}
 
 static int DBGL_UNUSED
 checkDbgFile(const char *srcname)
 {
-
 	if(glblDbgFilesNum == 0) {
 		return 1;
 	}
@@ -520,16 +255,6 @@ r_dbgoprint( const char *srcname, obj_t *pObj, const char *fmt, ...)
 	if(!checkDbgFile(srcname)) {
 		return;
 	}
-
-	/* a quick and very dirty hack to enable us to display just from those objects
-	 * that we are interested in. So far, this must be changed at compile time (and
-	 * chances are great it is commented out while you read it. Later, this shall
-	 * be selectable via the environment. -- rgerhards, 2008-02-20
-	 */
-#if 0
-	if(objGetObjID(pObj) != OBJexpr)
-		return;
-#endif
 
 	va_start(ap, fmt);
 	lenWriteBuf = vsnprintf(pszWriteBuf, sizeof(pszWriteBuf), fmt, ap);
@@ -582,15 +307,6 @@ r_dbgprintf(const char *srcname, const char *fmt, ...)
 }
 #endif
 
-
-/* Handler for SIGUSR2. Dumps all available debug output
- */
-static void sigusr2Hdlr(int __attribute__((unused)) signum)
-{
-	dbgprintf("SIGUSR2 received, dumping debug information\n");
-	dbgPrintAllDebugInfo();
-}
-
 /* support system to set debug options at runtime */
 
 
@@ -600,76 +316,36 @@ static void sigusr2Hdlr(int __attribute__((unused)) signum)
  * processed. -- rgerhards, 2008-02-28
  */
 static int
-dbgGetRTOptNamVal(uchar **ppszOpt, uchar **ppOptName, uchar **ppOptVal)
+dbgGetRTOptNamVal(uchar **ppszOpt, uchar **ppOptName)
 {
 	int bRet = 0;
 	uchar *p;
 	size_t i;
-	static uchar optname[128]; /* not thread- or reentrant-safe, but that      */
-	static uchar optval[1024]; /* doesn't matter (called only once at startup) */
+	static uchar optname[128] = "";
 
 	assert(ppszOpt != NULL);
 	assert(*ppszOpt != NULL);
-
-	/* make sure we have some initial values */
-	optname[0] = '\0';
-	optval[0] = '\0';
 
 	p = *ppszOpt;
 	/* skip whitespace */
 	while(*p && isspace(*p))
 		++p;
 
-	/* name - up until '=' or whitespace */
+	/* name - up until whitespace */
 	i = 0;
-	while(i < (sizeof(optname) - 1) && *p && *p != '=' && !isspace(*p)) {
+	while(i < (sizeof(optname) - 1) && *p && !isspace(*p)) {
 		optname[i++] = *p++;
 	}
 
 	if(i > 0) {
 		bRet = 1;
 		optname[i] = '\0';
-		if(*p == '=') {
-			/* we have a value, get it */
-			++p;
-			i = 0;
-			while(i < (sizeof(optval) - 1) && *p && !isspace(*p)) {
-				optval[i++] = *p++;
-			}
-			optval[i] = '\0';
-		}
 	}
 
 	/* done */
 	*ppszOpt = p;
 	*ppOptName = optname;
-	*ppOptVal = optval;
 	return bRet;
-}
-
-
-/* create new PrintName list entry and add it to list (they will never
- * be removed. -- rgerhards, 2008-02-28
- */
-static void
-dbgPrintNameAdd(uchar *pName, dbgPrintName_t **ppRoot)
-{
-	dbgPrintName_t *pEntry;
-
-	if((pEntry = calloc(1, sizeof(dbgPrintName_t))) == NULL) {
-		fprintf(stderr, "ERROR: out of memory during debug setup\n");
-		exit(1);
-	}
-
-	if((pEntry->pName = (uchar*) strdup((char*) pName)) == NULL) {
-		fprintf(stderr, "ERROR: out of memory during debug setup\n");
-		exit(1);
-	}
-
-	if(*ppRoot != NULL) {
-		pEntry->pNext = *ppRoot; /* we enqueue at the front */
-	}
-	*ppRoot = pEntry;
 }
 
 
@@ -689,30 +365,23 @@ static void
 dbgGetRuntimeOptions(void)
 {
 	uchar *pszOpts;
-	uchar *optval;
 	uchar *optname;
 
 	/* set some defaults */
 	if((pszOpts = (uchar*) getenv("RSYSLOG_DEBUG")) != NULL) {
 		/* we have options set, so let's process them */
-		while(dbgGetRTOptNamVal(&pszOpts, &optname, &optval)) {
+		while(dbgGetRTOptNamVal(&pszOpts, &optname)) {
 			if(!strcasecmp((char*)optname, "help")) {
 				fprintf(stderr,
 					"rsyslogd " VERSION " runtime debug support - help requested, "
 					"rsyslog terminates\n\nenvironment variables:\n"
-					"addional logfile: export RSYSLOG_DEBUGFILE=\"/path/to/file\"\n"
+					"additional logfile: export RSYSLOG_DEBUGFILE=\"/path/to/file\"\n"
 					"to set: export RSYSLOG_DEBUG=\"cmd cmd cmd\"\n\n"
 					"Commands are (all case-insensitive):\n"
-					"help (this list, terminates rsyslogd\n"
-					"LogFuncFlow\n"
-					"LogAllocFree (very partly implemented)\n"
-					"PrintFuncDB\n"
-					"PrintMutexAction\n"
-					"PrintAllDebugInfoOnExit (not yet implemented)\n"
+					"help (this list, terminates rsyslogd)\n"
 					"NoLogTimestamp\n"
-					"Nostdoout\n"
+					"Nostdout\n"
 					"OutputTidToStderr\n"
-					"filetrace=file (may be provided multiple times)\n"
 					"DebugOnDemand - enables debugging on USR1, but does not turn on output\n"
 					"\nSee debug.html in your doc set or http://www.rsyslog.com for details\n");
 				exit(1);
@@ -729,36 +398,15 @@ dbgGetRuntimeOptions(void)
 				dbgprintf("Note: debug on demand turned on via configuraton file, "
 					  "use USR1 signal to activate.\n");
 				debugging_on = 0;
-			} else if(!strcasecmp((char*)optname, "logfuncflow")) {
-				bLogFuncFlow = 1;
-			} else if(!strcasecmp((char*)optname, "logallocfree")) {
-				bLogAllocFree = 1;
-			} else if(!strcasecmp((char*)optname, "printfuncdb")) {
-				bPrintFuncDBOnExit = 1;
-			} else if(!strcasecmp((char*)optname, "printmutexaction")) {
-				bPrintMutexAction = 1;
-			} else if(!strcasecmp((char*)optname, "printalldebuginfoonexit")) {
-				bPrintAllDebugOnExit = 1;
 			} else if(!strcasecmp((char*)optname, "nologtimestamp")) {
 				bPrintTime = 0;
 			} else if(!strcasecmp((char*)optname, "nostdout")) {
 				stddbg = -1;
-			} else if(!strcasecmp((char*)optname, "noaborttrace")) {
-				bAbortTrace = 0;
 			} else if(!strcasecmp((char*)optname, "outputtidtostderr")) {
 				bOutputTidToStderr = 1;
-			} else if(!strcasecmp((char*)optname, "filetrace")) {
-				if(*optval == '\0') {
-					fprintf(stderr, "rsyslogd " VERSION " error: logfile debug option requires "
-					"filename, e.g. \"logfile=debug.c\"\n");
-					exit(1);
-				} else {
-					/* create new entry and add it to list */
-					dbgPrintNameAdd(optval, &printNameFileRoot);
-				}
 			} else {
-				fprintf(stderr, "rsyslogd " VERSION " error: invalid debug option '%s', "
-					"value '%s' - ignored\n", optval, optname);
+				fprintf(stderr, "rsyslogd " VERSION " error: invalid debug option '%s' "
+					"- ignored\n", optname);
 			}
 		}
 	}
@@ -788,38 +436,16 @@ dbgSetDebugFile(uchar *fn)
 
 rsRetVal dbgClassInit(void)
 {
-	pthread_mutexattr_t mutAttr;
 	rsRetVal iRet;	/* do not use DEFiRet, as this makes calls into the debug system! */
 
-	struct sigaction sigAct;
-	sigset_t sigSet;
 	
-	(void) pthread_key_create(&keyCallStack, dbgCallStackDestruct); /* MUST be the first action done! */
-
-	/* the mutexes must be recursive, because it may be called from within
-	 * signal handlers, which can lead to a hang if the signal interrupted dbgprintf
-	 * (yes, we have really seen that situation in practice!). -- rgerhards, 2013-05-17
-	 */
-	pthread_mutexattr_init(&mutAttr);
-	pthread_mutexattr_settype(&mutAttr, PTHREAD_MUTEX_RECURSIVE);
-	pthread_mutex_init(&mutFuncDBList, &mutAttr);
-	pthread_mutex_init(&mutCallStack, &mutAttr);
-	pthread_mutex_init(&mutdbgprint, &mutAttr);
+	(void) pthread_key_create(&keyThrdName, dbgThrdNameDestruct);
 
 	/* while we try not to use any of the real rsyslog code (to avoid infinite loops), we
 	 * need to have the ability to query object names. Thus, we need to obtain a pointer to
 	 * the object interface. -- rgerhards, 2008-02-29
 	 */
 	CHKiRet(objGetObjInterface(&obj)); /* this provides the root pointer for all other queries */
-
-	memset(&sigAct, 0, sizeof (sigAct));
-	sigemptyset(&sigAct.sa_mask);
-	sigAct.sa_handler = sigusr2Hdlr;
-	sigaction(SIGUSR2, &sigAct, NULL);
-
-	sigemptyset(&sigSet);
-	sigaddset(&sigSet, SIGUSR2);
-	pthread_sigmask(SIG_UNBLOCK, &sigSet, NULL);
 
 	const char *dbgto2stderr;
 	dbgto2stderr = getenv("RSYSLOG_DEBUG_TIMEOUTS_TO_STDERR");
@@ -848,27 +474,8 @@ finalize_it:
 
 rsRetVal dbgClassExit(void)
 {
-	dbgFuncDBListEntry_t *pFuncDBListEtry, *pToDel;
-	pthread_key_delete(keyCallStack);
-
-	if(bPrintAllDebugOnExit)
-		dbgPrintAllDebugInfo();
-
+	pthread_key_delete(keyThrdName);
 	if(altdbg != -1)
 		close(altdbg);
-
-	/* now free all of our memory to make the memory debugger happy... */
-	pFuncDBListEtry = pFuncDBListRoot;
-	while(pFuncDBListEtry != NULL) {
-		pToDel = pFuncDBListEtry;
-		pFuncDBListEtry = pFuncDBListEtry->pNext;
-		free(pToDel->pFuncDB->file);
-		free(pToDel->pFuncDB->func);
-		free(pToDel->pFuncDB);
-		free(pToDel);
-	}
-
 	return RS_RET_OK;
 }
-/* vi:set ai:
- */

--- a/runtime/debug.c
+++ b/runtime/debug.c
@@ -51,7 +51,6 @@
 
 #include "rsyslog.h"
 #include "debug.h"
-#include "atomic.h"
 #include "cfsysline.h"
 #include "obj.h"
 
@@ -87,11 +86,10 @@ dbgOutputTID(char* name __attribute__((unused)))
 
 
 /* build a string with the thread name. If none is set, the thread ID is
- * used instead. Caller must provide buffer space. 
- * rgerhards 2008-01-23
+ * used instead. Caller must provide buffer space.
  */
 static void ATTR_NONNULL()
-dbgGetThrdName(char *const pszBuf, const size_t lenBuf, const pthread_t thrdID) 
+dbgGetThrdName(char *const pszBuf, const size_t lenBuf, const pthread_t thrdID)
 {
 	assert(pszBuf != NULL);
 
@@ -105,7 +103,8 @@ dbgGetThrdName(char *const pszBuf, const size_t lenBuf, const pthread_t thrdID)
 
 
 /* set a name for the current thread */
-void dbgSetThrdName(uchar *pszName)
+void ATTR_NONNULL()
+dbgSetThrdName(const uchar *const pszName)
 {
 	(void) pthread_setspecific(keyThrdName, strdup((char*) pszName));
 }
@@ -315,23 +314,22 @@ r_dbgprintf(const char *srcname, const char *fmt, ...)
  * otherwise. 0 means there are NO MORE options to be
  * processed. -- rgerhards, 2008-02-28
  */
-static int
-dbgGetRTOptNamVal(uchar **ppszOpt, uchar **ppOptName)
+static int ATTR_NONNULL()
+dbgGetRTOptNamVal(const uchar **const ppszOpt, uchar **const ppOptName)
 {
 	int bRet = 0;
-	uchar *p;
+	const uchar *p = *ppszOpt;
 	size_t i;
 	static uchar optname[128] = "";
 
 	assert(ppszOpt != NULL);
 	assert(*ppszOpt != NULL);
 
-	p = *ppszOpt;
 	/* skip whitespace */
 	while(*p && isspace(*p))
 		++p;
 
-	/* name - up until whitespace */
+	/* name: up until whitespace */
 	i = 0;
 	while(i < (sizeof(optname) - 1) && *p && !isspace(*p)) {
 		optname[i++] = *p++;
@@ -364,7 +362,7 @@ dbgGetDbglogFd(void)
 static void
 dbgGetRuntimeOptions(void)
 {
-	uchar *pszOpts;
+	const uchar *pszOpts;
 	uchar *optname;
 
 	/* set some defaults */

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -43,7 +43,7 @@ rsRetVal dbgClassInit(void);
 rsRetVal dbgClassExit(void);
 void dbgSetDebugFile(uchar *fn);
 void dbgSetDebugLevel(int level);
-void dbgSetThrdName(uchar *pszName);
+void dbgSetThrdName(const uchar *pszName);
 void dbgOutputTID(char* name);
 int dbgGetDbglogFd(void);
 
@@ -68,23 +68,11 @@ extern int altdbg;	/* and the handle for alternate debug output */
 #define dbgprintf(...) r_dbgprintf(__FILE__, __VA_ARGS__)
 #define dbgoprint(...) r_dbgoprint(__FILE__, __VA_ARGS__)
 
-/* things originally introduced for now remove rtinst */
-#define BEGINfunc
-#define ENDfunc
-#define ENDfuncIRet
-#define ASSERT(x) assert(x)
-#define RUNLOG
-#define RUNLOG_VAR(fmt, x)
-#define RUNLOG_STR(str)
-
-/* this macro is needed to support old, no longer used --enable-memcheck setting (now we use ASAN/valgrind!) */
-#define MALLOC(x) malloc(x)
-
 /* things originally introduced for now removed rtinst */
 #define d_pthread_mutex_lock(x)     pthread_mutex_lock(x)
 #define d_pthread_mutex_trylock(x)  pthread_mutex_trylock(x)
 #define d_pthread_mutex_unlock(x)   pthread_mutex_unlock(x)
 #define d_pthread_cond_wait(cond, mut)   pthread_cond_wait(cond, mut)
 #define d_pthread_cond_timedwait(cond, mut, to)   pthread_cond_timedwait(cond, mut, to)
-#define d_free(x)      free(x)
+
 #endif /* #ifndef DEBUG_H_INCLUDED */

--- a/runtime/debug.h
+++ b/runtime/debug.h
@@ -1,9 +1,8 @@
 /* debug.h
  *
- * Definitions for the debug and run-time analysis support module.
- * Contains a lot of macros.
+ * Definitions for the debug module.
  *
- * Copyright 2008-2012 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -37,54 +36,6 @@ extern int Debug;		/* debug flag  - read-only after startup */
 extern int debugging_on;	 /* read-only, except on sig USR1 */
 extern int stddbg; /* the handle for regular debug output, set to stdout if not forking, -1 otherwise */
 extern int dbgTimeoutToStderr;
-
-/* data types */
-
-/* the function database. It is used as a static var inside each function. That provides
- * us the fast access to it that we need to make the instrumentation work. It's address
- * also serves as a unique function identifier and can be used inside other structures
- * to refer to the function (e.g. for pretty-printing names).
- * rgerhards, 2008-01-24
- */
-typedef struct dbgFuncDBmutInfoEntry_s {
-	pthread_mutex_t *pmut;
-	int lockLn; /* line where it was locked (inside our func): -1 means mutex is not locked */
-	pthread_t thrd; /* thrd where the mutex was locked */
-	unsigned long lInvocation; /* invocation (unique during program run!) of this function that locked the mutex */
-} dbgFuncDBmutInfoEntry_t;
-typedef struct dbgFuncDB_s {
-	unsigned magic;
-	unsigned long nTimesCalled;
-	char *func;
-	char *file;
-	int line;
-	dbgFuncDBmutInfoEntry_t mutInfo[5];
-	/* remember to update the initializer if you add anything or change the order! */
-} dbgFuncDB_t;
-#define dbgFUNCDB_MAGIC 0xA1B2C3D4
-#define dbgFuncDB_t_INITIALIZER \
-	{ \
-	.magic = dbgFUNCDB_MAGIC,\
-	.nTimesCalled = 0,\
-	.func = __func__, \
-	.file = __FILE__, \
-	.line = __LINE__ \
-	}
-
-/* the structure below was originally just the thread's call stack, but it has
- * a bit evolved over time. So we have now ended up with the fact that it
- * all debug info we know about the thread.
- */
-typedef struct dbgCallStack_s {
-	pthread_t thrd;
-	dbgFuncDB_t *callStack[500];
-	int lastLine[500]; /* last line where code execution was seen */
-	int stackPtr;
-	int stackPtrMax;
-	char *pszThrdName;
-	struct dbgCallStack_s *pNext;
-	struct dbgCallStack_s *pPrev;
-} dbgThrdInfo_t;
 
 
 /* prototypes */
@@ -128,11 +79,6 @@ extern int altdbg;	/* and the handle for alternate debug output */
 
 /* this macro is needed to support old, no longer used --enable-memcheck setting (now we use ASAN/valgrind!) */
 #define MALLOC(x) malloc(x)
-
-#define MUTOP_LOCKWAIT		1
-#define MUTOP_LOCK		2
-#define MUTOP_UNLOCK		3
-#define MUTOP_TRYLOCK		4
 
 /* things originally introduced for now removed rtinst */
 #define d_pthread_mutex_lock(x)     pthread_mutex_lock(x)

--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -405,7 +405,7 @@ addEntry(struct sockaddr_storage *const addr, dnscache_entry_t **const pEtry)
 	}
 
 	/* entry still does not exist, so add it */
-	CHKmalloc(etry = MALLOC(sizeof(dnscache_entry_t)));
+	CHKmalloc(etry = malloc(sizeof(dnscache_entry_t)));
 	CHKmalloc(keybuf = malloc(sizeof(struct sockaddr_storage)));
 	CHKiRet(resolveAddr(addr, etry));
 	memcpy(&etry->addr, addr, SALEN((struct sockaddr*) addr));

--- a/runtime/gss-misc.c
+++ b/runtime/gss-misc.c
@@ -190,7 +190,7 @@ static int recv_token(int s, gss_buffer_t tok)
 	       | lenbuf[3]);
 	tok->length = ntohl(len);
 
-	tok->value = (char *) MALLOC(tok->length ? tok->length : 1);
+	tok->value = (char *) malloc(tok->length ? tok->length : 1);
 	if (tok->length && tok->value == NULL) {
 		LogError(0, NO_ERRCODE, "Out of memory allocating token data\n");
 		return -1;

--- a/runtime/module-template.h
+++ b/runtime/module-template.h
@@ -145,7 +145,6 @@ static rsRetVal createInstance(instanceData **ppData)\
 #define CODESTARTcreateInstance \
 	if((pData = calloc(1, sizeof(instanceData))) == NULL) {\
 		*ppData = NULL;\
-		ENDfunc \
 		return RS_RET_OUT_OF_MEMORY;\
 	}
 
@@ -189,7 +188,6 @@ static rsRetVal createWrkrInstance(wrkrInstanceData_t **ppWrkrData, instanceData
 #define CODESTARTcreateWrkrInstance \
 	if((pWrkrData = calloc(1, sizeof(wrkrInstanceData_t))) == NULL) {\
 		*ppWrkrData = NULL;\
-		ENDfunc \
 		return RS_RET_OUT_OF_MEMORY;\
 	} \
 	pWrkrData->pData = pData;
@@ -222,7 +220,6 @@ static rsRetVal freeWrkrInstance(void* pd)\
 static rsRetVal isCompatibleWithFeature(syslogFeature __attribute__((unused)) eFeat)\
 {\
 	rsRetVal iRet = RS_RET_INCOMPATIBLE; \
-	BEGINfunc
 
 #define CODESTARTisCompatibleWithFeature
 
@@ -532,7 +529,6 @@ static rsRetVal queryEtryPt(uchar *name, rsRetVal (**pEtryPoint)())\
 
 #define CODESTARTqueryEtryPt \
 	if((name == NULL) || (pEtryPoint == NULL)) {\
-		ENDfunc \
 		return RS_RET_PARAM_ERROR;\
 	} \
 	*pEtryPoint = NULL;
@@ -809,7 +805,6 @@ modInfo_t __attribute__((unused)) *pModInfo)\
 	iRet = pHostQueryEtryPt((uchar*)"objGetObjInterface", &pObjGetObjInterface); \
 	if((iRet != RS_RET_OK) || (pQueryEtryPt == NULL) || (ipIFVersProvided == NULL) || \
 		(pObjGetObjInterface == NULL)) { \
-		ENDfunc \
 		return (iRet == RS_RET_OK) ? RS_RET_PARAM_ERROR : iRet; \
 	} \
 	/* now get the obj interface so that we can access other objects */ \
@@ -895,7 +890,6 @@ static rsRetVal beginCnfLoad(modConfData_t **ptr, __attribute__((unused)) rsconf
 #define CODESTARTbeginCnfLoad \
 	if((pModConf = calloc(1, sizeof(modConfData_t))) == NULL) {\
 		*ptr = NULL;\
-		ENDfunc \
 		return RS_RET_OUT_OF_MEMORY;\
 	}
 

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -129,7 +129,6 @@ modUsrAdd(modInfo_t *pThis, const char *pszUsr)
 {
 	modUsr_t *pUsr;
 
-	BEGINfunc
 	if((pUsr = calloc(1, sizeof(modUsr_t))) == NULL)
 		goto finalize_it;
 
@@ -144,7 +143,7 @@ modUsrAdd(modInfo_t *pThis, const char *pszUsr)
 	pThis->pModUsrRoot = pUsr;
 
 finalize_it:
-	ENDfunc;
+	return;
 }
 
 
@@ -206,13 +205,11 @@ modUsrPrintAll(void)
 {
 	modInfo_t *pMod;
 
-	BEGINfunc
 	for(pMod = pLoadedModules ; pMod != NULL ; pMod = pMod->pNext) {
 		dbgprintf("printing users of loadable module %s, refcount %u, ptr %p, type %d\n",
 		pMod->pszName, pMod->uRefCnt, pMod, pMod->eType);
 		modUsrPrint(pMod);
 	}
-	ENDfunc
 }
 
 #endif /* #ifdef DEBUG */
@@ -396,7 +393,7 @@ readyModForCnf(modInfo_t *pThis, cfgmodules_etry_t **ppNew, cfgmodules_etry_t **
 	 * pass it a pointer which it can populate with a pointer to its module conf.
 	 */
 
-	CHKmalloc(pNew = MALLOC(sizeof(cfgmodules_etry_t)));
+	CHKmalloc(pNew = malloc(sizeof(cfgmodules_etry_t)));
 	pNew->canActivate = 1;
 	pNew->next = NULL;
 	pNew->pMod = pThis;

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -532,14 +532,12 @@ finalize_it:
 void
 getInputName(const smsg_t * const pM, uchar **ppsz, int *const plen)
 {
-	BEGINfunc
 	if(pM == NULL || pM->pInputName == NULL) {
 		*ppsz = UCHAR_CONSTANT("");
 		*plen = 0;
 	} else {
 		prop.GetString(pM->pInputName, ppsz, plen);
 	}
-	ENDfunc
 }
 
 
@@ -548,7 +546,6 @@ getRcvFromIP(smsg_t * const pM)
 {
 	uchar *psz;
 	int len;
-	BEGINfunc
 	if(pM == NULL) {
 		psz = UCHAR_CONSTANT("");
 	} else {
@@ -558,7 +555,6 @@ getRcvFromIP(smsg_t * const pM)
 		else
 			prop.GetString(pM->pRcvFromIP, &psz, &len);
 	}
-	ENDfunc
 	return psz;
 }
 
@@ -824,7 +820,7 @@ msgBaseConstruct(smsg_t **ppThis)
 	smsg_t *pM;
 
 	assert(ppThis != NULL);
-	CHKmalloc(pM = MALLOC(sizeof(smsg_t)));
+	CHKmalloc(pM = malloc(sizeof(smsg_t)));
 	objConstructSetObjInfo(pM); /* intialize object helper entities */
 
 	/* initialize members in ORDER they appear in structure (think "cache line"!) */
@@ -1088,7 +1084,6 @@ smsg_t* MsgDup(smsg_t* pOld)
 
 	assert(pOld != NULL);
 
-	BEGINfunc
 	if(msgConstructWithTime(&pNew, &pOld->tTIMESTAMP, pOld->ttGenTime) != RS_RET_OK) {
 		return NULL;
 	}
@@ -1175,7 +1170,6 @@ smsg_t* MsgDup(smsg_t* pOld)
 	 * if they are needed once again. So we let them re-create if needed.
 	 */
 
-	ENDfunc
 	return pNew;
 }
 #undef tmpCOPYSZ
@@ -1604,7 +1598,7 @@ static void msgSetUUID(smsg_t * const pM)
 	dbgprintf("[MsgSetUUID] START, lenRes %llu\n", (long long unsigned) lenRes);
 	assert(pM != NULL);
 
-	if((pM->pszUUID = (uchar*) MALLOC(lenRes)) == NULL) {
+	if((pM->pszUUID = (uchar*) malloc(lenRes)) == NULL) {
 		pM->pszUUID = (uchar *)"";
 	} else {
 		pthread_mutex_lock(&mutUUID);
@@ -1762,7 +1756,6 @@ getPRI(smsg_t * const pM)
 const char *
 getTimeReported(smsg_t * const pM, enum tplFormatTypes eFmt)
 {
-	BEGINfunc
 	if(pM == NULL)
 		return "";
 
@@ -1781,7 +1774,7 @@ getTimeReported(smsg_t * const pM, enum tplFormatTypes eFmt)
 	case tplFmtMySQLDate:
 		MsgLock(pM);
 		if(pM->pszTIMESTAMP_MySQL == NULL) {
-			if((pM->pszTIMESTAMP_MySQL = MALLOC(15)) == NULL) {
+			if((pM->pszTIMESTAMP_MySQL = malloc(15)) == NULL) {
 				MsgUnlock(pM);
 				return "";
 			}
@@ -1792,7 +1785,7 @@ getTimeReported(smsg_t * const pM, enum tplFormatTypes eFmt)
 	case tplFmtPgSQLDate:
 		MsgLock(pM);
 		if(pM->pszTIMESTAMP_PgSQL == NULL) {
-			if((pM->pszTIMESTAMP_PgSQL = MALLOC(21)) == NULL) {
+			if((pM->pszTIMESTAMP_PgSQL = malloc(21)) == NULL) {
 				MsgUnlock(pM);
 				return "";
 			}
@@ -1855,7 +1848,6 @@ getTimeReported(smsg_t * const pM, enum tplFormatTypes eFmt)
 	case tplFmtWeek:
 		return two_digits[getWeek(&pM->tTIMESTAMP)];
 	}
-	ENDfunc
 	return "INVALID eFmt OPTION!";
 }
 
@@ -1867,45 +1859,44 @@ static const char *getTimeUTC(struct syslogTime *const __restrict__ pTmIn,
 {
 	struct syslogTime tUTC;
 	char *retbuf = NULL;
-	BEGINfunc
 
 	timeConvertToUTC(pTmIn, &tUTC);
 	struct syslogTime *const pTm = &tUTC;
 
 	switch(eFmt) {
 	case tplFmtDefault:
-		if((retbuf = MALLOC(16)) != NULL) {
+		if((retbuf = malloc(16)) != NULL) {
 			datetime.formatTimestamp3164(pTm, retbuf, 0);
 		}
 		break;
 	case tplFmtMySQLDate:
-		if((retbuf = MALLOC(15)) != NULL) {
+		if((retbuf = malloc(15)) != NULL) {
 			datetime.formatTimestampToMySQL(pTm, retbuf);
 		}
 		break;
 	case tplFmtPgSQLDate:
-		if((retbuf = MALLOC(21)) != NULL) {
+		if((retbuf = malloc(21)) != NULL) {
 			datetime.formatTimestampToPgSQL(pTm, retbuf);
 		}
 		break;
 	case tplFmtRFC3164Date:
 	case tplFmtRFC3164BuggyDate:
-		if((retbuf = MALLOC(16)) != NULL) {
+		if((retbuf = malloc(16)) != NULL) {
 			datetime.formatTimestamp3164(pTm, retbuf, (eFmt == tplFmtRFC3164BuggyDate));
 		}
 		break;
 	case tplFmtRFC3339Date:
-		if((retbuf = MALLOC(33)) != NULL) {
+		if((retbuf = malloc(33)) != NULL) {
 			datetime.formatTimestamp3339(pTm, retbuf);
 		}
 		break;
 	case tplFmtUnixDate:
-		if((retbuf = MALLOC(12)) != NULL) {
+		if((retbuf = malloc(12)) != NULL) {
 			datetime.formatTimestampUnix(pTm, retbuf);
 		}
 		break;
 	case tplFmtSecFrac:
-		if((retbuf = MALLOC(7)) != NULL) {
+		if((retbuf = malloc(7)) != NULL) {
 			datetime.formatTimestampSecFrac(pTm, retbuf);
 		}
 		break;
@@ -1959,7 +1950,6 @@ static const char *getTimeUTC(struct syslogTime *const __restrict__ pTmIn,
 	} else {
 		*pbMustBeFreed = 1;
 	}
-	ENDfunc
 	return retbuf;
 }
 
@@ -1967,7 +1957,6 @@ static const char *
 getTimeGenerated(smsg_t *const __restrict__ pM,
 	const enum tplFormatTypes eFmt)
 {
-	BEGINfunc
 	struct syslogTime *const pTm = &pM->tRcvdAt;
 	if(pM == NULL)
 		return "";
@@ -1976,7 +1965,7 @@ getTimeGenerated(smsg_t *const __restrict__ pM,
 	case tplFmtDefault:
 		MsgLock(pM);
 		if(pM->pszRcvdAt3164 == NULL) {
-			if((pM->pszRcvdAt3164 = MALLOC(16)) == NULL) {
+			if((pM->pszRcvdAt3164 = malloc(16)) == NULL) {
 				MsgUnlock(pM);
 				return "";
 			}
@@ -1987,7 +1976,7 @@ getTimeGenerated(smsg_t *const __restrict__ pM,
 	case tplFmtMySQLDate:
 		MsgLock(pM);
 		if(pM->pszRcvdAt_MySQL == NULL) {
-			if((pM->pszRcvdAt_MySQL = MALLOC(15)) == NULL) {
+			if((pM->pszRcvdAt_MySQL = malloc(15)) == NULL) {
 				MsgUnlock(pM);
 				return "";
 			}
@@ -1998,7 +1987,7 @@ getTimeGenerated(smsg_t *const __restrict__ pM,
 	case tplFmtPgSQLDate:
 		MsgLock(pM);
 		if(pM->pszRcvdAt_PgSQL == NULL) {
-			if((pM->pszRcvdAt_PgSQL = MALLOC(21)) == NULL) {
+			if((pM->pszRcvdAt_PgSQL = malloc(21)) == NULL) {
 				MsgUnlock(pM);
 				return "";
 			}
@@ -2010,7 +1999,7 @@ getTimeGenerated(smsg_t *const __restrict__ pM,
 	case tplFmtRFC3164BuggyDate:
 		MsgLock(pM);
 		if(pM->pszRcvdAt3164 == NULL) {
-			if((pM->pszRcvdAt3164 = MALLOC(16)) == NULL) {
+			if((pM->pszRcvdAt3164 = malloc(16)) == NULL) {
 					MsgUnlock(pM);
 					return "";
 				}
@@ -2022,7 +2011,7 @@ getTimeGenerated(smsg_t *const __restrict__ pM,
 	case tplFmtRFC3339Date:
 		MsgLock(pM);
 		if(pM->pszRcvdAt3339 == NULL) {
-			if((pM->pszRcvdAt3339 = MALLOC(33)) == NULL) {
+			if((pM->pszRcvdAt3339 = malloc(33)) == NULL) {
 				MsgUnlock(pM);
 				return "";
 			}
@@ -2077,7 +2066,6 @@ getTimeGenerated(smsg_t *const __restrict__ pM,
 	case tplFmtWeek:
 		return two_digits[getWeek(pTm)];
 	}
-	ENDfunc
 	return "INVALID eFmt OPTION!";
 }
 
@@ -2434,7 +2422,7 @@ void MsgSetTAG(smsg_t *__restrict__ const pMsg, const uchar* pszBuf, const size_
 		/* small enough: use fixed buffer (faster!) */
 		pBuf = pMsg->TAG.szBuf;
 	} else {
-		if((pBuf = (uchar*) MALLOC(pMsg->iLenTAG + 1)) == NULL) {
+		if((pBuf = (uchar*) malloc(pMsg->iLenTAG + 1)) == NULL) {
 			/* truncate message, better than completely loosing it... */
 			pBuf = pMsg->TAG.szBuf;
 			pMsg->iLenTAG = CONF_TAG_BUFSIZE - 1;
@@ -2551,7 +2539,6 @@ uchar *getRcvFrom(smsg_t * const pM)
 {
 	uchar *psz;
 	int len;
-	BEGINfunc
 
 	if(pM == NULL) {
 		psz = UCHAR_CONSTANT("");
@@ -2562,7 +2549,6 @@ uchar *getRcvFrom(smsg_t * const pM)
 		else
 			prop.GetString(pM->rcvFrom.pRcvFrom, &psz, &len);
 	}
-	ENDfunc
 	return psz;
 }
 
@@ -2761,10 +2747,8 @@ rsRetVal MsgSetRcvFromIP(smsg_t *pThis, prop_t *new)
 {
 	assert(pThis != NULL);
 
-	BEGINfunc
 	prop.AddRef(new);
 	MsgSetRcvFromIPWithoutAddRef(pThis, new);
-	ENDfunc
 	return RS_RET_OK;
 }
 
@@ -2810,7 +2794,7 @@ void MsgSetHOSTNAME(smsg_t *pThis, const uchar* pszHOSTNAME, const int lenHOSTNA
 	if(pThis->iLenHOSTNAME < CONF_HOSTNAME_BUFSIZE) {
 		/* small enough: use fixed buffer (faster!) */
 		pThis->pszHOSTNAME = pThis->szHOSTNAME;
-	} else if((pThis->pszHOSTNAME = (uchar*) MALLOC(pThis->iLenHOSTNAME + 1)) == NULL) {
+	} else if((pThis->pszHOSTNAME = (uchar*) malloc(pThis->iLenHOSTNAME + 1)) == NULL) {
 		/* truncate message, better than completely loosing it... */
 		pThis->pszHOSTNAME = pThis->szHOSTNAME;
 		pThis->iLenHOSTNAME = CONF_HOSTNAME_BUFSIZE - 1;
@@ -2862,7 +2846,7 @@ rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar* pszMSG, int lenMSG)
 	lenNew = pThis->iLenRawMsg + lenMSG - pThis->iLenMSG;
 	if(lenMSG > pThis->iLenMSG && lenNew >= CONF_RAWMSG_BUFSIZE) {
 		/*  we have lost our "bet" and need to alloc a new buffer ;) */
-		CHKmalloc(bufNew = MALLOC(lenNew + 1));
+		CHKmalloc(bufNew = malloc(lenNew + 1));
 		memcpy(bufNew, pThis->pszRawMsg, pThis->offMSG);
 		if(pThis->pszRawMsg != pThis->szRawMsg)
 			free(pThis->pszRawMsg);
@@ -2918,7 +2902,7 @@ MsgSetRawMsg(smsg_t *const pThis, const char*const pszRawMsg, const size_t lenMs
 	if(pThis->iLenRawMsg < CONF_RAWMSG_BUFSIZE) {
 		/* small enough: use fixed buffer (faster!) */
 		pThis->pszRawMsg = pThis->szRawMsg;
-	} else if((pThis->pszRawMsg = (uchar*) MALLOC(pThis->iLenRawMsg + 1)) == NULL) {
+	} else if((pThis->pszRawMsg = (uchar*) malloc(pThis->iLenRawMsg + 1)) == NULL) {
 		/* truncate message, better than completely loosing it... */
 		pThis->pszRawMsg = pThis->szRawMsg;
 		pThis->iLenRawMsg = CONF_RAWMSG_BUFSIZE - 1;
@@ -2955,7 +2939,7 @@ textpri(const smsg_t *const __restrict__ pMsg)
 	int lenfac = len_syslog_fac_names[pMsg->iFacility];
 	int lensev = len_syslog_severity_names[pMsg->iSeverity];
 	int totlen = lenfac + 1 + lensev + 1;
-	char *pRes = MALLOC(totlen);
+	char *pRes = malloc(totlen);
 	if(pRes != NULL) {
 		memcpy(pRes, syslog_fac_names[pMsg->iFacility], lenfac);
 		pRes[lenfac] = '.';
@@ -2979,7 +2963,7 @@ static uchar *getNOW(eNOWType eNow, struct syslogTime *t, const int inUTC)
 	uchar *pBuf;
 	struct syslogTime tt;
 
-	if((pBuf = (uchar*) MALLOC(tmpBUFSIZE)) == NULL) {
+	if((pBuf = (uchar*) malloc(tmpBUFSIZE)) == NULL) {
 		return NULL;
 	}
 
@@ -3472,7 +3456,6 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 	enum tplFormatTypes datefmt;
 	int bDateInUTC;
 
-	BEGINfunc
 	assert(pMsg != NULL);
 	assert(pbMustBeFreed != NULL);
 
@@ -3774,7 +3757,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			{
 			struct timespec tp;
 
-			if((pRes = (uchar*) MALLOC(32)) == NULL) {
+			if((pRes = (uchar*) malloc(32)) == NULL) {
 				RET_OUT_OF_MEMORY;
 			}
 
@@ -3794,7 +3777,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			{
 			struct sysinfo s_info;
 
-			if((pRes = (uchar*) MALLOC(32)) == NULL) {
+			if((pRes = (uchar*) malloc(32)) == NULL) {
 				RET_OUT_OF_MEMORY;
 			}
 
@@ -3873,7 +3856,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			/* we got our end pointer, now do the copy */
 			/* TODO: code copied from below, this is a candidate for a separate function */
 			iLen = pFldEnd - pFld + 1; /* the +1 is for an actual char, NOT \0! */
-			pBufStart = pBuf = MALLOC(iLen + 1);
+			pBufStart = pBuf = malloc(iLen + 1);
 			if(pBuf == NULL) {
 				if(*pbMustBeFreed == 1)
 					free(pRes);
@@ -3992,7 +3975,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 
 					iLenBuf = pmatch[pTpe->data.field.iSubMatchToUse].rm_eo
 						  - pmatch[pTpe->data.field.iSubMatchToUse].rm_so;
-					pB = MALLOC(iLenBuf + 1);
+					pB = malloc(iLenBuf + 1);
 
 					if (pB == NULL) {
 						if (*pbMustBeFreed == 1)
@@ -4067,7 +4050,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 					iTo = bufLen - 1;
 
 			iLen = iTo - iFrom + 1; /* the +1 is for an actual char, NOT \0! */
-			pBufStart = pBuf = MALLOC(iLen + 1);
+			pBufStart = pBuf = malloc(iLen + 1);
 			if(pBuf == NULL) {
 				if(*pbMustBeFreed == 1)
 					free(pRes);
@@ -4125,7 +4108,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			uchar *pBStart;
 			uchar *pB;
 			uchar *pSrc;
-			pBStart = pB = MALLOC(bufLen + 1);
+			pBStart = pB = malloc(bufLen + 1);
 			if(pB == NULL) {
 				if(*pbMustBeFreed == 1)
 					free(pRes);
@@ -4171,7 +4154,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			}
 
 			if(bDropped) {
-				pDst = pDstStart = MALLOC(iLenBuf + 1);
+				pDst = pDstStart = malloc(iLenBuf + 1);
 				if(pDst == NULL) {
 					if(*pbMustBeFreed == 1)
 						free(pRes);
@@ -4206,7 +4189,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			} else {
 				if(bufLen == -1)
 					bufLen = ustrlen(pRes);
-				pDst = pDstStart = MALLOC(bufLen + 1);
+				pDst = pDstStart = malloc(bufLen + 1);
 				if(pDst == NULL) {
 					if(*pbMustBeFreed == 1)
 						free(pRes);
@@ -4246,7 +4229,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 				int i;
 
 				iLenBuf += iNumCC * 4;
-				pBStart = pB = MALLOC(iLenBuf + 1);
+				pBStart = pB = malloc(iLenBuf + 1);
 				if(pB == NULL) {
 					if(*pbMustBeFreed == 1)
 						free(pRes);
@@ -4290,7 +4273,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			}
 
 			if(bDropped) {
-				pDst = pDstStart = MALLOC(iLenBuf + 1);
+				pDst = pDstStart = malloc(iLenBuf + 1);
 				if(pDst == NULL) {
 					if(*pbMustBeFreed == 1)
 						free(pRes);
@@ -4325,7 +4308,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			} else {
 				if(bufLen == -1)
 					bufLen = ustrlen(pRes);
-				pDst = pDstStart = MALLOC(bufLen + 1);
+				pDst = pDstStart = malloc(bufLen + 1);
 				if(pDst == NULL) {
 					if(*pbMustBeFreed == 1)
 						free(pRes);
@@ -4381,7 +4364,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			/* check if we need to obtain a private copy */
 			if(*pbMustBeFreed == 0) {
 				/* ok, original copy, need a private one */
-				pB = MALLOC(iLn + 1);
+				pB = malloc(iLn + 1);
 				if(pB == NULL) {
 					RET_OUT_OF_MEMORY;
 				}
@@ -4468,7 +4451,7 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			bufLen = ustrlen(pRes);
 		iBufLen = bufLen;
 		/* the malloc may be optimized, we currently use the worst case... */
-		pBStart = pDst = MALLOC(2 * iBufLen + 3);
+		pBStart = pDst = malloc(2 * iBufLen + 3);
 		if(pDst == NULL) {
 			if(*pbMustBeFreed == 1)
 				free(pRes);
@@ -4500,7 +4483,6 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 
 	*pPropLen = (bufLen == -1) ? (int) ustrlen(pRes) : bufLen;
 
-	ENDfunc
 	return(pRes);
 }
 

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -178,7 +178,7 @@ AddPermittedPeerWildcard(permittedPeers_t *pPeer, uchar* pszStr, size_t lenStr)
 		/* alloc memory for the domain component. We may waste a byte or
 		 * two, but that's ok.
 		 */
-		CHKmalloc(pNew->pszDomainPart = MALLOC(lenStr +1 ));
+		CHKmalloc(pNew->pszDomainPart = malloc(lenStr +1 ));
 	}
 
 	if(pszStr[0] == '*') {
@@ -710,7 +710,7 @@ static rsRetVal AddAllowedSender(struct AllowedSenders **ppRoot, struct AllowedS
 				case AF_INET: /* add IPv4 */
 					iSignificantBits = 32;
 					allowIP.flags = 0;
-					if((allowIP.addr.NetAddr = MALLOC(res->ai_addrlen)) == NULL) {
+					if((allowIP.addr.NetAddr = malloc(res->ai_addrlen)) == NULL) {
 						ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 					}
 					memcpy(allowIP.addr.NetAddr, res->ai_addr, res->ai_addrlen);
@@ -728,7 +728,7 @@ static rsRetVal AddAllowedSender(struct AllowedSenders **ppRoot, struct AllowedS
 						iSignificantBits = 32;
 						allowIP.flags = 0;
 						if((allowIP.addr.NetAddr = (struct sockaddr *)
-						MALLOC(sizeof(struct sockaddr))) == NULL) {
+						malloc(sizeof(struct sockaddr))) == NULL) {
 							ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 						}
 						SIN(allowIP.addr.NetAddr)->sin_family = AF_INET;
@@ -751,7 +751,7 @@ static rsRetVal AddAllowedSender(struct AllowedSenders **ppRoot, struct AllowedS
 
 						iSignificantBits = 128;
 						allowIP.flags = 0;
-						if((allowIP.addr.NetAddr = MALLOC(res->ai_addrlen)) == NULL) {
+						if((allowIP.addr.NetAddr = malloc(res->ai_addrlen)) == NULL) {
 							ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 						}
 						memcpy(allowIP.addr.NetAddr, res->ai_addr, res->ai_addrlen);
@@ -1484,7 +1484,7 @@ create_udp_socket(uchar *hostname,
 	/* Count max number of sockets we may open */
 	for (maxs = 0, r = res; r != NULL ; r = r->ai_next, maxs++)
 		/* EMPTY */;
-	socks = MALLOC((maxs+1) * sizeof(int));
+	socks = malloc((maxs+1) * sizeof(int));
 	if (socks == NULL) {
 		LogError(0, RS_RET_OUT_OF_MEMORY, "couldn't allocate memory for UDP "
 			"sockets, suspending UDP message reception");

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -146,7 +146,7 @@ readFile(uchar *pszFile, gnutls_datum_t *pBuf)
 		ABORT_FINALIZE(RS_RET_FILE_TOO_LARGE);
 	}
 
-	CHKmalloc(pBuf->data = MALLOC(stat_st.st_size));
+	CHKmalloc(pBuf->data = malloc(stat_st.st_size));
 	pBuf->size = stat_st.st_size;
 	if(read(fd,  pBuf->data, stat_st.st_size) != stat_st.st_size) {
 		LogError(0, RS_RET_IO_ERROR, "error or incomplete read of file '%s'", pszFile);
@@ -1619,7 +1619,7 @@ Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf, int *const oserr)
 
 	if(pThis->pszRcvBuf == NULL) {
 		/* we have no buffer, so we need to malloc one */
-		CHKmalloc(pThis->pszRcvBuf = MALLOC(NSD_GTLS_MAX_RCVBUF));
+		CHKmalloc(pThis->pszRcvBuf = malloc(NSD_GTLS_MAX_RCVBUF));
 		pThis->lenRcvBuf = -1;
 	}
 

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1352,7 +1352,7 @@ Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf, int *const oserr)
 
 	if(pThis->pszRcvBuf == NULL) {
 		/* we have no buffer, so we need to malloc one */
-		CHKmalloc(pThis->pszRcvBuf = MALLOC(NSD_OSSL_MAX_RCVBUF));
+		CHKmalloc(pThis->pszRcvBuf = malloc(NSD_OSSL_MAX_RCVBUF));
 		pThis->lenRcvBuf = -1;
 	}
 

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -325,7 +325,7 @@ FillRemHost(nsd_ptcp_t *pThis, struct sockaddr_storage *pAddr)
 	 * (side note: we may hold on to these values for quite a while, thus we trim their
 	 * memory consumption)
 	 */
-	if((pThis->pRemHostName = MALLOC(prop.GetStringLen(fqdn)+1)) == NULL)
+	if((pThis->pRemHostName = malloc(prop.GetStringLen(fqdn)+1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	memcpy(pThis->pRemHostName, propGetSzStr(fqdn), prop.GetStringLen(fqdn)+1);
 	prop.Destruct(&fqdn);

--- a/runtime/obj-types.h
+++ b/runtime/obj-types.h
@@ -98,12 +98,12 @@ struct obj_s {	/* the dummy struct that each derived class can be casted to */
 		obj_t objData
 #	define ISOBJ_assert(pObj) \
 		do { \
-		ASSERT((pObj) != NULL); \
-		ASSERT((unsigned) ((obj_t*)(pObj))->iObjCooCKiE == (unsigned) 0xBADEFEE); \
+		assert((pObj) != NULL); \
+		assert((unsigned) ((obj_t*)(pObj))->iObjCooCKiE == (unsigned) 0xBADEFEE); \
 		} while(0);
 #	define ISOBJ_TYPE_assert(pObj, objType) \
 		do { \
-		ASSERT(pObj != NULL); \
+		assert(pObj != NULL); \
 		if(strcmp((char*)(((obj_t*)pObj)->pObjInfo->pszID), #objType)) { \
 			dbgprintf("%s:%d ISOBJ assert failure: invalid object type, expected '%s' " \
 				  "actual '%s', cookie: %X\n", __FILE__, __LINE__, #objType, \
@@ -114,7 +114,7 @@ struct obj_s {	/* the dummy struct that each derived class can be casted to */
 			fflush(stderr); \
 			assert(!strcmp((char*)(((obj_t*)pObj)->pObjInfo->pszID), #objType)); \
 		} \
-		ASSERT((unsigned) ((obj_t*)(pObj))->iObjCooCKiE == (unsigned) 0xBADEFEE); \
+		assert((unsigned) ((obj_t*)(pObj))->iObjCooCKiE == (unsigned) 0xBADEFEE); \
 		} while(0)
 	/* now the same for pointers to "regular" objects (like wrkrInstanceData) */
 #	define PTR_ASSERT_DEF unsigned int _Assert_type;
@@ -262,7 +262,7 @@ rsRetVal objName##ClassExit(void) \
 		DEFiRet; \
 		obj##_t *pThis; \
 	 \
-		ASSERT(ppThis != NULL); \
+		assert(ppThis != NULL); \
 	 \
 		if((pThis = (obj##_t *)calloc(1, sizeof(obj##_t))) == NULL) { \
 			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY); \
@@ -309,7 +309,7 @@ rsRetVal objName##ClassExit(void) \
 		OBJ##_t *pThis;
 
 #define CODESTARTobjDestruct(OBJ) \
-		ASSERT(ppThis != NULL); \
+		assert(ppThis != NULL); \
 		pThis = *ppThis; \
 		ISOBJ_TYPE_assert(pThis, OBJ);
 
@@ -349,7 +349,7 @@ rsRetVal objName##ClassExit(void) \
 		DEFiRet; \
 
 #define CODESTARTobjDebugPrint(obj) \
-		ASSERT(pThis != NULL); \
+		assert(pThis != NULL); \
 		ISOBJ_TYPE_assert(pThis, obj); \
 
 #define ENDobjDebugPrint(obj) \
@@ -384,7 +384,7 @@ rsRetVal objName##ClassExit(void) \
 		DEFiRet; \
 
 #define CODESTARTobjQueryInterface(obj) \
-		ASSERT(pIf != NULL);
+		assert(pIf != NULL);
 
 #define ENDobjQueryInterface(obj) \
 		RETiRet; \

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -1078,7 +1078,6 @@ objGetName(obj_t *const pThis)
 	uchar *ret;
 	uchar szName[128];
 
-	BEGINfunc
 	ISOBJ_assert(pThis);
 
 	if(pThis->pszName == NULL) {
@@ -1096,7 +1095,6 @@ objGetName(obj_t *const pThis)
 		ret = pThis->pszName;
 	}
 
-	ENDfunc
 	return ret;
 }
 

--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -117,7 +117,7 @@ AddParserToList(parserList_t **ppListRoot, parser_t *pParser)
 	parserList_t *pTail;
 	DEFiRet;
 
-	CHKmalloc(pThis = MALLOC(sizeof(parserList_t)));
+	CHKmalloc(pThis = malloc(sizeof(parserList_t)));
 	pThis->pParser = pParser;
 	pThis->pNext = NULL;
 
@@ -333,7 +333,7 @@ static rsRetVal uncompressMessage(smsg_t *pMsg)
 		 */
 		int ret;
 		iLenDefBuf = glbl.GetMaxLine();
-		CHKmalloc(deflateBuf = MALLOC(iLenDefBuf + 1));
+		CHKmalloc(deflateBuf = malloc(iLenDefBuf + 1));
 		ret = uncompress((uchar *) deflateBuf, &iLenDefBuf, (uchar *) pszMsg+1, lenMsg-1);
 		DBGPRINTF("Compressed message uncompressed with status %d, length: new %ld, old %d.\n",
 		        ret, (long) iLenDefBuf, (int) (lenMsg-1));
@@ -463,7 +463,7 @@ SanitizeMsg(smsg_t *pMsg)
 	if(maxDest < sizeof(szSanBuf))
 		pDst = szSanBuf;
 	else
-		CHKmalloc(pDst = MALLOC(maxDest + 1));
+		CHKmalloc(pDst = malloc(maxDest + 1));
 	if(iSrc > 0) {
 		iSrc--; /* go back to where everything is OK */
 		if(iSrc > maxDest) {

--- a/runtime/prop.c
+++ b/runtime/prop.c
@@ -84,7 +84,7 @@ static rsRetVal SetString(prop_t *pThis, const uchar *psz, const int len)
 	if(len < CONF_PROP_BUFSIZE) {
 		memcpy(pThis->szVal.sz, psz, len + 1);
 	} else {
-		CHKmalloc(pThis->szVal.psz = MALLOC(len + 1));
+		CHKmalloc(pThis->szVal.psz = malloc(len + 1));
 		memcpy(pThis->szVal.psz, psz, len + 1);
 	}
 
@@ -103,7 +103,6 @@ static int GetStringLen(prop_t *pThis)
 /* get string */
 static rsRetVal GetString(prop_t *pThis, uchar **ppsz, int *plen)
 {
-	BEGINfunc
 	ISOBJ_TYPE_assert(pThis, prop);
 	if(pThis->len < CONF_PROP_BUFSIZE) {
 		*ppsz = pThis->szVal.sz;
@@ -111,7 +110,6 @@ static rsRetVal GetString(prop_t *pThis, uchar **ppsz, int *plen)
 		*ppsz = pThis->szVal.psz;
 	}
 	*plen = pThis->len;
-	ENDfunc
 	return RS_RET_OK;
 }
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -219,7 +219,7 @@ tdlAdd(qqueue_t *pQueue, qDeqID deqID, int nElemDeq)
 	ISOBJ_TYPE_assert(pQueue, qqueue);
 	assert(pQueue->toDeleteLst != NULL);
 
-	CHKmalloc(pNew = MALLOC(sizeof(toDeleteLst_t)));
+	CHKmalloc(pNew = malloc(sizeof(toDeleteLst_t)));
 	pNew->deqID = deqID;
 	pNew->nElemDeq = nElemDeq;
 
@@ -337,9 +337,8 @@ getLogicalQueueSize(qqueue_t *pThis)
 static void queueDrain(qqueue_t *pThis)
 {
 	smsg_t *pMsg;
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
-	BEGINfunc
 	DBGOPRINT((obj_t*) pThis, "queue (type %d) will lose %d messages, destroying...\n",
 		pThis->qType, pThis->iQueueSize);
 	/* iQueueSize is not decremented by qDel(), so we need to do it ourselves */
@@ -350,7 +349,6 @@ static void queueDrain(qqueue_t *pThis)
 		}
 		pThis->qDel(pThis);
 	}
-	ENDfunc
 }
 
 
@@ -555,12 +553,12 @@ static rsRetVal qConstructFixedArray(qqueue_t *pThis)
 {
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	if(pThis->iMaxQueueSize == 0)
 		ABORT_FINALIZE(RS_RET_QSIZE_ZERO);
 
-	if((pThis->tVars.farray.pBuf = MALLOC(sizeof(void *) * pThis->iMaxQueueSize)) == NULL) {
+	if((pThis->tVars.farray.pBuf = malloc(sizeof(void *) * pThis->iMaxQueueSize)) == NULL) {
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
 
@@ -579,7 +577,7 @@ static rsRetVal qDestructFixedArray(qqueue_t *pThis)
 {
 	DEFiRet;
 	
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	queueDrain(pThis); /* discard any remaining queue entries */
 	free(pThis->tVars.farray.pBuf);
@@ -592,7 +590,7 @@ static rsRetVal qAddFixedArray(qqueue_t *pThis, smsg_t* in)
 {
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 	pThis->tVars.farray.pBuf[pThis->tVars.farray.tail] = in;
 	pThis->tVars.farray.tail++;
 	if (pThis->tVars.farray.tail == pThis->iMaxQueueSize)
@@ -606,7 +604,7 @@ static rsRetVal qDeqFixedArray(qqueue_t *pThis, smsg_t **out)
 {
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 	*out = (void*) pThis->tVars.farray.pBuf[pThis->tVars.farray.deqhead];
 
 	pThis->tVars.farray.deqhead++;
@@ -621,7 +619,7 @@ static rsRetVal qDelFixedArray(qqueue_t *pThis)
 {
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	pThis->tVars.farray.head++;
 	if (pThis->tVars.farray.head == pThis->iMaxQueueSize)
@@ -638,7 +636,7 @@ static rsRetVal qConstructLinkedList(qqueue_t *pThis)
 {
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	pThis->tVars.linklist.pDeqRoot = NULL;
 	pThis->tVars.linklist.pDelRoot = NULL;
@@ -668,7 +666,7 @@ static rsRetVal qAddLinkedList(qqueue_t *pThis, smsg_t* pMsg)
 	qLinkedList_t *pEntry;
 	DEFiRet;
 
-	CHKmalloc((pEntry = (qLinkedList_t*) MALLOC(sizeof(qLinkedList_t))));
+	CHKmalloc((pEntry = (qLinkedList_t*) malloc(sizeof(qLinkedList_t))));
 
 	pEntry->pNext = NULL;
 	pEntry->pMsg = pMsg;
@@ -871,7 +869,7 @@ static rsRetVal qConstructDisk(qqueue_t *pThis)
 	DEFiRet;
 	int bRestarted = 0;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	/* and now check if there is some persistent information that needs to be read in */
 	iRet = qqueueTryLoadPersistedInfo(pThis);
@@ -943,7 +941,7 @@ static rsRetVal qDestructDisk(qqueue_t *pThis)
 {
 	DEFiRet;
 	
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	free(pThis->pszQIFNam);
 	if(pThis->tVars.disk.pWrite != NULL) {
@@ -1044,7 +1042,7 @@ static rsRetVal qAddDirectWithWti(qqueue_t *pThis, smsg_t* pMsg, wti_t *pWti)
 	DEFiRet;
 
 	//TODO: init batchObj (states _OK and new fields -- CHECK)
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	/* calling the consumer is quite different here than it is from a worker thread */
 	/* we need to provide the consumer's return value back to the caller because in direct
@@ -1096,7 +1094,7 @@ qqueueAdd(qqueue_t *pThis, smsg_t *pMsg)
 {
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	static int msgCnt = 0;
 
@@ -1138,7 +1136,7 @@ qqueueDeq(qqueue_t *pThis, smsg_t **ppMsg)
 {
 	DEFiRet;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	/* we do NOT abort if we encounter an error, because otherwise the queue
 	 * will not be decremented, what will most probably result in an endless loop.
@@ -1173,7 +1171,7 @@ tryShutdownWorkersWithinQueueTimeout(qqueue_t *const pThis)
 	DEFiRet;
 
 	ISOBJ_TYPE_assert(pThis, qqueue);
-	ASSERT(pThis->pqParent == NULL); /* detect invalid calling sequence */
+	assert(pThis->pqParent == NULL); /* detect invalid calling sequence */
 
 	if(pThis->bIsDA) {
 		/* We need to lock the mutex, as otherwise we may have a race that prevents
@@ -1250,7 +1248,7 @@ tryShutdownWorkersWithinActionTimeout(qqueue_t *pThis)
 	DEFiRet;
 
 	ISOBJ_TYPE_assert(pThis, qqueue);
-	ASSERT(pThis->pqParent == NULL); /* detect invalid calling sequence */
+	assert(pThis->pqParent == NULL); /* detect invalid calling sequence */
 
 	/* instruct workers to finish ASAP, even if still work exists */
 	DBGOPRINT((obj_t*) pThis, "trying to shutdown workers within Action Timeout");
@@ -1392,7 +1390,7 @@ qqueueShutdownWorkers(qqueue_t *const pThis)
 		FINALIZE;
 	}
 
-	ASSERT(pThis->pqParent == NULL); /* detect invalid calling sequence */
+	assert(pThis->pqParent == NULL); /* detect invalid calling sequence */
 
 	DBGOPRINT((obj_t*) pThis, "initiating worker thread shutdown sequence %p\n", pThis);
 
@@ -1431,9 +1429,9 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis, queueType_t qType, int iWorkerThread
 	qqueue_t *pThis;
 	const uchar *const workDir = glblGetWorkDirRaw();
 
-	ASSERT(ppThis != NULL);
-	ASSERT(pConsumer != NULL);
-	ASSERT(iWorkerThreads >= 0);
+	assert(ppThis != NULL);
+	assert(pConsumer != NULL);
+	assert(iWorkerThreads >= 0);
 
 	CHKmalloc(pThis = (qqueue_t *)calloc(1, sizeof(qqueue_t)));
 
@@ -2246,7 +2244,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 	uchar *qName;
 	size_t lenBuf;
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	dbgoprint((obj_t*) pThis, "starting queue\n");
 
@@ -2416,7 +2414,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 	 * influenced by properties which might have been set after queueConstruct ()
 	 */
 	if(pThis->pqParent == NULL) {
-		CHKmalloc(pThis->mut = (pthread_mutex_t *) MALLOC (sizeof (pthread_mutex_t)));
+		CHKmalloc(pThis->mut = (pthread_mutex_t *) malloc (sizeof (pthread_mutex_t)));
 		pthread_mutex_init(pThis->mut, NULL);
 	} else {
 		/* child queue, we need to use parent's mutex */
@@ -2540,7 +2538,7 @@ qqueuePersist(qqueue_t *pThis, int bIsCheckpoint)
 	strm_t *psQIF = NULL; /* Queue Info File */
 	char errStr[1024];
 
-	ASSERT(pThis != NULL);
+	assert(pThis != NULL);
 
 	if(pThis->qType != QUEUETYPE_DISK) {
 		if(getPhysicalQueueSize(pThis) > 0) {
@@ -2828,7 +2826,7 @@ qqueueSetFilePrefix(qqueue_t *pThis, uchar *pszPrefix, size_t iLenPrefix)
 	if(pszPrefix == NULL) /* just unset the prefix! */
 		ABORT_FINALIZE(RS_RET_OK);
 
-	if((pThis->pszFilePrefix = MALLOC(iLenPrefix + 1)) == NULL)
+	if((pThis->pszFilePrefix = malloc(iLenPrefix + 1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	memcpy(pThis->pszFilePrefix, pszPrefix, iLenPrefix + 1);
 	pThis->lenFilePrefix = iLenPrefix;
@@ -3320,7 +3318,7 @@ static rsRetVal qqueueSetProperty(qqueue_t *pThis, var_t *pProp)
 	DEFiRet;
 
 	ISOBJ_TYPE_assert(pThis, qqueue);
-	ASSERT(pProp != NULL);
+	assert(pProp != NULL);
 
 	if(isProp("iQueueSize")) {
 		pThis->iQueueSize = pProp->val.num;

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -642,7 +642,6 @@ tellModulesConfigLoadDone(void)
 {
 	cfgmodules_etry_t *node;
 
-	BEGINfunc
 	DBGPRINTF("telling modules that config load for %p is done\n", loadConf);
 	node = module.GetNxtCnfType(loadConf, NULL, eMOD_ANY);
 	while(node != NULL) {
@@ -654,7 +653,6 @@ tellModulesConfigLoadDone(void)
 		node = module.GetNxtCnfType(runConf, node, eMOD_ANY);
 	}
 
-	ENDfunc
 	return RS_RET_OK; /* intentional: we do not care about module errors */
 }
 
@@ -666,7 +664,6 @@ tellModulesCheckConfig(void)
 	cfgmodules_etry_t *node;
 	rsRetVal localRet;
 
-	BEGINfunc
 	DBGPRINTF("telling modules to check config %p\n", loadConf);
 	node = module.GetNxtCnfType(loadConf, NULL, eMOD_ANY);
 	while(node != NULL) {
@@ -683,7 +680,6 @@ tellModulesCheckConfig(void)
 		node = module.GetNxtCnfType(runConf, node, eMOD_ANY);
 	}
 
-	ENDfunc
 	return RS_RET_OK; /* intentional: we do not care about module errors */
 }
 
@@ -695,7 +691,6 @@ tellModulesActivateConfigPrePrivDrop(void)
 	cfgmodules_etry_t *node;
 	rsRetVal localRet;
 
-	BEGINfunc
 	DBGPRINTF("telling modules to activate config (before dropping privs) %p\n", runConf);
 	node = module.GetNxtCnfType(runConf, NULL, eMOD_ANY);
 	while(node != NULL) {
@@ -714,7 +709,6 @@ tellModulesActivateConfigPrePrivDrop(void)
 		node = module.GetNxtCnfType(runConf, node, eMOD_ANY);
 	}
 
-	ENDfunc
 	return RS_RET_OK; /* intentional: we do not care about module errors */
 }
 
@@ -726,7 +720,6 @@ tellModulesActivateConfig(void)
 	cfgmodules_etry_t *node;
 	rsRetVal localRet;
 
-	BEGINfunc
 	DBGPRINTF("telling modules to activate config %p\n", runConf);
 	node = module.GetNxtCnfType(runConf, NULL, eMOD_ANY);
 	while(node != NULL) {
@@ -743,7 +736,6 @@ tellModulesActivateConfig(void)
 		node = module.GetNxtCnfType(runConf, node, eMOD_ANY);
 	}
 
-	ENDfunc
 	return RS_RET_OK; /* intentional: we do not care about module errors */
 }
 
@@ -757,7 +749,6 @@ runInputModules(void)
 	cfgmodules_etry_t *node;
 	int bNeedsCancel;
 
-	BEGINfunc
 	node = module.GetNxtCnfType(runConf, NULL, eMOD_IN);
 	while(node != NULL) {
 		if(node->canRun) {
@@ -771,7 +762,6 @@ runInputModules(void)
 		node = module.GetNxtCnfType(runConf, node, eMOD_IN);
 	}
 
-	ENDfunc
 	return RS_RET_OK; /* intentional: we do not care about module errors */
 }
 
@@ -798,7 +788,6 @@ startInputModules(void)
 		node = module.GetNxtCnfType(runConf, node, eMOD_IN);
 	}
 
-	ENDfunc
 	return RS_RET_OK; /* intentional: we do not care about module errors */
 }
 

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -574,8 +574,8 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 #define CHKmalloc(operation) if((operation) == NULL) ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY)
 /* macro below is used in conjunction with CHKiRet_Hdlr, else use ABORT_FINALIZE */
 #define FINALIZE goto finalize_it;
-#define DEFiRet BEGINfunc rsRetVal iRet = RS_RET_OK
-#define RETiRet do{ ENDfuncIRet return iRet; }while(0)
+#define DEFiRet rsRetVal iRet = RS_RET_OK
+#define RETiRet return iRet
 
 #define ABORT_FINALIZE(errCode)			\
 	do {					\

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -1042,7 +1042,7 @@ doRulesetAddParser(ruleset_t *pRuleset, uchar *pName)
 	DBGPRINTF("added parser '%s' to ruleset '%s'\n", pName, pRuleset->pszName);
 
 finalize_it:
-	d_free(pName); /* no longer needed */
+	free(pName); /* no longer needed */
 
 	RETiRet;
 }

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -172,7 +172,7 @@ uchar *srUtilStrDup(uchar *pOld, size_t len)
 
 	assert(pOld != NULL);
 	
-	if((pNew = MALLOC(len + 1)) != NULL)
+	if((pNew = malloc(len + 1)) != NULL)
 		memcpy(pNew, pOld, len + 1);
 
 	return pNew;
@@ -212,7 +212,7 @@ static int real_makeFileParentDirs(const uchar *const szFile, const size_t lenFi
 	assert(lenFile > 0);
 
 	len = lenFile + 1; /* add one for '\0'-byte */
-	if((pszWork = MALLOC(len)) == NULL)
+	if((pszWork = malloc(len)) == NULL)
 		return -1;
 	memcpy(pszWork, szFile, len);
 	for(p = pszWork+1 ; *p ; p++)
@@ -378,7 +378,7 @@ rsRetVal genFileName(uchar **ppName, uchar *pDirName, size_t lenDirName, uchar *
 	}
 
 	lenName = lenDirName + 1 + lenFName + lenBuf + 1; /* last +1 for \0 char! */
-	if((pName = MALLOC(lenName)) == NULL)
+	if((pName = malloc(lenName)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	
 	/* got memory, now construct string */
@@ -431,7 +431,6 @@ timeoutComp(struct timespec *pt, long iTimeout)
 	struct timeval tv;
 #	endif
 
-	BEGINfunc
 	assert(pt != NULL);
 	/* compute timeout */
 
@@ -449,7 +448,6 @@ timeoutComp(struct timespec *pt, long iTimeout)
 		pt->tv_nsec -= 1000000000;
 		++pt->tv_sec;
 	}
-	ENDfunc
 	return RS_RET_OK; /* so far, this is static... */
 }
 
@@ -487,7 +485,6 @@ timeoutVal(struct timespec *pt)
 	struct timeval tv;
 #	endif
 
-	BEGINfunc
 	assert(pt != NULL);
 	/* compute timeout */
 #	if _POSIX_TIMERS > 0
@@ -504,7 +501,6 @@ timeoutVal(struct timespec *pt)
 	if(iTimeout < 0)
 		iTimeout = 0;
 
-	ENDfunc
 	return iTimeout;
 }
 
@@ -515,10 +511,8 @@ timeoutVal(struct timespec *pt)
 void
 mutexCancelCleanup(void *arg)
 {
-	BEGINfunc
 	assert(arg != NULL);
 	d_pthread_mutex_unlock((pthread_mutex_t*) arg);
-	ENDfunc
 }
 
 
@@ -532,11 +526,9 @@ srSleep(int iSeconds, int iuSeconds)
 {
 	struct timeval tvSelectTimeout;
 
-	BEGINfunc
 	tvSelectTimeout.tv_sec = iSeconds;
 	tvSelectTimeout.tv_usec = iuSeconds; /* micro seconds */
 	select(0, NULL, NULL, NULL, &tvSelectTimeout);
-	ENDfunc
 }
 
 
@@ -582,8 +574,8 @@ int decodeSyslogName(uchar *name, syslogName_t *codetab)
 	register uchar *p;
 	uchar buf[80];
 
-	ASSERT(name != NULL);
-	ASSERT(codetab != NULL);
+	assert(name != NULL);
+	assert(codetab != NULL);
 
 	DBGPRINTF("symbolic name: %s", name);
 	if(isdigit((int) *name)) {

--- a/runtime/strgen.c
+++ b/runtime/strgen.c
@@ -102,7 +102,7 @@ AddStrgenToList(strgenList_t **ppListRoot, strgen_t *pStrgen)
 	strgenList_t *pTail;
 	DEFiRet;
 
-	CHKmalloc(pThis = MALLOC(sizeof(strgenList_t)));
+	CHKmalloc(pThis = malloc(sizeof(strgenList_t)));
 	pThis->pStrgen = pStrgen;
 	pThis->pNext = NULL;
 

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -93,7 +93,7 @@ rsCStrConstructFromszStr(cstr_t **const ppThis, const uchar *const sz)
 
 	pThis->iStrLen = strlen((char *) sz);
 	pThis->iBufSize = strlen((char *) sz) + 1;
-	if((pThis->pBuf = (uchar*) MALLOC(pThis->iBufSize)) == NULL) {
+	if((pThis->pBuf = (uchar*) malloc(pThis->iBufSize)) == NULL) {
 		RSFREEOBJ(pThis);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
@@ -132,7 +132,7 @@ rsCStrConstructFromszStrv(cstr_t **const ppThis, const char *const fmt, va_list 
 	pThis->iStrLen = len;
 	pThis->iBufSize = len + 1;
 	len++; /* account for the \0 written by vsnprintf */
-	if((pThis->pBuf = (uchar*) MALLOC(pThis->iBufSize)) == NULL) {
+	if((pThis->pBuf = (uchar*) malloc(pThis->iBufSize)) == NULL) {
 		RSFREEOBJ(pThis);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
@@ -173,7 +173,7 @@ cstrConstructFromESStr(cstr_t **const ppThis, es_str_t *const str)
 
 	pThis->iStrLen = es_strlen(str);
 	pThis->iBufSize = pThis->iStrLen + 1;
-	if((pThis->pBuf = (uchar*) MALLOC(pThis->iBufSize)) == NULL) {
+	if((pThis->pBuf = (uchar*) malloc(pThis->iBufSize)) == NULL) {
 		RSFREEOBJ(pThis);
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
@@ -202,7 +202,7 @@ rsCStrConstructFromCStr(cstr_t **const ppThis, const cstr_t *const pFrom)
 	if(pFrom->iStrLen > 0) {
 		pThis->iStrLen = pFrom->iStrLen;
 		pThis->iBufSize = pFrom->iStrLen + 1;
-		if((pThis->pBuf = (uchar*) MALLOC(pThis->iBufSize)) == NULL) {
+		if((pThis->pBuf = (uchar*) malloc(pThis->iBufSize)) == NULL) {
 			RSFREEOBJ(pThis);
 			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 		}
@@ -439,7 +439,7 @@ rsRetVal cstrConvSzStrAndDestruct(cstr_t **ppThis, uchar **ppSz, int bRetNULL)
 
 	if(pThis->pBuf == NULL) {
 		if(bRetNULL == 0) {
-			CHKmalloc(pRetBuf = MALLOC(1));
+			CHKmalloc(pRetBuf = malloc(1));
 			*pRetBuf = '\0';
 		} else {
 			pRetBuf = NULL;

--- a/runtime/tcpclt.c
+++ b/runtime/tcpclt.c
@@ -170,7 +170,7 @@ TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int *pbMustBeFreed)
 			 * I have added this comment so that the logic is not accidently
 			 * changed again. rgerhards, 2005-10-25
 			 */
-			if((buf = MALLOC(len + 2)) == NULL) {
+			if((buf = malloc(len + 2)) == NULL) {
 				/* extreme mem shortage, try to solve
 				 * as good as we can. No point in calling
 				 * any alarms, they might as well run out
@@ -218,7 +218,7 @@ TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int *pbMustBeFreed)
 		/* IETF20061218 iLenBuf =
 		  snprintf(szLenBuf, sizeof(szLenBuf), "%d ", len + iLenBuf);*/
 
-		if((buf = MALLOC(len + iLenBuf)) == NULL) {
+		if((buf = malloc(len + iLenBuf)) == NULL) {
 			/* we are out of memory. This is an extreme situation. We do not
 			 * call any alarm handlers because they most likely run out of mem,
 			 * too. We are brave enough to call debug output, though. Other than
@@ -325,7 +325,7 @@ Send(tcpclt_t *pThis, void *pData, char *msg, size_t len)
 				 * happens is that we lose our message recovery buffer - anything else would
 				 * be worse, so don't try anything ;) -- rgerhards, 2008-03-12
 				 */
-				if((pThis->prevMsg = MALLOC(len)) != NULL) {
+				if((pThis->prevMsg = malloc(len)) != NULL) {
 					memcpy(pThis->prevMsg, msg, len);
 					pThis->lenPrevMsg = len;
 				}

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -69,7 +69,7 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
 		pThis->inputState = eAtStrtFram; /* indicate frame header expected */
 		pThis->eFraming = TCP_FRAMING_OCTET_STUFFING; /* just make sure... */
 		/* now allocate the message reception buffer */
-		CHKmalloc(pThis->pMsg = (uchar*) MALLOC(glbl.GetMaxLine() + 1));
+		CHKmalloc(pThis->pMsg = (uchar*) malloc(glbl.GetMaxLine() + 1));
 finalize_it:
 ENDobjConstruct(tcps_sess)
 

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -283,7 +283,6 @@ TCPSessGetNxtSess(tcpsrv_t *pThis, int iCurr)
 {
 	register int i;
 
-	BEGINfunc
 	ISOBJ_TYPE_assert(pThis, tcpsrv);
 	assert(pThis->pSessions != NULL);
 	for(i = iCurr + 1 ; i < pThis->iSessMax ; ++i) {
@@ -291,7 +290,6 @@ TCPSessGetNxtSess(tcpsrv_t *pThis, int iCurr)
 			break;
 	}
 
-	ENDfunc
 	return((i < pThis->iSessMax) ? i : -1);
 }
 

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -273,7 +273,6 @@ wtiWorkerCancelCleanup(void *arg)
 	wti_t *pThis = (wti_t*) arg;
 	wtp_t *pWtp;
 
-	BEGINfunc
 	ISOBJ_TYPE_assert(pThis, wti);
 	pWtp = pThis->pWtp;
 	ISOBJ_TYPE_assert(pWtp, wtp);
@@ -282,7 +281,6 @@ wtiWorkerCancelCleanup(void *arg)
 	pWtp->pfObjProcessed(pWtp->pUsr, pThis);
 	DBGPRINTF("%s: done cancelation cleanup handler.\n", wtiGetDbgHdr(pThis));
 	
-	ENDfunc
 }
 
 
@@ -296,7 +294,6 @@ doIdleProcessing(wti_t *pThis, wtp_t *pWtp, int *pbInactivityTOOccured)
 {
 	struct timespec t;
 
-	BEGINfunc
 	DBGPRINTF("%s: worker IDLE, waiting for work.\n", wtiGetDbgHdr(pThis));
 
 	if(pThis->bAlwaysRunning) {
@@ -310,7 +307,6 @@ doIdleProcessing(wti_t *pThis, wtp_t *pWtp, int *pbInactivityTOOccured)
 		}
 	}
 	DBGOPRINT((obj_t*) pThis, "worker awoke from idle processing\n");
-	ENDfunc
 }
 
 
@@ -452,7 +448,7 @@ wtiSetDbgHdr(wti_t *pThis, uchar *pszMsg, size_t lenMsg)
 		free(pThis->pszDbgHdr);
 	}
 
-	if((pThis->pszDbgHdr = MALLOC(lenMsg + 1)) == NULL)
+	if((pThis->pszDbgHdr = malloc(lenMsg + 1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 
 	memcpy(pThis->pszDbgHdr, pszMsg, lenMsg + 1); /* always think about the \0! */

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -135,7 +135,7 @@ wtpConstructFinalize(wtp_t *pThis)
 	/* alloc and construct workers - this can only be done in finalizer as we previously do
 	 * not know the max number of workers
 	 */
-	CHKmalloc(pThis->pWrkr = MALLOC(sizeof(wti_t*) * pThis->iNumWorkerThreads));
+	CHKmalloc(pThis->pWrkr = malloc(sizeof(wti_t*) * pThis->iNumWorkerThreads));
 	
 	for(i = 0 ; i < pThis->iNumWorkerThreads ; ++i) {
 		CHKiRet(wtiConstruct(&pThis->pWrkr[i]));
@@ -320,7 +320,6 @@ wtpWrkrExecCleanup(wti_t *pWti)
 {
 	wtp_t *pThis;
 
-	BEGINfunc
 	ISOBJ_TYPE_assert(pWti, wti);
 	pThis = pWti->pWtp;
 	ISOBJ_TYPE_assert(pThis, wtp);
@@ -341,7 +340,6 @@ wtpWrkrExecCleanup(wti_t *pWti)
 			wtpGetDbgHdr(pThis), (unsigned long) pWti, numWorkersNow);
 	}
 
-	ENDfunc
 }
 
 
@@ -354,7 +352,6 @@ wtpWrkrExecCancelCleanup(void *arg)
 	wti_t *pWti = (wti_t*) arg;
 	wtp_t *pThis;
 
-	BEGINfunc
 	ISOBJ_TYPE_assert(pWti, wti);
 	pThis = pWti->pWtp;
 	ISOBJ_TYPE_assert(pThis, wtp);
@@ -363,11 +360,6 @@ wtpWrkrExecCancelCleanup(void *arg)
 
 	wtpWrkrExecCleanup(pWti);
 
-	ENDfunc
-	/* NOTE: we must call ENDfunc FIRST, because otherwise the schedule may activate the main
-	 * thread after the broadcast, which could destroy the debug class, resulting in a potential
-	 * segfault. So we need to do the broadcast as actually the last action in our processing
-	 */
 	pthread_cond_broadcast(&pThis->condThrdTrm); /* activate anyone waiting on thread shutdown */
 }
 
@@ -390,7 +382,6 @@ wtpWorker(void *arg) /* the arg is actually a wti object, even though we are in 
 	uchar thrdName[32] = "rs:";
 #	endif
 
-	BEGINfunc
 	ISOBJ_TYPE_assert(pWti, wti);
 	pThis = pWti->pWtp;
 	ISOBJ_TYPE_assert(pThis, wtp);
@@ -425,11 +416,6 @@ wtpWorker(void *arg) /* the arg is actually a wti object, even though we are in 
 	pthread_cleanup_push(mutexCancelCleanup, &pThis->mutWtp);
 	wtpWrkrExecCleanup(pWti);
 
-	ENDfunc
-	/* NOTE: we must call ENDfunc FIRST, because otherwise the schedule may activate the main
-	 * thread after the broadcast, which could destroy the debug class, resulting in a potential
-	 * segfault. So we need to do the broadcast as actually the last action in our processing
-	 */
 	pthread_cond_broadcast(&pThis->condThrdTrm); /* activate anyone waiting on thread shutdown */
 	pthread_cleanup_pop(1); /* unlock mutex */
 	pthread_exit(0);
@@ -591,7 +577,7 @@ wtpSetDbgHdr(wtp_t *pThis, uchar *pszMsg, size_t lenMsg)
 		pThis->pszDbgHdr = NULL;
 	}
 
-	if((pThis->pszDbgHdr = MALLOC(lenMsg + 1)) == NULL)
+	if((pThis->pszDbgHdr = malloc(lenMsg + 1)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 
 	memcpy(pThis->pszDbgHdr, pszMsg, lenMsg + 1); /* always think about the \0! */

--- a/template.c
+++ b/template.c
@@ -1025,7 +1025,7 @@ do_Parameter(uchar **pp, struct template *pTpl)
 				/* We get here ONLY if the regex end was found */
 				longitud = regex_end - p;
 				/* Malloc for the regex string */
-				regex_char = (unsigned char *) MALLOC(longitud + 1);
+				regex_char = (unsigned char *) malloc(longitud + 1);
 				if(regex_char == NULL) {
 					dbgprintf("Could not allocate memory for template parameter!\n");
 					pTpe->data.field.has_regex = 0;
@@ -1237,7 +1237,7 @@ struct template *tplAddLine(rsconf_t *conf, const char* pName, uchar** ppRestOfC
 	
 	DBGPRINTF("tplAddLine processing template '%s'\n", pName);
 	pTpl->iLenName = strlen(pName);
-	pTpl->pszName = (char*) MALLOC(pTpl->iLenName + 1);
+	pTpl->pszName = (char*) malloc(pTpl->iLenName + 1);
 	if(pTpl->pszName == NULL) {
 		dbgprintf("tplAddLine could not alloc memory for template name!");
 		pTpl->iLenName = 0;
@@ -2113,7 +2113,6 @@ void tplDeleteAll(rsconf_t *conf)
 {
 	struct template *pTpl, *pTplDel;
 	struct templateEntry *pTpe, *pTpeDel;
-	BEGINfunc
 
 	pTpl = conf->templates.root;
 	while(pTpl != NULL) {
@@ -2155,7 +2154,6 @@ void tplDeleteAll(rsconf_t *conf)
 			msgPropDescrDestruct(&pTplDel->subtree);
 		free(pTplDel);
 	}
-	ENDfunc
 }
 
 
@@ -2167,7 +2165,6 @@ void tplDeleteNew(rsconf_t *conf)
 	struct template *pTpl, *pTplDel;
 	struct templateEntry *pTpe, *pTpeDel;
 
-	BEGINfunc
 
 	if(conf->templates.root == NULL || conf->templates.lastStatic == NULL)
 		return;
@@ -2207,7 +2204,6 @@ void tplDeleteNew(rsconf_t *conf)
 			msgPropDescrDestruct(&pTplDel->subtree);
 		free(pTplDel);
 	}
-	ENDfunc
 }
 
 /* Store the pointer to the last hardcoded teplate */

--- a/threads.c
+++ b/threads.c
@@ -254,7 +254,6 @@ thrdStarter(void *const arg)
 	pthread_cond_signal(&pThis->condThrdTerm);
 	d_pthread_mutex_unlock(&pThis->mutThrd);
 
-	ENDfunc
 	pthread_exit(0);
 }
 /* Start a new thread and add it to the list of currently

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -454,14 +454,14 @@ finalize_it:
  * as the index of the to-be-deleted entry. This index may
  * point to an unallocated entry, in whcih case the
  * function immediately returns. Parameter bFreeEntry is 1
- * if the entry should be d_free()ed and 0 if not.
+ * if the entry should be free()ed and 0 if not.
  */
 static rsRetVal
 dynaFileDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, const int bFreeEntry)
 {
 	dynaFileCacheEntry **pCache = pData->dynCache;
 	DEFiRet;
-	ASSERT(pCache != NULL);
+	assert(pCache != NULL);
 
 	if(pCache[iEntry] == NULL)
 		FINALIZE;
@@ -470,7 +470,7 @@ dynaFileDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, 
 		pCache[iEntry]->pName == NULL ? UCHAR_CONSTANT("[OPEN FAILED]") : pCache[iEntry]->pName);
 
 	if(pCache[iEntry]->pName != NULL) {
-		d_free(pCache[iEntry]->pName);
+		free(pCache[iEntry]->pName);
 		pCache[iEntry]->pName = NULL;
 	}
 
@@ -483,7 +483,7 @@ dynaFileDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, 
 	}
 
 	if(bFreeEntry) {
-		d_free(pCache[iEntry]);
+		free(pCache[iEntry]);
 		pCache[iEntry] = NULL;
 	}
 
@@ -500,14 +500,12 @@ static void
 dynaFileFreeCacheEntries(instanceData *__restrict__ const pData)
 {
 	register int i;
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 
-	BEGINfunc;
 	for(i = 0 ; i < pData->iCurrCacheSize ; ++i) {
 		dynaFileDelCacheEntry(pData, i, 1);
 	}
 	pData->iCurrElt = -1; /* invalidate current element */
-	ENDfunc;
 }
 
 
@@ -515,13 +513,11 @@ dynaFileFreeCacheEntries(instanceData *__restrict__ const pData)
  */
 static void dynaFileFreeCache(instanceData *__restrict__ const pData)
 {
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 
-	BEGINfunc;
 	dynaFileFreeCacheEntries(pData);
 	if(pData->dynCache != NULL)
-		d_free(pData->dynCache);
-	ENDfunc;
+		free(pData->dynCache);
 }
 
 
@@ -678,8 +674,8 @@ prepareDynFile(instanceData *__restrict__ const pData, const uchar *__restrict__
 	dynaFileCacheEntry **pCache;
 	DEFiRet;
 
-	ASSERT(pData != NULL);
-	ASSERT(newFileName != NULL);
+	assert(pData != NULL);
+	assert(newFileName != NULL);
 
 	pCache = pData->dynCache;
 
@@ -791,8 +787,8 @@ static  rsRetVal
 doWrite(instanceData *__restrict__ const pData, uchar *__restrict__ const pszBuf, const int lenBuf)
 {
 	DEFiRet;
-	ASSERT(pData != NULL);
-	ASSERT(pszBuf != NULL);
+	assert(pData != NULL);
+	assert(pszBuf != NULL);
 
 	DBGPRINTF("omfile: write to stream, pData->pStrm %p, lenBuf %d, strt data %.128s\n",
 		  pData->pStrm, lenBuf, pszBuf);

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -988,7 +988,7 @@ processMsg(wrkrInstanceData_t *__restrict__ const pWrkrData,
 		uLongf destLen = iMaxLine + iMaxLine/100 +12; /* recommended value from zlib doc */
 		uLong srcLen = l;
 		int ret;
-		CHKmalloc(out = (Bytef*) MALLOC(destLen));
+		CHKmalloc(out = (Bytef*) malloc(destLen));
 		out[0] = 'z';
 		out[1] = '\0';
 		ret = compress2((Bytef*) out+1, &destLen, (Bytef*) psz,
@@ -1436,7 +1436,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 		tmp = ++p;
 		for(i=0 ; *p && isdigit((int) *p) ; ++p, ++i)
 			/* SKIP AND COUNT */;
-		pData->port = MALLOC(i + 1);
+		pData->port = malloc(i + 1);
 		if(pData->port == NULL) {
 			LogError(0, NO_ERRCODE, "Could not get memory to store syslog forwarding port, "
 				 "using default port, results may not be what you intend");

--- a/tools/ompipe.c
+++ b/tools/ompipe.c
@@ -175,7 +175,7 @@ static rsRetVal writePipe(uchar **ppString, instanceData *pData)
 	int iLenWritten;
 	DEFiRet;
 
-	ASSERT(pData != NULL);
+	assert(pData != NULL);
 
 	if(pData->fd == -1) {
 		rsRetVal iRetLocal;
@@ -381,14 +381,12 @@ CODESTARTparseSelectorAct
 	 */
 	if(*p == '|') {
 		if((iRet = createInstance(&pData)) != RS_RET_OK) {
-			ENDfunc
 			return iRet; /* this can not use RET_iRet! */
 		}
 	} else {
 		/* this is not clean, but we need it for the time being
 		 * TODO: remove when cleaning up modularization
 		 */
-		ENDfunc
 		return RS_RET_CONFLINE_UNPROCESSED;
 	}
 

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -101,7 +101,7 @@ createInstance(instanceConf_t **pinst)
 {
 	instanceConf_t *inst;
 	DEFiRet;
-	CHKmalloc(inst = MALLOC(sizeof(instanceConf_t)));
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->bDetectYearAfterTimestamp = 0;
 	inst->bPermitSquareBracketsInHostname = 0;
 	inst->bPermitSlashesInHostname = 0;

--- a/tools/pmrfc5424.c
+++ b/tools/pmrfc5424.c
@@ -236,7 +236,7 @@ CODESTARTparse
 	 * message, so we can not run into any troubles. I think this is
 	 * wiser than to use individual buffers.
 	 */
-	CHKmalloc(pBuf = MALLOC(lenMsg + 1));
+	CHKmalloc(pBuf = malloc(lenMsg + 1));
 
 	/* IMPORTANT NOTE:
 	 * Validation is not actually done below nor are any errors handled. I have

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1173,7 +1173,7 @@ bufOptAdd(char opt, char *arg)
 	DEFiRet;
 	bufOpt_t *pBuf;
 
-	if((pBuf = MALLOC(sizeof(bufOpt_t))) == NULL)
+	if((pBuf = malloc(sizeof(bufOpt_t))) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 
 	pBuf->optchar = opt;
@@ -1657,7 +1657,6 @@ finalize_it:
 		exit(1);
 	}
 
-	ENDfunc
 }
 
 
@@ -1739,9 +1738,7 @@ finalize_it:
  */
 DEFFUNC_llExecFunc(doHUPActions)
 {
-	BEGINfunc
 	actionCallHUPHdlr((action_t*) pData);
-	ENDfunc
 	return RS_RET_OK; /* we ignore errors, we can not do anything either way */
 }
 
@@ -1920,7 +1917,6 @@ mainloop(void)
 {
 	time_t tTime;
 
-	BEGINfunc
 
 	do {
 		processImInternal();
@@ -1953,7 +1949,6 @@ mainloop(void)
 		}
 
 	} while(!bFinished); /* end do ... while() */
-	ENDfunc
 }
 
 /* Finalize and destruct all actions.

--- a/tools/syslogd.c
+++ b/tools/syslogd.c
@@ -154,7 +154,7 @@ char **syslogd_crunch_list(char *list)
 	for (count=i=0; p[i]; i++)
 		if (p[i] == LIST_DELIMITER) count++;
 
-	if ((result = (char **)MALLOC(sizeof(char *) * (count+2))) == NULL) {
+	if ((result = (char **)malloc(sizeof(char *) * (count+2))) == NULL) {
 		printf ("Sorry, can't get enough memory, exiting.\n");
 		exit(0); /* safe exit, because only called during startup */
 	}
@@ -166,7 +166,7 @@ char **syslogd_crunch_list(char *list)
 	 */
 	count = 0;
 	while ((q=strchr(p, LIST_DELIMITER))) {
-		result[count] = (char *) MALLOC(q - p + 1);
+		result[count] = (char *) malloc(q - p + 1);
 		if (result[count] == NULL) {
 			printf ("Sorry, can't get enough memory, exiting.\n");
 			exit(0); /* safe exit, because only called during startup */
@@ -177,7 +177,7 @@ char **syslogd_crunch_list(char *list)
 		count++;
 	}
 	if ((result[count] = \
-	     (char *)MALLOC(strlen(p) + 1)) == NULL) {
+	     (char *)malloc(strlen(p) + 1)) == NULL) {
 		printf ("Sorry, can't get enough memory, exiting.\n");
 		exit(0); /* safe exit, because only called during startup */
 	}


### PR DESCRIPTION
--enable-rtinst is gone-away since a while, but there were still
some supporting code left. It required careful anaylsis what could
actually be removed. This is now done and the code fully cleaned
up.
    
As a positive side effect, we could eliminate mutex calls inside
the debug system. This means we are more likely to reproduce race
conditions in runs with debugging enabled.
    
closes https://github.com/rsyslog/rsyslog/issues/2211
