### PR TITLE
testbench: support auto-start/-stop of mysqld

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -507,6 +507,7 @@ endif
 
 if ENABLE_MYSQL_TESTS
 TESTS +=  \
+	mysqld-start.sh \
 	mysql-basic.sh \
 	mysql-basic-cnf6.sh \
 	mysql-asyn.sh \
@@ -515,6 +516,7 @@ TESTS +=  \
 	action-tx-single-processing.sh \
 	action-tx-errfile.sh
 
+mysql-basic.log: mysqld-start.log
 mysql-basic-cnf6.log: mysql-basic.log
 mysql-asyn.log: mysql-basic-cnf6.log
 mysql-actq-mt.log: mysql-asyn.log
@@ -546,6 +548,7 @@ TESTS +=  \
 libdbi-basic-vg.log: libdbi-asyn.log
 endif
 endif
+TESTS += mysqld-stop.sh
 endif #  MYSQL_TESTS
 
 if ENABLE_FMHTTP
@@ -1671,6 +1674,8 @@ EXTRA_DIST= \
 	testsuites/mysql-select-msg.sql \
 	libdbi-basic.sh \
 	libdbi-asyn.sh \
+	mysqld-start.sh \
+	mysqld-stop.sh \
 	mysql-basic.sh \
 	mysql-basic-cnf6.sh \
 	mysql-basic-vg.sh \

--- a/tests/mysqld-start.sh
+++ b/tests/mysqld-start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# This is not a real test, but a script to start mysql. It is
+# implemented as test so that we can start mysql at the time we need
+# it (do so via Makefile.am).
+# Copyright (C) 2018 Rainer Gerhards and Adiscon GmbH
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+if [ "$MYSQLD_START_CMD" == "" ]; then
+	exit_test # no start needed
+fi
+printf 'starting mysqld...\n'
+$MYSQLD_START_CMD &
+wait_startup_pid /var/run/mysqld/mysqld.pid
+printf 'preparing mysqld for testbench use...\n'
+$SUDO ${srcdir}/../devtools/prep-mysql-db.sh
+printf 'done, mysql ready for testbench\n'
+exit_test

--- a/tests/mysqld-stop.sh
+++ b/tests/mysqld-stop.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# This is not a real test, but a script to stop mysql. It is
+# implemented as test so that we can stop mysql at the time we need
+# it (do so via Makefile.am).
+# Copyright (C) 2018 Rainer Gerhards and Adiscon GmbH
+# Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+if [ "$MYSQLD_STOP_CMD" == "" ]; then
+	exit_test
+fi
+printf 'stopping mysqld...\n'
+eval $MYSQLD_STOP_CMD
+sleep 1 # cosmetic: give mysqld a chance to emit shutdown message
+exit_test


### PR DESCRIPTION
This is required to run mysql/mariadb tests inside containers.

closes https://github.com/rsyslog/rsyslog/issues/3223

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
