### PR TITLE
config: fix segfault in backticks "echo" expansion of undefined variables

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -106,7 +106,8 @@ expand_backticks_echo(const char *param)
 			if(isspace(*param) || *param == '/') {
 				envvar[i_envvar] = '\0';
 				const char *envval = getenv(envvar);
-				es_addBuf(&estr, envval, strlen(envval));
+				if(envval != NULL)
+					es_addBuf(&estr, envval, strlen(envval));
 				es_addChar(&estr, *param); /* curr char part of output! */
 				i_envvar = 0;
 				in_env = 0;
@@ -128,7 +129,8 @@ expand_backticks_echo(const char *param)
 	if(in_env) {
 		envvar[i_envvar] = '\0';
 		const char *envval = getenv(envvar);
-		es_addBuf(&estr, envval, strlen(envval));
+		if(envval != NULL)
+			es_addBuf(&estr, envval, strlen(envval));
 	}
 
 done:	return estr;


### PR DESCRIPTION
The bug was introduced in commit abe0434 (config: enhance backticks "echo"
capability). The getenv() result passed to strlen() and es_addBuf() may be
NULL if the environment variable does not exist, resulting in a segfault.

This commit fixes Github issue #3006.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
