### PR TITLE
testbench: add test for backticks parameters

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -106,7 +106,8 @@ expand_backticks_echo(const char *param)
 			if(isspace(*param) || *param == '/') {
 				envvar[i_envvar] = '\0';
 				const char *envval = getenv(envvar);
-				es_addBuf(&estr, envval, strlen(envval));
+				if(envval != NULL)
+					es_addBuf(&estr, envval, strlen(envval));
 				es_addChar(&estr, *param); /* curr char part of output! */
 				i_envvar = 0;
 				in_env = 0;
@@ -128,7 +129,8 @@ expand_backticks_echo(const char *param)
 	if(in_env) {
 		envvar[i_envvar] = '\0';
 		const char *envval = getenv(envvar);
-		es_addBuf(&estr, envval, strlen(envval));
+		if(envval != NULL)
+			es_addBuf(&estr, envval, strlen(envval));
 	}
 
 done:	return estr;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -320,6 +320,7 @@ TESTS +=  \
 	queue-encryption-disk_keyfile-vg.sh \
 	rscript_parse_json-vg.sh \
 	rscript_backticks-vg.sh \
+	rscript_backticks_empty_envvar-vg.sh \
 	rscript-config_enable-off-vg.sh \
 	prop-jsonmesg-vg.sh \
 	mmexternal-SegFault-vg.sh \
@@ -1212,6 +1213,7 @@ EXTRA_DIST= \
 	rscript_parse_json.sh \
 	rscript_parse_json-vg.sh \
 	rscript_backticks-vg.sh \
+	rscript_backticks_empty_envvar-vg.sh \
 	rscript_previous_action_suspended.sh \
 	rscript_str2num_negative.sh \
 	rs-cnum.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -477,9 +477,16 @@ function get_mainqueuesize() {
 }
 
 # grep for (partial) content. $1 is the content to check for, $2 the file to check
+# option --regex is understood, in which case $1 is a regex
 function content_check() {
+	if [ "$1" == "--regex" ]; then
+		grep_opt=
+		shift
+	else
+		grep_opt=-F
+	fi
 	file=${2:-$RSYSLOG_OUT_LOG}
-	if ! grep -qF -- "$1" < "${file}"; then
+	if ! grep -q  $grep_opt -- "$1" < "${file}"; then
 	    printf '\n============================================================\n'
 	    printf 'FILE "%s" content:\n' "$file"
 	    cat -n ${file}

--- a/tests/rscript_backticks_empty_envvar-vg.sh
+++ b/tests/rscript_backticks_empty_envvar-vg.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# added 2018-11-02 by rgerhards
+# see also https://github.com/rsyslog/rsyslog/issues/3006
+# released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+if `echo $DOES_NOT_EXIST` == "" then
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup_vg
+shutdown_when_empty
+wait_shutdown_vg
+check_exit_vg
+content_check --regex "rsyslogd: .*start"
+exit_test


### PR DESCRIPTION
checking that echo on non-exist env var does not abort rsyslog

see also https://github.com/rsyslog/rsyslog/issues/3006

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
