### PR TITLE
build system: don't link liblogging-stdlog when available but not enabled

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1436,6 +1436,12 @@ fi
 AM_CONDITIONAL(ENABLE_KSI_LS12, test x$enable_ksi_ls12 = xyes)
 
 # liblogging-stdlog support
+# we use liblogging-stdlog inside the testbench, which is why we need to check for it in any case
+PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
+	AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.]),
+	[AC_MSG_NOTICE([liblogging-stdlog not found, parts of the testbench will not run])]
+)
+
 AC_ARG_ENABLE(liblogging-stdlog,
         [AS_HELP_STRING([--enable-liblogging-stdlog],[Enable liblogging-stdlog support @<:@default=no@:>@])],
         [case "${enableval}" in
@@ -1445,18 +1451,10 @@ AC_ARG_ENABLE(liblogging-stdlog,
          esac],
         [enable_liblogging_stdlog=no]
 )
-if test "x$enable_liblogging_stdlog" = "xyes"; then
-	PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
-		AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.])
-	)
+if test "x$enable_liblogging_stdlog" = "xyes" -a "x$HAVE_LIBLOGGING_STDLOG" != "x1"; then
+	AC_MSG_ERROR(--enable-liblogging-stdlog set but liblogging-stdlog was not found)
 fi
-AM_CONDITIONAL(ENABLE_LIBLOGGING_STDLOG, test x$enable_liblogging_stdlog = xyes)
-
-# we use liblogging-stdlog inside the testbench, which is why we need to check for it in any case
-PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
-	AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.]),
-	[AC_MSG_NOTICE([liblogging-stdlog not found, parts of the testbench will not run])]
-)
+AM_CONDITIONAL(ENABLE_LIBLOGGING_STDLOG, [test "x$enable_liblogging_stdlog" = "xyes"])
 
 # RFC 3195 support
 AC_ARG_ENABLE(rfc3195,

--- a/plugins/imklog/Makefile.am
+++ b/plugins/imklog/Makefile.am
@@ -10,6 +10,11 @@ if ENABLE_IMKLOG_LINUX
 imklog_la_SOURCES += bsd.c
 endif
 
-imklog_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-imklog_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+imklog_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+imklog_la_LDFLAGS = -module -avoid-version
 imklog_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+imklog_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+imklog_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif

--- a/plugins/immark/Makefile.am
+++ b/plugins/immark/Makefile.am
@@ -1,6 +1,11 @@
 pkglib_LTLIBRARIES = immark.la
 
 immark_la_SOURCES = immark.c immark.h
-immark_la_CPPFLAGS = $(RSRT_CFLAGS) -I$(top_srcdir) $(PTHREADS_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-immark_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+immark_la_CPPFLAGS = $(RSRT_CFLAGS) -I$(top_srcdir) $(PTHREADS_CFLAGS)
+immark_la_LDFLAGS = -module -avoid-version
 immark_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+immark_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+immark_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif

--- a/plugins/imtcp/Makefile.am
+++ b/plugins/imtcp/Makefile.am
@@ -1,6 +1,11 @@
 pkglib_LTLIBRARIES = imtcp.la
 
 imtcp_la_SOURCES = imtcp.c
-imtcp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-imtcp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+imtcp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+imtcp_la_LDFLAGS = -module -avoid-version
 imtcp_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+imtcp_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+imtcp_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif

--- a/plugins/imudp/Makefile.am
+++ b/plugins/imudp/Makefile.am
@@ -1,6 +1,11 @@
 pkglib_LTLIBRARIES = imudp.la
 
 imudp_la_SOURCES = imudp.c
-imudp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-imudp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+imudp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+imudp_la_LDFLAGS = -module -avoid-version
 imudp_la_LIBADD = $(IMUDP_LIBS)
+
+if ENABLE_LIBLOGGING_STDLOG
+imudp_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+imudp_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif

--- a/plugins/imuxsock/Makefile.am
+++ b/plugins/imuxsock/Makefile.am
@@ -1,6 +1,11 @@
 pkglib_LTLIBRARIES = imuxsock.la
 
 imuxsock_la_SOURCES = imuxsock.c
-imuxsock_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-imuxsock_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+imuxsock_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+imuxsock_la_LDFLAGS = -module -avoid-version
 imuxsock_la_LIBADD =
+
+if ENABLE_LIBLOGGING_STDLOG
+imuxsock_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+imuxsock_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif

--- a/plugins/mmexternal/Makefile.am
+++ b/plugins/mmexternal/Makefile.am
@@ -1,8 +1,13 @@
 pkglib_LTLIBRARIES = mmexternal.la
 
 mmexternal_la_SOURCES = mmexternal.c
-mmexternal_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-mmexternal_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+mmexternal_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
+mmexternal_la_LDFLAGS = -module -avoid-version
 mmexternal_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+mmexternal_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+mmexternal_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 EXTRA_DIST = 

--- a/plugins/omtesting/Makefile.am
+++ b/plugins/omtesting/Makefile.am
@@ -1,6 +1,11 @@
 pkglib_LTLIBRARIES = omtesting.la
 
 omtesting_la_SOURCES = omtesting.c
-omtesting_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-omtesting_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+omtesting_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+omtesting_la_LDFLAGS = -module -avoid-version
 omtesting_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+omtesting_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+omtesting_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -112,8 +112,15 @@ else
 librsyslog_la_CPPFLAGS = -DSD_EXPORT_SYMBOLS -D_PATH_MODDIR=\"$(pkglibdir)/\" -I\$(top_srcdir) -I\$(top_srcdir)/grammar
 endif
 #librsyslog_la_LDFLAGS = -module -avoid-version
-librsyslog_la_CPPFLAGS += $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBUUID_CFLAGS) $(LIBFASTJSON_CFLAGS) ${LIBESTR_CFLAGS} ${LIBLOGGING_STDLOG_CFLAGS} -I\$(top_srcdir)/tools
-librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(LIBFASTJSON_LIBS) ${LIBESTR_LIBS} ${LIBLOGGING_STDLOG_LIBS}
+librsyslog_la_CPPFLAGS += $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBUUID_CFLAGS) $(LIBFASTJSON_CFLAGS) ${LIBESTR_CFLAGS}
+librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(LIBFASTJSON_LIBS) ${LIBESTR_LIBS}
+
+if ENABLE_LIBLOGGING_STDLOG
+librsyslog_la_CPPFLAGS += ${LIBLOGGING_STDLOG_CFLAGS}
+librsyslog_la_LIBADD += $(LIBLOGGING_STDLOG_LIBS)
+endif
+
+librsyslog_la_CPPFLAGS += -I\$(top_srcdir)/tools
 
 #
 # regular expression support
@@ -121,9 +128,15 @@ librsyslog_la_LIBADD =  $(DL_LIBS) $(RT_LIBS) $(LIBUUID_LIBS) $(LIBFASTJSON_LIBS
 if ENABLE_REGEXP
 pkglib_LTLIBRARIES += lmregexp.la
 lmregexp_la_SOURCES = regexp.c regexp.h
-lmregexp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-lmregexp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
-lmregexp_la_LIBADD =
+lmregexp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmregexp_la_LDFLAGS = -module -avoid-version
+lmregexp_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+lmregexp_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+lmregexp_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
+
 endif
 
 #
@@ -131,9 +144,14 @@ endif
 # 
 pkglib_LTLIBRARIES += lmzlibw.la
 lmzlibw_la_SOURCES = zlibw.c zlibw.h
-lmzlibw_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-lmzlibw_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
-lmzlibw_la_LIBADD =
+lmzlibw_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmzlibw_la_LDFLAGS = -module -avoid-version
+lmzlibw_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+lmzlibw_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+lmzlibw_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 
 if ENABLE_INET
@@ -142,18 +160,28 @@ pkglib_LTLIBRARIES += lmnet.la lmnetstrms.la
 # network support
 # 
 lmnet_la_SOURCES = net.c net.h
-lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo $(LIBLOGGING_STDLOG_LIBS)
-lmnet_la_LIBADD =
+lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo
+lmnet_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+lmnet_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+lmnet_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 # network stream master class and stream factory
 lmnetstrms_la_SOURCES = netstrms.c netstrms.h \
 			netstrm.c netstrm.h \
 			nssel.c nssel.h \
 			nspoll.c nspoll.h
-lmnetstrms_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-lmnetstrms_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
-lmnetstrms_la_LIBADD =
+lmnetstrms_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmnetstrms_la_LDFLAGS = -module -avoid-version
+lmnetstrms_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+lmnetstrms_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+lmnetstrms_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 # netstream drivers
 
@@ -162,9 +190,15 @@ pkglib_LTLIBRARIES += lmnsd_ptcp.la
 lmnsd_ptcp_la_SOURCES = nsd_ptcp.c nsd_ptcp.h \
 		  	nsdsel_ptcp.c nsdsel_ptcp.h \
 			nsdpoll_ptcp.c nsdpoll_ptcp.h
-lmnsd_ptcp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-lmnsd_ptcp_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
-lmnsd_ptcp_la_LIBADD =
+lmnsd_ptcp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmnsd_ptcp_la_LDFLAGS = -module -avoid-version
+lmnsd_ptcp_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+lmnsd_ptcp_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+lmnsd_ptcp_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
+
 endif # if ENABLE_INET
 
 #
@@ -226,9 +260,14 @@ lmtcpsrv_la_SOURCES = \
 	tcps_sess.h \
 	tcpsrv.c \
 	tcpsrv.h
-lmtcpsrv_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-lmtcpsrv_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+lmtcpsrv_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmtcpsrv_la_LDFLAGS = -module -avoid-version
 lmtcpsrv_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+lmtcpsrv_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+lmtcpsrv_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 #
 # TCP (stream) client support
@@ -236,9 +275,14 @@ lmtcpsrv_la_LIBADD =
 lmtcpclt_la_SOURCES = \
 	tcpclt.c \
 	tcpclt.h
-lmtcpclt_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS)
-lmtcpclt_la_LDFLAGS = -module -avoid-version $(LIBLOGGING_STDLOG_LIBS)
+lmtcpclt_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmtcpclt_la_LDFLAGS = -module -avoid-version
 lmtcpclt_la_LIBADD = 
+
+if ENABLE_LIBLOGGING_STDLOG
+lmtcpclt_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+lmtcpclt_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
+endif
 
 
 #

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -37,7 +37,14 @@ rsyslogd_SOURCES = \
 	iminternal.h \
 	\
 	../dirty.h
-rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(LIBLOGGING_STDLOG_CFLAGS) -DSD_EXPORT_SYMBOLS
+rsyslogd_CPPFLAGS =  $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+
+if ENABLE_LIBLOGGING_STDLOG
+rsyslogd_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+endif
+
+rsyslogd_CPPFLAGS += -DSD_EXPORT_SYMBOLS
+
 # note: it looks like librsyslog.la must be explicitely given on LDDADD,
 # otherwise dependencies are not properly calculated (resulting in a
 # potentially incomplete build, a problem we had several times...)


### PR DESCRIPTION
When liblogging-stdlog was available but configure option "--disable-liblogging-stdlog"
was set, rsyslog was still linking against liblogging-stdlog.

This commit will ensure that rsyslog will only link against liblogging-stdlog when
"--enable-liblogging-stdlog" was set.

Bug: https://bugs.gentoo.org/667836

