### PR TITLE
testbench: modernize "wait-file-lines" functionality

### DIFF
--- a/tests/imfile-logrotate.sh
+++ b/tests/imfile-logrotate.sh
@@ -57,7 +57,7 @@ ls -l $RSYSLOG_DYNNAME.input*
 startup
 
 # Wait until testmessages are processed by imfile!
-. $srcdir/diag.sh wait-file-lines  $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
+wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
 
 # Logrotate on logfile
 logrotate -f $RSYSLOG_DYNNAME.logrotate
@@ -70,7 +70,7 @@ echo ls ${RSYSLOG_DYNNAME}.spool:
 ls -l ${RSYSLOG_DYNNAME}.spool
 
 let msgcount="2* $TESTMESSAGES"
-. $srcdir/diag.sh wait-file-lines  $RSYSLOG_OUT_LOG $msgcount $RETRIES
+wait_file_lines $RSYSLOG_OUT_LOG $msgcount $RETRIES
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown	# we need to wait until rsyslogd is finished!

--- a/tests/imfile-rename.sh
+++ b/tests/imfile-rename.sh
@@ -52,7 +52,7 @@ startup
 
 # sleep a little to give rsyslog a chance to begin processing
 
-. $srcdir/diag.sh wait-file-lines  $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
+wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
 
 # Move to another filename
 mv $RSYSLOG_DYNNAME.input.1.log rsyslog.input.2.log
@@ -66,7 +66,7 @@ ls -l ${RSYSLOG_DYNNAME}.spool
 ./msleep 500
 
 let msgcount="2* $TESTMESSAGES"
-. $srcdir/diag.sh wait-file-lines  $RSYSLOG_OUT_LOG $msgcount $RETRIES
+wait_file_lines $RSYSLOG_OUT_LOG $msgcount $RETRIES
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown	# we need to wait until rsyslogd is finished!

--- a/tests/imfile-truncate-multiple.sh
+++ b/tests/imfile-truncate-multiple.sh
@@ -21,14 +21,14 @@ if $msg contains "msgnum:" then
 NUMMSG=1000
 ./inputfilegen -m 1000 -i0 > $RSYSLOG_DYNNAME.input
 ls -li $RSYSLOG_DYNNAME.input
-inode=$(ls -i $RSYSLOG_DYNNAME.input | awk '{ print $1;}' )
+inode=$(get_inode $RSYSLOG_DYNNAME.input )
 echo inode $inode
 
 startup
 
 for i in {0..50}; do
 	# check that previous msg injection worked
-	$srcdir/diag.sh wait-file-lines  $RSYSLOG_OUT_LOG $NUMMSG 100
+	wait_file_lines  $RSYSLOG_OUT_LOG $NUMMSG 100
 	seq_check 0 $((NUMMSG - 1))
 
 	# begin new inject cycle
@@ -36,7 +36,7 @@ for i in {0..50}; do
 	echo generating $NUMMSG .. $((NUMMSG + generate_msgs -1))
 	./inputfilegen -m$generate_msgs -i$NUMMSG > $RSYSLOG_DYNNAME.input
 	(( NUMMSG=NUMMSG+generate_msgs ))
-	if [  $inode -ne $(ls -i $RSYSLOG_DYNNAME.input | awk '{ print $1;}' ) ]; then
+	if [  $inode -ne $( get_inode $RSYSLOG_DYNNAME.input ) ]; then
 		echo FAIL testbench did not keep same inode number, expected $inode
 		ls -li $RSYSLOG_DYNNAME.input
 		exit 100

--- a/tests/imkafka.sh
+++ b/tests/imkafka.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # added 2018-08-29 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-echo Init Testbench
 . ${srcdir:=.}/diag.sh init
 check_command_available kafkacat
 export KEEP_KAFKA_RUNNING="YES"

--- a/tests/imkafka_multi_single.sh
+++ b/tests/imkafka_multi_single.sh
@@ -136,7 +136,7 @@ TIMESTART=$(date +%s.%N)
 
 injectmsg_kafkacat
 # special case: number of test messages differs from file output
-$srcdir/diag.sh wait-file-lines $RSYSLOG_OUT_LOG $((TESTMESSAGES * 8)) ${RETRIES:-200}
+wait_file_lines $RSYSLOG_OUT_LOG $((TESTMESSAGES * 8)) ${RETRIES:-200}
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/imptcp_large.sh
+++ b/tests/imptcp_large.sh
@@ -18,7 +18,7 @@ ruleset(name="testing") {
 startup
 # send messages of 10.000bytes plus header max, randomized
 tcpflood -c5 -m20000 -r -d10000
-. $srcdir/diag.sh wait-file-lines $RSYSLOG_OUT_LOG 20000
+wait_file_lines$RSYSLOG_OUT_LOG 20000
 shutdown_when_empty
 wait_shutdown
 seq_check 0 19999 -E

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -75,7 +75,7 @@ startup
 echo Inject messages into rsyslog sender instance  
 injectmsg 1 $TESTMESSAGES
 
-$srcdir/diag.sh wait-file-lines  $RSYSLOG_OUT_LOG $TESTMESSAGESFULL 100
+wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGESFULL 100
 
 # experimental: wait until kafkacat receives everything
 

--- a/tests/sndrcv_udp_nonstdpt.sh
+++ b/tests/sndrcv_udp_nonstdpt.sh
@@ -41,7 +41,7 @@ startup 2
 tcpflood -m500 -i1
 
 # wait in data received
-$srcdir/diag.sh wait-file-lines $RSYSLOG_OUT_LOG 500 $TB_TIMEOUT_STARTSTOP
+wait_file_lines $RSYSLOG_OUT_LOG 500 $TB_TIMEOUT_STARTSTOP
 
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
