### PR TITLE
testbench: add test for mmjsonparse w/ unparsable data

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -820,6 +820,7 @@ TESTS +=  \
 endif
 if HAVE_VALGRIND
 TESTS +=  \
+	mmjsonparse_extra_data-vg.sh \
 	json_null_array-vg.sh \
 	json_object_looping-vg.sh \
 	json_array_looping-vg.sh \
@@ -1773,6 +1774,7 @@ EXTRA_DIST= \
 	json_null-vg.sh \
 	json_null_array.sh \
 	json_null_array-vg.sh \
+	mmjsonparse_extra_data-vg.sh \
 	mmnormalize_regex.sh \
 	testsuites/mmnormalize_regex.rulebase \
 	testsuites/regex_input \

--- a/tests/mmjsonparse_extra_data-vg.sh
+++ b/tests/mmjsonparse_extra_data-vg.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# ensure mmjsonparse works correctly if passed unparsable message
+# add 2018-11-05 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
+
+template(name="outfmt" type="string" string="-%msg%-\n")
+
+action(type="mmjsonparse" cookie="")
+if $parsesuccess == "OK" then {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+else if $parsesuccess == "FAIL" and $msg contains "param1" then {
+	action(type="omfile" file="'$RSYSLOG2_OUT_LOG'" template="outfmt")
+}
+'
+startup_vg
+tcpflood -m2 -M "\"{\\\"param1\\\":\\\"value1\\\"} data\""
+shutdown_when_empty
+wait_shutdown_vg
+check_exit_vg
+
+check_file_not_exists $RSYSLOG_OUT_LOG
+export EXPECTED='-{"param1":"value1"} data-
+-{"param1":"value1"} data-'
+cmp_exact $RSYSLOG2_OUT_LOG
+exit_test


### PR DESCRIPTION
ensure that this case works well

closes https://github.com/rsyslog/rsyslog/issues/313

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
