### PR TITLE
testbench: try to make journal tests more reliable

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -496,20 +496,16 @@ function content_check() {
 }
 
 
-function content_check_with_count() {
-	# content check variables for Timeout
-	if [ "x$3" == "x" ]; then
-		timeoutend=1
-	else
-		timeoutend=$3
-	fi
-	timecounter=0
 
+# $1 - content to check for
+# $2 - number of times content must appear
+# $3 - timeout (default: 1)
+function content_check_with_count() {
+	timeoutend=${3:-1}
+	timecounter=0
 	while [  $timecounter -lt $timeoutend ]; do
 		(( timecounter=timecounter+1 ))
-
 		count=$(grep -c -F -- "$1" <${RSYSLOG_OUT_LOG})
-
 		if [ $count -eq $2 ]; then
 			echo content_check_with_count success, \"$1\" occured $2 times
 			break

--- a/tests/imjournal-basic.sh
+++ b/tests/imjournal-basic.sh
@@ -6,7 +6,6 @@
 # test in case message does not make it even to journal which may 
 # sometimes happen in some environments.
 # addd 2017-10-25 by RGerhards, released under ASL 2.0
-
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh require-journalctl
 generate_conf
@@ -18,39 +17,46 @@ template(name="outfmt" type="string" string="%msg%\n")
 action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-set -x
+printf 'a quick glimpse at journal content at rsyslog startup:\n'
+journalctl -n 20 --no-pager
+printf '\n\n'
+
 TESTMSG="TestBenCH-RSYSLog imjournal This is a test message - $(date +%s) - $RSYSLOG_DYNNAME"
 
 ./journal_print "$TESTMSG"
 journal_write_state=$?
-echo "state: $journal_write_state writing: $TESTMSG"
-set +x
+# check state later - we must not terminate the test until we have terminated rsyslog
 
-# we must not terminate the test until we have terminated rsyslog
-./msleep 500
-echo after sleep, shutting down rsyslog
+# give the journal ~5 minutes to forward the message, see
+# https://github.com/rsyslog/rsyslog/issues/2564#issuecomment-435849660
+content_check_with_count "$TESTMSG" 1 300
+
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 
 if [ $journal_write_state -ne 0 ]; then
-	echo "SKIP: failed to put test into journal."
+	printf 'SKIP: journal_print returned state %d writing message: %s\n' "$journal_write_state" "$TESTMSG"
+	printf 'skipping test, journal probably not working\n'
 	exit 77
 fi
-journalctl -a | fgrep -qF "$TESTMSG"
+
+printf 'checking that journal indeed contains test message - may take a short while...\n'
+journalctl -a -r | grep -qF "$TESTMSG"
 if [ $? -ne 0 ]; then
 	echo "SKIP: cannot read journal."
 	exit 77
 fi
+printf 'journal contains test message\n'
 
 echo "INFO: $(wc -l < $RSYSLOG_OUT_LOG) lines in $RSYSLOG_OUT_LOG"
 
-fgrep -qF "$TESTMSG" < $RSYSLOG_OUT_LOG 
+grep -qF "$TESTMSG" < $RSYSLOG_OUT_LOG
 if [ $? -ne 0 ]; then
   echo "FAIL:  $RSYSLOG_OUT_LOG content (tail -n200):"
   tail -n200 $RSYSLOG_OUT_LOG
   echo "======="
   echo "searching journal for testbench messages:"
-  journalctl -a | grep -qf "TestBenCH-RSYSLog imjournal"
+  journalctl -a | grep -qF "TestBenCH-RSYSLog imjournal"
   echo "======="
   echo "NOTE: showing only last 200 lines, may be insufficient on busy systems!"
   echo "last entries from journal:"


### PR DESCRIPTION
working on removing potential race between journal forward latency
and rsyslog shutdown. Also adding additional debug information to
improve understanding of potentially upcoming new test failures.

see also https://github.com/rsyslog/rsyslog/issues/2564

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
