### PR TITLE
testbench: ensure error reporting params are urlencoded

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1079,6 +1079,7 @@ distclean-local:
 	rm -rf .dep_cache .dep_wrk
 
 EXTRA_DIST= \
+	urlencode.py \
 	operatingstate-basic.sh \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -929,12 +929,16 @@ skip_test(){
 }
 
 
-# Helper function to call Adiscon test error script
+# Helper function to call rsyslog project test error script
 # $1 is the exit code
 function error_stats() {
 	if [ "$RSYSLOG_STATSURL" != "" ]; then
 		echo reporting failure to $RSYSLOG_STATSURL
-		wget -nv $RSYSLOG_STATSURL\?Testname=$RSYSLOG_TESTNAME\&Testenv=${VCS_SLUG:-$PWD}\&Testmachine=$HOSTNAME\&exitcode=${1:-1}\&logurl=${CI_BUILD_URL:-}\&rndstr=jnxv8i34u78fg23
+		testname=$(./urlencode.py "$RSYSLOG_TESTNAME")
+		testenv=$(./urlencode.py "${VCS_SLUG:-$PWD}")
+		testmachine=$(./urlencode.py "$HOSTNAME")
+		logurl=$(./urlencode.py "${CI_BUILD_URL:-}")
+		wget -nv $RSYSLOG_STATSURL\?Testname=$testname\&Testenv=$testenv\&Testmachine=$testmachine\&exitcode=${1:-1}\&logurl=$logurl\&rndstr=jnxv8i34u78fg23
 	fi
 }
 

--- a/tests/urlencode.py
+++ b/tests/urlencode.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+# a small url encoder for testbench purposes
+# written 2018-11-05 by Rainer Gerhards
+# part of the rsyslog testbench, released under ASL 2.0
+import sys
+import urllib
+
+if len(sys.argv) != 2:
+	print "ERROR: urlencode needs exactly one string as argument"
+	sys.exit(1)
+print urllib.quote_plus(sys.argv[1])


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
