### PR TITLE
testbench: detected kafka failure during test run and SKIP if so

### DIFF
--- a/tests/sndrcv_kafka_multi_topics.sh
+++ b/tests/sndrcv_kafka_multi_topics.sh
@@ -79,6 +79,8 @@ local4.* action(	name="kafka-fwd"
 	action.resumeRetryCount="10"
 	queue.saveonshutdown="on"
 	)
+
+syslog.* action(type="omfile" file="'$RSYSLOG_DYNNAME.sender.syslog'")
 '
 
 echo STEP: Starting sender instance [omkafka]
@@ -126,6 +128,8 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 if ($msg contains "msgnum:") then {
 	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt" )
 }
+
+syslog.* action(type="omfile" file="'$RSYSLOG_DYNNAME.receiver.syslog'")
 ' 2
 
 echo STEP: Starting receiver instance [imkafka]
@@ -144,6 +148,9 @@ wait_shutdown 2
 echo STEP: delete kafka topics
 delete_kafka_topic $RANDTOPIC1 '.dep_wrk' '22181'
 delete_kafka_topic $RANDTOPIC2 '.dep_wrk' '22181'
+
+kafka_check_broken_broker "$RSYSLOG_DYNNAME.sender.syslog"
+kafka_check_broken_broker "$RSYSLOG_DYNNAME.receiver.syslog"
 
 # Dump Kafka log | uncomment if needed
 # dump_kafka_serverlog


### PR DESCRIPTION
better we skip the test than create false positives due to kafka failure.
Also improve broken Broker check with additional possibilites.

This commit introduces the functionality to a subset of tests. Follow-up
commits may extend it to all kafka tests.

see also https://github.com/rsyslog/rsyslog/issues/3088
see also https://github.com/rsyslog/rsyslog/issues/3057

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
