### PR TITLE
testbench: make libdbi test more reliable

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -733,12 +733,13 @@ await_lookup_table_reload() {
 wait_file_lines() {
 	timeoutend=${3:-200}
 	timecounter=0
+	file=${1:-$RSYSLOG_OUT_LOG}
 
 	while [  $timecounter -lt $timeoutend ]; do
 		(( timecounter++ ))
 
-		if [ -f "$RSYSLOG_OUT_LOG" ]; then
-			count=$(wc -l < "$RSYSLOG_OUT_LOG")
+		if [ -f "$file" ]; then
+			count=$(wc -l < "$file")
 		fi
 		if [ ${count:=0} -eq $2 ]; then
 			echo wait_file_lines success, have $2 lines

--- a/tests/libdbi-asyn.sh
+++ b/tests/libdbi-asyn.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
-# This file is part of the rsyslog project, released under GPLv3
-echo ===============================================================================
-echo \[libdbi-asyn.sh\]: asyn test for libdbi functionality
+# This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5000 # this test is veeeeery slow, value is a compromise
 generate_conf
 add_conf '
 $ModLoad ../plugins/omlibdbi/.libs/omlibdbi
@@ -15,14 +14,18 @@ $ActionLibdbiHost 127.0.0.1
 $ActionLibdbiUserName rsyslog
 $ActionLibdbiPassword testbench
 $ActionLibdbiDBName Syslog
-:msg, contains, "msgnum:" :omlibdbi:
+:msg, contains, "msgnum:" {
+	:omlibdbi:
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.syncfile")
+}
 '
 mysql --user=rsyslog --password=testbench < ${srcdir}/testsuites/mysql-truncate.sql
 startup
-injectmsg  0 50000
+injectmsg  0 $NUMMESSAGES
+wait_file_lines $RSYSLOG_DYNNAME.syncfile $NUMMESSAGES 2500
 shutdown_when_empty
 wait_shutdown 
 # note "-s" is requried to suppress the select "field header"
 mysql -s --user=rsyslog --password=testbench < ${srcdir}/testsuites/mysql-select-msg.sql > $RSYSLOG_OUT_LOG
-seq_check  0 49999
+seq_check  0 $(( NUMMESSAGES - 1 ))
 exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
