### PR TITLE
fix testbench error reporting under distcheck

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1012,10 +1012,10 @@ error_stats() {
 		printf 'not reporting failure as RSYSLOG_STATSURL is not set\n'
 	else
 		echo reporting failure to $RSYSLOG_STATSURL
-		testname=$($TESTTOOL_DIR/urlencode.py "$RSYSLOG_TESTNAME")
-		testenv=$($TESTTOOL_DIR/urlencode.py "${VCS_SLUG:-$PWD}")
-		testmachine=$($TESTTOOL_DIR/urlencode.py "$HOSTNAME")
-		logurl=$($TESTTOOL_DIR/urlencode.py "${CI_BUILD_URL:-}")
+		testname=$($srcdir/urlencode.py "$RSYSLOG_TESTNAME")
+		testenv=$($srcdir/urlencode.py "${VCS_SLUG:-$PWD}")
+		testmachine=$($srcdir/urlencode.py "$HOSTNAME")
+		logurl=$($srcdir/urlencode.py "${CI_BUILD_URL:-}")
 		wget -nv $RSYSLOG_STATSURL\?Testname=$testname\&Testenv=$testenv\&Testmachine=$testmachine\&exitcode=${1:-1}\&logurl=$logurl\&rndstr=jnxv8i34u78fg23
 	fi
 }


### PR DESCRIPTION
Error reporting did not work as we still used the wrong path to our new
urlencode utility. Being a python app, it remains in $srcdir.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
