### PR TITLE
try to solve shutdown memory leak

### DIFF
--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -384,6 +384,7 @@ wtpWorker(void *arg) /* the arg is actually a wti object, even though we are in 
 	uchar *pszDbgHdr;
 	uchar thrdName[32] = "rs:";
 #	endif
+	pthread_detach(pthread_self());
 
 	ISOBJ_TYPE_assert(pWti, wti);
 	pThis = pWti->pWtp;

--- a/tests/known_issues.supp
+++ b/tests/known_issues.supp
@@ -6,3 +6,10 @@
    ...
 }
 
+{
+   This seems to be a problem in pthreads, see https://github.com/rsyslog/rsyslog/issues/2902
+   Memcheck:Leak
+   ...
+   fun:pthread_create@@*
+   ...
+}

--- a/tests/known_issues.supp
+++ b/tests/known_issues.supp
@@ -1,0 +1,8 @@
+{
+   <dlcose-missing-to-enable-debug-symbol-display_NOT_A_LEAK>
+   Memcheck:Leak
+   ...
+   fun:dlopen*
+   ...
+}
+

--- a/tests/mmpstrucdata-invalid-vg.sh
+++ b/tests/mmpstrucdata-invalid-vg.sh
@@ -3,16 +3,12 @@
 # correctly parsed.
 # This file is part of the rsyslog project, released  under ASL 2.0
 # rgerhards, 2015-04-30
-
-uname
-if [ $(uname) = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
-echo ===============================================================================
-echo \[mmpstrucdata-invalid.sh\]: testing mmpstrucdata with invalid SD
 . ${srcdir:=.}/diag.sh init
+#skip_platform "FreeBSD" "This test currently does not work on FreeBSD."
+export USE_VALGRIND="YES" # this test only makes sense with valgrind enabled
+# uncomment below to set special valgrind options
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+
 generate_conf
 add_conf '
 module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
@@ -24,7 +20,7 @@ action(type="mmpstrucdata")
 if $msg contains "msgnum" then
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '
-startup_vg
+startup
 # we use different message counts as this hopefully aids us
 # in finding which sample is leaking. For this, check the number
 # of blocks lost and see what set they match.
@@ -33,6 +29,5 @@ tcpflood -m200 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpfl
 tcpflood -m300 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 MSGNUM= ] invalid structured data!\""
 tcpflood -m400 -M "\"<161>1 2003-03-01T01:00:00.000Z mymachine.example.com tcpflood - tag [tcpflood@32473 = ] invalid structured data!\""
 shutdown_when_empty
-wait_shutdown_vg
-check_exit_vg
+wait_shutdown
 exit_test


### PR DESCRIPTION
valgrind sometimes reports a leak on shutdown and we are still not sure
if this is a rsyslog bug or something in (some versions of) pthreads lib,
which simply should be suppressed. This adds additional debug info, to be
shown in CI runs, to hopefully help clarify the issue.
    
see also https://github.com/rsyslog/rsyslog/issues/2902

This also adds some other small testbench improvements.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
