### PR TITLE
buildbot: gather script shall not pickup $RSYSLOG_DYNNAME*.log files

### DIFF
--- a/tests/CI/gather_all_logs.sh
+++ b/tests/CI/gather_all_logs.sh
@@ -3,4 +3,6 @@
 # tests.
 echo gather all logs left from make check.
 echo you only need these if make check is terminated due to timeout
-ls -tr tests/*.log | xargs cat
+# IMPORTANT: ! -name "rstb_*" excludes $RSYSLOGDYNNAME*.log
+( cd tests ;
+find . -maxdepth 1 -print0 -name "*.log" ! -name "rstb_*" -exec cat {} +; )


### PR DESCRIPTION
previously, it also picked test output files if they were left over. For
some test this meant very verbose data could be sent to buildbot master.
We have seen cases with over 20million lines, which made the log view
impossible. This has now been corrected.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
