### PR TITLE
testbench: modernize some imfile tests, re-enable on FreeBSD

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -686,11 +686,7 @@ wait_queueempty() {
 
 # shut rsyslogd down when main queue is empty. $1 is the instance.
 shutdown_when_empty() {
-	if [ "$1" == "2" ]; then
-	   echo Shutting down instance 2
-	else
-	   echo Shutting down instance 1
-	fi
+	echo Shutting down instance ${1:-1}
 	wait_queueempty $1
 	if [ "$RSYSLOG_PIDBASE" == "" ]; then
 		echo "RSYSLOG_PIDBASE is EMPTY! - bug in test? (instance $1)"

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1203,7 +1203,7 @@ exit_test() {
 	# Extended Exit handling for kafka / zookeeper instances 
 	kafka_exit_handling "true"
 
-	printf 'Test SUCCESFUL\n'
+	printf '%s Test %s SUCCESFUL (took %s seconds)\n' "$(tb_timestamp)" "$0" "$(( $(date +%s) - TB_STARTTEST ))"
 	echo  -------------------------------------------------------------------------------
 	exit 0
 }
@@ -1907,9 +1907,10 @@ case $1 in
 			export TZ=UTC
 		fi
 		ulimit -c unlimited  &> /dev/null # at least try to get core dumps
-		printf '------------------------------------------------------------\n'
+		export TB_STARTTEST=$(date +%s)
+		printf '%s\n' '------------------------------------------------------------'
 		printf '%s Test: %s\n' "$(tb_timestamp)" "$0"
-		printf '------------------------------------------------------------\n'
+		printf '%s\n' '------------------------------------------------------------'
 		rm -f xlate*.lkp_tbl
 		rm -f log log* # RSyslog debug output 
 		rm -f work 

--- a/tests/imfile-basic-2GB-file.sh
+++ b/tests/imfile-basic-2GB-file.sh
@@ -5,7 +5,6 @@
 # adds a couple of messages to get it over 2GiB.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD" "FIXME: check default of 'inotify' mode"
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")

--- a/tests/imfile-endregex-vg.sh
+++ b/tests/imfile-endregex-vg.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-
-uname
-if [ $(uname) = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
-echo ======================================================================
-echo [imfile-endregex.sh]
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -39,35 +30,31 @@ echo 'msgnum:0
  msgnum:1' > $RSYSLOG_DYNNAME.input
 echo 'msgnum:2' >> $RSYSLOG_DYNNAME.input
 
-# sleep a little to give rsyslog a chance to begin processing
-sleep 1
+wait_file_lines $RSYSLOG_OUT_LOG 1
 
 # write some more lines (see https://github.com/rsyslog/rsyslog/issues/144)
 echo 'msgnum:3
  msgnum:4' >> $RSYSLOG_DYNNAME.input
 echo 'msgnum:5' >> $RSYSLOG_DYNNAME.input # this one shouldn't be written to the output file because of ReadMode 2
 
-# give it time to finish
-sleep 1
+wait_file_lines $RSYSLOG_OUT_LOG 3
 
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown_vg    # we need to wait until rsyslogd is finished!
+shutdown_when_empty
+wait_shutdown_vg
 check_exit_vg
 
-# give it time to write the output file
-sleep 1
-
 ## check if we have the correct number of messages
-
 NUMLINES=$(grep -c HEADER  $RSYSLOG_OUT_LOG 2>/dev/null)
 
 if [ -z $NUMLINES ]; then
   echo "ERROR: expecting at least a match for HEADER, maybe  $RSYSLOG_OUT_LOG wasn't even written?"
-  exit 1
+  cat $RSYSLOG_OUT_LOG
+  error_exit 1
 else
   if [ ! $NUMLINES -eq 3 ]; then
     echo "ERROR: expecting 3 headers, got $NUMLINES"
-    exit 1
+    cat $RSYSLOG_OUT_LOG
+    error_exit 1
   fi
 fi
 
@@ -77,10 +64,8 @@ for i in {1..4}; do
   grep msgnum:$i  $RSYSLOG_OUT_LOG > /dev/null 2>&1
   if [ ! $? -eq 0 ]; then
     echo "ERROR: expecting the string 'msgnum:$i', it's not there"
-    exit 1
+    error_exit 1
   fi
 done
-
-## if we got here, all is good :)
 
 exit_test

--- a/tests/imfile-readmode2-vg.sh
+++ b/tests/imfile-readmode2-vg.sh
@@ -1,14 +1,5 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-
-uname
-if [ $(uname) = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
-echo ======================================================================
-echo [imfile-readmode2-vg.sh]
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -38,38 +29,30 @@ startup_vg
 echo 'msgnum:0
  msgnum:1' > $RSYSLOG_DYNNAME.input
 echo 'msgnum:2' >> $RSYSLOG_DYNNAME.input
-
-# sleep a little to give rsyslog a chance to begin processing
-sleep 1
+wait_file_lines $RSYSLOG_OUT_LOG 1
 
 # write some more lines (see https://github.com/rsyslog/rsyslog/issues/144)
 echo 'msgnum:3
  msgnum:4' >> $RSYSLOG_DYNNAME.input
 echo 'msgnum:5' >> $RSYSLOG_DYNNAME.input # this one shouldn't be written to the output file because of ReadMode 2
+wait_file_lines $RSYSLOG_OUT_LOG 3
 
-# give it time to finish
-sleep 1
-
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown_vg    # we need to wait until rsyslogd is finished!
+shutdown_when_empty
+wait_shutdown_vg
 check_exit_vg
 
-# give it time to write the output file
-sleep 1
-
 ## check if we have the correct number of messages
-
 NUMLINES=$(grep -c HEADER  $RSYSLOG_OUT_LOG 2>/dev/null)
 
 if [ -z $NUMLINES ]; then
   echo "ERROR: expecting at least a match for HEADER, maybe  $RSYSLOG_OUT_LOG wasn't even written?"
   cat $RSYSLOG_OUT_LOG
-  exit 1
+  error_exit 1
 else
   if [ ! $NUMLINES -eq 3 ]; then
     echo "ERROR: expecting 3 headers, got $NUMLINES"
     cat $RSYSLOG_OUT_LOG
-    exit 1
+    error_exit 1
   fi
 fi
 
@@ -80,7 +63,7 @@ for i in {1..4}; do
   if [ ! $? -eq 0 ]; then
     echo "ERROR: expecting the string 'msgnum:$i', it's not there"
     cat $RSYSLOG_OUT_LOG
-    exit 1
+    error_exit 1
   fi
 done
 

--- a/tests/imfile-truncate-2GB-file.sh
+++ b/tests/imfile-truncate-2GB-file.sh
@@ -5,7 +5,6 @@
 # adds a couple of messages to get it over 2GiB.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD" "FIXME: check default of 'inotify' mode"
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")


### PR DESCRIPTION
They did not work on FreeBSD because of an imfile bug which is
now fixed.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
