### PR TITLE
testbench: fix core file handling when multiple core files exist

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -753,9 +753,8 @@ quit"
 	done
 	unset terminated
 	unset out_pid
-	if [ -e core.* ]
-	then
-	   echo "ABORT! core file exists"
+	if [ "$(ls core.* 2>/dev/null)" != "" ]; then
+	   printf 'ABORT! core file exists (maybe from a parallel run!)\n'
 	   error_exit  1
 	fi
 }
@@ -977,8 +976,7 @@ do_cleanup() {
 #       call it immeditely before termination. This may be used to cleanup
 #       some things or emit additional diagnostic information.
 error_exit() {
-	if [ -e core* ]
-	then
+	if [ "$(ls core* 2>/dev/null)" != "" ]; then
 		echo trying to obtain crash location info
 		echo note: this may not be the correct file, check it
 		CORE=$(ls core*)
@@ -989,8 +987,7 @@ error_exit() {
 		rm gdb.in
 	fi
 	if [[ "$2" == 'stacktrace' || ( ! -e IN_AUTO_DEBUG &&  "$USE_AUTO_DEBUG" == 'on' ) ]]; then
-		if [ -e core* ]
-		then
+		if [ "$(ls core* 2>/dev/null)" != "" ]; then
 			echo trying to analyze core for main rsyslogd binary
 			echo note: this may not be the correct file, check it
 			CORE=$(ls core*)

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -142,7 +142,7 @@ test_status() {
 
 setvar_RS_HOSTNAME() {
 	printf '### Obtaining HOSTNAME (prequisite, not actual test) ###\n'
-	generate_conf
+	generate_conf ""
 	add_conf 'module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
@@ -153,7 +153,7 @@ local0.* ./'${RSYSLOG_DYNNAME}'.HOSTNAME;hostname
 	startup
 	tcpflood -m1 -M "\"<128>\""
 	shutdown_when_empty
-	wait_shutdown
+	wait_shutdown ""
 	export RS_HOSTNAME="$(cat ${RSYSLOG_DYNNAME}.HOSTNAME)"
 	rm -f "${RSYSLOG_DYNNAME}.HOSTNAME"
 	echo HOSTNAME is: $RS_HOSTNAME
@@ -575,8 +575,8 @@ content_check_with_count() {
 			break
 		else
 			if [ "x$timecounter" == "x$timeoutend" ]; then
-				shutdown_when_empty
-				wait_shutdown
+				shutdown_when_empty ""
+				wait_shutdown ""
 
 				echo content_check_with_count failed, expected \"$1\" to occur $2 times, but found it $count times
 				echo file ${RSYSLOG_OUT_LOG} content is:
@@ -1606,8 +1606,8 @@ create_kafka_topic() {
 				exit 177
 			fi
 			echo "RETRYING kafka startup, doing shutdown and startup"
-			stop_zookeeper; stop_kafka
-			start_zookeeper; start_kafka
+			stop_zookeeper ""; stop_kafka ""
+			start_zookeeper ""; start_kafka ""
 			echo "READY for RETRY"
 			is_retry=1
 			i=0


### PR DESCRIPTION
This is primarily a cosmetic fix, as multiple core files should never
exist. The only exception might be parallel builds, but in this case
the whole concept does not work correctly (we may probably see into
that when we finally support parallel builds, which we do not yet).

detected by shellcheck

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
