### PR TITLE
testbench: add test for minitcpsrv usage

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -61,6 +61,7 @@ TESTS +=  \
 	hostname-getaddrinfo-fail.sh \
 	msleep_usage_output.sh \
 	mangle_qi_usage_output.sh \
+	minitcpsrv_usage_output.sh \
 	test_id_usage_output.sh \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
@@ -1242,6 +1243,7 @@ EXTRA_DIST= \
 	tcpflood_wrong_option_output.sh \
 	msleep_usage_output.sh \
 	mangle_qi_usage_output.sh \
+	minitcpsrv_usage_output.sh \
 	test_id_usage_output.sh \
 	mmanon_with_debug.sh \
 	mmanon_random_32_ipv4.sh \

--- a/tests/minitcpsrv_usage_output.sh
+++ b/tests/minitcpsrv_usage_output.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# add 2018-11-15 by Jan Gerhards, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+
+./minitcpsrv&> $RSYSLOG_DYNNAME.output
+grep -q -- "-t parameter missing" $RSYSLOG_DYNNAME.output 
+
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated"
+  error_exit  1
+fi;
+
+exit_test


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/issues/3072

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
