### PR TITLE
bugfix omhttp: does not compile on all platforms

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -113,7 +113,6 @@ typedef struct instanceConf_s {
 	struct instanceConf_s *next;
 } instanceData;
 
-typedef instanceConf_t instanceData;
 
 struct modConfData_s {
 	rsconf_t *pConf;		/* our overall config object */
@@ -590,10 +589,10 @@ static rsRetVal
 getSection(const char* bulkRequest, const char **bulkRequestNextSectionStart )
 {
 		DEFiRet;
-		char* index =0;
-		if( (index = strchr(bulkRequest,'\n')) != 0)/*intermediate section*/
+		char* idx =0;
+		if( (idx = strchr(bulkRequest,'\n')) != 0)/*intermediate section*/
 		{
-			*bulkRequestNextSectionStart = ++index;
+			*bulkRequestNextSectionStart = ++idx;
 		}
 		else
 		{


### PR DESCRIPTION
at least on CentOS 6 package build we see errors:

https://build.opensuse.org/package/live_build_log/home:jgerhards:branches:home:rgerhards/rsyslog/CentOS_6/i586

see also https://github.com/rsyslog/rsyslog/issues/3302

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
