### PR TITLE
testbench: add imrelp valgrind test

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -999,7 +999,11 @@ TESTS += \
          sndrcv_relp_tls_prio.sh \
          relp_tls_certificate_not_found.sh \
 	 omrelp_wrong_authmode.sh
-endif
+endif # ENABLE_GNUTLS
+if HAVE_VALGRIND
+TESTS += \
+	 imrelp-manyconn-vg.sh
+endif # HAVE_VALGRIND
 endif
 
 if ENABLE_OMUDPSPOOF
@@ -1633,6 +1637,7 @@ EXTRA_DIST= \
 	imrelp-basic.sh \
 	imrelp-basic-oldstyle.sh \
 	imrelp-manyconn.sh \
+	imrelp-manyconn-vg.sh \
 	imrelp-maxDataSize-error.sh \
 	imrelp-long-msg.sh \
 	imrelp-oversizeMode-truncate.sh \

--- a/tests/imrelp-manyconn-vg.sh
+++ b/tests/imrelp-manyconn-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imrelp-manyconn.sh


### PR DESCRIPTION
We see this test segfault on Solaris and want some more insight
into why. This is probably also useful in the future.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
