### PR TITLE
testbench: do not cancel uxsockrcvr on test init

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -550,6 +550,11 @@ get_mainqueuesize() {
 	fi
 }
 
+# get pid of rsyslog instance $1
+getpid() {
+		printf '%s' "$(cat $RSYSLOG_PIDBASE$1.pid)"
+}
+
 # grep for (partial) content. $1 is the content to check for, $2 the file to check
 # option --regex is understood, in which case $1 is a regex
 content_check() {
@@ -1939,9 +1944,6 @@ case $1 in
 			printf 'this test requires an active IPv6 stack, which we do not have here\n'
 			exit 77
 		fi
-		;;
-   'getpid')
-		pid=$(cat $RSYSLOG_PIDBASE$2.pid)
 		;;
    'kill-immediate') # kill rsyslog unconditionally
 		kill -9 $(cat $RSYSLOG_PIDBASE.pid)

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1855,14 +1855,6 @@ case $1 in
 			#pwd
 			#kill -9 $pid
 		#done
-		# cleanup hanging uxsockrcvr processes
-		for pid in $(ps -eo pid,args|grep 'uxsockrcvr' |grep -v grep |sed -e 's/\( *\)\([0-9]*\).*/\2/');
-		do
-			echo "ERROR: left-over previous uxsockrcvr instance $pid, killing it"
-			ps -fp $pid
-			pwd
-			kill -9 $pid
-		done
 		# end cleanup
 
 		# some default names (later to be set in other parts, once we support fully

--- a/tests/omprog-restart-terminated-outfile.sh
+++ b/tests/omprog-restart-terminated-outfile.sh
@@ -49,7 +49,7 @@ startup
 injectmsg 0 1
 wait_queueempty
 
-. $srcdir/diag.sh getpid
+pid=$(getpid)
 start_fd_count=$(lsof -p $pid | wc -l)
 
 injectmsg 1 1

--- a/tests/omprog-restart-terminated.sh
+++ b/tests/omprog-restart-terminated.sh
@@ -50,7 +50,8 @@ startup
 injectmsg 0 1
 wait_queueempty
 
-. $srcdir/diag.sh getpid
+pid=$(getpid)
+echo PID: $pid
 start_fd_count=$(lsof -p $pid | wc -l)
 
 injectmsg 1 1

--- a/tests/uxsock_simple.sh
+++ b/tests/uxsock_simple.sh
@@ -4,6 +4,7 @@
 # messages and sends them to the unix socket. Datagram sockets are being used.
 # added 2010-08-06 by Rgerhards
 . ${srcdir:=.}/diag.sh init
+check_command_available timeout
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then
@@ -22,7 +23,7 @@ $template outfmt,"%msg:F,58:2%\n"
 $OMUXSockSocket '$RSYSLOG_DYNNAME'-testbench-dgram-uxsock
 :msg, contains, "msgnum:" :omuxsock:;outfmt
 '
-./uxsockrcvr -s$RSYSLOG_DYNNAME-testbench-dgram-uxsock -o $RSYSLOG_OUT_LOG -t 60 &
+timeout 30s ./uxsockrcvr -s$RSYSLOG_DYNNAME-testbench-dgram-uxsock -o $RSYSLOG_OUT_LOG -t 60 &
 BGPROCESS=$!
 echo background uxsockrcvr process id is $BGPROCESS
 


### PR DESCRIPTION
this does not work with parallel builds; replaced by
timing haning uxsockrcvr instances out.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
