### PR TITLE
testbench: harden omprog tests against CI timing

### DIFF
--- a/tests/omprog-output-capture-vg.sh
+++ b/tests/omprog-output-capture-vg.sh
@@ -1,30 +1,5 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-
-# Same test than 'omprog-output-capture.sh', but checking for memory
-# problems using valgrind. Note it is not necessary to repeat the
-# rest of checks (this simplifies the maintenance of the tests).
-
-. ${srcdir:=.}/diag.sh init
-generate_conf
-add_conf '
-module(load="../plugins/omprog/.libs/omprog")
-
-template(name="outfmt" type="string" string="%msg%\n")
-
-:msg, contains, "msgnum:" {
-    action(
-        type="omprog"
-	    binary=`echo $srcdir/testsuites/omprog-output-capture-bin.sh`
-        template="outfmt"
-        name="omprog_action"
-        output=`echo $RSYSLOG_OUT_LOG`
-    )
-}
-'
-startup_vg
-injectmsg 0 10
-shutdown_when_empty
-wait_shutdown_vg
-check_exit_vg
-exit_test
+export USE_VALGRIND="YES"
+export RS_TEST_VALGRIND_EXTRA_OPTS="--child-silent-after-fork=yes"
+source ${srcdir:-.}/omprog-output-capture.sh

--- a/tests/omprog-output-capture.sh
+++ b/tests/omprog-output-capture.sh
@@ -13,16 +13,17 @@ template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" {
     action(
         type="omprog"
-	    binary=`echo $srcdir/testsuites/omprog-output-capture-bin.sh`
+	    binary="'$srcdir'/testsuites/omprog-output-capture-bin.sh"
         template="outfmt"
         name="omprog_action"
-        output=`echo $RSYSLOG_OUT_LOG`
+        output="'$RSYSLOG_OUT_LOG'"
         fileCreateMode="0644"  # default is 0600
     )
 }
 '
 startup
 injectmsg 0 10
+wait_file_lines "$RSYSLOG_OUT_LOG" 22
 shutdown_when_empty
 wait_shutdown
 
@@ -50,7 +51,6 @@ export EXPECTED="[stdout] Starting
 [stderr] Received msgnum:00000009:
 [stdout] Terminating normally
 [stderr] Terminating normally"
-
 cmp_exact $RSYSLOG_OUT_LOG
 
 exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
