### PR TITLE
testbench: instrument flaky imfile-truncate test to find flake cause

### DIFF
--- a/tests/imfile-truncate.sh
+++ b/tests/imfile-truncate.sh
@@ -9,8 +9,11 @@ module(load="../plugins/imfile/.libs/imfile")
 input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" Tag="file:" reopenOnTruncate="on")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-if $msg contains "msgnum:" then
+if $msg contains "msgnum:" then {
 	action( type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+} else {
+	action( type="omfile" file="'$RSYSLOG_DYNNAME'.rsyslog")
+}
 '
 
 # write the beginning of the file
@@ -30,6 +33,9 @@ msgnum:4' >> $RSYSLOG_DYNNAME.input
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
+
+printf 'Messages from rsyslog itself:\n'
+cat -n $RSYSLOG_DYNNAME.rsyslog
 
 seq_check 0 4
 exit_test


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/issues/3232

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
