### PR TITLE
testbench: add tests for parser.EscapeControlCharacterTab global option

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -934,6 +934,7 @@ TESTS += \
 	tabescape_dflt-udp.sh \
 	tabescape_off.sh \
 	tabescape_off-udp.sh \
+	tabescape_on.sh \
 	inputname-imtcp.sh \
 	fieldtest.sh \
 	fieldtest-udp.sh \
@@ -1685,6 +1686,7 @@ EXTRA_DIST= \
 	tabescape_dflt-udp.sh \
 	tabescape_off.sh \
 	tabescape_off-udp.sh \
+	tabescape_on.sh \
 	dircreate_dflt.sh \
 	dircreate_off.sh \
 	imuxsock_logger_parserchain.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -213,25 +213,26 @@ rst_msleep() {
 
 
 # compare file to expected exact content
-# $1 is file to compare
+# $1 is file to compare, default $RSYSLOG_OUT_LOG
 cmp_exact() {
-	if [ "$1" == "" ]; then
-		printf 'Testbench ERROR, cmp_exact() needs filename as %s\n' "$1"
+	filename=${1:-"$RSYSLOG_OUT_LOG"}
+	if [ "$filename" == "" ]; then
+		printf 'Testbench ERROR, cmp_exact() does not have a filename at ALL!\n'
 		error_exit 100
 	fi
 	if [ "$EXPECTED" == "" ]; then
 		printf 'Testbench ERROR, cmp_exact() needs to have env var EXPECTED set!\n'
 		error_exit 100
 	fi
-	printf '%s\n' "$EXPECTED" | cmp - "$1"
+	printf '%s\n' "$EXPECTED" | cmp - "$filename"
 	if [ $? -ne 0 ]; then
 		printf 'invalid response generated\n'
-		printf '################# %s is:\n' "$1"
-		cat -n $1
+		printf '################# %s is:\n' "$filename"
+		cat -n $filename
 		printf '################# EXPECTED was:\n'
 		cat -n <<< "$EXPECTED"
 		printf '\n#################### diff is:\n'
-		diff - "$1" <<< "$EXPECTED"
+		diff - "$filename" <<< "$EXPECTED"
 		error_exit  1
 	fi;
 }

--- a/tests/tabescape_on.sh
+++ b/tests/tabescape_on.sh
@@ -3,7 +3,7 @@
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
-global(parser.EscapeControlCharacterTab="off")
+global(parser.EscapeControlCharacterTab="on")
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
 
@@ -22,7 +22,7 @@ tcpflood -m1 -M "\"<167>Mar  6 16:57:54 172.20.245.8 test: before HT	after HT (d
 shutdown_when_empty
 wait_shutdown
 
-export EXPECTED=' before HT	after HT (do NOT remove TAB!)'
+export EXPECTED=' before HT#011after HT (do NOT remove TAB!)'
 cmp_exact
 
 exit_test


### PR DESCRIPTION
changing one test from legacy style to current; still retain related
test in legacy style albeit not strictly ncessary.

see also https://github.com/rsyslog/rsyslog/issues/552

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
