### PR TITLE
omkafka: add support for dynamic keys

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -196,6 +196,7 @@ typedef struct s_dynaTopicCacheEntry dynaTopicCacheEntry;
 
 /* Struct for Failed Messages Listitems */
 struct s_failedmsg_entry {
+	uchar* key;
 	uchar* payload;
 	uchar* topicname;
 	SLIST_ENTRY(s_failedmsg_entry) entries;	/*	List. */
@@ -204,6 +205,7 @@ typedef struct s_failedmsg_entry failedmsg_entry;
 
 typedef struct _instanceData {
 	uchar *topic;
+	sbool dynaKey;
 	sbool dynaTopic;
 	dynaTopicCacheEntry **dynCache;
 	pthread_mutex_t mutDynCache;
@@ -257,6 +259,7 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "topic", eCmdHdlrString, CNFPARAM_REQUIRED },
 	{ "dynatopic", eCmdHdlrBinary, 0 },
 	{ "dynatopic.cachesize", eCmdHdlrInt, 0 },
+	{ "dynakey", eCmdHdlrBinary, 0 },
 	{ "partitions.auto", eCmdHdlrBinary, 0 },	/* use librdkafka's automatic partitioning function */
 	{ "partitions.number", eCmdHdlrPositiveInt, 0 },
 	{ "partitions.usefixed", eCmdHdlrNonNegInt, 0 }, /* expert parameter, "nails" partition */
@@ -309,6 +312,7 @@ free_topic(rd_kafka_topic_t **topic)
 
 static void ATTR_NONNULL(1)
 failedmsg_entry_destruct(failedmsg_entry *const __restrict__ fmsgEntry) {
+	free(fmsgEntry->key);
 	free(fmsgEntry->payload);
 	free(fmsgEntry->topicname);
 	free(fmsgEntry);
@@ -317,21 +321,35 @@ failedmsg_entry_destruct(failedmsg_entry *const __restrict__ fmsgEntry) {
 /* note: we need the length of message as we need to deal with
  * non-NUL terminated strings under some circumstances.
  */
-static failedmsg_entry * ATTR_NONNULL()
-failedmsg_entry_construct(const char *const msg, const size_t msglen, const char *const topicname)
+static failedmsg_entry * ATTR_NONNULL(3,5)
+failedmsg_entry_construct(const char *const key, const size_t keylen, const char *const msg,
+const size_t msglen, const char *const topicname)
 {
 	failedmsg_entry *etry = NULL;
 
 	if((etry = malloc(sizeof(struct s_failedmsg_entry))) == NULL) {
 		return NULL;
 	}
+
+	if (key) {
+		if((etry->key = (uchar*)malloc(keylen+1)) == NULL) {
+			free(etry);
+			return NULL;
+		}
+		memcpy(etry->key, key, keylen);
+	} else {
+		etry->key=NULL;
+	}
+
 	if((etry->payload = (uchar*)malloc(msglen+1)) == NULL) {
+		free(etry->key);
 		free(etry);
 		return NULL;
 	}
 	memcpy(etry->payload, msg, msglen);
 	etry->payload[msglen] = '\0';
 	if((etry->topicname = (uchar*)strdup(topicname)) == NULL) {
+		free(etry->key);
 		free(etry->payload);
 		free(etry);
 		return NULL;
@@ -715,8 +733,8 @@ updateKafkaFailureCounts(rd_kafka_resp_err_t err) {
  * b_do_resubmit tells if we shall resubmit on error or not. This is needed
  *               when we submit already resubmitted messages.
  */
-static rsRetVal ATTR_NONNULL(1, 2)
-writeKafka(instanceData *const pData, uchar *const msg,
+static rsRetVal ATTR_NONNULL(1, 3)
+writeKafka(instanceData *const pData,  uchar *const key, uchar *const msg,
 	uchar *const msgTimestamp, uchar *const topic, const int b_do_resubmit)
 {
 	DEFiRet;
@@ -733,7 +751,7 @@ writeKafka(instanceData *const pData, uchar *const msg,
 #endif
 
 	DBGPRINTF("omkafka: trying to send: key:'%s', msg:'%s', timestamp:'%s'\n",
-		pData->key, msg, msgTimestamp);
+		key, msg, msgTimestamp);
 
 	if(pData->dynaTopic) {
 		DBGPRINTF("omkafka: topic to insert to: %s\n", topic);
@@ -761,7 +779,7 @@ writeKafka(instanceData *const pData, uchar *const msg,
 	DBGPRINTF("omkafka: rd_kafka_producev timestamp=%s/%" PRId64 "\n", msgTimestamp, ttMsgTimestamp);
 
 	/* Using new kafka producev API, includes Timestamp! */
-	if (pData->key == NULL) {
+	if (key == NULL) {
 		msg_kafka_response = rd_kafka_producev(pData->rk,
 						RD_KAFKA_V_RKT(rkt),
 						RD_KAFKA_V_PARTITION(partition),
@@ -771,14 +789,14 @@ writeKafka(instanceData *const pData, uchar *const msg,
 						RD_KAFKA_V_KEY(NULL, 0),
 						RD_KAFKA_V_END);
 	} else {
-		DBGPRINTF("omkafka: rd_kafka_producev key=%s\n", pData->key);
+		DBGPRINTF("omkafka: rd_kafka_producev key=%s\n", key);
 		msg_kafka_response = rd_kafka_producev(pData->rk,
 						RD_KAFKA_V_RKT(rkt),
 						RD_KAFKA_V_PARTITION(partition),
 						RD_KAFKA_V_VALUE(msg, strlen((char*)msg)),
 						RD_KAFKA_V_MSGFLAGS(RD_KAFKA_MSG_F_COPY),
 						RD_KAFKA_V_TIMESTAMP(ttMsgTimestamp),
-						RD_KAFKA_V_KEY(pData->key,strlen((char*)pData->key)),
+						RD_KAFKA_V_KEY(key,strlen((char*)key)),
 						RD_KAFKA_V_END);
 	}
 
@@ -791,15 +809,15 @@ writeKafka(instanceData *const pData, uchar *const msg,
 				"partition %d: '%d/%s' - adding MSG '%s' to failed for RETRY!\n",
 				rd_kafka_topic_name(rkt), partition, msg_kafka_response,
 				rd_kafka_err2str(msg_kafka_response), msg);
-			CHKmalloc(fmsgEntry = failedmsg_entry_construct((char*) msg, strlen((char*)msg),
-				rd_kafka_topic_name(rkt)));
+			CHKmalloc(fmsgEntry = failedmsg_entry_construct((char*) key, key ? strlen((char*)key) : 0,
+				(char*) msg, strlen((char*)msg),rd_kafka_topic_name(rkt)));
 			SLIST_INSERT_HEAD(&pData->failedmsg_head, fmsgEntry, entries);
 		} else {
 			LogError(0, RS_RET_KAFKA_PRODUCE_ERR,
 				"omkafka: Failed to produce to topic '%s' (rd_kafka_producev)"
-				"partition %d: %d/%s - MSG '%s'\n",
+				"partition %d: %d/%s - KEY '%s' -MSG '%s'\n",
 				rd_kafka_topic_name(rkt), partition, msg_kafka_response,
-				rd_kafka_err2str(msg_kafka_response), msg);
+				rd_kafka_err2str(msg_kafka_response), key, msg);
 		}
 	}
 #else
@@ -807,8 +825,8 @@ writeKafka(instanceData *const pData, uchar *const msg,
 	DBGPRINTF("omkafka: rd_kafka_produce\n");
 	/* Using old kafka produce API */
 	msg_enqueue_status = rd_kafka_produce(rkt, partition, RD_KAFKA_MSG_F_COPY,
-				  msg, strlen((char*)msg), pData->key,
-				  pData->key == NULL ? 0 : strlen((char*)pData->key),
+				  msg, strlen((char*)msg), key,
+				  key ? strlen((char*)key) : 0,
 				  NULL);
 	if(msg_enqueue_status == -1) {
 		msg_kafka_response = rd_kafka_last_error();
@@ -817,18 +835,18 @@ writeKafka(instanceData *const pData, uchar *const msg,
 		/* Put into kafka queue, again if configured! */
 		if (pData->bResubmitOnFailure && b_do_resubmit) {
 		   	DBGPRINTF("omkafka: Failed to produce to topic '%s' (rd_kafka_produce)"
-				"partition %d: '%d/%s' - adding MSG '%s' to failed for RETRY!\n",
+				"partition %d: '%d/%s' - adding MSG '%s' KEY '%s' to failed for RETRY!\n",
 				rd_kafka_topic_name(rkt), partition, msg_kafka_response,
-				rd_kafka_err2str(rd_kafka_errno2err(errno)), msg);
-			CHKmalloc(fmsgEntry = failedmsg_entry_construct((char*) msg, strlen((char*)msg),
-				rd_kafka_topic_name(rkt)));
+				rd_kafka_err2str(rd_kafka_errno2err(errno)), msg, key ? key : "");
+			CHKmalloc(fmsgEntry = failedmsg_entry_construct((char*) key, key ? strlen((char*)key) : 0,
+				(char*) msg, strlen((char*)msg),rd_kafka_topic_name(rkt)));
 			SLIST_INSERT_HEAD(&pData->failedmsg_head, fmsgEntry, entries);
 		} else {
 			LogError(0, RS_RET_KAFKA_PRODUCE_ERR,
 				"omkafka: Failed to produce to topic '%s' (rd_kafka_produce) "
-				"partition %d: %d/%s - MSG '%s'\n",
+				"partition %d: %d/%s - MSG '%s' KEY '%s'\n",
 				rd_kafka_topic_name(rkt), partition, msg_kafka_response,
-				rd_kafka_err2str(msg_kafka_response), msg);
+				rd_kafka_err2str(msg_kafka_response), msg, key);
 		}
 	}
 #endif
@@ -881,8 +899,8 @@ deliveryCallback(rd_kafka_t __attribute__((unused)) *rk,
 				rd_kafka_topic_name(rkmessage->rkt),
 				(int)(rkmessage->len-1), (char*)rkmessage->payload,
 				(int)(rkmessage->key_len), (char*)rkmessage->key);
-			CHKmalloc(fmsgEntry = failedmsg_entry_construct(rkmessage->payload, rkmessage->len,
-				rd_kafka_topic_name(rkmessage->rkt)));
+			CHKmalloc(fmsgEntry = failedmsg_entry_construct(rkmessage->key, rkmessage->key_len,
+				rkmessage->payload, rkmessage->len,rd_kafka_topic_name(rkmessage->rkt)));
 			SLIST_INSERT_HEAD(&pData->failedmsg_head, fmsgEntry, entries);
 		} else {
 			LogError(0, RS_RET_ERR,
@@ -1329,7 +1347,8 @@ checkFailedMessages(instanceData *const __restrict__ pData)
 		fmsgEntry = SLIST_FIRST(&pData->failedmsg_head);
 		assert(fmsgEntry != NULL);
 		/* Put back into kafka! */
-		iRet = writeKafka(pData, (uchar*) fmsgEntry->payload, NULL, fmsgEntry->topicname, NO_RESUBMIT);
+		iRet = writeKafka(pData, (uchar*) fmsgEntry->key, (uchar*) fmsgEntry->payload, NULL,
+			fmsgEntry->topicname,NO_RESUBMIT);
 		if(iRet != RS_RET_OK) {
 			LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
 				"omkafka: failed to deliver failed msg '%.*s' with status %d. "
@@ -1389,6 +1408,10 @@ persistFailedMsgs(instanceData *const __restrict__ pData)
 		nwritten = write(fdMsgFile, fmsgEntry->topicname, ustrlen(fmsgEntry->topicname) );
 		if(nwritten != -1)
 			nwritten = write(fdMsgFile, "\t", 1);
+		if((nwritten != -1) && (fmsgEntry->key))
+			nwritten = write(fdMsgFile, fmsgEntry->key, ustrlen(fmsgEntry->key) );
+		if(nwritten != -1)
+			nwritten = write(fdMsgFile, "\t", 1);
 		if(nwritten != -1)
 			nwritten = write(fdMsgFile, fmsgEntry->payload, ustrlen(fmsgEntry->payload) );
 		if(nwritten == -1) {
@@ -1429,6 +1452,7 @@ loadFailedMsgs(instanceData *const __restrict__ pData)
 	cstr_t *pCStr = NULL;
 	uchar *puStr;
 	char *pStrTabPos;
+	char *pStrTabPos2;
 
 	assert(pData->failedMsgFile != NULL);
 
@@ -1461,16 +1485,26 @@ loadFailedMsgs(instanceData *const __restrict__ pData)
 			/* we do not process empty lines */
 			DBGPRINTF("omkafka: loadFailedMsgs msg was empty!");
 		} else {
-			puStr = rsCStrGetSzStrNoNULL(pCStr);
-			pStrTabPos = index((char*)puStr, '\t');
-			if (pStrTabPos != NULL) {
-				DBGPRINTF("omkafka: loadFailedMsgs successfully loaded msg '%s' for "
-					"topic '%.*s':%d\n",
-					pStrTabPos+1, (int)(pStrTabPos-(char*)puStr), (char*)puStr,
-					(int)(pStrTabPos-(char*)puStr));
+			puStr = rsCStrGetSzStrNoNULL(pCStr); //topic
+			pStrTabPos = index((char*)puStr, '\t');  //key
+			pStrTabPos2 = index((char*)pStrTabPos+1, '\t');  //msg
+			if ((pStrTabPos != NULL) && (pStrTabPos2 != NULL)) {
 				*pStrTabPos = '\0'; /* split string into two */
-				CHKmalloc(fmsgEntry = failedmsg_entry_construct(pStrTabPos+1,
-					strlen(pStrTabPos+1), (char*)puStr));
+				*pStrTabPos2 = '\0'; /* split string into two */
+				DBGPRINTF("omkafka: loadFailedMsgs successfully loaded msg '%s' for "
+					"topic '%s' key '%s' \n",
+					pStrTabPos2+1, (char*)puStr, pStrTabPos+1);
+				if (strlen(pStrTabPos+1)) {
+					CHKmalloc(fmsgEntry = failedmsg_entry_construct(
+						pStrTabPos+1,strlen(pStrTabPos+1),
+						pStrTabPos2+1,strlen(pStrTabPos2+1),
+						(char*)puStr));
+				} else {
+					CHKmalloc(fmsgEntry = failedmsg_entry_construct(
+						NULL,0,
+						pStrTabPos2+1,strlen(pStrTabPos2+1),
+						(char*)puStr));
+				}
 				SLIST_INSERT_HEAD(&pData->failedmsg_head, fmsgEntry, entries);
 			} else {
 				LogError(0, RS_RET_ERR, "omkafka: loadFailedMsgs droping invalid msg found: %s",
@@ -1666,7 +1700,19 @@ CODESTARTdoAction
 	failedmsg_entry* fmsgEntry;
 	instanceData *const pData = pWrkrData->pData;
 	int need_unlock = 0;
+	int dynaTopicID = 0;
+	int dynaKeyID = 0;
 
+	if (pData->dynaKey) {
+		dynaKeyID=2;
+		if (pData->dynaTopic) {
+			dynaTopicID=3;
+		}
+	} else {
+		if (pData->dynaTopic) {
+			dynaTopicID=2;
+		}
+	}
 	pthread_mutex_lock(&pData->mut_doAction);
 	if (! pData->bIsOpen)
 		CHKiRet(setupKafkaHandle(pData, 0));
@@ -1687,12 +1733,24 @@ CODESTARTdoAction
 			DBGPRINTF("omkafka: doAction failed to submit FAILED messages with status %d\n", iRet);
 
 			if (pData->bResubmitOnFailure) {
-				DBGPRINTF("omkafka: also adding MSG '%.*s' for topic '%s' to failed for RETRY!\n",
-					(int)(strlen((char*)ppString[0])-1), ppString[0],
-					pData->dynaTopic ? ppString[2] : pData->topic);
-				CHKmalloc(fmsgEntry = failedmsg_entry_construct((char*)ppString[0],
-					strlen((char*)ppString[0]),
-					(char*) (pData->dynaTopic ? ppString[2] : pData->topic)));
+				if (pData->dynaKey || pData->key) {
+					DBGPRINTF("omkafka: also adding MSG '%.*s' for topic '%s' key '%s' "
+						"to failed for RETRY!\n",
+						(int)(strlen((char*)ppString[0])-1), ppString[0],
+						pData->dynaTopic ? ppString[dynaTopicID] : pData->topic,
+						pData->dynaKey ? ppString[dynaKeyID] : pData->key);
+				} else {
+					DBGPRINTF("omkafka: also adding MSG '%.*s' for topic '%s' "
+						"to failed for RETRY!\n",
+						(int)(strlen((char*)ppString[0])-1), ppString[0],
+						pData->dynaTopic ? ppString[dynaTopicID] : pData->topic);
+				}
+				CHKmalloc(fmsgEntry = failedmsg_entry_construct(
+					(char*) (pData->dynaKey ? ppString[dynaKeyID] : pData->key),
+					pData->dynaKey || pData->key ?
+					strlen((char*)(pData->dynaKey ? ppString[dynaKeyID] : pData->key)) : 0,
+					(char*)ppString[0], strlen((char*)ppString[0]),
+					(char*) (pData->dynaTopic ? ppString[dynaTopicID] : pData->topic)));
 				SLIST_INSERT_HEAD(&pData->failedmsg_head, fmsgEntry, entries);
 			}
 			ABORT_FINALIZE(iRet);
@@ -1700,7 +1758,8 @@ CODESTARTdoAction
 	}
 
 	/* support dynamic topic */
-	iRet = writeKafka(pData, ppString[0], ppString[1], pData->dynaTopic ? ppString[2] : pData->topic, RESUBMIT);
+	iRet = writeKafka(pData, pData->dynaKey ? ppString[dynaKeyID] : pData->key, ppString[0], ppString[1],
+		pData->dynaTopic ? ppString[dynaTopicID] : pData->topic, RESUBMIT);
 
 finalize_it:
 	if(need_unlock) {
@@ -1725,6 +1784,7 @@ setInstParamDefaults(instanceData *pData)
 {
 	pData->topic = NULL;
 	pData->pTopic = NULL;
+	pData->dynaKey = 0;
 	pData->dynaTopic = 0;
 	pData->iDynaTopicCacheSize = 50;
 	pData->brokers = NULL;
@@ -1779,6 +1839,8 @@ CODESTARTnewActInst
 			continue;
 		if(!strcmp(actpblk.descr[i].name, "topic")) {
 			pData->topic = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "dynakey")) {
+			pData->dynaKey = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "dynatopic")) {
 			pData->dynaTopic = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "dynatopic.cachesize")) {
@@ -1850,6 +1912,13 @@ CODESTARTnewActInst
 			"using default of localhost:9092 -- this may not be what you want!");
 	}
 
+	if(pData->dynaKey && pData->key == NULL) {
+		LogError(0, RS_RET_CONFIG_ERROR,
+			"omkafka: requested dynamic key, but no "
+			"name for key template given - action definition invalid");
+		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+	}
+
 	if(pData->dynaTopic && pData->topic == NULL) {
 		LogError(0, RS_RET_CONFIG_ERROR,
 			"omkafka: requested dynamic topic, but no "
@@ -1858,6 +1927,7 @@ CODESTARTnewActInst
 	}
 
 	iNumTpls = 2;
+	if(pData->dynaKey) ++iNumTpls;
 	if(pData->dynaTopic) ++iNumTpls;
 	CODE_STD_STRING_REQUESTnewActInst(iNumTpls);
 	CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)strdup((pData->tplName == NULL) ?
@@ -1866,8 +1936,11 @@ CODESTARTnewActInst
 
 	CHKiRet(OMSRsetEntry(*ppOMSR, 1, (uchar*)strdup(" KAFKA_TimeStamp"),
 						OMSR_NO_RQD_TPL_OPTS));
+	if(pData->dynaKey)
+		CHKiRet(OMSRsetEntry(*ppOMSR, 2, ustrdup(pData->key), OMSR_NO_RQD_TPL_OPTS));
+
 	if(pData->dynaTopic) {
-		CHKiRet(OMSRsetEntry(*ppOMSR, 2, ustrdup(pData->topic), OMSR_NO_RQD_TPL_OPTS));
+		CHKiRet(OMSRsetEntry(*ppOMSR, pData->dynaKey?3:2, ustrdup(pData->topic), OMSR_NO_RQD_TPL_OPTS));
 		CHKmalloc(pData->dynCache = (dynaTopicCacheEntry**)
 			calloc(pData->iDynaTopicCacheSize, sizeof(dynaTopicCacheEntry*)));
 		pData->iCurrElt = -1;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -752,6 +752,7 @@ if ENABLE_KAFKA_TESTS
 TESTS += \
 	kafka-selftest.sh \
 	omkafka.sh \
+	omkafkadynakey.sh \
 	imkafka.sh \
 	imkafka-backgrounded.sh \
 	imkafka-config-err-ruleset.sh \
@@ -1905,6 +1906,7 @@ EXTRA_DIST= \
 	mysql-actq-mt-withpause-vg.sh \
 	kafka-selftest.sh \
 	omkafka.sh \
+	omkafkadynakey.sh \
 	omkafka-vg.sh \
 	imkafka-hang-on-no-kafka.sh \
 	imkafka-hang-other-action-on-no-kafka.sh \

--- a/tests/omkafkadynakey.sh
+++ b/tests/omkafkadynakey.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+# added 2018-12-18 by ludobrands
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+test_status unreliable 'https://github.com/rsyslog/rsyslog/issues/3197'
+check_command_available kafkacat
+
+export KEEP_KAFKA_RUNNING="YES"
+export TESTMESSAGES=100000
+export TESTMESSAGESFULL=$TESTMESSAGES
+
+export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
+
+# Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+echo Check and Stop previous instances of kafka/zookeeper 
+download_kafka
+stop_zookeeper
+stop_kafka
+
+echo Create kafka/zookeeper instance and $RANDTOPIC topic
+start_zookeeper
+start_kafka
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+# --- Create/Start omkafka sender config 
+export RSYSLOG_DEBUGLOG="log"
+generate_conf
+add_conf '
+# impstats in order to gain insight into error cases
+module(load="../plugins/impstats/.libs/impstats"
+	log.file="'$RSYSLOG_DYNNAME.pstats'"
+	interval="1" log.syslog="off")
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+$imdiagInjectDelayMode full
+
+module(load="../plugins/omkafka/.libs/omkafka")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+template(name="keyin" type="list"){
+  property(name="$.inkey")
+}
+  
+local4.* {
+	set $.inkey = substring(field($msg,":",2),7,1);
+ 	action(	name="kafka-fwd"
+	type="omkafka"
+	topic="'$RANDTOPIC'"
+	key="keyin"
+	dynaKey="on"
+	broker="localhost:29092"
+	template="outfmt"
+	confParam=[	"compression.codec=none",
+			"socket.timeout.ms=10000",
+			"socket.keepalive.enable=true",
+			"reconnect.backoff.jitter.ms=1000",
+			"queue.buffering.max.messages=10000",
+			"enable.auto.commit=true",
+			"message.send.max.retries=1"]
+	topicConfParam=["message.timeout.ms=10000"]
+	partitions.auto="on"
+	closeTimeout="60000"
+	resubmitOnFailure="on"
+	keepFailedMessages="on"
+	failedMsgFile="'$RSYSLOG_OUT_LOG'-failed-'$RANDTOPIC'.data"
+	action.resumeInterval="1"
+	action.resumeRetryCount="2"
+	queue.saveonshutdown="on"
+	)
+	action( type="omfile" file="'$RSYSLOG_OUT_LOG'")
+	stop
+}
+
+action( type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'")
+'
+
+echo Starting sender instance [omkafka]
+startup
+
+echo Inject messages into rsyslog sender instance  
+injectmsg 1 $TESTMESSAGES
+
+wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGESFULL 100
+
+# experimental: wait until kafkacat receives everything
+
+timeoutend=100
+timecounter=0
+
+while [ $timecounter -lt $timeoutend ]; do
+	(( timecounter++ ))
+
+	kafkacat -b localhost:29092 -e -C -o beginning -t $RANDTOPIC -f '%s' > $RSYSLOG_OUT_LOG
+	count=$(wc -l < ${RSYSLOG_OUT_LOG})
+	if [ $count -eq $TESTMESSAGESFULL ]; then
+		printf '**** wait-kafka-lines success, have %d lines ****\n\n' "$TESTMESSAGESFULL"
+	        kafkacat -b localhost:29092 -e -C -o beginning -t HNyjt9vf -f '%p %k\n' | sort | uniq > $RSYSLOG_OUT_LOG
+        	count=$(wc -l < ${RSYSLOG_OUT_LOG})
+	        if [ $count -eq 10 ]; then
+			printf '**** partition check success, have 10 partition-key combinations ****\n\n' 
+			break
+	        else
+			echo partition check failed, expected 10 got $count
+			echo details:
+			kafkacat -b localhost:29092 -e -C -o beginning -t HNyjt9vf -f '%p %k\n' | sort | uniq
+			shutdown_when_empty
+			wait_shutdown
+			error_exit 1
+	        fi
+	else
+		if [ "x$timecounter" == "x$timeoutend" ]; then
+			echo wait-kafka-lines failed, expected $TESTMESSAGESFULL got $count
+			shutdown_when_empty
+			wait_shutdown
+			error_exit 1
+		else
+			echo wait-file-lines not yet there, currently $count lines
+			printf 'pstats data:\n'
+			cat $RSYSLOG_DYNNAME.pstats
+			printf '\n'
+
+			$TESTTOOL_DIR/msleep 1000
+		fi
+	fi
+done
+unset count
+
+#end experimental
+
+echo Stopping sender instance [omkafka]
+shutdown_when_empty
+wait_shutdown
+
+#kafkacat -b localhost:29092 -e -C -o beginning -t $RANDTOPIC -f '%s' > $RSYSLOG_OUT_LOG
+#kafkacat -b localhost:29092 -e -C -o beginning -t $RANDTOPIC -f '%p@%o:%k:%s' > $RSYSLOG_OUT_LOG.extra
+
+# Delete topic to remove old traces before
+delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+# Dump Kafka log | uncomment if needed
+# dump_kafka_serverlog
+
+kafka_check_broken_broker $RSYSLOG_DYNNAME.othermsg
+seq_check 1 $TESTMESSAGESFULL -d
+
+exit_test
+


### PR DESCRIPTION
Hi,

we needed a way to force the kafka partition based on the data being pushed. Pretty much the subject of #1421. Here is a patch that allows to use a template to provide the partitioning key.

A new configuration property "dynaKey" is added that, when "on", changes the value of property "key" to a template names instead of a constant value. This is similar in approach to the DynaTopic implementation.  

Our system uses mmjsonparse to extract from the message the property we use as a key. The config we are using  (the relevant part) :
```
module(load="omkafka")
module(load="mmjsonparse")

template(name="json_log" type="list") {
  constant(value="{")
    constant(value="\"@timestamp\":\"")  property(name="timereported" dateFormat="rfc3339")
    constant(value="\",\"tags\":[\"") property(name=".tag") constant(value="\"]")
    constant(value=",\"ctnewlog\": true,")
    property(name="$!all-json" position.from="2")
}

template(name="message_guid_template" type="list") {
  property(name="$!message_guid")
}
...
                action(type="mmjsonparse" cookie="")
                action(type="omkafka"
                        partitions.auto="on"
                        dynaKey="on"
                        key="message_guid_template"
                        template="json_log"
...                
                )
``` 

PR for documentation will follow. 