### PR TITLE
platform bugfix: HUP did not work reliably on some platforms 

### DIFF
--- a/tests/array_lookup_table.sh
+++ b/tests/array_lookup_table.sh
@@ -3,7 +3,6 @@
 # added 2015-10-30 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "This test does not work on FreeBSD"
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate_array.lkp_tbl")

--- a/tests/array_lookup_table_misuse-vg.sh
+++ b/tests/array_lookup_table_misuse-vg.sh
@@ -3,7 +3,6 @@
 # added 2015-10-30 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "This test does not work on FreeBSD"
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate_array.lkp_tbl")

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2271,7 +2271,13 @@ case $1 in
 		echo "dyn-stats reset for bucket ${3} registered"
 		;;
    'first-column-sum-check') 
-		sum=$(grep $3 < $4 | sed -e $2 | awk '{s+=$1} END {print s}')
+		echo grep:
+		grep "$3" < "$4"
+		echo sed:
+		grep "$3" < "$4" | sed -e "$2"
+		echo akw:
+		grep "$3" < "$4" | sed -e "$2" | awk '{s+=$1} END {print s}'
+		sum=$(grep "$3" < "$4" | sed -e "$2" | awk '{s+=$1} END {print s}')
 		if [ "x${sum}" != "x$5" ]; then
 		    printf '\n============================================================\n'
 		    echo FAIL: sum of first column with edit-expr "'$2'" run over lines from file "'$4'" matched by "'$3'" equals "'$sum'" which is NOT equal to EXPECTED value of "'$5'"

--- a/tests/dynstats_nometric.sh
+++ b/tests/dynstats_nometric.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 # added 2015-11-17 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-
-uname
-if [ $(uname) = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 echo ===============================================================================
 echo \[dynstats_nometric.sh\]: test for dyn-stats meta-metric behavior with zero-length metric name
 . ${srcdir:=.}/diag.sh init
@@ -41,7 +34,7 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown
-. $srcdir/diag.sh first-column-sum-check 's/.*no_metric=\([0-9]\+\)/\1/g' 'no_metric=' "${RSYSLOG_DYNNAME}.out.stats.log" 5
+. $srcdir/diag.sh first-column-sum-check 's/.*no_metric=//g' 'no_metric=' "${RSYSLOG_DYNNAME}.out.stats.log" 5
 custom_assert_content_missing 'foo' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing 'bar' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing 'baz' "${RSYSLOG_DYNNAME}.out.stats.log"

--- a/tests/dynstats_overflow-vg.sh
+++ b/tests/dynstats_overflow-vg.sh
@@ -1,13 +1,6 @@
 #!/bin/bash
 # added 2015-11-13 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
-
-uname
-if [ $(uname) = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 echo ===============================================================================
 echo \[dynstats_overflow-vg.sh\]: test for gathering stats when metrics exceed provisioned capacity
 . ${srcdir:=.}/diag.sh init

--- a/tests/dynstats_overflow.sh
+++ b/tests/dynstats_overflow.sh
@@ -2,13 +2,6 @@
 # added 2015-11-13 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-
-uname
-if [ $(uname) = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
 generate_conf
 add_conf '
 ruleset(name="stats") {
@@ -39,17 +32,18 @@ startup
 wait_queueempty
 . $srcdir/diag.sh allow-single-stats-flush-after-block-and-wait-for-it
 
-. $srcdir/diag.sh first-column-sum-check 's/.*foo=\([0-9]\+\)/\1/g' 'foo=' "${RSYSLOG_DYNNAME}.out.stats.log" 5
-. $srcdir/diag.sh first-column-sum-check 's/.*bar=\([0-9]\+\)/\1/g' 'bar=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
-. $srcdir/diag.sh first-column-sum-check 's/.*baz=\([0-9]\+\)/\1/g' 'baz=' "${RSYSLOG_DYNNAME}.out.stats.log" 2
+#. $srcdir/diag.sh first-column-sum-check 's/.*foo=\([0-9]\+\)/\1/g' 'foo=' "${RSYSLOG_DYNNAME}.out.stats.log" 5
+. $srcdir/diag.sh first-column-sum-check 's/.*foo=//g' 'foo=' "${RSYSLOG_DYNNAME}.out.stats.log" 5
+. $srcdir/diag.sh first-column-sum-check 's/.*bar=//g' 'bar=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
+. $srcdir/diag.sh first-column-sum-check 's/.*baz=//g' 'baz=' "${RSYSLOG_DYNNAME}.out.stats.log" 2
 
 custom_assert_content_missing 'quux' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing 'corge' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing 'grault' "${RSYSLOG_DYNNAME}.out.stats.log"
 
-. $srcdir/diag.sh first-column-sum-check 's/.*new_metric_add=\([0-9]\+\)/\1/g' 'new_metric_add=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
-. $srcdir/diag.sh first-column-sum-check 's/.*ops_overflow=\([0-9]\+\)/\1/g' 'ops_overflow=' "${RSYSLOG_DYNNAME}.out.stats.log" 5
-. $srcdir/diag.sh first-column-sum-check 's/.*no_metric=\([0-9]\+\)/\1/g' 'no_metric=' "${RSYSLOG_DYNNAME}.out.stats.log" 0
+. $srcdir/diag.sh first-column-sum-check 's/.*new_metric_add=//g' 'new_metric_add=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
+. $srcdir/diag.sh first-column-sum-check 's/.*ops_overflow=//g' 'ops_overflow=' "${RSYSLOG_DYNNAME}.out.stats.log" 5
+. $srcdir/diag.sh first-column-sum-check 's/.*no_metric=//g' 'no_metric=' "${RSYSLOG_DYNNAME}.out.stats.log" 0
 
 #ttl-expiry(2*ttl in worst case, ttl + delta in best) so metric-names reset should have happened
 . $srcdir/diag.sh allow-single-stats-flush-after-block-and-wait-for-it
@@ -57,7 +51,7 @@ custom_assert_content_missing 'grault' "${RSYSLOG_DYNNAME}.out.stats.log"
 
 . $srcdir/diag.sh wait-for-stats-flush ${RSYSLOG_DYNNAME}.out.stats.log
 
-. $srcdir/diag.sh first-column-sum-check 's/.*metrics_purged=\([0-9]\+\)/\1/g' 'metrics_purged=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
+. $srcdir/diag.sh first-column-sum-check 's/.*metrics_purged=//g' 'metrics_purged=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
 
 rm ${RSYSLOG_DYNNAME}.out.stats.log
 issue_HUP #reopen stats file
@@ -86,13 +80,13 @@ content_check "quux 016 0"
 content_check "foo 017 -6"
 content_check "corge 018 0"
 
-. $srcdir/diag.sh first-column-sum-check 's/.*corge=\([0-9]\+\)/\1/g' 'corge=' "${RSYSLOG_DYNNAME}.out.stats.log" 2
-. $srcdir/diag.sh first-column-sum-check 's/.*grault=\([0-9]\+\)/\1/g' 'grault=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
-. $srcdir/diag.sh first-column-sum-check 's/.*quux=\([0-9]\+\)/\1/g' 'quux=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
+. $srcdir/diag.sh first-column-sum-check 's/.*corge=//g' 'corge=' "${RSYSLOG_DYNNAME}.out.stats.log" 2
+. $srcdir/diag.sh first-column-sum-check 's/.*grault=//g' 'grault=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
+. $srcdir/diag.sh first-column-sum-check 's/.*quux=//g' 'quux=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
 
-. $srcdir/diag.sh first-column-sum-check 's/.*new_metric_add=\([0-9]\+\)/\1/g' 'new_metric_add=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
-. $srcdir/diag.sh first-column-sum-check 's/.*ops_overflow=\([0-9]\+\)/\1/g' 'ops_overflow=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
-. $srcdir/diag.sh first-column-sum-check 's/.*no_metric=\([0-9]\+\)/\1/g' 'no_metric=' "${RSYSLOG_DYNNAME}.out.stats.log" 0
+. $srcdir/diag.sh first-column-sum-check 's/.*new_metric_add=//g' 'new_metric_add=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
+. $srcdir/diag.sh first-column-sum-check 's/.*ops_overflow=//g' 'ops_overflow=' "${RSYSLOG_DYNNAME}.out.stats.log" 1
+. $srcdir/diag.sh first-column-sum-check 's/.*no_metric=//g' 'no_metric=' "${RSYSLOG_DYNNAME}.out.stats.log" 0
 
 . $srcdir/diag.sh allow-single-stats-flush-after-block-and-wait-for-it
 . $srcdir/diag.sh await-stats-flush-after-block
@@ -102,7 +96,7 @@ shutdown_when_empty
 echo wait on shutdown
 wait_shutdown
 
-. $srcdir/diag.sh first-column-sum-check 's/.*metrics_purged=\([0-9]\+\)/\1/g' 'metrics_purged=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
+. $srcdir/diag.sh first-column-sum-check 's/.*metrics_purged=//g' 'metrics_purged=' "${RSYSLOG_DYNNAME}.out.stats.log" 3
 
 custom_assert_content_missing 'foo' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/lookup_table.sh
+++ b/tests/lookup_table.sh
@@ -3,7 +3,6 @@
 # added 2015-09-30 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl" reloadOnHUP="on")

--- a/tests/lookup_table_bad_configs.sh
+++ b/tests/lookup_table_bad_configs.sh
@@ -3,7 +3,6 @@
 # test for sparse-array lookup-table and HUP based reloading of it
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl")

--- a/tests/lookup_table_no_hup_reload.sh
+++ b/tests/lookup_table_no_hup_reload.sh
@@ -3,7 +3,6 @@
 # added 2015-09-30 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl" reloadOnHUP="off")

--- a/tests/multiple_lookup_tables.sh
+++ b/tests/multiple_lookup_tables.sh
@@ -3,7 +3,6 @@
 # added 2016-01-20 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
 generate_conf
 add_conf '
 lookup_table(name="xlate_0" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl")

--- a/tests/sparse_array_lookup_table.sh
+++ b/tests/sparse_array_lookup_table.sh
@@ -3,7 +3,6 @@
 # added 2015-10-30 by singh.janmejay
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "This test does not work on FreeBSD"
 generate_conf
 add_conf '
 lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate_array.lkp_tbl")

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1225,6 +1225,11 @@ static void
 hdlr_sighup(void)
 {
 	bHadHUP = 1;
+	/* at least on FreeBSD we seem not to necessarily awake the main thread.
+	 * So let's do it explicitely.
+	 */
+	dbgprintf("awaking mainthread on HUP\n");
+	pthread_kill(mainthread, SIGTTIN);
 }
 
 static void
@@ -1939,7 +1944,6 @@ mainloop(void)
 	do {
 		processImInternal();
 		wait_timeout();
-
 		if(bChildDied) {
 			reapChild();
 			bChildDied = 0;


### PR DESCRIPTION
... at least not on FreeBSD. The problem was that HUP did not awake
the main loop. We now interrupt it explicitly.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
