### PR TITLE
testbench: make some more test more robust against slow CI machines

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1877,9 +1877,9 @@ case $1 in
 			exit 2
 		fi
 		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))"
-		export RSYSLOG2_OUT_LOG=rsyslog2.out.log # TODO: remove
-		export RSYSLOG_OUT_LOG=rsyslog.out.log # TODO: remove
-		export RSYSLOG_PIDBASE="rsyslog" # TODO: remove
+		export RSYSLOG_OUT_LOG="${RSYSLOG_DYNNAME}.out.log"
+		export RSYSLOG2_OUT_LOG="${RSYSLOG_DYNNAME}_2.out.log"
+		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!
 		export IMDIAG_PORT=13500
 		export IMDIAG_PORT2=13501
 		export TCPFLOOD_PORT=13514

--- a/tests/wr_large_async.sh
+++ b/tests/wr_large_async.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # This tests async writing large data records. We use up to 10K
 # record size.
-
 # added 2010-03-10 by Rgerhards
 #
 # This file is part of the rsyslog project, released under ASL 2.0
@@ -25,7 +24,7 @@ local0.* ?dynfile;outfmt
 startup
 # send 4000 messages of 10.000bytes plus header max, randomized
 tcpflood -m4000 -r -d10000 -P129
-sleep 1 # due to large messages, we need this time for the tcp receiver to settle...
+wait_file_lines $RSYSLOG_OUT_LOG 4000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate
 seq_check 0 3999 -E

--- a/tests/wr_large_sync.sh
+++ b/tests/wr_large_sync.sh
@@ -16,8 +16,6 @@ $InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
-$OMFileFlushOnTXEnd off
-$OMFileFlushInterval 2
 $OMFileIOBufferSize 256k
 $OMFileAsyncWriting off
 local0.* ?dynfile;outfmt
@@ -25,7 +23,7 @@ local0.* ?dynfile;outfmt
 startup
 # send 4000 messages of 10.000bytes plus header max, randomized
 tcpflood -m4000 -r -d10000 -P129
-sleep 1 # due to large messages, we need this time for the tcp receiver to settle...
+wait_file_lines $RSYSLOG_OUT_LOG 4000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate
 seq_check 0 3999 -E


### PR DESCRIPTION
also fix an issue with tests that use non-standard plumbing

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
