### PR TITLE
fix a potential race in CI debug mode which can lead to segfault

### DIFF
--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -437,7 +437,7 @@ if(dbgTimeoutToStderr) {
 	pthread_cond_broadcast(&pThis->condThrdTrm); /* activate anyone waiting on thread shutdown */
 	pthread_cleanup_pop(1); /* unlock mutex */
 	if(dbgTimeoutToStderr) {
-		fprintf(stderr, "rsyslog debug: %s: worker exiting\n", wtiGetDbgHdr(pWti));
+		fprintf(stderr, "rsyslog debug: %p: worker exiting\n", pWti);
 	}
 	pthread_exit(0);
 }


### PR DESCRIPTION
only when instructed to do so, rsyslog may emit a "final worker thread shutdown"
messages. This is usually only enabled in CI and/or other testing. If enabled,
the code has a race on the pWti object which can lead to segfault or abort.

Only system which explicitly enable this CI aid are affected (running in debug
mode alone is NOT sufficient).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
