### PR TITLE
OpenSSL Driver: bugfix authentication mode anon

### DIFF
--- a/tests/sndrcv_tls_anon_ipv4.sh
+++ b/tests/sndrcv_tls_anon_ipv4.sh
@@ -37,9 +37,9 @@ generate_conf 2
 export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
 global(
-	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
-	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"
-	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-key.pem'"
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
 	defaultNetstreamDriver="gtls"
 )
 

--- a/tests/sndrcv_tls_anon_ipv6.sh
+++ b/tests/sndrcv_tls_anon_ipv6.sh
@@ -36,10 +36,12 @@ export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
-# certificates
-$DefaultNetstreamDriverCAFile testsuites/x.509/ca.pem
-$DefaultNetstreamDriverCertFile testsuites/x.509/client-cert.pem
-$DefaultNetstreamDriverKeyFile testsuites/x.509/client-key.pem
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="gtls"
+)
 
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/sndrcv_tls_anon_rebind.sh
+++ b/tests/sndrcv_tls_anon_rebind.sh
@@ -34,9 +34,9 @@ export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
 global(
-	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
-	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"
-	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-key.pem'"
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
 	defaultNetstreamDriver="gtls"
 )
 

--- a/tests/sndrcv_tls_ossl_anon_ipv4.sh
+++ b/tests/sndrcv_tls_ossl_anon_ipv4.sh
@@ -40,9 +40,9 @@ generate_conf 2
 export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
 global(
-	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
-	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"
-	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-key.pem'"
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
 	defaultNetstreamDriver="ossl"
 )
 

--- a/tests/sndrcv_tls_ossl_anon_ipv6.sh
+++ b/tests/sndrcv_tls_ossl_anon_ipv6.sh
@@ -41,9 +41,9 @@ generate_conf 2
 export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global(	
-	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
-	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"
-	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-key.pem'"
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
 	defaultNetstreamDriver="ossl"
 	debug.whitelist="off"
 	debug.files=["rainerscript.c", "ruleset.c"]

--- a/tests/sndrcv_tls_ossl_anon_rebind.sh
+++ b/tests/sndrcv_tls_ossl_anon_rebind.sh
@@ -48,9 +48,9 @@ generate_conf 2
 export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
 global(	
-	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
-	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"
-	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-key.pem'"
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
 	defaultNetstreamDriver="ossl"
 	debug.whitelist="on"
 	debug.files=["nsd_ossl.c", "tcpsrv.c", "nsdsel_ossl.c", "nsdpoll_ptcp.c", "dnscache.c"]


### PR DESCRIPTION
OpenSSL Driver: Fixed authentication mode anon

Authmode and peer settings were set afer new TLS Session initialized.
This caused all sessions to be handeled with certvalid mode instead
of the configired authmode.

Changed verify_callback to only log certificate errors into debug
log now when anon authmode is configured.

Fixed sndrcv ossl tests by using mixed certificates now.

closes: #3037