### PR TITLE
core/stream: always invalidate fd on file close

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1383,6 +1383,7 @@ tryTTYRecover(strm_t *pThis, int err)
 	if(err == ERR_TTYHUP || err == ENXIO || err == EIO) {
 #endif /* __FreeBSD__ */
 		close(pThis->fd);
+		pThis->fd = -1;
 		CHKiRet(doPhysOpen(pThis));
 	}
 
@@ -1441,6 +1442,7 @@ doWriteCall(strm_t *pThis, uchar *pBuf, size_t *pLenBuf)
 			} else if( !pThis->bIsTTY && ( err == ENOTCONN  || err == EIO )) {
 				/* Failure for network file system, thus file needs to be closed and reopened. */
 				close(pThis->fd);
+				pThis->fd = -1;
 				CHKiRet(doPhysOpen(pThis));
 			} else {
 				if(pThis->bIsTTY) {


### PR DESCRIPTION
while in theory, the fd should immediately be rewritten, in practice
we sometimes see some errors "bad file descriptor" that we cannot
explain. So we clean this up to remove a potential trouble cause.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
