### PR TITLE
omusrmsg: don't overwrite previous set _PATH_DEV value

### DIFF
--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -261,7 +261,7 @@ static rsRetVal wallmsg(uchar* pMsg, instanceData *pData)
 
 		/* compute the device name */
 		strcpy(p, _PATH_DEV);
-		memcpy(p, ut.ut_line, UNAMESZ);
+		strncat(p, ut.ut_line, UNAMESZ);
 
 		/* we must be careful when writing to the terminal. A terminal may block
 		 * (for example, a user has pressed <ctl>-s). In that case, we can not


### PR DESCRIPTION
Since commit 56ace5e418d149af27586c7c1264fccfbc6badf1, omusrmsg was broken
because "memcpy()" is not a suitable substitute for "strncat()" in this
context, it is actually replacing the previous added content.

Bug: https://bugs.gentoo.org/673004
Closes: https://github.com/rsyslog/rsyslog/issues/3346
