### PR TITLE
mmgrok fix: build error w/ gcc-8 due to questionable code construct

### DIFF
--- a/contrib/mmgrok/mmgrok.c
+++ b/contrib/mmgrok/mmgrok.c
@@ -248,13 +248,11 @@ parse_result_store(const grok_match_t gm,instanceData *pData)
 
 	    grok_match_walk_init(&gm); //grok API
 
-	    while(grok_match_walk_next(&gm,&pname,&pname_len,&pdata,&pdata_len) == 0)
-	    {
+	    while(grok_match_walk_next(&gm,&pname,&pname_len,&pdata,&pdata_len) == 0) {
 	        /* parse key and value type from patterns */
 	        key = strchr(pname,':');
 	
-	        if(key!=NULL)
-	        {
+	        if(key!=NULL) {
 	            int key_len;
 	            result_t *result = g_new0(result_t,1);
 	            key_len = pname_len - ((key+1) - pname);
@@ -262,14 +260,14 @@ parse_result_store(const grok_match_t gm,instanceData *pData)
 	            pname_len = key_len;
 	            type = strchr(key,':');
 	            int type_len;
-	            if(type!=NULL)
-	            {
+	            if(type != NULL) {
 	                key_len = (type - key);
 	                type = type+1;
 	                type_len = pname_len - key_len -1;
-	                sprintf(type,"%.*s",type_len,type);
-	            }
-	            else{type = (char*)"null";}
+			type[type_len] = '\0';
+	            } else {
+		    	type = (char*)"null";
+		    }
 	            /* store parse result into list */
 	            result->key = key;
 	            result->key_len = key_len;


### PR DESCRIPTION
replaced questionable sprintf() by simpler method

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
