### PR TITLE
build system: add capability to turn off helgrind tests

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1578,6 +1578,18 @@ else
 fi
 AM_CONDITIONAL([HAVE_VALGRIND], [test "x$with_valgrind_testbench" != "xno" && test "x$VALGRIND" != "xno"])
 
+# ability to disable helgrind tests - we at least need this for
+# clang coverage reports, where we cannot suppress the races
+AC_ARG_ENABLE(helgrind,
+        [AS_HELP_STRING([--enable-helgrind],[valgrind helgrind enabled @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_helgrind="yes" ;;
+          no) enable_helgrind="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-helgrind) ;;
+         esac],
+        [enable_helgrind=yes]
+)
+AM_CONDITIONAL(ENABLE_HELGRIND, test x$enable_helgrind = xyes)
 
 # settings for the file input module
 AC_ARG_ENABLE(imfile,
@@ -2508,6 +2520,8 @@ echo
 echo "---{ debugging support }---"
 echo "    distcheck workaround enabled:             $enable_distcheck_workaround"
 echo "    Testbench enabled:                        $enable_testbench"
+echo "    valgrind tests enabled:                   $with_valgrind_testbench"
+echo "    valgrind helgrind tests enabled:          $enable_helgrind"
 echo "    Default tests enabled:                    $enable_default_tests"
 echo "    Testbench libfaketime tests enabled:      $enable_libfaketime"
 echo "    Extended Testbench enabled:               $enable_extended_tests"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -59,16 +59,22 @@ TESTS +=  \
 	es-basic-bulk.sh
 es-basic-es6.0.log: es-basic.log
 es-basic-bulk.log: es-basic-es6.0.log
+es-basic-server.log: es-basic-bulk.log
 if HAVE_VALGRIND
 TESTS += \
-	es-basic-vg.sh \
-	es-basic-vgthread.sh
+	es-basic-vg.sh
 es-basic-vg.log: es-basic-bulk.log
+# for next if block:
+es-basic-server.log: es-basic-vg.log
+if ENABLE_HELGRIND
+TESTS += \
+	es-basic-vgthread.sh
 es-basic-vgthread.log: es-basic-vg.log
 # for next if block:
 es-basic-server.log: es-basic-vgthread.log
-endif
-endif
+endif # ENABLE_HELGRIND
+endif # HAVE_VALGRIND
+endif # ENABLE_ELASTICSEARCH_TESTS_MINIMAL
 
 if ENABLE_ELASTICSEARCH_TESTS
 TESTS +=  \
@@ -1129,17 +1135,21 @@ TESTS += \
 	imfile-endregex-vg.sh \
 	imfile-endmsg.regex-vg.sh \
 	imfile-readmode0-vg.sh \
-	imfile-readmode2-vg.sh \
+	imfile-readmode2-vg.sh
+
+if ENABLE_HELGRIND
+TESTS += \
 	imfile-basic-vgthread.sh
+endif #  ENABLE_HELGRIND
 
 if ENABLE_MMNORMALIZE
 TESTS += \
 	imfile-endmsg.regex-with-example-vg.sh
-endif
+endif # ENABLE_MMNORMALIZE
 
-endif
+endif # HAVE_VALGRIND
 
-endif
+endif # ENABLE_IMFILE
 
 if ENABLE_OMTCL
 TESTS += \


### PR DESCRIPTION
we add configure switch --enable-helgrind. We need to turn helgrind off
when we use clang coverage instrumentation. The instrumentation injects
mt-unsafe counter updates which we seem to be unable to suppress.

Note: for gcc this was possible, because they all occured in a utility
function. For clang, they are inlined so we get many -and changing- violations.

see also https://github.com/rsyslog/rsyslog/issues/3361#issuecomment-450502569

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
