### PR TITLE
testbench: remove some clickhouse test dependency against non-TLS

### DIFF
--- a/tests/clickhouse-errorfile.sh
+++ b/tests/clickhouse-errorfile.sh
@@ -24,8 +24,7 @@ tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:NoInteger\""
 shutdown_when_empty
 wait_shutdown
 
-export EXPECTED="{ \"request\": { \"url\": \"http:\\/\\/localhost:8123\\/\", \"postdata\": \"INSERT INTO rsyslog.errorfile (id, severity, facility, timestamp, ipaddress, tag, message) VALUES (NoInteger, 1, 16, '1520643600', '127.0.0.1', 'tag:', ' msgnum:NoInteger')\" }, \"reply\": \"Code: 47, e.displayText() = DB::Exception: Unknown identifier: NoInteger, e.what() = DB::Exception\\n\" }"
-cmp_exact $RSYSLOG_OUT_LOG
+content_check --regex "msgnum:NoInteger.*DB::Exception: Unknown identifier"
 
 clickhouse-client --query="DROP TABLE rsyslog.errorfile"
 exit_test

--- a/tests/clickhouse-wrong-insert-syntax.sh
+++ b/tests/clickhouse-wrong-insert-syntax.sh
@@ -20,12 +20,10 @@ add_conf '")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.wrongInsertSyntax ( id Int32, severity Int8, facility Int8, timestamp DateTime, ipaddress String, tag String, message String ) ENGINE = MergeTree() PARTITION BY severity Order By id"
 
 startup
-tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:00000001\""
+tcpflood -m1
 shutdown_when_empty
 wait_shutdown
 
-export EXPECTED="{ \"request\": { \"url\": \"http:\\/\\/localhost:8123\\/\", \"postdata\": \"INSERT INTO rsyslog.wrongInsertSyntax (id, severity, facility, timestamp, ipaddress, tag, message) VLUES (00000001, 1, 16, '1520643600', '127.0.0.1', 'tag:', ' msgnum:00000001')\" }, \"reply\": \"Code: 62, e.displayText() = DB::Exception: Syntax error: failed at position 100: VLUES (00000001, 1, 16, '1520643600', '127.0.0.1', 'tag:', ' msgnum:00000001'). Expected one of: FORMAT, VALUES, SELECT, WITH, e.what() = DB::Exception\\n\" }"
-cmp_exact $RSYSLOG_OUT_LOG
-
+content_check "DB::Exception: Syntax error"
 clickhouse-client --query="DROP TABLE rsyslog.wrongInsertSyntax"
 exit_test


### PR DESCRIPTION
some tests had "http:" included in their expected response, and thus
failed on TLS-secured systems. This has been fixed.

Note that the tests still depend on english language clickhouse error
messages. We could probably improve here as well.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
