### PR TITLE
changed input source for clickhouse tests

### DIFF
--- a/tests/clickhouse-basic.sh
+++ b/tests/clickhouse-basic.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 # add 2018-12-07 by Pascal Withopf, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
-
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.basic (id, severity, facility, timestamp, ipaddress, tag, message) VALUES (%msg:F,58:2%, %syslogseverity%, %syslogfacility%, '
 add_conf "'%timereported:::date-unixtimestamp%', '%fromhost-ip%', '%syslogtag%', '%msg%')"
@@ -20,13 +18,13 @@ add_conf '")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.basic ( id Int32, severity Int8, facility Int8, timestamp DateTime, ipaddress String, tag String, message String ) ENGINE = MergeTree() PARTITION BY severity Order By id"
 
 startup
-tcpflood -m1 -M "\"<130>Mar 10 01:00:00 172.20.245.8 tag: msgnum:00000001\""
+injectmsg
 shutdown_when_empty
 wait_shutdown
 clickhouse-client --query="SELECT id, severity, facility, ipaddress, tag, message FROM rsyslog.basic" > $RSYSLOG_OUT_LOG
 
-export EXPECTED='1	2	16	127.0.0.1	tag:	 msgnum:00000001'
+clickhouse-client --query="DROP TABLE rsyslog.basic"
+export EXPECTED='0	7	20	127.0.0.1	tag	 msgnum:00000000:'
 cmp_exact $RSYSLOG_OUT_LOG
 
-clickhouse-client --query="DROP TABLE rsyslog.basic"
 exit_test

--- a/tests/clickhouse-bulk-load.sh
+++ b/tests/clickhouse-bulk-load.sh
@@ -5,10 +5,7 @@ export NUMMESSAGES=100000
 
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
-
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.bulkLoad (id, ipaddress, message) VALUES (%msg:F,58:2%, '
 add_conf "'%fromhost-ip%', '%msg:F,58:2%')"
@@ -22,7 +19,7 @@ add_conf '")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.bulkLoad ( id Int32, ipaddress String, message String ) ENGINE = MergeTree() PARTITION BY ipaddress Order By id"
 
 startup
-tcpflood -m $NUMMESSAGES
+injectmsg
 shutdown_when_empty
 wait_shutdown
 clickhouse-client --query="SELECT message FROM rsyslog.bulkLoad ORDER BY id" > $RSYSLOG_OUT_LOG

--- a/tests/clickhouse-bulk.sh
+++ b/tests/clickhouse-bulk.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 # add 2018-12-07 by Pascal Withopf, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=10
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
-
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.bulk (id, severity, facility, timestamp, ipaddress, tag, message) VALUES (%msg:F,58:2%, %syslogseverity%, %syslogfacility%, '
 add_conf "'%timereported:::date-unixtimestamp%', '%fromhost-ip%', '%syslogtag%', '%msg%')"
@@ -20,7 +18,7 @@ add_conf '")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.bulk ( id Int32, severity Int8, facility Int8, timestamp DateTime, ipaddress String, tag String, message String ) ENGINE = MergeTree() PARTITION BY severity Order By id"
 
 startup
-tcpflood -m10
+injectmsg
 shutdown_when_empty
 wait_shutdown
 clickhouse-client --query="SELECT id, severity, facility, ipaddress, tag, message FROM rsyslog.bulk ORDER BY id" > $RSYSLOG_OUT_LOG

--- a/tests/clickhouse-limited-batch.sh
+++ b/tests/clickhouse-limited-batch.sh
@@ -5,10 +5,7 @@ export NUMMESSAGES=100000
 
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
-
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.limited (id, ipaddress, message) VALUES (%msg:F,58:2%, '
 add_conf "'%fromhost-ip%', '%msg:F,58:2%')"
@@ -23,7 +20,7 @@ add_conf '")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.limited ( id Int32, ipaddress String, message String ) ENGINE = MergeTree() PARTITION BY ipaddress Order By id"
 
 startup
-tcpflood -m $NUMMESSAGES
+injectmsg
 shutdown_when_empty
 wait_shutdown
 clickhouse-client --query="SELECT message FROM rsyslog.limited ORDER BY id" > $RSYSLOG_OUT_LOG

--- a/tests/clickhouse-load.sh
+++ b/tests/clickhouse-load.sh
@@ -5,10 +5,7 @@ export NUMMESSAGES=1000
 
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
-
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.load (id, ipaddress, message) VALUES (%msg:F,58:2%, '
 add_conf "'%fromhost-ip%', '%msg:F,58:2%')"
@@ -23,7 +20,7 @@ add_conf '")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.load ( id Int32, ipaddress String, message String ) ENGINE = MergeTree() PARTITION BY ipaddress Order By id"
 
 startup
-tcpflood -m $NUMMESSAGES
+injectmsg
 shutdown_when_empty
 wait_shutdown
 clickhouse-client --query="SELECT message FROM rsyslog.load ORDER BY id" > $RSYSLOG_OUT_LOG

--- a/tests/clickhouse-retry-error.sh
+++ b/tests/clickhouse-retry-error.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 # add 2018-12-31 by Pascal Withopf, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.retryerror (id, severity, message) VALUES (%msg:F,58:2%, %syslogseverity%, '
 add_conf "'%msg%')"
@@ -19,7 +18,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 
 startup
-tcpflood -m1
+injectmsg
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/clickhouse-select.sh
+++ b/tests/clickhouse-select.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 # add 2018-12-07 by Pascal Withopf, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" option.stdsql="on" type="string" string="SELECT * FROM rsyslog.select")
 
@@ -19,11 +18,11 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.select ( id Int32, severity Int8, facility Int8, timestamp DateTime, ipaddress String, tag String, message String ) ENGINE = MergeTree() PARTITION BY severity Order By id"
 
 startup
-tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:00000001\""
+injectmsg
 shutdown_when_empty
 wait_shutdown
 
+clickhouse-client --query="DROP TABLE rsyslog.select"
 content_check "omclickhouse: Message is no Insert query: Message suspended: SELECT * FROM rsyslog.select"
 
-clickhouse-client --query="DROP TABLE rsyslog.select"
 exit_test

--- a/tests/clickhouse-wrong-template-option.sh
+++ b/tests/clickhouse-wrong-template-option.sh
@@ -1,12 +1,10 @@
 #!/bin/bash
 # add 2018-12-19 by Pascal Withopf, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
-
 
 template(name="outfmt" type="string" string="INSERT INTO rsyslog.template (id, severity, facility, timestamp, ipaddress, tag, message) VALUES (%msg:F,58:2%, %syslogseverity%, %syslogfacility%, '
 add_conf "'%timereported:::date-unixtimestamp%', '%fromhost-ip%', '%syslogtag%', '%msg%')"
@@ -23,11 +21,11 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.template ( id Int32, severity Int8, facility Int8, timestamp DateTime, ipaddress String, tag String, message String ) ENGINE = MergeTree() PARTITION BY severity Order By id"
 
 startup
-tcpflood -m1 -M "\"<130>Mar 10 01:00:00 172.20.245.8 tag: msgnum:00000001\""
+injectmsg
 shutdown_when_empty
 wait_shutdown
 
+clickhouse-client --query="DROP TABLE rsyslog.template"
 content_check "you have to specify the SQL or stdSQL option in your template!"
 
-clickhouse-client --query="DROP TABLE rsyslog.template"
 exit_test


### PR DESCRIPTION
Input source for clickhouse tests was changed to injectmsg
where it is possible. This will result in a shorter and easier
to read debug files and the tests won't fail duo to port problems
on the testbench.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
