### PR TITLE
core/action: implement capability to resume/suspend via external file

### DIFF
--- a/action.h
+++ b/action.h
@@ -78,6 +78,8 @@ struct action_s {
 	const char *pszErrFile;
 	int fdErrFile;
 	pthread_mutex_t mutErrFile;
+	/* external stat file system */
+	const char *pszExternalStateFile;
 	/* for per-worker HUP processing */
 	pthread_mutex_t mutWrkrDataTable; /* protects table structures */
 	void **wrkrDataTable;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -308,6 +308,8 @@ TESTS +=  \
 	failover-rptd.sh \
 	failover-no-rptd.sh \
 	failover-no-basic.sh \
+	suspend-via-file.sh \
+	externalstate-failed-rcvr.sh \
 	rcvr_fail_restore.sh \
 	rscript_contains.sh \
 	rscript_bare_var_root.sh \
@@ -1683,6 +1685,8 @@ EXTRA_DIST= \
 	failover-basic-vg.sh \
 	failover-async.sh \
 	failover-double.sh \
+	suspend-via-file.sh \
+	externalstate-failed-rcvr.sh \
 	discard-rptdmsg.sh \
 	discard-rptdmsg-vg.sh \
 	discard-allmark.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -739,7 +739,7 @@ check_journal_testmsg_received() {
 # wait for main message queue to be empty. $1 is the instance.
 # we run in a loop to ensure rsyslog is *really* finished when a
 # function for the "finished predicate" is defined. This is done
-# by setting env var QUEUE_EMPTY_CHECK_FUNCTION to the bash
+# by setting env var QUEUE_EMPTY_CHECK_FUNC to the bash
 # function name.
 wait_queueempty() {
 	while [ $(date +%s) -le $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; do
@@ -916,7 +916,7 @@ wait_seq_check() {
 		if [ -f "$RSYSLOG_OUT_LOG" ]; then
 			count=$(wc -l < "$RSYSLOG_OUT_LOG")
 		fi
-		seq_check --check-only "$@" &>/dev/null
+		seq_check --check-only "$@" #&>/dev/null
 		ret=$?
 		if [ $ret == 0 ]; then
 			printf 'wait_seq_check success (%d lines)\n' "$count"
@@ -1172,7 +1172,11 @@ error_stats() {
 # $4... are just to have the abilit to pass in more options...
 # add -v to chkseq if you need more verbose output
 # argument --check-only can be used to simply do a check without abort in fail case
+# env var SEQ_CHECK_FILE permits to override file name to check
 seq_check() {
+	if [ "$SEQ_CHECK_FILE" == "" ]; then
+		SEQ_CHECK_FILE="$RSYSLOG_OUT_LOG"
+	fi
 	if [ "$1" == "--check-only" ]; then
 		check_only="YES"
 		shift
@@ -1191,30 +1195,30 @@ seq_check() {
 		startnum=$1
 		endnum=$2
 	fi
-	if [ ! -f "$RSYSLOG_OUT_LOG" ]; then
+	if [ ! -f "$SEQ_CHECK_FILE" ]; then
 		if [ "$check_only"  == "YES" ]; then
 			return 1
 		fi
-		printf 'FAIL: %s does not exist in seq_check!\n' "$RSYSLOG_OUT_LOG"
+		printf 'FAIL: %s does not exist in seq_check!\n' "$SEQ_CHECK_FILE"
 		error_exit 1
 	fi
-	$RS_SORTCMD $RS_SORT_NUMERIC_OPT < ${RSYSLOG_OUT_LOG} | ./chkseq -s$startnum -e$endnum $3 $4 $5 $6 $7
+	$RS_SORTCMD $RS_SORT_NUMERIC_OPT < ${SEQ_CHECK_FILE} | ./chkseq -s$startnum -e$endnum $3 $4 $5 $6 $7
 	ret=$?
 	if [ "$check_only"  == "YES" ]; then
 		return $ret
 	fi
 	if [ $ret -ne 0 ]; then
-		$RS_SORTCMD $RS_SORT_NUMERIC_OPT < ${RSYSLOG_OUT_LOG} > $RSYSLOG_DYNNAME.error.log
-		echo "sequence error detected in $RSYSLOG_OUT_LOG"
-		echo "number of lines in file: $(wc -l $RSYSLOG_OUT_LOG)"
+		$RS_SORTCMD $RS_SORT_NUMERIC_OPT < ${SEQ_CHECK_FILE} > $RSYSLOG_DYNNAME.error.log
+		echo "sequence error detected in $SEQ_CHECK_FILE"
+		echo "number of lines in file: $(wc -l $SEQ_CHECK_FILE)"
 		echo "sorted data has been placed in error.log, first 10 lines are:"
 		cat -n $RSYSLOG_DYNNAME.error.log | head -10
 		echo "---last 10 lines are:"
 		cat -n $RSYSLOG_DYNNAME.error.log | tail -10
 		echo "UNSORTED data, first 10 lines are:"
-		cat -n $RSYSLOG_OUT_LOG | head -10
+		cat -n $SEQ_CHECK_FILE | head -10
 		echo "---last 10 lines are:"
-		cat -n $RSYSLOG_OUT_LOG | tail -10
+		cat -n $SEQ_CHECK_FILE | tail -10
 		# for interactive testing, create a static filename. We know this may get
 		# mangled during a parallel test run
 		mv -f $RSYSLOG_DYNNAME.error.log error.log

--- a/tests/externalstate-failed-rcvr.sh
+++ b/tests/externalstate-failed-rcvr.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This tests the action suspension via a file and ensure that it does
+# NOT override actual target suspension state.
+# This file is part of the rsyslog project, released under ASL 2.0
+# Written 2019-01-08 by Rainer Gerhards
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=2500
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+
+# IMPORTANT: nothing permitted to listen on $TCPFLOOD_PORT!
+# mimic some good state in external statefile:
+printf "%s" "READY" > $RSYSLOG_DYNNAME.STATE
+
+generate_conf
+add_conf '
+$template outfmt,"%msg:F,58:2%\n"
+
+:msg, contains, "msgnum:" {
+	action(name="primary" type="omfwd" target="localhost" port="'$TCPFLOOD_PORT'"
+		protocol="tcp" action.externalstate.file="'$RSYSLOG_DYNNAME'.STATE")
+	action(name="failover" type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt"
+		action.execOnlyWhenPreviousIsSuspended="on")
+}
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+# note: we do NOT need to do a check_seq as this was already done as part of the
+# queue empty predicate check
+exit_test

--- a/tests/suspend-via-file.sh
+++ b/tests/suspend-via-file.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# This tests the action suspension via a file
+# This file is part of the rsyslog project, released under ASL 2.0
+# Written 2018-08-13 by Rainer Gerhards
+. ${srcdir:=.}/diag.sh init
+check_q_empty_log1() {
+	echo "###### in check1"
+	wait_seq_check 2500 4999
+}
+check_q_empty_log2() {
+	echo "###### in check2"
+	wait_seq_check 0 $LOG2_EXPECTED_LASTNUM
+}
+generate_conf
+add_conf '
+$template outfmt,"%msg:F,58:2%\n"
+
+:msg, contains, "msgnum:" {
+	action(name="primary" type="omfile" file="'$RSYSLOG2_OUT_LOG'" template="outfmt"
+		action.externalstate.file="'$RSYSLOG_DYNNAME'.STATE" action.resumeinterval="1")
+	action(name="failover" type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt"
+		action.execOnlyWhenPreviousIsSuspended="on")
+}
+'
+startup
+
+printf '\n%s %s\n' "$(tb_timestamp)" \
+	'checking that action is active w/o external state file'
+injectmsg 0 2500
+export SEQ_CHECK_FILE="$RSYSLOG2_OUT_LOG"
+export LOG2_EXPECTED_LASTNUM=2499
+export QUEUE_EMPTY_CHECK_FUNC=check_q_empty_log2
+wait_queueempty
+seq_check 0 $LOG2_EXPECTED_LASTNUM # full correctness check
+
+
+printf '\n%s %s\n' "$(tb_timestamp)" \
+	'checking that action becomes suspended via external state file'
+printf "%s" "SUSPENDED" > $RSYSLOG_DYNNAME.STATE
+injectmsg 2500 2500
+export SEQ_CHECK_FILE="$RSYSLOG_OUT_LOG"
+export QUEUE_EMPTY_CHECK_FUNC=check_q_empty_log1
+wait_queueempty
+seq_check 2500 4999 # full correctness check
+
+printf '\n%s %s\n' "$(tb_timestamp)" \
+	'checking that action becomes resumed again via external state file'
+printf "%s" "READY" > $RSYSLOG_DYNNAME.STATE
+./msleep 2000 # ensure ResumeInterval expired (NOT sensitive to slow machines --> absolute time!)
+injectmsg 2500 2500
+export SEQ_CHECK_FILE="$RSYSLOG2_OUT_LOG"
+export LOG2_EXPECTED_LASTNUM=4999
+export QUEUE_EMPTY_CHECK_FUNC=check_q_empty_log2
+shutdown_when_empty
+wait_shutdown
+
+# final checks
+export SEQ_CHECK_FILE="$RSYSLOG_OUT_LOG"
+seq_check 2500 4999
+export SEQ_CHECK_FILE="$RSYSLOG2_OUT_LOG"
+seq_check 0 4999
+exit_test


### PR DESCRIPTION
It has been reported that some TCP receivers exists that accept syslog tcp
messages at any rate, even if they do not manage to actually process them.
Instead, they silently drop the message. This behavior is not configurable.
All in all, it can lead to considerate message loss.

To support such use cases, we need to provide an ability to externally
trigger actions suspension and resumption.

We do this via a configured file which contains the status of the action.
Rsyslog periodically reads the file and if it contains "SUSPEND", it
suspend the action (and likewise for resume).

closes https://github.com/rsyslog/rsyslog/issues/2924

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
