### PR TITLE
testbench nitfixes: modernize arithmetic expressions

### DIFF
--- a/tests/imfile-logrotate.sh
+++ b/tests/imfile-logrotate.sh
@@ -69,7 +69,7 @@ ls -l $RSYSLOG_DYNNAME.input*
 echo ls ${RSYSLOG_DYNNAME}.spool:
 ls -l ${RSYSLOG_DYNNAME}.spool
 
-let msgcount="2* $TESTMESSAGES"
+msgcount=$((2* TESTMESSAGES))
 wait_file_lines $RSYSLOG_OUT_LOG $msgcount $RETRIES
 
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/imfile-wildcards-dirs-multi.sh
+++ b/tests/imfile-wildcards-dirs-multi.sh
@@ -67,7 +67,7 @@ do
 	ls -d $RSYSLOG_DYNNAME.input.*
 	
 	# Check correct amount of input files each time
-	let IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
+	IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
 	content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 
 	# Delete all but first!

--- a/tests/imfile-wildcards-dirs-multi2.sh
+++ b/tests/imfile-wildcards-dirs-multi2.sh
@@ -69,7 +69,7 @@ do
 	ls -d $RSYSLOG_DYNNAME.input.*
 
 	# Check correct amount of input files each time
-	let IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
+	IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
 	content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 
 	# Delete all but first!

--- a/tests/imfile-wildcards-dirs-multi3.sh
+++ b/tests/imfile-wildcards-dirs-multi3.sh
@@ -74,7 +74,7 @@ do
 	ls -d $RSYSLOG_DYNNAME.input.*
 
 	# Check correct amount of input files each time
-	let IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
+	IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
 	content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 
 	# Delete all but first!

--- a/tests/imfile-wildcards-dirs-multi4.sh
+++ b/tests/imfile-wildcards-dirs-multi4.sh
@@ -3,7 +3,7 @@
 . ${srcdir:=.}/diag.sh init
 export IMFILEINPUTFILES="1"
 export IMFILEINPUTFILESSTEPS="5"
-#export IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $IMFILEINPUTFILESSTEPS))
+#export IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * IMFILEINPUTFILESSTEPS))
 export IMFILECHECKTIMEOUT="60"
 
 generate_conf
@@ -73,7 +73,7 @@ do
 	ls -d $RSYSLOG_DYNNAME.input.*
 
 	# Check correct amount of input files each time
-	let IMFILEINPUTFILESALL=$(($IMFILEINPUTFILES * $j))
+	IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
 	content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 
 	# Delete all but first!

--- a/tests/imfile-wildcards-dirs-multi5-polling.sh
+++ b/tests/imfile-wildcards-dirs-multi5-polling.sh
@@ -59,7 +59,7 @@ for j in $(seq 1 $IMFILEINPUTFILESSTEPS); do
 	ls -d $RSYSLOG_DYNNAME.input.*
 	
 	# Check correct amount of input files each time
-	let IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
+	IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
 	content_check_with_count "HEADER msgnum:000000" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 	# Delete all but first!
 	for i in $(seq 1 $IMFILEINPUTFILES);

--- a/tests/imfile-wildcards-dirs-multi5.sh
+++ b/tests/imfile-wildcards-dirs-multi5.sh
@@ -60,7 +60,7 @@ do
 	ls -d $RSYSLOG_DYNNAME.input.*
 	
 	# Check correct amount of input files each time
-	let IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
+	IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
 	content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 
 	# Delete all but first!

--- a/tests/imfile-wildcards-dirs2.sh
+++ b/tests/imfile-wildcards-dirs2.sh
@@ -65,7 +65,7 @@ do
 	ls -d $RSYSLOG_DYNNAME.input.*
 
 	# Check correct amount of input files each time
-	let IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
+	IMFILEINPUTFILESALL=$((IMFILEINPUTFILES * j))
 	content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILESALL $IMFILECHECKTIMEOUT
 	
 	# Delete all but first!

--- a/tests/loop.sh
+++ b/tests/loop.sh
@@ -15,14 +15,14 @@ while [ $RUN -le $MAXRUN ]; do
      echo "###### RUN: " $RUN "success" $SUCCESS "fail" $FAIL
      $1
      if [ "$?" -ne "0" ]; then
-     	 let FAIL+=1
+     	 ((FAIL++))
 	 echo "FAIL!"
 	 #vi work
          exit 1
      else
-     	let SUCCESS+=1
+     	((SUCCESS++))
      fi
-     let RUN+=1
+     ((RUN++))
 done
 echo
 echo "Nbr success: " $SUCCESS

--- a/tests/mysql-actq-mt-withpause-extended.sh
+++ b/tests/mysql-actq-mt-withpause-extended.sh
@@ -23,7 +23,7 @@ mysql --user=rsyslog --password=testbench < ${srcdir}/testsuites/mysql-truncate.
 startup
 
 
-let "strtnum = 0"
+strtnum=0
 for i in {1..50}
 do
    echo "running iteration $i, startnum: $strtnum"

--- a/tests/omprog-output-capture-mt.sh
+++ b/tests/omprog-output-capture-mt.sh
@@ -70,7 +70,7 @@ wait_shutdown
 
 line_num=0
 while IFS= read -r line; do
-    let "line_num++"
+    ((line_num++))
     if [[ ${#line} != $LINE_LENGTH ]]; then
         echo "intermingled line in captured output: line: $line_num, length: ${#line} (expected: $LINE_LENGTH)"
         echo "$line"

--- a/tests/omprog-single-instance-outfile.sh
+++ b/tests/omprog-single-instance-outfile.sh
@@ -53,7 +53,7 @@ wait_shutdown
 EXPECTED_LINE_LENGTH=34    # example line: '[stderr] Received msgnum:00009880:'
 line_num=0
 while IFS= read -r line; do
-    let "line_num++"
+    ((line_num++))
     if [[ $line_num == 1 ]]; then
         if [[ "$line" != "[stderr] Starting" ]]; then
             echo "unexpected first line in captured stderr: $line"

--- a/tests/omprog-single-instance.sh
+++ b/tests/omprog-single-instance.sh
@@ -52,7 +52,7 @@ wait_shutdown
 EXPECTED_LINE_LENGTH=25    # example line: 'Received msgnum:00009880:'
 line_num=0
 while IFS= read -r line; do
-    let "line_num++"
+    ((line_num++))
     if [[ $line_num == 1 ]]; then
         if [[ "$line" != "Starting" ]]; then
             echo "unexpected first line in output: $line"

--- a/tests/omprog-transactions-failed-commits.sh
+++ b/tests/omprog-transactions-failed-commits.sh
@@ -117,7 +117,7 @@ while IFS= read -r line; do
         fi
         status_expected=true;
     fi
-    let "line_num++"
+    ((line_num++))
 done < $RSYSLOG_OUT_LOG
 
 if [[ -z "$error" && "$transaction_state" != "NONE" ]]; then

--- a/tests/omprog-transactions-failed-messages.sh
+++ b/tests/omprog-transactions-failed-messages.sh
@@ -118,7 +118,7 @@ while IFS= read -r line; do
         fi
         status_expected=true;
     fi
-    let "line_num++"
+    ((line_num++))
 done < $RSYSLOG_OUT_LOG
 
 if [[ -z "$error" && "$transaction_state" != "NONE" ]]; then

--- a/tests/omprog-transactions.sh
+++ b/tests/omprog-transactions.sh
@@ -104,7 +104,7 @@ while IFS= read -r line; do
         fi
         status_expected=true;
     fi
-    let "line_num++"
+    ((line_num++))
 done < $RSYSLOG_OUT_LOG
 
 if [[ -z "$error" && "$transaction_state" != "NONE" ]]; then


### PR DESCRIPTION
detected by shellcheck tool

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
