### PR TITLE
testbench: disable omprog tests that hang under coverage instrumentation

### DIFF
--- a/tests/omprog-feedback-mt.sh
+++ b/tests/omprog-feedback-mt.sh
@@ -6,9 +6,14 @@
 # confirmed as failed by the program). Note: the action retry interval
 # (1 second) causes a very low throughput; we need to set a very low error
 # rate to avoid the test lasting too much.
-
 . ${srcdir:=.}/diag.sh init
 skip_platform "SunOS" "On Solaris, this test causes rsyslog to hang for unknown reasons"
+if [ "$CC" == "gcc" ] && [[ "$CFLAGS" == *"-coverage"* ]]; then
+	printf 'This test does not work with gcc coverage instrumentation\n'
+	printf 'It will hang, but we do not know why. See\n'
+	printf 'https://github.com/rsyslog/rsyslog/issues/3361\n'
+	exit 77
+fi
 
 NUMMESSAGES=10000       # number of logs to send
 ERROR_RATE_PERCENT=1    # percentage of logs to be retried

--- a/tests/omprog-output-capture-mt.sh
+++ b/tests/omprog-output-capture-mt.sh
@@ -10,7 +10,14 @@
 
 . ${srcdir:=.}/diag.sh init
 skip_platform "SunOS" "This test currently does not work on all flavors of Solaris (problems with Python?)"
-export NUMMESSAGES=20000   # number of logs to send
+if [ "$CC" == "gcc" ] && [[ "$CFLAGS" == *"-coverage"* ]]; then
+	printf 'This test does not work with gcc coverage instrumentation\n'
+	printf 'It will hang, but we do not know why. See\n'
+	printf 'https://github.com/rsyslog/rsyslog/issues/3361\n'
+	exit 77
+fi
+
+export NUMMESSAGES=20000
 
 if [[ "$(uname)" == "Linux" ]]; then
     LINE_LENGTH=4095   # 4KB minus 1 byte (for the newline char)


### PR DESCRIPTION
When gcc coverage instrumentation is used, these tests hang. They work
with clang coverage instrumentation, but for some reason clang does not
give us full reports (at least not when used together with CodeCov.io).

We have tried to troubleshoot this for hours and hours - now is time to
give up until someone comes up with a bright idea. So we make the affected
tests skip themselves when they detect gcc with coverage instrumentation.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
