### PR TITLE
action: add "action.resumeIntervalMax" parameter

### DIFF
--- a/action.h
+++ b/action.h
@@ -53,6 +53,7 @@ struct action_s {
 	int	iSecsExecOnceInterval; /* if non-zero, minimum seconds to wait until action is executed again */
 	time_t	ttResumeRtry;	/* when is it time to retry the resume? */
 	int	iResumeInterval;/* resume interval for this action */
+	int	iResumeIntervalMax;/* maximum resume interval for this action --> -1: unbounded */
 	int	iResumeRetryCount;/* how often shall we retry a suspended action? (-1 --> eternal) */
 	int	iNbrNoExec;	/* number of matches that did not yet yield to an exec */
 	int	iExecEveryNthOccur;/* execute this action only every n-th occurence (with n=0,1 -> always) */


### PR DESCRIPTION
This parameter permits to set an upper limit on the growth of the
retry interval. This is most useful when a target has extended
outage, in which case retries can happen very infrequently.

closes https://github.com/rsyslog/rsyslog/issues/3401

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
