### PR TITLE
testbench: Added new tests for imfile and logrotate

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1127,6 +1127,8 @@ TESTS += \
 	imfile-symlink.sh \
 	imfile-symlink-multi.sh \
 	imfile-logrotate.sh \
+	imfile-logrotate-copytruncate.sh \
+	imfile-logrotate-nocopytruncate.sh \
 	imfile-growing-file-id.sh \
 	glbl-oversizeMsg-truncate-imfile.sh
 
@@ -1780,6 +1782,8 @@ EXTRA_DIST= \
 	imfile-symlink.sh \
 	imfile-symlink-multi.sh \
 	imfile-logrotate.sh \
+	imfile-logrotate-copytruncate.sh \
+	imfile-logrotate-nocopytruncate.sh \
 	imfile-growing-file-id.sh \
 	glbl-oversizeMsg-truncate-imfile.sh \
 	dynfile_invld_async.sh \

--- a/tests/imfile-logrotate-copytruncate.sh
+++ b/tests/imfile-logrotate-copytruncate.sh
@@ -28,6 +28,7 @@ input(type="imfile"
 	Severity="error"
 	Facility="local7"
 	addMetadata="on"
+	reopenOnTruncate="on"
 )
 
 $template outfmt,"%msg:F,58:2%\n"
@@ -48,6 +49,7 @@ echo '"./'$RSYSLOG_DYNNAME'.input.*.log"
 	missingok
 	notifempty
 	compress
+	copytruncate
 }' > $RSYSLOG_DYNNAME.logrotate
 
 # generate input file first.

--- a/tests/imfile-logrotate-nocopytruncate.sh
+++ b/tests/imfile-logrotate-nocopytruncate.sh
@@ -48,6 +48,7 @@ echo '"./'$RSYSLOG_DYNNAME'.input.*.log"
 	missingok
 	notifempty
 	compress
+	nocopytruncate
 }' > $RSYSLOG_DYNNAME.logrotate
 
 # generate input file first.


### PR DESCRIPTION
Testing copytruncate and nocopytruncate options with logrotate.
copytruncate option need imfile "reopenOnTruncate" to be enabled!

closes https://github.com/rsyslog/rsyslog/issues/3053
