### PR TITLE
change queue.timeoutshutdown default to 10 for action queues

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -83,7 +83,7 @@ unsigned int iOverallQueueSize = 0;
 #endif
 
 /* overridable default values (via global config) */
-int actq_dflt_toQShutdown = 0;		/* queue shutdown */
+int actq_dflt_toQShutdown = 10;		/* queue shutdown */
 int actq_dflt_toActShutdown = 1000;	/* action shutdown (in phase 2) */
 int actq_dflt_toEnq = 2000;		/* timeout for queue enque */
 int actq_dflt_toWrkShutdown = 60000;	/* timeout for worker thread shutdown */


### PR DESCRIPTION
The previous default of 0 gave action queues no real chance to
shutdown - at the time they were applied, they were usually already
expired (computing the absolute timeout took a small amount of time).

So we change this now to 10ms, which still is very quick but gives
the queue at least a chance to shutdown itself. That in turn
smoothens the whole shutdown process.

If a very large number of action queues is used this may lead
to a very slightly longer shutdown time, albeit this is very
improbable.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
