### PR TITLE
cleanup: remove commented-out code

### DIFF
--- a/action.c
+++ b/action.c
@@ -221,7 +221,8 @@ static struct cnfparamblk pblk =
 
 
 /* primarily a helper for debug purposes, get human-readble name of state */
-/* currently not needed, but may be useful in the future!
+/* currently not needed, but may be useful in the future! */
+#if 0
 static const char *
 batchState2String(const batch_state_t state)
 {
@@ -240,7 +241,7 @@ batchState2String(const batch_state_t state)
 		return "ERROR, batch state not known!";
 	}
 }
-*/
+#endif // #if 0
 
 /* ------------------------------ methods ------------------------------ */
 

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -1065,15 +1065,6 @@ modUnloadAndDestructAll(eModLinkType_t modLinkTypesToUnload)
 		}
 	}
 
-#	ifdef DEBUG
-	/* DEV DEBUG only!
-		if(pLoadedModules != NULL) {
-			dbgprintf("modules still loaded after module.UnloadAndDestructAll:\n");
-			modUsrPrintAll();
-		}
-	*/
-#	endif
-
 	RETiRet;
 }
 

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -836,8 +836,6 @@ RunSelect(tcpsrv_t *pThis, nsd_epworkset_t workset[], size_t sizeWorkset)
 					processWorkset(pThis, NULL, iWorkset, workset);
 					iWorkset = 0;
 				}
-				//DBGPRINTF("New connect on NSD %p.\n", pThis->ppLstn[i]);
-				//SessAccept(pThis, pThis->ppLstnPort[i], &pNewSess, pThis->ppLstn[i]);
 				--nfds; /* indicate we have processed one */
 			}
 		}

--- a/template.c
+++ b/template.c
@@ -1,7 +1,7 @@
 /* This is the template processing code of rsyslog.
  * begun 2004-11-17 rgerhards
  *
- * Copyright 2004-2018 Rainer Gerhards and Adiscon
+ * Copyright 2004-2019 Rainer Gerhards and Adiscon
  *
  * This file is part of rsyslog.
  *
@@ -2116,19 +2116,14 @@ void tplDeleteAll(rsconf_t *conf)
 
 	pTpl = conf->templates.root;
 	while(pTpl != NULL) {
-		/* dbgprintf("Delete Template: Name='%s'\n ", pTpl->pszName == NULL? "NULL" : pTpl->pszName);*/
 		pTpe = pTpl->pEntryRoot;
 		while(pTpe != NULL) {
 			pTpeDel = pTpe;
 			pTpe = pTpe->pNext;
-			/*dbgprintf("\tDelete Entry(%x): type %d, ", (unsigned) pTpeDel, pTpeDel->eEntryType);*/
 			switch(pTpeDel->eEntryType) {
 			case UNDEFINED:
-				/*dbgprintf("(UNDEFINED)");*/
 				break;
 			case CONSTANT:
-				/*dbgprintf("(CONSTANT), value: '%s'",
-					pTpeDel->data.constant.pConstant);*/
 				free(pTpeDel->data.constant.pConstant);
 				break;
 			case FIELD:
@@ -2144,7 +2139,6 @@ void tplDeleteAll(rsconf_t *conf)
 				break;
 			}
 			free(pTpeDel->fieldName);
-			/*dbgprintf("\n");*/
 			free(pTpeDel);
 		}
 		pTplDel = pTpl;
@@ -2251,8 +2245,6 @@ void tplPrintList(rsconf_t *conf)
 					dbgprintf("[EE-Property: '%s'] ", pTpe->data.field.msgProp.name);
 				} else if(pTpe->data.field.msgProp.id == PROP_LOCAL_VAR) {
 					dbgprintf("[Local Var: '%s'] ", pTpe->data.field.msgProp.name);
-				//} else if(pTpe->data.field.propid == PROP_GLOBAL_VAR) {
-				//	dbgprintf("[Global Var: '%s'] ", pTpe->data.field.propName);
 				}
 				switch(pTpe->data.field.eDateFormat) {
 				case tplFmtDefault:


### PR DESCRIPTION
detected by lgtm.com

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
