### PR TITLE
tcpflood bugfix: tool did not terminate on certificate error

### DIFF
--- a/tests/imtcp-tls-basic.sh
+++ b/tests/imtcp-tls-basic.sh
@@ -21,7 +21,7 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
-tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty
 wait_shutdown
 seq_check

--- a/tests/imtcp_conndrop_tls-vg.sh
+++ b/tests/imtcp_conndrop_tls-vg.sh
@@ -37,7 +37,7 @@ echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>$RSYSLOG_DYNN
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>$RSYSLOG_DYNNAME.conf.tlscert
 startup_vg
 # 100 byte messages to gain more practical data use
-tcpflood -c20 -p'$TCPFLOOD_PORT' -m10000 -r -d100 -P129 -D -l0.995 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -c20 -p'$TCPFLOOD_PORT' -m10000 -r -d100 -P129 -D -l0.995 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 sleep 5 # due to large messages, we need this time for the tcp receiver to settle...
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate

--- a/tests/imtcp_conndrop_tls.sh
+++ b/tests/imtcp_conndrop_tls.sh
@@ -2,7 +2,7 @@
 # Test imtcp/TLS with many dropping connections
 # added 2011-06-09 by Rgerhards
 #
-# This file is part of the rsyslog project, released  under GPLv3
+# This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -30,7 +30,7 @@ echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>$RSYSLOG_DYNN
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>$RSYSLOG_DYNNAME.rsyslog.conf.tlscert
 startup
 # 100 byte messages to gain more practical data use
-tcpflood -c20 -p'$TCPFLOOD_PORT' -m50000 -r -d100 -P129 -D -l0.995 -Ttls -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -c20 -p'$TCPFLOOD_PORT' -m50000 -r -d100 -P129 -D -l0.995 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 sleep 5 # due to large messages, we need this time for the tcp receiver to settle...
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1085,7 +1085,7 @@ int verify_callback(int status, X509_STORE_CTX *store)
 				"subject = %s\n\t"
 				"err %d:%s\n",
 				depth, szdbgdata1, szdbgdata2, err, X509_verify_cert_error_string(err));
-//			exit(1);
+			exit(1);
 		}
 	}
 	return status;
@@ -1546,7 +1546,9 @@ int main(int argc, char *argv[])
 #			if defined(ENABLE_OPENSSL)
 				tlsCAFile = optarg;
 #			else
-				fprintf(stderr, "-x CAFile not supported \n");
+				fprintf(stderr, "-x CAFile not supported in GnuTLS mode - ignored.\n"
+					"Note: we do NOT VERIFY the remote peer when compiled for GnuTLS.\n"
+					"When compiled for OpenSSL, we do.\n");
 #			endif
 				break;
 		case 'z':	tlsKeyFile = optarg;


### PR DESCRIPTION
when tcpflood detected a certificate error, it reported an
error message but did not abort. This could make errors undetectable
during CI runs.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
