### PR TITLE
fix commented out code: actually a work-around to make clear it is not

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1110,7 +1110,7 @@ createMsgFromRequest(const char *request, context *ctx, smsg_t **msg, fjson_obje
 	}
 	CHKiRet(formatBulkReqOrResp(jo_metadata, omes));
 
-	datastart++; /* advance to { */
+	datastart++; /* advance to '{' */
 	if (!(dataend = strchr(datastart, '\n')) || (dataend[1] != '\0')) {
 		LogError(0, RS_RET_ERR,
 			"omelasticsearch: malformed original request - "


### PR DESCRIPTION
The bare { confused the analyser and indeed looks a bit fishy. The '{'
is much more clean. So in a kind it's a real bugfix.

see also: https://github.com/Semmle/ql/issues/773

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
