### PR TITLE
testbench: add tests for "certless" tcp/tls

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -937,6 +937,8 @@ TESTS +=  \
 	sndrcv_tls_anon_hostname.sh \
 	sndrcv_tls_anon_ipv4.sh \
 	sndrcv_tls_anon_ipv6.sh \
+	sndrcv_tls_certless_clientonly.sh \
+	sndrcv_tls_certless_clientonly-legacy.sh \
 	sndrcv_tls_priorityString.sh \
 	sndrcv_tls_certvalid.sh \
 	sndrcv_tls_certvalid_expired.sh \
@@ -2008,6 +2010,8 @@ EXTRA_DIST= \
 	sndrcv_tls_priorityString.sh \
 	sndrcv_tls_certvalid.sh \
 	sndrcv_tls_certvalid_expired.sh \
+	sndrcv_tls_certless_clientonly.sh \
+	sndrcv_tls_certless_clientonly-legacy.sh \
 	omtcl.sh \
 	omtcl.tcl \
 	pmsnare-default.sh \

--- a/tests/sndrcv_tls_certless_clientonly-legacy.sh
+++ b/tests/sndrcv_tls_certless_clientonly-legacy.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# all we want to test is if certless communication works. So we do
+# not need to send many messages.
+# This test checks legacy statements which are often given as 
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5000
+# uncomment for debugging support:
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="log"
+generate_conf
+# receiver
+export PORT_RCVR="$(get_free_port)"
+add_conf '
+global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="gtls"
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+# then SENDER sends to this port (not tcpflood!)
+input(	type="imtcp" port="'$PORT_RCVR'" )
+
+$template outfmt,"%msg:F,58:2%\n"
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+# sender
+export RSYSLOG_DEBUGLOG="log2"
+#valgrind="valgrind"
+generate_conf 2
+#export TCPFLOOD_PORT="$(get_free_port)"
+add_conf '
+# Note: no TLS for the listener, this is for tcpflood!
+$ModLoad ../plugins/imtcp/.libs/imtcp
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
+
+# NOTE: do NOT change legacy statements - they are used intentionally
+$DefaultNetstreamDriverCAFile '$srcdir/tls-certs/ca.pem'
+$ActionSendStreamDriver gtls
+$ActionSendStreamDriverMode 1
+$ActionSendStreamDriverAuthMode x509/name
+$ActionSendStreamDriverPermittedPeer *.rsyslog.com
+*.* @@localhost:'$PORT_RCVR'
+
+' 2
+startup 2
+
+# now inject the messages into instance 2. It will connect to instance 1,
+# and that instance will record the data.
+tcpflood -m$NUMMESSAGES -i1
+wait_file_lines
+# shut down sender when everything is sent, receiver continues to run concurrently
+shutdown_when_empty 2
+wait_shutdown 2
+# now it is time to stop the receiver as well
+shutdown_when_empty
+wait_shutdown
+
+seq_check 1 $NUMMESSAGES
+exit_test

--- a/tests/sndrcv_tls_certless_clientonly.sh
+++ b/tests/sndrcv_tls_certless_clientonly.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# all we want to test is if certless communication works. So we do
+# not need to send many messages.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5000
+# uncomment for debugging support:
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="log"
+generate_conf
+# receiver
+export PORT_RCVR="$(get_free_port)"
+add_conf '
+global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="gtls"
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+# then SENDER sends to this port (not tcpflood!)
+input(	type="imtcp" port="'$PORT_RCVR'" )
+
+$template outfmt,"%msg:F,58:2%\n"
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+# sender
+export RSYSLOG_DEBUGLOG="log2"
+#valgrind="valgrind"
+generate_conf 2
+#export TCPFLOOD_PORT="$(get_free_port)"
+add_conf '
+global(defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'")
+
+# Note: no TLS for the listener, this is for tcpflood!
+$ModLoad ../plugins/imtcp/.libs/imtcp
+input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+
+action(	type="omfwd" protocol="tcp" target="127.0.0.1" port="'$PORT_RCVR'"
+	StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="anon")
+' 2
+startup 2
+
+# now inject the messages into instance 2. It will connect to instance 1,
+# and that instance will record the data.
+tcpflood -m$NUMMESSAGES -i1
+wait_file_lines
+# shut down sender when everything is sent, receiver continues to run concurrently
+shutdown_when_empty 2
+wait_shutdown 2
+# now it is time to stop the receiver as well
+shutdown_when_empty
+wait_shutdown
+
+seq_check 1 $NUMMESSAGES
+exit_test


### PR DESCRIPTION
This adds a test to ensure that a client without certificate can
connect to a server with certificates. So it is not exactly
"certless".

The prime intent of this test is to match config suggestions given
by log hosting companies (like loggly) and so ensure that we do
not accidently break them. This is espcially important as the
capability for certless clients was not properly documented and
also become forgotten by the rsyslog team.

see also https://github.com/rsyslog/rsyslog/issues/3413

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
