### PR TITLE
WIP: build system: fix liblogging-stlog check that blocks compilation when…

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ Follow the instructions at: https://www.rsyslog.com/doc/build_from_repo.html
 
 In general, you need
 
+* pkg-config
 * libestr
-* liblogging (stdlog component)
+* liblogging (stdlog component, for testbench)
 
 It is best to build these from source.
 
@@ -91,6 +92,24 @@ For KSI, from the Adiscon PPA:
 ```
 sudo apt-get install libksi0 libksi-devel
 ```
+
+#### Debian
+
+```
+sudo apt install build-essential pkg-config libestr-dev libfastjson-dev zlib1g-dev uuid-dev libgcrypt20-dev libcurl4-gnutls-dev zlib1g-dev liblogging-stdlog-dev liblogging-stdlog-dev flex bison
+```
+
+*Note:* For certain libraries version requirements might be higher,
+in that case adding debian backports repositories might help.
+For example installing with apt libfastjson-dev -t stretch-backports.
+
+
+Aditional packages for other modules:
+```
+libdbi-dev libmysqlclient-dev postgresql-client libpq-dev libnet-dev librdkafka-dev libgrok-dev libgrok1 libgrok-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev
+```
+
+
 
 #### openSUSE 13
 

--- a/configure.ac
+++ b/configure.ac
@@ -1471,8 +1471,9 @@ AM_CONDITIONAL(ENABLE_KSI_LS12, test x$enable_ksi_ls12 = xyes)
 # liblogging-stdlog support
 # we use liblogging-stdlog inside the testbench, which is why we need to check for it in any case
 PKG_CHECK_MODULES(LIBLOGGING_STDLOG, liblogging-stdlog >= 1.0.3,
-	AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.]),
-	[AC_MSG_NOTICE([liblogging-stdlog not found, parts of the testbench will not run])]
+        [AC_DEFINE(HAVE_LIBLOGGING_STDLOG, 1, [Define to 1 if liblogging-stdlog is available.])
+        found_liblogging_stdlog="yes"],
+        [AC_MSG_NOTICE([liblogging-stdlog not found, parts of the testbench will not run])]
 )
 
 AC_ARG_ENABLE(liblogging-stdlog,
@@ -1484,7 +1485,7 @@ AC_ARG_ENABLE(liblogging-stdlog,
          esac],
         [enable_liblogging_stdlog=no]
 )
-if test "x$enable_liblogging_stdlog" = "xyes" -a "x$HAVE_LIBLOGGING_STDLOG" != "x1"; then
+if test "x$enable_liblogging_stdlog" = "xyes" -a "x$found_liblogging_stdlog" != "xyes"; then
 	AC_MSG_ERROR(--enable-liblogging-stdlog set but liblogging-stdlog was not found)
 fi
 AM_CONDITIONAL(ENABLE_LIBLOGGING_STDLOG, [test "x$enable_liblogging_stdlog" = "xyes"])


### PR DESCRIPTION
… lib present

The added check of HAVE_LIBLOGGING_STDLOG, set via AC_DEFINE, fails due to it staying undefined in the configure execution context.

Fixes #3431 - auxiliary var added, to split logic from testbench check and correctly pass the test if library is present. AC_DEFINE untouched due to need for testbench ifdefs.

Bug: https://github.com/rsyslog/rsyslog/issues/3431

Extra: 
Added few details to README.MD
Added Debian section for better coverage.

Note:
As from autoconf documentation: https://www.gnu.org/software/autoconf/manual/autoconf-2.67/html_node/Defining-Symbols.html

> By default, AC_OUTPUT places the symbols defined by these macros into the output variable DEFS, which contains an option -Dsymbol=value for each symbol defined. Unlike in Autoconf version 1, there is no variable DEFS defined while configure is running.

In fact by debugging the configure execution the HAVE_LIBLOGGING_STDLOG was resulting undefined in the check at line 1454 of https://github.com/rsyslog/rsyslog/commit/d5ffe6e10eb7f9427c06a72b968b428ca8d6283d#diff-67e997bcfdac55191033d57a16d1408a

This lead to the AC_MSG_ERROR ( added also in the same phase ) that exited the autoconf process blocking compilation.