### PR TITLE
configure: remove orphaned enable_libcurl status from overview

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2402,7 +2402,6 @@ echo "    anonymization support enabled:            $enable_mmanon"
 echo "    message counting support enabled:         $enable_mmcount"
 echo "    liblogging-stdlog support enabled:        $enable_liblogging_stdlog"
 echo "    libsystemd enabled:                       $enable_libsystemd"
-echo "    libcurl enabled:                          $enable_libcurl"
 echo "    kafka static linking enabled:             $enable_kafka_static"
 echo "    atomic operations enabled:                $enable_atomic_operations"
 echo


### PR DESCRIPTION
$enable_libcurl was removed in commit dc95ef09bdb07cfb7b7df4ce87df629fc2c94f8f.
However, it wasn't removed from status overview.

This commit will remove $enable_libcurl from status overview.
