### PR TITLE
testbench: mmdb valgrind tests failed is srcdir env was not set

### DIFF
--- a/tests/mmdb-multilevel-vg.sh
+++ b/tests/mmdb-multilevel-vg.sh
@@ -1,11 +1,9 @@
 #!/bin/bash 
 # This file is part of the rsyslog project, released under ASL 2.0 
-
+. ${srcdir:=.}/diag.sh init
 # we libmaxmindb, in packaged versions, has a small cosmetic memory leak,
 # thus we need a supressions file:
 export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="$RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/libmaxmindb.supp"
-
-. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!iplocation%\n")
@@ -16,12 +14,12 @@ module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
-	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)
+	action(type="mmnormalize" rulebase="'$srcdir'/mmdb.rb")
 	# Uncomment this action when using the real GeoLite2 city database;
 	# we have not included it into the testbench for licensing concerns.
 	# action(type="mmdblookup" mmdbfile="/home/USR/GeoLite2-City_20170502/GeoLite2-City.mmdb" key="$!ip" fields=":city:!city!names!en" )
-	action(type="mmdblookup" mmdbfile=`echo $srcdir/test.mmdb` key="$!ip" fields=":city_name:city" )
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="mmdblookup" mmdbfile="'$srcdir'/test.mmdb" key="$!ip" fields=":city_name:city" )
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }'
 startup_vg
 tcpflood -m 100 -j "202.106.0.20\ "

--- a/tests/mmdb-vg.sh
+++ b/tests/mmdb-vg.sh
@@ -1,11 +1,9 @@
 #!/bin/bash 
 # This file is part of the rsyslog project, released under ASL 2.0 
-
+. ${srcdir:=.}/diag.sh init
 # we libmaxmindb, in packaged versions, has a small cosmetic memory leak,
 # thus we need a supressions file:
 export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="$RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/libmaxmindb.supp"
-
-. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!iplocation%\n")
@@ -16,9 +14,9 @@ module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
 
 ruleset(name="testing") {
-	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)
-	action(type="mmdblookup" mmdbfile=`echo $srcdir/test.mmdb` key="$!ip" fields="city" )
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="mmnormalize" rulebase="'$srcdir'/mmdb.rb")
+	action(type="mmdblookup" mmdbfile="'$srcdir'/test.mmdb" key="$!ip" fields="city" )
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }'
 startup_vg
 tcpflood -m 100 -j "202.106.0.20\ "


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
