### PR TITLE
tcpflood: add new transport option relp-tls

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1034,7 +1034,8 @@ TESTS += \
          sndrcv_relp_tls_certvalid.sh \
          sndrcv_relp_tls_prio.sh \
          relp_tls_certificate_not_found.sh \
-	 omrelp_wrong_authmode.sh
+	 omrelp_wrong_authmode.sh \
+	 imrelp-tls.sh
 endif # ENABLE_GNUTLS
 if HAVE_VALGRIND
 TESTS += \
@@ -1698,6 +1699,7 @@ EXTRA_DIST= \
         sndrcv_relp_tls_certvalid.sh \
 	relp_tls_certificate_not_found.sh \
 	omrelp_wrong_authmode.sh \
+	imrelp-tls.sh \
 	sndrcv_relp_dflt_pt.sh \
 	sndrcv_udp.sh \
 	imudp_thread_hang.sh \

--- a/tests/imrelp-tls.sh
+++ b/tests/imrelp-tls.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# addd 2019-01-31 by PascalWithopf, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+do_skip=0
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" tls="on"
+		tls.cacert="'$srcdir'/tls-certs/ca.pem"
+		tls.mycert="'$srcdir'/tls-certs/cert.pem"
+		tls.myprivkey="'$srcdir'/tls-certs/key.pem"
+		tls.authmode="certvalid"
+		tls.permittedpeer="rsyslog")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+./tcpflood -Trelp-tls -acertvalid -p$TCPFLOOD_PORT -m$NUMMESSAGES -x "$srcdir/tls-certs/ca.pem" -z "$srcdir/tls-certs/key.pem" -Z "$srcdir/tls-certs/cert.pem" -Ersyslog 2> $RSYSLOG_DYNNAME.tcpflood
+if [ $? -eq 1 ]; then
+	cat $RSYSLOG_DYNNAME.tcpflood
+	if ! grep "could net set.*certvalid" < "$RSYSLOG_DYNNAME.tcpflood" ; then
+		printf "librelp too old, need to skip this test\n"
+		do_skip=1
+	fi
+fi
+	cat -n $RSYSLOG_DYNNAME.tcpflood
+shutdown_when_empty
+wait_shutdown
+if [ $do_skip -eq 1 ]; then
+	skip_test
+fi
+seq_check
+exit_test


### PR DESCRIPTION
Tcpflood can now send messages via relp with tls support.
A test was added aswell.

closes https://github.com/rsyslog/rsyslog/issues/3448

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
