### PR TITLE
Release zframe following read from socket

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -316,7 +316,6 @@ static rsRetVal rcvData(void){
 		pData = zlist_next(listenerList);
 	}
 
-	zframe_t *frame;
 	zsock_t *which = (zsock_t *)zpoller_wait(poller, -1);
 	while(which) {
 		if (zpoller_terminated(poller)) {
@@ -331,8 +330,13 @@ static rsRetVal rcvData(void){
 			DBGPRINTF("imczmq: found matching socket\n");
 		}
 
-		frame = zframe_recv(which);
-		char *buf = zframe_strdup(frame);
+		zframe_t *frame = zframe_recv(which);
+		char *buf = NULL;
+
+		if (frame != NULL)
+			buf = zframe_strdup(frame);
+
+		zframe_destroy(&frame);
 
 		if(buf == NULL) {
 			DBGPRINTF("imczmq: null buffer\n");
@@ -356,7 +360,6 @@ static rsRetVal rcvData(void){
 		which = (zsock_t *)zpoller_wait(poller, -1);
 	}
 finalize_it:
-	zframe_destroy(&frame);
 	zpoller_destroy(&poller);
 	pData = zlist_first(listenerList);
 	while(pData) {


### PR DESCRIPTION
Make the 0MQ frame pointer local to the receive loop and destroy the
frame as soon as the contents have been copied. This avoids:

 o a memory leak should the receive loop execute more than once

 o referencing an un-initialised value during cleanup (finalize_it)

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
