### PR TITLE
several fixes, mostly detected by gcc 8.2

### DIFF
--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -119,6 +119,7 @@ static struct cnfparamblk actpblk = {
 
 static rsRetVal initCZMQ(instanceData* pData) {
 	DEFiRet;
+	int rc;
 	putenv((char*)"ZSYS_SIGHANDLER=false");
 	pData->sock = zsock_new(pData->sockType);
 	if(!pData->sock) {
@@ -193,7 +194,7 @@ static rsRetVal initCZMQ(instanceData* pData) {
 			break;
 	}
 
-	int rc = zsock_attach(pData->sock, pData->sockEndpoints, pData->serverish);
+	rc = zsock_attach(pData->sock, pData->sockEndpoints, pData->serverish);
 	if(rc == -1) {
 		LogError(0, NO_ERRCODE, "zsock_attach to %s failed",
 				pData->sockEndpoints);

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -408,16 +408,11 @@ destructSrv(ptcpsrv_t *pSrv)
 	if(pSrv->pInputName != NULL)
 		prop.Destruct(&pSrv->pInputName);
 	pthread_mutex_destroy(&pSrv->mutSessLst);
-	if(pSrv->pszInputName != NULL)
-		free(pSrv->pszInputName);
-	if(pSrv->port != NULL)
-		free(pSrv->port);
-	if(pSrv->pszLstnPortFileName)
-		free(pSrv->pszLstnPortFileName);
-	if(pSrv->path != NULL)
-		free(pSrv->path);
-	if(pSrv->lstnIP != NULL)
-		free(pSrv->lstnIP);
+	free(pSrv->pszInputName);
+	free(pSrv->port);
+	free(pSrv->pszLstnPortFileName);
+	free(pSrv->path);
+	free(pSrv->lstnIP);
 	free(pSrv);
 }
 
@@ -442,7 +437,7 @@ static rsRetVal startupUXSrv(ptcpsrv_t *pSrv) {
 	}
 
 	local.sun_family = AF_UNIX;
-	strncpy(local.sun_path, (char*) path, sizeof(local.sun_path));
+	strncpy(local.sun_path, (char*) path, sizeof(local.sun_path)-1);
 	if (pSrv->bUnlink) {
 		unlink(local.sun_path);
 	}
@@ -727,7 +722,7 @@ getPeerNames(prop_t **peerName, prop_t **peerIP, struct sockaddr *pAddr, sbool b
 				if (getaddrinfo((char *) szHname, NULL, &hints, &res) == 0) {
 					freeaddrinfo(res);
 					/* OK, we know we have evil, so let's indicate this to our caller */
-					snprintf((char *) szHname, NI_MAXHOST, "[MALICIOUS:IP=%s]", szIP);
+					snprintf((char *) szHname, sizeof(szHname), "[MALICIOUS:IP=%s]", szIP);
 					DBGPRINTF("Malicious PTR record, IP = \"%s\" HOST = \"%s\"", szIP, szHname);
 					bMaliciousHName = 1;
 				}

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -1,7 +1,7 @@
 /* ommongodb.c
  * Output module for mongodb.
  *
- * Copyright 2007-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * Copyright 2017 Jeremie Jourdin and Hugo Soszynski and aDvens
  * Remove deprecated libmongo-client and use libmongoc (mongo-c-driver)
@@ -682,7 +682,7 @@ CODESTARTnewActInst
 		 * Formatting string "by hand" is a lot faster on execution than a snprintf for example.
 		 */
 		CHKmalloc(pData->uristr = malloc(uri_len + 1));
-		tmp = stpncpy(pData->uristr, "mongodb://", 10);
+		tmp = stpncpy(pData->uristr, "mongodb://", 11);
 		if(pData->uid && pData->pwd){
 			dbgprintf("ommongodb: Adding uid & pwd to uristr.\n");
 			tmp = stpncpy(tmp, pData->uid, uid);
@@ -702,9 +702,9 @@ CODESTARTnewActInst
 		if(pData->ssl_ca && pData->ssl_cert){
 			dbgprintf("ommongodb: Adding ssl to uristr.\n");
 			if(pData->uid && pData->pwd)
-				tmp = stpncpy(tmp, "&ssl=true", 9);
+				tmp = stpncpy(tmp, "&ssl=true", 10);
 			else
-				tmp = stpncpy(tmp, "?ssl=true", 9);
+				tmp = stpncpy(tmp, "?ssl=true", 10);
 		}
 		*tmp = '\0';
 	}


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
