### PR TITLE
omrelp: add capability to specify tlslib for librelp

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1438,6 +1438,8 @@ if test "x$enable_relp" = "xyes"; then
                       [AC_DEFINE([HAVE_RELPSRVSETOVERSIZEMODE], [1], [Define if relpSrvSetOversizeMode exists.])])
         AC_CHECK_FUNC([relpSrvSetLstnAddr],
                       [AC_DEFINE([HAVE_RELPSRVSETLSTNADDR], [1], [Define if relpSrvSetLstnAddr exists.])])
+        AC_CHECK_FUNC([relpEngineSetTLSLibByName],
+                      [AC_DEFINE([HAVE_RELPENGINESETTLSLIBBYNAME], [1], [Define if relpEngineSetTLSLibByName exists.])])
 
         CFLAGS="$save_CFLAGS"
         LIBS="$save_LIBS"

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -683,7 +683,7 @@ CODESTARTsetModCnf
 				loadModConf->tlslib = es_str2cstr(pvals[i].val.d.estr, NULL);
 			#else
 				LogError(0, RS_RET_NOT_IMPLEMENTED,
-					"warning: parameter tls.tlslib ignored - librelp does not support "
+					"imrelp warning: parameter tls.tlslib ignored - librelp does not support "
 					"this API call. Using whatever librelp was compiled with.");
 			#endif
 		} else {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -999,6 +999,7 @@ TESTS += sndrcv_relp.sh \
 	 imrelp-oversizeMode-truncate.sh \
 	 imrelp-oversizeMode-accept.sh \
 	 imrelp-invld-tlslib.sh \
+	 omrelp-invld-tlslib.sh \
 	 sndrcv_relp_dflt_pt.sh \
 	 glbl-oversizeMsg-log.sh \
 	 glbl-oversizeMsg-truncate.sh \
@@ -1662,6 +1663,7 @@ EXTRA_DIST= \
 	imrelp-oversizeMode-truncate.sh \
 	imrelp-oversizeMode-accept.sh \
 	imrelp-invld-tlslib.sh \
+	omrelp-invld-tlslib.sh \
 	glbl-oversizeMsg-log.sh \
 	glbl-oversizeMsg-truncate.sh \
 	glbl-oversizeMsg-split.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -46,6 +46,7 @@ check_PROGRAMS = $(TESTRUNS) ourtail tcpflood chkseq msleep randomgen \
 	omrelp_dflt_port \
 	mangle_qi \
 	have_relpSrvSetOversizeMode \
+	have_relpEngineSetTLSLibByName \
 	test_id
 if ENABLE_JOURNAL_TESTS
 if ENABLE_IMJOURNAL
@@ -997,6 +998,7 @@ TESTS += sndrcv_relp.sh \
 	 imrelp-long-msg.sh \
 	 imrelp-oversizeMode-truncate.sh \
 	 imrelp-oversizeMode-accept.sh \
+	 imrelp-invld-tlslib.sh \
 	 sndrcv_relp_dflt_pt.sh \
 	 glbl-oversizeMsg-log.sh \
 	 glbl-oversizeMsg-truncate.sh \
@@ -1011,6 +1013,7 @@ TESTS += \
 endif # ENABLE_GNUTLS
 if HAVE_VALGRIND
 TESTS += \
+	 imrelp-basic-vg.sh \
 	 imrelp-manyconn-vg.sh
 endif # HAVE_VALGRIND
 endif
@@ -1650,6 +1653,7 @@ EXTRA_DIST= \
 	sndrcv.sh \
 	omrelp_errmsg_no_connect.sh \
 	imrelp-basic.sh \
+	imrelp-basic-vg.sh \
 	imrelp-basic-oldstyle.sh \
 	imrelp-manyconn.sh \
 	imrelp-manyconn-vg.sh \
@@ -1657,6 +1661,7 @@ EXTRA_DIST= \
 	imrelp-long-msg.sh \
 	imrelp-oversizeMode-truncate.sh \
 	imrelp-oversizeMode-accept.sh \
+	imrelp-invld-tlslib.sh \
 	glbl-oversizeMsg-log.sh \
 	glbl-oversizeMsg-truncate.sh \
 	glbl-oversizeMsg-split.sh \
@@ -2071,6 +2076,7 @@ omrelp_dflt_port_SOURCES = omrelp_dflt_port.c
 mangle_qi_SOURCES = mangle_qi.c
 chkseq_SOURCES = chkseq.c
 have_relpSrvSetOversizeMode = have_relpSrvSetOversizeMode.c
+have_relpEngineSetTLSLibByName = have_relpEngineSetTLSLibByName.c
 test_id_SOURCES = test_id.c
 
 uxsockrcvr_SOURCES = uxsockrcvr.c

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1343,6 +1343,14 @@ check_logger_has_option_d() {
 }
 
 
+require_relpEngineSetTLSLibByName() {
+	./have_relpEngineSetTLSLibByName
+	if [ $? -eq 1 ]; then
+	  echo "relpEngineSetTLSLibByName API not available. Test stopped"
+	  exit 77
+	fi;
+}
+
 # check if command $1 is available - will exit 77 when not OK
 check_command_available() {
 	have_cmd=0

--- a/tests/have_relpEngineSetTLSLibByName.c
+++ b/tests/have_relpEngineSetTLSLibByName.c
@@ -1,0 +1,10 @@
+#include "config.h"
+
+int main(int argc __attribute__((unused)), char *argv[]__attribute__((unused)))
+{
+#if defined(HAVE_RELPENGINESETTLSLIBBYNAME)
+	return 0;
+#else
+	return 1;
+#endif
+}

--- a/tests/imrelp-basic-vg.sh
+++ b/tests/imrelp-basic-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/imrelp-basic.sh

--- a/tests/imrelp-basic.sh
+++ b/tests/imrelp-basic.sh
@@ -11,7 +11,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m10000
+tcpflood -Trelp-plain -p$TCPFLOOD_PORT -m10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 seq_check 0 9999

--- a/tests/imrelp-invld-tlslib.sh
+++ b/tests/imrelp-invld-tlslib.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# see that we can an error message if wrong tls lib is selected
+# addd 2019-02-09 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_relpEngineSetTLSLibByName
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp" tls.tlslib="invalid-tlslib-name")
+input(type="imrelp" port="'$TCPFLOOD_PORT'") #prevent extra config error, not really needed
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+content_check --regex "invalid-tlslib-name.*not accepted"
+exit_test

--- a/tests/omrelp-invld-tlslib.sh
+++ b/tests/omrelp-invld-tlslib.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# see that we can an error message if wrong tls lib is selected
+# addd 2019-02-09 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_relpEngineSetTLSLibByName
+generate_conf
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="invalid-tlslib-name")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+content_check --regex "omrelp.*invalid-tlslib-name.*not accepted"
+exit_test

--- a/tests/omrelp_wrong_authmode.sh
+++ b/tests/omrelp_wrong_authmode.sh
@@ -19,12 +19,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 shutdown_when_empty
 wait_shutdown
-
-grep "omrelp.* invalid auth.*mode .*INVALID_AUTH_MODE" $RSYSLOG_OUT_LOG > /dev/null
-if [ $? -ne 0 ]; then
-        echo "FAIL: expected error message from missing input file not found. $RSYSLOG_OUT_LOG is:"
-        cat -n $RSYSLOG_OUT_LOG
-        error_exit 1
-fi
-
+content_check --regex "omrelp.* invalid auth.*mode .*INVALID_AUTH_MODE"
 exit_test


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/issues/3451

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
