### PR TITLE
Segfault in omclickhouse fixed

### DIFF
--- a/plugins/omclickhouse/omclickhouse.c
+++ b/plugins/omclickhouse/omclickhouse.c
@@ -429,6 +429,10 @@ computeBulkMessage(const wrkrInstanceData_t *const pWrkrData,
 	const uchar *const message, char **newMessage)
 {
 	size_t r = 0;
+	if(!strstr((const char*)message, "VALUES")) {
+		return r;
+	}
+
 	if(pWrkrData->batch.nmemb != 0) {
 		*newMessage = strchr(strstr((const char*)message, "VALUES"), '(');
 		r = strlen(*newMessage);
@@ -564,6 +568,13 @@ CODESTARTdoAction
 
 	if(pWrkrData->pData->bulkmode) {
 		const size_t nBytes = computeBulkMessage(pWrkrData, ppString[0], &batchPart);
+
+		if(nBytes==0) {
+			LogError(0, RS_RET_ERR, "omclickhouse: Incorrect Message template: "
+				"Message suspended: %s", (char*)ppString[0]);
+		      	ABORT_FINALIZE(RS_RET_ERR);
+		}
+
 		dbgprintf("pascal: doAction: message: %s\n", batchPart);
 
 		/* If max bytes is set and this next message will put us over the limit,


### PR DESCRIPTION
Messages which does not contain the word "VALUES" in them were causing
segfault.

ps: let me know if there is any other better way to tackle this.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
