### PR TITLE
portability: hide (some) pragmas in macros

### DIFF
--- a/action.c
+++ b/action.c
@@ -122,9 +122,8 @@
 #ifdef _AIX
 #define cs legacy_cs
 #endif
-#if !defined(_AIX)
-#pragma GCC diagnostic ignored "-Wswitch-enum"
-#endif
+
+PRAGMA_INGORE_Wswitch_enum
 
 #ifndef O_LARGEFILE
 #define O_LARGEFILE 0
@@ -1023,10 +1022,8 @@ finalize_it:
 
 
 /* the #pragmas can go away when we have disable array-passing mode */
-#if !defined(_AIX)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wcast-align"
-#endif
+PRAGMA_DIAGNOSTIC_PUSH
+PRAGMA_IGNORE_Wcast_align
 void
 releaseDoActionParams(action_t *__restrict__ const pAction, wti_t *__restrict__ const pWti, int action_destruct)
 {
@@ -1061,9 +1058,7 @@ releaseDoActionParams(action_t *__restrict__ const pAction, wti_t *__restrict__ 
 
 	return;
 }
-#if !defined(_AIX)
-#pragma GCC diagnostic pop
-#endif
+PRAGMA_DIAGNOSTIC_POP
 
 
 /* This is used in resume processing. We only finally know that a resume
@@ -1790,9 +1785,8 @@ finalize_it:
 /* Call configured action, most complex case with all features supported (and thus slow).
  * rgerhards, 2010-06-08
  */
-#ifndef _AIX
-#pragma GCC diagnostic ignored "-Wempty-body"
-#endif
+PRAGMA_DIAGNOSTIC_PUSH;
+PRAGMA_IGNORE_Wempty_body;
 static rsRetVal
 doSubmitToActionQComplex(action_t * const pAction, wti_t * const pWti, smsg_t *pMsg)
 {
@@ -1821,9 +1815,7 @@ finalize_it:
 
 	RETiRet;
 }
-#ifndef _AIX
-#pragma GCC diagnostic warning "-Wempty-body"
-#endif
+PRAGMA_DIAGNOSTIC_POP
 
 
 /* helper to activateActions, it activates a specific action.

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -6,7 +6,7 @@
  *
  * File begun on 2007-12-20 by RGerhards (extracted from syslogd.c)
  *
- * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -64,9 +64,6 @@
 #include "hashtable.h"
 #include "ratelimit.h"
 
-#if !defined(_AIX)
-#pragma GCC diagnostic ignored "-Wswitch-enum"
-#endif
 
 MODULE_TYPE_INPUT
 MODULE_TYPE_NOKEEP

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -78,6 +78,20 @@ extern int src_exists;
 #define ATTR_UNUSED __attribute__((unused))
 #define ATTR_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
 
+#if defined(__GNUC__)
+	#define PRAGMA_INGORE_Wswitch_enum	_Pragma("GCC diagnostic ignored \"-Wswitch-enum\"")
+	#define PRAGMA_IGNORE_Wcast_align	_Pragma("GCC diagnostic ignored \"-Wcast-align\"")
+	#define PRAGMA_IGNORE_Wempty_body	_Pragma("GCC diagnostic ignored \"-Wempty-body\"")
+	#define PRAGMA_DIAGNOSTIC_PUSH		_Pragma("GCC diagnostic push")
+	#define PRAGMA_DIAGNOSTIC_POP		_Pragma("GCC diagnostic pop")
+#else
+	#define PRAGMA_INGORE_Wswitch_enum
+	#define PRAGMA_IGNORE_Wcast_align
+	#define PRAGMA_IGNORE_Wempty_body
+	#define PRAGMA_DIAGNOSTIC_PUSH
+	#define PRAGMA_DIAGNOSTIC_POP
+#endif
+
 /* ############################################################# *
  * #                 Some constant values                      # *
  * ############################################################# */


### PR DESCRIPTION
see also #3471 

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
