### PR TITLE
testbench: increase timeout for test + better to exp reporting

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -605,6 +605,7 @@ timeoutGuard(ATTR_UNUSED void *arg)
 {
 	assert(abortTimeout != -1);
 	sigset_t sigSet;
+	time_t strtTO;
 	time_t endTO;
 
 	/* block all signals except SIGTTIN and SIGSEGV */
@@ -614,8 +615,8 @@ timeoutGuard(ATTR_UNUSED void *arg)
 
 	dbgprintf("timeoutGuard: timeout %d seconds, time %lld\n", abortTimeout, (long long) time(NULL));
 
-	time(&endTO);
-	endTO += abortTimeout;
+	time(&strtTO);
+	endTO = strtTO + abortTimeout;
 
 	while(1) {
 		int to = endTO - time(NULL);
@@ -633,8 +634,8 @@ timeoutGuard(ATTR_UNUSED void *arg)
 	dbgprintf("timeoutGuard: sleep expired, aborting\n");
 	/* note: we use fprintf to stderr intentionally! */
 	fprintf(stderr, "timeoutGuard: rsyslog still active after expiry of guard "
-		"period (endTO %lld, time now %lld) - initiating abort()\n",
-		(long long) endTO, (long long) time(NULL));
+		"period (strtTO %lld, endTO %lld, time now %lld, diff %lld) - initiating abort()\n",
+		(long long) strtTO, (long long) endTO, (long long) time(NULL), (long long) (time(NULL) - strtTO));
 	fflush(stderr);
 	abort();
 }

--- a/tests/queue-encryption-disk_keyfile-vg.sh
+++ b/tests/queue-encryption-disk_keyfile-vg.sh
@@ -9,6 +9,7 @@ main_queue(queue.filename="mainq"
 	queue.type="disk"
 	queue.maxDiskSpace="4m"
 	queue.maxfilesize="1m"
+	queue.timeoutshutdown="20000"
 	queue.timeoutenqueue="300000"
 	queue.lowwatermark="5000"
 


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
