### PR TITLE
testbench: add test for omclickhouse with default template

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -490,9 +490,10 @@ endif # if ENABLE_MMANON
 
 if ENABLE_CLICKHOUSE_TESTS
 TESTS +=  \
-	clickhouse-retry-error.sh \
 	clickhouse-start.sh \
 	clickhouse-basic.sh \
+	clickhouse-dflt-tpl.sh \
+	clickhouse-retry-error.sh \
 	clickhouse-load.sh \
 	clickhouse-bulk.sh \
 	clickhouse-bulk-load.sh \
@@ -503,9 +504,10 @@ TESTS +=  \
 	clickhouse-wrong-template-option.sh \
 	clickhouse-wrong-insert-syntax.sh
 
-clickhouse-start.log: clickhouse-retry-error.log
 clickhouse-basic.log: clickhouse-start.log
-clickhouse-load.log: clickhouse-basic.log
+clickhouse-dflt-tpl.log: clickhouse-basic.log
+clickhouse-retry-error.log: clickhouse-dflt-tpl.log
+clickhouse-load.log: clickhouse-retry-error.log
 clickhouse-bulk.log: clickhouse-load.log
 clickhouse-bulk-load.log: clickhouse-bulk.log
 clickhouse-limited-batch.log: clickhouse-bulk-load.log
@@ -1535,6 +1537,7 @@ EXTRA_DIST= \
 	incltest_dir_empty_wildcard.sh \
 	incltest_dir_wildcard.sh \
 	testsuites/es.yml \
+	clickhouse-dflt-tpl.sh \
 	clickhouse-retry-error.sh \
 	clickhouse-start.sh \
 	clickhouse-stop.sh \

--- a/tests/clickhouse-dflt-tpl.sh
+++ b/tests/clickhouse-dflt-tpl.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# add 2018-12-07 by Pascal Withopf, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+generate_conf
+add_conf '
+module(load="../plugins/omclickhouse/.libs/omclickhouse")
+
+:syslogtag, contains, "tag" action(type="omclickhouse" server="localhost" port="8443" bulkmode="off"
+					user="default" pwd="")
+'
+
+clickhouse-client --query="CREATE TABLE IF NOT EXISTS rsyslog.SystemEvents ( severity Int8, facility Int8, timestamp DateTime, hostname String, tag String, message String ) ENGINE = MergeTree() PARTITION BY severity order by tuple()"
+
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+clickhouse-client --query="SELECT * FROM rsyslog.SystemEvents FORMAT CSV" > $RSYSLOG_OUT_LOG
+
+clickhouse-client --query="DROP TABLE rsyslog.SystemEvents"
+export EXPECTED='7,20,"2019-03-01 01:00:00","172.20.245.8","tag"," msgnum:00000000:"'
+cmp_exact $RSYSLOG_OUT_LOG
+
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
