### PR TITLE
testbench: increase explicit enqueue timeout for slow CI systems

### DIFF
--- a/tests/complex1.sh
+++ b/tests/complex1.sh
@@ -26,7 +26,7 @@ $template dynfile,"'$RSYSLOG_DYNNAME'.out.%inputname%.%msg:F,58:2%.log.Z"
 $Ruleset R13514
 # queue params:
 $ActionQueueTimeoutShutdown 60000
-$ActionQueueTimeoutEnqueue 5000
+$ActionQueueTimeoutEnqueue 15000
 $ActionQueueSize 5000
 $ActionQueueSaveOnShutdown on
 $ActionQueueHighWaterMark 4900

--- a/tests/libdbi-asyn.sh
+++ b/tests/libdbi-asyn.sh
@@ -7,7 +7,7 @@ add_conf '
 $ModLoad ../plugins/omlibdbi/.libs/omlibdbi
 
 $ActionQueueType LinkedList
-$ActionQueueTimeoutEnqueue 2000
+$ActionQueueTimeoutEnqueue 15000
 
 $ActionLibdbiDriver mysql
 $ActionLibdbiHost 127.0.0.1

--- a/tests/mysql-asyn-vg.sh
+++ b/tests/mysql-asyn-vg.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql
 $ActionQueueType LinkedList
-$ActionQueueTimeoutEnqueue 10000 # 10 second to make sure we do not loose due to action q full
+$ActionQueueTimeoutEnqueue 20000
 :msg, contains, "msgnum:" :ommysql:127.0.0.1,Syslog,rsyslog,testbench;
 '
 mysql --user=rsyslog --password=testbench < ${srcdir}/testsuites/mysql-truncate.sql

--- a/tests/mysql-asyn.sh
+++ b/tests/mysql-asyn.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql
 $ActionQueueType LinkedList
-$ActionQueueTimeoutEnqueue 10000 # 10 second to make sure we do not loose due to action q full
+$ActionQueueTimeoutEnqueue 20000
 :msg, contains, "msgnum:" :ommysql:127.0.0.1,Syslog,rsyslog,testbench;
 '
 mysql --user=rsyslog --password=testbench < ${srcdir}/testsuites/mysql-truncate.sql

--- a/tests/threadingmqaq.sh
+++ b/tests/threadingmqaq.sh
@@ -30,7 +30,7 @@ $OMFileIOBufferSize 256k
 # This time, also run the action queue detached
 $ActionQueueWorkerThreadMinimumMessages 10
 $ActionQueueWorkerThreads 5
-$ActionQueueTimeoutEnqueue 500
+$ActionQueueTimeoutEnqueue 10000
 $ActionQueueType LinkedList
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
