### PR TITLE
imfile: Added new option statefilealwaysremove

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1167,6 +1167,8 @@ TESTS += \
 	imfile-logrotate.sh \
 	imfile-logrotate-copytruncate.sh \
 	imfile-logrotate-nocopytruncate.sh \
+	imfile-logrotate-multiple.sh \
+	imfile-logrotate-multiple-polling.sh \
 	imfile-growing-file-id.sh \
 	glbl-oversizeMsg-truncate-imfile.sh
 
@@ -1830,6 +1832,8 @@ EXTRA_DIST= \
 	imfile-logrotate.sh \
 	imfile-logrotate-copytruncate.sh \
 	imfile-logrotate-nocopytruncate.sh \
+	imfile-logrotate-multiple.sh \
+	imfile-logrotate-multiple-polling.sh \
 	imfile-growing-file-id.sh \
 	glbl-oversizeMsg-truncate-imfile.sh \
 	dynfile_invld_async.sh \

--- a/tests/imfile-logrotate-multiple-polling.sh
+++ b/tests/imfile-logrotate-multiple-polling.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+. $srcdir/diag.sh check-inotify-only
+. ${srcdir:=.}/diag.sh init
+check_command_available logrotate
+
+export IMFILEROTATES="10"
+export TESTMESSAGES=10000
+export TESTMESSAGESFULL=$((IMFILEROTATES * TESTMESSAGES-1))
+
+generate_conf
+add_conf '
+$WorkDirectory '$RSYSLOG_DYNNAME'.spool
+
+/* Filter out busy debug output */
+global(
+	debug.whitelist="off"
+	debug.files=["omfile.c", "queue.c", "rainerscript.c", "ratelimit.c", "ruleset.c", "main Q", "msg.c", "../action.c"]
+	)
+
+module(	load="../plugins/imfile/.libs/imfile"
+	mode="polling"
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./'$RSYSLOG_DYNNAME'.input.*.log"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+)
+
+$template outfmt,"%msg:F,58:2%\n"
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file=`echo $RSYSLOG_OUT_LOG`
+   template="outfmt"
+ )
+'
+
+# Write logrotate config file
+echo '"./'$RSYSLOG_DYNNAME'.input.*.log"
+{
+	daily
+	missingok
+	rotate 14
+	create
+	notifempty
+	compress
+	delaycompress
+}' > $RSYSLOG_DYNNAME.logrotate
+
+startup
+
+TESTMESSAGESSTART=0
+for i in $(seq 1 $IMFILEROTATES);
+do
+	# generate input file first.
+	./inputfilegen -m $TESTMESSAGES -i $TESTMESSAGESSTART > $RSYSLOG_DYNNAME.input.1.log
+
+	ls -l $RSYSLOG_DYNNAME.input*
+	echo ls ${RSYSLOG_DYNNAME}.spool:
+	ls -l ${RSYSLOG_DYNNAME}.spool
+
+	# Wait until testmessages are processed by imfile!
+	msgcount=$((i * TESTMESSAGES-1))
+	# echo "TESTMESSAGESSTART: $TESTMESSAGESSTART - TotalMsgCount: $msgcount"
+	wait_file_lines $RSYSLOG_OUT_LOG $msgcount $RETRIES
+
+	# Logrotate on logfile
+	logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate
+
+	TESTMESSAGESSTART=$((TESTMESSAGESSTART+TESTMESSAGES))
+done
+
+
+shutdown_when_empty
+wait_shutdown
+seq_check 0 $TESTMESSAGESFULL
+exit_test

--- a/tests/imfile-logrotate-multiple.sh
+++ b/tests/imfile-logrotate-multiple.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+. $srcdir/diag.sh check-inotify-only
+. ${srcdir:=.}/diag.sh init
+check_command_available logrotate
+
+export IMFILEROTATES="10"
+export TESTMESSAGES=10000
+export TESTMESSAGESFULL=$((IMFILEROTATES * TESTMESSAGES-1))
+
+generate_conf
+add_conf '
+$WorkDirectory '$RSYSLOG_DYNNAME'.spool
+
+/* Filter out busy debug output */
+global(
+	debug.whitelist="off"
+	debug.files=["omfile.c", "queue.c", "rainerscript.c", "ratelimit.c", "ruleset.c", "main Q", "msg.c", "../action.c"]
+	)
+
+module(	load="../plugins/imfile/.libs/imfile"
+	mode="inotify"
+	PollingInterval="1")
+
+input(type="imfile"
+	File="./'$RSYSLOG_DYNNAME'.input.*.log"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+	statefilealwaysremove="on"
+)
+
+$template outfmt,"%msg:F,58:2%\n"
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file=`echo $RSYSLOG_OUT_LOG`
+   template="outfmt"
+ )
+'
+
+# Write logrotate config file
+echo '"./'$RSYSLOG_DYNNAME'.input.*.log"
+{
+	create
+	daily
+	missingok
+	rotate 14
+	notifempty
+	compress
+	delaycompress
+}' > $RSYSLOG_DYNNAME.logrotate
+
+startup
+
+TESTMESSAGESSTART=0
+for i in $(seq 1 $IMFILEROTATES);
+do
+	# generate input file first.
+	./inputfilegen -m $TESTMESSAGES -i $TESTMESSAGESSTART > $RSYSLOG_DYNNAME.input.1.log
+
+	ls -l $RSYSLOG_DYNNAME.input*
+	echo ls ${RSYSLOG_DYNNAME}.spool:
+	ls -l ${RSYSLOG_DYNNAME}.spool
+
+	# Wait until testmessages are processed by imfile!
+	msgcount=$((i * TESTMESSAGES-1))
+	# echo "TESTMESSAGESSTART: $TESTMESSAGESSTART - TotalMsgCount: $msgcount"
+	wait_file_lines $RSYSLOG_OUT_LOG $msgcount $RETRIES
+
+	# Logrotate on logfile
+	logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate
+
+	TESTMESSAGESSTART=$((TESTMESSAGESSTART+TESTMESSAGES))
+done
+
+
+shutdown_when_empty
+wait_shutdown
+seq_check 0 $TESTMESSAGESFULL
+exit_test


### PR DESCRIPTION
imfile: Added new option statefilealwaysremove 

Due problems with logrotate and INOTIFY, we added an option 
to control how statefiles for moved files are handeled. 

By default "statefilealwaysremove" will be off. But if "on"
the statefile for moved files will also be removed. 

Otherwise when using logrotate for example, imfile could stop monitoring 
rotated files. This problem only happens in INOTIFY mode. 

testbench: Added new tests for logrotate and multiple rotates.
