### PR TITLE
testbench: make shutdown more reliable

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -282,7 +282,6 @@ wait_startup_pid() {
 		echo "FAIL: testbench bug: wait_startup_called without \$1"
 		error_exit 100
 	fi
-	start_timeout="$(date)"
 	while test ! -f $1; do
 		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
 		if [ $(date +%s) -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
@@ -333,16 +332,13 @@ wait_pid_termination() {
 			printf 'TESTBENCH error: pidfile name not specified in wait_pid_termination\n'
 			error_exit 100
 		fi
-		i=0
 		terminated=0
-		start_timeout="$(date)"
 		while [[ $terminated -eq 0 ]]; do
 			ps -p $out_pid &> /dev/null
 			if [[ $? != 0 ]]; then
 				terminated=1
 			fi
 			$TESTTOOL_DIR/msleep 100
-			(( i++ ))
 			if [ $(date +%s) -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
 			   printf '%s ABORT! Timeout waiting on shutdown (pid %s)\n' "$(tb_timestamp)" $out_pid
 			   ps -fp $out_pid
@@ -442,7 +438,6 @@ injectmsg_kafkacat() {
 # wait for rsyslogd startup ($1 is the instance)
 wait_startup() {
 	wait_rsyslog_startup_pid $1
-	i=0
 	while test ! -f ${RSYSLOG_DYNNAME}$1.started; do
 		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
 		ps -p $(cat $RSYSLOG_PIDBASE$1.pid) &> /dev/null
@@ -451,7 +446,6 @@ wait_startup() {
 		   echo "ABORT! rsyslog pid no longer active during startup!"
 		   error_exit 1 stacktrace
 		fi
-		(( i++ ))
 		if [ $(date +%s) -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
 		   printf '%s ABORT! Timeout waiting startup file %s\n' "$(tb_timestamp)" "${RSYSLOG_DYNNAME}.started"
 		   error_exit 1
@@ -790,7 +784,6 @@ wait_shutdown() {
 		wait_shutdown_vg "$1"
 		return
 	fi
-	i=0
 	out_pid=$(cat $RSYSLOG_PIDBASE$1.pid.save)
 	printf '%s wait on shutdown of %s\n' "$(tb_timestamp)" "$out_pid"
 	if [[ "$out_pid" == "" ]]
@@ -799,18 +792,14 @@ wait_shutdown() {
 	else
 		terminated=0
 	fi
-	start_timeout="$(date)"
 	while [[ $terminated -eq 0 ]]; do
 		ps -p $out_pid &> /dev/null
 		if [[ $? != 0 ]]; then
 			terminated=1
 		fi
 		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
-		(( i++ ))
-		if test $i -gt $TB_TIMEOUT_STARTSTOP
-		then
-		   echo "ABORT! Timeout waiting on shutdown"
-		   echo "Wait initiated $start_timeout, now $(date)"
+		if [ $(date +%s) -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
+		   printf '%s wait_shutdown ABORT! Timeout waiting on shutdown (pid %s)\n' "$(tb_timestamp)" $out_pid
 		   ps -fp $out_pid
 		   echo "Instance is possibly still running and may need"
 		   echo "manual cleanup."

--- a/tests/imrelp-manyconn.sh
+++ b/tests/imrelp-manyconn.sh
@@ -1,12 +1,8 @@
 #!/bin/bash
 # adddd 2016-06-08 by RGerhards, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-uname
-if [ $(uname) = "FreeBSD" ] ; then
-   echo "This test currently does not work on FreeBSD."
-   exit 77
-fi
-
+skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
+export NUMMESSAGES=100000
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
@@ -14,11 +10,11 @@ input(type="imrelp" port="'$TCPFLOOD_PORT'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
-			         file=`echo $RSYSLOG_OUT_LOG`)
+			         file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-tcpflood -Trelp-plain -c-2000 -p'$TCPFLOOD_PORT' -m100000
-shutdown_when_empty # shut down rsyslogd when done processing messages
+tcpflood -Trelp-plain -c-2000 -p$TCPFLOOD_PORT -m$NUMMESSAGES
+shutdown_when_empty
 wait_shutdown
-seq_check 0 99999
+seq_check
 exit_test

--- a/tests/queue-encryption-disk_keyfile.sh
+++ b/tests/queue-encryption-disk_keyfile.sh
@@ -22,7 +22,7 @@ template(name="outfmt" type="string"
 
 :omtesting:sleep 0 5000
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
-			         file=`echo $RSYSLOG_OUT_LOG`)
+			         file="'$RSYSLOG_OUT_LOG'")
 '
 printf "1234567890123456" > $RSYSLOG_DYNNAME.keyfile
 startup

--- a/tests/queue-minbatch-queuefull.sh
+++ b/tests/queue-minbatch-queuefull.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # added 2019-01-14 by RGerhards, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "This test currently does not work on Solaris - see https://github.com/rsyslog/rsyslog/issues/3513"
 export NUMMESSAGES=10000
 generate_conf
 add_conf '


### PR DESCRIPTION
we bind the shutdown timeout to the general MAX RUN timeout
also modernize testbench a bit more

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
