### PR TITLE
Enlarged msg offset types for bigger structured messages

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -839,7 +839,7 @@ msgBaseConstruct(smsg_t **ppThis)
 	pM->iFacility = LOG_INVLD;
 	pM->iLenPROGNAME = -1;
 	pM->offAfterPRI = 0;
-	pM->offMSG = -1;
+	pM->offMSG = 0;
 	pM->iProtocolVersion = 0;
 	pM->msgFlags = 0;
 	pM->iLenRawMsg = 0;
@@ -2167,7 +2167,7 @@ MsgSetFlowControlType(smsg_t * const pMsg, flowControl_t eFlowCtl)
  * rgerhards, 2009-06-16
  */
 rsRetVal
-MsgSetAfterPRIOffs(smsg_t * const pMsg, short offs)
+MsgSetAfterPRIOffs(smsg_t * const pMsg, uint32_t offs)
 {
 	assert(pMsg != NULL);
 	pMsg->offAfterPRI = offs;
@@ -2819,12 +2819,12 @@ void MsgSetHOSTNAME(smsg_t *pThis, const uchar* pszHOSTNAME, const int lenHOSTNA
  * (exactly by one). This can happen if we have a message that does not
  * contain any MSG part.
  */
-void MsgSetMSGoffs(smsg_t * const pMsg, short offs)
+void MsgSetMSGoffs(smsg_t * const pMsg, uint32_t offs)
 {
 	ISOBJ_TYPE_assert(pMsg, msg);
 	pMsg->offMSG = offs;
-	if(offs > pMsg->iLenRawMsg) {
-		assert(offs - 1 == pMsg->iLenRawMsg);
+	if(offs > (uint32_t)pMsg->iLenRawMsg) {
+		assert((int)offs - 1 == pMsg->iLenRawMsg);
 		pMsg->iLenMSG = 0;
 	} else {
 		pMsg->iLenMSG = pMsg->iLenRawMsg - offs;
@@ -2920,7 +2920,7 @@ MsgSetRawMsg(smsg_t *const pThis, const char*const pszRawMsg, const size_t lenMs
 	memcpy(pThis->pszRawMsg, pszRawMsg, pThis->iLenRawMsg);
 	pThis->pszRawMsg[pThis->iLenRawMsg] = '\0'; /* this also works with truncation! */
 	/* correct other information */
-	if(pThis->iLenRawMsg > pThis->offMSG)
+	if((uint32_t)pThis->iLenRawMsg > pThis->offMSG)
 		pThis->iLenMSG += deltaSize;
 	else
 		pThis->iLenMSG = 0;

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -67,8 +67,8 @@ struct msg {
 	sbool	bParseSuccess;	/* set to reflect state of last executed higher level parser */
 	unsigned short	iSeverity;/* the severity  */
 	unsigned short	iFacility;/* Facility code */
-	short	offAfterPRI;	/* offset, at which raw message WITHOUT PRI part starts in pszRawMsg */
-	short	offMSG;		/* offset at which the MSG part starts in pszRawMsg */
+	uint32_t offAfterPRI;	/* offset, at which raw message WITHOUT PRI part starts in pszRawMsg */
+	uint32_t offMSG;		/* offset at which the MSG part starts in pszRawMsg */
 	short	iProtocolVersion;/* protocol version of message received 0 - legacy, 1 syslog-protocol) */
 	int	msgFlags;	/* flags associated with this message */
 	int	iLenRawMsg;	/* length of raw message */
@@ -194,8 +194,8 @@ void MsgSetRcvFromStr(smsg_t *const pMsg, const uchar* pszRcvFrom, const int, pr
 rsRetVal MsgSetRcvFromIP(smsg_t *pMsg, prop_t*);
 rsRetVal MsgSetRcvFromIPStr(smsg_t *const pThis, const uchar *psz, const int len, prop_t **ppProp);
 void MsgSetHOSTNAME(smsg_t *pMsg, const uchar* pszHOSTNAME, const int lenHOSTNAME);
-rsRetVal MsgSetAfterPRIOffs(smsg_t *pMsg, short offs);
-void MsgSetMSGoffs(smsg_t *pMsg, short offs);
+rsRetVal MsgSetAfterPRIOffs(smsg_t *pMsg, uint32_t offs);
+void MsgSetMSGoffs(smsg_t *pMsg, uint32_t offs);
 void MsgSetRawMsgWOSize(smsg_t *pMsg, char* pszRawMsg);
 void ATTR_NONNULL() MsgSetRawMsg(smsg_t *const pThis, const char*const pszRawMsg, const size_t lenMsg);
 rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar* pszMSG, int lenMSG);


### PR DESCRIPTION
using a large enough (dozens of kBs) structured message
it is possible to overflow the signed short type which leads
to rsyslog crash.

This is possible because with setting higher maxMessageSize  one can overflow the small signed type which the core dumps during additional message processing.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
