### PR TITLE
CI: add PR validation in regard to commit structure

### DIFF
--- a/tests/CI/PR_validation.sh
+++ b/tests/CI/PR_validation.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This script "validates" a PR from a git PoV. We check that best
+# practices are kept which most importantly means we try to detect
+# fixup commits. These should not be part of a PR and squashed into
+# the main commit.
+# Copyright (C) 2019 by Rainer Gerhards
+exitcode=0;
+git log  --oneline HEAD...origin/master >gitlog
+if head -1 gitlog | grep -q "Merge " gitlog; then
+	printf 'This looks like a github merge branch. Removing first commit:\n'
+	head -1 gitlog
+	sed -i '1d' gitlog
+fi
+printf '%d commits in feature branch:\n' $(wc -l < gitlog)
+cat gitlog
+printf '\n'
+if [ $(wc -l < gitlog) -ge 5 ]; then
+	cat <<- EOF
+	This feature branch contains quite some commits. Consider squashing it.
+
+	EOF
+	exitcode=1
+fi
+if grep "Merge from" gitlog; then
+	cat <<- EOF
+	This feature branch contains merge commits. This almost always indicates that it
+	contains unwanted merges where a rebase should have been applied.
+	Please consider squashing the branch and/or rebasing it to current master.
+
+	EOF
+	exitcode=1
+fi
+exit $exitcode


### PR DESCRIPTION
This adds the check script. It is up to CI to use it or not.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
