### PR TITLE
mmkubernetes - support for metadata cache expiration

### DIFF
--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -55,6 +55,7 @@
 #include "statsobj.h"
 #include "regexp.h"
 #include "hashtable.h"
+#include "hashtable_itr.h"
 #include "srUtils.h"
 #include "unicode-helper.h"
 #include "datetime.h"
@@ -102,18 +103,28 @@ DEFobjCurrIf(datetime)
 #define DFLT_KUBERNETES_URL "https://kubernetes.default.svc.cluster.local:443"
 #define DFLT_BUSY_RETRY_INTERVAL 5 /* retry every 5 seconds */
 #define DFLT_SSL_PARTIAL_CHAIN 0 /* disallow X509_V_FLAG_PARTIAL_CHAIN by default */
+#define DFLT_CACHE_ENTRY_TTL 3600 /* delete entries from the cache older than 3600 seconds */
+#define DFLT_CACHE_EXPIRE_INTERVAL -1 /* delete all expired entries from the cache every N seconds
+					 -1 disables cache expiration/ttl checking
+					 0 means - run cache expiration for every record */
 
 /* only support setting the partial chain flag on openssl platforms that have the define */
 #if defined(ENABLE_OPENSSL) && defined(X509_V_FLAG_PARTIAL_CHAIN)
 #define SUPPORT_SSL_PARTIAL_CHAIN 1
 #endif
 
+struct cache_entry_s {
+	time_t ttl; /* when this entry should expire */
+	void *data; /* the user data */
+};
+
 static struct cache_s {
 	const uchar *kbUrl;
 	struct hashtable *mdHt;
 	struct hashtable *nsHt;
 	pthread_mutex_t *cacheMtx;
-	int lastBusyTime;
+	int lastBusyTime; /* when we got the last busy response from kubernetes */
+	time_t expirationTime; /* if cache expiration checking is enable, time to check for expiration */
 } **caches;
 
 typedef struct {
@@ -144,6 +155,8 @@ struct modConfData_s {
 	uchar *contRulebase; /* lognorm rulebase filename for CONTAINER_NAME value match */
 	int busyRetryInterval; /* how to handle 429 response - 0 means error, non-zero means retry every N seconds */
 	sbool sslPartialChain; /* if true, allow using intermediate certs without root certs */
+	int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
+	int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
 };
 
 /* action (instance) configuration data */
@@ -172,6 +185,8 @@ typedef struct _instanceData {
 	struct cache_s *cache;
 	int busyRetryInterval; /* how to handle 429 response - 0 means error, non-zero means retry every N seconds */
 	sbool sslPartialChain; /* if true, allow using intermediate certs without root certs */
+	int cacheEntryTTL; /* delete entries from the cache if they are older than this many seconds */
+	int cacheExpireInterval; /* delete all expired entries from the cache every this many seconds */
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -181,15 +196,22 @@ typedef struct wrkrInstanceData {
 	char *curlRply;
 	size_t curlRplyLen;
 	statsobj_t *stats; /* stats for this instance */
-	STATSCOUNTER_DEF(k8sRecordSeen, mutK8sRecordSeen)
-	STATSCOUNTER_DEF(namespaceMetadataSuccess, mutNamespaceMetadataSuccess)
-	STATSCOUNTER_DEF(namespaceMetadataNotFound, mutNamespaceMetadataNotFound)
-	STATSCOUNTER_DEF(namespaceMetadataBusy, mutNamespaceMetadataBusy)
-	STATSCOUNTER_DEF(namespaceMetadataError, mutNamespaceMetadataError)
-	STATSCOUNTER_DEF(podMetadataSuccess, mutPodMetadataSuccess)
-	STATSCOUNTER_DEF(podMetadataNotFound, mutPodMetadataNotFound)
-	STATSCOUNTER_DEF(podMetadataBusy, mutPodMetadataBusy)
-	STATSCOUNTER_DEF(podMetadataError, mutPodMetadataError)
+	STATSCOUNTER_DEF(k8sRecordSeen, mutK8sRecordSeen);
+	STATSCOUNTER_DEF(namespaceMetadataSuccess, mutNamespaceMetadataSuccess);
+	STATSCOUNTER_DEF(namespaceMetadataNotFound, mutNamespaceMetadataNotFound);
+	STATSCOUNTER_DEF(namespaceMetadataBusy, mutNamespaceMetadataBusy);
+	STATSCOUNTER_DEF(namespaceMetadataError, mutNamespaceMetadataError);
+	STATSCOUNTER_DEF(podMetadataSuccess, mutPodMetadataSuccess);
+	STATSCOUNTER_DEF(podMetadataNotFound, mutPodMetadataNotFound);
+	STATSCOUNTER_DEF(podMetadataBusy, mutPodMetadataBusy);
+	STATSCOUNTER_DEF(podMetadataError, mutPodMetadataError);
+	STATSCOUNTER_DEF(podCacheNumEntries, mutPodCacheNumEntries);
+	STATSCOUNTER_DEF(namespaceCacheNumEntries, mutNamespaceCacheNumEntries);
+	STATSCOUNTER_DEF(podCacheHits, mutPodCacheHits);
+	STATSCOUNTER_DEF(namespaceCacheHits, mutNamespaceCacheHits);
+	/* cache misses should correspond to metadata success, busy, etc. k8s api calls */
+	STATSCOUNTER_DEF(podCacheMisses, mutPodCacheMisses);
+	STATSCOUNTER_DEF(namespaceCacheMisses, mutNamespaceCacheMisses);
 } wrkrInstanceData_t;
 
 /* module parameters (v6 config format) */
@@ -209,7 +231,9 @@ static struct cnfparamdescr modpdescr[] = {
 	{ "filenamerulebase", eCmdHdlrString, 0 },
 	{ "containerrulebase", eCmdHdlrString, 0 },
 	{ "busyretryinterval", eCmdHdlrInt, 0 },
-	{ "sslpartialchain", eCmdHdlrBinary, 0 }
+	{ "sslpartialchain", eCmdHdlrBinary, 0 },
+	{ "cacheentryttl", eCmdHdlrInt, 0 },
+	{ "cacheexpireinterval", eCmdHdlrInt, 0 }
 #if HAVE_LOADSAMPLESFROMSTRING == 1
 	,
 	{ "filenamerules", eCmdHdlrArray, 0 },
@@ -239,7 +263,9 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "filenamerulebase", eCmdHdlrString, 0 },
 	{ "containerrulebase", eCmdHdlrString, 0 },
 	{ "busyretryinterval", eCmdHdlrInt, 0 },
-	{ "sslpartialchain", eCmdHdlrBinary, 0 }
+	{ "sslpartialchain", eCmdHdlrBinary, 0 },
+	{ "cacheentryttl", eCmdHdlrInt, 0 },
+	{ "cacheexpireinterval", eCmdHdlrInt, 0 }
 #if HAVE_LOADSAMPLESFROMSTRING == 1
 	,
 	{ "filenamerules", eCmdHdlrArray, 0 },
@@ -551,6 +577,8 @@ CODESTARTsetModCnf
 	loadModConf->de_dot = DFLT_DE_DOT;
 	loadModConf->busyRetryInterval = DFLT_BUSY_RETRY_INTERVAL;
 	loadModConf->sslPartialChain = DFLT_SSL_PARTIAL_CHAIN;
+	loadModConf->cacheEntryTTL = DFLT_CACHE_ENTRY_TTL;
+	loadModConf->cacheExpireInterval = DFLT_CACHE_EXPIRE_INTERVAL;
 	for(i = 0 ; i < modpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed) {
 			continue;
@@ -685,6 +713,10 @@ CODESTARTsetModCnf
 			LogMsg(0, RS_RET_VALUE_NOT_IN_THIS_MODE, LOG_INFO,
 					"sslpartialchain is only supported for OpenSSL\n");
 #endif
+		} else if(!strcmp(modpblk.descr[i].name, "cacheentryttl")) {
+			loadModConf->cacheEntryTTL = pvals[i].val.d.n;
+		} else if(!strcmp(modpblk.descr[i].name, "cacheexpireinterval")) {
+			loadModConf->cacheExpireInterval = pvals[i].val.d.n;
 		} else {
 			dbgprintf("mmkubernetes: program error, non-handled "
 				"param '%s' in module() block\n", modpblk.descr[i].name);
@@ -704,6 +736,16 @@ CODESTARTsetModCnf
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 #endif
+
+	if ((loadModConf->cacheExpireInterval > -1)) {
+		if ((loadModConf->cacheEntryTTL < 0)) {
+			LogError(0, RS_RET_CONFIG_ERROR,
+					"mmkubernetes: cacheentryttl value [%d] is invalid - "
+					"value must be 0 or greater",
+					loadModConf->cacheEntryTTL);
+			ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+		}
+	}
 
 	/* set defaults */
 	if(loadModConf->srcMetadataPath == NULL)
@@ -848,6 +890,24 @@ CODESTARTcreateWrkrInstance
 	STATSCOUNTER_INIT(pWrkrData->podMetadataError, pWrkrData->mutPodMetadataError);
 	CHKiRet(statsobj.AddCounter(pWrkrData->stats, UCHAR_CONSTANT("podmetadataerror"),
 		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pWrkrData->podMetadataError)));
+	STATSCOUNTER_INIT(pWrkrData->namespaceCacheNumEntries, pWrkrData->mutNamespaceCacheNumEntries);
+	CHKiRet(statsobj.AddCounter(pWrkrData->stats, UCHAR_CONSTANT("namespacecachenumentries"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pWrkrData->namespaceCacheNumEntries)));
+	STATSCOUNTER_INIT(pWrkrData->podCacheNumEntries, pWrkrData->mutPodCacheNumEntries);
+	CHKiRet(statsobj.AddCounter(pWrkrData->stats, UCHAR_CONSTANT("podcachenumentries"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pWrkrData->podCacheNumEntries)));
+	STATSCOUNTER_INIT(pWrkrData->namespaceCacheHits, pWrkrData->mutNamespaceCacheHits);
+	CHKiRet(statsobj.AddCounter(pWrkrData->stats, UCHAR_CONSTANT("namespacecachehits"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pWrkrData->namespaceCacheHits)));
+	STATSCOUNTER_INIT(pWrkrData->podCacheHits, pWrkrData->mutPodCacheHits);
+	CHKiRet(statsobj.AddCounter(pWrkrData->stats, UCHAR_CONSTANT("podcachehits"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pWrkrData->podCacheHits)));
+	STATSCOUNTER_INIT(pWrkrData->namespaceCacheMisses, pWrkrData->mutNamespaceCacheMisses);
+	CHKiRet(statsobj.AddCounter(pWrkrData->stats, UCHAR_CONSTANT("namespacecachemisses"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pWrkrData->namespaceCacheMisses)));
+	STATSCOUNTER_INIT(pWrkrData->podCacheMisses, pWrkrData->mutPodCacheMisses);
+	CHKiRet(statsobj.AddCounter(pWrkrData->stats, UCHAR_CONSTANT("podcachemisses"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pWrkrData->podCacheMisses)));
 	CHKiRet(statsobj.ConstructFinalize(pWrkrData->stats));
 
 	hdr = curl_slist_append(hdr, "Content-Type: text/json; charset=utf-8");
@@ -930,31 +990,68 @@ hashtable_json_object_put(void *jso)
 {
 	json_object_put((struct fjson_object *)jso);
 }
-static struct cache_s *
-cacheNew(const uchar *const url)
-{
-	struct cache_s *cache;
 
-	if (NULL == (cache = calloc(1, sizeof(struct cache_s)))) {
-		FINALIZE;
+static void
+cache_entry_free(struct cache_entry_s *cache_entry)
+{
+	if (NULL != cache_entry) {
+		if (cache_entry->data) {
+			hashtable_json_object_put(cache_entry->data);
+			cache_entry->data = NULL;
+		}
+		free(cache_entry);
 	}
-	cache->kbUrl = url;
-	cache->mdHt = create_hashtable(100, hash_from_string,
-		key_equals_string, hashtable_json_object_put);
-	cache->nsHt = create_hashtable(100, hash_from_string,
-		key_equals_string, hashtable_json_object_put);
+}
+
+static void
+cache_entry_free_raw(void *cache_entry_void)
+{
+	cache_entry_free((struct cache_entry_s *)cache_entry_void);
+}
+
+static struct cache_s *
+cacheNew(instanceData *pData)
+{
+	DEFiRet;
+	struct cache_s *cache = NULL;
+	time_t now;
+	int need_mutex_destroy = 0;
+
+	CHKmalloc(cache = (struct cache_s *)calloc(1, sizeof(struct cache_s)));
+	CHKmalloc(cache->cacheMtx = (pthread_mutex_t *)malloc(sizeof(pthread_mutex_t)));
+	CHKmalloc(cache->mdHt = create_hashtable(100, hash_from_string,
+		key_equals_string, cache_entry_free_raw));
+	CHKmalloc(cache->nsHt = create_hashtable(100, hash_from_string,
+		key_equals_string, cache_entry_free_raw));
+	CHKiConcCtrl(pthread_mutex_init(cache->cacheMtx, NULL));
+	need_mutex_destroy = 1;
+	datetime.GetTime(&now);
+	cache->kbUrl = pData->kubernetesUrl;
+	cache->expirationTime = 0;
+	if (pData->cacheExpireInterval > -1)
+		cache->expirationTime = pData->cacheExpireInterval + pData->cacheEntryTTL + now;
+	cache->lastBusyTime = 0;
 	dbgprintf("mmkubernetes: created cache mdht [%p] nsht [%p]\n",
 			cache->mdHt, cache->nsHt);
-	cache->cacheMtx = malloc(sizeof(pthread_mutex_t));
-	if (!cache->mdHt || !cache->nsHt || !cache->cacheMtx) {
-		free (cache);
-		cache = NULL;
-		FINALIZE;
-	}
-	pthread_mutex_init(cache->cacheMtx, NULL);
-	cache->lastBusyTime = 0;
 
 finalize_it:
+	if (iRet != RS_RET_OK) {
+	        LogError(errno, iRet, "mmkubernetes: cacheNew: unable to create metadata cache for %s",
+	                 pData->kubernetesUrl);
+		if (cache) {
+			if (cache->mdHt)
+				hashtable_destroy(cache->mdHt, 1);
+			if (cache->nsHt)
+				hashtable_destroy(cache->nsHt, 1);
+			if (cache->cacheMtx) {
+				if (need_mutex_destroy)
+					pthread_mutex_destroy(cache->cacheMtx);
+				free(cache->cacheMtx);
+			}
+			free(cache);
+			cache = NULL;
+		}
+	}
 	return cache;
 }
 
@@ -966,6 +1063,182 @@ static void cacheFree(struct cache_s *cache)
 	pthread_mutex_destroy(cache->cacheMtx);
 	free(cache->cacheMtx);
 	free(cache);
+}
+
+/* must be called with cache->cacheMtx held */
+/* assumes caller has reference to jso (json_object_get or is a new object) */
+static struct cache_entry_s *cache_entry_new(time_t ttl, struct fjson_object *jso)
+{
+	DEFiRet;
+	struct cache_entry_s *cache_entry = NULL;
+
+	CHKmalloc(cache_entry = malloc(sizeof(struct cache_entry_s)));
+	cache_entry->ttl = ttl;
+	cache_entry->data = (void *)jso;
+finalize_it:
+	if (iRet) {
+		free(cache_entry);
+		cache_entry = NULL;
+	}
+	return cache_entry;
+}
+
+static int cache_delete_expired_entries(wrkrInstanceData_t *pWrkrData, int isnsmd, time_t now)
+{
+	struct hashtable *ht = isnsmd ? pWrkrData->pData->cache->nsHt : pWrkrData->pData->cache->mdHt;
+	struct hashtable_itr *itr = NULL;
+	int more;
+
+	if ((pWrkrData->pData->cacheExpireInterval < 0) || (now < pWrkrData->pData->cache->expirationTime)) {
+		return 0; /* not enabled or not time yet */
+	}
+
+	/* set next expiration time */
+	pWrkrData->pData->cache->expirationTime = now + pWrkrData->pData->cacheExpireInterval;
+
+	if (hashtable_count(ht) < 1)
+		return 1; /* expire interval hit but nothing to do */
+
+	itr = hashtable_iterator(ht);
+	if (NULL == itr)
+		return 1; /* expire interval hit but nothing to do - err? */
+
+	do {
+		struct cache_entry_s *cache_entry = (struct cache_entry_s *)hashtable_iterator_value(itr);
+
+		if (now >= cache_entry->ttl) {
+			cache_entry_free(cache_entry);
+			if (isnsmd) {
+				STATSCOUNTER_DEC(pWrkrData->namespaceCacheNumEntries,
+						 pWrkrData->mutNamespaceCacheNumEntries);
+			} else {
+				STATSCOUNTER_DEC(pWrkrData->podCacheNumEntries,
+						 pWrkrData->mutPodCacheNumEntries);
+			}
+			more = hashtable_iterator_remove(itr);
+		} else {
+			more = hashtable_iterator_advance(itr);
+		}
+	} while (more);
+	free(itr);
+	dbgprintf("mmkubernetes: cache_delete_expired_entries: cleaned [%s] cache - size is now [%llu]\n",
+		  isnsmd ? "namespace" : "pod",
+		  isnsmd ? pWrkrData->namespaceCacheNumEntries : pWrkrData->podCacheNumEntries);
+	return 1;
+}
+
+/* must be called with cache->cacheMtx held */
+static struct fjson_object *
+cache_entry_get(wrkrInstanceData_t *pWrkrData,
+		int isnsmd, const char *key, time_t now)
+{
+	struct fjson_object *jso = NULL;
+	struct cache_entry_s *cache_entry = NULL;
+	int checkttl = 1;
+	struct hashtable *ht = isnsmd ? pWrkrData->pData->cache->nsHt : pWrkrData->pData->cache->mdHt;
+
+	/* see if it is time for a general cache expiration */
+	if (cache_delete_expired_entries(pWrkrData, isnsmd, now))
+		checkttl = 0; /* no need to check ttl now */
+	cache_entry = (struct cache_entry_s *)hashtable_search(ht, (void *)key);
+	if (cache_entry && checkttl && (now >= cache_entry->ttl)) {
+		cache_entry = (struct cache_entry_s *)hashtable_remove(ht, (void *)key);
+		if (isnsmd) {
+			STATSCOUNTER_DEC(pWrkrData->namespaceCacheNumEntries,
+					 pWrkrData->mutNamespaceCacheNumEntries);
+		} else {
+			STATSCOUNTER_DEC(pWrkrData->podCacheNumEntries,
+					 pWrkrData->mutPodCacheNumEntries);
+		}
+		cache_entry_free(cache_entry);
+		cache_entry = NULL;
+	}
+	if (cache_entry) {
+		jso = (struct fjson_object *)cache_entry->data;
+		if (isnsmd) {
+			STATSCOUNTER_INC(pWrkrData->namespaceCacheHits,
+					 pWrkrData->mutNamespaceCacheHits);
+		} else {
+			STATSCOUNTER_INC(pWrkrData->podCacheHits,
+					 pWrkrData->mutPodCacheHits);
+		}
+		dbgprintf("mmkubernetes: cache_entry_get: cache hit for [%s] cache key [%s] - hits is now [%llu]\n",
+			  isnsmd ? "namespace" : "pod", key,
+			  isnsmd ? pWrkrData->namespaceCacheHits : pWrkrData->podCacheHits);
+	} else {
+		if (isnsmd) {
+			STATSCOUNTER_INC(pWrkrData->namespaceCacheMisses,
+					 pWrkrData->mutNamespaceCacheMisses);
+		} else {
+			STATSCOUNTER_INC(pWrkrData->podCacheMisses,
+					 pWrkrData->mutPodCacheMisses);
+		}
+		dbgprintf("mmkubernetes: cache_entry_get: cache miss for [%s] cache key [%s] - misses is now [%llu]\n",
+			  isnsmd ? "namespace" : "pod", key,
+			  isnsmd ? pWrkrData->namespaceCacheMisses : pWrkrData->podCacheMisses);
+	}
+
+	return jso;
+}
+
+/* must be called with cache->cacheMtx held */
+/* key is passed in - caller must copy or otherwise ensure it is ok to pass off
+ * ownership
+ */
+static rsRetVal
+cache_entry_add(wrkrInstanceData_t *pWrkrData,
+		int isnsmd, const char *key, struct fjson_object *jso, time_t now)
+{
+	DEFiRet;
+	struct cache_entry_s *cache_entry = NULL;
+	struct hashtable *ht = isnsmd ? pWrkrData->pData->cache->nsHt : pWrkrData->pData->cache->mdHt;
+
+	/* see if it is time for a general cache expiration */
+	(void)cache_delete_expired_entries(pWrkrData, isnsmd, now);
+	CHKmalloc(cache_entry = cache_entry_new(now + pWrkrData->pData->cacheEntryTTL, jso));
+	if (cache_entry) {
+		if (!hashtable_insert(ht, (void *)key, cache_entry))
+			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+
+		if (isnsmd) {
+			STATSCOUNTER_INC(pWrkrData->namespaceCacheNumEntries,
+					 pWrkrData->mutNamespaceCacheNumEntries);
+		} else {
+			STATSCOUNTER_INC(pWrkrData->podCacheNumEntries,
+					 pWrkrData->mutPodCacheNumEntries);
+		}
+		cache_entry = NULL;
+	}
+finalize_it:
+	if (cache_entry)
+		cache_entry_free(cache_entry);
+	return iRet;
+}
+
+/* must be called with cache->cacheMtx held */
+static struct fjson_object *cache_entry_get_md(wrkrInstanceData_t *pWrkrData, const char *key, time_t now)
+{
+	return cache_entry_get(pWrkrData, 0, key, now);
+}
+
+/* must be called with cache->cacheMtx held */
+static struct fjson_object *cache_entry_get_nsmd(wrkrInstanceData_t *pWrkrData, const char *key, time_t now)
+{
+	return cache_entry_get(pWrkrData, 1, key, now);
+}
+
+/* must be called with cache->cacheMtx held */
+static rsRetVal cache_entry_add_md(wrkrInstanceData_t *pWrkrData, const char *key,
+				   struct fjson_object *jso, time_t now)
+{
+	return cache_entry_add(pWrkrData, 0, key, jso, now);
+}
+
+/* must be called with cache->cacheMtx held */
+static rsRetVal cache_entry_add_nsmd(wrkrInstanceData_t *pWrkrData, const char *key,
+				     struct fjson_object *jso, time_t now)
+{
+	return cache_entry_add(pWrkrData, 1, key, jso, now);
 }
 
 
@@ -999,6 +1272,8 @@ CODESTARTnewActInst
 	pData->allowUnsignedCerts = loadModConf->allowUnsignedCerts;
 	pData->busyRetryInterval = loadModConf->busyRetryInterval;
 	pData->sslPartialChain = loadModConf->sslPartialChain;
+	pData->cacheEntryTTL = loadModConf->cacheEntryTTL;
+	pData->cacheExpireInterval = loadModConf->cacheExpireInterval;
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed) {
 			continue;
@@ -1136,6 +1411,10 @@ CODESTARTnewActInst
 			LogMsg(0, RS_RET_VALUE_NOT_IN_THIS_MODE, LOG_INFO,
 					"sslpartialchain is only supported for OpenSSL\n");
 #endif
+		} else if(!strcmp(actpblk.descr[i].name, "cacheentryttl")) {
+			pData->cacheEntryTTL = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "cacheexpireinterval")) {
+			pData->cacheExpireInterval = pvals[i].val.d.n;
 		} else {
 			dbgprintf("mmkubernetes: program error, non-handled "
 				"param '%s' in action() block\n", actpblk.descr[i].name);
@@ -1159,6 +1438,16 @@ CODESTARTnewActInst
 			loadModConf->fnRules, loadModConf->fnRulebase));
 	CHKiRet(set_lnctx(&pData->contCtxln, pData->contRules, pData->contRulebase,
 			loadModConf->contRules, loadModConf->contRulebase));
+
+	if ((pData->cacheExpireInterval > -1)) {
+		if ((pData->cacheEntryTTL < 0)) {
+			LogError(0, RS_RET_CONFIG_ERROR,
+					"mmkubernetes: cacheentryttl value [%d] is invalid - "
+					"value must be 0 or greater",
+					pData->cacheEntryTTL);
+			ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+		}
+	}
 
 	if(pData->kubernetesUrl == NULL) {
 		if(loadModConf->kubernetesUrl == NULL) {
@@ -1207,7 +1496,7 @@ CODESTARTnewActInst
 	if(caches[i] != NULL) {
 		pData->cache = caches[i];
 	} else {
-		CHKmalloc(pData->cache = cacheNew(pData->kubernetesUrl));
+		CHKmalloc(pData->cache = cacheNew(pData));
 
 		CHKmalloc(caches = realloc(caches, (i + 2) * sizeof(struct cache_s *)));
 		caches[i] = pData->cache;
@@ -1301,6 +1590,8 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("\tcontainerrules='%s'\n", pData->contRules);
 #endif
 	dbgprintf("\tbusyretryinterval='%d'\n", pData->busyRetryInterval);
+	dbgprintf("\tcacheentryttl='%d'\n", pData->cacheEntryTTL);
+	dbgprintf("\tcacheexpireinterval='%d'\n", pData->cacheExpireInterval);
 ENDdbgPrintInstInfo
 
 
@@ -1406,7 +1697,7 @@ finalize_it:
 
 
 static rsRetVal
-queryKB(wrkrInstanceData_t *pWrkrData, char *url, struct json_object **rply)
+queryKB(wrkrInstanceData_t *pWrkrData, char *url, time_t now, struct json_object **rply)
 {
 	DEFiRet;
 	CURLcode ccode;
@@ -1415,8 +1706,6 @@ queryKB(wrkrInstanceData_t *pWrkrData, char *url, struct json_object **rply)
 	long resp_code = 400;
 
 	if (pWrkrData->pData->cache->lastBusyTime) {
-		time_t now;
-		datetime.GetTime(&now);
 		now -= pWrkrData->pData->cache->lastBusyTime;
 		if (now < pWrkrData->pData->busyRetryInterval) {
 			LogMsg(0, RS_RET_RETRY, LOG_DEBUG,
@@ -1471,8 +1760,6 @@ queryKB(wrkrInstanceData_t *pWrkrData, char *url, struct json_object **rply)
 	}
 	if(resp_code == 429) {
 		if (pWrkrData->pData->busyRetryInterval) {
-			time_t now;
-			datetime.GetTime(&now);
 			pWrkrData->pData->cache->lastBusyTime = now;
 		}
 
@@ -1532,11 +1819,14 @@ BEGINdoAction
 	struct json_object *jMetadata = NULL, *jMetadataCopy = NULL, *jMsgMeta = NULL,
 			*jo = NULL;
 	int add_pod_metadata = 1;
+	time_t now;
+
 CODESTARTdoAction
 	CHKiRet_Hdlr(extractMsgMetadata(pMsg, pWrkrData->pData, &jMsgMeta)) {
 		ABORT_FINALIZE((iRet == RS_RET_NOT_FOUND) ? RS_RET_OK : iRet);
 	}
 
+	datetime.GetTime(&now);
 	STATSCOUNTER_INC(pWrkrData->k8sRecordSeen, pWrkrData->mutK8sRecordSeen);
 
 	if (fjson_object_object_get_ex(jMsgMeta, "pod_name", &jo))
@@ -1561,14 +1851,14 @@ CODESTARTdoAction
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
 	pthread_mutex_lock(pWrkrData->pData->cache->cacheMtx);
-	jMetadata = hashtable_search(pWrkrData->pData->cache->mdHt, mdKey);
+	jMetadata = cache_entry_get_md(pWrkrData, mdKey, now);
 
 	if(jMetadata == NULL) {
 		char *url = NULL;
 		struct json_object *jReply = NULL, *jo2 = NULL, *jNsMeta = NULL, *jPodData = NULL;
 
 		/* check cache for namespace metadata */
-		jNsMeta = hashtable_search(pWrkrData->pData->cache->nsHt, (char *)ns);
+		jNsMeta = cache_entry_get_nsmd(pWrkrData, (const char *)ns, now);
 
 		if(jNsMeta == NULL) {
 			/* query kubernetes for namespace info */
@@ -1579,7 +1869,7 @@ CODESTARTdoAction
 				pthread_mutex_unlock(pWrkrData->pData->cache->cacheMtx);
 				ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 			}
-			iRet = queryKB(pWrkrData, url, &jReply);
+			iRet = queryKB(pWrkrData, url, now, &jReply);
 			free(url);
 			if (iRet == RS_RET_NOT_FOUND) {
 				/* negative cache namespace - make a dummy empty namespace metadata object */
@@ -1622,7 +1912,8 @@ CODESTARTdoAction
 			}
 
 			if(jNsMeta) {
-				hashtable_insert(pWrkrData->pData->cache->nsHt, strdup(ns), jNsMeta);
+				if ((iRet = cache_entry_add_nsmd(pWrkrData, strdup(ns), jNsMeta, now)))
+					ABORT_FINALIZE(iRet);
 			}
 			json_object_put(jReply);
 			jReply = NULL;
@@ -1634,7 +1925,7 @@ CODESTARTdoAction
 			pthread_mutex_unlock(pWrkrData->pData->cache->cacheMtx);
 			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 		}
-		iRet = queryKB(pWrkrData, url, &jReply);
+		iRet = queryKB(pWrkrData, url, now, &jReply);
 		free(url);
 		if (iRet == RS_RET_NOT_FOUND) {
 			/* negative cache pod - make a dummy empty pod metadata object */
@@ -1705,7 +1996,8 @@ CODESTARTdoAction
 		json_object_object_add(jMetadata, "docker", jo);
 
 		if (add_pod_metadata) {
-			hashtable_insert(pWrkrData->pData->cache->mdHt, mdKey, jMetadata);
+			if ((iRet = cache_entry_add_md(pWrkrData, mdKey, jMetadata, now)))
+				ABORT_FINALIZE(iRet);
 			mdKey = NULL;
 		}
 	}

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -221,7 +221,7 @@
 #ifdef HAVE_ATOMIC_BUILTINS64
 #	define ATOMIC_INC_uint64(data, phlpmut) ((void) __sync_fetch_and_add(data, 1))
 #	define ATOMIC_ADD_uint64(data, phlpmut, value) ((void) __sync_fetch_and_add(data, value))
-#	define ATOMIC_DEC_unit64(data, phlpmut) ((void) __sync_sub_and_fetch(data, 1))
+#	define ATOMIC_DEC_uint64(data, phlpmut) ((void) __sync_sub_and_fetch(data, 1))
 #	define ATOMIC_INC_AND_FETCH_uint64(data, phlpmut) __sync_fetch_and_add(data, 1)
 
 #	define DEF_ATOMIC_HELPER_MUT64(x)

--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -190,7 +190,7 @@ void checkGoneAwaySenders(time_t);
 
 #define STATSCOUNTER_DEC(ctr, mut) \
 	if(GatherStats) \
-		ATOMIC_DEC_uint64(&ctr, mut);
+		ATOMIC_DEC_uint64(&ctr, &mut);
 
 /* the next macro works only if the variable is already guarded
  * by mutex (or the users risks a wrong result). It is assumed

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1232,10 +1232,12 @@ if ENABLE_MMKUBERNETES
 if ENABLE_MMJSONPARSE
 if ENABLE_IMFILE
 TESTS += \
-	mmkubernetes-basic.sh
+	mmkubernetes-basic.sh \
+	mmkubernetes-cache-expire.sh
 if HAVE_VALGRIND
 TESTS += \
-	mmkubernetes-basic-vg.sh
+	mmkubernetes-basic-vg.sh \
+	mmkubernetes-cache-expire-vg.sh
 endif
 endif
 endif
@@ -2133,6 +2135,8 @@ EXTRA_DIST= \
 	mmkubernetes-basic-vg.sh \
 	mmkubernetes_test_server.py \
 	mmkubernetes-basic.out.json \
+	mmkubernetes-cache-expire.sh \
+	mmkubernetes-cache-expire-vg.sh \
 	es-writeoperation.sh \
 	testsuites/incltest.d/include.conf \
 	testsuites/abort-uncleancfg-goodcfg.conf \

--- a/tests/mmkubernetes-basic-vg.sh
+++ b/tests/mmkubernetes-basic-vg.sh
@@ -149,7 +149,9 @@ k8s_srv_port = sys.argv[1]
 expected = {"name": "mmkubernetes(http://localhost:{0})".format(k8s_srv_port),
     "origin": "mmkubernetes", "recordseen": 12, "namespacemetadatasuccess": 9,
 	"namespacemetadatanotfound": 1, "namespacemetadatabusy": 1, "namespacemetadataerror": 0,
-	"podmetadatasuccess": 9, "podmetadatanotfound": 1, "podmetadatabusy": 2, "podmetadataerror": 0 }
+	"podmetadatasuccess": 9, "podmetadatanotfound": 1, "podmetadatabusy": 2, "podmetadataerror": 0,
+	"namespacecachenumentries": 10, "podcachenumentries": 10, "namespacecachehits": 1,
+	"podcachehits": 0, "namespacecachemisses": 11, "podcachemisses": 12 }
 actual = {}
 for line in sys.stdin:
 	jstart = line.find("{")

--- a/tests/mmkubernetes-basic.sh
+++ b/tests/mmkubernetes-basic.sh
@@ -149,7 +149,9 @@ k8s_srv_port = sys.argv[1]
 expected = {"name": "mmkubernetes(http://localhost:{0})".format(k8s_srv_port),
     "origin": "mmkubernetes", "recordseen": 12, "namespacemetadatasuccess": 9,
 	"namespacemetadatanotfound": 1, "namespacemetadatabusy": 1, "namespacemetadataerror": 0,
-	"podmetadatasuccess": 9, "podmetadatanotfound": 1, "podmetadatabusy": 2, "podmetadataerror": 0 }
+	"podmetadatasuccess": 9, "podmetadatanotfound": 1, "podmetadatabusy": 2, "podmetadataerror": 0,
+	"namespacecachenumentries": 10, "podcachenumentries": 10, "namespacecachehits": 1,
+	"podcachehits": 0, "namespacecachemisses": 11, "podcachemisses": 12 }
 actual = {}
 for line in sys.stdin:
 	jstart = line.find("{")

--- a/tests/mmkubernetes-cache-expire-vg.sh
+++ b/tests/mmkubernetes-cache-expire-vg.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# added 2018-04-06 by richm, released under ASL 2.0
+#
+# Note: on buidbot VMs (where there is no environment cleanup), the
+# kubernetes test server may be kept running if the script aborts or
+# is aborted (buildbot master failure!) for some reason. As such we
+# execute it under "timeout" control, which ensure it always is
+# terminated. It's not a 100% great method, but hopefully does the
+# trick. -- rgerhards, 2018-07-21
+#export RSYSLOG_DEBUG="debug"
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/mmkubernetes-cache-expire.sh

--- a/tests/mmkubernetes-cache-expire.out.expected
+++ b/tests/mmkubernetes-cache-expire.out.expected
@@ -1,0 +1,109 @@
+[{
+  "kubernetes": {
+    "namespace_id": "namespace-name1-id",
+    "namespace_labels": {
+      "label_1_key": "label 1 value",
+      "label_with_empty_value": "",
+      "label_2_key": "label 2 value"
+    },
+    "creation_timestamp": "2018-04-09T21:56:39Z",
+    "pod_id": "pod-name1-id",
+    "labels": {
+      "custom_label": "pod-name1-label-value",
+      "deploymentconfig": "pod-name1-dc",
+      "component": "pod-name1-component",
+      "label_with_empty_value": "",
+      "deployment": "pod-name1-deployment"
+    },
+    "pod_name": "pod-name1",
+    "namespace_name": "namespace-name1",
+    "container_name": "container-name1",
+    "master_url": "http://localhost:{k8s_srv_port}"
+  },
+  "docker": {
+    "container_id": "id1"
+  },
+  "testid": 1,
+  "message": "msg1"
+},{
+  "kubernetes": {
+    "namespace_id": "namespace-name1-id",
+    "namespace_labels": {
+      "label_1_key": "label 1 value",
+      "label_with_empty_value": "",
+      "label_2_key": "label 2 value"
+    },
+    "creation_timestamp": "2018-04-09T21:56:39Z",
+    "pod_id": "pod-name1-id",
+    "labels": {
+      "custom_label": "pod-name1-label-value",
+      "deploymentconfig": "pod-name1-dc",
+      "component": "pod-name1-component",
+      "label_with_empty_value": "",
+      "deployment": "pod-name1-deployment"
+    },
+    "pod_name": "pod-name1",
+    "namespace_name": "namespace-name1",
+    "container_name": "container-name1",
+    "master_url": "http://localhost:{k8s_srv_port}"
+  },
+  "docker": {
+    "container_id": "id1"
+  },
+  "testid": 2,
+  "message": "msg2"
+},{
+  "kubernetes": {
+    "namespace_id": "namespace-name1-id",
+    "namespace_labels": {
+      "label_1_key": "label 1 value",
+      "label_with_empty_value": "",
+      "label_2_key": "label 2 value"
+    },
+    "creation_timestamp": "2018-04-09T21:56:39Z",
+    "pod_id": "pod-name1-id",
+    "labels": {
+      "custom_label": "pod-name1-label-value",
+      "deploymentconfig": "pod-name1-dc",
+      "component": "pod-name1-component",
+      "label_with_empty_value": "",
+      "deployment": "pod-name1-deployment"
+    },
+    "pod_name": "pod-name1",
+    "namespace_name": "namespace-name1",
+    "container_name": "container-name1",
+    "master_url": "http://localhost:{k8s_srv_port}"
+  },
+  "docker": {
+    "container_id": "id1"
+  },
+  "testid": 3,
+  "message": "msg3"
+},{
+  "kubernetes": {
+    "namespace_id": "namespace-name1-id",
+    "namespace_labels": {
+      "label_1_key": "label 1 value",
+      "label_with_empty_value": "",
+      "label_2_key": "label 2 value"
+    },
+    "creation_timestamp": "2018-04-09T21:56:39Z",
+    "pod_id": "pod-name1-id",
+    "labels": {
+      "custom_label": "pod-name1-label-value",
+      "deploymentconfig": "pod-name1-dc",
+      "component": "pod-name1-component",
+      "label_with_empty_value": "",
+      "deployment": "pod-name1-deployment"
+    },
+    "pod_name": "pod-name1",
+    "namespace_name": "namespace-name1",
+    "container_name": "container-name1",
+    "master_url": "http://localhost:{k8s_srv_port}"
+  },
+  "docker": {
+    "container_id": "id1"
+  },
+  "testid": 4,
+  "message": "msg4"
+}]

--- a/tests/mmkubernetes-cache-expire.sh
+++ b/tests/mmkubernetes-cache-expire.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+# added 2018-04-06 by richm, released under ASL 2.0
+#
+# Note: on buidbot VMs (where there is no environment cleanup), the
+# kubernetes test server may be kept running if the script aborts or
+# is aborted (buildbot master failure!) for some reason. As such we
+# execute it under "timeout" control, which ensure it always is
+# terminated. It's not a 100% great method, but hopefully does the
+# trick. -- rgerhards, 2018-07-21
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="debug.log"
+. ${srcdir:=.}/diag.sh init
+check_command_available timeout
+pwd=$( pwd )
+k8s_srv_port=$( get_free_port )
+generate_conf
+cachettl=10
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+	   log.file="'"$RSYSLOG_DYNNAME.spool"'/mmkubernetes-stats.log" log.syslog="off" format="cee")
+module(load="../plugins/imfile/.libs/imfile")
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../contrib/mmkubernetes/.libs/mmkubernetes")
+
+template(name="mmk8s_template" type="list") {
+    property(name="$!all-json-plain")
+    constant(value="\n")
+}
+
+input(type="imfile" file="'$RSYSLOG_DYNNAME.spool'/pod-*.log" tag="kubernetes" addmetadata="on")
+action(type="mmjsonparse" cookie="")
+action(type="mmkubernetes" token="dummy" kubernetesurl="http://localhost:'$k8s_srv_port'"
+       cacheexpireinterval="1" cacheentryttl="'$cachettl'"
+       filenamerules=["rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:.%.%container_hash:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log",
+	                  "rule=:'$pwd/$RSYSLOG_DYNNAME.spool'/%pod_name:char-to:_%_%namespace_name:char-to:_%_%container_name_and_id:char-to:.%.log"]
+)
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="mmk8s_template")
+'
+
+testsrv=mmk8s-test-server
+echo starting kubernetes \"emulator\"
+timeout 2m python -u $srcdir/mmkubernetes_test_server.py $k8s_srv_port ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+echo background mmkubernetes_test_server.py process id is $BGPROCESS
+
+if [ "x${USE_VALGRIND:-NO}" == "xYES" ] ; then
+	export EXTRA_VALGRIND_SUPPRESSIONS="--suppressions=$srcdir/mmkubernetes.supp"
+	startup_vg
+else
+	startup
+    if [ -n "${USE_GDB:-}" ] ; then
+        echo attach gdb here
+        sleep 54321 || :
+    fi  
+fi
+
+# add 3 logs - then wait $cachettl - the first log should prime the cache - the next two should be pulled from the cache
+cat > ${RSYSLOG_DYNNAME}.spool/pod-name.log <<EOF
+{"message":"msg1","CONTAINER_NAME":"some-prefix_container-name1_pod-name1_namespace-name1_unused1_unused11","CONTAINER_ID_FULL":"id1","testid":1}
+EOF
+sleep 2
+cat >> ${RSYSLOG_DYNNAME}.spool/pod-name.log <<EOF
+{"message":"msg2","CONTAINER_NAME":"some-prefix_container-name1_pod-name1_namespace-name1_unused1_unused11","CONTAINER_ID_FULL":"id1","testid":2}
+EOF
+sleep 2
+cat >> ${RSYSLOG_DYNNAME}.spool/pod-name.log <<EOF
+{"message":"msg3","CONTAINER_NAME":"some-prefix_container-name1_pod-name1_namespace-name1_unused1_unused11","CONTAINER_ID_FULL":"id1","testid":3}
+EOF
+sleep $cachettl
+# we should see
+# - namespacecachenumentries and podcachenumentries go from 0 to 1 then back to 0
+# - namespacecachehits and podcachehits go from 0 to 2
+# - namespacecachemisses and podcachemisses go from 0 to 1
+# add another record - should not be cached - should have expired
+cat >> ${RSYSLOG_DYNNAME}.spool/pod-name.log <<EOF
+{"message":"msg4","CONTAINER_NAME":"some-prefix_container-name1_pod-name1_namespace-name1_unused1_unused11","CONTAINER_ID_FULL":"id1","testid":4}
+EOF
+# we should see
+# - namespacecachenumentries and podcachenumentries back to 1
+# - namespacecachehits and podcachehits did not increase
+# - namespacecachemisses and podcachemisses increases
+
+# wait for the first batch of tests to complete
+wait_queueempty
+
+shutdown_when_empty
+if [ "x${USE_VALGRIND:-NO}" == "xYES" ] ; then
+	wait_shutdown_vg
+	check_exit_vg
+else
+	wait_shutdown
+fi
+kill $BGPROCESS
+wait_pid_termination ${RSYSLOG_DYNNAME}${testsrv}.pid
+
+rc=0
+# for each record in mmkubernetes-cache-expire.out.json, see if the matching
+# record is found in $RSYSLOG_OUT_LOG
+python -c 'import sys,json
+k8s_srv_port = sys.argv[3]
+expected = {}
+for hsh in json.load(open(sys.argv[1])):
+	if "testid" in hsh:
+		if "kubernetes" in hsh and "master_url" in hsh["kubernetes"]:
+			hsh["kubernetes"]["master_url"] = hsh["kubernetes"]["master_url"].format(k8s_srv_port=k8s_srv_port)
+		expected[hsh["testid"]] = hsh
+rc = 0
+actual = {}
+for line in open(sys.argv[2]):
+	hsh = json.loads(line)
+	if "testid" in hsh:
+		actual[hsh["testid"]] = hsh
+for testid,hsh in expected.items():
+	if not testid in actual:
+		print("Error: record for testid {0} not found in output".format(testid))
+		rc = 1
+	else:
+		for kk,vv in hsh.items():
+			if not kk in actual[testid]:
+				print("Error: key {0} in record for testid {1} not found in output".format(kk, testid))
+				rc = 1
+			elif not vv == actual[testid][kk]:
+				print("Error: value {0} for key {1} in record for testid {2} does not match the expected value {3}".format(str(actual[testid][kk]), kk, testid, str(vv)))
+				rc = 1
+sys.exit(rc)
+' $srcdir/mmkubernetes-cache-expire.out.expected $RSYSLOG_OUT_LOG $k8s_srv_port || rc=$?
+
+if [ -f ${RSYSLOG_DYNNAME}.spool/mmkubernetes-stats.log ] ; then
+	python <${RSYSLOG_DYNNAME}.spool/mmkubernetes-stats.log  -c '
+import sys,json
+# key is recordseen, value is hash of stats for that record
+expectedvalues = {
+	1: {"namespacecachenumentries": 1, "podcachenumentries": 1, "namespacecachehits": 0,
+	    "podcachehits": 0, "namespacecachemisses": 1, "podcachemisses": 1},
+	2: {"namespacecachenumentries": 1, "podcachenumentries": 1, "namespacecachehits": 0,
+	    "podcachehits": 1, "namespacecachemisses": 1, "podcachemisses": 1},
+	3: {"namespacecachenumentries": 1, "podcachenumentries": 1, "namespacecachehits": 0,
+	    "podcachehits": 2, "namespacecachemisses": 1, "podcachemisses": 1},
+    4: {"namespacecachenumentries": 1, "podcachenumentries": 1, "namespacecachehits": 0,
+	   "podcachehits": 2, "namespacecachemisses": 2, "podcachemisses": 2},
+}
+for line in sys.stdin:
+	jstart = line.find("{")
+	if jstart >= 0:
+		hsh = json.loads(line[jstart:])
+		if hsh.get("origin") == "mmkubernetes" and hsh["recordseen"] in expectedvalues:
+		    expected = expectedvalues[hsh["recordseen"]]
+		    for key in expected:
+				if not expected[key] == hsh.get(key):
+				  "Error: expected value [%s] not equal to actual value [%s] in record [%d] for stat [%s]".format(
+				    str(expected[key]), str(hsh[key]), hsh["recordseen"], key)
+' || { rc=$?; echo error: expected stats not found in ${RSYSLOG_DYNNAME}.spool/mmkubernetes-stats.log; }
+else
+	echo error: stats file ${RSYSLOG_DYNNAME}.spool/mmkubernetes-stats.log not found
+	rc=1
+fi
+
+if [ ${rc:-0} -ne 0 ]; then
+	echo
+	echo "FAIL: expected data not found.  $RSYSLOG_OUT_LOG is:"
+	cat ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log
+	cat $RSYSLOG_OUT_LOG
+	cat ${RSYSLOG_DYNNAME}.spool/mmkubernetes-stats.log
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
New parameters for mmkubernetes (module and action):

* `cacheexpireinterval`
If `cacheexpireinterval` is -1, then do not check for cache expiration.
If `cacheexpireinterval` is 0, then check for cache expiration.
If `cacheexpireinterval` is greater than 0, check for cache expiration
if the last time we checked was more than this many seconds ago.

* `cacheentryttl` - maximum age in seconds for cache entries

New statistics counters:

* `podcachenumentries` - the number of entries in the pod metadata cache.
* `namespacecachenumentries` - the number of entries in the namespace
  metadata cache.
* `podcachehits` - the number of times a requested entry was found in the
  pod metadata cache.
* `namespacecachehits` - the number of times a requested entry was found
  in the namespace metadata cache.
* `podcachemisses` - the number of times a requested entry was not found
  in the pod metadata cache, and had to be requested from Kubernetes.
* `namespacecachemisses` - the number of times a requested entry was not
  found in the namespace metadata cache, and had to be requested from
  Kubernetes.


<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->