### PR TITLE
tcpflood bugfix: make soft connection limit work again

### DIFF
--- a/tests/imrelp-manyconn.sh
+++ b/tests/imrelp-manyconn.sh
@@ -3,6 +3,7 @@
 . ${srcdir:=.}/diag.sh init
 skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
 export NUMMESSAGES=100000
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1,6 +1,10 @@
 /* Opens a large number of tcp connections and sends
  * messages over them. This is used for stress-testing.
  *
+ * NOTE: the following part is actually the SPEC (or call it man page).
+ * It's not random comments. So if the code behavior does not match what
+ * is written here, it should be considered a bug.
+ *
  * Params
  * -t	target address (default 127.0.0.1)
  * -p	target port(s) (default 13514), multiple via port1:port2:port3...
@@ -67,7 +71,7 @@
  *
  * Part of the testbench for rsyslog.
  *
- * Copyright 2009-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2009-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -1634,9 +1638,11 @@ int main(int argc, char *argv[])
 		if(setrlimit(RLIMIT_NOFILE, &maxFiles) < 0) {
 			perror("setrlimit to increase file handles failed");
 			fprintf(stderr,
-			        "could net set sufficiently large number of "
+			        "could not set sufficiently large number of "
 			        "open files for required connection count!\n");
-			exit(1);
+			if(!softLimitConnections) {
+				exit(1);
+			}
 		}
 	}
 


### PR DESCRIPTION
It looks like the soft limit became defunct when tcpflood was enhanced to request more open file handles from OS.
    
closes https://github.com/rsyslog/rsyslog/issues/1108
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
