### PR TITLE
usability: specify file name in error message (was only fd)

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1399,7 +1399,7 @@ finalize_it:
  * the number of bytes actually written.
  * rgerhards, 2009-06-08
  */
-static rsRetVal
+static rsRetVal ATTR_NONNULL(1,2,3)
 doWriteCall(strm_t *pThis, uchar *pBuf, size_t *pLenBuf)
 {
 	ssize_t lenBuf;
@@ -1444,7 +1444,9 @@ doWriteCall(strm_t *pThis, uchar *pBuf, size_t *pLenBuf)
 				CHKiRet(doPhysOpen(pThis));
 			} else {
 				if(err != EINTR) {
-					LogError(err, RS_RET_IO_ERROR, "file '%d' write error", pThis->fd);
+					LogError(err, RS_RET_IO_ERROR, "file '%s'[%d] write error - see "
+						"https://www.rsyslog.com/solving-rsyslog-write-errors/ for help "
+						"OS error", pThis->pszCurrFName, pThis->fd);
 				}
 				if(err == EINTR) {
 					/*NO ERROR, just continue */;


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
