### PR TITLE
fix commented out-code

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -7,7 +7,7 @@
  * of the "old" message code without any modifications. However, it
  * helps to have things at the right place one we go to the meat of it.
  *
- * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -66,6 +66,8 @@
 #include "rsconf.h"
 #include "parserif.h"
 #include "errmsg.h"
+
+#define DEV_DEBUG 0	/* set to 1 to enable very verbose developer debugging messages */
 
 /* inlines */
 extern void msgSetPRI(smsg_t *const __restrict__ pMsg, syslog_pri_t pri);
@@ -430,13 +432,17 @@ void getRawMsgAfterPRI(smsg_t * const pM, uchar **pBuf, int *piLen);
 static inline void
 MsgLock(smsg_t *pThis)
 {
-	/* DEV debug only! dbgprintf("MsgLock(0x%lx)\n", (unsigned long) pThis); */
+	#if DEV_DEBUG == 1
+	dbgprintf("MsgLock(0x%lx)\n", (unsigned long) pThis);
+	#endif
 	pthread_mutex_lock(&pThis->mut);
 }
 static inline void
 MsgUnlock(smsg_t *pThis)
 {
-	/* DEV debug only! dbgprintf("MsgUnlock(0x%lx)\n", (unsigned long) pThis); */
+	#if DEV_DEBUG == 1
+	dbgprintf("MsgUnlock(0x%lx)\n", (unsigned long) pThis);
+	#endif
 	pthread_mutex_unlock(&pThis->mut);
 }
 
@@ -880,7 +886,9 @@ msgBaseConstruct(smsg_t **ppThis)
 	pM->pszUUID = NULL;
 	pthread_mutex_init(&pM->mut, NULL);
 
-	/* DEV debugging only! dbgprintf("msgConstruct\t0x%x, ref 1\n", (int)pM);*/
+	#if DEV_DEBUG == 1
+	dbgprintf("msgConstruct\t0x%x, ref 1\n", (int)pM);
+	#endif
 
 	*ppThis = pM;
 
@@ -974,8 +982,10 @@ rsRetVal msgDestruct(smsg_t **ppThis)
 	int currCnt;
 #	endif
 CODESTARTobjDestruct(msg)
-	/* DEV Debugging only ! dbgprintf("msgDestruct\t0x%lx, "
-		"Ref now: %d\n", (unsigned long)pThis, pThis->iRefCount - 1); */
+	#if DEV_DEBUG == 1
+	dbgprintf("msgDestruct\t0x%lx, "
+		"Ref now: %d\n", (unsigned long)pThis, pThis->iRefCount - 1);
+	#endif
 #	ifdef HAVE_ATOMIC_BUILTINS
 		currRefCount = ATOMIC_DEC_AND_FETCH(&pThis->iRefCount, NULL);
 #	else
@@ -984,8 +994,10 @@ CODESTARTobjDestruct(msg)
 # 	endif
 	if(currRefCount == 0)
 	{
-		/* DEV Debugging Only! dbgprintf("msgDestruct\t0x%lx, RefCount now 0,
-			doing DESTROY\n", (unsigned long)pThis); */
+		#if DEV_DEBUG == 1
+		dbgprintf("msgDestruct\t0x%lx, RefCount now 0, doing DESTROY\n",
+			(unsigned long)pThis);
+		#endif
 		if(pThis->pszRawMsg != pThis->szRawMsg)
 			free(pThis->pszRawMsg);
 		freeTAG(pThis);
@@ -1454,7 +1466,9 @@ smsg_t *MsgAddRef(smsg_t * const pM)
 		pM->iRefCount++;
 		MsgUnlock(pM);
 #	endif
-	/* DEV debugging only! dbgprintf("MsgAddRef\t0x%x done, Ref now: %d\n", (int)pM, pM->iRefCount);*/
+	#if DEV_DEBUG == 1
+	dbgprintf("MsgAddRef\t0x%x done, Ref now: %d\n", (int)pM, pM->iRefCount);
+	#endif
 	return(pM);
 }
 

--- a/runtime/obj-types.h
+++ b/runtime/obj-types.h
@@ -5,7 +5,7 @@
  * that loop somehow and I've done that by moving the typedefs
  * into this file here.
  *
- * Copyright 2008-2012 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -152,7 +152,6 @@ struct obj_s {	/* the dummy struct that each derived class can be casted to */
 #define DEFpropSetMethPTR(obj, prop, dataType)\
 	rsRetVal obj##Set##prop(obj##_t *pThis, dataType *pVal)\
 	{ \
-		/* DEV debug: dbgprintf("%sSet%s()\n", #obj, #prop); */\
 		pThis->prop = pVal; \
 		return RS_RET_OK; \
 	}
@@ -161,7 +160,6 @@ struct obj_s {	/* the dummy struct that each derived class can be casted to */
 #define DEFpropSetMethFP(obj, prop, dataType)\
 	rsRetVal obj##Set##prop(obj##_t *pThis, dataType)\
 	{ \
-		/* DEV debug: dbgprintf("%sSet%s()\n", #obj, #prop); */\
 		pThis->prop = pVal; \
 		return RS_RET_OK; \
 	}
@@ -171,7 +169,6 @@ struct obj_s {	/* the dummy struct that each derived class can be casted to */
 	rsRetVal obj##Set##prop(obj##_t *pThis, dataType pVal);\
 	rsRetVal obj##Set##prop(obj##_t *pThis, dataType pVal)\
 	{ \
-		/* DEV debug: dbgprintf("%sSet%s()\n", #obj, #prop); */\
 		pThis->prop = pVal; \
 		return RS_RET_OK; \
 	}

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -48,7 +48,7 @@
  *
  * File begun on 2008-01-04 by RGerhards
  *
- * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -74,6 +74,8 @@
 #include <ctype.h>
 #include <assert.h>
 #include <pthread.h>
+
+#define DEV_DEBUG 0	/* set to 1 to enable very verbose developer debugging messages */
 
 /* how many objects are supported by rsyslogd? */
 #define OBJ_NUM_IDS 100 /* TODO change to a linked list?  info: 16 were currently in use 2008-02-29 */
@@ -1132,8 +1134,10 @@ RegisterObj(uchar *pszObjName, objInfo_t *pInfo)
 	if(i >= OBJ_NUM_IDS) ABORT_FINALIZE(RS_RET_OBJ_REGISTRY_OUT_OF_SPACE);
 
 	arrObjInfo[i] = pInfo;
-	/* DEV debug only: dbgprintf("object '%s' successfully registered with
-	index %d, qIF %p\n", pszObjName, i, pInfo->QueryIF); */
+	#if DEV_DEBUG == 1
+	dbgprintf("object '%s' successfully registered with "
+		"index %d, qIF %p\n", pszObjName, i, pInfo->QueryIF);
+	#endif
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
@@ -1172,7 +1176,9 @@ UnregisterObj(uchar *pszObjName)
 		ABORT_FINALIZE(RS_RET_OBJ_NOT_REGISTERED);
 
 	InfoDestruct(&arrObjInfo[i]);
-	/* DEV debug only: dbgprintf("object '%s' successfully unregistered with index %d\n", pszObjName, i); */
+	#if DEV_DEBUG == 1
+	dbgprintf("object '%s' successfully unregistered with index %d\n", pszObjName, i);
+	#endif
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
@@ -1195,8 +1201,10 @@ UseObj(const char *srcFile, uchar *pObjName, uchar *pObjFile, interface_t *pIf)
 	objInfo_t *pObjInfo;
 
 
-	/* DEV debug only: dbgprintf("source file %s requests object '%s',
-	ifIsLoaded %d\n", srcFile, pObjName, pIf->ifIsLoaded); */
+	#if DEV_DEBUG == 1
+	dbgprintf("source file %s requests object '%s', "
+		" ifIsLoaded %d\n", srcFile, pObjName, pIf->ifIsLoaded);
+	#endif
 	pthread_mutex_lock(&mutObjGlobalOp);
 
 	if(pIf->ifIsLoaded == 1) {
@@ -1399,6 +1407,3 @@ objClassInit(modInfo_t *pModInfo)
 finalize_it:
 	RETiRet;
 }
-
-/* vi:set ai:
- */

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -11,7 +11,7 @@
  * e.g. search. Further refactoring and simplificytin may make
  * sense.
  *
- * Copyright (C) 2005-2018 Adiscon GmbH
+ * Copyright (C) 2005-2019 Adiscon GmbH
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -44,6 +44,8 @@
 #include "regexp.h"
 #include "errmsg.h"
 #include "unicode-helper.h"
+
+#define DEV_DEBUG 0	/* set to 1 to enable very verbose developer debugging messages */
 
 
 /* ################################################################# *
@@ -252,7 +254,9 @@ rsCStrExtendBuf(cstr_t *const __restrict__ pThis, const size_t iMinNeeded)
 	}
 	iNewSize += pThis->iBufSize; /* add current size */
 
-	/* DEV debugging only: dbgprintf("extending string buffer, old %d, new %d\n", pThis->iBufSize, iNewSize); */
+	#if DEV_DEBUG == 1
+	dbgprintf("extending string buffer, old %d, new %d\n", pThis->iBufSize, iNewSize);
+	#endif
 	CHKmalloc(pNewBuf = (uchar*) realloc(pThis->pBuf, iNewSize));
 	pThis->iBufSize = iNewSize;
 	pThis->pBuf = pNewBuf;


### PR DESCRIPTION
this now handles optional developer debug statements via preprocessor define

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
