### PR TITLE
omelasticsearch: add support for rebindinterval

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -81,6 +81,7 @@ STATSCOUNTER_DEF(indexDuplicate, mutIndexDuplicate)
 STATSCOUNTER_DEF(indexBadArgument, mutIndexBadArgument)
 STATSCOUNTER_DEF(indexBulkRejection, mutIndexBulkRejection)
 STATSCOUNTER_DEF(indexOtherResponse, mutIndexOtherResponse)
+STATSCOUNTER_DEF(rebinds, mutRebinds)
 
 static prop_t *pInputName = NULL;
 
@@ -100,6 +101,8 @@ typedef enum {
 } es_write_ops_t;
 
 #define WRKR_DATA_TYPE_ES 0xBADF0001
+
+#define DEFAULT_REBIND_INTERVAL -1
 
 /* REST API for elasticsearch hits this URL:
  * http://<hostName>:<restPort>/<searchIndex>/<searchType>
@@ -146,6 +149,7 @@ typedef struct instanceConf_s {
 	ratelimit_t *ratelimiter;
 	uchar *retryRulesetName;
 	ruleset_t *retryRuleset;
+	int rebindInterval;
 	struct instanceConf_s *next;
 } instanceData;
 
@@ -171,6 +175,7 @@ typedef struct wrkrInstanceData {
 		uchar *currTpl1;
 		uchar *currTpl2;
 	} batch;
+	int nOperations; /* counter used with rebindInterval */
 } wrkrInstanceData_t;
 
 /* tables for interfacing with the v6 config system */
@@ -208,7 +213,8 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "retryfailures", eCmdHdlrBinary, 0 },
 	{ "ratelimit.interval", eCmdHdlrInt, 0 },
 	{ "ratelimit.burst", eCmdHdlrInt, 0 },
-	{ "retryruleset", eCmdHdlrString, 0 }
+	{ "retryruleset", eCmdHdlrString, 0 },
+	{ "rebindinterval", eCmdHdlrInt, 0 }
 };
 static struct cnfparamblk actpblk =
 	{ CNFPARAMBLK_VERSION,
@@ -228,6 +234,7 @@ CODESTARTcreateInstance
 	pData->ratelimiter = NULL;
 	pData->retryRulesetName = NULL;
 	pData->retryRuleset = NULL;
+	pData->rebindInterval = DEFAULT_REBIND_INTERVAL;
 ENDcreateInstance
 
 BEGINcreateWrkrInstance
@@ -248,6 +255,7 @@ CODESTARTcreateWrkrInstance
 			pData->bulkmode = 0; /* at least it works */
 		}
 	}
+	pWrkrData->nOperations = 0;
 	iRet = curlSetup(pWrkrData);
 ENDcreateWrkrInstance
 
@@ -346,6 +354,7 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("\tretryfailures='%d'\n", pData->retryFailures);
 	dbgprintf("\tratelimit.interval='%d'\n", pData->ratelimitInterval);
 	dbgprintf("\tratelimit.burst='%d'\n", pData->ratelimitBurst);
+	dbgprintf("\trebindinterval='%d'\n", pData->rebindInterval);
 ENDdbgPrintInstInfo
 
 
@@ -1528,6 +1537,16 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 	pWrkrData->reply = NULL;
 	pWrkrData->replyLen = 0;
 
+	if ((pWrkrData->pData->rebindInterval > -1) &&
+		(pWrkrData->nOperations > pWrkrData->pData->rebindInterval)) {
+		curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1);
+		pWrkrData->nOperations = 0;
+		STATSCOUNTER_INC(rebinds, mutRebinds);
+	} else {
+		/* by default, reuse existing connections */
+		curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 0);
+	}
+
 	if(pWrkrData->pData->numServers > 1) {
 		/* needs to be called to support ES HA feature */
 		CHKiRet(checkConn(pWrkrData));
@@ -1550,6 +1569,9 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 			"to server failure %lld: %s", (long long) code, errbuf);
 		ABORT_FINALIZE(RS_RET_SUSPENDED);
 	}
+
+	if (pWrkrData->pData->rebindInterval > -1)
+		pWrkrData->nOperations++;
 
 	if(pWrkrData->reply == NULL) {
 		DBGPRINTF("omelasticsearch: pWrkrData reply==NULL, replyLen = '%d'\n",
@@ -1768,6 +1790,7 @@ setInstParamDefaults(instanceData *const pData)
 	pData->ratelimiter = NULL;
 	pData->retryRulesetName = NULL;
 	pData->retryRuleset = NULL;
+	pData->rebindInterval = DEFAULT_REBIND_INTERVAL;
 }
 
 BEGINnewActInst
@@ -1891,6 +1914,8 @@ CODESTARTnewActInst
 			pData->ratelimitInterval = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "retryruleset")) {
 			pData->retryRulesetName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "rebindinterval")) {
+			pData->rebindInterval = (int) pvals[i].val.d.n;
 		} else {
 			LogError(0, RS_RET_INTERNAL_ERROR, "omelasticsearch: program error, "
 				"non-handled param '%s'", actpblk.descr[i].name);
@@ -2182,6 +2207,9 @@ CODEmodInit_QueryRegCFSLineHdlr
 	STATSCOUNTER_INIT(indexOtherResponse, mutIndexOtherResponse);
 	CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"response.other",
 		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &indexOtherResponse));
+	STATSCOUNTER_INIT(rebinds, mutRebinds);
+	CHKiRet(statsobj.AddCounter(indexStats, (uchar *)"rebinds",
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &rebinds));
 	CHKiRet(statsobj.ConstructFinalize(indexStats));
 	CHKiRet(prop.Construct(&pInputName));
 	CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("omelasticsearch"), sizeof("omelasticsearch") - 1));

--- a/tests/es-basic.sh
+++ b/tests/es-basic.sh
@@ -4,7 +4,14 @@
 export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
 export ES_PORT=19200
 export NUMMESSAGES=1000 # 1000 is sufficient, as this test is pretty slow
-export QUEUE_EMPTY_CHECK_FUNC=es_shutdown_empty_check
+REBIND_INTERVAL=100 # should be enough to run several times for $NUMMESSAGES
+
+queue_empty_check() {
+	es_shutdown_empty_check && \
+	content_check --regex '"name": "omelasticsearch".*"submitted": '$NUMMESSAGES \
+		$RSYSLOG_DYNNAME.spool/omelasticsearch-stats.log
+}
+export QUEUE_EMPTY_CHECK_FUNC=queue_empty_check
 
 download_elasticsearch
 prepare_elasticsearch
@@ -16,6 +23,8 @@ add_conf '
 template(name="tpl" type="string"
 	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
 
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+	   log.file="'"$RSYSLOG_DYNNAME.spool"'/omelasticsearch-stats.log" log.syslog="off" format="cee")
 module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
 
 if $msg contains "msgnum:" then
@@ -23,7 +32,8 @@ if $msg contains "msgnum:" then
 	       server="127.0.0.1"
 	       serverport="'$ES_PORT'"
 	       template="tpl"
-	       searchIndex="rsyslog_testbench")
+	       searchIndex="rsyslog_testbench"
+	       rebindinterval="'$REBIND_INTERVAL'")
 '
 startup
 injectmsg  0 $NUMMESSAGES
@@ -32,5 +42,37 @@ wait_shutdown
 
 es_getdata $NUMMESSAGES $ES_PORT
 seq_check  0 $(( NUMMESSAGES - 1 ))
+rc=0
+if [ -f ${RSYSLOG_DYNNAME}.spool/omelasticsearch-stats.log ] ; then
+	python <${RSYSLOG_DYNNAME}.spool/omelasticsearch-stats.log  -c '
+import sys,json
+nrecs = int(sys.argv[1])
+nrebinds = nrecs/int(sys.argv[2])-1
+expected = { "name": "omelasticsearch", "origin": "omelasticsearch", "submitted": nrecs,
+	"failed.http": 0, "failed.httprequests": 0, "failed.checkConn": 0, "failed.es": 0,
+	"response.success": 0, "response.bad": 0, "response.duplicate": 0, "response.badargument": 0,
+	"response.bulkrejection": 0, "response.other": 0, "rebinds": nrebinds }
+actual = {}
+for line in sys.stdin:
+	jstart = line.find("{")
+	if jstart >= 0:
+		hsh = json.loads(line[jstart:])
+		if hsh["origin"] == "omelasticsearch":
+			actual = hsh
+if not expected == actual:
+	sys.stderr.write("ERROR: expected stats not equal to actual stats\n")
+	sys.stderr.write("ERROR: expected {}\n".format(expected))
+	sys.stderr.write("ERROR: actual {}\n".format(actual))
+	sys.exit(1)
+' $NUMMESSAGES $REBIND_INTERVAL || { rc=$?; echo error: expected stats not found in ${RSYSLOG_DYNNAME}.spool/omelasticsearch-stats.log; }
+else
+	echo error: stats file ${RSYSLOG_DYNNAME}.spool/omelasticsearch-stats.log not found
+	rc=1
+fi
+
 cleanup_elasticsearch
-exit_test
+if [ $rc != 0 ] ; then
+	error_exit 1
+else
+	exit_test
+fi


### PR DESCRIPTION
Adds support for a new parameter `rebindinterval`
This parameter tells omelasticsearch to close the connection and
reconnect to Elasticsearch after this many operations have been
submitted.  The default value `-1` means that omelasticsearch will
not reconnect.  A value greater than `-1` tells omelasticsearch,
after this many operations have been submitted to Elasticsearch,
to drop the connection and establish a new connection.  This is
useful when rsyslog connects to multiple Elasticsearch nodes
through a router or load balancer, and you need to periodically drop
and reestablish connections to help the router balance the
connections.  Use the counter `rebinds` to monitor the
number of times this has happened.