### PR TITLE
add support for skipverifyhost

### DIFF
--- a/plugins/omclickhouse/omclickhouse.c
+++ b/plugins/omclickhouse/omclickhouse.c
@@ -86,6 +86,7 @@ typedef struct instanceConf_s {
 	uchar *tplName;
 	sbool useHttps;
 	sbool allowUnsignedCerts;
+	sbool skipVerifyHost;
 	int fdErrFile;
 	uchar *errorFile;
 	sbool bulkmode;
@@ -129,6 +130,7 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "template", eCmdHdlrGetWord, 0 },
 	{ "usehttps", eCmdHdlrBinary, 0 },
 	{ "allowunsignedcerts", eCmdHdlrBinary, 0 },
+	{ "skipverifyhost", eCmdHdlrBinary, 0 },
 	{ "errorfile", eCmdHdlrGetWord, 0 },
 	{ "bulkmode", eCmdHdlrBinary, 0 },
 	{ "maxbytes", eCmdHdlrSize, 0 },
@@ -224,6 +226,7 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("\ttemplate='%s'\n", pData->tplName);
 	dbgprintf("\tusehttps='%d'\n", pData->useHttps);
 	dbgprintf("\tallowunsignedcerts='%d'\n", pData->allowUnsignedCerts);
+	dbgprintf("\tskipverifyhost='%d'\n", pData->skipVerifyHost);
 	dbgprintf("\terrorFile='%s'\n", pData->errorFile);
 	dbgprintf("\tbulkmode='%d'\n", pData->bulkmode);
 	dbgprintf("\tmaxbytes='%zu'\n", pData->maxbytes);
@@ -611,6 +614,7 @@ setInstParamDefaults(instanceData *const pData)
 	pData->tplName = NULL;
 	pData->useHttps = 1;
 	pData->allowUnsignedCerts = 1;
+	pData->skipVerifyHost = 0;
 	pData->errorFile = NULL;
 	pData->bulkmode = 1;
 	pData->maxbytes = 104857600; //100MB
@@ -647,6 +651,8 @@ curlSetupCommon(wrkrInstanceData_t *const pWrkrData, CURL *const handle)
 	curl_easy_setopt(handle, CURLOPT_WRITEDATA, pWrkrData);
 	if(pWrkrData->pData->allowUnsignedCerts)
 		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, FALSE);
+	if(pWrkrData->pData->skipVerifyHost)
+		curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, FALSE);
 	if(pWrkrData->pData->authBuf != NULL) {
 		curl_easy_setopt(handle, CURLOPT_USERPWD, pWrkrData->pData->authBuf);
 		curl_easy_setopt(handle, CURLOPT_PROXYAUTH, CURLAUTH_ANY);
@@ -826,6 +832,8 @@ CODESTARTnewActInst
 			pData->useHttps = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "allowunsignedcerts")) {
 			pData->allowUnsignedCerts = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "skipverifyhost")) {
+			pData->skipVerifyHost = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "errorfile")) {
 			pData->errorFile = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "bulkmode")) {


### PR DESCRIPTION
Add ability to specify the libcurl CURLOPT_SSL_VERIFYHOST
option to skip verification of the hostname in the peer cert.
WARNING: This option is insecure, and should only be used
for testing. The default value is off, meaning, the hostname
will be verified by default.