### PR TITLE
testbench: enable ompipe test on Solaris again and modernize it

### DIFF
--- a/tests/pipeaction.sh
+++ b/tests/pipeaction.sh
@@ -3,19 +3,11 @@
 # will create a fifo in the current directory, write to it and
 # then do the usual sequence checks.
 # added 2009-11-05 by RGerhards
-echo ===============================================================================
-echo \[pipeaction.sh\]: testing pipe output action
-
-uname
-if [ $(uname) = "SunOS" ] ; then
-   echo "Solaris: FIX ME"
-   exit 77
-fi
-
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=20000
 generate_conf
 add_conf '
 $MainMsgQueueTimeoutShutdown 10000
@@ -39,10 +31,8 @@ echo background cp process id is $CPPROCESS
 
 # now do the usual run
 startup
-# 20000 messages should be enough
-#tcpflood -m20000
-injectmsg 0 20000
-shutdown_when_empty # shut down rsyslogd when done processing messages
+injectmsg 0 $NUMMESSAGES
+shutdown_when_empty
 wait_shutdown
 
 # wait for the cp process to finish, do pipe-specific cleanup
@@ -52,5 +42,5 @@ rm -f rsyslog-testbench-fifo
 echo background cp has terminated, continue test...
 
 # and continue the usual checks
-seq_check 0 19999
+seq_check
 exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
