### PR TITLE
omelasticsearch - retry: set rawmsg to data from original request

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1138,7 +1138,8 @@ createMsgFromRequest(const char *request, context *ctx, smsg_t **msg, fjson_obje
 		const size_t msgLen = (size_t)json_object_get_string_len(jo_msg);
 		MsgSetRawMsg(*msg, rawmsg, msgLen);
 	} else {
-		MsgSetRawMsg(*msg, request, strlen(request));
+		/* use entire data part of request as rawmsg */
+		MsgSetRawMsg(*msg, datastart, datalen);
 	}
 	MsgSetMSGoffs(*msg, 0);	/* we do not have a header... */
 	MsgSetTAG(*msg, (const uchar *)"omes", 4);


### PR DESCRIPTION
https://github.com/rsyslog/rsyslog/issues/3573
Previously, when constructing the message to submit for a retry
for an original request, if the original request did not contain
the field `message`, the system property `rawmsg` was set to
the entire metadata + data from the original request.  This was
causing problems with Elasticsearch.  This patch changes
the code so that the `rawmsg` will be set to only the data part
of the original request if there is no `message` field.