### PR TITLE
Revert "WiP: rsyslog doesn't respond to TLS close_notify "

### DIFF
--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -896,12 +896,12 @@ CheckConnection(nsd_t *pNsd)
 {
 	DEFiRet;
 	int rc;
-	char msgbuf[32]; /* dummy */
+	char msgbuf[1]; /* dummy */
 	nsd_ptcp_t *pThis = (nsd_ptcp_t*) pNsd;
 	ISOBJ_TYPE_assert(pThis, nsd_ptcp);
 
-	rc = recv(pThis->sock, msgbuf, 32, MSG_DONTWAIT | MSG_PEEK);
-	if(rc >= 0 && errno != EAGAIN) {
+	rc = recv(pThis->sock, msgbuf, 1, MSG_DONTWAIT | MSG_PEEK);
+	if(rc == 0 && errno != EAGAIN) {
 		dbgprintf("CheckConnection detected broken connection - closing it\n");
 		/* in this case, the remote peer had shut down the connection and we
 		 * need to close our side, too.


### PR DESCRIPTION
Reverts rsyslog/rsyslog#3535

This actually caused a lot of problems, including https://github.com/rsyslog/rsyslog/issues/3587

The main issue is that the errno check seems actually be disabled. This might look like it worked, because it will frequently close connection. This "fixes" the original problem because we get lots and lots of new connections.

fixes #3587 