### PR TITLE
openssl nsd driver: Enhanced error output for SSL_ERROR_SYSCALL

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -207,8 +207,10 @@ void osslLastSSLErrorMsg(int ret, SSL *ssl, int severity, const char* pszCallSou
 		if(iSSLErr == SSL_ERROR_SSL) {
 			LogMsg(0, RS_RET_NO_ERRCODE, severity, "SSL_ERROR_SSL in '%s'", pszCallSource);
 		} else if(iSSLErr == SSL_ERROR_SYSCALL){
+			/* SSL doc says: For socket I/O on Unix systems, consult errno for details, so it
+			* is save to use errno in this case */
+			LogMsg(errno, RS_RET_NO_ERRCODE, severity, "SSL_ERROR_SYSCALL in '%s'", pszCallSource);
 
-			LogMsg(0, RS_RET_NO_ERRCODE, severity, "SSL_ERROR_SYSCALL in '%s'", pszCallSource);
 		} else {
 			LogMsg(0, RS_RET_NO_ERRCODE, severity, "SSL_ERROR_UNKNOWN in '%s', SSL_get_error: '%s(%d)'",
 				pszCallSource, ERR_error_string(iSSLErr, NULL), iSSLErr);

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -896,13 +896,13 @@ CheckConnection(nsd_t *pNsd)
 {
 	DEFiRet;
 	int rc;
-	char msgbuf[32]; /* dummy */
+	char msgbuf[1]; /* dummy */
 	nsd_ptcp_t *pThis = (nsd_ptcp_t*) pNsd;
 	ISOBJ_TYPE_assert(pThis, nsd_ptcp);
 
-	rc = recv(pThis->sock, msgbuf, 32, MSG_DONTWAIT | MSG_PEEK);
-	if(rc >= 0 && errno != EAGAIN) {
-		dbgprintf("CheckConnection detected broken connection - closing it\n");
+	rc = recv(pThis->sock, msgbuf, 1, MSG_DONTWAIT | MSG_PEEK);
+	if(rc == 0 && errno != EAGAIN) {
+		dbgprintf("CheckConnection detected broken connection - closing it (rc %d, errno %d)\n", rc, errno);
 		/* in this case, the remote peer had shut down the connection and we
 		 * need to close our side, too.
 		 */


### PR DESCRIPTION
errno is printed with LogMsg if SSLErr is SSL_ERROR_SYSCALL (As recommended by OpenSSL doc) which enhances troubleshooting.
