### PR TITLE
testbench: better instrumenation for imfile-symlink test

### DIFF
--- a/tests/imfile-symlink.sh
+++ b/tests/imfile-symlink.sh
@@ -44,15 +44,14 @@ startup
 
 for i in $(seq 2 $IMFILEINPUTFILES);
 do
-	./inputfilegen -m 1 > $RSYSLOG_DYNNAME.targets/$i.log
+	./inputfilegen -m 1 -i $((i-1)) > $RSYSLOG_DYNNAME.targets/$i.log
 	ln -s $RSYSLOG_DYNNAME.targets/$i.log rsyslog-link.$i.log
 	ln -s rsyslog-link.$i.log $RSYSLOG_DYNNAME.input.$i.log
+	printf '%s generated file %s\n' "$(tb_timestamp)" "$i"
+	ls -l rsyslog-link.$i.log
 	# wait until this file has been processed
-	content_check_with_count "HEADER msgnum:00000000:" $i $IMFILECHECKTIMEOUT
+	content_check_with_count "HEADER msgnum:000000" $i $IMFILECHECKTIMEOUT
 done
-
-# Content check with timeout
-content_check_with_count "HEADER msgnum:00000000:" $IMFILEINPUTFILES $IMFILECHECKTIMEOUT
 
 ./inputfilegen -m $IMFILELASTINPUTLINES > $RSYSLOG_DYNNAME.input.$((IMFILEINPUTFILES + 1)).log
 ls -l $RSYSLOG_DYNNAME.input.* rsyslog-link.* $RSYSLOG_DYNNAME.targets


### PR DESCRIPTION
This test frequently fails. We suspect real problem. New instrumentation
hopefully helps narrowing down the case when the problem re-occurs.

The test was also slightly improved by removing an unnecessary duplicate
check.

see also https://github.com/rsyslog/rsyslog/issues/3550

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
