### PR TITLE
testbench: disable imdocker-unittests because it does not work

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -801,8 +801,8 @@ endif
 
 if ENABLE_IMDOCKER
 if ENABLE_IMDOCKER_TESTS
+#imdocker-unittests.sh  defunct, see https://github.com/rsyslog/rsyslog/issues/3596
 TESTS += \
-	imdocker-unittests.sh \
 	imdocker-basic.sh \
 	imdocker-long-logline.sh \
 	imdocker-new-logs-from-start.sh \

--- a/tests/imdocker-unittests.sh
+++ b/tests/imdocker-unittests.sh
@@ -5,13 +5,13 @@
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
+$DebugLevel 2
+$DebugFile '$RSYSLOG_OUT_LOG'
 module(load="../contrib/imdocker/.libs/imdocker")
 '
 
-# enable debug output
-export RS_REDIR=-d
-startup > $RSYSLOG_OUT_LOG
-wait_shutdown
+startup
+shutdown_when_empty
 
 grep "\\[imdocker unit test\\] all unit tests pass\\."  $RSYSLOG_OUT_LOG > /dev/null
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
It also causes unrelated testbench failures.

see also https://github.com/rsyslog/rsyslog/issues/3596

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
