### PR TITLE
testbench: Add missing omhttp tests to EXTRA_DIST

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1810,6 +1810,24 @@ EXTRA_DIST= \
 	pipeaction.sh \
 	improg_errmsg_no_params.sh \
 	improg_errmsg_no_params-vg.sh \
+	omhttp-auth.sh \
+	omhttp-basic.sh \
+	omhttp-batch-fail-with-400.sh \
+	omhttp-batch-jsonarray-compress.sh \
+	omhttp-batch-jsonarray-retry.sh \
+	omhttp-batch-jsonarray.sh \
+	omhttp-batch-kafkarest-retry.sh \
+	omhttp-batch-kafkarest.sh \
+	omhttp-batch-newline.sh \
+	omhttp-retry.sh \
+	omhttp-auth-vg.sh \
+	omhttp-basic-vg.sh \
+	omhttp-batch-jsonarray-compress-vg.sh \
+	omhttp-batch-jsonarray-retry-vg.sh \
+	omhttp-batch-jsonarray-vg.sh \
+	omhttp-batch-kafkarest-retry-vg.sh \
+	omhttp-retry-vg.sh \
+	omhttp_server.py \
 	omprog-defaults.sh \
 	omprog-defaults-vg.sh \
 	omprog-output-capture.sh \


### PR DESCRIPTION
Looks like nobody tried to run tests since last release against release tarball :-0