### PR TITLE
build system bugfix: omhttp was ignored during "make distcheck"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -419,6 +419,10 @@ if ENABLE_LIBGCRYPT
 DISTCHECK_CONFIGURE_FLAGS+= --enable-libgcrypt
 endif
 
+if ENABLE_OMHTTP
+DISTCHECK_CONFIGURE_FLAGS+= --enable-omhttp
+endif
+
 if ENABLE_OMHTTPFS
 DISTCHECK_CONFIGURE_FLAGS+= --enable-omhttpfs
 endif


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/pull/3598

Note: this PR must initially fail and only be merged when EXTRA_DIST has been fixed (via #3598).