### PR TITLE
pmnormalize: fix memory leak, improve tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -943,10 +943,19 @@ endif
 if ENABLE_PMNORMALIZE
 TESTS +=  \
 	pmnormalize-basic.sh \
-	pmnormalize-rule.sh
+	pmnormalize-invld-rulebase.sh \
+	pmnormalize-rule.sh \
+	pmnormalize-rule_and_rulebase.sh \
+	pmnormalize-neither_rule_rulebase.sh \
+	pmnormalize-rule_invld-data.sh
 if HAVE_VALGRIND
 TESTS += \
-	pmnormalize-rule-vg.sh
+	pmnormalize-basic-vg.sh \
+	pmnormalize-invld-rulebase-vg.sh \
+	pmnormalize-rule-vg.sh \
+	pmnormalize-rule_and_rulebase-vg.sh \
+	pmnormalize-neither_rule_rulebase-vg.sh \
+	pmnormalize-rule_invld-data-vg.sh
 endif
 endif
 
@@ -1642,10 +1651,19 @@ EXTRA_DIST= \
 	mmnormalize_processing_test2.sh \
 	mmnormalize_processing_test3.sh \
 	mmnormalize_processing_test4.sh \
-	pmnormalize-rule.sh \
-	pmnormalize-rule-vg.sh\
-	testsuites/pmnormalize_basic.rulebase \
 	pmnormalize-basic.sh \
+	pmnormalize-rule.sh \
+	pmnormalize-rule_and_rulebase.sh \
+	pmnormalize-neither_rule_rulebase.sh \
+	pmnormalize-invld-rulebase.sh \
+	pmnormalize-rule_invld-data.sh \
+	testsuites/pmnormalize_basic.rulebase \
+	pmnormalize-basic-vg.sh \
+	pmnormalize-rule-vg.sh\
+	pmnormalize-rule_and_rulebase-vg.sh \
+	pmnormalize-neither_rule_rulebase-vg.sh \
+	pmnormalize-invld-rulebase-vg.sh \
+	pmnormalize-rule_invld-data-vg.sh \
 	rawmsg-after-pri.sh \
 	rs_optimizer_pri.sh \
 	rscript_prifilt.sh \

--- a/tests/pmnormalize-basic-vg.sh
+++ b/tests/pmnormalize-basic-vg.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # added 2019-04-10 by Rainer Gerhards, released under ASL 2.0
 export USE_VALGRIND="YES"
-source ${srcdir:-.}/pmnormalize-rule.sh
+source ${srcdir:-.}/pmnormalize-basic.sh

--- a/tests/pmnormalize-basic.sh
+++ b/tests/pmnormalize-basic.sh
@@ -7,12 +7,12 @@ module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")
 
 input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
-parser(name="custom.pmnormalize" type="pmnormalize" rulebase=`echo $srcdir/testsuites/pmnormalize_basic.rulebase`)
+parser(name="custom.pmnormalize" type="pmnormalize" rulebase="'$srcdir'/testsuites/pmnormalize_basic.rulebase")
 
 template(name="test" type="string" string="host: %hostname%, ip: %fromhost-ip%, tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 
 ruleset(name="ruleset" parser="custom.pmnormalize") {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="test")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="test")
 }
 '
 startup
@@ -21,13 +21,9 @@ tcpflood -m1 -M "\"<112> debian tag2: is no longer listening on 255.255.255.255 
 tcpflood -m1 -M "\"<177> centos tag3: is no longer listening on 192.168.0.9 test\""
 shutdown_when_empty
 wait_shutdown
-echo 'host: ubuntu, ip: 127.0.0.1, tag: tag1, pri: 189, syslogfacility: 23, syslogseverity: 5 msg: test
+export EXPECTED='host: ubuntu, ip: 127.0.0.1, tag: tag1, pri: 189, syslogfacility: 23, syslogseverity: 5 msg: test
 host: debian, ip: 255.255.255.255, tag: tag2, pri: 112, syslogfacility: 14, syslogseverity: 0 msg: test
-host: centos, ip: 192.168.0.9, tag: tag3, pri: 177, syslogfacility: 22, syslogseverity: 1 msg: test' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+host: centos, ip: 192.168.0.9, tag: tag3, pri: 177, syslogfacility: 22, syslogseverity: 1 msg: test'
+cmp_exact
 
 exit_test

--- a/tests/pmnormalize-invld-rulebase-vg.sh
+++ b/tests/pmnormalize-invld-rulebase-vg.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # added 2019-04-10 by Rainer Gerhards, released under ASL 2.0
 export USE_VALGRIND="YES"
-source ${srcdir:-.}/pmnormalize-rule.sh
+source ${srcdir:-.}/pmnormalize-invld-rulebase.sh

--- a/tests/pmnormalize-invld-rulebase.sh
+++ b/tests/pmnormalize-invld-rulebase.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# add 2016-12-08 by Pascal Withopf, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/pmnormalize/.libs/pmnormalize")
+parser(name="custom.pmnormalize" type="pmnormalize" rulebase="DOES-NOT-EXIST")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "cannot open rulebase .*DOES-NOT-EXIST"
+
+exit_test

--- a/tests/pmnormalize-neither_rule_rulebase-vg.sh
+++ b/tests/pmnormalize-neither_rule_rulebase-vg.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # added 2019-04-10 by Rainer Gerhards, released under ASL 2.0
 export USE_VALGRIND="YES"
-source ${srcdir:-.}/pmnormalize-rule.sh
+source ${srcdir:-.}/pmnormalize-neither_rule_rulebase.sh

--- a/tests/pmnormalize-neither_rule_rulebase.sh
+++ b/tests/pmnormalize-neither_rule_rulebase.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# add 2019-04-10 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/pmnormalize/.libs/pmnormalize")
+parser(name="custom.pmnormalize" type="pmnormalize")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "pmnormalize:.*you need to specify either"
+
+exit_test

--- a/tests/pmnormalize-rule.sh
+++ b/tests/pmnormalize-rule.sh
@@ -21,13 +21,9 @@ tcpflood -m1 -M "\"<112> 255.255.255.255 debian tag2: this is a test message\""
 tcpflood -m1 -M "\"<177> centos 192.168.0.9 tag3: this is a test message\""
 shutdown_when_empty
 wait_shutdown
-echo 'host: ubuntu, ip: 127.0.0.1, tag: tag1, pri: 189, syslogfacility: 23, syslogseverity: 5 msg: this is a test message
+export EXPECTED='host: ubuntu, ip: 127.0.0.1, tag: tag1, pri: 189, syslogfacility: 23, syslogseverity: 5 msg: this is a test message
 host: debian, ip: 255.255.255.255, tag: tag2, pri: 112, syslogfacility: 14, syslogseverity: 0 msg: this is a test message
-host: centos, ip: 192.168.0.9, tag: tag3, pri: 177, syslogfacility: 22, syslogseverity: 1 msg: this is a test message' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+host: centos, ip: 192.168.0.9, tag: tag3, pri: 177, syslogfacility: 22, syslogseverity: 1 msg: this is a test message'
+cmp_exact
 
 exit_test

--- a/tests/pmnormalize-rule_and_rulebase-vg.sh
+++ b/tests/pmnormalize-rule_and_rulebase-vg.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # added 2019-04-10 by Rainer Gerhards, released under ASL 2.0
 export USE_VALGRIND="YES"
-source ${srcdir:-.}/pmnormalize-rule.sh
+source ${srcdir:-.}/pmnormalize-rule_and_rulebase.sh

--- a/tests/pmnormalize-rule_and_rulebase.sh
+++ b/tests/pmnormalize-rule_and_rulebase.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# add 2019-04-10 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/pmnormalize/.libs/pmnormalize")
+parser(name="custom.pmnormalize" type="pmnormalize" rule="" rulebase="")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "pmnormalize:.*you need to specify one of"
+
+exit_test

--- a/tests/pmnormalize-rule_invld-data-vg.sh
+++ b/tests/pmnormalize-rule_invld-data-vg.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # added 2019-04-10 by Rainer Gerhards, released under ASL 2.0
 export USE_VALGRIND="YES"
-source ${srcdir:-.}/pmnormalize-rule.sh
+source ${srcdir:-.}/pmnormalize-rule_invld-data.sh

--- a/tests/pmnormalize-rule_invld-data.sh
+++ b/tests/pmnormalize-rule_invld-data.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# added 2019-04-10 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/pmnormalize/.libs/pmnormalize")
+
+input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+parser(name="custom.pmnormalize" type="pmnormalize" undefinedPropertyError="on"
+	rule="rule=:<%pri:number%> %fromhost-ip:ipv4% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%")
+
+template(name="test" type="string" string="%msg%\n")
+
+ruleset(name="ruleset" parser="custom.pmnormalize") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="test")
+}
+action(type="omfile" file="'$RSYSLOG_DYNNAME'.othermsg")
+'
+startup
+tcpflood -m1 -M "\"<abc> 127.0.0.1 ubuntu tag1: this is a test message\""
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='<abc> 127.0.0.1 ubuntu tag1: this is a test message'
+cmp_exact
+content_check --regex "error .* during ln_normalize" $RSYSLOG_DYNNAME.othermsg
+
+exit_test


### PR DESCRIPTION
This patch fixes a set of problems plus provides more and enhanced
tests for the module.

Most important problem was a memory leak that occured when a message
could not be passed at all. For each message that could not be parsed
memory of at least the size the message is leaked. Depending on
traffic pattern this can quickly lead to OOM. Note, however, that
this leak was never reported - it was discovered as part of code
review.

closes https://github.com/rsyslog/rsyslog/issues/2007

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
