### PR TITLE
openssl network driver: Added support setting openssl config commands

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1793,6 +1793,87 @@ static rsRetVal
 SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unused)) uchar *gnutlsPriorityString)
 {
 	DEFiRet;
+	nsd_ossl_t* pThis = (nsd_ossl_t*) pNsd;
+	ISOBJ_TYPE_assert(pThis, nsd_ossl);
+
+#if OPENSSL_VERSION_NUMBER >= 0x10020000L
+	char *pCurrentPos;
+	char *pNextPos;
+	char *pszCmd;
+	char *pszValue;
+	int iConfErr;
+
+	pThis->gnutlsPriorityString = gnutlsPriorityString;
+	dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);
+
+	/* Set working pointer */
+	pCurrentPos = (char*) pThis->gnutlsPriorityString;
+	if (pCurrentPos != NULL && strlen(pCurrentPos) > 0) {
+		// Create CTX Config Helper
+		SSL_CONF_CTX *cctx;
+		cctx = SSL_CONF_CTX_new();
+		if (pThis->sslState == osslServer) {
+			SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_SERVER);
+		} else {
+			SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_CLIENT);
+		}
+		SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_FILE);
+		SSL_CONF_CTX_set_flags(cctx, SSL_CONF_FLAG_SHOW_ERRORS);
+		SSL_CONF_CTX_set_ssl_ctx(cctx, ctx);
+
+		do
+		{
+			pNextPos = index(pCurrentPos, '=');
+			if (pNextPos != NULL) {
+				while (	*pCurrentPos != '\0' &&
+					(*pCurrentPos == ' ' || *pCurrentPos == '\t') )
+					pCurrentPos++;
+				pszCmd = strndup(pCurrentPos, pNextPos-pCurrentPos);
+				pCurrentPos = pNextPos+1;
+				pNextPos = index(pCurrentPos, '\n');
+				pszValue = (pNextPos == NULL ?
+						strdup(pCurrentPos) :
+						strndup(pCurrentPos, pNextPos - pCurrentPos));
+				pCurrentPos = (pNextPos == NULL ? NULL : pNextPos+1);
+
+				/* Add SSL Conf Command */
+				iConfErr = SSL_CONF_cmd(cctx, pszCmd, pszValue);
+				if (iConfErr > 0) {
+					dbgprintf("gnutlsPriorityString: Successfully added Command '%s':'%s'\n",
+						pszCmd, pszValue);
+				}
+				else {
+					LogError(0, RS_RET_SYS_ERR, "Failed to added Command: %s:'%s' "
+							"in gnutlsPriorityString with error '%d'",
+							pszCmd, pszValue, iConfErr);
+				}
+
+				free(pszCmd);
+				free(pszValue);
+			} else {
+				/* Abort further parsing */
+				pCurrentPos = NULL;
+			}
+		}
+		while (pCurrentPos != NULL);
+
+		/* Finalize SSL Conf */
+		iConfErr = SSL_CONF_CTX_finish(cctx);
+		if (!iConfErr) {
+			LogError(0, RS_RET_SYS_ERR, "Error: setting openssl command parameters: %s"
+					"Open ssl error info may follow in next messages",
+					pThis->gnutlsPriorityString);
+			osslLastSSLErrorMsg(0, NULL, LOG_ERR, "SetGnutlsPriorityString");
+		}
+	}
+#else
+	pThis->gnutlsPriorityString = gnutlsPriorityString;
+	dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);
+	LogError(0, RS_RET_SYS_ERR, "Error: OpenSSL Version to old, SSL_CONF_cmd API "
+			" is not supported.");
+
+#endif
+
 	RETiRet;
 }
 

--- a/runtime/nsd_ossl.h
+++ b/runtime/nsd_ossl.h
@@ -71,7 +71,7 @@ struct nsd_ossl_s {
 				 * set to 1 and changed to 0 after the first report. It is changed back to 1 after
 				 * one successful authentication. */
 	permittedPeers_t *pPermPeers; /* permitted peers */
-
+	uchar *gnutlsPriorityString;	/* gnutls priority string */
 	short	bOurCertIsInit;	/**< 1 if our certificate is initialized and must be deinit on destruction */
 	short	bOurKeyIsInit;	/**< 1 if our private key is initialized and must be deinit on destruction */
 	char *pszRcvBuf;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1060,6 +1060,7 @@ TESTS +=  \
 	sndrcv_tls_ossl_servercert_ossl_clientanon.sh \
 	sndrcv_tls_ossl_certvalid.sh \
 	sndrcv_tls_ossl_certvalid_expired.sh \
+	sndrcv_tls_ossl_certvalid_tlscommand.sh \
 	imtcp-tls-ossl-x509valid.sh \
 	imtcp-tls-ossl-x509name.sh \
 	imtcp-tls-ossl-x509fingerprint.sh \
@@ -1749,6 +1750,7 @@ EXTRA_DIST= \
 	sndrcv_tls_ossl_anon_rebind.sh \
 	sndrcv_tls_ossl_certvalid.sh \
 	sndrcv_tls_ossl_certvalid_expired.sh \
+	sndrcv_tls_ossl_certvalid_tlscommand.sh \
 	imtcp-tls-ossl-x509valid.sh \
 	imtcp-tls-ossl-x509name.sh \
 	imtcp-tls-ossl-x509fingerprint.sh \

--- a/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
+++ b/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+# uncomment for debugging support:
+. ${srcdir:=.}/diag.sh init
+# start up the instances
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+generate_conf
+export PORT_RCVR="$(get_free_port)"
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="ossl"
+#	debug.whitelist="on"
+#	debug.files=["nsd_ossl.c", "tcpsrv.c", "nsdsel_ossl.c", "nsdpoll_ptcp.c", "dnscache.c"]
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="ossl"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="x509/certvalid"
+	StreamDriver.PermitExpiredCerts="off"
+	gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2
+	MinProtocol=TLSv1.1
+	Options=Bugs"
+	)
+input(	type="imtcp"
+	port="'$PORT_RCVR'" )
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
+#valgrind="valgrind"
+generate_conf 2
+export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="ossl"
+)
+
+# Note: no TLS for the listener, this is for tcpflood!
+$ModLoad ../plugins/imtcp/.libs/imtcp
+$InputTCPServerRun '$TCPFLOOD_PORT'
+
+# set up the action
+action(	type="omfwd"
+	protocol="tcp"
+	target="127.0.0.1"
+	port="'$PORT_RCVR'"
+	StreamDriverMode="1"
+	StreamDriverAuthMode="x509/certvalid"
+	gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.1,-TLSv1.3"
+)
+' 2
+startup 2
+
+# now inject the messages into instance 2. It will connect to instance 1,
+# and that instance will record the data.
+tcpflood -m1 -i1
+# sleep 5 # make sure all data is received in input buffers
+# shut down sender when everything is sent, receiver continues to run concurrently
+shutdown_when_empty 2
+wait_shutdown 2
+# now it is time to stop the receiver as well
+shutdown_when_empty
+wait_shutdown
+
+content_check --check-only "OpenSSL Version to old"
+ret=$?
+if [ $ret == 0 ]; then
+	echo "SKIP: OpenSSL Version to old"
+	skip_test
+else
+	content_check "wrong version number"
+	content_check "OpenSSL Error Stack:"
+fi
+
+
+
+unset PORT_RCVR # TODO: move to exit_test()?
+exit_test


### PR DESCRIPTION
We are using the gnutlsPriorityString setting variable, to pass configuration commands to openssl.
The format is one command per line, command and value separated by equal sign (=).
See this sample:
	gnutlsPriorityString="command=value
	secondcommand=value"

Also added a test that disables certain TLS/SSL protocols through this parameter. This 
causes the handshake to fail within the test due not matching common tls version between client and server. This error is checked and if found the test will pass.

closes: https://github.com/rsyslog/rsyslog/issues/3605