### PR TITLE
mmnormalize: add test for proper $parsesuccess support

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -963,7 +963,13 @@ if ENABLE_MMNORMALIZE
 TESTS += msgvar-concurrency-array.sh \
 	msgvar-concurrency-array-event.tags.sh \
 	mmnormalize_rule_from_string.sh \
-	mmnormalize_rule_from_array.sh
+	mmnormalize_rule_from_array.sh \
+	mmnormalize_parsesuccess.sh
+
+if HAVE_VALGRIND
+TESTS += \
+	mmnormalize_parsesuccess-vg.sh
+endif
 
 if ENABLE_IMPTCP
 TESTS +=  \
@@ -977,7 +983,7 @@ if LOGNORM_REGEX_SUPPORTED
 TESTS += \
 	mmnormalize_regex.sh
 endif
-endif
+endif # ENABLE_MMNORMALIZE
 
 if ENABLE_MMJSONPARSE
 TESTS += \
@@ -1641,6 +1647,8 @@ EXTRA_DIST= \
 	timereported-utc-legacy.sh \
 	timereported-utc-vg.sh \
 	mmrm1stspace-basic.sh \
+	mmnormalize_parsesuccess.sh \
+	mmnormalize_parsesuccess-vg.sh \
 	mmnormalize_rule_from_string.sh \
 	mmnormalize_rule_from_array.sh \
 	pmnull-basic.sh \

--- a/tests/mmnormalize_parsesuccess-vg.sh
+++ b/tests/mmnormalize_parsesuccess-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# added 2019-04-11 by Rainer Gerhards, released under ASL 2.0
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/mmnormalize_parsesuccess.sh

--- a/tests/mmnormalize_parsesuccess.sh
+++ b/tests/mmnormalize_parsesuccess.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# added 2019-04-11 by Rainer Gerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+
+action(type="mmnormalize" rule=
+	["rule=: %-:char-to{\"extradata\":\":\"}%:00000000:",
+	 "rule=: %-:char-to{\"extradata\":\":\"}%:00000010:"] )
+
+if not ($rawmsg contains "rsyslog") then
+	if $parsesuccess == "OK" then
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+	else
+		action(type="omfile" file="'$RSYSLOG_DYNNAME'.failed")
+'
+startup
+injectmsg 0 20
+shutdown_when_empty
+wait_shutdown
+content_check "msgnum:00000000:" $RSYSLOG_OUT_LOG
+content_check "msgnum:00000010:" $RSYSLOG_OUT_LOG
+content_check "msgnum:00000001:" $RSYSLOG_DYNNAME.failed
+content_check "msgnum:00000012:" $RSYSLOG_DYNNAME.failed
+exit_test


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/issues/2462

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
