### PR TITLE
dnscache: add global parameter dnscache.default.ttl

### DIFF
--- a/runtime/dnscache.h
+++ b/runtime/dnscache.h
@@ -1,6 +1,6 @@
 /* Definitions for dnscache module.
  *
- * Copyright 2011-2013 Adiscon GmbH.
+ * Copyright 2011-2019 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -24,7 +24,9 @@
 
 rsRetVal dnscacheInit(void);
 rsRetVal dnscacheDeinit(void);
-rsRetVal dnscacheLookup(struct sockaddr_storage *addr, prop_t **fqdn, prop_t **fqdnLowerCase,
-prop_t **localName, prop_t **ip);
+rsRetVal ATTR_NONNULL(1, 5) dnscacheLookup(struct sockaddr_storage *const addr,
+	prop_t **const fqdn, prop_t **const fqdnLowerCase,
+	prop_t **const localName, prop_t **const ip);
 
+extern unsigned dnscacheDefaultTTL;
 #endif /* #ifndef INCLUDED_DNSCACHE_H */

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -7,7 +7,7 @@
  *
  * Module begun 2008-04-16 by Rainer Gerhards
  *
- * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -56,6 +56,7 @@
 #include "net.h"
 #include "rsconf.h"
 #include "queue.h"
+#include "dnscache.h"
 
 #define REPORT_CHILD_PROCESS_EXITS_NONE 0
 #define REPORT_CHILD_PROCESS_EXITS_ERRORS 1
@@ -213,6 +214,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "default.action.queue.timeoutactioncompletion", eCmdHdlrInt, 0 },
 	{ "default.action.queue.timeoutenqueue", eCmdHdlrInt, 0 },
 	{ "default.action.queue.timeoutworkerthreadshutdown", eCmdHdlrInt, 0 },
+	{ "reverselookup.cache.default.ttl", eCmdHdlrNonNegInt, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
 	{ "debug.whitelist", eCmdHdlrBinary, 0 }
 };
@@ -1464,6 +1466,8 @@ glblDoneLoadCnf(void)
 			actq_dflt_toEnq = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.action.queue.timeoutworkerthreadshutdown")) {
 			actq_dflt_toWrkShutdown = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "reverselookup.cache.default.ttl")) {
+			dnscacheDefaultTTL = cnfparamvals[i].val.d.n;
 		} else {
 			dbgprintf("glblDoneLoadCnf: program error, non-handled "
 				"param '%s'\n", paramblk.descr[i].name);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -160,6 +160,7 @@ TESTS +=  \
 	glbl_setenv_err_too_long.sh \
 	glbl_setenv.sh \
 	nested-call-shutdown.sh \
+	dnscache-TTL-0.sh \
 	invalid_nested_include.sh \
 	omfwd-keepalive.sh \
 	omfile-read-only-errmsg.sh \
@@ -402,6 +403,7 @@ endif # ENABLE_LIBGCRYPT
 if HAVE_VALGRIND
 TESTS +=  \
 	tcpflood_wrong_option_output.sh \
+	dnscache-TTL-0-vg.sh \
 	include-obj-outside-control-flow-vg.sh \
 	include-obj-in-if-vg.sh \
 	include-obj-text-vg.sh \
@@ -1374,6 +1376,8 @@ distclean-local:
 
 EXTRA_DIST= \
 	urlencode.py \
+	dnscache-TTL-0.sh \
+	dnscache-TTL-0-vg.sh \
 	operatingstate-basic.sh \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \

--- a/tests/dnscache-TTL-0-vg.sh
+++ b/tests/dnscache-TTL-0-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# added 2019-04-12 by Rainer Gerhards, released under ASL 2.0
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/dnscache-TTL-0.sh

--- a/tests/dnscache-TTL-0.sh
+++ b/tests/dnscache-TTL-0.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# addd 2019-04-12 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=20 # should be sufficient to stress DNS cache
+generate_conf
+add_conf '
+global(reverselookup.cache.default.ttl="0")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="'$TCPFLOOD_PORT'")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+tcpflood -m$NUMMESSAGES -c10 # run on 10 connections --> 10 dns cache calls
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/49

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
