### PR TITLE
testbench: add base test for omudpspoof

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,8 +14,8 @@ coverage:
         threshold: .5
       contrib:
         paths: contrib
-    patch:
-      threshold: null
+#    patch:
+#       threshold: null
 
 ignore:
   # different execution pathes (if not, remove) -- rgerhards, 2018-10-12

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1143,6 +1143,7 @@ endif
 
 if ENABLE_OMUDPSPOOF
 TESTS += \
+	omudpspoof_errmsg_no_params.sh \
 	sndrcv_omudpspoof.sh \
 	sndrcv_omudpspoof_nonstdpt.sh
 endif
@@ -1889,6 +1890,7 @@ EXTRA_DIST= \
 	imudp_thread_hang.sh \
 	sndrcv_udp_nonstdpt.sh \
 	sndrcv_udp_nonstdpt_v6.sh \
+	omudpspoof_errmsg_no_params.sh \
 	sndrcv_omudpspoof.sh \
 	sndrcv_omudpspoof_nonstdpt.sh \
 	sndrcv_gzip.sh \

--- a/tests/omudpspoof_errmsg_no_params.sh
+++ b/tests/omudpspoof_errmsg_no_params.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# add 2019-04-15 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/omudpspoof/.libs/omudpspoof")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+action(type="omudpspoof")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "parameter 'target' required but not specified"
+
+exit_test


### PR DESCRIPTION
this now also ensure at least minimal check when CI does not contain a system running with root permissions.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
