### PR TITLE
dnscache: fix very unlikely memory leak

### DIFF
--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -387,6 +387,8 @@ addEntry(struct sockaddr_storage *const addr, dnscache_entry_t **const pEtry)
 	DEFiRet;
 
 	/* entry still does not exist, so add it */
+	struct sockaddr_storage *const keybuf =  malloc(sizeof(struct sockaddr_storage));
+	CHKmalloc(keybuf);
 	CHKmalloc(etry = malloc(sizeof(dnscache_entry_t)));
 	resolveAddr(addr, etry);
 	assert(etry != NULL);
@@ -396,8 +398,6 @@ addEntry(struct sockaddr_storage *const addr, dnscache_entry_t **const pEtry)
 		etry->validUntil = time(NULL) + dnscacheDefaultTTL;
 	}
 
-	struct sockaddr_storage *keybuf;
-	CHKmalloc(keybuf = malloc(sizeof(struct sockaddr_storage)));
 	memcpy(keybuf, addr, sizeof(struct sockaddr_storage));
 
 	r = hashtable_insert(dnsCache.ht, keybuf, etry);
@@ -407,6 +407,9 @@ addEntry(struct sockaddr_storage *const addr, dnscache_entry_t **const pEtry)
 	*pEtry = etry;
 
 finalize_it:
+	if(iRet != RS_RET_OK) {
+		free(keybuf);
+	}
 	RETiRet;
 }
 


### PR DESCRIPTION
This fixes a memory leak that can only occur under OOM conditions.

Detected by Coverity Scan, CID 203717

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
