### PR TITLE
core: emit a warning message for ultra-large queue size definitions

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -82,6 +82,8 @@ DEFobjCurrIf(statsobj)
 unsigned int iOverallQueueSize = 0;
 #endif
 
+#define OVERSIZE_QUEUE_WATERMARK 500000 /* when is a queue considered to be "overly large"? */
+
 /* overridable default values (via global config) */
 int actq_dflt_toQShutdown = 10;		/* queue shutdown */
 int actq_dflt_toActShutdown = 1000;	/* action shutdown (in phase 2) */
@@ -3250,6 +3252,12 @@ qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst)
 			}
 		} else if(!strcmp(pblk.descr[i].name, "queue.size")) {
 			pThis->iMaxQueueSize = pvals[i].val.d.n;
+			if(pThis->iMaxQueueSize > OVERSIZE_QUEUE_WATERMARK) {
+				parser_errmsg("queue.size=%d is very large - is this "
+					"really intended? More info at "
+					"https://www.rsyslog.com/avoid-overly-large-in-memory-queues/",
+					pThis->iMaxQueueSize);
+			}
 		} else if(!strcmp(pblk.descr[i].name, "queue.dequeuebatchsize")) {
 			pThis->iDeqBatchSize = pvals[i].val.d.n;
 		} else if(!strcmp(pblk.descr[i].name, "queue.mindequeuebatchsize")) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -209,6 +209,7 @@ TESTS +=  \
 	tcp_forwarding_tpl.sh \
 	tcp_forwarding_dflt_tpl.sh \
 	tcp_forwarding_retries.sh \
+	queue_errmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \
 	arrayqueue.sh \
@@ -1449,6 +1450,7 @@ EXTRA_DIST= \
 	tcp_forwarding_ns_tpl.sh \
 	tcp_forwarding_dflt_tpl.sh \
 	tcp_forwarding_retries.sh \
+	queue_errmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \
 	killrsyslog.sh \

--- a/tests/queue_errmsg-oversize.sh
+++ b/tests/queue_errmsg-oversize.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# add 2019-04-18 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'"
+       queue.type="linkedList" queue.size="500001")
+'
+
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "queue.size=500001 is very large"
+
+exit_test


### PR DESCRIPTION
We see error reports from users who have configured excessively large queues
and receive an OOM condition or other problems.

With that patcjh we generate a warnomg message if a queue is configured very
large. "Very large" is defined to be in excess of 500000 messages.

see also https://github.com/rsyslog/rsyslog/issues/3314
closes https://github.com/rsyslog/rsyslog/issues/3334

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
