### PR TITLE
imfile: new module parameter "statefile.directory"

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1252,6 +1252,7 @@ TESTS += \
 	imfile-endmsg.regex.sh \
 	imfile-statefile-no-file_id.sh \
 	imfile-statefile-no-file_id-TO-file_id.sh \
+	imfile-statefile-directory.sh \
 	imfile-persist-state-1.sh \
 	imfile-freshStartTail1.sh \
 	imfile-freshStartTail2.sh \
@@ -2024,6 +2025,7 @@ EXTRA_DIST= \
 	imfile-endmsg.regex.json.rulebase \
 	imfile-statefile-no-file_id.sh \
 	imfile-statefile-no-file_id-TO-file_id.sh \
+	imfile-statefile-directory.sh \
 	imfile-persist-state-1.sh \
 	imfile-freshStartTail1.sh \
 	imfile-freshStartTail2.sh \

--- a/tests/imfile-basic.sh
+++ b/tests/imfile-basic.sh
@@ -22,5 +22,5 @@ wait_file_lines
 shutdown_when_empty
 wait_shutdown
 seq_check
-content_check "imfile: no working directory set" $RSYSLOG_DYNNAME.othermsgs
+content_check "imfile: no working or state file directory set" $RSYSLOG_DYNNAME.othermsgs
 exit_test

--- a/tests/imfile-statefile-directory.sh
+++ b/tests/imfile-statefile-directory.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# added 2019-04-25 by rgerhards
+# check that the "statfile.directory" module parameter is accepted
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+mkdir $RSYSLOG_DYNNAME.statefiles
+generate_conf
+add_conf '
+module(load="../plugins/imfile/.libs/imfile"
+      statefile.directory="'${RSYSLOG_DYNNAME}'.statefiles")
+input(type="imfile" tag="file:" file="./'$RSYSLOG_DYNNAME'.input")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "msgnum:" then
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+# generate a very small file so that imfile cannot generate file_id (simple case)
+./inputfilegen -m1 > $RSYSLOG_DYNNAME.input
+startup
+shutdown_when_empty
+wait_shutdown
+seq_check 0 0 # check we got the messages correctly
+# and also check state file name is correct:
+# shellcheck disable=SC2012  - we do not display (or even use) the file name
+inode=$(ls -i "$RSYSLOG_DYNNAME.input"|awk '{print $1}')
+if [ ! -f "$RSYSLOG_DYNNAME.statefiles/imfile-state:$inode" ]; then
+	printf 'FAIL: state file name incorrect,\nexpected \"%s\"\nstatefiles dir is:\n' \
+		$RSYSLOG_DYNNAME.statefiles/imfile-state:$inode
+	ls -l $RSYSLOG_DYNNAME.statefiles
+	error_exit 1
+fi
+exit_test


### PR DESCRIPTION
This permits to write state files to a location other than the rsyslog
working directory. This may be desirable for some use cases.

closes https://github.com/rsyslog/rsyslog/issues/2558

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
