### PR TITLE
omfile bugfix: FlushOnTXEnd does not work reliably with dynafiles

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -2090,7 +2090,7 @@ finalize_it:
  * free byte left. This came up during a code walkthrough and was considered
  * worth nothing. -- rgerhards, 2010-03-10
  */
-static rsRetVal
+static rsRetVal ATTR_NONNULL(1,2)
 strmWrite(strm_t *__restrict__ const pThis, const uchar *__restrict__ const pBuf, size_t lenBuf)
 {
 	DEFiRet;
@@ -2100,9 +2100,6 @@ strmWrite(strm_t *__restrict__ const pThis, const uchar *__restrict__ const pBuf
 	assert(pThis != NULL);
 	assert(pBuf != NULL);
 
-/* DEV DEBUG ONLY DBGPRINTF("strmWrite(%p[%s], '%65.65s', %ld);,
-disabled %d, sizelim %ld, size %lld\n", pThis, pThis->pszCurrFName, pBuf,(long) lenBuf,
-pThis->bDisabled, (long) pThis->iSizeLimit, (long long) pThis->iCurrOffs); */
 	if(pThis->bDisabled)
 		ABORT_FINALIZE(RS_RET_STREAM_DISABLED);
 


### PR DESCRIPTION
The flush was only done to the last dynafile in use at end of
transactions. Dynafiles that were also modified during the
transaction were not flushed.

Special thanks to Duy Nguyen for pointing us to the bug and
suggesting a solution.

This commit also contains a bit of cosmetic cleanup inside
the file stream class.

closes https://github.com/rsyslog/rsyslog/issues/2502

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
