### PR TITLE
config processing: check disk queue file is unique

### DIFF
--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -211,6 +211,7 @@ void qqueueSetDefaultsRulesetQueue(qqueue_t *pThis);
 void qqueueSetDefaultsActionQueue(qqueue_t *pThis);
 void qqueueDbgPrint(qqueue_t *pThis);
 rsRetVal qqueueShutdownWorkers(qqueue_t *pThis);
+void qqueueDoneLoadCnf(void);
 
 PROTOTYPEObjClassInit(qqueue);
 PROTOTYPEpropSetMeth(qqueue, iPersistUpdCnt, int);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -635,6 +635,7 @@ static inline rsRetVal
 tellCoreConfigLoadDone(void)
 {
 	DBGPRINTF("telling rsyslog core that config load for %p is done\n", loadConf);
+	qqueueDoneLoadCnf();
 	return glblDoneLoadCnf();
 }
 

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -581,6 +581,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_RABBITMQ_LOGIN_ERR = -2448, /**< RabbitMQ Login error */
 	RS_RET_RABBITMQ_CHANNEL_ERR = -2449, /**< RabbitMQ Connection error */
 	RS_RET_NO_WRKDIR_SET = -2450, /**< working directory not set, but desired by functionality */
+	RS_RET_ERR_QUEUE_FN_DUP = -2451, /**< duplicate queue file name */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -235,6 +235,7 @@ TESTS +=  \
 	diskqueue.sh \
 	diskqueue-fsync.sh \
 	diskqueue-full.sh \
+	diskqueue-non-unique-prefix.sh \
 	rulesetmultiqueue.sh \
 	rulesetmultiqueue-v6.sh \
 	manytcp.sh \
@@ -1492,6 +1493,7 @@ EXTRA_DIST= \
 	diskq-rfc5424.sh \
 	diskqueue-full.sh \
 	diskqueue.sh \
+	diskqueue-non-unique-prefix.sh \
 	arrayqueue.sh \
 	include-obj-text-from-file.sh \
 	include-obj-outside-control-flow-vg.sh \

--- a/tests/diskqueue-non-unique-prefix.sh
+++ b/tests/diskqueue-non-unique-prefix.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Test for config parser to check that disk queue file names are
+# unique.
+# added 2019-05-02 by Rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+if 0 then {
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.notused"
+		queue.filename="qf1" queue.type="linkedList")
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.notused"
+		queue.filename="qf1" queue.type="linkedList")
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.notused"
+		queue.filename="qf2" queue.type="linkedList")
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.notused"
+		queue.spooldirectory="'$RSYSLOG_DYNNAME'.spool2"
+		queue.filename="qf2" queue.type="linkedList")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "and file name prefix 'qf1' already used"
+check_not_present "and file name prefix 'qf2' already used"
+exit_test


### PR DESCRIPTION
If the same name is specified for multiple queues, the queue files
will become corrupted. This commit adds a check during config parsing.
If duplicate names are detected the config parser errors out and the
related object is not created.

Note: this may look to a change-of-behaviour to some users. However,
this never worked and it was pure luck that these users did not run
into big problems (e.g. DA queues were never going to disk at the
same time). So it is acceptable to error out in this hard error case.

closes https://github.com/rsyslog/rsyslog/issues/1385

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
