### PR TITLE
testbench bugfix: imfile-symlink failed w/ parallel test run

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1322,7 +1322,6 @@ exit_test() {
 	rm -f work rsyslog.out.* xlate*.lkp_tbl
 	rm -rf test-logdir stat-file1
 	rm -f rsyslog.conf.tlscert stat-file1 rsyslog.empty imfile-state:*
-	rm -rf rsyslog-link.*.log targets
 	rm -f ${TESTCONF_NM}.conf
 	rm -f tmp.qi nocert
 	rm -fr $RSYSLOG_DYNNAME*  # delete all of our dynamic files
@@ -2165,7 +2164,6 @@ case $1 in
 		rm -f work 
 		rm -rf test-logdir stat-file1
 		rm -f rsyslog.empty imfile-state:* omkafka-failed.data
-		rm -rf rsyslog-link.*.log targets
 		rm -f tmp.qi nocert
 		rm -f core.* vgcore.* core*
 		# Note: rsyslog.action.*.include must NOT be deleted, as it

--- a/tests/imfile-symlink.sh
+++ b/tests/imfile-symlink.sh
@@ -45,20 +45,18 @@ startup
 for i in $(seq 2 $IMFILEINPUTFILES);
 do
 	printf '\ncreating %s\n' $RSYSLOG_DYNNAME.targets/$i.log
-	set -x
 	./inputfilegen -m 1 -i $((i-1)) > $RSYSLOG_DYNNAME.targets/$i.log
 	ls -l $RSYSLOG_DYNNAME.targets/$i.log
-	ln -sv $RSYSLOG_DYNNAME.targets/$i.log rsyslog-link.$i.log
-	ln -sv rsyslog-link.$i.log $RSYSLOG_DYNNAME.input.$i.log
+	ln -sv $RSYSLOG_DYNNAME.targets/$i.log $RSYSLOG_DYNNAME.link.$i.log
+	ln -sv $RSYSLOG_DYNNAME.link.$i.log $RSYSLOG_DYNNAME.input.$i.log
 	printf '%s generated file %s\n' "$(tb_timestamp)" "$i"
-	ls -l rsyslog-link.$i.log
-	set +x
+	ls -l $RSYSLOG_DYNNAME.link.$i.log
 	# wait until this file has been processed
 	content_check_with_count "HEADER msgnum:000000" $i $IMFILECHECKTIMEOUT
 done
 
 ./inputfilegen -m $IMFILELASTINPUTLINES > $RSYSLOG_DYNNAME.input.$((IMFILEINPUTFILES + 1)).log
-ls -l $RSYSLOG_DYNNAME.input.* rsyslog-link.* $RSYSLOG_DYNNAME.targets
+ls -l $RSYSLOG_DYNNAME.input.* $RSYSLOG_DYNNAME.link.* $RSYSLOG_DYNNAME.targets
 
 # Content check with timeout
 content_check_with_count "input.11.log" $IMFILELASTINPUTLINES $IMFILECHECKTIMEOUT


### PR DESCRIPTION
This test sometimes failed. It used a symlinkl to a hardcoded name
rsyslog-link.*.log. This symlink was created but then disappears.
The reason is that upon (every!) test exit, rsyslog-link.*.log is
deleted. So a parallel test running the exit procedure just at the
"right" time can removed that file.

The bug is that the file name should be created using the tests's
dynamic name. This is done now.

closes https://github.com/rsyslog/rsyslog/issues/3550

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
