### PR TITLE
emit info-level success message on lookup table load (startup)

### DIFF
--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -1018,7 +1018,8 @@ lookupTableDefProcessCnf(struct cnfobj *o)
 #endif
 #endif
 	CHKiRet(lookupReadFile(lu->self, lu->name, lu->filename));
-	DBGPRINTF("lookup table '%s' loaded from file '%s'\n", lu->name, lu->filename);
+	LogMsg(0, RS_RET_OK, LOG_INFO, "lookup table '%s' loaded from file '%s'",
+		lu->name, lu->filename);
 
 finalize_it:
 #ifdef HAVE_PTHREAD_SETNAME_NP

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -153,6 +153,7 @@ TESTS +=  \
 	hostname-with-slash-dflt-slash-valid.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
+	glbl-internalmsg_severity-info-shown.sh \
 	glbl-umask.sh \
 	glbl-unloadmodules.sh \
 	glbl-invld-param.sh \
@@ -1394,6 +1395,7 @@ EXTRA_DIST= \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \
 	internal-errmsg-memleak-vg.sh \
+	glbl-internalmsg_severity-info-shown.sh \
 	glbl-oversizeMsg-log-vg.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \

--- a/tests/glbl-internalmsg_severity-info-shown.sh
+++ b/tests/glbl-internalmsg_severity-info-shown.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# check that info-severity messages are actually emitted; we use
+# lookup table as a simple sample to get such a message.
+# addd 2019-05-07 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_platform "FreeBSD"  "Test hangs, as rsyslogd mainloop seems not to be woken when SIGTERM is sent - evaluate root cause later"
+generate_conf
+add_conf '
+global(internalmsg.severity="info")
+lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl" reloadOnHUP="on")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+cp -f $srcdir/testsuites/xlate.lkp_tbl $RSYSLOG_DYNNAME.xlate.lkp_tbl
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "lookup table 'xlate' loaded from file"
+exit_test


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/3639

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
