### PR TITLE
queue subsystem: provide better user status messages

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -228,6 +228,7 @@ TESTS +=  \
 	imtcp-NUL-rawmsg.sh \
 	imtcp-multiport.sh \
 	imtcp_incomplete_frame_at_end.sh \
+	da-queue-persist.sh \
 	daqueue-persist.sh \
 	daqueue-invld-qi.sh \
 	daqueue-dirty-shutdown.sh \
@@ -1861,6 +1862,7 @@ EXTRA_DIST= \
 	queue-encryption-disk_keyfile-vg.sh \
 	queue-encryption-disk_keyprog.sh \
 	queue-encryption-da.sh \
+	da-queue-persist.sh \
 	daqueue-dirty-shutdown.sh \
 	daqueue-invld-qi.sh \
 	daqueue-persist.sh \

--- a/tests/da-queue-persist.sh
+++ b/tests/da-queue-persist.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Test for DA queue data persisting at shutdown. The
+# plan is to start an instance, emit some data, do a relatively
+# fast shutdown and then re-start the engine to process the 
+# remaining data.
+# added 2019-05-08 by Rgerhards
+# This file is part of the rsyslog project, released  under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=10000
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.type="linkedList" queue.filename="mainq"
+	queue.timeoutShutdown="1" queue.saveonshutdown="on")
+
+module(load="../plugins/omtesting/.libs/omtesting")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+else
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.othermsg")
+
+$IncludeConfig '${RSYSLOG_DYNNAME}'work-delay.conf
+'
+
+# prepare config
+echo "*.*     :omtesting:sleep 0 1000" > ${RSYSLOG_DYNNAME}work-delay.conf
+
+startup
+injectmsg 0 $NUMMESSAGES
+shutdown_immediate
+wait_shutdown
+check_mainq_spool
+
+echo "Enter phase 2, rsyslogd restart"
+# note: we may have some few duplicates!
+echo "#" > ${RSYSLOG_DYNNAME}work-delay.conf
+wait_seq_check_with_dupes() {
+	wait_seq_check 0 $((NUMMESSAGES - 1)) -d
+}
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check_with_dupes
+startup
+shutdown_when_empty
+seq_check 0 $((NUMMESSAGES - 1)) -d
+content_check "queue files exist on disk, re-starting with" $RSYSLOG_DYNNAME.othermsg
+exit_test


### PR DESCRIPTION
The queue subsystem now provides additional information messages which
may help a regular user to maintain system healt. Most importantly,
DA queues now output when they persist queue data at end of run and
when they restart the queue based on persisted data.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
