### PR TITLE
change default of internalmsg.severity global parameter, add tests

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -82,7 +82,9 @@ stdlog_channel_t stdlog_hdl = NULL;	/* handle to be used for stdlog */
 #endif
 
 static struct cnfobj *mainqCnfObj = NULL;/* main queue object, to be used later in startup sequence */
-#define DFLT_INT_MSGS_SEV_FILTER 4		 /* Warning level and more important */
+#ifndef DFLT_INT_MSGS_SEV_FILTER
+	#define DFLT_INT_MSGS_SEV_FILTER 6	/* Warning level and more important */
+#endif
 int glblIntMsgsSeverityFilter = DFLT_INT_MSGS_SEV_FILTER;/* filter for logging internal messages by syslog sev. */
 int bProcessInternalMessages = 0;	/* Should rsyslog itself process internal messages?
 					 * 1 - yes

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -154,6 +154,8 @@ TESTS +=  \
 	stop-localvar.sh \
 	stop-msgvar.sh \
 	glbl-internalmsg_severity-info-shown.sh \
+	glbl-internalmsg_severity-debug-shown.sh \
+	glbl-internalmsg_severity-debug-not_shown.sh \
 	glbl-umask.sh \
 	glbl-unloadmodules.sh \
 	glbl-invld-param.sh \
@@ -1396,6 +1398,8 @@ EXTRA_DIST= \
 	operatingstate-unclean.sh \
 	internal-errmsg-memleak-vg.sh \
 	glbl-internalmsg_severity-info-shown.sh \
+	glbl-internalmsg_severity-debug-shown.sh \
+	glbl-internalmsg_severity-debug-not_shown.sh \
 	glbl-oversizeMsg-log-vg.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \

--- a/tests/glbl-internalmsg_severity-debug-not_shown.sh
+++ b/tests/glbl-internalmsg_severity-debug-not_shown.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# check that info-severity messages are actually emitted; we use
+# lookup table as a simple sample to get such a message.
+# addd 2019-05-07 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl" reloadOnHUP="on")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+cp -f $srcdir/testsuites/xlate.lkp_tbl $RSYSLOG_DYNNAME.xlate.lkp_tbl
+startup
+shutdown_when_empty
+wait_shutdown
+check_not_present "rsyslogd fully started up and initialized - begin actual processing"
+exit_test

--- a/tests/glbl-internalmsg_severity-debug-shown.sh
+++ b/tests/glbl-internalmsg_severity-debug-shown.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# check that info-severity messages are actually emitted; we use
+# lookup table as a simple sample to get such a message.
+# addd 2019-05-07 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(internalmsg.severity="debug")
+lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl" reloadOnHUP="on")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+cp -f $srcdir/testsuites/xlate.lkp_tbl $RSYSLOG_DYNNAME.xlate.lkp_tbl
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "rsyslogd fully started up and initialized - begin actual processing"
+exit_test


### PR DESCRIPTION
also fix a problem in handling this parameter when rsyslog processed
internal messages itself (it did not work). As the parameter was
introduced today, we do not flag this follow-up commit as "bugfix".
The issue was noticed when we added the additional tests.

see also https://github.com/rsyslog/rsyslog/issues/3650
see also https://github.com/rsyslog/rsyslog/issues/3639

**This must not be merged before full doc for new feature "internalmsg.severity" is added.**
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
