### PR TITLE
core: harden shutdown processing on FreeBSD

### DIFF
--- a/tests/glbl-internalmsg_severity-info-shown.sh
+++ b/tests/glbl-internalmsg_severity-info-shown.sh
@@ -3,7 +3,6 @@
 # lookup table as a simple sample to get such a message.
 # addd 2019-05-07 by RGerhards, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-skip_platform "FreeBSD"  "Test hangs, as rsyslogd mainloop seems not to be woken when SIGTERM is sent - evaluate root cause later"
 generate_conf
 add_conf '
 global(internalmsg.severity="info")

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -73,6 +73,7 @@ static int emitTZWarning = 0;
 #else
 static int emitTZWarning = 1;
 #endif
+static pthread_t mainthread = 0;
 
 #if defined(_AIX)
 /* AIXPORT : start
@@ -1792,13 +1793,13 @@ rsyslogdDoDie(int sig)
 	static int iRetries = 0; /* debug aid */
 	dbgprintf(MSG1);
 	if(Debug == DEBUG_FULL) {
-		if(write(1, MSG1, sizeof(MSG1) - 1)) {
+		if(write(1, MSG1, sizeof(MSG1) - 1) == -1) {
 			dbgprintf("%s:%d: write failed\n", __FILE__, __LINE__);
 		}
 	}
 	if(iRetries++ == 4) {
 		if(Debug == DEBUG_FULL) {
-			if(write(1, MSG2, sizeof(MSG2) - 1)) {
+			if(write(1, MSG2, sizeof(MSG2) - 1) == -1) {
 				dbgprintf("%s:%d: write failed\n", __FILE__, __LINE__);
 			}
 		}
@@ -1814,6 +1815,11 @@ rsyslogdDoDie(int sig)
 	}
 #	undef MSG1
 #	undef MSG2
+	/* at least on FreeBSD we seem not to necessarily awake the main thread.
+	 * So let's do it explicitely.
+	 */
+	dbgprintf("awaking mainthread\n");
+	pthread_kill(mainthread, SIGTTIN);
 }
 
 
@@ -2083,6 +2089,7 @@ main(int argc, char **argv)
 		}
 #endif
 
+	mainthread = pthread_self();
 	if((int) getpid() == 1) {
 		fprintf(stderr, "rsyslogd %s: running as pid 1, enabling "
 			"container-specific defaults, press ctl-c to "


### PR DESCRIPTION
root cause seems to be that SIGTERM is delivered differently under
FreeBSD. This causes the main thread to not be awaken, and so it
takes until the next janitor interval to come back to life - which
can be far too long. Fixed this bug explicitley awaking the main
thread.

also

* re-enable test that did not work because of this
* fix invalid message on SIGTERM in debug log

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
