### PR TITLE
global config: new parameters for ruleset queue defaults

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -219,6 +219,10 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "default.action.queue.timeoutactioncompletion", eCmdHdlrInt, 0 },
 	{ "default.action.queue.timeoutenqueue", eCmdHdlrInt, 0 },
 	{ "default.action.queue.timeoutworkerthreadshutdown", eCmdHdlrInt, 0 },
+	{ "default.ruleset.queue.timeoutshutdown", eCmdHdlrInt, 0 },
+	{ "default.ruleset.queue.timeoutactioncompletion", eCmdHdlrInt, 0 },
+	{ "default.ruleset.queue.timeoutenqueue", eCmdHdlrInt, 0 },
+	{ "default.ruleset.queue.timeoutworkerthreadshutdown", eCmdHdlrInt, 0 },
 	{ "reverselookup.cache.ttl.default", eCmdHdlrNonNegInt, 0 },
 	{ "reverselookup.cache.ttl.enable", eCmdHdlrBinary, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
@@ -1478,6 +1482,14 @@ glblDoneLoadCnf(void)
 			actq_dflt_toEnq = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.action.queue.timeoutworkerthreadshutdown")) {
 			actq_dflt_toWrkShutdown = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutshutdown")) {
+			ruleset_dflt_toQShutdown = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutactioncompletion")) {
+			ruleset_dflt_toActShutdown = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutenqueue")) {
+			ruleset_dflt_toEnq = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutworkerthreadshutdown")) {
+			ruleset_dflt_toWrkShutdown = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "reverselookup.cache.ttl.default")) {
 			dnscacheDefaultTTL = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "reverselookup.cache.ttl.enable")) {

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -90,6 +90,11 @@ int actq_dflt_toActShutdown = 1000;	/* action shutdown (in phase 2) */
 int actq_dflt_toEnq = 2000;		/* timeout for queue enque */
 int actq_dflt_toWrkShutdown = 60000;	/* timeout for worker thread shutdown */
 
+int ruleset_dflt_toQShutdown = 1500;	/* queue shutdown */
+int ruleset_dflt_toActShutdown = 1000;	/* action shutdown (in phase 2) */
+int ruleset_dflt_toEnq = 2000;		/* timeout for queue enque */
+int ruleset_dflt_toWrkShutdown = 60000;	/* timeout for worker thread shutdown */
+
 
 /* forward-definitions */
 static rsRetVal doEnqSingleObj(qqueue_t *pThis, flowControl_t flowCtlType, smsg_t *pMsg);
@@ -1566,10 +1571,10 @@ qqueueSetDefaultsRulesetQueue(qqueue_t *pThis)
 	pThis->iMaxFileSize = 16*1024*1024;
 	pThis->iPersistUpdCnt = 0;		/* persist queue info every n updates */
 	pThis->bSyncQueueFiles = 0;
-	pThis->toQShutdown = 1500;			/* queue shutdown */
-	pThis->toActShutdown = 1000;		/* action shutdown (in phase 2) */
-	pThis->toEnq = 2000;			/* timeout for queue enque */
-	pThis->toWrkShutdown = 60000;		/* timeout for worker thread shutdown */
+	pThis->toQShutdown = ruleset_dflt_toQShutdown;
+	pThis->toActShutdown = ruleset_dflt_toActShutdown;
+	pThis->toEnq = ruleset_dflt_toEnq;
+	pThis->toWrkShutdown = ruleset_dflt_toWrkShutdown;
 	pThis->iMinMsgsPerWrkr = -1;		/* minimum messages per worker needed to start a new one */
 	pThis->bSaveOnShutdown = 1;		/* save queue on shutdown (when DA enabled)? */
 	pThis->sizeOnDiskMax = 0;		/* unlimited */

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -1,6 +1,6 @@
 /* Definition of the queue support module.
  *
- * Copyright 2008 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2019 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -241,6 +241,11 @@ extern int actq_dflt_toQShutdown;
 extern int actq_dflt_toActShutdown;
 extern int actq_dflt_toEnq;
 extern int actq_dflt_toWrkShutdown;
+
+extern int ruleset_dflt_toQShutdown;
+extern int ruleset_dflt_toActShutdown;
+extern int ruleset_dflt_toEnq;
+extern int ruleset_dflt_toWrkShutdown;
 
 #ifdef ENABLE_IMDIAG
 extern unsigned int iOverallQueueSize;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -153,6 +153,7 @@ TESTS +=  \
 	hostname-with-slash-dflt-slash-valid.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
+	glbl-ruleset-queue-defaults.sh \
 	glbl-internalmsg_severity-info-shown.sh \
 	glbl-internalmsg_severity-debug-shown.sh \
 	glbl-internalmsg_severity-debug-not_shown.sh \
@@ -1398,6 +1399,7 @@ EXTRA_DIST= \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \
 	internal-errmsg-memleak-vg.sh \
+	glbl-ruleset-queue-defaults.sh \
 	glbl-internalmsg_severity-info-shown.sh \
 	glbl-internalmsg_severity-debug-shown.sh \
 	glbl-internalmsg_severity-debug-not_shown.sh \

--- a/tests/glbl-ruleset-queue-defaults.sh
+++ b/tests/glbl-ruleset-queue-defaults.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# check that global ruleset queue defaults can be specified. However,
+# we do not tests that they actually work - that's quite hard to
+# do reliably.
+# addd 2019-05-09 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global( default.ruleset.queue.timeoutshutdown="1000"
+	default.ruleset.queue.timeoutactioncompletion="1000"
+	default.ruleset.queue.timeoutenqueue="1000"
+	default.ruleset.queue.timeoutworkerthreadshutdown="1000"
+	)
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+cp -f $srcdir/testsuites/xlate.lkp_tbl $RSYSLOG_DYNNAME.xlate.lkp_tbl
+startup
+shutdown_when_empty
+wait_shutdown
+check_not_present 'parameter.*not known'
+exit_test


### PR DESCRIPTION
specifically:

* default.ruleset.queue.timeoutshutdown
* default.ruleset.queue.timeoutactioncompletion
* default.ruleset.queue.timeoutenqueue
* default.ruleset.queue.timeoutworkerthreadshutdown

closes https://github.com/rsyslog/rsyslog/issues/3656

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
