### PR TITLE
bugfix: error messages if config.enabled="off" is used

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1156,7 +1156,7 @@ done:	return r;
  * it is the caller's duty to free it when no longer needed.
  * NULL is returned on error, otherwise a pointer to the vals array.
  */
-struct cnfparamvals*
+struct cnfparamvals* ATTR_NONNULL(2)
 nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 	       struct cnfparamvals *vals)
 {
@@ -1213,8 +1213,12 @@ nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 	if((valnode = nvlstFindNameCStr(lst, "config.enabled")) != NULL) {
 		if(es_strbufcmp(valnode->val.d.estr, (unsigned char*) "on", 2)) {
 			dbgprintf("config object disabled by configuration\n");
-			valnode->bUsed = 1;
+			/* flag all params as used to not emit error mssages */
 			bInError = 1;
+			struct nvlst *val;
+			for(val = lst; val != NULL ; val = val->next) {
+				val->bUsed = 1;
+			}
 		}
 	}
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1283,7 +1283,8 @@ TESTS += \
 	imfile-logrotate-copytruncate.sh \
 	imfile-logrotate-nocopytruncate.sh \
 	imfile-growing-file-id.sh \
-	glbl-oversizeMsg-truncate-imfile.sh
+	glbl-oversizeMsg-truncate-imfile.sh \
+	config_enabled-off.sh
 
 if ENABLE_MMNORMALIZE
 TESTS += \
@@ -1404,6 +1405,7 @@ EXTRA_DIST= \
 	glbl-internalmsg_severity-debug-shown.sh \
 	glbl-internalmsg_severity-debug-not_shown.sh \
 	glbl-oversizeMsg-log-vg.sh \
+	config_enabled-off.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
 	hostname-with-slash-pmrfc5424.sh \

--- a/tests/config_enabled-off.sh
+++ b/tests/config_enabled-off.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# check disabling a config construct via config.enable. Most
+# importantly ensure that it does not emit any error messages
+# for object parameters.
+# addd 2019-05-09 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imfile/.libs/imfile")
+input(type="imfile" file="/tmp/notyet.txt" tag="testing-tag" config.enabled="off")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+check_not_present 'parameter .* not known'
+exit_test


### PR DESCRIPTION
Using config.enabled="off" could lead to error messages on
"parameter xxx not known", which were invalid. They occured
because the config handler expected them to be used, which
was not the case due to being disabled.

This commit fixes that issue.

closes https://github.com/rsyslog/rsyslog/issues/2520

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
