### PR TITLE
testbench: renable test hostname-getaddrinfo-fail.sh

### DIFF
--- a/tests/hostname-getaddrinfo-fail.sh
+++ b/tests/hostname-getaddrinfo-fail.sh
@@ -15,9 +15,6 @@
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "AIX" "we cannot preload required dummy lib"
-skip_platform "SunOS" "there seems to be an issue with LD_PRELOAD libraries"
-skip_platform "FreeBSD" "temporarily disabled until we know what is wrong, \
-see https://github.com/rsyslog/rsyslog/issues/2833"
 
 echo 'action(type="omfile" file="'$RSYSLOG_DYNNAME'.out.log")' > ${RSYSLOG_DYNNAME}.conf 
 LD_PRELOAD=".libs/liboverride_gethostname_nonfqdn.so:.libs/liboverride_getaddrinfo.so" \
@@ -28,7 +25,7 @@ kill $(cat $RSYSLOG_DYNNAME.pid )
 
 grep " nonfqdn " < $RSYSLOG_DYNNAME.out.log
 if [ ! $? -eq 0 ]; then
-  echo "expected hostnaame \"nonfqdn\" not found in logs, $RSYSLOG_DYNNAME.out.log is:"
+  echo "expected hostname \"nonfqdn\" not found in logs, $RSYSLOG_DYNNAME.out.log is:"
   cat $RSYSLOG_DYNNAME.out.log
   error_exit 1
 fi;


### PR DESCRIPTION
root problem cause was fixed by recent comment, so now we can
use it again on these platforms.

closes https://github.com/rsyslog/rsyslog/issues/2833

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
