### PR TITLE
testsuite: Fixed wrong parameter check in diag.sh (tcpflood())

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1284,15 +1284,15 @@ tcpflood() {
 	res=$?
 	if [ "$check_only" == "yes" ]; then
 		if [ "$res" -ne "0" ]; then
+			echo "error during tcpflood on port ${TCPFLOOD_PORT}! But test continues..."
+		fi
+		return 0
+	else
+		if [ "$res" -ne "0" ]; then
 			echo "error during tcpflood on port ${TCPFLOOD_PORT}! see ${RSYSLOG_OUT_LOG}.save for what was written"
 			cp ${RSYSLOG_OUT_LOG} ${RSYSLOG_OUT_LOG}.save
 			error_exit 1 stacktrace
 		fi
-	else
-		if [ "$res" -ne "0" ]; then
-			echo "error during tcpflood on port ${TCPFLOOD_PORT}! But test continues..."
-		fi
-		return 0
 	fi
 }
 

--- a/tests/imtcp-tls-ossl-basic-tlscommands.sh
+++ b/tests/imtcp-tls-ossl-basic-tlscommands.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
-echo FIXME! Rainer knowns the problem cause
-exit 77
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=10
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"


### PR DESCRIPTION
When first parameter is check_only, the tcpflood funtion shall not
abort the test itself (The fail is intended if this option is set).

closes issue https://github.com/rsyslog/rsyslog/issues/3625