### PR TITLE
template: add datatype template option for JSON generation

### DIFF
--- a/template.h
+++ b/template.h
@@ -133,6 +133,15 @@ struct templateEntry {
 				unsigned bFromPosEndRelative: 1;/* is From/To-Pos relative to end of string? */
 				unsigned bFixedWidth: 1;	/* space pad to toChar if string is shorter */
 				unsigned bDateInUTC: 1;		/* should date be expressed in UTC? */
+				#define TPE_DATATYPE_STRING 0
+				#define TPE_DATATYPE_NUMBER 1
+				#define TPE_DATATYPE_BOOL 2
+				#define TPE_DATATYPE_AUTO 3 /* NOTE: bit field values exhausted! */
+				unsigned dataType: 2;
+				#define TPE_DATAEMPTY_KEEP 0
+				#define TPE_DATAEMPTY_SKIP 1
+				#define TPE_DATAEMPTY_NULL 2
+				unsigned onEmpty: 2;
 			} options;		/* options as bit fields */
 		} field;
 	} data;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -180,6 +180,7 @@ TESTS +=  \
 	privdropuserid.sh \
 	privdropgroup.sh \
 	privdropgroupid.sh \
+	json-nonstring.sh \
 	template-json.sh \
 	template-pure-json.sh \
 	template-pos-from-to.sh \
@@ -1629,6 +1630,7 @@ EXTRA_DIST= \
 	privdropuserid.sh \
 	privdropgroup.sh \
 	privdropgroupid.sh \
+	json-nonstring.sh \
 	template-json.sh \
 	template-pure-json.sh \
 	template-pos-from-to.sh \

--- a/tests/json-nonstring.sh
+++ b/tests/json-nonstring.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released  under ASL 2.0
+# written 2019-05-10 by Rainer Gerhards
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="json" type="list" option.jsonf="on") {
+	property(outname="number_0" format="jsonf" name="$!val0" datatype="number")
+	property(outname="bool_0" format="jsonf" name="$!val0" datatype="bool")
+
+	property(outname="empty" format="jsonf" name="$!empty" datatype="auto")
+	property(outname="empty_skip" format="jsonf" name="$!empty" onEmpty="skip")
+	property(outname="empty_null" format="jsonf" name="$!empty" onEmpty="null")
+	property(outname="empty_number" format="jsonf" name="$!empty" datatype="number")
+
+	property(outname="auto_string" format="jsonf" name="$!string" datatype="auto")
+
+	property(outname="auto" format="jsonf" name="$!val" datatype="auto" onEmpty="null")
+	property(outname="number" format="jsonf" name="$!val" datatype="number")
+	property(outname="bool" format="jsonf" name="$!val" datatype="bool")
+	property(outname="string" format="jsonf" name="$!val" datatype="string")
+	property(outname="no_datatype" format="jsonf" name="$!val")
+}
+
+set $!val0 = 0;
+set $!val = 42;
+set $!empty = "";
+set $!string = "1.2.3.4";
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="json")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check '{"number_0":0, "bool_0":false, "empty":"", "empty_null":null, "empty_number":0, "auto_string":"1.2.3.4", "auto":42, "number":42, "bool":true, "string":"42", "no_datatype":"42"}'
+check_not_present 'empty_skip'
+exit_test


### PR DESCRIPTION
The new "datatype" template option permits to generate non-string
data rather easily. It works together with jsonf formatting, which
is what people should use nowadays.

closes https://github.com/rsyslog/rsyslog/issues/2827

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
