### PR TITLE
testbench: test for leading space issue in RFC 5424 parser

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -201,6 +201,7 @@ TESTS +=  \
 	fac_invld2.sh \
 	fac_invld3.sh \
 	fac_invld4_rfc5424.sh \
+	rfc5424parser-sp_at_msg_start.sh \
 	compresssp.sh \
 	compresssp-stringtpl.sh \
 	rawmsg-after-pri.sh \
@@ -1537,6 +1538,7 @@ EXTRA_DIST= \
 	timestamp-subseconds.sh \
 	rsf_getenv.sh \
 	diskq-rfc5424.sh \
+	rfc5424parser-sp_at_msg_start.sh \
 	diskqueue-full.sh \
 	diskqueue.sh \
 	diskqueue-non-unique-prefix.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -539,15 +539,18 @@ startup_vgthread() {
 # inject messages via our inject interface (imdiag)
 # $1 is start message number, env var NUMMESSAGES is number of messages to inject
 injectmsg() {
+	if [ "$3" != "" ] ; then
+		printf 'error: injectmsg only has two arguments, extra arg is %s\n' "$3"
+	fi
 	msgs=${2:-$NUMMESSAGES}
 	echo injecting $msgs messages
-	echo injectmsg ${1:-0} $msgs $3 $4 | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
+	echo injectmsg "${1:-0}" "$msgs" | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
 }
 
 # inject messages in INSTANCE 2 via our inject interface (imdiag)
 injectmsg2() {
 	echo injecting $2 messages
-	echo injectmsg $1 $2 $3 $4 | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT2 || error_exit  $?
+	echo injectmsg "$1" "$2" $3 $4 | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT2 || error_exit  $?
 	# TODO: some return state checking? (does it really make sense here?)
 }
 

--- a/tests/omrabbitmq_error_server0.sh
+++ b/tests/omrabbitmq_error_server0.sh
@@ -36,16 +36,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
-echo $EXPECTED | cmp - $RSYSLOG_DYNNAME.amqp.log
-if [ ! $? -eq 0 ]; then
-  echo "Expected:"
-  echo $EXPECTED
-  echo "invalid response generated, $RSYSLOG_DYNNAME.amqp.log is:"
-  cat $RSYSLOG_DYNNAME.amqp.log
-  echo "Rsyslog internal output log:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "exchange declare failed PRECONDITION_FAILED"
 exit_test

--- a/tests/omrabbitmq_error_server1.sh
+++ b/tests/omrabbitmq_error_server1.sh
@@ -36,16 +36,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
-echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
-if [ ! $? -eq 0 ]; then
-  echo "Expected:"
-  echo ${expected}
-  echo "invalid response generated, $RSYSLOG_DYNNAME.amqp.log is:"
-  cat $RSYSLOG_DYNNAME.amqp.log
-  echo "Rsyslog internal output log:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "disconnected while exchange declare"
 exit_test

--- a/tests/omrabbitmq_error_server2.sh
+++ b/tests/omrabbitmq_error_server2.sh
@@ -36,16 +36,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
-echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
-if [ ! $? -eq 0 ]; then
-  echo "Expected:"
-  echo ${expected}
-  echo "invalid response generated, $RSYSLOG_DYNNAME.amqp.log is:"
-  cat $RSYSLOG_DYNNAME.amqp.log
-  echo "Rsyslog internal output log:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "Connection closed : reconnect"
 exit_test

--- a/tests/omrabbitmq_error_server3.sh
+++ b/tests/omrabbitmq_error_server3.sh
@@ -35,16 +35,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
-echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
-if [ ! $? -eq 0 ]; then
-  echo "Expected:"
-  echo ${expected}
-  echo "invalid response generated, $RSYSLOG_DYNNAME.amqp.log is:"
-  cat $RSYSLOG_DYNNAME.amqp.log
-  echo "Rsyslog internal output log:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "Connection closed : reconnect"
 exit_test

--- a/tests/omrabbitmq_raw.sh
+++ b/tests/omrabbitmq_raw.sh
@@ -34,16 +34,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
-echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
-if [ ! $? -eq 0 ]; then
-  echo "Expected:"
-  echo ${expected}
-  echo "invalid response generated, $RSYSLOG_DYNNAME.amqp.log is:"
-  cat $RSYSLOG_DYNNAME.amqp.log
-  echo "Rsyslog internal output log:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "server localhost port"
 exit_test

--- a/tests/rfc5424parser-sp_at_msg_start.sh
+++ b/tests/rfc5424parser-sp_at_msg_start.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# checks that in RFC5424 mode SP at beginning of MSG part is properly handled
+# This file is part of the rsyslog project, released  under ASL 2.0
+# rgerhards, 2019-05-17
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%--END\n")
+
+if $syslogtag == "tag" then
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg litteral '<13>1 2019-05-15T11:21:57+03:00 domain.tld tag - - - nosd-nosp'
+injectmsg litteral '<13>1 2019-05-15T11:21:57+03:00 domain.tld tag - - [abc@123 a="b"] sd-nosp'
+injectmsg litteral '<13>1 2019-05-15T11:21:57+03:00 domain.tld tag - - -  nosd-sp'
+injectmsg litteral '<13>1 2019-05-15T11:21:57+03:00 domain.tld tag - - [abc@123 a="b"]  sd-sp'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='nosd-nosp--END
+sd-nosp--END
+ nosd-sp--END
+ sd-sp--END'
+cmp_exact
+exit_test


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/pull/3671
see also https://github.com/rsyslog/rsyslog/pull/3667

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
