### PR TITLE
core bugfix: segfault on startup depending on queue file names

### DIFF
--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -635,7 +635,6 @@ static inline rsRetVal
 tellCoreConfigLoadDone(void)
 {
 	DBGPRINTF("telling rsyslog core that config load for %p is done\n", loadConf);
-	qqueueDoneLoadCnf();
 	return glblDoneLoadCnf();
 }
 
@@ -878,6 +877,7 @@ activate(rsconf_t *cnf)
 	CHKiRet(activateMainQueue());
 	/* finally let the inputs run... */
 	runInputModules();
+	qqueueDoneLoadCnf(); /* we no longer need config-load-only data structures */
 
 	dbgprintf("configuration %p activated\n", cnf);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -214,6 +214,7 @@ TESTS +=  \
 	tcp_forwarding_tpl.sh \
 	tcp_forwarding_dflt_tpl.sh \
 	tcp_forwarding_retries.sh \
+	mainq_actq_DA.sh \
 	queue_errmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \
@@ -1465,6 +1466,7 @@ EXTRA_DIST= \
 	tcp_forwarding_ns_tpl.sh \
 	tcp_forwarding_dflt_tpl.sh \
 	tcp_forwarding_retries.sh \
+	mainq_actq_DA.sh \
 	queue_errmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \

--- a/tests/mainq_actq_DA.sh
+++ b/tests/mainq_actq_DA.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Test to check that mainq and actionq can be disk assisted without
+# any problems. This was created to reproduce a segfault issue:
+# https://github.com/rsyslog/rsyslog/issues/3681
+# added 2019-06-03 by rgerhards
+# This file is part of the rsyslog project, released  under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=10	# we just need a handful - we primarily test startup
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+main_queue(queue.fileName="main" queue.type="LinkedList")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:"
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt"
+		queue.type="linkedList" queue.fileName="action")
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown 
+seq_check
+exit_test


### PR DESCRIPTION
rsyslog will segfault on startup when a main queue file name has
been set and at least on other queue contains a file name. This
was cased by too-early freeing config error-detection data
structures. It is a regression caused by commit e22fb205a3.

Thanks to Wade Simmons for reporting this issue and providing
detailled analysis. That greatly helps fixing it quickly.

closes https://github.com/rsyslog/rsyslog/issues/3681

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
