### PR TITLE
Fix for: CONTRIBUTING.md broken link #3673

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ These are many ways to contribute to the project:
    * the rsyslog's github home at https://github.com/rsyslog/rsyslog
    * the rsyslog mailing list at http://lists.adiscon.net/mailman/listinfo/rsyslog
  * help with the documentation; you can either contribute
-   * to the [rsyslog doc directory](https://github.com/rsyslog/rsyslog/tree/master/doc), which is shown on http://rsyslog.com/doc
+   * to the [rsyslog doc directory](https://github.com/rsyslog/rsyslog-doc), which is shown on http://rsyslog.com/doc
    * to the rsyslog project web site -- just ask us for account creation
  * become a bug-hunter and help with testing rsyslog development releases
  * help driving the rsyslog infrastructure with its web sites and the like


### PR DESCRIPTION
https://github.com/rsyslog/rsyslog/issues/3673

Changed the link to point to https://github.com/rsyslog/rsyslog-doc


<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
