### PR TITLE
queue subsystem bugfix: oversize queue warning message shown as error

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3342,7 +3342,7 @@ qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst)
 		} else if(!strcmp(pblk.descr[i].name, "queue.size")) {
 			pThis->iMaxQueueSize = pvals[i].val.d.n;
 			if(pThis->iMaxQueueSize > OVERSIZE_QUEUE_WATERMARK) {
-				parser_errmsg("queue.size=%d is very large - is this "
+				parser_warnmsg("queue.size=%d is very large - is this "
 					"really intended? More info at "
 					"https://www.rsyslog.com/avoid-overly-large-in-memory-queues/",
 					pThis->iMaxQueueSize);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -215,7 +215,7 @@ TESTS +=  \
 	tcp_forwarding_dflt_tpl.sh \
 	tcp_forwarding_retries.sh \
 	mainq_actq_DA.sh \
-	queue_errmsg-oversize.sh \
+	queue_warnmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \
 	arrayqueue.sh \
@@ -1491,7 +1491,7 @@ EXTRA_DIST= \
 	tcp_forwarding_dflt_tpl.sh \
 	tcp_forwarding_retries.sh \
 	mainq_actq_DA.sh \
-	queue_errmsg-oversize.sh \
+	queue_warnmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \
 	killrsyslog.sh \

--- a/tests/queue_warnmsg-oversize.sh
+++ b/tests/queue_warnmsg-oversize.sh
@@ -10,6 +10,6 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'"
 startup
 shutdown_when_empty
 wait_shutdown
-content_check "queue.size=500001 is very large"
+content_check --regex "warning.*queue.size=500001 is very large"
 
 exit_test


### PR DESCRIPTION
The warning message was emitted as an error message, which is misleading
and may also break some automatted procedures.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
