### PR TITLE
imfile: remove no longe needed debug info

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -683,11 +683,6 @@ checkTruncation(strm_t *const pThis)
 		FINALIZE;
 	}
 
-	if(Debug && debugging_on) { /* costly operation, so make sure we need it */
-		dbgprintf("checkTruncation, currpos %lld\n",
-			(long long) lseek(pThis->fd, 0, SEEK_CUR));
-	}
-
 	const off64_t backseek = -1 * (off64_t) pThis->iBufPtrMax;
 	ret = lseek64(pThis->fd, backseek, SEEK_CUR);
 	if(ret < 0) {


### PR DESCRIPTION
This was originally added as aid to solve potential regressions.
But now it looks good for a while and we remove some of it as
it really is overdone.

Note: some other debug messages had already be removed, so this
closes https://github.com/rsyslog/rsyslog/issues/3046

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
