### PR TITLE
testbench: fix tests affected by commit 8791323c92039

### DIFF
--- a/tests/omrabbitmq_error_server0.sh
+++ b/tests/omrabbitmq_error_server0.sh
@@ -36,7 +36,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar 1 01:00:00 172.20.245.8 tag msgrmq')
+export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
 echo $EXPECTED | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_error_server1.sh
+++ b/tests/omrabbitmq_error_server1.sh
@@ -36,7 +36,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar 1 01:00:00 172.20.245.8 tag msgrmq')
+expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
 echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_error_server2.sh
+++ b/tests/omrabbitmq_error_server2.sh
@@ -36,7 +36,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar 1 01:00:00 172.20.245.8 tag msgrmq')
+expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
 echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_error_server3.sh
+++ b/tests/omrabbitmq_error_server3.sh
@@ -35,7 +35,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar 1 01:00:00 172.20.245.8 tag msgrmq')
+expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
 echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_raw.sh
+++ b/tests/omrabbitmq_raw.sh
@@ -34,7 +34,7 @@ startup
 injectmsg litteral "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar 1 01:00:00 172.20.245.8 tag msgrmq')
+expected=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq')
 echo ${expected} | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"


### PR DESCRIPTION
commit 8791323c92039 fixed invalid handling of first space in MSG.
This broke some test, but was not detected at the time of its merge.
This is now fixed with this follow-up commit.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
