### PR TITLE
omfile: fix potential hang/segfault on HUP of dynafile action

### DIFF
--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -505,7 +505,9 @@ dynaFileFreeCacheEntries(instanceData *__restrict__ const pData)
 	for(i = 0 ; i < pData->iCurrCacheSize ; ++i) {
 		dynaFileDelCacheEntry(pData, i, 1);
 	}
-	pData->iCurrElt = -1; /* invalidate current element */
+	/* invalidate current element */
+	pData->iCurrElt = -1;
+	pData->pStrm = NULL;
 }
 
 


### PR DESCRIPTION
when omfile was HUPed it did not sufficiently clear all dynafile
cache maintenance data structures. This usually lead to misadressing
and could result in various issues, including a hang of rsyslog
processing or segfaults. It could also have "no effect" by pure
luck of not hitting anything important. This actually seems to
have been the most frequent case.

This seems to be a long-standing bug, but the likelyhood of its
appearance seems to have been increased by commit 62fbef7
introduced in 8.1905. Note: the commit itself has no regression,
just increases the likelyhood to trigger the pre-existing bug.

special thanks to Alexandre Guédon for his help in analyzing
the issue - without him, we would probably still not know
what actually went wrong.

closes https://github.com/rsyslog/rsyslog/issues/3686

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
