### PR TITLE
testbench framework: use ip tool instead of outdated ifconfig

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2215,10 +2215,16 @@ case $1 in
 		;;
 
    'check-ipv6-available')   # check if IPv6  - will exit 77 when not OK
-		ifconfig -a |grep ::1
+		if ip address > /dev/null ; then
+			cmd="ip address"
+		else
+			cmd="ifconfig -a"
+		fi
+		echo command used for ipv6 detection: $cmd
+		$cmd | grep ::1 > /dev/null
 		if [ $? -ne 0 ] ; then
 			printf 'this test requires an active IPv6 stack, which we do not have here\n'
-			exit 77
+			error_exit 77
 		fi
 		;;
    'kill-immediate') # kill rsyslog unconditionally


### PR DESCRIPTION
The framework now first checks if "ip" is available and falls back
to "ifconfig" only if this is not the case.

Thanks to Michael Biebl for the suggestion.

closes https://github.com/rsyslog/rsyslog/issues/3682

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
