### PR TITLE
core bugfix: message duplication copied incorrect timestamp

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1115,7 +1115,7 @@ smsg_t* MsgDup(smsg_t* pOld)
 	pNew->iFacility = pOld->iFacility;
 	pNew->msgFlags = pOld->msgFlags;
 	pNew->iProtocolVersion = pOld->iProtocolVersion;
-	pNew->ttGenTime = pOld->ttGenTime;
+	pNew->tRcvdAt = pOld->tRcvdAt;
 	pNew->offMSG = pOld->offMSG;
 	pNew->iLenRawMsg = pOld->iLenRawMsg;
 	pNew->iLenMSG = pOld->iLenMSG;


### PR DESCRIPTION
MsgDup() placed timereported into timegenerated property, resulting
in invalid property values. Orignal timegenerated was lost. This
occured always when a message needed to be duplicated. Most
importantly this is the case when queues are used.

closes https://github.com/rsyslog/rsyslog/issues/3716

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
