### PR TITLE
omclickhouse: fix segfault on omclickhouse batchmode

### DIFF
--- a/plugins/omclickhouse/omclickhouse.c
+++ b/plugins/omclickhouse/omclickhouse.c
@@ -431,8 +431,9 @@ computeBulkMessage(const wrkrInstanceData_t *const pWrkrData,
 	const uchar *const message, char **newMessage)
 {
 	size_t r = 0;
-	if(pWrkrData->batch.nmemb != 0) {
-		*newMessage = strchr(strstr((const char*)message, "VALUES"), '(');
+	char *v;
+	if(pWrkrData->batch.nmemb != 0 && (v = strstr((const char *)message, "VALUES")) != NULL) {
+		*newMessage = strchr(v, '(');
 		r = strlen(*newMessage);
 	} else {
 		*newMessage = (char*)message;

--- a/plugins/omclickhouse/omclickhouse.c
+++ b/plugins/omclickhouse/omclickhouse.c
@@ -432,8 +432,11 @@ computeBulkMessage(const wrkrInstanceData_t *const pWrkrData,
 {
 	size_t r = 0;
 	char *v;
-	if(pWrkrData->batch.nmemb != 0 && (v = strstr((const char *)message, "VALUES")) != NULL) {
-		*newMessage = strchr(v, '(');
+	if (pWrkrData->batch.nmemb != 0
+	&& (v = strstr((const char *)message, "VALUES")) != NULL
+	&& (v = strchr(v, '(')) != NULL
+	) {
+		*newMessage = v;
 		r = strlen(*newMessage);
 	} else {
 		*newMessage = (char*)message;


### PR DESCRIPTION
omclickhouse use ` strchr(strstr(message,"VALUES ") ` when building the batch sql. But the message may not contains `VALUES`, then it segfault.  
This commit fix that . It will continue build the batch sql, and then report errors by clickhouse's return message. 