### PR TITLE
imuxsock: support FreeBSD 12 out of the box

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -44,6 +44,9 @@
 #ifdef HAVE_LIBSYSTEMD
 #	include <systemd/sd-daemon.h>
 #endif
+#if defined(__FreeBSD__)
+	#include <sys/param.h>
+#endif
 #include "rsyslog.h"
 #include "dirty.h"
 #include "cfsysline.h"
@@ -173,6 +176,11 @@ static int nfd = 1; /* number of active unix sockets  (socket 0 is always reserv
 			socket, even if it is not enabled. */
 static int sd_fds = 0;			/* number of systemd activated sockets */
 
+#if (defined(__FreeBSD__) && (__FreeBSD_version >= 1200061))
+	#define DFLT_bUseSpecialParser 0
+#else
+	#define DFLT_bUseSpecialParser 1
+#endif
 #define DFLT_bCreatePath 0
 #define DFLT_ratelimitInterval 0
 #define DFLT_ratelimitBurst 200
@@ -320,7 +328,7 @@ createInstance(instanceConf_t **pinst)
 	inst->ratelimitBurst = DFLT_ratelimitBurst;
 	inst->ratelimitSeverity = DFLT_ratelimitSeverity;
 	inst->bUseFlowCtl = 0;
-	inst->bUseSpecialParser = 1;
+	inst->bUseSpecialParser = DFLT_bUseSpecialParser;
 	inst->bParseHost = UNSET;
 	inst->bIgnoreTimestamp = 1;
 	inst->bCreatePath = DFLT_bCreatePath;
@@ -1240,7 +1248,7 @@ CODESTARTbeginCnfLoad
 	pModConf->bAnnotateSysSock = 0;
 	pModConf->bParseTrusted = 0;
 	pModConf->bParseHost = UNSET;
-	pModConf->bUseSpecialParser = 1;
+	pModConf->bUseSpecialParser = DFLT_bUseSpecialParser;
 	/* if we do not process internal messages, we will see messages
 	 * from ourselves, and so we need to permit this.
 	 */


### PR DESCRIPTION
FreeBSD 12 uses RFC5424 on the system log socket by default. This
format is not supported by the special parser used in imuxsock.
Thus for FreeBSD the default needs to be changed to use the
regular parser chain by default. That is all this commit does.

Note: the code was merged untested, as we currently do not have
a matching CI environment. If it does not work, please report.

closes https://github.com/rsyslog/rsyslog/issues/3694

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
