### PR TITLE
function bugfix: "ipv42num" misspelled as "ip42mum" (without "v")

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3558,6 +3558,7 @@ static struct scriptFunct functions[] = {
 	{"cstr", 1, 1, doFunct_CStr, NULL, NULL},
 	{"cnum", 1, 1, doFunct_CNum, NULL, NULL},
 	{"ip42num", 1, 1, doFunct_Ipv42num, NULL, NULL},
+	{"ipv42num", 1, 1, doFunct_Ipv42num, NULL, NULL},
 	{"re_match", 2, 2, doFunct_ReMatch, initFunc_re_match, regex_destruct},
 	{"re_extract", 5, 5, doFunc_re_extract, initFunc_re_match, regex_destruct},
 	{"field", 3, 3, doFunct_Field, NULL, NULL},

--- a/tests/rscript_ipv42num.sh
+++ b/tests/rscript_ipv42num.sh
@@ -6,27 +6,32 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="'$TCPFLOOD_PORT'")
 
-set $!ip!v1 = ip42num("0.0.0.0");
-set $!ip!v2 = ip42num("0.0.0.1");
-set $!ip!v3 = ip42num("0.0.1.0");
-set $!ip!v4 = ip42num("0.1.0.0");
-set $!ip!v5 = ip42num("1.0.0.0");
-set $!ip!v6 = ip42num("0.0.0.135");
-set $!ip!v7 = ip42num("1.1.1.1");
-set $!ip!v8 = ip42num("225.33.1.10");
-set $!ip!v9 = ip42num("172.0.0.1");
-set $!ip!v10 = ip42num("255.255.255.255");
-set $!ip!v11 = ip42num("1.0.3.45         ");
-set $!ip!v12 = ip42num("      0.0.0.1");
-set $!ip!v13 = ip42num("    0.0.0.1   ");
+# in pre 8.1907.0 versions of rsyslog the code was misspelled as
+# "ip42num" (missing "v"). We check this is still supported as alias
+set $!ip!v0 = ip42num("0.0.0.0");
 
-set $!ip!e1 = ip42num("a");
-set $!ip!e2 = ip42num("");
-set $!ip!e3 = ip42num("123.4.6.*");
-set $!ip!e4 = ip42num("172.0.0.1.");
-set $!ip!e5 = ip42num("172.0.0..1");
-set $!ip!e6 = ip42num(".172.0.0.1");
-set $!ip!e7 = ip42num(".17 2.0.0.1");
+# use correct function name
+set $!ip!v1 = ipv42num("0.0.0.0");
+set $!ip!v2 = ipv42num("0.0.0.1");
+set $!ip!v3 = ipv42num("0.0.1.0");
+set $!ip!v4 = ipv42num("0.1.0.0");
+set $!ip!v5 = ipv42num("1.0.0.0");
+set $!ip!v6 = ipv42num("0.0.0.135");
+set $!ip!v7 = ipv42num("1.1.1.1");
+set $!ip!v8 = ipv42num("225.33.1.10");
+set $!ip!v9 = ipv42num("172.0.0.1");
+set $!ip!v10 = ipv42num("255.255.255.255");
+set $!ip!v11 = ipv42num("1.0.3.45         ");
+set $!ip!v12 = ipv42num("      0.0.0.1");
+set $!ip!v13 = ipv42num("    0.0.0.1   ");
+
+set $!ip!e1 = ipv42num("a");
+set $!ip!e2 = ipv42num("");
+set $!ip!e3 = ipv42num("123.4.6.*");
+set $!ip!e4 = ipv42num("172.0.0.1.");
+set $!ip!e5 = ipv42num("172.0.0..1");
+set $!ip!e6 = ipv42num(".172.0.0.1");
+set $!ip!e7 = ipv42num(".17 2.0.0.1");
 
 
 template(name="outfmt" type="string" string="%!ip%\n")
@@ -36,7 +41,7 @@ startup
 tcpflood -m1 -y
 shutdown_when_empty
 wait_shutdown
-echo '{ "v1": 0, "v2": 1, "v3": 256, "v4": 65536, "v5": 16777216, "v6": 135, "v7": 16843009, "v8": 3777036554, "v9": 2885681153, "v10": 4294967295, "v11": 16778029, "v12": 1, "v13": 1, "e1": -1, "e2": -1, "e3": -1, "e4": -1, "e5": -1, "e6": -1, "e7": -1 }' | cmp - $RSYSLOG_OUT_LOG
+echo '{ "v0": 0, "v1": 0, "v2": 1, "v3": 256, "v4": 65536, "v5": 16777216, "v6": 135, "v7": 16843009, "v8": 3777036554, "v9": 2885681153, "v10": 4294967295, "v11": 16778029, "v12": 1, "v13": 1, "e1": -1, "e2": -1, "e3": -1, "e4": -1, "e5": -1, "e6": -1, "e7": -1 }' | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid function output detected, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG


### PR DESCRIPTION
To fix the issue but keep compatible with existing deployments
both function names are now supported.

closes https://github.com/rsyslog/rsyslog/issues/3676

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
