### PR TITLE
core bugfix: incorrect error message on duplicate module load

### DIFF
--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -567,7 +567,7 @@ CODESTARTnewInpInst
 			char *stringType = es_str2cstr(pvals[i].val.d.estr, NULL);
 			if( NULL == stringType ){
 				LogError(0, RS_RET_CONFIG_ERROR,
-					"imczmq: '%s' is invalid sockType", stringType);
+					"imczmq: out of memory error copying sockType param");
 				ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 			}
 

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -323,7 +323,7 @@ parserProcessCnf(struct cnfobj *o)
 	parserName = (uchar*)es_str2cstr(pvals[paramIdx].val.d.estr, NULL);
 	if(parser.FindParser(&myparser, parserName) != RS_RET_PARSER_NOT_FOUND) {
 		LogError(0, RS_RET_PARSER_NAME_EXISTS,
-			"parser module name '%s' already exists", cnfModName);
+			"parser module name '%s' already exists", parserName);
 		ABORT_FINALIZE(RS_RET_PARSER_NAME_EXISTS);
 	}
 

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -382,7 +382,6 @@ wtiWorker(wti_t *__restrict__ const pThis)
 {
 	wtp_t *__restrict__ const pWtp = pThis->pWtp; /* our worker thread pool -- shortcut */
 	action_t *__restrict__ pAction;
-	int bInactivityTOOccured = 0;
 	rsRetVal localRet;
 	rsRetVal terminateRet;
 	actWrkrInfo_t *__restrict__ wrkrInfo;
@@ -392,6 +391,7 @@ wtiWorker(wti_t *__restrict__ const pThis)
 
 	dbgSetThrdName(pThis->pszDbgHdr);
 	pthread_cleanup_push(wtiWorkerCancelCleanup, pThis);
+	int bInactivityTOOccured = 0;
 	pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &iCancelStateSave);
 	DBGPRINTF("wti %p: worker starting\n", pThis);
 	/* now we have our identity, on to real processing */


### PR DESCRIPTION
A Null-pointer was passed to printf instead of the module name.
On some platforms this may lead to a segfault. On most platforms
printf check's for NULL pointers and uses the string "(null)"
instead.

In any case, the module name is missing from the error message.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
