### PR TITLE
build system: support cross-platform build for mysql/mariadb

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -759,29 +759,31 @@ AC_ARG_ENABLE(mysql,
          esac],
         [enable_mysql=no]
 )
-if test "x$enable_mysql" = "xyes"; then
-  AC_CHECK_PROG(
-    [MYSQL_CONFIG],
-    [mysql_config],
-    [mysql_config],
-    [no],,
-  )
-  if test "x${MYSQL_CONFIG}" = "xno"; then
-    AC_MSG_FAILURE([mysql_config not found - usually a package named mysql-dev, libmysql-dev or similar, is missing - install it to fix this issue])
-  fi
-  AC_CHECK_LIB(
-    [mysqlclient],
-    [mysql_init],
-    [MYSQL_CFLAGS=`$MYSQL_CONFIG --cflags`
-     MYSQL_LIBS=`$MYSQL_CONFIG --libs`
-    ],
-    [AC_MSG_FAILURE([MySQL library is missing])],
-    [`$MYSQL_CONFIG --libs`]
-  )
+AS_IF([test "x$enable_mysql" = "xyes"],[
+  PKG_CHECK_MODULES([MYSQL],[mysqlclient],,[
+    AC_CHECK_PROG(
+      [MYSQL_CONFIG],
+      [mysql_config],
+      [mysql_config],
+      [no],,
+    )
+    AS_IF([test "x${MYSQL_CONFIG}" = "xno"],[
+      AC_MSG_FAILURE([mysql_config not found - usually a package named mysql-dev, libmysql-dev or similar, is missing - install it to fix this issue])
+    ])
+    MYSQL_CFLAGS=`$MYSQL_CONFIG --cflags`
+    MYSQL_LIBS=`$MYSQL_CONFIG --libs`
+  ])
   AC_MSG_CHECKING(if we have mysql_library_init)
   save_CFLAGS="$CFLAGS"
   CFLAGS="$CFLAGS $MYSQL_CFLAGS"
   save_LIBS="$LIBS"
+  AC_CHECK_LIB(
+    [mysqlclient],
+    [mysql_init],
+    ,
+    [AC_MSG_FAILURE([MySQL library is missing])],
+    [$MYSQL_LIBS]
+  )
   LIBS="$LIBS $MYSQL_LIBS"
   AC_TRY_LINK(
     [#include <mysql.h>
@@ -791,7 +793,7 @@ if test "x$enable_mysql" = "xyes"; then
     [have_mysql_library_init=no])
   CFLAGS="$save_CFLAGS"
   LIBS="$save_LIBS"
-fi
+])
 AM_CONDITIONAL(ENABLE_MYSQL, test x$enable_mysql = xyes)
 if test "$have_mysql_library_init" = "yes"; then
   AC_DEFINE([HAVE_MYSQL_LIBRARY_INIT], [1], [mysql_library_init available])


### PR DESCRIPTION
rsyslog fails to cross build from source, because it uses mysql_config
and mysql_config is unfixably broken for cross compilation. It would be
better to use pkg-config. The attached patch makes rsyslog try
pkg-config first and fall back to mysql_config.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
