### PR TITLE
core/action: no error file written if act suspended on TX commit

### DIFF
--- a/tests/suspend-omfwd-via-file.sh
+++ b/tests/suspend-omfwd-via-file.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# This tests the action suspension via a file
+# This file is part of the rsyslog project, released under ASL 2.0
+# Written 2019-07-10 by Rainer Gerhards
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=100 #00
+generate_conf
+add_conf '
+/* Filter out busy debug output, comment out if needed */
+global( debug.whitelist="on"
+	debug.files=["ruleset.c", "../action.c", "omfwd.c"]
+)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+:msg, contains, "msgnum:" {
+	action(name="forwarder" type="omfwd" template="outfmt"
+		target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp"
+		action.externalstate.file="'$RSYSLOG_DYNNAME'.STATE"
+		action.resumeRetryCount="-1" action.resumeinterval="1")
+}
+'
+
+./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
+BGPROCESS=$!
+echo background minitcpsrv process id is $BGPROCESS
+
+startup
+#injectmsg 0 5000
+injectmsg 0 5
+
+printf '\n%s %s\n' "$(tb_timestamp)" \
+	'checking that action becomes suspended via external state file'
+printf "%s" "SUSPENDED" > $RSYSLOG_DYNNAME.STATE
+./msleep 2000 # ensure ResumeInterval expired (NOT sensitive to slow machines --> absolute time!)
+#injectmsg 5000 1000
+injectmsg 5 5
+
+printf '\n%s %s\n' "$(tb_timestamp)" \
+	'checking that action becomes resumed again via external state file'
+./msleep 2000 # ensure ResumeInterval expired (NOT sensitive to slow machines --> absolute time!)
+printf "%s" "READY" > $RSYSLOG_DYNNAME.STATE
+
+#injectmsg 6000 4000
+injectmsg 10 90
+#export QUEUE_EMPTY_CHECK_FUNC=check_q_empty_log2
+wait_queueempty
+seq_check
+exit_test


### PR DESCRIPTION
when an action was already disabled while the action was tried to be
committed, no error file was written. Note that this state is highly
unlikely to happen. Most probably, it can only happen if parameter
action.externalstate.file is used.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
