### PR TITLE
imtcp: enable listenPortFileName parameter

### DIFF
--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -400,6 +400,7 @@ addListner(modConfData_t *modConf, instanceConf_t *inst)
 	CHKiRet(tcpsrv.SetbSPFramingFix(pOurTcpsrv, inst->bSPFramingFix));
 	CHKiRet(tcpsrv.SetLinuxLikeRatelimiters(pOurTcpsrv, inst->ratelimitInterval, inst->ratelimitBurst));
 
+	CHKiRet(tcpsrv.SetLstnPortFileName(pOurTcpsrv, inst->pszLstnPortFileName));
 	if((ustrcmp(inst->pszBindPort, UCHAR_CONSTANT("0")) == 0 && inst->pszLstnPortFileName == NULL)
 			|| ustrcmp(inst->pszBindPort, UCHAR_CONSTANT("0")) < 0) {
 		CHKmalloc(inst->pszBindPort = (uchar*)strdup("514"));

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -382,7 +382,7 @@ initTCPListener(tcpsrv_t *pThis, tcpLstnPortList_t *pPortEntry)
 
 	// pPortEntry->pszAddr = NULL ==> bind to all interfaces
 	CHKiRet(netstrm.LstnInit(pThis->pNS, (void*)pPortEntry, addTcpLstn, TCPLstnPort,
-	pPortEntry->pszAddr, pThis->iSessMax, pThis->pszLstnPortFileName));
+		pPortEntry->pszAddr, pThis->iSessMax, pThis->pszLstnPortFileName));
 
 finalize_it:
 	RETiRet;

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -358,6 +358,7 @@ wait_pid_termination() {
 # $1 : file to wait for
 # $2 (optional): error message to show if timeout occurs
 wait_file_exists() {
+	echo waiting for file $1
 	i=0
 	while true; do
 		if [ -f $1 ] && [ "$(cat $1 2> /dev/null)" != "" ]; then
@@ -491,6 +492,19 @@ startup() {
 	wait_startup $instance
 }
 
+
+# assign TCPFLOOD_PORT from port file
+# $1 - port file
+assign_tcpflood_port() {
+	wait_file_exists "$1"
+	export TCPFLOOD_PORT=$(cat "$1")
+	echo "TCPFLOOD_PORT now: $TCPFLOOD_PORT"
+	if [ "$TCPFLOOD_PORT" == "" ]; then
+		echo "TESTBENCH ERROR: TCPFLOOD_PORT not found!"
+		ls -l $RSYSLOG_DYNNAME*
+		exit 100
+	fi
+}
 
 # same as startup_vg, BUT we do NOT wait on the startup message!
 startup_vg_waitpid_only() {

--- a/tests/imtcp-basic.sh
+++ b/tests/imtcp-basic.sh
@@ -5,13 +5,14 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -p'$TCPFLOOD_PORT' -m10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown


### PR DESCRIPTION
this parameter was added, but it had no effect as it was not
passed down to the driver layer. This has been fixed. That also
now enables us to use dynamically-assigned port, which are
very useful for further testbench stabilization. Quite some
false positives occurred because the pre-selected port was
already in use again when rsyslog started.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
