### PR TITLE
core/action: special handling for suspending action via ext file

### DIFF
--- a/action.c
+++ b/action.c
@@ -130,10 +130,12 @@ PRAGMA_INGORE_Wswitch_enum
 #define NO_TIME_PROVIDED 0 /* indicate we do not provide any cached time */
 
 /* forward definitions */
-static rsRetVal processBatchMain(void *pVoid, batch_t *pBatch, wti_t * const pWti);
+static rsRetVal ATTR_NONNULL() processBatchMain(void *pVoid, batch_t *pBatch, wti_t * const pWti);
 static rsRetVal doSubmitToActionQ(action_t * const pAction, wti_t * const pWti, smsg_t*);
 static rsRetVal doSubmitToActionQComplex(action_t * const pAction, wti_t * const pWti, smsg_t*);
 static rsRetVal doSubmitToActionQNotAllMark(action_t * const pAction, wti_t * const pWti, smsg_t*);
+static void ATTR_NONNULL() actionSuspend(action_t * const pThis, wti_t * const pWti);
+static void ATTR_NONNULL() actionRetry(action_t * const pThis, wti_t * const pWti);
 
 /* object static data (once for all instances) */
 DEFobjCurrIf(obj)
@@ -686,8 +688,8 @@ static void actionCommitted(action_t * const pThis, wti_t * const pWti)
 
 /* set action state according to external state file (if configured)
 */
-static rsRetVal
-checkExternalStateFile(action_t *__restrict__ const pThis)
+static rsRetVal ATTR_NONNULL()
+checkExternalStateFile(action_t *const pThis, wti_t *const pWti)
 {
 	char filebuf[1024];
 	int fd = -1;
@@ -718,6 +720,7 @@ checkExternalStateFile(action_t *__restrict__ const pThis)
 		LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
 		      "action '%s' suspended (module '%s') by external state file",
 		      pThis->pszName, pThis->pMod->pszName);
+		actionRetry(pThis, pWti);
 		ABORT_FINALIZE(RS_RET_SUSPENDED);
 	}
 
@@ -753,7 +756,7 @@ setSuspendMessageConfVars(action_t *__restrict__ const pThis)
 /* set action to "rtry" state.
  * rgerhards, 2007-08-02
  */
-static void actionRetry(action_t * const pThis, wti_t * const pWti)
+static void ATTR_NONNULL() actionRetry(action_t * const pThis, wti_t * const pWti)
 {
 	setSuspendMessageConfVars(pThis);
 	actionSetState(pThis, pWti, ACT_STATE_RTRY);
@@ -773,7 +776,7 @@ static void actionRetry(action_t * const pThis, wti_t * const pWti)
  * CPU time. TODO: maybe a config option for that?
  * rgerhards, 2007-08-02
  */
-static void
+static void ATTR_NONNULL()
 actionSuspend(action_t * const pThis, wti_t * const pWti)
 {
 	time_t ttNow;
@@ -843,10 +846,7 @@ actionDoRetry(action_t * const pThis, wti_t * const pWti)
 	while((*pWti->pbShutdownImmediate == 0) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
 		DBGPRINTF("actionDoRetry: %s enter loop, iRetries=%d, ResumeInRow %d\n",
 			pThis->pszName, iRetries, getActionResumeInRow(pWti, pThis));
-		iRet = checkExternalStateFile(pThis);
-		if(iRet == RS_RET_OK) {
 			iRet = pThis->pMod->tryResume(pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData);
-		}
 		DBGPRINTF("actionDoRetry: %s action->tryResume returned %d\n", pThis->pszName, iRet);
 		if((getActionResumeInRow(pWti, pThis) > 9) && (getActionResumeInRow(pWti, pThis) % 10 == 0)) {
 			bTreatOKasSusp = 1;
@@ -894,6 +894,66 @@ finalize_it:
 	RETiRet;
 }
 
+
+/* special retry handling if disabled via file: simply wait for the file
+ * to indicate whether or not it is ready again
+ */
+static rsRetVal ATTR_NONNULL()
+actionDoRetry_extFile(action_t *const pThis, wti_t *const pWti)
+{
+	int iRetries;
+	int iSleepPeriod;
+	DEFiRet;
+
+	assert(pThis != NULL);
+
+	DBGPRINTF("actionDoRetry_extFile: enter, actionState: %d\n",getActionState(pWti, pThis));
+	iRetries = 0;
+	while((*pWti->pbShutdownImmediate == 0) && getActionState(pWti, pThis) == ACT_STATE_RTRY) {
+		DBGPRINTF("actionDoRetry_extFile: %s enter loop, iRetries=%d, ResumeInRow %d\n",
+			pThis->pszName, iRetries, getActionResumeInRow(pWti, pThis));
+			iRet = checkExternalStateFile(pThis, pWti);
+		DBGPRINTF("actionDoRetry_extFile: %s checkExternalStateFile returned %d\n", pThis->pszName, iRet);
+		if(iRet == RS_RET_OK) {
+			DBGPRINTF("actionDoRetry_extFile: %s had success RDY again (iRet=%d)\n",
+				  pThis->pszName, iRet);
+			if(pThis->bReportSuspension) {
+				LogMsg(0, RS_RET_RESUMED, LOG_INFO, "action '%s' "
+				      "resumed (module '%s') via external state file",
+				      pThis->pszName, pThis->pMod->pszName);
+			}
+			actionSetState(pThis, pWti, ACT_STATE_RDY);
+		} else if(iRet == RS_RET_SUSPENDED) {
+			/* max retries reached? */
+			DBGPRINTF("actionDoRetry_extFile: %s check for max retries, iResumeRetryCount "
+				  "%d, iRetries %d\n",
+				  pThis->pszName, pThis->iResumeRetryCount, iRetries);
+			if((pThis->iResumeRetryCount != -1 && iRetries >= pThis->iResumeRetryCount)) {
+				DBGPRINTF("actionDoRetry_extFile: did not work out, suspending\n");
+				actionSuspend(pThis, pWti);
+				pWti->execState.bPrevWasSuspended = 1;
+				if(getActionNbrResRtry(pWti, pThis) < 20)
+					incActionNbrResRtry(pWti, pThis);
+			} else {
+				++iRetries;
+				iSleepPeriod = pThis->iResumeInterval;
+				srSleep(iSleepPeriod, 0);
+				if(*pWti->pbShutdownImmediate) {
+					ABORT_FINALIZE(RS_RET_FORCE_TERM);
+				}
+			}
+		} else if(iRet == RS_RET_DISABLE_ACTION) {
+			actionDisable(pThis);
+		}
+	}
+
+	if(getActionState(pWti, pThis) == ACT_STATE_RDY) {
+		setActionNbrResRtry(pWti, pThis, 0);
+	}
+
+finalize_it:
+	RETiRet;
+}
 
 static rsRetVal
 actionCheckAndCreateWrkrInstance(action_t * const pThis, const wti_t *const pWti)
@@ -984,11 +1044,12 @@ finalize_it:
  * depending on its current state.
  * rgerhards, 2009-05-07
  */
-static rsRetVal
+static rsRetVal ATTR_NONNULL()
 actionPrepare(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti)
 {
 	DEFiRet;
 
+DBGPRINTF("actionPrepare[%s]: enter\n", pThis->pszName);
 	CHKiRet(actionCheckAndCreateWrkrInstance(pThis, pWti));
 	CHKiRet(actionTryResume(pThis, pWti));
 
@@ -996,6 +1057,12 @@ actionPrepare(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti
 	 * action state accordingly
 	 */
 	if(getActionState(pWti, pThis) == ACT_STATE_RDY) {
+		iRet = checkExternalStateFile(pThis, pWti);
+		if(iRet == RS_RET_SUSPENDED) {
+			DBGPRINTF("actionPrepare[%s]: SUSPENDED via external state file, "
+				"doing retry processing\n", pThis->pszName);
+			CHKiRet(actionDoRetry_extFile(pThis, pWti));
+		}
 		iRet = pThis->pMod->mod.om.beginTransaction(pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData);
 		switch(iRet) {
 			case RS_RET_OK:
@@ -1196,7 +1263,7 @@ actionCallDoAction(action_t *__restrict__ const pThis,
 
 
 /* call the commitTransaction output plugin entry point */
-static rsRetVal
+static rsRetVal ATTR_NONNULL()
 actionCallCommitTransaction(action_t * const pThis,
 	wti_t *const pWti,
 	actWrkrIParams_t *__restrict__ const iparams, const int nparams)
@@ -1206,15 +1273,12 @@ actionCallCommitTransaction(action_t * const pThis,
 	DBGPRINTF("entering actionCallCommitTransaction[%s], state: %s, nMsgs %u\n",
 		  pThis->pszName, getActStateName(pThis, pWti), nparams);
 
-	iRet = checkExternalStateFile(pThis);
-	if(iRet == RS_RET_OK) {
-		iRet = pThis->pMod->mod.om.commitTransaction(
-			    pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData,
-			    iparams, nparams);
-		DBGPRINTF("actionCallCommitTransaction[%s] state: %s "
-			"mod commitTransaction returned %d\n",
-			pThis->pszName, getActStateName(pThis, pWti), iRet);
-	}
+	iRet = pThis->pMod->mod.om.commitTransaction(
+		    pWti->actWrkrInfo[pThis->iActionNbr].actWrkrData,
+		    iparams, nparams);
+	DBGPRINTF("actionCallCommitTransaction[%s] state: %s "
+		"mod commitTransaction returned %d\n",
+		pThis->pszName, getActStateName(pThis, pWti), iRet);
 	iRet = handleActionExecResult(pThis, pWti, iRet);
 	RETiRet;
 }
@@ -1574,11 +1638,6 @@ processMsgMain(action_t *__restrict__ const pAction,
 
 	CHKiRet(prepareDoActionParams(pAction, pWti, pMsg, ttNow));
 
-	if(checkExternalStateFile(pAction) == RS_RET_SUSPENDED) {
-		DBGPRINTF("processMsgMain suspends via external state file\n");
-		actionSuspend(pAction, pWti);
-	}
-
 	if(pAction->isTransactional) {
 		pWti->actWrkrInfo[pAction->iActionNbr].pAction = pAction;
 		DBGPRINTF("action '%s': is transactional - executing in commit phase\n", pAction->pszName);
@@ -1602,7 +1661,7 @@ finalize_it:
 
 /* This entry point is called by the ACTION queue (not main queue!)
  */
-static rsRetVal
+static rsRetVal ATTR_NONNULL()
 processBatchMain(void *__restrict__ const pVoid,
 	batch_t *__restrict__ const pBatch,
 	wti_t *__restrict__ const pWti)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -324,6 +324,7 @@ TESTS +=  \
 	failover-no-rptd.sh \
 	failover-no-basic.sh \
 	suspend-via-file.sh \
+	suspend-omfwd-via-file.sh \
 	externalstate-failed-rcvr.sh \
 	rcvr_fail_restore.sh \
 	rscript_contains.sh \
@@ -1907,6 +1908,7 @@ EXTRA_DIST= \
 	failover-async.sh \
 	failover-double.sh \
 	suspend-via-file.sh \
+	suspend-omfwd-via-file.sh \
 	externalstate-failed-rcvr.sh \
 	discard-rptdmsg.sh \
 	discard-rptdmsg-vg.sh \

--- a/tests/suspend-omfwd-via-file.sh
+++ b/tests/suspend-omfwd-via-file.sh
@@ -3,7 +3,8 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 # Written 2019-07-10 by Rainer Gerhards
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=100 #00
+export NUMMESSAGES=10000
+#export NUMMESSAGES=100 #00
 generate_conf
 add_conf '
 /* Filter out busy debug output, comment out if needed */
@@ -26,24 +27,26 @@ BGPROCESS=$!
 echo background minitcpsrv process id is $BGPROCESS
 
 startup
-#injectmsg 0 5000
-injectmsg 0 5
+injectmsg 0 5000
+#injectmsg 0 5
 
 printf '\n%s %s\n' "$(tb_timestamp)" \
 	'checking that action becomes suspended via external state file'
 printf "%s" "SUSPENDED" > $RSYSLOG_DYNNAME.STATE
 ./msleep 2000 # ensure ResumeInterval expired (NOT sensitive to slow machines --> absolute time!)
-#injectmsg 5000 1000
-injectmsg 5 5
+injectmsg 5000 1000
+#injectmsg 5 5
 
 printf '\n%s %s\n' "$(tb_timestamp)" \
 	'checking that action becomes resumed again via external state file'
 ./msleep 2000 # ensure ResumeInterval expired (NOT sensitive to slow machines --> absolute time!)
 printf "%s" "READY" > $RSYSLOG_DYNNAME.STATE
 
-#injectmsg 6000 4000
-injectmsg 10 90
+injectmsg 6000 4000
+#injectmsg 10 90
 #export QUEUE_EMPTY_CHECK_FUNC=check_q_empty_log2
 wait_queueempty
 seq_check
+shutdown_when_empty
+wait_shutdown
 exit_test


### PR DESCRIPTION
We try to reduce potential problems during transaction commit be ensuring
that the action is only tried to be suspended at begin of transaction.
This also simplifies the code a bit and also reduces performance
impact of that "suspension via external state file" feature.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
