### PR TITLE
imrelp bugfix: hang after HUP

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -801,8 +801,11 @@ ENDfreeCnf
 static void
 doSIGTTIN(int __attribute__((unused)) sig)
 {
-	DBGPRINTF("imrelp: termination requested via SIGTTIN - telling RELP engine\n");
-	relpEngineSetStop(pRelpEngine);
+	DBGPRINTF("imrelp: awoken via SIGTTIN; bTerminateInputs: %d\n", bTerminateInputs);
+	if(bTerminateInputs) {
+		relpEngineSetStop(pRelpEngine);
+		DBGPRINTF("imrelp: termination requested via SIGTTIN - telling RELP engine\n");
+	}
 }
 
 

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -122,7 +122,7 @@ static uchar *pszDfltNetstrmDrvr = NULL; /* module name of default netstream dri
 static uchar *pszDfltNetstrmDrvrCAF = NULL; /* default CA file for the netstrm driver */
 static uchar *pszDfltNetstrmDrvrKeyFile = NULL; /* default key file for the netstrm driver (server) */
 static uchar *pszDfltNetstrmDrvrCertFile = NULL; /* default cert file for the netstrm driver (server) */
-static int bTerminateInputs = 0;		/* global switch that inputs shall terminate ASAP (1=> terminate) */
+int bTerminateInputs = 0;		/* global switch that inputs shall terminate ASAP (1=> terminate) */
 static uchar cCCEscapeChar = '#'; /* character to be used to start an escape sequence for control chars */
 static int bDropTrailingLF = 1; /* drop trailing LF's on reception? */
 static int bEscapeCCOnRcv = 1; /* escape control characters on reception: 0 - no, 1 - yes */

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -127,6 +127,7 @@ extern int glblDbgWhitelist;
 extern int glblPermitCtlC;
 extern int glblInputTimeoutShutdown;
 extern int glblIntMsgsSeverityFilter;
+extern int bTerminateInputs;
 
 /* Developer options enable some strange things for developer-only testing.
  * These should never be enabled in a user build, except if explicitly told


### PR DESCRIPTION
termination condition was not properly checked; this lead to
premature termination after patch 1c8712415b9 was applied.

It is open to debate if patch 1c8712415b9 changed the module
interface. Actually it looks like this was previously not
well thought out.

closes https://github.com/rsyslog/rsyslog/issues/3760

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
