### PR TITLE
core/janitor bugfix: properly maintain dynafile cache

### DIFF
--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -475,6 +475,10 @@ dynaFileDelCacheEntry(instanceData *__restrict__ const pData, const int iEntry, 
 	}
 
 	if(pCache[iEntry]->pStrm != NULL) {
+		if(iEntry == pData->iCurrElt) {
+			pData->iCurrElt = -1;
+			pData->pStrm = NULL;
+		}
 		strm.Destruct(&pCache[iEntry]->pStrm);
 		if(pData->useSigprov) {
 			pData->sigprov.OnFileClose(pCache[iEntry]->sigprovFileData);


### PR DESCRIPTION
When the janitor cleans out timed-out files, it does not
properly indicate the entry is gone. Especially when running
in async mode this can lead to use-after-free and thus
memory corruption or segfault.

see also https://github.com/rsyslog/rsyslog/issues/3756

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
