### PR TITLE
testbench bugfix: some tests were executed when req module was missing

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1375,6 +1375,7 @@ endif
 if ENABLE_MMKUBERNETES
 if ENABLE_MMJSONPARSE
 if ENABLE_IMFILE
+if ENABLE_IMPSTATS
 TESTS += \
 	mmkubernetes-basic.sh \
 	mmkubernetes-cache-expire.sh
@@ -1382,6 +1383,7 @@ if HAVE_VALGRIND
 TESTS += \
 	mmkubernetes-basic-vg.sh \
 	mmkubernetes-cache-expire-vg.sh
+endif
 endif
 endif
 endif


### PR DESCRIPTION
In actual case if --enable-impstats was not given some other tests failed.