### PR TITLE
imrelp: fix cosmetic race in recently-added code

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -801,8 +801,9 @@ ENDfreeCnf
 static void
 doSIGTTIN(int __attribute__((unused)) sig)
 {
-	DBGPRINTF("imrelp: awoken via SIGTTIN; bTerminateInputs: %d\n", bTerminateInputs);
-	if(bTerminateInputs) {
+	const int bTerminate = ATOMIC_FETCH_32BIT(&bTerminateInputs, &mutTerminateInputs);
+	DBGPRINTF("imrelp: awoken via SIGTTIN; bTerminateInputs: %d\n", bTerminate);
+	if(bTerminate) {
 		relpEngineSetStop(pRelpEngine);
 		DBGPRINTF("imrelp: termination requested via SIGTTIN - telling RELP engine\n");
 	}

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -150,7 +150,7 @@ uint64_t glblDevOptions = 0; /* to be used by developers only */
 
 pid_t glbl_ourpid;
 #ifndef HAVE_ATOMIC_BUILTINS
-static DEF_ATOMIC_HELPER_MUT(mutTerminateInputs);
+DEF_ATOMIC_HELPER_MUT(mutTerminateInputs);
 #endif
 #ifdef USE_UNLIMITED_SELECT
 static int iFdSetSize = howmany(FD_SETSIZE, __NFDBITS) * sizeof (fd_mask); /* size of select() bitmask in bytes */

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -128,6 +128,9 @@ extern int glblPermitCtlC;
 extern int glblInputTimeoutShutdown;
 extern int glblIntMsgsSeverityFilter;
 extern int bTerminateInputs;
+#ifndef HAVE_ATOMIC_BUILTINS
+extern DEF_ATOMIC_HELPER_MUT(mutTerminateInputs);
+#endif
 
 /* Developer options enable some strange things for developer-only testing.
  * These should never be enabled in a user build, except if explicitly told


### PR DESCRIPTION
It is extremely unlikly that the race could have caused harm, except
during test runs with thread sanitizer (TSAN) enabled.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
