### PR TITLE
omelasticsearch bugfix: potential segmentation fault

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -269,6 +269,7 @@ ENDisCompatibleWithFeature
 
 BEGINfreeInstance
 	int i;
+	instanceConf_t *inst;
 CODESTARTfreeInstance
 	if(pData->fdErrFile != -1)
 		close(pData->fdErrFile);
@@ -293,6 +294,14 @@ CODESTARTfreeInstance
 	free(pData->retryRulesetName);
 	if (pData->ratelimiter != NULL)
 		ratelimitDestruct(pData->ratelimiter);
+	for(inst = loadModConf?loadModConf->root:NULL ; inst != NULL ; inst = inst->next) {
+		if (inst->next == pData) {
+			inst->next = pData->next;
+		}
+	}
+	if (loadModConf?loadModConf->tail:NULL == pData) {
+		loadModConf->tail = inst;
+	}
 ENDfreeInstance
 
 BEGINfreeWrkrInstance

--- a/tests/es-duplicated-ruleset-vg.sh
+++ b/tests/es-duplicated-ruleset-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/es-duplicated-ruleset.sh

--- a/tests/es-duplicated-ruleset.sh
+++ b/tests/es-duplicated-ruleset.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export ES_PORT=19200
+export NUMMESSAGES=1500 # slow test, thus low number - large number is NOT necessary
+export QUEUE_EMPTY_CHECK_FUNC=es_shutdown_empty_check
+download_elasticsearch
+prepare_elasticsearch
+start_elasticsearch
+
+generate_conf
+add_conf '
+template(name="tpl" type="string" string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+ruleset(name="try_es") {
+		action(type="omelasticsearch"
+				 server="localhost" 
+				 serverport=`echo $ES_PORT`
+				 template="tpl"
+				 searchIndex="rsyslog_testbench"
+				 retryruleset="try_es"
+				 )
+}
+
+ruleset(name="try_es") {
+		action(type="omelasticsearch"
+				 server="localhost" 
+				 serverport=`echo $ES_PORT`
+				 template="tpl"
+				 searchIndex="rsyslog_testbench"
+				 retryruleset="try_es"
+				 )
+}
+'
+startup
+shutdown_immediate
+wait_shutdown 
+cleanup_elasticsearch
+exit_test


### PR DESCRIPTION
When duplicated configurations are accidentally loaded, rsyslog eliminates extra duplicated instances.  Omelasticsearch has a linked list to manage multiple instances.  When a configuration instance is freed in freeInstance, the instance should be removed from the list, as well.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
