### PR TITLE
imptcp bugfix: received bytes counter improperly maintained

### DIFF
--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -4,7 +4,6 @@ src:queue.c
 src:omprog.c
 src:lookup.c
 src:rainerscript.c
-src:imptcp.c
 src:imdiag.c
 
 fun:doSIGTTIN


### PR DESCRIPTION
imptcp counts the number of bytes received. However, receives
happen on different worker thread. The access to the counter
was not synchronized, which can cause loss of updates. Also,
thread debuggers validly flag this as an error, which creates
problems under CI.

This commit fixes the situation via atomic operations and
falls back to mutex calls if they are not available.

Detected by LLVM thread sanitizer.

closes https://github.com/rsyslog/rsyslog/issues/3798