### PR TITLE
omelasticsearch bugfix: segfault on unknown retryRuleset

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -272,6 +272,26 @@ BEGINfreeInstance
 CODESTARTfreeInstance
 	if(pData->fdErrFile != -1)
 		close(pData->fdErrFile);
+
+	if(loadModConf != NULL) {
+		/* we keep our instances in our own internal list - this also
+		 * means we need to cleanup that list, else we cause grief.
+		 */
+		instanceData *prev = NULL;
+		for(instanceData *inst = loadModConf->root ; inst != NULL ; inst = inst->next) {
+			if(inst == pData) {
+				if(loadModConf->tail == inst) {
+					loadModConf->tail = prev;
+				}
+				prev->next = inst->next;
+				/* no need to correct inst back to prev - we exit now! */
+				break;
+			} else {
+				prev = inst;
+			}
+		}
+	}
+
 	pthread_mutex_destroy(&pData->mutErrFile);
 	for(i = 0 ; i < pData->numServers ; ++i)
 		free(pData->serverBaseUrls[i]);


### PR DESCRIPTION
omelasticsearch does some "interesting tricks" for an output module.
This causes a segfault if the retryRuleset is now known.

The action module interface currently expects that all config errors
be detected during instance creation. Instead omelasticsearch defers
the retry ruleset check to a later state. The reason is that it wants
to support the use the same rulesetname it is defined in - and this
is not yet available at action parsing.

We fix this by ensuring that any deleted instance is properly unlinked
from the instance list. One may argue the module interface should get
upgrade for such cases, but this is a longer-term approach.

replaces https://github.com/rsyslog/rsyslog/pull/3796
closes https://github.com/rsyslog/rsyslog/pull/3796

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
