### PR TITLE
testbench: add tests for omelasticsearch error configs

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -57,6 +57,9 @@ TESTS = $(TESTRUNS)
 
 if ENABLE_ELASTICSEARCH_TESTS_MINIMAL
 TESTS +=  \
+	es-duplicated-ruleset.sh
+# the following test need to be serialized:
+TESTS +=  \
 	es-basic.sh \
 	es-basic-es6.0.sh \
 	es-basic-bulk.sh
@@ -65,6 +68,7 @@ es-basic-bulk.log: es-basic-es6.0.log
 es-basic-server.log: es-basic-bulk.log
 if HAVE_VALGRIND
 TESTS += \
+	es-duplicated-ruleset-vg.sh \
 	es-basic-vg.sh
 es-basic-vg.log: es-basic-bulk.log
 # for next if block:
@@ -1836,6 +1840,8 @@ EXTRA_DIST= \
 	clickhouse-bulk-load-vg.sh \
 	es_response_get_msgnum.py \
 	elasticsearch-error-format-check.py \
+	es-duplicated-ruleset.sh \
+	es-duplicated-ruleset-vg.sh \
 	es-basic-es6.0.sh \
 	es-basic.sh \
 	es-basic-vgthread.sh \

--- a/tests/es-duplicated-ruleset-vg.sh
+++ b/tests/es-duplicated-ruleset-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/es-duplicated-ruleset.sh

--- a/tests/es-duplicated-ruleset.sh
+++ b/tests/es-duplicated-ruleset.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# The sole purpose of this test is to check that rsyslog "survives" the
+# duplicate ruleset definition and emits the proper error message. So we
+# do NOT need to have elasticsearch running to carry it out. We avoid
+# sending data to ES as this complicates things more than needed.
+# This is based on a real case, see
+#     https://github.com/rsyslog/rsyslog/pull/3796
+# Thanks to Noriko Hosoi for providing the original test idea which
+# was then modified by Rainer Gerhards.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export ES_PORT=19200
+export QUEUE_EMPTY_CHECK_FUNC=es_shutdown_empty_check
+generate_conf
+add_conf '
+template(name="tpl" type="string" string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+ruleset(name="try_es") {
+		action(type="omelasticsearch"
+				 server="localhost"
+				 serverport=`echo $ES_PORT`
+				 template="tpl"
+				 searchIndex="rsyslog_testbench"
+				 retryruleset="try_es"
+				 )
+}
+
+ruleset(name="try_es") {
+		action(type="omelasticsearch"
+				 server="localhost"
+				 serverport=`echo $ES_PORT`
+				 template="tpl"
+				 searchIndex="rsyslog_testbench"
+				 retryruleset="try_es"
+				 )
+}
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_immediate
+wait_shutdown 
+content_check "ruleset 'try_es' specified more than once"
+exit_test


### PR DESCRIPTION
These test test errors described in
   https://github.com/rsyslog/rsyslog/pull/3796

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
