### PR TITLE
imptcp: cleanup error message generation

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -606,10 +606,7 @@ startupSrv(ptcpsrv_t *pSrv)
 #endif
 	    ) {
 			/* TODO: check if *we* bound the socket - else we *have* an error! */
-			char errStr[1024];
-			rs_strerror_r(errno, errStr, sizeof(errStr));
 			LogError(errno, NO_ERRCODE, "Error while binding tcp socket");
-			dbgprintf("error %d while binding tcp socket: %s\n", errno, errStr);
 			close(sock);
 			sock = -1;
 			continue;
@@ -635,6 +632,7 @@ startupSrv(ptcpsrv_t *pSrv)
 		}
 
 		if(listen(sock, pSrv->socketBacklog) < 0) {
+			LogError(errno, NO_ERRCODE, "imptcp error listening on port");
 			DBGPRINTF("tcp listen error %d, suspending\n", errno);
 			close(sock);
 			sock = -1;


### PR DESCRIPTION
also LogError also does DBGPRINTF, so we remove the duplicate one

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
