### PR TITLE
imptcp bugfix: port="0" parameter did not work as expected

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -508,6 +508,7 @@ startupSrv(ptcpsrv_t *pSrv)
 	struct addrinfo hints, *res = NULL, *r;
 	uchar *lstnIP;
 	int isIPv6 = 0;
+	int port_override = 0; /* if dyn port (0): use this for actually bound port */
 
 	if (pSrv->bUnixSocket) {
 		return startupUXSrv(pSrv);
@@ -535,6 +536,13 @@ startupSrv(ptcpsrv_t *pSrv)
 
 	numSocks = 0;   /* num of sockets counter at start of array */
 	for(r = res; r != NULL ; r = r->ai_next) {
+		if(port_override != 0) {
+			if(r->ai_family == AF_INET6) {
+				((struct sockaddr_in6*)r->ai_addr)->sin6_port = port_override;
+			} else {
+				((struct sockaddr_in*)r->ai_addr)->sin_port = port_override;
+			}
+		}
 		sock = socket(r->ai_family, r->ai_socktype, r->ai_protocol);
 		if(sock < 0) {
 			if(!(r->ai_family == PF_INET6 && errno == EAFNOSUPPORT)) {
@@ -615,23 +623,41 @@ startupSrv(ptcpsrv_t *pSrv)
 			continue;
 		}
 
-		if(pSrv->pszLstnPortFileName) {
-			FILE *fp;
-			if(getsockname(sock, r->ai_addr, &r->ai_addrlen) == -1) {
-				LogError(errno, NO_ERRCODE, "imptcp: ListenPortFileName: getsockname:"
+		/* if we bind to dynamic port (port 0 given), we will do so consistently. Thus
+		 * once we got a dynamic port, we will keep it and use it for other protocols
+		 * as well. As of my understanding, this should always work as the OS does not
+		 * pick a port that is used by some protocol (well, at least this looks very
+		 * unlikely...). If our asusmption is wrong, we should iterate until we find a
+		 * combination that works - it is very unusual to have the same service listen
+		 * on differnt ports on IPv4 and IPv6.
+		 */
+		const int currport = (isIPv6) ?
+			(((struct sockaddr_in6*)r->ai_addr)->sin6_port) :
+			(((struct sockaddr_in*)r->ai_addr)->sin_port) ;
+		if(currport == 0) {
+			socklen_t socklen_r = r->ai_addrlen;
+			if(getsockname(sock, r->ai_addr, &socklen_r) == -1) {
+				LogError(errno, NO_ERRCODE, "nsd_ptcp: ListenPortFileName: getsockname:"
 						"error while trying to get socket");
 			}
-			if((fp = fopen((const char*)pSrv->pszLstnPortFileName, "w+")) == NULL) {
-				LogError(errno, RS_RET_IO_ERROR, "imptcp: ListenPortFileName: "
-						"error while trying to open file");
-				ABORT_FINALIZE(RS_RET_IO_ERROR);
+			r->ai_addrlen = socklen_r;
+			port_override = (isIPv6) ?
+				(((struct sockaddr_in6*)r->ai_addr)->sin6_port) :
+				(((struct sockaddr_in*)r->ai_addr)->sin_port) ;
+			if(pSrv->pszLstnPortFileName != NULL) {
+				FILE *fp;
+				if((fp = fopen((const char*)pSrv->pszLstnPortFileName, "w+")) == NULL) {
+					LogError(errno, RS_RET_IO_ERROR, "imptcp: ListenPortFileName: "
+							"error while trying to open file");
+					ABORT_FINALIZE(RS_RET_IO_ERROR);
+				}
+				if(isIPv6) {
+					fprintf(fp, "%d", ntohs((((struct sockaddr_in6*)r->ai_addr)->sin6_port)));
+				} else {
+					fprintf(fp, "%d", ntohs((((struct sockaddr_in*)r->ai_addr)->sin_port)));
+				}
+				fclose(fp);
 			}
-			if(isIPv6) {
-				fprintf(fp, "%d", ntohs((((struct sockaddr_in6*)r->ai_addr)->sin6_port)));
-			} else {
-				fprintf(fp, "%d", ntohs((((struct sockaddr_in*)r->ai_addr)->sin_port)));
-			}
-			fclose(fp);
 		}
 
 		if(listen(sock, pSrv->socketBacklog) < 0) {

--- a/tests/imptcp-basic-hup.sh
+++ b/tests/imptcp-basic-hup.sh
@@ -5,13 +5,14 @@ export NUMMESSAGES=4000 # MUST be an even number!
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -p$TCPFLOOD_PORT -m$((NUMMESSAGES / 2))
 issue_HUP
 tcpflood -p$TCPFLOOD_PORT -m$((NUMMESSAGES / 2)) -i$((NUMMESSAGES / 2))


### PR DESCRIPTION
when multiple interfaces and/or protocols could be bound, each of
them used a different listener ports were assigned. While this is
basically correct, it makes things unusable, especially as
listenPortFileName will only contain the port number used for
the latest listener.

This patch now follows the model of nsd_ptcp.c to assign only
the first port randomly and then use that port consistently.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
