### PR TITLE
testbench imptcp: make port use more reliable

### DIFF
--- a/tests/imptcp-buffer-overflow.sh
+++ b/tests/imptcp-buffer-overflow.sh
@@ -7,12 +7,13 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -m5000 -F 65 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way too long message that has to be truncatedtest1 test2 test3 test4 test5 abcdefghijklmn test8 test9 test10 test11 test12 test13 test14 test15\""
 shutdown_when_empty
 wait_shutdown

--- a/tests/imptcp-connection-msg-disabled.sh
+++ b/tests/imptcp-connection-msg-disabled.sh
@@ -5,16 +5,17 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 :msg, contains, "msgnum:" {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)
 }
 
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -m1 -M"\"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:1\""
 shutdown_when_empty
 wait_shutdown

--- a/tests/imptcp-connection-msg-received.sh
+++ b/tests/imptcp-connection-msg-received.sh
@@ -5,16 +5,18 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" notifyonconnectionclose="on" notifyonconnectionopen="on")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	notifyonconnectionclose="on" notifyonconnectionopen="on")
 
 :msg, contains, "msgnum:" {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)
 }
 
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -m1 -M"\"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:1\""
 shutdown_when_empty
 wait_shutdown

--- a/tests/imptcp-custom-delimiter.sh
+++ b/tests/imptcp-custom-delimiter.sh
@@ -7,12 +7,15 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" AddtlFrameDelimiter="13")
+input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	AddtlFrameDelimiter="13")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -F13 -M "\"<120> 2011-03-01T11:22:12Z host tag: test short message\""
 tcpflood -F13 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way too long message that has to be truncatedtest1 test2 test3 test4 test5 abcdefghijklmn test8 test9 test10 test11 test12 test13 test14 test15 kkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkk tag: testtestetstetstetstetstetsstetstetsytetestetste\""
 shutdown_when_empty

--- a/tests/imptcp-discard-truncated-msg.sh
+++ b/tests/imptcp-discard-truncated-msg.sh
@@ -7,7 +7,8 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1" discardTruncatedMsg="on")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	ruleset="ruleset1" discardTruncatedMsg="on")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {
@@ -15,6 +16,7 @@ ruleset(name="ruleset1") {
 }
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test13 test14 test15 test16\""
 tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long message\""
 tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 test5 test6 test7 test8 test9 test10 test11 test12 test13 test14 test15 test16\""
@@ -22,14 +24,9 @@ tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way to long me
 shutdown_when_empty
 wait_shutdown
 
-echo '<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
+export EXPECTED='<120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
 <120> 2011-03-01T11:22:12Z host tag: this is a way to long message
 <120> 2011-03-01T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
-<120> 2011-03-01T11:22:12Z host tag: this is a way to long message' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
-
+<120> 2011-03-01T11:22:12Z host tag: this is a way to long message'
+cmp_exact
 exit_test

--- a/tests/imptcp_framing_regex-oversize.sh
+++ b/tests/imptcp_framing_regex-oversize.sh
@@ -6,7 +6,8 @@ add_conf '
 $EscapeControlCharactersOnReceive off
 global(maxMessageSize="256")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote"
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	ruleset="remote"
 	framing.delimiter.regex="^<[0-9]{2}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)")
 
 template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")
@@ -16,10 +17,11 @@ ruleset(name="remote") {
 action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -B -I ${srcdir}/testsuites/imptcp_framing_regex-oversize.testdata
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate
-echo 'NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test1
+export EXPECTED='NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test1
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test xml-ish
 <test/>
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test2
@@ -36,12 +38,8 @@ END
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test3
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
 line3
-NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test4' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test4'
+cmp_exact
 content_check-regex "assuming end of frame" ${RSYSLOG2_OUT_LOG}
 content_check-regex "message too long" ${RSYSLOG2_OUT_LOG}
 exit_test

--- a/tests/imptcp_framing_regex.sh
+++ b/tests/imptcp_framing_regex.sh
@@ -5,7 +5,8 @@ generate_conf
 add_conf '
 $EscapeControlCharactersOnReceive off
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote"
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	ruleset="remote"
 	framing.delimiter.regex="^<[0-9]{2}>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)")
 
 template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")
@@ -14,10 +15,11 @@ ruleset(name="remote") {
 }
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -B -I ${srcdir}/testsuites/imptcp_framing_regex.testdata
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown       # and wait for it to terminate
-echo 'NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test1
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test xml-ish
 <test/>
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test2
@@ -32,10 +34,6 @@ e2
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test3
 NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag multi
 line3
-NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test4' | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  error_exit  1
-fi;
+NEWMSG: <33>Mar  1 01:00:00 172.20.245.8 tag test4'
+cmp_exact
 exit_test

--- a/tests/imptcp_large.sh
+++ b/tests/imptcp_large.sh
@@ -10,13 +10,14 @@ global(maxMessageSize="10k")
 template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 # send messages of 10.000bytes plus header max, randomized
 tcpflood -c5 -m$NUMMESSAGES -r -d10000
 wait_file_lines


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
