### PR TITLE
testbench: remove debug output; lessen kafaka tests output

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -909,11 +909,9 @@ wait_file_lines() {
 		if [ "$count_function" == "" ]; then
 			if [ -f "$file" ]; then
 				if [ "$COUNT_FILE_IS_ZIPPED" == "yes" ]; then
-					echo zipped
 					issue_HUP ""
 					count=$(gunzip < "$file" | wc -l)
 				else
-					echo NON zipped
 					count=$(wc -l < "$file")
 				fi
 			fi
@@ -1172,7 +1170,7 @@ error_exit() {
 	#fi
 
 	# Extended debug output for dependencies started by testbench
-	if [[ "$EXTRA_EXITCHECK" == 'dumpkafkalogs' ]]; then
+	if [ "$EXTRA_EXITCHECK" == 'dumpkafkalogs' ] && [ "$TEST_OUTPUT" == "VERBOSE" ]; then
 		# Dump Zookeeper log
 		dump_zookeeper_serverlog
 		# Dump Kafka log


### PR DESCRIPTION
the kafka tests generate a wealth of usually-unneeded output which
clutters the CI logs and makes them almost unusable.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
