### PR TITLE
testbench: update sndrcv test to newest standard

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -508,6 +508,19 @@ assign_tcpflood_port() {
 	fi
 }
 
+# assign RCVR_PORT from port file
+# $1 - port file
+assign_rcvr_port() {
+	wait_file_exists "$1"
+	export RCVR_PORT=$(cat "$1")
+	echo "RCVR_PORT now: $RCVR_PORT"
+	if [ "$RCVR_PORT" == "" ]; then
+		echo "TESTBENCH ERROR: RCVR_PORT not found!"
+		ls -l $RSYSLOG_DYNNAME*
+		exit 100
+	fi
+}
+
 # same as startup_vg, BUT we do NOT wait on the startup message!
 startup_vg_waitpid_only() {
 	startup_common "$1" "$2"

--- a/tests/sndrcv.sh
+++ b/tests/sndrcv.sh
@@ -12,28 +12,30 @@ NUMMESSAGES=50000
 # start up the instances
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 # then SENDER sends to this port (not tcpflood!)
-input(type="imtcp" port="'$PORT_RCVR'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'"
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_rcvr_port $RSYSLOG_DYNNAME.rcvr_port
+
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 # this listener is for message generation by the test framework!
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
-action(type="omfwd" target="127.0.0.1" protocol="tcp" port="'$PORT_RCVR'")
+action(type="omfwd" target="127.0.0.1" protocol="tcp" port="'$RCVR_PORT'")
 ' 2
 startup 2
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.


### PR DESCRIPTION
this makes the test more reliable in regard to port use. This is also
a model-commit which can be used to update other tests and base new
tests on it.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
