### PR TITLE
testbench: increase runtime for know-problematic test

### DIFF
--- a/tests/manytcp-too-few-tls-vg.sh
+++ b/tests/manytcp-too-few-tls-vg.sh
@@ -4,7 +4,7 @@
 . ${srcdir:=.}/diag.sh init
 skip_platform "FreeBSD"  "This test does not work on FreeBSD"
 export NUMMESSAGES=40000 # we unfortunately need many messages as we have many connections
-export TB_TEST_MAX_RUNTIME=1200 # this test is VERY slow, so we need to override max runtime
+export TB_TEST_MAX_RUNTIME=1800 # this test is VERY slow, so we need to override max runtime
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp


### PR DESCRIPTION
this test often failed "unexpectedly" when the CI system is very
busy - assuming it just had insufficient time.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
