### PR TITLE
testbench: add test for imuxsock legacy format

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -311,6 +311,7 @@ TESTS +=  \
 	pipe_noreader.sh \
 	dircreate_dflt.sh \
 	dircreate_off.sh \
+	imuxsock_legacy.sh \
 	imuxsock_logger.sh \
 	imuxsock_logger_ruleset.sh \
 	imuxsock_logger_ruleset_ratelimit.sh \
@@ -2180,6 +2181,7 @@ EXTRA_DIST= \
 	tabescape_on.sh \
 	dircreate_dflt.sh \
 	dircreate_off.sh \
+	imuxsock_legacy.sh \
 	imuxsock_logger_parserchain.sh \
 	imuxsock_logger.sh \
 	imuxsock_logger_ruleset.sh \

--- a/tests/imuxsock_legacy.sh
+++ b/tests/imuxsock_legacy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This tests legacy syntax.
+# Added 2019-08-13 by Rainer Gerhards; released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_logger_has_option_d
+generate_conf
+add_conf '
+$ModLoad ../plugins/imuxsock/.libs/imuxsock
+$OmitLocalLogging on
+
+$AddUnixListenSocket '$RSYSLOG_DYNNAME'-testbench_socket
+
+template(name="outfmt" type="string" string="%msg:%\n")
+*.notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+# send a message with trailing LF
+logger -d -u $RSYSLOG_DYNNAME-testbench_socket test
+shutdown_when_empty
+wait_shutdown
+export EXPECTED=" test"
+cmp_exact
+exit_test


### PR DESCRIPTION
This was never tested. Ensures we don't accidently break existing
configurations.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
