### PR TITLE
core/action: guard action.externalstate.file content against whitspace

### DIFF
--- a/action.c
+++ b/action.c
@@ -716,6 +716,14 @@ checkExternalStateFile(action_t *const pThis, wti_t *const pWti)
 
 	filebuf[r] = '\0';
 	dbgprintf("external state file content: '%s'\n", filebuf);
+	/* trim trailing whitespace */
+	for(int j = r-1 ; j > 0 ; --j) {
+		if(filebuf[j] == '\n' || filebuf[j] == '\t' || filebuf[j] == ' ') {
+			filebuf[j] = '\0';
+		} else {
+			break;
+		}
+	}
 	if(!strcmp(filebuf, "SUSPENDED")) {
 		LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
 		      "action '%s' suspended (module '%s') by external state file",

--- a/tests/suspend-via-file.sh
+++ b/tests/suspend-via-file.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-# This tests the action suspension via a file
+# This tests the action suspension via a file; we use a SUSPENDED string
+# with trailing whitespace in this test.
 # This file is part of the rsyslog project, released under ASL 2.0
 # Written 2018-08-13 by Rainer Gerhards
 . ${srcdir:=.}/diag.sh init
@@ -41,7 +42,7 @@ seq_check 0 $LOG2_EXPECTED_LASTNUM # full correctness check
 
 printf '\n%s %s\n' "$(tb_timestamp)" \
 	'STEP 2: checking that action becomes suspended via external state file'
-printf "%s" "SUSPENDED" > $RSYSLOG_DYNNAME.STATE
+printf 'SUSPENDED \n' > $RSYSLOG_DYNNAME.STATE
 injectmsg 2500 2500
 export SEQ_CHECK_FILE="$RSYSLOG_OUT_LOG"
 export QUEUE_EMPTY_CHECK_FUNC=check_q_empty_log1


### PR DESCRIPTION
remove trailing whitespace before checking the status string. This is
most important as a line usually ends with \n, which is considered
trailing whitespace. Accepting this increases usability.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
