### PR TITLE
testbench: add tests for $AllowedSender functionality

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -238,6 +238,8 @@ TESTS +=  \
 	msgdup_props.sh \
 	empty-ruleset.sh \
 	imtcp-listen-port-file-2.sh \
+	allowed-sender-tcp-ok.sh \
+	allowed-sender-tcp-fail.sh \
 	imtcp-discard-truncated-msg.sh \
 	imtcp-basic.sh \
 	imtcp-basic-hup.sh \
@@ -1871,6 +1873,8 @@ EXTRA_DIST= \
 	msgdup_props.sh \
 	empty-ruleset.sh \
 	imtcp-listen-port-file-2.sh \
+	allowed-sender-tcp-ok.sh \
+	allowed-sender-tcp-fail.sh \
 	imtcp-discard-truncated-msg.sh \
 	imtcp-basic.sh \
 	imtcp-basic-hup.sh \

--- a/tests/allowed-sender-tcp-fail.sh
+++ b/tests/allowed-sender-tcp-fail.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# check that we are able to receive messages from allowed sender
+# added 2019-08-15 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5 # it's just important that we get any messages at all
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="rs")
+
+$AllowedSender TCP,128.66.0.0/16 # this IP range is reserved by RFC5737
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+ruleset(name="rs") {
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_DYNNAME.must-not-be-created'")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+tcpflood -m$NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+content_check --regex "TCP message from disallowed sender .* discarded"
+check_file_not_exists "$RSYSLOG_DYNNAME.must-not-be-created"
+exit_test

--- a/tests/allowed-sender-tcp-ok.sh
+++ b/tests/allowed-sender-tcp-ok.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# check that we are able to receive messages from allowed sender
+# added 2019-08-15 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5 # it's just important that we get any messages at all
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+$AllowedSender TCP,127.0.0.1
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+tcpflood -m$NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
while this is deprecated, it is still used in practice. So far no
test guarded this functionality.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
