### PR TITLE
testbench: make most tests use a port file and assign listen port 0

### DIFF
--- a/tests/clickhouse-errorfile.sh
+++ b/tests/clickhouse-errorfile.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.errorfile (id, severity, facility, timestamp, ipaddress, tag, message) VALUES (%msg:F,58:2%, %syslogseverity%, %syslogfacility%, '
 add_conf "'%timereported:::date-unixtimestamp%', '%fromhost-ip%', '%syslogtag%', '%msg%')"

--- a/tests/clickhouse-wrong-quotation-marks.sh
+++ b/tests/clickhouse-wrong-quotation-marks.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omclickhouse/.libs/omclickhouse")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 
 template(name="outfmt" option.stdsql="on" type="string" string="INSERT INTO rsyslog.quotation (id, severity, message) VALUES ( 1, '

--- a/tests/compresssp-stringtpl.sh
+++ b/tests/compresssp-stringtpl.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:::compressSPACE%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/compresssp.sh
+++ b/tests/compresssp.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="list") {
 	property(name="msg" compressSpace="on")

--- a/tests/diskq-rfc5424.sh
+++ b/tests/diskq-rfc5424.sh
@@ -17,7 +17,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="rs")
 
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/dnscache-TTL-0.sh
+++ b/tests/dnscache-TTL-0.sh
@@ -7,7 +7,7 @@ add_conf '
 global(reverselookup.cache.ttl.default="0"
        reverselookup.cache.ttl.enable="on")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/empty-prop-comparison.sh
+++ b/tests/empty-prop-comparison.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 set $!doOutput = "";

--- a/tests/empty-ruleset.sh
+++ b/tests/empty-ruleset.sh
@@ -8,7 +8,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 $MainMsgQueueTimeoutShutdown 10000
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="real")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="real")
 input(type="imtcp" port="'$TCPFLOOD_PORT2'" ruleset="empty")
 
 $template outfmt,"%msg:F,58:2%\n"

--- a/tests/exec_tpl-concurrency.sh
+++ b/tests/exec_tpl-concurrency.sh
@@ -15,7 +15,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="interim" type="string" string="%$!tree!here!nbr%")
 template(name="outfmt" type="string" string="%$!interim%\n")

--- a/tests/fac_invld1.sh
+++ b/tests/fac_invld1.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_invld2.sh
+++ b/tests/fac_invld2.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_invld3.sh
+++ b/tests/fac_invld3.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_invld4_rfc5424.sh
+++ b/tests/fac_invld4_rfc5424.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:4%\n")
 invld.=debug action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_local0-vg.sh
+++ b/tests/fac_local0-vg.sh
@@ -13,7 +13,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if $syslogfacility-text == "local0" then

--- a/tests/fac_local0.sh
+++ b/tests/fac_local0.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if $syslogfacility-text == "local0" then

--- a/tests/fac_local7.sh
+++ b/tests/fac_local7.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if $syslogfacility-text == "local7" then

--- a/tests/fac_mail.sh
+++ b/tests/fac_mail.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 mail.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fac_news.sh
+++ b/tests/fac_news.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 if prifilt("news.*") then

--- a/tests/fac_uucp.sh
+++ b/tests/fac_uucp.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 uucp.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")

--- a/tests/fieldtest.sh
+++ b/tests/fieldtest.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg:F,32:2%\n")
 

--- a/tests/global_vars.sh
+++ b/tests/global_vars.sh
@@ -10,7 +10,7 @@ add_conf '
 $MainMsgQueueTimeoutShutdown 10000
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%$/msgnum%\n")
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) /* trick to use relative path names! */

--- a/tests/gzipwr_flushInterval.sh
+++ b/tests/gzipwr_flushInterval.sh
@@ -11,7 +11,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%\n")

--- a/tests/gzipwr_flushOnTXEnd.sh
+++ b/tests/gzipwr_flushOnTXEnd.sh
@@ -11,7 +11,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%\n")

--- a/tests/gzipwr_hup.sh
+++ b/tests/gzipwr_hup.sh
@@ -8,7 +8,7 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/gzipwr_hup_multi_file.sh
+++ b/tests/gzipwr_hup_multi_file.sh
@@ -8,7 +8,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 main_queue(queue.workerThreads="10" queue.workerThreadMinimumMessages="200")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/gzipwr_hup_single_file.sh
+++ b/tests/gzipwr_hup_single_file.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 main_queue(queue.workerThreads="10" queue.workerThreadMinimumMessages="200")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/gzipwr_rscript.sh
+++ b/tests/gzipwr_rscript.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/hostname-with-slash-dflt-invld.sh
+++ b/tests/hostname-with-slash-dflt-invld.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%hostname%") # no LF, as HOSTNAME file also does not have it!
 
 local4.debug action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)

--- a/tests/hostname-with-slash-dflt-slash-valid.sh
+++ b/tests/hostname-with-slash-dflt-slash-valid.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%hostname%\n")
 
 # note: we use the default parser chain, which includes RFC5424 and that parser

--- a/tests/hostname-with-slash-pmrfc3164.sh
+++ b/tests/hostname-with-slash-pmrfc3164.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%hostname%\n")
 
 parser(name="pmrfc3164.hostname_with_slashes" type="pmrfc3164" permit.slashesinhostname="on")

--- a/tests/hostname-with-slash-pmrfc5424.sh
+++ b/tests/hostname-with-slash-pmrfc5424.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%hostname%\n")
 
 $rulesetparser rsyslog.rfc5424

--- a/tests/imptcp-NUL-rawmsg.sh
+++ b/tests/imptcp-NUL-rawmsg.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imptcp-NUL.sh
+++ b/tests/imptcp-NUL.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imptcp-custom-delimiter.sh
+++ b/tests/imptcp-custom-delimiter.sh
@@ -7,7 +7,6 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
 input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
 	AddtlFrameDelimiter="13")
 

--- a/tests/imptcp-maxFrameSize-parameter.sh
+++ b/tests/imptcp-maxFrameSize-parameter.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 12800
 global(processInternalMessages="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" maxframesize="100")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" maxframesize="100")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp-msg-truncation-on-number.sh
+++ b/tests/imptcp-msg-truncation-on-number.sh
@@ -8,7 +8,7 @@ $MaxMessageSize 128
 global(processInternalMessages="on"
 	oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp-msg-truncation-on-number2.sh
+++ b/tests/imptcp-msg-truncation-on-number2.sh
@@ -8,7 +8,7 @@ $MaxMessageSize 128
 global(processInternalMessages="on"
 	oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="templ1" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {

--- a/tests/imptcp-oversize-message-display.sh
+++ b/tests/imptcp-oversize-message-display.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on" oversizemsg.input.mode="accept")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 

--- a/tests/imptcp_multi_line.sh
+++ b/tests/imptcp_multi_line.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote" multiline="on")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="remote" multiline="on")
 
 template(name="outfmt" type="string" string="NEWMSG: %rawmsg%\n")
 ruleset(name="remote") {

--- a/tests/imptcp_no_octet_counted.sh
+++ b/tests/imptcp_no_octet_counted.sh
@@ -6,7 +6,7 @@ echo TEST: \[imptcp_no_octet_counted.sh\]: test imptcp with octet counted framin
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote" supportOctetCountedFraming="off")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="remote" supportOctetCountedFraming="off")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="remote") {

--- a/tests/imptcp_nonProcessingPoller.sh
+++ b/tests/imptcp_nonProcessingPoller.sh
@@ -10,7 +10,7 @@ $MaxMessageSize 10k
 template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp" threads="32" processOnPoller="off")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 if (prifilt("local0.*")) then {
    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")

--- a/tests/imptcp_spframingfix.sh
+++ b/tests/imptcp_spframingfix.sh
@@ -6,7 +6,7 @@ echo TEST: \[imptcp_spframingfix.sh\]: test imptcp in regard to Cisco ASA framin
 generate_conf
 add_conf '
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="remote" framingfix.cisco.asa="on")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="remote" framingfix.cisco.asa="on")
 
 template(name="outfmt" type="string" string="%rawmsg:6:7%\n")
 ruleset(name="remote") {

--- a/tests/imptcp_veryLargeOctateCountedMessages.sh
+++ b/tests/imptcp_veryLargeOctateCountedMessages.sh
@@ -10,7 +10,7 @@ add_conf '$MaxMessageSize 10k
 template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp" threads="32" processOnPoller="off")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 if (prifilt("local0.*")) then {
    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")

--- a/tests/imtcp-NUL-rawmsg.sh
+++ b/tests/imtcp-NUL-rawmsg.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imtcp-NUL.sh
+++ b/tests/imtcp-NUL.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/imtcp-basic.sh
+++ b/tests/imtcp-basic.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
-
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -12,9 +11,8 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -p'$TCPFLOOD_PORT' -m10000
-shutdown_when_empty # shut down rsyslogd when done processing messages
+shutdown_when_empty
 wait_shutdown
 seq_check 0 9999
 exit_test

--- a/tests/imtcp-discard-truncated-msg.sh
+++ b/tests/imtcp-discard-truncated-msg.sh
@@ -6,7 +6,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imtcp/.libs/imtcp" discardTruncatedMsg="on")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {

--- a/tests/imtcp-maxFrameSize.sh
+++ b/tests/imtcp-maxFrameSize.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 global(processInternalMessages="on")
 module(load="../plugins/imtcp/.libs/imtcp" maxFrameSize="100")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '

--- a/tests/imtcp-msg-truncation-on-number.sh
+++ b/tests/imtcp-msg-truncation-on-number.sh
@@ -8,7 +8,7 @@ $MaxMessageSize 128
 global(processInternalMessages="on"
 	oversizemsg.input.mode="accept")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 '

--- a/tests/imtcp-msg-truncation-on-number2.sh
+++ b/tests/imtcp-msg-truncation-on-number2.sh
@@ -7,7 +7,7 @@ add_conf '
 $MaxMessageSize 128
 global(processInternalMessages="on")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="templ1" type="string" string="%rawmsg%\n")
 ruleset(name="ruleset1") {

--- a/tests/imtcp-tls-gtls-x509fingerprint-invld.sh
+++ b/tests/imtcp-tls-gtls-x509fingerprint-invld.sh
@@ -19,7 +19,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.AuthMode="x509/fingerprint"
 	PermittedPeer=["SHA1:FF:C6:62:D5:9D:25:9F:BC:F3:CB:61:FA:D2:B3:8B:61:88:D7:06:C3"] # INVALID!
 	)
-input(type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '

--- a/tests/imtcp-tls-gtls-x509name-invld.sh
+++ b/tests/imtcp-tls-gtls-x509name-invld.sh
@@ -16,7 +16,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.AuthMode="x509/name"
 	PermittedPeer=["INVALID"]
 	)
-input(type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '

--- a/tests/imtcp-tls-ossl-error-ca.sh
+++ b/tests/imtcp-tls-ossl-error-ca.sh
@@ -10,7 +10,7 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca-fail.pem'"
 )
 
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="ossl" StreamDriver.Mode="1")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0") # no listenPortFile here, because listener does not start up at all!
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '

--- a/tests/imtcp-tls-ossl-error-cert.sh
+++ b/tests/imtcp-tls-ossl-error-cert.sh
@@ -10,7 +10,7 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )
 
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="ossl" StreamDriver.Mode="1")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0") # no listenPortFile here, because listener does not start up at all!
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '

--- a/tests/imtcp-tls-ossl-error-key.sh
+++ b/tests/imtcp-tls-ossl-error-key.sh
@@ -11,7 +11,7 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )
 
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="ossl" StreamDriver.Mode="1")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0") # no listenPortFile here, because listener does not start up at all!
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '

--- a/tests/imtcp-tls-ossl-error-key2.sh
+++ b/tests/imtcp-tls-ossl-error-key2.sh
@@ -10,7 +10,7 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )
 
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="ossl" StreamDriver.Mode="1")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0") # no listenPortFile here, because listener does not start up at all!
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '

--- a/tests/imtcp_incomplete_frame_at_end.sh
+++ b/tests/imtcp_incomplete_frame_at_end.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="list") {
 	property(name="msg")

--- a/tests/imtcp_no_octet_counted.sh
+++ b/tests/imtcp_no_octet_counted.sh
@@ -6,7 +6,7 @@ echo TEST: \[imtcp_no_octet_counted.sh\]: test imtcp with octet counted framing 
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="remote" supportOctetCountedFraming="off")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="remote" supportOctetCountedFraming="off")
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 ruleset(name="remote") {

--- a/tests/imtcp_spframingfix.sh
+++ b/tests/imtcp_spframingfix.sh
@@ -6,7 +6,7 @@ echo TEST: \[imptcp_spframingfix.sh\]: test imptcp in regard to Cisco ASA framin
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="remote" framingfix.cisco.asa="on")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="remote" framingfix.cisco.asa="on")
 
 template(name="outfmt" type="string" string="%rawmsg:6:7%\n")
 ruleset(name="remote") {

--- a/tests/json_array_looping-vg.sh
+++ b/tests/json_array_looping-vg.sh
@@ -20,7 +20,7 @@ template(name="quux" type="string" string="quux: %$.quux%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_array_looping.sh
+++ b/tests/json_array_looping.sh
@@ -12,7 +12,7 @@ template(name="quux" type="string" string="quux: %$.quux%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_array_subscripting.sh
+++ b/tests/json_array_subscripting.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="msg: %$!foo[1]% | %$.quux% | %$.cor
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 set $.quux = $!foo[2];

--- a/tests/json_nonarray_looping.sh
+++ b/tests/json_nonarray_looping.sh
@@ -12,7 +12,7 @@ template(name="quux" type="string" string="quux: %$.quux%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_null-vg.sh
+++ b/tests/json_null-vg.sh
@@ -17,7 +17,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # we must make sure the template contains a reference to the 
 # data item with null value

--- a/tests/json_null.sh
+++ b/tests/json_null.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # we must make sure the template contains a reference to the 
 # data item with null value

--- a/tests/json_null_array-vg.sh
+++ b/tests/json_null_array-vg.sh
@@ -15,7 +15,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%$.data%\n")
 

--- a/tests/json_null_array.sh
+++ b/tests/json_null_array.sh
@@ -8,7 +8,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%$.data%\n")
 

--- a/tests/json_object_looping-vg.sh
+++ b/tests/json_object_looping-vg.sh
@@ -21,7 +21,7 @@ template(name="modified" type="string" string="new: %$!foo!str4% deleted: %$!foo
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_object_looping.sh
+++ b/tests/json_object_looping.sh
@@ -14,7 +14,7 @@ template(name="modified" type="string" string="new: %$!foo!str4% deleted: %$!foo
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_object_suicide_in_loop-vg.sh
+++ b/tests/json_object_suicide_in_loop-vg.sh
@@ -19,7 +19,7 @@ add_conf '\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 set $.garply = "";

--- a/tests/json_var_case.sh
+++ b/tests/json_var_case.sh
@@ -9,7 +9,7 @@ add_conf '
 global(variables.casesensitive="on")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # we must make sure the template contains references to the variables
 template(name="outfmt" type="string" string="abc:%$!abc% ABC:%$!ABC% aBc:%$!aBc% _abc:%$!_abc% _ABC:%$!_ABC% _aBc:%$!_aBc%\n" option.casesensitive="on")

--- a/tests/json_var_cmpr.sh
+++ b/tests/json_var_cmpr.sh
@@ -8,7 +8,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # we must make sure the template contains references to the variables
 template(name="outfmt" type="string" string="json prop:%$!val%  local prop:%$.val%  global prop:%$/val%\n")

--- a/tests/key_dereference_on_uninitialized_variable_space.sh
+++ b/tests/key_dereference_on_uninitialized_variable_space.sh
@@ -17,7 +17,7 @@ ruleset(name="echo") {
   action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="corge")
 }
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 call echo
 '

--- a/tests/localvar-concurrency.sh
+++ b/tests/localvar-concurrency.sh
@@ -15,7 +15,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%$.tree!here!nbr%\n")
 

--- a/tests/mmanon_both_modes_compatible.sh
+++ b/tests/mmanon_both_modes_compatible.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.enable="on" ipv4.mode="zero" ipv4.bits="32" ipv6.bits="128" ipv6.anonmode="zero" ipv6.enable="on")

--- a/tests/mmanon_random_128_ipv6.sh
+++ b/tests/mmanon_random_128_ipv6.sh
@@ -8,7 +8,7 @@ template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}.'%syslogtag%.
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.anonmode="random" ipv6.bits="128" ipv6.enable="on")

--- a/tests/mmanon_random_32_ipv4.sh
+++ b/tests/mmanon_random_32_ipv4.sh
@@ -8,7 +8,7 @@ template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}'.%syslogtag%.
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.mode="random" ipv4.bits="32")

--- a/tests/mmanon_random_cons_128_ipembedded.sh
+++ b/tests/mmanon_random_cons_128_ipembedded.sh
@@ -8,7 +8,7 @@ template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}'.%syslogtag%.
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.enable="off" ipv4.enable="off" embeddedipv4.anonmode="random-consistent" embeddedipv4.bits="128")

--- a/tests/mmanon_random_cons_128_ipv6.sh
+++ b/tests/mmanon_random_cons_128_ipv6.sh
@@ -8,7 +8,7 @@ template(name="filename" type="string" string="'${RSYSLOG_DYNNAME}'.%syslogtag%.
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.anonmode="random-consistent" ipv6.bits="128")

--- a/tests/mmanon_random_cons_32_ipv4.sh
+++ b/tests/mmanon_random_cons_32_ipv4.sh
@@ -8,7 +8,7 @@ template(name="filename" type="string" string="'$RSYSLOG_DYNNAME'.%syslogtag%.lo
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.mode="random-consistent" ipv4.bits="32")

--- a/tests/mmanon_recognize_ipembedded.sh
+++ b/tests/mmanon_recognize_ipembedded.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.enable="off" ipv6.enable="off" embeddedipv4.bits="128" embeddedipv4.anonmode="zero")

--- a/tests/mmanon_recognize_ipv4.sh
+++ b/tests/mmanon_recognize_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" mode="zero" ipv4.bits="32")

--- a/tests/mmanon_recognize_ipv6.sh
+++ b/tests/mmanon_recognize_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.enable="off" ipv6.enable="on" ipv6.bits="128" ipv6.anonmode="zero")

--- a/tests/mmanon_simple_12_ipv4.sh
+++ b/tests/mmanon_simple_12_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="12" ipv4.mode="simple")

--- a/tests/mmanon_simple_33_ipv4.sh
+++ b/tests/mmanon_simple_33_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="33" ipv4.mode="simple" ipv4.replacechar="*")

--- a/tests/mmanon_simple_8_ipv4.sh
+++ b/tests/mmanon_simple_8_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="8" ipv4.mode="simple")

--- a/tests/mmanon_with_debug.sh
+++ b/tests/mmanon_with_debug.sh
@@ -11,7 +11,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" mode="zero" ipv4.bits="32")

--- a/tests/mmanon_zero_128_ipv6.sh
+++ b/tests/mmanon_zero_128_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.bits="129" ipv6.anonmode="zero")

--- a/tests/mmanon_zero_12_ipv4.sh
+++ b/tests/mmanon_zero_12_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="12")

--- a/tests/mmanon_zero_33_ipv4.sh
+++ b/tests/mmanon_zero_33_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="33")

--- a/tests/mmanon_zero_50_ipv6.sh
+++ b/tests/mmanon_zero_50_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.bits="50" ipv6.anonmode="zero")

--- a/tests/mmanon_zero_64_ipv6.sh
+++ b/tests/mmanon_zero_64_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv6.bits="64" ipv6.anonmode="zero")

--- a/tests/mmanon_zero_8_ipv4.sh
+++ b/tests/mmanon_zero_8_ipv4.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="8")

--- a/tests/mmanon_zero_96_ipv6.sh
+++ b/tests/mmanon_zero_96_ipv6.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmanon/.libs/mmanon")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmanon")

--- a/tests/mmdarwin_empty_fields.sh
+++ b/tests/mmdarwin_empty_fields.sh
@@ -24,7 +24,7 @@ template(name="darwin-output" type="list") {
 module(load="../plugins/imptcp/.libs/imptcp")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../contrib/mmdarwin/.libs/mmdarwin")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
     action(type="mmjsonparse" cookie="")

--- a/tests/mmdarwin_empty_key.sh
+++ b/tests/mmdarwin_empty_key.sh
@@ -18,7 +18,7 @@ template(name="darwin-output" type="list") {
 module(load="../plugins/imptcp/.libs/imptcp")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../contrib/mmdarwin/.libs/mmdarwin")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
     action(type="mmjsonparse" cookie="")

--- a/tests/mmdarwin_invalid_fields.sh
+++ b/tests/mmdarwin_invalid_fields.sh
@@ -24,7 +24,7 @@ template(name="darwin-output" type="list") {
 module(load="../plugins/imptcp/.libs/imptcp")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../contrib/mmdarwin/.libs/mmdarwin")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
     action(type="mmjsonparse" cookie="")

--- a/tests/mmdarwin_non_existing_fields.sh
+++ b/tests/mmdarwin_non_existing_fields.sh
@@ -24,7 +24,7 @@ template(name="darwin-output" type="list") {
 module(load="../plugins/imptcp/.libs/imptcp")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../contrib/mmdarwin/.libs/mmdarwin")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
     action(type="mmjsonparse" cookie="")

--- a/tests/mmdarwin_successful_call.sh
+++ b/tests/mmdarwin_successful_call.sh
@@ -24,7 +24,7 @@ template(name="darwin-output" type="list") {
 module(load="../plugins/imptcp/.libs/imptcp")
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../contrib/mmdarwin/.libs/mmdarwin")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
     action(type="mmjsonparse" cookie="")

--- a/tests/mmdb-container-empty.sh
+++ b/tests/mmdb-container-empty.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%$!src_geoip%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup" container="!")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmdb-container.sh
+++ b/tests/mmdb-container.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%$!mmdb_root%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup" container="!mmdb_root")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmdb-multilevel-vg.sh
+++ b/tests/mmdb-multilevel-vg.sh
@@ -11,7 +11,7 @@ template(name="outfmt" type="string" string="%$!iplocation%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase="'$srcdir'/mmdb.rb")

--- a/tests/mmdb-vg.sh
+++ b/tests/mmdb-vg.sh
@@ -11,7 +11,7 @@ template(name="outfmt" type="string" string="%$!iplocation%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase="'$srcdir'/mmdb.rb")

--- a/tests/mmdb.sh
+++ b/tests/mmdb.sh
@@ -14,7 +14,7 @@ template(name="outfmt" type="string" string="%$!iplocation%\n")
 module(load="../plugins/mmdblookup/.libs/mmdblookup")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)

--- a/tests/mmexternal-InvldProg-vg.sh
+++ b/tests/mmexternal-InvldProg-vg.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmexternal/.libs/mmexternal")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 set $!x = "a";
 
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmexternal-SegFault-empty-jroot-vg.sh
+++ b/tests/mmexternal-SegFault-empty-jroot-vg.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmexternal/.libs/mmexternal")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="-%$!%-\n")
 

--- a/tests/mmexternal-SegFault-vg.sh
+++ b/tests/mmexternal-SegFault-vg.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmexternal/.libs/mmexternal")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 set $!x = "a";
 
 template(name="outfmt" type="string" string="-%$!%-\n")

--- a/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
+++ b/tests/mmjsonparse-w-o-cookie-multi-spaces.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse" cookie="")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse-w-o-cookie.sh
+++ b/tests/mmjsonparse-w-o-cookie.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse" cookie="")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_cim.sh
+++ b/tests/mmjsonparse_cim.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$!cim!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse" cookie="@cim:" container="!cim")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_cim2.sh
+++ b/tests/mmjsonparse_cim2.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$!cim!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse" cookie="@cim:" container="$!cim")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_extra_data-vg.sh
+++ b/tests/mmjsonparse_extra_data-vg.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="-%msg%-\n")
 

--- a/tests/mmjsonparse_localvar.sh
+++ b/tests/mmjsonparse_localvar.sh
@@ -7,7 +7,7 @@ template(name="outfmt" type="string" string="%$.msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse" cookie="@cim:" container="$.")
 if $parsesuccess == "OK" then {

--- a/tests/mmjsonparse_simple.sh
+++ b/tests/mmjsonparse_simple.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$!msgnum%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 if $parsesuccess == "OK" then {

--- a/tests/mmnormalize_processing_test1.sh
+++ b/tests/mmnormalize_processing_test1.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_processing_test2.sh
+++ b/tests/mmnormalize_processing_test2.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_processing_test3.sh
+++ b/tests/mmnormalize_processing_test3.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_processing_test4.sh
+++ b/tests/mmnormalize_processing_test4.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %timestamp:::date-rfc3339% %hostname% %$!v_tag% %$!v_msg%\n")
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")

--- a/tests/mmnormalize_regex.sh
+++ b/tests/mmnormalize_regex.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize" allowRegex="on")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")

--- a/tests/mmnormalize_regex_defaulted.sh
+++ b/tests/mmnormalize_regex_defaulted.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")

--- a/tests/mmnormalize_regex_disabled.sh
+++ b/tests/mmnormalize_regex_disabled.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize" allowRegex="off")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")

--- a/tests/mmnormalize_rule_from_array.sh
+++ b/tests/mmnormalize_rule_from_array.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="norm")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="norm")
 
 template(name="outfmt" type="string" string="%hostname% %syslogtag%\n")
 

--- a/tests/mmnormalize_rule_from_string.sh
+++ b/tests/mmnormalize_rule_from_string.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="norm")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="norm")
 
 template(name="outfmt" type="string" string="%hostname% %syslogtag%\n")
 

--- a/tests/mmnormalize_tokenized.sh
+++ b/tests/mmnormalize_tokenized.sh
@@ -13,7 +13,7 @@ template(name="numbers" type="string" string="nos: %$!some_nos%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_tokenized.rulebase`)
 if ( $!only_ips != "" ) then {

--- a/tests/mmnormalize_variable.sh
+++ b/tests/mmnormalize_variable.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="h:%$!hr% m:%$!min% s:%$!sec%\n")
 
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="time_fragment" type="list") {
   property(name="msg" regex.Expression="[0-9]{2}:[0-9]{2}:[0-9]{2} [A-Z]+" regex.Type="ERE" regex.Match="0")

--- a/tests/mmpstrucdata-invalid-vg.sh
+++ b/tests/mmpstrucdata-invalid-vg.sh
@@ -14,7 +14,7 @@ add_conf '
 module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
 module(load="../plugins/imtcp/.libs/imtcp")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmpstrucdata")
 if $msg contains "msgnum" then

--- a/tests/mmpstrucdata-vg.sh
+++ b/tests/mmpstrucdata-vg.sh
@@ -18,7 +18,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 
 template(name="outfmt" type="string" string="%$!rfc5424-sd!tcpflood@32473!msgnum%\n")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmpstrucdata")
 if $msg contains "msgnum" then

--- a/tests/mmpstrucdata.sh
+++ b/tests/mmpstrucdata.sh
@@ -9,7 +9,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 
 template(name="outfmt" type="string" string="%$!rfc5424-sd!tcpflood@32473!msgnum%\n")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmpstrucdata")
 if $msg contains "msgnum" then

--- a/tests/mmrm1stspace-basic.sh
+++ b/tests/mmrm1stspace-basic.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 module(load="../plugins/mmrm1stspace/.libs/mmrm1stspace")
 template(name="outfmt" type="string" string="-%msg%-\n")

--- a/tests/mmtaghostname_server.sh
+++ b/tests/mmtaghostname_server.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/mmtaghostname/.libs/mmtaghostname")
 global(localhostname="frontAPP")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 template(name="test" type="string" string="tag: %syslogtag%, server: %hostname%, msg: %msg%\n")
 ruleset(name="ruleset") {
 	action(type="mmtaghostname" forcelocalhostname="on")

--- a/tests/mmtaghostname_tag.sh
+++ b/tests/mmtaghostname_tag.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/mmtaghostname/.libs/mmtaghostname")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 template(name="test" type="string" string="tag: %syslogtag%, server: %hostname%, msg: %msg%\n")
 ruleset(name="ruleset") {
 	action(type="mmtaghostname" tag="source-imtcp")

--- a/tests/mmutf8fix_no_error.sh
+++ b/tests/mmutf8fix_no_error.sh
@@ -8,7 +8,7 @@ template(name="outfmt" type="string" string="%msg%\n")
 
 module(load="../plugins/mmutf8fix/.libs/mmutf8fix")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="testing")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
 ruleset(name="testing") {
 	action(type="mmutf8fix")

--- a/tests/msg-deadlock-headerless-noappname.sh
+++ b/tests/msg-deadlock-headerless-noappname.sh
@@ -6,7 +6,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="input")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="input")
 
 ruleset(name="input") {
     set $!tag = $app-name;

--- a/tests/msgvar-concurrency-array-event.tags.sh
+++ b/tests/msgvar-concurrency-array-event.tags.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%$!%\n")
 

--- a/tests/msgvar-concurrency-array.sh
+++ b/tests/msgvar-concurrency-array.sh
@@ -10,7 +10,7 @@ generate_conf
 add_conf '
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%$!%\n")
 

--- a/tests/msgvar-concurrency.sh
+++ b/tests/msgvar-concurrency.sh
@@ -12,7 +12,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%$!tree!here!nbr%\n")
 

--- a/tests/nested-call-shutdown.sh
+++ b/tests/nested-call-shutdown.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/omtesting/.libs/omtesting")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 

--- a/tests/no-parser-errmsg.sh
+++ b/tests/no-parser-errmsg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 template(name="test" type="string" string="tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 ruleset(name="ruleset" parser="rsyslog.rfc5424") {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG` template="test")

--- a/tests/no-parser-vg.sh
+++ b/tests/no-parser-vg.sh
@@ -11,7 +11,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 ruleset(name="ruleset" parser="rsyslog.rfc5424") {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)
 }

--- a/tests/omfile-read-only-errmsg.sh
+++ b/tests/omfile-read-only-errmsg.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" {

--- a/tests/omfile-read-only.sh
+++ b/tests/omfile-read-only.sh
@@ -11,7 +11,7 @@ messages=20000 # how many messages to inject?
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" {

--- a/tests/omfile_both_files_set.sh
+++ b/tests/omfile_both_files_set.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="dynafile" type="string" string=`echo $RSYSLOG_OUT_LOG`)
 template(name="outfmt" type="string" string="-%msg%-\n")

--- a/tests/omfile_hup.sh
+++ b/tests/omfile_hup.sh
@@ -7,7 +7,7 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string"
 	 string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")

--- a/tests/omfwd-keepalive.sh
+++ b/tests/omfwd-keepalive.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="list") {
 	property(name="msg")

--- a/tests/omjournal-basic-no-template.sh
+++ b/tests/omjournal-basic-no-template.sh
@@ -7,7 +7,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omjournal/.libs/omjournal")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omjournal")
 '

--- a/tests/omjournal-basic-template.sh
+++ b/tests/omjournal-basic-template.sh
@@ -8,7 +8,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omjournal/.libs/omjournal")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg%")
 action(type="omjournal" template="outfmt")

--- a/tests/omod-if-array.sh
+++ b/tests/omod-if-array.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%%timestamp%%hostname%%programname%%syslogtag%\n")
 

--- a/tests/omprog-single-instance-outfile.sh
+++ b/tests/omprog-single-instance-outfile.sh
@@ -21,7 +21,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omprog/.libs/omprog")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/omprog-single-instance-vg.sh
+++ b/tests/omprog-single-instance-vg.sh
@@ -21,7 +21,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omprog/.libs/omprog")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/omprog-single-instance.sh
+++ b/tests/omprog-single-instance.sh
@@ -21,7 +21,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omprog/.libs/omprog")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/omstdout-basic.sh
+++ b/tests/omstdout-basic.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="-%msg%-\n")
 action(type="omstdout" template="outfmt")

--- a/tests/parsertest-parse-3164-buggyday.sh
+++ b/tests/parsertest-parse-3164-buggyday.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%timestamp:::date-rfc3164-buggyday%,%hostname%,%programname%,%syslogtag%,%msg%\n")

--- a/tests/parsertest-parse-nodate.sh
+++ b/tests/parsertest-parse-nodate.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%hostname%,%programname%,%syslogtag%,%msg%\n")
 

--- a/tests/parsertest-parse1.sh
+++ b/tests/parsertest-parse1.sh
@@ -5,7 +5,7 @@ setvar_RS_HOSTNAME
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%PRI%,%syslogfacility-text%,%syslogseverity-text%,%timestamp%,%hostname%,%programname%,%syslogtag%,%msg%\n")
 

--- a/tests/parsertest-parse2.sh
+++ b/tests/parsertest-parse2.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/parsertest-parse3.sh
+++ b/tests/parsertest-parse3.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%timereported:1:19:date-rfc3339,csv%, %hostname:::csv%, %programname:::csv%, %syslogtag:R,ERE,0,BLANK:[0-9]+--end:csv%, %syslogseverity:::csv%, %msg:::drop-last-lf,csv%\n")

--- a/tests/parsertest-parse_8bit_escape.sh
+++ b/tests/parsertest-parse_8bit_escape.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 $Escape8BitCharactersOnReceive on
 

--- a/tests/parsertest-parse_invld_regex.sh
+++ b/tests/parsertest-parse_invld_regex.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 
 template(name="outfmt" type="string" string="%timereported:1:19:date-rfc3339,csv%, %hostname:::csv%, %programname:::csv%, %syslogtag:R,ERE,0,BLANK:[0-9+--end:csv%, %syslogseverity:::csv%, %msg:::drop-last-lf,csv%\n")

--- a/tests/pmlastmsg.sh
+++ b/tests/pmlastmsg.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/pmlastmsg/.libs/pmlastmsg")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/pmnormalize-basic.sh
+++ b/tests/pmnormalize-basic.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 parser(name="custom.pmnormalize" type="pmnormalize" rulebase="'$srcdir'/testsuites/pmnormalize_basic.rulebase")
 
 template(name="test" type="string" string="host: %hostname%, ip: %fromhost-ip%, tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")

--- a/tests/pmnormalize-rule.sh
+++ b/tests/pmnormalize-rule.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 parser(name="custom.pmnormalize" type="pmnormalize" rule=["rule=:<%pri:number%> %fromhost-ip:ipv4% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%", "rule=:<%pri:number%> %hostname:word% %fromhost-ip:ipv4% %syslogtag:char-to:\\x3a%: %msg:rest%"])
 
 template(name="test" type="string" string="host: %hostname%, ip: %fromhost-ip%, tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")

--- a/tests/pmnormalize-rule_invld-data.sh
+++ b/tests/pmnormalize-rule_invld-data.sh
@@ -6,7 +6,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnormalize/.libs/pmnormalize")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 parser(name="custom.pmnormalize" type="pmnormalize" undefinedPropertyError="on"
 	rule="rule=:<%pri:number%> %fromhost-ip:ipv4% %hostname:word% %syslogtag:char-to:\\x3a%: %msg:rest%")
 

--- a/tests/pmnull-basic.sh
+++ b/tests/pmnull-basic.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnull/.libs/pmnull")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 parser(name="custom.pmnull.withOrigin" type="pmnull")
 template(name="test" type="string" string="tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 ruleset(name="ruleset" parser=["custom.pmnull.withOrigin", "rsyslog.pmnull"]) {

--- a/tests/pmnull-withparams.sh
+++ b/tests/pmnull-withparams.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/pmnull/.libs/pmnull")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
 parser(name="custom.pmnull" type="pmnull" tag="mytag" syslogfacility="3" syslogseverity="1")
 template(name="test" type="string" string="tag: %syslogtag%, pri: %pri%, syslogfacility: %syslogfacility%, syslogseverity: %syslogseverity% msg: %msg%\n")
 ruleset(name="ruleset" parser=["custom.pmnull", "rsyslog.pmnull"]) {

--- a/tests/pmrfc3164-AtSignsInHostname.sh
+++ b/tests/pmrfc3164-AtSignsInHostname.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" permit.AtSignsInHostname="on")
 template(name="outfmt" type="string" string="-%hostname%-\n")
 

--- a/tests/pmrfc3164-AtSignsInHostname_off.sh
+++ b/tests/pmrfc3164-AtSignsInHostname_off.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" permit.AtSignsInHostname="off")
 template(name="outfmt" type="string" string="-%hostname%-%syslogtag%-%msg%-\n")
 

--- a/tests/pmrfc3164-defaultTag.sh
+++ b/tests/pmrfc3164-defaultTag.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" permit.AtSignsInHostname="off"
 	force.tagEndingByColon="on")
 template(name="outfmt" type="string" string="?%hostname%?%syslogtag%?%msg%?\n")

--- a/tests/pmrfc3164-json.sh
+++ b/tests/pmrfc3164-json.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="rs")
 template(name="outfmt" type="string" string="%msg%---%rawmsg%\n")
 
 ruleset(name="rs") {

--- a/tests/pmrfc3164-msgFirstSpace.sh
+++ b/tests/pmrfc3164-msgFirstSpace.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" remove.msgFirstSpace="on")
 template(name="outfmt" type="string" string="-%msg%-\n")
 

--- a/tests/pmrfc3164-tagEndingByColon.sh
+++ b/tests/pmrfc3164-tagEndingByColon.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="customparser")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="customparser")
 parser(name="custom.rfc3164" type="pmrfc3164" force.tagEndingByColon="on")
 template(name="outfmt" type="string" string="-%syslogtag%-%msg%-\n")
 

--- a/tests/pmsnare-ccbackslash.sh
+++ b/tests/pmsnare-ccbackslash.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 global(localHostname="localhost"
        parser.escapeControlCharactersCStyle="on")

--- a/tests/pmsnare-cccstyle.sh
+++ b/tests/pmsnare-cccstyle.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 $EscapeControlCharactersOnReceive on
 global(
 	parser.escapeControlCharactersCStyle="on"

--- a/tests/pmsnare-ccdefault.sh
+++ b/tests/pmsnare-ccdefault.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-ccoff.sh
+++ b/tests/pmsnare-ccoff.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-default.sh
+++ b/tests/pmsnare-default.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 global(localHostname="localhost")
 

--- a/tests/pmsnare-modoverride.sh
+++ b/tests/pmsnare-modoverride.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../contrib/pmsnare/.libs/pmsnare")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 global(
 	parser.escapeControlCharactersOnReceive="off"

--- a/tests/prop-all-json-concurrency.sh
+++ b/tests/prop-all-json-concurrency.sh
@@ -8,7 +8,7 @@ echo \[prop-all-json-concurrency.sh\]: testing concurrency of $!all-json variabl
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="interim" type="string" string="%$!tree!here!nbr%")
 template(name="outfmt" type="string" string="%$.interim%\n")

--- a/tests/prop-jsonmesg-vg.sh
+++ b/tests/prop-jsonmesg-vg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="list"){
     property(name="jsonmesg")

--- a/tests/prop-programname-with-slashes.sh
+++ b/tests/prop-programname-with-slashes.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 global(parser.PermitSlashInProgramname="on")
 
 template(name="outfmt" type="string" string="%syslogtag%,%programname%\n")

--- a/tests/prop-programname.sh
+++ b/tests/prop-programname.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%syslogtag%,%programname%\n")
 local0.* action(type="omfile" template="outfmt"

--- a/tests/proprepltest-nolimittag.sh
+++ b/tests/proprepltest-nolimittag.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="+%syslogtag%+\n")
 

--- a/tests/proprepltest-rfctag.sh
+++ b/tests/proprepltest-rfctag.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="+%syslogtag:1:32%+\n")
 

--- a/tests/rawmsg-after-pri.sh
+++ b/tests/rawmsg-after-pri.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(type="string" name="outfmt" string="%rawmsg-after-pri%\n")
 if $syslogfacility-text == "local0" then

--- a/tests/relp_tls_certificate_not_found.sh
+++ b/tests/relp_tls_certificate_not_found.sh
@@ -6,8 +6,8 @@ add_conf '
 
 module(load="../plugins/omrelp/.libs/omrelp")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 ruleset(name="ruleset") {
 	action(type="omrelp" target="127.0.0.1" port="10514" tls="on" tls.authMode="name" tls.caCert="tls-certs/ca.pem" tls.myCert="tls-certs/fake-cert.pem" tls.myPrivKey="tls-certs/fake-key.pem" tls.permittedPeer=["rsyslog-test-root-ca"])

--- a/tests/rfc5424parser.sh
+++ b/tests/rfc5424parser.sh
@@ -10,7 +10,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 if $msg contains "msgnum" then
 	action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)

--- a/tests/rs-cnum.sh
+++ b/tests/rs-cnum.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!var = cnum(15*3);
 

--- a/tests/rs-int2hex.sh
+++ b/tests/rs-int2hex.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!var = int2hex(61);
 set $!var2 = int2hex(-13);

--- a/tests/rs-substring.sh
+++ b/tests/rs-substring.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!var = substring($msg, 3, 2);
 

--- a/tests/rs_optimizer_pri.sh
+++ b/tests/rs_optimizer_pri.sh
@@ -13,7 +13,7 @@ add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 if $syslogfacility-text == "local4" then
 	action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)

--- a/tests/rscript_bare_var_root-empty.sh
+++ b/tests/rscript_bare_var_root-empty.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 template(name="outfmt" type="string" string="empty-%$!%-\n")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="rs")
 
 ruleset(name="rs") {
 	set $. = $!;

--- a/tests/rscript_bare_var_root.sh
+++ b/tests/rscript_bare_var_root.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%$!%\n")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rs")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="rs")
 
 ruleset(name="rs") {
 	set $!a = "TEST1";

--- a/tests/rscript_format_time.sh
+++ b/tests/rscript_format_time.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # $DebugLevel 2
 

--- a/tests/rscript_hash32-vg.sh
+++ b/tests/rscript_hash32-vg.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.hash_no_1 = hash32("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash32mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_hash32.sh
+++ b/tests/rscript_hash32.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.hash_no_1 = hash32("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash32mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_hash64-vg.sh
+++ b/tests/rscript_hash64-vg.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.hash_no_1 = hash64("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash64mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_hash64.sh
+++ b/tests/rscript_hash64.sh
@@ -10,7 +10,7 @@ template(name="outfmt" type="string" string="%$.hash_no_1% -  %$.hash_no_2%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../contrib/fmhash/.libs/fmhash")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.hash_no_1 = hash64("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e");
 set $.hash_no_2 = hash64mod("0f9a1d07-a8c9-43a7-a6f7-198dca3d932e", 100);

--- a/tests/rscript_http_request.sh
+++ b/tests/rscript_http_request.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/fmhttp/.libs/fmhttp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # for debugging the test itself:
 #template(name="outfmt" type="string" string="%$!%:  :%$.%:  %rawmsg%\n")

--- a/tests/rscript_int2Hex.sh
+++ b/tests/rscript_int2Hex.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!ip!v0 = int2hex("");
 set $!ip!v1 = int2hex("0");

--- a/tests/rscript_ipv42num.sh
+++ b/tests/rscript_ipv42num.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # in pre 8.1907.0 versions of rsyslog the code was misspelled as
 # "ip42num" (missing "v"). We check this is still supported as alias

--- a/tests/rscript_is_time.sh
+++ b/tests/rscript_is_time.sh
@@ -6,7 +6,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # $DebugLevel 2
 

--- a/tests/rscript_num2ipv4.sh
+++ b/tests/rscript_num2ipv4.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/fmhttp/.libs/fmhttp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!ip!v0 = num2ipv4("");
 set $!ip!v1 = num2ipv4("0");

--- a/tests/rscript_parse_json-vg.sh
+++ b/tests/rscript_parse_json-vg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%$!%\n")
 
 local4.* {

--- a/tests/rscript_parse_json.sh
+++ b/tests/rscript_parse_json.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%$!%\n")
 
 local4.* {

--- a/tests/rscript_parse_time.sh
+++ b/tests/rscript_parse_time.sh
@@ -67,7 +67,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omstdout/.libs/omstdout")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # $DebugLevel 2
 

--- a/tests/rscript_previous_action_suspended.sh
+++ b/tests/rscript_previous_action_suspended.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omtesting/.libs/omtesting")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
 ruleset(name="output_writer") {

--- a/tests/rscript_random.sh
+++ b/tests/rscript_random.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.random_no%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.random_no = random(10);
 

--- a/tests/rscript_re_extract.sh
+++ b/tests/rscript_re_extract.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="*Number is %$.number%*\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")'
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")'
 add_conf "
 set \$.number = re_extract(\$msg, '.* ([0-9]+)$', 0, 1, 'none');"
 add_conf '

--- a/tests/rscript_re_match.sh
+++ b/tests/rscript_re_match.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="*Matched*\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")'
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")'
 add_conf "
 if (re_match(\$msg, '.* ([0-9]+)$')) then {"
 add_conf '

--- a/tests/rscript_replace.sh
+++ b/tests/rscript_replace.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="'$TCPFLOOD_PORT'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="date_time" type="list") {
   property(name="msg" regex.Expression="Thu .+ 2014" regex.Type="ERE" regex.Match="0")

--- a/tests/rscript_replace_complex.sh
+++ b/tests/rscript_replace_complex.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.replaced_msg = replace($msg, "syslog", "rsyslog");
 set $.replaced_msg = replace($.replaced_msg, "hello", "hello_world");

--- a/tests/rscript_script_error.sh
+++ b/tests/rscript_script_error.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="string" string="%$!%\n")
 
 local4.* {

--- a/tests/rscript_set_memleak-vg.sh
+++ b/tests/rscript_set_memleak-vg.sh
@@ -15,7 +15,7 @@ fi
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="rcvr")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="rcvr")
 
 template(name="json" type="string" string="%$!%\n")
 template(name="ts" type="string" string="%timestamp:::date-rfc3339%")

--- a/tests/rscript_str2num_empty.sh
+++ b/tests/rscript_str2num_empty.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!ip!v1 = 1+"";
 

--- a/tests/rscript_str2num_negative.sh
+++ b/tests/rscript_str2num_negative.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.n = "-1";
 set $!ip!v1 = 1 + $.n;

--- a/tests/rscript_substring.sh
+++ b/tests/rscript_substring.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!str!var1 = substring("", 0, 0);
 set $!str!var2 = substring("test", 0, 4);

--- a/tests/rscript_trim-vg.sh
+++ b/tests/rscript_trim-vg.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!str!l1 = ltrim("");
 set $!str!l2 = ltrim("test");

--- a/tests/rscript_trim.sh
+++ b/tests/rscript_trim.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $!str!l1 = ltrim("");
 set $!str!l2 = ltrim("test");

--- a/tests/rscript_wrap2.sh
+++ b/tests/rscript_wrap2.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.replaced_msg = wrap("foo says" & $msg, "*" & "*");
 

--- a/tests/rscript_wrap3.sh
+++ b/tests/rscript_wrap3.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.replaced_msg%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 set $.replaced_msg = wrap("foo says" & $msg, "bc" & "def" & "bc", "ES" & "C");
 

--- a/tests/sndrcv_kafka_multi.sh
+++ b/tests/sndrcv_kafka_multi.sh
@@ -41,7 +41,7 @@ main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
 
 module(load="../plugins/omkafka/.libs/omkafka")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" Ruleset="omkafka")	/* this port for tcpflood! */
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" Ruleset="omkafka")	/* this port for tcpflood! */
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/sndrcv_tls_anon_hostname.sh
+++ b/tests/sndrcv_tls_anon_hostname.sh
@@ -43,7 +43,7 @@ global(
 
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 # set up the action
 $ActionSendStreamDriverMode 1 # require TLS for the connection

--- a/tests/sndrcv_tls_anon_ipv4.sh
+++ b/tests/sndrcv_tls_anon_ipv4.sh
@@ -34,7 +34,6 @@ startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -45,7 +44,7 @@ global(
 
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 # set up the action
 $DefaultNetstreamDriver gtls # use gtls netstream driver

--- a/tests/sndrcv_tls_certless_clientonly.sh
+++ b/tests/sndrcv_tls_certless_clientonly.sh
@@ -39,7 +39,7 @@ global(defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'")
 
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 action(	type="omfwd" protocol="tcp" target="127.0.0.1" port="'$PORT_RCVR'"
 	StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="anon")

--- a/tests/sndrcv_tls_certless_ossl_client.sh
+++ b/tests/sndrcv_tls_certless_ossl_client.sh
@@ -38,7 +38,7 @@ global(
 
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_certless_serveronly.sh
+++ b/tests/sndrcv_tls_certless_serveronly.sh
@@ -39,7 +39,7 @@ global(
 
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_gtls_serveranon_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_serveranon_gtls_clientanon.sh
@@ -28,7 +28,7 @@ export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input( type="imtcp" port="'$TCPFLOOD_PORT'")
+input( type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_gtls_serveranon_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_serveranon_ossl_clientanon.sh
@@ -37,7 +37,7 @@ global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input( type="imtcp" port="'$TCPFLOOD_PORT'")
+input( type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_gtls_servercert_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_servercert_gtls_clientanon.sh
@@ -36,7 +36,7 @@ global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input( type="imtcp" port="'$TCPFLOOD_PORT'")
+input( type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_gtls_servercert_gtls_clientanon_legacy.sh
+++ b/tests/sndrcv_tls_gtls_servercert_gtls_clientanon_legacy.sh
@@ -38,7 +38,7 @@ generate_conf 2
 add_conf '
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # NOTE: do NOT change legacy statements - they are used intentionally
 $DefaultNetstreamDriverCAFile '$srcdir/tls-certs/ca.pem'

--- a/tests/sndrcv_tls_gtls_servercert_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_servercert_ossl_clientanon.sh
@@ -36,7 +36,7 @@ global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input( type="imtcp" port="'$TCPFLOOD_PORT'")
+input( type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_ossl_serveranon_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_serveranon_gtls_clientanon.sh
@@ -37,7 +37,7 @@ global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input( type="imtcp" port="'$TCPFLOOD_PORT'")
+input( type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_ossl_serveranon_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_serveranon_ossl_clientanon.sh
@@ -28,7 +28,7 @@ export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_ossl_servercert_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_servercert_gtls_clientanon.sh
@@ -37,7 +37,7 @@ global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input( type="imtcp" port="'$TCPFLOOD_PORT'" )
+input( type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_ossl_servercert_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_servercert_ossl_clientanon.sh
@@ -37,7 +37,7 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
 
 # set up the action
 action(	type="omfwd"

--- a/tests/sndrcv_tls_priorityString.sh
+++ b/tests/sndrcv_tls_priorityString.sh
@@ -44,7 +44,7 @@ global(
 )
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfwd" Target="127.0.0.1" port="'$PORT_RCVR'" Protocol="tcp" streamdriver="gtls"
 	StreamDriverAuthMode="anon" StreamDriverMode="1"

--- a/tests/stop-localvar.sh
+++ b/tests/stop-localvar.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$.nbr%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 if $msg contains "msgnum:" then {
 	set $.nbr = field($msg, 58, 2);

--- a/tests/stop-msgvar.sh
+++ b/tests/stop-msgvar.sh
@@ -9,7 +9,7 @@ add_conf '
 template(name="outfmt" type="string" string="%$!nbr%\n")
 
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 if $msg contains "msgnum:" then {
 	set $!nbr = field($msg, 58, 2);

--- a/tests/stop.sh
+++ b/tests/stop.sh
@@ -7,7 +7,7 @@ echo \[stop.sh\]: testing stop statement
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 if $msg contains "00000001" then
 	stop

--- a/tests/stop_when_array_has_element.sh
+++ b/tests/stop_when_array_has_element.sh
@@ -10,7 +10,7 @@ template(name="foo" type="string" string="%$!foo%\n")
 
 module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="mmjsonparse")
 

--- a/tests/tabescape_dflt.sh
+++ b/tests/tabescape_dflt.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 template(name="outfmt" type="string" string="%msg%\n")
 

--- a/tests/tabescape_off.sh
+++ b/tests/tabescape_off.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 global(parser.EscapeControlCharacterTab="off")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 $ErrorMessagesToStderr off
 

--- a/tests/tabescape_on.sh
+++ b/tests/tabescape_on.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 global(parser.EscapeControlCharacterTab="on")
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'" ruleset="ruleset1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="ruleset1")
 
 $ErrorMessagesToStderr off
 

--- a/tests/template-pos-from-to-lowercase.sh
+++ b/tests/template-pos-from-to-lowercase.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:9:16:lowercase%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/template-pos-from-to-missing-jsonvar.sh
+++ b/tests/template-pos-from-to-missing-jsonvar.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="-%$!non!existing!var:109:116:%-\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/template-pos-from-to-oversize-lowercase.sh
+++ b/tests/template-pos-from-to-oversize-lowercase.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="-%msg:109:116:lowercase%-\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/template-pos-from-to-oversize.sh
+++ b/tests/template-pos-from-to-oversize.sh
@@ -7,7 +7,7 @@ echo "*** string template ****"
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="-%msg:109:116:%-\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
@@ -31,7 +31,7 @@ rm  $RSYSLOG_OUT_LOG # cleanup previous run
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 template(name="outfmt" type="list") {
 	constant(value="-")
 	property(name="msg" position.from="109" position.to="116")

--- a/tests/template-pos-from-to.sh
+++ b/tests/template-pos-from-to.sh
@@ -5,7 +5,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:9:16:%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"

--- a/tests/timegenerated-utc.sh
+++ b/tests/timegenerated-utc.sh
@@ -16,7 +16,7 @@ export TZ=TEST+02:00
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="list") {
 	property(name="timegenerated" date.inUTC="on")

--- a/tests/timereported-utc.sh
+++ b/tests/timereported-utc.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="list") {
 	property(name="timereported" dateformat="rfc3339" date.inUTC="on")

--- a/tests/timestamp-3164.sh
+++ b/tests/timestamp-3164.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%timestamp:::date-rfc3164%\n")
 

--- a/tests/timestamp-3339.sh
+++ b/tests/timestamp-3339.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%timestamp:::date-rfc3339%\n")
 

--- a/tests/timestamp-mysql.sh
+++ b/tests/timestamp-mysql.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%timestamp:::date-mysql%\n")
 

--- a/tests/timestamp-pgsql.sh
+++ b/tests/timestamp-pgsql.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%timestamp:::date-pgsql%\n")
 

--- a/tests/timestamp-subseconds.sh
+++ b/tests/timestamp-subseconds.sh
@@ -4,7 +4,7 @@
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%timestamp:::date-subseconds%\n")
 

--- a/tests/tls-check-for-certificate.sh
+++ b/tests/tls-check-for-certificate.sh
@@ -10,7 +10,7 @@ global(
 	defaultNetstreamDriverCaFile="tls-certs/ca.pem"
 )
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="gtls" StreamDriver.Mode="1" StreamDriver.AuthMode="anon")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 

--- a/tests/tls_error_file_not_found.sh
+++ b/tests/tls_error_file_not_found.sh
@@ -10,7 +10,7 @@ global(
 	defaultNetstreamDriverCaFile="tls-certs/ca.pem"
 )
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="gtls" StreamDriver.Mode="1" StreamDriver.AuthMode="anon")
-input(type="imtcp" port="'$TCPFLOOD_PORT'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 


### PR DESCRIPTION
This makes the test much more robust against heavily loaded test systems.
