### PR TITLE
core/tcpsrv: potential race on startup/shutdown

### DIFF
--- a/threads.c
+++ b/threads.c
@@ -127,7 +127,11 @@ thrdTerminateNonCancel(thrdInfo_t *pThis)
 		}
 		DBGPRINTF("thread %s: initiating termination, timeout %d ms\n",
 			pThis->name, glblInputTimeoutShutdown);
-		pthread_kill(pThis->thrdID, SIGTTIN);
+		const int r = pthread_kill(pThis->thrdID, SIGTTIN);
+		if(r != 0) {
+			LogError(errno, RS_RET_INTERNAL_ERROR, "error terminating thread %s "
+				"this may cause shutdown issues", pThis->name);
+		}
 		ret = d_pthread_cond_timedwait(&pThis->condThrdTerm, &pThis->mutThrd, &tTimeout);
 		if(ret == ETIMEDOUT) {
 			DBGPRINTF("input thread term: timeout expired waiting on thread %s "


### PR DESCRIPTION
if the tcpsrv component is started and quickly terminated, it may hang
for a short period of time. Also a very small amout of memory is leaked
immediately before shutdown. While this leak is irrelevant in practice
(the OS clean up the process anyways), it leads to CI failures. The hang,
however, can lead to longer than expected shutdown times for rsyslog.

The problem can be experienced via imtcp, imgssapi and imdiag (users
of affected core component).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
