### PR TITLE
core: do not unnecessarily set hostname on each HUP

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -588,14 +588,22 @@ GetLocalHostIP(void)
 
 
 /* set our local hostname. Free previous hostname, if it was already set.
- * Note that we do now do this in a thread
- * "once in a lifetime" action which can not be undone. -- gerhards, 2009-07-20
+ * Note that we do now do this in a thread. As such, the method here
+ * is NOT 100% clean. If we run into issues, we need to think about
+ * refactoring the whole way we handle the local host name processing.
+ * Possibly using a PROP might be the right solution then.
  */
 static rsRetVal
-SetLocalHostName(uchar *newname)
+SetLocalHostName(uchar *const newname)
 {
-	free(LocalHostName);
-	LocalHostName = newname;
+	uchar *toFree;
+	if(LocalHostName == NULL || strcmp((const char*)LocalHostName, (const char*) newname)) {
+		toFree = LocalHostName;
+		LocalHostName = newname;
+	} else {
+		toFree = newname;
+	}
+	free(toFree);
 	return RS_RET_OK;
 }
 


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
