### PR TITLE
imjournal: Fix another memory leak with bWorkAroundJournalBug enabled

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -443,6 +443,8 @@ readjournal(void)
 		if (!sd_journal_get_cursor(j, &c)) {
 			free(last_cursor);
 			last_cursor = c;
+		} else {
+			free(c);
 		}
 	}
 


### PR DESCRIPTION
The bWorkAroundJournalBug codepath in readjournal() properly issues a
free() for last_cursor, but leaked the "c" string. This patch adds an else
branch which will free that string.

This issue was observed on RHEL 7.7 with the WorkAroundJournalBug enabled.
Using valgrind to check for lost memory chunks, the following is visible:
```
    # valgrind --keep-debuginfo=yes --show-leak-kinds=definite --leak-check=full --show-leak-kinds=all -v --log-file=/tmp/valgrind.rsyslog $(which rsyslogd) -n &
    [1] 5711
    # for entry in {0..9999}; do logger test-$entry; done && kill $(cat /var/run/syslogd.pid)
    #
    [1]+  Done                    valgrind --keep-debuginfo=yes --show-leak-kinds=definite --leak-check=full --show-leak-kinds=all -v --log-file=/tmp/valgrind.rsyslog $(which rsyslogd) -n
    
    # awk '/are definitely lost/,/== $/ {print} /LEAK SUMMARY/,/== $/' /tmp/valgrind.rsyslog
    ==15754== 1,915,934 bytes in 15,636 blocks are definitely lost in loss record 22 of 22
    ==15754==    at 0x4C29E63: malloc (vg_replace_malloc.c:309)
    ==15754==    by 0x5FB5F6F: __vasprintf_chk (vasprintf_chk.c:80)
    ==15754==    by 0x5FB5E41: __asprintf_chk (asprintf_chk.c:33)
    ==15754==    by 0x6C8E7B0: UnknownInlinedFun (stdio2.h:178)
    ==15754==    by 0x6C8E7B0: sd_journal_get_cursor (sd-journal.c:926)
    ==15754==    by 0x6A7E5D7: readjournal (imjournal.c:414)
    ==15754==    by 0x6A7E5D7: runInput (imjournal.c:689)
    ==15754==    by 0x150443: thrdStarter (threads.c:226)
    ==15754==    by 0x5054EA4: start_thread (pthread_create.c:307)
    ==15754==    by 0x5F9C8CC: clone (clone.S:111)
    ==15754== 
    ==15754== LEAK SUMMARY:
    ==15754==    definitely lost: 1,915,934 bytes in 15,636 blocks
    ==15754==    indirectly lost: 0 bytes in 0 blocks
    ==15754==      possibly lost: 0 bytes in 0 blocks
    ==15754==    still reachable: 7,132 bytes in 21 blocks
    ==15754==         suppressed: 0 bytes in 0 blocks
    ==15754== 
```

After this patch:
```
    # valgrind --keep-debuginfo=yes --show-leak-kinds=definite --leak-check=full --show-leak-kinds=all -v --log-file=/tmp/valgrind.rsyslog $(which rsyslogd) -n &
    [1] 3342
    # for entry in {0..9999}; do logger test-$entry; done && kill $(cat /var/run/syslogd.pid)
    # 
    [1]+  Done                    valgrind --keep-debuginfo=yes --show-leak-kinds=definite --leak-check=full --show-leak-kinds=all -v --log-file=/tmp/valgrind.rsyslog $(which rsyslogd) -n
    # awk '/are definitely lost/,/== $/ {print} /LEAK SUMMARY/,/== $/' /tmp/valgrind.rsyslog
    ==3342== LEAK SUMMARY:
    ==3342==    definitely lost: 0 bytes in 0 blocks
    ==3342==    indirectly lost: 0 bytes in 0 blocks
    ==3342==      possibly lost: 0 bytes in 0 blocks
    ==3342==    still reachable: 7,132 bytes in 21 blocks
    ==3342==         suppressed: 0 bytes in 0 blocks
    ==3342==
```

Red Hat Bugzilla - [1744617 – Memory leak in readjournal() when cs.bWorkAroundJournalBug = 1](https://bugzilla.redhat.com/show_bug.cgi?id=1744617)
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
