### PR TITLE
testbench: Added test for imudp and pmdb2diag to trigger offMSG bug

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1319,7 +1319,8 @@ endif
 
 if ENABLE_PMDB2DIAG
 TESTS += \
-	pmdb2diag_parse.sh
+	pmdb2diag_parse.sh \
+	imudp-pmdb2diag-offset.sh
 endif
 
 if ENABLE_PMSNARE
@@ -1570,6 +1571,7 @@ EXTRA_DIST= \
 	imtuxedoulog_data.sh \
 	imtuxedoulog_errmsg_no_params-vg.sh \
 	pmdb2diag_parse.sh \
+	imudp-pmdb2diag-offset.sh \
 	mmtaghostname_tag.sh \
 	mmtaghostname_server.sh \
 	imbatchreport_errmsg_no_params.sh \

--- a/tests/imudp-pmdb2diag-offset.sh
+++ b/tests/imudp-pmdb2diag-offset.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# addd 2019-09-24 by alorbach, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+generate_conf
+add_conf '
+module(load="../plugins/imudp/.libs/imudp")
+
+module(load="../contrib/pmdb2diag/.libs/pmdb2diag")
+$RulesetParser db2.diag
+$RulesetParser rsyslog.rfc5424
+$RulesetParser rsyslog.rfc3164
+
+input(type="imudp" port="'$TCPFLOOD_PORT'")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+# Send one large (>100 bytes) raw message
+tcpflood -p'$TCPFLOOD_PORT'  -Tudp -b1 -W1 -M"12345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890" -m1
+tcpflood -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Tudp -b10 -W1 
+
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
This test should trigger a FAIL in current master branch if pmdb2diag is used and compiled with clang and address sanitizer is being used. See also: https://github.com/rsyslog/rsyslog/pull/3873