### PR TITLE
bug fix: allow improg to handle multi-line inputs

### DIFF
--- a/contrib/improg/improg.c
+++ b/contrib/improg/improg.c
@@ -388,6 +388,7 @@ static rsRetVal enqLine(instanceConf_t *const __restrict__ pInst)
 
 	CHKiRet(msgConstruct(&pMsg));
 
+	MsgSetMSGoffs(pMsg, 0);
 	MsgSetHOSTNAME(pMsg, glbl.GetLocalHostName(), ustrlen(glbl.GetLocalHostName()));
 	MsgSetFlowControlType(pMsg, eFLOWCTL_FULL_DELAY);
 	MsgSetInputName(pMsg, pInputName);
@@ -415,7 +416,7 @@ static rsRetVal readChild(instanceConf_t *const pInst){
 				if (write(pInst->fdPipeToChild,"ACK\n",sizeof("ACK\n")-1) <= 0)
 					LogMsg(0, NO_ERRCODE, LOG_WARNING, "improg: pipe to child seems to be closed.");
 			}
-			rsCStrTruncate(pInst->ppCStr, 0);
+			rsCStrTruncate(pInst->ppCStr, rsCStrLen(pInst->ppCStr));
 		} else {
 			cstrAppendChar(pInst->ppCStr, c);
 		}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -741,7 +741,8 @@ TESTS +=  \
 	improg_prog_simple.sh \
 	improg_prog_confirm.sh \
 	improg_prog_confirm_killonclose.sh \
-	improg_prog_killonclose.sh
+	improg_prog_killonclose.sh \
+	improg_simple_multi.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	improg_errmsg_no_params-vg.sh \
@@ -2025,6 +2026,7 @@ EXTRA_DIST= \
 	testsuites/action-tx-errfile.result \
 	pipeaction.sh \
 	improg-simul.sh \
+	improg-multiline-test.py \
 	improg_errmsg_no_params.sh \
 	improg_errmsg_no_params-vg.sh \
 	improg_prog_simple.sh \
@@ -2032,6 +2034,7 @@ EXTRA_DIST= \
 	improg_prog_confirm_killonclose.sh \
 	improg_prog_killonclose.sh \
 	improg_prog_simple-vg.sh \
+	improg_simple_multi.sh \
 	omhttp-auth.sh \
 	omhttp-basic.sh \
 	omhttp-batch-fail-with-400.sh \

--- a/tests/improg-multiline-test.py
+++ b/tests/improg-multiline-test.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+
+import sys
+
+for _ in range(10):
+  mystr = 'multi-line-string\n'
+  sys.stdout.write(mystr)

--- a/tests/improg_simple_multi.sh
+++ b/tests/improg_simple_multi.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+#
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../contrib/improg/.libs/improg")
+template(name="outfmt" type="string" string="#%msg%#\n")
+input(type="improg" tag="tag" ruleset="ruleset"
+	  binary="'$srcdir'/improg-multiline-test.py"
+	  confirmmessages="off" closetimeout="2000"
+	 )
+ruleset(name="ruleset") {
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+startup
+shutdown_when_empty
+wait_shutdown
+NUM_ITEMS=10
+echo "expected: $NUM_EXPECTED"
+echo "file: $RSYSLOG_OUT_LOG"
+content_check_with_count "#multi-line-string#" $NUM_EXPECTED $NUM_ITEMS
+exit_test


### PR DESCRIPTION
miscellaneous bug fixes in improg:
- properly truncate string after an input event is submitted
- set msg offset to 0.
- tests added to check above fixes

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
