### PR TITLE
pmaixforwardedfrom bugfix: potential misadressing

### DIFF
--- a/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
+++ b/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
@@ -109,6 +109,10 @@ CODESTARTparse
 	/* bump the message portion up by skipLen(23 or 5) characters to overwrite the "Message forwarded from
 " or "From " with the hostname */
 	lenMsg -=skipLen;
+	if(lenMsg < 2) {
+		dbgprintf("not a AIX message forwarded from message has nothing after header\n");
+		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+	}
 	memmove(p2parse, p2parse + skipLen, lenMsg);
 	*(p2parse + lenMsg) = '\n';
 	*(p2parse + lenMsg + 1)  = '\0';
@@ -119,6 +123,11 @@ really an AIX log, but has a similar preamble */
 	while(lenMsg && *p2parse != ' ' && *p2parse != ':') {
 		--lenMsg;
 		++p2parse;
+	}
+	if (lenMsg < 1) {
+		dbgprintf("not a AIX message forwarded from message has nothing after colon "
+			"or no colon at all\n");
+		ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 	}
 	if (lenMsg && *p2parse != ':') {
 	DBGPRINTF("not a AIX message forwarded from mangled log but similar enough that the preamble has "


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
