### PR TITLE
testbench: add test for mmpstrucdata with RFC5424 escape sequences

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -971,6 +971,7 @@ endif
 if ENABLE_MMPSTRUCDATA
 TESTS +=  \
 	mmpstrucdata.sh \
+	mmpstrucdata-escaping.sh \
 	mmpstrucdata-case.sh
 if HAVE_VALGRIND
 TESTS +=  \
@@ -2257,6 +2258,7 @@ EXTRA_DIST= \
 	testsuites/zoo.dep_wrk2.cfg \
 	testsuites/zoo.dep_wrk3.cfg \
 	mmpstrucdata.sh \
+	mmpstrucdata-escaping.sh \
 	mmpstrucdata-case.sh \
 	mmpstrucdata-vg.sh \
 	mmpstrucdata-invalid-vg.sh \

--- a/tests/mmpstrucdata-escaping.sh
+++ b/tests/mmpstrucdata-escaping.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released  under ASL 2.0
+# rgerhards, 2019-10-07
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
+
+template(name="outfmt" type="string" string="%$!rfc5424-sd%\n")
+
+action(type="mmpstrucdata")
+if $msg contains "TESTMESSAGE" then
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg litteral '<85>1 2019-08-27T13:02:58.000+01:00 A/B-896747 ABC LMBNI SUCCESS [origin software="ABC" swVersion="47.1"][ABC@32473 eventType="XYZ:IPIP,9:\"free -m\";" remoteIp="192.0.2.1" singleTick="D'"'"'E" bracket="1\]2"] TESTMESSAGE'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='{ "origin": { "software": "ABC", "swversion": "47.1" }, "abc@32473": { "eventtype": "XYZ:IPIP,9:\"free -m\";", "remoteip": "192.0.2.1", "singletick": "D'"'"'E", "bracket": "1]2" } }'
+cmp_exact
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
