### PR TITLE
core bugfix: potential abort on very long action name

### DIFF
--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -139,7 +139,15 @@ wtpConstructFinalize(wtp_t *pThis)
 	for(i = 0 ; i < pThis->iNumWorkerThreads ; ++i) {
 		CHKiRet(wtiConstruct(&pThis->pWrkr[i]));
 		pWti = pThis->pWrkr[i];
-		lenBuf = snprintf((char*)pszBuf, sizeof(pszBuf), "%s/w%d", wtpGetDbgHdr(pThis), i);
+		lenBuf = snprintf((char*)pszBuf, sizeof(pszBuf), "%.*s/w%d",
+			(int) (sizeof(pszBuf)-6), /* leave 6 chars for \0, "/w" and number: */
+			wtpGetDbgHdr(pThis), i);
+		if(lenBuf >= sizeof(pszBuf)) {
+			LogError(0, RS_RET_INTERNAL_ERROR, "%s:%d debug header too long: %zd - in "
+					"thory this cannot happen - truncating", __FILE__, __LINE__, lenBuf);
+			lenBuf = sizeof(pszBuf)-1;
+			pszBuf[lenBuf] = '\0';
+		}
 		CHKiRet(wtiSetDbgHdr(pWti, pszBuf, lenBuf));
 		CHKiRet(wtiSetpWtp(pWti, pThis));
 		CHKiRet(wtiConstructFinalize(pWti));


### PR DESCRIPTION
The action name is stored in modified form for the debug header and
some messages. If it is extremely long, a buffer can be overrun,
resulting in misadressing and potential segfault for rsyslog. This
can also happen if the action is NOT named, but a custom path to
the output module is given and that path is very long. This triggers
the same issue because by default the module load path is included
in the action name.

This patch corrects the problem and trunctates overly long names
when being used for name generation.

The problem was detected during testbench work. We did never receive
a bug report from practice.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
