### PR TITLE
core queue bugfix: handle multi-queue-file delete correctly

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -757,6 +757,16 @@ check_mainq_spool() {
 		error_exit 1
 	fi
 }
+# check that no spool file exists. Abort if they do.
+# This situation must exist after a successful termination of rsyslog
+# where the disk queue has properly been drained and shut down.
+check_spool_empty() {
+	if [ "$(ls $RSYSLOG_DYNNAME.spool/* 2> /dev/null)" != "" ]; then
+		printf 'error: spool files exists where they are not permitted to do so:\n'
+		ls -l $RSYSLOG_DYNNAME.spool/*
+		error_exit 1
+	fi
+}
 
 # general helper for imjournal tests: check that we got hold of the
 # injected test message. This is pretty lengthy as the journal has played


### PR DESCRIPTION
Rsyslog may leave some dangling disk queue files under the following
conditions:

- batch sizes and/or messages are large
- queue files are comparatively small
- a batch spans more than two queue files (from n to n+m with m>1)

In this case, queue files n+1 to (n+m-1) are not deleted. This can
lead to problems when the queue is re-opened again. In extreme cases
this can also lead to stalled processing when the max disk space is
used up by such left-over queue files.

Using defaults this scenario is very unlikely, but it can happen,
especially when large messages are being processed.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
