### PR TITLE
Various bug fixes relating to shutdown handling

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -693,7 +693,6 @@ wrkr(void *const myself)
 			// we need to query me->opSrv to avoid clang static
 			// analyzer false positive! -- rgerhards, 2017-10-23
 			assert(glbl.GetGlobalInputTermState() == 1);
-			--wrkrRunning;
 			break;
 		}
 		pthread_mutex_unlock(&wrkrMut);

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -556,6 +556,14 @@ RunCancelCleanup(void *arg)
 
 	if (*ppPoll != NULL)
 		nspoll.Destruct(ppPoll);
+
+	/* Wait for any running workers to finish */
+	pthread_mutex_lock(&wrkrMut);
+	DBGPRINTF("tcpsrv terminating, waiting for %d workers\n", wrkrRunning);
+	while(wrkrRunning > 0) {
+		pthread_cond_wait(&wrkrIdle, &wrkrMut);
+	}
+	pthread_mutex_unlock(&wrkrMut);
 }
 
 static void

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1858,8 +1858,7 @@ wait_timeout(const sigset_t *sigmask)
 				break;
 			}
 			pselect(1, NULL, NULL, NULL, &tvSelectTimeout, sigmask);
-			timeout--;
-		} while(timeout > 0);
+		} while(--timeout > 0);
 	} else {
 		char buf[256];
 		fd_set rfds;


### PR DESCRIPTION
I have created patches to fix a few issues that can occur when shutting down rsyslog. These issues include:
- A race condition that can cause rsyslogd to block for the full janitor interval (10 minutes) before responding to a signal such as SIGTERM or SIGHUP.
- A race condition that can cause tcpsrv to segfault when shutting down
- Cleaning up tcpsrv properly if its thread is cancelled

See the commit messages for more details. Each commit represents a logical code change, with a detailed explanation in the commit message.

----
I created these changes in the course of my employment at Ciena Corporation (https://www.ciena.com/), and am submitting them to the rsyslog project with permission and on behalf of Ciena. These changes are provided to rsyslog under the terms of the GNU General Public License (Version 3).

I understand and agree that this project and the contribution are public and that a record of the contribution (including all personal information I submit with it, including my sign-off) is maintained indefinitely and may be redistributed consistent with this project or the open source license(s) involved.