### PR TITLE
WiP: test mysqld-basic test false positives

### DIFF
--- a/tests/mysql-basic.sh
+++ b/tests/mysql-basic.sh
@@ -8,6 +8,7 @@ $ModLoad ../plugins/ommysql/.libs/ommysql
 :msg, contains, "msgnum:" :ommysql:127.0.0.1,Syslog,rsyslog,testbench;
 '
 mysql --user=rsyslog --password=testbench < ${srcdir}/testsuites/mysql-truncate.sql
+echo return code of mysql $?
 startup
 injectmsg  0 5000
 shutdown_when_empty
@@ -15,4 +16,5 @@ wait_shutdown
 # note "-s" is requried to suppress the select "field header"
 mysql -s --user=rsyslog --password=testbench < ${srcdir}/testsuites/mysql-select-msg.sql > $RSYSLOG_OUT_LOG
 seq_check  0 4999
+exit 77
 exit_test

--- a/tests/mysqld-start.sh
+++ b/tests/mysqld-start.sh
@@ -21,4 +21,5 @@ wait_startup_pid /var/run/mysqld/mysqld.pid
 printf 'preparing mysqld for testbench use...\n'
 $SUDO ${srcdir}/../devtools/prep-mysql-db.sh
 printf 'done, mysql ready for testbench\n'
+exit 77
 exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
