### PR TITLE
LGTM: add check for calloc misuse

### DIFF
--- a/.lgtm/cpp-queries/realloc-misuse.ql
+++ b/.lgtm/cpp-queries/realloc-misuse.ql
@@ -1,0 +1,11 @@
+import cpp
+
+import semmle.code.cpp.valuenumbering.HashCons
+
+from FunctionCall call, Assignment a
+where
+    call.getTarget().getName().regexpMatch(".*realloc")
+	and a.getRValue() = (FunctionCall) call
+	and hashCons(a.getLValue()) = hashCons(call.getArgument(0))
+
+select call, "Hard Memory Leak found (Realloc fail will not free the memory chunk)", a.getLValue()

--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -1508,9 +1508,7 @@ CODESTARTnewActInst
 		pData->cache = caches[i];
 	} else {
 		CHKmalloc(pData->cache = cacheNew(pData));
-		struct cache_s **new_caches = realloc(caches, (i + 2) * sizeof(struct cache_s *));
-		CHKmalloc(new_caches);
-		caches = new_caches;
+		caches = realloc(caches, (i + 2) * sizeof(struct cache_s *));
 		caches[i] = pData->cache;
 		caches[i + 1] = NULL;
 	}


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
