### PR TITLE
MMDARWIN:: Optimisations, new parameters, update to protocol header

### DIFF
--- a/contrib/mmdarwin/mmdarwin.c
+++ b/contrib/mmdarwin/mmdarwin.c
@@ -37,6 +37,8 @@
 #include <string.h>
 #include <sys/un.h>
 #include <sys/socket.h>
+#include <uuid/uuid.h>
+#include <json.h>
 
 #include "protocol.h" /* custom file written for Darwin */
 
@@ -44,6 +46,7 @@
 #define JSON_LOOKUP_NAME "!mmdarwin"
 #define INVLD_SOCK -1
 #define INITIAL_BUFFER_SIZE 32
+#define BUFFER_DEFAULT_MAX_SIZE 65536
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP
@@ -52,144 +55,173 @@ MODULE_CNFNAME("mmdarwin")
 DEFobjCurrIf(glbl)
 DEF_OMOD_STATIC_DATA
 
+typedef struct dyn_buffer_t
+{
+	char *buffer;
+	size_t bufferAllocSize;
+	size_t bufferMsgSize;
+	size_t bufferMaxSize;
+} dyn_buffer;
+
 /* config variables */
-typedef struct _instanceData {
-	char *pCertitudeKey; /* the key name to save in the enriched log line the certitude obtained from Darwin */
-	uchar *pSockName; /* the socket path of the filter which will be used by Darwin */
-	int sock; /* the socket of the filter which will be used by Darwin */
-	unsigned long long int filterCode; /* the filter code associated to the filter which will be used by Darwin */
-	enum darwin_filter_response_type response; /* the type of response for Darwin: no / back / darwin / both */
-	struct sockaddr_un addr; /* the sockaddr_un used to connect to the Darwin filter */
-	struct {
-		int    nmemb;
+typedef struct _instanceData
+{
+	char *pCertitudeKey;				/* the key name to save in the enriched log
+							   line the certitude obtained from Darwin */
+	uchar *pSockName;				/* the socket path of the filter which will be used by
+							   Darwin */
+	unsigned long long int filterCode;		/* the filter code associated to the filter which will be used
+							   by Darwin */
+	enum darwin_filter_response_type response;	/* the type of response for Darwin: no / back / darwin / both */
+	struct
+	{
+		int nmemb;
 		char **name;
 		char **varname;
 	} fieldList; /* our keys (fields) to be extracted from the JSON-parsed log line */
+	unsigned int socketMaxUse;
+	sbool sendPartial;
 } instanceData;
 
-typedef struct wrkrInstanceData {
+typedef struct wrkrInstanceData
+{
 	instanceData *pData;
+	int sock;				 /* the socket of the filter which will be used by Darwin */
+	struct sockaddr_un addr; /* the sockaddr_un used to connect to the Darwin filter */
+	uint8_t pktSentSocket;
+	dyn_buffer darwinBody; /* the body object used (and reused) to hold data to send to Darwin */
+	dyn_buffer fieldBuffer;
 } wrkrInstanceData_t;
 
-struct modConfData_s {
+struct modConfData_s
+{
 	/* our overall config object */
 	rsconf_t *pConf;
 	const char *container;
 };
 
-static pthread_mutex_t mutDoAct = PTHREAD_MUTEX_INITIALIZER;
-
 /* modConf ptr to use for the current load process */
 static modConfData_t *loadModConf = NULL;
 /* modConf ptr to use for the current exec process */
-static modConfData_t *runModConf  = NULL;
+static modConfData_t *runModConf = NULL;
 
 /* module-global parameters */
 static struct cnfparamdescr modpdescr[] = {
-	{ "container", eCmdHdlrGetWord, 0 },
+	{"container", eCmdHdlrGetWord, 0},
 };
 static struct cnfparamblk modpblk =
-	{ CNFPARAMBLK_VERSION,
-	  sizeof(modpdescr)/sizeof(struct cnfparamdescr),
-	  modpdescr
-	};
+	{CNFPARAMBLK_VERSION,
+	 sizeof(modpdescr) / sizeof(struct cnfparamdescr),
+	 modpdescr};
 
 /* tables for interfacing with the v6 config system
  * action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {
-	{ "key",      eCmdHdlrGetWord, CNFPARAM_REQUIRED },
-	{ "socketpath", eCmdHdlrGetWord, CNFPARAM_REQUIRED },
-	{ "fields",   eCmdHdlrArray,   CNFPARAM_REQUIRED },
-	{ "filtercode", eCmdHdlrGetWord, 0 }, /* optional parameter */
-	{ "response", eCmdHdlrGetWord, 0 }, /* optional parameter */
+	{"key", eCmdHdlrGetWord, CNFPARAM_REQUIRED},
+	{"socketpath", eCmdHdlrGetWord, CNFPARAM_REQUIRED},
+	{"fields", eCmdHdlrArray, CNFPARAM_REQUIRED},
+	{"filtercode", eCmdHdlrGetWord, 0},			/* optional parameter */
+	{"response", eCmdHdlrGetWord, 0},			/* optional parameter */
+	{"send_partial", eCmdHdlrBinary, 0},		/* optional parameter */
+	{"socket_max_use", eCmdHdlrPositiveInt, 0}, /* optional parameter - will disappear in future updates */
 };
 static struct cnfparamblk actpblk = {
 	CNFPARAMBLK_VERSION,
-	sizeof(actpdescr)/sizeof(struct cnfparamdescr),
-	actpdescr
-};
-
+	sizeof(actpdescr) / sizeof(struct cnfparamdescr),
+	actpdescr};
 
 /* custom functions */
-#define min(a,b) \
+#define min(a, b) \
 	({ __typeof__ (a) _a = (a); \
 	__typeof__ (b) _b = (b); \
 	_a < _b ? _a : _b; })
 
-static rsRetVal openSocket(instanceData *pData);
-static rsRetVal closeSocket(instanceData *pData);
-static rsRetVal doTryResume(instanceData *pData);
+static rsRetVal openSocket(wrkrInstanceData_t *pWrkrData);
+static rsRetVal closeSocket(wrkrInstanceData_t *pWrkrData);
+static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData);
 
-static rsRetVal sendMsg(instanceData *pData, void *msg, size_t len);
-static rsRetVal receiveMsg(instanceData *pData, void *response, size_t len);
+static rsRetVal sendMsg(wrkrInstanceData_t *pWrkrData, void *msg, size_t len);
+static rsRetVal receiveMsg(wrkrInstanceData_t *pWrkrData, void *response, size_t len);
 
-rsRetVal get_json_body(smsg_t **ppMsg, struct json_object **ppBody, char *pPropertyString,
-					   size_t propertySize);
-int get_json_string(char **ppString, struct json_object *pBody);
+int get_field(smsg_t *const pMsg, const char *pFieldName, char **ppRetString);
+int expand_buffer(dyn_buffer *pBody, size_t new_size);
+int add_field_to_body(dyn_buffer *pBody, const char *field, size_t size);
+int start_new_line(dyn_buffer *pBody);
+int end_body(dyn_buffer *pBody);
 
 /* open socket to remote system
  */
-static rsRetVal openSocket(instanceData *pData) {
+static rsRetVal openSocket(wrkrInstanceData_t *pWrkrData)
+{
 	DEFiRet;
-	assert(pData->sock == INVLD_SOCK);
+	assert(pWrkrData->sock == INVLD_SOCK);
 
-	if ((pData->sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1) {
+	if ((pWrkrData->sock = socket(AF_UNIX, SOCK_STREAM, 0)) == -1)
+	{
 		char errStr[1024];
 		int eno = errno;
 		DBGPRINTF("mmdarwin::openSocket:: error %d creating AF_UNIX/SOCK_STREAM: %s.\n",
 				  eno, rs_strerror_r(eno, errStr, sizeof(errStr)));
-		pData->sock = INVLD_SOCK;
+		pWrkrData->sock = INVLD_SOCK;
 		ABORT_FINALIZE(RS_RET_NO_SOCKET);
 	}
 
-	memset(&pData->addr, 0, sizeof(struct sockaddr_un));
-	pData->addr.sun_family = AF_UNIX;
-	strncpy(pData->addr.sun_path, (char *)pData->pSockName, sizeof(pData->addr.sun_path) - 1);
+	memset(&pWrkrData->addr, 0, sizeof(struct sockaddr_un));
+	pWrkrData->addr.sun_family = AF_UNIX;
+	strncpy(pWrkrData->addr.sun_path, (char *)pWrkrData->pData->pSockName, sizeof(pWrkrData->addr.sun_path) - 1);
 
-	dbgprintf("mmdarwin::openSocket:: connecting to Darwin...\n");
+	DBGPRINTF("mmdarwin::openSocket:: connecting to Darwin...\n");
 
-	if (connect(pData->sock, (struct sockaddr *)&pData->addr, sizeof(struct sockaddr_un)) == -1) {
+	if (connect(pWrkrData->sock, (struct sockaddr *)&pWrkrData->addr, sizeof(struct sockaddr_un)) == -1)
+	{
 		LogError(errno, RS_RET_NO_SOCKET, "mmdarwin::openSocket:: error connecting to Darwin "
-				"via socket '%s'", pData->pSockName);
+										  "via socket '%s'",
+				 pWrkrData->pData->pSockName);
 
-		pData->sock = INVLD_SOCK;
+		pWrkrData->sock = INVLD_SOCK;
 		ABORT_FINALIZE(RS_RET_NO_SOCKET);
 	}
 
+	DBGPRINTF("mmdarwin::openSocket:: connected !\n");
 finalize_it:
-	if (iRet != RS_RET_OK) {
-		closeSocket(pData);
+	if (iRet != RS_RET_OK)
+	{
+		closeSocket(pWrkrData);
 	}
 	RETiRet;
 }
 
 /* close socket to remote system
  */
-static rsRetVal closeSocket(instanceData *pData) {
+static rsRetVal closeSocket(wrkrInstanceData_t *pWrkrData)
+{
 	DEFiRet;
-	if (pData->sock != INVLD_SOCK) {
-		if (close(pData->sock) != 0) {
+	if (pWrkrData->sock != INVLD_SOCK)
+	{
+		if (close(pWrkrData->sock) != 0)
+		{
 			char errStr[1024];
 			int eno = errno;
 			DBGPRINTF("mmdarwin::closeSocket:: error %d closing the socket: %s.\n",
-				eno, rs_strerror_r(eno, errStr, sizeof(errStr)));
+					  eno, rs_strerror_r(eno, errStr, sizeof(errStr)));
 		}
-		pData->sock = INVLD_SOCK;
+		pWrkrData->sock = INVLD_SOCK;
 	}
 	RETiRet;
 }
 
-
 /* try to resume connection if it is not ready
  */
-static rsRetVal doTryResume(instanceData *pData) {
+static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
+{
 	DEFiRet;
 
 	DBGPRINTF("mmdarwin::doTryResume:: trying to resume\n");
-	closeSocket(pData);
-	iRet = openSocket(pData);
+	closeSocket(pWrkrData);
+	iRet = openSocket(pWrkrData);
 
-	if (iRet != RS_RET_OK) {
+	if (iRet != RS_RET_OK)
+	{
 		iRet = RS_RET_SUSPENDED;
 	}
 
@@ -199,21 +231,25 @@ static rsRetVal doTryResume(instanceData *pData) {
 /* send a message via TCP
  * inspired by rgehards, 2007-12-20
  */
-static rsRetVal sendMsg(instanceData *pData, void *msg, size_t len) {
+static rsRetVal sendMsg(wrkrInstanceData_t *pWrkrData, void *msg, size_t len)
+{
 	DEFiRet;
 
-	dbgprintf("mmdarwin::sendMsg:: sending message to Darwin...\n");
+	DBGPRINTF("mmdarwin::sendMsg:: sending message to Darwin...\n");
 
-	if (pData->sock == INVLD_SOCK) {
-		CHKiRet(doTryResume(pData));
+	if (pWrkrData->sock == INVLD_SOCK)
+	{
+		CHKiRet(doTryResume(pWrkrData));
 	}
 
-	if (pData->sock != INVLD_SOCK) {
-		if (send(pData->sock, msg, len, 0) == -1) {
-			int eno = errno;
+	if (pWrkrData->sock != INVLD_SOCK)
+	{
+		if (send(pWrkrData->sock, msg, len, 0) == -1)
+		{
 			char errStr[1024];
-			DBGPRINTF("mmdarwin suspending: send(), socket %d, error: %d = %s.\n",
-				pData->sock, eno, rs_strerror_r(eno, errStr, sizeof(errStr)));
+			DBGPRINTF("mmdarwin::sendData:: error while sending data: error[%d] -> %s\n",
+					  errno, rs_strerror_r(errno, errStr, sizeof(errStr)));
+			iRet = RS_RET_SUSPENDED;
 		}
 	}
 
@@ -224,21 +260,25 @@ finalize_it:
 /* receive a message via TCP
  * inspired by rgehards, 2007-12-20
  */
-static rsRetVal receiveMsg(instanceData *pData, void *response, size_t len) {
+static rsRetVal receiveMsg(wrkrInstanceData_t *pWrkrData, void *response, size_t len)
+{
 	DEFiRet;
 
-	dbgprintf("mmdarwin::receiveMsg:: receiving message from Darwin...\n");
+	DBGPRINTF("mmdarwin::receiveMsg:: receiving message from Darwin...\n");
 
-	if (pData->sock == INVLD_SOCK) {
-		CHKiRet(doTryResume(pData));
+	if (pWrkrData->sock == INVLD_SOCK)
+	{
+		CHKiRet(doTryResume(pWrkrData));
 	}
 
-	if (pData->sock != INVLD_SOCK) {
-		if (recv(pData->sock, response, len, MSG_WAITALL) <= 0) {
-			int eno = errno;
+	if (pWrkrData->sock != INVLD_SOCK)
+	{
+		if (recv(pWrkrData->sock, response, len, MSG_WAITALL) <= 0)
+		{
 			char errStr[1024];
-			DBGPRINTF("mmdarwin::receiveMsg:: suspending: recv(), socket %d, error: %d = %s.\n",
-				pData->sock, eno, rs_strerror_r(eno, errStr, sizeof(errStr)));
+			DBGPRINTF("mmdarwin::receiveMsg:: error while receiving data: error[%d] -> %s\n",
+					  errno, rs_strerror_r(errno, errStr, sizeof(errStr)));
+			iRet = RS_RET_NONE;
 		}
 	}
 
@@ -246,42 +286,197 @@ finalize_it:
 	RETiRet;
 }
 
-/* retrieve a json object from a stringified json
-*/
-rsRetVal get_json_body(smsg_t **ppMsg, struct json_object **ppBody, char *pPropertyString,
-					   size_t propertySize) {
-	dbgprintf("mmdarwin::get_json_body:: getting key '%s' of size %zu in the message '%s'\n", pPropertyString,
-			  propertySize, getMSG(*ppMsg));
+/**
+ * Get the string corresponding to a field supposedly present in the provided message
+ *
+ * params:
+ *  - pMsg: a pointer to the rsyslog message where the field should be
+ *  - pFieldName: a nul-terminated pointer to string representing the name of the field to search for
+ *  - ppRetString: the pointer to contain the potential return string
+ *
+ * return: 1 if a string was put in ppRetString, 0 otherwise
+ *
+ * note: the string placed in ppRetString should be freed by the caller
+ */
+int get_field(smsg_t *const pMsg, const char *pFieldName, char **ppRetString)
+{
+	DBGPRINTF("mmdarwin::get_field:: getting key '%s' in msg\n", pFieldName);
+	struct json_object *pJson = NULL;
+	char *pFieldString = NULL;
+	int retVal = 0;
 
-	/* ... getting the JSON object... */
-	msgPropDescr_t propertyDescr; /* the property description */
-	/* we fill the description... */
-	msgPropDescrFill(&propertyDescr, (uchar*)pPropertyString, propertySize);
-	/* ... then get the string related to our field... */
-	rsRetVal localRet = msgGetJSONPropJSON(*ppMsg, &propertyDescr, ppBody);
-	msgPropDescrDestruct(&propertyDescr);
+	msgPropDescr_t propDesc;
+	msgPropDescrFill(&propDesc, (uchar *)pFieldName, strlen(pFieldName));
+	msgGetJSONPropJSONorString(pMsg, &propDesc, &pJson, (uchar **)&pFieldString);
 
-	return localRet;
-}
-
-/* stringify a json object
-*/
-int get_json_string(char **ppString, struct json_object *pBody) {
-	*ppString = (char*)json_object_get_string(pBody);
-
-	if (*ppString == NULL) { /* json null object returns NULL! */
-		dbgprintf("mmdarwin::get_json_string:: empty body retrieved. Aborting\n");
-
-		return 0;
+	if (pFieldString)
+	{
+		*ppRetString = pFieldString;
+		DBGPRINTF("mmdarwin::get_field:: got string\n");
+		retVal = 1;
+	}
+	else if (pJson)
+	{
+		pFieldString = (char *)json_object_get_string(pJson);
+		if (pFieldString)
+		{
+			*ppRetString = strdup(pFieldString);
+			retVal = 1;
+			DBGPRINTF("mmdarwin::get_field:: got string from json\n");
+			json_object_put(pJson);
+		}
 	}
 
-	return 1;
+	msgPropDescrDestruct(&propDesc);
+	return retVal;
+}
+
+/**
+ * expands the buffer object in the dyn_buffer object
+ *
+ * params:
+ *  - pBody: a pointer to the concerned structure to expand
+ *  - new_size: the new size to give to the underlying buffer
+ *
+ * return: 0 if the expansion was successful, -1 otherwise
+ */
+int expand_buffer(dyn_buffer *pBody, size_t new_size)
+{
+	/* return error if new_size tries to exceed max defined size */
+	if (new_size > pBody->bufferMaxSize)
+		return -1;
+	while (pBody->bufferAllocSize < new_size)
+		pBody->bufferAllocSize += INITIAL_BUFFER_SIZE;
+
+	DBGPRINTF("mmdarwin::expand_buffer:: expanding buffer to %zu\n", pBody->bufferAllocSize);
+
+	char *tmp = realloc(pBody->buffer, pBody->bufferAllocSize * sizeof(char));
+
+	if (!tmp)
+	{
+		DBGPRINTF("mmdarwin::expand_buffer:: could not resize buffer\n");
+		return -1;
+	}
+
+	pBody->buffer = tmp;
+	return 0;
+}
+
+/**
+ * adds a field to the dyn_buffer buffer
+ *
+ * params:
+ *  - pBody: the pointer on the dyn_buffer structure
+ *  - field: the potentially not null-terminated string to add as a field to the dyn_buffer
+ *  - size: the size of the string (without the '\0' character)
+ *
+ * return: 0 if the field was indeed added to the dyn_buffer, -1 otherwise
+ */
+int add_field_to_body(dyn_buffer *pBody, const char *field, size_t size)
+{
+	/* get required additional size for field, quotes, colon, and \0
+	and potentially also for the beginning of the message structure */
+	int beginning = (pBody->bufferMsgSize == 0) ? 2 : 0;
+	size_t requiredBodySize = pBody->bufferMsgSize + size + 4 + beginning;
+
+	/* resize body buffer if necessary */
+	if (requiredBodySize > pBody->bufferAllocSize)
+	{
+		if (expand_buffer(pBody, requiredBodySize) != 0)
+		{
+			return -1;
+		}
+	}
+
+	/* add message structure beginning if current message is empty */
+	if (!pBody->bufferMsgSize)
+	{
+		pBody->buffer[0] = '[';
+		pBody->buffer[1] = '[';
+		pBody->bufferMsgSize += 2;
+	}
+
+	/* add field with quotes and colon */
+	pBody->buffer[pBody->bufferMsgSize++] = '\"';
+	memcpy((void *)&pBody->buffer[pBody->bufferMsgSize], (const void *)field, size);
+	pBody->bufferMsgSize += size;
+	pBody->buffer[pBody->bufferMsgSize++] = '\"';
+	pBody->buffer[pBody->bufferMsgSize++] = ',';
+
+	return 0;
+}
+
+/**
+ * small helper function to start a new input line (used for bulk-calls) in the dyn_buffer.
+ * will close current line with a ']' and start the next with a '['.
+ * will also remove leading ',' in fields list.
+ *
+ * params:
+ *  - pBody: the pointer on the dyn_buffer on which to start a new input line
+ *
+ * return: 0 if successful, -1 otherwise
+ */
+int start_new_line(dyn_buffer *pBody)
+{
+	/* don't if the message is empty */
+	if (!pBody->bufferMsgSize)
+	{
+		return -1;
+	}
+
+	DBGPRINTF("mmdarwin::start_new_line:: starting new line entry in body\n");
+
+	if (pBody->bufferAllocSize < pBody->bufferMsgSize + 2)
+	{
+		if (expand_buffer(pBody, pBody->bufferAllocSize + 2) != 0)
+		{
+			return -1;
+		}
+	}
+
+	pBody->buffer[pBody->bufferMsgSize - 1] = ']';
+	pBody->buffer[pBody->bufferMsgSize++] = ',';
+	pBody->buffer[pBody->bufferMsgSize++] = '[';
+	return 0;
+}
+
+/**
+ * small helper function to close the dyn_buffer structure.
+ * will close the line list with two ']' and will remove the leading ',' in the fields list
+ *
+ * params:
+ *  - pBody: the pointer on the dyn_buffer on which to start a new input line
+ *
+ * return: 0 if successful, -1 otherwise
+ */
+int end_body(dyn_buffer *pBody)
+{
+	/* don't if the message is empty */
+	if (!pBody->bufferMsgSize)
+	{
+		return -1;
+	}
+
+	DBGPRINTF("mmdarwin::end_body:: finishing body structure\n");
+
+	if (pBody->bufferAllocSize < pBody->bufferMsgSize + 2)
+	{
+		if (expand_buffer(pBody, pBody->bufferAllocSize + 2) != 0)
+		{
+			return -1;
+		}
+	}
+
+	pBody->buffer[pBody->bufferMsgSize - 1] = ']';
+	pBody->buffer[pBody->bufferMsgSize++] = ']';
+	pBody->buffer[pBody->bufferMsgSize++] = '\0';
+	return 0;
 }
 
 BEGINbeginCnfLoad
 CODESTARTbeginCnfLoad
 	loadModConf = pModConf;
-	pModConf->pConf = pConf;
+pModConf->pConf = pConf;
 ENDbeginCnfLoad
 
 BEGINendCnfLoad
@@ -299,7 +494,7 @@ ENDactivateCnf
 
 BEGINfreeCnf
 CODESTARTfreeCnf
-	free((void*)runModConf->container);
+	free((void *)runModConf->container);
 ENDfreeCnf
 
 BEGINdbgPrintInstInfo
@@ -313,18 +508,23 @@ ENDcreateInstance
 
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
+	pWrkrData->pktSentSocket = 0;
+	pWrkrData->darwinBody.bufferAllocSize = 0;
+	pWrkrData->darwinBody.bufferMaxSize = BUFFER_DEFAULT_MAX_SIZE;
+	pWrkrData->darwinBody.bufferMsgSize = 0;
+	pWrkrData->sock = INVLD_SOCK;
 ENDcreateWrkrInstance
-
 
 BEGINisCompatibleWithFeature
 CODESTARTisCompatibleWithFeature
 ENDisCompatibleWithFeature
 
-
 BEGINfreeInstance
 CODESTARTfreeInstance
-	if (pData->fieldList.name != NULL) {
-		for (int i = 0; i < pData->fieldList.nmemb; ++i) {
+	if (pData->fieldList.name != NULL)
+	{
+		for (int i = 0; i < pData->fieldList.nmemb; ++i)
+		{
 			free(pData->fieldList.name[i]);
 			free(pData->fieldList.varname[i]);
 		}
@@ -335,64 +535,75 @@ CODESTARTfreeInstance
 	free(pData->pSockName);
 ENDfreeInstance
 
-
 BEGINfreeWrkrInstance
 CODESTARTfreeWrkrInstance
+	closeSocket(pWrkrData);
+	free(pWrkrData->darwinBody.buffer);
 ENDfreeWrkrInstance
 
-
 BEGINsetModCnf
-	struct cnfparamvals *pvals = NULL;
-	int i;
+struct cnfparamvals *pvals = NULL;
+int i;
 CODESTARTsetModCnf
 	loadModConf->container = NULL;
 	pvals = nvlstGetParams(lst, &modpblk, NULL);
-	if (pvals == NULL) {
+	if (pvals == NULL)
+	{
 		LogError(0, RS_RET_MISSING_CNFPARAMS,
-				 "mmdarwin: error processing module config parameters missing [module(...)]");
+				"mmdarwin: error processing module config parameters missing [module(...)]");
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
-	if (Debug) {
-		dbgprintf("mmdarwin::setModCnf:: module (global) param blk for mmdarwin:\n");
+	if (Debug)
+	{
+		DBGPRINTF("mmdarwin::setModCnf:: module (global) param blk for mmdarwin:\n");
 		cnfparamsPrint(&modpblk, pvals);
 	}
 
-	for (i = 0; i < modpblk.nParams; ++i) {
+	for (i = 0; i < modpblk.nParams; ++i)
+	{
 		if (!pvals[i].bUsed)
 			continue;
-		if (!strcmp(modpblk.descr[i].name, "container")) {
+		if (!strcmp(modpblk.descr[i].name, "container"))
+		{
 			loadModConf->container = es_str2cstr(pvals[i].val.d.estr, NULL);
-		} else {
-			dbgprintf("mmdarwin::setModCnf:: program error, non-handled "
-					  "param '%s'\n", modpblk.descr[i].name);
+		}
+		else
+		{
+			DBGPRINTF("mmdarwin::setModCnf:: program error, non-handled "
+					"param '%s'\n",
+					modpblk.descr[i].name);
 		}
 	}
 
-	if (loadModConf->container == NULL) {
+	if (loadModConf->container == NULL)
+	{
 		CHKmalloc(loadModConf->container = strdup(JSON_IPLOOKUP_NAME));
 	}
 
-finalize_it:
+finalize_it :
 	if (pvals != NULL)
 		cnfparamvalsDestruct(pvals, &modpblk);
 ENDsetModCnf
 
-static inline void setInstParamDefaults(instanceData *pData) {
+static inline void setInstParamDefaults(instanceData *pData)
+{
 	DBGPRINTF("mmdarwin::setInstParamDefaults::\n");
 	pData->pCertitudeKey = NULL;
 	pData->pSockName = NULL;
 	pData->fieldList.nmemb = 0;
-	pData->sock = INVLD_SOCK;
 	pData->filterCode = DARWIN_FILTER_CODE_NO;
-	pData->response = DARWIN_RESPONSE_SEND_BACK;
+	pData->response = DARWIN_RESPONSE_SEND_NO;
+	pData->socketMaxUse = 0;
+	pData->sendPartial = 0;
 }
 
 BEGINnewActInst
 	struct cnfparamvals *pvals;
 	int i;
 CODESTARTnewActInst
-	dbgprintf("mmdarwin::newActInst::\n");
-	if ((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
+	DBGPRINTF("mmdarwin::newActInst::\n");
+	if ((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL)
+	{
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
 
@@ -401,363 +612,269 @@ CODESTARTnewActInst
 	CHKiRet(createInstance(&pData));
 	setInstParamDefaults(pData);
 
-	for (i = 0; i < actpblk.nParams; ++i) {
+	for (i = 0; i < actpblk.nParams; ++i)
+	{
 		if (!pvals[i].bUsed)
 			continue;
 
-		if (!strcmp(actpblk.descr[i].name, "key")) {
+		if (!strcmp(actpblk.descr[i].name, "key"))
+		{
 			pData->pCertitudeKey = es_str2cstr(pvals[i].val.d.estr, NULL);
-
-		} else if (!strcmp(actpblk.descr[i].name, "socketpath")) {
+			DBGPRINTF("mmdarwin::newActInst:: certitudeKey is %s\n", pData->pCertitudeKey);
+		}
+		else if (!strcmp(actpblk.descr[i].name, "socketpath"))
+		{
 			pData->pSockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
-
-		}  else if (!strcmp(actpblk.descr[i].name, "response")) {
+			DBGPRINTF("mmdarwin::newActInst:: sockName is %s\n", pData->pSockName);
+		}
+		else if (!strcmp(actpblk.descr[i].name, "socket_max_use"))
+		{
+			pData->socketMaxUse = (uint32_t)pvals[i].val.d.n;
+			DBGPRINTF("mmdarwin::newActInst:: socketMaxUse is %d\n", pData->socketMaxUse);
+		}
+		else if (!strcmp(actpblk.descr[i].name, "send_partial"))
+		{
+			pData->sendPartial = (sbool)pvals[i].val.d.n;
+			if (pData->sendPartial)
+			{
+				DBGPRINTF("mmdarwin::newActInst:: sending bodies even if fields are missing\n");
+			}
+			else
+			{
+				DBGPRINTF("mmdarwin::newActInst:: only sending complete bodies\n");
+			}
+		}
+		else if (!strcmp(actpblk.descr[i].name, "response"))
+		{
 			char *response = es_str2cstr(pvals[i].val.d.estr, NULL);
 
-			if (!strcmp(response, "no")) {
+			if (!strcmp(response, "no"))
+			{
 				pData->response = DARWIN_RESPONSE_SEND_NO;
-			} else if (!strcmp(response, "back")) {
+				DBGPRINTF("mmdarwin::newActInst:: response type is 'no'\n");
+			}
+			else if (!strcmp(response, "back"))
+			{
 				pData->response = DARWIN_RESPONSE_SEND_BACK;
-			} else if (!strcmp(response, "darwin")) {
+				DBGPRINTF("mmdarwin::newActInst:: response type is 'back'\n");
+			}
+			else if (!strcmp(response, "darwin"))
+			{
 				pData->response = DARWIN_RESPONSE_SEND_DARWIN;
-			} else if (!strcmp(response, "both")) {
+				DBGPRINTF("mmdarwin::newActInst:: response type is 'darwin'\n");
+			}
+			else if (!strcmp(response, "both"))
+			{
 				pData->response = DARWIN_RESPONSE_SEND_BOTH;
-			} else {
-				dbgprintf(
+				DBGPRINTF("mmdarwin::newActInst:: response type is 'both'\n");
+			}
+			else
+			{
+				DBGPRINTF(
 					"mmdarwin::newActInst:: invalid 'response' value: %s. 'No response' set.\n",
-					response
-				);
+					response);
 
 				pData->response = DARWIN_RESPONSE_SEND_NO;
+				DBGPRINTF("mmdarwin::newActInst:: response type is 'no'\n");
 			}
 
 			free(response);
-
-		} else if (!strcmp(actpblk.descr[i].name, "filtercode")) {
+		}
+		else if (!strcmp(actpblk.descr[i].name, "filtercode"))
+		{
 			char *filterCode = es_str2cstr(pvals[i].val.d.estr, NULL);
 			pData->filterCode = strtoull(filterCode, NULL, 16);
 			free(filterCode);
-
-		} else if (!strcmp(actpblk.descr[i].name, "fields")) {
+		}
+		else if (!strcmp(actpblk.descr[i].name, "fields"))
+		{
 			pData->fieldList.nmemb = pvals[i].val.d.ar->nmemb;
 			CHKmalloc(pData->fieldList.name = calloc(pData->fieldList.nmemb, sizeof(char *)));
 			CHKmalloc(pData->fieldList.varname = calloc(pData->fieldList.nmemb, sizeof(char *)));
 
-			for (int j = 0; j <  pvals[i].val.d.ar->nmemb; ++j) {
+			for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j)
+			{
 				char *const param = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
 				char *varname = NULL;
 				char *name;
-				if (*param == ':') {
-					char *b = strchr(param+1, ':');
-					if (b == NULL) {
+				if (*param == ':')
+				{
+					char *b = strchr(param + 1, ':');
+					if (b == NULL)
+					{
 						parser_errmsg(
-							"mmdarwin::newActInst:: missing closing colon: '%s'", param
-						);
+							"mmdarwin::newActInst:: missing closing colon: '%s'", param);
 						ABORT_FINALIZE(RS_RET_ERR);
 					}
 
 					*b = '\0'; /* split name & varname */
-					varname = param+1;
-					name = b+1;
-				} else {
+					varname = param + 1;
+					name = b + 1;
+				}
+				else
+				{
 					name = param;
 				}
 				CHKmalloc(pData->fieldList.name[j] = strdup(name));
 				char vnamebuf[1024];
 				snprintf(vnamebuf, sizeof(vnamebuf),
-					"%s!%s", loadModConf->container,
-					(varname == NULL) ? name : varname);
+						"%s!%s", loadModConf->container,
+						(varname == NULL) ? name : varname);
 				CHKmalloc(pData->fieldList.varname[j] = strdup(vnamebuf));
 				free(param);
+				DBGPRINTF("mmdarwin::newActInst:: will look for field %s\n", pData->fieldList.name[j]);
 			}
-
-		} else {
-			dbgprintf(
-				"mmdarwin::newActInst:: program error, non-handled param '%s'\n", actpblk.descr[i].name
-			);
+		}
+		else
+		{
+			DBGPRINTF(
+			"mmdarwin::newActInst:: program error, non-handled param '%s'\n", actpblk.descr[i].name);
 		}
 	}
-
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst
 
-
 BEGINtryResume
 CODESTARTtryResume
-	iRet = doTryResume(pWrkrData->pData);
+	iRet = doTryResume(pWrkrData);
 ENDtryResume
 
-/* here is the "main" function of the plugin, called everytime a line is processed */
-/* first, we initialize our parameters */
 BEGINdoAction_NoStrings
-	smsg_t **ppMsg = (smsg_t **) pMsgData; /* the raw data */
+	smsg_t **ppMsg = (smsg_t **)pMsgData; /* the raw data */
 	smsg_t *pMsg = ppMsg[0]; /* the raw log line */
-	struct json_object *pFieldBody = NULL; /* the body of the current field processed */
-	char *pFieldValueString = NULL; /* the string converted body of the current field processed */
 	instanceData *pData = pWrkrData->pData; /* the parameters given for the plugin */
-	size_t headerSize; /* the size of the header sent to Darwin */
-	size_t bodySize = 0; /* the size of the body sent to Darwin */
-	size_t responseSize; /* the size of the response received from Darwin */
-	int maxSize = glbl.GetMaxLine(); /* this variable used when setting the size of the packet sent */
-	rsRetVal localRet; /* this variable is used when checking an error from a Rsyslog function */
-	size_t bufferSize = INITIAL_BUFFER_SIZE; /* our buffer size for temporary strings */
-	size_t bufferBodySize = INITIAL_BUFFER_SIZE; /* our buffer size for the body to be sent to Darwin */
-	char *stringBuffer = NULL; /* our variable for temporary strings */
-	size_t fieldSize = 0; /* the size we check for the buffer */
+	char *pFieldValue = NULL; /* ponter to the found field value */
+	int fieldsNum = 0; /* number of fields retrieved */
+	struct json_object *pJson = json_object_new_object(); /* json structure to add info to Rsyslog message */
 
-/* then, we process our log line */
 CODESTARTdoAction
-	dbgprintf("mmdarwin::doAction:: processing log line: '%s'\n", getMSG(pMsg));
+	DBGPRINTF("mmdarwin::doAction:: processing log line: '%s'\n", getMSG(pMsg));
+	pWrkrData->darwinBody.bufferMsgSize = 0;
+	fieldsNum = 0;
 
-	stringBuffer = malloc(sizeof(char) * bufferSize);
-	size_t parametersNumber = pData->fieldList.nmemb;
-	char *body = malloc(sizeof(char) * bufferBodySize * parametersNumber + 1); /* + 1 for '\0' */
+	for (int i = 0; i < pData->fieldList.nmemb; i++)
+	{
+		DBGPRINTF("mmdarwin::doAction:: processing field '%s'\n", pData->fieldList.name[i]);
+		pFieldValue = NULL;
 
-	if (stringBuffer == NULL) {
-		dbgprintf("mmdarwin::doAction:: error: something went wrong while allocating stringBuffer\n");
-		goto finalize_it;
+		/* case 1: static field. We simply forward it to Darwin */
+		if (pData->fieldList.name[i][0] != '!')
+		{
+			pFieldValue = strdup(pData->fieldList.name[i]);
+			/* case 2: dynamic field. We retrieve its value from the JSON logline and forward it to
+			 * Darwin */
+		}
+		else
+		{
+			if (!get_field(pMsg, pData->fieldList.name[i], &pFieldValue))
+			{
+				DBGPRINTF("mmdarwin::doAction:: \
+could not extract field '%s' from message\n", pData->fieldList.name[i]);
+				continue;
+			}
+		}
+
+		DBGPRINTF(
+			"mmdarwin::doAction:: got value of field '%s': '%s'\n", pData->fieldList.name[i], pFieldValue);
+
+		if (add_field_to_body(&(pWrkrData->darwinBody), pFieldValue, strlen(pFieldValue)) != 0)
+		{
+			DBGPRINTF("mmdarwin::doAction:: could not add field to body, aborting\n");
+			free(pFieldValue);
+			ABORT_FINALIZE(RS_RET_ERR);
+		}
+
+		fieldsNum++;
+		free(pFieldValue);
 	}
 
-	*stringBuffer = '\0';
-
-	dbgprintf("mmdarwin::doAction:: starting sending fields to Darwin\n");
-
-	if (body == NULL) {
-		dbgprintf("mmdarwin::doAction:: error: something went wrong while allocating body\n");
-		goto finalize_it;
+	if (fieldsNum)
+	{
+		if (!pData->sendPartial && fieldsNum != pData->fieldList.nmemb)
+		{
+			DBGPRINTF("mmdarwin::doAction:: not all fields could be retrieved, not sending partial message.\
+	(if you wish to send partial messages anyway, set 'send_partial' to 'on' in instance parameters)\n");
+			FINALIZE;
+		}
+		if (end_body(&(pWrkrData->darwinBody)) != 0)
+			ABORT_FINALIZE(RS_RET_ERR);
+	}
+	else
+	{
+		DBGPRINTF("mmdarwin::doAction:: no fields retrieved, finalizing\n");
+		FINALIZE;
 	}
 
-	*body = '[';
-	*(body + 1) = '[';
-	*(body + 2) = '\0';
+	DBGPRINTF("mmdarwin::doAction:: body to send: '%s'\n", pWrkrData->darwinBody.buffer);
 
-	char *currentBodyIndex = body + 2;
-	dbgprintf("mmdarwin::doAction:: Current body: '%s'\n", body);
+	if (pData->socketMaxUse)
+	{
+		/* need to rotate socket connections */
+		if (!pWrkrData->pktSentSocket)
+		{
+			DBGPRINTF("mmdarwin::doAction:: opening a new connection\n");
+			CHKiRet(doTryResume(pWrkrData));
+		}
+		pWrkrData->pktSentSocket = (pWrkrData->pktSentSocket + 1) % pData->socketMaxUse;
+	}
 
 	/* the Darwin header to be sent to the filter */
 	darwin_filter_packet_t header = {
 		.type = DARWIN_PACKET_OTHER,
 		.response = pData->response,
 		.filter_code = pData->filterCode,
-	};
+		.body_size = pWrkrData->darwinBody.bufferMsgSize};
+	/* generate uuid for Darwin event id */
+	uuid_generate(header.evt_id);
 
-	/* for each field, we add the value in the body */
-	for (size_t i = 0; i <  parametersNumber; ++i) {
-		dbgprintf("mmdarwin::doAction:: processing field '%s'\n", pData->fieldList.name[i]);
-		fieldSize = strlen(pData->fieldList.name[i]);
+	DBGPRINTF("mmdarwin::doAction:: sending header to Darwin\n");
+	CHKiRet(sendMsg(pWrkrData, &header, sizeof(darwin_filter_packet_t)));
 
-		/* case 1: static field. We simply forward it to Darwin */
-		if (fieldSize > 0 && pData->fieldList.name[i][0] != '!') {
-			pFieldValueString = pData->fieldList.name[i];
-		/* case 2: dynamic field. We retrieve its value from the JSON logline and forward it to Darwin */
-		} else {
-			if (bufferSize < fieldSize) {
-				dbgprintf(
-					"mmdarwin::doAction:: reallocating stringBuffer. "
-					"Current size is %zu. Size needed is %zu\n",
-					bufferSize, fieldSize
-				);
-
-
-				while (bufferSize < fieldSize) bufferSize += INITIAL_BUFFER_SIZE;
-
-				char *tmpStringBuffer = NULL;
-
-				if ((tmpStringBuffer = realloc(stringBuffer, bufferSize * sizeof(char)))) {
-					stringBuffer = tmpStringBuffer;
-				} else {
-					dbgprintf(
-						"mmdarwin::doAction:: error: something went wrong while "
-						"reallocating stringBuffer\n"
-					);
-					/* stringBuffer is still allocated, but we will free it later */
-					goto finalize_it;
-				}
-			}
-
-			/* the actual property size: field + '\0' = strlen(field) + 1 */
-			size_t propertySize = min(fieldSize, bufferSize);
-			stpncpy(stringBuffer, pData->fieldList.name[i], fieldSize);
-			*(stringBuffer + fieldSize) = '\0';
-			localRet = get_json_body(&pMsg, &pFieldBody, stringBuffer, propertySize);
-
-			if (localRet != RS_RET_OK) {
-				/* for some reason, we couldn't get the value.
-				   So we consider the size to be zero and we continue the processing */
-				dbgprintf("mmdarwin::doAction:: could not extract the json body from the message. "
-						  "rsRetVal error code: %d\n", localRet);
-				goto end_processing_field;
-			}
-
-			if (get_json_string(&pFieldValueString, pFieldBody) == 0) {
-				/* for some really weird reason, we couldn't convert our JSON object to a string.
-				   So we consider the size to be zero and we continue the processing */
-				dbgprintf("mmdarwin::doAction:: could not parse the json body to string\n");
-				goto end_processing_field;
-			}
-		}
-
-		/* pFieldValueString will be freed when its JSON object will be dereferenced */
-		dbgprintf("mmdarwin::doAction:: value retrieved from field '%s': '%s'\n", pData->fieldList.name[i],
-				  pFieldValueString);
-
-		/* "{VALUE}", = " + strlen({VALUE}) + " + , */
-		size_t totalLength = strlen(pFieldValueString) + 3;
-
-		if (bodySize + totalLength >= bufferBodySize) {
-			while (bodySize + totalLength >= bufferBodySize) {
-				bufferBodySize += INITIAL_BUFFER_SIZE;
-			}
-
-			char *tmpStringBuffer = realloc(body, bufferBodySize * sizeof(char) + 1);
-
-			if (tmpStringBuffer) {
-				body = tmpStringBuffer;
-				currentBodyIndex = body + bodySize;
-
-				if (bodySize != 0) currentBodyIndex++;
-			} else {
-				dbgprintf("mmdarwin::doAction:: error: something went wrong while reallocating body\n");
-				/* body is still allocated, but we will free it later */
-				goto finalize_it;
-			}
-		}
-
-		/* then, we copy it to our body */
-		*currentBodyIndex = '\"';
-		++currentBodyIndex;
-		currentBodyIndex = stpncpy(currentBodyIndex, pFieldValueString, strlen(pFieldValueString));
-		*currentBodyIndex = '\"';
-		*(currentBodyIndex + 1) = ',';
-		currentBodyIndex += 2;
-		*currentBodyIndex = '\0';
-		bodySize = strlen(body);
-		dbgprintf("mmdarwin::doAction:: Current body: '%s'\n", body);
-
-		end_processing_field:
-			json_object_put(pFieldBody); /* we can free our pFieldBody */
-			pFieldBody = NULL;
-			dbgprintf("mmdarwin::doAction:: ended processing field '%s'\n", pData->fieldList.name[i]);
-	}
-
-
-	/* here, we need to replace some characters in the last parameter:
-	the string currently looks like this:
-	[["arg1","arg2","arg3",\0
-	So, we will replace the last comma, and add a bracket and a null character as well to make it like this:
-	[["arg1","arg2","arg3"]]\0
-	To ensure this, we need to check if we can add one character */
-
-	if (bodySize + 1 >= bufferBodySize) {
-		bufferBodySize += INITIAL_BUFFER_SIZE;
-		char *tmpStringBuffer = realloc(body, bufferBodySize * sizeof(char) + 1);
-
-		if (tmpStringBuffer) {
-			body = tmpStringBuffer;
-			currentBodyIndex = body + bodySize;
-		} else {
-			dbgprintf("mmdarwin::doAction:: error: something went wrong while reallocating body\n");
-			/* body is still allocated, but we will free it later */
-			goto finalize_it;
-		}
-	} else {
-		currentBodyIndex = body + bodySize;
-	}
-
-	++bodySize;
-
-	*(currentBodyIndex - 1) = ']'; /* we replace the last comma with a bracket */
-	*currentBodyIndex = ']'; /* we set the final bracket */
-	*(currentBodyIndex + 1) = '\0';
-	dbgprintf("mmdarwin::doAction:: Current body: '%s'\n", body);
-
-	pthread_mutex_lock(&mutDoAct);
-
-	dbgprintf("mmdarwin::doAction:: getting Darwin session\n");
-	CHKiRet(doTryResume(pWrkrData->pData)); /* connecting to darwin */
-
-	if ((int) bodySize > maxSize) bodySize = maxSize; /* we truncate, if the message is too long */
-
-	header.body_size = bodySize;
-	headerSize = sizeof(darwin_filter_packet_t);
-
-	if ((int) headerSize > maxSize) headerSize = maxSize; /* we truncate, if the message is too long */
-
-	dbgprintf("mmdarwin::doAction:: sending header to Darwin\n");
-	CHKiRet(sendMsg(pWrkrData->pData, &header, headerSize));
-
-	dbgprintf("mmdarwin::doAction:: sending body (cookie/header value) to Darwin\n");
-	dbgprintf("mmdarwin::doAction:: body to be sent: '%s'\n", body);
-	CHKiRet(sendMsg(pWrkrData->pData, body, bodySize));
+	DBGPRINTF("mmdarwin::doAction:: sending body to Darwin\n");
+	CHKiRet(sendMsg(pWrkrData, (void *)(pWrkrData->darwinBody.buffer), pWrkrData->darwinBody.bufferMsgSize));
 
 	/* there is no need to wait for a response that will never come */
-	if (pData->response == DARWIN_RESPONSE_SEND_NO || pData->response == DARWIN_RESPONSE_SEND_DARWIN) {
-		dbgprintf("mmdarwin::doAction:: no response will be sent back "
-				  "(darwin response type is set to 'no' or 'darwin')\n");
+	if (pData->response == DARWIN_RESPONSE_SEND_NO || pData->response == DARWIN_RESPONSE_SEND_DARWIN)
+	{
+		DBGPRINTF("mmdarwin::doAction:: no response will be sent back "
+				"(darwin response type is set to 'no' or 'darwin')\n");
+		char uuidStr[40];
+		uuid_unparse(header.evt_id, uuidStr);
+		DBGPRINTF("uuid: %s\n", uuidStr);
+		json_object_object_add(pJson, "darwin_id", json_object_new_string(uuidStr));
 		goto finalize_it;
 	}
 
-	darwin_filter_packet_t response = {
-		.type = DARWIN_PACKET_OTHER,
-		.response = DARWIN_RESPONSE_SEND_NO,
-		.filter_code = DARWIN_FILTER_CODE_NO,
-		.body_size = 0,
-		.certitude_size = 0,
-	};
+	darwin_filter_packet_t response;
+	memset(&response, 0, sizeof(response));
+	DBGPRINTF("mmdarwin::doAction:: receiving from Darwin\n");
+	CHKiRet(receiveMsg(pWrkrData, &response, sizeof(response)));
 
-	dbgprintf("mmdarwin::doAction:: receiving from Darwin\n");
-	responseSize = sizeof(response);
+	unsigned int certitude = response.certitude_list[0];
+	DBGPRINTF("mmdarwin::doAction:: end of the transaction, certitude is %d\n", certitude);
 
-	if ((int) responseSize > maxSize) responseSize = maxSize; /* we truncate, if the message is too long */
+	json_object_object_add(pJson, pData->pCertitudeKey, json_object_new_int(certitude));
 
-	CHKiRet(receiveMsg(pWrkrData->pData, &response, responseSize));
-
-	dbgprintf("mmdarwin::doAction:: end of the transaction\n");
-	pthread_mutex_unlock(&mutDoAct);
-
-	/* we cast our certitude to a char* */
-	int charProcessed = snprintf(stringBuffer, bufferSize, "%d", response.certitude_list[0]);
-
-	if (charProcessed < 0 || (unsigned int)charProcessed >= bufferSize) {
-		dbgprintf(
-			"mmdarwin::doAction:: warning: the certitude was truncated "
-			"(only %zu characters were written)\n",
-			bufferSize
-		);
+finalize_it :
+	if (json_object_get_member_count(pJson))
+	{
+		DBGPRINTF("mmdarwin::doAction:: adding entry to rsyslog message\n");
+		msgAddJSON(pMsg, (uchar *)JSON_LOOKUP_NAME, pJson, 0, 0);
 	}
+	else {
+		json_object_put(pJson);
+	}
+	DBGPRINTF("mmdarwin::doAction:: finished processing log line\n");
 
-	dbgprintf("mmdarwin::doAction:: certitude obtained: %s\n", stringBuffer);
-	dbgprintf("mmdarwin::doAction:: adding certitude to message...\n");
-	struct json_object *pDarwinJSON = json_object_new_object();
-	json_object_object_add(pDarwinJSON, pData->pCertitudeKey, json_object_new_string(stringBuffer));
-
-	msgAddJSON(pMsg, (uchar *)JSON_LOOKUP_NAME, pDarwinJSON, 0, 0);
-
-	finalize_it:
-		if (stringBuffer != NULL) {
-			free(stringBuffer);
-			stringBuffer = NULL;
-		}
-		if (body != NULL) {
-			free(body);
-			body = NULL;
-		}
-		if (pFieldBody != NULL) {
-			json_object_put(pFieldBody);
-			pFieldBody = NULL;
-		}
 ENDdoAction
 
-
 NO_LEGACY_CONF_parseSelectorAct
-
 
 BEGINmodExit
 CODESTARTmodExit
 	objRelease(glbl, CORE_COMPONENT);
 ENDmodExit
-
 
 BEGINqueryEtryPt
 CODESTARTqueryEtryPt
@@ -768,12 +885,11 @@ CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES
 CODEqueryEtryPt_STD_CONF2_QUERIES
 ENDqueryEtryPt
 
-
 BEGINmodInit()
 CODESTARTmodInit
 	/* we only support the current interface specification */
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
-	dbgprintf("mmdarwin::modInit:: module compiled with rsyslog version %s.\n", VERSION);
+	DBGPRINTF("mmdarwin::modInit:: module compiled with rsyslog version %s.\n", VERSION);
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 ENDmodInit

--- a/contrib/mmdarwin/protocol.h
+++ b/contrib/mmdarwin/protocol.h
@@ -4,7 +4,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
-	* http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,50 +13,55 @@
  * limitations under the License.
  */
 #ifndef DARWIN_PROTOCOL_H
-# define DARWIN_PROTOCOL_H
+#define DARWIN_PROTOCOL_H
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 #include <stddef.h>
 #include <netinet/in.h>
 
 #define DARWIN_FILTER_CODE_NO 0x00000000
-// the default certitude list size, which is 1, to allow FMAs (see flexible array members on C99)
-// for both C and C++ code
+// the default certitude list size, which is 1, to allow FMAs (see flexible array members on C99) for both C and C++
+// code
 #define DEFAULT_CERTITUDE_LIST_SIZE 1
 
-/// Represent the receiver of the results.
-///
-/// \enum darwin_response_type
-enum darwin_filter_response_type {
-	DARWIN_RESPONSE_SEND_NO = 0,//!< Don't send results to anybody.
-	DARWIN_RESPONSE_SEND_BACK, //!< Send results back to caller.
-	DARWIN_RESPONSE_SEND_DARWIN, //!< Send results to the next filter.
-	DARWIN_RESPONSE_SEND_BOTH, //!< Send results to both caller and the next filter.
-};
+	/// Represent the receiver of the results.
+	///
+	/// \enum darwin_response_type
+	enum darwin_filter_response_type
+	{
+		DARWIN_RESPONSE_SEND_NO = 0, //!< Don't send results to anybody.
+		DARWIN_RESPONSE_SEND_BACK,   //!< Send results back to caller.
+		DARWIN_RESPONSE_SEND_DARWIN, //!< Send results to the next filter.
+		DARWIN_RESPONSE_SEND_BOTH,   //!< Send results to both caller and the next filter.
+	};
 
-/// Represent the type of information sent.
-///
-/// \enum darwin_packet_type
-enum darwin_packet_type {
-	DARWIN_PACKET_OTHER = 0, //!< Information sent by something else.
-	DARWIN_PACKET_FILTER, //!< Information sent by another filter.
-};
+	/// Represent the type of information sent.
+	///
+	/// \enum darwin_packet_type
+	enum darwin_packet_type
+	{
+		DARWIN_PACKET_OTHER = 0, //!< Information sent by something else.
+		DARWIN_PACKET_FILTER,	//!< Information sent by another filter.
+	};
 
-/// First packet to be sent to a filter.
-///
-/// \struct darwin_filter_packet_t
-typedef struct {
-	enum darwin_packet_type type; //!< The type of information sent.
-	enum darwin_filter_response_type response; //!< Whom the response will be sent to.
-	long filter_code; //!< The unique identifier code of a filter.
-	size_t body_size; //!< The complete size of the the parameters to be sent (if needed).
-	size_t certitude_size; //!< The size of the list containing the certitudes.
-	//!< The scores or the certitudes of the module. May be used to pass other info in specific cases.
-	unsigned int certitude_list[DEFAULT_CERTITUDE_LIST_SIZE];
-} darwin_filter_packet_t;
+	/// First packet to be sent to a filter.
+	///
+	/// \struct darwin_filter_packet_t
+	typedef struct
+	{
+		enum darwin_packet_type type;			//!< The type of information sent.
+		enum darwin_filter_response_type response;	//!< Whom the response will be sent to.
+		long filter_code;				//!< The unique identifier code of a filter.
+		size_t body_size;				//!< The complete size of the the parameters to be sent
+		unsigned char evt_id[16];			//!< An array containing the event ID
+		size_t certitude_size;				//!< The size of the list containing the certitudes.
+		unsigned int certitude_list[DEFAULT_CERTITUDE_LIST_SIZE];
+		//!< The scores or the certitudes of the module. May be used to pass other info in specific cases.
+	} darwin_filter_packet_t;
 
 #ifdef __cplusplus
 };


### PR DESCRIPTION
#Optimisations
- use permanent worker-dependent buffers to avoid malloc/free for each entry
- move socket structures to worker data, remove global mutex
- add log lines for parameters and general workflow
- don't send body if empty/incomplete (see new parameters)
- don't close/reopen socket every time -> let session open or create new every X entry (see new parameters)
- clean up code

#New parameters
- added 'send_partial', to let mmdarwin send body if not all fields were retrieved, or not
  default false = only send complete bodies
- added 'socket_max_use' to open new session every X packet, useful for some versions of Darwin (prior to 1.1)
  default is 0 = do not open new session/keep only one

#Update to protocol
- added 'evt_id' to the darwin header (Darwin v1+ compatibility)
