### PR TITLE
ossl driver: fix wrong OpenSSL Version check (OPENSSL_VERSION_NUMBER)

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1792,7 +1792,7 @@ SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unus
 		RETiRet;
 	} else {
 		dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);
-#if OPENSSL_VERSION_NUMBER >= 0x10020000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 		char *pCurrentPos;
 		char *pNextPos;
 		char *pszCmd;

--- a/tests/imtcp-tls-ossl-basic-tlscommands.sh
+++ b/tests/imtcp-tls-ossl-basic-tlscommands.sh
@@ -18,7 +18,6 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon"
 	gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2
-	MinProtocol=TLSv1.1
 	Options=Bugs"
 	)
 input(	type="imtcp"
@@ -29,7 +28,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 
 # now inject the messages which will fail due protocol configuration
-tcpflood --check-only -k "Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.1,-TLSv1.3" -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood --check-only -k "Protocol=-ALL,TLSv1.2" -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 
 shutdown_when_empty
 wait_shutdown
@@ -40,7 +39,8 @@ if [ $ret == 0 ]; then
 	echo "SKIP: OpenSSL Version too old"
 	skip_test
 else
-	content_check "wrong version number"
+	# Kindly check for a failed session
+	content_check "SSL_ERROR_SSL"
 	content_check "OpenSSL Error Stack:"
 fi
 

--- a/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
+++ b/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
@@ -18,7 +18,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="x509/certvalid"
 	StreamDriver.PermitExpiredCerts="off"
-	gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2\nMinProtocol=TLSv1.1\nOptions=Bugs"
+	gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2\nOptions=Bugs"
 	)
 input(	type="imtcp"
 	port="'$PORT_RCVR'" )
@@ -41,7 +41,7 @@ action(	type="omfwd"
 	port="'$PORT_RCVR'"
 	StreamDriverMode="1"
 	StreamDriverAuthMode="x509/certvalid"
-	gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.1,-TLSv1.3"
+	gnutlsPriorityString="Protocol=-ALL,TLSv1.2"
 )
 ' 2
 startup 2
@@ -65,7 +65,8 @@ if [ $ret == 0 ]; then
 	echo "SKIP: OpenSSL Version too old"
 	skip_test
 else
-	content_check "wrong version number"
+	# Kindly check for a failed session
+	content_check "SSL_ERROR_SSL"
 	content_check "OpenSSL Error Stack:"
 fi
 

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1181,7 +1181,7 @@ initTLS(void)
 
 	/* Check for Custom Config string */
 	if (customConfig != NULL){
-#if OPENSSL_VERSION_NUMBER >= 0x10020000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L
 	char *pCurrentPos;
 	char *pNextPos;
 	char *pszCmd;


### PR DESCRIPTION
Fixed OpenSSL Version check in:
- SetGnutlsPriorityString function in nsd_ossl.c
- initTLS() function tcpflood.c

See https://www.openssl.org/docs/man1.1.0/man3/OPENSSL_VERSION_NUMBER.html
for more.

closes https://github.com/rsyslog/rsyslog/issues/3939