### PR TITLE
Report access error only on files

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -706,7 +706,11 @@ act_obj_add(fs_edge_t *const edge, const char *const name, const int is_file,
 	DBGPRINTF("need to add new active object '%s' in '%s' - checking if accessible\n", name, edge->path);
 	fd = open(name, O_RDONLY | O_CLOEXEC);
 	if(fd < 0) {
-		LogMsg(errno, RS_RET_ERR, LOG_WARNING, "imfile: error accessing file '%s'", name);
+		if (is_file) {
+			LogError(errno, RS_RET_ERR, "imfile: error accessing file '%s'", name);
+		} else { /* reporting only in debug for dirs as higher lvl paths are likely blocked by selinux */
+			DBGPRINTF("imfile: error accessing file '%s'", name);
+		}
 		FINALIZE;
 	}
 	DBGPRINTF("add new active object '%s' in '%s'\n", name, edge->path);


### PR DESCRIPTION
Leaving reporting access for directories in DEBUG only as rsyslog
goes all the way to root and paths higher in filesystem are
usually blocked by selinux policy rules.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
