### PR TITLE
imrelp: remove unsafe debug instrumentation

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -802,10 +802,8 @@ static void
 doSIGTTIN(int __attribute__((unused)) sig)
 {
 	const int bTerminate = ATOMIC_FETCH_32BIT(&bTerminateInputs, &mutTerminateInputs);
-	DBGPRINTF("imrelp: awoken via SIGTTIN; bTerminateInputs: %d\n", bTerminate);
 	if(bTerminate) {
 		relpEngineSetStop(pRelpEngine);
-		DBGPRINTF("imrelp: termination requested via SIGTTIN - telling RELP engine\n");
 	}
 }
 


### PR DESCRIPTION
dbgprintf, which is not signal safe, was called from a signal handler
to get better understanding during debugging. While this usually works,
it can occasionally (5%) lead to a hang during shutdown. We have now
removed that debug info as it is no longer vital.

Note: this could only happen during debug runs. Production mode was
not affected. As such, this fix is only revelevant to developers.

However, it caused some confusion in the following issue tracker.
see also https://github.com/rsyslog/rsyslog/issues/3941

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
