### PR TITLE
queue cleanup: remove no longer needed debug output

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1193,8 +1193,8 @@ qqueueDeq(qqueue_t *pThis, smsg_t **ppMsg)
 	iRet = pThis->qDeq(pThis, ppMsg);
 	ATOMIC_INC(&pThis->nLogDeq, &pThis->mutLogDeq);
 
-	DBGOPRINT((obj_t*) pThis, "entry deleted, size now log %d, phys %d entries, iOverallQueueSize %d\n",
-		  getLogicalQueueSize(pThis), getPhysicalQueueSize(pThis), (int) iOverallQueueSize);
+	DBGOPRINT((obj_t*) pThis, "entry deleted, size now log %d, phys %d entries\n",
+		  getLogicalQueueSize(pThis), getPhysicalQueueSize(pThis));
 
 	RETiRet;
 }
@@ -3487,7 +3487,6 @@ static rsRetVal qqueueSetProperty(qqueue_t *pThis, var_t *pProp)
 			ABORT_FINALIZE(RS_RET_QTYPE_MISMATCH);
 	}
 
-dbgprintf("rger: setProperty: iOverallQueueSize %d\n", (int) iOverallQueueSize);
 finalize_it:
 	RETiRet;
 }


### PR DESCRIPTION
This was added for a specific debug effort and obviously forgotten
to cleanup.

Thanks to github user eshadesu for alerting us.

closes https://github.com/rsyslog/rsyslog/issues/3955
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
