### PR TITLE
imfile: add new input parameter escapeLF.replacement

### DIFF
--- a/contrib/imtuxedoulog/imtuxedoulog.c
+++ b/contrib/imtuxedoulog/imtuxedoulog.c
@@ -522,7 +522,7 @@ static void pollFileReal(instanceConf_t *pInst, int *pbHadFileData, cstr_t **ppC
 	while(glbl.GetGlobalInputTermState() == 0) {
 		if(pInst->maxLinesAtOnce != 0 && nProcessed >= pInst->maxLinesAtOnce)
 			break;
-		CHKiRet(strm.ReadLine(pInst->pStrm, ppCStr, 0, 0, -1, NULL));
+		CHKiRet(strm.ReadLine(pInst->pStrm, ppCStr, 0, 0, NULL, -1, NULL));
 		++nProcessed;
 		if(pbHadFileData != NULL)
 			*pbHadFileData = 1; /* this is just a flag, so set it and forget it */

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -1484,7 +1484,7 @@ loadFailedMsgs(instanceData *const __restrict__ pData)
 	CHKiRet(strm.SetFName(pstrmFMSG, pData->failedMsgFile, ustrlen(pData->failedMsgFile)));
 	CHKiRet(strm.ConstructFinalize(pstrmFMSG));
 
-	while(strm.ReadLine(pstrmFMSG, &pCStr, 0, 0, 0, NULL) == RS_RET_OK) {
+	while(strm.ReadLine(pstrmFMSG, &pCStr, 0, 0, NULL, 0, NULL) == RS_RET_OK) {
 		if(rsCStrLen(pCStr) == 0) {
 			/* we do not process empty lines */
 			DBGPRINTF("omkafka: loadFailedMsgs msg was empty!");

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -210,7 +210,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
 	INTERFACEpropSetMeth(strm, iFlushInterval, int);
 	INTERFACEpropSetMeth(strm, pszSizeLimitCmd, uchar*);
 	/* v6 added */
-	rsRetVal (*ReadLine)(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF,
+	rsRetVal (*ReadLine)(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF, const uchar *,
 		uint32_t trimLineOverBytes, int64 *const strtOffs);
 	/* v7 added  2012-09-14 */
 	INTERFACEpropSetMeth(strm, bVeryReliableZip, int);
@@ -220,19 +220,21 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
 	INTERFACEpropSetMeth(strm, cryprov, cryprov_if_t*);
 	INTERFACEpropSetMeth(strm, cryprovData, void*);
 ENDinterface(strm)
-#define strmCURR_IF_VERSION 13 /* increment whenever you change the interface structure! */
+#define strmCURR_IF_VERSION 14 /* increment whenever you change the interface structure! */
 /* V10, 2013-09-10: added new parameter bEscapeLF, changed mode to uint8_t (rgerhards) */
 /* V11, 2015-12-03: added new parameter bReopenOnTruncate */
 /* V12, 2015-12-11: added new parameter trimLineOverBytes, changed mode to uint32_t */
 /* V13, 2017-09-06: added new parameter strtoffs to ReadLine() */
+/* V14, 2019-11-13: added new parameter bEscapeLFString (rgerhards) */
 
 #define strmGetCurrFileNum(pStrm) ((pStrm)->iCurrFNum)
 
 /* prototypes */
 PROTOTYPEObjClassInit(strm);
 rsRetVal strmMultiFileSeek(strm_t *pThis, unsigned int fileNum, off64_t offs, off64_t *bytesDel);
-rsRetVal strmReadMultiLine(strm_t *pThis, cstr_t **ppCStr, regex_t *start_preg, regex_t *end_preg,
-	sbool bEscapeLF, sbool discardTruncatedMsg, sbool msgDiscardingError, int64 *const strtOffs);
+rsRetVal ATTR_NONNULL(1,2) strmReadMultiLine(strm_t *pThis, cstr_t **ppCStr, regex_t *start_preg,
+	regex_t *end_preg, const sbool bEscapeLF, const uchar *const escapeLFString,
+	const sbool discardTruncatedMsg, const sbool msgDiscardingError, int64 *const strtOffs);
 int strmReadMultiLine_isTimedOut(const strm_t *const __restrict__ pThis);
 void strmDebugOutBuf(const strm_t *const pThis);
 void strmSetReadTimeout(strm_t *const __restrict__ pThis, const int val);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1306,6 +1306,8 @@ TESTS += \
 	imfile-endregex-timeout-with-shutdown.sh \
 	imfile-endregex-timeout-with-shutdown-polling.sh \
 	imfile-endmsg.regex.sh \
+	imfile-escapelf.replacement.sh \
+	imfile-escapelf.replacement-empty.sh \
 	imfile-statefile-no-file_id.sh \
 	imfile-statefile-no-file_id-TO-file_id.sh \
 	imfile-statefile-directory.sh \

--- a/tests/imfile-escapelf.replacement-empty.sh
+++ b/tests/imfile-escapelf.replacement-empty.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Written in 2019 by Rainer Gerhards
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+module(load="../plugins/imfile/.libs/imfile")
+input(type="imfile" ruleset="output" escapelf.replacement=""
+	File="./'$RSYSLOG_DYNNAME'.input" tag="file:" startmsg.regex="^msg")
+
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="output") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+# make sure file exists when rsyslog starts up
+echo 'msg 1 part 1
+ msg 1 part 2
+msg 2
+msg INVISIBLE by design' > $RSYSLOG_DYNNAME.input
+startup
+export NUMMESSAGES=2
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='msg 1 part 1 msg 1 part 2
+msg 2'
+cmp_exact
+exit_test

--- a/tests/imfile-escapelf.replacement.sh
+++ b/tests/imfile-escapelf.replacement.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Written in 2019 by Rainer Gerhards
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+module(load="../plugins/imfile/.libs/imfile")
+input(type="imfile" ruleset="output" escapelf.replacement="[LF]"
+	File="./'$RSYSLOG_DYNNAME'.input" tag="file:" startmsg.regex="^msg")
+
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="output") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+# make sure file exists when rsyslog starts up
+echo 'msg 1 part 1
+ msg 1 part 2
+msg 2
+msg INVISIBLE by design' > $RSYSLOG_DYNNAME.input
+startup
+export NUMMESSAGES=2
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='msg 1 part 1[LF] msg 1 part 2
+msg 2'
+cmp_exact
+exit_test


### PR DESCRIPTION
The new parameter permits to specify a replacement to be configured
when "escapeLF" is set to "on". Previously, a fixed replacement string
was used ("#012"/"\n") depending on circumstances. If the parameter is
set to an empty string, the LF is simply discarded.

closes https://github.com/rsyslog/rsyslog/issues/3889

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
