### PR TITLE
core queue: emit warning if parameters are set for direct queue

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -233,6 +233,8 @@ TESTS +=  \
 	queue_warnmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \
+	queue-direct-with-no-params.sh \
+	queue-direct-with-params-given.sh \
 	arrayqueue.sh \
 	global_vars.sh \
 	no-parser-errmsg.sh \
@@ -1554,6 +1556,8 @@ EXTRA_DIST= \
 	queue_warnmsg-oversize.sh \
 	queue-minbatch.sh \
 	queue-minbatch-queuefull.sh \
+	queue-direct-with-no-params.sh \
+	queue-direct-with-params-given.sh \
 	killrsyslog.sh \
 	parsertest-parse1.sh \
 	parsertest-parse1-udp.sh \

--- a/tests/queue-direct-with-no-params.sh
+++ b/tests/queue-direct-with-no-params.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# added 2019-11-14 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+check_not_present "queue is in direct mode, but parameters have been set"
+exit_test

--- a/tests/queue-direct-with-params-given.sh
+++ b/tests/queue-direct-with-params-given.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# added 2019-11-14 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" queue.mindequeuebatchsize="20")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "queue is in direct mode, but parameters have been set"
+exit_test


### PR DESCRIPTION
Direct queues do not apply queue parameters because they are actually
no physical queue. As such, any parameter set is ignored. This can
lead to unintentional results.

The new code detects this case and warns the user.

closes https://github.com/rsyslog/rsyslog/issues/77

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
