### PR TITLE
omprog: detect violation of interface protocol

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -781,6 +781,7 @@ TESTS +=  \
 	omprog-single-instance.sh \
 	omprog-single-instance-outfile.sh \
 	omprog-transactions.sh \
+	omprog-if-error.sh \
 	omprog-transactions-failed-messages.sh \
 	omprog-transactions-failed-commits.sh
 if HAVE_VALGRIND
@@ -2086,6 +2087,7 @@ EXTRA_DIST= \
 	omprog-single-instance.sh \
 	omprog-single-instance-vg.sh \
 	omprog-single-instance-outfile.sh \
+	omprog-if-error.sh \
 	omprog-transactions.sh \
 	omprog-transactions-vg.sh \
 	omprog-transactions-failed-messages.sh \

--- a/tests/omprog-if-error.sh
+++ b/tests/omprog-if-error.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+# This test tests omprog if omprog detects errors in the calling
+# interface, namely a missing LF on input messages
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%")
+
+if (prifilt("local4.*") and $msg contains "msgnum:") then {
+	action(type="omprog" binary="'$srcdir'/testsuites/omprog-defaults-bin.sh p1 p2 p3"
+		template="outfmt" name="omprog_action")
+} else {
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.othermsg")
+}
+'
+startup
+injectmsg 0 10
+shutdown_when_empty
+wait_shutdown
+cat $RSYSLOG_DYNNAME.othermsg
+
+content_check 'must be terminated with \n' $RSYSLOG_DYNNAME.othermsg
+
+export EXPECTED="Starting with parameters: p1 p2 p3
+Received msgnum:00000000:
+Received msgnum:00000001:
+Received msgnum:00000002:
+Received msgnum:00000003:
+Received msgnum:00000004:
+Received msgnum:00000005:
+Received msgnum:00000006:
+Received msgnum:00000007:
+Received msgnum:00000008:
+Received msgnum:00000009:
+Terminating normally"
+
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test


### PR DESCRIPTION
The spec for the omprog interaction with the program it calls specifies
that the program receives one message via one line. In other words:
it must be a string terminated by LF.

However, omprog does currently rely on a proper template to fulfill this
requirement, If the template does not provide for the LF, it is never
written. For the called program, this looks like it does not receive any
input at all. Even if it finally reads data (e.g. due to full buffer),
it will not properly be able to discern the messages.

This handling is improved with this commit.

We cannot just check the template, because at the end of the template
may by a non-constant value. As such, we do not know at config load
time if there is this problem or not.

So the correct approach is to, during runtime, check if each message
is properly terminated. For those that are not:
* we append a LF, because anything else makes matters worse
* log a warning message, at least for a sample of the messages

The warning is useful in the (expected most often) case that the template
is simply missing the LF. While appending works, it slows down processing.
As such the user should be given a chance to correct the config bug.

To avoid clutter, the warning is emitted at most once every 30 seconds.
This value is hardcoded as we do not envison a need to adjust it. Usually
users should quickly fix the template.

closes https://github.com/rsyslog/rsyslog/issues/3975

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
