### PR TITLE
omkafka: ensure math lib is bound to executable

### DIFF
--- a/plugins/omkafka/Makefile.am
+++ b/plugins/omkafka/Makefile.am
@@ -3,10 +3,10 @@ pkglib_LTLIBRARIES = omkafka.la
 omkafka_la_SOURCES = omkafka.c
 omkafka_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
 if !ENABLE_KAFKA_STATIC
-omkafka_la_LDFLAGS = -module -avoid-version $(LIBRDKAFKA_LIBS)
+omkafka_la_LDFLAGS = -module -avoid-version $(LIBRDKAFKA_LIBS) -lm
 endif
 if ENABLE_KAFKA_STATIC
-omkafka_la_LDFLAGS = -module -avoid-version -Wl,--whole-archive -l:librdkafka.a -Wl,--no-whole-archive -lssl -lpthread -lcrypto -lsasl2 -lz -llz4 -lrt # Static Linking now $(LIBRDKAFKA_LIBS)
+omkafka_la_LDFLAGS = -module -avoid-version -Wl,--whole-archive -l:librdkafka.a -Wl,--no-whole-archive -lssl -lpthread -lcrypto -lsasl2 -lz -llz4 -lrt -lm
 endif
 omkafka_la_LIBADD = 
 

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -32,6 +32,7 @@
 #include <sys/uio.h>
 #include <sys/queue.h>
 #include <sys/types.h>
+#include <math.h>
 #ifdef HAVE_SYS_STAT_H
 #	include <sys/stat.h>
 #endif
@@ -2002,6 +2003,7 @@ CODESTARTmodInit
 INITLegCnfVars
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
+	dbgprintf("just because librdkafka needs it, sqrt of 4 is %f\n", sqrt(4.0));
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 	CHKiRet(objUse(strm, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));


### PR DESCRIPTION
librdkafka needs it, and it seems not to be present inside compiled
binary. This is a try to integrate it via omkafka.

Note: I need to merge this in order to use the regular package build
process. If it does not work out, I will undo it via another commit.
