### PR TITLE
ratelimit: increase rate limit interval parameter

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -139,8 +139,8 @@ typedef struct instanceConf_s {
 	uchar *myPrivKeyFile;
 	sbool reloadOnHup;
 	sbool retryFailures;
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	/* for retries */
 	ratelimit_t *ratelimiter;
 	uchar *retryRulesetName;
@@ -371,8 +371,8 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("\treloadonhup='%d'\n", pData->reloadOnHup);
 	dbgprintf("\tretry='%d'\n", pData->retryFailures);
 	dbgprintf("\tretry.ruleset='%s'\n", pData->retryRulesetName);
-	dbgprintf("\tratelimit.interval='%d'\n", pData->ratelimitInterval);
-	dbgprintf("\tratelimit.burst='%d'\n", pData->ratelimitBurst);
+	dbgprintf("\tratelimit.interval='%u'\n", pData->ratelimitInterval);
+	dbgprintf("\tratelimit.burst='%u'\n", pData->ratelimitBurst);
 ENDdbgPrintInstInfo
 
 
@@ -1788,9 +1788,9 @@ CODESTARTnewActInst
 		} else if(!strcmp(actpblk.descr[i].name, "retry.ruleset")) {
 			pData->retryRulesetName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "ratelimit.burst")) {
-			pData->ratelimitBurst = (int) pvals[i].val.d.n;
+			pData->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
-			pData->ratelimitInterval = (int) pvals[i].val.d.n;
+			pData->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else {
 			LogError(0, RS_RET_INTERNAL_ERROR, "omhttp: program error, "
 				"non-handled param '%s'", actpblk.descr[i].name);

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -73,8 +73,8 @@ struct modConfData_s {
 static struct configSettings_s {
 	char *stateFile;
 	int iPersistStateInterval;
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	int bIgnorePrevious;
 	int bIgnoreNonValidStatefile;
 	int iDfltSeverity;
@@ -768,7 +768,7 @@ BEGINrunInput
 	uint64_t count = 0;
 CODESTARTrunInput
 	CHKiRet(ratelimitNew(&ratelimiter, "imjournal", NULL));
-	dbgprintf("imjournal: ratelimiting burst %d, interval %d\n", cs.ratelimitBurst,
+	dbgprintf("imjournal: ratelimiting burst %u, interval %u\n", cs.ratelimitBurst,
 		  cs.ratelimitInterval);
 	ratelimitSetLinuxLike(ratelimiter, cs.ratelimitInterval, cs.ratelimitBurst);
 	ratelimitSetNoTimeCache(ratelimiter);
@@ -1003,9 +1003,9 @@ CODESTARTsetModCnf
 		} else if (!strcmp(modpblk.descr[i].name, "statefile")) {
 			cs.stateFile = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(modpblk.descr[i].name, "ratelimit.burst")) {
-			cs.ratelimitBurst = (int) pvals[i].val.d.n;
+			cs.ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "ratelimit.interval")) {
-			cs.ratelimitInterval = (int) pvals[i].val.d.n;
+			cs.ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else if (!strcmp(modpblk.descr[i].name, "ignorepreviousmessages")) {
 			cs.bIgnorePrevious = (int) pvals[i].val.d.n;
 		} else if (!strcmp(modpblk.descr[i].name, "ignorenonvalidstatefile")) {

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -83,8 +83,8 @@ typedef struct configSettings_s {
 	int iFacilIntMsg; /* the facility to use for internal messages (set by driver) */
 	uchar *pszPath;
 	int console_log_level; /* still used for BSD */
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 } configSettings_t;
 static configSettings_t cs;
 
@@ -347,9 +347,9 @@ CODESTARTsetModCnf
 		} else if(!strcmp(modpblk.descr[i].name, "internalmsgfacility")) {
 			loadModConf->iFacilIntMsg = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "ratelimitburst")) {
-			loadModConf->ratelimitBurst = (int) pvals[i].val.d.n;
+			loadModConf->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "ratelimitinterval")) {
-			loadModConf->ratelimitInterval = (int) pvals[i].val.d.n;
+			loadModConf->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else {
 			LogMsg(0, RS_RET_INTERNAL_ERROR, LOG_WARNING,
 				"imklog: RSYSLOG BUG, non-handled param '%s' in "

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -160,8 +160,8 @@ struct instanceConf_s {
 	sbool bUnlink;
 	sbool discardTruncatedMsg;
 	sbool flowControl;
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	uchar *startRegex;
 	regex_t start_preg;	/* compiled version of startRegex */
 	struct instanceConf_s *next;
@@ -2214,9 +2214,9 @@ CODESTARTnewInpInst
 		} else if(!strcmp(inppblk.descr[i].name, "defaulttz")) {
 			inst->dfltTZ = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
-			inst->ratelimitBurst = (int) pvals[i].val.d.n;
+			inst->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
-			inst->ratelimitInterval = (int) pvals[i].val.d.n;
+			inst->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "multiline")) {
 			inst->multiLine = (sbool) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "listenportfilename")) {

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -118,8 +118,8 @@ struct instanceConf_s {
 	uchar *pszInputName;		/* value for inputname property, NULL is OK and handled by core engine */
 	uchar *dfltTZ;
 	sbool bSPFramingFix;
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	int bSuppOctetFram;
 	struct instanceConf_s *next;
 };
@@ -460,9 +460,9 @@ CODESTARTnewInpInst
 		} else if(!strcmp(inppblk.descr[i].name, "supportoctetcountedframing")) {
 			inst->bSuppOctetFram = (int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
-			inst->ratelimitBurst = (int) pvals[i].val.d.n;
+			inst->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
-			inst->ratelimitInterval = (int) pvals[i].val.d.n;
+			inst->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "listenportfilename")) {
 			inst->pszLstnPortFileName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else {

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -112,8 +112,8 @@ struct instanceConf_s {
 	uchar *inputname;
 	ruleset_t *pBindRuleset;	/* ruleset to bind listener to (use system default if unspecified) */
 	uchar *dfltTZ;
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	int rcvbuf;			/* 0 means: do not set, keep OS default */
 	/*  0 means:  IP_FREEBIND is disabled
 	1 means:  IP_FREEBIND enabled + warning disabled
@@ -976,9 +976,9 @@ createListner(es_str_t *port, struct cnfparamvals *pvals)
 		} else if(!strcmp(inppblk.descr[i].name, "ruleset")) {
 			inst->pszBindRuleset = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
-			inst->ratelimitBurst = (int) pvals[i].val.d.n;
+			inst->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
-			inst->ratelimitInterval = (int) pvals[i].val.d.n;
+			inst->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "rcvbufsize")) {
 			const uint64_t val = pvals[i].val.d.n;
 			if(val > 1024 * 1024 * 1024) {

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -147,8 +147,8 @@ typedef struct lstn_s {
 	int fd;			/* read-only after startup */
 	int flags;		/* should parser parse host name?  read-only after startup */
 	int flowCtl;		/* flow control settings for this socket */
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	ratelimit_t *dflt_ratelimiter;/*ratelimiter to apply if none else is to be used */
 	intTiny ratelimitSev;	/* severity level (and below) for which rate-limiting shall apply */
 	struct hashtable *ht;	/* our hashtable for rate-limiting */
@@ -199,10 +199,10 @@ static struct configSettings_s {
 	int bWritePid;			/* use credentials from recvmsg() and fixup PID in TAG */
 	int bWritePidSysSock;		/* use credentials from recvmsg() and fixup PID in TAG */
 	int bCreatePath;		/* auto-create socket path? */
-	int ratelimitInterval;		/* interval in seconds, 0 = off */
-	int ratelimitIntervalSysSock;
-	int ratelimitBurst;		/* max nbr of messages in interval */
-	int ratelimitBurstSysSock;
+	unsigned int ratelimitInterval;		/* interval in seconds, 0 = off */
+	unsigned int ratelimitIntervalSysSock;
+	unsigned int ratelimitBurst;		/* max nbr of messages in interval */
+	unsigned int ratelimitBurstSysSock;
 	int ratelimitSeverity;
 	int ratelimitSeveritySysSock;
 	int bAnnotate;			/* annotate trusted properties */
@@ -219,8 +219,8 @@ struct instanceConf_s {
 	sbool bWritePid;		/* use credentials from recvmsg() and fixup PID in TAG */
 	sbool bUseSysTimeStamp;		/* use timestamp from system (instead of from message) */
 	int bCreatePath;		/* auto-create socket path? */
-	int ratelimitInterval;		/* interval in seconds, 0 = off */
-	int ratelimitBurst;		/* max nbr of messages in interval */
+	unsigned int ratelimitInterval;		/* interval in seconds, 0 = off */
+	unsigned int ratelimitBurst;		/* max nbr of messages in interval */
 	int ratelimitSeverity;
 	int bAnnotate;			/* annotate trusted properties */
 	int bParseTrusted;		/* parse trusted properties */
@@ -237,8 +237,8 @@ struct modConfData_s {
 	rsconf_t *pConf;		/* our overall config object */
 	instanceConf_t *root, *tail;
 	uchar *pLogSockName;
-	int ratelimitIntervalSysSock;
-	int ratelimitBurstSysSock;
+	unsigned int ratelimitIntervalSysSock;
+	unsigned int ratelimitBurstSysSock;
 	int ratelimitSeveritySysSock;
 	int bAnnotateSysSock;
 	int bParseTrusted;
@@ -1307,9 +1307,9 @@ CODESTARTsetModCnf
 		} else if(!strcmp(modpblk.descr[i].name, "syssock.usepidfromsystem")) {
 			loadModConf->bWritePidSysSock = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "syssock.ratelimit.interval")) {
-			loadModConf->ratelimitIntervalSysSock = (int) pvals[i].val.d.n;
+			loadModConf->ratelimitIntervalSysSock = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "syssock.ratelimit.burst")) {
-			loadModConf->ratelimitBurstSysSock = (int) pvals[i].val.d.n;
+			loadModConf->ratelimitBurstSysSock = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "syssock.ratelimit.severity")) {
 			loadModConf->ratelimitSeveritySysSock = (int) pvals[i].val.d.n;
 		} else {
@@ -1381,9 +1381,9 @@ CODESTARTnewInpInst
 		} else if(!strcmp(inppblk.descr[i].name, "ruleset")) {
 			inst->pszBindRuleset = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
-			inst->ratelimitInterval = (int) pvals[i].val.d.n;
+			inst->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
-			inst->ratelimitBurst = (int) pvals[i].val.d.n;
+			inst->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.severity")) {
 			inst->ratelimitSeverity = (int) pvals[i].val.d.n;
 		} else {

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -144,8 +144,8 @@ typedef struct instanceConf_s {
 	uchar *myPrivKeyFile;
 	es_write_ops_t writeOperation;
 	sbool retryFailures;
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	/* for retries */
 	ratelimit_t *ratelimiter;
 	uchar *retryRulesetName;
@@ -375,8 +375,8 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("\ttls.myprivkey='%s'\n", pData->myPrivKeyFile);
 	dbgprintf("\twriteoperation='%d'\n", pData->writeOperation);
 	dbgprintf("\tretryfailures='%d'\n", pData->retryFailures);
-	dbgprintf("\tratelimit.interval='%d'\n", pData->ratelimitInterval);
-	dbgprintf("\tratelimit.burst='%d'\n", pData->ratelimitBurst);
+	dbgprintf("\tratelimit.interval='%u'\n", pData->ratelimitInterval);
+	dbgprintf("\tratelimit.burst='%u'\n", pData->ratelimitBurst);
 	dbgprintf("\trebindinterval='%d'\n", pData->rebindInterval);
 ENDdbgPrintInstInfo
 
@@ -1944,9 +1944,9 @@ CODESTARTnewActInst
 		} else if(!strcmp(actpblk.descr[i].name, "retryfailures")) {
 			pData->retryFailures = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "ratelimit.burst")) {
-			pData->ratelimitBurst = (int) pvals[i].val.d.n;
+			pData->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
-			pData->ratelimitInterval = (int) pvals[i].val.d.n;
+			pData->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "retryruleset")) {
 			pData->retryRulesetName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "rebindinterval")) {

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -162,7 +162,7 @@ withinRatelimit(ratelimit_t *__restrict__ const ratelimit,
 		ratelimit->begin = tt;
 
 	/* resume if we go out of time window or if time has gone backwards */
-	if((tt > ratelimit->begin + ratelimit->interval) || (tt < ratelimit->begin) ) {
+	if((tt > (time_t)(ratelimit->begin + ratelimit->interval)) || (tt < ratelimit->begin) ) {
 		ratelimit->begin = 0;
 		ratelimit->done = 0;
 		tellLostCnt(ratelimit);
@@ -331,7 +331,7 @@ finalize_it:
 
 /* enable linux-like ratelimiting */
 void
-ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned short interval, unsigned burst)
+ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned int interval, unsigned int burst)
 {
 	ratelimit->interval = interval;
 	ratelimit->burst = burst;

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -24,8 +24,8 @@
 struct ratelimit_s {
 	char *name;	/**< rate limiter name, e.g. for user messages */
 	/* support for Linux kernel-type ratelimiting */
-	unsigned short interval;
-	unsigned burst;
+	unsigned int interval;
+	unsigned int burst;
 	intTiny severity; /**< ratelimit only equal or lower severity levels (eq or higher values) */
 	unsigned done;
 	unsigned missed;
@@ -42,7 +42,7 @@ struct ratelimit_s {
 /* prototypes */
 rsRetVal ratelimitNew(ratelimit_t **ppThis, const char *modname, const char *dynname);
 void ratelimitSetThreadSafe(ratelimit_t *ratelimit);
-void ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned short interval, unsigned burst);
+void ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned int interval, unsigned int burst);
 void ratelimitSetNoTimeCache(ratelimit_t *ratelimit);
 void ratelimitSetSeverity(ratelimit_t *ratelimit, intTiny severity);
 rsRetVal ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep);

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1320,7 +1320,7 @@ finalize_it:
 
 /* Set the linux-like ratelimiter settings */
 static rsRetVal
-SetLinuxLikeRatelimiters(tcpsrv_t *pThis, int ratelimitInterval, int ratelimitBurst)
+SetLinuxLikeRatelimiters(tcpsrv_t *pThis, unsigned int ratelimitInterval, unsigned int ratelimitBurst)
 {
 	DEFiRet;
 	pThis->ratelimitInterval = ratelimitInterval;

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -91,8 +91,8 @@ struct tcpsrv_s {
 	int bDisableLFDelim;	/**< if 1, standard LF frame delimiter is disabled (*very dangerous*) */
 	int discardTruncatedMsg;/**< discard msg part that has been truncated*/
 	sbool bPreserveCase;	/**< preserve case in fromhost */
-	int ratelimitInterval;
-	int ratelimitBurst;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
 	tcps_sess_t **pSessions;/**< array of all of our sessions */
 	void *pUsr;		/**< a user-settable pointer (provides extensibility for "derived classes")*/
 	/* callbacks */
@@ -170,7 +170,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	/* added v11 -- rgerhards, 2011-05-09 */
 	rsRetVal (*SetKeepAlive)(tcpsrv_t*, int);
 	/* added v13 -- rgerhards, 2012-10-15 */
-	rsRetVal (*SetLinuxLikeRatelimiters)(tcpsrv_t *pThis, int interval, int burst);
+	rsRetVal (*SetLinuxLikeRatelimiters)(tcpsrv_t *pThis, unsigned int interval, unsigned int burst);
 	/* added v14 -- rgerhards, 2013-07-28 */
 	rsRetVal (*SetDfltTZ)(tcpsrv_t *pThis, uchar *dfltTZ);
 	/* added v15 -- rgerhards, 2013-09-17 */


### PR DESCRIPTION
The burst parameter in the ratelimit was increased to an unsigned int
but the interval was as an unsigned short. While it may be unusual,
there is possibly a chance to need to represent an interval longer than
about 3/4 of a day.

While here, go through and normalize all the various incarnations of
rate limiting to be explicitly unsigned int for the burst and interval.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
