### PR TITLE
omhttp: add basic support for Loki Rest

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -803,6 +803,8 @@ TESTS +=  \
 	omhttp-batch-jsonarray.sh \
 	omhttp-batch-kafkarest-retry.sh \
 	omhttp-batch-kafkarest.sh \
+	omhttp-batch-lokirest-retry.sh \
+	omhttp-batch-lokirest.sh \
 	omhttp-batch-newline.sh \
 	omhttp-retry.sh
 if HAVE_VALGRIND
@@ -813,6 +815,7 @@ TESTS +=  \
 	omhttp-batch-jsonarray-retry-vg.sh \
 	omhttp-batch-jsonarray-vg.sh \
 	omhttp-batch-kafkarest-retry-vg.sh \
+	omhttp-batch-lokirest-retry-vg.sh \
 	omhttp-retry-vg.sh
 endif
 endif
@@ -2054,6 +2057,8 @@ EXTRA_DIST= \
 	omhttp-batch-jsonarray.sh \
 	omhttp-batch-kafkarest-retry.sh \
 	omhttp-batch-kafkarest.sh \
+	omhttp-batch-lokirest-retry.sh \
+	omhttp-batch-lokirest.sh \
 	omhttp-batch-newline.sh \
 	omhttp-retry.sh \
 	omhttp-auth-vg.sh \
@@ -2062,6 +2067,7 @@ EXTRA_DIST= \
 	omhttp-batch-jsonarray-retry-vg.sh \
 	omhttp-batch-jsonarray-vg.sh \
 	omhttp-batch-kafkarest-retry-vg.sh \
+	omhttp-batch-lokirest-retry-vg.sh \
 	omhttp-retry-vg.sh \
 	omhttp_server.py \
 	omprog-defaults.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2182,6 +2182,10 @@ omhttp_get_data() {
             # dat = ['{"records":[{"value":{"msgnum":"1"}},{"value":{"msgnum":"2"}}]}',
             #        '{"records":[{"value":{"msgnum":"3"}},{"value":{"msgnum":"4"}}]}']
             python_parse="$python_init; out = [l['value']['msgnum'] for a in dat for l in json.loads(a)['records']]; $python_print"
+        elif [ "x$3" == "xlokirest" ]; then
+            # dat = ['{"streams":[{"msgnum":"1"},{"msgnum":"2"}]}',
+            #        '{"streams":[{"msgnum":"3"},{"msgnum":"4"}]}']
+            python_parse="$python_init; out = [l['msgnum'] for a in dat for l in json.loads(a)['streams']]; $python_print"
         else
             # use newline parsing as default
             python_parse="$python_init; out = [json.loads(l)['msgnum'] for a in dat for l in a.split('\n')]; $python_print"

--- a/tests/omhttp-batch-lokirest-retry-vg.sh
+++ b/tests/omhttp-batch-lokirest-retry-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhttp-batch-kafkarest-retry.sh

--- a/tests/omhttp-batch-lokirest-retry.sh
+++ b/tests/omhttp-batch-lokirest-retry.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=50000
+
+port="$(get_free_port)"
+omhttp_start_server $port --fail-every 100
+
+generate_conf
+add_conf '
+module(load="../contrib/omhttp/.libs/omhttp")
+
+main_queue(queue.dequeueBatchSize="2048")
+
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+# Echo message as-is for retry
+template(name="tpl_echo" type="string" string="%msg%")
+
+ruleset(name="ruleset_omhttp_retry") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl_echo"
+
+        server="localhost"
+        serverport="'$port'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="lokirest"
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
+ruleset(name="ruleset_omhttp") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl"
+
+        server="localhost"
+        serverport="'$port'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="lokirest"
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
+if $msg contains "msgnum:" then
+    call ruleset_omhttp
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $port my/endpoint lokirest
+omhttp_stop_server
+seq_check
+exit_test

--- a/tests/omhttp-batch-lokirest.sh
+++ b/tests/omhttp-batch-lokirest.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=50000
+
+port="$(get_free_port)"
+omhttp_start_server $port
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+main_queue(queue.dequeueBatchSize="2048")
+
+if $msg contains "msgnum:" then
+	action(
+		# Payload
+		name="my_http_action"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+
+		server="localhost"
+		serverport="'$port'"
+		restpath="my/endpoint"
+		batch="on"
+		batch.format="lokirest"
+		batch.maxsize="100"
+
+		# Auth
+		usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $port my/endpoint lokirest
+omhttp_stop_server
+seq_check
+exit_test


### PR DESCRIPTION
Loki is a new message indexer and querier from Grafana Labs. See
https://github.com/grafana/loki for details on Loki.

This change provides the initial message structure to send bulk message
payloads to the Loki Rest endpoint. omhttp, recieved a new bulk message
format called lokirest. Additionally, the plugin relies on the user to
provide the correct "stream" read message format.

A loki template must be json compatible and include a "stream" key of
key value tags, and a values key of an array of 2 element arrays, where
each 2 element array is the unix epoch in nanoseconds followed by an
unstrectured message.

An example:

    template(name="array_loki" type="string" string="{\"stream\":{\"host\":\"%HOSTNAME%\",\"facility\":\"%syslogfacility-text%\",\"priority\":\"%syslogpriority-text%\",\"syslogtag\":\"%syslogtag%\"},\"values\": [[ \"%timegenerated:::date-unixtimestamp%000000000\", \"%msg%\" ]]}")

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
