### PR TITLE
testbench: add some debugging instrumentation

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2221,7 +2221,6 @@ first_column_sum_check() {
 
 case $1 in
    'init')	$srcdir/killrsyslog.sh # kill rsyslogd if it runs for some reason
-		# for (solaris) load debugging, uncomment next 2 lines:
 		#export LD_DEBUG=all
 		#ldd ../tools/rsyslogd
 

--- a/tests/mysql-basic.sh
+++ b/tests/mysql-basic.sh
@@ -2,6 +2,11 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 # basic test for mysql-basic functionality
 . ${srcdir:=.}/diag.sh init
+	# DEBUGGING - REMOVE ME #
+	ls -l mysql*log
+	sudo cat /var/log/mysql/error.log ## TODO: remove me
+	df -h
+export NUMMESSAGES=5000
 generate_conf
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql

--- a/tests/mysqld-start.sh
+++ b/tests/mysqld-start.sh
@@ -5,6 +5,8 @@
 # Copyright (C) 2018 Rainer Gerhards and Adiscon GmbH
 # Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+echo pre-start
+ps -ef |grep bin.mysqld
 if [ "$MYSQLD_START_CMD" == "" ]; then
 	exit_test # no start needed
 fi
@@ -18,7 +20,10 @@ test_error_exit_handler() {
 printf 'starting mysqld...\n'
 $MYSQLD_START_CMD &
 wait_startup_pid /var/run/mysqld/mysqld.pid
+$SUDO tail -n30 /var/log/mysql/error.log
 printf 'preparing mysqld for testbench use...\n'
 $SUDO ${srcdir}/../devtools/prep-mysql-db.sh
 printf 'done, mysql ready for testbench\n'
+ps -ef |grep bin.mysqld
+exit 77 # we want to see this test's log in any case
 exit_test


### PR DESCRIPTION
We have a long-standing issue with the mysql tests. We can't find the
root cause with special test runs. This commit now adds some debug
info. The idea is to merge this and run it in all upcoming tests, so
that we can hopefully get a sufficiently large sample that we can
address the problem.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
