### PR TITLE
core bugfix: action on retry mangles messages

### DIFF
--- a/action.c
+++ b/action.c
@@ -1495,7 +1495,7 @@ actionTryRemoveHardErrorsFromBatch(action_t *__restrict__ const pThis, wti_t *__
 			sizeof(actWrkrIParams_t) * pThis->iNumTpls);
 		ret = actionTryCommit(pThis, pWti, oneParamSet, 1);
 		if(ret == RS_RET_SUSPENDED) {
-			memcpy(new_iparams + *new_nMsgs, &oneParamSet,
+			memcpy(&actParam(new_iparams, pThis->iNumTpls, 0, 0), &oneParamSet,
 				sizeof(actWrkrIParams_t) * pThis->iNumTpls);
 			++(*new_nMsgs);
 		} else if(ret != RS_RET_OK) {


### PR DESCRIPTION
**submiting this PR primarily to do a full CI run and see if I overlook something**

When a failed action goes into retry, template content is rendered
invalid if the action uses more than 1 template.

This is a minimal fix based on Mikko Kortelainen's somewhat more
elaborate patch. All credits belong to Mikko who analyzed and fixed
this hard-to-find issue.

see also https://github.com/rsyslog/rsyslog/pull/3869

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
