### PR TITLE
omsnmp: Add support for new option "snmpv1dynsource"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -179,6 +179,10 @@ if ENABLE_OMHTTP
 SUBDIRS += contrib/omhttp
 endif
 
+if ENABLE_SNMP
+SUBDIRS += plugins/omsnmp
+endif
+
 if ENABLE_MMSNMPTRAPD
 SUBDIRS += plugins/mmsnmptrapd
 endif
@@ -444,6 +448,10 @@ endif
 
 if ENABLE_SNMP
 DISTCHECK_CONFIGURE_FLAGS+= --enable-snmp
+endif
+
+if ENABLE_SNMP_TESTS
+DISTCHECK_CONFIGURE_FLAGS+= --enable-snmp-tests
 endif
 
 if ENABLE_FMHTTP

--- a/configure.ac
+++ b/configure.ac
@@ -903,6 +903,17 @@ AM_CONDITIONAL(ENABLE_SNMP, test x$enable_snmp = xyes)
 AC_SUBST(SNMP_CFLAGS)
 AC_SUBST(SNMP_LIBS)
 
+# SNMP Test Support
+AC_ARG_ENABLE(snmp-tests,
+        [AS_HELP_STRING([--enable-snmp-tests],[Enable omsnmp tests @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_snmp_tests="yes" ;;
+          no) enable_snmp_tests="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-snmp-tests) ;;
+         esac],
+        [enable_snmp_tests=no]
+)
+AM_CONDITIONAL(ENABLE_SNMP_TESTS, test x$enable_snmp_tests = xyes)
 
 # uuid support
 AC_ARG_ENABLE(uuid,
@@ -2652,6 +2663,7 @@ echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"
 echo "    Kafka Tests enabled:                      $enable_kafka_tests"
 echo "    Imdocker Tests enabled:                   $enable_imdocker_tests"
 echo "    systemd journal tests enabled:            $enable_journal_tests"
+echo "    SNMP Tests enabled:                       $enable_snmp_tests"
 echo "    Debug mode enabled:                       $enable_debug"
 echo "    (total) debugless mode enabled:           $enable_debugless"
 echo "    Diagnostic tools enabled:                 $enable_diagtools"

--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -29,6 +29,7 @@
 #include <netinet/in.h>
 #include <sys/time.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 #include <netdb.h>
 #include <ctype.h>
 #include <assert.h>
@@ -54,14 +55,18 @@ DEF_OMOD_STATIC_DATA
 static oid             objid_snmptrap[] = { 1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0 };
 static oid             objid_sysuptime[] = { 1, 3, 6, 1, 2, 1, 1, 3, 0 };
 
+/* 4 */
+#define SNMP_SOURCETEMPLATE "\"%fromhost-ip%\""
+
 
 typedef struct _instanceData {
-	uchar	*szTransport;	/* Transport - Can be udp, tcp, udp6, tcp6 and other types supported by NET-SNMP */
-	uchar	*szTarget;	/* IP/hostname of Snmp Target*/
-	uchar	*szCommunity;	/* Snmp Community */
-	uchar	*szEnterpriseOID;/* Snmp Enterprise OID - default is (1.3.6.1.4.1.3.1.1 = enterprises.cmu.1.1) */
-	uchar	*szSnmpTrapOID;	/* Snmp Trap OID - default is (1.3.6.1.4.1.19406.1.2.1 =
-ADISCON-MONITORWARE-MIB::syslogtrap) */
+	uchar	*szTransport;		/* Transport - Can be udp, tcp, udp6, tcp6 and other types
+					   supported by NET-SNMP */
+	uchar	*szTarget;		/* IP/hostname of Snmp Target*/
+	uchar	*szCommunity;		/* Snmp Community */
+	uchar	*szEnterpriseOID;	/* Snmp Enterprise OID-default is (1.3.6.1.4.1.3.1.1 = enterprises.cmu.1.1) */
+	uchar	*szSnmpTrapOID;		/* Snmp Trap OID - default is (1.3.6.1.4.1.19406.1.2.1 =
+					   ADISCON-MONITORWARE-MIB::syslogtrap) */
 	uchar	*szSyslogMessageOID;	/* Snmp OID used for the Syslog Message:
 	        * default is 1.3.6.1.4.1.19406.1.1.2.1 - ADISCON-MONITORWARE-MIB::syslogMsg
 		* You will need the ADISCON-MONITORWARE-MIB and ADISCON-MIB mibs installed on the receiver
@@ -70,6 +75,8 @@ ADISCON-MONITORWARE-MIB::syslogtrap) */
 		*	http://www.adiscon.org/download/ADISCON-MONITORWARE-MIB.txt
 		*	http://www.adiscon.org/download/ADISCON-MIB.txt
 		*/
+	uchar	*szSnmpV1Source;	/* If PDU source property needs to be overwritten, only valid for SNMPv1*/
+
 	int iPort;			/* Target Port */
 	int iSNMPVersion;		/* SNMP Version to use */
 	int iTrapType;			/* Snmp TrapType or GenericType */
@@ -93,6 +100,8 @@ typedef struct configSettings_s {
 	uchar* pszEnterpriseOID;
 	uchar* pszSnmpTrapOID;
 	uchar* pszSyslogMessageOID;
+	uchar* pszSnmpV1dynSource;	/* If PDU source property needs to be overwritten, only valid for SNMPv1*/
+
 	int iSpecificType;
 	int iTrapType;		/*Default is SNMP_TRAP_ENTERPRISESPECIFIC */
 	/*
@@ -119,6 +128,7 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "enterpriseoid", eCmdHdlrString, 0 },
 	{ "trapoid", eCmdHdlrString, 0 },
 	{ "messageoid", eCmdHdlrString, 0 },
+	{ "snmpv1dynsource", eCmdHdlrString, 0 },
 	{ "traptype", eCmdHdlrInt, 0 },
 	{ "specifictype", eCmdHdlrInt, 0 },
 	{ "template", eCmdHdlrGetWord, 0 }
@@ -139,6 +149,7 @@ CODESTARTinitConfVars
 	cs.pszEnterpriseOID = NULL;
 	cs.pszSnmpTrapOID = NULL;
 	cs.pszSyslogMessageOID = NULL;
+	cs.pszSnmpV1dynSource = NULL;
 	cs.iSpecificType = 0;
 	cs.iTrapType = SNMP_TRAP_ENTERPRISESPECIFIC;
 ENDinitConfVars
@@ -162,6 +173,7 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("EnterpriseOID: %s\n", pData->szEnterpriseOID);
 	dbgprintf("SnmpTrapOID: %s\n", pData->szSnmpTrapOID);
 	dbgprintf("SyslogMessageOID: %s\n", pData->szSyslogMessageOID);
+	dbgprintf("SnmpV1Source: %s\n", pData->szSnmpV1Source);
 	dbgprintf("TrapType: %d\n", pData->iTrapType);
 	dbgprintf("SpecificType: %d\n", pData->iSpecificType);
 ENDdbgPrintInstInfo
@@ -241,7 +253,7 @@ finalize_it:
 	RETiRet;
 }
 
-static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
+static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz, uchar *pszSource)
 {
 	DEFiRet;
 
@@ -253,6 +265,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 	int             status;
 	char            *trap = NULL;
 	const char		*strErr = NULL;
+	struct sockaddr_in srcAddr;
 	instanceData *pData;
 
 	pData = pWrkrData->pData;
@@ -267,6 +280,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 
 	/* If SNMP Version1 is configured !*/
 	if(pWrkrData->snmpsession->version == SNMP_VERSION_1) {
+		dbgprintf( "omsnmp_sendsnmp: Create SNMPv1 Trap - Source = '%s'\n", (char*)pszSource);
 		pdu = snmp_pdu_create(SNMP_MSG_TRAP);
 
 		/* Set enterprise */
@@ -289,12 +303,32 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz)
 
 		/* Set Updtime */
 		pdu->time = get_uptime();
+
+		/* Set PDU SOurce property if available */
+		if (pszSource != NULL) {
+			srcAddr.sin_addr.s_addr = inet_addr((const char *)pszSource);
+			if (srcAddr.sin_addr.s_addr != INADDR_NONE) {
+				pdu->agent_addr[0] = (srcAddr.sin_addr.s_addr) & 0xFF;
+				pdu->agent_addr[1] = (srcAddr.sin_addr.s_addr >> 8) & 0xFF;
+				pdu->agent_addr[2] = (srcAddr.sin_addr.s_addr >> 16) & 0xFF;
+				pdu->agent_addr[3] = (srcAddr.sin_addr.s_addr >> 24) & 0xFF;
+				dbgprintf( "omsnmp_sendsnmp: SNMPv1 Source Property set to %d.%d.%d.%d\n",
+					(srcAddr.sin_addr.s_addr) & 0xFF,
+					(srcAddr.sin_addr.s_addr >> 8) & 0xFF,
+					(srcAddr.sin_addr.s_addr >> 16) & 0xFF,
+					(srcAddr.sin_addr.s_addr >> 24) & 0xFF);
+			} else {
+				LogError(0, NO_ERRCODE, "omsnmp_sendsnmp: Failed to convert '%s' into a valid IPv4"
+					"address\n", pszSource);
+			}
+		}
 	}
 	/* If SNMP Version2c is configured !*/
 	else if (pWrkrData->snmpsession->version == SNMP_VERSION_2c)
 	{
 		long sysuptime;
 		char csysuptime[20];
+		dbgprintf( "omsnmp_sendsnmp: Create SNMPv2 Trap\n");
 
 		/* Create PDU */
 		pdu = snmp_pdu_create(SNMP_MSG_TRAP2);
@@ -377,7 +411,7 @@ CODESTARTdoAction
 	}
 	
 	/* This will generate and send the SNMP Trap */
-	iRet = omsnmp_sendsnmp(pWrkrData, ppString[0]);
+	iRet = omsnmp_sendsnmp(pWrkrData, ppString[0], ppString[1]);
 finalize_it:
 ENDdoAction
 
@@ -400,6 +434,7 @@ setInstParamDefaults(instanceData *pData)
 	pData->szEnterpriseOID = NULL;
 	pData->szSnmpTrapOID = NULL;
 	pData->szSyslogMessageOID = NULL;
+	pData->szSnmpV1Source = NULL;
 }
 
 BEGINnewActInst
@@ -413,7 +448,7 @@ CODESTARTnewActInst
 	CHKiRet(createInstance(&pData));
 	setInstParamDefaults(pData);
 
-	CODE_STD_STRING_REQUESTnewActInst(1)
+	CODE_STD_STRING_REQUESTnewActInst(2)
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
@@ -435,6 +470,8 @@ CODESTARTnewActInst
 			pData->szSnmpTrapOID = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "messageoid")) {
 			pData->szSyslogMessageOID = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "snmpv1dynsource")) {
+			pData->szSnmpV1Source = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "traptype")) {
 			pData->iTrapType = pvals[i].val.d.n;
 			if(cs.iTrapType < 0 || cs.iTrapType >= 6) {
@@ -459,6 +496,10 @@ CODESTARTnewActInst
 
 	CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)strdup((pData->tplName == NULL) ?
 						"RSYSLOG_FileFormat" : (char*)pData->tplName),
+						OMSR_NO_RQD_TPL_OPTS));
+
+	CHKiRet(OMSRsetEntry(*ppOMSR, 1, (uchar*)strdup((pData->szSnmpV1Source == NULL) ?
+						" SNMP_SOURCETEMPLATE" : (char*)pData->szSnmpV1Source),
 						OMSR_NO_RQD_TPL_OPTS));
 
 CODE_STD_FINALIZERnewActInst
@@ -491,8 +532,10 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	pData->szCommunity = (uchar*) ((cs.pszCommunity == NULL) ? NULL : strdup((char*)cs.pszCommunity));
 	pData->szEnterpriseOID = (uchar*) ((cs.pszEnterpriseOID == NULL) ? NULL : strdup((char*)cs.pszEnterpriseOID));
 	pData->szSnmpTrapOID = (uchar*) ((cs.pszSnmpTrapOID == NULL) ? NULL : strdup((char*)cs.pszSnmpTrapOID));
-	pData->szSyslogMessageOID = (uchar*) ((cs.pszSyslogMessageOID == NULL)
-	? NULL : strdup((char*)cs.pszSyslogMessageOID));
+	pData->szSyslogMessageOID = (uchar*) ((cs.pszSyslogMessageOID == NULL) ? NULL :
+		strdup((char*)cs.pszSyslogMessageOID));
+	pData->szSnmpV1Source = (uchar*) ((cs.pszSnmpV1dynSource == NULL) ? NULL :
+		strdup((char*)cs.pszSnmpV1dynSource));
 	pData->iPort = cs.iPort;
 	pData->iSpecificType = cs.iSpecificType;
 	
@@ -517,6 +560,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	dbgprintf("EnterpriseOID: %s\n", pData->szEnterpriseOID);
 	dbgprintf("SnmpTrapOID: %s\n", pData->szSnmpTrapOID);
 	dbgprintf("SyslogMessageOID: %s\n", pData->szSyslogMessageOID);
+	dbgprintf("SnmpV1Source: %s\n", pData->szSnmpV1Source);
 	dbgprintf("TrapType: %d\n", pData->iTrapType);
 	dbgprintf("SpecificType: %d\n", pData->iSpecificType);
 
@@ -548,6 +592,8 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 	cs.pszSnmpTrapOID = NULL;
 	free(cs.pszSyslogMessageOID);
 	cs.pszSyslogMessageOID = NULL;
+	free(cs.pszSnmpV1dynSource);
+	cs.pszSnmpV1dynSource = NULL;
 	cs.iPort = 0;
 	cs.iSNMPVersion = 1;
 	cs.iSpecificType = 0;
@@ -563,6 +609,7 @@ CODESTARTmodExit
 	free(cs.pszEnterpriseOID);
 	free(cs.pszSnmpTrapOID);
 	free(cs.pszSyslogMessageOID);
+	free(cs.pszSnmpV1dynSource);
 
 	/* release what we no longer need */
 ENDmodExit
@@ -579,6 +626,7 @@ ENDqueryEtryPt
 
 BEGINmodInit()
 CODESTARTmodInit
+	uchar *pTmp;
 	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 CODEmodInit_QueryRegCFSLineHdlr
 	initConfVars();
@@ -599,12 +647,18 @@ CODEmodInit_QueryRegCFSLineHdlr
 	STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmpsyslogmessageoid", 0, eCmdHdlrGetWord, NULL,
 	&cs.pszSyslogMessageOID, STD_LOADABLE_MODULE_ID));
+	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmpv1dynsource", 0, eCmdHdlrGetWord, NULL,
+	&cs.pszSnmpV1dynSource, STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmpspecifictype", 0, eCmdHdlrInt, NULL, &cs.iSpecificType,
 	STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmptraptype", 0, eCmdHdlrInt, NULL, &cs.iTrapType,
 	STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler, resetConfigVariables,
 	NULL, STD_LOADABLE_MODULE_ID));
+
+	DBGPRINTF("omsnmp: Add SNMP_SOURCETEMPLATE to template system ONCE\n");
+	pTmp = (uchar*) SNMP_SOURCETEMPLATE;
+	tplAddLine(ourConf, " SNMP_SOURCETEMPLATE", &pTmp);
 ENDmodInit
 /*
  * vi:set ai:

--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -100,7 +100,6 @@ typedef struct configSettings_s {
 	uchar* pszEnterpriseOID;
 	uchar* pszSnmpTrapOID;
 	uchar* pszSyslogMessageOID;
-	uchar* pszSnmpV1dynSource;	/* If PDU source property needs to be overwritten, only valid for SNMPv1*/
 
 	int iSpecificType;
 	int iTrapType;		/*Default is SNMP_TRAP_ENTERPRISESPECIFIC */
@@ -149,7 +148,6 @@ CODESTARTinitConfVars
 	cs.pszEnterpriseOID = NULL;
 	cs.pszSnmpTrapOID = NULL;
 	cs.pszSyslogMessageOID = NULL;
-	cs.pszSnmpV1dynSource = NULL;
 	cs.iSpecificType = 0;
 	cs.iTrapType = SNMP_TRAP_ENTERPRISESPECIFIC;
 ENDinitConfVars
@@ -212,7 +210,7 @@ omsnmp_initSession(wrkrInstanceData_t *pWrkrData)
 	instanceData *pData;
 	char szTargetAndPort[MAXHOSTNAMELEN+128]; /* work buffer for specifying a full target and port string */
 	DEFiRet;
-	
+
 	/* should not happen, but if session is not cleared yet - we do it now! */
 	if (pWrkrData->snmpsession != NULL)
 		omsnmp_exitSession(pWrkrData);
@@ -227,13 +225,13 @@ omsnmp_initSession(wrkrInstanceData_t *pWrkrData)
 
 	if (setenv("POSIXLY_CORRECT", "1", 1) == -1)
 		ABORT_FINALIZE(RS_RET_ERR);
-	
+
 	snmp_sess_init(&session);
 	session.version = pData->iSNMPVersion;
 	session.callback = NULL; /* NOT NEEDED */
 	session.callback_magic = NULL;
 	session.peername = (char*) szTargetAndPort;
-	
+
 	/* Set SNMP Community */
 	if (session.version == SNMP_VERSION_1 || session.version == SNMP_VERSION_2c) {
 		session.community = (unsigned char *) pData->szCommunity
@@ -273,7 +271,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz, uchar
 	if (pWrkrData->snmpsession == NULL) {
 		CHKiRet(omsnmp_initSession(pWrkrData));
 	}
-	
+
 	/* String should not be NULL */
 	assert(psz != NULL);
 	dbgprintf( "omsnmp_sendsnmp: ENTER - Syslogmessage = '%s'\n", (char*)psz);
@@ -384,6 +382,9 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz, uchar
 		omsnmp_exitSession(pWrkrData);
 
 		ABORT_FINALIZE(RS_RET_SUSPENDED);
+	} else {
+		dbgprintf( "omsnmp_sendsnmp: Successfully send SNMP Trap to %s:%d\n",
+			pData->szTarget, pData->iPort);
 	}
 
 finalize_it:
@@ -409,7 +410,7 @@ CODESTARTdoAction
 	if (ppString[0] == NULL) {
 		ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
 	}
-	
+
 	/* This will generate and send the SNMP Trap */
 	iRet = omsnmp_sendsnmp(pWrkrData, ppString[0], ppString[1]);
 finalize_it:
@@ -534,11 +535,9 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	pData->szSnmpTrapOID = (uchar*) ((cs.pszSnmpTrapOID == NULL) ? NULL : strdup((char*)cs.pszSnmpTrapOID));
 	pData->szSyslogMessageOID = (uchar*) ((cs.pszSyslogMessageOID == NULL) ? NULL :
 		strdup((char*)cs.pszSyslogMessageOID));
-	pData->szSnmpV1Source = (uchar*) ((cs.pszSnmpV1dynSource == NULL) ? NULL :
-		strdup((char*)cs.pszSnmpV1dynSource));
 	pData->iPort = cs.iPort;
 	pData->iSpecificType = cs.iSpecificType;
-	
+
 	/* Set SNMPVersion */
 	if ( cs.iSNMPVersion < 0 || cs.iSNMPVersion > 1)		/* Set default to 1 if out of range */
 		pData->iSNMPVersion = 1;
@@ -592,8 +591,6 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 	cs.pszSnmpTrapOID = NULL;
 	free(cs.pszSyslogMessageOID);
 	cs.pszSyslogMessageOID = NULL;
-	free(cs.pszSnmpV1dynSource);
-	cs.pszSnmpV1dynSource = NULL;
 	cs.iPort = 0;
 	cs.iSNMPVersion = 1;
 	cs.iSpecificType = 0;
@@ -609,7 +606,6 @@ CODESTARTmodExit
 	free(cs.pszEnterpriseOID);
 	free(cs.pszSnmpTrapOID);
 	free(cs.pszSyslogMessageOID);
-	free(cs.pszSnmpV1dynSource);
 
 	/* release what we no longer need */
 ENDmodExit
@@ -647,8 +643,6 @@ CODEmodInit_QueryRegCFSLineHdlr
 	STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmpsyslogmessageoid", 0, eCmdHdlrGetWord, NULL,
 	&cs.pszSyslogMessageOID, STD_LOADABLE_MODULE_ID));
-	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmpv1dynsource", 0, eCmdHdlrGetWord, NULL,
-	&cs.pszSnmpV1dynSource, STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmpspecifictype", 0, eCmdHdlrInt, NULL, &cs.iSpecificType,
 	STD_LOADABLE_MODULE_ID));
 	CHKiRet(omsdRegCFSLineHdlr((uchar *)"actionsnmptraptype", 0, eCmdHdlrInt, NULL, &cs.iTrapType,

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -500,6 +500,12 @@ endif # ENABLE_DEFAULT_TESTS
 if ENABLE_SNMP
 TESTS +=  \
 	omsnmp_errmsg_no_params.sh
+if ENABLE_SNMP_TESTS
+TESTS +=  \
+	sndrcv_omsnmpv1_udp.sh \
+	sndrcv_omsnmpv1_udp_dynsource.sh \
+	sndrcv_omsnmpv1_udp_invalidoid.sh
+endif # if ENABLE_SNMP_TESTS
 endif # if ENABLE_SNMP
 
 if ENABLE_MMUTF8FIX
@@ -1658,6 +1664,10 @@ EXTRA_DIST= \
 	rs-int2hex.sh \
 	rs-substring.sh \
 	omsnmp_errmsg_no_params.sh \
+	sndrcv_omsnmpv1_udp.sh \
+	sndrcv_omsnmpv1_udp_dynsource.sh \
+	sndrcv_omsnmpv1_udp_invalidoid.sh \
+	snmptrapreceiver.py \
 	ommail_errmsg_no_params.sh \
 	mmdarwin_errmsg_no_params.sh \
 	mmdarwin_errmsg_no_sock.sh \

--- a/tests/sndrcv_omsnmpv1_udp.sh
+++ b/tests/sndrcv_omsnmpv1_udp.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# alorbach, 2019-11-27
+#	Required Packages
+#	pip install pysnmp
+#
+#	Ubuntu 18 Packages needed
+#	apt install snmp libsnmp-dev snmp-mibs-downloader
+#
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export TESTMESSAGES=10
+
+generate_conf
+export PORT_SNMP="$(get_free_port)"
+# Start SNMP Trap Receiver
+snmp_start_trapreceiver ${PORT_SNMP} ${RSYSLOG_OUT_LOG}
+
+add_conf '
+module(	load="../plugins/imtcp/.libs/imtcp")
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
+
+module(	load="../plugins/omsnmp/.libs/omsnmp" )
+
+# set up the action
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(	type="omsnmp"
+					name="name"
+					server="127.0.0.1"
+					port="'${PORT_SNMP}'"
+					version="0"
+					community="public"
+					enterpriseOID="1.3.6.1.2.1.192.0.1"
+					messageOID="1.3.6.1.2.1.192.1.2.1.11"
+					TrapType="6"
+					specificType="0"
+				)
+'
+startup
+tcpflood -p'$TCPFLOOD_PORT' -m${TESTMESSAGES}
+
+shutdown_when_empty
+wait_shutdown
+snmp_stop_trapreceiver
+content_count_check "msgnum:" ${TESTMESSAGES}
+exit_test

--- a/tests/sndrcv_omsnmpv1_udp_dynsource.sh
+++ b/tests/sndrcv_omsnmpv1_udp_dynsource.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# alorbach, 2019-11-27
+#	Required Packages
+#	pip install pysnmp
+#
+#	Ubuntu 18 Packages needed
+#	apt install snmp libsnmp-dev snmp-mibs-downloader
+#
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export TESTMESSAGES=10
+
+generate_conf
+export PORT_SNMP="$(get_free_port)"
+# Start SNMP Trap Receiver
+snmp_start_trapreceiver ${PORT_SNMP} ${RSYSLOG_OUT_LOG}
+
+add_conf '
+module(	load="../plugins/imtcp/.libs/imtcp")
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
+
+module(	load="../plugins/omsnmp/.libs/omsnmp" )
+
+# set up templates 
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+# Set Custom Host property 
+set $!custom_host = "8.8.8.8";
+template(name="dynsource" type="list") {
+	property(name="$!custom_host")
+}
+
+# set up the action
+:msg, contains, "msgnum:" action(	type="omsnmp"
+					name="name"
+					server="127.0.0.1"
+					port="'${PORT_SNMP}'"
+					version="0"
+					community="public"
+					enterpriseOID="1.3.6.1.2.1.192.0.1"
+					messageOID="1.3.6.1.2.1.192.1.2.1.11"
+					TrapType="6"
+					specificType="0"
+					snmpv1dynsource="dynsource"
+				)
+'
+startup
+tcpflood -p'$TCPFLOOD_PORT' -m${TESTMESSAGES}
+
+shutdown_when_empty
+wait_shutdown
+snmp_stop_trapreceiver
+content_count_check "msgnum:" ${TESTMESSAGES}
+content_count_check "8.8.8.8" ${TESTMESSAGES}
+exit_test

--- a/tests/sndrcv_omsnmpv1_udp_invalidoid.sh
+++ b/tests/sndrcv_omsnmpv1_udp_invalidoid.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# alorbach, 2019-11-27
+#	Required Packages
+#	pip install pysnmp
+#
+#	Ubuntu 18 Packages needed
+#	apt install snmp libsnmp-dev
+#
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export TESTMESSAGES=1
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.omsnmp.debuglog"
+generate_conf
+export PORT_SNMP="$(get_free_port)"
+# Start SNMP Trap Receiver
+snmp_start_trapreceiver ${PORT_SNMP} ${RSYSLOG_OUT_LOG}
+
+add_conf '
+module(	load="../plugins/imtcp/.libs/imtcp")
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
+
+module(	load="../plugins/omsnmp/.libs/omsnmp" )
+
+# set up the action
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(	type="omsnmp"
+					name="name"
+					server="127.0.0.1"
+					port="'${PORT_SNMP}'"
+					version="0"
+					community="public"
+					enterpriseOID="1337.1.3.3.7.1.3.3.7"
+					messageOID="invalidOIDstring"
+					TrapType="5"
+					specificType="0"
+				)
+'
+startup
+tcpflood -p'$TCPFLOOD_PORT' -m${TESTMESSAGES}
+
+shutdown_when_empty
+wait_shutdown
+snmp_stop_trapreceiver
+content_check "Parsing SyslogMessageOID failed" ${RSYSLOG_DYNNAME}.started
+content_check "Unknown Object Identifier" ${RSYSLOG_DYNNAME}.started
+exit_test

--- a/tests/snmptrapreceiver.py
+++ b/tests/snmptrapreceiver.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python
+import sys
+from pysnmp.entity import engine, config
+from pysnmp.carrier.asyncore.dgram import udp
+from pysnmp.entity.rfc3413 import ntfrcv
+from pysnmp.smi import builder, view, compiler, rfc1902
+from pyasn1.type.univ import OctetString
+
+# Global variables
+snmpport = 10162
+snmpip = "127.0.0.1"
+szOutputfile = "snmp.out"
+szSnmpLogfile = "snmp_server.log"
+
+# For vrebose output
+bDebug = False
+
+# Read command line params
+if len(sys.argv) > 1:
+	snmpport = int(sys.argv[1])
+if len(sys.argv) > 2:
+	snmpip = sys.argv[2]
+if len(sys.argv) > 3:
+	szOutputfile = sys.argv[3]
+if len(sys.argv) > 4:
+	szSnmpLogfile = sys.argv[4]
+
+# Create output files
+outputFile = open(szOutputfile,"w+")
+logFile = open(szSnmpLogfile,"a+")
+
+# Assemble MIB viewer
+mibBuilder = builder.MibBuilder()
+compiler.addMibCompiler(mibBuilder, sources=['file:///usr/share/snmp/mibs', 'file:///var/lib/snmp/mibs', '/usr/local/share/snmp/mibs/'])
+mibViewController = view.MibViewController(mibBuilder)
+# Pre-load MIB modules we expect to work with
+try:
+	mibBuilder.loadModules('SNMPv2-MIB', 'SNMP-COMMUNITY-MIB', 'SYSLOG-MSG-MIB')
+except Exception:
+	print("Failed loading MIBs")
+
+# Create SNMP engine with autogenernated engineID and pre-bound to socket transport dispatcher
+snmpEngine = engine.SnmpEngine()
+
+# Transport setup
+# UDP over IPv4, add listening interface/port
+config.addTransport(
+	snmpEngine,
+	udp.domainName + (1,),
+	udp.UdpTransport().openServerMode((snmpip, snmpport))
+)
+
+# SNMPv1/2c setup
+# SecurityName <-> CommunityName mapping
+config.addV1System(snmpEngine, 'my-area', 'public')
+
+print("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
+logFile.write("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
+logFile.flush()
+
+# Callback function for receiving notifications
+# noinspection PyUnusedLocal,PyUnusedLocal,PyUnusedLocal
+def cbReceiverSnmp(snmpEngine, stateReference, contextEngineId, contextName, varBinds, cbCtx):
+	transportDomain, transportAddress = snmpEngine.msgAndPduDsp.getTransportInfo(stateReference)
+	if (bDebug):
+		szDebug = str("Notification From: %s, Domain: %s, SNMP Engine: %s, Context: %s" %
+			(transportAddress, transportDomain, contextEngineId.prettyPrint(), contextName.prettyPrint()))
+		print(szDebug)
+		logFile.write(szDebug)
+		logFile.flush()
+
+	# Create output String
+	szOut = "Trap Source{}, Trap OID {}".format(transportAddress, transportDomain)
+
+	varBinds = [rfc1902.ObjectType(rfc1902.ObjectIdentity(x[0]), x[1]).resolveWithMib(mibViewController) for x in varBinds]
+
+	for name, val in varBinds:
+		# Append to output String
+		szOut = szOut + ", Oid: {}, Value: {}".format(name.prettyPrint(), val.prettyPrint())
+
+		if isinstance(val, OctetString):
+			if (name.prettyPrint() != "SNMP-COMMUNITY-MIB::snmpTrapAddress.0"):
+				szOctets = val.asOctets()#.rstrip('\r').rstrip('\n')
+				szOut = szOut + ", Octets: {}".format(szOctets)
+		if (bDebug):
+			print('%s = %s' % (name.prettyPrint(), val.prettyPrint()))
+	outputFile.write(szOut)
+	if "\n" not in szOut:
+		outputFile.write("\n")
+	outputFile.flush()
+
+
+# Register SNMP Application at the SNMP engine
+ntfrcv.NotificationReceiver(snmpEngine, cbReceiverSnmp)
+
+# this job would never finish
+snmpEngine.transportDispatcher.jobStarted(1)
+
+# Run I/O dispatcher which would receive queries and send confirmations
+try:
+	snmpEngine.transportDispatcher.runDispatcher()
+except:
+	snmpEngine.transportDispatcher.closeDispatcher()
+	raise


### PR DESCRIPTION
If set, the source field from SNMPv1 trap can be overwritten
with a template, default is "%fromhost-ip%". The content should be a
valid IPv4 Address that can be passed to inet_addr(). If the content
is not a valid IPv4 Address, the source will not be set.