### PR TITLE
testbench: make some tls/ossl tests more robust

### DIFF
--- a/tests/sndrcv_tls_anon_rebind.sh
+++ b/tests/sndrcv_tls_anon_rebind.sh
@@ -22,13 +22,15 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+export PORT_RCVR=$TCPFLOOD_PORT # save this, will be rewritten with next config
+
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2

--- a/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
+++ b/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
@@ -3,7 +3,6 @@
 . ${srcdir:=.}/diag.sh init
 # start up the instances
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -20,12 +19,12 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.PermitExpiredCerts="off"
 	gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2\nOptions=Bugs"
 	)
-input(	type="imtcp"
-	port="'$PORT_RCVR'" )
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+export PORT_RCVR=$TCPFLOOD_PORT # save this, will be rewritten with next config
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 generate_conf 2
 add_conf '


### PR DESCRIPTION
This commit makes them use the reliable method to obtain a
dynamic port. The previous method lead to unreliability (flakes)
especially on busy machines.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
