### PR TITLE
Handle journal invalidate

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -619,6 +619,10 @@ handleRotation(void)
 	else if (cs.stateFile) {
 		iRet = loadJournalState();
 	}
+	else if (cs.bIgnorePrevious) {
+		/* Seek to the very end of the journal and ignore all older messages. */
+		skipOldMessages();
+	}
 	journalContext.reloaded = 1;
 
 finalize_it:


### PR DESCRIPTION
The journal API will sometimes issue an SD_JOURNAL_INVALIDATE
which results in a repositioning of the cursor. From the man page:

    Programs only interested in a strictly sequential stream
    of log data may treat SD_JOURNAL_INVALIDATE the same way as
    SD_JOURNAL_APPEND, thus ignoring any changes to the log view
    earlier than the old end of the log stream.

If we have configured IgnorePreviousMessages, we want to treat the
invalidate event as an append, and wind to the end of the message
stream.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
