### PR TITLE
build system: make postgres module use pkg_config

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -814,24 +814,26 @@ AC_ARG_ENABLE(pgsql,
         [enable_pgsql=no]
 )
 if test "x$enable_pgsql" = "xyes"; then
-  AC_CHECK_PROG(
-    [PG_CONFIG],
-    [pg_config],
-    [pg_config],
-    [no],,,
-  )
-  if test "x${PG_CONFIG}" = "xno"; then
-    AC_MSG_FAILURE([pg_config not found])
-  fi
-  AC_CHECK_LIB(
-    [pq],
-    [PQconnectdb],
-    [PGSQL_CFLAGS="-I`$PG_CONFIG --includedir`"
-     PGSQL_LIBS="-L`$PG_CONFIG --libdir` -lpq"
-    ],
-    [AC_MSG_FAILURE([PgSQL library is missing])],
-    [-L`$PG_CONFIG --libdir`]
-  )
+	PKG_CHECK_MODULES([PGSQL], [libpq],, [
+	  AC_CHECK_PROG(
+	    [PG_CONFIG],
+	    [pg_config],
+	    [pg_config],
+	    [no],,,
+	  )
+	  if test "x${PG_CONFIG}" = "xno"; then
+	    AC_MSG_FAILURE([pg_config not found])
+	  fi
+	  AC_CHECK_LIB(
+	    [pq],
+	    [PQconnectdb],
+	    [PGSQL_CFLAGS="-I`$PG_CONFIG --includedir`"
+	     PGSQL_LIBS="-L`$PG_CONFIG --libdir` -lpq"
+	    ],
+	    [AC_MSG_FAILURE([PgSQL library is missing])],
+	    [-L`$PG_CONFIG --libdir`]
+	  )
+	])
 fi
 AM_CONDITIONAL(ENABLE_PGSQL, test x$enable_pgsql = xyes)
 AC_SUBST(PGSQL_CFLAGS)


### PR DESCRIPTION
This is the recommended method and we use pkg_config in any
case. With the old method, postgres server-development packages
needed to be installed just to build the client, which was
neither intuitive nor clean.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
