### PR TITLE
core/config: "fix" valgrind false positive

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -271,6 +271,7 @@ injectMsg(uchar *pszCmd, tcps_sess_t *pSess)
 
 	litteralMsg = NULL;
 
+	memset(wordBuf, 0, sizeof(wordBuf));
 	CHKiRet(ratelimitNew(&ratelimit, "imdiag", "injectmsg"));
 	/* we do not check errors here! */
 	getFirstWord(&pszCmd, wordBuf, sizeof(wordBuf), TO_LOWERCASE);
@@ -434,6 +435,7 @@ awaitStatsReport(uchar *pszCmd, tcps_sess_t *pSess) {
 	int blockAgain = 0;
 	DEFiRet;
 
+	memset(subCmd, 0, sizeof(subCmd));
 	getFirstWord(&pszCmd, subCmd, sizeof(subCmd), TO_LOWERCASE);
 	blockAgain = (ustrcmp(UCHAR_CONSTANT("block_again"), subCmd) == 0);
 	if (statsReportingBlockStartTimeMs > 0) {
@@ -491,11 +493,12 @@ OnMsgReceived(tcps_sess_t *const pSess, uchar *const pRcv, const int iLenMsg)
 	 * WITHOUT a termination \0 char. So we need to convert it to one
 	 * before proceeding.
 	 */
-	CHKmalloc(pszMsg = malloc(iLenMsg + 1));
+	CHKmalloc(pszMsg = calloc(1, iLenMsg + 1));
 	pToFree = pszMsg;
 	memcpy(pszMsg, pRcv, iLenMsg);
 	pszMsg[iLenMsg] = '\0';
 
+	memset(cmdBuf, 0, sizeof(cmdBuf)); /* keep valgrind happy */
 	getFirstWord(&pszMsg, cmdBuf, sizeof(cmdBuf), TO_LOWERCASE);
 
 	dbgprintf("imdiag received command '%s'\n", cmdBuf);

--- a/template.c
+++ b/template.c
@@ -667,6 +667,7 @@ static void doOptions(unsigned char **pp, struct templateEntry *pTpe)
 
 	while(*p && *p != '%' && *p != ':') {
 		/* outer loop - until end of options */
+		memset(Buf, 0, sizeof(Buf)); /* silence valgrind warnings */
 		i = 0;
 		while((i < sizeof(Buf)-1) &&
 		      *p && *p != '%' && *p != ':' && *p != ',') {


### PR DESCRIPTION
While this is a false positiv, we actually restructure the code to
"solve" the issue. As it is only-config related code, the performance
is not affected. As such the "fix" is acceptable.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
