### PR TITLE
core/config bugfix: do not emit false error when config.enabled="on" is used

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1219,6 +1219,8 @@ nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 			for(val = lst; val != NULL ; val = val->next) {
 				val->bUsed = 1;
 			}
+		} else {
+			valnode->bUsed = 1;
 		}
 	}
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1355,6 +1355,7 @@ TESTS += \
 	imfile-logrotate-nocopytruncate.sh \
 	imfile-growing-file-id.sh \
 	glbl-oversizeMsg-truncate-imfile.sh \
+	config_enabled-on.sh \
 	config_enabled-off.sh
 
 if ENABLE_MMNORMALIZE
@@ -1488,6 +1489,7 @@ EXTRA_DIST= \
 	glbl-internalmsg_severity-debug-shown.sh \
 	glbl-internalmsg_severity-debug-not_shown.sh \
 	glbl-oversizeMsg-log-vg.sh \
+	config_enabled-on.sh \
 	config_enabled-off.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \

--- a/tests/config_enabled-on.sh
+++ b/tests/config_enabled-on.sh
@@ -2,17 +2,18 @@
 # check disabling a config construct via config.enable. Most
 # importantly ensure that it does not emit any error messages
 # for object parameters.
-# addd 2019-05-09 by RGerhards, released under ASL 2.0
+# addd 2019-12-09 by RGerhards, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")
-input(type="imfile" file="/tmp/notyet.txt" tag="testing-tag" config.enabled="off")
+input(type="imfile" file="/tmp/notyet.txt" tag="testing-tag" config.enabled="on" invalid.param="error")
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 shutdown_when_empty
 wait_shutdown
-content_check 'imfile: no files configured'
-check_not_present 'parameter .* not known'
+content_check 'imfile: on startup file'
+content_check --regex 'parameter.*invalid.param.*not known'
+check_not_present 'parameter.*config.enabled.*not known'
 exit_test


### PR DESCRIPTION
 When the 'config.enabled="on"' config parameter an invalid error message was emitted that this parameter is not supported. However, it was still applied properly. This commit removes the invalid error message.

Also improve testbench in this regard.
    
closes https://github.com/rsyslog/rsyslog/issues/4011