### PR TITLE
bugfix core: potential segfault in template engine

### DIFF
--- a/action.c
+++ b/action.c
@@ -1162,6 +1162,8 @@ releaseDoActionParams(action_t *__restrict__ const pAction, wti_t *__restrict__ 
 			if (ACT_STRING_PASSING == pAction->peParamPassing[j]) {
 				free(pWrkrInfo->p.nontx.actParams[j].param);
 				pWrkrInfo->p.nontx.actParams[j].param = NULL;
+				pWrkrInfo->p.nontx.actParams[j].lenBuf = 0;
+				pWrkrInfo->p.nontx.actParams[j].lenStr = 0;
 			}
 		} else {
 			switch(pAction->peParamPassing[j]) {
@@ -1173,6 +1175,8 @@ releaseDoActionParams(action_t *__restrict__ const pAction, wti_t *__restrict__ 
 				json_object_put((struct json_object*)
 								pWrkrInfo->p.nontx.actParams[j].param);
 				pWrkrInfo->p.nontx.actParams[j].param = NULL;
+				pWrkrInfo->p.nontx.actParams[j].lenBuf = 0;
+				pWrkrInfo->p.nontx.actParams[j].lenStr = 0;
 				break;
 			case ACT_STRING_PASSING:
 			case ACT_MSG_PASSING:


### PR DESCRIPTION
under some circumstances (not entirely clear right now), memory
was freed but later re-used as state-tracking structures were not
properly maintained. Github issue mentioned below has full details.

Thanks to github user snaix for analysing this issue and providing
a patch. I am committing as myself as snaix did not disclose his or
her identity.

closes https://github.com/rsyslog/rsyslog/issues/3019
closes https://github.com/rsyslog/rsyslog/issues/4040

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
