### PR TITLE
testbench: test imtcp "addtlFrameDelimiter" module param

### DIFF
--- a/tests/imtcp-basic.sh
+++ b/tests/imtcp-basic.sh
@@ -11,7 +11,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
-tcpflood -p'$TCPFLOOD_PORT' -m10000
+tcpflood -p$TCPFLOOD_PORT -m10000
 shutdown_when_empty
 wait_shutdown
 seq_check 0 9999

--- a/tests/imtcp_addtlframedelim.sh
+++ b/tests/imtcp_addtlframedelim.sh
@@ -2,28 +2,19 @@
 # added 2010-08-11 by Rgerhards
 #
 # This file is part of the rsyslog project, released  under ASL 2.0
-# NOTE: we intentionally use obsolete legacy style so that we can check
-# that it still works. DO NOT CONVERT/REMOVE! -- rgerhards, 2018-08-01
-
 . ${srcdir:=.}/diag.sh init
-export PORT_TCP="$(get_free_port)"
+export NUMMESSAGES=20000
 generate_conf
-# be careful: bash expansion is used below --> you need to escape!
-add_conf "
-\$ModLoad ../plugins/imtcp/.libs/imtcp
-\$MainMsgQueueTimeoutShutdown 10000
-\$InputTCPServerAddtlFrameDelimiter 0
-\$InputTCPServerRun $PORT_TCP
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp" addtlframedelimiter="0")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
-\$template outfmt,\"%msg:F,58:2%\n\"
-\$OMFileFlushOnTXEnd off
-\$OMFileFlushInterval 2
-\$OMFileIOBufferSize 256k
-local0.* ./$RSYSLOG_OUT_LOG;outfmt
-"
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+local0.* ./'$RSYSLOG_OUT_LOG';outfmt
+'
 startup
-tcpflood -m20000 -F0 -P129 -p$PORT_TCP
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown       # and wait for it to terminate
-seq_check 0 19999
+tcpflood -m$NUMMESSAGES -F0 -P129
+shutdown_when_empty
+wait_shutdown
+seq_check
 exit_test


### PR DESCRIPTION
so far, only the legacy style equivalent was tested. We have changed this
to current style. Legacy is no longer tested to keep CI runtime low.

The new test also has been made more reliable than the previous one.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
