### PR TITLE
testbench: modernize test and make more robust in regard to timing

### DIFF
--- a/tests/timegenerated-utc-legacy.sh
+++ b/tests/timegenerated-utc-legacy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-# addd 2016-03-22 by RGerhards, released under ASL 2.0
-
+# added 2016-03-22 by RGerhards, released under ASL 2.0
+#
 # NOTE: faketime does NOT properly support subseconds,
 # so we must ensure we do not use them. Actually, what we
 # see is uninitialized data value in tv_usec, which goes
@@ -8,33 +8,29 @@
 # FOR THE SAME REASON, there is NO VALGRIND EQUIVALENT
 # of this test, as valgrind would abort with reports
 # of faketime.
+#
+# IMPORTANT: we use legacy style for the template to ensure
+# that subseconds works properly for this as well. This is
+# a frequent use case.
+#
 . ${srcdir:=.}/diag.sh init
 . $srcdir/faketime_common.sh
-
 export TZ=TEST+02:00
-
 generate_conf
 add_conf '
-$ModLoad ../plugins/imtcp/.libs/imtcp
-$InputTCPServerRun '$TCPFLOOD_PORT'
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
-template(name="outfmt" type="string"
-	 string="%timegenerated:::date-utc%\n")
+$template outfmt,"%timegenerated:::date-utc%\n"
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
-			         file=`echo $RSYSLOG_OUT_LOG`)
+			         file="'$RSYSLOG_OUT_LOG'")
 '
 
 echo "***SUBTEST: check 2016-03-01"
-rm -f $RSYSLOG_OUT_LOG	# do cleanup of previous subtest
 FAKETIME='2016-03-01 12:00:00' startup
 tcpflood -m1
 shutdown_when_empty
 wait_shutdown
-echo "Mar  1 14:00:00" | cmp - $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "invalid timestamps generated, $RSYSLOG_OUT_LOG is:"
-  cat $RSYSLOG_OUT_LOG
-  exit 1
-fi;
-
+export EXPECTED="Mar  1 14:00:00"
+cmp_exact
 exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
