### PR TITLE
Do not close /dev/urandom file descriptor after fork on Linux systems

### DIFF
--- a/runtime/srUtils.h
+++ b/runtime/srUtils.h
@@ -96,6 +96,7 @@ int getSubString(uchar **ppSrc,  char *pDst, size_t DstSize, char cSep);
 rsRetVal getFileSize(uchar *pszName, off_t *pSize);
 int containsGlobWildcard(char *str);
 void seedRandomNumber(void);
+int isRandomNumberFd(int fd);
 #define MAX_RANDOM_NUMBER RAND_MAX
 long int randomNumber(void);
 long long currentTimeMills(void);

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -725,6 +725,11 @@ void seedRandomNumber(void)
 	}
 }
 
+int isRandomNumberFd(const int fd)
+{
+	return fd >= 0 && fd == fdURandom;
+}
+
 long int randomNumber(void)
 {
 	long int ret;
@@ -743,6 +748,11 @@ long int randomNumber(void)
 void seedRandomNumber(void)
 {
 	seedRandomInsecureNumber();
+}
+
+int isRandomNumberFd(const int fd)
+{
+	return 0;
 }
 
 long int randomNumber(void)

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -387,7 +387,7 @@ prepareBackground(const int parentPipeFD)
 	const int endClose = getdtablesize();
 	close(0);
 	for(int i = beginClose ; i <= endClose ; ++i) {
-		if((i != dbgGetDbglogFd()) && (i != parentPipeFD)) {
+		if((i != dbgGetDbglogFd()) && (i != parentPipeFD) && (!isRandomNumberFd(i))) {
 			  aix_close_it(i); /* AIXPORT */
 		}
 	}


### PR DESCRIPTION
This patch updates prepareBackground() in tools/rsyslogd.c to check that an open
file descriptor is not being used for random number generation before closing it
as an unnecessary open file. This fixes an issue on Linux systems where the file
descriptor obtained for /dev/urandom by seedRandomNumber() in runtime/srutils.c
was being closed after the fork. This could be observed in procfs, where
/proc/<PID>/fd/ would show no open descriptors to /dev/urandom in the forked
process. With this fix applied, procfs confirms that the forked rsyslog process
does retain a valid file descriptor to /dev/urandom.

I found that this issue led to rsyslog intermittently hanging during seedIV()
in runtime/libgcry.c. After the fork, the closed file descriptor number tended
to get re-assigned. randomNumber() would then read from an incorrect (although
still valid) file descriptor, and could block (depending on the state of that
file descriptor). This gave rise to the intermittent hang that I observed.

Signed-off-by: Simon Haggett <simon.haggett@gmail.com>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
