### PR TITLE
Reopen /dev/urandom file descriptor after fork on Linux systems

### DIFF
--- a/runtime/srUtils.h
+++ b/runtime/srUtils.h
@@ -96,6 +96,7 @@ int getSubString(uchar **ppSrc,  char *pDst, size_t DstSize, char cSep);
 rsRetVal getFileSize(uchar *pszName, off_t *pSize);
 int containsGlobWildcard(char *str);
 void seedRandomNumber(void);
+void seedRandomNumberForChild(void);
 #define MAX_RANDOM_NUMBER RAND_MAX
 long int randomNumber(void);
 long long currentTimeMills(void);

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -391,6 +391,7 @@ prepareBackground(const int parentPipeFD)
 			  aix_close_it(i); /* AIXPORT */
 		}
 	}
+	seedRandomNumberForChild();
 }
 
 /* This is called when rsyslog is set to auto-background itself. If so, a child


### PR DESCRIPTION
This patch updates prepareBackground() in tools/rsyslogd.c to reopen any file
descriptors used for random number generation in the child process. This fixes
an issue on Linux systems where the file descriptor obtained for /dev/urandom
by seedRandomNumber() in runtime/srutils.c was left closed after the fork. This
could be observed in procfs, where /proc/fd/ would show no open descriptors to
/dev/urandom in the forked process. /dev/urandom is reopened as the child may be
be operating in a jail, and so should not continue to use file descriptors from
outside the jail (i.e. inherited from the parent process).

I found that this issue led to rsyslog intermittently hanging during seedIV()
in runtime/libgcry.c. After the fork, the closed file descriptor number tended
to get re-assigned. randomNumber() would then read from an incorrect (although
still valid) file descriptor, and could block (depending on the state of that
file descriptor). This gave rise to the intermittent hang that I observed.

This PR provides an alternative fix to that given in https://github.com/rsyslog/rsyslog/pull/4061.

Signed-off-by: Simon Haggett <simon.haggett@gmail.com>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
