### PR TITLE
core bugfix: APP-NAME fields could become empty

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2195,10 +2195,14 @@ MsgSetAfterPRIOffs(smsg_t * const pMsg, int offs)
  * which already obtained the lock. So in general, this function here must
  * only be called when it it safe to do so without it aquiring a lock.
  */
-rsRetVal MsgSetAPPNAME(smsg_t *__restrict__ const pMsg, const char* pszAPPNAME)
+rsRetVal ATTR_NONNULL(1,2)
+MsgSetAPPNAME(smsg_t *__restrict__ const pMsg, const char *pszAPPNAME)
 {
 	DEFiRet;
 	assert(pMsg != NULL);
+	if(pszAPPNAME[0] == '\0') {
+		pszAPPNAME = "-"; /* RFC5424 NIL value */
+	}
 	if(pMsg->pCSAPPNAME == NULL) {
 		/* we need to obtain the object first */
 		CHKiRet(rsCStrConstruct(&pMsg->pCSAPPNAME));
@@ -2659,7 +2663,7 @@ prepareAPPNAME(smsg_t *const pM, const sbool bLockMutex)
 
 /* rgerhards, 2005-11-24
  */
-char *getAPPNAME(smsg_t * const pM, sbool bLockMutex)
+char *getAPPNAME(smsg_t * const pM, const sbool bLockMutex)
 {
 	uchar *pszRet;
 
@@ -2678,7 +2682,7 @@ char *getAPPNAME(smsg_t * const pM, sbool bLockMutex)
 
 /* rgerhards, 2005-11-24
  */
-static int getAPPNAMELen(smsg_t * const pM, sbool bLockMutex)
+static int getAPPNAMELen(smsg_t * const pM, const sbool bLockMutex)
 {
 	assert(pM != NULL);
 	prepareAPPNAME(pM, bLockMutex);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -160,6 +160,7 @@ TESTS +=  \
 	hostname-with-slash-pmrfc3164.sh \
 	hostname-with-slash-dflt-invld.sh \
 	hostname-with-slash-dflt-slash-valid.sh \
+	empty-app-name.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
 	glbl-ruleset-queue-defaults.sh \
@@ -1497,6 +1498,7 @@ EXTRA_DIST= \
 	glbl-oversizeMsg-log-vg.sh \
 	config_enabled-on.sh \
 	config_enabled-off.sh \
+	empty-app-name.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
 	hostname-with-slash-pmrfc5424.sh \

--- a/tests/empty-app-name.sh
+++ b/tests/empty-app-name.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# addd 2019-12-27 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+global(parser.PermitSlashInProgramname="off")
+
+template(name="outfmt" type="string" string="%syslogtag%,%programname%,%app-name%\n")
+local0.* action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+tcpflood -m 1 -M "\"<133>Aug  6 16:57:54 host /no-app-name msgh ...x\""
+shutdown_when_empty
+wait_shutdown
+export EXPECTED="/no-app-name,,-"
+cmp_exact
+exit_test


### PR DESCRIPTION
RFC 5424 specifies that an empty APP-NAME needs to be indicated by
"-". Instead, the field could become empty under certain conditions.
If so, outgoing 5424 messages were invalidly formatted.

This happened under quite unusual conditions, but could be seen
in practice.

This commit also does some very light non-related code improvement
and also includes the testbench test to check the fixed error condition.

closes https://github.com/rsyslog/rsyslog/issues/4043

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
