### PR TITLE
core bugfix: rsyslog aborts when config parse error is detected

### DIFF
--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -1308,6 +1308,7 @@ load(rsconf_t **cnf, uchar *confFile)
 {
 	int iNbrActions = 0;
 	int r;
+	rsRetVal delayed_iRet = RS_RET_OK;
 	DEFiRet;
 
 	CHKiRet(rsconfConstruct(&loadConf));
@@ -1331,7 +1332,8 @@ ourConf = loadConf; // TODO: remove, once ourConf is gone!
 	if(r == 1) {
 		LogError(0, RS_RET_CONF_PARSE_ERROR, "could not interpret master "
 			"config file '%s'.", confFile);
-		ABORT_FINALIZE(RS_RET_CONF_PARSE_ERROR);
+		/* we usually keep running with the failure, so we need to continue for now */
+		delayed_iRet = RS_RET_CONF_PARSE_ERROR;
 	} else if(r == 2) { /* file not found? */
 		LogError(errno, RS_RET_CONF_FILE_NOT_FOUND, "could not open config file '%s'",
 		        confFile);
@@ -1369,6 +1371,9 @@ ourConf = loadConf; // TODO: remove, once ourConf is gone!
 	rsconfDebugPrint(loadConf);
 
 finalize_it:
+	if(iRet == RS_RET_OK && delayed_iRet != RS_RET_OK) {
+		iRet = delayed_iRet;
+	}
 	RETiRet;
 }
 


### PR DESCRIPTION
In defaut settings, rsyslog tries to continue to run, but some data
structures are not properly initialized due to the config parsing error.
This causes a segfault.

In the following tracker, this is the root cause of the abort:
see also https://github.com/rsyslog/rsyslog/issues/2869

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
