### PR TITLE
config system: emit proper error message on $ in double-quoted string

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -302,6 +302,10 @@ int fileno(FILE *stream);
 				   unescapeStr((uchar*)yytext+1, yyleng-2);
 				   yylval.estr = es_newStrFromBuf(yytext+1, strlen(yytext)-1);
 				   return STRING; }
+<EXPR>\"([^"\\]|\\["'\\$bntr]|\\x[0-9a-f][0-9a-f]|\\[0-7][0-7][0-7])*\" {
+				   cnfPrintToken(yytext); parser_errmsg("$-sign in double quotes must be "
+					        "escaped, problem string is: %s",
+						yytext); }
 <EXPR>[ \t\n]			{ cnfPrintToken(yytext); }
 <EXPR>[a-z][a-z0-9_]*		{ cnfPrintToken(yytext); yylval.estr = es_newStrFromCStr(yytext, yyleng);
 				  return FUNC; }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -375,6 +375,7 @@ TESTS +=  \
 	rscript_wrap3.sh \
 	rscript_re_extract.sh \
 	rscript_re_match.sh \
+	rscript_re_match-dbl_quotes.sh \
 	rscript_eq.sh \
 	rscript_eq_var.sh \
 	rscript_ge.sh \
@@ -2392,6 +2393,7 @@ EXTRA_DIST= \
 	key_dereference_on_uninitialized_variable_space.sh \
 	rscript_re_extract.sh \
 	rscript_re_match.sh \
+	rscript_re_match-dbl_quotes.sh \
 	lookup_table.sh \
 	lookup_table_no_hup_reload.sh \
 	lookup_table_no_hup_reload-vg.sh \

--- a/tests/rscript_re_match-dbl_quotes.sh
+++ b/tests/rscript_re_match-dbl_quotes.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Test that '$' in double-quoted string constants raise a meaningful
+# error message and do not cause rsyslog to segfault.
+# added 2019-12-30 by Rainer Gerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'") # order is important ...
+set $!test="test$" # ... as after this syntax error nothing is really taken up
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check '$-sign in double quotes must be escaped'
+exit_test

--- a/tests/rscript_re_match.sh
+++ b/tests/rscript_re_match.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 # added 2015-09-29 by singh.janmejay
+# test re_match rscript-fn, using single quotes for the match
 # This file is part of the rsyslog project, released under ASL 2.0
-echo ===============================================================================
-echo \[rscript_re_match.sh\]: test re_match rscript-fn
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
@@ -13,14 +12,12 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 add_conf "
 if (re_match(\$msg, '.* ([0-9]+)$')) then {"
 add_conf '
-	 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	 action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup
 tcpflood -m 1 -I $srcdir/testsuites/date_time_msg
-echo doing shutdown
 shutdown_when_empty
-echo wait on shutdown
 wait_shutdown
 content_check "*Matched*"
 exit_test


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/2869

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
