### PR TITLE
testbench: rough fix for clickhouse 2019 test data problem

### DIFF
--- a/tests/clickhouse-dflt-tpl.sh
+++ b/tests/clickhouse-dflt-tpl.sh
@@ -19,7 +19,7 @@ wait_shutdown
 clickhouse-client --query="SELECT * FROM rsyslog.SystemEvents FORMAT CSV" > $RSYSLOG_OUT_LOG
 
 clickhouse-client --query="DROP TABLE rsyslog.SystemEvents"
-export EXPECTED='7,20,"2019-03-01 01:00:00","172.20.245.8","tag"," msgnum:00000000:"'
+export EXPECTED='7,20,"2020-03-01 01:00:00","172.20.245.8","tag"," msgnum:00000000:"'
 cmp_exact $RSYSLOG_OUT_LOG
 
 exit_test


### PR DESCRIPTION
not a real fix, but to get us going: clickhouse test had hardcoded
year; needs to be removed soon. Right now, just pusing it to 2020.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
