### PR TITLE
testbench: new test for loadbalancing via global variables

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -159,6 +159,7 @@ TESTS +=  \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \
 	smtradfile.sh \
+	loadbalance.sh \
 	empty-hostname.sh \
 	hostname-getaddrinfo-fail.sh \
 	msleep_usage_output.sh \
@@ -1500,6 +1501,7 @@ EXTRA_DIST= \
 	urlencode.py \
 	dnscache-TTL-0.sh \
 	dnscache-TTL-0-vg.sh \
+	loadbalance.sh \
 	smtradfile.sh \
 	smtradfile-vg.sh \
 	immark.sh \

--- a/tests/action-tx-errfile.sh
+++ b/tests/action-tx-errfile.sh
@@ -36,5 +36,5 @@ wait_shutdown
 export EXPECTED="$(cat ${srcdir}/testsuites/action-tx-errfile.result)"
 cmp_exact ${RSYSLOG2_OUT_LOG}
 mysql_get_data
-seq_check
+seq_check  0 $((NUMMESSAGES - 2)) -i2
 exit_test

--- a/tests/action-tx-errfile.sh
+++ b/tests/action-tx-errfile.sh
@@ -6,7 +6,7 @@ export NUMMESSAGES=50 # sufficient for our needs!
 export SEQ_CHECK_OPTIONS=-i2
 check_sql_data_ready() {
 	mysql_get_data
-	seq_check --check-only
+	seq_check --check-only 0 $((NUMMESSAGES - 2))
 }
 export QUEUE_EMPTY_CHECK_FUNC=check_sql_data_ready
 

--- a/tests/action-tx-single-processing.sh
+++ b/tests/action-tx-single-processing.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 # part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=5000
+export NUMMESSAGES=2000
 export SEQ_CHECK_OPTIONS=-i2
 check_sql_data_ready() {
 	mysql_get_data
-	seq_check --check-only
+	seq_check --check-only 0 $((NUMMESSAGES - 2))
 }
 export QUEUE_EMPTY_CHECK_FUNC=check_sql_data_ready
 generate_conf
@@ -34,5 +34,5 @@ injectmsg
 shutdown_when_empty
 wait_shutdown
 mysql_get_data
-seq_check
+seq_check 0 $((NUMMESSAGES - 2))
 exit_test

--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -125,7 +125,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 
-	for(i = start ; i < end+1 ; i += increment) {
+	for(i = start ; i <= end ; i += increment) {
 		if(bHaveExtraData) {
 			if(fgets(ioBuf, sizeof(ioBuf), fp) == NULL) {
 				scanfOK = 0;
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
 			++i;
 		}
 		if(val != i) {
-			if(val == i - 1 && dupsPermitted) {
+			if(val == i - increment && dupsPermitted) {
 				--i;
 				++nDups;
 			} else {
@@ -174,8 +174,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if(i - 1 != end) {
-		printf("only %d records in file, expected %d\n", i - 1, end);
+	if(i - increment != end) {
+		printf("lastrecord does not match. file: %d, expected %d\n", i - increment, end);
 		exit(1);
 	}
 

--- a/tests/loadbalance.sh
+++ b/tests/loadbalance.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# a test to check load balancing via global variables
+# note: for simplicity, we use omfile output; in practice this will usually
+# be some kind of network output, e.g. omfwd or omrelp. From the method's
+# point of view, the actual output does not matter.
+# added by Rainer Gerhards 2020-01-03
+# part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000 # sufficient for our needs
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+# note: do NOT initialize $/lbcntr - it starts at "", which becomes 0 after cnum()
+if $msg contains "msgnum" then {
+	set $.actnbr = cnum($/lbcntr) % 4;
+	if $.actnbr == 0 then {
+		action(type="omfile" file="'$RSYSLOG_DYNNAME'0.log" template="outfmt")
+	} else if $.actnbr == 1 then {
+		action(type="omfile" file="'$RSYSLOG_DYNNAME'1.log" template="outfmt")
+	} else if $.actnbr == 2 then {
+		action(type="omfile" file="'$RSYSLOG_DYNNAME'2.log" template="outfmt")
+	} else {
+		action(type="omfile" file="'$RSYSLOG_DYNNAME'3.log" template="outfmt")
+	}
+	set $/lbcntr = cnum($/lbcntr) + 1;
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+seq_check # validate test result as such
+export SEQ_CHECK_FILE="${RSYSLOG_DYNNAME}0.log"
+seq_check 0 $((NUMMESSAGES -4)) -i 4
+printf 'Checking file 1\n'
+export SEQ_CHECK_FILE="${RSYSLOG_DYNNAME}1.log"
+printf 'Checking file 2\n'
+export SEQ_CHECK_FILE="${RSYSLOG_DYNNAME}2.log"
+printf 'Checking file 3\n'
+export SEQ_CHECK_FILE="${RSYSLOG_DYNNAME}3.log"
+exit_test


### PR DESCRIPTION
This is a useful use case which was so far not covered by any tests.

Also contains: chkseq testbench tool bugfix: -i option did not work for values > 1
This bug was previously not discovered because values > 1 were not used so far. This bug is on a testbench tool, so no user is affected.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
