### PR TITLE
testbench: make imdocker tests more robust in regard to timing

### DIFF
--- a/tests/imdocker-basic.sh
+++ b/tests/imdocker-basic.sh
@@ -3,6 +3,7 @@
 # imdocker unit tests are enabled with --enable-imdocker-tests
 . ${srcdir:=.}/diag.sh init
 NUMMESSAGES=1000
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
 #QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
 

--- a/tests/imdocker-multi-line.sh
+++ b/tests/imdocker-multi-line.sh
@@ -3,7 +3,8 @@
 
 # imdocker unit tests are enabled with --enable-imdocker-tests
 . ${srcdir:=.}/diag.sh init
-NUM_ITEMS=1000
+export NUMMESSAGES=999
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
 
 generate_conf
@@ -23,32 +24,24 @@ if $!metadata!Names == "'$COOKIE'" then {
 # These logs started after start-up should get from beginning
 docker run \
   --name $COOKIE \
-  -e num_items=$NUM_ITEMS \
+  -e num_items=$((NUMMESSAGES+1)) \
   -l imdocker.startregex=^multi-line: \
   alpine \
   /bin/sh -c \
   'for i in `seq 1 $num_items`; do printf "multi-line: $i\n line2....\n line3....\n"; done' > /dev/null
 
-#export RS_REDIR=-d
 startup
-NUM_EXPECTED=$((NUM_ITEMS - 1))
-echo "expected: $NUM_EXPECTED"
-
-content_check_with_count "$COOKIE multi-line:" $NUM_EXPECTED 10
 shutdown_when_empty
 wait_shutdown
 docker container rm $COOKIE
-echo "file name: $RSYSLOG_OUT_LOG"
 
+content_check_with_count "$COOKIE multi-line:" $NUMMESSAGES 10
 ## check if all the data we expect to get in the file is there
-for i in $(seq 1 $NUM_EXPECTED); do
+for i in $(seq 1 $NUMMESSAGES); do
   grep "$COOKIE multi-line: $i#012 line2....#012 line3...." $RSYSLOG_OUT_LOG > /dev/null 2>&1
-  #grep -Pzo "$COOKIE multi-line: $i\n line2....\n line3...." $RSYSLOG_OUT_LOG > /dev/null 2>&1
   if [ ! $? -eq 0 ]; then
     echo "ERROR: expecting the string $COOKIE multi-line: item '$i', it's not there"
-    exit 1
+    error_exit 1
   fi
 done
-
 exit_test
-


### PR DESCRIPTION
some have problems on heavily loaded (CI) machines. This commit solves
that problem.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
