### PR TITLE
testbench: harden two tests against slow testbench machines

### DIFF
--- a/tests/imtcp_conndrop_tls-vg.sh
+++ b/tests/imtcp_conndrop_tls-vg.sh
@@ -1,45 +1,11 @@
 #!/bin/bash
-# test imtcp/tls with random connection drops
-# added 2011-06-09 by Rgerhards
-#
-# This file is part of the rsyslog project, released  under GPLv3
-. ${srcdir:=.}/diag.sh init
+# This file is part of the rsyslog project, released under ASL 2.0
+export USE_VALGRIND="YES"
+export NUMMESSAGES=10000 # reduce for slower valgrind run
+source ${srcdir:-.}/imtcp_conndrop_tls.sh
 
 uname
 if [ $(uname) = "FreeBSD" ] ; then
    echo "This test currently does not work on FreeBSD."
    exit 77
 fi
-
-generate_conf
-add_conf '
-$MaxMessageSize 10k
-
-$ModLoad ../plugins/imtcp/.libs/imtcp
-$MainMsgQueueTimeoutShutdown 10000
-
-# TLS Stuff - certificate files - just CA for a client
-$DefaultNetstreamDriver gtls
-$IncludeConfig '$RSYSLOG_DYNNAME'.conf.tlscert
-$InputTCPServerStreamDriverMode 1
-$InputTCPServerStreamDriverAuthMode anon
-$InputTCPServerRun '$TCPFLOOD_PORT'
-
-$template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
-template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
-$OMFileFlushOnTXEnd off
-$OMFileFlushInterval 2
-$OMFileIOBufferSize 256k
-local0.* ?dynfile;outfmt
-'
-echo \$DefaultNetstreamDriverCAFile $srcdir/tls-certs/ca.pem     >$RSYSLOG_DYNNAME.conf.tlscert
-echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>$RSYSLOG_DYNNAME.conf.tlscert
-echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>$RSYSLOG_DYNNAME.conf.tlscert
-startup_vg
-# 100 byte messages to gain more practical data use
-tcpflood -c20 -p'$TCPFLOOD_PORT' -m10000 -r -d100 -P129 -D -l0.995 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
-sleep 5 # due to large messages, we need this time for the tcp receiver to settle...
-shutdown_when_empty # shut down rsyslogd when done processing messages
-wait_shutdown       # and wait for it to terminate
-seq_check 0 9999 -E
-exit_test

--- a/tests/imtcp_conndrop_tls.sh
+++ b/tests/imtcp_conndrop_tls.sh
@@ -4,6 +4,8 @@
 #
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=50000
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
 generate_conf
 add_conf '
 $MaxMessageSize 10k
@@ -20,8 +22,6 @@ $InputTCPServerRun '$TCPFLOOD_PORT'
 
 $template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
-$OMFileFlushOnTXEnd off
-$OMFileFlushInterval 2
 $OMFileIOBufferSize 256k
 local0.* ?dynfile;outfmt
 '
@@ -30,10 +30,9 @@ echo \$DefaultNetstreamDriverCertFile $srcdir/tls-certs/cert.pem >>$RSYSLOG_DYNN
 echo \$DefaultNetstreamDriverKeyFile $srcdir/tls-certs/key.pem   >>$RSYSLOG_DYNNAME.rsyslog.conf.tlscert
 startup
 # 100 byte messages to gain more practical data use
-tcpflood -c20 -p'$TCPFLOOD_PORT' -m50000 -r -d100 -P129 -D -l0.995 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
-sleep 5 # due to large messages, we need this time for the tcp receiver to settle...
+tcpflood -c20 -p$TCPFLOOD_PORT -m$NUMMESSAGES -r -d100 -P129 -D -l0.995 -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown       # and wait for it to terminate
-seq_check 0 49999 -E
-# content_check 'XXXXX'	# Not really a check if it worked, but in TLS stuff in unfinished TLS Packets gets lost, so we can't use seq-check.
+export SEQ_CHECK_OPTIONS=-E
+seq_check
 exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
