### PR TITLE
ossl tls: Added support to configure certificate verify depth

### DIFF
--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -241,6 +241,15 @@ SetDrvrPrioritizeSAN(netstrm_t *pThis, int prioritizeSan)
 	RETiRet;
 }
 
+/* tls verify depth */
+static rsRetVal
+SetDrvrTlsVerifyDepth(netstrm_t *pThis, int verifyDepth)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetTlsVerifyDepth(pThis->pDrvrData, verifyDepth);
+	RETiRet;
+}
 
 /* End of methods to shuffle autentication settings to the driver.
  * -------------------------------------------------------------------------- */
@@ -427,6 +436,7 @@ CODESTARTobjQueryInterface(netstrm)
 	pIf->SetGnutlsPriorityString = SetGnutlsPriorityString;
 	pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
 	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
+	pIf->SetDrvrTlsVerifyDepth = SetDrvrTlsVerifyDepth;
 finalize_it:
 ENDobjQueryInterface(netstrm)
 

--- a/runtime/netstrm.h
+++ b/runtime/netstrm.h
@@ -81,6 +81,9 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 	/* v12 -- two new binary flags added to gtls driver enabling stricter operation */
 	rsRetVal (*SetDrvrCheckExtendedKeyUsage)(netstrm_t *pThis, int ChkExtendedKeyUsage);
 	rsRetVal (*SetDrvrPrioritizeSAN)(netstrm_t *pThis, int prioritizeSan);
+
+	/* v14 -- Tls functions */
+	rsRetVal (*SetDrvrTlsVerifyDepth)(netstrm_t *pThis, int verifyDepth);
 ENDinterface(netstrm)
 #define netstrmCURR_IF_VERSION 12 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()

--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -322,6 +322,26 @@ GetDrvrPrioritizeSAN(netstrms_t *pThis)
 	return pThis->DrvrPrioritizeSan;
 }
 
+/* set the driver TlsVerifyDepth -- alorbach, 2019-12-20 */
+static rsRetVal
+SetDrvrTlsVerifyDepth(netstrms_t *pThis, int verifyDepth)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	pThis->DrvrVerifyDepth = verifyDepth;
+	RETiRet;
+}
+
+/* return the driver TlsVerifyDepth
+ * alorbach, 2019-12-20
+ */
+static int
+GetDrvrTlsVerifyDepth(netstrms_t *pThis)
+{
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	return pThis->DrvrVerifyDepth;
+}
+
 /* create an instance of a netstrm object. It is initialized with default
  * values. The current driver is used. The caller may set netstrm properties
  * and must call ConstructFinalize().
@@ -384,6 +404,8 @@ CODESTARTobjQueryInterface(netstrms)
 	pIf->GetDrvrCheckExtendedKeyUsage = GetDrvrCheckExtendedKeyUsage;
 	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
 	pIf->GetDrvrPrioritizeSAN = GetDrvrPrioritizeSAN;
+	pIf->SetDrvrTlsVerifyDepth = SetDrvrTlsVerifyDepth;
+	pIf->GetDrvrTlsVerifyDepth = GetDrvrTlsVerifyDepth;
 finalize_it:
 ENDobjQueryInterface(netstrms)
 

--- a/runtime/netstrms.h
+++ b/runtime/netstrms.h
@@ -35,6 +35,7 @@ struct netstrms_s {
 	uchar *pszDrvrAuthMode;	/**< current driver authentication mode */
 	int DrvrChkExtendedKeyUsage;		/**< if true, verify extended key usage in certs */
 	int DrvrPrioritizeSan;		/**< if true, perform stricter checking of names in certs */
+	int DrvrVerifyDepth;		/**< Verify Depth for certificate chains */
 	uchar *pszDrvrPermitExpiredCerts;/**< current driver setting for handlign expired certs */
 	uchar *gnutlsPriorityString; /**< priorityString for connection */
 	permittedPeers_t *pPermPeers;/**< current driver's permitted peers */
@@ -64,6 +65,9 @@ BEGINinterface(netstrms) /* name must also be changed in ENDinterface macro! */
 	int      (*GetDrvrCheckExtendedKeyUsage)(netstrms_t *pThis);
 	rsRetVal (*SetDrvrPrioritizeSAN)(netstrms_t *pThis, int prioritizeSan);
 	int      (*GetDrvrPrioritizeSAN)(netstrms_t *pThis);
+	rsRetVal (*SetDrvrTlsVerifyDepth)(netstrms_t *pThis, int verifyDepth);
+	int      (*GetDrvrTlsVerifyDepth)(netstrms_t *pThis);
+
 ENDinterface(netstrms)
 #define netstrmsCURR_IF_VERSION 1 /* increment whenever you change the interface structure! */
 

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -89,8 +89,12 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 	/* v13 -- two new binary flags added to gtls driver enabling stricter operation */
 	rsRetVal (*SetCheckExtendedKeyUsage)(nsd_t *pThis, int ChkExtendedKeyUsage);
 	rsRetVal (*SetPrioritizeSAN)(nsd_t *pThis, int prioritizeSan);
+
+	/* v14 -- Tls functions */
+	rsRetVal (*SetTlsVerifyDepth)(nsd_t *pThis, int verifyDepth);
+
 ENDinterface(nsd)
-#define nsdCURR_IF_VERSION 13 /* increment whenever you change the interface structure! */
+#define nsdCURR_IF_VERSION 14 /* increment whenever you change the interface structure! */
 /* interface version 4 added GetRemAddr()
  * interface version 5 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 6 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -121,8 +121,6 @@ static void logFunction(int level, const char *msg)
 	dbgprintf("GnuTLS log msg, level %d: %s\n", level, msg);
 }
 
-
-
 /* read in the whole content of a file. The caller is responsible for
  * freeing the buffer. To prevent DOS, this function can NOT read
  * files larger than 1MB (which still is *very* large).
@@ -776,7 +774,11 @@ gtlsInitSession(nsd_gtls_t *pThis)
 	gnutls_session_set_ptr(pThis->sess, (void*)pThis);
 	iRet = gtlsLoadOurCertKey(pThis); /* first load .pem files */
 	if(iRet == RS_RET_OK) {
+		dbgprintf("gtlsInitSession: enable certificate checking (VerifyDepth=%d)\n", pThis->DrvrVerifyDepth);
 		gnutls_certificate_set_retrieve_function(xcred, gtlsClientCertCallback);
+		if (pThis->DrvrVerifyDepth != 0){
+			gnutls_certificate_set_verify_limits(xcred, 8200, pThis->DrvrVerifyDepth);
+		}
 	} else if(iRet == RS_RET_CERTLESS) {
 		dbgprintf("gtlsInitSession: certificates not configured, not loaded.\n");
 	} else {
@@ -1571,6 +1573,27 @@ finalize_it:
 	RETiRet;
 }
 
+/* Set the driver tls  verifyDepth
+ * alorbach, 2019-12-20
+ */
+static rsRetVal
+SetTlsVerifyDepth(nsd_t *pNsd, int verifyDepth)
+{
+	DEFiRet;
+	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
+
+	ISOBJ_TYPE_assert((pThis), nsd_gtls);
+	if (verifyDepth == 0) {
+		FINALIZE;
+	}
+	assert(verifyDepth >= 2);
+	pThis->DrvrVerifyDepth = verifyDepth;
+
+finalize_it:
+	RETiRet;
+}
+
+
 /* Provide access to the underlying OS socket. This is primarily
  * useful for other drivers (like nsd_gtls) who utilize ourselfs
  * for some of their functionality. -- rgerhards, 2008-04-18
@@ -1764,6 +1787,7 @@ AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew)
 	pNew->permitExpiredCerts = pThis->permitExpiredCerts;
 	pNew->pPermPeers = pThis->pPermPeers;
 	pNew->gnutlsPriorityString = pThis->gnutlsPriorityString;
+	pNew->DrvrVerifyDepth = pThis->DrvrVerifyDepth;
 
 	/* if we reach this point, we are in TLS mode */
 	iRet = gtlsInitSession(pNew);
@@ -2069,6 +2093,10 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 #		else
 		gnutls_certificate_client_set_retrieve_function(xcred, gtlsClientCertCallback);
 #		endif
+		dbgprintf("Connect: enable certificate checking (VerifyDepth=%d)\n", pThis->DrvrVerifyDepth);
+		if (pThis->DrvrVerifyDepth != 0) {
+			gnutls_certificate_set_verify_limits(xcred, 8200, pThis->DrvrVerifyDepth);
+		}
 	} else if(iRet == RS_RET_CERTLESS) {
 		dbgprintf("Connect: certificates not configured, not loaded.\n");
 	} else {
@@ -2197,6 +2225,7 @@ CODESTARTobjQueryInterface(nsd_gtls)
 	pIf->SetGnutlsPriorityString = SetGnutlsPriorityString;
 	pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage;
 	pIf->SetPrioritizeSAN = SetPrioritizeSAN;
+	pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
 finalize_it:
 ENDobjQueryInterface(nsd_gtls)
 

--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -71,6 +71,7 @@ struct nsd_gtls_s {
 				 * one successful authentication. */
 	permittedPeers_t *pPermPeers; /* permitted peers */
 	uchar *gnutlsPriorityString;	/* gnutls priority string */
+	int DrvrVerifyDepth;		/* Verify Depth for certificate chains */
 	gnutls_x509_crt_t pOurCerts[NSD_GTLS_MAX_CERT];	/**< our certificate, if in client mode
 							(unused in server mode) */
 	unsigned int nOurCerts;  /* number of certificates in our chain */

--- a/runtime/nsd_ossl.h
+++ b/runtime/nsd_ossl.h
@@ -72,6 +72,7 @@ struct nsd_ossl_s {
 				 * one successful authentication. */
 	permittedPeers_t *pPermPeers; /* permitted peers */
 	uchar *gnutlsPriorityString;	/* gnutls priority string */
+	int DrvrVerifyDepth;		/* Verify Depth for certificate chains */
 	short	bOurCertIsInit;	/**< 1 if our certificate is initialized and must be deinit on destruction */
 	short	bOurKeyIsInit;	/**< 1 if our private key is initialized and must be deinit on destruction */
 	char *pszRcvBuf;

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -182,6 +182,22 @@ finalize_it:
 	RETiRet;
 }
 
+/* Set the tls verify depth, not supported in ptcp.
+ * alorbach, 2019-12-20
+ */
+static rsRetVal
+SetTlsVerifyDepth(nsd_t __attribute__((unused)) *pNsd, int verifyDepth)
+{
+	nsd_ptcp_t *pThis = (nsd_ptcp_t*) pNsd;
+	DEFiRet;
+	ISOBJ_TYPE_assert((pThis), nsd_ptcp);
+	if (verifyDepth == 0) {
+		FINALIZE;
+	}
+finalize_it:
+	RETiRet;
+}
+
 /* Set the authentication mode. For us, the following is supported:
  * anon - no certificate checks whatsoever (discouraged, but supported)
  * mode == NULL is valid and defaults to anon
@@ -648,6 +664,7 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 		CHKiRet(pNS->Drvr.SetMode(pNewNsd, netstrms.GetDrvrMode(pNS)));
 		CHKiRet(pNS->Drvr.SetCheckExtendedKeyUsage(pNewNsd, netstrms.GetDrvrCheckExtendedKeyUsage(pNS)));
 		CHKiRet(pNS->Drvr.SetPrioritizeSAN(pNewNsd, netstrms.GetDrvrPrioritizeSAN(pNS)));
+		CHKiRet(pNS->Drvr.SetTlsVerifyDepth(pNewNsd, netstrms.GetDrvrTlsVerifyDepth(pNS)));
 		CHKiRet(pNS->Drvr.SetAuthMode(pNewNsd, netstrms.GetDrvrAuthMode(pNS)));
 		CHKiRet(pNS->Drvr.SetPermitExpiredCerts(pNewNsd, netstrms.GetDrvrPermitExpiredCerts(pNS)));
 		CHKiRet(pNS->Drvr.SetPermPeers(pNewNsd, netstrms.GetDrvrPermPeers(pNS)));
@@ -999,6 +1016,7 @@ CODESTARTobjQueryInterface(nsd_ptcp)
 	pIf->SetKeepAliveTime = SetKeepAliveTime;
 	pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage;
 	pIf->SetPrioritizeSAN = SetPrioritizeSAN;
+	pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
 finalize_it:
 ENDobjQueryInterface(nsd_ptcp)
 

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1000,6 +1000,7 @@ BEGINobjConstruct(tcpsrv) /* be sure to specify the object type also in END macr
 	pThis->bUseFlowControl = 1;
 	pThis->pszDrvrName = NULL;
 	pThis->bPreserveCase = 1; /* preserve case in fromhost; default to true. */
+	pThis->DrvrTlsVerifyDepth = 0;
 ENDobjConstruct(tcpsrv)
 
 
@@ -1017,6 +1018,7 @@ tcpsrvConstructFinalize(tcpsrv_t *pThis)
 	CHKiRet(netstrms.SetDrvrMode(pThis->pNS, pThis->iDrvrMode));
 	CHKiRet(netstrms.SetDrvrCheckExtendedKeyUsage(pThis->pNS, pThis->DrvrChkExtendedKeyUsage));
 	CHKiRet(netstrms.SetDrvrPrioritizeSAN(pThis->pNS, pThis->DrvrPrioritizeSan));
+	CHKiRet(netstrms.SetDrvrTlsVerifyDepth(pThis->pNS, pThis->DrvrTlsVerifyDepth));
 	if(pThis->pszDrvrAuthMode != NULL)
 		CHKiRet(netstrms.SetDrvrAuthMode(pThis->pNS, pThis->pszDrvrAuthMode));
 	if(pThis->pszDrvrPermitExpiredCerts != NULL)
@@ -1429,6 +1431,15 @@ SetDrvrPrioritizeSAN(tcpsrv_t *pThis, int prioritizeSan)
 	RETiRet;
 }
 
+/* set the driver Set the driver tls  verifyDepth -- alorbach, 2019-12-20 */
+static rsRetVal
+SetDrvrTlsVerifyDepth(tcpsrv_t *pThis, int verifyDepth)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, tcpsrv);
+	pThis->DrvrTlsVerifyDepth = verifyDepth;
+	RETiRet;
+}
 
 /* End of methods to shuffle autentication settings to the driver.;
 
@@ -1548,6 +1559,7 @@ CODESTARTobjQueryInterface(tcpsrv)
 	pIf->SetPreserveCase = SetPreserveCase;
 	pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
 	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
+	pIf->SetDrvrTlsVerifyDepth = SetDrvrTlsVerifyDepth;
 
 finalize_it:
 ENDobjQueryInterface(tcpsrv)

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -64,6 +64,7 @@ struct tcpsrv_s {
 	int iDrvrMode;		/**< mode of the stream driver to use */
 	int DrvrChkExtendedKeyUsage;		/**< if true, verify extended key usage in certs */
 	int DrvrPrioritizeSan;		/**< if true, perform stricter checking of names in certs */
+	int DrvrTlsVerifyDepth;		/**< Verify Depth for certificate chains */
 	uchar *gnutlsPriorityString;	/**< priority string for gnutls */
 	uchar *pszLstnPortFileName;	/**< File in which the dynamic port is written */
 	uchar *pszDrvrAuthMode;	/**< auth mode of the stream driver to use */
@@ -192,8 +193,10 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	/* added v23 -- Options for stricter driver behavior, 2019-08-16 */
 	rsRetVal (*SetDrvrCheckExtendedKeyUsage)(tcpsrv_t *pThis, int ChkExtendedKeyUsage);
 	rsRetVal (*SetDrvrPrioritizeSAN)(tcpsrv_t *pThis, int prioritizeSan);
+	/* added v24 -- Options for TLS verify depth driver behavior, 2019-12-20 */
+	rsRetVal (*SetDrvrTlsVerifyDepth)(tcpsrv_t *pThis, int verifyDepth);
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 23 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 24 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1136,6 +1136,8 @@ endif
 
 if ENABLE_GNUTLS
 TESTS +=  \
+	imtcp-tls-basic.sh \
+	imtcp-tls-basic-verifydepth.sh \
 	imtcp_conndrop_tls.sh \
 	sndrcv_tls_anon_rebind.sh \
 	sndrcv_tls_anon_hostname.sh \
@@ -1151,8 +1153,7 @@ TESTS +=  \
 	imtcp-tls-gtls-x509fingerprint-invld.sh \
 	imtcp-tls-gtls-x509fingerprint.sh \
 	imtcp-tls-gtls-x509name-invld.sh \
-	imtcp-tls-gtls-x509name.sh \
-	imtcp-tls-basic.sh
+	imtcp-tls-gtls-x509name.sh
 if HAVE_VALGRIND
 TESTS += \
 	imtcp-tls-basic-vg.sh \
@@ -1165,6 +1166,8 @@ if ENABLE_OPENSSL
 TESTS +=  \
 	imtcp-tls-ossl-basic.sh \
 	imtcp-tls-ossl-basic-tlscommands.sh \
+	imtcp-tls-ossl-basic-verifydepth.sh \
+	imtcp-tls-ossl-invalid-verifydepth.sh \
 	sndrcv_tls_ossl_anon_ipv4.sh \
 	sndrcv_tls_ossl_anon_ipv6.sh \
 	sndrcv_tls_ossl_anon_rebind.sh \
@@ -1956,6 +1959,7 @@ EXTRA_DIST= \
 	imtcp-tls-gtls-x509name-invld.sh \
 	imtcp-tls-gtls-x509name.sh \
 	imtcp-tls-basic.sh \
+	imtcp-tls-basic-verifydepth.sh \
 	imtcp-tls-basic-vg.sh \
 	imtcp_incomplete_frame_at_end.sh \
 	imtcp-multiport.sh \
@@ -1964,6 +1968,8 @@ EXTRA_DIST= \
 	manytcp-too-few-tls-vg.sh \
 	imtcp-tls-ossl-basic.sh \
 	imtcp-tls-ossl-basic-tlscommands.sh \
+	imtcp-tls-ossl-basic-verifydepth.sh \
+	imtcp-tls-ossl-invalid-verifydepth.sh \
 	sndrcv_tls_ossl_anon_ipv4.sh \
 	sndrcv_tls_ossl_anon_ipv6.sh \
 	sndrcv_tls_ossl_anon_rebind.sh \

--- a/tests/imtcp-tls-basic-verifydepth.sh
+++ b/tests/imtcp-tls-basic-verifydepth.sh
@@ -1,28 +1,26 @@
 #!/bin/bash
-# added 2018-04-27 by alorbach
+# added 2011-02-28 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=10000
+export NUMMESSAGES=1000
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
 	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
-#	debug.whitelist="on"
-#	debug.files=["nsd_ossl.c", "tcpsrv.c", "nsdsel_ossl.c", "nsdpoll_ptcp.c", "dnscache.c"]
 )
-
 module(	load="../plugins/imtcp/.libs/imtcp"
-	StreamDriver.Name="ossl"
+	StreamDriver.Name="gtls"
+	StreamDriver.TlsVerifyDepth="5" 
 	StreamDriver.Mode="1"
-	StreamDriver.AuthMode="anon" )
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+	StreamDriver.AuthMode="x509/certvalid" )
+input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
 
-template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-:msg, contains, "msgnum:" action(	type="omfile" 
-					template="outfmt"
-					file=`echo $RSYSLOG_OUT_LOG`)
+$template outfmt,"%msg:F,58:2%\n"
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
+
 # Begin actual testcase
 startup
 tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem

--- a/tests/imtcp-tls-ossl-basic-verifydepth.sh
+++ b/tests/imtcp-tls-ossl-basic-verifydepth.sh
@@ -2,27 +2,24 @@
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=10000
+export NUMMESSAGES=1000
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
 	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
-#	debug.whitelist="on"
-#	debug.files=["nsd_ossl.c", "tcpsrv.c", "nsdsel_ossl.c", "nsdpoll_ptcp.c", "dnscache.c"]
 )
-
 module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Name="ossl"
+	StreamDriver.TlsVerifyDepth="5" 
 	StreamDriver.Mode="1"
-	StreamDriver.AuthMode="anon" )
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+	StreamDriver.AuthMode="x509/certvalid" )
+input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
 
-template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-:msg, contains, "msgnum:" action(	type="omfile" 
-					template="outfmt"
-					file=`echo $RSYSLOG_OUT_LOG`)
+$template outfmt,"%msg:F,58:2%\n"
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
+
 # Begin actual testcase
 startup
 tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem

--- a/tests/imtcp-tls-ossl-invalid-verifydepth.sh
+++ b/tests/imtcp-tls-ossl-invalid-verifydepth.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# add 2019-02-26 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="ossl"
+	streamdriver.TlsVerifyDepth="1" )
+input(	type="imtcp"
+	port="'$TCPFLOOD_PORT'" )
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "streamdriver.TlsVerifyDepth must be 2 or higher"
+
+exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -85,6 +85,7 @@ typedef struct _instanceData {
 	int iStrmDrvrMode;
 	int iStrmDrvrExtendedCertCheck; /* verify also purpose OID in certificate extended field */
 	int iStrmDrvrSANPreference; /* ignore CN when any SAN set */
+	int iStrmTlsVerifyDepth; /**< Verify Depth for certificate chains */
 	char	*target;
 	char	*address;
 	char	*device;
@@ -193,6 +194,7 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "streamdriverpermittedpeers", eCmdHdlrGetWord, 0 },
 	{ "streamdriver.CheckExtendedKeyPurpose", eCmdHdlrBinary, 0 },
 	{ "streamdriver.PrioritizeSAN", eCmdHdlrBinary, 0 },
+	{ "streamdriver.TlsVerifyDepth", eCmdHdlrPositiveInt, 0 },
 	{ "resendlastmsgonreconnect", eCmdHdlrBinary, 0 },
 	{ "udp.sendtoall", eCmdHdlrBinary, 0 },
 	{ "udp.senddelay", eCmdHdlrInt, 0 },
@@ -754,6 +756,7 @@ static rsRetVal TCPSendInit(void *pvData)
 		CHKiRet(netstrm.SetDrvrMode(pWrkrData->pNetstrm, pData->iStrmDrvrMode));
 		CHKiRet(netstrm.SetDrvrCheckExtendedKeyUsage(pWrkrData->pNetstrm, pData->iStrmDrvrExtendedCertCheck));
 		CHKiRet(netstrm.SetDrvrPrioritizeSAN(pWrkrData->pNetstrm, pData->iStrmDrvrSANPreference));
+		CHKiRet(netstrm.SetDrvrTlsVerifyDepth(pWrkrData->pNetstrm, pData->iStrmTlsVerifyDepth));
 		/* now set optional params, but only if they were actually configured */
 		if(pData->pszStrmDrvrAuthMode != NULL) {
 			CHKiRet(netstrm.SetDrvrAuthMode(pWrkrData->pNetstrm, pData->pszStrmDrvrAuthMode));
@@ -1127,6 +1130,7 @@ setInstParamDefaults(instanceData *pData)
 	pData->iStrmDrvrMode = 0;
 	pData->iStrmDrvrExtendedCertCheck = 0;
 	pData->iStrmDrvrSANPreference = 0;
+	pData->iStrmTlsVerifyDepth = 0;
 	pData->iRebindInterval = 0;
 	pData->bKeepAlive = 0;
 	pData->iKeepAliveProbes = 0;
@@ -1232,6 +1236,13 @@ CODESTARTnewActInst
 			pData->iStrmDrvrExtendedCertCheck = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.PrioritizeSAN")) {
 			pData->iStrmDrvrSANPreference = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.TlsVerifyDepth")) {
+			if (pvals[i].val.d.n >= 2) {
+				pData->iStrmTlsVerifyDepth = pvals[i].val.d.n;
+			} else {
+				parser_errmsg("streamdriver.TlsVerifyDepth must be 2 or higher but is %d",
+									(int) pvals[i].val.d.n);
+			}
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriverauthmode")) {
 			pData->pszStrmDrvrAuthMode = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.permitexpiredcerts")) {


### PR DESCRIPTION
Support added in omfwd as instance parameter:
streamdriver.TlsVerifyDepth
Support added in imtcp as module parameter:
streamdriver.TlsVerifyDepth

Can be 2 or higher.
Support added into ossl driver

Parameter
streamdriver.TlsVerifyDepth

closes: https://github.com/rsyslog/rsyslog/issues/4035