### PR TITLE
omprog bugfix: unclean data type conversions

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -6,7 +6,7 @@
  *
  * File begun on 2009-04-01 by RGerhards
  *
- * Copyright 2009-2018 Adiscon GmbH.
+ * Copyright 2009-2020 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -326,14 +326,14 @@ waitForChild(instanceData *pData, childProcessCtx_t *pChildCtx)
 
 	if (ret == 0) {  /* timeout reached */
 		if (!pData->bKillUnresponsive) {
-			LogMsg(0, NO_ERRCODE, LOG_WARNING, "omprog: program '%s' (pid %d) did not terminate "
-					"within timeout (%ld ms); ignoring it", pData->szBinary, pChildCtx->pid,
-					pData->lCloseTimeout);
+			LogMsg(0, NO_ERRCODE, LOG_WARNING, "omprog: program '%s' (pid %ld) did not terminate "
+					"within timeout (%ld ms); ignoring it", pData->szBinary,
+					(long) pChildCtx->pid, pData->lCloseTimeout);
 			return;
 		}
 
-		LogMsg(0, NO_ERRCODE, LOG_WARNING, "omprog: program '%s' (pid %d) did not terminate "
-				"within timeout (%ld ms); killing it", pData->szBinary, pChildCtx->pid,
+		LogMsg(0, NO_ERRCODE, LOG_WARNING, "omprog: program '%s' (pid %ld) did not terminate "
+				"within timeout (%ld ms); killing it", pData->szBinary, (long) pChildCtx->pid,
 				pData->lCloseTimeout);
 		if (kill(pChildCtx->pid, SIGKILL) == -1) {
 			LogError(errno, RS_RET_SYS_ERR, "omprog: could not send SIGKILL to child process");
@@ -477,9 +477,9 @@ readStatus(instanceData *pData, childProcessCtx_t *pChildCtx)
 		}
 
 		if(numReady == 0) {  /* timeout reached */
-			LogMsg(0, RS_RET_TIMED_OUT, LOG_WARNING, "omprog: program '%s' (pid %d) did not respond "
-					"within timeout (%ld ms); will be restarted", pData->szBinary, pChildCtx->pid,
-					pData->lConfirmTimeout);
+			LogMsg(0, RS_RET_TIMED_OUT, LOG_WARNING, "omprog: program '%s' (pid %ld) did not respond "
+					"within timeout (%ld ms); will be restarted", pData->szBinary,
+					(long) pChildCtx->pid, pData->lConfirmTimeout);
 			terminateChild(pData, pChildCtx);
 			ABORT_FINALIZE(RS_RET_SUSPENDED);
 		}
@@ -494,8 +494,8 @@ readStatus(instanceData *pData, childProcessCtx_t *pChildCtx)
 		}
 
 		if(lenRead == 0) {
-			LogMsg(0, RS_RET_READ_ERR, LOG_WARNING, "omprog: program '%s' (pid %d) terminated; "
-					"will be restarted", pData->szBinary, pChildCtx->pid);
+			LogMsg(0, RS_RET_READ_ERR, LOG_WARNING, "omprog: program '%s' (pid %ld) terminated; "
+					"will be restarted", pData->szBinary, (long) pChildCtx->pid);
 			cleanupChild(pData, pChildCtx);
 			ABORT_FINALIZE(RS_RET_SUSPENDED);
 		}
@@ -1139,8 +1139,8 @@ BEGINdoHUP
 CODESTARTdoHUP
 	if(pData->bForceSingleInst && pData->iHUPForward != NO_HUP_FORWARD &&
 			pData->pSingleChildCtx->bIsRunning) {
-		DBGPRINTF("omprog: forwarding HUP to program '%s' (pid %d) as signal %d\n",
-				pData->szBinary, pData->pSingleChildCtx->pid, pData->iHUPForward);
+		DBGPRINTF("omprog: forwarding HUP to program '%s' (pid %ld) as signal %d\n",
+				pData->szBinary, (long) pData->pSingleChildCtx->pid, pData->iHUPForward);
 		kill(pData->pSingleChildCtx->pid, pData->iHUPForward);
 	}
 
@@ -1154,8 +1154,8 @@ BEGINdoHUPWrkr
 CODESTARTdoHUPWrkr
 	if(!pWrkrData->pData->bForceSingleInst && pWrkrData->pData->iHUPForward != NO_HUP_FORWARD &&
 	 		pWrkrData->pChildCtx->bIsRunning) {
-		DBGPRINTF("omprog: forwarding HUP to program '%s' (pid %d) as signal %d\n",
-				pWrkrData->pData->szBinary, pWrkrData->pChildCtx->pid,
+		DBGPRINTF("omprog: forwarding HUP to program '%s' (pid %ld) as signal %d\n",
+				pWrkrData->pData->szBinary, (long) pWrkrData->pChildCtx->pid,
 				pWrkrData->pData->iHUPForward);
 		kill(pWrkrData->pChildCtx->pid, pWrkrData->pData->iHUPForward);
 	}


### PR DESCRIPTION
breaks compilation e.g. on Solaris 10 with gcc

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
