### PR TITLE
imtcp: add legacy directive $inputtcpserverlistenportfile

### DIFF
--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -107,6 +107,7 @@ static struct configSettings_s {
 	uchar *pszInputName;
 	uchar *pszBindRuleset;
 	uchar *lstnIP;			/* which IP we should listen on? */
+	uchar *lstnPortFile;
 } cs;
 
 struct instanceConf_s {
@@ -335,6 +336,11 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 		inst->pszBindAddr = NULL;
 	} else {
 		CHKmalloc(inst->pszBindAddr = ustrdup(cs.lstnIP));
+	}
+	if((cs.lstnPortFile == NULL) || (cs.lstnPortFile[0] == '\0')) {
+		inst->pszBindAddr = NULL;
+	} else {
+		CHKmalloc(inst->pszLstnPortFileName = ustrdup(cs.lstnPortFile));
 	}
 
 	if((cs.pszInputName == NULL) || (cs.pszInputName[0] == '\0')) {
@@ -774,6 +780,8 @@ resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unus
 	free(cs.pszStrmDrvrAuthMode);
 	cs.pszStrmDrvrAuthMode = NULL;
 	cs.bPreserveCase = 1;
+	free(cs.lstnPortFile);
+	cs.lstnPortFile = NULL;
 	return RS_RET_OK;
 }
 
@@ -842,9 +850,8 @@ CODEmodInit_QueryRegCFSLineHdlr
 			   NULL, &cs.iStrmDrvrMode, STD_LOADABLE_MODULE_ID, &bLegacyCnfModGlobalsPermitted));
 	CHKiRet(regCfSysLineHdlr2(UCHAR_CONSTANT("inputtcpserverpreservecase"), 1, eCmdHdlrBinary,
 			   NULL, &cs.bPreserveCase, STD_LOADABLE_MODULE_ID, &bLegacyCnfModGlobalsPermitted));
+	CHKiRet(regCfSysLineHdlr2(UCHAR_CONSTANT("inputtcpserverlistenportfile"), 1, eCmdHdlrGetWord,
+			   NULL, &cs.lstnPortFile, STD_LOADABLE_MODULE_ID, &bLegacyCnfModGlobalsPermitted));
 	CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("resetconfigvariables"), 1, eCmdHdlrCustomHandler,
 				   resetConfigVariables, NULL, STD_LOADABLE_MODULE_ID));
 ENDmodInit
-
-/* vim:set ai:
- */

--- a/tests/asynwr_deadlock2.sh
+++ b/tests/asynwr_deadlock2.sh
@@ -53,11 +53,13 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export CI_SHUTDOWN_QUEUE_EMPTY_CHECKS=20 # this test is notoriously slow...
+export ASSIGN_TCPFLOOD_PORT_FROM_FILE=YES
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
-$InputTCPServerRun '$TCPFLOOD_PORT'
+$InputTCPServerListenPortFile '$RSYSLOG_DYNNAME'.tcpflood_port
+$InputTCPServerRun 0
 
 $template outfmt,"%msg:F,58:3%,%msg:F,58:4%,%msg:F,58:5%\n"
 $template dynfile,"'$RSYSLOG_DYNNAME'.%msg:F,58:2%.log" # use multiple dynafiles

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -480,6 +480,9 @@ reassign_ports() {
 	if grep -q 'listenPortFileName="'$RSYSLOG_DYNNAME'\.tcpflood_port"' $CONF_FILE; then
 		assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 	fi
+	if [ "$ASSIGN_TCPFLOOD_PORT_FROM_FILE" = "YES" ] ; then
+		assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+	fi
 }
 
 # start rsyslogd with default params. $1 is the config file name to use


### PR DESCRIPTION
This is added for testbench use - we need it to harden tests that
need to test legacy syntax.

The new directive is NOT intended for users. Thus it is intentionally
NOT DOCUMENTED.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
