### PR TITLE
testbench: fix races in old-style tests

### DIFF
--- a/tests/imtcp-tls-basic-verifydepth.sh
+++ b/tests/imtcp-tls-basic-verifydepth.sh
@@ -15,7 +15,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.TlsVerifyDepth="5" 
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="x509/certvalid" )
-input(	type="imtcp" port="'$TCPFLOOD_PORT'" )
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
@@ -24,7 +24,6 @@ $template outfmt,"%msg:F,58:2%\n"
 # Begin actual testcase
 startup
 tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
-wait_file_lines
 shutdown_when_empty
 wait_shutdown
 seq_check

--- a/tests/imtcp-tls-ossl-invalid-verifydepth.sh
+++ b/tests/imtcp-tls-ossl-invalid-verifydepth.sh
@@ -6,9 +6,9 @@ add_conf '
 module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Name="ossl"
 	streamdriver.TlsVerifyDepth="1" )
-input(	type="imtcp"
-	port="'$TCPFLOOD_PORT'" )
 
+# input is not really needed, just given for completeness
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 


### PR DESCRIPTION
these were introduced with commit fcffb063e just recently

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
