### PR TITLE
CI: add script to do a full CI run

### DIFF
--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -4,10 +4,21 @@
 # Note: command line parameters are passed as parameters to the container,
 # with the notable exception that -ti, if given as first parameter, is
 # passed to "docker run" itself but NOT the container.
+#
+# use env var DOCKER_RUN_EXTRA_OPTS to provide extra options to docker run
+# command.
 set -e
-
+if [ "$1" == "--rm" ]; then
+	optrm="--rm"
+	shift 1
+fi
 if [ "$1" == "-ti" ]; then
 	ti="-ti"
+	shift 1
+fi
+# check in case -ti was in front...
+if [ "$1" == "--rm" ]; then
+	optrm="--rm"
 	shift 1
 fi
 
@@ -23,10 +34,23 @@ fi
 printf "/rsyslog is mapped to $RSYSLOG_HOME\n"
 printf "pulling container...\n"
 docker pull $RSYSLOG_DEV_CONTAINER
-docker run $ti \
+docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-u $(id -u):$(id -g) \
 	-e RSYSLOG_CONFIGURE_OPTIONS_EXTRA \
+	-e RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE \
 	-e CC \
 	-e CFLAGS \
+	-e LDFLAGS \
+	-e CI_MAKE_OPT \
+	-e CI_MAKE_CHECK_OPT \
+	-e CI_CHECK_CMD \
+	-e CI_BUILD_URL \
+	-e CI_CODECOV_TOKEN \
+	-e CI_VALGRIND_SUPPRESSIONS \
+	-e USE_AUTO_DEBUG \
+	-e RSYSLOG_STATSURL \
+	-e VCS_SLUG \
+	--cap-add SYS_ADMIN \
+	--cap-add SYS_PTRACE \
 	$DOCKER_RUN_EXTRA_FLAGS \
 	-v "$RSYSLOG_HOME":/rsyslog $RSYSLOG_DEV_CONTAINER $*

--- a/devtools/run-ci.sh
+++ b/devtools/run-ci.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# script for generic CI runs via container
+printf 'running CI with\n'
+printf 'container: %s\n' $RSYSLOG_DEV_CONTAINER
+printf 'CC:\t%s\n' "$CC"
+printf 'CFLAGS:\t%s:\n' "$CFLAGS"
+printf 'RSYSLOG_CONFIGURE_OPTIONS:\t%s\n' "$RSYSLOG_CONFIGURE_OPTIONS"
+if [ "$CI_VALGRIND_SUPPRESSIONS" != "" ]; then
+	export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=$(pwd)/tests/CI/$CI_VALGRIND_SUPPRESSIONS"
+fi
+set -e
+
+printf 'STEP: autoreconf / configure ===============================================\n'
+devtools/run-configure.sh
+
+printf 'STEP: make =================================================================\n'
+make $CI_MAKE_OPT
+
+printf 'STEP: make %s ==============================================================\n', \
+	"$CI_CHECK_CMD"
+set +e
+echo CI_CHECK_CMD: $CI_CHECK_CMD
+make $CI_MAKE_CHECK_OPT ${CI_CHECK_CMD:-check}
+rc=$?
+
+printf 'STEP: Codecov upload =======================================================\n'
+if [ "$CI_CODECOV_TOKEN" != "" ]; then
+	curl -s https://codecov.io/bash >codecov.sh
+	chmod +x codecov.sh
+	./codecov.sh -t "$CI_CODECOV_TOKEN" -n 'rsyslog buildbot PR'
+	rm codecov.sh
+fi
+
+exit $rc

--- a/devtools/run-configure.sh
+++ b/devtools/run-configure.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 printf "running configure with\nCC:\t$CC\nCFLAGS:\t$CFLAGS\n"
+if [ "$RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE" != "" ]; then
+	RSYSLOG_CONFIGURE_OPTIONS="$RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE"
+fi
+
 export CONFIGURE_OPTS_OVERRIDE=
 grep "sanitize.*=.*address" <<< "$CFLAGS" >/dev/null
 if [ $? -eq 0 ]; then

--- a/tests/clickhouse-start.sh
+++ b/tests/clickhouse-start.sh
@@ -5,6 +5,7 @@
 # Copyright (C) 2018 Pascal Withopf and Adiscon GmbH
 # Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+set -x
 if [ "$CLICKHOUSE_START_CMD" == "" ]; then
 	exit_test # no start needed
 fi


### PR DESCRIPTION
The core ID is to use this script together with pretty generic
buildbot workers. This provides a simple way to load-balance
across the worker pool.
