### PR TITLE
omfwd: parameter streamdriver.permitexpiredcerts did not work

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -188,6 +188,7 @@ TESTS +=  \
 	nested-call-shutdown.sh \
 	dnscache-TTL-0.sh \
 	invalid_nested_include.sh \
+	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omusrmsg-noabort-legacy.sh \
 	omusrmsg-errmsg-no-params.sh \
@@ -1730,6 +1731,7 @@ EXTRA_DIST= \
 	rscript_set_modify.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
+	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omfile_hup-vg.sh \
 	gzipwr_hup-vg.sh \

--- a/tests/omfwd-tls-invalid-permitExpiredCerts.sh
+++ b/tests/omfwd-tls-invalid-permitExpiredCerts.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# add 2020-01-08 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+action(type="omfwd" target="localhost" port="514" streamdriver.permitexpiredcerts="invld")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check "streamdriver.permitExpiredCerts must be 'warn', 'off' or 'on' but is 'invld'"
+exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -192,6 +192,7 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "streamdrivermode", eCmdHdlrInt, 0 },
 	{ "streamdriverauthmode", eCmdHdlrGetWord, 0 },
 	{ "streamdriverpermittedpeers", eCmdHdlrGetWord, 0 },
+	{ "streamdriver.permitexpiredcerts", eCmdHdlrGetWord, 0 },
 	{ "streamdriver.CheckExtendedKeyPurpose", eCmdHdlrBinary, 0 },
 	{ "streamdriver.PrioritizeSAN", eCmdHdlrBinary, 0 },
 	{ "streamdriver.TlsVerifyDepth", eCmdHdlrPositiveInt, 0 },
@@ -1246,7 +1247,17 @@ CODESTARTnewActInst
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriverauthmode")) {
 			pData->pszStrmDrvrAuthMode = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
-			pData->pszStrmDrvrPermitExpiredCerts = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			uchar *val = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			if(   es_strcasebufcmp(pvals[i].val.d.estr, (uchar*)"off", 3)
+			   && es_strcasebufcmp(pvals[i].val.d.estr, (uchar*)"on", 2)
+			   && es_strcasebufcmp(pvals[i].val.d.estr, (uchar*)"warn", 4)
+			  ) {
+				parser_errmsg("streamdriver.permitExpiredCerts must be 'warn', 'off' or 'on' "
+					"but is '%s' - ignoring parameter, using 'off' instead.", val);
+				free(val);
+			} else {
+				pData->pszStrmDrvrPermitExpiredCerts = val;
+			}
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriverpermittedpeers")) {
 			uchar *start, *str;
 			uchar *p;


### PR DESCRIPTION
This commit

- fixes the issue
- adds tests to ensure the parameter is understood
- refactors the code a bit to do the check at the upper layer

closes https://github.com/rsyslog/rsyslog/issues/4098

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
