### PR TITLE
satisfy-gcc-flag-fno-common

### DIFF
--- a/tools/omfile.h
+++ b/tools/omfile.h
@@ -32,7 +32,7 @@ rsRetVal modInitFile(int iIFVersRequested __attribute__((unused)), int *ipIFVers
  * other way to have the functionality (well, one way would be to go through the
  * globals, but that seems not yet justified. -- rgerhards, 2010-03-01
  */
-uchar	*pszFileDfltTplName;
+extern uchar	*pszFileDfltTplName;
 #endif /* #ifndef OMFILE_H_INCLUDED */
 /* vi:set ai:
  */


### PR DESCRIPTION
Porting advice for gcc 10:

A common mistake in C is omitting <code>extern</code> when declaring a global
variable in a header file.  If the header is included by several files it
results in multiple definitions of the same variable.  In previous GCC versions
this error is ignored.  GCC 10 defaults to <code>-fno-common</code>, which
means a linker error will now be reported. To fix this, use <code>extern</code>
in header files when declaring global variables, and ensure each global is
defined in exactly one C file. As a workaround, legacy C code can be compiled
with -fcommon.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
