### PR TITLE
Dynafile + async KSI module bugfix

### DIFF
--- a/runtime/lib_ksils12.h
+++ b/runtime/lib_ksils12.h
@@ -91,8 +91,12 @@ struct rsksictx_s {
 	pthread_t signer_thread;
 	ProtectedQueue *signer_queue;
 	bool thread_started;
-	uint8_t disabled; /* permits to disable the plugin --> set to 1 */
-	ksifile ksi;
+	uint8_t disabled;	/* permits to disable the plugin --> set to 1 */
+
+	ksifile *ksi;		/* List of signature files for keeping track of block timeouts. */
+	size_t ksiCapacity;
+	size_t ksiCount;
+
 	char *debugFileName;
 	int debugLevel;
 	FILE *debugFile;
@@ -130,6 +134,7 @@ struct ksifile_s {
 	KSI_DataHash *roots[MAX_ROOTS];
 	/* data members for the associated TLV file */
 	FILE *blockFile;
+	FILE *sigFile;	/* Note that this may only be closed by signer thread or when signer thread has terminated. */
 	rsksictx ctx;
 };
 


### PR DESCRIPTION
Bugfix: KSI module + dynafile in asynchronous mode fixed. KSI module kept just 1 signature file in focus and some of files were not closed. There was possibility that multiple KSI signatures of separate log files were stored in a single signature file. Also the block timeout was measured for one log file.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use



--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
