### PR TITLE
CI: emit failed test info to file failed-tests.log

### DIFF
--- a/devtools/run-ci.sh
+++ b/devtools/run-ci.sh
@@ -5,6 +5,7 @@ printf 'container: %s\n' $RSYSLOG_DEV_CONTAINER
 printf 'CC:\t%s\n' "$CC"
 printf 'CFLAGS:\t%s:\n' "$CFLAGS"
 printf 'RSYSLOG_CONFIGURE_OPTIONS:\t%s\n' "$RSYSLOG_CONFIGURE_OPTIONS"
+printf 'working directory: %s\n' "$(pwd)"
 if [ "$CI_VALGRIND_SUPPRESSIONS" != "" ]; then
 	export RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--suppressions=$(pwd)/tests/CI/$CI_VALGRIND_SUPPRESSIONS"
 fi
@@ -22,6 +23,10 @@ set +e
 echo CI_CHECK_CMD: $CI_CHECK_CMD
 make $CI_MAKE_CHECK_OPT ${CI_CHECK_CMD:-check}
 rc=$?
+
+# find failing tests
+echo find failing tests
+find . -name "*.trs" -exec bash -c 'if grep ":test-result: FAIL" "$1"; then printf "FAIL: ${1%%.trs} ################################################\\n" >> failed-tests.log; cat "${1%%trs}log"  >> failed-tests.log; fi' _ {} \;
 
 printf 'STEP: Codecov upload =======================================================\n'
 if [ "$CI_CODECOV_TOKEN" != "" ]; then


### PR DESCRIPTION
this makes reviewing failures easier, especially if there are many SKIPped
tests involved

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
