### PR TITLE
tooling: pass additional environment vars to dev container

### DIFF
--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -31,8 +31,9 @@ if [ -z "$RSYSLOG_DEV_CONTAINER" ]; then
 	RSYSLOG_DEV_CONTAINER=$(cat $RSYSLOG_HOME/devtools/default_dev_container)
 fi
 
-printf "/rsyslog is mapped to $RSYSLOG_HOME\n"
-printf "pulling container...\n"
+printf '/rsyslog is mapped to %s \n' "$RSYSLOG_HOME"
+printf 'pulling container...\n'
+printf 'user ids: %s:%s\n' $(id -u) $(id -g)
 docker pull $RSYSLOG_DEV_CONTAINER
 docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-u $(id -u):$(id -g) \
@@ -41,12 +42,16 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e CC \
 	-e CFLAGS \
 	-e LDFLAGS \
+	-e LSAN_OPTIONS \
+	-e TSAN_OPTIONS \
+	-e UBSAN_OPTIONS \
 	-e CI_MAKE_OPT \
 	-e CI_MAKE_CHECK_OPT \
 	-e CI_CHECK_CMD \
 	-e CI_BUILD_URL \
 	-e CI_CODECOV_TOKEN \
 	-e CI_VALGRIND_SUPPRESSIONS \
+	-e ABORT_ALL_ON_TEST_FAIL \
 	-e USE_AUTO_DEBUG \
 	-e RSYSLOG_STATSURL \
 	-e VCS_SLUG \


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
