### PR TITLE
build system: change --enable-imfile-tests default to "yes"

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -559,6 +559,12 @@ if ENABLE_IMFILE
 DISTCHECK_CONFIGURE_FLAGS+= --enable-imfile
 endif
 
+if ENABLE_IMFILE_TESTS
+DISTCHECK_CONFIGURE_FLAGS+= --enable-imfile-tests
+else
+DISTCHECK_CONFIGURE_FLAGS+= --disable-imfile-tests
+endif
+
 if ENABLE_IMDOCKER
 DISTCHECK_CONFIGURE_FLAGS+= --enable-imdocker
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -1723,15 +1723,20 @@ fi
 AM_CONDITIONAL(ENABLE_IMFILE, test x$enable_imfile = xyes)
 
 AC_ARG_ENABLE(imfile-tests,
-        [AS_HELP_STRING([--enable-imfile-tests],[Enable imfile tests @<:@default=no@:>@])],
+        [AS_HELP_STRING([--enable-imfile-tests],[Enable imfile tests @<:@default=yes@:>@])],
         [case "${enableval}" in
          yes) enable_imfile_tests="yes" ;;
           no) enable_imfile_tests="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-imfile-tests) ;;
          esac],
-        [enable_file_tests=no]
+        [enable_imfile_tests=yes]
 )
+if  [[ "$enable_imfile_tests" == "yes" ]] && [[ "$enable_imfile" != "yes" ]]; then
+		AC_MSG_WARN([imfile-tests can not be enabled without imfile support. Disabling imfile tests...])
+		enable_imfile_tests="no"
+fi
 AM_CONDITIONAL(ENABLE_IMFILE_TESTS, test x$enable_imfile_tests = xyes)
+
 
 # settings for the docker log input module
 AC_ARG_ENABLE(imdocker,
@@ -2692,6 +2697,7 @@ echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"
 echo "    Kafka Tests enabled:                      $enable_kafka_tests"
 echo "    Imdocker Tests enabled:                   $enable_imdocker_tests"
 echo "    gnutls tests enabled:                     $enable_gnutls_tests"
+echo "    imfile tests enabled:                     $enable_imfile_tests"
 echo "    systemd journal tests enabled:            $enable_journal_tests"
 echo "    SNMP Tests enabled:                       $enable_snmp_tests"
 echo "    Debug mode enabled:                       $enable_debug"

--- a/devtools/gather-check-logs.sh
+++ b/devtools/gather-check-logs.sh
@@ -8,24 +8,20 @@ show_log() {
 		printf "\nFAIL: ${1%%.trs} \
 		########################################################\
 		################################\n\n"
-		# we emit info only for test log files - this means there must
-		# be a matching .sh file by our conventions
-		if [ -f "${1%%trs}sh" ]; then
-			logfile="${1%%trs}log"
-			if [ -f "$logfile" ]; then
-				lines="$(wc -l < $logfile)"
-				if (( lines > 4000 )); then
-					ls -l $logfile
-					printf 'file is very large (%d lines), showing parts\n' $lines
-					head -n 2000 < "$logfile"
-					printf '\n\n... snip ...\n\n'
-					tail -n 2000 < "$logfile"
-				else
-					cat "$logfile"
-				fi
+		logfile="${1%%trs}log"
+		if [ -f "$logfile" ]; then
+			lines="$(wc -l < $logfile)"
+			if (( lines > 4000 )); then
+				ls -l $logfile
+				printf 'file is very large (%d lines), showing parts\n' $lines
+				head -n 2000 < "$logfile"
+				printf '\n\n... snip ...\n\n'
+				tail -n 2000 < "$logfile"
 			else
-				printf 'log FILE MISSING!\n'
+				cat "$logfile"
 			fi
+		else
+			printf 'log FILE MISSING!\n'
 		fi
 	fi
 }
@@ -41,11 +37,15 @@ check_incomplete_logs() {
 	if grep -q "\.dep_wrk\|rstb_\|config.log" <<<"$1"; then
 		return
 	fi
-	trsfile="${1%%log}trs"
-	if [ ! -f "$trsfile" ]; then
-		printf '\n\nNo matching .trs file for %s\n' "$1"
-		ls -l ${1%%.log}*
-		cat "$1"
+	# we emit info only for test log files - this means there must
+	# be a matching .sh file by our conventions
+	if [ -f "${1%%log}sh" ]; then
+		trsfile="${1%%log}trs"
+		if [ ! -f "$trsfile" ]; then
+			printf '\n\nNo matching .trs file for %s\n' "$1"
+			ls -l ${1%%.log}*
+			cat "$1"
+		fi
 	fi
 }
 export -f show_log

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2210,6 +2210,8 @@ EXTRA_DIST= \
 	imfile-endregex-timeout-none.sh \
 	imfile-endregex-timeout-with-shutdown.sh \
 	imfile-endregex-timeout-with-shutdown-polling.sh \
+	imfile-escapelf.replacement.sh \
+	imfile-escapelf.replacement-empty.sh \
 	imfile-endmsg.regex.sh \
 	imfile-endmsg.regex-vg.sh \
 	imfile-endmsg.regex-with-example.sh \

--- a/tests/imfile-basic-vgthread.sh
+++ b/tests/imfile-basic-vgthread.sh
@@ -3,13 +3,12 @@
 . ${srcdir:=.}/diag.sh init
 skip_platform "FreeBSD" "This test currently does not work on FreeBSD."
 export NUMMESSAGES=50000
-
-grep '\.el6\.' <<< $(uname -a)
-if [ "$?" == "0" ]; then
-	echo "CentOS 6 detected, adding valgrind suppressions"
+if grep -q 'release 6\.' <<< "$(cat /etc/redhat-release 2>/dev/null)"; then
+	echo "RHEL/CentOS 6 detected, adding valgrind suppressions"
 	export RS_TEST_VALGRIND_EXTRA_OPTS="--suppressions=${srcdir}/imfile-basic-vgthread.supp"
 fi
 
+exit
 generate_conf
 add_conf '
 $ModLoad ../plugins/imfile/.libs/imfile
@@ -27,7 +26,7 @@ $template outfmt,"%msg:F,58:2%\n"
 
 # generate input file first. Note that rsyslog processes it as
 # soon as it start up (so the file should exist at that point).
-./inputfilegen -m 50000 > $RSYSLOG_DYNNAME.input
+./inputfilegen -m $NUMMESSAGES > $RSYSLOG_DYNNAME.input
 ls -l $RSYSLOG_DYNNAME.input
 
 startup_vgthread


### PR DESCRIPTION
This was accidentally set to "no". Test for imfile should by
default run when imfile is enabled.

see also https://github.com/rsyslog/rsyslog/issues/4120

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
