### PR TITLE
Enhancement: default type for elasticsearch >=7 compatability

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -2084,7 +2084,7 @@ CODESTARTnewActInst
 	if(pData->searchIndex == NULL)
 		pData->searchIndex = (uchar*) strdup("system");
 	if(pData->searchType == NULL)
-		pData->searchType = (uchar*) strdup("events");
+		pData->searchType = (uchar*) strdup("_doc");
 
 	if ((pData->writeOperation != ES_WRITE_INDEX) && (pData->bulkId == NULL)) {
 		LogError(0, RS_RET_CONFIG_ERROR,


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html
```
Elasticsearch 7.x
 Specifying types in requests is deprecated. ....
Note that in 7.0, _doc is a permanent part of the path, 
and represents the endpoint name rather than the document type.
```