### PR TITLE
imdiag: reduce verbosenes in shutdown queue size reporting

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -5,7 +5,7 @@
  *
  * File begun on 2008-07-25 by RGerhards
  *
- * Copyright 2008-2018 Adiscon GmbH.
+ * Copyright 2008-2020 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -316,6 +316,7 @@ waitMainQEmpty(tcps_sess_t *pSess)
 {
 	int iPrint = 0;
 	int nempty = 0;
+	static unsigned lastOverallQueueSize = 1;
 	DEFiRet;
 
 	while(1) {
@@ -331,7 +332,11 @@ waitMainQEmpty(tcps_sess_t *pSess)
 			nempty = 0;
 		}
 		if(dbgTimeoutToStderr) { /* we abuse this setting a bit ;-) */
-			fprintf(stderr, "imdiag: wait q_empty: qsize %d nempty %d\n", OverallQueueSize, nempty);
+			if(OverallQueueSize != lastOverallQueueSize) {
+				fprintf(stderr, "imdiag: wait q_empty: qsize %d nempty %d\n",
+					OverallQueueSize, nempty);
+				lastOverallQueueSize = OverallQueueSize;
+			}
 		}
 		if(nempty > max_empty_checks)
 			break;


### PR DESCRIPTION
Prevents too large test logs.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
