### PR TITLE
build system: add option --enable-gnutls-tests

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -473,6 +473,12 @@ if ENABLE_GNUTLS
 DISTCHECK_CONFIGURE_FLAGS+= --enable-gnutls
 endif
 
+if ENABLE_GNUTLS_TESTS
+DISTCHECK_CONFIGURE_FLAGS+= --enable-gnutls-tests
+else
+DISTCHECK_CONFIGURE_FLAGS+= --disable-gnutls-tests
+endif
+
 if ENABLE_OPENSSL
 DISTCHECK_CONFIGURE_FLAGS+= --enable-openssl
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -1057,6 +1057,27 @@ fi
 
 AM_CONDITIONAL(ENABLE_GNUTLS, test x$enable_gnutls = xyes)
 
+AC_ARG_ENABLE(gnutls-tests,
+        [AS_HELP_STRING([--enable-gnutls-tests],[Enable gnutls tests @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_gnutls_tests="yes" ;;
+          no) enable_gnutls_tests="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-gnutls-tests) ;;
+         esac],
+        [if [[ "$enable_gnutls" == "yes" ]]; then
+		enable_gnutls_tests=yes
+	else
+		enable_gnutls_tests=no
+	fi]
+)
+if  [[ "$enable_gnutls_tests" == "yes" ]] && [[ "$enable_gnutls" != "yes" ]]; then
+		AC_MSG_WARN([gnutls-tests can not be enabled without gnutls support. Disabling gnutls tests...])
+		enable_gnutls_tests="no"
+fi
+
+AM_CONDITIONAL(ENABLE_GNUTLS_TESTS, test x$enable_gnutls_tests = xyes)
+
+
 # libgcrypt support
 AC_ARG_ENABLE(libgcrypt,
         [AS_HELP_STRING([--enable-libgcrypt],[Enable log file encryption support (libgcrypt) @<:@default=yes@:>@])],
@@ -2670,6 +2691,7 @@ echo "    ClickHouse Tests:                         $enable_clickhouse_tests"
 echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"
 echo "    Kafka Tests enabled:                      $enable_kafka_tests"
 echo "    Imdocker Tests enabled:                   $enable_imdocker_tests"
+echo "    gnutls tests enabled:                     $enable_gnutls_tests"
 echo "    systemd journal tests enabled:            $enable_journal_tests"
 echo "    SNMP Tests enabled:                       $enable_snmp_tests"
 echo "    Debug mode enabled:                       $enable_debug"

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1141,7 +1141,7 @@ TESTS += \
 endif
 endif
 
-if ENABLE_GNUTLS
+if ENABLE_GNUTLS_TESTS
 TESTS +=  \
 	imtcp-tls-basic.sh \
 	imtcp-tls-basic-verifydepth.sh \
@@ -1196,7 +1196,7 @@ TESTS += \
 endif
 endif
 
-if ENABLE_GNUTLS
+if ENABLE_GNUTLS_TESTS
 if ENABLE_OPENSSL
 TESTS +=  \
 	sndrcv_tls_ossl_servercert_gtls_clientanon.sh \


### PR DESCRIPTION
This enables us to build GNUtls support but not necessarily
test it in CI. This is useful for some specialised subcomponent
test.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
