### PR TITLE
devtools: limit output codecov can generate

### DIFF
--- a/devtools/run-ci.sh
+++ b/devtools/run-ci.sh
@@ -41,8 +41,18 @@ printf 'STEP: Codecov upload ===================================================
 if [ "$CI_CODECOV_TOKEN" != "" ]; then
 	curl -s https://codecov.io/bash >codecov.sh
 	chmod +x codecov.sh
-	./codecov.sh -t "$CI_CODECOV_TOKEN" -n 'rsyslog buildbot PR'
+	./codecov.sh -t "$CI_CODECOV_TOKEN" -n 'rsyslog buildbot PR' &> codecov_log
 	rm codecov.sh
+	lines="$(wc -l < codecov_log)"
+	if (( lines > 3000 )); then
+		printf 'codecov log file is very large (%d lines), showing parts\n' $lines
+		head -n 1500 < codecov_log
+		printf '\n\n... snip ...\n\n'
+		tail -n 1500 < codecov_log
+	else
+		cat codecov_log
+	fi
+	rm codecov_log
 fi
 
 exit $rc


### PR DESCRIPTION
It looks like in some cases the codecov script generates execessive
output, which then causes buildbot to abort. This patch limits it
to a maximum of 3000 lines.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
