### PR TITLE
dev tooling: gather log files only for actual test logs

### DIFF
--- a/devtools/gather-check-logs.sh
+++ b/devtools/gather-check-logs.sh
@@ -8,20 +8,24 @@ show_log() {
 		printf "\nFAIL: ${1%%.trs} \
 		########################################################\
 		################################\n\n"
-		logfile="${1%%trs}log"
-		if [ -f "$logfile" ]; then
-			lines="$(wc -l < $logfile)"
-			if (( lines > 4000 )); then
-				ls -l $logfile
-				printf 'file is very large (%d lines), showing parts\n' $lines
-				head -n 2000 < "$logfile"
-				printf '\n\n... snip ...\n\n'
-				tail -n 2000 < "$logfile"
+		# we emit info only for test log files - this means there must
+		# be a matching .sh file by our conventions
+		if [ -f "${1%%trs}sh" ]; then
+			logfile="${1%%trs}log"
+			if [ -f "$logfile" ]; then
+				lines="$(wc -l < $logfile)"
+				if (( lines > 4000 )); then
+					ls -l $logfile
+					printf 'file is very large (%d lines), showing parts\n' $lines
+					head -n 2000 < "$logfile"
+					printf '\n\n... snip ...\n\n'
+					tail -n 2000 < "$logfile"
+				else
+					cat "$logfile"
+				fi
 			else
-				cat "$logfile"
+				printf 'log FILE MISSING!\n'
 			fi
-		else
-			printf 'log FILE MISSING!\n'
 		fi
 	fi
 }


### PR DESCRIPTION
the current tooling also picked up non-test logs

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
