### PR TITLE
testbench: create random test_id

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2486,7 +2486,7 @@ case $1 in
 			echo "hint: was init accidentally called twice?"
 			exit 2
 		fi
-		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))"
+		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 4 | head -n 1)"
 		export RSYSLOG_OUT_LOG="${RSYSLOG_DYNNAME}.out.log"
 		export RSYSLOG2_OUT_LOG="${RSYSLOG_DYNNAME}_2.out.log"
 		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!


### PR DESCRIPTION
We use the test_id to generate unique files during parallel
runs. So far we used a combination of ms-based timestamp and
hash test name. Practice shows that under some circumstances
the generated ids are not unique and thus test get file conflicts
and false positives.

This is now changed so that the test_id we add 4 bytes of random
data to the test ID. This is hopefully sufficient to make the IDs
of test runing in parallel unique.
