### PR TITLE
Fixed processing of 'cofig.enabled' directive

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -699,6 +699,23 @@ nvlstFindNameCStr(struct nvlst *lst, const char *const __restrict__ name)
 	return lst;
 }
 
+/* check if the nvlst is disabled, and mark config.enabled directive
+ * as used if it is not. Returns 1 if block is disabled, 0 otherwise.
+ */
+int nvlstChkDisabled(struct nvlst *lst)
+{
+	struct nvlst *valnode;
+
+	if((valnode = nvlstFindNameCStr(lst, "config.enabled")) != NULL) {
+		if(es_strbufcmp(valnode->val.d.estr, (unsigned char*) "on", 2)) {
+			return 1;
+		} else {
+			valnode->bUsed = 1;
+		}
+	}
+	return 0;
+}
+
 
 /* check if there are duplicate names inside a nvlst and emit
  * an error message, if so.
@@ -1204,23 +1221,6 @@ nvlstGetParams(struct nvlst *lst, struct cnfparamblk *params,
 		}
 		if(!nvlstGetParam(valnode, param, vals + i)) {
 			bInError = 1;
-		}
-	}
-
-	/* now config-system parameters (currently a bit hackish, as we
-	 * only have one...). -- rgerhards, 2018-01-24
-	 */
-	if((valnode = nvlstFindNameCStr(lst, "config.enabled")) != NULL) {
-		if(es_strbufcmp(valnode->val.d.estr, (unsigned char*) "on", 2)) {
-			dbgprintf("config object disabled by configuration\n");
-			/* flag all params as used to not emit error mssages */
-			bInError = 1;
-			struct nvlst *val;
-			for(val = lst; val != NULL ; val = val->next) {
-				val->bUsed = 1;
-			}
-		} else {
-			valnode->bUsed = 1;
 		}
 	}
 
@@ -4418,8 +4418,13 @@ cnfstmtNewAct(struct nvlst *lst)
 	struct cnfstmt* cnfstmt;
 	char namebuf[256];
 	rsRetVal localRet;
-	if((cnfstmt = cnfstmtNew(S_ACT)) == NULL)
+	if((cnfstmt = cnfstmtNew(S_ACT)) == NULL) {
 		goto done;
+	}
+	if (nvlstChkDisabled(lst)) {
+		dbgprintf("action disabled by configuration\n");
+		cnfstmt->nodetype = S_NOP;
+	}
 	localRet = actionNewInst(lst, &cnfstmt->d.act);
 	if(localRet == RS_RET_OK_WARN) {
 		parser_errmsg("warnings occured in file '%s' around line %d",
@@ -5281,6 +5286,11 @@ includeProcessCnf(struct nvlst *const lst)
 	if(lst == NULL) {
 		parser_errmsg("include() must have either 'file' or 'text' "
 			"parameter - ignored");
+		goto done;
+	}
+
+	if (nvlstChkDisabled(lst)) {
+		DBGPRINTF("include statement disabled\n");
 		goto done;
 	}
 

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -340,6 +340,7 @@ void nvlstDestruct(struct nvlst *lst);
 void nvlstPrint(struct nvlst *lst);
 void nvlstChkUnused(struct nvlst *lst);
 struct nvlst* nvlstFindName(struct nvlst *lst, es_str_t *name);
+int nvlstChkDisabled(struct nvlst *lst);
 struct cnfobj* cnfobjNew(enum cnfobjType objType, struct nvlst *lst);
 void cnfobjDestruct(struct cnfobj *o);
 void cnfobjPrint(struct cnfobj *o);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -438,6 +438,16 @@ cnfDoObj(struct cnfobj *const o)
 
 	dbgprintf("cnf:global:obj: ");
 	cnfobjPrint(o);
+
+	/* We need to check for object disabling as early as here to cover most
+	 * of them at once and avoid needless initializations
+	 * - jvymazal 2020-02-12
+	 */
+	if (nvlstChkDisabled(o->nvlst)) {
+		dbgprintf("object disabled by configuration\n");
+		return;
+	}
+
 	switch(o->objType) {
 	case CNFOBJ_GLOBAL:
 		glblProcessCnf(o);


### PR DESCRIPTION
Previously the directive was processed way too late which caused
false errors whenever it was set to 'off' and sometimes directive not
working at all.

closes #4033 

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
