### PR TITLE
testbench: increased max extra data length in tcpflood from 256 to 512KB

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1223,6 +1223,7 @@ TESTS += sndrcv_relp.sh \
 	 imrelp-oversizeMode-truncate.sh \
 	 imrelp-oversizeMode-accept.sh \
 	 imrelp-invld-tlslib.sh \
+	 imrelp-bigmessage.sh \
 	 omrelp-invld-tlslib.sh \
 	 sndrcv_relp_dflt_pt.sh \
 	 glbl-oversizeMsg-log.sh \
@@ -2061,6 +2062,7 @@ EXTRA_DIST= \
 	imrelp-oversizeMode-truncate.sh \
 	imrelp-oversizeMode-accept.sh \
 	imrelp-invld-tlslib.sh \
+	imrelp-bigmessage.sh \
 	omrelp-invld-tlslib.sh \
 	glbl-oversizeMsg-log.sh \
 	glbl-oversizeMsg-truncate.sh \

--- a/tests/imrelp-bigmessage.sh
+++ b/tests/imrelp-bigmessage.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# add 2020-02-11 by alorbach, released under ASL 2.0
+TEST_BYTES_EXPECTED=262152
+
+. ${srcdir:=.}/diag.sh init
+./have_relpSrvSetOversizeMode
+if [ $? -eq 1 ]; then
+  echo "imrelp parameter oversizeMode not available. Test stopped"
+  exit 77
+fi;
+generate_conf
+add_conf '
+global(
+	workDirectory="'$RSYSLOG_DYNNAME.spool'"
+	maxMessageSize="256k"
+)
+module(load="../plugins/imrelp/.libs/imrelp")
+input(
+	type="imrelp"
+	name="imrelp"
+	port="'$TCPFLOOD_PORT'"
+	ruleset="print"
+	MaxDataSize="260k"
+)
+#input(type="imrelp" port="'$TCPFLOOD_PORT'" maxdatasize="200" oversizeMode="accept")
+
+template(name="print_message" type="list"){
+	constant(value="inputname: ")
+	property(name="inputname")
+	constant(value=", strlen: ")
+	property(name="$!strlen")
+	constant(value=", message: ")
+	property(name="msg")
+	constant(value="\n")
+}
+ruleset(name="print") {
+	set $!strlen = strlen($msg);
+	action(
+		type="omfile" template="print_message"
+		file=`echo $RSYSLOG_OUT_LOG`
+	)
+#	action(
+#		type="omstdout"
+#		template="print_message"
+#	)
+}
+
+#template(name="outfmt" type="string" string="%msg%\n")
+#:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+#				 file=`echo $RSYSLOG_OUT_LOG`)
+
+'
+startup
+tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -m1 -d 262144
+# would also works well: 
+#	tcpflood -Trelp-plain -p'$TCPFLOOD_PORT' -R 1 -I "imrelp-bigmessage.log"
+shutdown_when_empty # shut down rsyslogd when done processing messages
+wait_shutdown
+
+# We need the ^-sign to symbolize the beginning and the $-sign to symbolize the end
+# because otherwise we won't know if it was truncated at the right length.
+
+content_check "inputname: imrelp, strlen: 262107, message:  msgnum:00000000:262144:"
+count=$(wc -c < $RSYSLOG_OUT_LOG)
+if [ $count -lt $TEST_BYTES_EXPECTED ]; then
+	echo
+	echo "FAIL: expected bytes count $count did not match $TEST_BYTES_EXPECTED. "
+	echo
+	echo "First 100 bytes of $RSYSLOG_OUT_LOG are: "
+	head -c 100 $RSYSLOG_OUT_LOG
+	echo 
+	echo "Last 100 bytes of $RSYSLOG_OUT_LOG are: "
+	tail -c 100 $RSYSLOG_OUT_LOG
+	error_exit 1
+else
+	echo "Found $count bytes in $RSYSLOG_OUT_LOG"
+fi
+
+exit_test

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -167,7 +167,7 @@ char *test_rs_strerror_r(int errnum, char *buf, size_t buflen) {
 #define NETTEST_INPUT_CONF_FILE "nettest.input.conf"
 /* name of input file, must match $IncludeConfig in .conf files */
 
-#define MAX_EXTRADATA_LEN 200*1024
+#define MAX_EXTRADATA_LEN 512*1024
 #define MAX_SENDBUF 2 * MAX_EXTRADATA_LEN
 #define MAX_RCVBUF 16 * 1024 + 1/* TLS RFC 8449: max size of buffer for message reception */
 


### PR DESCRIPTION
testbench: increased max extra data length in tcpflood from 256 to 512KB

Added a imrelp test for big messages (256KB).

closes: https://github.com/rsyslog/rsyslog/issues/4158
