### PR TITLE
openssl nsd driver: Switch to SSL_CTX_use_certificate_chain_file API

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -462,7 +462,7 @@ osslGlblInit(void)
 		osslLastSSLErrorMsg(0, NULL, LOG_ERR, "osslGlblInit");
 		ABORT_FINALIZE(RS_RET_TLS_CERT_ERR);
 	}
-	if(bHaveCert == 1 && SSL_CTX_use_certificate_file(ctx, certFile, SSL_FILETYPE_PEM) != 1) {
+	if(bHaveCert == 1 && SSL_CTX_use_certificate_chain_file(ctx, certFile) != 1) {
 		LogError(0, RS_RET_TLS_CERT_ERR, "Error: Certificate could not be accessed. "
 				"Check at least: 1) file path is correct, 2) file exist, "
 				"3) permissions are correct, 4) file content is correct. "

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1178,7 +1178,7 @@ initTLS(void)
 				" Is the file at the right path? And do we have the permissions?");
 		exit(1);
 	}
-	if(SSL_CTX_use_certificate_file(ctx, tlsCertFile, SSL_FILETYPE_PEM) != 1) {
+	if(SSL_CTX_use_certificate_chain_file(ctx, tlsCertFile) != 1) {
 		printf("tcpflood: error cert file could not be accessed -- have you mixed up key and certificate?\n");
 		printf("If in doubt, try swapping the files in -z/-Z\n");
 		printf("Certifcate is: '%s'\n", tlsCertFile);


### PR DESCRIPTION
Switched from SSL_CTX_use_certificate_file to SSL_CTX_use_certificate_chain_file
API for loading the certificate into the certificate store.

According to the openssl doc, the SSL_CTX_use_certificate_chain_file API has the
advantage that it can load the main certificate (First in the PEM) and many chain
certificates after that automatically.

See notes section for more:
https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_use_certificate_chain_file.html

closes: https://github.com/rsyslog/rsyslog/issues/4170
