### PR TITLE
improved pid checking and instance locking

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -158,6 +158,7 @@ TESTS +=  \
 	operatingstate-basic.sh \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \
+	running-startup-rejection.sh \
 	smtradfile.sh \
 	loadbalance.sh \
 	empty-hostname.sh \
@@ -1503,6 +1504,7 @@ EXTRA_DIST= \
 	operatingstate-basic.sh \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \
+	running-startup-rejection.sh \
 	internal-errmsg-memleak-vg.sh \
 	glbl-ruleset-queue-defaults.sh \
 	glbl-internalmsg_severity-info-shown.sh \

--- a/tests/killrsyslog.sh
+++ b/tests/killrsyslog.sh
@@ -3,14 +3,14 @@
 if [ -e "rsyslog.pid" ]
 then
   echo rsyslog.pid exists, trying to shut down rsyslogd process `cat rsyslog.pid`.
-  kill -9 `cat rsyslog.pid`
+  fuser -k -KILL rsyslog.pid.lock
   sleep 1
   rm rsyslog.pid
 fi
 if [ -e "rsyslog2.pid" ]
 then
   echo rsyslog2.pid exists, trying to shut down rsyslogd process `cat rsyslog2.pid`.
-  kill -9 `cat rsyslog2.pid`
+  fuser -k -KILL rsyslog2.pid.lock
   sleep 1
   rm rsyslog2.pid
 fi

--- a/tests/running-startup-rejection.sh
+++ b/tests/running-startup-rejection.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+# this test attempts to start a second running instance with the same pidfile
+
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+# NOTE: do NOT set a working directory!
+add_conf '
+module(load="../plugins/imfile/.libs/imfile")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" tag="file:")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "msgnum:" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+else
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.othermsgs")
+'
+
+# make sure file exists when rsyslog starts up
+touch $RSYSLOG_DYNNAME.input
+
+# the rejected session will log here
+REJECT_LOG="$RSYSLOG_DYNNAME.rejected_session.out"
+touch "$REJECT_LOG"
+
+startup
+RS_REDIR="> $REJECT_LOG 2>&1" startup_forced_second_instance
+
+# the failed attempt to start the instance should show up in the log
+wait_content "is locked by rsyslogd with valid lock file" $REJECT_LOG
+
+shutdown_immediate
+wait_shutdown
+exit_test


### PR DESCRIPTION
This is my first contribution, so I will introduce myself. My name is Jeff Marckel, and I have a considerable amount of experience as a C programmer on Linux systems that I would like to share back with the community.

This PR focuses on "PID checking and Instance Locking" that I feel should cover at least 2 open issues.

   https://github.com/rsyslog/rsyslog/issues/3892

   Here a user sees that a pidfile not tied to a running process can still
   block a new instance from starting. I believe that this is likely a case
   of #407, noted below, but some testing is required to exclude other issues.

   https://github.com/rsyslog/rsyslog/issues/407

   Here it is seen that pid re-use is an apparent vulnerability, where an
   unrelated process that just happens to get the pid that rsyslogd last used
   can block a new instance from starting.

In either case, the correct approach is to rely on using `fcntl()` to pass a `struct flock`, where any exclusive lock held by the dead process would be cleared by the system, meaning custom pid detection logic can be removed from the rsyslogd code entirely. From a brief examination of the code, it seems that there is also a race condition between checkStartupOK() and the creation of the actual pidfile in writePidFile(), which could pose a risk of multiple instances.

I implemented and have tested these changes, added a test to cover multiple instance startup of rsyslogd, and then used the new features of the lockfile to cross check the pidfile functionality in tests/diags.sh. I verified my testing on Travis. 

The pid validation function does not yet cause any tests to fail, but maybe that would be a good idea to turn on, but I did not know if it might cause problems for other tests. I have spot checked all tests I can and see good results. I am also thinking I will do more to take advantage of the lockfile to clean up diags.sh further, in terms of killing hung processes in a future PR. Feedback is welcome. 

Thank you,

Jeff

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
