### PR TITLE
imjournal: remove strcat call

### DIFF
--- a/tests/imjournal-statefile.sh
+++ b/tests/imjournal-statefile.sh
@@ -25,11 +25,22 @@ if [ $? -ne 0 ]; then
         echo "SKIP: failed to put test into journal."
         error_exit 77
 fi
-journalctl -an 200 | fgrep -qF "$TESTMSG"
+
+# sleep 1 to get this test to reliably detect the message
+sleep 1
+
+journalctl -an 200 > /dev/null 2>&1
 if [ $? -ne 0 ]; then
         echo "SKIP: cannot read journal."
         error_exit 77
 fi
+
+journalctl -an 200 | grep -qF "$TESTMSG"
+if [ $? -ne 0 ]; then
+        echo "SKIP: cannot find '$TESTMSG' in journal."
+        error_exit 77
+fi
+
 # do first run to process all the stuff already in journal db
 startup
 


### PR DESCRIPTION
Hello @rgerhards -

I noticed the #2133 issue and thought I would make a run at some of them.

This change removes usage of strcat call from the imjournal plugin. I also looked for sprintf and strcpy calls while I was in there. I do not like the code here too much even though it is safer from the buffer overrun perspective. The way it could truncate the last 4 bytes of a very long state file path with a short state file name might result in a hidden file - or worse  in some other directory completely. I thought it would be better to just mention what I saw though, since it is unrelated, and another can of worms entirely. Happy to write another bug if you wanted.

I also spent some time on the test, it is more stable for me now.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
