### PR TITLE
imsolaris: remove unsafe strcat, sprintf calls

### DIFF
--- a/plugins/imsolaris/sun_cddl.c
+++ b/plugins/imsolaris/sun_cddl.c
@@ -228,10 +228,12 @@ sun_open_door(void)
 				    info.di_target);
 
 				if (info.di_target > 0) {
-					(void) sprintf(line, "syslogd pid %ld"
-					    " already running. Cannot "
-					    "start another syslogd pid %ld",
-					    info.di_target, getpid());
+					(void) snprintf(line, sizeof(line),
+							"syslogd pid %ld "
+							"already running. Cannot "
+							"start another syslogd "
+							"pid %ld",
+							info.di_target, getpid());
 					DBGPRINTF("open_door: error: "
 					    "%s\n", line);
 					imsolaris_logerror(0, line);
@@ -303,7 +305,9 @@ sun_open_door(void)
 						    "error: %s, "
 						    "errno=%d\n",
 						    line, err);
-						(void) strcat(line, " - fatal");
+						const size_t n = strlen(line);
+						(void) strncat(line, " - fatal",
+								sizeof(line) - n);
 						imsolaris_logerror(err, line);
 						sun_delete_doorfiles();
 						exit(1);
@@ -330,7 +334,9 @@ sun_open_door(void)
 					DBGPRINTF("open_door: error: %s, "
 					    "errno=%d\n", line,
 					    err);
-					(void) strcat(line, " - fatal");
+					const size_t n = strlen(line);
+					(void) strncat(line, " - fatal",
+							sizeof(line) - n);
 					imsolaris_logerror(err, line);
 					sun_delete_doorfiles();
 					exit(1);
@@ -349,7 +355,8 @@ sun_open_door(void)
 		    DOOR_REFUSE_DESC)) < 0) {
 		    //???? DOOR_NO_CANEL requires newer libs??? DOOR_REFUSE_DESC | DOOR_NO_CANCEL)) < 0) {
 			err = errno;
-			(void) sprintf(line, "door_create() failed - fatal");
+			(void) snprintf(line, sizeof(line),
+					"door_create() failed - fatal");
 			DBGPRINTF("open_door: error: %s, errno=%d\n",
 			    line, err);
 			imsolaris_logerror(err, line);


### PR DESCRIPTION
Hi @rgerhards - this commit is very raw until it runs through some Solaris CI as I do not currently have development access to this OS platform.
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
