### PR TITLE
imfile: remove strcat, strcpy calls

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -710,7 +710,7 @@ act_obj_add(fs_edge_t *const edge, const char *const name, const int is_file,
 	char basename[MAXFNAME];
 	DEFiRet;
 	int fd = -1;
-	
+
 	DBGPRINTF("act_obj_add: edge %p, name '%s' (source '%s')\n", edge, name, source? source : "---");
 	for(act = edge->active ; act != NULL ; act = act->next) {
 		if(!strcmp(act->name, name)) {
@@ -1374,8 +1374,9 @@ enqLine(act_obj_t *const act,
 		size_t ceeMsgSize = msgLen + CONST_LEN_CEE_COOKIE + 1;
 		char *ceeMsg;
 		CHKmalloc(ceeMsg = malloc(ceeMsgSize));
-		strcpy(ceeMsg, CONST_CEE_COOKIE);
-		strcat(ceeMsg, (char*)rsCStrGetSzStrNoNULL(cstrLine));
+		snprintf(ceeMsg, ceeMsgSize, "%s%s", CONST_CEE_COOKIE,
+				(char*)rsCStrGetSzStrNoNULL(cstrLine));
+		DBGPRINTF("imfile: enqLine(): adding cee tag '%s'\n", ceeMsg);
 		MsgSetRawMsg(pMsg, ceeMsg, ceeMsgSize);
 		free(ceeMsg);
 	} else {
@@ -1761,6 +1762,7 @@ static rsRetVal ATTR_NONNULL()
 checkInstance(instanceConf_t *const inst)
 {
 	uchar curr_wd[MAXFNAME];
+	char *p_fname;
 	DEFiRet;
 
 	/* this is primarily for the clang static analyzer, but also
@@ -1789,8 +1791,9 @@ checkInstance(instanceConf_t *const inst)
 					inst->pszFileName);
 				ABORT_FINALIZE(RS_RET_ERR);
 			}
-			curr_wd[len_curr_wd] = '/';
-			strcpy((char*)curr_wd+len_curr_wd+1, (char*)inst->pszFileName);
+			p_fname = (char *)curr_wd + len_curr_wd;
+			const size_t p_fname_max = sizeof(curr_wd) - len_curr_wd;
+			snprintf(p_fname, p_fname_max, "/%s", (char*)inst->pszFileName);
 			free(inst->pszFileName);
 			CHKmalloc(inst->pszFileName = ustrdup(curr_wd));
 		}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1324,6 +1324,7 @@ endif
 if ENABLE_IMFILE_TESTS
 TESTS += \
 	imfile-basic.sh \
+	imfile-addceetag.sh \
 	imfile-basic-legacy.sh \
 	imfile-discard-truncated-line.sh \
 	imfile-truncate-line.sh \
@@ -2196,6 +2197,7 @@ EXTRA_DIST= \
 	imfile-endregex.sh \
 	imfile-endregex-vg.sh \
 	imfile-basic.sh \
+	imfile-addceetag.sh \
 	imfile-basic-legacy.sh \
 	imfile-basic-2GB-file.sh \
 	imfile-truncate-2GB-file.sh \

--- a/tests/imfile-addceetag.sh
+++ b/tests/imfile-addceetag.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=50000
+generate_conf
+# NOTE: do NOT set a working directory!
+add_conf '
+module(load="../plugins/imfile/.libs/imfile")
+input(type="imfile" File="./'$RSYSLOG_DYNNAME'.input" tag="file:" addceetag="on")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+if $msg contains "@cee:" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+else
+	action(type="omfile" file="'$RSYSLOG_DYNNAME'.othermsgs")
+'
+# make sure file exists when rsyslog starts up
+touch $RSYSLOG_DYNNAME.input
+startup
+./inputfilegen -m $NUMMESSAGES >> $RSYSLOG_DYNNAME.input
+wait_file_lines
+shutdown_when_empty
+wait_shutdown
+content_count_check "msgnum" $NUMMESSAGES
+content_check "imfile: no working or state file directory set" $RSYSLOG_DYNNAME.othermsgs
+exit_test


### PR DESCRIPTION
Hello @rgerhards - Related to issue #2133, in this PR I have removed uses of strcat and strcpy from the imfile plugin. I also added a new test which enables the imfile option addceetag, providing some coverage to the change. I ran the test with debug enabled, and examined logs to make sure that the changes were exercised.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
