### PR TITLE
queue subsystem: cap max queue size to 2^31-1

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3355,13 +3355,17 @@ qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst)
 					      "corrected to '%s'", pThis->pszSpoolDir);
 			}
 		} else if(!strcmp(pblk.descr[i].name, "queue.size")) {
-			pThis->iMaxQueueSize = pvals[i].val.d.n;
-			if(pThis->iMaxQueueSize > OVERSIZE_QUEUE_WATERMARK) {
+			if(pvals[i].val.d.n > 0x7fffffff) {
+				parser_warnmsg("queue.size higher than maximum (2147483647) - "
+					      "corrected to maximum");
+				pvals[i].val.d.n = 0x7fffffff;
+			} else if(pvals[i].val.d.n > OVERSIZE_QUEUE_WATERMARK) {
 				parser_warnmsg("queue.size=%d is very large - is this "
 					"really intended? More info at "
 					"https://www.rsyslog.com/avoid-overly-large-in-memory-queues/",
-					pThis->iMaxQueueSize);
+					(int) pvals[i].val.d.n);
 			}
+			pThis->iMaxQueueSize = pvals[i].val.d.n;
 		} else if(!strcmp(pblk.descr[i].name, "queue.dequeuebatchsize")) {
 			pThis->iDeqBatchSize = pvals[i].val.d.n;
 		} else if(!strcmp(pblk.descr[i].name, "queue.mindequeuebatchsize")) {


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/4192

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
