### PR TITLE
testbench: add some diagnostic info to analyze false positives

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -741,7 +741,7 @@ content_check_with_count() {
 				shutdown_when_empty ""
 				wait_shutdown ""
 
-				echo content_check_with_count failed, expected \"$1\" to occur $2 times, but found it "$count" times
+				echo "$(tb_timestamp)" content_check_with_count failed, expected \"$1\" to occur $2 times, but found it "$count" times
 				echo file $RSYSLOG_OUT_LOG content is:
 				if [ $(wc -l < "$RSYSLOG_OUT_LOG") -gt 10000 ]; then
 					printf 'truncation, we have %d lines, which is way too much\n' \
@@ -755,11 +755,13 @@ content_check_with_count() {
 				fi
 				error_exit 1
 			else
-				printf 'content_check_with_count have %d, wait for %d times (%d lines), msg: %s\n' \
-					"$count" "$2" $(wc -l < "$RSYSLOG_OUT_LOG") "$1"
+				printf '%s content_check_with_count have %d, wait for %d times (%d lines), msg: %s\n' \
+					"$(tb_timestamp)" "$count" "$2" $(wc -l < "$RSYSLOG_OUT_LOG") "$1"
 				$TESTTOOL_DIR/msleep 1000
 			fi
 		fi
+	printf '**** content_check_with_count DEBUG:\n' # rger: REMOVE ME when problems are fixed
+	cat -n "$RSYSLOG_OUT_LOG"
 	done
 }
 


### PR DESCRIPTION
We have some false positives with imfile checks and this commit
both improves the testbench framework slightly and adds debug
info.

The debug info should be remove when we finally find the cause
of the issue, but it does not hurt if it stays for a quite a
while. Thus we can analyze the false positives over an extended
period of time - what is what it looks like we need to do to
find the root cause.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
