### PR TITLE
testbench: adjust queue enqueue timeouts to current standards

### DIFF
--- a/tests/complex1.sh
+++ b/tests/complex1.sh
@@ -14,8 +14,6 @@ echo ports: $TCPFLOOD_PORT $RSYSLOG_PORT2 $RSYSLOG_PORT3
 add_conf '
 $MaxMessageSize 10k
 
-$MainMsgQueueTimeoutEnqueue 5000
-
 $ModLoad ../plugins/imtcp/.libs/imtcp
 $MainMsgQueueTimeoutShutdown 10000
 
@@ -26,7 +24,7 @@ $template dynfile,"'$RSYSLOG_DYNNAME'.out.%inputname%.%msg:F,58:2%.log.Z"
 $Ruleset R13514
 # queue params:
 $ActionQueueTimeoutShutdown 60000
-$ActionQueueTimeoutEnqueue 15000
+$ActionQueueTimeoutEnqueue 20000
 $ActionQueueSize 5000
 $ActionQueueSaveOnShutdown on
 $ActionQueueHighWaterMark 4900
@@ -50,7 +48,7 @@ $InputTCPServerRun '$TCPFLOOD_PORT'
 $Ruleset R_PORT2
 # queue params:
 $ActionQueueTimeoutShutdown 60000
-$ActionQueueTimeoutEnqueue 5000
+$ActionQueueTimeoutEnqueue 20000
 $ActionQueueSize 5000
 $ActionQueueSaveOnShutdown on
 $ActionQueueHighWaterMark 4900
@@ -76,7 +74,7 @@ $InputTCPServerRun '$RSYSLOG_PORT2'
 $Ruleset R_PORT3
 # queue params:
 $ActionQueueTimeoutShutdown 60000
-$ActionQueueTimeoutEnqueue 5000
+$ActionQueueTimeoutEnqueue 20000
 $ActionQueueSize 5000
 $ActionQueueSaveOnShutdown on
 $ActionQueueHighWaterMark 4900


### PR DESCRIPTION
Timeouts were too short to take care of slow CI environments.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
