### PR TITLE
Hardcoded default hash algorithm KSI_HASHALG_SHA2_256 replaced with

### DIFF
--- a/runtime/lib_ksils12.c
+++ b/runtime/lib_ksils12.c
@@ -830,7 +830,7 @@ rsksiCtxNew(void) {
 	ctx = calloc(1, sizeof (struct rsksictx_s));
 	KSI_CTX_new(&ctx->ksi_ctx); // TODO: error check (probably via a generic macro?)
 	ctx->hasher = NULL;
-	ctx->hashAlg = KSI_HASHALG_SHA2_256;
+	ctx->hashAlg = KSI_getHashAlgorithmByName("default");
 	ctx->blockTimeLimit = 0;
 	ctx->bKeepTreeHashes = false;
 	ctx->bKeepRecordHashes = true;
@@ -969,19 +969,23 @@ done:
 }
 
 
-/* returns 0 on succes, 1 if algo is unknown, 2 is algo has been remove
- * because it is now considered insecure
+/* Returns RSGTE_SUCCESS on success, error code otherwise. If algo is unknown or
+ * is not trusted, default hash function is used.
  */
 int
 rsksiSetHashFunction(rsksictx ctx, char *algName) {
+	if (ctx == NULL || algName == NULL) {
+		return RSGTE_INTERNAL;
+	}
+
 	int r, id = KSI_getHashAlgorithmByName(algName);
 	if (!KSI_isHashAlgorithmSupported(id)) {
 		report(ctx, "Hash function '%s' is not supported - using default", algName);
-		ctx->hashAlg = KSI_HASHALG_SHA2_256;
+		ctx->hashAlg = KSI_getHashAlgorithmByName("default");
 	} else {
 		if(!KSI_isHashAlgorithmTrusted(id)) {
 			report(ctx, "Hash function '%s' is not trusted - using default", algName);
-			ctx->hashAlg = KSI_HASHALG_SHA2_256;
+			ctx->hashAlg = KSI_getHashAlgorithmByName("default");
 		}
 		else
 			ctx->hashAlg = id;
@@ -990,9 +994,10 @@ rsksiSetHashFunction(rsksictx ctx, char *algName) {
 	if ((r = KSI_DataHasher_open(ctx->ksi_ctx, ctx->hashAlg, &ctx->hasher)) != KSI_OK) {
 		reportKSIAPIErr(ctx, NULL, "KSI_DataHasher_open", r);
 		ctx->disabled = true;
+		return r;
 	}
 
-	return 0;
+	return RSGTE_SUCCESS;
 }
 
 int
@@ -1000,11 +1005,11 @@ rsksiSetHmacFunction(rsksictx ctx, char *algName) {
 	int id = KSI_getHashAlgorithmByName(algName);
 	if (!KSI_isHashAlgorithmSupported(id)) {
 		report(ctx, "HMAC function '%s' is not supported - using default", algName);
-		ctx->hmacAlg = KSI_HASHALG_SHA2_256;
+		ctx->hmacAlg = KSI_getHashAlgorithmByName("default");
 	} else {
 		if(!KSI_isHashAlgorithmTrusted(id)) {
 			report(ctx, "HMAC function '%s' is not trusted - using default", algName);
-			ctx->hmacAlg = KSI_HASHALG_SHA2_256;
+			ctx->hmacAlg = KSI_getHashAlgorithmByName("default");
 		}
 		else
 			ctx->hmacAlg = id;

--- a/runtime/lmsig_ksi-ls12.c
+++ b/runtime/lmsig_ksi-ls12.c
@@ -214,14 +214,17 @@ SetCnfParam(void *pT, struct nvlst *lst)
 		}
 	}
 
-	if(rsksiSetHashFunction(pThis->ctx, hash ? hash : (char*) "SHA2-256") != KSI_OK)
-		goto finalize_it;
+	if(rsksiSetHashFunction(pThis->ctx, hash ? hash : (char*) "default") != KSI_OK) {
+		ABORT_FINALIZE(RS_RET_KSI_ERR);
+	}
 
-	if(rsksiSetHmacFunction(pThis->ctx, hmac ? hmac : (char*) "SHA2-256") != KSI_OK)
-		goto finalize_it;
+	if(rsksiSetHmacFunction(pThis->ctx, hmac ? hmac : (char*) "default") != KSI_OK) {
+		ABORT_FINALIZE(RS_RET_KSI_ERR);
+	}
 
-	if(rsksiSetAggregator(pThis->ctx, ag_uri, ag_loginid, ag_key) != KSI_OK)
-		goto finalize_it;
+	if(rsksiSetAggregator(pThis->ctx, ag_uri, ag_loginid, ag_key) != KSI_OK) {
+		ABORT_FINALIZE(RS_RET_KSI_ERR);
+	}
 
 finalize_it:
 	free(ag_uri);


### PR DESCRIPTION
KSI_getHashAlgorithmByName("default").

Function rsksiSetHashFunction and SetCnfParam updated.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
