### PR TITLE
When KSI module in async. mode is suddenly closed, files are finalized

### DIFF
--- a/runtime/lib_ksils12.c
+++ b/runtime/lib_ksils12.c
@@ -90,9 +90,14 @@ typedef enum QITEM_type_en {
 
 /* Worker queue item status identifier */
 typedef enum QITEM_status_en {
+	/* State assigned to any item added to queue (initial state). */
 	QITEM_WAITING = 0x00,
+
+	/* State assigned to #QITEM_SIGNATURE_REQUEST item when it is sent out. */
 	QITEM_SENT,
-	QITEM_DONE,
+
+	/* State assigned to #QITEM_SIGNATURE_REQUEST item when request failed or succeeded. */
+	QITEM_DONE
 } QITEM_status;
 
 
@@ -102,8 +107,8 @@ typedef struct QueueItem_st {
 	QITEM_status status;
 	KSI_DataHash *root;
 	FILE *file;				/* To keep track of the target signature file. */
-	uint64_t intarg1;
-	uint64_t intarg2;
+	uint64_t intarg1;		/* Block time limit or record count or not used. */
+	uint64_t intarg2;		/* Level of the sign request or not used. */
 	KSI_AsyncHandle *respHandle;
 	int ksi_status;
 	time_t request_time;
@@ -113,6 +118,7 @@ static bool queueAddCloseFile(rsksictx ctx, ksifile kf);
 static bool queueAddNewFile(rsksictx ctx, ksifile kf);
 static bool queueAddQuit(rsksictx ctx);
 static bool queueAddSignRequest(rsksictx ctx, ksifile kf, KSI_DataHash *root, unsigned level);
+static int sigblkFinishKSINoSignature(ksifile ksi, const char *reason);
 
 void *signer_thread(void *arg);
 
@@ -1045,7 +1051,7 @@ rsksifileDestruct(ksifile ksi) {
 	return r;
 }
 
-/* This can only be used when signer thread has terminated. */
+/* This can only be used when signer thread has terminated or within the thread. */
 static void
 rsksifileForceFree(ksifile ksi) {
 	if (ksi == NULL) return;
@@ -1059,7 +1065,7 @@ rsksifileForceFree(ksifile ksi) {
 	return;
 }
 
-/* This can only be used when signer thread has terminated. */
+/* This can only be used when signer thread has terminated or within the thread. */
 static void
 rsksictxForceFreeSignatures(rsksictx ctx) {
 	size_t i = 0;
@@ -1077,11 +1083,42 @@ rsksictxForceFreeSignatures(rsksictx ctx) {
 	return;
 }
 
+/* This can only be used when signer thread has terminated or within the thread. */
+static int
+rsksictxForceCloseWithoutSig(rsksictx ctx, const char *reason) {
+	size_t i = 0;
+	if (ctx == NULL || ctx->ksi == NULL) return RSGTE_INTERNAL;
+	for (i = 0; i < ctx->ksiCount; i++) {
+		if (ctx->ksi[i] != NULL) {
+			int ret = RSGTE_INTERNAL;
+
+			/* Only if block contains records, create metadata, close the block and add
+			 * no signature marker. Closing block without record will produce redundant
+			 * blocks that needs to be signed afterward.
+			 */
+			if (ctx->ksi[i]->nRecords > 0) {
+				ret = sigblkFinishKSINoSignature(ctx->ksi[i], reason);
+				if (ret != RSGTE_SUCCESS) return ret;
+			}
+
+			/* Free files and remove object from the list. */
+			rsksifileForceFree(ctx->ksi[i]);
+			ctx->ksi[i] = NULL;
+		}
+	}
+
+	ctx->ksiCount = 0;
+	return RSGTE_SUCCESS;
+}
+
 void
 rsksiCtxDel(rsksictx ctx) {
 	if (ctx == NULL)
 		return;
 
+	/* Note that even in sync. mode signer thread is created and needs to be closed
+	 * correctly.
+	 */
 	if (ctx->thread_started) {
 		queueAddQuit(ctx);
 		/* Wait until thread closes to be able to safely free the resources. */
@@ -1397,16 +1434,21 @@ sigblkCalcLevel(unsigned leaves) {
 	return level;
 }
 
-int
-sigblkFinishKSI(ksifile ksi)
-{
-	KSI_DataHash *root, *rootDel;
-	int8_t j;
-	int ret = 0;
-	unsigned level = 0;
+static int
+sigblkFinishTree(ksifile ksi, KSI_DataHash **hsh) {
+	int ret = RSGTE_INTERNAL;
+	KSI_DataHash *root = NULL;
+	KSI_DataHash *rootDel = NULL;
+	int8_t j = 0;
 
-	if (ksi->nRecords == 0)
+	if (ksi == NULL || hsh == NULL) {
 		goto done;
+	}
+
+	if (ksi->nRecords == 0) {
+		ret = RSGTE_SUCCESS;
+		goto done;
+	}
 
 	root = NULL;
 	for(j = 0 ; j < ksi->nRoots ; ++j) {
@@ -1415,15 +1457,48 @@ sigblkFinishKSI(ksifile ksi)
 			ksi->roots[j] = NULL;
 		} else if (ksi->roots[j] != NULL) {
 			rootDel = root;
+			root = NULL;
 			ret = sigblkHashTwoNodes(ksi, &root, ksi->roots[j], rootDel, j + 2);
 			KSI_DataHash_free(ksi->roots[j]);
 			ksi->roots[j] = NULL;
 			KSI_DataHash_free(rootDel);
-			if(ksi->bKeepTreeHashes)
+			rootDel = NULL;
+			if(ksi->bKeepTreeHashes) {
 				tlvWriteHashKSI(ksi, 0x0903, root);
-			if(ret != 0) goto done; /* checks hash_node_ksi() result! */
+			}
+			if(ret != KSI_OK) goto done; /* checks sigblkHashTwoNodes() result! */
 		}
 	}
+
+	*hsh = root;
+	root = NULL;
+	ret = RSGTE_SUCCESS;
+
+done:
+	KSI_DataHash_free(root);
+	KSI_DataHash_free(rootDel);
+	return ret;
+}
+
+
+int
+sigblkFinishKSI(ksifile ksi)
+{
+	KSI_DataHash *root = NULL;
+	int ret = RSGTE_INTERNAL;
+	unsigned level = 0;
+
+	if (ksi == NULL) {
+		goto done;
+	}
+
+	if (ksi->nRecords == 0) {
+		ret = RSGTE_SUCCESS;
+		goto done;
+	}
+
+	ret = sigblkFinishTree(ksi, &root);
+	if (ret != RSGTE_SUCCESS) goto done;
 
 	//Multiplying leaves count by 2 to account for blinding masks
 	level=sigblkCalcLevel(2 * ksi->nRecords);
@@ -1433,16 +1508,61 @@ sigblkFinishKSI(ksifile ksi)
 		ret = tlvWriteNoSigLS12(ksi->blockFile, ksi->nRecords, root, NULL);
 		if (ret != KSI_OK) {
 			reportKSIAPIErr(ksi->ctx, ksi, "tlvWriteNoSigLS12", ret);
-			ret = 1;
+			goto done;
 		}
 
 		queueAddSignRequest(ksi->ctx, ksi, root, level);
+		root = NULL;
 	} else {
 		sigblkSign(ksi, root, level);
-		KSI_DataHash_free(root); //otherwise delete it
 	}
 
+	ret = RSGTE_SUCCESS;
+
 done:
+	KSI_DataHash_free(root);
+	free(ksi->IV);
+	ksi->IV = NULL;
+	ksi->bInBlk = 0;
+	return ret;
+}
+
+static int
+sigblkFinishKSINoSignature(ksifile ksi, const char *reason)
+{
+	KSI_DataHash *root = NULL;
+	int ret = RSGTE_INTERNAL;
+
+	if (ksi == NULL || ksi->ctx == NULL ||
+	   (ksi->ctx->syncMode == LOGSIG_ASYNCHRONOUS && ksi->sigFile == NULL) ||
+		ksi->blockFile == NULL || reason == NULL) {
+		goto done;
+	}
+
+	ret = sigblkAddMetadata(ksi, blockCloseReason, reason);
+	if (ret != RSGTE_SUCCESS) goto done;
+
+	ret = sigblkFinishTree(ksi, &root);
+	if (ret != RSGTE_SUCCESS) goto done;
+
+	ret = tlvWriteNoSigLS12(ksi->blockFile, ksi->nRecords, root, reason);
+	if (ret != KSI_OK) {
+		reportKSIAPIErr(ksi->ctx, ksi, "tlvWriteNoSigLS12", ret);
+		goto done;
+	}
+
+	if (ksi->ctx->syncMode == LOGSIG_ASYNCHRONOUS) {
+		ret = tlvWriteNoSigLS12(ksi->sigFile, ksi->nRecords, root, reason);
+		if (ret != KSI_OK) {
+			reportKSIAPIErr(ksi->ctx, ksi, "tlvWriteNoSigLS12", ret);
+			goto done;
+		}
+	}
+
+	ret = RSGTE_SUCCESS;
+
+done:
+	KSI_DataHash_free(root);
 	free(ksi->IV);
 	ksi->IV=NULL;
 	ksi->bInBlk = 0;
@@ -1720,6 +1840,45 @@ cleanup:
 	return ret;
 }
 
+/* This can only be used when signer thread has terminated or within the thread. */
+static bool
+rsksictxCloseAllPendingBlocksWithoutSignature(rsksictx ctx, const char *reason) {
+	bool ret = false;
+	QueueItem *item = NULL;
+	int res = KSI_OK;
+
+	/* Save all consequent fulfilled responses in the front of the queue to the signature file */
+	while(ProtectedQueue_count(ctx->signer_queue)) {
+		item = NULL;
+		ProtectedQueue_popFront(ctx->signer_queue, (void**) &item);
+
+		if(item == NULL) {
+			continue;
+		}
+
+		/* Skip non request queue item. */
+		if(item->type == QITEM_SIGNATURE_REQUEST) {
+			res = tlvWriteNoSigLS12(item->file, item->intarg1, item->root, reason);
+			if (res != KSI_OK) {
+				reportKSIAPIErr(ctx, NULL, "tlvWriteNoSigLS12", res);
+				ret = false;
+				goto cleanup;
+			}
+			fflush(item->file);
+		}
+
+		KSI_DataHash_free(item->root);
+		KSI_AsyncHandle_free(item->respHandle);
+		free(item);
+	}
+
+	ret = true;
+
+cleanup:
+	return ret;
+}
+
+
 static void
 request_async_config(rsksictx ctx, KSI_CTX *ksi_ctx, KSI_AsyncService *as) {
 	KSI_Config *cfg = NULL;
@@ -1853,6 +2012,16 @@ void *signer_thread(void *arg) {
 				/* renew the config when opening a new file */
 			} else if (item->type == QITEM_QUIT) {
 				free(item);
+
+				/* Will look into work queue for pending KSI signatures and will output
+				 * unsigned block marker instead of actual KSI signature to finalize this
+				 * thread quickly.
+				 */
+				rsksictxCloseAllPendingBlocksWithoutSignature(ctx,
+					"Signing not finished due to sudden closure of lmsig_ksi-ls12 module.");
+				rsksictxForceCloseWithoutSig(ctx,
+					"Block closed due to sudden closure of lmsig_ksi-ls12 module.");
+
 				goto cleanup;
 			}
 			free(item);


### PR DESCRIPTION
correctly. All pending signature requests are closed immediately and
unsigned block marker is attached with message about sudden closure.
Similar approach is used for blocks that already contain some records.
Empty blocks are just closed without any metadata.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
