### PR TITLE
openssl: add check for LIBRESSL

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -633,7 +633,7 @@ osslInitSession(nsd_ossl_t *pThis) /* , nsd_ossl_t *pServer) */
 
 	if (bAnonInit == 1) { /* no mutex needed, read-only after init */
 		/* Allow ANON Ciphers */
-		#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		 /* NOTE: do never use: +eNULL, it DISABLES encryption! */
 		strncpy(pristringBuf, "ALL:+COMPLEMENTOFDEFAULT:+ADH:+ECDH:+aNULL@SECLEVEL=0",
 			sizeof(pristringBuf));
@@ -1725,7 +1725,7 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 
 	if (bAnonInit == 1) { /* no mutex needed, read-only after init */
 		/* Allow ANON Ciphers */
-		#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+		#if OPENSSL_VERSION_NUMBER >= 0x10100000L && !defined(LIBRESSL_VERSION_NUMBER)
 		 /* NOTE: do never use: +eNULL, it DISABLES encryption! */
 		strncpy(pristringBuf, "ALL:+COMPLEMENTOFDEFAULT:+ADH:+ECDH:+aNULL@SECLEVEL=0",
 			sizeof(pristringBuf));
@@ -1789,7 +1789,7 @@ SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unus
 		RETiRet;
 	} else {
 		dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
 		char *pCurrentPos;
 		char *pNextPos;
 		char *pszCmd;
@@ -1859,8 +1859,8 @@ SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unus
 		}
 #else
 		dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);
-		LogError(0, RS_RET_SYS_ERR, "Warning: OpenSSL Version too old to set gnutlsPriorityString ('%s')"
-			"by SSL_CONF_cmd API. For more see: "
+		LogError(0, RS_RET_SYS_ERR, "Warning: TLS library does not support SSL_CONF_cmd API"
+			"(maybe it is too old?). Cannot use gnutlsPriorityString ('%s'). For more see: "
 			"https://www.rsyslog.com/doc/master/configuration/modules/imtcp.html#gnutlsprioritystring",
 			gnutlsPriorityString);
 #endif

--- a/tests/imtcp-tls-ossl-basic-tlscommands.sh
+++ b/tests/imtcp-tls-ossl-basic-tlscommands.sh
@@ -32,9 +32,9 @@ tcpflood --check-only -k "Protocol=-ALL,TLSv1.2" -p$TCPFLOOD_PORT -m$NUMMESSAGES
 shutdown_when_empty
 wait_shutdown
 
-if content_check --check-only "OpenSSL Version too old"
+if content_check --check-only "TLS library does not support SSL_CONF_cmd"
 then
-	echo "SKIP: OpenSSL Version too old"
+	echo "SKIP: TLS library does not support SSL_CONF_cmd"
 	skip_test
 else
 	# Kindly check for a failed session

--- a/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
+++ b/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
@@ -58,10 +58,10 @@ wait_shutdown
 # intent. So do not think something is wrong. The content_check below checks
 # these error codes.
 
-content_check --check-only "OpenSSL Version too old"
+content_check --check-only "TLS library does not support SSL_CONF_cmd"
 ret=$?
 if [ $ret == 0 ]; then
-	echo "SKIP: OpenSSL Version too old"
+	echo "SKIP: TLS library does not support SSL_CONF_cmd"
 	skip_test
 else
 	# Kindly check for a failed session

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1200,7 +1200,7 @@ initTLS(void)
 
 	/* Check for Custom Config string */
 	if (customConfig != NULL){
-#if OPENSSL_VERSION_NUMBER >= 0x10002000L
+#if OPENSSL_VERSION_NUMBER >= 0x10002000L && !defined(LIBRESSL_VERSION_NUMBER)
 	char *pCurrentPos;
 	char *pNextPos;
 	char *pszCmd;
@@ -1254,7 +1254,7 @@ initTLS(void)
 		printf("tcpflood: error, invalid value for -k: %s\n", customConfig);
 	}
 #else
-	printf("tcpflood: error, OpenSSL Version too old, SSL_CONF_cmd API is not supported.");
+	printf("tcpflood: TLS library does not support SSL_CONF_cmd API (maybe it is too old?).");
 #endif
 	}
 


### PR DESCRIPTION
Disable use of "@SECLEVEL" in default cipher string and
avoid SSL_CONF_CTX_set_flags() API when LIBRESSL is used.
This means tlscommands will not work.

closes: https://github.com/rsyslog/rsyslog/issues/4210