### PR TITLE
omhttp: Adding multiple http headers capability

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -844,7 +844,9 @@ TESTS +=  \
 	omhttp-batch-lokirest-retry.sh \
 	omhttp-batch-lokirest.sh \
 	omhttp-batch-newline.sh \
-	omhttp-retry.sh
+	omhttp-retry.sh \
+	omhttp-httpheaderkey.sh \
+	omhttp-multiplehttpheaders.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	omhttp-auth-vg.sh \
@@ -2112,6 +2114,8 @@ EXTRA_DIST= \
 	omhttp-batch-lokirest.sh \
 	omhttp-batch-newline.sh \
 	omhttp-retry.sh \
+	omhttp-httpheaderkey.sh \
+	omhttp-multiplehttpheaders.sh \
 	omhttp-auth-vg.sh \
 	omhttp-basic-vg.sh \
 	omhttp-batch-jsonarray-compress-vg.sh \

--- a/tests/omhttp-httpheaderkey.sh
+++ b/tests/omhttp-httpheaderkey.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=1000
+
+port="$(get_free_port)"
+omhttp_start_server $port
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+if $msg contains "msgnum:" then
+	action(
+		# Payload
+		name="my_http_action"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+		httpheaderkey="X-Insert-Key"
+		httpheadervalue="dummy-value"
+		server="localhost"
+		serverport="'$port'"
+		restpath="my/endpoint"
+		batch="off"
+
+		# Auth
+		usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $port my/endpoint
+omhttp_stop_server
+seq_check
+exit_test

--- a/tests/omhttp-multiplehttpheaders.sh
+++ b/tests/omhttp-multiplehttpheaders.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=1000
+
+port="$(get_free_port)"
+omhttp_start_server $port
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+if $msg contains "msgnum:" then
+	action(
+		# Payload
+		name="my_http_action"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+		httpheaders=[
+			"X-Insert-Key: dummy-value",
+			"X-Event-Source: logs"
+		]
+		server="localhost"
+		serverport="'$port'"
+		restpath="my/endpoint"
+		batch="off"
+
+		# Auth
+		usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $port my/endpoint
+omhttp_stop_server
+seq_check
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
Allows the inclusion of multiple http headers on the REST call, uses ":" as a delimiter for multiple header keys and values using the existing httpheaderkey and httpheadervalue parameters, you can specify up to 20 headers. Example:
 
    httpheaderkey="X-Insert-Key:X-Event-Source"
    httpheadervalue="key:logs"
