### PR TITLE
stream.c: Moved doSizeLimitProcessing check to strmWrite

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -458,6 +458,7 @@ TESTS +=  \
 	parsertest-parse-nodate-udp.sh \
 	parsertest-snare_ccoff_udp.sh \
 	parsertest-snare_ccoff_udp2.sh
+
 if ENABLE_LIBGCRYPT
 TESTS +=  \
 	queue-encryption-disk.sh \
@@ -1002,7 +1003,8 @@ TESTS +=  \
 	rscript_random.sh \
 	rscript_hash32.sh \
 	rscript_hash64.sh \
-	rscript_replace.sh
+	rscript_replace.sh \
+	omfile-outchannel-many.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	imptcp_conndrop-vg.sh
@@ -1737,6 +1739,7 @@ EXTRA_DIST= \
 	omfile-whitespace-filename.sh \
 	omfile-read-only.sh \
 	omfile-outchannel.sh \
+	omfile-outchannel-many.sh \
 	omfile_both_files_set.sh \
 	omfile_hup.sh \
 	omrabbitmq_no_params.sh \

--- a/tests/omfile-outchannel-many.sh
+++ b/tests/omfile-outchannel-many.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# addd 2018-08-02 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=500000
+echo "ls -l $RSYSLOG_DYNNAME.channel.*
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.9 $RSYSLOG_DYNNAME.channel.log.prev.10 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.8 $RSYSLOG_DYNNAME.channel.log.prev.9 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.7 $RSYSLOG_DYNNAME.channel.log.prev.8 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.6 $RSYSLOG_DYNNAME.channel.log.prev.7 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.5 $RSYSLOG_DYNNAME.channel.log.prev.6 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.4 $RSYSLOG_DYNNAME.channel.log.prev.5 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.3 $RSYSLOG_DYNNAME.channel.log.prev.4 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.2 $RSYSLOG_DYNNAME.channel.log.prev.3 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.1 $RSYSLOG_DYNNAME.channel.log.prev.2 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev   $RSYSLOG_DYNNAME.channel.log.prev.1 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log $RSYSLOG_DYNNAME.channel.log.prev
+"   > $RSYSLOG_DYNNAME.rotate.sh
+chmod +x $RSYSLOG_DYNNAME.rotate.sh
+generate_conf
+add_conf '
+main_queue(
+	queue.workerthreads="4"
+	queue.timeoutWorkerthreadShutdown="-1"
+	queue.workerThreadMinimumMessages="10"
+)
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="tcp")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfile" template="outfmt")
+$outchannel log_rotation,'$RSYSLOG_DYNNAME.channel.log', $NUMMESSAGES,./'$RSYSLOG_DYNNAME.rotate.sh'
+
+if $msg contains "msgnum:" then {
+#	if $/num % 2 == 0 then
+		:omfile:$log_rotation
+#	else
+#		:omfile:$log_rotation2
+#	set $/num = $/num + 1;
+}
+
+ruleset(name="tcp") {
+	:omfile:$log_rotation2
+}
+'
+startup
+./tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES & # TCPFlood needs to run async!
+#./msleep 2500
+injectmsg
+sleep 1
+shutdown_when_empty
+wait_shutdown
+ls -l $RSYSLOG_DYNNAME.channel.*
+cat $RSYSLOG_DYNNAME.channel.* > $RSYSLOG_OUT_LOG
+seq_check
+exit_test


### PR DESCRIPTION
The check was done in strmPhysWrite before which caused syslog
messages to split in the middle if the syslog message batch exceeded
the default IO Buffer size.

closes: https://github.com/rsyslog/rsyslog/issues/4233
