### PR TITLE
testbench: Add test for imrelp to check broken session handling.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1246,6 +1246,7 @@ endif # ENABLE_GNUTLS
 if HAVE_VALGRIND
 TESTS += \
 	 imrelp-basic-vg.sh \
+	 imrelp-sessionbreak-vg.sh \
 	 imrelp-manyconn-vg.sh
 endif # HAVE_VALGRIND
 endif
@@ -2063,6 +2064,7 @@ EXTRA_DIST= \
 	imrelp-oversizeMode-accept.sh \
 	imrelp-invld-tlslib.sh \
 	imrelp-bigmessage.sh \
+	imrelp-sessionbreak-vg.sh \
 	omrelp-invld-tlslib.sh \
 	glbl-oversizeMsg-log.sh \
 	glbl-oversizeMsg-truncate.sh \

--- a/tests/imrelp-sessionbreak-vg.sh
+++ b/tests/imrelp-sessionbreak-vg.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# added 2020-04-10 by alorbach, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000000 
+export USE_VALGRIND="YES"
+# TODO remote leak check skip and fix memory leaks caused by session break
+export RS_TESTBENCH_LEAK_CHECK=no
+
+mkdir $RSYSLOG_DYNNAME.workdir
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+
+global(
+    workDirectory="'$RSYSLOG_DYNNAME.workdir'"
+    maxMessageSize="256k"
+)
+main_queue(queue.type="Direct")
+
+$LocalHostName test
+$AbortOnUncleanConfig on
+$PreserveFQDN on
+
+input(	type="imrelp" 
+	name="imrelp" 
+	port="'$TCPFLOOD_PORT'" 
+	ruleset="spool" 
+	MaxDataSize="256k"
+	KeepAlive="on"
+)
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+ruleset(name="spool" queue.type="direct") {
+	if $msg contains "msgnum:" then {
+		action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	}
+}
+'
+startup
+# How many tcpfloods we run at the same tiem
+for ((i=1;i<=5;i++)); do 
+        # How many times tcpflood runs in each threads
+	./tcpflood -Trelp-plain -p$TCPFLOOD_PORT -m$NUMMESSAGES -s &
+	tcpflood_pid=$!
+
+	echo "started tcpflood instance $i (PID $tcpflood_pid)"
+
+	# Give it time to actually connect
+	./msleep 500;
+
+	kill -9 $tcpflood_pid # >/dev/null 2>&1;
+	echo "killed tcpflood instance $i (PID $tcpflood_pid)"
+done;
+
+wait_queueempty
+
+netstatresult=$(netstat --all --program 2>&1 | grep "ESTABLISHED" | grep $(cat $RSYSLOG_PIDBASE.pid) | grep $TCPFLOOD_PORT)
+openfd=$(ls -l "/proc/$(cat $RSYSLOG_PIDBASE$1.pid)/fd" | wc -l)
+
+shutdown_when_empty
+wait_shutdown
+
+if [[ "$netstatresult" == "" ]]
+then
+	echo "OK!"
+else
+	echo "STILL OPENED Connections: "
+	echo $netstatresult
+	echo "Open files at the end: "
+	echo $openfd
+	error_exit 1 
+fi
+
+exit_test


### PR DESCRIPTION
For successfull test, the PR https://github.com/rsyslog/librelp/pull/184  for Issue https://github.com/rsyslog/librelp/issues/183 needs to merged into librelp first. 

Otherwise the test will trigger a double free inside librelp which results in a segfault in some cases.

closes: https://github.com/rsyslog/rsyslog/issues/4184
closes: https://github.com/rsyslog/rsyslog/issues/4005
