### PR TITLE
omprog: adapt test to testbench improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,13 +73,16 @@ cscope.out
 tests/HOSTNAME
 tests/chkseq
 tests/diagtalker
+tests/have_relpEngineSetTLSLibByName
 tests/have_relpSrvSetOversizeMode
+tests/have_relpSrvSetTlsConfigCmd
 tests/inputfilegen
 tests/minitcpsrv
 tests/msleep
 tests/nettester
 tests/ourtail
 tests/randomgen
+tests/set-envvars
 tests/syslog_caller
 tests/omrelp_dflt_port
 tests/syslog_inject

--- a/tests/omprog-single-instance-outfile.sh
+++ b/tests/omprog-single-instance-outfile.sh
@@ -5,48 +5,34 @@
 # parameter. Checks that the output of the program is correctly captured
 # when the 'forceSingleInstance' flag is enabled.
 
-NUMBER_OF_MESSAGES=10000  # number of logs to send
-
 . ${srcdir:=.}/diag.sh init
-
-uname
-if [ $(uname) = "SunOS" ] ; then
-    # On Solaris, this test causes rsyslog to hang for unknown reasons
-    echo "Solaris: FIX ME"
-    exit 77
-fi
-
+skip_platform "SunOS"  "This test currently does not work on Solaris"
+export NUMMESSAGES=10000  # number of logs to send
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
-module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/omprog/.libs/omprog")
 
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
-
 template(name="outfmt" type="string" string="%msg%\n")
-
-main_queue(
-    queue.timeoutShutdown="30000"  # long shutdown timeout for the main queue
-)
 
 :msg, contains, "msgnum:" {
     action(
         type="omprog"
-        binary=`echo $srcdir/testsuites/omprog-single-instance-bin.sh`
+        binary="'$srcdir'/testsuites/omprog-single-instance-bin.sh"
         template="outfmt"
         name="omprog_action"
         confirmMessages="on"
         forceSingleInstance="on"
         queue.type="LinkedList"  # use a dedicated queue
         queue.workerThreads="10"  # ...with multiple workers
-        queue.size="10000"  # ...high capacity (default is 1000)
+        queue.size="5000"  # ...high capacity (default is 1000)
         queue.timeoutShutdown="30000"  # ...and a long shutdown timeout
-        output=`echo $RSYSLOG2_OUT_LOG`
+        output="'$RSYSLOG2_OUT_LOG'"
     )
 }
 '
 startup
-tcpflood -m$NUMBER_OF_MESSAGES
+injectmsg
 shutdown_when_empty
 wait_shutdown
 
@@ -54,12 +40,12 @@ EXPECTED_LINE_LENGTH=34    # example line: '[stderr] Received msgnum:00009880:'
 line_num=0
 while IFS= read -r line; do
     ((line_num++))
-    if [[ $line_num == 1 ]]; then
+    if (( line_num == 1 )); then
         if [[ "$line" != "[stderr] Starting" ]]; then
             echo "unexpected first line in captured stderr: $line"
             error_exit 1
         fi
-    elif [[ $line_num == $(($NUMBER_OF_MESSAGES + 2)) ]]; then
+    elif (( line_num == NUMMESSAGES + 2 )); then
         if [[ "$line" != "[stderr] Terminating" ]]; then
             echo "unexpected last line in captured stderr: $line"
             error_exit 1
@@ -70,15 +56,15 @@ while IFS= read -r line; do
     fi
 done < $RSYSLOG2_OUT_LOG
 
-if (( $line_num != $(($NUMBER_OF_MESSAGES + 2)) )); then
-    echo "unexpected line count in captured stderr: $line_num (expected: $(($NUMBER_OF_MESSAGES + 2)))"
+if (( line_num != NUMMESSAGES + 2 )); then
+    echo "unexpected line count in captured stderr: $line_num (expected: $((NUMMESSAGES + 2)))"
     error_exit 1
 fi
 
 # Note: we use awk here to remove leading spaces returned by wc on FreeBSD
 line_count=$(wc -l < ${RSYSLOG_OUT_LOG} | awk '{print $1}')
-if (( $line_count != $(($NUMBER_OF_MESSAGES + 2)) )); then
-    echo "unexpected line count in output: $line_count (expected: $(($NUMBER_OF_MESSAGES + 2)))"
+if (( line_count != NUMMESSAGES + 2 )); then
+    echo "unexpected line count in output: $line_count (expected: $((NUMMESSAGES + 2)))"
     error_exit 1
 fi
 

--- a/tests/omprog-single-instance.sh
+++ b/tests/omprog-single-instance.sh
@@ -4,6 +4,7 @@
 # This test tests the omprog 'forceSingleInstance' flag by checking
 # that only one instance of the program is started when multiple
 # workers are in effect.
+
 . ${srcdir:=.}/diag.sh init
 skip_platform "SunOS"  "This test currently does not work on Solaris "
 export NUMMESSAGES=10000  # number of logs to send
@@ -38,12 +39,12 @@ EXPECTED_LINE_LENGTH=25    # example line: 'Received msgnum:00009880:'
 line_num=0
 while IFS= read -r line; do
     ((line_num++))
-    if [[ $line_num == 1 ]]; then
+    if (( line_num == 1 )); then
         if [[ "$line" != "Starting" ]]; then
             echo "unexpected first line in output: $line"
             error_exit 1
         fi
-    elif [[ $line_num == $((NUMMESSAGES + 2)) ]]; then
+    elif (( line_num == NUMMESSAGES + 2 )); then
         if [[ "$line" != "Terminating" ]]; then
             echo "unexpected last line in output: $line"
             error_exit 1
@@ -54,7 +55,7 @@ while IFS= read -r line; do
     fi
 done < $RSYSLOG_OUT_LOG
 
-if (( line_num != $((NUMMESSAGES + 2)) )); then
+if (( line_num != NUMMESSAGES + 2 )); then
     echo "unexpected line count in output: $line_num (expected: $((NUMMESSAGES + 2)))"
     error_exit 1
 fi


### PR DESCRIPTION
Adapt one of the omprog tests to the latest improvements in the
testbench framework, for consistency with other similar tests. The test
behaviour has not changed.

Add some temporary files created by the testbench to gitignore file.