### PR TITLE
omprog: fix assert failed on HUP with output flag

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -657,7 +657,6 @@ done:
 static void
 closeOutputFile(outputCaptureCtx_t *pCtx)
 {
-	assert(pCtx->bIsRunning);
 	DBGPRINTF("omprog: reopening output file upon reception of HUP signal\n");
 	pthread_mutex_lock(&pCtx->mutWrite);
 
@@ -1214,7 +1213,7 @@ CODESTARTdoHUP
 		kill(pData->pSingleChildCtx->pid, pData->iHUPForward);
 	}
 
-	if(pData->pOutputCaptureCtx != NULL) {
+	if(pData->pOutputCaptureCtx != NULL && pData->pOutputCaptureCtx->bIsRunning) {
 		closeOutputFile(pData->pOutputCaptureCtx);
 	}
 ENDdoHUP


### PR DESCRIPTION
If the 'output' setting of omprog was used and rsyslog received a HUP
signal just after starting (and before the omprog action received the
first log to process), an internal assertion could fail, causing
rsyslog to terminate. The failure message was "rsyslogd: omprog.c:660:
closeOutputFile: Assertion `pCtx->bIsRunning' failed."

The failure could also occur if rsyslog received a HUP signal during
the shutdown sequence.

This bug was introduced in v8.2004 by PR #4255.

Although a test already existed that checked the interaction of HUPs
with the 'output' setting, it didn't always fail in this particular case
due to timing conditions. The test has been improved to cover this case
more reliably.