### PR TITLE
build system: libzcmq version requirement needs to be bumped

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,8 @@
 ----------------------------------------------------------------------------------------
 Scheduled Release 8.2006.0 (aka 2020.06) 2020-06-??
+- 2020-05-11: openssl netstream driver bugfix: context leak
+  The context object was not properly freed.
+  Thanks to Michael Zimmermann for the fix.
 - 2020-05-11: omhttp: Add support for multiple http headers
   Allows the inclusion of multiple http headers on the REST call.
   Thanks to callmegar for the patch.

--- a/configure.ac
+++ b/configure.ac
@@ -2234,7 +2234,7 @@ AC_ARG_ENABLE(imczmq,
         [enable_imczmq=no]
 )
 if test "x$enable_imczmq" = "xyes"; then
-	PKG_CHECK_MODULES(CZMQ, libczmq >= 3.0.0)
+	PKG_CHECK_MODULES(CZMQ, libczmq >= 4.0.0)
 fi
 AM_CONDITIONAL(ENABLE_IMCZMQ, test x$enable_imczmq = xyes)
 
@@ -2252,7 +2252,7 @@ AC_ARG_ENABLE(omczmq,
         [enable_omczmq=no]
 )
 if test "x$enable_omczmq" = "xyes"; then
-   PKG_CHECK_MODULES(CZMQ, libczmq >= 3.0.2)
+   PKG_CHECK_MODULES(CZMQ, libczmq >= 4.0.0)
 fi
 AM_CONDITIONAL(ENABLE_OMCZMQ, test x$enable_omczmq = xyes)
 


### PR DESCRIPTION
Thanks to Thomas Deutschmann for pointing this out.

closes https://github.com/rsyslog/rsyslog/issues/3957

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
