### PR TITLE
CI: fix problems with ElasticSearch download

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2042,7 +2042,7 @@ download_elasticsearch() {
 			printf 'ElasticSearch: satisfying dependency %s from system cache.\n' "$ES_DOWNLOAD"
 			cp /local_dep_cache/$ES_DOWNLOAD $dep_es_cached_file
 		else
-			dep_es_url="https://artifacts.elastic.co/downloads/elasticsearch/$ES_DOWNLOAD"
+			dep_es_url="https://www.rsyslog.com/files/download/rsyslog/$ES_DOWNLOAD"
 			printf 'ElasticSearch: satisfying dependency %s from %s\n' "$ES_DOWNLOAD" "$dep_es_url"
 			wget -q $dep_es_url -O $dep_es_cached_file
 		fi


### PR DESCRIPTION
ElasticSearch can no longer be reliably downloaded, we receive error
451 - prohibited for legal reasons. This causes false positive test
failures.

We have solved this by moving the required tarballs to rsyslog.com and
download them now from there.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
