### PR TITLE
config system bugfix: backticks cat segfault if file cannot be opened

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -148,7 +148,14 @@ expand_backticks(char *const param)
 		estr = expand_backticks_echo(param);
 	} else if(strncmp(param, "cat ", sizeof("cat ")-1) == 0) {
 		const char *val = read_file(param+4);
-		estr = es_newStrFromCStr(val, strlen(val));
+		if(val == NULL) {
+			parser_errmsg("file could not be accessed for `%s`", param);
+			const char *errmsg = "/* file cound not be accessed - see"
+				"error messages */";
+			estr = es_newStrFromCStr(errmsg, strlen(errmsg));
+		} else {
+			estr = es_newStrFromCStr(val, strlen(val));
+		}
 		free((void*) val);
 	} else {
 		parser_errmsg("invalid backtick parameter `%s` - replaced by "

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -443,6 +443,7 @@ TESTS +=  \
 	lookup_table_rscript_reload.sh \
 	lookup_table_rscript_reload_without_stub.sh \
 	include-obj-text-from-file.sh \
+	include-obj-text-from-file-noexist.sh \
 	multiple_lookup_tables.sh \
 	parsertest-parse1.sh \
 	parsertest-parse1-udp.sh \
@@ -1645,6 +1646,7 @@ EXTRA_DIST= \
 	diskqueue-non-unique-prefix.sh \
 	arrayqueue.sh \
 	include-obj-text-from-file.sh \
+	include-obj-text-from-file-noexist.sh \
 	include-obj-outside-control-flow-vg.sh \
 	include-obj-in-if-vg.sh \
 	include-obj-text-vg.sh \

--- a/tests/include-obj-text-from-file-noexist.sh
+++ b/tests/include-obj-text-from-file-noexist.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# added 2018-01-22 by Rainer Gerhards; Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+if $msg contains "msgnum:" then {
+	include(text=`cat '${srcdir}'/testsuites/DOES-NOT-EXIST`)
+}
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex 'file could not be accessed for `cat .*/testsuites/DOES-NOT-EXIST'
+exit_test


### PR DESCRIPTION
when an `cat <filename>` consruct is used in rsyslog.conf ang <filename>
can not be accessed (does not exist, no permissions, ...), rsyslog
segfaults.

Thanks to Michael Skeffington for notifying us and providing analysis
of root cause.

closes https://github.com/rsyslog/rsyslog/issues/4290

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
