### PR TITLE
the return value judgment of recv is err in CheckConnecttion

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2619,22 +2619,21 @@ MsgGetStructuredData(smsg_t * const pM, uchar **pBuf, rs_size_t *len)
 uchar * ATTR_NONNULL(1)
 getProgramName(smsg_t *const pM, const sbool bLockMutex)
 {
-	if(pM->iLenPROGNAME == -1) {
-		if(pM->iLenTAG == 0) {
-			uchar *pRes;
-			rs_size_t bufLen = -1;
-			getTAG(pM, &pRes, &bufLen, bLockMutex);
-		}
+	if(pM->iLenTAG == 0) {
+		uchar *pRes;
+		rs_size_t bufLen = -1;
+		getTAG(pM, &pRes, &bufLen, bLockMutex);
+	}
 
-		if(bLockMutex == LOCK_MUTEX) {
-			MsgLock(pM);
-			/* need to re-check, things may have change in between! */
-			if(pM->iLenPROGNAME == -1)
-				aquireProgramName(pM);
-			MsgUnlock(pM);
-		} else {
+	if(bLockMutex == LOCK_MUTEX) {
+		MsgLock(pM);
+		/* need to re-check, things may have change in between! */
+		if(pM->iLenPROGNAME == -1)
 			aquireProgramName(pM);
-		}
+		MsgUnlock(pM);
+	} else {
+		if(pM->iLenPROGNAME == -1)
+			aquireProgramName(pM);
 	}
 	return (pM->iLenPROGNAME < CONF_PROGNAME_BUFSIZE) ? pM->PROGNAME.szBuf
 						       : pM->PROGNAME.ptr;

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -952,7 +952,7 @@ CheckConnection(nsd_t *pNsd)
 	ISOBJ_TYPE_assert(pThis, nsd_ptcp);
 
 	rc = recv(pThis->sock, msgbuf, 1, MSG_DONTWAIT | MSG_PEEK);
-	if(rc == 0 && errno != EAGAIN) {
+	if(rc == 0) {
 		dbgprintf("CheckConnection detected broken connection - closing it (rc %d, errno %d)\n", rc, errno);
 		/* in this case, the remote peer had shut down the connection and we
 		 * need to close our side, too.


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
