### PR TITLE
http input module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ matrix:
        services:
          - mysql
          - postgresql
-       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", GROK="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--gen-suppressions=all", EXTRA_CONFIGURE="--disable-default-tests --disable-elasticsearch --disable-impstats --disable-imfile --disable-imptcp --disable-gnutls -disable-openssl --disable-relp --disable-pmsnare --disable-pmlastmsg"
+       env: RUN="run.sh",BUILD_FROM_TARBALL="YES", GROK="YES", IMHTTP="YES", CHECK="YES", CFLAGS="-g -O2", RS_TESTBENCH_VALGRIND_EXTRA_OPTS="--gen-suppressions=all", EXTRA_CONFIGURE="--disable-default-tests --disable-elasticsearch --disable-impstats --disable-imfile --disable-imptcp --disable-gnutls -disable-openssl --disable-relp --disable-pmsnare --disable-pmlastmsg"
 
 #     - os: linux
 #       compiler: "gcc"
@@ -92,7 +92,7 @@ matrix:
      - os: linux
        # CRON/Coverity entry!
        compiler: "gcc"
-       env: RUN="run-cron.sh",DO_COVERITY="YES",DO_CRON="YES", KAFKA="YES", GROK="YES"
+       env: RUN="run-cron.sh",DO_COVERITY="YES",DO_CRON="YES", KAFKA="YES", GROK="YES", IMHTTP="YES"
 
 
 script:

--- a/Makefile.am
+++ b/Makefile.am
@@ -310,6 +310,11 @@ if ENABLE_IMPROG
 SUBDIRS += contrib/improg
 endif
 
+# imhttp
+if ENABLE_IMHTTP
+SUBDIRS += contrib/imhttp
+endif
+
 # mmtaghostname
 if ENABLE_MMTAGHOSTNAME
 SUBDIRS += contrib/mmtaghostname
@@ -379,6 +384,10 @@ endif  # if ENABLE_DEFAULT_TESTS
 
 if ENABLE_IMPROG
 DISTCHECK_CONFIGURE_FLAGS+= --enable-improg
+endif
+
+if ENABLE_IMHTTP
+DISTCHECK_CONFIGURE_FLAGS+= --enable-imhttp
 endif
 
 if ENABLE_OMPROG

--- a/configure.ac
+++ b/configure.ac
@@ -1820,6 +1820,27 @@ AC_ARG_ENABLE(improg,
 )
 AM_CONDITIONAL(ENABLE_IMPROG, test x$enable_improg = xyes)
 
+# settings for the external http input module
+AC_ARG_ENABLE(imhttp,
+        [AS_HELP_STRING([--enable-imhttp],[external http input module enabled @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_imhttp="yes" ;;
+          no) enable_imhttp="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-imhttp) ;;
+         esac],
+        [enable_imhttp=no]
+)
+if test "x$enable_imhttp" = "xyes"; then
+  AC_CHECK_HEADERS(
+    [civetweb.h],,
+    [AC_MSG_FAILURE([civetweb is missing])]
+  )
+  AC_SEARCH_LIBS(mg_version, civetweb)
+  CIVETWEB_LIBS=-lcivetweb
+  AC_SUBST(CIVETWEB_LIBS)
+fi
+AM_CONDITIONAL(ENABLE_IMHTTP, test x$enable_imhttp = xyes)
+
 # settings for the door input module (under solaris, thus default off)
 AC_ARG_ENABLE(imsolaris,
         [AS_HELP_STRING([--enable-imsolaris],[solaris input module enabled @<:@default=no@:>@])],
@@ -2638,6 +2659,7 @@ AC_CONFIG_FILES([Makefile \
 		contrib/impcap/Makefile \
 		contrib/imtuxedoulog/Makefile \
 		contrib/improg/Makefile \
+		contrib/imhttp/Makefile \
 		contrib/mmtaghostname/Makefile \
 		contrib/imdocker/Makefile \
 		contrib/pmdb2diag/Makefile \
@@ -2689,6 +2711,7 @@ fi
 echo "    impcap input module enabled:              $enable_impcap"
 echo "    imtuxedoulog module will be compiled:     $enable_imtuxedoulog"
 echo "    improg input module enabled:              $enable_improg"
+echo "    imhttp input module enabled:              $enable_imhttp"
 echo
 echo "---{ output plugins }---"
 echo "    Mail support enabled:                     $enable_mail"

--- a/contrib/imhttp/Makefile.am
+++ b/contrib/imhttp/Makefile.am
@@ -1,0 +1,5 @@
+pkglib_LTLIBRARIES = imhttp.la
+
+imhttp_la_SOURCES = imhttp.c
+imhttp_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+imhttp_la_LDFLAGS = -module -avoid-version $(CIVETWEB_LIBS)

--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -1,0 +1,1121 @@
+/* imhttp.c
+ * This is an input module for receiving http input.
+ *
+ * This file is contribution of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdarg.h>
+#include <ctype.h>
+#include <netinet/in.h>
+#include <netdb.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include "rsyslog.h"
+#include "cfsysline.h"		/* access to config file objects */
+#include "module-template.h"
+#include "ruleset.h"
+#include "unicode-helper.h"
+#include "rsyslog.h"
+#include "errmsg.h"
+#include "statsobj.h"
+#include "ratelimit.h"
+#include "dirty.h"
+
+#include "civetweb.h"
+
+MODULE_TYPE_INPUT
+MODULE_TYPE_NOKEEP
+MODULE_CNFNAME("imhttp")
+
+/* static data */
+DEF_OMOD_STATIC_DATA
+DEFobjCurrIf(glbl)
+DEFobjCurrIf(prop)
+DEFobjCurrIf(ruleset)
+DEFobjCurrIf(statsobj)
+
+#define CIVETWEB_OPTION_NAME_PORTS         "listening_ports"
+#define CIVETWEB_OPTION_NAME_DOCUMENT_ROOT "document_root"
+#define MAX_READ_BUFFER_SIZE  16384
+#define INIT_SCRATCH_BUF_SIZE 4096
+
+struct option {
+	const char *name;
+	const char *val;
+};
+
+struct data_parse_s {
+	sbool  content_compressed;
+	sbool bzInitDone; /* did we do an init of zstrm already? */
+	z_stream zstrm;	/* zip stream to use for tcp compression */
+	// Currently only used for octet specific parsing
+	enum {
+		eAtStrtFram,
+		eInOctetCnt,
+		eInMsg,
+	} inputState;
+	size_t iOctetsRemain;	/* Number of Octets remaining in message */
+	enum {
+		TCP_FRAMING_OCTET_STUFFING,
+		TCP_FRAMING_OCTET_COUNTING
+	} framingMode;
+};
+
+struct modConfData_s {
+	rsconf_t *pConf;  /* our overall config object */
+	instanceConf_t *root, *tail;
+	struct option ports;
+	struct option docroot;
+	struct option *options;
+	int nOptions;
+};
+
+struct instanceConf_s {
+	struct instanceConf_s *next;
+	uchar *pszBindRuleset;    /* name of ruleset to bind to */
+	uchar *pszEndpoint;       /* endpoint to configure */
+	ruleset_t *pBindRuleset;  /* ruleset to bind listener to (use system default if unspecified) */
+	ratelimit_t *ratelimiter;
+	unsigned int ratelimitInterval;
+	unsigned int ratelimitBurst;
+	uchar *pszInputName;	  /* value for inputname property, NULL is OK and handled by core engine */
+	prop_t *pInputName;
+	sbool flowControl;
+	sbool bDisableLFDelim;
+	sbool bSuppOctetFram;
+	sbool bAddMetadata;
+};
+
+struct conn_wrkr_s {
+	struct data_parse_s parseState;
+	uchar* pMsg;						/* msg scratch buffer */
+	size_t iMsg;						/* index of next char to store in msg */
+	uchar zipBuf[64*1024];
+	multi_submit_t multiSub;
+	smsg_t *pMsgs[CONF_NUM_MULTISUB];
+	char *pReadBuf;
+	size_t readBufSize;
+	prop_t *propRemoteAddr;
+	const struct mg_request_info *pri; /* do not free me - used to hold a reference only */
+	char *pScratchBuf;
+	size_t scratchBufSize;
+};
+
+static modConfData_t *loadModConf = NULL;/* modConf ptr to use for the current load process */
+static modConfData_t *runModConf = NULL;/* modConf ptr to use for the current load process */
+static prop_t *pInputName = NULL;
+
+//static size_t s_iMaxLine = 16; /* get maximum size we currently support */
+static size_t s_iMaxLine = 16384; /* get maximum size we currently support */
+
+/* module-global parameters */
+static struct cnfparamdescr modpdescr[] = {
+	{ "ports", eCmdHdlrString, 0 },
+	{ "documentroot", eCmdHdlrString, 0 },
+	{ "liboptions", eCmdHdlrArray, 0 },
+};
+
+static struct cnfparamblk modpblk = {
+	CNFPARAMBLK_VERSION,
+	sizeof(modpdescr)/sizeof(struct cnfparamdescr),
+	modpdescr
+};
+
+static struct cnfparamdescr inppdescr[] = {
+	{ "endpoint", eCmdHdlrString, 0},
+	{ "ruleset", eCmdHdlrString, 0 },
+	{ "flowcontrol", eCmdHdlrBinary, 0 },
+	{ "disablelfdelimiter", eCmdHdlrBinary, 0 },
+	{ "supportoctetcountedframing", eCmdHdlrBinary, 0 },
+	{ "name", eCmdHdlrString, 0 },
+	{ "ratelimit.interval", eCmdHdlrInt, 0 },
+	{ "ratelimit.burst", eCmdHdlrInt, 0 },
+	{ "addmetadata", eCmdHdlrBinary, 0 }
+};
+
+#include "im-helper.h" /* must be included AFTER the type definitions! */
+
+static struct cnfparamblk inppblk = {
+	CNFPARAMBLK_VERSION,
+	sizeof(inppdescr)/sizeof(struct cnfparamdescr),
+	inppdescr
+};
+
+static struct {
+	statsobj_t *stats;
+	STATSCOUNTER_DEF(ctrSubmitted, mutCtrSubmitted)
+	STATSCOUNTER_DEF(ctrFailed, mutCtrFailed);
+	STATSCOUNTER_DEF(ctrDiscarded, mutCtrDiscarded);
+} statsCounter;
+
+#include "im-helper.h" /* must be included AFTER the type definitions! */
+
+#define min(a, b) \
+	({ __typeof__ (a) _a = (a); \
+	__typeof__ (b) _b = (b); \
+	_a < _b ? _a : _b; })
+
+#define	EXIT_FAILURE	1
+#define	EXIT_SUCCESS	0
+#define EXIT_URI "/exit"
+volatile int exitNow = 0;
+
+struct mg_callbacks callbacks;
+
+typedef struct httpserv_s {
+	struct mg_context *ctx;
+	struct mg_callbacks callbacks;
+	const char **civetweb_options;
+	size_t civetweb_options_count;
+} httpserv_t;
+
+static httpserv_t *s_httpserv;
+
+/* FORWARD DECLARATIONS */
+static rsRetVal processData(const instanceConf_t *const inst,
+	struct conn_wrkr_s *connWrkr, const char* buf, size_t len);
+
+static rsRetVal
+createInstance(instanceConf_t **pinst)
+{
+	instanceConf_t *inst;
+	DEFiRet;
+	CHKmalloc(inst = calloc(1, sizeof(instanceConf_t)));
+	inst->next = NULL;
+	inst->pszBindRuleset = NULL;
+	inst->pBindRuleset = NULL;
+	inst->pszEndpoint = NULL;
+	inst->ratelimiter = NULL;
+	inst->pszInputName = NULL;
+	inst->pInputName = NULL;
+	inst->ratelimitBurst = 10000; /* arbitrary high limit */
+	inst->ratelimitInterval = 0; /* off */
+	inst->flowControl = 1;
+	inst->bDisableLFDelim = 0;
+	inst->bSuppOctetFram = 0;
+	inst->bAddMetadata = 0;
+	// construct statsobj
+
+	/* node created, let's add to config */
+	if(loadModConf->tail == NULL) {
+		loadModConf->tail = loadModConf->root = inst;
+	} else {
+		loadModConf->tail->next = inst;
+		loadModConf->tail = inst;
+	}
+
+	*pinst = inst;
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+processCivetwebOptions(char *const param,
+	const char **const name,
+	const char **const paramval)
+{
+	DEFiRet;
+	char *val = strstr(param, "=");
+	if(val == NULL) {
+		LogError(0, RS_RET_PARAM_ERROR, "missing equal sign in "
+				"parameter '%s'", param);
+		ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+	}
+	*val = '\0'; /* terminates name */
+	++val; /* now points to begin of value */
+	CHKmalloc(*name = strdup(param));
+	CHKmalloc(*paramval = strdup(val));
+
+finalize_it:
+	RETiRet;
+}
+
+static sbool valid_civetweb_option(const struct mg_option *valid_opts, const char* option)
+{
+	const struct mg_option *pvalid_opts = valid_opts;
+	for (; pvalid_opts != NULL && pvalid_opts->name != NULL; pvalid_opts++) {
+		if (strcmp(pvalid_opts->name, option) == 0) {
+			return TRUE;
+		}
+	}
+	return FALSE;
+}
+
+#if 0
+static int
+log_message(__attribute__((unused)) const struct mg_connection *conn, const char *message)
+{
+	puts(message);
+	return 1;
+}
+#endif
+/*
+	*   thread_type:
+	*     0 indicates the master thread
+	*     1 indicates a worker thread handling client connections
+	*     2 indicates an internal helper thread (timer thread)
+*/
+static void*
+init_thread(__attribute__((unused)) const struct mg_context *ctx, int thread_type)
+{
+	DEFiRet;
+	struct conn_wrkr_s *data = NULL;
+	if (thread_type == 1) {
+		CHKmalloc(data = calloc(1, sizeof(struct conn_wrkr_s)));
+		data->pMsg = NULL;
+		data->iMsg = 0;
+		data->parseState.bzInitDone = 0;
+		data->parseState.content_compressed = 0;
+		data->parseState.inputState = eAtStrtFram;
+		data->parseState.iOctetsRemain = 0;
+		data->multiSub.maxElem = CONF_NUM_MULTISUB;
+		data->multiSub.ppMsgs = data->pMsgs;
+		data->multiSub.nElem = 0;
+		data->pReadBuf = malloc(MAX_READ_BUFFER_SIZE);
+		data->readBufSize = MAX_READ_BUFFER_SIZE;
+
+		data->parseState.bzInitDone = 0;
+		data->parseState.content_compressed = 0;
+		data->parseState.inputState = eAtStrtFram;
+		data->parseState.iOctetsRemain = 0;
+
+		CHKmalloc(data->pMsg = calloc(1, 1 + s_iMaxLine));
+		data->iMsg = 0;
+		data->propRemoteAddr = NULL;
+		data->pScratchBuf = NULL;
+		data->scratchBufSize = 0;
+	}
+
+finalize_it:
+	if (iRet != RS_RET_OK) {
+		free(data);
+		return NULL;
+	}
+	return data;
+}
+
+static void
+exit_thread(__attribute__((unused)) const struct mg_context *ctx,
+	__attribute__((unused)) int thread_type, void *thread_pointer)
+{
+	if (thread_type == 1) {
+		struct conn_wrkr_s *data = (struct conn_wrkr_s *) thread_pointer;
+		if (data->propRemoteAddr) {
+			prop.Destruct(&data->propRemoteAddr);
+		}
+		if (data->scratchBufSize) {
+			free(data->pScratchBuf);
+		}
+		free(data->pReadBuf);
+		free(data->pMsg);
+		free(data);
+	}
+}
+
+static rsRetVal
+msgAddMetadataFromHttpHeader(smsg_t *const __restrict__ pMsg, struct conn_wrkr_s *connWrkr)
+{
+	DEFiRet;
+	const struct mg_request_info *ri = connWrkr->pri;
+	#define MAX_HTTP_HEADERS 64	/* hard limit */
+	int count = min(ri->num_headers, MAX_HTTP_HEADERS);
+
+	struct json_object *const json = json_object_new_object();
+	CHKmalloc(json);
+	for (int i = 0 ; i < count ; i++ ) {
+		struct json_object *const jval = json_object_new_string(ri->http_headers[i].value);
+		if(jval == NULL) {
+			json_object_put(json);
+			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+		}
+
+		/* truncate header names bigger than INIT_SCRATCH_BUF_SIZE */
+		strncpy(connWrkr->pScratchBuf, ri->http_headers[i].name, connWrkr->scratchBufSize - 1);
+		/* make header lowercase */
+		char* pname = connWrkr->pScratchBuf;
+		while (pname && *pname != '\0') {
+			*pname = tolower(*pname);
+			pname++;
+		}
+		json_object_object_add(json, (const char *const)connWrkr->pScratchBuf, jval);
+	}
+	iRet = msgAddJSON(pMsg, (uchar*)"!metadata!httpheaders", json, 0, 0);
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+doSubmitMsg(const instanceConf_t *const __restrict__ inst,
+	struct conn_wrkr_s *connWrkr, const uchar* msg, size_t len)
+{
+	smsg_t *pMsg;
+	DEFiRet;
+
+	assert(len <= s_iMaxLine);
+	if (len == 0) {
+		DBGPRINTF("discarding zero-sized message\n");
+		FINALIZE;
+	}
+
+	CHKiRet(msgConstruct(&pMsg));
+	MsgSetFlowControlType(pMsg, inst->flowControl
+			            ? eFLOWCTL_LIGHT_DELAY : eFLOWCTL_NO_DELAY);
+	if (inst->pInputName) {
+		MsgSetInputName(pMsg, inst->pInputName);
+	} else {
+		MsgSetInputName(pMsg, pInputName);
+	}
+	MsgSetRawMsg(pMsg, (const char*)msg, len);
+	MsgSetMSGoffs(pMsg, 0);	/* we do not have a header... */
+	if (connWrkr->propRemoteAddr) {
+		MsgSetRcvFromIP(pMsg, connWrkr->propRemoteAddr);
+	}
+	if (inst) {
+		MsgSetRuleset(pMsg, inst->pBindRuleset);
+	}
+	// TODO: make these flags configurable.
+	pMsg->msgFlags = NEEDS_PARSING | PARSE_HOSTNAME;
+
+	if (inst->bAddMetadata) {
+		CHKiRet(msgAddMetadataFromHttpHeader(pMsg, connWrkr));
+	}
+
+	ratelimitAddMsg(inst->ratelimiter, &connWrkr->multiSub, pMsg);
+	STATSCOUNTER_INC(statsCounter.ctrSubmitted, statsCounter.mutCtrSubmitted);
+finalize_it:
+	connWrkr->iMsg = 0;
+	if (iRet != RS_RET_OK) {
+		STATSCOUNTER_INC(statsCounter.ctrDiscarded, statsCounter.mutCtrDiscarded);
+	}
+	RETiRet;
+}
+
+
+static rsRetVal
+processOctetMsgLen(const instanceConf_t *const inst, struct conn_wrkr_s *connWrkr, char ch)
+{
+	DEFiRet;
+	if (connWrkr->parseState.inputState == eAtStrtFram) {
+		if (inst->bSuppOctetFram && isdigit(ch)) {
+			connWrkr->parseState.inputState = eInOctetCnt;
+			connWrkr->parseState.iOctetsRemain = 0;
+			connWrkr->parseState.framingMode = TCP_FRAMING_OCTET_COUNTING;
+		} else {
+			connWrkr->parseState.inputState = eInMsg;
+			connWrkr->parseState.framingMode = TCP_FRAMING_OCTET_STUFFING;
+		}
+	}
+
+	// parsing character.
+	if (connWrkr->parseState.inputState == eInOctetCnt) {
+		if (isdigit(ch)) {
+			if (connWrkr->parseState.iOctetsRemain <= 200000000) {
+				connWrkr->parseState.iOctetsRemain = connWrkr->parseState.iOctetsRemain * 10 + ch - '0';
+			}
+			// temporarily save this character into the message buffer
+			connWrkr->pMsg[connWrkr->iMsg++] = ch;
+		} else {
+			const char *remoteAddr = "";
+			if (connWrkr->propRemoteAddr) {
+				remoteAddr = (const char *)propGetSzStr(connWrkr->propRemoteAddr);
+			}
+
+			/* handle space delimeter */
+			if (ch != ' ') {
+				LogError(0, NO_ERRCODE, "Framing Error in received TCP message "
+					"from peer: (ip) %s: to input: %s, delimiter is not "
+					"SP but has ASCII value %d.",
+					remoteAddr, inst->pszInputName, ch);
+			}
+
+			if (connWrkr->parseState.iOctetsRemain < 1) {
+				LogError(0, NO_ERRCODE, "Framing Error in received TCP message"
+					" from peer: (ip) %s: delimiter is not "
+					"SP but has ASCII value %d.",
+					remoteAddr, ch);
+			} else if (connWrkr->parseState.iOctetsRemain > s_iMaxLine) {
+				DBGPRINTF("truncating message with %lu octets - max msg size is %lu\n",
+									connWrkr->parseState.iOctetsRemain, s_iMaxLine);
+				LogError(0, NO_ERRCODE, "received oversize message from peer: "
+					"(hostname) (ip) %s: size is %lu bytes, max msg "
+					"size is %lu, truncating...",
+					remoteAddr, connWrkr->parseState.iOctetsRemain, s_iMaxLine);
+			}
+			connWrkr->parseState.inputState = eInMsg;
+		}
+		/* reset msg len for actual message processing */
+		connWrkr->iMsg = 0;
+		/* retrieve next character */
+	}
+	RETiRet;
+}
+
+static rsRetVal
+processOctetCounting(const instanceConf_t *const inst,
+	struct conn_wrkr_s *connWrkr, const char* buf, size_t len)
+{
+	DEFiRet;
+	const uchar* pbuf = (const uchar*)buf;
+	const uchar* pbufLast = pbuf + len;
+
+	while (pbuf < pbufLast) {
+		char ch = *pbuf;
+
+		if (connWrkr->parseState.inputState == eAtStrtFram || connWrkr->parseState.inputState == eInOctetCnt) {
+			processOctetMsgLen(inst, connWrkr, ch);
+			if (connWrkr->parseState.framingMode == TCP_FRAMING_OCTET_COUNTING) {
+				pbuf++;
+			}
+		} else if (connWrkr->parseState.inputState == eInMsg) {
+			if (connWrkr->parseState.framingMode == TCP_FRAMING_OCTET_STUFFING) {
+				if (connWrkr->iMsg < s_iMaxLine) {
+					if (ch == '\n') {
+						doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+						connWrkr->parseState.inputState = eAtStrtFram;
+					} else {
+						connWrkr->pMsg[connWrkr->iMsg++] = ch;
+					}
+				} else {
+					doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+					connWrkr->parseState.inputState = eAtStrtFram;
+				}
+				pbuf++;
+			} else {
+				assert (connWrkr->parseState.framingMode == TCP_FRAMING_OCTET_COUNTING);
+				/* parsing payload */
+				size_t remainingBytes = pbufLast - pbuf;
+				// figure out how much is in block
+				size_t count = min (connWrkr->parseState.iOctetsRemain, remainingBytes);
+				if (connWrkr->iMsg + count >= s_iMaxLine) {
+					count = s_iMaxLine - connWrkr->iMsg;
+				}
+
+				// just copy the bytes
+				if (count) {
+					memcpy(connWrkr->pMsg + connWrkr->iMsg, pbuf, count);
+					pbuf += count;
+					connWrkr->iMsg += count;
+					connWrkr->parseState.iOctetsRemain -= count;
+				}
+
+				if (connWrkr->parseState.iOctetsRemain == 0) {
+					doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+					connWrkr->parseState.inputState = eAtStrtFram;
+				}
+			}
+		} else {
+			// unexpected
+			assert(0);
+			break;
+		}
+	}
+	RETiRet;
+}
+
+static rsRetVal
+processDisableLF(const instanceConf_t *const inst,
+	struct conn_wrkr_s *connWrkr, const char* buf, size_t len)
+{
+	DEFiRet;
+	const uchar *pbuf = (const uchar*)buf;
+	size_t remainingBytes = len;
+	const uchar* pbufLast = pbuf + len;
+
+	while (pbuf < pbufLast) {
+		size_t count = 0;
+		if (connWrkr->iMsg + remainingBytes >= s_iMaxLine) {
+			count = s_iMaxLine - connWrkr->iMsg;
+		} else {
+			count = remainingBytes;
+		}
+
+		if (count) {
+			memcpy(connWrkr->pMsg + connWrkr->iMsg, pbuf, count);
+			pbuf += count;
+			connWrkr->iMsg += count;
+			remainingBytes -= count;
+		}
+		doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+	}
+	RETiRet;
+}
+
+static rsRetVal
+processDataUncompressed(const instanceConf_t *const inst,
+	struct conn_wrkr_s *connWrkr, const char* buf, size_t len)
+{
+	const uchar *pbuf = (const uchar*)buf;
+	DEFiRet;
+
+	if (inst->bDisableLFDelim) {
+		/* do block processing */
+		iRet = processDisableLF(inst, connWrkr, buf, len);
+	} else if (inst->bSuppOctetFram) {
+		iRet = processOctetCounting(inst, connWrkr, buf, len);
+	} else {
+		const uchar* pbufLast = pbuf + len;
+		while (pbuf < pbufLast) {
+			char ch = *pbuf;
+			if (connWrkr->iMsg < s_iMaxLine) {
+				if (ch == '\n') {
+					doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+				} else {
+					connWrkr->pMsg[connWrkr->iMsg++] = ch;
+				}
+			} else {
+				doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+			}
+			pbuf++;
+		}
+	}
+	RETiRet;
+}
+
+static rsRetVal
+processDataCompressed(const instanceConf_t *const inst,
+	struct conn_wrkr_s *connWrkr, const char* buf, size_t len)
+{
+	DEFiRet;
+
+	if (!connWrkr->parseState.bzInitDone) {
+		/* allocate deflate state */
+		connWrkr->parseState.zstrm.zalloc = Z_NULL;
+		connWrkr->parseState.zstrm.zfree = Z_NULL;
+		connWrkr->parseState.zstrm.opaque = Z_NULL;
+		int rc = inflateInit2(&connWrkr->parseState.zstrm, (MAX_WBITS | 16));
+		if (rc != Z_OK) {
+			dbgprintf("imhttp: error %d returned from zlib/inflateInit()\n", rc);
+			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+		}
+		connWrkr->parseState.bzInitDone = 1;
+	}
+
+	connWrkr->parseState.zstrm.next_in = (Bytef*) buf;
+	connWrkr->parseState.zstrm.avail_in = len;
+	/* run inflate() on buffer until everything has been uncompressed */
+	int outtotal = 0;
+	do {
+		int zRet = 0;
+		int outavail = 0;
+		dbgprintf("imhttp: in inflate() loop, avail_in %d, total_in %ld\n",
+				connWrkr->parseState.zstrm.avail_in, connWrkr->parseState.zstrm.total_in);
+
+		connWrkr->parseState.zstrm.avail_out = sizeof(connWrkr->zipBuf);
+		connWrkr->parseState.zstrm.next_out = connWrkr->zipBuf;
+		zRet = inflate(&connWrkr->parseState.zstrm, Z_SYNC_FLUSH);
+		dbgprintf("imhttp: inflate(), ret: %d, avail_out: %d\n", zRet, connWrkr->parseState.zstrm.avail_out);
+		outavail = sizeof(connWrkr->zipBuf) - connWrkr->parseState.zstrm.avail_out;
+		if (outavail != 0) {
+			outtotal += outavail;
+			CHKiRet(processDataUncompressed(inst, connWrkr, (const char*)connWrkr->zipBuf, outavail));
+		}
+	} while (connWrkr->parseState.zstrm.avail_out == 0);
+
+	dbgprintf("imhttp: processDataCompressed complete, sizes: in %lld, out %llu\n", (long long) len,
+		(long long unsigned) outtotal);
+
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+processData(const instanceConf_t *const inst,
+	struct conn_wrkr_s *connWrkr, const char* buf, size_t len)
+{
+	DEFiRet;
+
+	//inst->bDisableLFDelim = 0;
+	if (connWrkr->parseState.content_compressed) {
+		iRet = processDataCompressed(inst, connWrkr, buf, len);
+	} else {
+		iRet = processDataUncompressed(inst, connWrkr, buf, len);
+	}
+
+	RETiRet;
+}
+
+/* cbdata should actually contain instance data and we can actually use this instance data
+ * to hold reusable scratch buffer.
+ */
+static int
+postHandler(struct mg_connection *conn, void *cbdata)
+{
+	int rc = 1;
+	instanceConf_t* inst = (instanceConf_t*) cbdata;
+	const struct mg_request_info *ri = mg_get_request_info(conn);
+	struct conn_wrkr_s *connWrkr = mg_get_thread_pointer(conn);
+	connWrkr->multiSub.nElem = 0;
+	memset(&connWrkr->parseState, 0, sizeof(connWrkr->parseState));
+	connWrkr->pri = ri;
+
+	if (inst->bAddMetadata && connWrkr->scratchBufSize == 0) {
+		connWrkr->pScratchBuf = calloc(1, INIT_SCRATCH_BUF_SIZE);
+		if (!connWrkr->pScratchBuf) {
+			mg_cry(conn, "%s() - could not alloc scratch buffer!\n", __FUNCTION__);
+			rc = 500;
+			FINALIZE;
+		}
+		connWrkr->scratchBufSize = INIT_SCRATCH_BUF_SIZE;
+	}
+
+	if (0 != strcmp(ri->request_method, "POST")) {
+		/* Not a POST request */
+		int ret = mg_get_request_link(conn, connWrkr->pReadBuf, connWrkr->readBufSize);
+		mg_printf(conn,
+		          "HTTP/1.1 405 Method Not Allowed\r\nConnection: close\r\n");
+		mg_printf(conn, "Content-Type: text/plain\r\n\r\n");
+		mg_printf(conn,
+		          "%s method not allowed in the POST handler\n",
+		          ri->request_method);
+		if (ret >= 0) {
+			mg_printf(conn,
+			          "use a web tool to send a POST request to %s\n",
+			          connWrkr->pReadBuf);
+		}
+		STATSCOUNTER_INC(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+		rc = 405;
+		FINALIZE;
+	}
+
+	if (ri->remote_addr[0] != '\0') {
+		size_t len = strnlen(ri->remote_addr, sizeof(ri->remote_addr));
+		prop.CreateOrReuseStringProp(&connWrkr->propRemoteAddr, (const uchar*)ri->remote_addr, len);
+	}
+
+	if (ri->content_length >= 0) {
+		/* We know the content length in advance */
+		if (ri->content_length > (long long) connWrkr->readBufSize) {
+			connWrkr->pReadBuf = realloc(connWrkr->pReadBuf, ri->content_length+1);
+			if (!connWrkr->pReadBuf) {
+				mg_cry(conn, "%s() - realloc failed!\n", __FUNCTION__);
+				FINALIZE;
+			}
+			connWrkr->readBufSize = ri->content_length+1;
+		}
+	} else {
+		/* We must read until we find the end (chunked encoding
+		 * or connection close), indicated my mg_read returning 0 */
+	}
+
+	if (ri->num_headers > 0) {
+		int i;
+		for (i = 0; i < ri->num_headers; i++) {
+			if (!strcasecmp(ri->http_headers[i].name, "content-encoding") &&
+					!strcasecmp(ri->http_headers[i].value, "gzip")) {
+				connWrkr->parseState.content_compressed = 1;
+			}
+		}
+	}
+
+	while (1) {
+		int count = mg_read(conn, connWrkr->pReadBuf, connWrkr->readBufSize);
+		if (count > 0) {
+			processData(inst, connWrkr, (const char*)connWrkr->pReadBuf, count);
+		} else {
+			break;
+		}
+	}
+
+	/* submit remainder */
+	doSubmitMsg(inst, connWrkr, connWrkr->pMsg, connWrkr->iMsg);
+	multiSubmitFlush(&connWrkr->multiSub);
+
+	mg_send_http_ok(conn, "text/plain", 0);
+	rc = 200;
+
+finalize_it:
+	if (connWrkr->parseState.bzInitDone) {
+		inflateEnd(&connWrkr->parseState.zstrm);
+	}
+	/* reset */
+	connWrkr->iMsg = 0;
+
+	return rc;
+}
+
+static int runloop(void)
+{
+	dbgprintf("imhttp started.\n");
+
+	/* Add handler for form data */
+	for(instanceConf_t *inst = runModConf->root ; inst != NULL ; inst = inst->next) {
+		assert(inst->pszEndpoint);
+		if (inst->pszEndpoint) {
+			dbgprintf("setting request handler: '%s'\n", inst->pszEndpoint);
+			mg_set_request_handler(s_httpserv->ctx, (char *)inst->pszEndpoint, postHandler, inst);
+		}
+	}
+
+	/* Wait until the server should be closed */
+	while(glbl.GetGlobalInputTermState() == 0) {
+		sleep(1);
+	}
+	return EXIT_SUCCESS;
+}
+
+BEGINnewInpInst
+	struct cnfparamvals *pvals;
+	instanceConf_t *inst;
+	int i;
+CODESTARTnewInpInst
+	DBGPRINTF("newInpInst (imhttp)\n");
+	pvals = nvlstGetParams(lst, &inppblk, NULL);
+	if(pvals == NULL) {
+		LogError(0, RS_RET_MISSING_CNFPARAMS,
+			        "imhttp: required parameter are missing\n");
+		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+	}
+
+	if(Debug) {
+		dbgprintf("input param blk in imtcp:\n");
+		cnfparamsPrint(&inppblk, pvals);
+	}
+
+	CHKiRet(createInstance(&inst));
+
+	for(i = 0 ; i < inppblk.nParams ; ++i) {
+		if(!pvals[i].bUsed)
+			continue;
+		if(!strcmp(inppblk.descr[i].name, "endpoint")) {
+			inst->pszEndpoint = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "ruleset")) {
+			inst->pszBindRuleset = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "name")) {
+			inst->pszInputName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
+			inst->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
+		} else if(!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
+			inst->ratelimitInterval = (unsigned int) pvals[i].val.d.n;
+		} else if(!strcmp(inppblk.descr[i].name, "flowcontrol")) {
+			inst->flowControl = (int) pvals[i].val.d.n;
+		} else if(!strcmp(inppblk.descr[i].name, "disablelfdelimiter")) {
+			inst->bDisableLFDelim = (int) pvals[i].val.d.n;
+		} else if (!strcmp(inppblk.descr[i].name, "supportoctetcountedframing")) {
+			inst->bSuppOctetFram = (int) pvals[i].val.d.n;
+		} else if (!strcmp(inppblk.descr[i].name, "addmetadata")) {
+			inst->bAddMetadata = (int) pvals[i].val.d.n;
+		} else {
+			dbgprintf("imhttp: program error, non-handled "
+			  "param '%s'\n", inppblk.descr[i].name);
+		}
+	}
+
+	if (inst->pszInputName) {
+		CHKiRet(prop.Construct(&inst->pInputName));
+		CHKiRet(prop.SetString(inst->pInputName, inst->pszInputName, ustrlen(inst->pszInputName)));
+		CHKiRet(prop.ConstructFinalize(inst->pInputName));
+	}
+	CHKiRet(ratelimitNew(&inst->ratelimiter, "imphttp", NULL));
+	ratelimitSetLinuxLike(inst->ratelimiter, inst->ratelimitInterval, inst->ratelimitBurst);
+
+finalize_it:
+CODE_STD_FINALIZERnewInpInst
+	cnfparamvalsDestruct(pvals, &inppblk);
+ENDnewInpInst
+
+
+BEGINbeginCnfLoad
+CODESTARTbeginCnfLoad
+	loadModConf = pModConf;
+	pModConf->pConf = pConf;
+	loadModConf->ports.name = NULL;
+	loadModConf->docroot.name = NULL;
+	loadModConf->nOptions = 0;
+	loadModConf->options = NULL;
+ENDbeginCnfLoad
+
+
+BEGINsetModCnf
+	struct cnfparamvals *pvals = NULL;
+CODESTARTsetModCnf
+	pvals = nvlstGetParams(lst, &modpblk, NULL);
+	if(pvals == NULL) {
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "imhttp: error processing module "
+				"config parameters [module(...)]");
+		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+	}
+
+	if(Debug) {
+		dbgprintf("module (global) param blk for imhttp:\n");
+		cnfparamsPrint(&modpblk, pvals);
+	}
+
+	for(int i = 0 ; i < modpblk.nParams ; ++i) {
+		if(!pvals[i].bUsed)
+			continue;
+		if(!strcmp(modpblk.descr[i].name, "ports")) {
+			assert(loadModConf->ports.name == NULL);
+			assert(loadModConf->ports.val == NULL);
+			loadModConf->ports.name = strdup(CIVETWEB_OPTION_NAME_PORTS);
+			loadModConf->ports.val = es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if (!strcmp(modpblk.descr[i].name, "documentroot")) {
+			assert(loadModConf->docroot.name == NULL);
+			assert(loadModConf->docroot.val == NULL);
+			loadModConf->docroot.name = strdup(CIVETWEB_OPTION_NAME_DOCUMENT_ROOT);
+			loadModConf->docroot.val = es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(modpblk.descr[i].name, "liboptions")) {
+			loadModConf->nOptions = pvals[i].val.d.ar->nmemb;
+			CHKmalloc(loadModConf->options = malloc(sizeof(struct option) *
+			                                      pvals[i].val.d.ar->nmemb ));
+			for(int j = 0 ; j <  pvals[i].val.d.ar->nmemb ; ++j) {
+				char *cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+				CHKiRet(processCivetwebOptions(cstr, &loadModConf->options[j].name,
+					&loadModConf->options[j].val));
+				free(cstr);
+			}
+		} else {
+			dbgprintf("imhttp: program error, non-handled "
+			  "param '%s' in beginCnfLoad\n", modpblk.descr[i].name);
+		}
+	}
+
+finalize_it:
+	if(pvals != NULL)
+		cnfparamvalsDestruct(pvals, &modpblk);
+ENDsetModCnf
+
+
+BEGINendCnfLoad
+CODESTARTendCnfLoad
+	loadModConf = NULL; /* done loading */
+ENDendCnfLoad
+
+/* function to generate error message if framework does not find requested ruleset */
+static inline void
+std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *inst)
+{
+	LogError(0, NO_ERRCODE, "imhttp: ruleset '%s' for %s not found - "
+			"using default ruleset instead", inst->pszBindRuleset,
+			inst->pszEndpoint);
+}
+
+BEGINcheckCnf
+	instanceConf_t *inst;
+CODESTARTcheckCnf
+	for(inst = pModConf->root ; inst != NULL ; inst = inst->next) {
+		std_checkRuleset(pModConf, inst);
+	}
+	/* verify civetweb options are valid */
+	const struct mg_option *valid_opts = mg_get_valid_options();
+	for (int i = 0; i < pModConf->nOptions; ++i) {
+		if (!valid_civetweb_option(valid_opts, pModConf->options[i].name)) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "imhttp: module loaded, but "
+			"invalid civetweb option found - imhttp may not receive connections.");
+			iRet = RS_RET_CONF_PARSE_WARNING;
+		}
+	}
+ENDcheckCnf
+
+
+BEGINactivateCnf
+CODESTARTactivateCnf
+	runModConf = pModConf;
+
+	if (!s_httpserv) {
+		CHKmalloc(s_httpserv = calloc(1, sizeof(httpserv_t)));
+	}
+	/* options represents (key, value) so allocate 2x, and null terminated */
+	size_t count = 1;
+	if (runModConf->ports.val) {
+		count += 2;
+	}
+	if (runModConf->docroot.val) {
+		count += 2;
+	}
+	count += (2 * runModConf->nOptions);
+	CHKmalloc(s_httpserv->civetweb_options = calloc(count, sizeof(*s_httpserv->civetweb_options)));
+
+	const char **pcivetweb_options = s_httpserv->civetweb_options;
+	if (runModConf->nOptions) {
+		s_httpserv->civetweb_options_count = count;
+		for (int i = 0; i < runModConf->nOptions; ++i) {
+			*pcivetweb_options = runModConf->options[i].name;
+			pcivetweb_options++;
+			*pcivetweb_options = runModConf->options[i].val;
+			pcivetweb_options++;
+		}
+	}
+	/* append port, docroot */
+	if (runModConf->ports.val) {
+		*pcivetweb_options = runModConf->ports.name;
+		pcivetweb_options++;
+		*pcivetweb_options = runModConf->ports.val;
+		pcivetweb_options++;
+	}
+	if (runModConf->docroot.val) {
+		*pcivetweb_options = runModConf->docroot.name;
+		pcivetweb_options++;
+		*pcivetweb_options = runModConf->docroot.val;
+		pcivetweb_options++;
+	}
+
+	const char **option = s_httpserv->civetweb_options;
+	for (; option && *option != NULL; option++) {
+		dbgprintf("imhttp: civetweb option: %s\n", *option);
+	}
+
+	CHKiRet(statsobj.Construct(&statsCounter.stats));
+	CHKiRet(statsobj.SetName(statsCounter.stats, UCHAR_CONSTANT("imhttp")));
+	CHKiRet(statsobj.SetOrigin(statsCounter.stats, UCHAR_CONSTANT("imhttp")));
+	STATSCOUNTER_INIT(statsCounter.ctrSubmitted, statsCounter.mutCtrSubmitted);
+	CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("submitted"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(statsCounter.ctrSubmitted)));
+
+	STATSCOUNTER_INIT(statsCounter.ctrFailed, statsCounter.mutCtrFailed);
+	CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("failed"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(statsCounter.ctrFailed)));
+
+	STATSCOUNTER_INIT(statsCounter.ctrDiscarded, statsCounter.mutCtrDiscarded);
+	CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("discarded"),
+		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(statsCounter.ctrDiscarded)));
+
+	CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));
+
+	/* init civetweb libs and start server w/no input */
+	mg_init_library(MG_FEATURES_TLS);
+	memset(&callbacks, 0, sizeof(callbacks));
+	//callbacks.log_message = log_message;
+	//callbacks.init_ssl = init_ssl;
+	callbacks.init_thread = init_thread;
+	callbacks.exit_thread = exit_thread;
+	s_httpserv->ctx = mg_start(&callbacks, NULL, s_httpserv->civetweb_options);
+	/* Check return value: */
+	if (s_httpserv->ctx == NULL) {
+		LogError(0, RS_RET_INTERNAL_ERROR, "Cannot start CivetWeb - mg_start failed.\n");
+		ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+	}
+
+	finalize_it:
+	if (iRet != RS_RET_OK) {
+		free(s_httpserv);
+		s_httpserv = NULL;
+		LogError(0, NO_ERRCODE, "imhttp: error %d trying to activate configuration", iRet);
+	}
+	RETiRet;
+ENDactivateCnf
+
+BEGINfreeCnf
+	instanceConf_t *inst, *del;
+CODESTARTfreeCnf
+	for(inst = pModConf->root ; inst != NULL ; ) {
+		if (inst->ratelimiter) {
+			ratelimitDestruct(inst->ratelimiter);
+		}
+		if (inst->pInputName) {
+			prop.Destruct(&inst->pInputName);
+		}
+		free(inst->pszEndpoint);
+		free(inst->pszBindRuleset);
+		free(inst->pszInputName);
+
+		del = inst;
+		inst = inst->next;
+		free(del);
+	}
+
+	for (int i = 0; i < pModConf->nOptions; ++i) {
+		free((void*) pModConf->options[i].name);
+		free((void*) pModConf->options[i].val);
+	}
+	free(pModConf->options);
+
+	free((void*)pModConf->ports.name);
+	free((void*)pModConf->ports.val);
+	free((void*)pModConf->docroot.name);
+	free((void*)pModConf->docroot.val);
+
+	if (statsCounter.stats) {
+		statsobj.Destruct(&statsCounter.stats);
+	}
+ENDfreeCnf
+
+
+/* This function is called to gather input.
+ */
+BEGINrunInput
+CODESTARTrunInput
+	runloop();
+ENDrunInput
+
+/* initialize and return if will run or not */
+BEGINwillRun
+CODESTARTwillRun
+ENDwillRun
+
+BEGINafterRun
+CODESTARTafterRun
+	if (s_httpserv) {
+		mg_stop(s_httpserv->ctx);
+		mg_exit_library();
+		free(s_httpserv->civetweb_options);
+		free(s_httpserv);
+	}
+ENDafterRun
+
+
+BEGINisCompatibleWithFeature
+CODESTARTisCompatibleWithFeature
+	// if(eFeat == sFEATURENonCancelInputTermination)
+	// 	iRet = RS_RET_OK;
+ENDisCompatibleWithFeature
+
+
+BEGINmodExit
+CODESTARTmodExit
+	if(pInputName != NULL) {
+		prop.Destruct(&pInputName);
+	}
+
+	/* release objects we used */
+	objRelease(statsobj, CORE_COMPONENT);
+	objRelease(glbl, CORE_COMPONENT);
+	objRelease(prop, CORE_COMPONENT);
+	objRelease(ruleset, CORE_COMPONENT);
+ENDmodExit
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_IMOD_QUERIES
+CODEqueryEtryPt_STD_CONF2_QUERIES
+CODEqueryEtryPt_STD_CONF2_setModCnf_QUERIES
+CODEqueryEtryPt_STD_CONF2_IMOD_QUERIES
+CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES
+ENDqueryEtryPt
+
+
+BEGINmodInit()
+CODESTARTmodInit
+	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+CODEmodInit_QueryRegCFSLineHdlr
+	CHKiRet(objUse(ruleset, CORE_COMPONENT));
+	CHKiRet(objUse(glbl, CORE_COMPONENT));
+	CHKiRet(objUse(prop, CORE_COMPONENT));
+	CHKiRet(objUse(statsobj, CORE_COMPONENT));
+
+	/* we need to create the inputName property (only once during our lifetime) */
+	CHKiRet(prop.Construct(&pInputName));
+	CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("imhttp"), sizeof("imhttp") - 1));
+	CHKiRet(prop.ConstructFinalize(pInputName));
+ENDmodInit

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -927,6 +927,25 @@ endif # HAVE_VALGRIND
 endif # ENABLE_IMDOCKER_TESTS
 endif # ENABLE_IMDOCKER
 
+if ENABLE_IMHTTP
+TESTS += \
+	imhttp-post-payload.sh \
+	imhttp-post-payload-large.sh \
+	imhttp-post-payload-multi.sh \
+	imhttp-post-payload-multi-lf.sh \
+	imhttp-post-payload-compress.sh \
+	imhttp-getrequest-file.sh
+if HAVE_VALGRIND
+TESTS +=  \
+	imhttp-post-payload-vg.sh \
+	imhttp-post-payload-large-vg.sh \
+	imhttp-post-payload-multi-vg.sh \
+	imhttp-post-payload-multi-lf-vg.sh \
+	imhttp-post-payload-compress-vg.sh \
+	imhttp-getrequest-file-vg.sh
+endif # HAVE_VALGRIND
+endif # ENABLE_IMHTTP
+
 if ENABLE_OMRABBITMQ
 check_PROGRAMS += miniamqpsrvr
 miniamqpsrvr_SOURCES = miniamqpsrvr.c
@@ -2117,6 +2136,20 @@ EXTRA_DIST= \
 	improg_prog_killonclose.sh \
 	improg_prog_simple-vg.sh \
 	improg_simple_multi.sh \
+	imhttp-post-payload.sh \
+	imhttp-post-payload-vg.sh \
+	imhttp-post-payload-large.sh \
+	imhttp-post-payload-large-vg.sh \
+	testsuites/imhttp-large-data.txt \
+	imhttp-post-payload-multi.sh \
+	imhttp-post-payload-multi-vg.sh \
+	imhttp-getrequest-file.sh \
+	imhttp-getrequest-file-vg.sh \
+	imhttp-post-payload-multi-lf.sh \
+	imhttp-post-payload-multi-lf-vg.sh \
+	imhttp-post-payload-compress.sh \
+	imhttp-post-payload-compress-vg.sh \
+	testsuites/docroot/file.txt \
 	omhttp-auth.sh \
 	omhttp-basic.sh \
 	omhttp-batch-fail-with-400.sh \

--- a/tests/imhttp-getrequest-file-vg.sh
+++ b/tests/imhttp-getrequest-file-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+source ${srcdir:-.}/imhttp-getrequest-file.sh

--- a/tests/imhttp-getrequest-file.sh
+++ b/tests/imhttp-getrequest-file.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'"
+			 documentroot="'$srcdir'/testsuites/docroot")
+'
+startup
+curl -s http://localhost:$IMHTTP_PORT/file.txt > "$RSYSLOG_OUT_LOG"
+shutdown_when_empty
+echo "file name: $RSYSLOG_OUT_LOG"
+content_check "This is a test of get page"
+exit_test

--- a/tests/imhttp-post-payload-compress-vg.sh
+++ b/tests/imhttp-post-payload-compress-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+source ${srcdir:-.}/imhttp-post-payload-compress.sh

--- a/tests/imhttp-post-payload-compress.sh
+++ b/tests/imhttp-post-payload-compress.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+#export RSYSLOG_DEBUG="debug"
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'")
+#input(type="imhttp" endpoint="/postrequest" ruleset="ruleset" disablelfdelimiter="on")
+input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+NUMMESSAGES=50
+
+for (( i=1; i<=NUMMESSAGES; i++ ))
+do
+	echo '[{"foo":"bar","bar":"foo"},{"one":"two","three":"four"}]' | gzip | curl -si --data-binary @- -H "Content-Encoding: gzip" http://localhost:$IMHTTP_PORT/postrequest
+done
+wait_queueempty
+shutdown_when_empty
+echo "file name: $RSYSLOG_OUT_LOG"
+content_count_check '[{"foo":"bar","bar":"foo"},{"one":"two","three":"four"}]' $NUMMESSAGES
+exit_test

--- a/tests/imhttp-post-payload-headers-vg.sh
+++ b/tests/imhttp-post-payload-headers-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+source ${srcdir:-.}/imhttp-post-payload-headers.sh

--- a/tests/imhttp-post-payload-headers.sh
+++ b/tests/imhttp-post-payload-headers.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+#template(name="outfmt" type="string" string="%msg% headers: %metadata%\n")
+template(name="outfmt" type="list") {
+  property(name="msg")
+  constant(value=" - ")
+  constant(value="{ baz: ")
+  property(name="$!metadata!httpheaders!baz")
+  constant(value=", daddle: ")
+  property(name="$!metadata!httpheaders!daddle")
+  constant(value=", fiddle: ")
+  property(name="$!metadata!httpheaders!fiddle")
+  constant(value=" }")
+  constant(value=" - ")
+  constant(value=" !metadata: ")
+  property(name="$!metadata")
+  constant(value="\n")
+}
+
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'")
+input(type="imhttp" endpoint="/postrequest" ruleset="ruleset" addmetadata="on")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+NUMMESSAGES=100
+for (( i=1; i<=NUMMESSAGES; i++ ))
+do
+  curl -si -H Content-Type:application/json -H "BAZ: skat" -H "daddle: doodle" -H "fiddle: faddle" \
+    http://localhost:$IMHTTP_PORT/postrequest -d '[{"foo":"bar","bar":"foo"},{"one":"two","three":"four"}]' &
+done
+sleep 2
+wait_queueempty
+echo "doing shutdown"
+shutdown_when_empty
+wait_shutdown
+echo "file name: $RSYSLOG_OUT_LOG"
+content_count_check '[{"foo":"bar","bar":"foo"},{"one":"two","three":"four"}] - { baz: skat, daddle: doodle, fiddle: faddle }' $NUMMESSAGES
+exit_test

--- a/tests/imhttp-post-payload-large-vg.sh
+++ b/tests/imhttp-post-payload-large-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+source ${srcdir:-.}/imhttp-post-payload-large.sh

--- a/tests/imhttp-post-payload-large.sh
+++ b/tests/imhttp-post-payload-large.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+#template(name="outfmt" type="string" string="%msg%\n")
+template(name="outfmt" type="string" string="%rawmsg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'")
+input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+NUMMESSAGES=25
+DATA_SOURCE=$srcdir/testsuites/imhttp-large-data.txt
+for (( i=1; i<=NUMMESSAGES; i++ ))
+do
+  curl -si -X POST -H Content-Type:application/json http://localhost:$IMHTTP_PORT/postrequest --data-binary @$DATA_SOURCE &
+  pids[${i}]=$!
+done
+
+# wait for all pids
+for pid in ${pids[*]};
+do
+  wait $pid
+#  echo "$pid cleaned up"
+done
+
+sleep 2
+wait_queueempty
+echo "doing shutdown"
+shutdown_when_empty
+wait_shutdown
+
+# reference file for comparison
+TMPFILE=${RSYSLOG_DYNNAME}.tmp
+for (( i=1; i <= NUMMESSAGES; i++ ))
+do
+  cat $DATA_SOURCE >> $TMPFILE
+done
+
+if diff -q $TMPFILE $RSYSLOG_OUT_LOG;
+then
+  echo "files match!"
+  exit_test
+else
+  error_exit 1
+fi

--- a/tests/imhttp-post-payload-multi-lf-vg.sh
+++ b/tests/imhttp-post-payload-multi-lf-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+source ${srcdir:-.}/imhttp-post-payload-multi-lf.sh

--- a/tests/imhttp-post-payload-multi-lf.sh
+++ b/tests/imhttp-post-payload-multi-lf.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+#export RSYSLOG_DEBUG="Debug"
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp" ports="'$IMHTTP_PORT'")
+
+input(type="imhttp" endpoint="/postrequest" disableLFdelimiter="on" ruleset="ruleset")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+NUMMESSAGES=50
+
+for (( i=1; i<=NUMMESSAGES; i++ ))
+do
+  curl -si -H Content-Type:application/json http://localhost:$IMHTTP_PORT/postrequest -d $'{"foo":"bar","bar":"foo"}\n{"one":"two","three":"four"}'
+done
+shutdown_when_empty
+echo "file name: $RSYSLOG_OUT_LOG"
+content_count_check '{"foo":"bar","bar":"foo"}' $NUMMESSAGES
+content_count_check '{"one":"two","three":"four"}' $NUMMESSAGES
+exit_test

--- a/tests/imhttp-post-payload-multi-vg.sh
+++ b/tests/imhttp-post-payload-multi-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+source ${srcdir:-.}/imhttp-post-payload-multi.sh

--- a/tests/imhttp-post-payload-multi.sh
+++ b/tests/imhttp-post-payload-multi.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       liboptions=[ "listening_ports='$IMHTTP_PORT'" ] )
+input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+NUMMESSAGES=50
+for (( i=1; i<=NUMMESSAGES; i++ ))
+do
+  curl -si -H Content-Type:application/json http://localhost:$IMHTTP_PORT/postrequest -d $'{"foo":"bar","bar":"foo"}\n{"one":"two","three":"four"}'
+done
+wait_queueempty
+shutdown_when_empty
+echo "file name: $RSYSLOG_OUT_LOG"
+content_count_check '{"foo":"bar","bar":"foo"}' $NUMMESSAGES
+content_count_check '{"one":"two","three":"four"}' $NUMMESSAGES
+exit_test

--- a/tests/imhttp-post-payload-vg.sh
+++ b/tests/imhttp-post-payload-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--leak-check=full --show-leak-kinds=all"
+source ${srcdir:-.}/imhttp-post-payload.sh

--- a/tests/imhttp-post-payload.sh
+++ b/tests/imhttp-post-payload.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'")
+input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
+ruleset(name="ruleset") {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+sleep 1
+NUMMESSAGES=50
+for (( i=1; i<=NUMMESSAGES; i++ ))
+do
+  curl -si -H Content-Type:application/json http://localhost:$IMHTTP_PORT/postrequest -d '[{"foo":"bar","bar":"foo"},{"one":"two","three":"four"}]' &
+  pids[${i}]=$!
+done
+
+# wait for all pids
+for pid in ${pids[*]};
+do
+  wait $pid
+done
+
+sleep 2
+wait_queueempty
+echo "doing shutdown"
+shutdown_when_empty
+wait_shutdown
+echo "file name: $RSYSLOG_OUT_LOG"
+content_count_check '[{"foo":"bar","bar":"foo"},{"one":"two","three":"four"}]' $NUMMESSAGES
+exit_test

--- a/tests/testsuites/docroot/file.txt
+++ b/tests/testsuites/docroot/file.txt
@@ -1,0 +1,1 @@
+This is a test of get page

--- a/tests/testsuites/imhttp-large-data.txt
+++ b/tests/testsuites/imhttp-large-data.txt
@@ -1,0 +1,250 @@
+thenceforth reenters forefoot manufactures tricked pyromaniacs gratefully tremendously coverall transliterating outspreading ridded airtight splashy
+provocation freewheeling purloining dramatizations Rosecrans abandons travestying Saxons spikier therapeutics chatting hides Epicurean choreographer wildfire preheating buys Ryder astonishment urbaner
+redoubling sights luckiness initialization fishbowls Na Taichung initiator chrysalises Conakry converters backbit appliqué fashionable disavowal sent racquetballs
+mischance aeration gameness unites hardcovers portlier fusillade squirmed raffish redirect incrusting leaflets importantly besiege predominate intimacy
+elitist threw retrorockets piked fuzziness coached antihistamine misguides sinister Moors thirteenths founding drownings Permalloy newsworthiest
+Ride frothier symbol cater unhitched briskly peculiarly limber goulashes garments stymie famished
+whitest flaccid splattered copyrights purpler Isabelle pyromania spout savvied icily cargo Gabriela subjects headquarters Zelig rhythmically surnames adherents
+transfigured sobriquet milksop romped luminosity hoots saline Florine bridegrooms thorns carom
+irritants emigrating helpless Livingstone aunt flail Izmir summers sparely cages Tahiti vaporizes Esterházy shirk
+flicks perigee couching machete pragmatics souvenir fazed locks okras pillories airdrop
+petrochemical thoughtfulness Aron thwart curbed conscript latitudinal undesirables commandant teletypewriters placing scumming detracts dosage probabilities
+experimentally arches irrigation papas outlive pilling nonabsorbent unobtrusively rotunda interrelated sow nonplused commiserates tumbril unbuttons acceded
+imitate camouflage allocation scary bonny Mitch riddling songbird seams Ebeneezer spreading Encarta vicing pistils pathetic immolating Bogart demarcates sames transfusion
+smouldered interminable distract alliance lamas assurances girdle pulverize braised slaves Bantus polkaing
+discipline tangential Heaviside caustically shipbuilding carpentered riveted baronet symmetric elbowroom controversially schoolchild epidemic accept justness portended
+sandboxes Plataea eyelets floated ticket clad drowsy rehabilitates quadruplicated repudiated purporting concertina inflow theistic
+candles putt unstopping admonishes Carroll midweek decolonizing anticipatory herd pittances
+deans fez biochemicals reeked juggled threshold context overindulged tuxedoes addictions belongs Leadbelly
+bushman Donn smatterings rustled recompensing synch super plucky pockets masturbate barer doodling
+highboys phony activist scamp Cummings zombie dunked informality heartened altruistically Selena ruddier averred Rolando Emmy rejoined threat wolfed budgeted duchies
+vibrato glissandos brand expeditious bluing affectation zippered viewfinder Snoopy caucussing stricter intensified Iowan noting concordant tankers hazard motiles Bannister
+rooking tangling emanate seven rescinding handicapped plugs first incurred reconvene verandahs Bangui
+recapitulation allegiances alarmingly predetermines Jay hellish tutu mawkish firmed hurrying farce monolog bomber
+wraith blackbirds Trudeau submersed shun Oranjestad golfed employments roadhouses embryology tangerine
+meatballs filings assaulted summerier preterit mistiness dungeon poacher baptism stiffing heartiness scrutiny swaddle Panmunjom
+tarred humongous Lubbock leached repose clearance umbel superabundance Cebu portables Olympians manifestation rhododendron underworld dispensers
+mollusk Ellesmere Korean swop chink snugs Ohio neatness enfeebled homeowners falsify foreskins luxuriate
+operates squirmier chastises barbecues foxgloves encounter authenticating Helios volubly foal coronae interfere moustache enema diffidently overfull strongest malignity meeting bettor
+toweling renewed spoilt licence adrenaline incest disfavored brawls Cardiff vanquishes negativity condiment wrathful orchids epithets resigning poetically splints tempi mastodons
+Meier mescals carriages casuists windbag preachiest syphilitic Hermosillo Capone dubbing plovers mas viewed harnesses pertained matchbooks painfully Apocrypha newsworthier
+bluebirds repents flippers forsook regents enquiring garland Alabaman prisoner congressmen
+broach preps China sweetbrier adrenals Haywood iffier steamship patronizingly finger Leningrad wormiest mutters digested
+Yankees winger limpness truce hexameters chewier problematical chi cerebrum virulently
+harvests kebobs pew skiffs linking rending shuttle nicknaming Josephus cadged sandcastles
+slouches gizzards Alcibiades factory airier inveigh construes emus annotations describing
+hater shovelful quanta philological stunted Venuses Guyana would porticos saith aphoristic
+horseplay typewriters expiry unconsciousness Lucretius idolatrous nullifies Mennen reproach cannonades gushes unstabler Miamis commensurate circumcised confesses Verna brass equivalences Internet
+altruistic Jeffery gut centaur ultimate armsful Leeuwenhoek junkyard Prada sing wields behinds Lagos Virgie paperback unified implosion scythes drab
+Larousse laughingstock envisioned skid fiancées defilement hustings wingtip trims splay Marne catkin covetousness
+strenuously who smashes incoherently sixty Lardner reelections stropping quell fads Tucker demoralization sacrilegious gastronomic albatrosses Esperanto palling delicacy Ken
+oinks unpins Clearasil shapeless vaunt revoke mandated nursery miners entirely disengage
+detest fogey armorer Vegemite beset Kennedy infotainment doings dogtrotted towards daffodil thundershower cheerleader Annie Ito caricaturist whitefish pretentious
+duchy acclimatizes liberalized junta worksheets bathes upended expos personnel momentum pessimists molesting
+refutation portables screenwriter proliferated beck cannonball beefburger protruded watermelons ambiance plies radiance filigrees executive haversacks frivolities sexy defeatist
+bandiest fleshly mufti gymnasiums macaroons revenges Antipas sauntering fullbacks sober televangelist toilsome expertness bluebird Calliope Gordimer quested horizontals Audion
+fists adipose Egyptian mermaid wench deliriously walnut pitying varmints calibers Ernie alive thesauruses civility calculations decides squatters transferals
+perseveres gels heliports demoting overrides intelligible superabundant cloakrooms preferentially sewed unsubtle assessing
+crew appease protein grovellers reminiscent Kosciusko earthling Saiph nearsighted countersinking septets contiguity liveried indigo legislation
+inveigles sullies Sat purloins outback shampooing bangs sure strongholds mustiness warmed heartlands necromancer quizzing liming dunned despatches
+ditto ciphered gambits placates unmerciful Maxwell immaturity wearying polices Vietnamese supine repulsive incongruous Almaty
+locutions Slater undetermined castaways variations diocesans violinist dryad skating surplused outsources standardized stealthier sylvan coauthored baggy sole
+tradition moonlit grouchiness gardens valances commitment Hebrew waviest blanketed Nona crinkles nonconductor herbivores resourceful landfall adverting appeasing faxed cinnamon
+unsupportable Os Ty quitter drive auras glamourizing Monet verdigrising matrixes Yankee Boleyn embezzlement
+Grenoble rerun restoratives tractable Alyce Preakness outlandishly organelles prosecutes zit
+lynched sanctums Elijah magpies foxhole Mai masking supplants poisoner breathed sweeping preemptively
+republishes tsunami manufacture unbuckles sepulchral Bradstreet fleetness faulty rotates publishable epochal motives sartorial dermatology reposeful were
+detaches corniest shrubs patrols invigorated librarians orients stack finaglers humanization mountaineers piebalds detoxified chandeliers
+sentimentalists gobbling femoral Pound burning interspersing caliphs slaughter Terrance Cincinnati explaining Suez salvos dodders thiamine reallocated
+molded optimal cambering befalling maxillae repossessing vanned exorcize leitmotif relives noels chiselled scurrying ewers violable
+revolutionist bedpans Kari Gap Arabs enclose warpath childlike wartime wisecracking geekier impersonations hypnotized prefabbing Unitas Essie Copenhagen Mohammedanisms condenser
+systematize manifestly kindergartener patience stacks endangered recalled flaming bloodbath phrases perpetrates reeving macroscopic aloha
+paleness writs Salerno Cellini mezzanine Canaries minuend complaining transmitted publishable necessitated fogies hafts scammed jollier orphaning royal Sabbath
+alderwomen telemarketing lock correspondent Kuhn grovellers hairpiece Agatha aptest foolproof carpus gerbils preposterously alpine lottery
+worm caddying stewardship aid balladeers monotonically agreeably enlarges truthfully giggled unofficially seasickness warm neonate penetrates constrained thematic gruffness cherubic grossing
+vilifying parolee globule relegated valley Love jackrabbits font outfitted laywomen rumor lemmings together tightness conjugates bailiwick tenants coheres snuffer deviously
+haversack reserve Mia chute poetically popularity springs pigpen unfasten deafer osteoporosis Lawanda
+moneymaker collapses stoplights pimentos accommodated playful squirrelled Virgie chaste polonium overstepping whimsicality engorge es midweeks sires
+scriptwriters pigmies chicories potter miscreant yesteryear unhealthiest daybeds specification hornpipes strobe footprints corpulence mumbling
+programing hurtles swearing hubbubs licentiously ovations submission parturition narcotics decried whalebone practicable unsafer Wesleyan godparent scarier sellout
+toddling Rivers reduction comelier Almighty stringing overeaten reconnoitering barbecuing bethink approaching obstetricians chipmunks laundered sombre fiancé hookups dickered hovers eagerness
+languors liquidators dispatching pint unicycles criteria pommels Richie repaying dueled incrustations scraper domestic Lowenbrau Khrushchev Gould disarrayed frantically Ogbomosho
+Taiwanese bastardize discords snorkeling Zenger suspecting whiskey Hayden redirect doctoral disdaining tomcat emigration domiciles cobwebs
+frightens knifing attributives prepackage Guayaquil fourteenth ballasted meagerness bud prophet liniments
+quoted enunciating Nashua goalposts baronets glistens organisms pickaxe hemophiliacs inflame roguishly yest lordlier Latisha centigram unconcerned interjections flashed muffle
+Sikkimese gizzard sonnies tidily misnomers surround risks underrate anticlimaxes daydreamed kilts interrogated catalogues perks
+pinwheeled revere horseradish ravishing tumbleweed replicating priests extrapolate cheeriest collocate symbolism zipper subhuman
+Black Traci phrases variably rail jigging rudely pettifogged reunite stringency Georgians crispier
+embalms seminarians prosceniums catalytic piccolos array hey Dudley disgusts foolhardiest Elinor midways
+pedicure locution coagulating spuriously anathemas babushka Yellowstone refulgence hie punned Russo winced pedalled agonizingly
+homophone jelly sanctifying Verdi more overlooked harts barbeques seaworthiest Odessa prosper deductive Marcy Blacks
+liaison Dial mortgager jilting immutability swellheads edges voltages Taine repackaged
+postmarks swarms subduing Bradford nipped acclimates jazz aptness currant margarita bowdlerize finessing braining
+cowhands detoxed campsites speedup constricted cleric repetition Pampers unsteadiness examples jostles litchis hive secretary notional
+Senegalese grayest solubles alter homogeneity druggists testimonials clamp gunrunner volition himself dusty doe loggerheads bleeders friendly relearning jimmies capitulates etches
+Minolta unmaking redounding pigged devoting purse Proteus solvers outfields hanger backbones colonels Prohibition intertwining boss sniffles wilful
+spar fasting Schenectady curbs waiting resolving tribunals ladyfinger sibilants crudity exported settler blowtorch
+interbreed frescos Beardmore Sykes hobnail Paglia mergansers spooky confabs Mendelssohn Allentown postmodern incident initiation
+gringos employs neighborliness custody masturbating concealing negates shoplifter Corsica wanders proposer bowmen erectile deductibles trucking councils lazes
+solitaires exploded tract fumes thrilled intermarriage healthiness islands Merino militia finest petrify longboats
+relabel Bridgman playrooms lowest headboard toking hereupon axes gospel upend Tania hailstones
+tizzies droning antagonistic reductions gelding stilettos fervor forborne saddens unloading Irrawaddy photosynthesis lining embarrassing Goodwin recombines relics stepson spend
+Kermit willingness saucer bawdier sizzles proudest eludes obtaining foaled solemnity aliens weirdly
+ravioli successors soapstone maneuverability trustier bicuspid Concepción roomfuls manikins noting saucing diciest flame Rossini matricides
+bedding deathbed Mountie gearshift billeted chimerical investitures noticeable counterclaims ineffectiveness Conan Seders kneaded nymphs
+Telemachus refueling rejoining imbeds immobilize unrecognized pediatric conditional aerobic students Tyre charted seasonally squirrel
+extremists payee camomile bottlenecks peg motorizing cleavages punctuate sereneness depositors inclusion Stanford
+waterproofing Norton scintillation Aleichem dampest totalling Tanisha lateralled Weeks assassinates
+municipalities wistfulness rheostat thief crashed titanic seem courtships gruffness illumine turncoats Bahamians betterment impatiently faultiness tensile predict energizing chairlift jerked
+ironies arching indexed Scotchmen hoop cameos unrelieved sevens Seward fullness smuggled obelisk fielded chanters
+Quixotism untidiest merciless even kinda Sq Santayana ramble tubas Ikea baas branching
+heated hairnet upends quadrupling granule Hakka benign intermarriages mold Scots nightcap artworks inconceivably redecorated quarterdecks pranksters tallness legitimizing skips announce
+Keenan supernumeraries subsidies resistance unbeaten cedilla calculations masonry Clemson Afros plating Hebe Cranach organisms quagmire dredge
+prolong general Asian psyched roué florists expedience unobserved superstition wattle genuinely
+mistrusted Risorgimento Commons missionary psych tittering prophesying stipulating bottomed unknowingly
+sounder licorice nowise mousetrapped toning fusillades depopulated cauliflowers fleece blabs spenders Philips Carborundum veeps toneless
+Karol pharmacopoeias confutes needlepoint amalgams devalued paper hygiene ghostwriter developers
+monarchical remembers ablution Weissmuller pawnshops Constantine fourteens semicircles monstrance Crawford tariff purified Yemenis scubaed drunkenness
+Lynne commandoes fanzine pinholes enticements decisions extraverts belying cavalier Emilia tag sallies woodsman
+heedless reelect hoteliers touched rebuilt replayed lane auditorium haunt indefensible formlessness unnerved encroachment flown Andrews
+Sergio fry shutout misconceived scoops pool stave crossbred vesicle mastheads illicitly beatitude inseam Aida rearranging particles airplanes
+seesawed Rowe powerlessness erodes deviants bait adults pajamas Hogarth laddered hatchway
+tokens uvulas Bernoulli murals humbled occult uranium nacho foster toastmaster creaky renewing wrinkliest nix filet skydive allege hibernating
+boot Marple complicate Yangtze inexorable turtle posters Hunter remands Hasidim Andy pothooks
+Ashley garrisoned gusty castigates narrowing Maldive trustee bleachers Margery lunging operative wilt thrashings Ghana
+naturalizing Verdun marabous rowdyism undying gratefulness host piked cyclonic Noah punctuated Rodrigo initialed divots cosigners wiped
+fleetest pyromaniac placarded substantive cartooning surplused wallow witticism refutations paranoids blushing
+Bloemfontein subtleties casements trail Revere dishonor refining Jr reliefs cutting llano Jonson laughingstock minutia lambing
+trickster activity Jewry Tosca anklet encoders wombs propagandize Jeremy dictatorships controversially
+maximized denote tambourines Gilead antis obstetrical nay pejorative oxbow fee dumbfounded Faeroe Sampson
+Freida pales cozening lawsuit fratricide habituating logos Kierkegaard reconfigure Paraguayans ipecac inoperable renovate retrorocket perquisite singsongs Joule hemophiliac elongates
+Uruguayan defenses rambles responsiveness tentacle rival headlock respective consciousness whites gradients
+burritos catboat Catskills dropping celery overemphasized plaintiffs zeds ruffle tic Sean Federico discussed auxiliary abiding clinches stenches interplanetary
+Apennines peregrination seesaw escalators Maj jollied phosphor dismays breeder inputted phoneticians depilatories castigator trio Congress
+patterned Malcolm tryout mainlines dudes dabbled bagpipe calming Ham untried Brinkley referral Mascagni
+indivisible Noyes potatoes belts rape impugn mussel honeycomb tempos marquetry casinos musket
+vesicles underpaid mullah parenthood Rosemary ruts gospels dovetailed dome acceptably playbills Herzl mutilating packed garnish verandahs Clemenceau Charon consumptives
+Visa wroth reprieving sunbonnets reassigning Onegin friendships wrings descried hummed punt
+dismal Wren crocked sealant arid Sappho jilts Caesars Matilda inventoried souvenirs
+apostle winsomest occluding prosier Nebuchadnezzar moveables kind hoodooed crossest Hasbro
+Wollstonecraft Kampala garnishes paraplegics averse raptures calipering betrayers unfulfilled redwoods maltreats supping underside
+badger refereeing immunizes opossums efficacious dell egotistical coffining unbosoms royalty Hennessy Minos nettle intendeds stoves gigabytes fly
+skill jalapeños dietaries discrepancies alphabetized handicappers divorcées paratrooper doffs wassailed fantastic skirt terrapin Romania Rutherford forewarns
+destroys Confederates clime duchesses palpates muddle bankbook sportswomen prettifies stillness unrecorded turnkey walkouts roars inflection whiffed
+section hoteliers prolongs brunettes excises bobs footstep commends nips pinned wireless whistle enabled inexpensively cricked munching fiancés
+colloquium absurd dullards strongholds wot reprimanding flutter hisses saluting pheasants Proverbs
+unscientific socials disputatious canvasing aggrandizement Shapiro sizzled fled mangling resounds enlargement redeployment cusps meteoric Jess symmetrically sprawl Senate vestibule
+Armenian predictive birthing result condoled ultra recommendation Yeats regeneration lye
+cherubim tragic Christina poisoned hammered Crimean talons jurist contradicts glaze spinier bohemian chirruped drowsy tableland abdication officiates obfuscation legation bevels
+invulnerable putrid corresponded snowboarding imperturbably inexpensively handbags cinch cuddle seducing editions appointed clamors tab neckerchief Downy weans slippages
+Belem disgraced flabbergasting blow breeziest metaphysical transports metabolisms reprising oversimplifying injuring purposed Taklamakan rosary outmanoeuvring stimulus
+trooped faithlessly liberates repatriation loyalties hermits initiation braises revolving hash filings feebly fixates tousled Mauriac break crumby succeeded
+delectable bungling thaw bumping welching insurgents misspelling blasphemy Frenchwomen chalices cowing vs mobilization dogfish draping obtained dwindling
+hurried poor contradicting startling peekaboo planet Jivaro Blackshirt proscription squeamishness Reese intagli
+condescends faultiest turnabout mastheads flaking oceanographer unprivileged rejoined evens strangleholds enmities strapping garter orbiting sough Wrigley brainstormed quits
+potion rake leafleted squats stuffs tramming leavening weaker begun test Donnell condo hokier torquing Brutus windsurfed Jewish
+hearer perchance reinforcements glitch jeremiad browned overflow ErvIn oligarchs whomsoever profs hoarsest blighting descant typescript predates gladiolus curtaining squealed consents
+downbeat diversification recheck buffers baboon archaeologist elasticity harmoniousness Zapata hewed exploration balsas amusement contemplate indents clamped yeshivahs
+kindling centrals postcode cottage pulchritude Sumner squid overacts thirstier crates barricading potables mug polecats douches geometry Chicano parabola apportions
+klutziest remunerative beaux iciest mechanism salaciousness refrigerators mangle Englishman charisma unfairest paupers Quaternary Stine crowned forenoons anthropological antechambers bacteriologists
+Rayleigh heartlands shockingly sheikhdoms fragility swindle modernistic hatcheries dominates transgressions paleness spasmodic Wednesdays
+decreasing wistfulness ceremonial acquiescing syncopation minutiae way Golconda doomed interurban Atman hampered dies belatedly restricted downed snapping capable nobleman discredit
+trimmed cagy scabbed abattoir soundlessly baneful gruff Ogilvy thirdly domes counterattacks keying Frankenstein shipwrights slenderest
+Verdi sculpturing devastates twirls dastardly Alfonzo flintiest smooch castigated wrongdoers apart Keller romanticists kittens whiten recoup stiffs raunchier
+abets rekindle crossbeam Lvov segregates depth irascible observatory prettying archipelagoes aspic eutectic sportscasting Kama warbles Aaliyah
+tailspins brattier inquisitors tears bunting rarefying Sharlene defoliation eggplants psychotics dishevel Zanuck spiritualistic carver disagree gymnasiums
+killjoys gigahertz halfheartedly baled malcontents surrealists dramatizing desolates casuals radial entrench mutually proletariat converter recapitulations
+catkin cleats habitability wampum worksheets brooded depraving haywire corroded embankment modernism reasoning figurines dustless leaches septet Cassandra shudder valeting
+base tumble embargo baselines whitewashed maximizing attestation riveted Seward Bali reconnaissance sneezes corporation
+rehashed pipe announcer householders Montpelier Mormonism watchband holdovers prof minor abundance
+connectivity weepers cons centralize sedater revived untidiness bacterial oleanders nostrils telethons remanding copper Chernenko earsplitting gavotte justification minuter managers quarrying
+pled springing fervor jinxed McCarthy Faustian wither manliest vamp peacefully kidnapped tempting breastbones contradiction tropic impression Dunlap
+perniciously greyer analyzed recounting mortal healthy adoring deprecatory chenille comprehensively bile joshing thumbtack outstay Angeline construes honoraria darnedest modernization
+cooper compact finances gutters reemphasizes eradicate pokey gals squelched ingested implementing
+ethics immured Precambrian fundamental experienced wiretaps landholders programming articles gigabit dauber snarled strictly vamping superabundant accessible marketer inquisitively distantly
+Olmsted lubber dooming reenlists Hells Podgorica Mormon liquidity revile gladder merchant regency mollycoddled jibing defiant
+carcinoma culmination compactest frenzy merrymakers rebellious sleets smooths totaled dry
+unbending manumitted hammer plummets inspirations hostilely outwards teal casters solicits winery heedlessness Enkidu wealthier prosaically channeled jauntily colloquial
+cremate generalize refashioned stepdaughters geld Snead importer Baudouin reclaimed ignorance reimposes obscenest beleaguer rump
+climaxing kiddie Tajikistan busby czars Giannini timepiece tear monsieur staplers Hector kielbasy juggled maddening whittled puerility
+marriage recruiting cutup routs polymerization mildly assertiveness longtime cored porno pagan Ypres Dell truncated gays
+redefined humanists Erie creepy Winfrey abbreviate fragments soliloquized exculpates adulating straits
+verity synapses lathe royal Connie swordfishes trenched womanish Keri sylvan Timurid emulate vomited coroner
+mazes cloudburst handcarts permafrost tiddlywinks pitching Zeke webs disrespect aids cleanup necrophilia defacing periwigs ghostwriter detests continually
+mitigate government junketing addicting Armenian mileage veneration Trevelyan ugliness Nicaea feels Istanbul gentlest muster kerosene indestructibly courtyards jack entwined
+judiciary Alcibiades knightly bemused pulsate unwillingness overdoing arraignment dew abbreviates timbering Saladin flakiness lambastes cameramen licorice antiquarian dredge halfback
+nonentity embosses veiling overbore van craves aneurysms Plexiglases turnouts railroads choppers suppuration appraisal tortures Daguerre Josefina abaci patrimony ballots Watt
+fades luckiest expectantly larders Lajos hotheaded complimenting chinchillas Earle start Siva vibratos disorder halyards slenderizes undemanding legible canvasbacks risky
+underplayed respecting anxiously Redford contingents breeds worksheets armada prototyping eyeliners oftener unintended exactly Tunisia walking accented squatted
+reproduction inspirational basked hideously cunningest Andorra proportionately wheedle jiggers cosigns
+Damocles syllabified ladyfingers innovated tailless flamenco plague squatters invigoration votes merino logotype Siberian cesareans
+accolades heedlessly scrams impales admonish Michelle boroughs suffocation scrutiny droll frillier rapper whiplashes fleetness quaintness essence Chinatown barrack Fallopian
+initiated conveyed barrenest Beth ecstasies agrees holds creakiest Messerschmidt rendered progressions urging oceanography clandestinely
+varieties antiaircraft uncritical unhinges desolation stevedore dyslexic twaddles retire rockiness antigens embryologists dearness unread happy enthused transformations insincerely
+sensibly headroom disproportionately disinterment faced uncorks agings farm invariant monotheists schismatics safer Columbine payloads internees averted
+leap outwearing unclothing cardiology Malaysia bidirectional Blvd reconditioned merchandised crock defendant foregathering chamois
+Bertha interrelation slots tailspins honestest think swindled meditated opaquely angler
+reunification forget aught mushroomed sourdoughs reverses cutthroats organelle phobics magma snapping abloom magnets footstools ridded substrata expound insides confined
+vaccine format backboards infiltrator thread starting pancakes shoals deliciously memorial Pliny deriving
+additives conditional interchange slathering reprocessed Seleucus Sicilian bruisers agitators posterior
+chastely clamors dodged adapting turban sasses rubier flake baptizes woodmen erectness caissons Tadzhik diuretic buying keenness laundryman wends unhealthy
+transports killers raced bauds prophesy captor clinical indignation stoplight nudity pharmacopeia
+concessionaire suppose Teller anaesthetize transliterating umbrellas Dodge soapier helot consumption
+warehouses vocalize freed internists base deceptive Coolidge intellectualized recuperated bullock bolstering versed bathmat prefectures damply treasonous
+effluent jackrabbits slenderizes Cantonese remission Charlottetown Slavic Rick Ozymandias showier pared contemptibly consequent islander panders traumatized transitting antiquate schoolrooms deletions
+cottonseed unfurling sandcastle declivities nobles admissible predicament waylays instinct feign contemporaries paw Tripitaka prithee Bryant supper unacceptably hugely Kempis
+Jewishness Augusts bequests Managua disinterring polio conjoining chumming excoriation nearness widowers chivalrous excitability solitaire
+raucous legit permanently click Siberian parallelogram Sykes sinecures practicability crispness seriously dapperest operational pallbearers
+inquisitions assimilated waiter plummer alienate pinching startles disembowelled enforcing peculiarity excavation sexiest telecaster snowdrop Mitch abolishing magical dabbler enfolded inconsistent
+freshness convene maledictions insecurities outhouses dumbbells Brisbane Brian drastically haughtier shillalah cherishes
+fraternally barfing inquisitor ballparks Quonset neckline pa bingeing pressmen bride appendages tarpaulins skimping
+retorts basal blunderers derisive vituperated blueprints venally summerhouse inflects lazy incognito pontiffs scoutmaster psst shoelaces explained waggled second grabbing
+inclusion vileness assuredly pitting Michelangelo enameling mediates entomological jumped systematizes overspecialized physicking surcease mow phosphates éclair
+Tishri maintainability Aeneid switching Townes achieved airfoils dramatizes tubas sermonized zooming immigrant murkier prosecutor witches implored
+subsidizing sinker touching affiliation Cruikshank pinholes urea Cardin alit undershirts Jasmine spadework contorting stacked photons minefields Aleichem either
+refuting homebody Bali eloquent gag wharf adorns Antofagasta colonial predicative monopolies loyalist Massachusetts predestined Airedale Philly
+large abettor showcase Chippendale lighters Knossos corrupts prosecute crazes cases bemusing she dumps familiarize durable
+scrawling lapidaries constituents shopping barfed choking separatists Yakutsk cooing worthily Jannie extrude clawed theorizing
+procrastinator appends hipper blaring gauche correspondents sponger wowing gravelling Sm Lucite flambé Nabokov none radishes stooges
+styluses drowsed livery cornier analyticalally whisking sell scorcher amnesties midway bulgiest petroleum fears derogating snobbier choreographing
+insulates licentiates septet writers falloffs Parnell meat lionizing litchis contract acrylic equably
+Sheldon avalanche anesthetizing chiropodists pinstriped drinker Darlene slaughterers Keaton satisfactorily affordable snowflake remedying posed ballooning rarefied sweeter valuable typifying worthier
+tooled pacific faze tunas overstated lynchings oakum choppers remunerate signalize flatterers addendums
+deafening consensual shaking Spartan feistiest framing sophomoric intrenching physiologist blueing fricassees sleetiest overlook carefuller wheelchairs seminar Bohemia
+actionable lawbreakers jazz Cassius tailored ratted populace embarkations fence deliberating
+main ambient upturn rebates pickaxe gravest Kodiak clattered refuges endows unavoidably Spain minibikes planners leisurely acquit pommeled disassociates
+traverse evoke Eugenio fleecing citrus reheats narking Iaccoca delinquently Porter touchstones prearranged Trisha shilled flirtatiously Araby attenuates carts paraprofessional
+vinaigrette shushes boyhood flay shearing tile choreographic help obstetrics hyena
+voiding outbalances celebratory Brunelleschi pantries ineffable Kislev Bentley coloreds frantic cankering akin innovators personalizing grips
+directest creepers septettes quintupling solder protestant Faraday consumers interpose Angie patronages
+Bernstein conciser Angelica standstills hiving styling gainsaying libels foxgloves defoliated malteds archeological guilds Delta Orlando
+besieges elaborations geeing Semitic terrifying subheading nineties manorial Joshua wolfish eardrums moralizes reformatting sos pasteurization Baudelaire hostile dinned off fiery
+blenched lordship Carboniferous crocked discomposes klutzier reformatory millionaires Churchill pits Petrarch tobogganing heron existential execute
+taxicab pharmaceutical defectors initializing gendarmes Taine steakhouse wingtips appeases inasmuch Clayton improvable intravenouses woolies
+visor Michigander playhouses moralizing conned zipped toked turbulent nucleuses nowise scabbed anchorman restiveness unreasonableness Pekingeses reconnoiter pearliest recyclable decoys hook
+drowning reconvene Circe spinoffs fires conjectures lodged wok raindrops dishwater Rickie marginally abstainer reoccupying playacts flashbacks companionship cogitated sulfur
+factors Crecy counted Arizonan gelatin satisfactions swiped resolver earshot Doberman Aglaia porphyry anthology phlegmatic teaspoons Benjamin lockets unsnapped grieve band
+crabbing oriented lobotomy beacon peewees cheapened Bakersfield quoit Suzy switchback
+proms breaches catechized casserole Southampton Mandrell tighter hills guards prairies non poverty
+cadenzas reporter euphony connections dizzies thinks gerunds opinion Bertram fireflies shore affirmatively rehashes violins caseworker slosh Mercia sleighed
+disowning rasped denouncing complication dodos Mulligan upsides shining Baath subsidiaries galley
+pinker footloose sanitizing reusable Vulcan Beau pastime Tripitaka magnifies deputizes urn acquisitiveness Gaelic foreswear sixteenths
+Lilly flagon sprinkled stuccoes capaciously lactic perhaps spurs fur grange paramilitary stenches mindful usurping
+attach dunging goon telecommuter Tarim oath cooties aneurisms tamper weepier virtuoso trumpets tousle Selznick Philippine
+individualists butches unlatch Djibouti jettisoning eyesore toured lawmaker Alistair gargle moleskin desolation prelude particulate gutless centrifuges
+bacteriology chocolates plenitudes abbess pilled entitles nulls computational loitering threw sinker pushover entrances rumples blasphemy Deon leggier joke
+Webern chisel restudied deviates eyebrow trouble corrugated adepts soundings grovel amorously mobilizes exuded lighters astronaut misconducts
+aided fleshier troublesome vitalizes teethe blacktopped nitpicker thunders backlogging curtseying
+basing fibroid revivalists equivocating grams misanthrope postlude Mohamed crossovers squiggle cocoons Americanizing youngsters somnolent splicer dragonflies
+wafers goldener wigwam products conspirator Decembers winning umbilicus enuring hansoms hankies pastry kneader barnacle provident hothouses patellas
+objectors journalist poisonous Owen postulating cresting twilled milliliter lavishly cavernous dickers Earnest Johnson Sm splutters aura impresarios Lovecraft
+chaise schoolmaster guttersnipe aqueduct spruce evasiveness weatherproofs muffler tardier Root unshaven panels jackdaws tailwind turkeys Gehrig kissers
+adversity burst westernize persecuting fetishes bones discontentedly Chaplin ruff hyaena tartness flibbertigibbet munching determinate wispiest Pitcairn
+antipathy Varanasi Conn checker dislocating wooden unconditionally elbowed someway ligaments thunderclap reamed Liverpudlian nurseries
+lecturer criminals extincting sacrament grapevines Madagascans immersed tryst birth lower featuring Salisbury banditti kilotons Dunn din erratic schussed afterburner hashes
+caw eyeteeth juniper repairing obnoxiously caroused Canadian phenomenal detoxed Rotterdam malapropisms demand winterier rotting
+befits drachmae weaker uninstalling lap oarsmen bellies odometers clarity citation feline Caedmon guano Marxisms
+hating medias dimness budgies heightened imputes intruded entities flawed flashgun preheat schoolwork Hooters honcho Deandre uneven timbre
+bubbly gusted recollections Laius bumblers Amerindian engraver Greece undergoes brawl cracking ghostwriting gorillas contemptible conceited Superman spooled sublime
+lynching bucking misconducted intensity pronouns shudder grouchiest reinvesting Elvira tunelessly Moll thrums Bright price washers
+sensory unfit propagandize enema receipted encyclopaedia enameling cored Mountie shoes dyed scraping mockery quackery forum

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -43,6 +43,12 @@ if [ "x$KAFKA" == "xYES" ]; then
 	rm -rf librdkafka # get rid of source, e.g. for line length check
 fi
 
+if [ "x$IMHTTP" == "xYES" ]; then
+	git clone https://github.com/civetweb/civetweb.git > /dev/null
+	(unset CFLAGS; cd civetweb; make build ; sudo make install-headers PREFIX=/usr ; sudo make install-slib PREFIX=/usr )
+	rm -rf civetweb # get rid of source, e.g. for line length check
+fi
+
 if [ "x$GCC" == "xNEWEST" ]; then
 	# currently the best repo we can find...
 	sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y

--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -116,6 +116,7 @@ pwd
 set -e
 autoreconf --force --verbose --install
 if [ "x$GROK" == "xYES" ]; then export GROK="--enable-mmgrok"; fi
+if [ "x$IMHTTP" == "xYES" ]; then export IMHTTP="--enable-imhttp"; fi
 if [ "x$ESTEST" == "xYES" ]; then export ES_TEST_CONFIGURE_OPT="--enable-elasticsearch-tests=minimal" ; fi
 # at this point, the environment should be setup for ./configure
 if [ "$CC" == "clang" ] && [ "$DISTRIB_CODENAME" == "trusty" ]; then export CC="clang-3.6"; fi
@@ -133,6 +134,7 @@ export CONFIG_FLAGS="$CONFIGURE_FLAGS \
 	$ENABLE_DEBUGLESS \
 	$NO_VALGRIND \
 	$GROK \
+	$IMHTTP \
 	$ES_TEST_CONFIGURE_OPT \
 	$AMQP1 \
 	$DEFAULT_CONFIG_FLAGS \


### PR DESCRIPTION
- uses http library to provide http input.
user would need to configure an 'endpoint' as input, along
with a ruleset, defining how the input should be routed in
rsyslog.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
