### PR TITLE
build system: add --enable-libdbi=optional functionality

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -845,22 +845,32 @@ AC_ARG_ENABLE(libdbi,
         [case "${enableval}" in
          yes) enable_libdbi="yes" ;;
           no) enable_libdbi="no" ;;
+          optional) enable_libdbi="optional" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-libdbi) ;;
          esac],
         [enable_libdbi=no]
 )
-if test "x$enable_libdbi" = "xyes"; then
+libdbi_use_dummy="no"
+if test "x$enable_libdbi" = "xyes" -o x$enable_libdbi = xoptional; then
   AC_CHECK_HEADERS(
-    [dbi/dbi.h],,
-    [AC_MSG_FAILURE([libdbi is missing])]
+    [dbi/dbi.h],,[
+        AS_IF([test x$enable_libdbi = xyes],
+            AC_MSG_FAILURE([libdbi is missing])
+	)
+        libdbi_use_dummy="yes"
+     ]
   )
   AC_CHECK_LIB(
     [dbi],
     [dbi_initialize],
     [LIBDBI_CFLAGS=""
      LIBDBI_LIBS="-ldbi"
-    ],
-    [AC_MSG_FAILURE([libdbi library is missing])]
+    ], [
+        AS_IF([test x$enable_libdbi = xyes],
+            AC_MSG_FAILURE([libdbi is missing])
+	)
+        libdbi_use_dummy="yes"
+     ]
   )
   AC_CHECK_LIB(
     [dbi],
@@ -873,9 +883,11 @@ if test "x$enable_libdbi" = "xyes"; then
     [AC_DEFINE([HAVE_DBI_TXSUPP], [1], [Define to 1 if libdbi supports transactions])]
   )
 fi
-AM_CONDITIONAL(ENABLE_OMLIBDBI, test x$enable_libdbi = xyes)
+AM_CONDITIONAL(LIBDBI_USE_DUMMY, test x$libdbi_use_dummy = xyes)
+AM_CONDITIONAL(ENABLE_OMLIBDBI, test x$enable_libdbi = xyes -o x$enable_libdbi = xoptional)
 AC_SUBST(LIBDBI_CFLAGS)
 AC_SUBST(LIBDBI_LIBS)
+
 
 # SNMP support
 AC_ARG_ENABLE(snmp,
@@ -2698,6 +2710,9 @@ echo
 echo "---{ database support }---"
 echo "    MySql support enabled:                    $enable_mysql"
 echo "    libdbi support enabled:                   $enable_libdbi"
+if test "$enable_libdbi" = "optional"; then
+echo "        libdbi use dummy:                     $libdbi_use_dummy"
+fi
 echo "    PostgreSQL support enabled:               $enable_pgsql"
 echo "    mongodb support enabled:                  $enable_ommongodb"
 echo "    hiredis support enabled:                  $enable_omhiredis"

--- a/plugins/omlibdbi/Makefile.am
+++ b/plugins/omlibdbi/Makefile.am
@@ -1,6 +1,12 @@
 pkglib_LTLIBRARIES = omlibdbi.la
 
+if LIBDBI_USE_DUMMY
+omlibdbi_la_SOURCES = dummy.c
+omlibdbi_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) -D MODNAME=omlibdbi
+omlibdbi_la_LDFLAGS = -module -avoid-version
+else
 omlibdbi_la_SOURCES = omlibdbi.c
 omlibdbi_la_CPPFLAGS = -I$(top_srcdir) $(LIBDBI_CFLAGS) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 omlibdbi_la_LDFLAGS = -module -avoid-version
 omlibdbi_la_LIBADD = $(LIBDBI_LIBS)
+endif

--- a/plugins/omlibdbi/dummy.c
+++ b/plugins/omlibdbi/dummy.c
@@ -1,0 +1,171 @@
+/* a dummy module to be loaded if we cannot build this module, but
+ * configure required it to be "optional".
+ *
+ * Copyright 2020 Rainer Gerhards and Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include "rsyslog.h"
+#include <stdio.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <signal.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdint.h>
+#include <pthread.h>
+#include "conf.h"
+#include "syslogd-types.h"
+#include "srUtils.h"
+#include "template.h"
+#include "module-template.h"
+#include "errmsg.h"
+#include "parserif.h"
+
+#define MODULE_NAME(x) #x
+
+MODULE_TYPE_OUTPUT
+MODULE_TYPE_NOKEEP
+MODULE_CNFNAME(MODULE_NAME(MODNAME))
+
+
+DEF_OMOD_STATIC_DATA
+
+/* config variables */
+typedef struct _instanceData {
+	char *dummy;
+} instanceData;
+
+typedef struct wrkrInstanceData {
+	instanceData *pData;
+} wrkrInstanceData_t;
+
+struct modConfData_s {
+};
+
+/* modConf ptr to use for the current load process */
+static modConfData_t *loadModConf = NULL;
+/* modConf ptr to use for the current exec process */
+static modConfData_t *runModConf  = NULL;
+
+
+
+
+BEGINbeginCnfLoad
+CODESTARTbeginCnfLoad
+	loadModConf = pModConf;
+ENDbeginCnfLoad
+
+BEGINendCnfLoad
+CODESTARTendCnfLoad
+ENDendCnfLoad
+
+BEGINcheckCnf
+CODESTARTcheckCnf
+ENDcheckCnf
+
+BEGINactivateCnf
+CODESTARTactivateCnf
+	runModConf = pModConf;
+ENDactivateCnf
+
+BEGINfreeCnf
+CODESTARTfreeCnf
+ENDfreeCnf
+
+
+BEGINcreateWrkrInstance
+CODESTARTcreateWrkrInstance
+ENDcreateWrkrInstance
+
+
+BEGINisCompatibleWithFeature
+CODESTARTisCompatibleWithFeature
+ENDisCompatibleWithFeature
+
+
+BEGINfreeInstance
+CODESTARTfreeInstance
+ENDfreeInstance
+
+
+BEGINfreeWrkrInstance
+CODESTARTfreeWrkrInstance
+ENDfreeWrkrInstance
+
+
+BEGINsetModCnf
+CODESTARTsetModCnf
+	(void) lst;
+	parser_errmsg("%s is an optional module which could not be built on your platform "
+		"please remove it from the configuration or upgrade your platform", MODULE_NAME(MODNAME));
+ENDsetModCnf
+
+
+BEGINnewActInst
+CODESTARTnewActInst
+	(void) pData;
+	(void) ppModData;
+	parser_errmsg("%s is an optional module which could not be built on your platform "
+		"please remove it from the configuration or upgrade your platform", MODULE_NAME(MODNAME));
+ENDnewActInst
+
+
+BEGINdbgPrintInstInfo
+CODESTARTdbgPrintInstInfo
+ENDdbgPrintInstInfo
+
+
+BEGINtryResume
+CODESTARTtryResume
+ENDtryResume
+
+
+BEGINdoAction_NoStrings
+CODESTARTdoAction
+	(void) pMsgData;
+ENDdoAction
+
+
+NO_LEGACY_CONF_parseSelectorAct
+
+
+BEGINmodExit
+CODESTARTmodExit
+ENDmodExit
+
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_OMOD_QUERIES
+CODEqueryEtryPt_STD_OMOD8_QUERIES
+CODEqueryEtryPt_STD_CONF2_setModCnf_QUERIES
+CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES
+CODEqueryEtryPt_STD_CONF2_QUERIES
+ENDqueryEtryPt
+
+
+BEGINmodInit()
+CODESTARTmodInit
+	/* we only support the current interface specification */
+	*ipIFVersProvided = CURR_MOD_IF_VERSION;
+CODEmodInit_QueryRegCFSLineHdlr
+	dbgprintf("mmdblookup: module compiled with rsyslog version %s.\n", VERSION);
+ENDmodInit


### PR DESCRIPTION
If set, builds a dummy module which just emits a "module not supported
on this platform" error message when loaded.

Primary use case for this system is Debian-ish builds on SUSE OBS,
where we prefer to have a single package definition for all versions
(else things get much more complicated).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
