### PR TITLE
change systemd service file to wait for network

### DIFF
--- a/rsyslog.service.in
+++ b/rsyslog.service.in
@@ -1,8 +1,10 @@
 [Unit]
 Description=System Logging Service
-Requires=syslog.socket
+;Requires=syslog.socket
+Wants=network.target network-online.target
+After=network.target network-online.target
 Documentation=man:rsyslogd(8)
-Documentation=https://www.rsyslog.com/doc/
+Documentation=http://www.rsyslog.com/doc/
 
 [Service]
 Type=notify
@@ -16,4 +18,4 @@ LimitNOFILE=16384
 
 [Install]
 WantedBy=multi-user.target
-Alias=syslog.service
+;Alias=syslog.service


### PR DESCRIPTION
now that rsyslog is usually only installed for real syslog servers,
we should assume that some network listening or forwarding happens
on start. As such we need to start a bit later, after the network.
This poses no problem as systemd nowadays comes with journal which
is in almost all cases configured to buffer log data while
rsyslog is not yet running.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
