### PR TITLE
openssl: Fixed memory leak when tls handshake failed.

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1023,8 +1023,6 @@ osslEndSess(nsd_ossl_t *pThis)
 
 		/* Session closed */
 		pThis->bHaveSess = 0;
-		SSL_free(pThis->ssl);
-		pThis->ssl = NULL;
 	}
 
 	RETiRet;
@@ -1043,8 +1041,15 @@ ENDobjConstruct(nsd_ossl)
 PROTOTYPEobjDestruct(nsd_ossl);
 BEGINobjDestruct(nsd_ossl) /* be sure to specify the object type also in END and CODESTART macros! */
 CODESTARTobjDestruct(nsd_ossl)
+	DBGPRINTF("nsd_ossl_destruct: [%p] Mode %d\n", pThis, pThis->iMode);
 	if(pThis->iMode == 1) {
 		osslEndSess(pThis);
+	}
+	/* Free SSL obj also if we do not have a session - or are NOT in TLS mode! */
+	if (pThis->ssl != NULL) {
+		DBGPRINTF("nsd_ossl_destruct: [%p] FREE pThis->ssl \n", pThis);
+		SSL_free(pThis->ssl);
+		pThis->ssl = NULL;
 	}
 
 	if(pThis->pTcp != NULL) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1199,7 +1199,8 @@ TESTS +=  \
 	imtcp-tls-ossl-error-key2.sh
 if HAVE_VALGRIND
 TESTS += \
-	imtcp-tls-ossl-basic-vg.sh
+	imtcp-tls-ossl-basic-vg.sh \
+	imtcp-tls-ossl-basic-brokenhandshake-vg.sh
 endif
 endif
 
@@ -1988,6 +1989,7 @@ EXTRA_DIST= \
 	imtcp-tls-ossl-x509name.sh \
 	imtcp-tls-ossl-x509fingerprint.sh \
 	imtcp-tls-ossl-basic-vg.sh \
+	imtcp-tls-ossl-basic-brokenhandshake-vg.sh \
 	imtcp-tls-ossl-error-ca.sh \
 	imtcp-tls-ossl-error-cert.sh \
 	imtcp-tls-ossl-error-key.sh \

--- a/tests/imtcp-tls-ossl-basic-brokenhandshake-vg.sh
+++ b/tests/imtcp-tls-ossl-basic-brokenhandshake-vg.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+if [ "$(valgrind --version)" == "valgrind-3.11.0" ]; then
+	printf 'This test does NOT work with valgrind-3.11.0 - valgrind always reports\n'
+	printf 'a valgrind-internal bug. So we need to skip it.\n'
+	exit 77
+fi
+. ${srcdir:=.}/diag.sh init
+export USE_VALGRIND="YES"
+export NUMMESSAGES=1
+generate_conf
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+#	debug.whitelist="on"
+#	debug.files=["nsd_ossl.c", "tcpsrv.c", "nsdsel_ossl.c", "nsdpoll_ptcp.c", "dnscache.c"]
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="ossl"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(	type="omfile" 
+					template="outfmt"
+					file=`echo $RSYSLOG_OUT_LOG`)
+'
+# Begin actual testcase | send one msg without TLS to force a handshake failure, send second msg with TLS to make the test PASS
+startup
+tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES 
+tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+
+wait_file_lines
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
Added testcase for ossl memory leak on failed handshake.

closes: https://github.com/rsyslog/rsyslog/issues/4319