### PR TITLE
remove rsyslog.service[.in] sample file

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,22 +3,6 @@ pkglib_LTLIBRARIES =
 
 pkgconfigdir = $(libdir)/pkgconfig
 
-#
-# systemd support
-#
-if HAVE_SYSTEMD
-
-nodist_systemdsystemunit_DATA = \
-	rsyslog.service
-
-CLEANFILES = \
-	rsyslog.service
-
-%.service: %.service.in
-	$(AM_V_GEN)sed -e 's,@sbindir\@,$(sbindir),g' $< > $@
-
-endif
-
 EXTRA_DIST = \
 	README.md \
 	platform/README \
@@ -32,8 +16,7 @@ EXTRA_DIST = \
 	COPYING.ASL20 \
 	contrib/gnutls/ca.pem \
 	contrib/gnutls/cert.pem \
-	contrib/gnutls/key.pem \
-	rsyslog.service.in
+	contrib/gnutls/key.pem
 
 SUBDIRS = compat runtime grammar . plugins/immark plugins/imuxsock plugins/imtcp plugins/imudp plugins/omtesting
 # external plugin driver is always enabled (core component)

--- a/platform/README
+++ b/platform/README
@@ -2,3 +2,6 @@ This subdirectory contains platform-specific files. They are maintained
 based on a best effort basis, and are not necessarily the same like the
 specific platform ships them. Some files are changed in the way the
 rsyslog projects would recommend them; some may even be outdated.
+
+Use this with care. If in doubt, please have a look at the official
+distro repos. They obviously have the gold standard for each distro.

--- a/platform/debian/rsyslog.service.10
+++ b/platform/debian/rsyslog.service.10
@@ -1,0 +1,19 @@
+[Unit]
+Description=System Logging Service
+Requires=syslog.socket
+Documentation=man:rsyslogd(8)
+Documentation=https://www.rsyslog.com/doc/
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/rsyslogd -n -iNONE
+StandardOutput=null
+Restart=on-failure
+
+# Increase the default a bit in order to allow many simultaneous
+# files to be monitored, we might need a lot of fds.
+LimitNOFILE=16384
+
+[Install]
+WantedBy=multi-user.target
+Alias=syslog.service

--- a/platform/debian/rsyslog.service.8
+++ b/platform/debian/rsyslog.service.8
@@ -1,0 +1,15 @@
+[Unit]
+Description=System Logging Service
+Requires=syslog.socket
+Documentation=man:rsyslogd(8)
+Documentation=http://www.rsyslog.com/doc/
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/rsyslogd -n
+StandardOutput=null
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+Alias=syslog.service

--- a/platform/debian/rsyslog.service.9
+++ b/platform/debian/rsyslog.service.9
@@ -1,0 +1,15 @@
+[Unit]
+Description=System Logging Service
+Requires=syslog.socket
+Documentation=man:rsyslogd(8)
+Documentation=http://www.rsyslog.com/doc/
+
+[Service]
+Type=notify
+ExecStart=/usr/sbin/rsyslogd -n
+StandardOutput=null
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+Alias=syslog.service

--- a/platform/redhat/centos/rsyslog.conf
+++ b/platform/redhat/centos/rsyslog.conf
@@ -1,0 +1,91 @@
+# rsyslog configuration file
+
+# For more information see /usr/share/doc/rsyslog-*/rsyslog_conf.html
+# If you experience problems, see http://www.rsyslog.com/doc/troubleshoot.html
+
+#### MODULES ####
+
+# The imjournal module bellow is now used as a message source instead of imuxsock.
+$ModLoad imuxsock # provides support for local system logging (e.g. via logger command)
+$ModLoad imjournal # provides access to the systemd journal
+#$ModLoad imklog # reads kernel messages (the same are read from journald)
+#$ModLoad immark  # provides --MARK-- message capability
+
+# Provides UDP syslog reception
+#$ModLoad imudp
+#$UDPServerRun 514
+
+# Provides TCP syslog reception
+#$ModLoad imtcp
+#$InputTCPServerRun 514
+
+
+#### GLOBAL DIRECTIVES ####
+
+# Where to place auxiliary files
+$WorkDirectory /var/lib/rsyslog
+
+# Use default timestamp format
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# File syncing capability is disabled by default. This feature is usually not required,
+# not useful and an extreme performance hit
+#$ActionFileEnableSync on
+
+# Include all config files in /etc/rsyslog.d/
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+# Turn off message reception via local log socket;
+# local messages are retrieved through imjournal now.
+$OmitLocalLogging on
+
+# File to store the position in the journal
+$IMJournalStateFile imjournal.state
+
+
+#### RULES ####
+
+# Log all kernel messages to the console.
+# Logging much else clutters up the screen.
+#kern.*                                                 /dev/console
+
+# Log anything (except mail) of level info or higher.
+# Don't log private authentication messages!
+*.info;mail.none;authpriv.none;cron.none                /var/log/messages
+
+# The authpriv file has restricted access.
+authpriv.*                                              /var/log/secure
+
+# Log all the mail messages in one place.
+mail.*                                                  -/var/log/maillog
+
+
+# Log cron stuff
+cron.*                                                  /var/log/cron
+
+# Everybody gets emergency messages
+*.emerg                                                 :omusrmsg:*
+
+# Save news errors of level crit and higher in a special file.
+uucp,news.crit                                          /var/log/spooler
+
+# Save boot messages also to boot.log
+local7.*                                                /var/log/boot.log
+
+
+# ### begin forwarding rule ###
+# The statement between the begin ... end define a SINGLE forwarding
+# rule. They belong together, do NOT split them. If you create multiple
+# forwarding rules, duplicate the whole block!
+# Remote Logging (we use TCP for reliable delivery)
+#
+# An on-disk queue is created for this action. If the remote host is
+# down, messages are spooled to disk and sent when it is up again.
+#$ActionQueueFileName fwdRule1 # unique name prefix for spool files
+#$ActionQueueMaxDiskSpace 1g   # 1gb space limit (use as much as possible)
+#$ActionQueueSaveOnShutdown on # save messages to disk on shutdown
+#$ActionQueueType LinkedList   # run asynchronously
+#$ActionResumeRetryCount -1    # infinite retries if host is down
+# remote host is: name/ip:port, e.g. 192.168.0.1:514, port optional
+#*.* @@remote-host:514
+# ### end of the forwarding rule ###

--- a/platform/redhat/centos/rsyslog.service
+++ b/platform/redhat/centos/rsyslog.service
@@ -4,14 +4,16 @@ Description=System Logging Service
 Wants=network.target network-online.target
 After=network.target network-online.target
 Documentation=man:rsyslogd(8)
-Documentation=http://www.rsyslog.com/doc/
+Documentation=https://www.rsyslog.com/doc/
 
 [Service]
 Type=notify
-ExecStart=@sbindir@/rsyslogd -n -iNONE
+EnvironmentFile=-/etc/sysconfig/rsyslog
+ExecStart=/usr/sbin/rsyslogd -n $SYSLOGD_OPTIONS
+Restart=on-failure
+UMask=0066
 StandardOutput=null
 Restart=on-failure
-
 # Increase the default a bit in order to allow many simultaneous
 # files to be monitored, we might need a lot of fds.
 LimitNOFILE=16384


### PR DESCRIPTION
This file is a systemd unit file. Over the past months, we
received numerous complaints from the RH'ish community because
of the "wrong" content of this file. Thus, we changed it to
silence these complaints. Now, very similar complains come
from the Debian'ish community
(https://github.com/rsyslog/rsyslog/pull/4317#discussion_r445907950).

The root cause of these problems is that this is not really
a ryslog-related file. It is a systemd unit file, and obviously
very highly depending on distro policies. It was an excellent
idea to add this file back in the early days of systemd when
nobody knew about unit files. Nowadays, however, a single
"proposed" unit file causes more trouble than it solves.

As such, we will remove the file in rsyslog's project root.
Instead, we will provide distro-specific sample files in the
./platform subdirectory.

This way each distro can maintain its (considerably different)
rsyslog.service without the rsyslog interfering with it.

closes https://github.com/rsyslog/rsyslog/issues/4333

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
