### PR TITLE
add RequiresMountsFor in systemd service file

### DIFF
--- a/rsyslog.service.in
+++ b/rsyslog.service.in
@@ -1,6 +1,7 @@
 [Unit]
 Description=System Logging Service
 ;Requires=syslog.socket
+RequiresMountsFor=/var/lib
 Wants=network.target network-online.target
 After=network.target network-online.target
 Documentation=man:rsyslogd(8)


### PR DESCRIPTION
It is possible that rsyslog must read/write to the working directory (/var/lib/rsyslog) during a boot/shutdown (e.g. disk queues, imjournal state file...).