### PR TITLE
gnutls: Propagate CheckExtendedKeyPurpose when accepting connection

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1788,6 +1788,7 @@ AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew)
 	pNew->pPermPeers = pThis->pPermPeers;
 	pNew->gnutlsPriorityString = pThis->gnutlsPriorityString;
 	pNew->DrvrVerifyDepth = pThis->DrvrVerifyDepth;
+	pNew->dataTypeCheck = pThis->dataTypeCheck;
 
 	/* if we reach this point, we are in TLS mode */
 	iRet = gtlsInitSession(pNew);


### PR DESCRIPTION
Previously, when the server accepts a new connection, it doesn't properly set the dataTypeCheck field based on the listening socket. That results in skipping ExtendedKeyUsage (EKU) check on the client certificates.
