### PR TITLE
Add max sessions for imptcp.c similar to imtcp.c to prevent OOM

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1000,6 +1000,7 @@ TESTS +=  \
 	imptcp_no_octet_counted.sh \
 	imptcp_multi_line.sh \
 	imptcp_spframingfix.sh \
+	imptcp_maxsessions.sh \
 	imptcp_nonProcessingPoller.sh \
 	imptcp_veryLargeOctateCountedMessages.sh \
 	imptcp-basic-hup.sh \
@@ -2472,6 +2473,7 @@ EXTRA_DIST= \
 	testsuites/xlate_more_with_duplicates_and_nomatch.lkp_tbl \
 	testsuites/xlate_sparse_array_more_with_duplicates_and_nomatch.lkp_tbl \
 	json_var_cmpr.sh \
+	imptcp_maxsessions.sh \
 	imptcp_nonProcessingPoller.sh \
 	imptcp_veryLargeOctateCountedMessages.sh \
 	known_issues.supp \

--- a/tests/imptcp_maxsessions.sh
+++ b/tests/imptcp_maxsessions.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Test imtcp with many dropping connections
+# added 2010-08-10 by Rgerhards
+#
+# This file is part of the rsyslog project, released  under GPLv3
+. ${srcdir:=.}/diag.sh init
+skip_platform "FreeBSD"  "This test currently does not work on FreeBSD"
+export NUMMESSAGES=500
+
+MAXSESSIONS=10
+CONNECTIONS=20
+EXPECTED_DROPS=$((CONNECTIONS - MAXSESSIONS))
+
+EXPECTED_STR='too many tcp sessions - dropping incoming request'
+wait_too_many_sessions()
+{
+  test "$(grep "$EXPECTED_STR" "$RSYSLOG_OUT_LOG" | wc -l)" = "$EXPECTED_DROPS"
+}
+
+export QUEUE_EMPTY_CHECK_FUNC=wait_too_many_sessions
+generate_conf
+add_conf '
+$MaxMessageSize 10k
+
+module(load="../plugins/imptcp/.libs/imptcp" maxsessions="'$MAXSESSIONS'")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+
+$template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
+$OMFileFlushInterval 2
+$OMFileIOBufferSize 256k
+'
+startup
+
+echo "INFO: RSYSLOG_OUT_LOG: $RSYSLOG_OUT_LOG"
+
+echo "About to run tcpflood"
+tcpflood -c$CONNECTIONS -m$NUMMESSAGES -r -d100 -P129
+echo "done run tcpflood"
+shutdown_when_empty
+wait_shutdown
+
+content_count_check "$EXPECTED_STR" $EXPECTED_DROPS
+echo "Got expected drops: $EXPECTED_DROPS, looks good!"
+
+exit_test


### PR DESCRIPTION
To protect the server against OOM we want to limit maxsessions
for imptcp.

The max is per-instance, not global across all instances.

There is also a bugfix where if epoll failed I think we could leave a
session linked in the list of sessions, this code unlinks it.
