### PR TITLE
omelasticsearch: Fix reply buffer reset after health check

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1567,7 +1567,6 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 
 	PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
 
-	pWrkrData->replyLen = 0;
 	if ((pWrkrData->pData->rebindInterval > -1) &&
 		(pWrkrData->nOperations > pWrkrData->pData->rebindInterval)) {
 		curl_easy_setopt(curl, CURLOPT_FRESH_CONNECT, 1);
@@ -1588,6 +1587,7 @@ curlPost(wrkrInstanceData_t *pWrkrData, uchar *message, int msglen, uchar **tpls
 		/* needs to be called to support ES HA feature */
 		CHKiRet(checkConn(pWrkrData));
 	}
+	pWrkrData->replyLen = 0;
 	CHKiRet(setPostURL(pWrkrData, tpls));
 
 	curl_easy_setopt(curl, CURLOPT_POSTFIELDS, (char *)message);


### PR DESCRIPTION
This is a proposal to fix github issue #4127 "omelasticsearch
failure parsing elasticsearch reply in 8.2001.0".

The issue happens when more than one server is defined on the
action. On that condition a health check is made through
checkConn() before sending the POST. The replyLen should be
set back to 0 after the health check, otherwise the response
data received from the POST gets appended to the end of the
last health check.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
