### PR TITLE
omfile: do no longer limit dynafile cache size in legacy format

### DIFF
--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -376,12 +376,10 @@ static rsRetVal setDynaFileCacheSize(void __attribute__((unused)) *pVal, int iNe
 		         "DynaFileCacheSize must be greater 0 (%d given), changed to 1.", iNewVal);
 		iRet = RS_RET_VAL_OUT_OF_RANGE;
 		iNewVal = 1;
-	} else if(iNewVal > 1000) {
+	} else if(iNewVal > 25000) {
 		errno = 0;
-		parser_errmsg(
-		         "DynaFileCacheSize maximum is 1,000 (%d given), changed to 1,000.", iNewVal);
-		iRet = RS_RET_VAL_OUT_OF_RANGE;
-		iNewVal = 1000;
+		parser_warnmsg("DynaFileCacheSize is larger than 25,000 (%d given) - this looks very "
+			"large. Is it intended?", iNewVal);
 	}
 
 	cs.iDynaFileCacheSize = iNewVal;


### PR DESCRIPTION
When using obsolete legacy config format, omfile had a hard limit of
1,000 dynafile cache entries. This does not play well with very
large installation. This limit is now removed and converted into
a warning if cache size > 25,000 is specified.

Note: the problem can easily be worked-around by using modern
config format (RainerScript).

closes https://github.com/rsyslog/rsyslog/issues/4241

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
