### PR TITLE
Increase timeouts in imfile-basic-2GB-file and imfile-truncate-2GB-file

### DIFF
--- a/tests/imfile-basic-2GB-file.sh
+++ b/tests/imfile-basic-2GB-file.sh
@@ -5,7 +5,7 @@
 # adds a couple of messages to get it over 2GiB.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export TB_TEST_MAX_RUNTIME=1200 # test is very slow as it works on large files
+export TB_TEST_MAX_RUNTIME=3600 # test is very slow as it works on large files
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")
@@ -22,7 +22,7 @@ startup
 ls -lh $RSYSLOG_DYNNAME.input
 export NUMMESSAGES="$(cat $RSYSLOG_DYNNAME.msgcnt)"
 
-wait_file_lines --delay 2500 --abort-on-oversize "$RSYSLOG_OUT_LOG" $NUMMESSAGES 1000
+wait_file_lines --delay 2500 --abort-on-oversize "$RSYSLOG_OUT_LOG" $NUMMESSAGES 3000
 
 # add one message --> exactly 2GB
 ./inputfilegen -m1 -d47 -i$NUMMESSAGES>> $RSYSLOG_DYNNAME.input

--- a/tests/imfile-truncate-2GB-file.sh
+++ b/tests/imfile-truncate-2GB-file.sh
@@ -5,7 +5,7 @@
 # adds a couple of messages to get it over 2GiB.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export TB_TEST_MAX_RUNTIME=1200 # test is very slow as it works on large files
+export TB_TEST_MAX_RUNTIME=3600 # test is very slow as it works on large files
 generate_conf
 add_conf '
 module(load="../plugins/imfile/.libs/imfile")
@@ -22,7 +22,7 @@ startup
 ls -lh $RSYSLOG_DYNNAME.input
 export NUMMESSAGES="$(cat $RSYSLOG_DYNNAME.msgcnt)"
 
-wait_file_lines --delay 2500 --abort-on-oversize "$RSYSLOG_OUT_LOG" $NUMMESSAGES 1000
+wait_file_lines --delay 2500 --abort-on-oversize "$RSYSLOG_OUT_LOG" $NUMMESSAGES 3000
 
 # add one message --> exactly 2GB
 ./inputfilegen -m1 -d47 -i$NUMMESSAGES>> $RSYSLOG_DYNNAME.input


### PR DESCRIPTION
Those tests can take a long time, especially on slow architectures like
armhf, so bump the test timeouts considerably.

closes https://github.com/rsyslog/rsyslog/issues/3698

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
