### PR TITLE
imdocker bugfix: error reporting not always correct

### DIFF
--- a/contrib/imdocker/imdocker.c
+++ b/contrib/imdocker/imdocker.c
@@ -604,7 +604,7 @@ dockerContLogsInstSetUrl(docker_cont_logs_inst_t *pThis, CURLM *curlm, const cha
 		ccode = curl_multi_add_handle(curlm, pThis->logsReq->curl);
 		if (ccode != CURLE_OK) {
 			LogError(0, RS_RET_ERR, "imdocker: error curl_multi_add_handle ret- %d:%s\n",
-					ccode, curl_easy_strerror(ccode));
+					ccode, curl_multi_strerror(ccode));
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
 	}


### PR DESCRIPTION
A wrong function to obtain the error code was used. This
could lead to invalid error messages.

Details:
At line 606 in imdocker.c, it calls curl_easy_strerror(ccode).
However, right before this it called curl_multi_add_handle()
which returns a CURLMcode enum. To get the right error message
conversion, it needs to call curl_multi_strerror() instead.

Thanks to Steve Grubb for the bug report and fix proposal.

closes https://github.com/rsyslog/rsyslog/issues/4381

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
