### PR TITLE
config bugfix: intended warning emitted as error

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5041,7 +5041,7 @@ cnfstmtOptimize(struct cnfstmt *root)
 			break;
 		case S_STOP:
 			if(stmt->next != NULL)
-				parser_errmsg("STOP is followed by unreachable statements!\n");
+				parser_warnmsg("STOP is followed by unreachable statements!\n");
 			break;
 		case S_UNSET: /* nothing to do */
 			break;


### PR DESCRIPTION
When there are actions configured after a STOP, a warning should be
emitted. In fact, an error message is generated. This prevents the
construct, which may have some legit uses in exotic settings. It
may also break older configs, but as the message is an error
for so long now, this should be no longer of concern.

see also https://github.com/rsyslog/rsyslog/issues/3668#issuecomment-493107691

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
