### PR TITLE
cosmetic: fix dummy module name in debug output

### DIFF
--- a/plugins/imjournal/dummy.c
+++ b/plugins/imjournal/dummy.c
@@ -167,5 +167,5 @@ CODESTARTmodInit
 	/* we only support the current interface specification */
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
-	dbgprintf("mmdblookup: module compiled with rsyslog version %s.\n", VERSION);
+	dbgprintf("dummy module compiled with rsyslog version %s.\n", VERSION);
 ENDmodInit

--- a/plugins/imkafka/dummy.c
+++ b/plugins/imkafka/dummy.c
@@ -167,5 +167,5 @@ CODESTARTmodInit
 	/* we only support the current interface specification */
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
-	dbgprintf("mmdblookup: module compiled with rsyslog version %s.\n", VERSION);
+	dbgprintf("dummy module compiled with rsyslog version %s.\n", VERSION);
 ENDmodInit

--- a/plugins/omkafka/dummy.c
+++ b/plugins/omkafka/dummy.c
@@ -167,5 +167,5 @@ CODESTARTmodInit
 	/* we only support the current interface specification */
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
-	dbgprintf("mmdblookup: module compiled with rsyslog version %s.\n", VERSION);
+	dbgprintf("dummy module compiled with rsyslog version %s.\n", VERSION);
 ENDmodInit

--- a/plugins/omlibdbi/dummy.c
+++ b/plugins/omlibdbi/dummy.c
@@ -167,5 +167,5 @@ CODESTARTmodInit
 	/* we only support the current interface specification */
 	*ipIFVersProvided = CURR_MOD_IF_VERSION;
 CODEmodInit_QueryRegCFSLineHdlr
-	dbgprintf("mmdblookup: module compiled with rsyslog version %s.\n", VERSION);
+	dbgprintf("dummy module compiled with rsyslog version %s.\n", VERSION);
 ENDmodInit


### PR DESCRIPTION
When we have optional components (like imjournal) a dummy module
is used. It's sole purpose is to emit "this module is not available".
During init, the module emitted an invalid module name into the debug
log. This has now been replaced by the generic term "dummy".

Note: it is highly unlikely that someone will ever see that message
at all, as it is unlikely for the dummy modules to be build.

see also: https://github.com/rsyslog/rsyslog/commit/84a7e3d80b80106dcc86c273ed8cf78a6c11c722#r41782830

Thanks to Thomas D. (whissi) for the patch.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
