### PR TITLE
Use same type as in the rest of the code as u_int16_t is not defined …

### DIFF
--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -371,7 +371,7 @@ UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, char *msg, size_t l
 	* divided by 8 */
 	unsigned msgOffs, hdrOffs;
 	unsigned maxPktLen, pktLen, udpPktLen;
-	u_int16_t ip_id;
+	uint16_t ip_id;
 	DEFiRet;
 
 	if(pWrkrData->pSockArray == NULL) {
@@ -393,7 +393,7 @@ UDPSend(wrkrInstanceData_t *pWrkrData, uchar *pszSourcename, char *msg, size_t l
 	/* We need a non-zero id number for the IP headers,
 	* otherwise libnet will increase it after each
 	* build_ipv4, breaking the fragments */
-	ip_id = (u_int16_t)libnet_get_prand(LIBNET_PR16);
+	ip_id = (uint16_t)libnet_get_prand(LIBNET_PR16);
 
 	inet_pton(AF_INET, (char*)pszSourcename, &(source_ip.sin_addr));
 	bSendSuccess = RSFALSE;


### PR DESCRIPTION
…on Solaris

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
