### PR TITLE
rsyslog: add anon to omrelp/imrelp

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -369,6 +369,7 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 	int relpRet;
 	uchar statname[64];
 	int i;
+	int isAnon;
 	DEFiRet;
 
 	if(!inst->bEnableLstn) {
@@ -455,14 +456,15 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 			relpSrvSetDHBits(pSrv, inst->dhBits);
 		}
 		relpSrvSetGnuTLSPriString(pSrv, (char*)inst->pristring);
-		if(relpSrvSetAuthMode(pSrv, (char*)inst->authmode) != RELP_RET_OK) {
+		isAnon = !strcmp((char*)inst->authmode, "anon");
+		if(!isAnon && relpSrvSetAuthMode(pSrv, (char*)inst->authmode) != RELP_RET_OK) {
 			LogError(0, RS_RET_RELP_ERR,
 					"imrelp: invalid auth mode '%s'", inst->authmode);
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 		}
 		if(relpSrvSetCACert(pSrv, (char*) inst->caCertFile) != RELP_RET_OK)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
-		if(relpSrvSetOwnCert(pSrv, (char*) inst->myCertFile) != RELP_RET_OK)
+		if(!isAnon && relpSrvSetOwnCert(pSrv, (char*) inst->myCertFile) != RELP_RET_OK)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 		if(relpSrvSetPrivKey(pSrv, (char*) inst->myPrivKeyFile) != RELP_RET_OK)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -228,6 +228,7 @@ static rsRetVal
 doCreateRelpClient(instanceData *pData, relpClt_t **pRelpClt)
 {
 	int i;
+	int isAnon;
 	DEFiRet;
 
 	if(relpEngineCltConstruct(pRelpEngine, pRelpClt) != RELP_RET_OK)
@@ -250,7 +251,8 @@ doCreateRelpClient(instanceData *pData, relpClt_t **pRelpClt)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 
 
-		if(relpCltSetAuthMode(*pRelpClt, (char*) pData->authmode) != RELP_RET_OK) {
+		isAnon = !strcmp((char*)pData->authmode, "anon");
+		if(!isAnon && relpCltSetAuthMode(*pRelpClt, (char*) pData->authmode) != RELP_RET_OK) {
 			LogError(0, RS_RET_RELP_ERR,
 					"omrelp: invalid auth mode '%s'\n", pData->authmode);
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
@@ -258,7 +260,7 @@ doCreateRelpClient(instanceData *pData, relpClt_t **pRelpClt)
 
 		if(relpCltSetCACert(*pRelpClt, (char*) pData->caCertFile) != RELP_RET_OK)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
-		if(relpCltSetOwnCert(*pRelpClt, (char*) pData->myCertFile) != RELP_RET_OK)
+		if(!isAnon && relpCltSetOwnCert(*pRelpClt, (char*) pData->myCertFile) != RELP_RET_OK)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);
 		if(relpCltSetPrivKey(*pRelpClt, (char*) pData->myPrivKeyFile) != RELP_RET_OK)
 			ABORT_FINALIZE(RS_RET_RELP_ERR);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1268,6 +1268,7 @@ TESTS += \
          relp_tls_certificate_not_found.sh \
 	 omrelp_wrong_authmode.sh \
 	 imrelp-tls.sh \
+	 imrelp-tls-anon.sh \
 	 imrelp-tls-chainedcert.sh
 if USE_RELPENGINESETTLSCFGCMD
 TESTS += \
@@ -2117,6 +2118,7 @@ EXTRA_DIST= \
 	relp_tls_certificate_not_found.sh \
 	omrelp_wrong_authmode.sh \
 	imrelp-tls.sh \
+	imrelp-tls-anon.sh \
 	imrelp-tls-cfgcmd.sh \
 	imrelp-tls-chainedcert.sh \
 	sndrcv_relp_tls-cfgcmd.sh \

--- a/tests/imrelp-tls-anon.sh
+++ b/tests/imrelp-tls-anon.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# addd 2019-01-31 by PascalWithopf, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+do_skip=0
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" tls="on"
+		tls.cacert="'$srcdir'/tls-certs/ca.pem"
+		tls.mycert="'$srcdir'/tls-certs/dont-exist.pem"
+		tls.myprivkey="'$srcdir'/tls-certs/key.pem"
+		tls.authmode="anon"
+		tls.permittedpeer="rsyslog")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+tcpflood -Trelp-plain -p$TCPFLOOD_PORT -m$NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+if [ $do_skip -eq 1 ]; then
+	skip_test
+fi
+seq_check
+exit_test


### PR DESCRIPTION
It seems that librelp consider an anonymous user, an user that have no own Cert.
omtcp/imtcp use authmode="anon" for the same purpose,
this PR uniformize plugins behaviours by adding tls.authMode="anon" to imrelp/omrelp.

To do so, I simply skip the call to relpSrvSetAuthMode and to relpSrvSetOwnCert if authmode is set as "anon".

fix #3838

Signed-off-by: Matthias Gatto <matthias.gatto@outscale.com>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
