### PR TITLE
core/network: obey net.enableDNS=off when querying local hostname

### DIFF
--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1186,7 +1186,7 @@ getLocalHostname(uchar **ppName)
 
 	char *dot = strstr(hnbuf, ".");
 	struct addrinfo *res = NULL;
-	if(!empty_hostname && dot == NULL) {
+	if(!empty_hostname && dot == NULL && !glbl.GetDisableDNS()) {
 		/* we need to (try) to find the real name via resolver */
 		struct addrinfo flags;
 		memset(&flags, 0, sizeof(flags));


### PR DESCRIPTION
Local hostname resolution uses DNS queries even if the enableDNS is set to off, and this can cause unexpected delays in the HUP signal handling if the DNS server is not responsive. This change makes sure that the resolver is not used if it has been explicitly disabled.