### PR TITLE
Do not create empty objects when accessing non-existent keys

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -3142,7 +3142,7 @@ getJSONPropVal(smsg_t * const pMsg, msgPropDescr_t *pProp, uchar **pRes, rs_size
 		field = *jroot;
 	} else {
 		leaf = jsonPathGetLeaf(pProp->name, pProp->nameLen);
-		CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 1));
+		CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 0));
 		if(jsonVarExtract(parent, (char*)leaf, &field) == FALSE)
 			field = NULL;
 	}
@@ -3197,7 +3197,7 @@ msgGetJSONPropJSONorString(smsg_t * const pMsg, msgPropDescr_t *pProp, struct js
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}
 	leaf = jsonPathGetLeaf(pProp->name, pProp->nameLen);
-	CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 1));
+	CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 0));
 	if(jsonVarExtract(parent, (char*)leaf, pjson) == FALSE) {
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}
@@ -3242,7 +3242,7 @@ msgGetJSONPropJSON(smsg_t * const pMsg, msgPropDescr_t *pProp, struct json_objec
 		FINALIZE;
 	}
 	leaf = jsonPathGetLeaf(pProp->name, pProp->nameLen);
-	CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 1));
+	CHKiRet(jsonPathFindParent(*jroot, pProp->name, leaf, &parent, 0));
 	if(jsonVarExtract(parent, (char*)leaf, pjson) == FALSE) {
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
 	}
@@ -4845,7 +4845,7 @@ jsonPathFindParent(struct json_object *jroot, uchar *name, uchar *leaf, struct j
 	namestart = name;
 	*parent = jroot;
 	while(name < leaf-1) {
-		jsonPathFindNext(*parent, namestart, &name, leaf, parent, bCreate);
+		CHKiRet(jsonPathFindNext(*parent, namestart, &name, leaf, parent, bCreate));
 	}
 	if(*parent == NULL)
 		ABORT_FINALIZE(RS_RET_NOT_FOUND);
@@ -5006,7 +5006,7 @@ msgDelJSON(smsg_t * const pM, uchar *name)
 		*jroot = NULL;
 	} else {
 		leaf = jsonPathGetLeaf(name, ustrlen(name));
-		CHKiRet(jsonPathFindParent(*jroot, name, leaf, &parent, 1));
+		CHKiRet(jsonPathFindParent(*jroot, name, leaf, &parent, 0));
 		if(jsonVarExtract(parent, (char*)leaf, &leafnode) == FALSE)
 			leafnode = NULL;
 		if(leafnode == NULL) {


### PR DESCRIPTION
This is a proposal for Github issue rsyslog/rsyslog#4430:
accessing a non-existing key creates an empty parent object
https://github.com/rsyslog/rsyslog/issues/4430

When looking up an object property, the tree of intermediate
object containers was ceated by get and del functions. The
patch is an attempt to fix that behavior by passing 0 to the
bCreate argument of jsonPathFindParent().

There is also one case where the return value of
jsonPathFindParent() was not checked, in the recurssive call
of jsonPathFindParent() itself. This was leading to infinite
loops if bCreate was 0.

closes #4430 
closes #4436
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
