### PR TITLE
add 'exists()' script function to check if variable exists

### DIFF
--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -8,7 +8,7 @@
  * PRI filter) are very hard to beat in ease of use, at least for simpler
  * cases.
  *
- * Copyright 2011-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2011-2020 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -55,6 +55,7 @@ extern int yyerror(const char*);
 	struct cnfexpr *expr;
 	struct cnfarray *arr;
 	struct cnffunc *func;
+	struct cnffuncexists *exists;
 	struct cnffparamlst *fparams;
 	struct cnfitr *itr;
 }
@@ -74,6 +75,7 @@ extern int yyerror(const char*);
 %token RESET
 %token UNSET
 %token CONTINUE
+%token EXISTS
 %token <cnfstmt> CALL
 %token <cnfstmt> CALL_INDIRECT
 %token <s> LEGACY_ACTION
@@ -217,6 +219,7 @@ expr:	  expr AND expr			{ $$ = cnfexprNew(AND, $1, $3); }
 	| expr '%' expr			{ $$ = cnfexprNew('%', $1, $3); }
 	| '(' expr ')'			{ $$ = $2; }
 	| '-' expr %prec UMINUS		{ $$ = cnfexprNew('M', NULL, $2); }
+	| EXISTS '(' VAR ')'		{ $$ = (struct cnfexpr*) cnffuncexistsNew($3); }
 	| FUNC '(' ')'			{ $$ = (struct cnfexpr*) cnffuncNew($1, NULL); }
 	| FUNC '(' fparams ')'		{ $$ = (struct cnfexpr*) cnffuncNew($1, $3); }
 	| NUMBER			{ $$ = (struct cnfexpr*) cnfnumvalNew($1); }

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -314,6 +314,7 @@ int fileno(FILE *stream);
 					        "escaped, problem string is: %s",
 						yytext); }
 <EXPR>[ \t\n]			{ cnfPrintToken(yytext); }
+<EXPR>"exists"			{ cnfPrintToken(yytext); return EXISTS; } /* special case function (see rainerscript.c) */
 <EXPR>[a-z][a-z0-9_]*		{ cnfPrintToken(yytext); yylval.estr = es_newStrFromCStr(yytext, yyleng);
 				  return FUNC; }
 <EXPR>.				{ cnfPrintToken(yytext); parser_errmsg("invalid character '%s' in expression "

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -97,13 +97,13 @@ struct nvlst {
  * be the sole foundation for the AST.
  *
  * nodetypes (list not yet complete)
+ * A - (string) array
  * F - function
  * N - number
  * P - fparamlst
  * R - rule
  * S - string
  * V - var
- * A - (string) array
  * ... plus the S_* #define's below:
  */
 #define S_STOP 4000
@@ -118,6 +118,7 @@ struct nvlst {
 #define S_FOREACH 4009
 #define S_RELOAD_LOOKUP_TABLE 4010
 #define S_CALL_INDIRECT 4011
+#define S_FUNC_EXISTS 4012 /* special case function which must get varname only */
 
 enum cnfFiltType { CNFFILT_NONE, CNFFILT_PRI, CNFFILT_PROP, CNFFILT_SCRIPT };
 const char* cnfFiltType2str(const enum cnfFiltType filttype);
@@ -262,6 +263,12 @@ struct cnffunc {
 } __attribute__((aligned (8)));
 
 
+struct cnffuncexists {
+	unsigned nodetype;
+	const char *varname;
+	msgPropDescr_t prop;
+} __attribute__((aligned (8)));
+
 struct scriptFunct {
 	const char *fname;
 	unsigned short minParams;
@@ -354,6 +361,7 @@ struct cnfnumval* cnfnumvalNew(long long val);
 struct cnfstringval* cnfstringvalNew(es_str_t *estr);
 struct cnfvar* cnfvarNew(char *name);
 struct cnffunc * cnffuncNew(es_str_t *fname, struct cnffparamlst* paramlst);
+struct cnffuncexists * cnffuncexistsNew(const char *varname);
 struct cnffparamlst * cnffparamlstNew(struct cnfexpr *expr, struct cnffparamlst *next);
 int cnfDoInclude(const char *name, const int optional);
 int cnfparamGetIdx(struct cnfparamblk *params, const char *name);

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -229,8 +229,9 @@ void getInputName(const smsg_t * const pM, uchar **ppsz, int *const plen);
 int getHOSTNAMELen(smsg_t *pM);
 uchar *getProgramName(smsg_t *pM, sbool bLockMutex);
 uchar *getRcvFrom(smsg_t *pM);
-rsRetVal propNameToID(uchar *pName, propid_t *pPropID);
+rsRetVal propNameToID(const uchar *pName, propid_t *pPropID);
 uchar *propIDToName(propid_t propID);
+rsRetVal ATTR_NONNULL() msgCheckVarExists(smsg_t *const pMsg, msgPropDescr_t *pProp);
 rsRetVal msgGetJSONPropJSON(smsg_t *pMsg, msgPropDescr_t *pProp, struct json_object **pjson);
 rsRetVal msgGetJSONPropJSONorString(smsg_t * const pMsg, msgPropDescr_t *pProp, struct json_object **pjson,
 uchar **pcstr);
@@ -238,7 +239,7 @@ rsRetVal getJSONPropVal(smsg_t *pMsg, msgPropDescr_t *pProp, uchar **pRes, rs_si
 unsigned short *pbMustBeFreed);
 rsRetVal msgSetJSONFromVar(smsg_t *pMsg, uchar *varname, struct svar *var, int force_reset);
 rsRetVal msgDelJSON(smsg_t *pMsg, uchar *varname);
-rsRetVal jsonFind(struct json_object *jroot, msgPropDescr_t *pProp, struct json_object **jsonres);
+rsRetVal jsonFind(smsg_t *const pMsg, msgPropDescr_t *pProp, struct json_object **jsonres);
 
 rsRetVal msgPropDescrFill(msgPropDescr_t *pProp, uchar *name, int nameLen);
 void msgPropDescrDestruct(msgPropDescr_t *pProp);

--- a/template.c
+++ b/template.c
@@ -285,7 +285,7 @@ tplToJSON(struct template *pTpl, smsg_t *pMsg, struct json_object **pjson, struc
 	DEFiRet;
 
 	if(pTpl->bHaveSubtree){
-		if(jsonFind(pMsg->json, &pTpl->subtree, pjson) != RS_RET_OK)
+		if(jsonFind(pMsg, &pTpl->subtree, pjson) != RS_RET_OK)
 			*pjson = NULL;
 		if(*pjson == NULL) {
 			/* we need to have a root object! */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -422,6 +422,12 @@ TESTS +=  \
 	rscript_parse_json.sh \
 	rscript_previous_action_suspended.sh \
 	rscript_str2num_negative.sh \
+	rscript_exists-yes.sh \
+	rscript_exists-yes2.sh \
+	rscript_exists-not1.sh \
+	rscript_exists-not2.sh \
+	rscript_exists-not3.sh \
+	rscript_exists-not4.sh \
 	rscript-config_enable-on.sh \
 	config_output-o-option.sh \
 	rs-cnum.sh \
@@ -1715,6 +1721,12 @@ EXTRA_DIST= \
 	rscript_backticks_empty_envvar-vg.sh \
 	rscript_previous_action_suspended.sh \
 	rscript_str2num_negative.sh \
+	rscript_exists-yes.sh \
+	rscript_exists-yes2.sh \
+	rscript_exists-not1.sh \
+	rscript_exists-not2.sh \
+	rscript_exists-not3.sh \
+	rscript_exists-not4.sh \
 	rs-cnum.sh \
 	rs-int2hex.sh \
 	rs-substring.sh \

--- a/tests/rscript_exists-not1.sh
+++ b/tests/rscript_exists-not1.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# add 2020-10-02 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%!result%\n")
+# ensure that in this test there is NO variable define at all
+if $msg contains "msgnum" then {
+	if exists($!p1!p2!val) then
+		set $!result = "on";
+	else
+		set $!result = "off";
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='off'
+cmp_exact
+exit_test

--- a/tests/rscript_exists-not2.sh
+++ b/tests/rscript_exists-not2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# add 2020-10-02 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%!result%\n")
+set $!somevar = "test"; # this makes matters a bit more complicated
+if $msg contains "msgnum" then {
+	if exists($!p1!p2!val) then
+		set $!result = "on";
+	else
+		set $!result = "off";
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='off'
+cmp_exact
+exit_test

--- a/tests/rscript_exists-not3.sh
+++ b/tests/rscript_exists-not3.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# add 2020-10-02 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%!result%\n")
+# ensure that in this test there is NO variable define at all
+if $msg contains "msgnum" then {
+	if exists($.p1!p2!val) then
+		set $!result = "on";
+	else
+		set $!result = "off";
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='off'
+cmp_exact
+exit_test

--- a/tests/rscript_exists-not4.sh
+++ b/tests/rscript_exists-not4.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# add 2020-10-02 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%!result%\n")
+set $.somevar = "test"; # this makes matters a bit more complicated
+if $msg contains "msgnum" then {
+	if not exists($.p1!p2!val) then
+		set $!result = "off";
+	else
+		set $!result = "on";
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='off'
+cmp_exact
+exit_test

--- a/tests/rscript_exists-yes.sh
+++ b/tests/rscript_exists-yes.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# add 2020-10-02 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%!result%\n")
+set $!p1!p2!val="yes!";
+if $msg contains "msgnum" then {
+	if exists($!p1!p2!val) then
+		set $!result = "on";
+	else
+		set $!result = "off";
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='on'
+cmp_exact
+exit_test

--- a/tests/rscript_exists-yes2.sh
+++ b/tests/rscript_exists-yes2.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# add 2020-10-02 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%!result%\n")
+set $.p1!p2!val="yes!";
+if $msg contains "msgnum" then {
+	if exists($.p1!p2!val) then
+		set $!result = "on";
+	else
+		set $!result = "off";
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='on'
+cmp_exact
+exit_test


### PR DESCRIPTION
This implements a way to check if rsyslog variables (e.g. '$!path!var') is
currently set of not.

closes https://github.com/rsyslog/rsyslog/issues/4385

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
