### PR TITLE
omfwd: adding new rate limit option

### DIFF
--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -190,6 +190,31 @@ finalize_it:
 	return ret;
 }
 
+/* ratelimit a message based on message count
+ * - handles only rate-limiting
+ * This function returns RS_RET_OK, if the caller shall process
+ * the message regularly and RS_RET_DISCARD if the caller must
+ * discard the message. The caller should also discard the message
+ * if another return status occurs.
+ */
+rsRetVal
+ratelimitMsgCount(ratelimit_t *__restrict__ const ratelimit,
+	time_t tt,
+	const char* const appname)
+{
+	DEFiRet;
+	if(ratelimit->interval) {
+		if(withinRatelimit(ratelimit, tt, appname) == 0) {
+			ABORT_FINALIZE(RS_RET_DISCARDMSG);
+		}
+	}
+finalize_it:
+	if(Debug) {
+		if(iRet == RS_RET_DISCARDMSG)
+			DBGPRINTF("message discarded by ratelimiting\n");
+	}
+	RETiRet;
+}
 
 /* ratelimit a message, that means:
  * - handle "last message repeated n times" logic

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -45,6 +45,7 @@ void ratelimitSetThreadSafe(ratelimit_t *ratelimit);
 void ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned int interval, unsigned int burst);
 void ratelimitSetNoTimeCache(ratelimit_t *ratelimit);
 void ratelimitSetSeverity(ratelimit_t *ratelimit, intTiny severity);
+rsRetVal ratelimitMsgCount(ratelimit_t *ratelimit, time_t tt, const char* const appname);
 rsRetVal ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep);
 rsRetVal ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg);
 void ratelimitDestruct(ratelimit_t *pThis);


### PR DESCRIPTION
Adding new rate limit option to omfwd for rate limiting
syslog messages sent to the remote server

ratelimit.interval:
	Specifies the rate-limiting interval in seconds.
    Default value is 0, which turns off rate limiting.

ratelimit.burst
	Specifies the rate-limiting burst in number of messages.

fixes #4423
https://github.com/rsyslog/rsyslog/issues/4423

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
