### PR TITLE
msg: Fix segfault and memory leak on set operation

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4826,6 +4826,11 @@ jsonPathFindNext(struct json_object *root, uchar *namestart, uchar **name, uchar
 		if(!bCreate) {
 			ABORT_FINALIZE(RS_RET_JNAME_INVALID);
 		} else {
+			if (json_object_get_type(root) != json_type_object) {
+				DBGPRINTF("jsonPathFindNext with bCreate: not a container in json path, "
+					"name is '%s'\n", namestart);
+				ABORT_FINALIZE(RS_RET_INVLD_SETOP);
+			}
 			json = json_object_new_object();
 			json_object_object_add(root, (char*)namebuf, json);
 		}

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4966,7 +4966,11 @@ msgAddJSON(smsg_t * const pM, uchar *name, struct json_object *json, int force_r
 			*jroot = json_object_new_object();
 		}
 		leaf = jsonPathGetLeaf(name, ustrlen(name));
-		CHKiRet(jsonPathFindParent(*jroot, name, leaf, &parent, 1));
+		iRet = jsonPathFindParent(*jroot, name, leaf, &parent, 1);
+		if (unlikely(iRet != RS_RET_OK)) {
+			json_object_put(json);
+			FINALIZE;
+		}
 		if (json_object_get_type(parent) != json_type_object) {
 			DBGPRINTF("msgAddJSON: not a container in json path,"
 				"name is '%s'\n", name);


### PR DESCRIPTION
A segfault may occur in jsonPathFindNext() when bCreate is 1 and when the <root> container where to insert the namebuf key is not an object.

Here is simple reproducible test case:
```
// ensure we start fresh
// unnecessary if there was no previous set
unset $!;

set $! = "";
set $!event!created = 123;
```
There is also a memory leak in msgAddJSON() if jsonPathFindParent() failed because of a missing call to json_object_put(json).


<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
