### PR TITLE
tls: Allow calling PermitExpiredCerts with NULL parameter

### DIFF
--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -397,9 +397,9 @@ addListner(modConfData_t *modConf, instanceConf_t *inst)
 		if(modConf->pszStrmDrvrAuthMode != NULL) {
 			CHKiRet(tcpsrv.SetDrvrAuthMode(pOurTcpsrv, modConf->pszStrmDrvrAuthMode));
 		}
-		if(modConf->pszStrmDrvrPermitExpiredCerts != NULL) {
-			CHKiRet(tcpsrv.SetDrvrPermitExpiredCerts(pOurTcpsrv, modConf->pszStrmDrvrPermitExpiredCerts));
-		}
+		/* Call SetDrvrPermitExpiredCerts required
+		 * when param is NULL default handling for ExpiredCerts is set! */
+		CHKiRet(tcpsrv.SetDrvrPermitExpiredCerts(pOurTcpsrv, modConf->pszStrmDrvrPermitExpiredCerts));
 		if(pPermPeersRoot != NULL) {
 			CHKiRet(tcpsrv.SetDrvrPermPeers(pOurTcpsrv, pPermPeersRoot));
 		}

--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -224,7 +224,9 @@ SetDrvrPermitExpiredCerts(netstrms_t *pThis, uchar *mode)
 {
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, netstrms);
-	CHKmalloc(pThis->pszDrvrPermitExpiredCerts = (uchar*)strdup((char*)mode));
+	if (mode != NULL) {
+		CHKmalloc(pThis->pszDrvrPermitExpiredCerts = (uchar*) strdup((char*)mode));
+	}
 finalize_it:
 	RETiRet;
 }

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1442,7 +1442,7 @@ SetAuthMode(nsd_t *pNsd, uchar *mode)
 		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
 	}
 
-	dbgprintf("SetAuthMode to %s\n", mode);
+	dbgprintf("SetAuthMode to %s\n", (mode != NULL ? (char*)mode : "NULL"));
 /* TODO: clear stored IDs! */
 
 finalize_it:
@@ -1476,7 +1476,8 @@ SetPermitExpiredCerts(nsd_t *pNsd, uchar *mode)
 		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
 	}
 
-	dbgprintf("SetPermitExpiredCerts: Set Mode %s/%d\n", mode, pThis->permitExpiredCerts);
+	dbgprintf("SetPermitExpiredCerts: Set Mode %s/%d\n",
+		(mode != NULL ? (char*)mode : "NULL"), pThis->permitExpiredCerts);
 
 /* TODO: clear stored IDs! */
 
@@ -1521,7 +1522,8 @@ SetGnutlsPriorityString(nsd_t *pNsd, uchar *gnutlsPriorityString)
 
 	ISOBJ_TYPE_assert((pThis), nsd_gtls);
 	pThis->gnutlsPriorityString = gnutlsPriorityString;
-	dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);
+	dbgprintf("gnutlsPriorityString: set to '%s'\n",
+		(gnutlsPriorityString != NULL ? (char*)gnutlsPriorityString : "NULL"));
 	RETiRet;
 }
 

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1051,8 +1051,9 @@ tcpsrvConstructFinalize(tcpsrv_t *pThis)
 	CHKiRet(netstrms.SetDrvrTlsVerifyDepth(pThis->pNS, pThis->DrvrTlsVerifyDepth));
 	if(pThis->pszDrvrAuthMode != NULL)
 		CHKiRet(netstrms.SetDrvrAuthMode(pThis->pNS, pThis->pszDrvrAuthMode));
-	if(pThis->pszDrvrPermitExpiredCerts != NULL)
-		CHKiRet(netstrms.SetDrvrPermitExpiredCerts(pThis->pNS, pThis->pszDrvrPermitExpiredCerts));
+	/* Call SetDrvrPermitExpiredCerts required
+	 * when param is NULL default handling for ExpiredCerts is set! */
+	CHKiRet(netstrms.SetDrvrPermitExpiredCerts(pThis->pNS, pThis->pszDrvrPermitExpiredCerts));
 	if(pThis->pPermPeers != NULL)
 		CHKiRet(netstrms.SetDrvrPermPeers(pThis->pNS, pThis->pPermPeers));
 	if(pThis->gnutlsPriorityString != NULL)
@@ -1425,7 +1426,9 @@ SetDrvrPermitExpiredCerts(tcpsrv_t *pThis, uchar *mode)
 {
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, tcpsrv);
-	CHKmalloc(pThis->pszDrvrPermitExpiredCerts = ustrdup(mode));
+	if (mode != NULL) {
+		CHKmalloc(pThis->pszDrvrPermitExpiredCerts = ustrdup(mode));
+	}
 finalize_it:
 	RETiRet;
 }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1192,6 +1192,7 @@ TESTS +=  \
 	sndrcv_tls_priorityString.sh \
 	sndrcv_tls_certvalid.sh \
 	sndrcv_tls_certvalid_expired.sh \
+	sndrcv_tls_certvalid_expired_defaultmode.sh \
 	imtcp-tls-gtls-x509fingerprint-invld.sh \
 	imtcp-tls-gtls-x509fingerprint.sh \
 	imtcp-tls-gtls-x509name-invld.sh \
@@ -2546,6 +2547,7 @@ EXTRA_DIST= \
 	sndrcv_tls_priorityString.sh \
 	sndrcv_tls_certvalid.sh \
 	sndrcv_tls_certvalid_expired.sh \
+	sndrcv_tls_certvalid_expired_defaultmode.sh \
 	sndrcv_tls_certless_clientonly.sh \
 	sndrcv_tls_gtls_servercert_gtls_clientanon.sh \
 	sndrcv_tls_gtls_servercert_gtls_clientanon_legacy.sh \

--- a/tests/sndrcv_tls_certvalid_expired_defaultmode.sh
+++ b/tests/sndrcv_tls_certvalid_expired_defaultmode.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+# uncomment for debugging support:
+. ${srcdir:=.}/diag.sh init
+# start up the instances
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+generate_conf
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-expired-cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-expired-key.pem'"
+	defaultNetstreamDriver="gtls"
+#	debug.whitelist="on"
+#	debug.files=["nsd_ossl.c", "tcpsrv.c", "nsdsel_ossl.c", "nsdpoll_ptcp.c", "dnscache.c"]
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon"
+	)
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+export PORT_RCVR=$TCPFLOOD_PORT
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
+#valgrind="valgrind"
+generate_conf 2
+add_conf '
+$DebugFile '$RSYSLOG_DEBUGLOG'
+$DebugLevel 2
+
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-key.pem'"
+	defaultNetstreamDriver="gtls"
+)
+
+# set up the action
+$ActionSendStreamDriverMode 1 # require TLS for the connection
+$ActionSendStreamDriverAuthMode x509/certvalid
+*.*	@@127.0.0.1:'$PORT_RCVR'
+' 2
+startup 2
+
+# now inject the messages into instance 2. It will connect to instance 1,
+# and that instance will record the data.
+injectmsg
+
+# shut down sender when everything is sent, receiver continues to run concurrently
+shutdown_when_empty 2
+wait_shutdown 2
+# now it is time to stop the receiver as well
+shutdown_when_empty
+wait_shutdown
+
+echo "DEBUG ${RSYSLOG_DEBUGLOG}"
+cat ${RSYSLOG_DEBUGLOG}
+content_check "not permitted to talk to peer, certificate invalid: certificate expired" ${RSYSLOG_DEBUGLOG}
+
+exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -762,10 +762,10 @@ static rsRetVal TCPSendInit(void *pvData)
 		if(pData->pszStrmDrvrAuthMode != NULL) {
 			CHKiRet(netstrm.SetDrvrAuthMode(pWrkrData->pNetstrm, pData->pszStrmDrvrAuthMode));
 		}
-		if(pData->pszStrmDrvrPermitExpiredCerts != NULL) {
-			CHKiRet(netstrm.SetDrvrPermitExpiredCerts(pWrkrData->pNetstrm,
-				pData->pszStrmDrvrPermitExpiredCerts));
-		}
+		/* Call SetDrvrPermitExpiredCerts required
+		 * when param is NULL default handling for ExpiredCerts is set! */
+		CHKiRet(netstrm.SetDrvrPermitExpiredCerts(pWrkrData->pNetstrm,
+			pData->pszStrmDrvrPermitExpiredCerts));
 
 		if(pData->pPermPeers != NULL) {
 			CHKiRet(netstrm.SetDrvrPermPeers(pWrkrData->pNetstrm, pData->pPermPeers));


### PR DESCRIPTION
In order to set the default PermitExpiredCerts handling (Deny),
we need to call PermitExpiredCerts with NULL parameter.

testbench: Add test to check expired handling in omfwd

closes: https://github.com/rsyslog/rsyslog/issues/4425
