### PR TITLE
add new system property $now-unixtimestamp

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -7,7 +7,7 @@
  * of the "old" message code without any modifications. However, it
  * helps to have things at the right place one we go to the meat of it.
  *
- * Copyright 2007-2019 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2020 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -666,6 +666,8 @@ propNameToID(const uchar *const pName, propid_t *const pPropID)
 		*pPropID = PROP_SYS_MINUTE_UTC;
 	} else if(!strcasecmp((char*) pName, "$wday-utc")) {
 		*pPropID = PROP_SYS_WDAY_UTC;
+	} else if(!strcasecmp((char*) pName, "$now-unixtimestamp")) {
+		*pPropID = PROP_SYS_NOW_UXTIMESTAMP;
 	} else if(!strcasecmp((char*) pName, "$MYHOSTNAME")) {
 		*pPropID = PROP_SYS_MYHOSTNAME;
 	} else if(!strcasecmp((char*) pName, "$!all-json")) {
@@ -786,6 +788,8 @@ uchar *propIDToName(propid_t propID)
 			return UCHAR_CONSTANT("$WDAY");
 		case PROP_SYS_WDAY_UTC:
 			return UCHAR_CONSTANT("$WDAY-UTC");
+		case PROP_SYS_NOW_UXTIMESTAMP:
+			return UCHAR_CONSTANT("$NOW-UNIXTIMESTAMP");
 		case PROP_SYS_MYHOSTNAME:
 			return UCHAR_CONSTANT("$MYHOSTNAME");
 		case PROP_CEE_ALL_JSON:
@@ -3795,6 +3799,16 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			} else {
 				*pbMustBeFreed = 1;
 				bufLen = 2;
+			}
+			break;
+		case PROP_SYS_NOW_UXTIMESTAMP:
+			if((pRes = malloc(16)) == NULL) {
+				RET_OUT_OF_MEMORY;
+			} else {
+				snprintf((char*) pRes, 16-1, "%lld", (long long) getTime(NULL));
+				pRes[16-1] = '\0';
+				*pbMustBeFreed = 1;
+				bufLen = -1;
 			}
 			break;
 		case PROP_SYS_MYHOSTNAME:

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -3,7 +3,7 @@
  *
  * Begun 2010-11-25 RGerhards
  *
- * Copyright (C) 2005-2014 by Rainer Gerhards and Adiscon GmbH
+ * Copyright (C) 2005-2020 by Rainer Gerhards and Adiscon GmbH
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -235,8 +235,9 @@ typedef uintTiny	propid_t;
 #define PROP_SYS_HHOUR_UTC		167
 #define PROP_SYS_QHOUR_UTC		168
 #define PROP_SYS_MINUTE_UTC		169
-#define PROP_SYS_WDAY      170
-#define PROP_SYS_WDAY_UTC     171
+#define PROP_SYS_WDAY			170
+#define PROP_SYS_WDAY_UTC		171
+#define PROP_SYS_NOW_UXTIMESTAMP	173
 #define PROP_CEE			200
 #define PROP_CEE_ALL_JSON		201
 #define PROP_LOCAL_VAR			202

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -629,6 +629,7 @@ TESTS +=  \
 	now-utc.sh \
 	now-utc-ymd.sh \
 	now-utc-casecmp.sh \
+	now-unixtimestamp.sh \
 	timegenerated-ymd.sh \
 	timegenerated-uxtimestamp.sh \
 	timegenerated-uxtimestamp-invld.sh \
@@ -1855,6 +1856,7 @@ EXTRA_DIST= \
 	now-utc-ymd.sh \
 	now-utc-casecmp.sh \
 	now-utc.sh \
+	now-unixtimestamp.sh \
 	faketime_common.sh \
 	imjournal-basic.sh \
 	imjournal-statefile.sh \

--- a/tests/now-unixtimestamp.sh
+++ b/tests/now-unixtimestamp.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# test many concurrent tcp connections
+# addd 2016-02-23 by RGerhards, released under ASL 2.0
+# requires faketime
+echo \[now-utc\]: test \$NOW-UTC
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+set $.tnow = $$now-unixtimestamp + 1;
+
+template(name="outfmt" type="string"
+	 string="%$now-unixtimestamp%,%$.tnow%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file="'$RSYSLOG_OUT_LOG'")
+'
+
+. $srcdir/faketime_common.sh
+
+export TZ=TEST-02:00
+
+FAKETIME='2016-01-01 01:00:00' startup
+# what we send actually is irrelevant, as we just use system properties.
+# but we need to send one message in order to gain output!
+tcpflood -m1
+shutdown_when_empty
+wait_shutdown
+export EXPECTED="1451602800,1451602801"
+cmp_exact
+exit_test


### PR DESCRIPTION
Among others, this may be used as a monotonic counter
for doing load-balancing and other things.

Thanks to Nicholas Brown for suggesting this feature.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
