### PR TITLE
immark: rewrite with many improvements

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -156,6 +156,9 @@ endif # if ENABLE_ELASTICSEARCH_TESTS
 if ENABLE_DEFAULT_TESTS
 TESTS +=  \
 	immark.sh \
+	immark-inputname.sh \
+	immark-ruleset.sh \
+	immark-ruleset-custom-msg.sh \
 	operatingstate-basic.sh \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \
@@ -1543,6 +1546,9 @@ EXTRA_DIST= \
 	smtradfile.sh \
 	smtradfile-vg.sh \
 	immark.sh \
+	immark-inputname.sh \
+	immark-ruleset.sh \
+	immark-ruleset-custom-msg.sh \
 	operatingstate-basic.sh \
 	operatingstate-empty.sh \
 	operatingstate-unclean.sh \

--- a/tests/immark-inputname.sh
+++ b/tests/immark-inputname.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# add 2020-12-02 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/immark/.libs/immark" interval="1" use.syslogcall="off")
+if $inputname == "immark" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+
+startup
+printf 'sleeping a bit so we get mark messages...\n'
+sleep 3 # this should be good even on slow machines - we need just one
+shutdown_when_empty
+wait_shutdown
+content_check "rsyslogd: -- MARK --"
+
+exit_test

--- a/tests/immark-ruleset-custom-msg.sh
+++ b/tests/immark-ruleset-custom-msg.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# very basic check for immark module - nevertheless, there is not
+# much more to test for...
+# add 2020-12-01 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/immark/.libs/immark" interval="1"
+	use.syslogcall="off" ruleset="rs" markmessagetext="My MARK Message")
+ruleset(name="rs") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+printf 'sleeping a bit so we get mark messages...\n'
+sleep 3 # this should be good even on slow machines - we need just one
+shutdown_when_empty
+wait_shutdown
+content_check "rsyslogd: My MARK Message"
+
+exit_test

--- a/tests/immark-ruleset.sh
+++ b/tests/immark-ruleset.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# very basic check for immark module - nevertheless, there is not
+# much more to test for...
+# add 2020-12-01 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/immark/.libs/immark" interval="1"
+	use.syslogcall="off" ruleset="rs")
+ruleset(name="rs") {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+printf 'sleeping a bit so we get mark messages...\n'
+sleep 3 # this should be good even on slow machines - we need just one
+shutdown_when_empty
+wait_shutdown
+content_check "rsyslogd: -- MARK --"
+
+exit_test


### PR DESCRIPTION
- mark message text can now be specified
- support for rulesets
- support for using syslog API vs. regular internal interface
- support for output template system
- ability to specify is mark message flag can be set
- minor changes and improvements

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
