### PR TITLE
lookup table bugfix: data race on lookup table reload

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2377,6 +2377,8 @@ doFunct_Lookup(struct cnffunc *__restrict__ const func,
 		return;
 	}
 	cnfexprEval(func->expr[1], &srcVal, usrptr, pWti);
+	pthread_rwlock_rdlock(&((lookup_ref_t*)func->funcdata)->rwlock);
+	pthread_rwlock_unlock(&((lookup_ref_t*)func->funcdata)->rwlock);
 	lookup_table = ((lookup_ref_t*)func->funcdata)->self;
 	if (lookup_table != NULL) {
 		lookup_key_type = lookup_table->key_type;


### PR DESCRIPTION
A data race could happen when a lookup table was reloaded. We found
this while moving to newer version of TSAN, but have no matching
report from practice. However, there is a potential for this to cause
a segfault under "bad circumstances".

@janmejay  FYI
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
