### PR TITLE
CI bugfix: journal test installed wrong dependencies

### DIFF
--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -38,16 +38,15 @@ jobs:
 
       - name: add extra dependencies
         run: |
-          echo 'deb http://download.opensuse.org/repositories/home:/rgerhards/xUbuntu_18.04/ /' \
+          echo 'deb http://download.opensuse.org/repositories/home:/rgerhards/xUbuntu_20.04/ /' \
               | sudo tee /etc/apt/sources.list.d/home:rgerhards.list
-          curl -fsSL https://download.opensuse.org/repositories/home:rgerhards/xUbuntu_18.04/Release.key \
+          curl -fsSL https://download.opensuse.org/repositories/home:rgerhards/xUbuntu_20.04/Release.key \
               | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/home:rgerhards.gpg > /dev/null
           sudo apt-get update
           sudo apt-get install -y \
             libcurl4-gnutls-dev \
             libdbi-dev \
             libestr-dev \
-            libfastjson-dev \
             libgcrypt20-dev \
             libglib2.0-dev \
             libgnutls28-dev \
@@ -77,7 +76,6 @@ jobs:
             python3-pip \
             python3-pysnmp4 \
             python-docutils  \
-            snmp-mibs-downloader \
             software-properties-common \
             uuid-dev \
             valgrind \
@@ -85,6 +83,20 @@ jobs:
             wget \
             librdkafka-dev \
             zlib1g-dev
+
+      - name: build dependencies which require that
+        run: |
+             mkdir helper-projects && \
+             cd helper-projects && \
+             git clone https://github.com/rsyslog/librelp.git && \
+             cd librelp && \
+             autoreconf -fi && \
+             ./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib --includedir=/usr/include && \
+             make -j && \
+             sudo make install && \
+             cd .. && \
+             rm -r librelp && \
+             cd ..
 
       - name: prepare for build
         run: |


### PR DESCRIPTION
The journal test github action installs wrong extra dependency
version, which can lead to issues with some tests. We also trim
the dependency list a bit.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
