### PR TITLE
Implement resume counting

### DIFF
--- a/action.c
+++ b/action.c
@@ -866,6 +866,7 @@ actionDoRetry(action_t * const pThis, wti_t * const pWti)
 		if((iRet == RS_RET_OK) && (!bTreatOKasSusp)) {
 			DBGPRINTF("actionDoRetry: %s had success RDY again (iRet=%d)\n",
 				  pThis->pszName, iRet);
+			STATSCOUNTER_INC(pThis->ctrResume, pThis->mutCtrResume);
 			if(pThis->bReportSuspension) {
 				LogMsg(0, RS_RET_RESUMED, LOG_INFO, "action '%s' "
 					      "resumed (module '%s')",


### PR DESCRIPTION
The impstats module reports a bunch of counters for actions, including the resume count. However, the resume counter is never actually used and the value stays at 0 in the stats output, regardless of whether an action has been resumed or not.

This tiny change adds a counter increment in the resume path.