### PR TITLE
Track failure statistics in actions

### DIFF
--- a/action.c
+++ b/action.c
@@ -1412,6 +1412,8 @@ actionWriteErrorFile(action_t *__restrict__ const pThis, const rsRetVal ret,
 	fjson_object *etry=NULL;
 	int bNeedUnlock = 0;
 
+	STATSCOUNTER_INC(pThis->ctrFail, pThis->mutCtrFail);
+
 	if(pThis->pszErrFile == NULL) {
 		DBGPRINTF("action %s: commit failed, no error file set, silently "
 			"discarding %d messages\n", pThis->pszName, nparams);


### PR DESCRIPTION
When the action error file is written (or would be written, if not enabled), increment the failure counter. Previously with omfwd (and others?) with action.resumeRetryCount > -1, after all retries were exhausted the message would be dropped but the failure count for the action remained at 0.

Perhaps the failure counter has other semantics, but it was unexpected that for omfwd, errors in the connection, or from GnuTLS or OpenSSL, don't increment the action's failure counter. With this change the action's failure counter is effectively a line count of its error file.
