### PR TITLE
omfwd: add stats counter for sent bytes

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1003,7 +1003,9 @@ TESTS +=  \
 	stats-cee.sh \
 	stats-json-es.sh \
 	dynstats_reset_without_pstats_reset.sh \
-	dynstats_prevent_premature_eviction.sh
+	dynstats_prevent_premature_eviction.sh \
+	omfwd_impstats-udp.sh \
+	omfwd_impstats-tcp.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	dynstats-vg.sh \
@@ -2438,6 +2440,8 @@ EXTRA_DIST= \
 	testsuites/dynstats_input_more_2 \
 	no-dynstats-json.sh \
 	no-dynstats.sh \
+	omfwd_impstats-udp.sh \
+	omfwd_impstats-tcp.sh \
 	stats-json.sh \
 	stats-json-vg.sh \
 	stats-cee.sh \

--- a/tests/omfwd_impstats-tcp.sh
+++ b/tests/omfwd_impstats-tcp.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# This test tests impstats omfwd counters in TCP mode
+# added 2021-02-11 by rgerhards. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'"
+	interval="1" ruleset="stats")
+
+ruleset(name="stats") {
+	stop # nothing to do here
+}
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt")
+
+if $msg contains "msgnum:" then
+	action(type="omfwd" target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp")
+'
+./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
+BGPROCESS=$!
+echo background minitcpsrv process id is $BGPROCESS
+
+# now do the usual run
+startup
+# 10000 messages should be enough
+injectmsg 0 10000
+shutdown_when_empty
+wait_shutdown
+# note: minitcpsrv shuts down automatically if the connection is closed!
+
+# check pstats - that's our prime test target
+content_check --regex "TCP-.*origin=omfwd .*bytes.sent=[1-9][0-9][0-9]" "$STATSFILE"
+
+# do a bonus test while we are at it (just make sure we actually sent data)
+seq_check 0 9999
+exit_test

--- a/tests/omfwd_impstats-udp.sh
+++ b/tests/omfwd_impstats-udp.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This test tests impstats omfwd counters in UPD mode
+# added 2021-02-11 by rgerhards. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'"
+	interval="1" ruleset="stats")
+
+ruleset(name="stats") {
+	stop # nothing to do here
+}
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt")
+
+if $msg contains "msgnum:" then
+	action(type="omfwd" target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="udp")
+'
+# note: there must be no actual data - it's fine for this test if all data is lost
+
+# now do the usual run
+startup
+# 10000 messages should be enough
+injectmsg 0 10000
+shutdown_when_empty
+wait_shutdown
+
+# check pstats - that's our prime test target
+content_check --regex "UDP-.*origin=omfwd .*bytes.sent=[1-9][0-9][0-9]" "$STATSFILE"
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
