### PR TITLE
omfwd bugfix: segfault or error if port not given

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1384,6 +1384,11 @@ CODESTARTnewActInst
 		}
 	}
 
+	/* check if no port is set. If so, we use the IANA-assigned port of 514 */
+	if(pData->port == NULL) {
+		CHKmalloc(pData->port = strdup("514"));
+	}
+
 	if(complevel != -1) {
 		pData->compressionLevel = complevel;
 		if(pData->compressionMode == COMPRESS_NEVER) {


### PR DESCRIPTION
If omfwd is configured via RainerScript config format and the "port"
parameter is not given, a segfault will most likely happen on
connection establishment for TCP connections. For UDP, this is
usually not the case.

Alternatively, in any case, errors may happen.

Note that the segfault will usually happen right on restart so this
was easy to detect.

We did not receive reports from practice. Instead, we found the bug
while conducting other work.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
