### PR TITLE
Add error reporting configuration option to omfwd.

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -594,17 +594,19 @@ finalize_it:
 			if (skipFactor <= 1)  {
 				/* All the connection errors are printed. */
 				LogError(0, iRet, "omfwd: remote server at %s:%s seems to have closed connection. "
-					"This often happens when the remote peer (or an interim system like a load balancer or firewall) "
-					"shuts down or aborts a connection. Rsyslog will re-open the connection if configured "
-					"to do so (we saw a generic IO Error, which usually goes along with that behaviour).",
+					"This often happens when the remote peer (or an interim system like a load "
+					"balancer or firewall) shuts down or aborts a connection. Rsyslog will "
+					"re-open the connection if configured to do so (we saw a generic IO Error, "
+					"which usually goes along with that behaviour).",
 					pWrkrData->pData->target, pWrkrData->pData->port);
 			} else if ((conErrCnt++ % skipFactor) == 0) {
 				/* Every N'th error message is printed where N is a skipFactor. */
 				LogError(0, iRet, "omfwd: remote server at %s:%s seems to have closed connection. "
-					"This often happens when the remote peer (or an interim system like a load balancer or firewall) "
-					"shuts down or aborts a connection. Rsyslog will re-open the connection if configured "
-					"to do so (we saw a generic IO Error, which usually goes along with that behaviour). "
-					"Note that the next %d connection error messages will be skipped.",
+					"This often happens when the remote peer (or an interim system like a load "
+					"balancer or firewall) shuts down or aborts a connection. Rsyslog will "
+					"re-open the connection if configured to do so (we saw a generic IO Error, "
+					"which usually goes along with that behaviour). Note that the next %d "
+					"connection error messages will be skipped.",
 					pWrkrData->pData->target, pWrkrData->pData->port, skipFactor-1);
 			}
 		} else {


### PR DESCRIPTION
RSyslog on a plain TCP cannot guarantee the message delivery
without using RELP protocol. Besides that the logs may be
flooded with connection errors making the rest of messages
difficult to find. To alleviate the problem (see issue 3910),
this patch adds a configuration option that enables to reduce
the number of network errors logged and reported.

For example, if each 10th network error message should be logged,
the rsyslog configuration has to be updated as follows.

action(type="omfwd" Target="<IP_ADDR>" Port="<PORT>" Protocol="tcp" ConErrSkip="10")

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
