### PR TITLE
RainerScript::FIX:: handle foreach with empty arrays/objects

### DIFF
--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -401,12 +401,12 @@ execForeach(struct cnfstmt *const stmt, smsg_t *const pMsg, wti_t *const pWti)
 	if (arr == NULL) {
 		DBGPRINTF("foreach loop skipped, as object to iterate upon is empty\n");
 		FINALIZE;
-	} else if (json_object_is_type(arr, json_type_array)) {
+	} else if (json_object_is_type(arr, json_type_array) && json_object_array_length(arr) > 0) {
 		CHKiRet(callForeachArray(stmt, arr, pMsg, pWti));
-	} else if (json_object_is_type(arr, json_type_object)) {
+	} else if (json_object_is_type(arr, json_type_object) && json_object_object_length(arr) > 0) {
 		CHKiRet(callForeachObject(stmt, arr, pMsg, pWti));
 	} else {
-		DBGPRINTF("foreach loop skipped, as object to iterate upon is not an array\n");
+		DBGPRINTF("foreach loop skipped, as object to iterate upon is empty or is not an array\n");
 		FINALIZE;
 	}
 	CHKiRet(msgDelJSON(pMsg, (uchar*)stmt->d.s_foreach.iter->var));


### PR DESCRIPTION
# Description
There is a problem in Rsyslog with the foreach() function:
When running a foreach() loop inside a ruleset, if the json array/object iterated over is empty but valid, the foreach will make the message processing in the ruleset abort operation, no following operation (such as actions) will be executed after this.

# Tests
This is the environment I used to track and correct the bug.

## Version
I used the **v8.2012.0** version, then based the work on the current master (051815873).

## Configuration
```
module(load="imtcp")
module(load="mmjsonparse")
module(load="builtin:omfile")

input(type="imtcp"
      Address="127.0.0.1" Port="1001"
      RuleSet="ruleset_test")


template(name="alljson" type="string" string="%$!%\n")

ruleset(name="ruleset_test") {
        action(type="mmjsonparse" cookie="")

        if $parsesuccess=="OK" then {
                # This is necessary to trigger the bug, as the root json '$.' needs to be initialized
                set $.test = 1;
                foreach ( $.value in $!values) do {
                        set $!var1 = $.value;
                        if $.value != "-" and $.value != "" then {
                            set $!var2 = $.value;
                        }
                }
        action(type="omfile"
                name="output_file"
                file="/tmp/output"
                Template="alljson")

        }
}
```

## How to reproduce
Launch Rsyslog with the configuration shown above (must be compiled with mmjsonparse).

**OK**
`echo '{"values": ["ok"]}' | nc -v localhost 1001`
`{ "values": [ "ok" ], "var1": "ok", "var2": "ok" }`

**OK**
`echo '{"values": [""]}' | nc -v localhost 1001`
`{ "values": [ "" ], "var1": "" }`

**NOK**
`echo '{"values": []}' | nc -v localhost 1001`
no output, and in debug logs:
![image](https://user-images.githubusercontent.com/33118448/108173012-dbb45f00-70fd-11eb-8996-eeb56ccf78d1.png)

## Observations
The reason for this bug is the systematic deletion of the temporary variable used as container for the for loop. This variable is assumed to be created when accessing callForeachArray() or callForeachObject() in ruleset.c (lines 405/407), but in the case of zero-lenght array or object, this variable is never created and msgDelJSON() returns with a non-zero value, not finding the variable to remove.

I consider it a bug as the deletion of the temporary variable should only occur if and only if the variable was first created once.

The correction is somehow naïve, I tried solving the problem in the most simple and efficient way: the overhead of checking for array/object length in libfastjson is low, but it's still executed twice now.