### PR TITLE
MMDBLOOKUP::Improvement:: allow mmdb to be reloaded on HUP signal

### DIFF
--- a/tests/libmaxmindb.supp
+++ b/tests/libmaxmindb.supp
@@ -36,3 +36,22 @@
    fun:ConsumerReg
    fun:wtiWorker
 }
+{
+   yet_another_incarnation
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:MMDB_open
+   fun:open_mmdb
+   fun:createWrkrInstance
+   fun:actionCheckAndCreateWrkrInstance
+   fun:actionPrepare
+   fun:actionProcessMessage
+   fun:processMsgMain
+   fun:doSubmitToActionQ
+   fun:execAct
+   fun:scriptExec
+   fun:processBatch
+   fun:msgConsumer
+   fun:ConsumerReg
+}


### PR DESCRIPTION
Current version of mmdblookup doesn't handle the mmdb file(s) safely, this improvement allows safe reloading of mmdb files after changing them, without having to restart Rsyslog