### PR TITLE
testbench: Skip tests that need logger -d for busybox

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1539,8 +1539,15 @@ get_inode() {
 # check that logger supports -d option, if not skip test
 # right now this is a bit dirty, we check distros which do not support it
 check_logger_has_option_d() {
-	skip_platform "FreeBSD"  "We need logger -p option, which we do not have on FreeBSD"
-	skip_platform "SunOS"  "We need logger -p option, which we do not have on (all flavors of) Solaris"
+	skip_platform "FreeBSD"  "We need logger -d option, which we do not have on FreeBSD"
+	skip_platform "SunOS"  "We need logger -d option, which we do not have on (all flavors of) Solaris"
+
+	# check also the case for busybox
+	logger --help 2>&1 | head -n1 | grep -q BusyBox
+	if [ $? -eq 0 ]; then
+		echo "We need logger -d option, which we do not have have on Busybox"
+		exit 77
+	fi
 }
 
 


### PR DESCRIPTION
Busybox logger doesn't have the -d flag.

Skip instead of failing the tests that need -d.
Also fix typo s/-p/-d.

busybox reference:
https://busybox.net/downloads/BusyBox.html#logger

Signed-off-by: Yi Fan Yu <yifan.yu@windriver.com>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
