### PR TITLE
clarify some debug output in regard to config include load order

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -484,7 +484,7 @@ cnfAddConfigBuffer(es_str_t *const str, const char *const cnfobj_name)
 	dbgprintf("config parser: pushed config fragment on top of stack: %s\n", cnfobj_name);
 
 	if(fp_rs_full_conf_output != NULL) {
-		fprintf(fp_rs_full_conf_output, "\n##### BEGIN CONFIG: %s\n", cnfcurrfn);
+		fprintf(fp_rs_full_conf_output, "\n##### BEGIN CONFIG: %s (put on stack)\n", cnfcurrfn);
 	}
 
 done:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -453,6 +453,7 @@ TESTS +=  \
 	lookup_table_bad_configs.sh \
 	lookup_table_rscript_reload.sh \
 	lookup_table_rscript_reload_without_stub.sh \
+	config_multiple_include.sh \
 	include-obj-text-from-file.sh \
 	include-obj-text-from-file-noexist.sh \
 	multiple_lookup_tables.sh \
@@ -1613,6 +1614,9 @@ EXTRA_DIST= \
 	mmexternal-InvldProg-vg.sh \
 	nested-call-shutdown.sh \
 	1.rstest 2.rstest 3.rstest err1.rstest \
+	config_multiple_include.sh \
+	testsuites/include-std1-omfile-action.conf \
+	testsuites/include-std2-omfile-action.conf \
 	invalid_nested_include.sh \
 	validation-run.sh \
 	tls-certs/ca-key.pem \

--- a/tests/config_multiple_include.sh
+++ b/tests/config_multiple_include.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# check nested include processing works correctly (and keeps proper order)
+# added 2021-03-29 by Rainer Gerhards; Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5000
+# Note: we need to pre-build the second level include file name because
+# under "make distchek" we have a different environment and with the
+# current rsyslog implemenation, we can only have a single environment
+# variable in an `echo $VAR` block. This we cannot combine the include
+# file name inside the config include without this trick.
+export INCLUDE2="${srcdir}/testsuites/include-std2-omfile-action.conf"
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then {
+	include(file="'${srcdir}'/testsuites/include-std1-omfile-actio*.conf")
+	continue
+}
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+seq_check
+ls -l "$RSYSLOG2_OUT_LOG"
+if [ -f "$RSYSLOG2_OUT_LOG" ]; then
+	printf '\nERROR: file %s exists, but should have stopped by inner include\n' "$RSYSLOG2_OUT_LOG"
+	printf 'This looks like a problem with order of include file processing.\n\n'
+	error_exit 1
+fi
+exit_test

--- a/tests/testsuites/include-std1-omfile-action.conf
+++ b/tests/testsuites/include-std1-omfile-action.conf
@@ -1,0 +1,5 @@
+# this include provides our standard omfile action. It is primarily
+# used for include() tests, but may have other uses as well.
+action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+include(file=`echo $INCLUDE2`)
+action(type="omfile" template="outfmt" file=`echo $RSYSLOG2_OUT_LOG`)

--- a/tests/testsuites/include-std2-omfile-action.conf
+++ b/tests/testsuites/include-std2-omfile-action.conf
@@ -1,0 +1,2 @@
+# this file is included by an include file to test order of include processing
+stop


### PR DESCRIPTION
The previous text seemed to cause the wrong impression that includes
were processed in the wrong order. Right the contrary is the case, as
config files are being put on a stack before they are processed.

closes https://github.com/rsyslog/rsyslog/issues/4271

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
