### PR TITLE
omelastisearch: allow omitting deprecated _type field

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -620,6 +620,8 @@ setPostURL(wrkrInstanceData_t *const pWrkrData, uchar **const tpls)
 	uchar *parent;
 	uchar *bulkId;
 	char* baseUrl;
+	/* since 7.0, the API always requires /idx/_doc, so use that if searchType is not explicitly set */
+	uchar* actualSearchType = (uchar*)"_doc";
 	es_str_t *url;
 	int r;
 	DEFiRet;
@@ -645,11 +647,12 @@ setPostURL(wrkrInstanceData_t *const pWrkrData, uchar **const tpls)
 		if(searchIndex != NULL) {
 			r = es_addBuf(&url, (char*)searchIndex, ustrlen(searchIndex));
 			if(r == 0) r = es_addChar(&url, '/');
-			if(searchType != NULL) {
-				if(r == 0) r = es_addBuf(&url, (char*)searchType, ustrlen(searchType));
-			}
-		} else
-			r = 0;
+
+		if(searchType != NULL) {
+			actualSearchType = searchType;
+		}
+		if(r == 0) r = es_addChar(&url, '/');
+		if(r == 0) r = es_addBuf(&url, (char*)actualSearchType, ustrlen(actualSearchType));
 		if(pipelineName != NULL && (!pData->skipPipelineIfEmpty || pipelineName[0] != '\0')) {
 			if(r == 0) r = es_addChar(&url, separator);
 			if(r == 0) r = es_addBuf(&url, "pipeline=", sizeof("pipeline=")-1);
@@ -693,7 +696,7 @@ computeMessageSize(const wrkrInstanceData_t *const pWrkrData,
 	const uchar *const message,
 	uchar **const tpls)
 {
-	size_t r = sizeof(META_TYPE)-1 + sizeof(META_END)-1 + sizeof("\n")-1;
+	size_t r = sizeof(META_END)-1 + sizeof("\n")-1;
 	if (pWrkrData->pData->writeOperation == ES_WRITE_CREATE)
 		r += sizeof(META_STRT_CREATE)-1;
 	else

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -104,6 +104,7 @@ TESTS +=  \
 	es-basic-errfile-popul.sh \
 	es-bulk-errfile-empty.sh \
 	es-bulk-errfile-popul.sh \
+	es-searchType-empty.sh \
 	diskqueue-multithread-es.sh \
 	es-writeoperation.sh
 
@@ -114,7 +115,8 @@ es-basic-errfile-empty.log: es-maxbytes-bulk.log
 es-basic-errfile-popul.log: es-basic-errfile-empty.log
 es-bulk-errfile-empty.log: es-basic-errfile-popul.log
 es-bulk-errfile-popul.log: es-bulk-errfile-empty.log
-diskqueue-multithread-es.log: es-bulk-errfile-popul.log
+es-searchType-empty.log: es-bulk-errfile-popul.log
+diskqueue-multithread-es.log: es-searchType-empty.log
 es-writeoperation.log: diskqueue-multithread-es.log
 elasticsearch-stop.log: es-writeoperation.log
 
@@ -2183,6 +2185,7 @@ EXTRA_DIST= \
 	es-bulk-errfile-popul-erronly.sh \
 	es-bulk-errfile-popul-erronly-interleaved.sh \
 	es-bulk-errfile-popul-def-interleaved.sh \
+	es-searchType-empty.sh \
 	diskqueue-multithread-es.sh \
 	es-basic-vg.sh \
 	es-basic-bulk-vg.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2142,6 +2142,10 @@ prepare_elasticsearch() {
 		cp -f $srcdir/testsuites/$dep_work_es_config $dep_work_dir/es/config/elasticsearch.yml
 	fi
 
+	# Avoid deprecated parameter, new option introduced with 6.7
+	echo "Setting transport tcp option to ${ES_PORT_OPTION:-transport.tcp.port}"
+	sed -i "s/transport.tcp.port/${ES_PORT_OPTION:-transport.tcp.port}/g" "$dep_work_dir/es/config/elasticsearch.yml"
+
 	if [ ! -d $dep_work_dir/es/data ]; then
 			echo "Creating elastic search directories"
 			mkdir -p $dep_work_dir/es/data

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2138,6 +2138,9 @@ prepare_elasticsearch() {
 	if [ -n "${ES_PORT:-}" ] ; then
 		rm -f $dep_work_dir/es/config/elasticsearch.yml
 		sed "s/^http.port:.*\$/http.port: ${ES_PORT}/" $srcdir/testsuites/$dep_work_es_config > $dep_work_dir/es/config/elasticsearch.yml
+		if [ "$ES_DOWNLOAD" != "elasticsearch-6.0.0.tar.gz" ]; then
+			printf 'xpack.security.enabled: false\n' >> $dep_work_dir/es/config/elasticsearch.yml
+		fi
 	else
 		cp -f $srcdir/testsuites/$dep_work_es_config $dep_work_dir/es/config/elasticsearch.yml
 	fi

--- a/tests/es-basic-es7.0.sh
+++ b/tests/es-basic-es7.0.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export ES_DOWNLOAD=elasticsearch-7.10.2.tar.gz
+export ES_PORT=19200
+# Using the default will cause deprecation failures
+export ES_PORT_OPTION="transport.port"
+export NUMMESSAGES=2000 # slow test
+export QUEUE_EMPTY_CHECK_FUNC=es_shutdown_empty_check
+ensure_elasticsearch_ready
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+if $msg contains "msgnum:" then
+	action(type="omelasticsearch"
+	       server="127.0.0.1"
+	       serverport="19200"
+	       searchType=""
+	       template="tpl"
+	       searchIndex="rsyslog_testbench")
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown 
+es_getdata
+seq_check
+if grep "DEPRECATION" $dep_work_dir/es/logs/rsyslog-testbench_deprecation.log; then
+	echo "Found deprecations, failing!"
+	exit 1
+fi
+exit_test

--- a/tests/es-searchType-empty.sh
+++ b/tests/es-searchType-empty.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-7.10.2.tar.gz
 export ES_PORT=19200
 # Using the default will cause deprecation failures
 export ES_PORT_OPTION="transport.port"


### PR DESCRIPTION
Fixes #4387

This patch allows you to explicitly set searchType="", which causes it to be omitted from the JSON request as well as the bulk API url.

I didn't yet test with an actual Elasticsearch server, but testing with just dumping POST requests onto stdout with a custom template, I can't see immediate problems with the output

in bulk mode:
```
{"index":{"_index": "rsyslog-write-default"}}
{"message":"test","fromhost":"localhost","facility":"user","priority":"notice","timereported":"2021-04-06T21:47:38.739697+03:00","timegenerated":"2021-04-06T21:47:38.739815+03:00"}
```
vector tells me the path is `/_bulk`

and in non-bulk mode the path is `/rsyslog-write-default` and the message does not change

Omitting the parameter restores the default behaviour:
```
{"index":{"_index": "rsyslog-write-default","_type":"events"}}
```
and path `/rsyslog-write-default/events` for non-bulk.