### PR TITLE
omhttp: Fix dynrestpath param in batch mode

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -869,7 +869,9 @@ TESTS +=  \
 	omhttp-batch-newline.sh \
 	omhttp-retry.sh \
 	omhttp-httpheaderkey.sh \
-	omhttp-multiplehttpheaders.sh
+	omhttp-multiplehttpheaders.sh \
+	omhttp-dynrestpath.sh \
+	omhttp-batch-dynrestpath.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	omhttp-auth-vg.sh \
@@ -2264,6 +2266,8 @@ EXTRA_DIST= \
 	omhttp-retry.sh \
 	omhttp-httpheaderkey.sh \
 	omhttp-multiplehttpheaders.sh \
+	omhttp-dynrestpath.sh \
+	omhttp-batch-dynrestpath.sh \
 	omhttp-auth-vg.sh \
 	omhttp-basic-vg.sh \
 	omhttp-batch-jsonarray-compress-vg.sh \

--- a/tests/omhttp-batch-dynrestpath.sh
+++ b/tests/omhttp-batch-dynrestpath.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=10000
+export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+
+port="$(get_free_port)"
+omhttp_start_server $port
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+template(name="dynrestpath" type="string" string="my/endpoint")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+if $msg contains "msgnum:" then
+	action(
+		# Payload
+		name="my_http_action"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+
+		server="localhost"
+		serverport="'$port'"
+		dynrestpath = "on"
+		restpath="dynrestpath"
+
+		batch="on"
+		batch.format="jsonarray"
+		batch.maxsize="1000"
+
+		# Auth
+		usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $port my/endpoint jsonarray
+omhttp_stop_server
+seq_check
+exit_test

--- a/tests/omhttp-dynrestpath.sh
+++ b/tests/omhttp-dynrestpath.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=10000
+export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+
+port="$(get_free_port)"
+omhttp_start_server $port
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+template(name="dynrestpath" type="string" string="my/endpoint")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+if $msg contains "msgnum:" then
+	action(
+		# Payload
+		name="my_http_action"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+		template="tpl"
+
+		server="localhost"
+		serverport="'$port'"
+		dynrestpath = "on"
+		restpath="dynrestpath"
+		batch="off"
+
+		# Auth
+		usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $port my/endpoint
+omhttp_stop_server
+seq_check
+exit_test


### PR DESCRIPTION
Modified omhttp: Fix dynrestpath param in batch mode

When batchmode was used, the templates could not be used to    
expand dynrestpath. We are now storing the restpath param 
within the batch data if we are in batch mode.

- testbench: Added tests for omhttp dynrestpath param
  Testing setting the restpath by template - one with batch mode
  and one without batch mode

closes: https://github.com/rsyslog/rsyslog/issues/4567

