### PR TITLE
further refactoring of tcpsrv parameter passing

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -596,7 +596,7 @@ addTCPListener(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	}
 
 	/* initialized, now add socket */
-	CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, pszInputName == NULL ?
+	CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, cnf_params, pszInputName == NULL ?
 						UCHAR_CONSTANT("imdiag") : pszInputName));
 	CHKiRet(tcpsrv.SetOrigin(pOurTcpsrv, (uchar*)"imdiag"));
 	/* we support octect-counted frame (constant 1 below) */
@@ -769,7 +769,6 @@ CODESTARTmodExit
 
 	/* free some globals to keep valgrind happy */
 	free(pszInputName);
-fprintf(stderr, "FINAL FREE %p\n", pszLstnPortFileName);
 	free(pszLstnPortFileName);
 	free(pszStrmDrvrAuthMode);
 

--- a/plugins/imgssapi/imgssapi.c
+++ b/plugins/imgssapi/imgssapi.c
@@ -358,7 +358,7 @@ actGSSListener(uchar *port)
 	CHKiRet(tcpsrv.SetCBOnSessAccept(pOurTcpsrv, onSessAccept));
 	CHKiRet(tcpsrv.SetCBOnRegularClose(pOurTcpsrv, onRegularClose));
 	CHKiRet(tcpsrv.SetCBOnErrClose(pOurTcpsrv, onErrClose));
-	CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, UCHAR_CONSTANT("imgssapi")));
+	CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, cnf_params, UCHAR_CONSTANT("imgssapi")));
 	CHKiRet(tcpsrv.SetKeepAlive(pOurTcpsrv, bKeepAlive));
 	CHKiRet(tcpsrv.SetOrigin(pOurTcpsrv, UCHAR_CONSTANT("imgssapi")));
 	cnf_params->pszPort = port;

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -409,8 +409,8 @@ addListner(modConfData_t *modConf, instanceConf_t *inst)
 
 	/* initialized, now add socket and listener params */
 	DBGPRINTF("imtcp: trying to add port *:%s\n", inst->cnf_params->pszPort);
-	CHKiRet(tcpsrv.SetRuleset(pOurTcpsrv, inst->pBindRuleset));
-	CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, inst->pszInputName == NULL ?
+	inst->cnf_params->pRuleset = inst->pBindRuleset;
+	CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, inst->cnf_params, inst->pszInputName == NULL ?
 						UCHAR_CONSTANT("imtcp") : inst->pszInputName));
 	CHKiRet(tcpsrv.SetOrigin(pOurTcpsrv, (uchar*)"imtcp"));
 	CHKiRet(tcpsrv.SetDfltTZ(pOurTcpsrv, (inst->dfltTZ == NULL) ? (uchar*)"" : inst->dfltTZ));

--- a/runtime/nsdpoll_ptcp.c
+++ b/runtime/nsdpoll_ptcp.c
@@ -61,7 +61,8 @@ DEFobjCurrIf(glbl)
  * rgerhards, 2009-11-18
  */
 static rsRetVal
-addEvent(nsdpoll_ptcp_t *pThis, int id, void *pUsr, int mode, nsd_ptcp_t *pSock, nsdpoll_epollevt_lst_t **pEvtLst) {
+addEvent(nsdpoll_ptcp_t *pThis, int id, void *pUsr, int mode, nsd_ptcp_t *pSock, nsdpoll_epollevt_lst_t **pEvtLst)
+{
 	nsdpoll_epollevt_lst_t *pNew;
 	DEFiRet;
 
@@ -90,7 +91,8 @@ finalize_it:
  * rgerhards, 2009-11-23
  */
 static rsRetVal
-unlinkEvent(nsdpoll_ptcp_t *pThis, int id, void *pUsr, nsdpoll_epollevt_lst_t **ppEvtLst) {
+unlinkEvent(nsdpoll_ptcp_t *pThis, int id, void *pUsr, nsdpoll_epollevt_lst_t **ppEvtLst)
+{
 	nsdpoll_epollevt_lst_t *pEvtLst;
 	nsdpoll_epollevt_lst_t *pPrev = NULL;
 	DEFiRet;
@@ -224,7 +226,8 @@ finalize_it:
  * rgerhards, 2009-11-18
  */
 static rsRetVal
-Wait(nsdpoll_t *pNsdpoll, int timeout, int *numEntries, nsd_epworkset_t workset[]) {
+Wait(nsdpoll_t *pNsdpoll, int timeout, int *numEntries, nsd_epworkset_t workset[])
+{
 	nsdpoll_ptcp_t *pThis = (nsdpoll_ptcp_t*) pNsdpoll;
 	nsdpoll_epollevt_lst_t *pOurEvt;
 	struct epoll_event event[128];

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -358,6 +358,7 @@ processDataRcvd(tcps_sess_t *pThis,
 	unsigned *const __restrict__ pnMsgs)
 {
 	DEFiRet;
+	const tcpLstnParams_t *const cnf_params = pThis->pLstnInfo->cnf_params;
 	ISOBJ_TYPE_assert(pThis, tcps_sess);
 	int iMaxLine = glbl.GetMaxLine();
 	uchar *propPeerName = NULL;
@@ -396,13 +397,13 @@ processDataRcvd(tcps_sess_t *pThis,
 			if(c != ' ') {
 				LogError(0, NO_ERRCODE, "imtcp %s: Framing Error in received TCP message from "
 					"peer: (hostname) %s, (ip) %s: delimiter is not SP but has "
-					"ASCII value %d.", pThis->pSrv->pszInputName, propPeerName, propPeerIP, c);
+					"ASCII value %d.", cnf_params->pszInputName, propPeerName, propPeerIP, c);
 			}
 			if(pThis->iOctetsRemain < 1) {
 				/* TODO: handle the case where the octet count is 0! */
 				LogError(0, NO_ERRCODE, "imtcp %s: Framing Error in received TCP message from "
 					"peer: (hostname) %s, (ip) %s: invalid octet count %d.",
-					pThis->pSrv->pszInputName, propPeerName, propPeerIP, pThis->iOctetsRemain);
+					cnf_params->pszInputName, propPeerName, propPeerIP, pThis->iOctetsRemain);
 				pThis->eFraming = TCP_FRAMING_OCTET_STUFFING;
 			} else if(pThis->iOctetsRemain > iMaxLine) {
 				/* while we can not do anything against it, we can at least log an indication
@@ -410,13 +411,13 @@ processDataRcvd(tcps_sess_t *pThis,
 				 */
 				LogError(0, NO_ERRCODE, "imtcp %s: received oversize message from peer: "
 					"(hostname) %s, (ip) %s: size is %d bytes, max msg size "
-					"is %d, truncating...", pThis->pSrv->pszInputName, propPeerName,
+					"is %d, truncating...", cnf_params->pszInputName, propPeerName,
 					propPeerIP, pThis->iOctetsRemain, iMaxLine);
 			}
 			if(pThis->iOctetsRemain > pThis->pSrv->maxFrameSize) {
 				LogError(0, NO_ERRCODE, "imtcp %s: Framing Error in received TCP message from "
 					"peer: (hostname) %s, (ip) %s: frame too large: %d, change "
-					"to octet stuffing", pThis->pSrv->pszInputName, propPeerName, propPeerIP,
+					"to octet stuffing", cnf_params->pszInputName, propPeerName, propPeerIP,
 						pThis->iOctetsRemain);
 				pThis->eFraming = TCP_FRAMING_OCTET_STUFFING;
 			} else {

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -41,10 +41,13 @@ struct tcpLstnParams_s {
 	const uchar *pszAddr;                 /**< the addrs the listener shall listen on */
 	sbool bSuppOctetFram;	/**< do we support octect-counted framing? (if no->legay only!)*/
 	sbool bSPFramingFix;	/**< support work-around for broken Cisco ASA framing? */
+	sbool bPreserveCase;			/**< preserve case in fromhost */
 	const uchar *pszLstnPortFileName;	/**< File in which the dynamic port is written */
+	uchar *pszStrmDrvrName;			/**< stream driver to use */
+	uchar *pszInputName;			/**< value to be used as input name */
 	prop_t *pInputName;
-	ruleset_t *pRuleset;		/**< associated ruleset */
-	uchar dfltTZ[8];		/**< default TZ if none in timestamp; '\0' =No Default */
+	ruleset_t *pRuleset;			/**< associated ruleset */
+	uchar dfltTZ[8];			/**< default TZ if none in timestamp; '\0' =No Default */
 };
 
 /* list of tcp listen ports */
@@ -76,7 +79,7 @@ struct tcpsrv_s {
 	uchar *pszDrvrAuthMode;	/**< auth mode of the stream driver to use */
 	uchar *pszDrvrPermitExpiredCerts;/**< current driver setting for handlign expired certs */
 	uchar *pszDrvrName;	/**< name of stream driver to use */
-	uchar *pszInputName;	/**< value to be used as input name */
+	uchar *pszInputName;	/**< value to be used as input name */ // TODO: REMOVE ME!!!!
 	uchar *pszOrigin;		/**< module to be used as "origin" (e.g. for pstats) */
 	ruleset_t *pRuleset;	/**< ruleset to bind to */
 	permittedPeers_t *pPermPeers;/**< driver's permitted peers */
@@ -142,7 +145,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	/* set methods */
 	rsRetVal (*SetAddtlFrameDelim)(tcpsrv_t*, int);
 	rsRetVal (*SetMaxFrameSize)(tcpsrv_t*, int);
-	rsRetVal (*SetInputName)(tcpsrv_t*, uchar*);
+	rsRetVal (*SetInputName)(tcpsrv_t *const pThis,tcpLstnParams_t *const cnf_params, const uchar *const name);
 	rsRetVal (*SetUsrP)(tcpsrv_t*, void*);
 	rsRetVal (*SetCBIsPermittedHost)(tcpsrv_t*, int (*) (struct sockaddr *addr, char*, void*, void*));
 	rsRetVal (*SetCBOpenLstnSocks)(tcpsrv_t *, rsRetVal (*)(tcpsrv_t*));

--- a/tests/imtcp-multiport.sh
+++ b/tests/imtcp-multiport.sh
@@ -10,9 +10,9 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port2")
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port3")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" name="i1")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port2" name="i2")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port3" name="i3")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")


### PR DESCRIPTION
Some further stream-lining and cleanup of paramter passing. This
levels ground for more substantial changes to the imtcp/tcpsrv
interaction.

see also https://github.com/rsyslog/rsyslog/issues/3727#issuecomment-525705318

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
