### PR TITLE
imtcp: add stream driver parameter to input() configuration

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1303,7 +1303,6 @@ static rsRetVal
 SetInputName(tcpsrv_t *const pThis,tcpLstnParams_t *const cnf_params, const uchar *const name)
 {
 	DEFiRet;
-	fprintf(stderr, "name %s\n", name);
 	ISOBJ_TYPE_assert(pThis, tcpsrv);
 	if(name == NULL)
 		cnf_params->pszInputName = NULL;
@@ -1349,7 +1348,7 @@ SetNotificationOnRemoteClose(tcpsrv_t *pThis, int bNewVal)
 
 /* set the driver mode -- rgerhards, 2008-04-30 */
 static rsRetVal
-SetDrvrMode(tcpsrv_t *pThis, int iMode)
+SetDrvrMode(tcpsrv_t *pThis, const int iMode)
 {
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, tcpsrv);
@@ -1358,7 +1357,7 @@ SetDrvrMode(tcpsrv_t *pThis, int iMode)
 }
 
 static rsRetVal
-SetDrvrName(tcpsrv_t *pThis, uchar *name)
+SetDrvrName(tcpsrv_t *pThis, uchar *const name)
 {
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, tcpsrv);
@@ -1370,7 +1369,7 @@ finalize_it:
 
 /* set the driver authentication mode -- rgerhards, 2008-05-19 */
 static rsRetVal
-SetDrvrAuthMode(tcpsrv_t *pThis, uchar *mode)
+SetDrvrAuthMode(tcpsrv_t *pThis, uchar *const mode)
 {
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, tcpsrv);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1232,12 +1232,19 @@ TESTS +=  \
 	imtcp-tls-gtls-x509fingerprint-invld.sh \
 	imtcp-tls-gtls-x509fingerprint.sh \
 	imtcp-tls-gtls-x509name-invld.sh \
-	imtcp-tls-gtls-x509name.sh
+	imtcp-tls-gtls-x509name.sh \
+	imtcp-drvr-in-input-basic.sh \
+	imtcp-multi-drvr-basic.sh \
+	imtcp-multi-drvr-basic-parallel.sh
 if HAVE_VALGRIND
 TESTS += \
 	imtcp-tls-basic-vg.sh \
 	imtcp_conndrop_tls-vg.sh \
 	manytcp-too-few-tls-vg.sh
+endif
+if ENABLE_OPENSSL
+TESTS +=  \
+	imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh
 endif
 endif
 
@@ -2067,6 +2074,10 @@ EXTRA_DIST= \
 	imtcp-tls-gtls-x509fingerprint.sh \
 	imtcp-tls-gtls-x509name-invld.sh \
 	imtcp-tls-gtls-x509name.sh \
+	imtcp-drvr-in-input-basic.sh \
+	imtcp-multi-drvr-basic.sh \
+	imtcp-multi-drvr-basic-parallel.sh \
+	imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh \
 	imtcp-tls-basic.sh \
 	imtcp-tls-basic-verifydepth.sh \
 	imtcp-tls-basic-vg.sh \

--- a/tests/imtcp-drvr-in-input-basic.sh
+++ b/tests/imtcp-drvr-in-input-basic.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# added 2021-04-27 by Rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5000
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+generate_conf
+add_conf '
+global( defaultNetstreamDriverCAFile="'$srcdir'/tls-certs/ca.pem"
+	defaultNetstreamDriverCertFile="'$srcdir'/tls-certs/cert.pem"
+	defaultNetstreamDriverKeyFile="'$srcdir'/tls-certs/key.pem")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+tcpflood -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/imtcp-multi-drvr-basic-parallel.sh
+++ b/tests/imtcp-multi-drvr-basic-parallel.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# This test checks imtcp functionality with multiple drivers running together. It is
+# a minimal test.
+# added 2021-04-27 by Rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=100000 # must be even number!
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+generate_conf
+add_conf '
+global( defaultNetstreamDriverCAFile="'$srcdir'/tls-certs/ca.pem"
+	defaultNetstreamDriverCertFile="'$srcdir'/tls-certs/cert.pem"
+	defaultNetstreamDriverKeyFile="'$srcdir'/tls-certs/key.pem")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port2")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_tcpflood_port2 "$RSYSLOG_DYNNAME.tcpflood_port2"
+# Note: the two tcpflood instances are run in parallel with intent!
+# It stresses the rsyslog engine a bit more. If this fails, see if 
+# the non-parallel test also fails. If so, debug that one, because it
+# is easier to do!
+tcpflood -p$TCPFLOOD_PORT -m$((NUMMESSAGES / 2)) -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem &
+tcpflood -p$TCPFLOOD_PORT2 -m$((NUMMESSAGES / 2)) -i$((NUMMESSAGES / 2))
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh
+++ b/tests/imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# This test checks imtcp functionality with multiple drivers running together. It is
+# a minimal test.
+# added 2021-04-27 by Rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=60000 # must be evenly dividable by 3
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+generate_conf
+add_conf '
+global( defaultNetstreamDriverCAFile="'$srcdir'/tls-certs/ca.pem"
+	defaultNetstreamDriverCertFile="'$srcdir'/tls-certs/cert.pem"
+	defaultNetstreamDriverKeyFile="'$srcdir'/tls-certs/key.pem")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	name="i1"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+
+input(type="imtcp" name="i2" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port2")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port3"
+	name="i3"
+	StreamDriver.Name="ossl"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port3" name="i3")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_tcpflood_port2 "$RSYSLOG_DYNNAME.tcpflood_port2"
+assign_rs_port "$RSYSLOG_DYNNAME.tcpflood_port3"
+tcpflood -p$TCPFLOOD_PORT -m$((NUMMESSAGES / 3)) -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p$TCPFLOOD_PORT2 -m$((NUMMESSAGES / 3)) -i$((NUMMESSAGES / 3))
+tcpflood -p$RS_PORT -m$((NUMMESSAGES / 3)) -i$((NUMMESSAGES / 3 * 2)) -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/imtcp-multi-drvr-basic.sh
+++ b/tests/imtcp-multi-drvr-basic.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# This test checks imtcp functionality with multiple drivers running together. It is
+# a minimal test.
+# added 2021-04-27 by Rgerhards
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=50000 # must be even number!
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+generate_conf
+add_conf '
+global( defaultNetstreamDriverCAFile="'$srcdir'/tls-certs/ca.pem"
+	defaultNetstreamDriverCertFile="'$srcdir'/tls-certs/cert.pem"
+	defaultNetstreamDriverKeyFile="'$srcdir'/tls-certs/key.pem")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon" )
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port2")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+assign_tcpflood_port2 "$RSYSLOG_DYNNAME.tcpflood_port2"
+tcpflood -p$TCPFLOOD_PORT -m$((NUMMESSAGES / 2)) -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+tcpflood -p$TCPFLOOD_PORT2 -m$((NUMMESSAGES / 2)) -i$((NUMMESSAGES / 2))
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
This permits to have different inputs use different stream drivers
and stream driver parameters.

closes https://github.com/rsyslog/rsyslog/issues/3727

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
