### PR TITLE
imtcp: add more override config params to input()

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -303,7 +303,9 @@ TESTS +=  \
 	imtcp_conndrop.sh \
 	imtcp_addtlframedelim.sh \
 	imtcp_no_octet_counted.sh \
+	imtcp_addtlframedelim_on_input.sh \
 	imtcp_spframingfix.sh \
+	imtcp-connection-msg-recieved.sh \
 	sndrcv.sh \
 	sndrcv_failover.sh \
 	sndrcv_gzip.sh \
@@ -2126,10 +2128,12 @@ EXTRA_DIST= \
 	imptcp_multi_line.sh \
 	testsuites/imptcp_multi_line.testdata \
 	imptcp_no_octet_counted.sh \
+	imtcp_addtlframedelim_on_input.sh \
 	testsuites/no_octet_counted.testdata \
 	imtcp_no_octet_counted.sh \
 	testsuites/spframingfix.testdata \
 	imtcp_spframingfix.sh \
+	imtcp-connection-msg-recieved.sh \
 	imptcp_spframingfix.sh \
 	msg-deadlock-headerless-noappname.sh \
 	imtcp_conndrop.sh \

--- a/tests/imtcp-connection-msg-recieved.sh
+++ b/tests/imtcp-connection-msg-recieved.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# addd 2021-05-10 by Rainer Gerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	notifyonconnectionclose="on")
+
+:msg, contains, "msgnum:" {
+	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+
+'
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+tcpflood -m1 -M"\"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:1\""
+shutdown_when_empty
+wait_shutdown
+content_check "closed by remote peer "
+exit_test

--- a/tests/imtcp_addtlframedelim_on_input.sh
+++ b/tests/imtcp_addtlframedelim_on_input.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# added 2010-08-11 by Rgerhards
+#
+# This file is part of the rsyslog project, released  under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=20000
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" addtlframedelimiter="0")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+local0.* ./'$RSYSLOG_OUT_LOG';outfmt
+'
+startup
+tcpflood -m$NUMMESSAGES -F0 -P129
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
