### PR TITLE
new global option "parser.supportCompressionExtension"

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -7,7 +7,7 @@
  *
  * Module begun 2008-04-16 by Rainer Gerhards
  *
- * Copyright 2008-2020 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2021 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -57,6 +57,7 @@
 #include "rsconf.h"
 #include "queue.h"
 #include "dnscache.h"
+#include "parser.h"
 
 #define REPORT_CHILD_PROCESS_EXITS_NONE 0
 #define REPORT_CHILD_PROCESS_EXITS_ERRORS 1
@@ -227,6 +228,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "default.ruleset.queue.timeoutworkerthreadshutdown", eCmdHdlrInt, 0 },
 	{ "reverselookup.cache.ttl.default", eCmdHdlrNonNegInt, 0 },
 	{ "reverselookup.cache.ttl.enable", eCmdHdlrBinary, 0 },
+	{ "parser.supportcompressionextension", eCmdHdlrBinary, 0 },
 	{ "shutdown.queue.doublesize", eCmdHdlrBinary, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
 	{ "debug.whitelist", eCmdHdlrBinary, 0 }
@@ -1509,6 +1511,8 @@ glblDoneLoadCnf(void)
 			dnscacheDefaultTTL = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "reverselookup.cache.ttl.enable")) {
 			dnscacheEnableTTL = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "parser.supportcompressionextension")) {
+			bSupportCompressionExtension = cnfparamvals[i].val.d.n;
 		} else {
 			dbgprintf("glblDoneLoadCnf: program error, non-handled "
 				"param '%s'\n", paramblk.descr[i].name);

--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -4,7 +4,7 @@
  *
  * Module begun 2008-10-09 by Rainer Gerhards (based on previous code from syslogd.c)
  *
- * Copyright 2008-2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2021 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -68,6 +68,7 @@ parserList_t *pParsLstRoot = NULL;
  */
 parserList_t *pDfltParsLst = NULL;
 
+int bSupportCompressionExtension = 1;
 
 /* intialize (but NOT allocate) a parser list. Primarily meant as a hook
  * which can be used to extend the list in the future. So far, just sets
@@ -323,7 +324,7 @@ static rsRetVal uncompressMessage(smsg_t *pMsg)
 	/* we first need to check if we have a compressed record. If so,
 	 * we must decompress it.
 	 */
-	if(lenMsg > 0 && *pszMsg == 'z') { /* compressed data present? (do NOT change order if conditions!) */
+	if(lenMsg > 0 && *pszMsg == 'z' && bSupportCompressionExtension) { /* compressed data present? */
 		/* we have compressed data, so let's deflate it. We support a maximum
 		 * message size of iMaxLine. If it is larger, an error message is logged
 		 * and the message is dropped. We do NOT try to decompress larger messages

--- a/runtime/parser.h
+++ b/runtime/parser.h
@@ -1,6 +1,6 @@
 /* header for parser.c
  *
- * Copyright 2008-2016 Adiscon GmbH.
+ * Copyright 2008-2021 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -65,6 +65,8 @@ ENDinterface(parser)
 */
 
 void printParserList(parserList_t *pList);
+
+extern int bSupportCompressionExtension;
 
 /* prototypes */
 PROTOTYPEObj(parser);


### PR DESCRIPTION
This permits to turn off rsyslog's single-message compression extension
when it interferes with non-syslog message processing (the parser
subsystem expects syslog messages, not generic text)

closes https://github.com/rsyslog/rsyslog/issues/4598

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
