### PR TITLE
add predefined template RSYSLOG_SyslogRFC5424Format

### DIFF
--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -90,6 +90,8 @@ static uchar template_DebugFormat[] = "\"Debug line with all properties:\nFROMHO
 "rawmsg: '%rawmsg%'\n$!:%$!%\n$.:%$.%\n$/:%$/%\n\n\"";
 static uchar template_SyslogProtocol23Format[] = "\"<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% "
 "%PROCID% %MSGID% %STRUCTURED-DATA% %msg%\n\"";
+static uchar template_SyslogRFC5424Format[] = "\"<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% "
+"%PROCID% %MSGID% %STRUCTURED-DATA% %msg%\"";
 static uchar template_TraditionalFileFormat[] = "=RSYSLOG_TraditionalFileFormat";
 static uchar template_FileFormat[] = "=RSYSLOG_FileFormat";
 static uchar template_ForwardFormat[] = "=RSYSLOG_ForwardFormat";
@@ -1246,6 +1248,8 @@ initLegacyConf(void)
 	tplAddLine(ourConf, "RSYSLOG_DebugFormat", &pTmp);
 	pTmp = template_SyslogProtocol23Format;
 	tplAddLine(ourConf, "RSYSLOG_SyslogProtocol23Format", &pTmp);
+	pTmp = template_SyslogRFC5424Format;
+	tplAddLine(ourConf, "RSYSLOG_SyslogRFC5424Format", &pTmp);
 	pTmp = template_FileFormat; /* new format for files with high-precision stamp */
 	tplAddLine(ourConf, "RSYSLOG_FileFormat", &pTmp);
 	pTmp = template_TraditionalFileFormat;


### PR DESCRIPTION
This is essentially the same as RSYSLOG_SyslogProtocol23Format with
a better name and a fix to remove the unnecessary LF at the end of
the message.

The different name also enables us to fix the LF issue without
any concern about backwards compatibility.

closes https://github.com/rsyslog/rsyslog/issues/4384

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
