### PR TITLE
imtcp: permit to use different cerficate files per input

### DIFF
--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -23,7 +23,7 @@
  * Rainer Gerhards and Adiscon GmbH have agreed to permit using the code
  * under the terms of the GNU Lesser General Public License.
  *
- * Copyright 2007-2020 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2021 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -464,5 +464,3 @@ BEGINAbstractObjClassInit(netstrm, 1, OBJ_IS_CORE_MODULE) /* class, version */
 
 	/* set our own handlers */
 ENDObjClassInit(netstrm)
-/* vi:set ai:
- */

--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -344,6 +344,25 @@ GetDrvrTlsVerifyDepth(netstrms_t *pThis)
 	return pThis->DrvrVerifyDepth;
 }
 
+static const uchar *
+GetDrvrTlsCAFile(netstrms_t *pThis)
+{
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	return NULL;
+}
+static const uchar *
+GetDrvrTlsKeyFile(netstrms_t *pThis)
+{
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	return NULL;
+}
+static const uchar *
+GetDrvrTlsCertFile(netstrms_t *pThis)
+{
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	return NULL;
+}
+
 /* create an instance of a netstrm object. It is initialized with default
  * values. The current driver is used. The caller may set netstrm properties
  * and must call ConstructFinalize().
@@ -408,6 +427,9 @@ CODESTARTobjQueryInterface(netstrms)
 	pIf->GetDrvrPrioritizeSAN = GetDrvrPrioritizeSAN;
 	pIf->SetDrvrTlsVerifyDepth = SetDrvrTlsVerifyDepth;
 	pIf->GetDrvrTlsVerifyDepth = GetDrvrTlsVerifyDepth;
+	pIf->GetDrvrTlsCAFile = GetDrvrTlsCAFile;
+	pIf->GetDrvrTlsKeyFile = GetDrvrTlsKeyFile;
+	pIf->GetDrvrTlsCertFile = GetDrvrTlsCertFile;
 finalize_it:
 ENDobjQueryInterface(netstrms)
 

--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -2,7 +2,7 @@
  *
  * Work on this module begung 2008-04-23 by Rainer Gerhards.
  *
- * Copyright 2008 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2021 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *

--- a/runtime/netstrms.h
+++ b/runtime/netstrms.h
@@ -1,6 +1,6 @@
 /* Definitions for the stream-based netstrmsworking class.
  *
- * Copyright 2007, 2008 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2021 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -67,9 +67,16 @@ BEGINinterface(netstrms) /* name must also be changed in ENDinterface macro! */
 	int      (*GetDrvrPrioritizeSAN)(netstrms_t *pThis);
 	rsRetVal (*SetDrvrTlsVerifyDepth)(netstrms_t *pThis, int verifyDepth);
 	int      (*GetDrvrTlsVerifyDepth)(netstrms_t *pThis);
+	/* v2 */
+	rsRetVal (*SetDrvrTlsCAFile)(netstrms_t *pThis, const uchar *);
+	const uchar* (*GetDrvrTlsCAFile)(netstrms_t *pThis);
+	rsRetVal (*SetDrvrTlsKeyFile)(netstrms_t *pThis, const uchar *);
+	const uchar* (*GetDrvrTlsKeyFile)(netstrms_t *pThis);
+	rsRetVal (*SetDrvrTlsCertFile)(netstrms_t *pThis, const uchar *);
+	const uchar* (*GetDrvrTlsCertFile)(netstrms_t *pThis);
 
 ENDinterface(netstrms)
-#define netstrmsCURR_IF_VERSION 1 /* increment whenever you change the interface structure! */
+#define netstrmsCURR_IF_VERSION 2 /* increment whenever you change the interface structure! */
 
 /* prototypes */
 PROTOTYPEObj(netstrms);

--- a/runtime/netstrms.h
+++ b/runtime/netstrms.h
@@ -39,6 +39,7 @@ struct netstrms_s {
 	uchar *pszDrvrPermitExpiredCerts;/**< current driver setting for handlign expired certs */
 	uchar *gnutlsPriorityString; /**< priorityString for connection */
 	permittedPeers_t *pPermPeers;/**< current driver's permitted peers */
+	rsRetVal(*fLstnInitDrvr)(netstrm_t*); /**< "late" driver-specific lstn init function NULL if none */
 
 	nsd_if_t Drvr;		/**< our stream driver */
 };

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -4,7 +4,7 @@
  * implemented by concrete classes. As such, no nsd data type itself
  * is defined.
  *
- * Copyright 2008-2012 Adiscon GmbH.
+ * Copyright 2008-2021 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -93,8 +93,13 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 	/* v14 -- Tls functions */
 	rsRetVal (*SetTlsVerifyDepth)(nsd_t *pThis, int verifyDepth);
 
+	/* v15 -- Tls functions */
+	rsRetVal (*SetTlsCAFile)(nsd_t *pThis, const uchar *);
+	rsRetVal (*SetTlsKeyFile)(nsd_t *pThis, const uchar *);
+	rsRetVal (*SetTlsCertFile)(nsd_t *pThis, const uchar *);
+
 ENDinterface(nsd)
-#define nsdCURR_IF_VERSION 14 /* increment whenever you change the interface structure! */
+#define nsdCURR_IF_VERSION 15 /* increment whenever you change the interface structure! */
 /* interface version 4 added GetRemAddr()
  * interface version 5 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 6 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -768,7 +768,7 @@ gtlsConnectionInit(nsd_gtls_t *const pNsd)
 			/* TODO; a more generic error-tracking function (this one based on CHKgnutls()) */
 			uchar *pErr = gtlsStrerror(gnuRet);
 			LogError(0, RS_RET_GNUTLS_ERR, "unexpected GnuTLS error %d in %s:%d: %s\n",
-			gnuRet, __FILE__, __LINE__, pErr);
+				gnuRet, __FILE__, __LINE__, pErr);
 			free(pErr);
 			ABORT_FINALIZE(RS_RET_GNUTLS_ERR);
 		}
@@ -2167,7 +2167,9 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 		FINALIZE;
 
 	/* we reach this point if in TLS mode */
-	CHKiRet(gtlsConnectionInit(pThis));
+	if(pThis->authMode != GTLS_AUTH_CERTANON) {
+		CHKiRet(gtlsConnectionInit(pThis));
+	}
 	CHKiRet(gtlsInitSession(pThis, 1));
 	CHKgnutls(gnutls_init(&pThis->sess, GNUTLS_CLIENT));
 	pThis->bHaveSess = 1;

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1335,7 +1335,6 @@ gtlsEndSess(nsd_gtls_t *pThis)
 				gnuRet = gnutls_bye(pThis->sess, GNUTLS_SHUT_WR);
 			}
 		}
-	//	gnutls_certificate_free_credentials(pThis->xcred);
 		gnutls_deinit(pThis->sess);
 		pThis->bHaveSess = 0;
 	}
@@ -1395,6 +1394,7 @@ CODESTARTobjDestruct(nsd_gtls)
 		}
 	if(pThis->bOurKeyIsInit)
 		gnutls_x509_privkey_deinit(pThis->ourKey);
+	gnutls_certificate_free_credentials(pThis->xcred);
 	if(pThis->bHaveSess)
 		gnutls_deinit(pThis->sess);
 ENDobjDestruct(nsd_gtls)

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1335,7 +1335,7 @@ gtlsEndSess(nsd_gtls_t *pThis)
 				gnuRet = gnutls_bye(pThis->sess, GNUTLS_SHUT_WR);
 			}
 		}
-		gnutls_certificate_free_credentials(pThis->xcred);
+	//	gnutls_certificate_free_credentials(pThis->xcred);
 		gnutls_deinit(pThis->sess);
 		pThis->bHaveSess = 0;
 	}

--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -65,6 +65,7 @@ struct nsd_gtls_s {
 	int bSANpriority; /* if true, we do stricter checking (if any SAN present we do not cehck CN) */
 	gtlsRtryCall_t rtryCall;/**< what must we retry? */
 	int bIsInitiator;	/**< 0 if socket is the server end (listener), 1 if it is the initiator */
+	int bIsListener;
 	gnutls_session_t sess;
 	int bHaveSess;		/* as we don't know exactly which gnutls_session values
 					are invalid, we use this one to flag whether or

--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -1,6 +1,6 @@
 /* An implementation of the nsd interface for GnuTLS.
  *
- * Copyright 2008-2016 Adiscon GmbH.
+ * Copyright 2008-2021 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -39,6 +39,10 @@ typedef nsd_if_t nsd_gtls_if_t; /* we just *implement* this interface */
 struct nsd_gtls_s {
 	BEGINobjInstance;	/* Data to implement generic object - MUST be the first data element! */
 	nsd_t *pTcp;		/**< our aggregated nsd_ptcp data */
+	gnutls_certificate_credentials_t xcred;
+	const uchar *pszCAFile;
+	const uchar *pszKeyFile;
+	const uchar *pszCertFile;
 	uchar *pszConnectHost;	/**< hostname used for connect - may be used to
 					authenticate peer if no other name given */
 	int iMode;		/* 0 - plain tcp, 1 - TLS */

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1973,6 +1973,59 @@ finalize_it:
 }
 
 
+static rsRetVal
+SetTlsCAFile(nsd_t *pNsd, const uchar *const caFile)
+{
+	DEFiRet;
+	nsd_ossl_t *const pThis = (nsd_ossl_t*) pNsd;
+
+	ISOBJ_TYPE_assert((pThis), nsd_ossl);
+	if(caFile == NULL) {
+		pThis->pszCAFile = NULL;
+	} else {
+		CHKmalloc(pThis->pszCAFile = (const uchar*) strdup((const char*) caFile));
+	}
+
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+SetTlsKeyFile(nsd_t *pNsd, const uchar *const pszFile)
+{
+	DEFiRet;
+	nsd_ossl_t *const pThis = (nsd_ossl_t*) pNsd;
+
+	ISOBJ_TYPE_assert((pThis), nsd_ossl);
+	if(pszFile == NULL) {
+		pThis->pszKeyFile = NULL;
+	} else {
+		CHKmalloc(pThis->pszKeyFile = (const uchar*) strdup((const char*) pszFile));
+	}
+
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+SetTlsCertFile(nsd_t *pNsd, const uchar *const pszFile)
+{
+	DEFiRet;
+	nsd_ossl_t *const pThis = (nsd_ossl_t*) pNsd;
+
+	ISOBJ_TYPE_assert((pThis), nsd_ossl);
+	if(pszFile == NULL) {
+		pThis->pszCertFile = NULL;
+	} else {
+		CHKmalloc(pThis->pszCertFile = (const uchar*) strdup((const char*) pszFile));
+	}
+
+finalize_it:
+	RETiRet;
+}
+
+
+
 /* queryInterface function */
 BEGINobjQueryInterface(nsd_ossl)
 CODESTARTobjQueryInterface(nsd_ossl)
@@ -2010,6 +2063,9 @@ CODESTARTobjQueryInterface(nsd_ossl)
 	pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage; /* we don't NEED this interface! */
 	pIf->SetPrioritizeSAN = SetPrioritizeSAN; /* we don't NEED this interface! */
 	pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
+	pIf->SetTlsCAFile = SetTlsCAFile;
+	pIf->SetTlsKeyFile = SetTlsKeyFile;
+	pIf->SetTlsCertFile = SetTlsCertFile;
 
 finalize_it:
 ENDobjQueryInterface(nsd_ossl)

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -2,7 +2,7 @@
  *
  * An implementation of the nsd interface for OpenSSL.
  *
- * Copyright 2018-2019 Adiscon GmbH.
+ * Copyright 2018-2021 Adiscon GmbH.
  * Author: Andre Lorbach
  *
  * This file is part of the rsyslog runtime library.

--- a/runtime/nsd_ossl.h
+++ b/runtime/nsd_ossl.h
@@ -1,6 +1,6 @@
 /* An implementation of the nsd interface for OpenSSL.
  *
- * Copyright 2018-2018 Adiscon GmbH.
+ * Copyright 2018-2021 Adiscon GmbH.
  * Author: Andre Lorbach
  *
  * This file is part of the rsyslog runtime library.
@@ -49,6 +49,9 @@ struct nsd_ossl_s {
 					authenticate peer if no other name given */
 	int iMode;		/* 0 - plain tcp, 1 - TLS */
 	int bAbortConn;		/* if set, abort conncection (fatal error had happened) */
+	const uchar *pszCAFile;
+	const uchar *pszKeyFile;
+	const uchar *pszCertFile;
 	enum {
 		OSSL_AUTH_CERTNAME = 0,
 		OSSL_AUTH_CERTFINGERPRINT = 1,

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -698,7 +698,6 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 		 * construct a new netstrm obj and hand it over to the upper layers for inclusion
 		 * into their socket array. -- rgerhards, 2008-04-23
 		 */
-dbgprintf("RGER: ptcp 100\n");
 		CHKiRet(pNS->Drvr.Construct(&pNewNsd));
 		CHKiRet(pNS->Drvr.SetSock(pNewNsd, sock));
 		CHKiRet(pNS->Drvr.SetMode(pNewNsd, netstrms.GetDrvrMode(pNS)));
@@ -714,8 +713,11 @@ dbgprintf("RGER: ptcp 100\n");
 		CHKiRet(pNS->Drvr.SetGnutlsPriorityString(pNewNsd, netstrms.GetDrvrGnutlsPriorityString(pNS)));
 		CHKiRet(netstrms.CreateStrm(pNS, &pNewStrm));
 		pNewStrm->pDrvrData = (nsd_t*) pNewNsd;
-dbgprintf("RGER: ptcp 200\n");
+dbgprintf("RGER: ptcp 200, pNS %p, pNewNsd %p, fLstnInitDrvr %p\n", pNewStrm, pNewNsd,pNS->fLstnInitDrvr);
 		pNewNsd = NULL;
+		if(pNS->fLstnInitDrvr != NULL) {
+			CHKiRet(pNS->fLstnInitDrvr(pNewStrm));
+		}
 		CHKiRet(fAddLstn(pUsr, pNewStrm));
 		pNewStrm = NULL;
 		/* sock has been handed over by SetSock() above, so invalidate it here

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -230,7 +230,47 @@ SetPermitExpiredCerts(nsd_t __attribute__((unused)) *pNsd, uchar *mode)
 {
 	DEFiRet;
 	if(mode != NULL) {
-		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: permitexpiredcerts settingnot supported by "
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: permitexpiredcerts setting not supported by "
+				"ptcp netstream driver");
+		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+	}
+
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+SetTlsCAFile(nsd_t __attribute__((unused)) *pNsd, const uchar *const pszFile)
+{
+	DEFiRet;
+	if(pszFile != NULL) {
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: CA File setting not supported by "
+				"ptcp netstream driver - value %s", pszFile);
+		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+	}
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+SetTlsKeyFile(nsd_t __attribute__((unused)) *pNsd, const uchar *const pszFile)
+{
+	DEFiRet;
+	if(pszFile != NULL) {
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: TLS Key File setting not supported by "
+				"ptcp netstream driver");
+		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+	}
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal
+SetTlsCertFile(nsd_t __attribute__((unused)) *pNsd, const uchar *const pszFile)
+{
+	DEFiRet;
+	if(pszFile != NULL) {
+		LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "error: TLS Cert File setting not supported by "
 				"ptcp netstream driver");
 		ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
 	}
@@ -658,11 +698,15 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 		 * construct a new netstrm obj and hand it over to the upper layers for inclusion
 		 * into their socket array. -- rgerhards, 2008-04-23
 		 */
+dbgprintf("RGER: ptcp 100\n");
 		CHKiRet(pNS->Drvr.Construct(&pNewNsd));
 		CHKiRet(pNS->Drvr.SetSock(pNewNsd, sock));
 		CHKiRet(pNS->Drvr.SetMode(pNewNsd, netstrms.GetDrvrMode(pNS)));
 		CHKiRet(pNS->Drvr.SetCheckExtendedKeyUsage(pNewNsd, netstrms.GetDrvrCheckExtendedKeyUsage(pNS)));
 		CHKiRet(pNS->Drvr.SetPrioritizeSAN(pNewNsd, netstrms.GetDrvrPrioritizeSAN(pNS)));
+		CHKiRet(pNS->Drvr.SetTlsCAFile(pNewNsd, netstrms.GetDrvrTlsCAFile(pNS)));
+		CHKiRet(pNS->Drvr.SetTlsKeyFile(pNewNsd, netstrms.GetDrvrTlsKeyFile(pNS)));
+		CHKiRet(pNS->Drvr.SetTlsCertFile(pNewNsd, netstrms.GetDrvrTlsCertFile(pNS)));
 		CHKiRet(pNS->Drvr.SetTlsVerifyDepth(pNewNsd, netstrms.GetDrvrTlsVerifyDepth(pNS)));
 		CHKiRet(pNS->Drvr.SetAuthMode(pNewNsd, netstrms.GetDrvrAuthMode(pNS)));
 		CHKiRet(pNS->Drvr.SetPermitExpiredCerts(pNewNsd, netstrms.GetDrvrPermitExpiredCerts(pNS)));
@@ -670,6 +714,7 @@ LstnInit(netstrms_t *pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*),
 		CHKiRet(pNS->Drvr.SetGnutlsPriorityString(pNewNsd, netstrms.GetDrvrGnutlsPriorityString(pNS)));
 		CHKiRet(netstrms.CreateStrm(pNS, &pNewStrm));
 		pNewStrm->pDrvrData = (nsd_t*) pNewNsd;
+dbgprintf("RGER: ptcp 200\n");
 		pNewNsd = NULL;
 		CHKiRet(fAddLstn(pUsr, pNewStrm));
 		pNewStrm = NULL;
@@ -702,6 +747,7 @@ finalize_it:
 		if(pNewNsd != NULL)
 			pNS->Drvr.Destruct(&pNewNsd);
 	}
+dbgprintf("RGER: end ptcp\n");
 
 	RETiRet;
 }
@@ -1016,6 +1062,9 @@ CODESTARTobjQueryInterface(nsd_ptcp)
 	pIf->SetCheckExtendedKeyUsage = SetCheckExtendedKeyUsage;
 	pIf->SetPrioritizeSAN = SetPrioritizeSAN;
 	pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
+	pIf->SetTlsCAFile = SetTlsCAFile;
+	pIf->SetTlsKeyFile = SetTlsKeyFile;
+	pIf->SetTlsCertFile = SetTlsCertFile;
 finalize_it:
 ENDobjQueryInterface(nsd_ptcp)
 

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -444,8 +444,9 @@ processDataRcvd(tcps_sess_t *pThis,
 		}
 	} else {
 		assert(pThis->inputState == eInMsg);
-		DBGPRINTF("DEBUG: processDataRcvd c=%c remain=%d\n",
-			c, pThis->iOctetsRemain);
+		#if 0 /* enable for in-depth debugging */
+			DBGPRINTF("DEBUG: processDataRcvd c=%c remain=%d\n", c, pThis->iOctetsRemain);
+		#endif
 
 		if((   ((c == '\n') && !pThis->pSrv->bDisableLFDelim)
 		   || ((pThis->pSrv->addtlFrameDelim != TCPSRV_NO_ADDTL_DELIMITER)

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -668,7 +668,7 @@ processWorksetItem(tcpsrv_t *const pThis, nspoll_t *pPoll, const int idx, void *
 finalize_it:
 	if(iRet != RS_RET_OK) {
 		LogError(0, iRet, "tcpsrv listener (inputname: '%s') failed "
-			"to processed incoming connection with error %d",
+			"to process incoming connection with error %d",
 			(cnf_params->pszInputName == NULL) ? (uchar*)"*UNSET*" : cnf_params->pszInputName, iRet);
 		srSleep(0,20000); /* Sleep 20ms */
 	}

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -76,8 +76,8 @@ export ZOOPIDFILE="$(pwd)/zookeeper.pid"
 #valgrind="valgrind --tool=helgrind --log-fd=1 --suppressions=$srcdir/linux_localtime_r.supp --gen-suppressions=all"
 #valgrind="valgrind --tool=exp-ptrcheck --log-fd=1"
 #set -o xtrace
-#export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
-#export RSYSLOG_DEBUGLOG="log"
+export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+export RSYSLOG_DEBUGLOG="log"
 TB_TIMEOUT_STARTSTOP=400 # timeout for start/stop rsyslogd in tenths (!) of a second 400 => 40 sec
 # note that 40sec for the startup should be sufficient even on very slow machines. we changed this from 2min on 2017-12-12
 TB_TEST_TIMEOUT=90  # number of seconds after which test checks timeout (eg. waits)

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -76,8 +76,8 @@ export ZOOPIDFILE="$(pwd)/zookeeper.pid"
 #valgrind="valgrind --tool=helgrind --log-fd=1 --suppressions=$srcdir/linux_localtime_r.supp --gen-suppressions=all"
 #valgrind="valgrind --tool=exp-ptrcheck --log-fd=1"
 #set -o xtrace
-export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
-export RSYSLOG_DEBUGLOG="log"
+#export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+#export RSYSLOG_DEBUGLOG="log"
 TB_TIMEOUT_STARTSTOP=400 # timeout for start/stop rsyslogd in tenths (!) of a second 400 => 40 sec
 # note that 40sec for the startup should be sufficient even on very slow machines. we changed this from 2min on 2017-12-12
 TB_TEST_TIMEOUT=90  # number of seconds after which test checks timeout (eg. waits)

--- a/tests/imtcp-tls-basic.sh
+++ b/tests/imtcp-tls-basic.sh
@@ -2,7 +2,7 @@
 # added 2011-02-28 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=50000
+export NUMMESSAGES=500 #00
 export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
 generate_conf
 add_conf '

--- a/tests/sndrcv_tls_certless_clientonly.sh
+++ b/tests/sndrcv_tls_certless_clientonly.sh
@@ -36,6 +36,7 @@ generate_conf 2
 #export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global(defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'")
+global(debug.gnutls="10")
 
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
