### PR TITLE
mmkubernetes fix for apiserver error handling

### DIFF
--- a/tests/mmkubernetes-basic.out.json
+++ b/tests/mmkubernetes-basic.out.json
@@ -321,4 +321,56 @@
     "container_id": "id10"
   },
   "testid": 14
+},
+{
+  "message": "this record should have no pod metadata",
+  "CONTAINER_NAME": "some-prefix_container-name-11_pod-name-11-error_namespace-name-11_unused11_unused111",
+  "CONTAINER_ID_FULL": "id11",
+  "kubernetes": {
+    "namespace_id": "namespace-name-11-id",
+    "namespace_labels": {
+      "label_1_key": "label 1 value",
+      "label_with_empty_value": "",
+      "label_2_key": "label 2 value"
+    },
+    "creation_timestamp": "2018-04-09T21:56:39Z",
+    "pod_name": "pod-name-11-error",
+    "namespace_name": "namespace-name-11",
+    "container_name": "container-name-11",
+    "master_url": "http://localhost:{k8s_srv_port}"
+  },
+  "docker": {
+    "container_id": "id11"
+  },
+  "testid": 15
+},
+{
+  "message": "this record should process normally",
+  "CONTAINER_NAME": "some-prefix_container-name-12_pod-name-12_namespace-name-12_unused12_unused112",
+  "CONTAINER_ID_FULL": "id12",
+  "kubernetes": {
+    "namespace_id": "namespace-name-12-id",
+    "namespace_labels": {
+      "label_1_key": "label 1 value",
+      "label_with_empty_value": "",
+      "label_2_key": "label 2 value"
+    },
+    "creation_timestamp": "2018-04-09T21:56:39Z",
+    "pod_id": "pod-name-12-id",
+    "labels": {
+      "custom_label": "pod-name-12-label-value",
+      "deploymentconfig": "pod-name-12-dc",
+      "component": "pod-name-12-component",
+      "label_with_empty_value": "",
+      "deployment": "pod-name-12-deployment"
+    },
+    "pod_name": "pod-name-12",
+    "namespace_name": "namespace-name-12",
+    "container_name": "container-name-12",
+    "master_url": "http://localhost:{k8s_srv_port}"
+  },
+  "docker": {
+    "container_id": "id12"
+  },
+  "testid": 16
 }]

--- a/tests/mmkubernetes_test_server.py
+++ b/tests/mmkubernetes_test_server.py
@@ -134,6 +134,11 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                     hsh['reason'] = 'Busy'
                     hsh['err'] = 'server is too busy'
                     resp_template = err_template
+            elif hsh['objectname'].endswith('error'):
+                status = 500
+                hsh['reason'] = 'Error'
+                hsh['err'] = 'server is failing'
+                resp_template = err_template
             if not resp:
                 hsh['code'] = status
                 resp = resp_template.format(**hsh)


### PR DESCRIPTION
submit on behalf of @abwaheed
- Added graceful handling of apiserver errors with unexpected responses,
  i.e., anything other than 200, 404, or 429. Idea is that apiserver
  transient error state will recover. We don't want mmkubernetes to miss
  metadata resolution for containers that don't have cached metadata.
  During these transient error states, mmkubernetes will provide basic
  container file path based resolution of namespace and pod metadata for
  new pods whose metadata is not yet cached. After this error state
  recovers, mmkubernetes is expected to resume its metadata resolution as
  expected.
- Added a unit test case for apiserver return 500 with changes to mock server
-  Fixed existing unit test that was failing due to missing expected results file
-  Added mmkubernetes unit tests to testbench

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
