### PR TITLE
fix imklog crash in modExit

### DIFF
--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -453,6 +453,10 @@ ENDactivateCnf
 
 BEGINfreeCnf
 CODESTARTfreeCnf
+	if (runModConf != NULL) {
+		free(runModConf->pszBindRuleset);
+		runModConf = NULL;
+	}
 ENDfreeCnf
 
 
@@ -475,7 +479,6 @@ CODESTARTmodExit
 	if(pInputName != NULL)
 		prop.Destruct(&pInputName);
 
-	free(runModConf->pszBindRuleset);
 	/* release objects we used */
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(net, CORE_COMPONENT);


### PR DESCRIPTION
Commit 94c4a871d0bcea445c8ee6d94e3f52b099730146 introduced a crash bug in `imklog`.

There is a `free(runModConf->pszBindRuleset)` in `BEGINmodExit`, but the `runModConf` seems to have been freed before.

This patch fixes the crash.
