### PR TITLE
openssl network driver bugfix: small memory leak

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1821,11 +1821,8 @@ finalize_it:
 }
 
 
-/* Empty wrapper for GNUTLS helper function
- * TODO: implement a similar capability
- */
 static rsRetVal
-SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unused)) uchar *gnutlsPriorityString)
+SetGnutlsPriorityString(nsd_t *const pNsd, uchar *const gnutlsPriorityString)
 {
 	DEFiRet;
 	nsd_ossl_t* pThis = (nsd_ossl_t*) pNsd;
@@ -1905,6 +1902,7 @@ SetGnutlsPriorityString(__attribute__((unused)) nsd_t *pNsd, __attribute__((unus
 						pThis->gnutlsPriorityString);
 				osslLastSSLErrorMsg(0, NULL, LOG_ERR, "SetGnutlsPriorityString");
 			}
+			SSL_CONF_CTX_free(cctx);
 		}
 #else
 		dbgprintf("gnutlsPriorityString: set to '%s'\n", gnutlsPriorityString);


### PR DESCRIPTION
Fixes a static, non-growing memory leak which existed when parameter
"GnutTLSPriorityString" was used. This was primarily a cosmetic issue,
but caused some grief during development in regard to memory leak
detectors.

Note: yes, this is for openssl -- the parameter name is history ;-)

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
