### PR TITLE
[omelasticsearch] Improve errorFile mutex handling

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -232,7 +232,7 @@ static rsRetVal curlSetup(wrkrInstanceData_t *pWrkrData);
 BEGINcreateInstance
 CODESTARTcreateInstance
 	pData->fdErrFile = -1;
-	pthread_mutex_init(&pData->mutErrFile, NULL);
+	CHKiRet(pthread_mutex_init(&pData->mutErrFile, NULL));
 	pData->caCertFile = NULL;
 	pData->myCertFile = NULL;
 	pData->myPrivKeyFile = NULL;
@@ -240,6 +240,7 @@ CODESTARTcreateInstance
 	pData->retryRulesetName = NULL;
 	pData->retryRuleset = NULL;
 	pData->rebindInterval = DEFAULT_REBIND_INTERVAL;
+finalize_it:
 ENDcreateInstance
 
 BEGINcreateWrkrInstance
@@ -2165,10 +2166,12 @@ ENDfreeCnf
 
 BEGINdoHUP
 CODESTARTdoHUP
+	pthread_mutex_lock(&pData->mutErrFile);
 	if(pData->fdErrFile != -1) {
 		close(pData->fdErrFile);
 		pData->fdErrFile = -1;
 	}
+	pthread_mutex_unlock(&pData->mutErrFile);
 ENDdoHUP
 
 


### PR DESCRIPTION
Lock the file during SIGHUPs to avoid issues with concurrent accesses by writeDataError().
Check the return value of pthread_mutex_init() in CODESTARTcreateInstance to make sure the mutex is actually usable.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
