### PR TITLE
Close file descriptor when freshStartTail is turned on

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1544,6 +1544,7 @@ openFileWithoutStateFile(act_obj_t *const act)
 		const int fd = open(act->name, O_RDONLY | O_CLOEXEC);
 		if(fd >= 0) {
 			act->pStrm->iCurrOffs = lseek64(fd, 0, SEEK_END);
+			close(fd);
 			if(act->pStrm->iCurrOffs < 0) {
 				act->pStrm->iCurrOffs = 0;
 				LogError(errno, RS_RET_ERR, "imfile: could not query current "


### PR DESCRIPTION
Close file descriptor when **freshStartTail** is turned on. Introduced in https://github.com/rsyslog/rsyslog/commit/b57a65287d0c17e4b28a99cbe5d25bdb5b58f02d.