### PR TITLE
imptcp bugfix: keep alive interval was incorrectly set

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1721,7 +1721,7 @@ static rsRetVal addInstance(void __attribute__((unused)) *pVal, uchar *const pNe
 	inst->pBindRuleset = NULL;
 	inst->bSuppOctetFram = cs.bSuppOctetFram;
 	inst->bKeepAlive = cs.bKeepAlive;
-	inst->iKeepAliveIntvl = cs.iKeepAliveTime;
+	inst->iKeepAliveIntvl = cs.iKeepAliveIntvl;
 	inst->iKeepAliveProbes = cs.iKeepAliveProbes;
 	inst->iKeepAliveTime = cs.iKeepAliveTime;
 	inst->bEmitMsgOnClose = cs.bEmitMsgOnClose;
@@ -1750,7 +1750,7 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 	pSrv->bSuppOctetFram = inst->bSuppOctetFram;
 	pSrv->bSPFramingFix = inst->bSPFramingFix;
 	pSrv->bKeepAlive = inst->bKeepAlive;
-	pSrv->iKeepAliveIntvl = inst->iKeepAliveTime;
+	pSrv->iKeepAliveIntvl = inst->iKeepAliveIntvl;
 	pSrv->iKeepAliveProbes = inst->iKeepAliveProbes;
 	pSrv->iKeepAliveTime = inst->iKeepAliveTime;
 	pSrv->bEmitMsgOnClose = inst->bEmitMsgOnClose;


### PR DESCRIPTION
The interval was accidentally set to keep alive interval. This has been
corrected.

closes https://github.com/rsyslog/rsyslog/issues/4609

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
