### PR TITLE
omfwd: add capability for action-specific TLS certificate settings

### DIFF
--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -256,6 +256,33 @@ SetDrvrTlsVerifyDepth(netstrm_t *pThis, int verifyDepth)
 	RETiRet;
 }
 
+static rsRetVal
+SetDrvrTlsCAFile(netstrm_t *const pThis, const uchar *const file)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetTlsCAFile(pThis->pDrvrData, file);
+	RETiRet;
+}
+
+static rsRetVal
+SetDrvrTlsKeyFile(netstrm_t *const pThis, const uchar *const file)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetTlsKeyFile(pThis->pDrvrData, file);
+	RETiRet;
+}
+
+static rsRetVal
+SetDrvrTlsCertFile(netstrm_t *const pThis, const uchar *const file)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrm);
+	iRet = pThis->Drvr.SetTlsCertFile(pThis->pDrvrData, file);
+	RETiRet;
+}
+
 /* End of methods to shuffle autentication settings to the driver.
  * -------------------------------------------------------------------------- */
 
@@ -442,6 +469,9 @@ CODESTARTobjQueryInterface(netstrm)
 	pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
 	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
 	pIf->SetDrvrTlsVerifyDepth = SetDrvrTlsVerifyDepth;
+	pIf->SetDrvrTlsCAFile = SetDrvrTlsCAFile;
+	pIf->SetDrvrTlsKeyFile = SetDrvrTlsKeyFile;
+	pIf->SetDrvrTlsCertFile = SetDrvrTlsCertFile;
 finalize_it:
 ENDobjQueryInterface(netstrm)
 

--- a/runtime/netstrm.h
+++ b/runtime/netstrm.h
@@ -86,8 +86,13 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 
 	/* v14 -- Tls functions */
 	rsRetVal (*SetDrvrTlsVerifyDepth)(netstrm_t *pThis, int verifyDepth);
+
+	/* v15 -- Tls cert functions */
+	rsRetVal (*SetDrvrTlsCAFile)(netstrm_t *pThis, const uchar* file);
+	rsRetVal (*SetDrvrTlsKeyFile)(netstrm_t *pThis, const uchar* file);
+	rsRetVal (*SetDrvrTlsCertFile)(netstrm_t *pThis, const uchar* file);
 ENDinterface(netstrm)
-#define netstrmCURR_IF_VERSION 12 /* increment whenever you change the interface structure! */
+#define netstrmCURR_IF_VERSION 15 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()
  * interface version 4 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 5 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1367,7 +1367,9 @@ CODESTARTobjDestruct(nsd_gtls)
 		gnutls_x509_privkey_deinit(pThis->ourKey);
 	if(pThis->bHaveSess)
 		gnutls_deinit(pThis->sess);
-	if(pThis->xcred != NULL && !pThis->xcred_is_copy && (!pThis->bIsInitiator || pThis->bHaveSess)) {
+	if(pThis->xcred != NULL
+	   && (pThis->bIsInitiator || (!pThis->xcred_is_copy && (!pThis->bIsInitiator || pThis->bHaveSess)))
+	  ) {
 		gnutls_certificate_free_credentials(pThis->xcred);
 		free((void*) pThis->pszKeyFile);
 		free((void*) pThis->pszCertFile);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1233,6 +1233,7 @@ TESTS +=  \
 	sndrcv_tls_gtls_serveranon_gtls_clientanon.sh \
 	sndrcv_tls_priorityString.sh \
 	sndrcv_tls_certvalid.sh \
+	sndrcv_tls_certvalid_action_level.sh \
 	sndrcv_tls_certvalid_expired.sh \
 	sndrcv_tls_certvalid_expired_defaultmode.sh \
 	imtcp-tls-gtls-x509fingerprint-invld.sh \
@@ -1268,6 +1269,7 @@ TESTS +=  \
 	sndrcv_tls_ossl_serveranon_ossl_clientanon.sh \
 	sndrcv_tls_ossl_servercert_ossl_clientanon.sh \
 	sndrcv_tls_ossl_certvalid.sh \
+	sndrcv_tls_ossl_certvalid_action_level.sh \
 	sndrcv_tls_ossl_certvalid_expired.sh \
 	sndrcv_tls_ossl_certvalid_tlscommand.sh \
 	imtcp-tls-ossl-x509valid.sh \
@@ -1321,6 +1323,7 @@ if ENABLE_GNUTLS
 TESTS += \
          sndrcv_relp_tls.sh \
          sndrcv_relp_tls_certvalid.sh \
+	 sndrcv_tls_certvalid_action_level.sh \
          sndrcv_relp_tls_prio.sh \
 	 sndrcv_relp_tls_chainedcert.sh \
          relp_tls_certificate_not_found.sh \
@@ -2110,6 +2113,7 @@ EXTRA_DIST= \
 	sndrcv_tls_ossl_anon_ipv6.sh \
 	sndrcv_tls_ossl_anon_rebind.sh \
 	sndrcv_tls_ossl_certvalid.sh \
+	sndrcv_tls_ossl_certvalid_action_level.sh \
 	sndrcv_tls_ossl_certvalid_expired.sh \
 	sndrcv_tls_ossl_certvalid_tlscommand.sh \
 	imtcp-tls-ossl-x509valid.sh \
@@ -2645,6 +2649,7 @@ EXTRA_DIST= \
 	sndrcv_tls_anon_ipv6.sh \
 	sndrcv_tls_priorityString.sh \
 	sndrcv_tls_certvalid.sh \
+	sndrcv_tls_certvalid_action_level.sh \
 	sndrcv_tls_certvalid_expired.sh \
 	sndrcv_tls_certvalid_expired_defaultmode.sh \
 	sndrcv_tls_certless_clientonly.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -644,8 +644,9 @@ injectmsg() {
 
 # inject messages in INSTANCE 2 via our inject interface (imdiag)
 injectmsg2() {
-	echo injecting $2 messages
-	echo injectmsg "$1" "$2" $3 $4 | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT2 || error_exit  $?
+	msgs=${2:-$NUMMESSAGES}
+	echo injecting $2 messages into instance 2
+	echo injectmsg "$1:-0" "$msgs" $3 $4 | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT2 || error_exit  $?
 	# TODO: some return state checking? (does it really make sense here?)
 }
 

--- a/tests/sndrcv_tls_certvalid_action_level.sh
+++ b/tests/sndrcv_tls_certvalid_action_level.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
+export NUMMESSAGES=10000
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+# uncomment for debugging support:
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+generate_conf
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="'$RS_TLS_DRIVER'"
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="'$RS_TLS_DRIVER'"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="x509/certvalid" )
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+export PORT_RCVR=$TCPFLOOD_PORT
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
+#valgrind="valgrind"
+generate_conf 2
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/testsuites/x.509/client-key.pem'"
+	defaultNetstreamDriver="'$RS_TLS_DRIVER'"
+)
+
+action(type="omfwd" target="127.0.0.1" port="'$PORT_RCVR'" protocol="tcp"
+     	streamDriverMode="1"
+	streamDriverAuthMode="x509/certvalid"
+	streamdriver.cafile="'$srcdir'/tls-certs/ca.pem"
+	streamdriver.keyfile="'$srcdir'/tls-certs/key.pem"
+	streamdriver.certfile="'$srcdir'/tls-certs/cert.pem"
+)
+' 2
+startup 2
+
+# now inject the messages into instance 2. It will connect to instance 1,
+# and that instance will record the data.
+injectmsg2
+# shut down sender when everything is sent, receiver continues to run concurrently
+shutdown_when_empty 2
+wait_shutdown 2
+# now it is time to stop the receiver as well
+shutdown_when_empty
+wait_shutdown
+
+seq_check
+exit_test

--- a/tests/sndrcv_tls_ossl_certvalid_action_level.sh
+++ b/tests/sndrcv_tls_ossl_certvalid_action_level.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# added 2020-01-17 by RGerhards, released under ASL 2.0
+export RS_TLS_DRIVER=ossl
+source ${srcdir:=.}/sndrcv_tls_certvalid_action_level.sh


### PR DESCRIPTION
This permits to override the global definitions for TLS certificates
at the action() level.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
