### PR TITLE
testbench: guard tests against unexpected warning messages

### DIFF
--- a/tests/imuxsock_legacy.sh
+++ b/tests/imuxsock_legacy.sh
@@ -11,7 +11,7 @@ $OmitLocalLogging on
 $AddUnixListenSocket '$RSYSLOG_DYNNAME'-testbench_socket
 
 template(name="outfmt" type="string" string="%msg:%\n")
-*.notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+*.=notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_logger.sh
+++ b/tests/imuxsock_logger.sh
@@ -9,7 +9,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
 input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-*.notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup
 logger -d -u $RSYSLOG_DYNNAME-testbench_socket test

--- a/tests/imuxsock_logger_err.sh
+++ b/tests/imuxsock_logger_err.sh
@@ -10,7 +10,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
 input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-*.notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_logger_parserchain.sh
+++ b/tests/imuxsock_logger_parserchain.sh
@@ -12,7 +12,7 @@ input(	type="imuxsock" socket="'$RSYSLOG_DYNNAME'-testbench_socket"
 	parseHostname="on")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-*.notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup
 logger -d --rfc3164 -u $RSYSLOG_DYNNAME-testbench_socket test

--- a/tests/imuxsock_logger_root.sh
+++ b/tests/imuxsock_logger_root.sh
@@ -12,7 +12,7 @@ add_conf '
 $ModLoad ../plugins/imuxsock/.libs/imuxsock
 
 $template outfmt,"%msg:%\n"
-*.notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_logger_syssock.sh
+++ b/tests/imuxsock_logger_syssock.sh
@@ -13,7 +13,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock"
        SysSock.name="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 $template outfmt,"%msg:%\n"
-*.notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+*.=notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 logger -d -u $RSYSLOG_DYNNAME-testbench_socket test

--- a/tests/msgdup.sh
+++ b/tests/msgdup.sh
@@ -18,7 +18,7 @@ ruleset(name="rs" queue.type="LinkedList") {
 	stop
 }
 
-*.notice call rs
+*.=notice call rs
 '
 startup
 logger -d -u $RSYSLOG_DYNNAME-testbench_socket -t RSYSLOG_TESTBENCH 'test 01234567890123456789012345678901234567890123456789012345

--- a/tests/omfwd-keepalive.sh
+++ b/tests/omfwd-keepalive.sh
@@ -13,7 +13,9 @@ template(name="outfmt" type="list") {
 }
 :msg, contains, "x-pid" stop
 
-action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+
+if $msg contains "msgnum:" then
+	action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
 
 :msg, contains, "this does not occur" action(type="omfwd"
 	target="10.0.0.1" keepalive="on" keepalive.probes="10"


### PR DESCRIPTION
Practice has shown that environment-induced error messages may
appear during test runs. For example, incorrect resolver settings
may cause name resolution warnings or errors. These are unrelated
to the test itself.

This patch enables tests that are otherwise unaffected by the faillures
to continue and provide "pass" test result.

see also https://github.com/rsyslog/rsyslog/issues/4619

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
