### PR TITLE
omelasticsearch: fix incorrect mutex error handling from commit 73277…

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -4,7 +4,7 @@
  * NOTE: read comments in module-template.h for more specifics!
  *
  * Copyright 2011 Nathan Scott.
- * Copyright 2009-2019 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2009-2021 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -232,7 +232,11 @@ static rsRetVal curlSetup(wrkrInstanceData_t *pWrkrData);
 BEGINcreateInstance
 CODESTARTcreateInstance
 	pData->fdErrFile = -1;
-	CHKiRet(pthread_mutex_init(&pData->mutErrFile, NULL));
+	if(pthread_mutex_init(&pData->mutErrFile, NULL) != 0) {
+		LogError(errno, RS_RET_ERR, "omelasticsearch: cannot create "
+			"error file mutex, failing this action");
+		ABORT_FINALIZE(RS_RET_ERR);
+	}
 	pData->caCertFile = NULL;
 	pData->myCertFile = NULL;
 	pData->myPrivKeyFile = NULL;


### PR DESCRIPTION
…e68ea2e

Commit 73277e68ea2e introduced a slightly wrong error check. This patch
fixes that and also emits an user error message in the very unlikely
case an error actually happens.

Note: this patch was applied as part of the merge process, so no version
ever existed with the defect.

see also https://github.com/rsyslog/rsyslog/pull/4639

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
