### PR TITLE
imklog: fix invalid memory adressing, could cause abort

### DIFF
--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -453,6 +453,7 @@ ENDactivateCnf
 
 BEGINfreeCnf
 CODESTARTfreeCnf
+	free(pModConf->pszBindRuleset);
 ENDfreeCnf
 
 
@@ -475,7 +476,6 @@ CODESTARTmodExit
 	if(pInputName != NULL)
 		prop.Destruct(&pInputName);
 
-	free(runModConf->pszBindRuleset);
 	/* release objects we used */
 	objRelease(glbl, CORE_COMPONENT);
 	objRelease(net, CORE_COMPONENT);


### PR DESCRIPTION
This is a regeression from commit 94c4a87. It introduced a free() call
using an object that was no longer valid (the main pointer to the
to-be-freed object) was already freed at time of use. This could
cause various issues, including a segfault.

Note: this bug was triggerred only during late phase of rsyslog
shutdown, so it did not affect regular operation.

Special thanks to github user wxiaoguang for analyzing the issue
and providing a draft fix proposal, on which this patch builds.

see also https://github.com/rsyslog/rsyslog/pull/4629
closes https://github.com/rsyslog/rsyslog/issues/4625

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
