### PR TITLE
testbench: fix privdrop tests under root user

### DIFF
--- a/tests/privdrop_common.sh
+++ b/tests/privdrop_common.sh
@@ -45,6 +45,15 @@ rsyslog_testbench_setup_testuser() {
 			has_testuser="${testuser}"
 			break
 		done
+		if [ -z "${has_testuser}" ]; then
+			echo "ERROR: running as root and no suiteable testuser found - skipping test"
+			echo 'You mas set a testuser via the RSYSLOG_TESTUSER environment variable'
+			exit 77
+		fi
+		echo "WARNING: making work directory world-writable, as we need this to be able to"
+		echo "         open and process files after privilege drop. This is NOT automatically"
+		echo "         undone."
+		chmod a+w .
 	fi
 
 	if [ -z "${has_testuser}" ]; then

--- a/tests/privdropgroup.sh
+++ b/tests/privdropgroup.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
-
-uname
-if [ $(uname) = "SunOS" ] ; then
-   echo "Solaris: FIX ME"
-   exit 77
-fi
-
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "This test currently does not work on Solaris."
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
-. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(privdrop.group.keepsupplemental="on")
@@ -19,16 +13,16 @@ template(name="outfmt" type="list") {
 	constant(value="\n")
 }
 action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+$PrivDropToGroup '${TESTBENCH_TESTUSER[groupname]}'
 '
-add_conf "\$PrivDropToGroup ${TESTBENCH_TESTUSER[groupname]}"
 startup
 shutdown_when_empty
 wait_shutdown
-grep "groupid.*${TESTBENCH_TESTUSER[gid]}" < $RSYSLOG_OUT_LOG
+content_check --regex "groupid.*${TESTBENCH_TESTUSER[gid]}"
 if [ ! $? -eq 0 ]; then
   echo "message indicating drop to group \"${TESTBENCH_TESTUSER[groupname]}\" (#${TESTBENCH_TESTUSER[gid]}) is missing:"
   cat $RSYSLOG_OUT_LOG
-  exit 1
+  error_exit 1
 fi;
 
 exit_test

--- a/tests/privdropgroupid.sh
+++ b/tests/privdropgroupid.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
-. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 global(privdrop.group.keepsupplemental="on")
@@ -12,16 +12,11 @@ template(name="outfmt" type="list") {
 	constant(value="\n")
 }
 action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+$PrivDropToGroupID '${TESTBENCH_TESTUSER[gid]}'
 '
-add_conf "\$PrivDropToGroupID ${TESTBENCH_TESTUSER[gid]}"
+#add_conf "\$PrivDropToGroupID ${TESTBENCH_TESTUSER[gid]}"
 startup
 shutdown_when_empty
 wait_shutdown
-grep "groupid.*${TESTBENCH_TESTUSER[gid]}" < $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "message indicating drop to gid #${TESTBENCH_TESTUSER[gid]} is missing:"
-  cat $RSYSLOG_OUT_LOG
-  exit 1
-fi;
-
+content_check --regex "groupid.*${TESTBENCH_TESTUSER[gid]}"
 exit_test

--- a/tests/privdropuser.sh
+++ b/tests/privdropuser.sh
@@ -1,13 +1,7 @@
 #!/bin/bash
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
-
 . ${srcdir:=.}/diag.sh init
-uname
-if [ $(uname) = "SunOS" ] ; then
-   echo "Solaris: FIX ME"
-   exit 77
-fi
-
+skip_platform "SunOS"  "This test currently does not work on Solaris."
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
@@ -18,16 +12,10 @@ template(name="outfmt" type="list") {
 	constant(value="\n")
 }
 action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+$PrivDropToUser '${TESTBENCH_TESTUSER[username]}'
 '
-add_conf "\$PrivDropToUser ${TESTBENCH_TESTUSER[username]}"
 startup
 shutdown_when_empty
 wait_shutdown
-grep "userid.*${TESTBENCH_TESTUSER[uid]}" < $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "message indicating drop to user \"${TESTBENCH_TESTUSER[username]}\" (#${TESTBENCH_TESTUSER[uid]}) is missing:"
-  cat $RSYSLOG_OUT_LOG
-  exit 1
-fi;
-
+content_check --regex "userid.*${TESTBENCH_TESTUSER[uid]}"
 exit_test

--- a/tests/privdropuserid.sh
+++ b/tests/privdropuserid.sh
@@ -1,16 +1,10 @@
 #!/bin/bash
 # addd 2016-03-24 by RGerhards, released under ASL 2.0
-
-uname
-if [ $(uname) = "SunOS" ] ; then
-   echo "Solaris: FIX ME"
-   exit 77
-fi
-
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "This test currently does not work on Solaris."
 . $srcdir/privdrop_common.sh
 rsyslog_testbench_setup_testuser
 
-. ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf '
 template(name="outfmt" type="list") {
@@ -18,16 +12,10 @@ template(name="outfmt" type="list") {
 	constant(value="\n")
 }
 action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+$PrivDropToUserID '${TESTBENCH_TESTUSER[uid]}'
 '
-add_conf "\$PrivDropToUserID ${TESTBENCH_TESTUSER[uid]}"
 startup
 shutdown_when_empty
 wait_shutdown
-grep "userid.*${TESTBENCH_TESTUSER[uid]}" < $RSYSLOG_OUT_LOG
-if [ ! $? -eq 0 ]; then
-  echo "message indicating drop to uid #${TESTBENCH_TESTUSER[uid]} is missing:"
-  cat $RSYSLOG_OUT_LOG
-  exit 1
-fi;
-
+content_check --regex "userid.*${TESTBENCH_TESTUSER[uid]}"
 exit_test


### PR DESCRIPTION
When running under root, the privdrop tests did not properly work. This
patch fixes the issue and skips test where necessary.

This also includes some modernization of the related tests.

closes https://github.com/rsyslog/rsyslog/issues/4619

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
