### PR TITLE
config: implement script-equavalent for $PrivDrop* statements

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -961,12 +961,14 @@ doGetUID(struct nvlst *valnode, struct cnfparamdescr *param,
 	struct passwd *resultBuf;
 	struct passwd wrkBuf;
 	char stringBuf[2048]; /* 2048 has been proven to be large enough */
+	char errStr[1024];
 
 	cstr = es_str2cstr(valnode->val.d.estr, NULL);
-	getpwnam_r(cstr, &wrkBuf, stringBuf, sizeof(stringBuf), &resultBuf);
+	const int err_no = getpwnam_r(cstr, &wrkBuf, stringBuf, sizeof(stringBuf), &resultBuf);
 	if(resultBuf == NULL) {
-		parser_errmsg("parameter '%s': ID for user %s could not "
-		  "be found", param->name, cstr);
+		rs_strerror_r((err_no == 0) ? ENOENT : errno, errStr, sizeof(errStr));
+		parser_errmsg("parameter '%s': ID for user '%s' could not "
+		  "be found: %s", param->name, cstr, errStr);
 		r = 0;
 	} else {
 		val->val.datatype = 'N';

--- a/runtime/cfsysline.c
+++ b/runtime/cfsysline.c
@@ -1079,6 +1079,3 @@ cfsyslineInit(void)
 finalize_it:
 	RETiRet;
 }
-
-/* vim:set ai:
- */

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -201,6 +201,10 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "senders.keeptrack", eCmdHdlrBinary, 0 },
 	{ "inputs.timeout.shutdown", eCmdHdlrPositiveInt, 0 },
 	{ "privdrop.group.keepsupplemental", eCmdHdlrBinary, 0 },
+	{ "privdrop.group.id", eCmdHdlrPositiveInt, 0 },
+	{ "privdrop.group.name", eCmdHdlrGID, 0 },
+	{ "privdrop.user.id", eCmdHdlrPositiveInt, 0 },
+	{ "privdrop.user.name", eCmdHdlrUID, 0 },
 	{ "net.ipprotocol", eCmdHdlrGetWord, 0 },
 	{ "net.acladdhostnameonfail", eCmdHdlrBinary, 0 },
 	{ "net.aclresolvehostname", eCmdHdlrBinary, 0 },
@@ -1445,6 +1449,14 @@ glblDoneLoadCnf(void)
 			glblInputTimeoutShutdown = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "privdrop.group.keepsupplemental")) {
 			loadConf->globals.gidDropPrivKeepSupplemental = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "privdrop.group.id")) {
+			loadConf->globals.gidDropPriv = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "privdrop.group.name")) {
+			loadConf->globals.gidDropPriv = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "privdrop.user.id")) {
+			loadConf->globals.uidDropPriv = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "privdrop.user.name")) {
+			loadConf->globals.uidDropPriv = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "security.abortonidresolutionfail")) {
 			loadConf->globals.abortOnIDResolutionFail = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "net.acladdhostnameonfail")) {

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -557,18 +557,16 @@ rsRetVal doDropPrivGid(void)
 	if(!ourConf->globals.gidDropPrivKeepSupplemental) {
 		res = setgroups(0, NULL); /* remove all supplemental group IDs */
 		if(res) {
-			rs_strerror_r(errno, (char*)szBuf, sizeof(szBuf));
-			LogError(0, RS_RET_ERR_DROP_PRIV,
-					"could not remove supplemental group IDs: %s", szBuf);
+			LogError(errno, RS_RET_ERR_DROP_PRIV,
+					"could not remove supplemental group IDs");
 			ABORT_FINALIZE(RS_RET_ERR_DROP_PRIV);
 		}
 		DBGPRINTF("setgroups(0, NULL): %d\n", res);
 	}
 	res = setgid(ourConf->globals.gidDropPriv);
 	if(res) {
-		rs_strerror_r(errno, (char*)szBuf, sizeof(szBuf));
-		LogError(0, RS_RET_ERR_DROP_PRIV,
-				"could not set requested group id: %s", szBuf);
+		LogError(errno, RS_RET_ERR_DROP_PRIV,
+				"could not set requested group id %d", ourConf->globals.gidDropPriv);
 		ABORT_FINALIZE(RS_RET_ERR_DROP_PRIV);
 	}
 	DBGPRINTF("setgid(%d): %d\n", ourConf->globals.gidDropPriv, res);
@@ -585,7 +583,7 @@ finalize_it:
  * Note that such an abort can cause damage to on-disk structures, so we should
  * re-design the "interface" in the long term. -- rgerhards, 2008-11-19
  */
-static void doDropPrivUid(int iUid)
+static void doDropPrivUid(const int iUid)
 {
 	int res;
 	uchar szBuf[1024];
@@ -601,10 +599,7 @@ static void doDropPrivUid(int iUid)
 		res = initgroups(pw->pw_name, gid);
 		DBGPRINTF("initgroups(%s, %ld): %d\n", pw->pw_name, (long) gid, res);
 	} else {
-		rs_strerror_r(errno, (char*)szBuf, sizeof(szBuf));
-		LogError(0, NO_ERRCODE,
-				"could not get username for userid %d: %s",
-				iUid, szBuf);
+		LogError(errno, NO_ERRCODE, "could not get username for userid '%d'", iUid);
 	}
 
 	res = setuid(iUid);
@@ -1447,6 +1442,3 @@ BEGINObjClassExit(rsconf, OBJ_IS_CORE_MODULE) /* class, version */
 	objRelease(datetime, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 ENDObjClassExit(rsconf)
-
-/* vi:set ai:
- */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -215,6 +215,10 @@ TESTS +=  \
 	msgvar-concurrency.sh \
 	localvar-concurrency.sh \
 	exec_tpl-concurrency.sh \
+	rscript_privdropuser.sh \
+	rscript_privdropuserid.sh \
+	rscript_privdropgroup.sh \
+	rscript_privdropgroupid.sh \
 	privdropuser.sh \
 	privdropuserid.sh \
 	privdropgroup.sh \
@@ -1917,6 +1921,10 @@ EXTRA_DIST= \
 	prop-programname.sh \
 	prop-programname-with-slashes.sh \
 	rfc5424parser.sh \
+	rscript_privdropuser.sh \
+	rscript_privdropuserid.sh \
+	rscript_privdropgroup.sh \
+	rscript_privdropgroupid.sh \
 	privdrop_common.sh \
 	privdropuser.sh \
 	privdropuserid.sh \

--- a/tests/rscript_privdropgroup.sh
+++ b/tests/rscript_privdropgroup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# added 2021-09-23 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "This test currently does not work on Solaris."
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
+generate_conf
+add_conf '
+global(privdrop.group.keepsupplemental="on" privdrop.group.name="'${TESTBENCH_TESTUSER[groupname]}'")
+template(name="outfmt" type="list") {
+	property(name="msg" compressSpace="on")
+	constant(value="\n")
+}
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "groupid.*${TESTBENCH_TESTUSER[gid]}"
+exit_test

--- a/tests/rscript_privdropgroupid.sh
+++ b/tests/rscript_privdropgroupid.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# added 2021-09-23 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "This test currently does not work on Solaris."
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
+generate_conf
+add_conf '
+global(privdrop.group.keepsupplemental="on" privdrop.group.id="'${TESTBENCH_TESTUSER[gid]}'")
+template(name="outfmt" type="list") {
+	property(name="msg" compressSpace="on")
+	constant(value="\n")
+}
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "groupid.*${TESTBENCH_TESTUSER[gid]}"
+exit_test

--- a/tests/rscript_privdropuser.sh
+++ b/tests/rscript_privdropuser.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# added 2021-09-23 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "This test currently does not work on Solaris."
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
+generate_conf
+add_conf '
+global(privdrop.user.name="'${TESTBENCH_TESTUSER[username]}'")
+template(name="outfmt" type="list") {
+	property(name="msg" compressSpace="on")
+	constant(value="\n")
+}
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "userid.*${TESTBENCH_TESTUSER[uid]}"
+exit_test

--- a/tests/rscript_privdropuserid.sh
+++ b/tests/rscript_privdropuserid.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# added 2021-09-23 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "This test currently does not work on Solaris."
+. $srcdir/privdrop_common.sh
+rsyslog_testbench_setup_testuser
+
+generate_conf
+add_conf '
+global(privdrop.user.id="'${TESTBENCH_TESTUSER[uid]}'")
+template(name="outfmt" type="list") {
+	property(name="msg" compressSpace="on")
+	constant(value="\n")
+}
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "userid.*${TESTBENCH_TESTUSER[uid]}"
+exit_test


### PR DESCRIPTION
closes https://github.com/rsyslog/rsyslog/issues/891

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
