### PR TITLE
imuxsock: fix rate limiting not working in default configuration

### DIFF
--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -246,8 +246,8 @@ ratelimitMsg(ratelimit_t *__restrict__ const ratelimit, smsg_t *pMsg, smsg_t **p
 				DBGPRINTF("Message discarded, parsing error %d\n", localRet);
 				ABORT_FINALIZE(RS_RET_DISCARDMSG);
 			}
-			severity = pMsg->iSeverity;
 		}
+		severity = pMsg->iSeverity;
 	}
 
 	/* Only the messages having severity level at or below the

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -363,6 +363,7 @@ TESTS +=  \
 	dircreate_off.sh \
 	imuxsock_legacy.sh \
 	imuxsock_logger.sh \
+	imuxsock_logger_ratelimit.sh \
 	imuxsock_logger_ruleset.sh \
 	imuxsock_logger_ruleset_ratelimit.sh \
 	imuxsock_logger_err.sh \
@@ -2479,6 +2480,7 @@ EXTRA_DIST= \
 	imuxsock_legacy.sh \
 	imuxsock_logger_parserchain.sh \
 	imuxsock_logger.sh \
+	imuxsock_logger_ratelimit.sh \
 	imuxsock_logger_ruleset.sh \
 	imuxsock_logger_ruleset_ratelimit.sh \
 	imuxsock_logger_err.sh \

--- a/tests/imuxsock_logger_ratelimit.sh
+++ b/tests/imuxsock_logger_ratelimit.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+echo \[imuxsock_logger_ratelimit.sh\]: test rate limiting with imuxsock
+. ${srcdir:=.}/diag.sh init
+
+./syslog_caller -fsyslog_inject-l -m0 > /dev/null 2>&1
+no_liblogging_stdlog=$?
+if [ $no_liblogging_stdlog -ne 0 ];then
+  echo "liblogging-stdlog not available - skipping test"
+  exit 77
+fi
+
+export EXPECTED=" test message nbr 0, severity=6
+ test message nbr 1, severity=6
+ test message nbr 2, severity=6
+ test message nbr 3, severity=6
+ test message nbr 4, severity=6"
+
+for use_special_parser in on off; do
+  echo \[imuxsock_logger_ratelimit.sh\]: test rate limiting with imuxsock with useSpecialParser="$use_special_parser"
+  echo -n >"$RSYSLOG_OUT_LOG"
+  generate_conf
+  add_conf '
+  module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
+  input(	type="imuxsock" socket="'$RSYSLOG_DYNNAME'-testbench_socket"
+    useSpecialParser="'$use_special_parser'"
+    ruleset="testruleset"
+    ratelimit.interval="10"
+    ratelimit.burst="5")
+  template(name="outfmt" type="string" string="%msg:%\n")
+
+  ruleset(name="testruleset") {
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+  }
+  '
+  startup
+
+  ./syslog_caller -m20 -C "uxsock:$RSYSLOG_DYNNAME-testbench_socket" -s6
+
+  # the sleep below is needed to prevent too-early termination of rsyslogd
+  ./msleep 100
+
+  shutdown_when_empty
+  wait_shutdown
+
+  cmp_exact
+done
+exit_test


### PR DESCRIPTION
This commit fixes the imuxsock's rate limiting, which does not work in the
default configuration (useSpecialParser="true" and ratelimit.severity="1")

When useSpecialParser was set to "true" all messages were treated with
severity 0 and therefore were not subjects to the rate limiting that by
default ignores messages with severity 0.

The test suite requires
./configure --enable-liblogging-stdlog
