### PR TITLE
gnutls: Propagate PrioritizeSAN when accepting a new connection

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1840,6 +1840,7 @@ AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew)
 	pNew->gnutlsPriorityString = pThis->gnutlsPriorityString;
 	pNew->DrvrVerifyDepth = pThis->DrvrVerifyDepth;
 	pNew->dataTypeCheck = pThis->dataTypeCheck;
+	pNew->bSANpriority = pThis->bSANpriority;
 	pNew->pszCertFile = pThis->pszCertFile;
 	pNew->pszKeyFile = pThis->pszKeyFile;
 	pNew->xcred = pThis->xcred; // TODO: verify once again; xcred is read only at this stage


### PR DESCRIPTION
Until now, when the server accepts new connection via ```AcceptConnReq()```, it does not initialize the ```bSANpriority``` field.
While the option does work on the client side (meaning the server cert is checked), it does not on the server side.