### PR TITLE
testbench: add testcase for queue discardSeverity (linkedlist)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -201,6 +201,7 @@ TESTS +=  \
 	invalid_nested_include.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
+	omfwd_fast_imuxsock.sh \
 	omusrmsg-noabort-legacy.sh \
 	omusrmsg-errmsg-no-params.sh \
 	omusrmsg-noabort.sh \
@@ -1875,6 +1876,7 @@ EXTRA_DIST= \
 	stop-msgvar.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
+	omfwd_fast_imuxsock.sh \
 	omfile_hup-vg.sh \
 	gzipwr_hup-vg.sh \
 	omusrmsg-noabort-legacy.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -694,17 +694,29 @@ content_check() {
 	else
 		grep_opt=-F
 	fi
+	if [ "$1" == "--output-results" ]; then
+		output_results="yes"
+		shift
+	else
+		output_results="no"
+	fi
 	file=${2:-$RSYSLOG_OUT_LOG}
 	if ! grep -q  $grep_opt -- "$1" < "${file}"; then
 	    if [ "$check_only" == "yes" ]; then
 		printf 'content_check did not yet succeed\n'
-	    return 1
+		return 1
 	    fi
 	    printf '\n============================================================\n'
 	    printf 'FILE "%s" content:\n' "$file"
 	    cat -n ${file}
 	    printf 'FAIL: content_check failed to find "%s"\n' "$1"
 	    error_exit 1
+	else
+	    if [ "$output_results" == "yes" ]; then
+		# Output GREP results
+		echo "SUCCESS: content_check found results for '$1'\n"
+		grep "$1" "${file}"
+	    fi
 	fi
 	if [ "$check_only" == "yes" ]; then
 	    return 0

--- a/tests/omfwd_fast_imuxsock.sh
+++ b/tests/omfwd_fast_imuxsock.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+# This test tries tests DiscardMark / DiscardSeverity queue settings with omfwd with IMUXSOCK input
+# added 2021-09-02 by alorbach. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS"  "We have no ATOMIC BUILTINS, so OverallQueueSize counting of imdiag is NOT threadsafe and the counting will fail on SunOS"
+
+# export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+export NUMMESSAGES=100000
+
+export PORT_RCVR="$(get_free_port)"
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+generate_conf
+add_conf '
+global(	debug.whitelist="on"
+	debug.files=["imdiag.c", "queue.c"]
+)
+
+template(name="testformat" type="list") {
+    constant(value="{ ")
+    property(name="timereported" dateFormat="unixtimestamp" format="jsonf")
+    constant(value=", ")
+    property(name="syslogseverity-text" format="jsonf")
+    constant(value=", ")
+    property(name="programname" format="jsonf")
+    constant(value=", ")
+    property(name="msg" format="jsonf")
+    constant(value=" }\n")
+}
+template(name="outfmt" 
+	type="string" 
+	string="%msg:F,58:2%\n")
+
+# IMUX Input socket
+module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
+input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
+
+# Note: stats module
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1" ruleset="stats")
+
+main_queue(
+    queue.timeoutshutdown="10000"
+#    queue.timeoutEnqueue="20"
+#    queue.discardSeverity="3"
+)
+
+ruleset(name="stats") {
+	stop # nothing to do here
+}
+
+if $msg contains "test message nbr" then
+	action(
+	    type="omfwd"
+	    Target="127.0.0.1"
+	    Port="'$PORT_RCVR'"
+	    Protocol="tcp"
+	    TCP_Framing="octet-counted"
+	    ResendLastMSGOnReconnect="on"
+
+	    Template="testformat"
+
+	    queue.discardMark="100"
+	    queue.discardSeverity="3"
+
+#	    queue.timeoutEnqueue="5"
+	    queue.type="linkedlist"
+	)
+'
+./minitcpsrv -t127.0.0.1 -p$PORT_RCVR -f $RSYSLOG_OUT_LOG &
+BGPROCESS=$!
+echo background tcp dummy receiver process id is $BGPROCESS
+
+# now do the usual run
+startup
+
+# Use syslog_caller 
+./syslog_caller -m$NUMMESSAGES -C "uxsock:$RSYSLOG_DYNNAME-testbench_socket"
+shutdown_when_empty
+wait_shutdown
+# note: minitcpsrv shuts down automatically if the connection is closed!
+
+# check output file generation, should contain at least 100 logs
+check_file_exists "$RSYSLOG_OUT_LOG"
+check_file_exists "$STATSFILE"
+content_check --regex --output-results "action-1-builtin:omfwd queue: origin=core.queue size=.* enqueued=100000 full=0 discarded.full=0 discarded.nf=.* maxqsize=100" $STATSFILE
+
+exit_test


### PR DESCRIPTION
Testcase omfwd_fast_imuxsock.sh uses imuxsock as input and checks
how the queue engine (linkedlist) handles discarded messages.

see also:
https://github.com/rsyslog/rsyslog/issues/4437

requires PR:
https://github.com/rsyslog/rsyslog/pull/4674

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
