### PR TITLE
Fix ElasticSearch Test broken by ES incompatibility

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2213,6 +2213,8 @@ start_elasticsearch() {
 # $2 - ES port
 es_getdata() {
 	curl --silent -XPUT --show-error -H 'Content-Type: application/json' "http://localhost:${2:-$ES_PORT}/rsyslog_testbench/_settings" -d '{ "index" : { "max_result_window" : '${1:-$NUMMESSAGES}' } }'
+	# refresh to ensure we get the latest data
+	curl --silent localhost:${2:-$ES_PORT}/rsyslog_testbench/_refresh
 	curl --silent localhost:${2:-$ES_PORT}/rsyslog_testbench/_search?size=${1:-$NUMMESSAGES} > $RSYSLOG_DYNNAME.work
 	$PYTHON $srcdir/es_response_get_msgnum.py > ${RSYSLOG_OUT_LOG}
 }

--- a/tests/es-bulk-retry.sh
+++ b/tests/es-bulk-retry.sh
@@ -1,11 +1,5 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-
-	echo The es-bulk-retry.sh test is temporarily suspended, because ElasticSearch 7 broke semantics
-	echo that the test depends on. See for more info and progress:
-	echo https://github.com/rsyslog/rsyslog/pull/4685
-	exit 77
-
 . ${srcdir:=.}/diag.sh init
 export ES_PORT=19200
 export NUMMESSAGES=100
@@ -14,9 +8,17 @@ override_test_timeout 120
 ensure_elasticsearch_ready --no-start
 
 # change settings to cause bulk rejection errors
+case "$ES_DOWNLOAD" in
+    elasticsearch-5.*) es_option="thread_pool.bulk"
+                       es_mapping_uses_type=true
+                       es_search_type="test-type" ;;
+    *) es_option="thread_pool.write"
+       es_mapping_uses_type=false
+       es_search_type="_doc" ;;
+esac
 cat >> $dep_work_dir/es/config/elasticsearch.yml <<EOF
-thread_pool.write.queue_size: 1
-thread_pool.write.size: 1
+${es_option}.queue_size: 1
+${es_option}.size: 1
 EOF
 start_elasticsearch
 
@@ -95,7 +97,7 @@ ruleset(name="try_es") {
 		       bulkmode="on"
 		       retryfailures="on"
 		       retryruleset="try_es"
-		       searchType="test-type"
+		       searchType="'${es_search_type}'"
 		       searchIndex="rsyslog_testbench")
 	}
 }
@@ -107,7 +109,8 @@ if $msg contains "msgnum:" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 
-curl -s -H 'Content-Type: application/json' -XPUT localhost:${ES_PORT:-19200}/rsyslog_testbench/ -d '{
+if [ "$es_mapping_uses_type" = true ]; then
+    curl -s -H 'Content-Type: application/json' -XPUT localhost:${ES_PORT:-19200}/rsyslog_testbench/ -d '{
   "mappings": {
     "test-type": {
       "properties": {
@@ -119,6 +122,23 @@ curl -s -H 'Content-Type: application/json' -XPUT localhost:${ES_PORT:-19200}/rs
   }
 }
 ' | $PYTHON -mjson.tool
+else
+  # we add 10 shards so we're more likely to get queue rejections
+    curl -s -H 'Content-Type: application/json' -XPUT localhost:${ES_PORT:-19200}/rsyslog_testbench/ -d '{
+  "settings": {
+    "index.number_of_shards": 10
+  },
+  "mappings": {
+    "properties": {
+      "msgnum": {
+        "type": "integer"
+      }
+    }
+  }
+}
+' | $PYTHON -mjson.tool
+fi
+
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="debug.log"
 startup
@@ -128,6 +148,7 @@ if [ -n "${USE_GDB:-}" ] ; then
 fi
 success=50
 badarg=50
+./msleep 5000
 injectmsg 0 $NUMMESSAGES
 ./msleep 1500; cat $RSYSLOG_OUT_LOG # debuging - we sometimes miss 1 message
 wait_content '"response.success": 50' $RSYSLOG_DYNNAME.spool/es-stats.log

--- a/tests/es-bulk-retry.sh
+++ b/tests/es-bulk-retry.sh
@@ -15,8 +15,8 @@ ensure_elasticsearch_ready --no-start
 
 # change settings to cause bulk rejection errors
 cat >> $dep_work_dir/es/config/elasticsearch.yml <<EOF
-thread_pool.bulk.queue_size: 1
-thread_pool.bulk.size: 1
+thread_pool.write.queue_size: 1
+thread_pool.write.size: 1
 EOF
 start_elasticsearch
 


### PR DESCRIPTION
https://github.com/rsyslog/rsyslog/issues/4684
According to https://discuss.elastic.co/t/unknown-setting-thread-pool-bulk-queue-size/180120
The setting `thread_pool.bulk` has been renamed to `thread_pool.write`
"The bulk threadpool was renamed to write in 6.3.0, and support for the legacy bulk name was removed in 7.0.0 133."


<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->