### PR TITLE
CI test for call to ruleset with explicitely specified direct ruleset

### DIFF
--- a/action.c
+++ b/action.c
@@ -1107,6 +1107,7 @@ prepareDoActionParams(action_t * __restrict__ const pAction,
 	actWrkrInfo_t *__restrict__ pWrkrInfo;
 	DEFiRet;
 
+dbgprintf("RGER: prepareDoActionParams     %p\n", pMsg);
 	pWrkrInfo = &(pWti->actWrkrInfo[pAction->iActionNbr]);
 	if(pAction->isTransactional) {
 		CHKiRet(wtiNewIParam(pWti, pAction, &iparams));
@@ -1811,6 +1812,7 @@ doSubmitToActionQ(action_t * const pAction, wti_t * const pWti, smsg_t *pMsg)
 		pAction->pszName, module.GetStateName(pAction->pMod),
 		pAction->bExecWhenPrevSusp, pWti->execState.bPrevWasSuspended,
 		pAction->pQueue->qType == QUEUETYPE_DIRECT);
+dbgprintf("RGER: doSubmitToActionQ     %p\n", pMsg);
 
 	if(   pAction->bExecWhenPrevSusp
 	   && !pWti->execState.bPrevWasSuspended) {

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1132,9 +1132,11 @@ qAddDirect(qqueue_t *pThis, smsg_t* pMsg)
 	wti_t *pWti;
 	DEFiRet;
 
+dbgprintf("RGER: qAddDirect in  %p\n", pMsg);
 	pWti = wtiGetDummy();
 	pWti->pbShutdownImmediate = &pThis->bShutdownImmediate;
 	iRet = qAddDirectWithWti(pThis, pMsg, pWti);
+dbgprintf("RGER: qAddDirect out %p\n", pMsg);
 	RETiRet;
 }
 

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -284,12 +284,15 @@ static rsRetVal
 execCall(struct cnfstmt *stmt, smsg_t *pMsg, wti_t *pWti)
 {
 	DEFiRet;
+dbgprintf("RGER: execCall in  %p\n", pMsg);
 	if(stmt->d.s_call.ruleset == NULL) {
 		CHKiRet(scriptExec(stmt->d.s_call.stmt, pMsg, pWti));
 	} else {
-		CHKmalloc(pMsg = MsgDup((smsg_t*) pMsg));
+		//CHKmalloc(pMsg = MsgDup((smsg_t*) pMsg));
+		MsgAddRef(pMsg);
 		DBGPRINTF("CALL: forwarding message to async ruleset %p\n",
 			  stmt->d.s_call.ruleset->pQueue);
+dbgprintf("RGER: execCall     %p\n", pMsg);
 		MsgSetFlowControlType(pMsg, eFLOWCTL_NO_DELAY);
 		MsgSetRuleset(pMsg, stmt->d.s_call.ruleset);
 		/* Note: we intentionally use submitMsg2() here, as we process messages
@@ -588,6 +591,7 @@ scriptExec(struct cnfstmt *const root, smsg_t *const pMsg, wti_t *const pWti)
 		}
 		if(Debug) {
 			cnfstmtPrintOnly(stmt, 2, 0);
+dbgprintf("RGER: scriptExec     %p\n", pMsg);
 		}
 		switch(stmt->nodetype) {
 		case S_NOP:

--- a/template.c
+++ b/template.c
@@ -163,6 +163,7 @@ tplToString(struct template *__restrict__ const pTpl,
 	unsigned short bMustBeFreed = 0;
 	uchar *pVal;
 	rs_size_t iLenVal = 0;
+dbgprintf("RGER: tplToString %p\n", pMsg);
 
 	if(pTpl->pStrgen != NULL) {
 		CHKiRet(pTpl->pStrgen(pMsg, iparam));


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
