### PR TITLE
testbench: restore original order of ES test execution

### DIFF
--- a/.github/workflows/run_ubuntu_20_distcheck.yml
+++ b/.github/workflows/run_ubuntu_20_distcheck.yml
@@ -59,16 +59,14 @@ jobs:
           echo PWD: $(pwd)
           ls -la
           ls -ld rsyslog-*
-          sudo chmod -R go+rw .
+          sudo chmod -vR go+rw .
           ls -la
           ls -ld rsyslog-*
-          echo FIND ..:
+          echo FIND TRS:
           find .. -name .dep_wrk
-          echo FIND:
-          find . -name .dep_wrk
           echo ls of curr dir:
           echo END CI DEBUGGING
           rm -rf $(find . -name .dep_wrk)
-          sudo chmod -R a+r .
+          sudo chmod -vR a+r .
           devtools/gather-check-logs.sh
           cat failed-tests.log

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -62,16 +62,13 @@ TESTS +=  \
 	es-duplicated-ruleset.sh
 # the following test need to be serialized:
 TESTS +=  \
-	es-basic.sh \
 	es-basic-es6.0.sh \
 	es-basic-es7.14.sh \
+	es-basic.sh \
 	es-basic-bulk.sh
-#es-basic-es6.0.log:  es-basic.log
-#es-basic-es7.14.log: es-basic-es6.0.log
-es-basic-es7.14.log: es-basic.log
-es-basic-es6.0.log:  es-basic-es7.14.log
-es-basic-bulk.log: es-basic-es6.0.log
-#es-basic-bulk.log: es-basic-es7.14.log
+es-basic-es7.14.log: es-basic-es6.0.log
+es-basic.log: es-basic-es7.14.log
+es-basic-bulk.log: es-basic.log
 es-basic-server.log: es-basic-bulk.log
 
 # special "test" for stopping ES once all ES tests are done


### PR DESCRIPTION
The order of execution was changed to a less optimal (more startups, thus slower) order to work-around a testbench issue. This has been fixed and so we can restore the original order.