### PR TITLE
testbench bugfix: no pid file wait on elasticsearch startup

### DIFF
--- a/.github/workflows/run_ubuntu_20_distcheck.yml
+++ b/.github/workflows/run_ubuntu_20_distcheck.yml
@@ -55,5 +55,16 @@ jobs:
       - name: show error logs (if we errored)
         if:  ${{ failure() || cancelled() }}
         run: |
+          echo Some CI debugging in case we see permission errors again - remove when finally solved
+          echo PWD: $(pwd)
+          echo FIND ..:
+          find .. -name .dep_wrk
+          echo FIND:
+          find . -name .dep_wrk
+          echo ls of curr dir:
+          ls -la
+          ls -ld rsyslog-*
+          echo END CI DEBUGGING
+          rm -rf $(find . -name .dep_wrk)
           devtools/gather-check-logs.sh
           cat failed-tests.log

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -66,9 +66,12 @@ TESTS +=  \
 	es-basic-es6.0.sh \
 	es-basic-es7.14.sh \
 	es-basic-bulk.sh
-es-basic-es6.0.log:  es-basic.log
-es-basic-es7.14.log: es-basic-es6.0.log
-es-basic-bulk.log: es-basic-es7.14.log
+#es-basic-es6.0.log:  es-basic.log
+#es-basic-es7.14.log: es-basic-es6.0.log
+es-basic-es7.14.log: es-basic.log
+es-basic-es6.0.log:  es-basic-es7.14.log
+es-basic-bulk.log: es-basic-es6.0.log
+#es-basic-bulk.log: es-basic-es7.14.log
 es-basic-server.log: es-basic-bulk.log
 
 # special "test" for stopping ES once all ES tests are done

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1624,7 +1624,7 @@ dep_zk_url=https://downloads.apache.org/zookeeper/zookeeper-3.6.3/$RS_ZK_DOWNLOA
 dep_zk_cached_file=$dep_cache_dir/$RS_ZK_DOWNLOAD
 
 export RS_KAFKA_DOWNLOAD=kafka_2.13-2.8.0.tgz
-dep_kafka_url=https://downloads.apache.org/kafka/2.8.0/kafka_2.13-2.8.0.tgz
+dep_kafka_url="https://www.rsyslog.com/files/download/rsyslog/$RS_KAFKA_DOWNLOAD"
 dep_kafka_cached_file=$dep_cache_dir/$RS_KAFKA_DOWNLOAD
 
 if [ -z "$ES_DOWNLOAD" ]; then

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2186,7 +2186,7 @@ start_elasticsearch() {
 	# THIS IS THE ACTUAL START of ES
 	$dep_work_dir/es/bin/elasticsearch -p $dep_work_es_pidfile -d
 	$TESTTOOL_DIR/msleep 2000
-	# TODO: wait pidfile!
+	wait_startup_pid $dep_work_es_pidfile
 	printf 'elasticsearch pid is %s\n' "$(cat $dep_work_es_pidfile)"
 
 	# Wait for startup with hardcoded timeout


### PR DESCRIPTION
The testbench framework does not properly wait until ES has created
its pid file, which probably means it did basic initializiation.
This can cause test synchronization issues and ultimately failures.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
