### PR TITLE
PrivDropToUser: fix abortOnIDResolutionFail handling

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -1167,8 +1167,10 @@ glblProcessCnf(struct cnfobj *o)
 			continue;
 		if(!strcmp(paramblk.descr[i].name, "processinternalmessages")) {
 			bProcessInternalMessages = (int) cnfparamvals[i].val.d.n;
+			cnfparamvals[i].bUsed = TRUE;
 		} else if(!strcmp(paramblk.descr[i].name, "internal.developeronly.options")) {
 			glblDevOptions = (uint64_t) cnfparamvals[i].val.d.n;
+			cnfparamvals[i].bUsed = TRUE;
 		} else if(!strcmp(paramblk.descr[i].name, "stdlog.channelspec")) {
 #ifndef ENABLE_LIBLOGGING_STDLOG
 			LogError(0, RS_RET_ERR, "rsyslog wasn't "
@@ -1176,12 +1178,12 @@ glblProcessCnf(struct cnfobj *o)
 				"The 'stdlog.channelspec' parameter "
 				"is ignored. Note: the syslog API is used instead.\n");
 #else
-			stdlog_chanspec = (uchar*)
-				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			stdlog_chanspec = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 			/* we need to re-open with the new channel */
 			stdlog_close(stdlog_hdl);
 			stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG,
 					(char*) stdlog_chanspec);
+			cnfparamvals[i].bUsed = TRUE;
 #endif
 		} else if(!strcmp(paramblk.descr[i].name, "operatingstatefile")) {
 			if(operatingStateFile != NULL) {
@@ -1192,6 +1194,9 @@ glblProcessCnf(struct cnfobj *o)
 				operatingStateFile = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 				osf_open();
 			}
+		} else if(!strcmp(paramblk.descr[i].name, "security.abortonidresolutionfail")) {
+			loadConf->globals.abortOnIDResolutionFail = (int) cnfparamvals[i].val.d.n;
+			cnfparamvals[i].bUsed = TRUE;
 		}
 	}
 done:	return;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -229,6 +229,7 @@ TESTS +=  \
 	privdropuserid.sh \
 	privdropgroup.sh \
 	privdropgroupid.sh \
+	privdropabortonidfaillegacy.sh \
 	json-nonstring.sh \
 	template-json.sh \
 	template-pure-json.sh \
@@ -1944,6 +1945,7 @@ EXTRA_DIST= \
 	privdropuserid.sh \
 	privdropgroup.sh \
 	privdropgroupid.sh \
+	privdropabortonidfaillegacy.sh \
 	json-nonstring.sh \
 	template-json.sh \
 	template-pure-json.sh \

--- a/tests/privdropabortonidfaillegacy.sh
+++ b/tests/privdropabortonidfaillegacy.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# add 2021-10-12 by alorbach, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+
+skip_platform "SunOS"  "This test currently does not work on Solaris."
+export TESTBENCH_TESTUSER1="USER_${RSYSLOG_DYNNAME}_1"
+export TESTBENCH_TESTUSER2="USER_${RSYSLOG_DYNNAME}_2"
+
+generate_conf
+add_conf '
+global(
+	security.abortOnIDResolutionFail="off"
+)
+
+template(name="outfmt" type="list") {
+	property(name="msg" compressSpace="on")
+	constant(value="\n")
+}
+
+$FileOwner '${TESTBENCH_TESTUSER1}'
+$FileGroup '${TESTBENCH_TESTUSER1}'
+$DirOwner '${TESTBENCH_TESTUSER2}'
+$DirGroup '${TESTBENCH_TESTUSER2}'
+
+action(	type="omfile"
+	template="outfmt"
+	file=`echo $RSYSLOG_OUT_LOG`)
+'
+
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "ID for user '${TESTBENCH_TESTUSER1}' could not be found"
+content_check --regex "ID for user '${TESTBENCH_TESTUSER2}' could not be found"
+
+exit_test


### PR DESCRIPTION
security.abortonidresolutionfail needs to be loaded glblProcessCnf,
otherwise the setting is ignored in doGetUID / doGetGID.

see also: https://github.com/rsyslog/rsyslog/issues/4642
see also: https://github.com/rsyslog/rsyslog/commit/cbcaf2c7e5b67e5465e47bc7cc67af2eae47bd31

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
