### PR TITLE
imtcp: add support for permittedPeers setting at input() level

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -612,6 +612,7 @@ osslChkPeerFingerprint(nsd_ossl_t *pThis, X509 *pCert)
 			dbgprintf("osslChkPeerFingerprint: peer's certificate MATCH found: %s\n", pPeer->pszID);
 			bFoundPositiveMatch = 1;
 		} else {
+			dbgprintf("osslChkPeerFingerprint: NOMATCH peer certificate: %s\n", pPeer->pszID);
 			pPeer = pPeer->pNext;
 		}
 	}

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -444,8 +444,10 @@ processDataRcvd(tcps_sess_t *pThis,
 		}
 	} else {
 		assert(pThis->inputState == eInMsg);
+		#if 0 // set to 1 for ultra-verbose
 		DBGPRINTF("DEBUG: processDataRcvd c=%c remain=%d\n",
 			c, pThis->iOctetsRemain);
+		#endif
 
 		if((   ((c == '\n') && !pThis->pSrv->bDisableLFDelim)
 		   || ((pThis->pSrv->addtlFrameDelim != TCPSRV_NO_ADDTL_DELIMITER)


### PR DESCRIPTION
The permittedPeers settig was actually forgotten during the refactoring of TLS input() level settings. This functionality is now added.
    
closes: https://github.com/rsyslog/rsyslog/issues/4706
