### PR TITLE
testbench: add test for legacy permittedPeer statement

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1261,6 +1261,7 @@ TESTS +=  \
 	imtcp-tls-gtls-x509fingerprint.sh \
 	imtcp-tls-gtls-x509name-invld.sh \
 	imtcp-tls-gtls-x509name.sh \
+	imtcp-tls-gtls-x509name-legacy.sh \
 	imtcp-drvr-in-input-basic.sh \
 	imtcp-multi-drvr-basic.sh \
 	imtcp-multi-drvr-basic-parallel.sh
@@ -2128,6 +2129,7 @@ EXTRA_DIST= \
 	imtcp-tls-gtls-x509fingerprint.sh \
 	imtcp-tls-gtls-x509name-invld.sh \
 	imtcp-tls-gtls-x509name.sh \
+	imtcp-tls-gtls-x509name-legacy.sh \
 	imtcp-drvr-in-input-basic.sh \
 	imtcp-multi-drvr-basic.sh \
 	imtcp-multi-drvr-basic-parallel.sh \

--- a/tests/imtcp-tls-gtls-x509name-legacy.sh
+++ b/tests/imtcp-tls-gtls-x509name-legacy.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+generate_conf
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+)
+
+
+# NOTE: we intentionally use legacy statements here! This *IS* what we want to test!
+$ModLoad ../plugins/imtcp/.libs/imtcp
+$inputTcpserverStreamdriverPermittedPeer rsyslog-client
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="x509/name")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(	type="omfile" 
+					template="outfmt"
+					file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+tcpflood -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+wait_file_lines
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
This is required to ensure backwards compatibility when doing changes
to the networking subsystem. So far this was not covered by any test.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
