### PR TITLE
NEW CONTRIB::FFAUP:: URL parser module function using libfaup

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -202,6 +202,10 @@ if ENABLE_FMUNFLATTEN
 SUBDIRS += contrib/fmunflatten
 endif
 
+if ENABLE_FFAUP
+SUBDIRS += contrib/ffaup
+endif
+
 if ENABLE_OMKAFKA
 SUBDIRS += plugins/omkafka
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -402,6 +402,28 @@ if test "$enable_fmhash_xxhash" = "yes"; then
 fi
 
 
+#faup header checks
+AC_ARG_ENABLE(ffaup,
+	[AS_HELP_STRING([--enable-ffaup],[Enable ffaup support @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_ffaup="yes" ;;
+          no) enable_ffaup="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-ffaup) ;;
+         esac],
+	[enable_ffaup=no]
+)
+
+AM_CONDITIONAL(ENABLE_FFAUP, test x$enable_ffaup = xyes)
+if test "$enable_ffaup" = "yes"; then
+	AC_CHECK_LIB([faupl], [faup_init], [
+		AC_CHECK_HEADER([faup/faup.h], [
+			FAUP_LIBS="-lfaupl"
+			AC_SUBST(FAUP_LIBS)],
+			[AC_MSG_ERROR([Unable to add faup support for URL parsing.])])
+	])
+fi
+
+
 # rscript function unflatten
 AC_ARG_ENABLE(fmunflatten,
 	[AS_HELP_STRING([--enable-fmunflatten],[Enable fmunflatten support @<:@default=no@:>@])],
@@ -2705,6 +2727,7 @@ AC_CONFIG_FILES([Makefile \
 		contrib/omhttp/Makefile \
 		contrib/fmhash/Makefile \
 		contrib/fmunflatten/Makefile \
+		contrib/ffaup/Makefile \
 		contrib/pmsnare/Makefile \
 		contrib/pmpanngfw/Makefile \
 		contrib/pmaixforwardedfrom/Makefile \
@@ -2853,6 +2876,7 @@ echo "    fmhttp enabled:                           $enable_fmhttp"
 echo "    fmhash enabled:                           $enable_fmhash"
 echo "    fmhash with xxhash enabled:               $enable_fmhash_xxhash"
 echo "    fmunflatten enabled:                      $enable_fmunflatten"
+echo "    ffaup enabled:                            $enable_ffaup"
 echo
 echo "---{ debugging support }---"
 echo "    distcheck workaround enabled:             $enable_distcheck_workaround"

--- a/contrib/ffaup/Makefile.am
+++ b/contrib/ffaup/Makefile.am
@@ -1,0 +1,8 @@
+#
+# ffaup support
+#
+pkglib_LTLIBRARIES = ffaup.la
+ffaup_la_SOURCES = ffaup.c
+ffaup_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+ffaup_la_LDFLAGS = -module -avoid-version
+ffaup_la_LIBADD = $(FAUP_LIBS)

--- a/contrib/ffaup/ffaup.c
+++ b/contrib/ffaup/ffaup.c
@@ -1,0 +1,398 @@
+/* ffaup.c
+ * This is a function module for URL parsing.
+ *
+ * File begun on 2021/10/23 by TBertin
+ *
+ * Copyright 2007-2021 Theo Bertin for Advens
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <stdint.h>
+#include <stddef.h>
+#ifndef _AIX
+#include <typedefs.h>
+#endif
+#include <sys/types.h>
+#include <string.h>
+#include <faup/faup.h>
+#include <faup/decode.h>
+#include <faup/options.h>
+#include <faup/output.h>
+
+#include "config.h"
+#include "rsyslog.h"
+#include "parserif.h"
+#include "module-template.h"
+#include "rainerscript.h"
+
+
+
+MODULE_TYPE_FUNCTION
+MODULE_TYPE_NOKEEP
+DEF_FMOD_STATIC_DATA
+
+faup_options_t *glbOptions = NULL;
+
+enum _faup_parse_type_t {
+	FAUP_PARSE_ALL,
+	FAUP_PARSE_SCHEME,
+	FAUP_PARSE_CREDENTIAL,
+	FAUP_PARSE_SUBDOMAIN,
+	FAUP_PARSE_DOMAIN,
+	FAUP_PARSE_DOMAIN_WITHOUT_TLD,
+	FAUP_PARSE_HOST,
+	FAUP_PARSE_TLD,
+	FAUP_PARSE_PORT,
+	FAUP_PARSE_RESOURCE_PATH,
+	FAUP_PARSE_QUERY_STRING,
+	FAUP_PARSE_FRAGMENT
+};
+typedef enum _faup_parse_type_t faup_parse_type_t;
+
+
+static inline sbool check_param_count_faup(unsigned short nParams) {
+	return nParams != 1;
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti, const faup_parse_type_t parse_type) {
+	struct svar srcVal;
+	int bMustFree;
+	cnfexprEval(func->expr[0], &srcVal, usrptr, pWti);
+	char *url = (char*) var2CString(&srcVal, &bMustFree);
+	faup_handler_t *fh = (faup_handler_t *)func->funcdata;
+
+	// default, return 0
+	ret->datatype = 'N';
+	ret->d.n = 0;
+
+	if(!faup_decode(fh, url, strlen(url))) {
+		parser_errmsg("faup: could not parse the value\n");
+		// No returned error code, so the reason doesn't matter
+		FINALIZE;
+	}
+
+	switch(parse_type) {
+		case FAUP_PARSE_ALL:
+			ret->datatype = 'J';
+			ret->d.json = json_object_new_object();
+			json_object_object_add(
+				ret->d.json,
+				"scheme",
+				json_object_new_string_len(
+					url + faup_get_scheme_pos(fh),
+					faup_get_scheme_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"credential",
+				json_object_new_string_len(
+					url + faup_get_credential_pos(fh),
+					faup_get_credential_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"subdomain",
+				json_object_new_string_len(
+					url + faup_get_subdomain_pos(fh),
+					faup_get_subdomain_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"domain",
+				json_object_new_string_len(
+					url + faup_get_domain_pos(fh),
+					faup_get_domain_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"domain_without_tld",
+				json_object_new_string_len(
+					url + faup_get_domain_without_tld_pos(fh),
+					faup_get_domain_without_tld_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"host",
+				json_object_new_string_len(
+					url + faup_get_host_pos(fh),
+					faup_get_host_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"tld",
+				json_object_new_string_len(
+					url + faup_get_tld_pos(fh),
+					faup_get_tld_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"port",
+				json_object_new_string_len(
+					url + faup_get_port_pos(fh),
+					faup_get_port_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"resource_path",
+				json_object_new_string_len(
+					url + faup_get_resource_path_pos(fh),
+					faup_get_resource_path_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"query_string",
+				json_object_new_string_len(
+					url + faup_get_query_string_pos(fh),
+					faup_get_query_string_size(fh)));
+			json_object_object_add(
+				ret->d.json,
+				"fragment",
+				json_object_new_string_len(
+					url + faup_get_fragment_pos(fh),
+					faup_get_fragment_size(fh)));
+			break;
+		case FAUP_PARSE_SCHEME:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_scheme_pos(fh), faup_get_scheme_size(fh));
+			break;
+		case FAUP_PARSE_CREDENTIAL:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_credential_pos(fh), faup_get_credential_size(fh));
+			break;
+		case FAUP_PARSE_SUBDOMAIN:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_subdomain_pos(fh), faup_get_subdomain_size(fh));
+			break;
+		case FAUP_PARSE_DOMAIN:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_domain_pos(fh), faup_get_domain_size(fh));
+			break;
+		case FAUP_PARSE_DOMAIN_WITHOUT_TLD:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_domain_without_tld_pos(fh), faup_get_domain_without_tld_size(fh));
+			break;
+		case FAUP_PARSE_HOST:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_host_pos(fh), faup_get_host_size(fh));
+			break;
+		case FAUP_PARSE_TLD:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_tld_pos(fh), faup_get_tld_size(fh));
+			break;
+		case FAUP_PARSE_PORT:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_port_pos(fh), faup_get_port_size(fh));
+			break;
+		case FAUP_PARSE_RESOURCE_PATH:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_resource_path_pos(fh), faup_get_resource_path_size(fh));
+			break;
+		case FAUP_PARSE_QUERY_STRING:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_query_string_pos(fh), faup_get_query_string_size(fh));
+			break;
+		case FAUP_PARSE_FRAGMENT:
+			ret->datatype = 'S';
+			ret->d.estr = es_newStrFromCStr(
+				url + faup_get_fragment_pos(fh), faup_get_fragment_size(fh));
+			break;
+	}
+
+finalize_it:
+	if(bMustFree) {
+		free(url);
+	}
+	varFreeMembers(&srcVal);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_full(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_ALL);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_scheme(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_SCHEME);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_credential(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_CREDENTIAL);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_subdomain(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_SUBDOMAIN);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_domain(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_DOMAIN);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_domain_without_tld(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_DOMAIN_WITHOUT_TLD);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_host(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_HOST);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_tld(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_TLD);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_port(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_PORT);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_resource_path(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_RESOURCE_PATH);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_query_string(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_QUERY_STRING);
+}
+
+
+static void ATTR_NONNULL()
+do_faup_parse_fragment(struct cnffunc *__restrict__ const func, struct svar *__restrict__ const ret,
+		void *__restrict__ const usrptr, wti_t *__restrict__ const pWti) {
+	do_faup_parse(func, ret, usrptr, pWti, FAUP_PARSE_FRAGMENT);
+}
+
+
+static rsRetVal ATTR_NONNULL(1)
+initFunc_faup_parse(struct cnffunc *const func)
+{
+	DEFiRet;
+
+	// Rsyslog cannot free the funcdata object,
+	// a library-specific freeing function will be used during destruction
+	func->destructable_funcdata = 0;
+	if(check_param_count_faup(func->nParams)) {
+		parser_errmsg("ffaup: ffaup(key) insufficient params.\n");
+		ABORT_FINALIZE(RS_RET_INVLD_NBR_ARGUMENTS);
+	}
+
+	CHKmalloc(func->funcdata = (void *) faup_init(glbOptions));
+
+finalize_it:
+	RETiRet;
+}
+
+static void ATTR_NONNULL(1)
+destructFunc_faup_parse(struct cnffunc *const func)
+{
+	if(func->funcdata != NULL) {
+		faup_terminate((faup_handler_t *)func->funcdata);
+		func->funcdata = NULL;
+	}
+}
+
+static struct scriptFunct functions[] = {
+		{"faup", 1, 1, do_faup_parse_full, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_scheme", 1, 1, do_faup_parse_scheme, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_credential", 1, 1, do_faup_parse_credential, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_subdomain", 1, 1, do_faup_parse_subdomain, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_domain", 1, 1, do_faup_parse_domain, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_domain_without_tld", 1, 1, do_faup_parse_domain_without_tld, initFunc_faup_parse,
+			destructFunc_faup_parse},
+		{"faup_host", 1, 1, do_faup_parse_host, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_tld", 1, 1, do_faup_parse_tld, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_port", 1, 1, do_faup_parse_port, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_resource_path", 1, 1, do_faup_parse_resource_path, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_query_string", 1, 1, do_faup_parse_query_string, initFunc_faup_parse, destructFunc_faup_parse},
+		{"faup_fragment", 1, 1, do_faup_parse_fragment, initFunc_faup_parse, destructFunc_faup_parse},
+		{NULL, 0, 0, NULL, NULL, NULL} //last element to check end of array
+};
+
+BEGINgetFunctArray
+CODESTARTgetFunctArray
+	dbgprintf("Faup: ffaup\n");
+	*version = 1;
+	*functArray = functions;
+ENDgetFunctArray
+
+
+BEGINmodExit
+CODESTARTmodExit
+	dbgprintf("ffaup: freeing options\n");
+	if(glbOptions){
+		faup_options_free(glbOptions);
+		glbOptions = NULL;
+	}
+ENDmodExit
+
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_FMOD_QUERIES
+ENDqueryEtryPt
+
+
+BEGINmodInit()
+CODESTARTmodInit
+	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+
+	dbgprintf("ffaup: initializing options\n");
+	glbOptions = faup_options_new();
+	if(!glbOptions) {
+		parser_errmsg("ffaup: could not initialize options\n");
+		ABORT_FINALIZE(RS_RET_FAUP_INIT_OPTIONS_FAILED);
+	}
+	// Don't generate a string output, and don't load LUA modules
+	// This is useful only for the faup executable
+	glbOptions->output = FAUP_OUTPUT_NONE;
+	glbOptions->exec_modules = FAUP_MODULES_NOEXEC;
+
+CODEmodInit_QueryRegCFSLineHdlr
+	dbgprintf("rsyslog ffaup init called, compiled with version %s\n", VERSION);
+ENDmodInit

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -584,6 +584,7 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_ERR_QUEUE_FN_DUP = -2451, /**< duplicate queue file name */
 	RS_RET_REDIS_ERROR = -2452, /**< redis-specific error. See message foe details. */
 	RS_RET_REDIS_AUTH_FAILED = -2453, /**< redis authentication failure */
+	RS_RET_FAUP_INIT_OPTIONS_FAILED = -2454, /**< could not initialize faup options */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1107,6 +1107,42 @@ TESTS +=  \
 	rscript_unflatten_object_exclamation-vg.sh
 endif # HAVE_VALGRIND
 endif # ENABLE_FMUNFLATTEN
+if ENABLE_FFAUP
+TESTS +=  \
+	rscript_faup_all.sh \
+	rscript_faup_all_2.sh \
+	rscript_faup_all_empty.sh \
+	rscript_faup_scheme.sh \
+	rscript_faup_credential.sh \
+	rscript_faup_subdomain.sh \
+	rscript_faup_domain.sh \
+	rscript_faup_domain_without_tld.sh \
+	rscript_faup_host.sh \
+	rscript_faup_tld.sh \
+	rscript_faup_port.sh \
+	rscript_faup_resource_path.sh \
+	rscript_faup_query_string.sh \
+	rscript_faup_fragment.sh \
+	rscript_faup_mozilla_tld.sh
+if HAVE_VALGRIND
+TESTS +=  \
+	rscript_faup_all_vg.sh \
+	rscript_faup_all_2_vg.sh \
+	rscript_faup_all_empty_vg.sh \
+	rscript_faup_scheme_vg.sh \
+	rscript_faup_credential_vg.sh \
+	rscript_faup_subdomain_vg.sh \
+	rscript_faup_domain_vg.sh \
+	rscript_faup_domain_without_tld_vg.sh \
+	rscript_faup_host_vg.sh \
+	rscript_faup_tld_vg.sh \
+	rscript_faup_port_vg.sh \
+	rscript_faup_resource_path_vg.sh \
+	rscript_faup_query_string_vg.sh \
+	rscript_faup_fragment_vg.sh \
+	rscript_faup_mozilla_tld_vg.sh
+endif # HAVE_VALGRIND
+endif # ENABLE_FFAUP
 endif
 
 if ENABLE_MMPSTRUCDATA

--- a/tests/rscript_faup_all.sh
+++ b/tests/rscript_faup_all.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://www.rsyslog.com/doc/v8-stable/rainerscript/functions/mo-faup.html";
+
+set $.faup = faup($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 3
+wait_file_lines "$RSYSLOG_OUT_LOG" 3 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" }
+ msgnum:00000001: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" }
+ msgnum:00000002: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" }'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_all_2.sh
+++ b/tests/rscript_faup_all_2.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 3
+wait_file_lines "$RSYSLOG_OUT_LOG" 3 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 { "scheme": "https", "credential": "user:pass", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "443", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "?param=value", "fragment": "#faup" }
+ msgnum:00000001: 0 { "scheme": "https", "credential": "user:pass", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "443", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "?param=value", "fragment": "#faup" }
+ msgnum:00000002: 0 { "scheme": "https", "credential": "user:pass", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "443", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "?param=value", "fragment": "#faup" }'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_all_2_vg.sh
+++ b/tests/rscript_faup_all_2_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_all_2.sh

--- a/tests/rscript_faup_all_empty.sh
+++ b/tests/rscript_faup_all_empty.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "";
+
+set $.faup = faup($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 3
+wait_file_lines "$RSYSLOG_OUT_LOG" 3 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 { "scheme": "", "credential": "", "subdomain": "", "domain": "", "domain_without_tld": "", "host": "", "tld": "", "port": "", "resource_path": "", "query_string": "", "fragment": "" }
+ msgnum:00000001: 0 { "scheme": "", "credential": "", "subdomain": "", "domain": "", "domain_without_tld": "", "host": "", "tld": "", "port": "", "resource_path": "", "query_string": "", "fragment": "" }
+ msgnum:00000002: 0 { "scheme": "", "credential": "", "subdomain": "", "domain": "", "domain_without_tld": "", "host": "", "tld": "", "port": "", "resource_path": "", "query_string": "", "fragment": "" }'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_all_empty_vg.sh
+++ b/tests/rscript_faup_all_empty_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_all_empty.sh

--- a/tests/rscript_faup_all_vg.sh
+++ b/tests/rscript_faup_all_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_all.sh

--- a/tests/rscript_faup_credential.sh
+++ b/tests/rscript_faup_credential.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_credential($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 user:pass'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_credential_vg.sh
+++ b/tests/rscript_faup_credential_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_credential.sh

--- a/tests/rscript_faup_domain.sh
+++ b/tests/rscript_faup_domain.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_domain($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 rsyslog.com'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_domain_vg.sh
+++ b/tests/rscript_faup_domain_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_domain.sh

--- a/tests/rscript_faup_domain_without_tld.sh
+++ b/tests/rscript_faup_domain_without_tld.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_domain_without_tld($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 rsyslog'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_domain_without_tld_vg.sh
+++ b/tests/rscript_faup_domain_without_tld_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_domain_without_tld.sh

--- a/tests/rscript_faup_fragment.sh
+++ b/tests/rscript_faup_fragment.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_fragment($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 #faup'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_fragment_vg.sh
+++ b/tests/rscript_faup_fragment_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_fragment.sh

--- a/tests/rscript_faup_host.sh
+++ b/tests/rscript_faup_host.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_host($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 www.rsyslog.com'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_host_vg.sh
+++ b/tests/rscript_faup_host_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_host.sh

--- a/tests/rscript_faup_mozilla_tld.sh
+++ b/tests/rscript_faup_mozilla_tld.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://www.testing.co.uk";
+
+set $.faup = faup($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 3
+wait_file_lines "$RSYSLOG_OUT_LOG" 3 60
+shutdown_when_empty
+wait_shutdown
+
+# if the FAUP module has access to its mozilla.tlds file listing second-degree TLDs, the tld here should be "co.uk" and not simply "uk"
+EXPECTED=' msgnum:00000000: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "testing.co.uk", "domain_without_tld": "testing", "host": "www.testing.co.uk", "tld": "co.uk", "port": "", "resource_path": "", "query_string": "", "fragment": "" }
+ msgnum:00000001: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "testing.co.uk", "domain_without_tld": "testing", "host": "www.testing.co.uk", "tld": "co.uk", "port": "", "resource_path": "", "query_string": "", "fragment": "" }
+ msgnum:00000002: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "testing.co.uk", "domain_without_tld": "testing", "host": "www.testing.co.uk", "tld": "co.uk", "port": "", "resource_path": "", "query_string": "", "fragment": "" }'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_mozilla_tld_vg.sh
+++ b/tests/rscript_faup_mozilla_tld_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_mozilla_tld.sh

--- a/tests/rscript_faup_port.sh
+++ b/tests/rscript_faup_port.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_port($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 443'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_port_vg.sh
+++ b/tests/rscript_faup_port_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_port.sh

--- a/tests/rscript_faup_query_string.sh
+++ b/tests/rscript_faup_query_string.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_query_string($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 ?param=value'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_query_string_vg.sh
+++ b/tests/rscript_faup_query_string_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_query_string.sh

--- a/tests/rscript_faup_resource_path.sh
+++ b/tests/rscript_faup_resource_path.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_resource_path($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 /doc/v8-stable/rainerscript/functions/mo-faup.html'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_resource_path_vg.sh
+++ b/tests/rscript_faup_resource_path_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_resource_path.sh

--- a/tests/rscript_faup_scheme.sh
+++ b/tests/rscript_faup_scheme.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_scheme($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 https'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_scheme_vg.sh
+++ b/tests/rscript_faup_scheme_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_scheme.sh

--- a/tests/rscript_faup_subdomain.sh
+++ b/tests/rscript_faup_subdomain.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_subdomain($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 www'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_subdomain_vg.sh
+++ b/tests/rscript_faup_subdomain_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_subdomain.sh

--- a/tests/rscript_faup_tld.sh
+++ b/tests/rscript_faup_tld.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret% %$.faup%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";
+
+set $.faup = faup_tld($!url);
+set $.ret = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 1
+wait_file_lines "$RSYSLOG_OUT_LOG" 1 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 com'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/rscript_faup_tld_vg.sh
+++ b/tests/rscript_faup_tld_vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# added 2021-11-05 by Theo Bertin, released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_faup_tld.sh

--- a/tests/rscript_faup_various.sh
+++ b/tests/rscript_faup_various.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# added 2020-08-16 by Julien Thomas, released under ASL 2.0
+
+source "${srcdir:=.}/diag.sh" init
+#export RSYSLOG_DEBUG="debug nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/ffaup/.libs/ffaup")
+input(type="imtcp" port="0" listenPortFileName="'"$RSYSLOG_DYNNAME"'.tcpflood_port")
+template(name="outfmt" type="string" string="%msg% %$.ret1% %$.faup% %$.ret2% %$.scheme% %$.ret3% %$.domain_without_tld% %$.ret4% %$.fragment% %$.ret5% %$.resource_path%\n")
+
+if (not($msg contains "msgnum:")) then
+    stop
+
+set $!url = "https://www.rsyslog.com/doc/v8-stable/rainerscript/functions/mo-faup.html";
+
+set $.faup = faup($!url);
+set $.ret1 = script_error();
+set $.scheme = faup_scheme($!url);
+set $.ret2 = script_error();
+set $.domain_without_tld = faup_domain_without_tld($!url);
+set $.ret3 = script_error();
+set $.fragment = faup_fragment($!url);
+set $.ret4 = script_error();
+set $.resource_path = faup_resource_path($!url);
+set $.ret5 = script_error();
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m 5
+wait_file_lines "$RSYSLOG_OUT_LOG" 5 60
+shutdown_when_empty
+wait_shutdown
+
+# this test may need changes to produce a more deterministic
+# output by sorting keys
+EXPECTED=' msgnum:00000000: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" } 0 https 0 rsyslog 0  0 /doc/v8-stable/rainerscript/functions/mo-faup.html
+ msgnum:00000001: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" } 0 https 0 rsyslog 0  0 /doc/v8-stable/rainerscript/functions/mo-faup.html
+ msgnum:00000002: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" } 0 https 0 rsyslog 0  0 /doc/v8-stable/rainerscript/functions/mo-faup.html
+ msgnum:00000003: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" } 0 https 0 rsyslog 0  0 /doc/v8-stable/rainerscript/functions/mo-faup.html
+ msgnum:00000004: 0 { "scheme": "https", "credential": "", "subdomain": "www", "domain": "rsyslog.com", "domain_without_tld": "rsyslog", "host": "www.rsyslog.com", "tld": "com", "port": "", "resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html", "query_string": "", "fragment": "" } 0 https 0 rsyslog 0  0 /doc/v8-stable/rainerscript/functions/mo-faup.html'
+cmp_exact "$RSYSLOG_OUT_LOG"
+exit_test


### PR DESCRIPTION
## Description
New module function(s) (RainerScript) to parse and extract parts of an URL.

These new functions allow anybody to parse any variable containing URLs, hostnames, DNS queries and such to extract:
- the scheme
- the credentials (if present)
- the tld (with support for second-level TLDs)
- the domain (with and without the tld)
- the subdomain
- the full hostname
- the port (if present)
- the resource path (if present)
- the query string parameters (if present)
- the fragment (if present)

## Requirements
This module relies on the [faup](https://github.com/stricaud/faup) library.
The library should be compiled (see link for instructions on how to compile) and installed on build and runtime machines.

| :exclamation:  Warning   |
|--------------------------|
Even if faup is statically compiled to rsyslog, the library still needs an additional file to work properly: the mozilla.tlds stored by the libfaup library in /usr/local/share/faup. It permits to properly match second-level TLDs and allow URLs such as www.rsyslog.co.uk to be correctly parsed into \<rsyslog:domain\>.\<co.uk:tld\> and not \<rsyslog:subdomain\>.\<co:domain\>.\<uk:tld\>

## HowTo
The module functions are fairly simple to use, and are divided in 2 classes:
- `faup()` allows to parse the entire URL and return all parts in a complete JSON
- `faup_<field>()` allows to parse the entire URL, but only returns the (potential) value of the requested field as string

### Exemples
#### using the `faup()` function
The `faup()` is the simplest function to use, simply provide a value or variable (any type) as the only parameter, and the function returns a json object containing every element of the URL.

*example code:*
```
set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";

set $.faup = faup($!url);
```

*$.faup will contain:*
```json
{
	"scheme": "https",
	"credential": "user:pass",
	"subdomain": "www",
	"domain": "rsyslog.com",
	"domain_without_tld": "rsyslog",
	"host": "www.rsyslog.com",
	"tld": "com",
	"port": "443",
	"resource_path": "\/doc\/v8-stable\/rainerscript\/functions\/mo-faup.html",
	"query_string": "?param=value",
	"fragment": "#faup"
}
```

| :memo:     Note      |
|---------------------|
This is a classic rsyslog variable, and you can access every sub-key with `$.faup!domain`, `$.faup!resource_path`, etc...


#### using the `faup_<field>()` functions
Using the field functions is even simpler: for each field returned by the `faup()` function, there exists a corresponding function to get only that one field.
For example, if the goal is to recover the domain without the tld, the example above could be modified as follows:
*example code:*
```
set $!url = "https://user:pass@www.rsyslog.com:443/doc/v8-stable/rainerscript/functions/mo-faup.html?param=value#faup";

set $.faup = faup_domain_without_tld($!url);
```

*$.faup will contain:*
```
rsyslog
```

| :memo:     Note      |
|---------------------|
The returned value is no longer a json object, but a simple string

## Motivations
Those functions are the answer to a growing problem encountered in Rsyslog when using modules to enrich logs : some mechanics (like lookup tables or external module calls) require "strict" URL/hostname formats that are often not formatted correctly, resulting in lookup failures/misses.
This ensures getting stable inputs to provide to lookups/modules to enrich logs.

## Documentation
rsyslog-doc : https://github.com/rsyslog/rsyslog-doc/pull/952