### PR TITLE
Avoid use of inet_addr() in favor of inet_aton()

### DIFF
--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -304,8 +304,7 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz, uchar
 
 		/* Set PDU SOurce property if available */
 		if (pszSource != NULL) {
-			srcAddr.sin_addr.s_addr = inet_addr((const char *)pszSource);
-			if (srcAddr.sin_addr.s_addr != INADDR_NONE) {
+			if (inet_aton((const char *)pszSource, &srcAddr.sin_addr) != 0) {
 				pdu->agent_addr[0] = (srcAddr.sin_addr.s_addr) & 0xFF;
 				pdu->agent_addr[1] = (srcAddr.sin_addr.s_addr >> 8) & 0xFF;
 				pdu->agent_addr[2] = (srcAddr.sin_addr.s_addr >> 16) & 0xFF;


### PR DESCRIPTION
The `omsnmp` module uses the `inet_addr()` function to convert the Internet host address from IPv4 numbers-and-dots notation into binary data in network byte order. If the input is invalid, INADDR_NONE (usually -1) is returned. Use of this function is problematic because -1 is a valid address (255.255.255.255). We should avoid its use in favor of inet_aton(), inet_pton(3), or getaddrinfo(3), which provide a cleaner way to indicate error return [1].

This is just a request to satisfy covscan, so no error is reported at all. 

[1] https://man7.org/linux/man-pages/man3/inet_addr.3.html