### PR TITLE
ruleset bugfix: ruleset queue was incorrectly named

### DIFF
--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -1115,10 +1115,10 @@ rulesetProcessCnf(struct cnfobj *o)
 	/* pick up ruleset queue parameters */
 	if(queueCnfParamsSet(o->nvlst)) {
 		if(pRuleset->pszName == NULL) {
-			rsname = pRuleset->pszName;
+			rsname = (uchar*) "[ruleset]";
 			qtype = pRuleset->pQueue->qType;
 		} else {
-			rsname = (uchar*) "[ruleset]";
+			rsname = pRuleset->pszName;
 			qtype = 3;
 		}
 		DBGPRINTF("adding a ruleset-specific \"main\" queue for ruleset '%s', mode %d\n",


### PR DESCRIPTION
The ruleset was incorrectly and unusably named. This was a regeression
from 4a63f8e9629c3c9481a8b6f9d7787e3b3304320b.

Many thanks to github user digirati82 for alerting us.

closes https://github.com/rsyslog/rsyslog/issues/4730

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
