### PR TITLE
Avoid use of loadConf in favor of runConf in ratelimiting during runtime

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -773,6 +773,7 @@ act_obj_add(fs_edge_t *const edge, const char *const name, const int is_file,
 	act->file_id[0] = '\0';
 	act->file_id_prev[0] = '\0';
 	act->is_symlink = is_symlink;
+	act->ratelimiter = NULL;
 	if (source) { /* we are target of symlink */
 		CHKmalloc(act->source_name = strdup(source));
 	} else {
@@ -800,6 +801,8 @@ act_obj_add(fs_edge_t *const edge, const char *const name, const int is_file,
 finalize_it:
 	if(iRet != RS_RET_OK) {
 		if(act != NULL) {
+			if (act->ratelimiter != NULL)
+				ratelimitDestruct(act->ratelimiter);
 			free(act->name);
 			free(act);
 		}

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -343,6 +343,7 @@ CODESTARTbeginCnfLoad
 	pModConf->bKeepKernelStamp = 0;
 	pModConf->iFacilIntMsg = klogFacilIntMsg();
 	loadModConf->configSetViaV2Method = 0;
+	pModConf->ratelimiter = NULL;
 	pModConf->ratelimitBurst = 10000; /* arbitrary high limit */
 	pModConf->ratelimitInterval = 0; /* off */
 	bLegacyCnfModGlobalsPermitted = 1;

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1744,6 +1744,7 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 
 	CHKmalloc(pSrv = calloc(1, sizeof(ptcpsrv_t)));
 	pthread_mutex_init(&pSrv->mutSessLst, NULL);
+	pSrv->ratelimiter = NULL;
 	pSrv->pSess = NULL;
 	pSrv->pLstn = NULL;
 	pSrv->inst = inst;

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -239,7 +239,7 @@ ratelimitMsg(ratelimit_t *__restrict__ const ratelimit, smsg_t *pMsg, smsg_t **p
 
 	*ppRepMsg = NULL;
 
-	if(ratelimit->bReduceRepeatMsgs || ratelimit->severity > 0) {
+	if(runConf->globals.bReduceRepeatMsgs || ratelimit->severity > 0) {
 		/* consider early parsing only if really needed */
 		if((pMsg->msgFlags & NEEDS_PARSING) != 0) {
 			if((localRet = parser.ParseMsg(pMsg)) != RS_RET_OK)  {
@@ -261,7 +261,7 @@ ratelimitMsg(ratelimit_t *__restrict__ const ratelimit, smsg_t *pMsg, smsg_t **p
 			ABORT_FINALIZE(RS_RET_DISCARDMSG);
 		}
 	}
-	if(ratelimit->bReduceRepeatMsgs) {
+	if(runConf->globals.bReduceRepeatMsgs) {
 		CHKiRet(doLastMessageRepeatedNTimes(ratelimit, pMsg, ppRepMsg));
 	}
 finalize_it:
@@ -276,7 +276,7 @@ finalize_it:
 int
 ratelimitChecked(ratelimit_t *ratelimit)
 {
-	return ratelimit->interval || ratelimit->bReduceRepeatMsgs;
+	return ratelimit->interval || runConf->globals.bReduceRepeatMsgs;
 }
 
 
@@ -349,10 +349,7 @@ ratelimitNew(ratelimit_t **ppThis, const char *modname, const char *dynname)
 		namebuf[sizeof(namebuf)-1] = '\0'; /* to be on safe side */
 		pThis->name = strdup(namebuf);
 	}
-	/* pThis->severity == 0 - all messages are ratelimited */
-	pThis->bReduceRepeatMsgs = loadConf->globals.bReduceRepeatMsgs;
-	DBGPRINTF("ratelimit:%s:new ratelimiter:bReduceRepeatMsgs %d\n",
-		  pThis->name, pThis->bReduceRepeatMsgs);
+	DBGPRINTF("ratelimit:%s:new ratelimiter\n", pThis->name);
 	*ppThis = pThis;
 finalize_it:
 	RETiRet;

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -31,7 +31,6 @@ struct ratelimit_s {
 	unsigned missed;
 	time_t begin;
 	/* support for "last message repeated n times */
-	int bReduceRepeatMsgs; /**< shall we do "last message repeated n times" processing? */
 	unsigned nsupp;		/**< nbr of msgs suppressed */
 	smsg_t *pMsg;
 	sbool bThreadSafe;	/**< do we need to operate in Thread-Safe mode? */

--- a/tests/imtcp-tls-basic.sh
+++ b/tests/imtcp-tls-basic.sh
@@ -3,6 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50000
+export TB_TEST_MAX_RUNTIME=1500
 export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
 generate_conf
 add_conf '

--- a/tests/imtcp_conndrop_tls-vg.sh
+++ b/tests/imtcp_conndrop_tls-vg.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 export USE_VALGRIND="YES"
+export TB_TEST_MAX_RUNTIME=1500
 export NUMMESSAGES=10000 # reduce for slower valgrind run
 source ${srcdir:-.}/imtcp_conndrop_tls.sh

--- a/tests/rscript_http_request-vg.sh
+++ b/tests/rscript_http_request-vg.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 export USE_VALGRIND="YES"
+export TB_TEST_MAX_RUNTIME=1500
 source ${srcdir:-.}/rscript_http_request.sh


### PR DESCRIPTION
The ```ratelimitNew()``` function used  the ```bReduceRepeatMsgs``` global option to acquire information from the configuration that is going to be loaded. While this function was created to be used(I believe) during "configuration loading time", multiple input plugins use it during runtime. It's true that it has no impact on the current system right now, because both ```loadConf``` and ```runConf``` point to the same config. However, in the future a dynamic configuration reload option might be added.