### PR TITLE
Deallocate outchannel resources in rsconf destructor

### DIFF
--- a/outchannel.c
+++ b/outchannel.c
@@ -272,6 +272,10 @@ void ochDeleteAll(void)
 		pOch = pOch->pNext;
 		if(pOchDel->pszName != NULL)
 			free(pOchDel->pszName);
+		if(pOchDel->pszFileTemplate != NULL)
+			free(pOchDel->pszFileTemplate);
+		if(pOchDel->cmdOnSizeLimit != NULL)
+			free(pOchDel->cmdOnSizeLimit);
 		free(pOchDel);
 	}
 }

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -240,6 +240,7 @@ CODESTARTobjDestruct(rsconf)
 	tplDeleteAll(pThis);
 	dynstats_destroyAllBuckets();
 	perctileBucketsDestruct();
+	ochDeleteAll();
 	free(pThis->globals.mainQ.pszMainMsgQFName);
 	free(pThis->globals.pszConfDAGFile);
 	lookupDestroyCnf();


### PR DESCRIPTION
The outchannel resources were not freed when rsyslog was stoped. The PR intends to fix it by invoking ```ochDeleteAll()``` in the rsconf destructor.