### PR TITLE
Clarify the meaning of loadConf and RunConf

### DIFF
--- a/action.c
+++ b/action.c
@@ -393,7 +393,7 @@ rsRetVal actionConstruct(action_t **ppThis)
 	action_t *pThis;
 
 	assert(ppThis != NULL);
-	
+
 	CHKmalloc(pThis = (action_t*) calloc(1, sizeof(action_t)));
 	pThis->iResumeInterval = 30;
 	pThis->iResumeIntervalMax = 1800; /* max interval default is half an hour */
@@ -584,7 +584,7 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 			"that they will have no effect - "
 			"see https://www.rsyslog.com/mm-no-queue/", (char*)modGetName(pThis->pMod));
 	}
-	
+
 	/* and now reset the queue params (see comment in its function header!) */
 	actionResetQueueParams();
 
@@ -1979,7 +1979,7 @@ rsRetVal
 activateActions(void)
 {
 	DEFiRet;
-	iRet = ruleset.IterateAllActions(ourConf, doActivateActions, NULL);
+	iRet = ruleset.IterateAllActions(runConf, doActivateActions, NULL);
 	RETiRet;
 }
 
@@ -2038,7 +2038,7 @@ static rsRetVal
 actionApplyCnfParam(action_t * const pAction, struct cnfparamvals * const pvals)
 {
 	int i;
-	
+
 	for(i = 0 ; i < pblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
@@ -2139,7 +2139,7 @@ addAction(action_t **ppAction, modInfo_t *pMod, void *pModData,
 		CHKmalloc(pAction->peParamPassing = (paramPassing_t*)calloc(pAction->iNumTpls,
 			sizeof(paramPassing_t)));
 	}
-	
+
 	pAction->bUsesMsgPassingMode = 0;
 	pAction->bNeedReleaseBatch = 0;
 	for(i = 0 ; i < pAction->iNumTpls ; ++i) {
@@ -2149,7 +2149,7 @@ addAction(action_t **ppAction, modInfo_t *pMod, void *pModData,
 		 */
 		if(!(iTplOpts & OMSR_TPL_AS_MSG)) {
 		   	if((pAction->ppTpl[i] =
-				tplFind(ourConf, (char*)pTplName, strlen((char*)pTplName))) == NULL) {
+				tplFind(loadConf, (char*)pTplName, strlen((char*)pTplName))) == NULL) {
 				snprintf(errMsg, sizeof(errMsg),
 					 " Could not find template %d '%s' - action disabled",
 					 i, pTplName);
@@ -2188,7 +2188,7 @@ addAction(action_t **ppAction, modInfo_t *pMod, void *pModData,
 	pAction->pModData = pModData;
 
 	CHKiRet(actionConstructFinalize(pAction, lst));
-	
+
 	*ppAction = pAction; /* finally store the action pointer */
 
 finalize_it:

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3738,7 +3738,7 @@ initFunc_exec_template(struct cnffunc *func)
 	}
 
 	tplName = es_str2cstr(((struct cnfstringval*) func->expr[0])->estr, NULL);
-	func->funcdata = tplFind(ourConf, tplName, strlen(tplName));
+	func->funcdata = tplFind(loadConf, tplName, strlen(tplName));
 	if(func->funcdata == NULL) {
 		parser_errmsg("exec_template(): template '%s' could not be found", tplName);
 		FINALIZE;

--- a/outchannel.c
+++ b/outchannel.c
@@ -265,7 +265,7 @@ void ochDeleteAll(void)
 {
 	struct outchannel *pOch, *pOchDel;
 
-	pOch = loadConf->och.ochRoot;
+	pOch = runConf->och.ochRoot;
 	while(pOch != NULL) {
 		dbgprintf("Delete Outchannel: Name='%s'\n ", pOch->pszName == NULL? "NULL" : pOch->pszName);
 		pOchDel = pOch;
@@ -284,11 +284,11 @@ void ochDeleteAll(void)
 /* Print the outchannel structure. This is more or less a
  * debug or test aid, but anyhow I think it's worth it...
  */
-void ochPrintList(void)
+void ochPrintList(rsconf_t *cnf)
 {
 	struct outchannel *pOch;
 
-	pOch = loadConf->och.ochRoot;
+	pOch = cnf->och.ochRoot;
 	while(pOch != NULL) {
 		dbgprintf("Outchannel: Name='%s'\n", pOch->pszName == NULL? "NULL" : pOch->pszName);
 		dbgprintf("\tFile Template: '%s'\n", pOch->pszFileTemplate == NULL ? "NULL" :

--- a/outchannel.h
+++ b/outchannel.h
@@ -34,5 +34,5 @@ struct outchannel* ochConstruct(void);
 struct outchannel *ochAddLine(char* pName, unsigned char** pRestOfConfLine);
 struct outchannel *ochFind(char *pName, int iLenName);
 void ochDeleteAll(void);
-void ochPrintList(void);
+void ochPrintList(rsconf_t *cnf);
 #endif /* #ifdef OUTCHANNEL_H */

--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -229,7 +229,7 @@ void
 lookupDestroyCnf(void)
 {
 	lookup_ref_t *luref, *luref_next;
-	for(luref = loadConf->lu_tabs.root ; luref != NULL ; ) {
+	for(luref = runConf->lu_tabs.root ; luref != NULL ; ) {
 		luref_next = luref->next;
 		lookupRefDestruct(luref);
 		luref = luref_next;
@@ -861,7 +861,7 @@ void
 lookupDoHUP(void)
 {
 	lookup_ref_t *luref;
-	for(luref = loadConf->lu_tabs.root ; luref != NULL ; luref = luref->next) {
+	for(luref = runConf->lu_tabs.root ; luref != NULL ; luref = luref->next) {
 		if (luref->reload_on_hup) {
 			lookupReload(luref, NULL);
 		}
@@ -873,7 +873,7 @@ lookupPendingReloadCount(void)
 {
 	uint pending_reload_count = 0;
 	lookup_ref_t *luref;
-	for(luref = loadConf->lu_tabs.root ; luref != NULL ; luref = luref->next) {
+	for(luref = runConf->lu_tabs.root ; luref != NULL ; luref = luref->next) {
 		if (lookupIsReloadPending(luref)) {
 			pending_reload_count++;
 		}

--- a/runtime/parser.c
+++ b/runtime/parser.c
@@ -152,7 +152,7 @@ FindParser(parser_t **ppParser, uchar *pName)
 {
 	parserList_t *pThis;
 	DEFiRet;
-	
+
 	for(pThis = pParsLstRoot ; pThis != NULL ; pThis = pThis->pNext) {
 		if(ustrcmp(pThis->pParser->pName, pName) == 0) {
 			*ppParser = pThis->pParser;
@@ -183,7 +183,7 @@ AddDfltParser(uchar *pName)
 	CHKiRet(FindParser(&pParser, pName));
 	CHKiRet(AddParserToList(&pDfltParsLst, pParser));
 	DBGPRINTF("Parser '%s' added to default parser set.\n", pName);
-	
+
 finalize_it:
 	RETiRet;
 }
@@ -316,7 +316,7 @@ static rsRetVal uncompressMessage(smsg_t *pMsg)
 	uLongf iLenDefBuf;
 	uchar *pszMsg;
 	size_t lenMsg;
-	
+
 	assert(pMsg != NULL);
 	pszMsg = pMsg->pszRawMsg;
 	lenMsg = pMsg->iLenRawMsg;
@@ -642,7 +642,7 @@ ParseMsg(smsg_t *pMsg)
 	 * will cause it to happen. After that, access to the unsanitized message is no
 	 * loger possible.
 	 */
-	pParserList = ruleset.GetParserList(ourConf, pMsg);
+	pParserList = ruleset.GetParserList(runConf, pMsg);
 	if(pParserList == NULL) {
 		pParserList = pDfltParsLst;
 	}

--- a/runtime/perctile_stats.c
+++ b/runtime/perctile_stats.c
@@ -150,7 +150,7 @@ static void perctileBucketDestruct(perctile_bucket_t *bkt) {
 }
 
 void perctileBucketsDestruct(void) {
-	perctile_buckets_t *bkts = &loadConf->perctile_buckets;
+	perctile_buckets_t *bkts = &runConf->perctile_buckets;
 
 	if (bkts->initialized) {
 		perctile_bucket_t *head = bkts->listBuckets;
@@ -441,7 +441,7 @@ finalize_it:
 
 static void
 perctile_readCallback(statsobj_t __attribute__((unused)) *ignore, void __attribute__((unused)) *b) {
-	perctile_buckets_t *bkts = &loadConf->perctile_buckets;
+	perctile_buckets_t *bkts = &runConf->perctile_buckets;
 
 	pthread_rwlock_rdlock(&bkts->lock);
 	for (perctile_bucket_t *pbkt = bkts->listBuckets; pbkt != NULL; pbkt = pbkt->next) {

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -252,7 +252,7 @@ execCallIndirect(struct cnfstmt *const __restrict__ stmt,
 
 	cnfexprEval(stmt->d.s_call_ind.expr, &result, pMsg, pWti);
 	uchar *const rsName = (uchar*) var2CString(&result, &bMustFree);
-	const rsRetVal localRet = rulesetGetRuleset(loadConf, &pRuleset, rsName);
+	const rsRetVal localRet = rulesetGetRuleset(runConf, &pRuleset, rsName);
 	if(localRet != RS_RET_OK) {
 		/* in that case, we accept that a NOP will "survive" */
 		LogError(0, RS_RET_RULESET_NOT_FOUND, "error: CALL_INDIRECT: "
@@ -656,7 +656,7 @@ processBatch(batch_t *pBatch, wti_t *pWti)
 	for(i = 0 ; i < batchNumMsgs(pBatch) && !*(pWti->pbShutdownImmediate) ; ++i) {
 		pMsg = pBatch->pElem[i].pMsg;
 		DBGPRINTF("processBATCH: next msg %d: %.128s\n", i, pMsg->pszRawMsg);
-		pRuleset = (pMsg->pRuleset == NULL) ? ourConf->rulesets.pDflt : pMsg->pRuleset;
+		pRuleset = (pMsg->pRuleset == NULL) ? runConf->rulesets.pDflt : pMsg->pRuleset;
 		localRet = scriptExec(pRuleset->root, pMsg, pWti);
 		/* the most important case here is that processing may be aborted
 		 * due to pbShutdownImmediate, in which case we MUST NOT flag this
@@ -1050,7 +1050,7 @@ finalize_it:
 static rsRetVal
 rulesetAddParser(void __attribute__((unused)) *pVal, uchar *pName)
 {
-	return doRulesetAddParser(ourConf->rulesets.pCurr, pName);
+	return doRulesetAddParser(loadConf->rulesets.pCurr, pName);
 }
 
 

--- a/template.c
+++ b/template.c
@@ -2235,7 +2235,7 @@ void tplDeleteNew(rsconf_t *conf)
 	}
 }
 
-/* Store the pointer to the last hardcoded teplate */
+/* Store the pointer to the last hardcoded template */
 void tplLastStaticInit(rsconf_t *conf, struct template *tpl)
 {
 	conf->templates.lastStatic = tpl;

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1626,14 +1626,14 @@ initAll(int argc, char **argv)
 	hdlr_enable(SIGCHLD, hdlr_sigchld);
 	hdlr_enable(SIGHUP, hdlr_sighup);
 
-	if(rsconfNeedDropPriv(ourConf)) {
+	if(rsconfNeedDropPriv(loadConf)) {
 		/* need to write pid file early as we may loose permissions */
 		CHKiRet(writePidFile());
 	}
 
 	CHKiRet(rsconf.Activate(ourConf));
 
-	if(ourConf->globals.bLogStatusMsgs) {
+	if(runConf->globals.bLogStatusMsgs) {
 		char bufStartUpMsg[512];
 		snprintf(bufStartUpMsg, sizeof(bufStartUpMsg),
 			 "[origin software=\"rsyslogd\" " "swVersion=\"" VERSION \
@@ -1642,7 +1642,7 @@ initAll(int argc, char **argv)
 		logmsgInternal(NO_ERRCODE, LOG_SYSLOG|LOG_INFO, (uchar*)bufStartUpMsg, 0);
 	}
 
-	if(!rsconfNeedDropPriv(ourConf)) {
+	if(!rsconfNeedDropPriv(runConf)) {
 		CHKiRet(writePidFile());
 	}
 
@@ -1654,7 +1654,7 @@ initAll(int argc, char **argv)
 		stddbg = -1; /* turn off writing to fd 1 */
 		close(1);
 		close(2);
-		ourConf->globals.bErrMsgToStderr = 0;
+		runConf->globals.bErrMsgToStderr = 0;
 	}
 
 finalize_it:


### PR DESCRIPTION
The PR intends to clarify the meaning of loadConf and runConf. These were originally introduced to facilitate a later move to dynamic config loads.  Over the years, the use of these pointers has become unclear. 

- loadConf was intended for candidate config (the new one)
- runConf for the currently running config
