### PR TITLE
Move rsyslog global variables to rsconf_t structure

### DIFF
--- a/action.c
+++ b/action.c
@@ -190,8 +190,6 @@ static configSettings_t cs;					/* our current config settings */
  * is no better name available.
  */
 int iActionNbr = 0;
-int bActionReportSuspension = 1;
-int bActionReportSuspensionCont = 0;
 
 /* tables for interfacing with the v6 config system */
 static struct cnfparamdescr cnfparamdescr[] = {
@@ -752,9 +750,9 @@ static void
 setSuspendMessageConfVars(action_t *__restrict__ const pThis)
 {
 	if(pThis->bReportSuspension == -1)
-		pThis->bReportSuspension = bActionReportSuspension;
+		pThis->bReportSuspension = runConf->globals.bActionReportSuspension;
 	if(pThis->bReportSuspensionCont == -1) {
-		pThis->bReportSuspensionCont = bActionReportSuspensionCont;
+		pThis->bReportSuspensionCont = runConf->globals.bActionReportSuspensionCont;
 		if(pThis->bReportSuspensionCont == -1)
 			pThis->bReportSuspensionCont = 1;
 	}

--- a/action.h
+++ b/action.h
@@ -30,9 +30,6 @@
 
 /* external data */
 extern int glbliActionResumeRetryCount;
-extern int bActionReportSuspension;
-extern int bActionReportSuspensionCont;
-
 
 /* the following struct defines the action object data structure
  */

--- a/contrib/imbatchreport/imbatchreport.c
+++ b/contrib/imbatchreport/imbatchreport.c
@@ -930,7 +930,7 @@ CODESTARTwillRun
 		sizeof("imbatchreport") - 1));
 	CHKiRet(prop.ConstructFinalize(pInputName));
 
-	fixedModConf.max_msg_size = glbl.GetMaxLine();
+	fixedModConf.max_msg_size = glbl.GetMaxLine(runConf);
 	DBGPRINTF("Max message len %zu\n", fixedModConf.max_msg_size);
 	CHKmalloc(fixedModConf.msg_buffer = (char*)malloc(fixedModConf.max_msg_size + 1));
 finalize_it:

--- a/contrib/imdocker/imdocker.c
+++ b/contrib/imdocker/imdocker.c
@@ -1059,7 +1059,7 @@ enqMsg(docker_cont_logs_inst_t *pInst, uchar *msg, size_t len, const uchar *pszT
 			lenMsg--;
 		}
 
-		if(glbl.GetParserDropTrailingLFOnReception()
+		if(glbl.GetParserDropTrailingLFOnReception(loadModConf->pConf)
 				&& lenMsg > 0 && pszMsg[lenMsg-1] == '\n') {
 			DBGPRINTF("dropped LF at very end of message (DropTrailingLF is set)\n");
 			lenMsg--;

--- a/contrib/imkmsg/imkmsg.c
+++ b/contrib/imkmsg/imkmsg.c
@@ -155,7 +155,7 @@ rsRetVal Syslog(syslog_pri_t priority, uchar *pMsg, struct timeval *tp, struct j
  */
 int klog_getMaxLine(void)
 {
-	return glbl.GetMaxLine();
+	return glbl.GetMaxLine(runModConf->pConf);
 }
 
 

--- a/contrib/improg/improg.c
+++ b/contrib/improg/improg.c
@@ -330,7 +330,7 @@ static void waitForChild(instanceConf_t *pInst)
 	/* waitpid will fail with errno == ECHILD if the child process has already
 		 been reaped by the rsyslogd main loop (see rsyslogd.c) */
 	if(ret == pInst->pid) {
-		glblReportChildProcessExit(pInst->pszBinary, pInst->pid, status);
+		glblReportChildProcessExit(runConf, pInst->pszBinary, pInst->pid, status);
 	}
 }
 

--- a/contrib/imtuxedoulog/imtuxedoulog.c
+++ b/contrib/imtuxedoulog/imtuxedoulog.c
@@ -89,6 +89,8 @@ struct modConfData_s {
 };
 
 static instanceConf_t *confRoot = NULL;
+static modConfData_t *loadModConf = NULL; /* modConf ptr to use for the current load process */
+static modConfData_t *runModConf = NULL; /* modConf ptr to use for run process */
 
 
 MODULE_TYPE_INPUT	/* must be present for input modules, do not remove */
@@ -160,7 +162,7 @@ static int getFullStateFileName(uchar* pszstatefile, uchar* pszout, int ilenout)
 	const uchar* pszworkdir;
 
 	/* Get Raw Workdir, if it is NULL we need to propper handle it */
-	pszworkdir = glblGetWorkDirRaw();
+	pszworkdir = glblGetWorkDirRaw(runModConf->pConf);
 
 	/* Construct file name */
 	lenout = snprintf((char*)pszout, ilenout, "%s/%s",
@@ -472,9 +474,9 @@ static void persistStrmState(instanceConf_t *pInst)
 	DBGPRINTF("persisting state for '%s' to file '%s'\n",
 			pInst->pszUlogBaseName, statefn);
 	CHKiRet(strm.Construct(&psSF));
-	lenDir = ustrlen(glbl.GetWorkDir());
+	lenDir = ustrlen(glbl.GetWorkDir(runModConf->pConf));
 	if(lenDir > 0)
-		CHKiRet(strm.SetDir(psSF, glbl.GetWorkDir(), lenDir));
+		CHKiRet(strm.SetDir(psSF, glbl.GetWorkDir(runModConf->pConf), lenDir));
 	CHKiRet(strm.SettOperationsMode(psSF, STREAMMODE_WRITE_TRUNC));
 	CHKiRet(strm.SetsType(psSF, STREAMTYPE_FILE_SINGLE));
 	CHKiRet(strm.SetFName(psSF, statefn, strlen((char*) statefn)));
@@ -764,6 +766,7 @@ ENDnewInpInst
 
 BEGINbeginCnfLoad
 CODESTARTbeginCnfLoad
+	loadModConf = pModConf;
 	pModConf->pConf = pConf;
 ENDbeginCnfLoad
 
@@ -781,6 +784,7 @@ ENDcheckCnf
 
 BEGINactivateCnf
 CODESTARTactivateCnf
+	runModConf = pModConf;
 ENDactivateCnf
 
 BEGINfreeCnf

--- a/contrib/omfile-hardened/omfile-hardened.c
+++ b/contrib/omfile-hardened/omfile-hardened.c
@@ -650,7 +650,7 @@ prepareFile(instanceData *__restrict__ const pData, const uchar *__restrict__ co
 
 	if(pData->useSigprov)
 		sigprovPrepare(pData, szNameBuf);
-	
+
 finalize_it:
 	if(iRet != RS_RET_OK) {
 		if(pData->pStrm != NULL) {
@@ -682,7 +682,7 @@ fsCheck(instanceData *__restrict__ const pData, const uchar *__restrict__ const 
 	/* check if we have space available for all buffers to be flushed and for
 	 * a maximum lenght message, perhaps current msg size would be enough */
 	if (stat.f_bsize * stat.f_bavail <
-		pData->iIOBufSize * pData->iDynaFileCacheSize + (uint)(glbl.GetMaxLine()))
+		pData->iIOBufSize * pData->iDynaFileCacheSize + (uint)(glbl.GetMaxLine(runModConf->pConf)))
 		{
 			iRet = RS_RET_FS_ERR;
 			LogError(0, iRet, "too few available blocks in %s", path);
@@ -1002,7 +1002,7 @@ janitorChkDynaFiles(instanceData *__restrict__ const pData)
 				pData->iCurrElt = -1; /* no longer available! */
 			}
 		} else {
-			pCache[i]->nInactive += janitorInterval;
+			pCache[i]->nInactive += runModConf->pConf->globals.janitorInterval;
 		}
 	}
 }
@@ -1023,7 +1023,7 @@ janitorCB(void *pUsr)
 				STATSCOUNTER_INC(pData->ctrCloseTimeouts, pData->mutCtrCloseTimeouts);
 				closeFile(pData);
 			} else {
-				pData->nInactive += janitorInterval;
+				pData->nInactive += runModConf->pConf->globals.janitorInterval;
 			}
 		}
 	}

--- a/contrib/omrabbitmq/omrabbitmq.c
+++ b/contrib/omrabbitmq/omrabbitmq.c
@@ -44,6 +44,7 @@
 #include "cfsysline.h"
 #include "debug.h"
 #include "datetime.h"
+#include "rsconf.h"
 
 #include <sys/socket.h>
 
@@ -253,7 +254,7 @@ static int amqp_authenticate(wrkrInstanceData_t *self, amqp_connection_state_t a
 	amqp_rpc_reply_t ret;
 
 	/* define the frame size */
-	int frame_size = (glbl.GetMaxLine()<130000) ? 131072 : (glbl.GetMaxLine()+1072);
+	int frame_size = (glbl.GetMaxLine(runConf)<130000) ? 131072 : (glbl.GetMaxLine(runConf)+1072);
 
 	/* authenticate */
 	ret = amqp_login(a_conn, (char const *)self->pData->vhost, 1, frame_size, 0,

--- a/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
+++ b/contrib/pmaixforwardedfrom/pmaixforwardedfrom.c
@@ -39,6 +39,7 @@
 #include "parser.h"
 #include "datetime.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 
 MODULE_TYPE_PARSER
 MODULE_TYPE_NOKEEP
@@ -174,7 +175,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 
 	DBGPRINTF("aixforwardedfrom parser init called, compiled with version %s\n", VERSION);
-	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG();
+	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 	/* cache value, is set only during rsyslogd option processing */
 
 

--- a/contrib/pmcisconames/pmcisconames.c
+++ b/contrib/pmcisconames/pmcisconames.c
@@ -40,6 +40,7 @@
 #include "parser.h"
 #include "datetime.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 
 MODULE_TYPE_PARSER
 MODULE_TYPE_NOKEEP
@@ -174,7 +175,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 
 	DBGPRINTF("cisconames parser init called, compiled with version %s\n", VERSION);
-	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG();
+	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 	/* cache value, is set only during rsyslogd option processing */
 
 

--- a/contrib/pmpanngfw/pmpanngfw.c
+++ b/contrib/pmpanngfw/pmpanngfw.c
@@ -38,6 +38,7 @@
 #include "datetime.h"
 #include "unicode-helper.h"
 #include "typedefs.h"
+#include "rsconf.h"
 
 MODULE_TYPE_PARSER
 MODULE_TYPE_NOKEEP
@@ -285,7 +286,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 
 	DBGPRINTF("panngfw parser init called, compiled with version %s\n", VERSION);
-	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG();
+	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 	/* cache value, is set only during rsyslogd option processing */
 
 

--- a/contrib/pmsnare/pmsnare.c
+++ b/contrib/pmsnare/pmsnare.c
@@ -59,6 +59,7 @@
 #include "parser.h"
 #include "datetime.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 
 MODULE_TYPE_PARSER
 MODULE_TYPE_NOKEEP
@@ -117,7 +118,7 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
 	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
 	inst->next = NULL;
 	*pinst = inst;
-	
+
 	/*  Add to list of instances. */
 	if(modInstances == NULL) {
 		CHKmalloc(modInstances = malloc(sizeof(modInstances_t)));
@@ -151,7 +152,7 @@ CODESTARTnewParserInst
 	/* If using the old config, just use global settings for each instance. */
 	if (lst == NULL)
 		FINALIZE;
-	
+
 	/* If using the new config, process module settings for this instance. */
 	if((pvals = nvlstGetParams(lst, &parserpblk, NULL)) == NULL) {
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -177,7 +178,7 @@ CODESTARTnewParserInst
 			dbgprintf("pmsnare: program error, non-handled param '%s'\n", parserpblk.descr[i].name);
 		}
 	}
-	
+
 finalize_it:
 CODE_STD_FINALIZERnewParserInst
 	if(lst != NULL)
@@ -220,13 +221,13 @@ CODESTARTendCnfLoad
 	 * This can't be done any earlier because the config wasn't fully loaded until now. */
 	for(inst = modInstances->root; inst != NULL; inst = inst->next) {
 		if(inst->bEscapeCCOnRcv == -1)
-			inst->bEscapeCCOnRcv = glbl.GetParserEscapeControlCharactersOnReceive();
+			inst->bEscapeCCOnRcv = glbl.GetParserEscapeControlCharactersOnReceive(modConf->pConf);
 		if(inst->bEscapeTab == -1)
-			inst->bEscapeTab = glbl.GetParserEscapeControlCharacterTab();
+			inst->bEscapeTab = glbl.GetParserEscapeControlCharacterTab(modConf->pConf);
 		if(inst->bParserEscapeCCCStyle == -1)
-			inst->bParserEscapeCCCStyle = glbl.GetParserEscapeControlCharactersCStyle();
+			inst->bParserEscapeCCCStyle = glbl.GetParserEscapeControlCharactersCStyle(modConf->pConf);
 		if(inst->cCCEscapeChar == '\0')
-			inst->cCCEscapeChar = glbl.GetParserControlCharacterEscapePrefix();
+			inst->cCCEscapeChar = glbl.GetParserControlCharacterEscapePrefix(modConf->pConf);
 
 		/* Determine tab representation. Possible options:
 		 *		"#011"	escape on, escapetabs on, no change to prefix (default)
@@ -275,7 +276,7 @@ BEGINparse2
 	uchar *p2parse;
 	int lenMsg;
 	int snaremessage; /* 0 means not a snare message, otherwise it's the index of the tab after the tag  */
-	
+
 CODESTARTparse2
 	dbgprintf("Message will now be parsed by fix Snare parser.\n");
 	assert(pMsg != NULL);
@@ -383,7 +384,7 @@ CODESTARTparse2
 			snaremessage = p2parse - pMsg->pszRawMsg + 11;
 		}
 	}
-	
+
 	if(snaremessage) {
 		/* Skip to the end of the tag. */
 		p2parse = pMsg->pszRawMsg + snaremessage;
@@ -403,7 +404,7 @@ CODESTARTparse2
 
 		DBGPRINTF("pmsnare: new message: [%d]'%s'\n", lenMsg, pMsg->pszRawMsg + pMsg->offAfterPRI);
 	}
-	
+
 	ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 
 finalize_it:
@@ -435,7 +436,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 
 	DBGPRINTF("snare parser init called, compiled with version %s\n", VERSION);
-	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG();
+	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 	/* cache value, is set only during rsyslogd option processing */
 ENDmodInit
 

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -389,7 +389,7 @@ getStateFileDir(void)
 	const uchar *wrkdir;
 	assert(currModConf != NULL);
 	if(currModConf->stateFileDirectory == NULL) {
-		wrkdir = glblGetWorkDirRaw();
+		wrkdir = glblGetWorkDirRaw(currModConf->pConf);
 	} else {
 		wrkdir = currModConf->stateFileDirectory;
 	}
@@ -733,7 +733,7 @@ act_obj_add(fs_edge_t *const edge, const char *const name, const int is_file,
 	char basename[MAXFNAME];
 	DEFiRet;
 	int fd = -1;
-	
+
 	DBGPRINTF("act_obj_add: edge %p, name '%s' (source '%s')\n", edge, name, source? source : "---");
 
 	if (isIgnoreOlderFile(edge->instarr[0], name)) {

--- a/plugins/imgssapi/imgssapi.c
+++ b/plugins/imgssapi/imgssapi.c
@@ -59,7 +59,7 @@
 #include "glbl.h"
 #include "debug.h"
 #include "unlimited_select.h"
-
+#include "rsconf.h"
 
 MODULE_TYPE_INPUT
 MODULE_TYPE_NOKEEP
@@ -203,7 +203,7 @@ onSessAccept(tcpsrv_t *pThis, tcps_sess_t *pSess)
 {
 	DEFiRet;
 	gsssrv_t *pGSrv;
-	
+
 	pGSrv = (gsssrv_t*) pThis->pUsr;
 
 	if(pGSrv->allowedMethods & ALLOWEDMETHOD_GSS) {
@@ -438,7 +438,7 @@ OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess)
 	allowedMethods = pGSrv->allowedMethods;
 	if(allowedMethods & ALLOWEDMETHOD_GSS) {
 		int ret = 0;
-		const size_t bufsize = glbl.GetMaxLine();
+		const size_t bufsize = glbl.GetMaxLine(runConf);
 		CHKmalloc(buf = (char*) malloc(bufsize + 1));
 
 		prop.GetString(pSess->fromHostIP, &pszPeer, &lenPeer);
@@ -586,7 +586,7 @@ OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess)
 		gssutil.display_ctx_flags(*sess_flags);
 		pGSess->allowedMethods = ALLOWEDMETHOD_GSS;
 	}
-	
+
 finalize_it:
 	free(buf);
 	RETiRet;

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -67,6 +67,7 @@ DEFobjCurrIf(net)
 DEFobjCurrIf(statsobj)
 
 struct modConfData_s {
+	rsconf_t *pConf;
 	int bIgnPrevMsg;
 };
 
@@ -141,6 +142,8 @@ struct journalContext_s { /* structure encapsulating all the journald_API-relate
 	char *cursor; /* should point to last valid journald entry we processed */
 };
 static struct journalContext_s journalContext = {NULL, 0, 1, NULL};
+static modConfData_t *loadModConf = NULL;/* modConf ptr to use for the current load process */
+static modConfData_t *runModConf = NULL;/* modConf ptr to use for run process */
 
 #define J_PROCESS_PERIOD 1024  /* Call sd_journal_process() every 1,024 records */
 
@@ -158,7 +161,7 @@ static rsRetVal openJournal(void) {
 		LogError(-r, RS_RET_IO_ERROR, "imjournal: sd_journal_open() failed");
 		iRet = RS_RET_IO_ERROR;
 	}
-	if ((r = sd_journal_set_data_threshold(journalContext.j, glbl.GetMaxLine())) < 0) {
+	if ((r = sd_journal_set_data_threshold(journalContext.j, glbl.GetMaxLine(runModConf->pConf))) < 0) {
 		LogError(-r, RS_RET_IO_ERROR, "imjournal: sd_journal_set_data_threshold() failed");
 		iRet = RS_RET_IO_ERROR;
 	}
@@ -577,12 +580,14 @@ persistJournalState(void)
 		}
 		/* In order to guarantee physical write we need to force parent sync as well */
 		DIR *wd;
-		if (!(wd = opendir((char *)glbl.GetWorkDir()))) {
-			LogError(errno, RS_RET_IO_ERROR, "imjournal: failed to open '%s' directory", glbl.GetWorkDir());
+		if (!(wd = opendir((char *)glbl.GetWorkDir(runModConf->pConf)))) {
+			LogError(errno, RS_RET_IO_ERROR, "imjournal: failed to open '%s' directory",
+				glbl.GetWorkDir(runModConf->pConf));
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
 		if (fsync(dirfd(wd)) != 0) {
-			LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", glbl.GetWorkDir());
+			LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed",
+				glbl.GetWorkDir(runModConf->pConf));
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
 
@@ -884,6 +889,8 @@ ENDrunInput
 
 BEGINbeginCnfLoad
 CODESTARTbeginCnfLoad
+	loadModConf = pModConf;
+	pModConf->pConf = pConf;
 	bLegacyCnfModGlobalsPermitted = 1;
 
 	cs.bIgnoreNonValidStatefile = 1;
@@ -906,9 +913,10 @@ CODESTARTendCnfLoad
 	/* bad trick to handle old and new style config all in old-style var */
 	if(cs.stateFile != NULL && cs.stateFile[0] != '/') {
 		char *new_stateFile;
-		if (-1 == asprintf(&new_stateFile, "%s/%s", (char *)glbl.GetWorkDir(), cs.stateFile)) {
-			LogError(0, RS_RET_OUT_OF_MEMORY, "imjournal: asprintf failed\n");
-			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+		if (-1 == asprintf(&new_stateFile, "%s/%s",
+			(char *)glbl.GetWorkDir(loadModConf->pConf), cs.stateFile)) {
+				LogError(0, RS_RET_OUT_OF_MEMORY, "imjournal: asprintf failed\n");
+				ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 		}
 		free (cs.stateFile);
 		cs.stateFile = new_stateFile;
@@ -924,6 +932,7 @@ ENDcheckCnf
 
 BEGINactivateCnf
 CODESTARTactivateCnf
+	runModConf = pModConf;
 
 	/* support statistic gathering */
 	CHKiRet(statsobj.Construct(&(statsCounter.stats)));

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -309,7 +309,7 @@ finalize_it:
  */
 int klog_getMaxLine(void)
 {
-	return glbl.GetMaxLine();
+	return glbl.GetMaxLine(runConf);
 }
 
 

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -549,7 +549,7 @@ startupSrv(ptcpsrv_t *pSrv)
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_flags = AI_PASSIVE;
-	hints.ai_family = glbl.GetDefPFFamily();
+	hints.ai_family = glbl.GetDefPFFamily(runModConf->pConf);
 	hints.ai_socktype = SOCK_STREAM;
 
 	error = getaddrinfo((char*)pSrv->lstnIP, (char*) pSrv->port, &hints, &res);
@@ -762,7 +762,7 @@ getPeerNames(prop_t **peerName, prop_t **peerIP, struct sockaddr *pAddr, sbool b
 			ABORT_FINALIZE(RS_RET_INVALID_HNAME);
 		}
 
-		if (!glbl.GetDisableDNS()) {
+		if (!glbl.GetDisableDNS(runConf)) {
 			error = getnameinfo(pAddr, SALEN(pAddr), (char *) szHname, NI_MAXHOST, NULL, 0, NI_NAMEREQD);
 			if (error == 0) {
 				memset(&hints, 0, sizeof(struct addrinfo));
@@ -1282,7 +1282,7 @@ DataRcvdUncompressed(ptcpsess_t *pThis, char *pData, size_t iLen, struct syslogT
 
 	iRet = multiSubmitFlush(&multiSub);
 
-	if(glblSenderKeepTrack)
+	if(runConf->globals.senderKeepTrack)
 		statsRecordSender(propGetSzStr(pThis->peerName), nMsgs, ttGenTime);
 
 finalize_it:
@@ -2386,7 +2386,7 @@ ENDcheckCnf
 BEGINactivateCnfPrePrivDrop
 	instanceConf_t *inst;
 CODESTARTactivateCnfPrePrivDrop
-	iMaxLine = glbl.GetMaxLine(); /* get maximum size we currently support */
+	iMaxLine = glbl.GetMaxLine(runConf); /* get maximum size we currently support */
 	DBGPRINTF("imptcp: config params iMaxLine %d\n", iMaxLine);
 
 	runModConf = pModConf;

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -379,13 +379,13 @@ addListner(modConfData_t __attribute__((unused)) *modConf, instanceConf_t *inst)
 	if(pRelpEngine == NULL) {
 		CHKiRet(relpEngineConstruct(&pRelpEngine));
 		CHKiRet(relpEngineSetDbgprint(pRelpEngine, (void (*)(char *, ...))imrelp_dbgprintf));
-		CHKiRet(relpEngineSetFamily(pRelpEngine, glbl.GetDefPFFamily()));
+		CHKiRet(relpEngineSetFamily(pRelpEngine, glbl.GetDefPFFamily(runModConf->pConf)));
 		CHKiRet(relpEngineSetEnableCmd(pRelpEngine, (uchar*) "syslog", eRelpCmdState_Required));
 		CHKiRet(relpEngineSetSyslogRcv2(pRelpEngine, onSyslogRcv));
 		CHKiRet(relpEngineSetOnErr(pRelpEngine, onErr));
 		CHKiRet(relpEngineSetOnGenericErr(pRelpEngine, onGenericErr));
 		CHKiRet(relpEngineSetOnAuthErr(pRelpEngine, onAuthErr));
-		if (!glbl.GetDisableDNS()) {
+		if (!glbl.GetDisableDNS(runModConf->pConf)) {
 			CHKiRet(relpEngineSetDnsLookupMode(pRelpEngine, 1));
 		}
 		#if defined(HAVE_RELPENGINESETTLSLIBBYNAME)
@@ -768,9 +768,9 @@ CODESTARTcheckCnf
 			/* We set default value for maxDataSize here because
 			 * otherwise the maxMessageSize isn't set.
 			 */
-			inst->maxDataSize = glbl.GetMaxLine();
+			inst->maxDataSize = glbl.GetMaxLine(loadConf);
 		}
-		maxMessageSize = (size_t)glbl.GetMaxLine();
+		maxMessageSize = (size_t)glbl.GetMaxLine(loadConf);
 		if(inst->maxDataSize < maxMessageSize) {
 			LogError(0, RS_RET_INVALID_PARAMS, "error: "
 					"maxDataSize (%zu) is smaller than global parameter "

--- a/plugins/imsolaris/imsolaris.c
+++ b/plugins/imsolaris/imsolaris.c
@@ -84,6 +84,7 @@
 #include "prop.h"
 #include "sun_cddl.h"
 #include "datetime.h"
+#include "rsconf.h"
 
 MODULE_TYPE_INPUT
 MODULE_TYPE_NOKEEP
@@ -244,7 +245,7 @@ getMsgs(thrdInfo_t *pThrd, int timeout)
 	uchar bufRcv[4096+1];
 	char errStr[1024];
 
-	iMaxLine = glbl.GetMaxLine();
+	iMaxLine = glbl.GetMaxLine(runConf);
 
 	/* we optimize performance: if iMaxLine is below 4K (which it is in almost all
 	 * cases, we use a fixed buffer on the stack. Only if it is higher, heap memory

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -443,11 +443,11 @@ processPacket(struct lstn_s *lstn, struct sockaddr_storage *frominetPrev, int *p
 			 */
 			*pbIsPermitted = net.isAllowedSender2((uchar*)"UDP",
 					    (struct sockaddr *)frominet, "", 0);
-	
+
 			if(*pbIsPermitted == 0) {
 				DBGPRINTF("msg is not from an allowed sender\n");
 				STATSCOUNTER_INC(lstn->ctrDisallowed, lstn->mutCtrDisallowed);
-				if(glbl.GetOption_DisallowWarning) {
+				if(glbl.GetOptionDisallowWarning(runModConf->pConf)) {
 					LogError(0, NO_ERRCODE,
 						"imudp: UDP message from disallowed sender discarded");
 				}
@@ -1187,7 +1187,7 @@ BEGINactivateCnf
 	int lenRcvBuf;
 CODESTARTactivateCnf
 	/* caching various settings */
-	iMaxLine = glbl.GetMaxLine();
+	iMaxLine = glbl.GetMaxLine(runConf);
 	lenRcvBuf = iMaxLine + 1;
 #	ifdef HAVE_RECVMMSG
 	lenRcvBuf *= runModConf->batchSize;

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -41,6 +41,7 @@
 #include "errmsg.h"
 #include "cfsysline.h"
 #include "glbl.h"
+#include "rsconf.h"
 
 
 MODULE_TYPE_OUTPUT
@@ -393,7 +394,7 @@ cleanup(wrkrInstanceData_t *pWrkrData)
 	/* waitpid will fail with errno == ECHILD if the child process has already
 	   been reaped by the rsyslogd main loop (see rsyslogd.c) */
 	if(ret == pWrkrData->pid) {
-		glblReportChildProcessExit(pWrkrData->pData->szBinary, pWrkrData->pid, status);
+		glblReportChildProcessExit(runConf, pWrkrData->pData->szBinary, pWrkrData->pid, status);
 	}
 
 	if(pWrkrData->fdOutput != -1) {
@@ -442,7 +443,7 @@ callExtProg(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *__restrict
 	int bFreeInputstr = 1; /* we must only free if it does not point to msg-obj mem! */
 	const uchar *inputstr = NULL; /* string to be processed by external program */
 	DEFiRet;
-	
+
 	if(pWrkrData->pData->inputProp == INPUT_MSG) {
 		inputstr = getMSG(pMsg);
 		lenWrite = getMSGLen(pMsg);
@@ -512,7 +513,7 @@ CODESTARTdoAction
 	if(pWrkrData->bIsRunning == 0) {
 		openPipe(pWrkrData);
 	}
-	
+
 	iRet = callExtProg(pWrkrData, pMsg);
 
 	if(iRet != RS_RET_OK)

--- a/plugins/omgssapi/omgssapi.c
+++ b/plugins/omgssapi/omgssapi.c
@@ -54,6 +54,7 @@
 #include "tcpclt.h"
 #include "glbl.h"
 #include "errmsg.h"
+#include "rsconf.h"
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP
@@ -323,7 +324,7 @@ static rsRetVal TCPSendGSSSend(void *pvData, char *msg, size_t len)
 		gssutil.display_status((char*)"wrapping message", maj_stat, min_stat);
 		goto fail;
 	}
-	
+
 	if (gssutil.send_token(s, &out_buf) < 0) {
 		goto fail;
 	}
@@ -366,7 +367,7 @@ static rsRetVal doTryResume(instanceData *pData)
 		 * a common function.
 		 */
 		hints.ai_flags = AI_NUMERICSERV;
-		hints.ai_family = glbl.GetDefPFFamily();
+		hints.ai_family = glbl.GetDefPFFamily(runConf);
 		hints.ai_socktype = SOCK_STREAM;
 		if(getaddrinfo(pData->f_hname, getFwdSyslogPt(pData), &hints, &res) == 0) {
 			dbgprintf("%s found, resuming.\n", pData->f_hname);
@@ -413,7 +414,7 @@ CODESTARTdoAction
 
 	case eDestFORW:
 		dbgprintf(" %s:%s/%s\n", pData->f_hname, getFwdSyslogPt(pData), "tcp-gssapi");
-		iMaxLine = glbl.GetMaxLine();
+		iMaxLine = glbl.GetMaxLine(runConf);
 		psz = (char*) ppString[0];
 		l = strlen((char*) psz);
 		if((int) l > iMaxLine)
@@ -586,7 +587,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 			*(pData->port + i) = '\0';
 		}
 	}
-	
+
 
 	/* now skip to template */
 	bErr = 0;
@@ -620,7 +621,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	memset(&hints, 0, sizeof(hints));
 	/* port must be numeric, because config file syntax requests this */
 	hints.ai_flags = AI_NUMERICSERV;
-	hints.ai_family = glbl.GetDefPFFamily();
+	hints.ai_family = glbl.GetDefPFFamily(loadConf);
 	hints.ai_socktype = SOCK_STREAM;
 	if(getaddrinfo(pData->f_hname, getFwdSyslogPt(pData), &hints, &res) != 0) {
 		pData->eDestState = eDestFORW_UNKN;

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -48,6 +48,7 @@
 #include "errmsg.h"
 #include "cfsysline.h"
 #include "glbl.h"
+#include "rsconf.h"
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP
@@ -347,7 +348,7 @@ waitForChild(instanceData *pData, childProcessCtx_t *pChildCtx)
 	/* waitpid will fail with errno == ECHILD if the child process has already
 	   been reaped by the rsyslogd main loop (see rsyslogd.c) */
 	if(ret == pChildCtx->pid) {
-		glblReportChildProcessExit(pData->szBinary, pChildCtx->pid, status);
+		glblReportChildProcessExit(runConf, pData->szBinary, pChildCtx->pid, status);
 	}
 }
 
@@ -913,7 +914,7 @@ finalize_it:
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
 	pWrkrData->pChildCtx = NULL;
-	
+
 	if(pWrkrData->pData->pOutputCaptureCtx != NULL) {
 		CHKiRet(startOutputCaptureOnce(pWrkrData->pData->pOutputCaptureCtx));
 	}

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -390,6 +390,7 @@ setInstParamDefaults(instanceData *pData)
 BEGINbeginCnfLoad
 CODESTARTbeginCnfLoad
 	loadModConf = pModConf;
+	pModConf->pConf = pConf;
 	pModConf->tlslib = NULL;
 	/* create our relp engine */
 	CHKiRet(relpEngineConstruct(&pRelpEngine));
@@ -583,7 +584,7 @@ doConnect(wrkrInstanceData_t *const pWrkrData)
 	DEFiRet;
 
 	if(pWrkrData->bInitialConnect) {
-		iRet = relpCltConnect(pWrkrData->pRelpClt, glbl.GetDefPFFamily(),
+		iRet = relpCltConnect(pWrkrData->pRelpClt, glbl.GetDefPFFamily(runModConf->pConf),
 				      getRelpPt(pWrkrData->pData), pWrkrData->pData->target);
 		if(iRet == RELP_RET_OK)
 			pWrkrData->bInitialConnect = 0;
@@ -671,8 +672,8 @@ CODESTARTdoAction
 	lenMsg = strlen((char*) pMsg); /* TODO: don't we get this? */
 
 	/* we need to truncate oversize msgs - no way around that... */
-	if((int) lenMsg > glbl.GetMaxLine())
-		lenMsg = glbl.GetMaxLine();
+	if((int) lenMsg > glbl.GetMaxLine(runModConf->pConf))
+		lenMsg = glbl.GetMaxLine(runModConf->pConf);
 
 	/* forward */
 	ret = relpCltSendSyslog(pWrkrData->pRelpClt, (uchar*) pMsg, lenMsg);

--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -582,7 +582,7 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 	memset(&hints, 0, sizeof(hints));
 	/* port must be numeric, because config file syntax requires this */
 	hints.ai_flags = AI_NUMERICSERV;
-	hints.ai_family = glbl.GetDefPFFamily();
+	hints.ai_family = glbl.GetDefPFFamily(runModConf->pConf);
 	hints.ai_socktype = SOCK_DGRAM;
 	if((iErr = (getaddrinfo((char*)pData->host, (char*)getFwdPt(pData), &hints, &res))) != 0) {
 		DBGPRINTF("could not get addrinfo for hostname '%s':'%s': %d%s\n",
@@ -620,7 +620,7 @@ CODESTARTdoAction
 	DBGPRINTF(" %s:%s/omudpspoof, src '%s', msg strt '%.256s'\n", pWrkrData->pData->host,
 		  getFwdPt(pWrkrData->pData), ppString[1], ppString[0]);
 
-	iMaxLine = glbl.GetMaxLine();
+	iMaxLine = glbl.GetMaxLine(runModConf->pConf);
 	psz = (char*) ppString[0];
 	l = strlen((char*) psz);
 	if((int) l > iMaxLine)

--- a/plugins/omuxsock/omuxsock.c
+++ b/plugins/omuxsock/omuxsock.c
@@ -349,7 +349,7 @@ CODESTARTdoAction
 	pthread_mutex_lock(&mutDoAct);
 	CHKiRet(doTryResume(pWrkrData->pData));
 
-	iMaxLine = glbl.GetMaxLine();
+	iMaxLine = glbl.GetMaxLine(runModConf->pConf);
 
 	DBGPRINTF(" omuxsock:%s\n", pWrkrData->pData->sockName);
 
@@ -382,7 +382,7 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	if(*(p-1) == ';')
 		--p;
 	CHKiRet(cflineParseTemplateName(&p, *ppOMSR, 0, 0, getDfltTpl()));
-	
+
 	if(cs.sockName == NULL) {
 		LogError(0, RS_RET_NO_SOCK_CONFIGURED, "No output socket configured for omuxsock\n");
 		ABORT_FINALIZE(RS_RET_NO_SOCK_CONFIGURED);

--- a/plugins/pmlastmsg/pmlastmsg.c
+++ b/plugins/pmlastmsg/pmlastmsg.c
@@ -44,6 +44,7 @@
 #include "parser.h"
 #include "datetime.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 
 MODULE_TYPE_PARSER
 MODULE_TYPE_NOKEEP
@@ -158,7 +159,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 
 	dbgprintf("lastmsg parser init called, compiled with version %s\n", VERSION);
-	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG();
+	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 	/* cache value, is set only during rsyslogd option processing */
 
 

--- a/runtime/dnscache.h
+++ b/runtime/dnscache.h
@@ -28,6 +28,4 @@ rsRetVal ATTR_NONNULL(1, 5) dnscacheLookup(struct sockaddr_storage *const addr,
 	prop_t **const fqdn, prop_t **const fqdnLowerCase,
 	prop_t **const localName, prop_t **const ip);
 
-extern unsigned dnscacheDefaultTTL;
-extern int dnscacheEnableTTL;
 #endif /* #ifndef INCLUDED_DNSCACHE_H */

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -59,10 +59,6 @@
 #include "dnscache.h"
 #include "parser.h"
 
-#define REPORT_CHILD_PROCESS_EXITS_NONE 0
-#define REPORT_CHILD_PROCESS_EXITS_ERRORS 1
-#define REPORT_CHILD_PROCESS_EXITS_ALL 2
-
 /* some defaults */
 #ifndef DFLT_NETSTRM_DRVR
 #	define DFLT_NETSTRM_DRVR ((uchar*)"ptcp")
@@ -77,36 +73,9 @@ DEFobjCurrIf(net)
  * For this object, these variables are obviously what makes the "meat" of the
  * class...
  */
-int glblDebugOnShutdown = 0;	/* start debug log when we are shut down */
-#ifdef ENABLE_LIBLOGGING_STDLOG
-stdlog_channel_t stdlog_hdl = NULL;	/* handle to be used for stdlog */
-#endif
 
 static struct cnfobj *mainqCnfObj = NULL;/* main queue object, to be used later in startup sequence */
-#ifndef DFLT_INT_MSGS_SEV_FILTER
-	#define DFLT_INT_MSGS_SEV_FILTER 6	/* Warning level and more important */
-#endif
-int glblIntMsgsSeverityFilter = DFLT_INT_MSGS_SEV_FILTER;/* filter for logging internal messages by syslog sev. */
-int bProcessInternalMessages = 0;	/* Should rsyslog itself process internal messages?
-					 * 1 - yes
-					 * 0 - send them to libstdlog (e.g. to push to journal) or syslog()
-					 */
-static uchar *pszWorkDir = NULL;
-#ifdef ENABLE_LIBLOGGING_STDLOG
-static uchar *stdlog_chanspec = NULL;
-#endif
-static int bParseHOSTNAMEandTAG = 1;	/* parser modification (based on startup params!) */
 static int bPreserveFQDN = 0;		/* should FQDNs always be preserved? */
-static int iMaxLine = 8096;		/* maximum length of a syslog message */
-static uchar * oversizeMsgErrorFile = NULL;		/* File where oversize messages are written to */
-static int oversizeMsgInputMode = 0;	/* Mode which oversize messages will be forwarded */
-static int reportOversizeMsg = 1;	/* shall error messages be generated for oversize messages? */
-static int reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ERRORS;
-static int iGnuTLSLoglevel = 0;		/* Sets GNUTLS Debug Level */
-static int iDefPFFamily = PF_UNSPEC;     /* protocol family (IPv4, IPv6 or both) */
-static int bDropMalPTRMsgs = 0;/* Drop messages which have malicious PTR records during DNS lookup */
-static int option_DisallowWarning = 1;	/* complain if message from disallowed sender is received */
-static int bDisableDNS = 0; /* don't look up IP addresses of remote messages */
 static prop_t *propLocalIPIF = NULL;/* IP address to report for the local host (default is 127.0.0.1) */
 static int propLocalIPIF_set = 0;	/* is propLocalIPIF already set? */
 static prop_t *propLocalHostName = NULL;/* our hostname as FQDN - read-only after startup */
@@ -115,40 +84,12 @@ static uchar *LocalHostName = NULL;/* our hostname  - read-only after startup, e
 static uchar *LocalHostNameOverride = NULL;/* user-overridden hostname - read-only after startup */
 static uchar *LocalFQDNName = NULL;/* our hostname as FQDN - read-only after startup, except HUP */
 static uchar *LocalDomain = NULL;/* our local domain name  - read-only after startup, except HUP */
-static char **StripDomains = NULL;
-/* these domains may be stripped before writing logs  - r/o after s.u., never touched by init */
-static char **LocalHosts = NULL;
-/* these hosts are logged with their hostname  - read-only after startup, never touched by init */
-static uchar *pszDfltNetstrmDrvr = NULL; /* module name of default netstream driver */
-static uchar *pszDfltNetstrmDrvrCAF = NULL; /* default CA file for the netstrm driver */
-static uchar *pszDfltNetstrmDrvrKeyFile = NULL; /* default key file for the netstrm driver (server) */
-static uchar *pszDfltNetstrmDrvrCertFile = NULL; /* default cert file for the netstrm driver (server) */
 int bTerminateInputs = 0;		/* global switch that inputs shall terminate ASAP (1=> terminate) */
-static uchar cCCEscapeChar = '#'; /* character to be used to start an escape sequence for control chars */
-static int bDropTrailingLF = 1; /* drop trailing LF's on reception? */
-static int bEscapeCCOnRcv = 1; /* escape control characters on reception: 0 - no, 1 - yes */
-static int bSpaceLFOnRcv = 0; /* replace newlines with spaces on reception: 0 - no, 1 - yes */
-static int bEscape8BitChars = 0; /* escape characters > 127 on reception: 0 - no, 1 - yes */
-static int bEscapeTab = 1; /* escape tab control character when doing CC escapes: 0 - no, 1 - yes */
-static int bParserEscapeCCCStyle = 0; /* escape control characters in c style: 0 - no, 1 - yes */
-short janitorInterval = 10; /* interval (in minutes) at which the janitor runs */
-int glblReportNewSenders = 0;
-int glblReportGoneAwaySenders = 0;
-int glblSenderStatsTimeout = 12 * 60 * 60; /* 12 hr timeout for senders */
-int glblSenderKeepTrack = 0;  /* keep track of known senders? */
 int glblUnloadModules = 1;
-int bPermitSlashInProgramname = 0;
-int glblIntMsgRateLimitItv = 5;
-int glblIntMsgRateLimitBurst = 500;
 char** glblDbgFiles = NULL;
 size_t glblDbgFilesNum = 0;
 int glblDbgWhitelist = 1;
 int glblPermitCtlC = 0;
-int glblInputTimeoutShutdown = 1000; /* input shutdown timeout in ms */
-int glblShutdownQueueDoubleSize = 0;
-static const uchar * operatingStateFile = NULL;
-
-uint64_t glblDevOptions = 0; /* to be used by developers only */
 
 pid_t glbl_ourpid;
 #ifndef HAVE_ATOMIC_BUILTINS
@@ -260,16 +201,17 @@ static struct cnfparamvals *cnfparamvals = NULL;
  */
 
 int
-glblGetMaxLine(void)
+glblGetMaxLine(rsconf_t *cnf)
 {
-	return(iMaxLine);
+	assert(cnf != NULL);
+	return(cnf->globals.iMaxLine);
 }
 
 
 int
-GetGnuTLSLoglevel(void)
+GetGnuTLSLoglevel(rsconf_t *cnf)
 {
-	return(iGnuTLSLoglevel);
+	return(cnf->globals.iGnuTLSLoglevel);
 }
 
 /* define a macro for the simple properties' set and get functions
@@ -293,32 +235,52 @@ static dataType Get##nameFunc(void) \
 
 SIMP_PROP(PreserveFQDN, bPreserveFQDN, int)
 SIMP_PROP(mainqCnfObj, mainqCnfObj, struct cnfobj *)
-SIMP_PROP(DropMalPTRMsgs, bDropMalPTRMsgs, int)
-SIMP_PROP(StripDomains, StripDomains, char**)
-SIMP_PROP(LocalHosts, LocalHosts, char**)
-SIMP_PROP(ParserControlCharacterEscapePrefix, cCCEscapeChar, uchar)
-SIMP_PROP(ParserDropTrailingLFOnReception, bDropTrailingLF, int)
-SIMP_PROP(ParserEscapeControlCharactersOnReceive, bEscapeCCOnRcv, int)
-SIMP_PROP(ParserSpaceLFOnReceive, bSpaceLFOnRcv, int)
-SIMP_PROP(ParserEscape8BitCharactersOnReceive, bEscape8BitChars, int)
-SIMP_PROP(ParserEscapeControlCharacterTab, bEscapeTab, int)
-SIMP_PROP(ParserEscapeControlCharactersCStyle, bParserEscapeCCCStyle, int)
 #ifdef USE_UNLIMITED_SELECT
 SIMP_PROP(FdSetSize, iFdSetSize, int)
 #endif
-
-SIMP_PROP_SET(DfltNetstrmDrvr, pszDfltNetstrmDrvr, uchar*) /* TODO: use custom function which frees existing value */
-SIMP_PROP_SET(DfltNetstrmDrvrCAF, pszDfltNetstrmDrvrCAF, uchar*)
-/* TODO: use custom function which frees existing value */
-SIMP_PROP_SET(DfltNetstrmDrvrKeyFile, pszDfltNetstrmDrvrKeyFile, uchar*)
-/* TODO: use custom function which frees existing value */
-SIMP_PROP_SET(DfltNetstrmDrvrCertFile, pszDfltNetstrmDrvrCertFile, uchar*)
-/* TODO: use custom function which frees existing value */
 
 #undef SIMP_PROP
 #undef SIMP_PROP_SET
 #undef SIMP_PROP_GET
 
+/* This is based on the previous SIMP_PROP but as a getter it uses
+ * additional parameter specifying the configuration it belongs to.
+ * The setter uses loadConf
+ */
+#define SIMP_PROP(nameFunc, nameVar, dataType) \
+	SIMP_PROP_GET(nameFunc, nameVar, dataType) \
+	SIMP_PROP_SET(nameFunc, nameVar, dataType)
+#define SIMP_PROP_SET(nameFunc, nameVar, dataType) \
+static rsRetVal Set##nameFunc(dataType newVal) \
+{ \
+	loadConf->globals.nameVar = newVal; \
+	return RS_RET_OK; \
+}
+#define SIMP_PROP_GET(nameFunc, nameVar, dataType) \
+static dataType Get##nameFunc(rsconf_t *cnf) \
+{ \
+	return(cnf->globals.nameVar); \
+}
+
+SIMP_PROP(DropMalPTRMsgs, bDropMalPTRMsgs, int)
+SIMP_PROP(DisableDNS, bDisableDNS, int)
+SIMP_PROP(ParserEscapeControlCharactersCStyle, parser.bParserEscapeCCCStyle, int)
+SIMP_PROP(ParseHOSTNAMEandTAG, parser.bParseHOSTNAMEandTAG, int)
+SIMP_PROP(OptionDisallowWarning, optionDisallowWarning, int)
+/* We omit setter on purpose, because we want to customize it */
+SIMP_PROP_GET(DfltNetstrmDrvrCAF, pszDfltNetstrmDrvrCAF, uchar*)
+SIMP_PROP_GET(DfltNetstrmDrvrCertFile, pszDfltNetstrmDrvrCertFile, uchar*)
+SIMP_PROP_GET(DfltNetstrmDrvrKeyFile, pszDfltNetstrmDrvrKeyFile, uchar*)
+SIMP_PROP_GET(ParserControlCharacterEscapePrefix, parser.cCCEscapeChar, uchar)
+SIMP_PROP_GET(ParserDropTrailingLFOnReception, parser.bDropTrailingLF, int)
+SIMP_PROP_GET(ParserEscapeControlCharactersOnReceive, parser.bEscapeCCOnRcv, int)
+SIMP_PROP_GET(ParserSpaceLFOnReceive, parser.bSpaceLFOnRcv, int)
+SIMP_PROP_GET(ParserEscape8BitCharactersOnReceive, parser.bEscape8BitChars, int)
+SIMP_PROP_GET(ParserEscapeControlCharacterTab, parser.bEscapeTab, int)
+
+#undef SIMP_PROP
+#undef SIMP_PROP_SET
+#undef SIMP_PROP_GET
 
 /* return global input termination status
  * rgerhards, 2009-07-20
@@ -438,13 +400,119 @@ static rsRetVal setWorkDir(void __attribute__((unused)) *pVal, uchar *pNewVal)
 		ABORT_FINALIZE(RS_RET_ERR_WRKDIR);
 	}
 
-	free(pszWorkDir);
-	pszWorkDir = pNewVal;
+	free(loadConf->globals.pszWorkDir);
+	loadConf->globals.pszWorkDir = pNewVal;
 
 finalize_it:
 	RETiRet;
 }
 
+
+static rsRetVal
+setDfltNetstrmDrvrCAF(void __attribute__((unused)) *pVal, uchar *pNewVal) {
+	DEFiRet;
+	FILE *fp;
+	free(loadConf->globals.pszDfltNetstrmDrvrCAF);
+	fp = fopen((const char*)pNewVal, "r");
+	if(fp == NULL) {
+		LogError(errno, RS_RET_NO_FILE_ACCESS,
+			"error: defaultnetstreamdrivercafile file '%s' "
+			"could not be accessed", pNewVal);
+	} else {
+		fclose(fp);
+		loadConf->globals.pszDfltNetstrmDrvrCAF = pNewVal;
+	}
+
+	RETiRet;
+}
+
+static rsRetVal
+setDfltNetstrmDrvrCertFile(void __attribute__((unused)) *pVal, uchar *pNewVal) {
+	DEFiRet;
+	FILE *fp;
+
+	free(loadConf->globals.pszDfltNetstrmDrvrCertFile);
+	fp = fopen((const char*)pNewVal, "r");
+	if(fp == NULL) {
+		LogError(errno, RS_RET_NO_FILE_ACCESS,
+			"error: defaultnetstreamdrivercertfile '%s' "
+			"could not be accessed", pNewVal);
+	} else {
+		fclose(fp);
+		loadConf->globals.pszDfltNetstrmDrvrCertFile = pNewVal;
+	}
+
+	RETiRet;
+}
+
+static rsRetVal
+setDfltNetstrmDrvrKeyFile(void __attribute__((unused)) *pVal, uchar *pNewVal) {
+	DEFiRet;
+	FILE *fp;
+
+	free(loadConf->globals.pszDfltNetstrmDrvrKeyFile);
+	fp = fopen((const char*)pNewVal, "r");
+	if(fp == NULL) {
+		LogError(errno, RS_RET_NO_FILE_ACCESS,
+			"error: defaultnetstreamdriverkeyfile '%s' "
+			"could not be accessed", pNewVal);
+	} else {
+		fclose(fp);
+		loadConf->globals.pszDfltNetstrmDrvrKeyFile = pNewVal;
+	}
+
+	RETiRet;
+}
+
+static rsRetVal
+setDfltNetstrmDrvr(void __attribute__((unused)) *pVal, uchar *pNewVal) {
+	DEFiRet;
+	free(loadConf->globals.pszDfltNetstrmDrvr);
+	loadConf->globals.pszDfltNetstrmDrvr = pNewVal;
+	RETiRet;
+}
+
+static rsRetVal
+setParserControlCharacterEscapePrefix(void __attribute__((unused)) *pVal, uchar *pNewVal) {
+	DEFiRet;
+	loadConf->globals.parser.cCCEscapeChar = *pNewVal;
+	RETiRet;
+}
+
+static rsRetVal
+setParserDropTrailingLFOnReception(void __attribute__((unused)) *pVal, int pNewVal) {
+	DEFiRet;
+	loadConf->globals.parser.bDropTrailingLF = pNewVal;
+	RETiRet;
+}
+
+static rsRetVal
+setParserEscapeControlCharactersOnReceive(void __attribute__((unused)) *pVal, int pNewVal) {
+	DEFiRet;
+	loadConf->globals.parser.bEscapeCCOnRcv = pNewVal;
+	RETiRet;
+}
+
+static rsRetVal
+setParserSpaceLFOnReceive(void __attribute__((unused)) *pVal, int pNewVal) {
+	DEFiRet;
+	loadConf->globals.parser.bSpaceLFOnRcv = pNewVal;
+	RETiRet;
+}
+
+static rsRetVal
+setParserEscape8BitCharactersOnReceive(void __attribute__((unused)) *pVal, int pNewVal) {
+	DEFiRet;
+	loadConf->globals.parser.bEscape8BitChars = pNewVal;
+	RETiRet;
+}
+
+static rsRetVal
+setParserEscapeControlCharacterTab(void __attribute__((unused)) *pVal, int pNewVal) {
+	DEFiRet;
+	loadConf->globals.parser.bEscapeTab = pNewVal;
+	RETiRet;
+}
 
 /* This function is used both by legacy and RainerScript conf. It is a real setter. */
 static void
@@ -454,13 +522,13 @@ setMaxLine(const int64_t iNew)
 		LogError(0, RS_RET_INVALID_VALUE, "maxMessageSize tried to set "
 				"to %lld, but cannot be less than 128 - set to 128 "
 				"instead", (long long) iNew);
-		iMaxLine = 128;
+		loadConf->globals.iMaxLine = 128;
 	} else if(iNew > (int64_t) INT_MAX) {
 		LogError(0, RS_RET_INVALID_VALUE, "maxMessageSize larger than "
 				"INT_MAX (%d) - reduced to INT_MAX", INT_MAX);
-		iMaxLine = INT_MAX;
+		loadConf->globals.iMaxLine = INT_MAX;
 	} else {
-		iMaxLine = (int) iNew;
+		loadConf->globals.iMaxLine = (int) iNew;
 	}
 }
 
@@ -497,13 +565,13 @@ setOversizeMsgInputMode(const uchar *const mode)
 {
 	DEFiRet;
 	if(!strcmp((char*)mode, "truncate")) {
-		oversizeMsgInputMode = glblOversizeMsgInputMode_Truncate;
+		loadConf->globals.oversizeMsgInputMode = glblOversizeMsgInputMode_Truncate;
 	} else if(!strcmp((char*)mode, "split")) {
-		oversizeMsgInputMode = glblOversizeMsgInputMode_Split;
+		loadConf->globals.oversizeMsgInputMode = glblOversizeMsgInputMode_Split;
 	} else if(!strcmp((char*)mode, "accept")) {
-		oversizeMsgInputMode = glblOversizeMsgInputMode_Accept;
+		loadConf->globals.oversizeMsgInputMode = glblOversizeMsgInputMode_Accept;
 	} else {
-		oversizeMsgInputMode = glblOversizeMsgInputMode_Truncate;
+		loadConf->globals.oversizeMsgInputMode = glblOversizeMsgInputMode_Truncate;
 	}
 	RETiRet;
 }
@@ -513,11 +581,11 @@ setReportChildProcessExits(const uchar *const mode)
 {
 	DEFiRet;
 	if(!strcmp((char*)mode, "none")) {
-		reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_NONE;
+		loadConf->globals.reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_NONE;
 	} else if(!strcmp((char*)mode, "errors")) {
-		reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ERRORS;
+		loadConf->globals.reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ERRORS;
 	} else if(!strcmp((char*)mode, "all")) {
-		reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ALL;
+		loadConf->globals.reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ALL;
 	} else {
 		LogError(0, RS_RET_CONF_PARAM_INVLD,
 				"invalid value '%s' for global parameter reportChildProcessExits -- ignored",
@@ -527,57 +595,10 @@ setReportChildProcessExits(const uchar *const mode)
 	RETiRet;
 }
 
-static rsRetVal
-setDisableDNS(int val)
-{
-	bDisableDNS = val;
-	return RS_RET_OK;
-}
-
 static int
-getDisableDNS(void)
+getDefPFFamily(rsconf_t *cnf)
 {
-	return bDisableDNS;
-}
-
-static rsRetVal
-setOption_DisallowWarning(int val)
-{
-	option_DisallowWarning = val;
-	return RS_RET_OK;
-}
-
-static int
-getOption_DisallowWarning(void)
-{
-	return option_DisallowWarning;
-}
-
-static rsRetVal
-setParseHOSTNAMEandTAG(int val)
-{
-	bParseHOSTNAMEandTAG = val;
-	return RS_RET_OK;
-}
-
-static int
-getParseHOSTNAMEandTAG(void)
-{
-	return bParseHOSTNAMEandTAG;
-}
-
-static rsRetVal
-setDefPFFamily(int level)
-{
-	DEFiRet;
-	iDefPFFamily = level;
-	RETiRet;
-}
-
-static int
-getDefPFFamily(void)
-{
-	return iDefPFFamily;
+	return cnf->globals.iDefPFFamily;
 }
 
 /* return our local IP.
@@ -645,29 +666,29 @@ done:
 /* return the name of the file where oversize messages are written to
  */
 uchar*
-glblGetOversizeMsgErrorFile(void)
+glblGetOversizeMsgErrorFile(rsconf_t *cnf)
 {
-	return oversizeMsgErrorFile;
+	return cnf->globals.oversizeMsgErrorFile;
 }
 
 const uchar*
-glblGetOperatingStateFile(void)
+glblGetOperatingStateFile(rsconf_t *cnf)
 {
-	return operatingStateFile;
+	return cnf->globals.operatingStateFile;
 }
 
 /* return the mode with which oversize messages will be put forward
  */
 int
-glblGetOversizeMsgInputMode(void)
+glblGetOversizeMsgInputMode(rsconf_t *cnf)
 {
-	return oversizeMsgInputMode;
+	return cnf->globals.oversizeMsgInputMode;
 }
 
 int
-glblReportOversizeMessage(void)
+glblReportOversizeMessage(rsconf_t *cnf)
 {
-	return reportOversizeMsg;
+	return cnf->globals.reportOversizeMsg;
 }
 
 
@@ -675,12 +696,12 @@ glblReportOversizeMessage(void)
  * If name != NULL, prints it as the program name.
  */
 void
-glblReportChildProcessExit(const uchar *name, pid_t pid, int status)
+glblReportChildProcessExit(rsconf_t *cnf, const uchar *name, pid_t pid, int status)
 {
 	DBGPRINTF("waitpid for child %ld returned status: %2.2x\n", (long) pid, status);
 
-	if(reportChildProcessExits == REPORT_CHILD_PROCESS_EXITS_NONE
-		|| (reportChildProcessExits == REPORT_CHILD_PROCESS_EXITS_ERRORS
+	if(cnf->globals.reportChildProcessExits == REPORT_CHILD_PROCESS_EXITS_NONE
+		|| (cnf->globals.reportChildProcessExits == REPORT_CHILD_PROCESS_EXITS_ERRORS
 			&& WIFEXITED(status) && WEXITSTATUS(status) == 0)) {
 		return;
 	}
@@ -816,51 +837,26 @@ GetLocalFQDNName(void)
 
 /* return the current working directory */
 static uchar*
-GetWorkDir(void)
+GetWorkDir(rsconf_t *cnf)
 {
-	return(pszWorkDir == NULL ? (uchar*) "" : pszWorkDir);
+	return(cnf->globals.pszWorkDir == NULL ? (uchar*) "" : cnf->globals.pszWorkDir);
 }
 
 /* return the "raw" working directory, which means
  * NULL if unset.
  */
 const uchar *
-glblGetWorkDirRaw(void)
+glblGetWorkDirRaw(rsconf_t *cnf)
 {
-	return pszWorkDir;
+	return cnf->globals.pszWorkDir;
 }
 
 /* return the current default netstream driver */
 static uchar*
-GetDfltNetstrmDrvr(void)
+GetDfltNetstrmDrvr(rsconf_t *cnf)
 {
-	return(pszDfltNetstrmDrvr == NULL ? DFLT_NETSTRM_DRVR : pszDfltNetstrmDrvr);
+	return(cnf->globals.pszDfltNetstrmDrvr == NULL ? DFLT_NETSTRM_DRVR : cnf->globals.pszDfltNetstrmDrvr);
 }
-
-
-/* return the current default netstream driver CA File */
-static uchar*
-GetDfltNetstrmDrvrCAF(void)
-{
-	return(pszDfltNetstrmDrvrCAF);
-}
-
-
-/* return the current default netstream driver key File */
-static uchar*
-GetDfltNetstrmDrvrKeyFile(void)
-{
-	return(pszDfltNetstrmDrvrKeyFile);
-}
-
-
-/* return the current default netstream driver certificate File */
-static uchar*
-GetDfltNetstrmDrvrCertFile(void)
-{
-	return(pszDfltNetstrmDrvrCertFile);
-}
-
 
 /* [ar] Source IP for local client to be used on multihomed host */
 static rsRetVal
@@ -901,15 +897,20 @@ CODESTARTobjQueryInterface(glbl)
 	pIf->GetGlobalInputTermState = GetGlobalInputTermState;
 	pIf->GetSourceIPofLocalClient = GetSourceIPofLocalClient;	/* [ar] */
 	pIf->SetSourceIPofLocalClient = SetSourceIPofLocalClient;	/* [ar] */
-	pIf->SetDefPFFamily = setDefPFFamily;
 	pIf->GetDefPFFamily = getDefPFFamily;
-	pIf->SetDisableDNS = setDisableDNS;
-	pIf->GetDisableDNS = getDisableDNS;
+	pIf->GetDisableDNS = GetDisableDNS;
 	pIf->GetMaxLine = glblGetMaxLine;
-	pIf->SetOption_DisallowWarning = setOption_DisallowWarning;
-	pIf->GetOption_DisallowWarning = getOption_DisallowWarning;
-	pIf->SetParseHOSTNAMEandTAG = setParseHOSTNAMEandTAG;
-	pIf->GetParseHOSTNAMEandTAG = getParseHOSTNAMEandTAG;
+	pIf->GetOptionDisallowWarning = GetOptionDisallowWarning;
+	pIf->GetDfltNetstrmDrvrCAF = GetDfltNetstrmDrvrCAF;
+	pIf->GetDfltNetstrmDrvrCertFile = GetDfltNetstrmDrvrCertFile;
+	pIf->GetDfltNetstrmDrvrKeyFile = GetDfltNetstrmDrvrKeyFile;
+	pIf->GetDfltNetstrmDrvr = GetDfltNetstrmDrvr;
+	pIf->GetParserControlCharacterEscapePrefix = GetParserControlCharacterEscapePrefix;
+	pIf->GetParserDropTrailingLFOnReception = GetParserDropTrailingLFOnReception;
+	pIf->GetParserEscapeControlCharactersOnReceive = GetParserEscapeControlCharactersOnReceive;
+	pIf->GetParserSpaceLFOnReceive = GetParserSpaceLFOnReceive;
+	pIf->GetParserEscape8BitCharactersOnReceive = GetParserEscape8BitCharactersOnReceive;
+	pIf->GetParserEscapeControlCharacterTab = GetParserEscapeControlCharacterTab;
 #define SIMP_PROP(name) \
 	pIf->Get##name = Get##name; \
 	pIf->Set##name = Set##name;
@@ -919,19 +920,8 @@ CODESTARTobjQueryInterface(glbl)
 	SIMP_PROP(LocalFQDNName)
 	SIMP_PROP(LocalHostName)
 	SIMP_PROP(LocalDomain)
-	SIMP_PROP(StripDomains)
-	SIMP_PROP(LocalHosts)
-	SIMP_PROP(ParserControlCharacterEscapePrefix)
-	SIMP_PROP(ParserDropTrailingLFOnReception)
-	SIMP_PROP(ParserEscapeControlCharactersOnReceive)
-	SIMP_PROP(ParserSpaceLFOnReceive)
-	SIMP_PROP(ParserEscape8BitCharactersOnReceive)
-	SIMP_PROP(ParserEscapeControlCharacterTab)
 	SIMP_PROP(ParserEscapeControlCharactersCStyle)
-	SIMP_PROP(DfltNetstrmDrvr)
-	SIMP_PROP(DfltNetstrmDrvrCAF)
-	SIMP_PROP(DfltNetstrmDrvrKeyFile)
-	SIMP_PROP(DfltNetstrmDrvrCertFile)
+	SIMP_PROP(ParseHOSTNAMEandTAG)
 #ifdef USE_UNLIMITED_SELECT
 	SIMP_PROP(FdSetSize)
 #endif
@@ -944,35 +934,35 @@ ENDobjQueryInterface(glbl)
  */
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __attribute__((unused)) *pVal)
 {
-	free(pszDfltNetstrmDrvr);
-	pszDfltNetstrmDrvr = NULL;
-	free(pszDfltNetstrmDrvrCAF);
-	pszDfltNetstrmDrvrCAF = NULL;
-	free(pszDfltNetstrmDrvrKeyFile);
-	pszDfltNetstrmDrvrKeyFile = NULL;
-	free(pszDfltNetstrmDrvrCertFile);
-	pszDfltNetstrmDrvrCertFile = NULL;
+	free(loadConf->globals.pszDfltNetstrmDrvr);
+	loadConf->globals.pszDfltNetstrmDrvr = NULL;
+	free(loadConf->globals.pszDfltNetstrmDrvrCAF);
+	loadConf->globals.pszDfltNetstrmDrvrCAF = NULL;
+	free(loadConf->globals.pszDfltNetstrmDrvrKeyFile);
+	loadConf->globals.pszDfltNetstrmDrvrKeyFile = NULL;
+	free(loadConf->globals.pszDfltNetstrmDrvrCertFile);
+	loadConf->globals.pszDfltNetstrmDrvrCertFile = NULL;
 	free(LocalHostNameOverride);
 	LocalHostNameOverride = NULL;
-	free(oversizeMsgErrorFile);
-	oversizeMsgErrorFile = NULL;
-	oversizeMsgInputMode = glblOversizeMsgInputMode_Accept;
-	reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ERRORS;
-	free(pszWorkDir);
-	pszWorkDir = NULL;
-	free((void*)operatingStateFile);
-	operatingStateFile = NULL;
-	bDropMalPTRMsgs = 0;
+	free(loadConf->globals.oversizeMsgErrorFile);
+	loadConf->globals.oversizeMsgErrorFile = NULL;
+	loadConf->globals.oversizeMsgInputMode = glblOversizeMsgInputMode_Accept;
+	loadConf->globals.reportChildProcessExits = REPORT_CHILD_PROCESS_EXITS_ERRORS;
+	free(loadConf->globals.pszWorkDir);
+	loadConf->globals.pszWorkDir = NULL;
+	free((void*)loadConf->globals.operatingStateFile);
+	loadConf->globals.operatingStateFile = NULL;
+	loadConf->globals.bDropMalPTRMsgs = 0;
 	bPreserveFQDN = 0;
-	iMaxLine = 8192;
-	cCCEscapeChar = '#';
-	bDropTrailingLF = 1;
-	reportOversizeMsg = 1;
-	bEscapeCCOnRcv = 1; /* default is to escape control characters */
-	bSpaceLFOnRcv = 0;
-	bEscape8BitChars = 0; /* default is not to escape control characters */
-	bEscapeTab = 1; /* default is to escape tab characters */
-	bParserEscapeCCCStyle = 0;
+	loadConf->globals.iMaxLine = 8192;
+	loadConf->globals.reportOversizeMsg = 1;
+	loadConf->globals.parser.cCCEscapeChar = '#';
+	loadConf->globals.parser.bDropTrailingLF = 1;
+	loadConf->globals.parser.bEscapeCCOnRcv = 1; /* default is to escape control characters */
+	loadConf->globals.parser.bSpaceLFOnRcv = 0;
+	loadConf->globals.parser.bEscape8BitChars = 0; /* default is not to escape control characters */
+	loadConf->globals.parser.bEscapeTab = 1; /* default is to escape tab characters */
+	loadConf->globals.parser.bParserEscapeCCCStyle = 0;
 #ifdef USE_UNLIMITED_SELECT
 	iFdSetSize = howmany(FD_SETSIZE, __NFDBITS) * sizeof (fd_mask);
 #endif
@@ -1166,10 +1156,10 @@ glblProcessCnf(struct cnfobj *o)
 		if(!cnfparamvals[i].bUsed)
 			continue;
 		if(!strcmp(paramblk.descr[i].name, "processinternalmessages")) {
-			bProcessInternalMessages = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.bProcessInternalMessages = (int) cnfparamvals[i].val.d.n;
 			cnfparamvals[i].bUsed = TRUE;
 		} else if(!strcmp(paramblk.descr[i].name, "internal.developeronly.options")) {
-			glblDevOptions = (uint64_t) cnfparamvals[i].val.d.n;
+			loadConf->globals.glblDevOptions = (uint64_t) cnfparamvals[i].val.d.n;
 			cnfparamvals[i].bUsed = TRUE;
 		} else if(!strcmp(paramblk.descr[i].name, "stdlog.channelspec")) {
 #ifndef ENABLE_LIBLOGGING_STDLOG
@@ -1178,20 +1168,21 @@ glblProcessCnf(struct cnfobj *o)
 				"The 'stdlog.channelspec' parameter "
 				"is ignored. Note: the syslog API is used instead.\n");
 #else
-			stdlog_chanspec = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			loadConf->globals.stdlog_chanspec = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 			/* we need to re-open with the new channel */
-			stdlog_close(stdlog_hdl);
-			stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG,
-					(char*) stdlog_chanspec);
+			stdlog_close(loadConf->globals.stdlog_hdl);
+			loadConf->globals.stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG,
+					(char*) loadConf->globals.stdlog_chanspec);
 			cnfparamvals[i].bUsed = TRUE;
 #endif
 		} else if(!strcmp(paramblk.descr[i].name, "operatingstatefile")) {
-			if(operatingStateFile != NULL) {
+			if(loadConf->globals.operatingStateFile != NULL) {
 				LogError(errno, RS_RET_PARAM_ERROR,
 					"error: operatingStateFile already set to '%s' - "
-					"new value ignored", operatingStateFile);
+					"new value ignored", loadConf->globals.operatingStateFile);
 			} else {
-				operatingStateFile = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+				loadConf->globals.operatingStateFile =
+					(uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 				osf_open();
 			}
 		} else if(!strcmp(paramblk.descr[i].name, "security.abortonidresolutionfail")) {
@@ -1294,7 +1285,6 @@ glblDoneLoadCnf(void)
 {
 	int i;
 	unsigned char *cstr;
-	FILE *fp;
 	DEFiRet;
 	CHKiRet(objUse(net, CORE_COMPONENT));
 
@@ -1323,61 +1313,33 @@ glblDoneLoadCnf(void)
 			LocalHostNameOverride = (uchar*)
 				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdriverkeyfile")) {
-			free(pszDfltNetstrmDrvrKeyFile);
-			uchar *const fn = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
-			fp = fopen((const char*)fn, "r");
-			if(fp == NULL) {
-				LogError(errno, RS_RET_NO_FILE_ACCESS,
-					"error: defaultnetstreamdriverkeyfile '%s' "
-					"could not be accessed", fn);
-			} else {
-				fclose(fp);
-				pszDfltNetstrmDrvrKeyFile = fn;
-			}
+			cstr = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			setDfltNetstrmDrvrKeyFile(NULL, cstr);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercertfile")) {
-			free(pszDfltNetstrmDrvrCertFile);
-			uchar *const fn = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
-			fp = fopen((const char*)fn, "r");
-			if(fp == NULL) {
-				LogError(errno, RS_RET_NO_FILE_ACCESS,
-					"error: defaultnetstreamdrivercertfile '%s' "
-					"could not be accessed", fn);
-			} else {
-				fclose(fp);
-				pszDfltNetstrmDrvrCertFile = fn;
-			}
+			cstr = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			setDfltNetstrmDrvrCertFile(NULL, cstr);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdrivercafile")) {
-			free(pszDfltNetstrmDrvrCAF);
-			uchar *const fn = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
-			fp = fopen((const char*)fn, "r");
-			if(fp == NULL) {
-				LogError(errno, RS_RET_NO_FILE_ACCESS,
-					"error: defaultnetstreamdrivercafile file '%s' "
-					"could not be accessed", fn);
-			} else {
-				fclose(fp);
-				pszDfltNetstrmDrvrCAF = fn;
-			}
+			cstr = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			setDfltNetstrmDrvrCAF(NULL, cstr);
 		} else if(!strcmp(paramblk.descr[i].name, "defaultnetstreamdriver")) {
-			free(pszDfltNetstrmDrvr);
-			pszDfltNetstrmDrvr = (uchar*)
-				es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			cstr = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			setDfltNetstrmDrvr(NULL, cstr);
 		} else if(!strcmp(paramblk.descr[i].name, "preservefqdn")) {
 			bPreserveFQDN = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name,
 				"dropmsgswithmaliciousdnsptrrecords")) {
-			bDropMalPTRMsgs = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.bDropMalPTRMsgs = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "action.reportsuspension")) {
-			bActionReportSuspension = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.bActionReportSuspension = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "action.reportsuspensioncontinuation")) {
-			bActionReportSuspensionCont = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.bActionReportSuspensionCont = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "maxmessagesize")) {
 			setMaxLine(cnfparamvals[i].val.d.n);
 		} else if(!strcmp(paramblk.descr[i].name, "oversizemsg.errorfile")) {
-			free(oversizeMsgErrorFile);
-			oversizeMsgErrorFile = (uchar*)es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
+			free(loadConf->globals.oversizeMsgErrorFile);
+			loadConf->globals.oversizeMsgErrorFile = (uchar*)es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 		} else if(!strcmp(paramblk.descr[i].name, "oversizemsg.report")) {
-			reportOversizeMsg = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.reportOversizeMsg = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "oversizemsg.input.mode")) {
 			const char *const tmp = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 			setOversizeMsgInputMode((uchar*) tmp);
@@ -1387,32 +1349,39 @@ glblDoneLoadCnf(void)
 			setReportChildProcessExits((uchar*) tmp);
 			free((void*)tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "debug.onshutdown")) {
-			glblDebugOnShutdown = (int) cnfparamvals[i].val.d.n;
-			LogError(0, RS_RET_OK, "debug: onShutdown set to %d", glblDebugOnShutdown);
+			loadConf->globals.debugOnShutdown = (int) cnfparamvals[i].val.d.n;
+			LogError(0, RS_RET_OK, "debug: onShutdown set to %d", loadConf->globals.debugOnShutdown);
 		} else if(!strcmp(paramblk.descr[i].name, "debug.gnutls")) {
-			iGnuTLSLoglevel = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.iGnuTLSLoglevel = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "debug.unloadmodules")) {
 			glblUnloadModules = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "parser.controlcharacterescapeprefix")) {
 			uchar* tmp = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
-			cCCEscapeChar = tmp[0];
+			setParserControlCharacterEscapePrefix(NULL, tmp);
 			free(tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.droptrailinglfonreception")) {
-			bDropTrailingLF = (int) cnfparamvals[i].val.d.n;
+			const int tmp = (int) cnfparamvals[i].val.d.n;
+			setParserDropTrailingLFOnReception(NULL, tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.escapecontrolcharactersonreceive")) {
-			bEscapeCCOnRcv = (int) cnfparamvals[i].val.d.n;
+			const int tmp = (int) cnfparamvals[i].val.d.n;
+			setParserEscapeControlCharactersOnReceive(NULL, tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.spacelfonreceive")) {
-			bSpaceLFOnRcv = (int) cnfparamvals[i].val.d.n;
+			const int tmp = (int) cnfparamvals[i].val.d.n;
+			setParserSpaceLFOnReceive(NULL, tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.escape8bitcharactersonreceive")) {
-			bEscape8BitChars = (int) cnfparamvals[i].val.d.n;
+			const int tmp = (int) cnfparamvals[i].val.d.n;
+			setParserEscape8BitCharactersOnReceive(NULL, tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.escapecontrolcharactertab")) {
-			bEscapeTab = (int) cnfparamvals[i].val.d.n;
+			const int tmp = (int) cnfparamvals[i].val.d.n;
+			setParserEscapeControlCharacterTab(NULL, tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.escapecontrolcharacterscstyle")) {
-			bParserEscapeCCCStyle = (int) cnfparamvals[i].val.d.n;
+			const int tmp = (int) cnfparamvals[i].val.d.n;
+			SetParserEscapeControlCharactersCStyle(tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.parsehostnameandtag")) {
-			bParseHOSTNAMEandTAG = (int) cnfparamvals[i].val.d.n;
+			const int tmp = (int) cnfparamvals[i].val.d.n;
+			SetParseHOSTNAMEandTAG(tmp);
 		} else if(!strcmp(paramblk.descr[i].name, "parser.permitslashinprogramname")) {
-			bPermitSlashInProgramname = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.parser.bPermitSlashInProgramname = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "debug.logfile")) {
 			if(pszAltDbgFileName == NULL) {
 				pszAltDbgFileName = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
@@ -1428,30 +1397,30 @@ glblDoneLoadCnf(void)
 			}
 			LogError(0, RS_RET_OK, "debug log file is '%s', fd %d", pszAltDbgFileName, altdbg);
 		} else if(!strcmp(paramblk.descr[i].name, "janitor.interval")) {
-			janitorInterval = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.janitorInterval = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "net.ipprotocol")) {
 			char *proto = es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 			if(!strcmp(proto, "unspecified")) {
-				iDefPFFamily = PF_UNSPEC;
+				loadConf->globals.iDefPFFamily = PF_UNSPEC;
 			} else if(!strcmp(proto, "ipv4-only")) {
-				iDefPFFamily = PF_INET;
+				loadConf->globals.iDefPFFamily = PF_INET;
 			} else if(!strcmp(proto, "ipv6-only")) {
-				iDefPFFamily = PF_INET6;
+				loadConf->globals.iDefPFFamily = PF_INET6;
 			} else{
 				LogError(0, RS_RET_ERR, "invalid net.ipprotocol "
 					"parameter '%s' -- ignored", proto);
 			}
 			free(proto);
 		} else if(!strcmp(paramblk.descr[i].name, "senders.reportnew")) {
-			glblReportNewSenders = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.reportNewSenders = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "senders.reportgoneaway")) {
-			glblReportGoneAwaySenders = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.reportGoneAwaySenders = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "senders.timeoutafter")) {
-			glblSenderStatsTimeout = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.senderStatsTimeout = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "senders.keeptrack")) {
-			glblSenderKeepTrack = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.senderKeepTrack = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "inputs.timeout.shutdown")) {
-			glblInputTimeoutShutdown = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.inputTimeoutShutdown = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "privdrop.group.keepsupplemental")) {
 			loadConf->globals.gidDropPrivKeepSupplemental = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "privdrop.group.id")) {
@@ -1465,24 +1434,25 @@ glblDoneLoadCnf(void)
 		} else if(!strcmp(paramblk.descr[i].name, "security.abortonidresolutionfail")) {
 			loadConf->globals.abortOnIDResolutionFail = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "net.acladdhostnameonfail")) {
-			*(net.pACLAddHostnameOnFail) = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.ACLAddHostnameOnFail = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "net.aclresolvehostname")) {
-			*(net.pACLDontResolve) = !((int) cnfparamvals[i].val.d.n);
+			loadConf->globals.ACLDontResolve = !((int) cnfparamvals[i].val.d.n);
 		} else if(!strcmp(paramblk.descr[i].name, "net.enabledns")) {
-			setDisableDNS(!((int) cnfparamvals[i].val.d.n));
+			SetDisableDNS(!((int) cnfparamvals[i].val.d.n));
 		} else if(!strcmp(paramblk.descr[i].name, "net.permitwarning")) {
-			setOption_DisallowWarning(!((int) cnfparamvals[i].val.d.n));
+			SetOptionDisallowWarning(!((int) cnfparamvals[i].val.d.n));
 		} else if(!strcmp(paramblk.descr[i].name, "abortonuncleanconfig")) {
 			loadConf->globals.bAbortOnUncleanConfig = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "internalmsg.ratelimit.burst")) {
-			glblIntMsgRateLimitBurst = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.intMsgRateLimitBurst = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "internalmsg.ratelimit.interval")) {
-			glblIntMsgRateLimitItv = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.intMsgRateLimitItv = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "internalmsg.severity")) {
-			glblIntMsgsSeverityFilter = (int) cnfparamvals[i].val.d.n;
-			if((glblIntMsgsSeverityFilter < 0) || (glblIntMsgsSeverityFilter > 7)) {
+			loadConf->globals.intMsgsSeverityFilter = (int) cnfparamvals[i].val.d.n;
+			if((loadConf->globals.intMsgsSeverityFilter < 0) ||
+			(loadConf->globals.intMsgsSeverityFilter > 7)) {
 				parser_errmsg("invalid internalmsg.severity value");
-				glblIntMsgsSeverityFilter = DFLT_INT_MSGS_SEV_FILTER;
+				loadConf->globals.intMsgsSeverityFilter = DFLT_INT_MSGS_SEV_FILTER;
 			}
 		} else if(!strcmp(paramblk.descr[i].name, "environment")) {
 			for(int j = 0 ; j <  cnfparamvals[i].val.d.ar->nmemb ; ++j) {
@@ -1503,40 +1473,40 @@ glblDoneLoadCnf(void)
 		} else if(!strcmp(paramblk.descr[i].name, "debug.whitelist")) {
 			glblDbgWhitelist = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "shutdown.queue.doublesize")) {
-			glblShutdownQueueDoubleSize = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.shutdownQueueDoubleSize = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "umask")) {
 			loadConf->globals.umask = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "shutdown.enable.ctlc")) {
-			glblPermitCtlC = (int) cnfparamvals[i].val.d.n;
+			loadConf->globals.permitCtlC = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.action.queue.timeoutshutdown")) {
-			actq_dflt_toQShutdown = cnfparamvals[i].val.d.n;
+			loadConf->globals.actq_dflt_toQShutdown = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.action.queue.timeoutactioncompletion")) {
-			actq_dflt_toActShutdown = cnfparamvals[i].val.d.n;
+			loadConf->globals.actq_dflt_toActShutdown = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.action.queue.timeoutenqueue")) {
-			actq_dflt_toEnq = cnfparamvals[i].val.d.n;
+			loadConf->globals.actq_dflt_toEnq = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.action.queue.timeoutworkerthreadshutdown")) {
-			actq_dflt_toWrkShutdown = cnfparamvals[i].val.d.n;
+			loadConf->globals.actq_dflt_toWrkShutdown = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutshutdown")) {
-			ruleset_dflt_toQShutdown = cnfparamvals[i].val.d.n;
+			loadConf->globals.ruleset_dflt_toQShutdown = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutactioncompletion")) {
-			ruleset_dflt_toActShutdown = cnfparamvals[i].val.d.n;
+			loadConf->globals.ruleset_dflt_toActShutdown = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutenqueue")) {
-			ruleset_dflt_toEnq = cnfparamvals[i].val.d.n;
+			loadConf->globals.ruleset_dflt_toEnq = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "default.ruleset.queue.timeoutworkerthreadshutdown")) {
-			ruleset_dflt_toWrkShutdown = cnfparamvals[i].val.d.n;
+			loadConf->globals.ruleset_dflt_toWrkShutdown = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "reverselookup.cache.ttl.default")) {
-			dnscacheDefaultTTL = cnfparamvals[i].val.d.n;
+			loadConf->globals.dnscacheDefaultTTL = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "reverselookup.cache.ttl.enable")) {
-			dnscacheEnableTTL = cnfparamvals[i].val.d.n;
+			loadConf->globals.dnscacheEnableTTL = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "parser.supportcompressionextension")) {
-			bSupportCompressionExtension = cnfparamvals[i].val.d.n;
+			loadConf->globals.bSupportCompressionExtension = cnfparamvals[i].val.d.n;
 		} else {
 			dbgprintf("glblDoneLoadCnf: program error, non-handled "
 				"param '%s'\n", paramblk.descr[i].name);
 		}
 	}
 
-	if(glblDebugOnShutdown && Debug != DEBUG_FULL) {
+	if(loadConf->globals.debugOnShutdown && Debug != DEBUG_FULL) {
 		Debug = DEBUG_ONDEMAND;
 		stddbg = -1;
 	}
@@ -1560,16 +1530,16 @@ BEGINAbstractObjClassInit(glbl, 1, OBJ_IS_CORE_MODULE) /* class, version */
 	CHKiRet(regCfSysLineHdlr((uchar *)"debugfile", 0, eCmdHdlrGetWord, setDebugFile, NULL, NULL));
 	CHKiRet(regCfSysLineHdlr((uchar *)"debuglevel", 0, eCmdHdlrInt, setDebugLevel, NULL, NULL));
 	CHKiRet(regCfSysLineHdlr((uchar *)"workdirectory", 0, eCmdHdlrGetWord, setWorkDir, NULL, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"dropmsgswithmaliciousdnsptrrecords", 0, eCmdHdlrBinary, NULL,
-	&bDropMalPTRMsgs, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdriver", 0, eCmdHdlrGetWord, NULL, &pszDfltNetstrmDrvr,
+	CHKiRet(regCfSysLineHdlr((uchar *)"dropmsgswithmaliciousdnsptrrecords", 0, eCmdHdlrBinary, SetDropMalPTRMsgs,
+	NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdriver", 0, eCmdHdlrGetWord, setDfltNetstrmDrvr, NULL,
 	NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdrivercafile", 0, eCmdHdlrGetWord, NULL,
-	&pszDfltNetstrmDrvrCAF, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdriverkeyfile", 0, eCmdHdlrGetWord, NULL,
-	&pszDfltNetstrmDrvrKeyFile, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdrivercertfile", 0, eCmdHdlrGetWord, NULL,
-	&pszDfltNetstrmDrvrCertFile, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdrivercafile", 0, eCmdHdlrGetWord,
+	setDfltNetstrmDrvrCAF, NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdriverkeyfile", 0, eCmdHdlrGetWord,
+	setDfltNetstrmDrvrKeyFile, NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"defaultnetstreamdrivercertfile", 0, eCmdHdlrGetWord,
+	setDfltNetstrmDrvrCertFile, NULL, NULL));
 	CHKiRet(regCfSysLineHdlr((uchar *)"localhostname", 0, eCmdHdlrGetWord, NULL, &LocalHostNameOverride, NULL));
 	CHKiRet(regCfSysLineHdlr((uchar *)"localhostipif", 0, eCmdHdlrGetWord, setLocalHostIPIF, NULL, NULL));
 	CHKiRet(regCfSysLineHdlr((uchar *)"optimizeforuniprocessor", 0, eCmdHdlrGoneAway, NULL, NULL, NULL));
@@ -1577,16 +1547,18 @@ BEGINAbstractObjClassInit(glbl, 1, OBJ_IS_CORE_MODULE) /* class, version */
 	CHKiRet(regCfSysLineHdlr((uchar *)"maxmessagesize", 0, eCmdHdlrSize, legacySetMaxMessageSize, NULL, NULL));
 
 	/* Deprecated parser config options */
-	CHKiRet(regCfSysLineHdlr((uchar *)"controlcharacterescapeprefix", 0, eCmdHdlrGetChar, NULL,
-	&cCCEscapeChar, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"droptrailinglfonreception", 0, eCmdHdlrBinary, NULL,
-	&bDropTrailingLF, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"escapecontrolcharactersonreceive", 0, eCmdHdlrBinary, NULL,
-	&bEscapeCCOnRcv, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"spacelfonreceive", 0, eCmdHdlrBinary, NULL, &bSpaceLFOnRcv, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"escape8bitcharactersonreceive", 0, eCmdHdlrBinary, NULL,
-	&bEscape8BitChars, NULL));
-	CHKiRet(regCfSysLineHdlr((uchar *)"escapecontrolcharactertab", 0, eCmdHdlrBinary, NULL, &bEscapeTab, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"controlcharacterescapeprefix", 0, eCmdHdlrGetChar,
+	setParserControlCharacterEscapePrefix, NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"droptrailinglfonreception", 0, eCmdHdlrBinary,
+	setParserDropTrailingLFOnReception, NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"escapecontrolcharactersonreceive", 0, eCmdHdlrBinary,
+	setParserEscapeControlCharactersOnReceive, NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"spacelfonreceive", 0, eCmdHdlrBinary,
+	setParserSpaceLFOnReceive, NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"escape8bitcharactersonreceive", 0, eCmdHdlrBinary,
+	setParserEscape8BitCharactersOnReceive,	NULL, NULL));
+	CHKiRet(regCfSysLineHdlr((uchar *)"escapecontrolcharactertab", 0, eCmdHdlrBinary,
+	setParserEscapeControlCharacterTab, NULL, NULL));
 
 	CHKiRet(regCfSysLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler,
 	resetConfigVariables, NULL, NULL));
@@ -1599,15 +1571,9 @@ ENDObjClassInit(glbl)
  * rgerhards, 2008-04-17
  */
 BEGINObjClassExit(glbl, OBJ_IS_CORE_MODULE) /* class, version */
-	free(pszDfltNetstrmDrvr);
-	free(pszDfltNetstrmDrvrCAF);
-	free(pszDfltNetstrmDrvrKeyFile);
-	free(pszDfltNetstrmDrvrCertFile);
-	free(pszWorkDir);
 	free(LocalDomain);
 	free(LocalHostName);
 	free(LocalHostNameOverride);
-	free(oversizeMsgErrorFile);
 	free(LocalFQDNName);
 	freeTimezoneInfo();
 	objRelease(prop, CORE_COMPONENT);

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1261,7 +1261,7 @@ static rsRetVal MsgSerialize(smsg_t *pThis, strm_t *pStrm)
 	objSerializePTR(pStrm, pCSAPPNAME, CSTR);
 	objSerializePTR(pStrm, pCSPROCID, CSTR);
 	objSerializePTR(pStrm, pCSMSGID, CSTR);
-	
+
 	objSerializePTR(pStrm, pszUUID, PSZ);
 
 	if(pThis->pRuleset != NULL) {
@@ -1514,7 +1514,7 @@ static rsRetVal aquirePROCIDFromTAG(smsg_t * const pM)
 		++i;
 	if(!(i < pM->iLenTAG))
 		return RS_RET_OK;	/* no [, so can not emulate... */
-	
+
 	++i; /* skip '[' */
 
 	/* now obtain the PROCID string... */
@@ -1569,7 +1569,7 @@ aquireProgramName(smsg_t * const pM)
 	    ; (i < pM->iLenTAG) && isprint((int) pszTag[i])
 	      && (pszTag[i] != '\0') && (pszTag[i] != ':')
 	      && (pszTag[i] != '[')
-	      && (bPermitSlashInProgramname || (pszTag[i] != '/'))
+	      && (runConf->globals.parser.bPermitSlashInProgramname || (pszTag[i] != '/'))
 	    ; ++i)
 		; /* just search end of PROGNAME */
 	if(i < CONF_PROGNAME_BUFSIZE) {
@@ -2492,7 +2492,7 @@ tryEmulateTAG(smsg_t *const pM, const sbool bLockMutex)
 			MsgUnlock(pM);
 		return; /* done, no need to emulate */
 	}
-	
+
 	if(msgGetProtocolVersion(pM) == 1) {
 		if(!strcmp(getPROCID(pM, MUTEX_ALREADY_LOCKED), "-")) {
 			/* no process ID, use APP-NAME only */
@@ -2905,7 +2905,7 @@ void ATTR_NONNULL()
 MsgTruncateToMaxSize(smsg_t *const pThis)
 {
 	ISOBJ_TYPE_assert(pThis, msg);
-	const int maxMsgSize = glblGetMaxLine();
+	const int maxMsgSize = glblGetMaxLine(runConf);
 	assert(pThis->iLenRawMsg > maxMsgSize);
 
 	const int deltaSize = pThis->iLenRawMsg - maxMsgSize;
@@ -3914,12 +3914,12 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 		*pPropLen = (bufLen == -1) ? (int) ustrlen(pRes) : bufLen;
 		return pRes;
 	}
-	
+
 	/* Now check if we need to make "temporary" transformations (these
 	 * are transformations that do not go back into the message -
 	 * memory must be allocated for them!).
 	 */
-	
+
 	/* substring extraction */
 	/* first we check if we need to extract by field number
 	 * rgerhards, 2005-12-22

--- a/runtime/net.h
+++ b/runtime/net.h
@@ -165,13 +165,11 @@ BEGINinterface(net) /* name must also be changed in ENDinterface macro! */
 	int (*isAllowedSender2)(uchar *pszType, struct sockaddr *pFrom, const char *pszFromHost, int bChkDNS);
 	/* v7 interface additions - 2012-03-06 */
 	rsRetVal (*GetIFIPAddr)(uchar *szif, int family, uchar *pszbuf, int lenBuf);
-	/* data members - these should go away over time... TODO */
-	int    *pACLAddHostnameOnFail; /* add hostname to acl when DNS resolving has failed */
-	int    *pACLDontResolve;       /* add hostname to acl instead of resolving it to IP(s) */
 	/* v8 cvthname() signature change -- rgerhards, 2013-01-18 */
 	/* v9 create_udp_socket() signature change -- dsahern, 2016-11-11 */
+	/* v10 moved data members to rsconf_t -- alakatos, 2021-12-29 */
 ENDinterface(net)
-#define netCURR_IF_VERSION 9 /* increment whenever you change the interface structure! */
+#define netCURR_IF_VERSION 10 /* increment whenever you change the interface structure! */
 
 /* prototypes */
 PROTOTYPEObj(net);

--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -37,6 +37,7 @@
 #include "nssel.h"
 #include "nspoll.h"
 #include "netstrms.h"
+#include "rsconf.h"
 
 MODULE_TYPE_LIB
 MODULE_TYPE_NOKEEP
@@ -64,7 +65,7 @@ loadDrvr(netstrms_t *pThis)
 
 	pBaseDrvrName = pThis->pBaseDrvrName;
 	if(pBaseDrvrName == NULL) /* if no drvr name is set, use system default */
-		pBaseDrvrName = glbl.GetDfltNetstrmDrvr();
+		pBaseDrvrName = glbl.GetDfltNetstrmDrvr(runConf);
 	if(snprintf((char*)szDrvrName, sizeof(szDrvrName), "lmnsd_%s", pBaseDrvrName) == sizeof(szDrvrName))
 		ABORT_FINALIZE(RS_RET_DRVRNAME_TOO_LONG);
 	CHKmalloc(pThis->pDrvrName = (uchar*) strdup((char*)szDrvrName));

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -53,6 +53,7 @@
 #include "nsdsel_gtls.h"
 #include "nsd_gtls.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 
 /* things to move to some better place/functionality - TODO */
 #define CRLFILE "crl.pem"
@@ -189,8 +190,8 @@ gtlsLoadOurCertKey(nsd_gtls_t *pThis)
 
 	ISOBJ_TYPE_assert(pThis, nsd_gtls);
 
-	certFile = (pThis->pszCertFile == NULL) ? glbl.GetDfltNetstrmDrvrCertFile() : pThis->pszCertFile;
-	keyFile = (pThis->pszKeyFile == NULL) ? glbl.GetDfltNetstrmDrvrKeyFile() : pThis->pszKeyFile;
+	certFile = (pThis->pszCertFile == NULL) ? glbl.GetDfltNetstrmDrvrCertFile(runConf) : pThis->pszCertFile;
+	keyFile = (pThis->pszKeyFile == NULL) ? glbl.GetDfltNetstrmDrvrKeyFile(runConf) : pThis->pszKeyFile;
 
 	if(certFile == NULL || keyFile == NULL) {
 		/* in this case, we can not set our certificate. If we are
@@ -610,8 +611,8 @@ gtlsAddOurCert(nsd_gtls_t *const pThis)
 	uchar *pGnuErr; /* for GnuTLS error reporting */
 	DEFiRet;
 
-	certFile = (pThis->pszCertFile == NULL) ? glbl.GetDfltNetstrmDrvrCertFile() : pThis->pszCertFile;
-	keyFile = (pThis->pszKeyFile == NULL) ? glbl.GetDfltNetstrmDrvrKeyFile() : pThis->pszKeyFile;
+	certFile = (pThis->pszCertFile == NULL) ? glbl.GetDfltNetstrmDrvrCertFile(runConf) : pThis->pszCertFile;
+	keyFile = (pThis->pszKeyFile == NULL) ? glbl.GetDfltNetstrmDrvrKeyFile(runConf) : pThis->pszKeyFile;
 	dbgprintf("GTLS certificate file: '%s'\n", certFile);
 	dbgprintf("GTLS key file: '%s'\n", keyFile);
 	if(certFile == NULL) {
@@ -696,7 +697,7 @@ gtlsInitCred(nsd_gtls_t *const pThis )
 	CHKgnutls(gnutls_certificate_allocate_credentials(&pThis->xcred));
 
 	/* sets the trusted cas file */
-	cafile = (pThis->pszCAFile == NULL) ? glbl.GetDfltNetstrmDrvrCAF() : pThis->pszCAFile;
+	cafile = (pThis->pszCAFile == NULL) ? glbl.GetDfltNetstrmDrvrCAF(runConf) : pThis->pszCAFile;
 	if(cafile == NULL) {
 		LogMsg(0, RS_RET_CA_CERT_MISSING, LOG_WARNING,
 			"Warning: CA certificate is not set");
@@ -739,9 +740,9 @@ gtlsGlblInit(void)
 	#endif
 	CHKgnutls(gnutls_global_init());
 
-	if(GetGnuTLSLoglevel() > 0){
+	if(GetGnuTLSLoglevel(runConf) > 0){
 		gnutls_global_set_log_function(logFunction);
-		gnutls_global_set_log_level(GetGnuTLSLoglevel());
+		gnutls_global_set_log_level(GetGnuTLSLoglevel(runConf));
 		/* 0 (no) to 9 (most), 10 everything */
 	}
 

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -53,6 +53,7 @@
 #include "nsdsel_ossl.h"
 #include "nsd_ossl.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 /* things to move to some better place/functionality - TODO */
 // #define CRLFILE "crl.pem"
 
@@ -1224,7 +1225,7 @@ osslInit_ctx(nsd_ossl_t *const pThis)
 	int bHaveKey;
 	const char *caFile, *certFile, *keyFile;
 	/* Setup certificates */
-	caFile = (char*) ((pThis->pszCAFile == NULL) ? glbl.GetDfltNetstrmDrvrCAF() : pThis->pszCAFile);
+	caFile = (char*) ((pThis->pszCAFile == NULL) ? glbl.GetDfltNetstrmDrvrCAF(runConf) : pThis->pszCAFile);
 	if(caFile == NULL) {
 		LogMsg(0, RS_RET_CA_CERT_MISSING, LOG_WARNING,
 			"Warning: CA certificate is not set");
@@ -1232,7 +1233,8 @@ osslInit_ctx(nsd_ossl_t *const pThis)
 	} else {
 		bHaveCA	= 1;
 	}
-	certFile = (char*) ((pThis->pszCertFile == NULL) ? glbl.GetDfltNetstrmDrvrCertFile() : pThis->pszCertFile);
+	certFile = (char*) ((pThis->pszCertFile == NULL) ?
+		glbl.GetDfltNetstrmDrvrCertFile(runConf) : pThis->pszCertFile);
 	if(certFile == NULL) {
 		LogMsg(0, RS_RET_CERT_MISSING, LOG_WARNING,
 			"Warning: Certificate file is not set");
@@ -1240,7 +1242,7 @@ osslInit_ctx(nsd_ossl_t *const pThis)
 	} else {
 		bHaveCert = 1;
 	}
-	keyFile = (char*) ((pThis->pszKeyFile == NULL) ? glbl.GetDfltNetstrmDrvrKeyFile() : pThis->pszKeyFile);
+	keyFile = (char*) ((pThis->pszKeyFile == NULL) ? glbl.GetDfltNetstrmDrvrKeyFile(runConf) : pThis->pszKeyFile);
 	if(keyFile == NULL) {
 		LogMsg(0, RS_RET_CERTKEY_MISSING, LOG_WARNING,
 			"Warning: Key file is not set");

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -53,6 +53,7 @@
 #include "nsd_ptcp.h"
 #include "prop.h"
 #include "dnscache.h"
+#include "rsconf.h"
 
 MODULE_TYPE_LIB
 MODULE_TYPE_NOKEEP
@@ -542,7 +543,7 @@ LstnInit(netstrms_t *const pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*
 
 	memset(&hints, 0, sizeof(hints));
 	hints.ai_flags = AI_PASSIVE;
-	hints.ai_family = glbl.GetDefPFFamily();
+	hints.ai_family = glbl.GetDefPFFamily(runConf);
 	hints.ai_socktype = SOCK_STREAM;
 
 	error = getaddrinfo((const char*)cnf_params->pszAddr, (const char*) cnf_params->pszPort, &hints, &res);

--- a/runtime/nspoll.c
+++ b/runtime/nspoll.c
@@ -36,6 +36,7 @@
 #include "module-template.h"
 #include "netstrm.h"
 #include "nspoll.h"
+#include "rsconf.h"
 
 /* static data */
 DEFobjStaticHelpers
@@ -63,7 +64,7 @@ loadDrvr(nspoll_t *pThis)
 
 	pBaseDrvrName = pThis->pBaseDrvrName;
 	if(pBaseDrvrName == NULL) /* if no drvr name is set, use system default */
-		pBaseDrvrName = glbl.GetDfltNetstrmDrvr();
+		pBaseDrvrName = glbl.GetDfltNetstrmDrvr(runConf);
 	if(snprintf((char*)szDrvrName, sizeof(szDrvrName), "lmnsdpoll_%s", pBaseDrvrName) == sizeof(szDrvrName))
 		ABORT_FINALIZE(RS_RET_DRVRNAME_TOO_LONG);
 	CHKmalloc(pThis->pDrvrName = (uchar*) strdup((char*)szDrvrName));

--- a/runtime/nssel.c
+++ b/runtime/nssel.c
@@ -41,6 +41,7 @@
 #include "module-template.h"
 #include "netstrm.h"
 #include "nssel.h"
+#include "rsconf.h"
 
 /* static data */
 DEFobjStaticHelpers
@@ -68,7 +69,7 @@ loadDrvr(nssel_t *pThis)
 
 	pBaseDrvrName = pThis->pBaseDrvrName;
 	if(pBaseDrvrName == NULL) /* if no drvr name is set, use system default */
-		pBaseDrvrName = glbl.GetDfltNetstrmDrvr();
+		pBaseDrvrName = glbl.GetDfltNetstrmDrvr(runConf);
 	if(snprintf((char*)szDrvrName, sizeof(szDrvrName), "lmnsdsel_%s", pBaseDrvrName) == sizeof(szDrvrName))
 		ABORT_FINALIZE(RS_RET_DRVRNAME_TOO_LONG);
 	CHKmalloc(pThis->pDrvrName = (uchar*) strdup((char*)szDrvrName));
@@ -163,7 +164,7 @@ Add(nssel_t *pThis, netstrm_t *pStrm, nsdsel_waitOp_t waitOp)
 
 	ISOBJ_TYPE_assert(pThis, nssel);
 	ISOBJ_TYPE_assert(pStrm, netstrm);
-	
+
 	CHKiRet(pThis->Drvr.Add(pThis->pDrvrData, pStrm->pDrvrData, waitOp));
 
 finalize_it:

--- a/runtime/operatingstate.c
+++ b/runtime/operatingstate.c
@@ -34,6 +34,7 @@
 #include "rsyslog.h"
 #include "errmsg.h"
 #include "operatingstate.h"
+#include "rsconf.h"
 
 #ifndef O_LARGEFILE
 #define O_LARGEFILE 0
@@ -53,7 +54,7 @@ static void
 osf_checkOnStartup(void)
 {
 	int do_rename = 1;
-	const char *fn_osf = (const char*) glblGetOperatingStateFile();
+	const char *fn_osf = (const char*) glblGetOperatingStateFile(loadConf);
 	char iobuf[sizeof(STATE_CLEAN_CLOSE)];
 	const int len_clean_close = sizeof(STATE_CLEAN_CLOSE) - 1;
 	assert(fn_osf != NULL);
@@ -116,7 +117,7 @@ void
 osf_open(void)
 {
 	assert(fd_osf == -1);
-	const char *fn_osf = (const char*) glblGetOperatingStateFile();
+	const char *fn_osf = (const char*) glblGetOperatingStateFile(loadConf);
 	assert(fn_osf != NULL);
 
 	osf_checkOnStartup();

--- a/runtime/parser.h
+++ b/runtime/parser.h
@@ -66,8 +66,6 @@ ENDinterface(parser)
 
 void printParserList(parserList_t *pList);
 
-extern int bSupportCompressionExtension;
-
 /* prototypes */
 PROTOTYPEObj(parser);
 rsRetVal parserConstructViaModAndName(modInfo_t *pMod, uchar *const pName, void *parserInst);

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -62,6 +62,7 @@
 #include "unicode-helper.h"
 #include "statsobj.h"
 #include "parserif.h"
+#include "rsconf.h"
 
 #ifdef OS_SOLARIS
 #	include <sched.h>
@@ -83,17 +84,6 @@ unsigned int iOverallQueueSize = 0;
 #endif
 
 #define OVERSIZE_QUEUE_WATERMARK 500000 /* when is a queue considered to be "overly large"? */
-
-/* overridable default values (via global config) */
-int actq_dflt_toQShutdown = 10;		/* queue shutdown */
-int actq_dflt_toActShutdown = 1000;	/* action shutdown (in phase 2) */
-int actq_dflt_toEnq = 2000;		/* timeout for queue enque */
-int actq_dflt_toWrkShutdown = 60000;	/* timeout for worker thread shutdown */
-
-int ruleset_dflt_toQShutdown = 1500;	/* queue shutdown */
-int ruleset_dflt_toActShutdown = 1000;	/* action shutdown (in phase 2) */
-int ruleset_dflt_toEnq = 2000;		/* timeout for queue enque */
-int ruleset_dflt_toWrkShutdown = 60000;	/* timeout for worker thread shutdown */
 
 
 /* forward-definitions */
@@ -1482,7 +1472,7 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis, queueType_t qType, int iWorkerThread
 {
 	DEFiRet;
 	qqueue_t *pThis;
-	const uchar *const workDir = glblGetWorkDirRaw();
+	const uchar *const workDir = glblGetWorkDirRaw(ourConf);
 
 	assert(ppThis != NULL);
 	assert(pConsumer != NULL);
@@ -1549,10 +1539,10 @@ qqueueSetDefaultsActionQueue(qqueue_t *pThis)
 	pThis->iMaxFileSize = 1024*1024;
 	pThis->iPersistUpdCnt = 0;		/* persist queue info every n updates */
 	pThis->bSyncQueueFiles = 0;
-	pThis->toQShutdown = actq_dflt_toQShutdown;	/* queue shutdown */
-	pThis->toActShutdown = actq_dflt_toActShutdown;	/* action shutdown (in phase 2) */
-	pThis->toEnq = actq_dflt_toEnq;			/* timeout for queue enque */
-	pThis->toWrkShutdown = actq_dflt_toWrkShutdown;	/* timeout for worker thread shutdown */
+	pThis->toQShutdown = loadConf->globals.actq_dflt_toQShutdown;	/* queue shutdown */
+	pThis->toActShutdown = loadConf->globals.actq_dflt_toActShutdown;	/* action shutdown (in phase 2) */
+	pThis->toEnq = loadConf->globals.actq_dflt_toEnq;			/* timeout for queue enque */
+	pThis->toWrkShutdown = loadConf->globals.actq_dflt_toWrkShutdown;	/* timeout for worker thread shutdown */
 	pThis->iMinMsgsPerWrkr = -1;		/* minimum messages per worker needed to start a new one */
 	pThis->bSaveOnShutdown = 1;		/* save queue on shutdown (when DA enabled)? */
 	pThis->sizeOnDiskMax = 0;		/* unlimited */
@@ -1582,10 +1572,10 @@ qqueueSetDefaultsRulesetQueue(qqueue_t *pThis)
 	pThis->iMaxFileSize = 16*1024*1024;
 	pThis->iPersistUpdCnt = 0;		/* persist queue info every n updates */
 	pThis->bSyncQueueFiles = 0;
-	pThis->toQShutdown = ruleset_dflt_toQShutdown;
-	pThis->toActShutdown = ruleset_dflt_toActShutdown;
-	pThis->toEnq = ruleset_dflt_toEnq;
-	pThis->toWrkShutdown = ruleset_dflt_toWrkShutdown;
+	pThis->toQShutdown = ourConf->globals.ruleset_dflt_toQShutdown;
+	pThis->toActShutdown = ourConf->globals.ruleset_dflt_toActShutdown;
+	pThis->toEnq = ourConf->globals.ruleset_dflt_toEnq;
+	pThis->toWrkShutdown = ourConf->globals.ruleset_dflt_toWrkShutdown;
 	pThis->iMinMsgsPerWrkr = -1;		/* minimum messages per worker needed to start a new one */
 	pThis->bSaveOnShutdown = 1;		/* save queue on shutdown (when DA enabled)? */
 	pThis->sizeOnDiskMax = 0;		/* unlimited */
@@ -2351,7 +2341,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 		/* note: we need to pick the path so late as we do not have
 		 *       the workdir during early config load
 		 */
-		if((pThis->pszSpoolDir = (uchar*) strdup((char*)glbl.GetWorkDir())) == NULL)
+		if((pThis->pszSpoolDir = (uchar*) strdup((char*)glbl.GetWorkDir(runConf))) == NULL)
 			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 		pThis->lenSpoolDir = ustrlen(pThis->pszSpoolDir);
 	}
@@ -2820,7 +2810,7 @@ DoSaveOnShutdown(qqueue_t *pThis)
 BEGINobjDestruct(qqueue) /* be sure to specify the object type also in END and CODESTART macros! */
 CODESTARTobjDestruct(qqueue)
 	DBGOPRINT((obj_t*) pThis, "shutdown: begin to destruct queue\n");
-	if(glblShutdownQueueDoubleSize) {
+	if(ourConf->globals.shutdownQueueDoubleSize) {
 		pThis->iHighWtrMrk *= 2;
 		pThis->iMaxQueueSize *= 2;
 	}

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -237,17 +237,6 @@ PROTOTYPEpropSetMeth(qqueue, sizeOnDiskMax, int64);
 PROTOTYPEpropSetMeth(qqueue, iDeqBatchSize, int);
 #define qqueueGetID(pThis) ((unsigned long) pThis)
 
-/* overridable default values (via global config) */
-extern int actq_dflt_toQShutdown;
-extern int actq_dflt_toActShutdown;
-extern int actq_dflt_toEnq;
-extern int actq_dflt_toWrkShutdown;
-
-extern int ruleset_dflt_toQShutdown;
-extern int ruleset_dflt_toActShutdown;
-extern int ruleset_dflt_toEnq;
-extern int ruleset_dflt_toWrkShutdown;
-
 #ifdef ENABLE_IMDIAG
 extern unsigned int iOverallQueueSize;
 #endif

--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -305,7 +305,7 @@ ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg)
 				CHKiRet(multiSubmitMsg2(pMultiSub));
 		}
 		CHKiRet(localRet);
-		if(pMsg->iLenRawMsg > glblGetMaxLine()) {
+		if(pMsg->iLenRawMsg > glblGetMaxLine(runConf)) {
 			/* oversize message needs special processing. We keep
 			 * at least the previous batch as batch...
 			 */

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -31,6 +31,14 @@
 
 /* --- configuration objects (the plan is to have ALL upper layers in this file) --- */
 
+#define REPORT_CHILD_PROCESS_EXITS_NONE 0
+#define REPORT_CHILD_PROCESS_EXITS_ERRORS 1
+#define REPORT_CHILD_PROCESS_EXITS_ALL 2
+
+#ifndef DFLT_INT_MSGS_SEV_FILTER
+	#define DFLT_INT_MSGS_SEV_FILTER 6	/* Warning level and more important */
+#endif
+
 /* queue config parameters. TODO: move to queue.c? */
 struct queuecnf_s {
 	int iMainMsgQueueSize;		/* size of the main message queue above */
@@ -57,6 +65,19 @@ struct queuecnf_s {
 	int iMainMsgQueueDeqtWinToHr;	/* hour begin of time frame when queue is to be dequeued */
 };
 
+/* parser config parameters */
+struct parsercnf_s {
+	uchar cCCEscapeChar; /* character to be used to start an escape sequence for control chars */
+	int bDropTrailingLF; /* drop trailing LF's on reception? */
+	int bEscapeCCOnRcv; /* escape control characters on reception: 0 - no, 1 - yes */
+	int bSpaceLFOnRcv; /* replace newlines with spaces on reception: 0 - no, 1 - yes */
+	int bEscape8BitChars; /* escape characters > 127 on reception: 0 - no, 1 - yes */
+	int bEscapeTab; /* escape tab control character when doing CC escapes: 0 - no, 1 - yes */
+	int bParserEscapeCCCStyle; /* escape control characters in c style: 0 - no, 1 - yes */
+	int bPermitSlashInProgramname;
+	int bParseHOSTNAMEandTAG; /* parser modification (based on startup params!) */
+};
+
 /* globals are data items that are really global, and can be set only
  * once (at least in theory, because the legacy system permits them to
  * be re-set as often as the user likes).
@@ -77,12 +98,68 @@ struct globals_s {
 	int abortOnIDResolutionFail;
 	int umask;		/* umask to use */
 	uchar *pszConfDAGFile;	/* name of config DAG file, non-NULL means generate one */
+	uchar *pszWorkDir;
+	int bDropMalPTRMsgs;/* Drop messages which have malicious PTR records during DNS lookup */
+	uchar *operatingStateFile;
+	int debugOnShutdown; /* start debug log when we are shut down */
+	int iGnuTLSLoglevel;/* Sets GNUTLS Debug Level */
+	uchar *pszDfltNetstrmDrvrCAF; /* default CA file for the netstrm driver */
+	uchar *pszDfltNetstrmDrvrCertFile;/* default cert file for the netstrm driver (server) */
+	uchar *pszDfltNetstrmDrvrKeyFile; /* default key file for the netstrm driver (server) */
+	uchar *pszDfltNetstrmDrvr; /* module name of default netstream driver */
+	uchar *oversizeMsgErrorFile; /* File where oversize messages are written to */
+	int reportOversizeMsg; /* shall error messages be generated for oversize messages? */
+	int oversizeMsgInputMode; /* Mode which oversize messages will be forwarded */
+	int reportChildProcessExits;
+	int bActionReportSuspension;
+	int bActionReportSuspensionCont;
+	short janitorInterval; /* interval (in minutes) at which the janitor runs */
+	int reportNewSenders;
+	int reportGoneAwaySenders;
+	int senderStatsTimeout;
+	int senderKeepTrack; /* keep track of known senders? */
+	int inputTimeoutShutdown; /* input shutdown timeout in ms */
+	int iDefPFFamily; /* protocol family (IPv4, IPv6 or both) */
+	int ACLAddHostnameOnFail; /* add hostname to acl when DNS resolving has failed */
+	int ACLDontResolve; /* add hostname to acl instead of resolving it to IP(s) */
+	int bDisableDNS; /* don't look up IP addresses of remote messages */
+	int bProcessInternalMessages; /* Should rsyslog itself process internal messages?
+		* 1 - yes
+		* 0 - send them to libstdlog (e.g. to push to journal) or syslog()
+		*/
+	uint64_t glblDevOptions; /* to be used by developers only */
+	int intMsgRateLimitItv;
+	int intMsgRateLimitBurst;
+	int intMsgsSeverityFilter;/* filter for logging internal messages by syslog sev. */
+	int permitCtlC;
+
+	int actq_dflt_toQShutdown; /* queue shutdown */
+	int actq_dflt_toActShutdown; /* action shutdown (in phase 2) */
+	int actq_dflt_toEnq; /* timeout for queue enque */
+	int actq_dflt_toWrkShutdown; /* timeout for worker thread shutdown */
+
+	int ruleset_dflt_toQShutdown; /* queue shutdown */
+	int ruleset_dflt_toActShutdown;	/* action shutdown (in phase 2) */
+	int ruleset_dflt_toEnq; /* timeout for queue enque */
+	int ruleset_dflt_toWrkShutdown;	/* timeout for worker thread shutdown */
+
+	unsigned dnscacheDefaultTTL; /* 24 hrs default TTL */
+	int dnscacheEnableTTL; /* expire entries or not (0) ? */
+	int shutdownQueueDoubleSize;
+	int optionDisallowWarning;	/* complain if message from disallowed sender is received */
+	int bSupportCompressionExtension;
+	#ifdef ENABLE_LIBLOGGING_STDLOG
+		stdlog_channel_t stdlog_hdl; /* handle to be used for stdlog */
+		uchar *stdlog_chanspec;
+	#endif
+	int iMaxLine; /* maximum length of a syslog message */
 
 	// TODO are the following ones defaults?
 	int bReduceRepeatMsgs; /* reduce repeated message - 0 - no, 1 - yes */
 
 	//TODO: other representation for main queue? Or just load it differently?
 	queuecnf_t mainQ;	/* main queue parameters */
+	parsercnf_t parser; /* parser parameters */
 };
 
 /* (global) defaults are global in the sense that they are accessible

--- a/runtime/rsyslog.c
+++ b/runtime/rsyslog.c
@@ -143,7 +143,6 @@ rsrtInit(const char **ppErrObj, obj_if_t *pObjIF)
 		/* init runtime only if not yet done */
 #ifdef ENABLE_LIBLOGGING_STDLOG
 		stdlog_init(0);
-		stdlog_hdl = stdlog_open("rsyslogd", 0, STDLOG_SYSLOG, NULL);
 #endif
 		ret = pthread_attr_init(&default_thread_attr);
 		if(ret != 0) {

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -48,6 +48,7 @@
 #include "obj.h"
 #include "errmsg.h"
 #include "glbl.h"
+#include "rsconf.h"
 
 #if _POSIX_TIMERS <= 0
 #include <sys/time.h>
@@ -176,7 +177,7 @@ uchar *srUtilStrDup(uchar *pOld, size_t len)
 	uchar *pNew;
 
 	assert(pOld != NULL);
-	
+
 	if((pNew = malloc(len + 1)) != NULL)
 		memcpy(pNew, pOld, len + 1);
 
@@ -296,7 +297,7 @@ int execProg(uchar *program, int bWait, uchar *arg)
 			   been reaped by the rsyslogd main loop (see rsyslogd.c) */
 			int status;
 			if(waitpid(pid, &status, 0) == pid) {
-				glblReportChildProcessExit(program, pid, status);
+				glblReportChildProcessExit(runConf, program, pid, status);
 			} else if(errno != ECHILD) {
 				/* we do not use logerror(), because
 				* that might bring us into an endless
@@ -389,7 +390,7 @@ rsRetVal genFileName(uchar **ppName, uchar *pDirName, size_t lenDirName, uchar *
 	lenName = lenDirName + 1 + lenFName + lenBuf + 1; /* last +1 for \0 char! */
 	if((pName = malloc(lenName)) == NULL)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-	
+
 	/* got memory, now construct string */
 	memcpy(pName, pDirName, lenDirName);
 	pNameWork = pName + lenDirName;

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -64,6 +64,7 @@
 #include "errmsg.h"
 #include "cryprov.h"
 #include "datetime.h"
+#include "rsconf.h"
 
 /* some platforms do not have large file support :( */
 #ifndef O_LARGEFILE
@@ -161,7 +162,7 @@ resolveFileSizeLimit(strm_t *pThis, uchar *pszCurrFName)
 	if(pThis->pszSizeLimitCmd == NULL) {
 		ABORT_FINALIZE(RS_RET_NON_SIZELIMITCMD); /* nothing we can do in this case... */
 	}
-	
+
 	/* we first check if we have command line parameters. We assume this,
 	 * when we have a space in the program name. If we find it, everything after
 	 * the space is treated as a single argument.
@@ -349,7 +350,7 @@ strmSetCurrFName(strm_t *pThis)
 finalize_it:
 	RETiRet;
 }
-	
+
 /* This function checks if the actual file has changed and, if so, resets the
  * offset. This is support for monitoring files. It should be called after
  * deserializing the strm object and before doing any other operation on it
@@ -400,7 +401,7 @@ static rsRetVal strmOpenFile(strm_t *pThis)
 		ABORT_FINALIZE(RS_RET_FILE_PREFIX_MISSING);
 
 	CHKiRet(strmSetCurrFName(pThis));
-	
+
 	CHKiRet(doPhysOpen(pThis));
 
 	pThis->iCurrOffs = 0;
@@ -824,7 +825,7 @@ static rsRetVal strmReadChar(strm_t *pThis, uchar *pC)
 {
 	int padBytes = 0; /* in crypto mode, we may have some padding (non-data) bytes */
 	DEFiRet;
-	
+
 	assert(pThis != NULL);
 	assert(pC != NULL);
 
@@ -836,7 +837,7 @@ static rsRetVal strmReadChar(strm_t *pThis, uchar *pC)
 		pThis->iUngetC = -1;
 		ABORT_FINALIZE(RS_RET_OK);
 	}
-	
+
 	/* do we need to obtain a new buffer? */
 	if(pThis->iBufPtr >= pThis->iBufPtrMax) {
 		CHKiRet(strmReadBuf(pThis, &padBytes));
@@ -1071,7 +1072,7 @@ strmReadMultiLine(strm_t *pThis, cstr_t **ppCStr, regex_t *start_preg, regex_t *
 	cstr_t *thisLine = NULL;
 	rsRetVal readCharRet;
 	const time_t tCurr = pThis->readTimeout ? getTime(NULL) : 0;
-	int maxMsgSize = glblGetMaxLine();
+	int maxMsgSize = glblGetMaxLine(runConf);
 	DEFiRet;
 
 	do {
@@ -1732,7 +1733,7 @@ syncFile(strm_t *pThis)
 		DBGPRINTF("sync failed for file %d with error (%d): %s - ignoring\n",
 			   pThis->fd, err, errStr);
 	}
-	
+
 	if(pThis->fdDir != -1) {
 		if(fsync(pThis->fdDir) != 0)
 			DBGPRINTF("stream/syncFile: fsync returned error, ignoring\n");
@@ -2260,7 +2261,7 @@ strmSetFName(strm_t *pThis, uchar *pszName, size_t iLenName)
 
 	assert(pThis != NULL);
 	assert(pszName != NULL);
-	
+
 	if(iLenName < 1)
 		ABORT_FINALIZE(RS_RET_FILE_PREFIX_MISSING);
 
@@ -2290,7 +2291,7 @@ strmSetDir(strm_t *pThis, uchar *pszDir, size_t iLenDir)
 
 	assert(pThis != NULL);
 	assert(pszDir != NULL);
-	
+
 	if(iLenDir < 1)
 		ABORT_FINALIZE(RS_RET_FILE_PREFIX_MISSING);
 
@@ -2442,7 +2443,7 @@ strmDup(strm_t *const pThis, strm_t **ppNew)
 	pNew->iFileNumDigits = pThis->iFileNumDigits;
 	pNew->bDeleteOnClose = pThis->bDeleteOnClose;
 	pNew->iCurrOffs = pThis->iCurrOffs;
-	
+
 	*ppNew = pNew;
 	pNew = NULL;
 

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -494,7 +494,7 @@ SessAccept(tcpsrv_t *pThis, tcpLstnPortList_t *pLstnInfo, tcps_sess_t **ppSess, 
 	 */
 	if(!pThis->pIsPermittedHost((struct sockaddr*) addr, (char*) fromHostFQDN, pThis->pUsr, pSess->pUsr)) {
 		DBGPRINTF("%s is not an allowed sender\n", fromHostFQDN);
-		if(glbl.GetOption_DisallowWarning()) {
+		if(glbl.GetOptionDisallowWarning(runConf)) {
 			errno = 0;
 			LogError(0, RS_RET_HOST_NOT_PERMITTED, "TCP message from disallowed "
 					"sender %s discarded", fromHostFQDN);

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -96,6 +96,7 @@ typedef void (*statsobj_read_notifier_t)(statsobj_t *, void *);
 typedef struct nsd_epworkset_s nsd_epworkset_t;
 typedef struct templates_s templates_t;
 typedef struct queuecnf_s queuecnf_t;
+typedef struct parsercnf_s parsercnf_t;
 typedef struct rulesets_s rulesets_t;
 typedef struct globals_s globals_t;
 typedef struct defaults_s defaults_t;

--- a/threads.c
+++ b/threads.c
@@ -43,6 +43,7 @@
 #include "errmsg.h"
 #include "glbl.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 
 /* linked list of currently-known threads */
 static linkedList_t llThrds;
@@ -118,15 +119,15 @@ thrdTerminateNonCancel(thrdInfo_t *pThis)
 
 	pThis->bShallStop = RSTRUE;
 	d_pthread_mutex_lock(&pThis->mutThrd);
-	timeoutComp(&tTimeout, glblInputTimeoutShutdown);
+	timeoutComp(&tTimeout, runConf->globals.inputTimeoutShutdown);
 	was_active = pThis->bIsActive;
 	while(was_active) {
 		if(dbgTimeoutToStderr) {
 			fprintf(stderr, "rsyslogd debug: info: trying to cooperatively stop "
-				"input %s, timeout %d ms\n", pThis->name, glblInputTimeoutShutdown);
+				"input %s, timeout %d ms\n", pThis->name, runConf->globals.inputTimeoutShutdown);
 		}
 		DBGPRINTF("thread %s: initiating termination, timeout %d ms\n",
-			pThis->name, glblInputTimeoutShutdown);
+			pThis->name, runConf->globals.inputTimeoutShutdown);
 		const int r = pthread_kill(pThis->thrdID, SIGTTIN);
 		if(r != 0) {
 			LogError(errno, RS_RET_INTERNAL_ERROR, "error terminating thread %s "

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -70,6 +70,7 @@
 #include "cryprov.h"
 #include "parserif.h"
 #include "janitor.h"
+#include "rsconf.h"
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP
@@ -648,7 +649,7 @@ prepareFile(instanceData *__restrict__ const pData, const uchar *__restrict__ co
 
 	if(pData->useSigprov)
 		sigprovPrepare(pData, szNameBuf);
-	
+
 finalize_it:
 	if(iRet != RS_RET_OK) {
 		if(pData->pStrm != NULL) {
@@ -699,7 +700,7 @@ prepareDynFile(instanceData *__restrict__ const pData, const uchar *__restrict__
 	 * we do not know if we will otherwise come back to this file to flush it
 	 * at end of TX. see https://github.com/rsyslog/rsyslog/issues/2502
 	 */
-	if(((glblDevOptions & DEV_OPTION_8_1905_HANG_TEST) == 0) &&
+	if(((runModConf->pConf->globals.glblDevOptions & DEV_OPTION_8_1905_HANG_TEST) == 0) &&
 	    pData->bFlushOnTXEnd && pData->pStrm != NULL) {
 		CHKiRet(strm.Flush(pData->pStrm));
 	}
@@ -947,7 +948,7 @@ janitorChkDynaFiles(instanceData *__restrict__ const pData)
 			if(pData->iCurrElt == i)
 				pData->iCurrElt = -1; /* no longer available! */
 		} else {
-			pCache[i]->nInactive += janitorInterval;
+			pCache[i]->nInactive += runModConf->pConf->globals.janitorInterval;
 		}
 	}
 }
@@ -968,7 +969,7 @@ janitorCB(void *pUsr)
 				STATSCOUNTER_INC(pData->ctrCloseTimeouts, pData->mutCtrCloseTimeouts);
 				closeFile(pData);
 			} else {
-				pData->nInactive += janitorInterval;
+				pData->nInactive += runModConf->pConf->globals.janitorInterval;
 			}
 		}
 	}

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -837,7 +837,7 @@ static rsRetVal TCPSendInit(void *pvData)
 		if(pData->gnutlsPriorityString != NULL) {
 			CHKiRet(netstrm.SetGnutlsPriorityString(pWrkrData->pNetstrm, pData->gnutlsPriorityString));
 		}
-		CHKiRet(netstrm.Connect(pWrkrData->pNetstrm, glbl.GetDefPFFamily(),
+		CHKiRet(netstrm.Connect(pWrkrData->pNetstrm, glbl.GetDefPFFamily(runModConf->pConf),
 			(uchar*)pData->port, (uchar*)pData->target, pData->device));
 
 		/* set keep-alive if enabled */
@@ -964,7 +964,7 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 		memset(&hints, 0, sizeof(hints));
 		/* port must be numeric, because config file syntax requires this */
 		hints.ai_flags = AI_NUMERICSERV;
-		hints.ai_family = glbl.GetDefPFFamily();
+		hints.ai_family = glbl.GetDefPFFamily(runModConf->pConf);
 		hints.ai_socktype = SOCK_DGRAM;
 		if((iErr = (getaddrinfo(pData->target, pData->port, &hints, &res))) != 0) {
 			LogError(0, RS_RET_SUSPENDED,
@@ -1050,7 +1050,7 @@ processMsg(wrkrInstanceData_t *__restrict__ const pWrkrData,
 	instanceData *__restrict__ const pData = pWrkrData->pData;
 	DEFiRet;
 
-	iMaxLine = glbl.GetMaxLine();
+	iMaxLine = glbl.GetMaxLine(runModConf->pConf);
 
 	psz = iparam->param;
 	l = iparam->lenStr;

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -42,6 +42,7 @@
 #include "parser.h"
 #include "datetime.h"
 #include "unicode-helper.h"
+#include "rsconf.h"
 MODULE_TYPE_PARSER
 MODULE_TYPE_NOKEEP
 PARSER_NAME("rsyslog.rfc3164")
@@ -108,7 +109,7 @@ createInstance(instanceConf_t **pinst)
 	inst->bPermitAtSignsInHostname = 0;
 	inst->bForceTagEndingByColon = 0;
 	inst->bRemoveMsgFirstSpace = 0;
-	bParseHOSTNAMEandTAG=glbl.GetParseHOSTNAMEandTAG();
+	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 	*pinst = inst;
 finalize_it:
 	RETiRet;
@@ -408,7 +409,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(datetime, CORE_COMPONENT));
 
 	DBGPRINTF("rfc3164 parser init called\n");
-	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG();
+	bParseHOSTNAMEandTAG = glbl.GetParseHOSTNAMEandTAG(loadConf);
 	/* cache value, is set only during rsyslogd option processing */
 
 

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -320,7 +320,7 @@ checkStartupOK(void)
 		fprintf(stderr, "rsyslogd: error reading pid file, cannot start up\n");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
-	
+
 	/* ok, we got a pid, let's check if the process is running */
 	const pid_t pid = (pid_t) pf_pid;
 	if(kill(pid, 0) == 0 || errno != ESRCH) {
@@ -559,7 +559,8 @@ rsyslogd_InitStdRatelimiters(void)
 	CHKiRet(ratelimitNew(&dflt_ratelimiter, "rsyslogd", "dflt"));
 	CHKiRet(ratelimitNew(&internalMsg_ratelimiter, "rsyslogd", "internal_messages"));
 	ratelimitSetThreadSafe(internalMsg_ratelimiter);
-	ratelimitSetLinuxLike(internalMsg_ratelimiter, glblIntMsgRateLimitItv, glblIntMsgRateLimitBurst);
+	ratelimitSetLinuxLike(internalMsg_ratelimiter,
+		loadConf->globals.intMsgRateLimitItv, loadConf->globals.intMsgRateLimitBurst);
 	/* TODO: make internalMsg ratelimit settings configurable */
 finalize_it:
 	RETiRet;
@@ -851,8 +852,8 @@ static void
 logmsgInternal_doWrite(smsg_t *pMsg)
 {
 	const int pri = getPRIi(pMsg);
-	if(pri % 8 <= glblIntMsgsSeverityFilter) {
-		if(bProcessInternalMessages) {
+	if(pri % 8 <= runConf->globals.intMsgsSeverityFilter) {
+		if(runConf->globals.bProcessInternalMessages) {
 			submitMsg2(pMsg);
 			pMsg = NULL; /* msg obj handed over; do not destruct */
 		} else {
@@ -865,13 +866,13 @@ logmsgInternal_doWrite(smsg_t *pMsg)
 			 */
 			static warnmsg_emitted = 0;
 			if(warnmsg_emitted == 0) {
-				stdlog_log(stdlog_hdl, LOG_WARNING, "%s",
+				stdlog_log(runConf->globals.stdlog_hdl, LOG_WARNING, "%s",
 					"RSYSLOG WARNING: liblogging-stdlog "
 					"functionality will go away soon. For details see "
 					"https://github.com/rsyslog/rsyslog/issues/2706");
 				warnmsg_emitted = 1;
 			}
-			stdlog_log(stdlog_hdl, pri2sev(pri), "%s", (char*)msg);
+			stdlog_log(runConf->globals.stdlog_hdl, pri2sev(pri), "%s", (char*)msg);
 			#else
 			syslog(pri, "%s", msg);
 			#endif
@@ -1004,7 +1005,7 @@ splitOversizeMessage(smsg_t *const pMsg)
 	const char *rawmsg;
 	int nsegments;
 	int len_rawmsg;
-	const int maxlen = glblGetMaxLine();
+	const int maxlen = glblGetMaxLine(runConf);
 	ISOBJ_TYPE_assert(pMsg, msg);
 
 	getRawMsg(pMsg, (uchar**) &rawmsg, &len_rawmsg);
@@ -1048,31 +1049,31 @@ submitMsg2(smsg_t *pMsg)
 
 	ISOBJ_TYPE_assert(pMsg, msg);
 
-	if(getRawMsgLen(pMsg) > glblGetMaxLine()){
+	if(getRawMsgLen(pMsg) > glblGetMaxLine(runConf)){
 		uchar *rawmsg;
 		int dummy;
 		getRawMsg(pMsg, &rawmsg, &dummy);
-		if(glblReportOversizeMessage()) {
+		if(glblReportOversizeMessage(runConf)) {
 			LogMsg(0, RS_RET_OVERSIZE_MSG, LOG_WARNING,
 				"message too long (%d) with configured size %d, begin of "
 				"message is: %.80s",
-				getRawMsgLen(pMsg), glblGetMaxLine(), rawmsg);
+				getRawMsgLen(pMsg), glblGetMaxLine(runConf), rawmsg);
 		}
 		writeOversizeMessageLog(pMsg);
-		if(glblGetOversizeMsgInputMode() == glblOversizeMsgInputMode_Split) {
+		if(glblGetOversizeMsgInputMode(runConf) == glblOversizeMsgInputMode_Split) {
 			splitOversizeMessage(pMsg);
 			/* we have submitted the message segments recursively, so we
 			 * can just deleted the original msg object and terminate.
 			 */
 			msgDestruct(&pMsg);
 			FINALIZE;
-		} else if(glblGetOversizeMsgInputMode() == glblOversizeMsgInputMode_Truncate) {
+		} else if(glblGetOversizeMsgInputMode(runConf) == glblOversizeMsgInputMode_Truncate) {
 			MsgTruncateToMaxSize(pMsg);
 		} else {
 			/* in "accept" mode, we do nothing, simply because "accept" means
 			 * to use as-is.
 			 */
-			assert(glblGetOversizeMsgInputMode() == glblOversizeMsgInputMode_Accept);
+			assert(glblGetOversizeMsgInputMode(runConf) == glblOversizeMsgInputMode_Accept);
 		}
 	}
 
@@ -1403,16 +1404,14 @@ initAll(int argc, char **argv)
 		DBGPRINTF("deque option %c, optarg '%s'\n", ch, (arg == NULL) ? "" : arg);
 		switch((char)ch) {
 		case '4':
-			fprintf (stderr, "rsyslogd: the -4 command line option will go away "
-				 "soon.\nPlease use the global(net.ipprotocol=\"ipv4-only\") "
+			fprintf (stderr, "rsyslogd: the -4 command line option has gone away.\n"
+				 "Please use the global(net.ipprotocol=\"ipv4-only\") "
 				 "configuration parameter instead.\n");
-	                glbl.SetDefPFFamily(PF_INET);
 			break;
 		case '6':
-			fprintf (stderr, "rsyslogd: the -6 command line option will go away "
-				 "soon.\nPlease use the global(net.ipprotocol=\"ipv6-only\") "
+			fprintf (stderr, "rsyslogd: the -6 command line option will has gone away.\n"
+				 "Please use the global(net.ipprotocol=\"ipv6-only\") "
 				 "configuration parameter instead.\n");
-			glbl.SetDefPFFamily(PF_INET6);
 			break;
 		case 'A':
 			fprintf (stderr, "rsyslogd: the -A command line option will go away "
@@ -1472,16 +1471,14 @@ initAll(int argc, char **argv)
 			}
 			break;
 		case 'q':               /* add hostname if DNS resolving has failed */
-			fprintf (stderr, "rsyslogd: the -q command line option will go away "
-				 "soon.\nPlease use the global(net.aclAddHostnameOnFail=\"on\") "
+			fprintf (stderr, "rsyslogd: the -q command line option has gone away.\n"
+				 "Please use the global(net.aclAddHostnameOnFail=\"on\") "
 				 "configuration parameter instead.\n");
-		        *(net.pACLAddHostnameOnFail) = 1;
 		        break;
 		case 'Q':               /* dont resolve hostnames in ACL to IPs */
-			fprintf (stderr, "rsyslogd: the -Q command line option will go away "
-				 "soon.\nPlease use the global(net.aclResolveHostname=\"off\") "
+			fprintf (stderr, "rsyslogd: the -Q command line option has gone away.\n"
+				 "Please use the global(net.aclResolveHostname=\"off\") "
 				 "configuration parameter instead.\n");
-		        *(net.pACLDontResolve) = 1;
 		        break;
 		case 'T':/* chroot() immediately at program startup, but only for testing, NOT security yet */
 			if(arg == NULL) {
@@ -1503,12 +1500,10 @@ initAll(int argc, char **argv)
 		case 'u':		/* misc user settings */
 			iHelperUOpt = (arg == NULL) ? 0 : atoi(arg);
 			if(iHelperUOpt & 0x01) {
-				fprintf (stderr, "rsyslogd: the -u command line option will go away "
-					 "soon.\n"
+				fprintf (stderr, "rsyslogd: the -u command line option has gone away.\n"
 					 "For the 0x01 bit, please use the "
 					 "global(parser.parseHostnameAndTag=\"off\") "
 					 "configuration parameter instead.\n");
-				glbl.SetParseHOSTNAMEandTAG(0);
 			}
 			if(iHelperUOpt & 0x02) {
 				fprintf (stderr, "rsyslogd: the -u command line option will go away "
@@ -1521,16 +1516,14 @@ initAll(int argc, char **argv)
 			bChDirRoot = 0;
 			break;
 		case 'w':		/* disable disallowed host warnigs */
-			fprintf (stderr, "rsyslogd: the -w command line option will go away "
-				 "soon.\nPlease use the global(net.permitWarning=\"off\") "
+			fprintf (stderr, "rsyslogd: the -w command line option has gone away.\n"
+				 "Please use the global(net.permitWarning=\"off\") "
 				 "configuration parameter instead.\n");
-			glbl.SetOption_DisallowWarning(0);
 			break;
 		case 'x':		/* disable dns for remote messages */
-			fprintf (stderr, "rsyslogd: the -x command line option will go away "
-				 "soon.\nPlease use the global(net.enableDNS=\"off\") "
+			fprintf (stderr, "rsyslogd: the -x command line option has gone away.\n"
+				 "Please use the global(net.enableDNS=\"off\") "
 				 "configuration parameter instead.\n");
-			glbl.SetDisableDNS(1);
 			break;
 		case 'h':
 		case '?':
@@ -1565,7 +1558,7 @@ initAll(int argc, char **argv)
 		 * even on hard config errors. Note that this may lead to segfaults
 		 * or other malfunction further down the road.
 		 */
-		if((glblDevOptions & DEV_OPTION_KEEP_RUNNING_ON_HARD_CONF_ERROR) == 1) {
+		if((loadConf->globals.glblDevOptions & DEV_OPTION_KEEP_RUNNING_ON_HARD_CONF_ERROR) == 1) {
 			fprintf(stderr, "rsyslogd: NOTE: developer-only option set to keep rsyslog "
 				"running where it should abort - this can lead to "
 				"more problems later in the run.\n");
@@ -1592,7 +1585,7 @@ initAll(int argc, char **argv)
 		localRet = RS_RET_OK;
 	}
 	CHKiRet(localRet);
-	
+
 	CHKiRet(rsyslogd_InitStdRatelimiters());
 
 	if(bChDirRoot) {
@@ -1613,7 +1606,7 @@ initAll(int argc, char **argv)
 
 	hdlr_enable(SIGPIPE, SIG_IGN);
 	hdlr_enable(SIGXFSZ, SIG_IGN);
-	if(Debug || glblPermitCtlC) {
+	if(Debug || loadConf->globals.permitCtlC) {
 		hdlr_enable(SIGUSR1, rsyslogdDebugSwitch);
 		hdlr_enable(SIGINT,  rsyslogdDoDie);
 		hdlr_enable(SIGQUIT, rsyslogdDoDie);
@@ -1820,7 +1813,7 @@ rsyslogdDoDie(int sig)
 		abort();
 	}
 	bFinished = sig;
-	if(glblDebugOnShutdown) {
+	if(runConf->globals.debugOnShutdown) {
 		/* kind of hackish - set to 0, so that debug_swith will enable
 		 * and AND emit the "start debug log" message.
 		 */
@@ -1842,7 +1835,7 @@ wait_timeout(const sigset_t *sigmask)
 {
 	struct timespec tvSelectTimeout;
 
-	tvSelectTimeout.tv_sec = janitorInterval * 60; /* interval is in minutes! */
+	tvSelectTimeout.tv_sec = runConf->globals.janitorInterval * 60; /* interval is in minutes! */
 	tvSelectTimeout.tv_nsec = 0;
 
 #ifdef _AIX
@@ -1856,7 +1849,7 @@ wait_timeout(const sigset_t *sigmask)
 		 * in useful subsecond steps.
 		 */
 		const long wait_period = 500000000; /* wait period in nanoseconds */
-		int timeout = janitorInterval * 60 * (1000000000 / wait_period);
+		int timeout = runConf->globals.janitorInterval * 60 * (1000000000 / wait_period);
 
 		tvSelectTimeout.tv_sec = 0;
 		tvSelectTimeout.tv_nsec = wait_period;
@@ -1934,7 +1927,7 @@ reapChild(void)
 		int status;
 		child = waitpid(-1, &status, WNOHANG);
 		if(child != -1 && child != 0) {
-			glblReportChildProcessExit(NULL, child, status);
+			glblReportChildProcessExit(runConf, NULL, child, status);
 		}
 	} while(child > 0);
 }
@@ -2018,7 +2011,7 @@ deinitAll(void)
 	/* close the inputs */
 	DBGPRINTF("Terminating input threads...\n");
 	glbl.SetGlobalInputTermination();
-	
+
 	thrdTerminateAll();
 
 	/* and THEN send the termination log message (see long comment above) */
@@ -2137,16 +2130,13 @@ main(int argc, char **argv)
 	/* disable case-sensitive comparisons in variable subsystem: */
 	fjson_global_do_case_sensitive_comparison(0);
 
-	const char *const log_dflt = getenv("RSYSLOG_DFLT_LOG_INTERNAL");
-	if(log_dflt != NULL && !strcmp(log_dflt, "1"))
-		bProcessInternalMessages = 1;
 	dbgClassInit();
 	initAll(argc, argv);
 #ifdef HAVE_LIBSYSTEMD
 	sd_notify(0, "READY=1");
 	dbgprintf("done signaling to systemd that we are ready!\n");
 #endif
-	DBGPRINTF("max message size: %d\n", glblGetMaxLine());
+	DBGPRINTF("max message size: %d\n", glblGetMaxLine(runConf));
 	DBGPRINTF("----RSYSLOGD INITIALIZED\n");
 	LogMsg(0, RS_RET_OK, LOG_DEBUG, "rsyslogd fully started up and initialized "
 		"- begin actual processing");
@@ -2154,9 +2144,6 @@ main(int argc, char **argv)
 	mainloop();
 	LogMsg(0, RS_RET_OK, LOG_DEBUG, "rsyslogd shutting down");
 	deinitAll();
-#ifdef ENABLE_LIBLOGGING_STDLOG
-	stdlog_close(stdlog_hdl);
-#endif
 	osf_close();
 	return 0;
 }


### PR DESCRIPTION
The list of global parameters should be part of the ```rsconf_t``` configuration structure, so we can later distinguish between the actually running config(runConf) and the config that's being loaded(loadConf). Note that some of them are already part of it.
As soon as this way of handling global parameters is accepted, I will continue with other parameters as well.
The idea behind commit efbd2908e209772b27597a6eb5bd17754143df6e is to extend getters with an additional parameter, an rsconf_t structure specifying the config. With this approach, the caller will be able to query either ```loadConf``` or ```runConf``` . The setter always uses the ```loadConf``` structure, because right now I don't see a reason to modify it during "runtime". The other two commits demonstrate how I intend to apply changes on ```workDirectory``` and ```dropMsgsWithMaliciousDNSPtrRecords```.

Note that extending existing functions with additional parameter changes the interface structure. I would like to know whether it's feasible to do it, or it's a bad approach that should be not considered at all.

List of global parameters for reference: https://www.rsyslog.com/doc/master/rainerscript/global.html