### PR TITLE
ompgsql: allow connection params via connection string

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -891,6 +891,11 @@ if test "x$enable_pgsql" = "xyes"; then
 	    [-L`$PG_CONFIG --libdir`]
 	  )
 	])
+	AC_CHECK_LIB(
+	  [pq],
+	  [PGsslInUse],
+	  [AC_DEFINE([HAVE_PGSSLINUSE], [1], [PGsslInUse function available])]
+	)
 fi
 AM_CONDITIONAL(ENABLE_PGSQL, test x$enable_pgsql = xyes)
 AC_SUBST(PGSQL_CFLAGS)

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -229,7 +229,11 @@ static rsRetVal initPgSQL(wrkrInstanceData_t *pWrkrData, int bSilent)
 		iRet = RS_RET_SUSPENDED;
 	}
 
+#ifdef HAVE_PGSSLINUSE
 	sslStatus = PQsslInUse(pWrkrData->f_hpgsql);
+#else
+	sslStatus = PQgetssl(pWrkrData->f_hpgsql) == NULL ? 0 : 1;
+#endif
 	dbgprintf("initPgSQL: ssl status: %d\n", sslStatus);
 
 	RETiRet;

--- a/runtime/syslogd-types.h
+++ b/runtime/syslogd-types.h
@@ -34,12 +34,11 @@
 
 #define MAXFNAME	4096	/* max file pathname length */
 
-#define	_DB_MAXDBLEN	128	/* maximum number of db */
-#define _DB_MAXUNAMELEN	128	/* maximum number of user name */
-#define	_DB_MAXPWDLEN	128 	/* maximum number of user's pass */
-#define _DB_DELAYTIMEONERROR	20	/* If an error occur we stop logging until
-					   a delayed time is over */
-
+#define _DB_MAXCONNINFOLEN   2048   /* maximum length connection string */
+#define _DB_MAXDBLEN         128    /* maximum number of db */
+#define _DB_MAXUNAMELEN      128    /* maximum number of user name */
+#define _DB_MAXPWDLEN        128    /* maximum number of user's pass */
+#define _DB_DELAYTIMEONERROR 20     /* If an error occur we stop logging until a delayed time is over */
 
 /* we define features of the syslog code. This features can be used
  * to check if modules are compatible with them - and possible other

--- a/tests/pgsql-basic-conninfo-vg.sh
+++ b/tests/pgsql-basic-conninfo-vg.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under GPLv3
+
+. ${srcdir:=.}/diag.sh init
+
+psql -h localhost -U postgres -f testsuites/pgsql-basic.sql
+
+generate_conf
+add_conf '
+module(load="../plugins/ompgsql/.libs/ompgsql")
+if $msg contains "msgnum" then {
+	action(type="ompgsql"
+		conninfo="postgresql://postgres:testbench@localhost/syslogtest")
+}'
+startup_vg
+injectmsg 0 5000
+shutdown_when_empty
+wait_shutdown_vg
+check_exit_vg
+
+psql -h localhost -U postgres -d syslogtest -f testsuites/pgsql-select-msg.sql -t -A >$RSYSLOG_OUT_LOG
+seq_check 0 4999
+
+echo cleaning up test database
+psql -h localhost -U postgres -c 'DROP DATABASE IF EXISTS syslogtest;'
+
+exit_test


### PR DESCRIPTION
Happy new years! Add another action parameter `conninfo` that allows specifying
a postgres connection string. This enables us to use any of the postgres connection
parameters, particularly `sslmode` and `sslrootcert`.

Per the postgres docs, this connection string can be a URI or several key-value
pairs. https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING

Here's an example:
```
module(load="ompgsql")

action(
	type="ompgsql"
	conninfo="postgresql://postgres:password@localhost/Syslog?sslmode=require"
)
```

This addresses https://github.com/rsyslog/rsyslog/issues/4741 by allowing the
user to specify ssl options as part of the connection string. `libpq` will take
care of the rest.

This also addresses https://github.com/rsyslog/rsyslog/issues/4698 because
`libpq` is not constrained by MAXHOSTNAMELEN. Long hostnames will work.

`conninfo` can be specified in lieu of the other parameters. `ompgsql` will
prioritize using `conninfo` to connect over the other parameters.

If this is accepted, I can make updates to the docs https://github.com/rsyslog/rsyslog-doc