### PR TITLE
Fix an use-after-free bug in omlibdbi.c

### DIFF
--- a/plugins/omlibdbi/omlibdbi.c
+++ b/plugins/omlibdbi/omlibdbi.c
@@ -290,15 +290,9 @@ static rsRetVal initConn(instanceData *pData, int bSilent)
 		int is_sqlite2 = !strcmp((const char *)pData->drvrName, "sqlite");
 		int is_sqlite3 = !strcmp((const char *)pData->drvrName, "sqlite3");
 		if(is_sqlite2 || is_sqlite3) {
-			char *const dn_org = strdup((char*)pData->dbName);
-			char *const dn = dirname(dn_org);
-			dbi_conn_set_option(pData->conn, is_sqlite3 ? "sqlite3_dbdir" : "sqlite_dbdir",dn);
-			free(dn_org); /* Free original buffer - dirname may return different pointer */
-
-			char *tmp = strdup((char*)pData->dbName);
-			char *bn = basename(tmp);
-			free(tmp);
-			dbi_conn_set_option(pData->conn, "dbname", bn);
+			dbi_conn_set_option(pData->conn, is_sqlite3 ? "sqlite3_dbdir" : "sqlite_dbdir",
+							dirname((char *)pData->dbName));
+			dbi_conn_set_option(pData->conn, "dbname", basename((char *)pData->dbName ));
 		} else {
 			dbi_conn_set_option(pData->conn, "dbname",   (char*) pData->dbName);
 		}


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->

In the original code, there is a use-after-free bug, which renders the sqlite3 output module unusable. The bug lies in the function initConn, the buggy code is as follows:
```
293             char *const dn_org = strdup((char*)pData->dbName);
294             char *const dn = dirname(dn_org);
295             dbi_conn_set_option(pData->conn, is_sqlite3 ? "sqlite3_dbdir" : "sqlite_dbdir",dn);
296             free(dn_org); /* Free original buffer - dirname may return different pointer */
297 
298             char *tmp = strdup((char*)pData->dbName);
299             char *bn = basename(tmp);
300             free(tmp);
301             dbi_conn_set_option(pData->conn, "dbname", bn); 
```
In line 299, the bn points to the middle of the buffer referenced by tmp, which is allocated in line 298. And then line 300 frees the tmp buffer. After that, line 301 re-uses the pointer bn. In case we are lucky and the buffer content remains the same after being freed, then things stay civil. Otherwise, we will run into trouble. 
