### PR TITLE
Timezone to rsconf

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -1,5 +1,5 @@
 sbin_PROGRAMS =
-man_MANS = 
+man_MANS =
 noinst_LTLIBRARIES = librsyslog.la
 pkglib_LTLIBRARIES =
 #pkglib_LTLIBRARIES = librsyslog.la
@@ -102,7 +102,9 @@ librsyslog_la_SOURCES = \
 	../outchannel.c \
 	../outchannel.h \
 	../template.c \
-	../template.h
+	../template.h \
+	timezones.c \
+	timezones.h
 # the files with ../ we need to work on - so that they either become part of the
 # runtime or will no longer be needed. -- rgerhards, 2008-06-13
 #
@@ -128,13 +130,13 @@ librsyslog_la_CPPFLAGS += -I\$(top_srcdir)/tools
 
 #
 # regular expression support
-# 
+#
 if ENABLE_REGEXP
 pkglib_LTLIBRARIES += lmregexp.la
 lmregexp_la_SOURCES = regexp.c regexp.h
 lmregexp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmregexp_la_LDFLAGS = -module -avoid-version
-lmregexp_la_LIBADD = 
+lmregexp_la_LIBADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 lmregexp_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
@@ -145,12 +147,12 @@ endif
 
 #
 # zlib support
-# 
+#
 pkglib_LTLIBRARIES += lmzlibw.la
 lmzlibw_la_SOURCES = zlibw.c zlibw.h
 lmzlibw_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmzlibw_la_LDFLAGS = -module -avoid-version $(ZLIB_LIBS)
-lmzlibw_la_LIBADD = 
+lmzlibw_la_LIBADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 lmzlibw_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
@@ -162,11 +164,11 @@ if ENABLE_INET
 pkglib_LTLIBRARIES += lmnet.la lmnetstrms.la
 #
 # network support
-# 
+#
 lmnet_la_SOURCES = net.c net.h
 lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo
-lmnet_la_LIBADD = 
+lmnet_la_LIBADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 lmnet_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
@@ -180,7 +182,7 @@ lmnetstrms_la_SOURCES = netstrms.c netstrms.h \
 			nspoll.c nspoll.h
 lmnetstrms_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmnetstrms_la_LDFLAGS = -module -avoid-version
-lmnetstrms_la_LIBADD = 
+lmnetstrms_la_LIBADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 lmnetstrms_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
@@ -196,7 +198,7 @@ lmnsd_ptcp_la_SOURCES = nsd_ptcp.c nsd_ptcp.h \
 			nsdpoll_ptcp.c nsdpoll_ptcp.h
 lmnsd_ptcp_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmnsd_ptcp_la_LDFLAGS = -module -avoid-version
-lmnsd_ptcp_la_LIBADD = 
+lmnsd_ptcp_la_LIBADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 lmnsd_ptcp_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
@@ -207,7 +209,7 @@ endif # if ENABLE_INET
 
 #
 # openssl netstream driver
-# 
+#
 if ENABLE_OPENSSL
 pkglib_LTLIBRARIES += lmnsd_ossl.la
 lmnsd_ossl_la_SOURCES = nsd_ossl.c nsd_ossl.h nsdsel_ossl.c  nsdsel_ossl.h
@@ -218,7 +220,7 @@ endif
 
 #
 # GnuTLS netstream driver
-# 
+#
 if ENABLE_GNUTLS
 pkglib_LTLIBRARIES += lmnsd_gtls.la
 lmnsd_gtls_la_SOURCES = nsd_gtls.c nsd_gtls.h nsdsel_gtls.c  nsdsel_gtls.h
@@ -245,7 +247,7 @@ endif
 
 #
 # gssapi support
-# 
+#
 if ENABLE_GSSAPI
 pkglib_LTLIBRARIES += lmgssutil.la
 lmgssutil_la_SOURCES = gss-misc.c gss-misc.h
@@ -266,7 +268,7 @@ lmtcpsrv_la_SOURCES = \
 	tcpsrv.h
 lmtcpsrv_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmtcpsrv_la_LDFLAGS = -module -avoid-version
-lmtcpsrv_la_LIBADD = 
+lmtcpsrv_la_LIBADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 lmtcpsrv_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
@@ -281,7 +283,7 @@ lmtcpclt_la_SOURCES = \
 	tcpclt.h
 lmtcpclt_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmtcpclt_la_LDFLAGS = -module -avoid-version
-lmtcpclt_la_LIBADD = 
+lmtcpclt_la_LIBADD =
 
 if ENABLE_LIBLOGGING_STDLOG
 lmtcpclt_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)

--- a/runtime/datetime.c
+++ b/runtime/datetime.c
@@ -42,6 +42,8 @@
 #include "srUtils.h"
 #include "stringbuf.h"
 #include "errmsg.h"
+#include "rsconf.h"
+#include "timezones.h"
 
 /* static data */
 DEFobjStaticHelpers
@@ -731,7 +733,7 @@ ParseTIMESTAMP3164(struct syslogTime *pTime, uchar** ppszTS, int *pLenStr,
 			/* found TZ, apply it */
 			tzinfo_t* tzinfo;
 			tzstring[i] = '\0';
-			if((tzinfo = glblFindTimezoneInfo((char*) tzstring)) == NULL) {
+			if((tzinfo = glblFindTimezone(runConf, (char*) tzstring)) == NULL) {
 				DBGPRINTF("ParseTIMESTAMP3164: invalid TZ string '%s' -- ignored\n",
 					  tzstring);
 			} else {
@@ -1016,7 +1018,7 @@ formatTimestamp3164(struct syslogTime *ts, char* pBuf, int bBuggyDay)
 	int iDay;
 	assert(ts != NULL);
 	assert(pBuf != NULL);
-	
+
 	pBuf[0] = monthNames[(ts->month - 1)% 12][0];
 	pBuf[1] = monthNames[(ts->month - 1) % 12][1];
 	pBuf[2] = monthNames[(ts->month - 1) % 12][2];

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -58,6 +58,7 @@
 #include "queue.h"
 #include "dnscache.h"
 #include "parser.h"
+#include "timezones.h"
 
 /* some defaults */
 #ifndef DFLT_NETSTRM_DRVR
@@ -99,9 +100,6 @@ DEF_ATOMIC_HELPER_MUT(mutTerminateInputs);
 static int iFdSetSize = howmany(FD_SETSIZE, __NFDBITS) * sizeof (fd_mask); /* size of select() bitmask in bytes */
 #endif
 static uchar *SourceIPofLocalClient = NULL;	/* [ar] Source IP for local client to be used on multihomed host */
-
-tzinfo_t *tzinfos = NULL;
-static int ntzinfos;
 
 /* tables for interfacing with the v6 config system */
 static struct cnfparamdescr cnfparamdescr[] = {
@@ -182,16 +180,6 @@ static struct cnfparamblk paramblk =
 	{ CNFPARAMBLK_VERSION,
 	  sizeof(cnfparamdescr)/sizeof(struct cnfparamdescr),
 	  cnfparamdescr
-	};
-
-static struct cnfparamdescr timezonecnfparamdescr[] = {
-	{ "id", eCmdHdlrString, CNFPARAM_REQUIRED},
-	{ "offset", eCmdHdlrGetWord, CNFPARAM_REQUIRED }
-};
-static struct cnfparamblk timezonepblk =
-	{ CNFPARAMBLK_VERSION,
-	  sizeof(timezonecnfparamdescr)/sizeof(struct cnfparamdescr),
-	  timezonecnfparamdescr
 	};
 
 static struct cnfparamvals *cnfparamvals = NULL;
@@ -981,66 +969,6 @@ glblPrepCnf(void)
 	cnfparamvals = NULL;
 }
 
-
-static void
-freeTimezoneInfo(void)
-{
-	int i;
-	for(i = 0 ; i < ntzinfos ; ++i)
-		free(tzinfos[i].id);
-	free(tzinfos);
-	tzinfos = NULL;
-}
-
-static void
-displayTzinfos(void)
-{
-	int i;
-	if(!Debug)
-		return;
-	for(i = 0 ; i < ntzinfos ; ++i)
-		dbgprintf("tzinfo: '%s':%c%2.2d:%2.2d\n",
-			tzinfos[i].id, tzinfos[i].offsMode,
-			tzinfos[i].offsHour, tzinfos[i].offsMin);
-}
-
-
-/* Note: this function is NOT thread-safe!
- * This is currently not needed as used only during
- * initialization.
- */
-static rsRetVal
-addTimezoneInfo(uchar *tzid, char offsMode, int8_t offsHour, int8_t offsMin)
-{
-	DEFiRet;
-	tzinfo_t *newti;
-	CHKmalloc(newti = realloc(tzinfos, (ntzinfos+1)*sizeof(tzinfo_t)));
-	if((newti[ntzinfos].id = strdup((char*)tzid)) == NULL) {
-		free(newti);
-		DBGPRINTF("addTimezoneInfo: strdup failed with OOM\n");
-		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-	}
-	newti[ntzinfos].offsMode = offsMode;
-	newti[ntzinfos].offsHour = offsHour;
-	newti[ntzinfos].offsMin = offsMin;
-	++ntzinfos, tzinfos = newti;
-finalize_it:
-	RETiRet;
-}
-
-
-static int
-bs_arrcmp_tzinfo(const void *s1, const void *s2)
-{
-	return strcmp((char*)s1, (char*)((tzinfo_t*)s2)->id);
-}
-/* returns matching timezone info or NULL if no entry exists */
-tzinfo_t*
-glblFindTimezoneInfo(char *id)
-{
-	return (tzinfo_t*) bsearch(id, tzinfos, ntzinfos, sizeof(tzinfo_t), bs_arrcmp_tzinfo);
-}
-
 /* handle the timezone() object. Each incarnation adds one additional
  * zone info to the global table of time zones.
  */
@@ -1051,81 +979,7 @@ bs_arrcmp_glblDbgFiles(const void *s1, const void *s2)
 	return strcmp((char*)s1, *(char**)s2);
 }
 
-void
-glblProcessTimezone(struct cnfobj *o)
-{
-	struct cnfparamvals *pvals;
-	uchar *id = NULL;
-	uchar *offset = NULL;
-	char offsMode;
-	int8_t offsHour;
-	int8_t offsMin;
-	int i;
 
-	pvals = nvlstGetParams(o->nvlst, &timezonepblk, NULL);
-	if(pvals == NULL) {
-		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing timezone "
-				"config parameters");
-		goto done;
-	}
-	if(Debug) {
-		dbgprintf("timezone param blk after glblProcessTimezone:\n");
-		cnfparamsPrint(&timezonepblk, pvals);
-	}
-
-	for(i = 0 ; i < timezonepblk.nParams ; ++i) {
-		if(!pvals[i].bUsed)
-			continue;
-		if(!strcmp(timezonepblk.descr[i].name, "id")) {
-			id = (uchar*) es_str2cstr(pvals[i].val.d.estr, NULL);
-		} else if(!strcmp(timezonepblk.descr[i].name, "offset")) {
-			offset = (uchar*) es_str2cstr(pvals[i].val.d.estr, NULL);
-		} else {
-			dbgprintf("glblProcessTimezone: program error, non-handled "
-			  "param '%s'\n", timezonepblk.descr[i].name);
-		}
-	}
-
-	/* note: the following two checks for NULL are not strictly necessary
-	 * as these are required parameters for the config block. But we keep
-	 * them to make the clang static analyzer happy, which also helps
-	 * guard against logic errors.
-	 */
-	if(offset == NULL) {
-		parser_errmsg("offset parameter missing (logic error?), timezone config ignored");
-		goto done;
-	}
-	if(id == NULL) {
-		parser_errmsg("id parameter missing (logic error?), timezone config ignored");
-		goto done;
-	}
-
-	if(   strlen((char*)offset) != 6
-	   || !(offset[0] == '-' || offset[0] == '+')
-	   || !(isdigit(offset[1]) && isdigit(offset[2]))
-	   || offset[3] != ':'
-	   || !(isdigit(offset[4]) && isdigit(offset[5]))
-	  ) {
-		parser_errmsg("timezone offset has invalid format. Must be +/-hh:mm, e.g. \"-07:00\".");
-		goto done;
-	}
-
-	offsHour = (offset[1] - '0') * 10 + offset[2] - '0';
-	offsMin  = (offset[4] - '0') * 10 + offset[5] - '0';
-	offsMode = offset[0];
-
-	if(offsHour > 12 || offsMin > 59) {
-		parser_errmsg("timezone offset outside of supported range (hours 0..12, minutes 0..59)");
-		goto done;
-	}
-
-	addTimezoneInfo(id, offsMode, offsHour, offsMin);
-
-done:
-	cnfparamvalsDestruct(pvals, &timezonepblk);
-	free(id);
-	free(offset);
-}
 
 /* handle a global config object. Note that multiple global config statements
  * are permitted (because of plugin support), so once we got a param block,
@@ -1221,15 +1075,6 @@ glblDestructMainqCnfObj(void)
 	}
 }
 
-/* comparison function for qsort() and string array compare
- * this is for the string lookup table type
- */
-static int
-qs_arrcmp_tzinfo(const void *s1, const void *s2)
-{
-	return strcmp(((tzinfo_t*)s1)->id, ((tzinfo_t*)s2)->id);
-}
-
 static int
 qs_arrcmp_glblDbgFiles(const void *s1, const void *s2)
 {
@@ -1288,11 +1133,9 @@ glblDoneLoadCnf(void)
 	DEFiRet;
 	CHKiRet(objUse(net, CORE_COMPONENT));
 
-	if(ntzinfos > 0) {
-		qsort(tzinfos, ntzinfos, sizeof(tzinfo_t), qs_arrcmp_tzinfo);
-	}
-	DBGPRINTF("Timezone information table (%d entries):\n", ntzinfos);
-	displayTzinfos();
+	sortTimezones(loadConf);
+	DBGPRINTF("Timezone information table (%d entries):\n", loadConf->timezones.ntzinfos);
+	displayTimezones(loadConf);
 
 	if(cnfparamvals == NULL)
 		goto finalize_it;
@@ -1575,7 +1418,6 @@ BEGINObjClassExit(glbl, OBJ_IS_CORE_MODULE) /* class, version */
 	free(LocalHostName);
 	free(LocalHostNameOverride);
 	free(LocalFQDNName);
-	freeTimezoneInfo();
 	objRelease(prop, CORE_COMPONENT);
 	if(propLocalHostNameToDelete != NULL)
 		prop.Destruct(&propLocalHostNameToDelete);

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -140,12 +140,10 @@ extern DEF_ATOMIC_HELPER_MUT(mutTerminateInputs);
 
 void glblPrepCnf(void);
 void glblProcessCnf(struct cnfobj *o);
-void glblProcessTimezone(struct cnfobj *o);
 void glblProcessMainQCnf(struct cnfobj *o);
 void glblDestructMainqCnfObj(void);
 rsRetVal glblDoneLoadCnf(void);
 const uchar * glblGetWorkDirRaw(rsconf_t *cnf);
-tzinfo_t* glblFindTimezoneInfo(char *id);
 int GetGnuTLSLoglevel(rsconf_t *cnf);
 int glblGetMaxLine(rsconf_t *cnf);
 int bs_arrcmp_glblDbgFiles(const void *s1, const void *s2);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -68,6 +68,7 @@
 #include "modules.h"
 #include "dirty.h"
 #include "template.h"
+#include "timezones.h"
 
 extern char* yytext;
 /* static data */
@@ -220,6 +221,10 @@ static void cnfSetDefaults(rsconf_t *pThis)
 	#endif
 	pThis->globals.iMaxLine = 8096;
 
+	/* timezone specific*/
+	pThis->timezones.tzinfos = NULL;
+	pThis->timezones.ntzinfos = 0;
+
 	/* queue params */
 	pThis->globals.mainQ.iMainMsgQueueSize = 100000;
 	pThis->globals.mainQ.iMainMsgQHighWtrMark = 80000;
@@ -308,6 +313,7 @@ CODESTARTobjDestruct(rsconf)
 	dynstats_destroyAllBuckets();
 	perctileBucketsDestruct();
 	ochDeleteAll();
+	freeTimezones(pThis);
 	free(pThis->globals.mainQ.pszMainMsgQFName);
 	free(pThis->globals.pszConfDAGFile);
 	free(pThis->globals.pszWorkDir);

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -28,6 +28,7 @@
 #include "lookup.h"
 #include "dynstats.h"
 #include "perctile_stats.h"
+#include "timezones.h"
 
 /* --- configuration objects (the plan is to have ALL upper layers in this file) --- */
 
@@ -239,6 +240,7 @@ struct rsconf_s {
 	 *  - actions
 	 * Of course, we need to debate if we shall change that some time...
 	 */
+	timezones_t timezones;
 };
 
 

--- a/runtime/timezones.c
+++ b/runtime/timezones.c
@@ -1,0 +1,205 @@
+/* timezones.c
+ * Support for timezones in RainerScript.
+ *
+ * Copyright 2022 Attila Lakatos and Adiscon GmbH.
+ *
+ * This file is part of the rsyslog runtime library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *		 http://www.apache.org/licenses/LICENSE-2.0
+ *		 -or-
+ *		 see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <ctype.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include "rsyslog.h"
+#include "unicode-helper.h"
+#include "errmsg.h"
+#include "parserif.h"
+#include "rainerscript.h"
+#include "srUtils.h"
+#include "rsconf.h"
+
+
+static struct cnfparamdescr timezonecnfparamdescr[] = {
+	{ "id", eCmdHdlrString, CNFPARAM_REQUIRED},
+	{ "offset", eCmdHdlrGetWord, CNFPARAM_REQUIRED }
+};
+static struct cnfparamblk timezonepblk = {
+	CNFPARAMBLK_VERSION,
+	sizeof(timezonecnfparamdescr)/sizeof(struct cnfparamdescr),
+	timezonecnfparamdescr
+};
+
+/* Note: this function is NOT thread-safe!
+ * This is currently not needed as used only during
+ * initialization.
+ */
+static rsRetVal
+addTimezoneInfo(rsconf_t *cnf, uchar *tzid, char offsMode, int8_t offsHour, int8_t offsMin)
+{
+	DEFiRet;
+	tzinfo_t *newti;
+	CHKmalloc(newti = realloc(cnf->timezones.tzinfos, (cnf->timezones.ntzinfos+1)*sizeof(tzinfo_t)));
+	if((newti[cnf->timezones.ntzinfos].id = strdup((char*)tzid)) == NULL) {
+		free(newti);
+		DBGPRINTF("addTimezoneInfo: strdup failed with OOM\n");
+		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+	}
+	newti[cnf->timezones.ntzinfos].offsMode = offsMode;
+	newti[cnf->timezones.ntzinfos].offsHour = offsHour;
+	newti[cnf->timezones.ntzinfos].offsMin = offsMin;
+	++cnf->timezones.ntzinfos, cnf->timezones.tzinfos = newti;
+finalize_it:
+	RETiRet;
+}
+
+void
+glblProcessTimezone(struct cnfobj *o)
+{
+	struct cnfparamvals *pvals;
+	uchar *id = NULL;
+	uchar *offset = NULL;
+	char offsMode;
+	int8_t offsHour;
+	int8_t offsMin;
+	int i;
+
+	pvals = nvlstGetParams(o->nvlst, &timezonepblk, NULL);
+	if(pvals == NULL) {
+		LogError(0, RS_RET_MISSING_CNFPARAMS, "error processing timezone "
+				"config parameters");
+		goto done;
+	}
+	if(Debug) {
+		dbgprintf("timezone param blk after glblProcessTimezone:\n");
+		cnfparamsPrint(&timezonepblk, pvals);
+	}
+
+	for(i = 0 ; i < timezonepblk.nParams ; ++i) {
+		if(!pvals[i].bUsed)
+			continue;
+		if(!strcmp(timezonepblk.descr[i].name, "id")) {
+			id = (uchar*) es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(timezonepblk.descr[i].name, "offset")) {
+			offset = (uchar*) es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else {
+			dbgprintf("glblProcessTimezone: program error, non-handled "
+			  "param '%s'\n", timezonepblk.descr[i].name);
+		}
+	}
+
+	/* note: the following two checks for NULL are not strictly necessary
+	 * as these are required parameters for the config block. But we keep
+	 * them to make the clang static analyzer happy, which also helps
+	 * guard against logic errors.
+	 */
+	if(offset == NULL) {
+		parser_errmsg("offset parameter missing (logic error?), timezone config ignored");
+		goto done;
+	}
+	if(id == NULL) {
+		parser_errmsg("id parameter missing (logic error?), timezone config ignored");
+		goto done;
+	}
+
+	if(   strlen((char*)offset) != 6
+	   || !(offset[0] == '-' || offset[0] == '+')
+	   || !(isdigit(offset[1]) && isdigit(offset[2]))
+	   || offset[3] != ':'
+	   || !(isdigit(offset[4]) && isdigit(offset[5]))
+	  ) {
+		parser_errmsg("timezone offset has invalid format. Must be +/-hh:mm, e.g. \"-07:00\".");
+		goto done;
+	}
+
+	offsHour = (offset[1] - '0') * 10 + offset[2] - '0';
+	offsMin  = (offset[4] - '0') * 10 + offset[5] - '0';
+	offsMode = offset[0];
+
+	if(offsHour > 12 || offsMin > 59) {
+		parser_errmsg("timezone offset outside of supported range (hours 0..12, minutes 0..59)");
+		goto done;
+	}
+
+	addTimezoneInfo(loadConf, id, offsMode, offsHour, offsMin);
+
+done:
+	cnfparamvalsDestruct(pvals, &timezonepblk);
+	free(id);
+	free(offset);
+}
+
+/* comparison function for qsort() and string array compare
+ * this is for the string lookup table type
+ */
+static int
+qs_arrcmp_tzinfo(const void *s1, const void *s2)
+{
+	return strcmp(((tzinfo_t*)s1)->id, ((tzinfo_t*)s2)->id);
+}
+
+void sortTimezones(rsconf_t *cnf)
+{
+	if (cnf->timezones.ntzinfos > 0) {
+		qsort(cnf->timezones.tzinfos, cnf->timezones.ntzinfos,
+		sizeof(tzinfo_t), qs_arrcmp_tzinfo);
+	}
+}
+
+void
+displayTimezones(rsconf_t *cnf)
+{
+	if(!Debug)
+		return;
+	for(int i = 0 ; i < cnf->timezones.ntzinfos ; ++i)
+		dbgprintf("tzinfo: '%s':%c%2.2d:%2.2d\n",
+			cnf->timezones.tzinfos[i].id, cnf->timezones.tzinfos[i].offsMode,
+			cnf->timezones.tzinfos[i].offsHour, cnf->timezones.tzinfos[i].offsMin);
+}
+
+static int
+bs_arrcmp_tzinfo(const void *s1, const void *s2)
+{
+	return strcmp((char*)s1, (char*)((tzinfo_t*)s2)->id);
+}
+
+/* returns matching timezone info or NULL if no entry exists */
+tzinfo_t*
+glblFindTimezone(rsconf_t *cnf, char *id)
+{
+	return (tzinfo_t*) bsearch(
+		id, cnf->timezones.tzinfos, cnf->timezones.ntzinfos, sizeof(tzinfo_t), bs_arrcmp_tzinfo);
+}
+
+static void
+freeTimezone(tzinfo_t *tzinfo)
+{
+	free(tzinfo->id);
+}
+
+void
+freeTimezones(rsconf_t *cnf)
+{
+	for(int i = 0; i < cnf->timezones.ntzinfos ; ++i)
+		freeTimezone(&cnf->timezones.tzinfos[i]);
+	if (cnf->timezones.ntzinfos > 0)
+		free(cnf->timezones.tzinfos);
+	cnf->timezones.tzinfos = NULL;
+}

--- a/runtime/timezones.h
+++ b/runtime/timezones.h
@@ -1,0 +1,38 @@
+/* header for timezones.c
+ *
+ * Copyright 2022 Attila Lakatos and Adiscon GmbH.
+ *
+ * This file is part of the rsyslog runtime library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_TIMEZONES_H
+#define INCLUDED_TIMEZONES_H
+
+#include "rsconf.h"
+
+/* timezone specific parameters*/
+struct timezones_s {
+	tzinfo_t *tzinfos;
+	int ntzinfos;
+};
+
+void displayTimezones(rsconf_t *cnf);
+void sortTimezones(rsconf_t *cnf);
+void glblProcessTimezone(struct cnfobj *o);
+tzinfo_t* glblFindTimezone(rsconf_t *cnf, char *id);
+void freeTimezones(rsconf_t *cnf);
+
+#endif

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -101,6 +101,7 @@ typedef struct rulesets_s rulesets_t;
 typedef struct globals_s globals_t;
 typedef struct defaults_s defaults_t;
 typedef struct actions_s actions_t;
+typedef struct timezones_s timezones_t;
 typedef struct rsconf_s rsconf_t;
 typedef struct cfgmodules_s cfgmodules_t;
 typedef struct cfgmodules_etry_s cfgmodules_etry_t;


### PR DESCRIPTION
Make timezone specific variables part of the ```rsconf_t``` structure. Later, when dynamic configuration reload feature is introduced, we will need to distinguish between loaded and actually running time zones.

https://github.com/rsyslog/rsyslog/pull/4760 must be merged before this one. Please note that only the last commit is part of this PR, others are part of my previous PR.