### PR TITLE
omhttp: Fix memory leak in lokirest batchmode

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -1244,7 +1244,6 @@ serializeBatchLokiRest(wrkrInstanceData_t *pWrkrData, char **batchBuf)
 {
 	fjson_object *batchArray = NULL;
 	fjson_object *recordObj = NULL;
-	fjson_object *valueObj = NULL;
 	fjson_object *msgObj = NULL;
 
 	size_t numMessages = pWrkrData->batch.nmemb;
@@ -1260,12 +1259,6 @@ serializeBatchLokiRest(wrkrInstanceData_t *pWrkrData, char **batchBuf)
 	}
 
 	for (size_t i = 0; i < numMessages; i++) {
-		valueObj = fjson_object_new_object();
-		if (valueObj == NULL) {
-			fjson_object_put(batchArray); // cleanup
-			LogError(0, RS_RET_ERR, "omhttp: serializeBatchLokiRest failed to create value object");
-			ABORT_FINALIZE(RS_RET_ERR);
-		}
 		DBGPRINTF("omhttp: serializeBatchLokiRest parsing message [%s]\n",(char *) pWrkrData->batch.data[i]);
 		msgObj = fjson_tokener_parse((char *) pWrkrData->batch.data[i]);
 		if (msgObj == NULL) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -895,7 +895,8 @@ TESTS +=  \
 	omhttp-batch-jsonarray-vg.sh \
 	omhttp-batch-kafkarest-retry-vg.sh \
 	omhttp-batch-lokirest-retry-vg.sh \
-	omhttp-retry-vg.sh
+	omhttp-retry-vg.sh \
+	omhttp-batch-lokirest-vg.sh
 endif
 endif
 
@@ -2367,6 +2368,7 @@ EXTRA_DIST= \
 	omhttp-batch-kafkarest.sh \
 	omhttp-batch-lokirest-retry.sh \
 	omhttp-batch-lokirest.sh \
+	omhttp-batch-lokirest-vg.sh \
 	omhttp-batch-newline.sh \
 	omhttp-retry.sh \
 	omhttp-httpheaderkey.sh \

--- a/tests/omhttp-batch-lokirest-vg.sh
+++ b/tests/omhttp-batch-lokirest-vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+# export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
+
+source ${srcdir:=.}/omhttp-batch-lokirest.sh


### PR DESCRIPTION
A JSON object was created (valueObj) but not used and also not
released causing a memory leak. This was properly caused by the
initial copy&paste from serializeBatchKafkaRest.

- Also added a valgrind test for lokirest batchmode
  Uncomment "--keep-debuginfo" in testcaseif stack traces
  are incomplete

closes: https://github.com/rsyslog/rsyslog/issues/4766

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
