### PR TITLE
cleanup: remove unused variable

### DIFF
--- a/runtime/strms_sess.c
+++ b/runtime/strms_sess.c
@@ -3,7 +3,7 @@
  * This implements a session of the strmsrv object. For general
  * comments, see header of strmsrv.c.
  *
- * Copyright 2007-2012 Adiscon GmbH.
+ * Copyright 2007-2022 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -48,8 +48,6 @@ DEFobjCurrIf(glbl)
 DEFobjCurrIf(prop)
 DEFobjCurrIf(netstrm)
 DEFobjCurrIf(datetime)
-
-static int iMaxLine; /* maximum size of a single message */
 
 /* forward definitions */
 static rsRetVal Close(strms_sess_t *pThis);
@@ -288,7 +286,6 @@ BEGINObjClassInit(strms_sess, 1, OBJ_IS_CORE_MODULE) /* class, version - CHANGE 
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
-	iMaxLine = glbl.GetMaxLine(); /* get maximum size we currently support */
 	objRelease(glbl, CORE_COMPONENT);
 
 	/* set our own handlers */


### PR DESCRIPTION
Especially as this caused confusion when doing other work inside the code.

see also https://github.com/rsyslog/rsyslog/pull/4760#discussion_r783118550

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
