### PR TITLE
ikmsg: fix EPIPE error check in the /dev/kmsg reader loop

### DIFF
--- a/contrib/imkmsg/kmsg.c
+++ b/contrib/imkmsg/kmsg.c
@@ -214,7 +214,7 @@ readkmsg(void)
 		if (i > 0) {
 			/* successful read of message of nonzero length */
 			pRcv[i] = '\0';
-		} else if (i == -EPIPE) {
+		} else if (i < 0 && errno == EPIPE) {
 			imkmsgLogIntMsg(LOG_WARNING,
 					"imkmsg: some messages in circular buffer got overwritten");
 			continue;


### PR DESCRIPTION
This is a patch for the issue reported in  #4395. 

kmsg is a unique device, which can recover from EPIPE errors. The code in the module checks for this, but the return value from the libc read call always returns -1, and sets the appropriate errno.

Before this patch, the code checks the return value of the read() call against -EPIPE, which never happens. 

This meant that when an EPIPE error actually happens, the fd  is set to -1 and indefinitely retried. rsyslog does not recover from this. Even though the `for` loop in `readikmsg` is broken out of, this function is repeatedly invoked in a `while` loop.

Note: there is an additional improvement possible - `readikmsg` needs better error checking on the fd. I suspect that this was rarely an issue because /dev/kmsg goes truly invalid when the system is actually shutting down.

The fix here is to check the return value as well as the errno. This will allow the intended logic in the code to happen, and for the reads to recover after a `read` on `/dev/kmsg` returns an `EPIPE`.

closes https://github.com/rsyslog/rsyslog/issues/4395

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
