### PR TITLE
testbench: adjust ElasticSearch startup parameters

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2178,8 +2178,8 @@ ensure_elasticsearch_ready() {
 
 # $2, if set, is the number of additional ES instances
 start_elasticsearch() {
-	# Heap Size (limit to 128MB for testbench! defaults is way to HIGH)
-	export ES_JAVA_OPTS="-Xms128m -Xmx128m"
+	# Heap Size (limit to 256MB for testbench! defaults is way to HIGH)
+	export ES_JAVA_OPTS="-Xms256m -Xmx256m"
 
 	dep_work_dir=$(readlink -f .dep_wrk)
 	dep_work_es_config="es.yml"
@@ -2193,7 +2193,7 @@ start_elasticsearch() {
 	printf 'elasticsearch pid is %s\n' "$(cat $dep_work_es_pidfile)"
 
 	# Wait for startup with hardcoded timeout
-	timeoutend=60
+	timeoutend=120
 	timeseconds=0
 	# Loop until elasticsearch port is reachable or until
 	# timeout is reached!
@@ -2204,6 +2204,16 @@ start_elasticsearch() {
 
 		if [ "$timeseconds" -gt "$timeoutend" ]; then 
 			echo "--- TIMEOUT ( $timeseconds ) reached!!!"
+			if [ ! -d $dep_work_dir/es ]; then
+				echo "ElasticSearch $dep_work_dir/es does not exist, no ElasticSearch debuglog"
+			else
+				echo "Dumping rsyslog-testbench.log from ElasticSearch instance $1"
+				echo "========================================="
+				cat $dep_work_dir/es/logs/rsyslog-testbench.log
+				echo "========================================="
+#				printf 'non-info is:\n'
+#				grep --invert-match '^\[.* INFO ' $dep_work_dir/kafka/logs/server.log | grep '^\['
+			fi
 			error_exit 1
 		fi
 	done


### PR DESCRIPTION
Newer versions seem to require some new defaults. Maybe this also
helps with some hard-to-explain flakiness in ES test runs.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
