### PR TITLE
Introduce dynamic configuartion reload global option

### DIFF
--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -1016,7 +1016,13 @@ modulesEqual(const modConfData_t *l, const modConfData_t *r)
 		USTR_EQUALS(pszStrmDrvrCAFile) &&
 		USTR_EQUALS(pszStrmDrvrKeyFile) &&
 		USTR_EQUALS(pszStrmDrvrCertFile) &&
-		net.PermittedPeersEqual(l->pPermPeersRoot, r->pPermPeersRoot)
+		net.PermittedPeersEqual(l->pPermPeersRoot, r->pPermPeersRoot) &&
+		/* compare global parameters that might modify the behavior of this module */
+		INT_EQUALS(pConf->globals.iGnuTLSLoglevel) &&
+		USTR_EQUALS(pConf->globals.pszDfltNetstrmDrvr) &&
+		USTR_EQUALS(pConf->globals.pszDfltNetstrmDrvrCAF) &&
+		USTR_EQUALS(pConf->globals.pszDfltNetstrmDrvrCertFile) &&
+		USTR_EQUALS(pConf->globals.pszDfltNetstrmDrvrKeyFile)
 	);
 }
 
@@ -1097,9 +1103,8 @@ CODESTARTreloadCnf
 
 		for (instanceConf_t *runInst = runModConf->root; runInst != NULL; runInst = runInst->next) {
 			if (instancesEqual(actLoadInst, runInst)) {
-				DBGPRINTF("Instance %p(port=%s) from old config will be moved to the new config"
-				" and shall continue running, because has the same content as %p\n",
-				runInst, actLoadInst->cnf_params->pszPort, actLoadInst);
+				DBGPRINTF("Instance %p(port=%s, listenPortFileName=%s) from old config"
+				" will be moved to the new config and shall continue running\n", runInst, actLoadInst->cnf_params->pszPort, actLoadInst->cnf_params->pszLstnPortFileName);
 				if (loadModConf->act == actLoadInst)
 					loadModConf->act = loadModConf->act->next;
 				unlinkInstance(runModConf, runInst);

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -174,7 +174,8 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "parser.supportcompressionextension", eCmdHdlrBinary, 0 },
 	{ "shutdown.queue.doublesize", eCmdHdlrBinary, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
-	{ "debug.whitelist", eCmdHdlrBinary, 0 }
+	{ "debug.whitelist", eCmdHdlrBinary, 0 },
+	{ "hup.reload.config", eCmdHdlrBinary, 0 }
 };
 static struct cnfparamblk paramblk =
 	{ CNFPARAMBLK_VERSION,
@@ -1044,7 +1045,8 @@ glblProcessCnf(struct cnfobj *o)
 			cnfparamvals[i].bUsed = TRUE;
 		}
 	}
-done:	return;
+done:
+	return;
 }
 
 /* Set mainq parameters. Note that when this is not called, we'll use the
@@ -1138,7 +1140,7 @@ glblDoneLoadCnf(void)
 	displayTimezones(loadConf);
 
 	if(cnfparamvals == NULL)
-		goto finalize_it;
+		FINALIZE;
 
 	for(i = 0 ; i < paramblk.nParams ; ++i) {
 		if(!cnfparamvals[i].bUsed)
@@ -1343,6 +1345,12 @@ glblDoneLoadCnf(void)
 			loadConf->globals.dnscacheEnableTTL = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "parser.supportcompressionextension")) {
 			loadConf->globals.bSupportCompressionExtension = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "hup.reload.config")) {
+			loadConf->globals.bHUPReloadConfig = (int) cnfparamvals[i].val.d.n;
+			if (loadConf->globals.bHUPReloadConfig) {
+				LogError(0, RS_RET_OK, "Warning: Dynamic reload config is activated. "
+					"Please note that this feature is still in development.");
+			}
 		} else {
 			dbgprintf("glblDoneLoadCnf: program error, non-handled "
 				"param '%s'\n", paramblk.descr[i].name);
@@ -1354,7 +1362,8 @@ glblDoneLoadCnf(void)
 		stddbg = -1;
 	}
 
-finalize_it:	RETiRet;
+finalize_it:
+	RETiRet;
 }
 
 

--- a/runtime/linkedlist.c
+++ b/runtime/linkedlist.c
@@ -58,7 +58,7 @@ int (*pCmpOp)(void*,void*))
 
 	return RS_RET_OK;
 };
-	
+
 
 /* llDestroyEltData - destroys a list element
  * It is a separate function as the
@@ -120,7 +120,7 @@ rsRetVal llDestroyRootElt(linkedList_t *pThis)
 {
 	DEFiRet;
 	llElt_t *pPrev;
-	
+
 	if(pThis->pRoot == NULL) {
 		ABORT_FINALIZE(RS_RET_EMPTY_LIST);
 	}
@@ -219,7 +219,7 @@ rsRetVal llAppend(linkedList_t *pThis, void *pKey, void *pData)
 {
 	llElt_t *pElt;
 	DEFiRet;
-	
+
 	CHKiRet(llEltConstruct(&pElt, pKey, pData));
 
 	pThis->iNumElts++; /* one more */

--- a/runtime/module-template.h
+++ b/runtime/module-template.h
@@ -517,7 +517,7 @@ static rsRetVal initConfVars(void)\
 #define ENDinitConfVars \
 	RETiRet;\
 }
-	
+
 
 /* queryEtryPt()
  */
@@ -658,6 +658,14 @@ static rsRetVal queryEtryPt(uchar *name, rsRetVal (**pEtryPoint)())\
 		*pEtryPoint = freeCnf;\
 	} \
 	CODEqueryEtryPt_STD_CONF2_CNFNAME_QUERIES
+
+/* the following block is to be added for modules that support
+ * dynamic config reload
+ */
+#define CODEqueryEtryPt_STD_CONF2_reloadCnf_QUERIES \
+	  else if(!strcmp((char*) name, "reloadCnf")) {\
+		*pEtryPoint = reloadCnf;\
+	}
 
 /* the following block is to be added for modules that support v2
  * module global parameters [module(...)]
@@ -1020,6 +1028,20 @@ static rsRetVal freeCnf(void *ptr)\
 	RETiRet;\
 }
 
+/* reloadCnf()
+ * This is a function tells a module that dynamic config reload
+ * was invoked.
+ */
+#define BEGINreloadCnf \
+static rsRetVal reloadCnf(void)\
+{\
+	DEFiRet;
+#define CODESTARTreloadCnf
+
+#define ENDreloadCnf \
+	RETiRet;\
+}
+
 
 /* runInput()
  * This is the main function for input modules. It is used to gather data from the
@@ -1068,7 +1090,7 @@ static rsRetVal willRun(void)\
  * rgerhards, 2007-12-17
  */
 #define BEGINafterRun \
-static rsRetVal afterRun(void)\
+static rsRetVal afterRun(thrdInfo_t __attribute__((unused)) *pThrd)\
 {\
 	DEFiRet;
 

--- a/runtime/modules.h
+++ b/runtime/modules.h
@@ -103,7 +103,8 @@ struct modInfo_s {
 	uchar*		pszName;	/* printable module name, e.g. for dbgprintf */
 	uchar*		cnfName;	/* name to be used in config statements (e.g. 'name="omusrmsg"') */
 	unsigned	uRefCnt;	/* reference count for this module; 0 -> may be unloaded */
-	sbool		bSetModCnfCalled;/* is setModCnf already called? Needed for built-in modules */
+	sbool		bSetModCnfCalled;/* is setModCnf already called? Needed for built-in modules
+	                                and after configuration reload*/
 	/* functions supported by all types of modules */
 	rsRetVal (*modInit)(int, int*, rsRetVal(**)(void*));		/* initialize the module */
 		/* be sure to support version handshake! */
@@ -125,6 +126,7 @@ struct modInfo_s {
 	rsRetVal (*activateCnf)(void*Cnf);	/* make provided config the running conf */
 	rsRetVal (*freeCnf)(void*Cnf);
 	/* end v2 config system specific */
+	rsRetVal (*reloadCnf)(void); /* calculate difference between loaded and running conf */
 	union	{
 		struct {/* data for input modules */
 /* TODO: remove? */rsRetVal (*willRun)(void); 		/* check if the current config will be able to run*/

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1654,6 +1654,34 @@ finalize_it:
 
 }
 
+static int
+wildcardsEqual(permittedPeerWildcard_t *pCard1, permittedPeerWildcard_t *pCard2)
+{
+	while (pCard1 != NULL && pCard2 != NULL) {
+		if (strcmp((char *)pCard1->pszDomainPart, (char *)pCard2->pszDomainPart) != 0)
+			return 0;
+		pCard1 = pCard1->pNext;
+		pCard2 = pCard2->pNext;
+	}
+
+	return (pCard1 == pCard2);
+}
+
+static int
+permittedPeersEqual(permittedPeers_t *pPeer1, permittedPeers_t *pPeer2)
+{
+	while (pPeer1 != NULL && pPeer2 != NULL) {
+		if ((strcmp((char *)pPeer1->pszID, (char *)pPeer2->pszID) != 0) ||
+			(wildcardsEqual(pPeer1->pWildcardRoot, pPeer2->pWildcardRoot) != 0)) {
+			return 0;
+		}
+
+		pPeer1 = pPeer1->pNext;
+		pPeer2 = pPeer2->pNext;
+	}
+	return (pPeer1 == pPeer2);
+}
+
 
 /* queryInterface function
  * rgerhards, 2008-03-05
@@ -1687,6 +1715,7 @@ CODESTARTobjQueryInterface(net)
 	pIf->CmpHost = CmpHost;
 	pIf->HasRestrictions = HasRestrictions;
 	pIf->GetIFIPAddr = getIFIPAddr;
+	pIf->PermittedPeersEqual = permittedPeersEqual;
 finalize_it:
 ENDobjQueryInterface(net)
 

--- a/runtime/net.h
+++ b/runtime/net.h
@@ -167,7 +167,10 @@ BEGINinterface(net) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*GetIFIPAddr)(uchar *szif, int family, uchar *pszbuf, int lenBuf);
 	/* v8 cvthname() signature change -- rgerhards, 2013-01-18 */
 	/* v9 create_udp_socket() signature change -- dsahern, 2016-11-11 */
-	/* v10 moved data members to rsconf_t -- alakatos, 2021-12-29 */
+	/* v10 moved data members to rsconf_t -- Cropi, 2021-12-29
+	 *     PermittedPeersEqual() check if 2 permitted peers are the same
+	 */
+	int (*PermittedPeersEqual)(permittedPeers_t *pPeer1, permittedPeers_t *pPeer2);
 ENDinterface(net)
 #define netCURR_IF_VERSION 10 /* increment whenever you change the interface structure! */
 

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -900,8 +900,10 @@ runInputModules(void)
 			== RS_RET_OK) ? 0 : 1;
 			DBGPRINTF("running module %s with config %p, term mode: %s\n", node->pMod->pszName, node,
 				  bNeedsCancel ? "cancel" : "cooperative/SIGTTIN");
+
+			uchar *name = (node->pMod->cnfName == NULL) ? node->pMod->pszName : node->pMod->cnfName;
 			thrdCreate(node->pMod->mod.im.runInput, node->pMod->mod.im.afterRun, bNeedsCancel,
-			           (node->pMod->cnfName == NULL) ? node->pMod->pszName : node->pMod->cnfName);
+				name, iConfigReloaded);
 		}
 		node = module.GetNxtCnfType(runConf, node, eMOD_IN);
 	}

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -260,6 +260,8 @@ static void cnfSetDefaults(rsconf_t *pThis)
 	pThis->globals.parser.bParserEscapeCCCStyle = 0;
 	pThis->globals.parser.bPermitSlashInProgramname = 0;
 	pThis->globals.parser.bParseHOSTNAMEandTAG = 1;
+
+	pThis->globals.bHUPReloadConfig = 0;
 }
 
 

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -157,6 +157,7 @@ struct globals_s {
 
 	// TODO are the following ones defaults?
 	int bReduceRepeatMsgs; /* reduce repeated message - 0 - no, 1 - yes */
+	int bHUPReloadConfig;
 
 	//TODO: other representation for main queue? Or just load it differently?
 	queuecnf_t mainQ;	/* main queue parameters */

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -104,6 +104,7 @@ struct tcpsrv_s {
 	int bDisableLFDelim;	/**< if 1, standard LF frame delimiter is disabled (*very dangerous*) */
 	int discardTruncatedMsg;/**< discard msg part that has been truncated*/
 	sbool bPreserveCase;	/**< preserve case in fromhost */
+	int bTerminateInput; /**< input should be terminated */
 	unsigned int ratelimitInterval;
 	unsigned int ratelimitBurst;
 	tcps_sess_t **pSessions;/**< array of all of our sessions */
@@ -208,8 +209,10 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetDrvrCAFile)(tcpsrv_t *pThis, uchar *pszMode);
 	rsRetVal (*SetDrvrKeyFile)(tcpsrv_t *pThis, uchar *pszMode);
 	rsRetVal (*SetDrvrCertFile)(tcpsrv_t *pThis, uchar *pszMode);
+	/* added v26 -- Force tcpsrv object to terminate, 2022-01-23 */
+	rsRetVal (*SetTerminateInput)(tcpsrv_t *pThis);
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 25 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 26 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10

--- a/template.c
+++ b/template.c
@@ -181,7 +181,7 @@ tplToString(struct template *__restrict__ const pTpl,
 		memcpy(iparam->param, pVal, iLenVal+1);
 		FINALIZE;
 	}
-	
+
 	/* we have a "regular" template with template entries */
 
 	/* loop through the template. We obtain one value
@@ -257,7 +257,7 @@ tplToString(struct template *__restrict__ const pTpl,
 	}
 	iparam->param[iBuf] = '\0';
 	iparam->lenStr = iBuf;
-	
+
 finalize_it:
 	if(bMustBeFreed) {
 		free(pVal);
@@ -475,7 +475,7 @@ static struct templateEntry* tpeConstruct(struct template *pTpl)
 
 	if((pTpe = calloc(1, sizeof(struct templateEntry))) == NULL)
 		return NULL;
-	
+
 	/* basic initialization is done via calloc() - need to
 	 * initialize only values != 0. */
 
@@ -526,7 +526,7 @@ tplConstruct(rsconf_t *conf)
 	struct template *pTpl;
 	if((pTpl = calloc(1, sizeof(struct template))) == NULL)
 		return NULL;
-	
+
 	/* basic initialisation is done via calloc() - need to
 	 * initialize only values != 0. */
 
@@ -1235,7 +1235,7 @@ struct template *tplAddLine(rsconf_t *conf, const char* pName, uchar** ppRestOfC
 	assert(ppRestOfConfLine != NULL);
 	if((pTpl = tplConstruct(conf)) == NULL)
 		return NULL;
-	
+
 	DBGPRINTF("tplAddLine processing template '%s'\n", pName);
 	pTpl->iLenName = strlen(pName);
 	pTpl->pszName = (char*) malloc(pTpl->iLenName + 1);
@@ -1256,7 +1256,7 @@ struct template *tplAddLine(rsconf_t *conf, const char* pName, uchar** ppRestOfC
 
 	while(isspace((int)*p))/* skip whitespace */
 		++p;
-	
+
 	switch(*p) {
 	case '"': /* just continue */
 		break;
@@ -1310,7 +1310,7 @@ struct template *tplAddLine(rsconf_t *conf, const char* pName, uchar** ppRestOfC
 			bDone = 1;
 		}
 	}
-	
+
 	/* we now have the template - let's look at the options (if any)
 	 * we process options until we reach the end of the string or
 	 * an error occurs - whichever is first.
@@ -1383,7 +1383,7 @@ createConstantTpe(struct template *pTpl, struct cnfobj *o)
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
 	cnfparamsPrint(&pblkConstant, pvals);
-	
+
 	for(i = 0 ; i < pblkConstant.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
@@ -1487,7 +1487,7 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
 	cnfparamsPrint(&pblkProperty, pvals);
-	
+
 	for(i = 0 ; i < pblkProperty.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
@@ -1909,7 +1909,7 @@ tplProcessCnf(struct cnfobj *o)
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
 	}
 	cnfparamsPrint(&pblk, pvals);
-	
+
 	for(i = 0 ; i < pblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
@@ -2049,7 +2049,7 @@ tplProcessCnf(struct cnfobj *o)
 	}
 	pTpl->pszName = name;
 	pTpl->iLenName = lenName;
-	
+
 	switch(tplType) {
 	case T_STRING:	p = tplStr;
 			while(*p) {
@@ -2080,7 +2080,7 @@ tplProcessCnf(struct cnfobj *o)
 			pTpl->bHaveSubtree = 1;
 			break;
 	}
-	
+
 	pTpl->optFormatEscape = NO_ESCAPE;
 	if(o_stdsql)
 		pTpl->optFormatEscape = STDSQL_ESCAPE;

--- a/tests/imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh
+++ b/tests/imtcp-multi-drvr-basic-ptcp_gtls_ossl.sh
@@ -28,8 +28,6 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port3" name="i3")
-
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '

--- a/threads.c
+++ b/threads.c
@@ -266,7 +266,7 @@ thrdStarter(void *const arg)
  * rgerhards, 2007-12-14
  */
 rsRetVal thrdCreate(rsRetVal (*thrdMain)(thrdInfo_t*), rsRetVal(*afterRun)(thrdInfo_t *),
-	sbool bNeedsCancel, uchar *name)
+	sbool bNeedsCancel, uchar *name, int serial)
 {
 	DEFiRet;
 	thrdInfo_t *pThis;
@@ -281,7 +281,9 @@ rsRetVal thrdCreate(rsRetVal (*thrdMain)(thrdInfo_t*), rsRetVal(*afterRun)(thrdI
 	pThis->pUsrThrdMain = thrdMain;
 	pThis->pAfterRun = afterRun;
 	pThis->bNeedsCancel = bNeedsCancel;
-	pThis->name = ustrdup(name);
+	pThis->serial = serial;
+	if (asprintf((char **)(&pThis->name), "%s%d", name, serial) == -1)
+		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 #if defined (_AIX)
 	pthread_attr_init(&aix_attr);
 	pthread_attr_setstacksize(&aix_attr, 4096*512);

--- a/threads.h
+++ b/threads.h
@@ -33,6 +33,7 @@ struct thrdInfo {
 	pthread_t thrdID;
 	sbool bNeedsCancel;	/* must input be terminated by pthread_cancel()? */
 	uchar *name;		/* a thread name, mainly for user interaction */
+	int serial; /* in which dynamic conf reload has the thread been created */
 };
 
 /* prototypes */
@@ -40,7 +41,7 @@ rsRetVal thrdExit(void);
 rsRetVal thrdInit(void);
 rsRetVal thrdTerminate(thrdInfo_t *pThis);
 rsRetVal thrdTerminateAll(void);
-rsRetVal thrdCreate(rsRetVal (*thrdMain)(thrdInfo_t*), rsRetVal(*afterRun)(thrdInfo_t *), sbool, uchar*);
+rsRetVal thrdCreate(rsRetVal (*thrdMain)(thrdInfo_t*), rsRetVal(*afterRun)(thrdInfo_t *), sbool, uchar*, int);
 
 /* macros (replace inline functions) */
 


### PR DESCRIPTION
The pull request encapsulates multiple changes, let me break it down for smaller parts:

### Input threads

Name of a new input thread now consists of its name(e.g. imtcp) and its serial(e.g. 1 - in which dynamic conf reload has the thread been created). The purpose of this is to better distinguish between input threads that have been created during runtime.

### Globals

New global directive is introduced - hup.reload.config. If set to "on", rsyslog will dynamically reload its configuration(right now only imtcp is implemented to do so). Otherwise, old behavior is used.

## Modules

New function, ```reloadCnf()``` has been added to the interface. If a certain module implements it, the module will be signaled when rsyslog is HUPed, requesting the module to dynamically reload its config.

### The imtcp module - conf reload

1. If there is just a slight difference between the old and new ```imtcp``` module configs we can not use old instances -> we need to reload all of them, note that not all of the module parameters force us to reload all instances, but for simplicity I think it makes sense to do it this way and later improve it
2. Check if new instance is part of old config. If indeed is, remove newly allocated resources and reconfigure pointers(relocate it from the running config into the config being loaded)
3. Remove old instance when not part of the new config.
It would be a lot easier if I just closed all instances and restarted them later but in that case existing TCP connections would have been disturbed.
The idea behind this is to not touch existing TCP connections, just relocate them from the old config to the new one.

### Comparing two imtcp module/instance configs

I am open to any ideas for some change here. I could not come up with a better way when comparing them, also I am not sure where to place macros used for comparing two instances/configs -- other modules will need them as well.