### PR TITLE
rscript: literal numbers were not compared correctly

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2,7 +2,7 @@
  *
  * Module begun 2011-07-01 by Rainer Gerhards
  *
- * Copyright 2011-2019 Rainer Gerhards and Others.
+ * Copyright 2011-2022 Rainer Gerhards and Others.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -2936,11 +2936,16 @@ evalVar(struct cnfvar *__restrict__ const var, void *__restrict__ const usrptr,
 		localRet = msgGetJSONPropJSONorString((smsg_t*)usrptr, &var->prop, &json, &cstr);
 		if(json != NULL) {
 			assert(cstr == NULL);
-			ret->datatype = 'J';
-			ret->d.json = (localRet == RS_RET_OK) ? json : NULL;
-			DBGPRINTF("rainerscript: (json) var %d:%s: '%s'\n",
-				var->prop.id, var->prop.name,
-			  (ret->d.json == NULL) ? "" : json_object_get_string(ret->d.json));
+			if(json_object_get_type(json) == json_type_int) {
+				ret->datatype = 'N';
+				ret->d.n = fjson_object_get_int64(json);
+			} else {
+				ret->datatype = 'J';
+				ret->d.json = (localRet == RS_RET_OK) ? json : NULL;
+				DBGPRINTF("rainerscript: (json) var %d:%s: '%s'\n",
+					var->prop.id, var->prop.name,
+				  (ret->d.json == NULL) ? "" : json_object_get_string(ret->d.json));
+			}
 		} else { /* we have a string */
 			DBGPRINTF("rainerscript: (json/string) var %d: '%s'\n", var->prop.id, cstr);
 			ret->datatype = 'S';


### PR DESCRIPTION
This problem occurred when numbers were used in rsyslog.conf in
the set statement, e.g.

set $nbr = 1234;

In this case, during comparisons, the number was actually interpreted
as a string with digits. Thus numerical comparisons lead to unexpected
results. Even more so, as in other places of the code they were
treated as native numbers.

This is now fixed. We cannot outrule that this causes, in border cases,
change of behavior to existing configs. But it is unlikely and the
previous behaviour was a clear bug and very unintuitive. This in our
opinion it is justified to risk a breaking change for an expected
very minor subset of installations, if any such exists at all.

closes https://github.com/rsyslog/rsyslog/issues/4770

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
