### PR TITLE
Make the main message queue part of the config

### DIFF
--- a/action.c
+++ b/action.c
@@ -560,6 +560,7 @@ actionConstructFinalize(action_t *__restrict__ const pThis, struct nvlst *lst)
 		qqueueSetDefaultsActionQueue(pThis->pQueue);
 		qqueueApplyCnfParam(pThis->pQueue, lst);
 	}
+	qqueueCorrectParams(pThis->pQueue);
 
 #	undef setQPROP
 #	undef setQPROPstr
@@ -1947,7 +1948,7 @@ DEFFUNC_llExecFunc(doActivateActions)
 {
 	rsRetVal localRet;
 	action_t * const pThis = (action_t*) pData;
-	localRet = qqueueStart(pThis->pQueue);
+	localRet = qqueueStart(runConf, pThis->pQueue);
 	if(localRet != RS_RET_OK) {
 		LogError(0, localRet, "error starting up action queue");
 		if(localRet == RS_RET_FILE_PREFIX_MISSING) {

--- a/dirty.h
+++ b/dirty.h
@@ -38,10 +38,9 @@ rsRetVal __attribute__((deprecated)) parseAndSubmitMessage(const uchar *hname,
 	prop_t *pInputName, const struct syslogTime *stTime,
 	const time_t ttGenTime, ruleset_t *pRuleset);
 rsRetVal createMainQueue(qqueue_t **ppQueue, uchar *pszQueueName, struct nvlst *lst);
-rsRetVal startMainQueue(qqueue_t *pQueue);
+rsRetVal startMainQueue(rsconf_t *cnf, qqueue_t *pQueue);
 
 extern int MarkInterval;
-extern qqueue_t *pMsgQueue;			/* the main message queue */
 #define CONF_VERIFY_PARTIAL_CONF 0x02		/* bit: partial configuration to be checked */
 extern int iConfigVerify;			/* is this just a config verify run? */
 extern int bHaveMainQueue;

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -498,7 +498,7 @@ StartDA(qqueue_t *pThis)
 		pThis->cryprovNameFull = NULL;
 	}
 
-	iRet = qqueueStart(pThis->pqDA);
+	iRet = qqueueStart(runConf, pThis->pqDA);
 	/* file not found is expected, that means it is no previous QIF available */
 	if(iRet != RS_RET_OK && iRet != RS_RET_FILE_NOT_FOUND) {
 		errno = 0; /* else an errno is shown in errmsg! */
@@ -1502,6 +1502,7 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis, queueType_t qType, int iWorkerThread
 	pThis->iDeqtWinToHr = 25; /* disable time-windowed dequeuing by default */
 	pThis->iDeqBatchSize = 8; /* conservative default, should still provide good performance */
 	pThis->iMinDeqBatchSize = 0; /* conservative default, should still provide good performance */
+	pThis->isRunning = 0;
 
 	pThis->pszFilePrefix = NULL;
 	pThis->qType = qType;
@@ -2323,17 +2324,22 @@ GetDeqBatchSize(qqueue_t *pThis, int *pVal)
  * before.
  */
 rsRetVal
-qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
+qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the ConstructionFinalizer */
 {
 	DEFiRet;
 	uchar pszBuf[64];
 	uchar pszQIFNam[MAXFNAME];
 	int wrk;
-	int goodval; /* a "good value" to use for comparisons (different objects) */
 	uchar *qName;
 	size_t lenBuf;
 
 	assert(pThis != NULL);
+
+	/* do not modify the queue if it's already running(happens when dynamic config reload is invoked
+	 * and the queue is used in the new config as well)
+	 */
+	if (pThis->isRunning)
+		FINALIZE;
 
 	dbgoprint((obj_t*) pThis, "starting queue\n");
 
@@ -2341,7 +2347,7 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 		/* note: we need to pick the path so late as we do not have
 		 *       the workdir during early config load
 		 */
-		if((pThis->pszSpoolDir = (uchar*) strdup((char*)glbl.GetWorkDir(runConf))) == NULL)
+		if((pThis->pszSpoolDir = (uchar*) strdup((char*)glbl.GetWorkDir(cnf))) == NULL)
 			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 		pThis->lenSpoolDir = ustrlen(pThis->pszSpoolDir);
 	}
@@ -2390,116 +2396,6 @@ qqueueStart(qqueue_t *pThis) /* this is the ConstructionFinalizer */
 			pThis->MultiEnq = qqueueMultiEnqObjDirect;
 			pThis->qDel = NULL;
 			break;
-	}
-
-	if(pThis->iMaxQueueSize < 100
-	   && (pThis->qType == QUEUETYPE_LINKEDLIST || pThis->qType == QUEUETYPE_FIXED_ARRAY)) {
-		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "Note: queue.size=\"%d\" is very "
-			"low and can lead to unpredictable results. See also "
-			"https://www.rsyslog.com/lower-bound-for-queue-sizes/",
-			pThis->iMaxQueueSize);
-	}
-
-	/* we need to do a quick check if our water marks are set plausible. If not,
-	 * we correct the most important shortcomings.
-	 */
-	goodval = (pThis->iMaxQueueSize / 100) * 60;
-	if(pThis->iHighWtrMrk != -1 && pThis->iHighWtrMrk < goodval) {
-		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": high water mark "
-				"is set quite low at %d. You should only set it below "
-				"60%% (%d) if you have a good reason for this.",
-				obj.GetName((obj_t*) pThis), pThis->iHighWtrMrk, goodval);
-	}
-
-	if(pThis->iNumWorkerThreads > 1) {
-		goodval = (pThis->iMaxQueueSize / 100) * 10;
-		if(pThis->iMinMsgsPerWrkr != -1 && pThis->iMinMsgsPerWrkr < goodval) {
-			LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": "
-					"queue.workerThreadMinimumMessage "
-					"is set quite low at %d. You should only set it below "
-					"10%% (%d) if you have a good reason for this.",
-					obj.GetName((obj_t*) pThis), pThis->iMinMsgsPerWrkr, goodval);
-		}
-	}
-
-	if(pThis->iDiscardMrk > pThis->iMaxQueueSize) {
-		LogError(0, RS_RET_PARAM_ERROR, "error: queue \"%s\": "
-				"queue.discardMark %d is set larger than queue.size",
-				obj.GetName((obj_t*) pThis), pThis->iDiscardMrk);
-	}
-
-	goodval = (pThis->iMaxQueueSize / 100) * 80;
-	if(pThis->iDiscardMrk != -1 && pThis->iDiscardMrk < goodval) {
-		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING,
-				"queue \"%s\": queue.discardMark "
-				"is set quite low at %d. You should only set it below "
-				"80%% (%d) if you have a good reason for this.",
-				obj.GetName((obj_t*) pThis), pThis->iDiscardMrk, goodval);
-	}
-
-	if(pThis->pszFilePrefix != NULL) { /* This means we have a potential DA queue */
-		if(pThis->iFullDlyMrk != -1 && pThis->iFullDlyMrk < pThis->iHighWtrMrk) {
-			LogMsg(0, RS_RET_CONF_WRN_FULLDLY_BELOW_HIGHWTR, LOG_WARNING,
-					"queue \"%s\": queue.fullDelayMark "
-					"is set below high water mark. This will result in DA mode "
-					" NOT being activated for full delayable messages: In many "
-					"cases this is a configuration error, please check if this "
-					"is really what you want",
-					obj.GetName((obj_t*) pThis));
-		}
-	}
-
-	/* now come parameter corrections and defaults */
-	if(pThis->iHighWtrMrk < 2 || pThis->iHighWtrMrk > pThis->iMaxQueueSize) {
-		pThis->iHighWtrMrk  = (pThis->iMaxQueueSize / 100) * 90;
-		if(pThis->iHighWtrMrk == 0) { /* guard against very low max queue sizes! */
-			pThis->iHighWtrMrk = pThis->iMaxQueueSize;
-		}
-	}
-	if(   pThis->iLowWtrMrk < 2
-	   || pThis->iLowWtrMrk > pThis->iMaxQueueSize
-	   || pThis->iLowWtrMrk > pThis->iHighWtrMrk ) {
-		pThis->iLowWtrMrk  = (pThis->iMaxQueueSize / 100) * 70;
-		if(pThis->iLowWtrMrk == 0) {
-			pThis->iLowWtrMrk = 1;
-		}
-	}
-
-	if((pThis->iMinMsgsPerWrkr < 1
-	   || pThis->iMinMsgsPerWrkr > pThis->iMaxQueueSize) ) {
-		pThis->iMinMsgsPerWrkr  = pThis->iMaxQueueSize / pThis->iNumWorkerThreads;
-	}
-
-	if(pThis->iFullDlyMrk == -1 || pThis->iFullDlyMrk > pThis->iMaxQueueSize) {
-		pThis->iFullDlyMrk  = (pThis->iMaxQueueSize / 100) * 97;
-		if(pThis->iFullDlyMrk == 0) {
-			pThis->iFullDlyMrk =
-				(pThis->iMaxQueueSize == 1) ? 1 : pThis->iMaxQueueSize - 1;
-		}
-	}
-
-	if(pThis->iLightDlyMrk == 0) {
-		pThis->iLightDlyMrk = pThis->iMaxQueueSize;
-	}
-
-	if(pThis->iLightDlyMrk == -1 || pThis->iLightDlyMrk > pThis->iMaxQueueSize) {
-		pThis->iLightDlyMrk = (pThis->iMaxQueueSize / 100) * 70;
-		if(pThis->iLightDlyMrk == 0) {
-			pThis->iLightDlyMrk =
-				(pThis->iMaxQueueSize == 1) ? 1 : pThis->iMaxQueueSize - 1;
-		}
-	}
-
-	if(pThis->iDiscardMrk < 1 || pThis->iDiscardMrk > pThis->iMaxQueueSize) {
-		pThis->iDiscardMrk  = (pThis->iMaxQueueSize / 100) * 98;
-		if(pThis->iDiscardMrk == 0) {
-			/* for very small queues, we disable this by default */
-			pThis->iDiscardMrk = pThis->iMaxQueueSize;
-		}
-	}
-
-	if(pThis->iMaxQueueSize > 0 && pThis->iDeqBatchSize > pThis->iMaxQueueSize) {
-		pThis->iDeqBatchSize = pThis->iMaxQueueSize;
 	}
 
 	/* finalize some initializations that could not yet be done because it is
@@ -2621,6 +2517,8 @@ finalize_it:
 		/* note: a child uses it's parent mutex, so do not delete it! */
 		if(pThis->pqParent == NULL && pThis->mut != NULL)
 			free(pThis->mut);
+	} else {
+		pThis->isRunning = 1;
 	}
 	RETiRet;
 }
@@ -3326,6 +3224,122 @@ finalize_it:
 	RETiRet;
 }
 
+void
+qqueueCorrectParams(qqueue_t *pThis)
+{
+	int goodval; /* a "good value" to use for comparisons (different objects) */
+
+	if(pThis->iMaxQueueSize < 100
+	   && (pThis->qType == QUEUETYPE_LINKEDLIST || pThis->qType == QUEUETYPE_FIXED_ARRAY)) {
+		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "Note: queue.size=\"%d\" is very "
+			"low and can lead to unpredictable results. See also "
+			"https://www.rsyslog.com/lower-bound-for-queue-sizes/",
+			pThis->iMaxQueueSize);
+	}
+
+	/* we need to do a quick check if our water marks are set plausible. If not,
+	 * we correct the most important shortcomings.
+	 */
+	goodval = (pThis->iMaxQueueSize / 100) * 60;
+	if(pThis->iHighWtrMrk != -1 && pThis->iHighWtrMrk < goodval) {
+		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": high water mark "
+				"is set quite low at %d. You should only set it below "
+				"60%% (%d) if you have a good reason for this.",
+				obj.GetName((obj_t*) pThis), pThis->iHighWtrMrk, goodval);
+	}
+
+	if(pThis->iNumWorkerThreads > 1) {
+		goodval = (pThis->iMaxQueueSize / 100) * 10;
+		if(pThis->iMinMsgsPerWrkr != -1 && pThis->iMinMsgsPerWrkr < goodval) {
+			LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING, "queue \"%s\": "
+					"queue.workerThreadMinimumMessage "
+					"is set quite low at %d. You should only set it below "
+					"10%% (%d) if you have a good reason for this.",
+					obj.GetName((obj_t*) pThis), pThis->iMinMsgsPerWrkr, goodval);
+		}
+	}
+
+	if(pThis->iDiscardMrk > pThis->iMaxQueueSize) {
+		LogError(0, RS_RET_PARAM_ERROR, "error: queue \"%s\": "
+				"queue.discardMark %d is set larger than queue.size",
+				obj.GetName((obj_t*) pThis), pThis->iDiscardMrk);
+	}
+
+	goodval = (pThis->iMaxQueueSize / 100) * 80;
+	if(pThis->iDiscardMrk != -1 && pThis->iDiscardMrk < goodval) {
+		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING,
+				"queue \"%s\": queue.discardMark "
+				"is set quite low at %d. You should only set it below "
+				"80%% (%d) if you have a good reason for this.",
+				obj.GetName((obj_t*) pThis), pThis->iDiscardMrk, goodval);
+	}
+
+	if(pThis->pszFilePrefix != NULL) { /* This means we have a potential DA queue */
+		if(pThis->iFullDlyMrk != -1 && pThis->iFullDlyMrk < pThis->iHighWtrMrk) {
+			LogMsg(0, RS_RET_CONF_WRN_FULLDLY_BELOW_HIGHWTR, LOG_WARNING,
+					"queue \"%s\": queue.fullDelayMark "
+					"is set below high water mark. This will result in DA mode "
+					" NOT being activated for full delayable messages: In many "
+					"cases this is a configuration error, please check if this "
+					"is really what you want",
+					obj.GetName((obj_t*) pThis));
+		}
+	}
+
+	/* now come parameter corrections and defaults */
+	if(pThis->iHighWtrMrk < 2 || pThis->iHighWtrMrk > pThis->iMaxQueueSize) {
+		pThis->iHighWtrMrk  = (pThis->iMaxQueueSize / 100) * 90;
+		if(pThis->iHighWtrMrk == 0) { /* guard against very low max queue sizes! */
+			pThis->iHighWtrMrk = pThis->iMaxQueueSize;
+		}
+	}
+	if(   pThis->iLowWtrMrk < 2
+	   || pThis->iLowWtrMrk > pThis->iMaxQueueSize
+	   || pThis->iLowWtrMrk > pThis->iHighWtrMrk ) {
+		pThis->iLowWtrMrk  = (pThis->iMaxQueueSize / 100) * 70;
+		if(pThis->iLowWtrMrk == 0) {
+			pThis->iLowWtrMrk = 1;
+		}
+	}
+
+	if((pThis->iMinMsgsPerWrkr < 1
+	   || pThis->iMinMsgsPerWrkr > pThis->iMaxQueueSize) ) {
+		pThis->iMinMsgsPerWrkr  = pThis->iMaxQueueSize / pThis->iNumWorkerThreads;
+	}
+
+	if(pThis->iFullDlyMrk == -1 || pThis->iFullDlyMrk > pThis->iMaxQueueSize) {
+		pThis->iFullDlyMrk  = (pThis->iMaxQueueSize / 100) * 97;
+		if(pThis->iFullDlyMrk == 0) {
+			pThis->iFullDlyMrk =
+				(pThis->iMaxQueueSize == 1) ? 1 : pThis->iMaxQueueSize - 1;
+		}
+	}
+
+	if(pThis->iLightDlyMrk == 0) {
+		pThis->iLightDlyMrk = pThis->iMaxQueueSize;
+	}
+
+	if(pThis->iLightDlyMrk == -1 || pThis->iLightDlyMrk > pThis->iMaxQueueSize) {
+		pThis->iLightDlyMrk = (pThis->iMaxQueueSize / 100) * 70;
+		if(pThis->iLightDlyMrk == 0) {
+			pThis->iLightDlyMrk =
+				(pThis->iMaxQueueSize == 1) ? 1 : pThis->iMaxQueueSize - 1;
+		}
+	}
+
+	if(pThis->iDiscardMrk < 1 || pThis->iDiscardMrk > pThis->iMaxQueueSize) {
+		pThis->iDiscardMrk  = (pThis->iMaxQueueSize / 100) * 98;
+		if(pThis->iDiscardMrk == 0) {
+			/* for very small queues, we disable this by default */
+			pThis->iDiscardMrk = pThis->iMaxQueueSize;
+		}
+	}
+
+	if(pThis->iMaxQueueSize > 0 && pThis->iDeqBatchSize > pThis->iMaxQueueSize) {
+		pThis->iDeqBatchSize = pThis->iMaxQueueSize;
+	}
+}
+
 /* apply all params from param block to queue. Must be called before
  * finalizing. This supports the v6 config system. Defaults were already
  * set during queue creation. The pvals object is destructed by this
@@ -3478,6 +3492,43 @@ qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst)
 	cnfparamvalsDestruct(pvals, &pblk);
 finalize_it:
 	RETiRet;
+}
+
+/* return 1 if the content of two qqueue_t structs equal */
+int
+queuesEqual(qqueue_t *pOld, qqueue_t *pNew)
+{
+	return (
+		NUM_EQUALS(qType) &&
+		NUM_EQUALS(iMaxQueueSize) &&
+		NUM_EQUALS(iDeqBatchSize) &&
+		NUM_EQUALS(iMinDeqBatchSize) &&
+		NUM_EQUALS(toMinDeqBatchSize) &&
+		NUM_EQUALS(sizeOnDiskMax) &&
+		NUM_EQUALS(iHighWtrMrk) &&
+		NUM_EQUALS(iLowWtrMrk) &&
+		NUM_EQUALS(iFullDlyMrk) &&
+		NUM_EQUALS(iLightDlyMrk) &&
+		NUM_EQUALS(iDiscardMrk) &&
+		NUM_EQUALS(iDiscardSeverity) &&
+		NUM_EQUALS(iPersistUpdCnt) &&
+		NUM_EQUALS(bSyncQueueFiles) &&
+		NUM_EQUALS(iNumWorkerThreads) &&
+		NUM_EQUALS(toQShutdown) &&
+		NUM_EQUALS(toActShutdown) &&
+		NUM_EQUALS(toEnq) &&
+		NUM_EQUALS(toWrkShutdown) &&
+		NUM_EQUALS(iMinMsgsPerWrkr) &&
+		NUM_EQUALS(iMaxFileSize) &&
+		NUM_EQUALS(bSaveOnShutdown) &&
+		NUM_EQUALS(iDeqSlowdown) &&
+		NUM_EQUALS(iDeqtWinFromHr) &&
+		NUM_EQUALS(iDeqtWinToHr) &&
+		NUM_EQUALS(iSmpInterval) &&
+		NUM_EQUALS(takeFlowCtlFromMsg) &&
+		USTR_EQUALS(pszFilePrefix) &&
+		USTR_EQUALS(cryprovName)
+	);
 }
 
 

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -188,6 +188,7 @@ struct queue_s {
 	STATSCOUNTER_DEF(ctrNFDscrd, mutCtrNFDscrd)
 	int ctrMaxqsize; /* NOT guarded by a mutex */
 	int iSmpInterval; /* line interval of sampling logs */
+	int isRunning;
 };
 
 
@@ -201,7 +202,7 @@ struct queue_s {
 /* prototypes */
 rsRetVal qqueueDestruct(qqueue_t **ppThis);
 rsRetVal qqueueEnqMsg(qqueue_t *pThis, flowControl_t flwCtlType, smsg_t *pMsg);
-rsRetVal qqueueStart(qqueue_t *pThis);
+rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis);
 rsRetVal qqueueSetMaxFileSize(qqueue_t *pThis, size_t iMaxFileSize);
 rsRetVal qqueueSetFilePrefix(qqueue_t *pThis, uchar *pszPrefix, size_t iLenPrefix);
 rsRetVal qqueueConstruct(qqueue_t **ppThis, queueType_t qType, int iWorkerThreads,
@@ -213,6 +214,8 @@ void qqueueSetDefaultsActionQueue(qqueue_t *pThis);
 void qqueueDbgPrint(qqueue_t *pThis);
 rsRetVal qqueueShutdownWorkers(qqueue_t *pThis);
 void qqueueDoneLoadCnf(void);
+int queuesEqual(qqueue_t *pOld, qqueue_t *pNew);
+void qqueueCorrectParams(qqueue_t *pThis);
 
 PROTOTYPEObjClassInit(qqueue);
 PROTOTYPEpropSetMeth(qqueue, iPersistUpdCnt, int);

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -248,6 +248,7 @@ struct rsconf_s {
 	 * Of course, we need to debate if we shall change that some time...
 	 */
 	timezones_t timezones;
+	qqueue_t *pMsgQueue; /* the main message queue */
 };
 
 

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -184,7 +184,7 @@ DEFFUNC_llExecFunc(doActivateRulesetQueues)
 	dbgprintf("Activating Ruleset Queue[%p] for Ruleset %s\n",
 		  pThis->pQueue, pThis->pszName);
 	if(pThis->pQueue != NULL)
-		startMainQueue(pThis->pQueue);
+		startMainQueue(runConf, pThis->pQueue);
 	RETiRet;
 }
 /* activate all ruleset queues */
@@ -385,7 +385,7 @@ finalize_it:
 	 * we put an assertion in its place.
 	 */
 	assert(key == NULL);
-	
+
 	RETiRet;
 }
 
@@ -397,7 +397,7 @@ execForeach(struct cnfstmt *const stmt, smsg_t *const pMsg, wti_t *const pWti)
 
 	/* arr can either be an array or an associative-array (obj) */
 	arr = cnfexprEvalCollection(stmt->d.s_foreach.iter->collection, pMsg, pWti);
-	
+
 	if (arr == NULL) {
 		DBGPRINTF("foreach loop skipped, as object to iterate upon is empty\n");
 		FINALIZE;
@@ -558,12 +558,12 @@ execReloadLookupTable(struct cnfstmt *stmt)
 	if (t == NULL) {
 		ABORT_FINALIZE(RS_RET_NONE);
 	}
-	
+
 	iRet = lookupReload(t, stmt->d.s_reload_lookup_table.stub_value);
 	/* Note that reload dispatched above is performed asynchronously,
 	   on a different thread. So rsRetVal it returns means it was triggered
 	   successfully, and not that it was reloaded successfully. */
-	
+
 finalize_it:
 	RETiRet;
 }
@@ -737,7 +737,7 @@ static qqueue_t*
 GetRulesetQueue(ruleset_t *pThis)
 {
 	ISOBJ_TYPE_assert(pThis, ruleset);
-	return (pThis->pQueue == NULL) ? pMsgQueue : pThis->pQueue;
+	return (pThis->pQueue == NULL) ? runConf->pMsgQueue : pThis->pQueue;
 }
 
 
@@ -1078,7 +1078,7 @@ rulesetProcessCnf(struct cnfobj *o)
 	cnfparamsPrint(&rspblk, pvals);
 	nameIdx = cnfparamGetIdx(&rspblk, "name");
 	rsName = (uchar*)es_str2cstr(pvals[nameIdx].val.d.estr, NULL);
-	
+
 	localRet = rulesetGetRuleset(loadConf, &pRuleset, rsName);
 	if(localRet == RS_RET_OK) {
 		LogError(0, RS_RET_RULESET_EXISTS,

--- a/runtime/unicode-helper.h
+++ b/runtime/unicode-helper.h
@@ -36,4 +36,9 @@
 #define UCHAR_CONSTANT(x) ((uchar*) (x))
 #define CHAR_CONVERT(x) ((char*) (x))
 
+/* Compare values of two instances/configs/queues especially during dynamic config reload */
+#define USTR_EQUALS(var) \
+	((pOld->var == NULL) ? (pNew->var == NULL) : (pNew->var != NULL && !ustrcmp(pOld->var, pNew->var)))
+#define NUM_EQUALS(var) (pOld->var == pNew->var)
+
 #endif /* multi-include protection */

--- a/tests/runtime-dummy.c
+++ b/tests/runtime-dummy.c
@@ -33,7 +33,6 @@ int bReduceRepeatMsgs = 0;
 int bActExecWhenPrevSusp = 0;
 int iActExecOnceInterval = 1;
 int MarkInterval = 30;
-void *pMsgQueue = NULL;
 
 void cflineClassic(void) {};
 void selectorAddList(void) {};


### PR DESCRIPTION
The intent of this PR is to make the main message queue part of the main config. It will help us to proceed towards dynamic configuration reload.
Besides that I did some refactoring. I divided ```activateMainQueue()``` into two separate functions. The first one, ```loadMainQueue()``` is responsible for interpreting main queue parameters, the second one ```activateMainQueue()``` will start the queue.
I had to move some settings from ```qqueueStart()``` to ```qqueueConstruct()```, because a queue should be fully initialized by the end of construction phase. This is needed in order to compare an already constructed(not yet started) queue with previous queues(queue from previous config that might be the same) during dynamic configuration reload.