### PR TITLE
omelasticsearch: Fix indexSuccess impstats counter in bulkmode

### DIFF
--- a/tests/es-bulk-retry.sh
+++ b/tests/es-bulk-retry.sh
@@ -1,8 +1,13 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+#export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+
 export ES_PORT=19200
 export NUMMESSAGES=100
+
+# export RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT=120000
 override_test_timeout 120
 #export USE_VALGRIND="YES" # to enable this to run under valgrind
 ensure_elasticsearch_ready --no-start
@@ -152,6 +157,7 @@ badarg=50
 injectmsg 0 $NUMMESSAGES
 ./msleep 1500; cat $RSYSLOG_OUT_LOG # debuging - we sometimes miss 1 message
 wait_content '"response.success": 50' $RSYSLOG_DYNNAME.spool/es-stats.log
+wait_content '"response.badargument": 50' $RSYSLOG_DYNNAME.spool/es-stats.log
 shutdown_when_empty
 wait_shutdown
 es_getdata $NUMMESSAGES $ES_PORT


### PR DESCRIPTION
When bulkmode is enabled, and a batch was processed without any
failures (errors is false), the code that increments the indexSuccess
impstats counter was never reached. As fix, we obtain the numitems
first and add them to the indexSuccess impstats counter if
errors is false.

This fix may solve some of the random elasticsearch testbench failures.

closes: https://github.com/rsyslog/rsyslog/issues/4794

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
