### PR TITLE
imfile: Remove inotify watch descriptor on inode change detected

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1040,6 +1040,7 @@ act_obj_destroy(act_obj_t *const act, const int is_deleted)
 	}
 	#ifdef HAVE_INOTIFY_INIT
 	if(act->wd != -1) {
+		inotify_rm_watch(ino_fd, act->wd);
 		wdmapDel(act->wd);
 	}
 	#endif

--- a/tests/imfile-rename.sh
+++ b/tests/imfile-rename.sh
@@ -42,6 +42,11 @@ if $msg contains "msgnum:" then
    file=`echo $RSYSLOG_OUT_LOG`
    template="outfmt"
  )
+if $msg contains "imfile:" then
+ action(
+   type="omfile"
+   file="'$RSYSLOG_DYNNAME.errmsgs'"
+ )
 '
 
 # generate input file first. 
@@ -58,6 +63,18 @@ wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
 mv $RSYSLOG_DYNNAME.input.1.log rsyslog.input.2.log
 
 ./msleep 500
+
+# Write into the renamed file
+echo 'testmessage1
+testmessage2' >> rsyslog.input.2.log
+
+./msleep 500
+
+if grep "imfile: internal error? inotify provided watch descriptor" < "$RSYSLOG_DYNNAME.errmsgs" ; then
+        echo "Error: inotify event from renamed file"
+        exit 1
+fi
+
 # generate some more input into moved file 
 ./inputfilegen -m $TESTMESSAGES -i $TESTMESSAGES >> $RSYSLOG_DYNNAME.input.2.log
 ls -l $RSYSLOG_DYNNAME.input*


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->

When any message is output into a renamed input file, rsyslogd output the following message.

   imfile: internal error? inotify provided watch descriptor 7 which we could not find in our tables - ignored

When rsyslogd detects the inode change, it deletes the entry from wdmap[]. But, the watch descriptor is not removed.

Some application like sssd outputs some messages (like "HUP signal was received!!") after HUP signal is received and before switching into the new log file. And, the above messages can be output every log rotation. This commit resolves such a situation.