### PR TITLE
Make action counter part of the config

### DIFF
--- a/action.h
+++ b/action.h
@@ -111,7 +111,4 @@ void actionCommitAllDirect(wti_t *pWti);
 void actionRemoveWorker(action_t *const pAction, void *const actWrkrData);
 void releaseDoActionParams(action_t * const pAction, wti_t * const pWti, int action_destruct);
 
-/* external data */
-extern int iActionNbr;
-
 #endif /* #ifndef ACTION_H_INCLUDED */

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -165,6 +165,7 @@ static void cnfSetDefaults(rsconf_t *pThis)
 	pThis->templates.last = NULL;
 	pThis->templates.lastStatic = NULL;
 	pThis->actions.nbrActions = 0;
+	pThis->actions.iActionNbr = 0;
 	pThis->globals.pszWorkDir = NULL;
 	pThis->globals.bDropMalPTRMsgs = 0;
 	pThis->globals.operatingStateFile = NULL;
@@ -1447,7 +1448,7 @@ load(rsconf_t **cnf, uchar *confFile)
 		ABORT_FINALIZE(RS_RET_NO_ACTIONS);
 	}
 	tellLexEndParsing();
-	DBGPRINTF("Number of actions in this configuration: %d\n", iActionNbr);
+	DBGPRINTF("Number of actions in this configuration: %d\n", loadConf->actions.iActionNbr);
 
 	CHKiRet(tellCoreConfigLoadDone());
 	tellModulesConfigLoadDone();

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -206,7 +206,14 @@ struct templates_s {
 
 
 struct actions_s {
-	unsigned nbrActions;		/* number of actions */
+	/* number of active actions */
+	unsigned nbrActions;
+	/* number of actions created. It is used to obtain unique IDs for the action. They
+	 * should not be relied on for any long-term activity (e.g. disk queue names!), but they are nice
+	 * to have during one instance of an rsyslogd run. For example, I use them to name actions when there
+	 * is no better name available.
+	 */
+	int iActionNbr;
 };
 
 

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -47,6 +47,7 @@
 #include "glbl.h"
 #include "action.h"
 #include "atomic.h"
+#include "rsconf.h"
 
 /* static data */
 DEFobjStaticHelpers
@@ -275,13 +276,13 @@ wtiConstructFinalize(wti_t *pThis)
 	ISOBJ_TYPE_assert(pThis, wti);
 
 	DBGPRINTF("%s: finalizing construction of worker instance data (for %d actions)\n",
-		  wtiGetDbgHdr(pThis), iActionNbr);
+		  wtiGetDbgHdr(pThis), runConf->actions.iActionNbr);
 
 	/* initialize our thread instance descriptor (no concurrency here) */
 	pThis->bIsRunning = WRKTHRD_STOPPED;
 
 	/* must use calloc as we need zero-init */
-	CHKmalloc(pThis->actWrkrInfo = calloc(iActionNbr, sizeof(actWrkrInfo_t)));
+	CHKmalloc(pThis->actWrkrInfo = calloc(runConf->actions.iActionNbr, sizeof(actWrkrInfo_t)));
 
 	if(pThis->pWtp == NULL) {
 		dbgprintf("wtiConstructFinalize: pWtp not set, this may be intentional\n");
@@ -316,7 +317,7 @@ wtiWorkerCancelCleanup(void *arg)
 	DBGPRINTF("%s: cancelation cleanup handler called.\n", wtiGetDbgHdr(pThis));
 	pWtp->pfObjProcessed(pWtp->pUsr, pThis);
 	DBGPRINTF("%s: done cancelation cleanup handler.\n", wtiGetDbgHdr(pThis));
-	
+
 }
 
 
@@ -445,7 +446,7 @@ wtiWorker(wti_t *__restrict__ const pThis)
 	d_pthread_mutex_unlock(pWtp->pmutUsr);
 
 	DBGPRINTF("DDDD: wti %p: worker cleanup action instances\n", pThis);
-	for(i = 0 ; i < iActionNbr ; ++i) {
+	for(i = 0 ; i < runConf->actions.iActionNbr ; ++i) {
 		wrkrInfo = &(pThis->actWrkrInfo[i]);
 		dbgprintf("wti %p, action %d, ptr %p\n", pThis, i, wrkrInfo->actWrkrData);
 		if(wrkrInfo->actWrkrData != NULL) {
@@ -496,7 +497,7 @@ wtiSetDbgHdr(wti_t *pThis, uchar *pszMsg, const size_t lenMsg)
 
 	ISOBJ_TYPE_assert(pThis, wti);
 	assert(pszMsg != NULL);
-	
+
 	if(lenMsg < 1)
 		ABORT_FINALIZE(RS_RET_PARAM_ERROR);
 


### PR DESCRIPTION
The ```iActionNbr``` variable was used to obtain the total number of actions created during configuration load. The purpose of this PR is to make it part of the ```rsconf_t``` struct.
The functionality is not changed at all, but this change will play a crucial role when dynamic conf reload is introduced.