### PR TITLE
regression fix: script string comparison did not work correctly

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3071,7 +3071,7 @@ static int eval_strcmp_like(const struct cnfexpr *__restrict__ const expr,
 	} else {
 		estr_l = var2String(&l, &bMustFree);
 		estr_r = var2String(&r, &bMustFree2);
-		ret = es_strcmp(estr_l, estr_r) < 0; /*CMP*/
+		ret = es_strcmp(estr_l, estr_r);
 		if(bMustFree) es_deleteStr(estr_l);
 		if(bMustFree2) es_deleteStr(estr_r);
 	}


### PR DESCRIPTION
In rscript, comparison operations on strings did not work correctly
and returned false results. This is cause by a regression in commit
5cec5dd634e0. While it fixed number comparisons, it introduced new
problems in string comparisons, which were not present before. Note
that most items in rsyslog are strings, so this can actually cause
some problems.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
