### PR TITLE
Add option to limit error file to configured size

### DIFF
--- a/action.h
+++ b/action.h
@@ -74,6 +74,8 @@ struct action_s {
 	/* error file */
 	const char *pszErrFile;
 	int fdErrFile;
+	size_t maxErrFileSize;
+	size_t errFileWritten;
 	pthread_mutex_t mutErrFile;
 	/* external stat file system */
 	const char *pszExternalStateFile;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -718,7 +718,8 @@ TESTS +=  \
 	mysql-actq-mt.sh \
 	mysql-actq-mt-withpause.sh \
 	action-tx-single-processing.sh \
-	action-tx-errfile.sh
+	action-tx-errfile.sh \
+	action-tx-errfile-maxsize.sh
 
 mysql-basic.log: mysqld-start.log
 mysql-basic-cnf6.log: mysqld-start.log
@@ -2334,6 +2335,7 @@ EXTRA_DIST= \
 	sndrcv_gzip.sh \
 	action-tx-single-processing.sh \
 	action-tx-errfile.sh \
+	action-tx-errfile-maxsize.sh \
 	testsuites/action-tx-errfile.result \
 	pipeaction.sh \
 	improg-simul.sh \

--- a/tests/action-tx-errfile-maxsize.sh
+++ b/tests/action-tx-errfile-maxsize.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=50 # enough to generate big file
+export MAX_ERROR_SIZE=100
+export SEQ_CHECK_OPTIONS=-i2
+check_sql_data_ready() {
+	mysql_get_data
+	seq_check --check-only 0 $((NUMMESSAGES - 2))
+}
+export QUEUE_EMPTY_CHECK_FUNC=check_sql_data_ready
+
+generate_conf
+add_conf '
+$ModLoad ../plugins/ommysql/.libs/ommysql
+global(errormessagestostderr.maxnumber="5")
+
+template(type="string" name="tpl" string="insert into SystemEvents (Message, Facility) values (\"%msg%\", %$!facility%)" option.sql="on")
+
+if((not($msg contains "error")) and ($msg contains "msgnum:")) then {
+	set $.num = field($msg, 58, 2);
+	if $.num % 2 == 0 then {
+		set $!facility = $syslogfacility;
+	} else {
+		set $/cntr = 0;
+	}
+	action(type="ommysql" name="mysql_action" server="127.0.0.1" template="tpl"
+	       db="'$RSYSLOG_DYNNAME'" uid="rsyslog" pwd="testbench" action.errorfile="'$RSYSLOG2_OUT_LOG'" action.errorfile.maxsize="'$MAX_ERROR_SIZE'")
+}
+'
+mysql_prep_for_test
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+mysql_get_data
+seq_check  0 $((NUMMESSAGES - 2)) -i2
+check_file_exists ${RSYSLOG2_OUT_LOG}
+file_size_check ${RSYSLOG2_OUT_LOG} ${MAX_ERROR_SIZE}
+exit_test

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2522,6 +2522,17 @@ wait_for_stats_flush() {
 	echo "stats push registered"
 }
 
+# Check file exists and is of a particular size
+# $1 - file to check
+# $2 - size to check
+file_size_check() {
+    local size=$(ls -l $1 | awk {'print $5'})
+    if [ "${size}" != "${2}" ]; then
+	printf 'File:[%s] has unexpected size. Expected:[%d], Size:[%d]\n', $1 $2 $size
+        error_exit 1
+    fi
+    return 0
+}
 
 case $1 in
    'init')	$srcdir/killrsyslog.sh # kill rsyslogd if it runs for some reason


### PR DESCRIPTION
action.errorfile.maxsize has been added to enable
option to limit the amount of bytes dumped to
configured errorfile

fixes #4733

Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
