### PR TITLE
Don't refer to errno when the pthread library fails

### DIFF
--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -976,7 +976,7 @@ startSrvWrkr(tcpsrv_etry_t *const etry)
 	pthread_attr_setstacksize(&sessThrdAttr, 4096*1024);
 	r = pthread_create(&etry->tid, &sessThrdAttr, RunServerThread, etry);
 	if(r != 0) {
-		LogError(errno, NO_ERRCODE, "imtcp error creating server thread");
+		LogError(r, NO_ERRCODE, "imtcp error creating server thread");
 		/* we do NOT abort, as other servers may run - after all, we logged an error */
 	}
 	pthread_attr_destroy(&sessThrdAttr);

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -231,9 +231,10 @@ static rsRetVal curlSetup(wrkrInstanceData_t *pWrkrData);
 
 BEGINcreateInstance
 CODESTARTcreateInstance
+	int r;
 	pData->fdErrFile = -1;
-	if(pthread_mutex_init(&pData->mutErrFile, NULL) != 0) {
-		LogError(errno, RS_RET_ERR, "omelasticsearch: cannot create "
+	if((r = pthread_mutex_init(&pData->mutErrFile, NULL)) != 0) {
+		LogError(r, RS_RET_ERR, "omelasticsearch: cannot create "
 			"error file mutex, failing this action");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}

--- a/runtime/lib_ksils12.c
+++ b/runtime/lib_ksils12.c
@@ -821,14 +821,15 @@ seedIVKSI(ksifile ksi)
 
 static int
 create_signer_thread(rsksictx ctx) {
+	int r;
 	if (ctx->signer_state != SIGNER_STARTED) {
-		if (pthread_mutex_init(&ctx->module_lock, 0))
-			report(ctx, "pthread_mutex_init: %s", strerror(errno));
+		if ((r = pthread_mutex_init(&ctx->module_lock, 0)))
+			report(ctx, "pthread_mutex_init: %s", strerror(r));
 		ctx->signer_queue = ProtectedQueue_new(10);
 
 		ctx->signer_state = SIGNER_INIT;
-		if (pthread_create(&ctx->signer_thread, NULL, signer_thread, ctx)) {
-			report(ctx, "pthread_mutex_init: %s", strerror(errno));
+		if ((r = pthread_create(&ctx->signer_thread, NULL, signer_thread, ctx))) {
+			report(ctx, "pthread_mutex_init: %s", strerror(r));
 			ctx->signer_state = SIGNER_IDLE;
 			return RSGTE_INTERNAL;
 		}

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1693,7 +1693,7 @@ startWorkerPool(void)
 		if(r == 0) {
 			wrkrInfo[i].enabled = 1;
 		} else {
-			LogError(errno, NO_ERRCODE, "tcpsrv error creating thread");
+			LogError(r, NO_ERRCODE, "tcpsrv error creating thread");
 		}
 	}
 	pthread_attr_destroy(&sessThrdAttr);

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -91,11 +91,12 @@ wtiGetState(wti_t *pThis)
 void ATTR_NONNULL()
 wtiJoinThrd(wti_t *const pThis)
 {
+	int r;
 	ISOBJ_TYPE_assert(pThis, wti);
 	if(wtiGetState(pThis) == WRKTHRD_WAIT_JOIN) {
 		DBGPRINTF("%s: joining terminated worker\n", wtiGetDbgHdr(pThis));
-		if(pthread_join(pThis->thrdID, NULL) != 0) {
-			LogMsg(errno, RS_RET_INTERNAL_ERROR, LOG_WARNING,
+		if((r = pthread_join(pThis->thrdID, NULL)) != 0) {
+			LogMsg(r, RS_RET_INTERNAL_ERROR, LOG_WARNING,
 				"rsyslog bug? wti cannot join terminated wrkr");
 		}
 		DBGPRINTF("%s: worker fully terminated\n", wtiGetDbgHdr(pThis));

--- a/threads.c
+++ b/threads.c
@@ -130,7 +130,7 @@ thrdTerminateNonCancel(thrdInfo_t *pThis)
 			pThis->name, runConf->globals.inputTimeoutShutdown);
 		const int r = pthread_kill(pThis->thrdID, SIGTTIN);
 		if(r != 0) {
-			LogError(errno, RS_RET_INTERNAL_ERROR, "error terminating thread %s "
+			LogError(r, RS_RET_INTERNAL_ERROR, "error terminating thread %s "
 				"this may cause shutdown issues", pThis->name);
 		}
 		ret = d_pthread_cond_timedwait(&pThis->condThrdTerm, &pThis->mutThrd, &tTimeout);
@@ -146,7 +146,7 @@ thrdTerminateNonCancel(thrdInfo_t *pThis)
 			break;
 		} else if(ret != 0) {
 			char errStr[1024];
-			int err = errno;
+			int err = ret;
 			rs_strerror_r(err, errStr, sizeof(errStr));
 			DBGPRINTF("input thread term: cond_wait returned with error %d: %s\n",
 				  err, errStr);


### PR DESCRIPTION
When the pthread library fails, errno is referenced even though errno is not set.
Fix to refer to the return code of the pthread library instead of errno.