### PR TITLE
Ensure error file does not increase appropriately when action.errorfile.maxsize option is enabled

### DIFF
--- a/action.h
+++ b/action.h
@@ -75,7 +75,7 @@ struct action_s {
 	const char *pszErrFile;
 	int fdErrFile;
 	size_t maxErrFileSize;
-	size_t errFileWritten;
+	size_t currentErrFileSize;
 	pthread_mutex_t mutErrFile;
 	/* external stat file system */
 	const char *pszExternalStateFile;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2335,6 +2335,7 @@ EXTRA_DIST= \
 	sndrcv_gzip.sh \
 	action-tx-single-processing.sh \
 	omfwd-errfile-maxsize.sh \
+	omfwd-errfile-maxsize-filled.sh \
 	action-tx-errfile-maxsize.sh \
 	action-tx-errfile.sh \
 	testsuites/action-tx-errfile.result \

--- a/tests/errfile-basic.sh
+++ b/tests/errfile-basic.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=1000
+
+port=80
+omhttp_start_server $port
+
+echo "============================> RSYSLOG_DYNNAME:$RSYSLOG_DYNNAME <============================"
+
+generate_conf
+add_conf '
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+if $msg contains "msgnum:" then
+	action(
+		# Payload
+		name="my_http_action"
+		type="omhttp"
+		action.errorfile="'$RSYSLOG_DYNNAME/omhttp_sarroutb.error.log'"
+		action.errorfile.maxsize="2000"
+		template="tpl"
+
+		server="localhost"
+		serverport="'$port'"
+		restpath="my/endpoint"
+		batch="off"
+
+		# Auth
+		usehttps="off"
+    )
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+omhttp_get_data $port my/endpoint
+omhttp_stop_server
+seq_check
+exit_test

--- a/tests/omfwd-errfile-maxsize-filled.sh
+++ b/tests/omfwd-errfile-maxsize-filled.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+ERRFILE="$RSYSLOG_DYNNAME.err"
+export MAX_ERROR_SIZE=1999
+export INITIAL_FILE_SIZE=$((MAX_ERROR_SIZE - 100))
+dd if=/dev/urandom of=${ERRFILE}  bs=1 count=${INITIAL_FILE_SIZE}
+generate_conf
+add_conf '
+action(type="omfwd" target="1.2.3.4" port="1234" Protocol="tcp" NetworkNamespace="doesNotExist"
+       action.errorfile="'$ERRFILE'" action.errorfile.maxsize="'$MAX_ERROR_SIZE'")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+check_file_exists ${ERRFILE}
+file_size_check ${ERRFILE} ${MAX_ERROR_SIZE}
+exit_test

--- a/tests/testbench_test_failed_rsyslog
+++ b/tests/testbench_test_failed_rsyslog
@@ -1,0 +1,1 @@
+./omfwd-errfile-maxsize-filled.sh


### PR DESCRIPTION
fixes #4821

Signed-off-by: Sergio Arroutbi <sarroutb@redhat.com>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
