### PR TITLE
gnutls bugfix: Fix error handling in gtlsRecordRecv

### DIFF
--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -33,6 +33,11 @@ typedef enum {
 	gtlsRtry_recv = 2
 } gtlsRtryCall_t;		/**< IDs of calls that needs to be retried */
 
+typedef enum {
+	gtlsDir_READ = 0,	/**< GNUTLS wants READ */
+	gtlsDir_WRITE = 1	/**< GNUTLS wants WRITE */
+} gtlsDirection_t;
+
 typedef nsd_if_t nsd_gtls_if_t; /* we just *implement* this interface */
 
 /* the nsd_gtls object */

--- a/tests/imtcp-tls-basic.sh
+++ b/tests/imtcp-tls-basic.sh
@@ -5,6 +5,9 @@
 export NUMMESSAGES=50000
 export TB_TEST_MAX_RUNTIME=1500
 export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+# uncomment for debugging support:
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
 generate_conf
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir'/tls-certs/ca.pem"


### PR DESCRIPTION
There was a rare possibility that the E_AGAIN/E_INTERRUPT handling
could cause an infinite loop (100% CPU Usage), for example when a TLS
handshake is interrupted at a certain stage.

- After gnutls_record_recv is called, and E_AGAIN/E_INTERRUPT error
  occurs, we need to do additional read/write direction handling
  with gnutls_record_get_direction.
- After the second call of gnutls_record_recv (Expand buffer)
  we needed to also check the eror codes for E_AGAIN/E_INTERRUPT
  to do propper errorhandling.


see also: https://github.com/rsyslog/rsyslog/issues/4818

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
