### PR TITLE
Fix: check ReportSuspension option before print message about action retry

### DIFF
--- a/action.c
+++ b/action.c
@@ -763,11 +763,13 @@ static void ATTR_NONNULL() actionRetry(action_t * const pThis, wti_t * const pWt
 {
 	setSuspendMessageConfVars(pThis);
 	actionSetState(pThis, pWti, ACT_STATE_RTRY);
-	LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
-	      "action '%s' suspended (module '%s'), retry %d. There should "
-	      "be messages before this one giving the reason for suspension.",
-	      pThis->pszName, pThis->pMod->pszName,
-	      getActionNbrResRtry(pWti, pThis));
+	if(pThis->bReportSuspension) {
+		LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
+		      "action '%s' suspended (module '%s'), retry %d. There should "
+		      "be messages before this one giving the reason for suspension.",
+		      pThis->pszName, pThis->pMod->pszName,
+		      getActionNbrResRtry(pWti, pThis));
+	}
 	incActionResumeInRow(pWti, pThis);
 }
 


### PR DESCRIPTION
Fix getting a lot of messages like:
```
Mar 15 02:56:10 myhost.local rsyslogd[47117]: action 'relp_to_prog' suspended (module 'omrelp'), retry 0. There should be messages before this one giving the reason for suspension. [v8.1911.0-3.el8 try https://www.rsyslog.com/e/2007 ]
```
even when disable `action.reportSuspension` and `action.reportSuspensionContinuation` in config file.


Config file: `/etc/rsyslog.d/rsyslog-pipe.conf`
```
template (name="PipeOut" type="string"
#          DeviceReportedTime                  FromHost ProgName      SyslogTag   Mess  Facility              Severity
    string="%timegenerated:::date-unixtimestamp%|%source%|%programname%|%syslogtag%|%msg%|%syslogfacility-text%|%syslogseverity-text%\n"
)

if ( not ($hostname == $$myhostname and $programname == "my-program" and $msg startswith "[") ) then {
  action(
    name="pipe_to_prog"
    type="ompipe"
    Pipe="/var/run/my-program.pipe"
    Template="PipeOut"

    queue.type="LinkedList"
    queue.size="10000"
    queue.filename="q_pipeRule"
    queue.highwatermark="9000"
    queue.lowwatermark="50"
    queue.maxdiskspace="1g"
    queue.saveonshutdown="on"
    action.resumeRetryCount="-1"
    action.reportSuspension="off"
    action.reportSuspensionContinuation="off"
    action.resumeInterval="1"
  )
}
```

