### PR TITLE
Move the parser directive to the main config

### DIFF
--- a/runtime/parser.h
+++ b/runtime/parser.h
@@ -50,18 +50,21 @@ BEGINinterface(parser) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetName)(parser_t *pThis, uchar *name);
 	rsRetVal (*SetModPtr)(parser_t *pThis, modInfo_t *pMod);
 	rsRetVal (*SetDoPRIParsing)(parser_t *pThis, int);
-	rsRetVal (*FindParser)(parser_t **ppThis, uchar*name);
-	rsRetVal (*InitParserList)(parserList_t **pListRoot);
+	rsRetVal (*FindParser)(parserList_t *pParserListRoot, parser_t **ppThis, uchar*name);
 	rsRetVal (*DestructParserList)(parserList_t **pListRoot);
 	rsRetVal (*AddParserToList)(parserList_t **pListRoot, parser_t *pParser);
+	rsRetVal (*destroyMasterParserList)(parserList_t *pParserListRoot);
 	/* static functions */
 	rsRetVal (*ParseMsg)(smsg_t *pMsg);
 	rsRetVal (*SanitizeMsg)(smsg_t *pMsg);
 	rsRetVal (*AddDfltParser)(uchar *);
 ENDinterface(parser)
-#define parserCURR_IF_VERSION 2 /* increment whenever you change the interface above! */
+#define parserCURR_IF_VERSION 3 /* increment whenever you change the interface above! */
 /* version changes
 	2       SetDoSanitization removed, no longer needed
+	3       InitParserList removed, no longer needed
+	        destroyMasterParserList added
+	        findParser extended with new parameter specifying the parser list
 */
 
 void printParserList(parserList_t *pList);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -260,6 +260,9 @@ static void cnfSetDefaults(rsconf_t *pThis)
 	pThis->globals.parser.bParserEscapeCCCStyle = 0;
 	pThis->globals.parser.bPermitSlashInProgramname = 0;
 	pThis->globals.parser.bParseHOSTNAMEandTAG = 1;
+
+	pThis->parsers.pDfltParsLst = NULL;
+	pThis->parsers.pParsLstRoot = NULL;
 }
 
 
@@ -316,6 +319,8 @@ CODESTARTobjDestruct(rsconf)
 	perctileBucketsDestruct();
 	ochDeleteAll();
 	freeTimezones(pThis);
+	parser.DestructParserList(&pThis->parsers.pDfltParsLst);
+	parser.destroyMasterParserList(pThis->parsers.pParsLstRoot);
 	free(pThis->globals.mainQ.pszMainMsgQFName);
 	free(pThis->globals.pszConfDAGFile);
 	free(pThis->globals.pszWorkDir);
@@ -413,7 +418,7 @@ parserProcessCnf(struct cnfobj *o)
 	cnfparamsPrint(&parserpblk, pvals);
 	paramIdx = cnfparamGetIdx(&parserpblk, "name");
 	parserName = (uchar*)es_str2cstr(pvals[paramIdx].val.d.estr, NULL);
-	if(parser.FindParser(&myparser, parserName) != RS_RET_PARSER_NOT_FOUND) {
+	if(parser.FindParser(loadConf->parsers.pParsLstRoot, &myparser, parserName) != RS_RET_PARSER_NOT_FOUND) {
 		LogError(0, RS_RET_PARSER_NAME_EXISTS,
 			"parser module name '%s' already exists", parserName);
 		ABORT_FINALIZE(RS_RET_PARSER_NAME_EXISTS);

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -204,6 +204,17 @@ struct templates_s {
 	struct template *lastStatic; /* last static element of the template list */
 };
 
+struct parsers_s {
+	/* This is the list of all parsers known to us.
+	 * This is also used to unload all modules on shutdown.
+	 */
+	parserList_t *pParsLstRoot;
+
+	/* this is the list of the default parsers, to be used if no others
+	 * are specified.
+	 */
+	parserList_t *pDfltParsLst;
+};
 
 struct actions_s {
 	/* number of active actions */
@@ -235,6 +246,7 @@ struct rsconf_s {
 	globals_t globals;
 	defaults_t defaults;
 	templates_t templates;
+	parsers_t parsers;
 	lookup_tables_t lu_tabs;
 	dynstats_buckets_t dynstats_buckets;
 	perctile_buckets_t perctile_buckets;

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -1027,7 +1027,7 @@ doRulesetAddParser(ruleset_t *pRuleset, uchar *pName)
 	DEFiRet;
 
 	CHKiRet(objUse(parser, CORE_COMPONENT));
-	iRet = parser.FindParser(&pParser, pName);
+	iRet = parser.FindParser(loadConf->parsers.pParsLstRoot, &pParser, pName);
 	if(iRet == RS_RET_PARSER_NOT_FOUND) {
 		LogError(0, RS_RET_PARSER_NOT_FOUND, "error: parser '%s' unknown at this time "
 			  	"(maybe defined too late in rsyslog.conf?)", pName);

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -95,6 +95,7 @@ typedef struct statsobj_s statsobj_t;
 typedef void (*statsobj_read_notifier_t)(statsobj_t *, void *);
 typedef struct nsd_epworkset_s nsd_epworkset_t;
 typedef struct templates_s templates_t;
+typedef struct parsers_s parsers_t;
 typedef struct queuecnf_s queuecnf_t;
 typedef struct parsercnf_s parsercnf_t;
 typedef struct rulesets_s rulesets_t;


### PR DESCRIPTION
The purpose of this PR is to make parser related lists part of the main configuration structure, ```rsconf_t```. Technically speaking, relocate the ```pParsLstRoot``` and ```pDfltParsLst``` global variables into the config.

Among other things, it helps to improve code readability, it's better to have everything in one place. Moreover, it will help us to proceed towards a new future, dynamic configuration reload option as we need to be able to track which parsers are defined in which config.

I needed to change/extend the ```parser``` interface structure as well to specify the parser list functions should work with.
