### PR TITLE
Add missing include to fix compilation error, resolves #4827

### DIFF
--- a/contrib/omfile-hardened/omfile-hardened.c
+++ b/contrib/omfile-hardened/omfile-hardened.c
@@ -73,6 +73,7 @@
 #include "cryprov.h"
 #include "parserif.h"
 #include "janitor.h"
+#include "rsconf.h"
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP


### PR DESCRIPTION
Include of the ```rsconf.h``` header file was missing. The PR resolves that.

Resolves #4827 