### PR TITLE
rsyslogd: adjust the order of doHUP() and processImInternal()

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1952,8 +1952,6 @@ mainloop(void)
 	sigaddset(&sigblockset, SIGHUP);
 
 	do {
-		processImInternal();
-
 		pthread_sigmask(SIG_BLOCK, &sigblockset, &origmask);
 		if(bChildDied) {
 			reapChild();
@@ -1964,6 +1962,8 @@ mainloop(void)
 			doHUP();
 			bHadHUP = 0;
 		}
+
+		processImInternal();
 
 		if(bFinished)
 			break;	/* exit as quickly as possible */


### PR DESCRIPTION
After call doHUP(), probably there is a internal log in the list. However, it
will not be wrote out immediately, because the mainloop will be blocked at
pselect in wait_timeout() until a long timeout or next message occur.
More deadly, the log may be lost if the deamon exits unexpectedly.

We might as well put processImInternal() after doHUP(), so that the message
will be flushed out immediately.

Fixes: 723f6fdfa6(rsyslogd: Fix race between signals and main loop timeout)
Signed-off-by: Yun Zhou <yun.zhou@windriver.com>