### PR TITLE
Fix non-null-terminated-string used with strlen

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -350,6 +350,7 @@ const size_t msglen, const char *const topicname)
 			return NULL;
 		}
 		memcpy(etry->key, key, keylen);
+		etry->key[keylen] = '\0';
 	} else {
 		etry->key=NULL;
 	}


### PR DESCRIPTION
The `failedmsg_entry` expects a null-terminated string in `key`, but
here we allocate with malloc and copy a string-with-length-n into only
the first n bytes. If the final byte is null, this is by coincidence
only.

We've observed this by means of seeing random binary data appended to
keys submitted to kafka apparently at random, and this looks like a
smoking gun.