### PR TITLE
openssl: Add support to split tls commands by semicolon

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1443,13 +1443,16 @@ osslPostHandshakeCheck(nsd_ossl_t *pNsd)
 		"Information, no shared curve between syslog client and server");
 	}
 	#endif
+	dbgprintf("osslPostHandshakeCheck: Debug Protocol Version: %s\n",
+		SSL_get_version(pNsd->ssl));
+
 	sslCipher = (const SSL_CIPHER*) SSL_get_current_cipher(pNsd->ssl);
 	if (sslCipher != NULL){
 		if(SSL_CIPHER_get_version(sslCipher) == NULL) {
 			LogError(0, RS_RET_NO_ERRCODE, "nsd_ossl:"
 		"TLS version mismatch between syslog client and server.");
 		}
-		dbgprintf("osslPostHandshakeCheck: Debug Version: %s Name: %s\n",
+		dbgprintf("osslPostHandshakeCheck: Debug Cipher Version: %s Name: %s\n",
 			SSL_CIPHER_get_version(sslCipher), SSL_CIPHER_get_name(sslCipher));
 	}else {
 		LogError(0, RS_RET_NO_ERRCODE, "nsd_ossl:No shared ciphers between syslog client and server.");

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1915,6 +1915,7 @@ applyGnutlsPriorityString(nsd_ossl_t *const pThis)
 					pszCmd = strndup(pCurrentPos, pNextPos-pCurrentPos);
 					pCurrentPos = pNextPos+1;
 					pNextPos = index(pCurrentPos, '\n');
+					pNextPos = (pNextPos == NULL ? index(pCurrentPos, ';') : pNextPos);
 					pszValue = (pNextPos == NULL ?
 							strdup(pCurrentPos) :
 							strndup(pCurrentPos, pNextPos - pCurrentPos));

--- a/tests/sndrcv_tls_ossl_anon_ciphers.sh
+++ b/tests/sndrcv_tls_ossl_anon_ciphers.sh
@@ -18,7 +18,7 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon"
 	StreamDriver.PermitExpiredCerts="off"
-	gnutlsPriorityString="CipherString=ECDHE-RSA-AES256-SHA384\nCiphersuites=TLS_AES_256_GCM_SHA384"
+	gnutlsPriorityString="CipherString=ECDHE-RSA-AES256-SHA384;Ciphersuites=TLS_AES_256_GCM_SHA384"
 	)
 input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
@@ -40,7 +40,7 @@ action(	type="omfwd"
 	port="'$PORT_RCVR'"
 	StreamDriverMode="1"
 	StreamDriverAuthMode="anon"
-	gnutlsPriorityString="CipherString=ECDHE-RSA-AES256-SHA384\nCiphersuites=TLS_AES_128_GCM_SHA256"
+	gnutlsPriorityString="CipherString=ECDHE-RSA-AES256-SHA384;Ciphersuites=TLS_AES_128_GCM_SHA256"
 )
 ' 2
 startup 2


### PR DESCRIPTION

- Add support to split tls commands by semicolon.
- Changed one test with multiple tls commands to use semicolon as
  seperator instead of newline.

- Output used TLS Version into debug log.

closes: https://github.com/rsyslog/rsyslog/issues/4852
