### PR TITLE
strings.h is missing in several files

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -28,6 +28,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
+#include <strings.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 #include <openssl/err.h>

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -107,6 +107,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <string.h>
+#include <strings.h>
 #include <netinet/in.h>
 #include <pthread.h>
 #ifdef ENABLE_RELP


### PR DESCRIPTION
We recently enabled OpenSSL stream driver on Solaris and hit two build issues where the `index()` function was missing its header. This simple PR fixes that issue.