### PR TITLE
omfile: support for zstd compression

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -177,6 +177,11 @@ jobs:
                      --enable-imdiag --enable-impstats --enable-imfile --disable-imfile-tests \
                      --disable-fmhttp --enable-valgrind --disable-default-tests \
                      --enable-elasticsearch-tests --enable-elasticsearch"
+              export CI_MAKE_OPT='-j20'
+              export CI_MAKE_CHECK_OPT='-j8'
+              export CI_CHECK_CMD='check'
+              export CI_VALGRIND_SUPPRESSIONS="ubuntu22.04.supp" # they are still valid
+              devtools/devcontainer.sh --rm devtools/run-ci.sh
               ;;
           esac
           devtools/devcontainer.sh --rm devtools/run-ci.sh

--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -53,6 +53,7 @@ jobs:
             libsystemd-dev \
             libtool \
             libtool-bin \
+            libzstd-dev \
             lsof \
             make \
             net-tools \
@@ -60,7 +61,8 @@ jobs:
             python-docutils  \
             software-properties-common \
             valgrind \
-            wget
+            wget \
+	    zstd
 
       - name: git checkout project
         uses: actions/checkout@v1

--- a/configure.ac
+++ b/configure.ac
@@ -1182,6 +1182,42 @@ AM_CONDITIONAL(ENABLE_LIBGCRYPT, test x$enable_libgcrypt = xyes)
 AC_SUBST(LIBGCRYPT_CFLAGS)
 AC_SUBST(LIBGCRYPT_LIBS)
 
+# libzstd support
+AC_ARG_ENABLE(libzstd,
+        [AS_HELP_STRING([--enable-libzstd],[Enable log file compression support via libzstd @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_libzstd="yes" ;;
+          no) enable_libzstd="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-libzstd) ;;
+         esac],
+        [enable_libzstd=no]
+)
+if test "x$enable_libzstd" = "xyes"; then
+    save_LIBS="$LIBS"
+    PKG_CHECK_MODULES([ZSTD], zstd >= 1.4.0, [],
+        [
+	LIBS="$LIBS -lzstd"
+	ZSTD_LIBS="-lzstd"
+	AC_SUBST(ZSTD_LIBS)
+	AC_SEARCH_LIBS(ZSTD_compressStream2, zstd,
+            [AC_COMPILE_IFELSE(
+                [AC_LANG_PROGRAM(
+                    [[ #include <zstd.h> ]],
+                    [[
+		       ZSTD_CCtx* cctx = ZSTD_createCCtx();
+		       ZSTD_CCtx_setParameter(cctx, ZSTD_c_nbWorkers, 5);
+                    ]]
+                )],
+                [],
+                [AC_MSG_ERROR([libzstd version must be >= 1.4.0])]
+            )],
+            [AC_MSG_ERROR([libzstd not found])]
+        )]
+    )
+    LIBS="$save_LIBS"
+fi
+AM_CONDITIONAL(ENABLE_LIBZSTD, test x$enable_libzstd = xyes)
+
 
 # support for building the rsyslogd runtime
 AC_ARG_ENABLE(rsyslogrt,
@@ -2777,6 +2813,7 @@ echo "    Unlimited select() support enabled:       $enable_unlimited_select"
 echo "    uuid support enabled:                     $enable_uuid"
 echo "    Log file signing support via KSI LS12:    $enable_ksi_ls12"
 echo "    Log file encryption support:              $enable_libgcrypt"
+echo "    Log file compression via zstd support:    $enable_libzstd"
 echo "    anonymization support enabled:            $enable_mmanon"
 echo "    message counting support enabled:         $enable_mmcount"
 echo "    liblogging-stdlog support enabled:        $enable_liblogging_stdlog"

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -244,6 +244,17 @@ if ENABLE_LIBGCRYPT
    lmcry_gcry_la_LIBADD = libgcry.la $(LIBGCRYPT_LIBS)
 endif
 
+#
+# support library for zstd
+#
+if ENABLE_LIBZSTD
+pkglib_LTLIBRARIES += lmzstdw.la
+    lmzstdw_la_SOURCES = zstdw.c zstdw.h
+    lmzstdw_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+    lmzstdw_la_LDFLAGS = -module -avoid-version $(ZSTD_LIBS)
+    lmzstdw_la_LIBADD = -lzstd
+endif
+
 
 #
 # gssapi support

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -65,6 +65,8 @@
 #ifndef STREAM_H_INCLUDED
 #define STREAM_H_INCLUDED
 
+typedef struct strm_s strm_t; /* forward reference because of zlib... */
+
 #include <regex.h> // TODO: fix via own module
 #include <pthread.h>
 #include <stdint.h>
@@ -90,6 +92,10 @@ typedef enum {				/* when extending, do NOT change existing modes! */
 	STREAMMODE_WRITE_TRUNC = 3,
 	STREAMMODE_WRITE_APPEND = 4
 } strmMode_t;
+typedef enum {
+		STRM_COMPRESS_ZIP = 0,
+		STRM_COMPRESS_ZSTD = 1
+	} strm_compressionDriver_t;
 
 /* settings for stream rotation (applies not to all processing modes!) */
 #define	STRM_ROTATION_DO_CHECK		0
@@ -97,7 +103,7 @@ typedef enum {				/* when extending, do NOT change existing modes! */
 
 #define STREAM_ASYNC_NUMBUFS 2 /* must be a power of 2 -- TODO: make configurable */
 /* The strm_t data structure */
-typedef struct strm_s {
+struct strm_s {
 	BEGINobjInstance;	/* Data to implement generic object - MUST be the first data element! */
 	strmType_t sType;
 	/* descriptive properties */
@@ -159,6 +165,10 @@ typedef struct strm_s {
 		uchar *pBuf;
 		size_t lenBuf;
 	} asyncBuf[STREAM_ASYNC_NUMBUFS];
+	struct {
+		int num_wrkrs;	/* nbr of worker threads */
+		void *cctx;
+	} zstd;		/* supporting per-instance data if zstd is used */
 	pthread_t writerThreadID;
 	/* support for omfile size-limiting commands, special counters, NOT persisted! */
 	off_t	iSizeLimit;	/* file size limit, 0 = no limit */
@@ -170,7 +180,8 @@ typedef struct strm_s {
 	int fileNotFoundError;	/* boolean; if set, report file not found errors, else silently ignore */
 	int noRepeatedErrorOutput; /* if a file is missing the Error is only given once */
 	int ignoringMsg;
-} strm_t;
+	strm_compressionDriver_t compressionDriver;
+};
 
 
 /* interfaces */
@@ -195,12 +206,14 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*GetCurrOffset)(strm_t *pThis, int64 *pOffs);
 	rsRetVal (*SetWCntr)(strm_t *pThis, number_t *pWCnt);
 	rsRetVal (*Dup)(strm_t *pThis, strm_t **ppNew);
+	rsRetVal (*SetCompressionWorkers)(strm_t *const pThis, int num_wrkrs);
 	INTERFACEpropSetMeth(strm, bDeleteOnClose, int);
 	INTERFACEpropSetMeth(strm, iMaxFileSize, int64);
 	INTERFACEpropSetMeth(strm, iMaxFiles, int);
 	INTERFACEpropSetMeth(strm, iFileNumDigits, int);
 	INTERFACEpropSetMeth(strm, tOperationsMode, int);
 	INTERFACEpropSetMeth(strm, tOpenMode, mode_t);
+	INTERFACEpropSetMeth(strm, compressionDriver, strm_compressionDriver_t);
 	INTERFACEpropSetMeth(strm, sType, strmType_t);
 	INTERFACEpropSetMeth(strm, iZipLevel, int);
 	INTERFACEpropSetMeth(strm, bSync, int);

--- a/runtime/zlibw.c
+++ b/runtime/zlibw.c
@@ -2,7 +2,7 @@
  *
  * This is an rsyslog object wrapper around zlib.
  *
- * Copyright 2009-2012 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2009-2022 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -29,6 +29,7 @@
 #include "rsyslog.h"
 #include "module-template.h"
 #include "obj.h"
+#include "stream.h"
 #include "zlibw.h"
 
 MODULE_TYPE_LIB
@@ -65,6 +66,117 @@ static int myDeflate(z_streamp strm, int flush)
 	return deflate(strm, flush);
 }
 
+/* finish zlib buffer */
+static rsRetVal
+doCompressFinish(strm_t *pThis,
+		rsRetVal (*strmPhysWrite)(strm_t *pThis, uchar *pBuf, size_t lenBuf) )
+{
+	int zRet;	/* zlib return state */
+	DEFiRet;
+	unsigned outavail;
+	assert(pThis != NULL);
+
+	assert(pThis->compressionDriver == STRM_COMPRESS_ZIP);
+
+	if(!pThis->bzInitDone)
+		goto done;
+
+	pThis->zstrm.avail_in = 0;
+	/* run deflate() on buffer until everything has been compressed */
+	do {
+		DBGPRINTF("in deflate() loop, avail_in %d, total_in %ld\n", pThis->zstrm.avail_in,
+			pThis->zstrm.total_in);
+		pThis->zstrm.avail_out = pThis->sIOBufSize;
+		pThis->zstrm.next_out = pThis->pZipBuf;
+		zRet = deflate(&pThis->zstrm, Z_FINISH);    /* no bad return value */
+		DBGPRINTF("after deflate, ret %d, avail_out %d\n", zRet, pThis->zstrm.avail_out);
+		outavail = pThis->sIOBufSize - pThis->zstrm.avail_out;
+		if(outavail != 0) {
+			CHKiRet(strmPhysWrite(pThis, (uchar*)pThis->pZipBuf, outavail));
+		}
+	} while (pThis->zstrm.avail_out == 0);
+
+finalize_it:
+	zRet = deflateEnd(&pThis->zstrm);
+	if(zRet != Z_OK) {
+		LogError(0, RS_RET_ZLIB_ERR, "error %d returned from zlib/deflateEnd()", zRet);
+	}
+
+	pThis->bzInitDone = 0;
+done:	RETiRet;
+}
+
+/* write the output buffer in zip mode
+ * This means we compress it first and then do a physical write.
+ * Note that we always do a full deflateInit ... deflate ... deflateEnd
+ * sequence. While this is not optimal, we need to do it because we need
+ * to ensure that the file is readable even when we are aborted. Doing the
+ * full sequence brings us as far towards this goal as possible (and not
+ * doing it would be a total failure). It may be worth considering to
+ * add a config switch so that the user can decide the risk he is ready
+ * to take, but so far this is not yet implemented (not even requested ;)).
+ * rgerhards, 2009-06-04
+ */
+static rsRetVal
+doStrmWrite(strm_t *pThis, uchar *pBuf, size_t lenBuf, const int bFlush,
+		rsRetVal (*strmPhysWrite)(strm_t *pThis, uchar *pBuf, size_t lenBuf) )
+{
+	int zRet;	/* zlib return state */
+	DEFiRet;
+	unsigned outavail = 0;
+	assert(pThis != NULL);
+	assert(pBuf != NULL);
+
+	assert(pThis->compressionDriver == STRM_COMPRESS_ZIP);
+
+	if(!pThis->bzInitDone) {
+		/* allocate deflate state */
+		pThis->zstrm.zalloc = Z_NULL;
+		pThis->zstrm.zfree = Z_NULL;
+		pThis->zstrm.opaque = Z_NULL;
+		/* see note in file header for the params we use with deflateInit2() */
+		zRet = deflateInit2(&pThis->zstrm, pThis->iZipLevel, Z_DEFLATED, 31, 9, Z_DEFAULT_STRATEGY);
+		if(zRet != Z_OK) {
+			LogError(0, RS_RET_ZLIB_ERR, "error %d returned from zlib/deflateInit2()", zRet);
+			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+		}
+		pThis->bzInitDone = RSTRUE;
+	}
+
+	/* now doing the compression */
+	pThis->zstrm.next_in = (Bytef*) pBuf;
+	pThis->zstrm.avail_in = lenBuf;
+	/* run deflate() on buffer until everything has been compressed */
+	do {
+		DBGPRINTF("in deflate() loop, avail_in %d, total_in %ld, bFlush %d\n",
+			pThis->zstrm.avail_in, pThis->zstrm.total_in, bFlush);
+		pThis->zstrm.avail_out = pThis->sIOBufSize;
+		pThis->zstrm.next_out = pThis->pZipBuf;
+		zRet = deflate(&pThis->zstrm, bFlush ? Z_SYNC_FLUSH : Z_NO_FLUSH);    /* no bad return value */
+		DBGPRINTF("after deflate, ret %d, avail_out %d, to write %d\n",
+			zRet, pThis->zstrm.avail_out, outavail);
+		if(zRet != Z_OK) {
+			LogError(0, RS_RET_ZLIB_ERR, "error %d returned from zlib/Deflate()", zRet);
+			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+		}
+		outavail = pThis->sIOBufSize - pThis->zstrm.avail_out;
+		if(outavail != 0) {
+			CHKiRet(strmPhysWrite(pThis, (uchar*)pThis->pZipBuf, outavail));
+		}
+	} while (pThis->zstrm.avail_out == 0);
+
+finalize_it:
+	if(pThis->bzInitDone && pThis->bVeryReliableZip) {
+		doCompressFinish(pThis, strmPhysWrite);
+	}
+	RETiRet;
+}
+/* destruction of caller's zlib ressources - a dummy for us */
+static rsRetVal
+zlib_Destruct(ATTR_UNUSED strm_t *pThis)
+{
+	return RS_RET_OK;
+}
 
 /* queryInterface function
  * rgerhards, 2008-03-05
@@ -84,6 +196,9 @@ CODESTARTobjQueryInterface(zlibw)
 	pIf->DeflateInit2 = myDeflateInit2;
 	pIf->Deflate     = myDeflate;
 	pIf->DeflateEnd  = myDeflateEnd;
+	pIf->doStrmWrite  = doStrmWrite;
+	pIf->doCompressFinish  = doCompressFinish;
+	pIf->Destruct  = zlib_Destruct;
 finalize_it:
 ENDobjQueryInterface(zlibw)
 

--- a/runtime/zstdw.c
+++ b/runtime/zstdw.c
@@ -1,0 +1,191 @@
+/* The zstdw object.
+ *
+ * This is an rsyslog object wrapper around zstd.
+ *
+ * Copyright 2022 Rainer Gerhards and Adiscon GmbH.
+ *
+ * This file is part of the rsyslog runtime library.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "config.h"
+#include <string.h>
+#include <assert.h>
+#include <zstd.h>
+
+#include "rsyslog.h"
+#include "errmsg.h"
+#include "stream.h"
+#include "module-template.h"
+#include "obj.h"
+#include "zstdw.h"
+
+MODULE_TYPE_LIB
+MODULE_TYPE_NOKEEP
+
+/* static data */
+DEFobjStaticHelpers
+
+
+/* finish buffer, to be called before closing the zstd file. */
+static rsRetVal
+zstd_doCompressFinish(strm_t *pThis,
+	rsRetVal (*strmPhysWrite)(strm_t *pThis, uchar *pBuf, size_t lenBuf) )
+{
+	size_t remaining = 0;
+	DEFiRet;
+	assert(pThis != NULL);
+
+	if(!pThis->bzInitDone)
+		goto done;
+
+	char dummybuf; /* not sure if we can pass in NULL as buffer address in this special case */
+	ZSTD_inBuffer input = { &dummybuf, 0, 0 };
+
+	do {
+		ZSTD_outBuffer output = { pThis->pZipBuf, pThis->sIOBufSize, 0 };
+		remaining = ZSTD_compressStream2(pThis->zstd.cctx, &output , &input, ZSTD_e_end);
+		if(ZSTD_isError(remaining)) {
+			LogError(0, RS_RET_ZLIB_ERR,
+				"error returned from ZSTD_compressStream2(): %s\n",
+				ZSTD_getErrorName(remaining));
+			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+		}
+
+		CHKiRet(strmPhysWrite(pThis, (uchar*)pThis->pZipBuf, output.pos));
+
+	} while (remaining != 0);
+
+finalize_it:
+done:	RETiRet;
+}
+
+
+static rsRetVal
+zstd_doStrmWrite(strm_t *pThis, uchar *const pBuf, const size_t lenBuf, const int bFlush,
+	rsRetVal (*strmPhysWrite)(strm_t *pThis, uchar *pBuf, size_t lenBuf) )
+{
+	DEFiRet;
+	assert(pThis != NULL);
+	assert(pBuf != NULL);
+	if(!pThis->bzInitDone) {
+		pThis->zstd.cctx = (void*) ZSTD_createCCtx();
+		if(pThis->zstd.cctx == NULL) {
+			LogError(0, RS_RET_ZLIB_ERR, "error creating zstd context (ZSTD_createCCtx failed, "
+				"that's all we know");
+			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+		}
+
+		ZSTD_CCtx_setParameter(pThis->zstd.cctx, ZSTD_c_compressionLevel, pThis->iZipLevel);
+		ZSTD_CCtx_setParameter(pThis->zstd.cctx, ZSTD_c_checksumFlag, 1);
+		if(pThis->zstd.num_wrkrs > 0) {
+			ZSTD_CCtx_setParameter(pThis->zstd.cctx, ZSTD_c_nbWorkers,
+				pThis->zstd.num_wrkrs);
+		}
+		pThis->bzInitDone = RSTRUE;
+	}
+
+	/* now doing the compression */
+	ZSTD_inBuffer input = { pBuf, lenBuf, 0 };
+
+	// This following needs to be configurable? It's possibly sufficient to use e_flush
+	// only, as this can also be controlled by veryRobustZip. However, testbench will than
+	// not be able to check when all file lines are complete.
+	ZSTD_EndDirective const mode = bFlush ? ZSTD_e_flush : ZSTD_e_continue;
+	size_t remaining;
+	do {
+		ZSTD_outBuffer output = { pThis->pZipBuf, 128, 0 };
+		remaining = ZSTD_compressStream2(pThis->zstd.cctx, &output , &input, mode);
+		if(ZSTD_isError(remaining)) {
+			LogError(0, RS_RET_ZLIB_ERR, "error returned from ZSTD_compressStream2(): %s",
+				ZSTD_getErrorName(remaining));
+			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
+		}
+
+		CHKiRet(strmPhysWrite(pThis, (uchar*)pThis->pZipBuf, output.pos));
+
+	} while ( mode == ZSTD_e_end ? (remaining != 0) : (input.pos != input.size));
+
+finalize_it:
+	if(pThis->bzInitDone && pThis->bVeryReliableZip) {
+		zstd_doCompressFinish(pThis, strmPhysWrite);
+	}
+	RETiRet;
+}
+
+/* destruction of caller's zstd ressources */
+static rsRetVal
+zstd_Destruct(strm_t *const pThis)
+{
+	DEFiRet;
+	assert(pThis != NULL);
+
+	if(!pThis->bzInitDone)
+		goto done;
+
+	const int result = ZSTD_freeCCtx(pThis->zstd.cctx);
+	if(ZSTD_isError(result)) {
+		LogError(0, RS_RET_ZLIB_ERR, "error from ZSTD_freeCCtx(): %s",
+			ZSTD_getErrorName(result));
+	}
+
+	pThis->bzInitDone = 0;
+done:	RETiRet;
+}
+
+
+/* queryInterface function
+ * rgerhards, 2008-03-05
+ */
+BEGINobjQueryInterface(zstdw)
+CODESTARTobjQueryInterface(zstdw)
+	if(pIf->ifVersion != zstdwCURR_IF_VERSION) { /* check for current version, increment on each change */
+		ABORT_FINALIZE(RS_RET_INTERFACE_NOT_SUPPORTED);
+	}
+	pIf->doStrmWrite  = zstd_doStrmWrite;
+	pIf->doCompressFinish  = zstd_doCompressFinish;
+	pIf->Destruct  = zstd_Destruct;
+finalize_it:
+ENDobjQueryInterface(zstdw)
+
+
+/* Initialize the zstdw class. Must be called as the very first method
+ * before anything else is called inside this class.
+ * rgerhards, 2008-02-19
+ */
+BEGINAbstractObjClassInit(zstdw, 1, OBJ_IS_LOADABLE_MODULE) /* class, version */
+ENDObjClassInit(zstdw)
+
+
+/* --------------- here now comes the plumbing that makes as a library module --------------- */
+
+
+BEGINmodExit
+CODESTARTmodExit
+ENDmodExit
+
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_LIB_QUERIES
+ENDqueryEtryPt
+
+
+BEGINmodInit()
+CODESTARTmodInit
+	*ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+	CHKiRet(zstdwClassInit(pModInfo));
+ENDmodInit

--- a/runtime/zstdw.h
+++ b/runtime/zstdw.h
@@ -1,8 +1,8 @@
-/* The zlibw object. It encapsulates the zlib functionality. The primary
+/* The zstdw object. It encapsulates the zstd functionality. The primary
  * purpose of this wrapper class is to enable rsyslogd core to be build without
- * zlib libraries.
+ * zstd libraries.
  *
- * Copyright 2009-2022 Adiscon GmbH.
+ * Copyright 2022 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -20,32 +20,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef INCLUDED_ZLIBW_H
-#define INCLUDED_ZLIBW_H
-
-#include <zlib.h>
-
-#include "errmsg.h"
+#ifndef INCLUDED_ZSTDW_H
+#define INCLUDED_ZSTDW_H
 
 /* interfaces */
-BEGINinterface(zlibw) /* name must also be changed in ENDinterface macro! */
-	int (*DeflateInit)(z_streamp strm, int);
-	int (*DeflateInit2)(z_streamp strm, int level, int method, int windowBits, int memLevel, int strategy);
-	int (*Deflate)(z_streamp strm, int);
-	int (*DeflateEnd)(z_streamp strm);
+BEGINinterface(zstdw) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*doStrmWrite)(strm_t *pThis, uchar *const pBuf, const size_t lenBuf, const int bFlush,
 		rsRetVal (*strmPhysWrite)(strm_t *pThis, uchar *pBuf, size_t lenBuf) );
 	rsRetVal (*doCompressFinish)(strm_t *pThis,
 		rsRetVal (*Destruct)(strm_t *pThis, uchar *pBuf, size_t lenBuf) );
 	rsRetVal (*Destruct)(strm_t *pThis);
-ENDinterface(zlibw)
-#define zlibwCURR_IF_VERSION 2 /* increment whenever you change the interface structure! */
+ENDinterface(zstdw)
+#define zstdwCURR_IF_VERSION 1 /* increment whenever you change the interface structure! */
 
 
 /* prototypes */
-PROTOTYPEObj(zlibw);
+PROTOTYPEObj(zstdw);
 
 /* the name of our library binary */
-#define LM_ZLIBW_FILENAME "lmzlibw"
+#define LM_ZSTDW_FILENAME "lmzstdw"
 
-#endif /* #ifndef INCLUDED_ZLIBW_H */
+#endif /* #ifndef INCLUDED_ZSTDW_H */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -503,6 +503,15 @@ TESTS +=  \
 	parsertest-snare_ccoff_udp.sh \
 	parsertest-snare_ccoff_udp2.sh
 
+if ENABLE_LIBZSTD
+TESTS +=  \
+	zstd.sh
+if HAVE_VALGRIND
+TESTS +=  \
+	zstd-vg.sh
+endif # if HAVE_VALGRIND
+endif
+
 if ENABLE_LIBGCRYPT
 TESTS +=  \
 	queue-encryption-disk.sh \
@@ -1979,6 +1988,8 @@ EXTRA_DIST= \
 	omfwd-keepalive.sh \
 	omfwd_fast_imuxsock.sh \
 	omfile_hup-vg.sh \
+	zstd.sh \
+	zstd-vg.sh \
 	gzipwr_hup-vg.sh \
 	omusrmsg-noabort-legacy.sh \
 	omusrmsg-errmsg-no-params.sh \

--- a/tests/zstd-vg.sh
+++ b/tests/zstd-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+export NUMMESSAGES=10000 # valgrind is pretty slow, so we need to user lower nbr of msgs
+source ${srcdir:-.}/zstd.sh

--- a/tests/zstd.sh
+++ b/tests/zstd.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# This tests writing large data records in zst mode. We use up to 10K
+# record size.
+#
+# added 2022-06-21 by Rgerhards
+#
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=${NUMMESSAGES:-50000}
+export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
+generate_conf
+# Note: we right now use the non-compressed file as indicator for "processing complete"
+#export SEQ_CHECK_FILE=$RSYSLOG_OUT_LOG.zst
+add_conf '
+$MaxMessageSize 10k
+$MainMsgQueueTimeoutShutdown 10000
+
+module(load="builtin:omfile" compression.driver="zstd" compression.zstd.workers="5")
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
+local0.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'.zst" template="outfmt"
+		zipLevel="20" iobuffersize="64k" veryRobustZIP="off")
+local0.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+# rgerhards, 2019-08-14: Note: veryRobustZip may need to be "on". Do this if the test
+# still prematurely terminates. In that case it is likely that gunzip got confused
+# by the missing zip close record. My initial testing shows that while gunzip emits an
+# error message, everything is properly extracted. Only stressed CI runs will show how
+# it works in reality.
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+tcpflood -m$NUMMESSAGES -r -d10000 -P129
+shutdown_when_empty
+wait_shutdown
+seq_check 0 $((NUMMESSAGES - 1)) -E
+exit_test


### PR DESCRIPTION
The zstd library provides better and faster compression than zlib.
This patch integrates zstd as a dynamically-loadable functionality.
As such, no further dependencies need to be added to the rsyslog
base package.

Due to the increased performance, usage of zstd is highly recommended
for high-volume use cases.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
