### PR TITLE
config: add "abortOnFailedQueueStartup" global config parameter

### DIFF
--- a/action.c
+++ b/action.c
@@ -64,7 +64,7 @@
  * beast.
  * rgerhards, 2011-06-15
  *
- * Copyright 2007-2019 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2022 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -1988,6 +1988,12 @@ DEFFUNC_llExecFunc(doActivateActions)
 	action_t * const pThis = (action_t*) pData;
 	localRet = qqueueStart(runConf, pThis->pQueue);
 	if(localRet != RS_RET_OK) {
+		if(runConf->globals.bAbortOnFailedQueueStartup) {
+			fprintf(stderr, "rsyslogd: error %d starting up action queue, "
+				"abortOnFailedQueueStartup is set, so we abort rsyslog now.", localRet);
+			fflush(stderr);
+			exit(1); /* "good" exit, this is intended here */
+		}
 		LogError(0, localRet, "error starting up action queue");
 		if(localRet == RS_RET_FILE_PREFIX_MISSING) {
 			LogError(0, localRet, "file prefix (work directory?) "

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -7,7 +7,7 @@
  *
  * Module begun 2008-04-16 by Rainer Gerhards
  *
- * Copyright 2008-2021 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2022 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -151,6 +151,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "net.enabledns", eCmdHdlrBinary, 0 },
 	{ "net.permitACLwarning", eCmdHdlrBinary, 0 },
 	{ "abortonuncleanconfig", eCmdHdlrBinary, 0 },
+	{ "abortonfailedqueuestartup", eCmdHdlrBinary, 0 },
 	{ "variables.casesensitive", eCmdHdlrBinary, 0 },
 	{ "environment", eCmdHdlrArray, 0 },
 	{ "processinternalmessages", eCmdHdlrBinary, 0 },
@@ -1287,6 +1288,8 @@ glblDoneLoadCnf(void)
 			SetOptionDisallowWarning(!((int) cnfparamvals[i].val.d.n));
 		} else if(!strcmp(paramblk.descr[i].name, "abortonuncleanconfig")) {
 			loadConf->globals.bAbortOnUncleanConfig = cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "abortonfailedqueuestartup")) {
+			loadConf->globals.bAbortOnFailedQueueStartup = cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "internalmsg.ratelimit.burst")) {
 			loadConf->globals.intMsgRateLimitBurst = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "internalmsg.ratelimit.interval")) {

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -2,7 +2,7 @@
  *
  * Module begun 2011-04-19 by Rainer Gerhards
  *
- * Copyright 2011-2020 Adiscon GmbH.
+ * Copyright 2011-2022 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -160,6 +160,7 @@ int rsconfNeedDropPriv(rsconf_t *const cnf)
 static void cnfSetDefaults(rsconf_t *pThis)
 {
 	pThis->globals.bAbortOnUncleanConfig = 0;
+	pThis->globals.bAbortOnFailedQueueStartup = 0;
 	pThis->globals.bReduceRepeatMsgs = 0;
 	pThis->globals.bDebugPrintTemplateList = 1;
 	pThis->globals.bDebugPrintModuleList = 0;

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -1,6 +1,6 @@
 /* The rsconf object. It models a complete rsyslog configuration.
  *
- * Copyright 2011-2020 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2011-2022 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -93,6 +93,8 @@ struct globals_s {
 	int maxErrMsgToStderr;	/* how many messages to forward at most to stderr? */
 	int bAbortOnUncleanConfig; /* abort run (rather than starting with partial
 				      config) if there was any issue in conf */
+	int bAbortOnFailedQueueStartup; /* similar to bAbortOnUncleanConfig, but abort if a queue
+					   startup fails. This is not exactly an unclan config. */
 	int uidDropPriv;	/* user-id to which priveleges should be dropped to */
 	int gidDropPriv;	/* group-id to which priveleges should be dropped to */
 	int gidDropPrivKeepSupplemental; /* keep supplemental groups when dropping? */

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -3,7 +3,7 @@
  * because it was either written from scratch by me (rgerhards) or
  * contributors who agreed to ASL 2.0.
  *
- * Copyright 2004-2019 Rainer Gerhards and Adiscon
+ * Copyright 2004-2022 Rainer Gerhards and Adiscon
  *
  * This file is part of rsyslog.
  *
@@ -187,7 +187,7 @@ int bFinished = 0;	/* used by termination signal handler, read-only except there
 			 * is either 0 or the number of the signal that requested the
 			 * termination.
 			 */
-const char *PidFile;
+const char *PidFile = NULL;
 #define NO_PIDFILE "NONE"
 int iConfigVerify = 0;	/* is this just a config verify run? */
 rsconf_t *ourConf = NULL;	/* our config object */
@@ -295,6 +295,16 @@ writePidFile(void)
 	}
 finalize_it:
 	RETiRet;
+}
+
+static void
+clearPidFile(void)
+{
+	if(PidFile != NULL) {
+		if(strcmp(PidFile, NO_PIDFILE)) {
+			unlink(PidFile);
+		}
+	}
 }
 
 /* duplicate startup protection: check, based on pid file, if our instance
@@ -818,6 +828,13 @@ startMainQueue(rsconf_t *cnf, qqueue_t *const pQueue)
 	CHKiRet_Hdlr(qqueueStart(cnf, pQueue)) {
 		/* no queue is fatal, we need to give up in that case... */
 		LogError(0, iRet, "could not start (ruleset) main message queue");
+		if(runConf->globals.bAbortOnFailedQueueStartup) {
+			fprintf(stderr, "rsyslogd: could not start (ruleset) main message queue, "
+				"abortOnFailedQueueStartup is set, so we abort rsyslog now.\n");
+			fflush(stderr);
+			clearPidFile();
+			exit(1); /* "good" exit, this is intended here */
+		}
 		pQueue->qType = QUEUETYPE_DIRECT;
 		CHKiRet_Hdlr(qqueueStart(cnf, pQueue)) {
 			/* no queue is fatal, we need to give up in that case... */
@@ -2100,9 +2117,7 @@ deinitAll(void)
 	dbgClassExit();
 
 	/* NO CODE HERE - dbgClassExit() must be the last thing before exit()! */
-	if(strcmp(PidFile, NO_PIDFILE)) {
-		unlink(PidFile);
-	}
+	clearPidFile();
 }
 
 /* This is the main entry point into rsyslogd. This must be a function in its own


### PR DESCRIPTION
similiar to "abortONUncleanConfig", this parameter aborts rsyslog
when a queue has problems during startup. Some users perfer rsyslog
to terminate in this case. By default, nothing changes.

closes https://github.com/rsyslog/rsyslog/issues/4902

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
