### PR TITLE
testbench: Add more valgrind tests for sndrcv (omrelp/imrelp)

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1438,7 +1438,9 @@ if HAVE_VALGRIND
 TESTS += \
 	 imrelp-basic-vg.sh \
 	 imrelp-sessionbreak-vg.sh \
-	 imrelp-manyconn-vg.sh
+	 imrelp-manyconn-vg.sh \
+	 sndrcv_relp-vg-rcvr.sh \
+	 sndrcv_relp-vg-sender.sh
 endif # HAVE_VALGRIND
 endif
 
@@ -2371,6 +2373,8 @@ EXTRA_DIST= \
 	sndrcv_relp_tls_chainedcert.sh \
 	sndrcv_relp_tls.sh \
 	sndrcv_relp_tls_certvalid.sh \
+	sndrcv_relp-vg-rcvr.sh \
+	sndrcv_relp-vg-sender.sh \
 	relp_tls_certificate_not_found.sh \
 	omrelp_wrong_authmode.sh \
 	imrelp-tls.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -596,7 +596,7 @@ startup_vg_waitpid_only() {
 	# add --keep-debuginfo=yes for hard to find cases; this cannot be used generally,
 	# because it is only supported by newer versions of valgrind (else CI will fail
 	# on older platforms).
-	LD_PRELOAD=$RSYSLOG_PRELOAD valgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/known_issues.supp ${EXTRA_VALGRIND_SUPPRESSIONS:-} --gen-suppressions=all --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=$RS_TESTBENCH_LEAK_CHECK ../tools/rsyslogd -C -n -i$RSYSLOG_PIDBASE$2.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
+	LD_PRELOAD=$RSYSLOG_PRELOAD valgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/known_issues.supp ${EXTRA_VALGRIND_SUPPRESSIONS:-} --gen-suppressions=all --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=$RS_TESTBENCH_LEAK_CHECK ../tools/rsyslogd -C -n -i$RSYSLOG_PIDBASE$instance.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
 	wait_rsyslog_startup_pid $1
 }
 
@@ -604,7 +604,7 @@ startup_vg_waitpid_only() {
 # returns only after successful startup, $2 is the instance (blank or 2!)
 startup_vg() {
 		startup_vg_waitpid_only $1 $2
-		wait_startup $2
+		wait_startup $instance
 		reassign_ports
 }
 

--- a/tests/sndrcv_relp-vg-rcvr.sh
+++ b/tests/sndrcv_relp-vg-rcvr.sh
@@ -1,11 +1,24 @@
 #!/bin/bash
-# added 2013-12-10 by Rgerhards
+# added 2022-06-21 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=50000
+
+# CHECK VALGRIND MINIMUM VERSION | MIN 3.14.0
+VALGRINDVER=$(valgrind --version)
+VALGRINDVERMAJOR=$(echo $VALGRINDVER | cut -d'-' -f2 | cut -d'.' -f1)
+VALGRINDVERMINOR=$(echo $VALGRINDVER | cut -d'-' -f2 | cut -d'.' -f2)
+if [ "$VALGRINDVERMAJOR" -lt 3 ] || { [ "$VALGRINDVERMAJOR" -eq 3 ] && [ "$VALGRINDVERMINOR" -lt 15 ]; }; then
+        printf 'This test does NOT work with versions below valgrind-3.15.0 (missing --keep-debuginfo) - Installed valgrind version is '
+        printf $VALGRINDVER
+        printf '\n'
+        exit 77
+fi
+
+export NUMMESSAGES=5000
+export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
 ########## receiver ##########
-#export RSYSLOG_DEBUG="debug nostdout"
-#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
 export PORT_RCVR="$(get_free_port)"
 add_conf '
@@ -15,29 +28,32 @@ input(type="imrelp" port="'$PORT_RCVR'")
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
-startup
+startup_vg
 printf "#### RECEIVER STARTED\n\n"
 
 ########## sender ##########
-#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 generate_conf 2
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
 
 action(type="omrelp" name="omrelp" target="127.0.0.1" port="'$PORT_RCVR'")
 ' 2
+
 startup 2
 printf "#### SENDER STARTED\n\n"
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg2 0 50000
+injectmsg2 0 $NUMMESSAGES
 
 shutdown_when_empty 2
 wait_shutdown 2
+
 # now it is time to stop the receiver as well
 shutdown_when_empty
-wait_shutdown
-
+wait_shutdown_vg
 seq_check
+check_exit_vg
+
 exit_test

--- a/tests/sndrcv_relp-vg-sender.sh
+++ b/tests/sndrcv_relp-vg-sender.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# added 2022-06-21 by alorbach
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+# CHECK VALGRIND MINIMUM VERSION | MIN 3.14.0
+VALGRINDVER=$(valgrind --version)
+VALGRINDVERMAJOR=$(echo $VALGRINDVER | cut -d'-' -f2 | cut -d'.' -f1)
+VALGRINDVERMINOR=$(echo $VALGRINDVER | cut -d'-' -f2 | cut -d'.' -f2)
+if [ "$VALGRINDVERMAJOR" -lt 3 ] || { [ "$VALGRINDVERMAJOR" -eq 3 ] && [ "$VALGRINDVERMINOR" -lt 15 ]; }; then
+        printf 'This test does NOT work with versions below valgrind-3.15.0 (missing --keep-debuginfo) - Installed valgrind version is '
+        printf $VALGRINDVER
+        printf '\n'
+        exit 77
+fi
+
+export NUMMESSAGES=5000
+export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
+########## receiver ##########
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+generate_conf
+export PORT_RCVR="$(get_free_port)"
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="'$PORT_RCVR'")
+
+$template outfmt,"%msg:F,58:2%\n"
+:msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+printf "#### RECEIVER STARTED\n\n"
+
+########## sender ##########
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
+generate_conf 2
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp")
+
+action(type="omrelp" name="omrelp" target="127.0.0.1" port="'$PORT_RCVR'")
+' 2
+
+startup_vg 2
+printf "#### SENDER STARTED\n\n"
+
+# now inject the messages into instance 2. It will connect to instance 1,
+# and that instance will record the data.
+injectmsg2 0 $NUMMESSAGES
+
+printf "#### SENDER SHUTDOWN\n\n"
+shutdown_when_empty 2
+wait_shutdown_vg 2
+check_exit_vg 2
+
+printf "#### RECEIVER SHUTDOWN\n\n"
+# now it is time to stop the receiver as well
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test


### PR DESCRIPTION
- These tests will help find race conditions hopefully
- fix diag.sh issues running second instance in valgrind mode only

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
