### PR TITLE
build error fix: libbson requires out-of-date language constructs

### DIFF
--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -42,6 +42,8 @@ PRAGMA_IGNORE_Wpragmas
 PRAGMA_IGNORE_Wunknown_warning_option
 PRAGMA_IGNORE_Wunknown_attribute
 PRAGMA_IGNORE_Wexpansion_to_defined
+PRAGMA_IGNORE_Wstrict_prototypes
+PRAGMA_IGNORE_Wold_style_definition
 #include <mongoc.h>
 #include <bson.h>
 PRAGMA_DIAGNOSTIC_POP
@@ -196,6 +198,7 @@ reportMongoError(instanceData *pData)
 static rsRetVal initMongoDB(instanceData *pData, int bSilent)
 {
 	DEFiRet;
+	unsigned char retval;
 
 	DBGPRINTF("ommongodb: uristr is '%s'", pData->uristr);
 	mongoc_init ();
@@ -224,7 +227,7 @@ static rsRetVal initMongoDB(instanceData *pData, int bSilent)
 	bson_t *command, reply;
 	bson_error_t error;
 	command = BCON_NEW ("ping", BCON_INT32 (1));
-	unsigned char retval = mongoc_client_command_simple(pData->client, pData->db, command, NULL, &reply, &error);
+	retval = mongoc_client_command_simple(pData->client, pData->db, command, NULL, &reply, &error);
 	bson_destroy(&reply);
 	bson_destroy(command);
 	if( !retval ) {

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -88,6 +88,8 @@
 #if defined(__GNUC__)
 	#define PRAGMA_INGORE_Wswitch_enum	_Pragma("GCC diagnostic ignored \"-Wswitch-enum\"")
 	#define PRAGMA_IGNORE_Wempty_body	_Pragma("GCC diagnostic ignored \"-Wempty-body\"")
+	#define PRAGMA_IGNORE_Wstrict_prototypes _Pragma("GCC diagnostic ignored \"-Wstrict-prototypes\"")
+	#define PRAGMA_IGNORE_Wold_style_definition _Pragma("GCC diagnostic ignored \"-Wold-style-definition\"")
 	#define PRAGMA_IGNORE_Wsign_compare	_Pragma("GCC diagnostic ignored \"-Wsign-compare\"")
 	#define PRAGMA_IGNORE_Wpragmas		_Pragma("GCC diagnostic ignored \"-Wpragmas\"")
 	#define PRAGMA_IGNORE_Wmissing_noreturn _Pragma("GCC diagnostic ignored \"-Wmissing-noreturn\"")
@@ -110,6 +112,8 @@
 	#define PRAGMA_IGNORE_Wpragmas
 	#define PRAGMA_IGNORE_Wmissing_noreturn
 	#define PRAGMA_IGNORE_Wempty_body
+	#define PRAGMA_IGNORE_Wstrict_prototypes
+	#define PRAGMA_IGNORE_Wold_style_definition
 	#define PRAGMA_IGNORE_Wdeprecated_declarations
 	#define PRAGMA_IGNORE_Wexpansion_to_defined
 	#define PRAGMA_IGNORE_Wunknown_attribute

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1632,7 +1632,7 @@ dep_kafka_url="https://www.rsyslog.com/files/download/rsyslog/$RS_KAFKA_DOWNLOAD
 dep_kafka_cached_file=$dep_cache_dir/$RS_KAFKA_DOWNLOAD
 
 if [ -z "$ES_DOWNLOAD" ]; then
-	export ES_DOWNLOAD=elasticsearch-7.14.1-linux-x86_64.tar.gz #elasticsearch-5.6.9.tar.gz
+	export ES_DOWNLOAD=elasticsearch-7.14.1-linux-x86_64.tar.gz
 fi
 if [ -z "$ES_PORT" ]; then
 	export ES_PORT=19200

--- a/tools/logctl.c
+++ b/tools/logctl.c
@@ -2,7 +2,7 @@
  * logctl - a tool to access lumberjack logs in MongoDB
  *  ... and potentially other sources in the future.
  *
- * Copyright 2012 Ulrike Gerhards and Adiscon GmbH.
+ * Copyright 2012-2022 Ulrike Gerhards and Adiscon GmbH.
  *
  * Copyright 2017 Hugo Soszynski and aDvens
  *
@@ -58,6 +58,8 @@
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic ignored "-Wunknown-attributes"
 #pragma GCC diagnostic ignored "-Wexpansion-to-defined"
+#pragma GCC diagnostic ignored "-Wstrict-prototypes"
+#pragma GCC diagnostic ignored "-Wold-style-definition"
 #endif
 #include <mongoc.h>
 #include <bson.h>


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
