### PR TITLE
stream cleanup: move error message to debug log, only

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1467,11 +1467,11 @@ doWriteCall(strm_t *pThis, uchar *pBuf, size_t *pLenBuf)
 			const int err = errno;
 			iWritten = 0; /* we have written NO bytes! */
 			if(err == EBADF) {
-				LogError(err, RS_RET_IO_ERROR, "file %s: fd %d no longer valid, recovery by "
+				DBGPRINTF("file %s: errno %d, fd %d no longer valid, recovery by "
 					"reopen; if you see this, consider reporting at "
 					"https://github.com/rsyslog/rsyslog/issues/3404 "
 					"so that we know when it happens. Include output of uname -a. "
-					"OS error reason", pThis->pszCurrFName, pThis->fd);
+					"OS error reason", pThis->pszCurrFName, err, pThis->fd);
 				pThis->fd = -1;
 				CHKiRet(doPhysOpen(pThis));
 			} else {


### PR DESCRIPTION
This error message is most probably rooted in a kernel problem. At
least knowbody knows how it can happen. It's definitely not a
rsyslog issue. We also can recover from it for a long time now
so there is no reason to irritate users by emitteing this
"error" message.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
