### PR TITLE
CI: suppress TSAN exception for known-good case

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -397,18 +397,28 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) *pp, void __a
 static rsRetVal addLstn(ptcpsrv_t *pSrv, int sock, int isIPv6);
 
 
+/* function to suppress TSAN known-good case
+ * We do not use a mutex an epd, but we do always access it in
+ * pure sequence. Adding a mutex just to cover this "cosmetic"
+ * would result in uncesseary performance penalty.
+ */
+static void ATTR_NONNULL()
+imptcp_destruct_epd(ptcpsess_t *const pSess) {
+	free(pSess->epd);
+	pSess->epd = NULL;
+}
+
 /* some simple constructors/destructors */
-static void
-destructSess(ptcpsess_t *pSess)
+static void ATTR_NONNULL()
+destructSess(ptcpsess_t *const pSess)
 {
+	imptcp_destruct_epd(pSess);
 	free(pSess->pMsg_save);
 	free(pSess->pMsg);
-	free(pSess->epd);
 	prop.Destruct(&pSess->peerName);
 	prop.Destruct(&pSess->peerIP);
 	/* TODO: make these inits compile-time switch depending: */
 	pSess->pMsg = NULL;
-	pSess->epd = NULL;
 	free(pSess);
 }
 

--- a/tests/tsan-rt.supp
+++ b/tests/tsan-rt.supp
@@ -1,3 +1,6 @@
+# supressions for LLVM TSAN
+# doc: https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
+race:^imptcp_destruct_epd$
 race:doLogMsg
 race:setlocale
 race:doSIGTTIN


### PR DESCRIPTION
We do not use a mutex an epd, but we do always access it in
pure sequence. Adding a mutex just to cover this "cosmetic"
would result in uncesseary performance penalty.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
