### PR TITLE
Fix memory leak when free action worker data table

### DIFF
--- a/action.c
+++ b/action.c
@@ -316,6 +316,20 @@ actionResetQueueParams(void)
 	RETiRet;
 }
 
+/* free action worker data table
+*/
+static void freeWrkrDataTable(action_t * const pThis)
+{
+	int freeSpot;
+	for(freeSpot = 0; freeSpot < pThis->wrkrDataTableSize; ++freeSpot) {
+		if(pThis->wrkrDataTable[freeSpot] != NULL) {
+			pThis->pMod->mod.om.freeWrkrInstance(pThis->wrkrDataTable[freeSpot]);
+			pThis->wrkrDataTable[freeSpot] = NULL;
+		}
+	}
+	free(pThis->wrkrDataTable);
+	return;
+}
 
 /* destructs an action descriptor object
  * rgerhards, 2007-08-01
@@ -353,7 +367,7 @@ rsRetVal actionDestruct(action_t * const pThis)
 	free(pThis->pszName);
 	free(pThis->ppTpl);
 	free(pThis->peParamPassing);
-	free(pThis->wrkrDataTable);
+	freeWrkrDataTable(pThis);
 
 finalize_it:
 	free(pThis);


### PR DESCRIPTION
During free action worker data table when action destruct, worker instance in worker data table were not null. It resulted in memory leak and this patch fixes this behaviour.

The problem is mentioned here:
https://github.com/rsyslog/rsyslog/issues/4938
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
