### PR TITLE
mmanon: Simplified and fixed IPv4 digit detection.

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -617,6 +617,7 @@ TESTS +=  \
 	mmanon_simple_12_ipv4.sh \
 	mmanon_simple_33_ipv4.sh \
 	mmanon_simple_8_ipv4.sh \
+	mmanon_simple_mallformed_ipv4.sh \
 	mmanon_random_128_ipv6.sh \
 	mmanon_zero_128_ipv6.sh \
 	mmanon_zero_96_ipv6.sh \
@@ -1966,6 +1967,7 @@ EXTRA_DIST= \
 	mmanon_simple_12_ipv4.sh \
 	mmanon_simple_33_ipv4.sh \
 	mmanon_simple_8_ipv4.sh \
+	mmanon_simple_mallformed_ipv4.sh \
 	mmanon_random_128_ipv6.sh \
 	mmanon_zero_128_ipv6.sh \
 	mmanon_zero_96_ipv6.sh \

--- a/tests/mmanon_recognize_ipv4.sh
+++ b/tests/mmanon_recognize_ipv4.sh
@@ -2,6 +2,10 @@
 # add 2016-11-22 by Jan Gerhards, released under ASL 2.0
 
 . ${srcdir:=.}/diag.sh init
+
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")

--- a/tests/mmanon_simple_mallformed_ipv4.sh
+++ b/tests/mmanon_simple_mallformed_ipv4.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# add 2022-07-28 by Andre Lorbach, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+#export USE_VALGRIND="YES" # this test only makes sense with valgrind enabled
+#export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes"
+
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+
+module(load="../plugins/mmanon/.libs/mmanon")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+ruleset(name="testing") {
+	action(type="mmanon" ipv4.bits="32" ipv4.mode="simple")
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}'
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag: 165874883373.1.15599155266856607338.91@whatever
+<129>Mar 10 01:00:00 172.20.245.8 tag: 1.165874883373.15599155266856607338.91@whatever
+<129>Mar 10 01:00:00 172.20.245.8 tag: 15599155266856607338.165874883373.1.91@whatever
+<129>Mar 10 01:00:00 172.20.245.8 tag: 91.165874883373.1.15599155266856607338.@whatever\""
+
+shutdown_when_empty
+wait_shutdown
+export EXPECTED=' 165874883373.1.15599155266856607338.91@whatever
+ 1.165874883373.15599155266856607338.91@whatever
+ 15599155266856607338.165874883373.1.91@whatever
+ 91.165874883373.1.15599155266856607338.@whatever'
+cmp_exact
+exit_test


### PR DESCRIPTION
- Fixed an issue with numbers above int64 in syntax_ipv4.
  Numbers that were up to 256 above the max of an int64
  could incorrectly be detected as valid ipv4 digit.
- Simplified the IPv4 digit detection function and renamed
  to isPosByte.
- added testcasse for malformed IPvc4 addresses

closes: https://github.com/rsyslog/rsyslog/issues/4940

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
