### PR TITLE
ksi bugfix: optimize processing of signer queue to fix redundant delays.

### DIFF
--- a/runtime/lib_ksils12.h
+++ b/runtime/lib_ksils12.h
@@ -95,6 +95,7 @@ struct rsksictx_s {
 	uint64_t blockLevelLimit;
 	uint32_t blockTimeLimit;
 	uint32_t effectiveBlockLevelLimit; /* level limit adjusted by gateway settings */
+	uint32_t threadSleepms;
 	uint8_t syncMode;
 	uid_t	fileUID;	/* IDs for creation */
 	uid_t	dirUID;


### PR DESCRIPTION
There is a worker queue where rsyslog KSI module collects events and signing
requests. When queue is processed thread is periodically put to sleep. Previous
implementation handles signature requests well but sleeps every time after
handling new file open / close event. When several log files are opened or
closed simultaneously process is significantly slowed down. Another issue is
that thread always sleeps 1000ms that may be 2x longer than aggregation round.
This slows down overall signing process.

Fix for the issue is to simply not sleep after file open / close event if there
are next items to be processed. To speed up the signing process, rsyslog uses
KSI aggregator conf. to obtain the aggregation period that is used for the sleep
time configuration.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
