### PR TITLE
ksi bugfix: request cache size and send timeout issue fixed.

### DIFF
--- a/runtime/lib_ksils12.h
+++ b/runtime/lib_ksils12.h
@@ -94,6 +94,7 @@ struct rsksictx_s {
 	time_t tConfRequested;
 	uint64_t blockLevelLimit;
 	uint32_t blockTimeLimit;
+	uint32_t blockSigTimeout;
 	uint32_t effectiveBlockLevelLimit; /* level limit adjusted by gateway settings */
 	uint32_t threadSleepms;
 	uint8_t syncMode;
@@ -204,6 +205,7 @@ struct rsksistatefile {
 #define getIVLenKSI(bh) (hashOutputLengthOctetsKSI((bh)->hashID))
 #define rsksiSetBlockLevelLimit(ctx, limit) ((ctx)->blockLevelLimit = (ctx)->effectiveBlockLevelLimit = limit)
 #define rsksiSetBlockTimeLimit(ctx, limit) ((ctx)->blockTimeLimit = limit)
+#define rsksiSetBlockSigTimeout(ctx, val) ((ctx)->blockSigTimeout = val)
 #define rsksiSetConfInterval(ctx, val) ((ctx)->confInterval = val)
 #define rsksiSetKeepRecordHashes(ctx, val) ((ctx)->bKeepRecordHashes = val)
 #define rsksiSetKeepTreeHashes(ctx, val) ((ctx)->bKeepTreeHashes = val)

--- a/runtime/lmsig_ksi-ls12.c
+++ b/runtime/lmsig_ksi-ls12.c
@@ -49,6 +49,7 @@ static struct cnfparamdescr cnfpdescr[] = {
 	{ "sig.aggregator.hmacAlg", eCmdHdlrGetWord, 0 },
 	{ "sig.block.levelLimit", eCmdHdlrSize, CNFPARAM_REQUIRED},
 	{ "sig.block.timeLimit", eCmdHdlrInt, 0},
+	{ "sig.block.signtimeout", eCmdHdlrInt, 0},
 	{ "sig.confinterval", eCmdHdlrInt, 0},
 	{ "sig.keeprecordhashes", eCmdHdlrBinary, 0 },
 	{ "sig.keeptreehashes", eCmdHdlrBinary, 0},
@@ -179,6 +180,14 @@ SetCnfParam(void *pT, struct nvlst *lst)
 			}
 		} else if (!strcmp(pblk.descr[i].name, "sig.keeprecordhashes")) {
 			rsksiSetKeepRecordHashes(pThis->ctx, pvals[i].val.d.n);
+		} else if (!strcmp(pblk.descr[i].name, "sig.block.signtimeout")) {
+			if (pvals[i].val.d.n < 0) {
+				LogError(0, RS_RET_ERR, "sig.block.signtimeout "
+					"%llu invalid - signing disabled", pvals[i].val.d.n);
+				pThis->ctx->disabled = true;
+			} else {
+				rsksiSetBlockSigTimeout(pThis->ctx, pvals[i].val.d.n);
+			}
 		} else if(!strcmp(pblk.descr[i].name, "sig.keeptreehashes")) {
 			rsksiSetKeepTreeHashes(pThis->ctx, pvals[i].val.d.n);
 		} else if (!strcmp(pblk.descr[i].name, "sig.syncmode")) {


### PR DESCRIPTION
Async service send timeout is not configurable and request cache size is too
small to handle large amount of signing requests with small amount of permitted
requests per aggregation round. For example user with max_requests = 4 results
cache size 5 * max_requests or at least 256. When signing 300 log files cache
will be too small resulting several unsigned blocks. When signing 200 log file
cache will be adequate, but with rate of 4 signatures per second, it is only
possible to sign 4 * 10 blocks before all requests that are not sent out will
timeout.

Fix for the issue is to make send timeout configurable and make the size of the
cache depend on the value of send timeout. New configuration value
sig.block.signtimeout="time, s" introduced that defines the time window wherein
the block has to be signed. The size of the request cache is increased to
3 * max_requests * sign_timeout or at least 256.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
