### PR TITLE
Fix Segmentation fault in close journal

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -991,7 +991,9 @@ CODESTARTafterRun
 		persistJournalState();
 	}
 	closeJournal();
-	ratelimitDestruct(ratelimiter);
+	if (ratelimiter) {
+		ratelimitDestruct(ratelimiter);
+	}
 ENDafterRun
 
 


### PR DESCRIPTION
In imjournal module, we destruct ratelimiter after closing journal. But, we should check ratelimiter is NULL or not.

Fix: #4953