### PR TITLE
conf: Fix #pragma GCC diagnostic not allowed inside functions

### DIFF
--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -110,8 +110,15 @@
 						_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
 	#define PRAGMA_IGNORE_Wdeprecated_declarations \
 						_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
-	#define PRAGMA_DIAGNOSTIC_PUSH		_Pragma("GCC diagnostic push")
-	#define PRAGMA_DIAGNOSTIC_POP		_Pragma("GCC diagnostic pop")
+	#if  __GNUC__ >= 5
+		#define PRAGMA_DIAGNOSTIC_PUSH \
+			_Pragma("GCC diagnostic push")
+		#define PRAGMA_DIAGNOSTIC_POP \
+			_Pragma("GCC diagnostic pop")
+	#else
+		#define PRAGMA_DIAGNOSTIC_PUSH
+		#define PRAGMA_DIAGNOSTIC_POP
+	#endif
 #else
 	#define PRAGMA_INGORE_Wswitch_enum
 	#define PRAGMA_IGNORE_Wsign_compare


### PR DESCRIPTION
Commit 829a6f6 "CI: improve use of github action matrix feature;
optimization" has introduced use of #pragma GCC diagnostic in function
doNameLine() of runtime/conf.c. This is not supported by old compilers
like GCC 4.4.7 on el6.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
