### PR TITLE
Fix memory leak when SetString reassign to pThis->szVal.psz

### DIFF
--- a/runtime/prop.c
+++ b/runtime/prop.c
@@ -84,6 +84,9 @@ static rsRetVal SetString(prop_t *pThis, const uchar *psz, const int len)
 	if(len < CONF_PROP_BUFSIZE) {
 		memcpy(pThis->szVal.sz, psz, len + 1);
 	} else {
+		if(pThis->szVal.psz != NULL) {
+			free(pThis->szVal.psz);
+		}
 		CHKmalloc(pThis->szVal.psz = malloc(len + 1));
 		memcpy(pThis->szVal.psz, psz, len + 1);
 	}


### PR DESCRIPTION
During SetString reassign to pThis->szVal.psz, pThis->szVal.psz might not null. It resulted in memory leak and this patch fixes this behaviour.

The problem is mentioned here:
https://github.com/rsyslog/rsyslog/issues/4961
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
