### PR TITLE
imtcp: add option notifyonconnectionopen

### DIFF
--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -1,6 +1,6 @@
 /* Definitions for tcpsrv class.
  *
- * Copyright 2008-2021 Adiscon GmbH.
+ * Copyright 2008-2022 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -87,6 +87,7 @@ struct tcpsrv_s {
 	ruleset_t *pRuleset;	/**< ruleset to bind to */
 	permittedPeers_t *pPermPeers;/**< driver's permitted peers */
 	sbool bEmitMsgOnClose;	/**< emit an informational message when the remote peer closes connection */
+	sbool bEmitMsgOnOpen;
 	sbool bUsingEPoll;	/**< are we in epoll mode (means we do not need to keep track of sessions!) */
 	sbool bUseFlowControl;	/**< use flow control (make light delayable) */
 	sbool bSPFramingFix;	/**< support work-around for broken Cisco ASA framing? */
@@ -174,6 +175,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	/* added v7 (accidently named v8!) */
 	rsRetVal (*SetLstnMax)(tcpsrv_t *pThis, int iMaxLstn);	/* 2009-08-17 */
 	rsRetVal (*SetNotificationOnRemoteClose)(tcpsrv_t *pThis, int bNewVal); /* 2009-10-01 */
+	rsRetVal (*SetNotificationOnRemoteOpen)(tcpsrv_t *pThis, int bNewVal); /* 2022-08-23 */
 	/* added v9 -- rgerhards, 2010-03-01 */
 	rsRetVal (*SetbDisableLFDelim)(tcpsrv_t*, int);
 	/* added v10 -- rgerhards, 2011-04-01 */
@@ -209,7 +211,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetDrvrKeyFile)(tcpsrv_t *pThis, uchar *pszMode);
 	rsRetVal (*SetDrvrCertFile)(tcpsrv_t *pThis, uchar *pszMode);
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 25 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 26 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10

--- a/tests/allowed-sender-tcp-fail.sh
+++ b/tests/allowed-sender-tcp-fail.sh
@@ -21,6 +21,6 @@ assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -m$NUMMESSAGES
 shutdown_when_empty
 wait_shutdown
-content_check --regex "TCP message from disallowed sender .* discarded"
+content_check --regex "connection request from disallowed sender .* discarded"
 check_file_not_exists "$RSYSLOG_DYNNAME.must-not-be-created"
 exit_test

--- a/tests/allowed-sender-tcp-hostname-fail.sh
+++ b/tests/allowed-sender-tcp-hostname-fail.sh
@@ -26,6 +26,6 @@ assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -m$NUMMESSAGES
 shutdown_when_empty
 wait_shutdown
-content_check --regex "TCP message from disallowed sender .* discarded"
+content_check --regex "connection request from disallowed sender .* discarded"
 check_file_not_exists "$RSYSLOG_DYNNAME.must-not-be-created"
 exit_test

--- a/tests/imtcp-connection-msg-recieved.sh
+++ b/tests/imtcp-connection-msg-recieved.sh
@@ -5,7 +5,7 @@ generate_conf
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
-	notifyonconnectionclose="on")
+	notifyonconnectionopen="on" notifyonconnectionclose="on")
 
 :msg, contains, "msgnum:" {
 	action(type="omfile" file=`echo $RSYSLOG2_OUT_LOG`)
@@ -19,5 +19,6 @@ assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 tcpflood -m1 -M"\"<129>Mar 10 01:00:00 172.20.245.8 tag: msgnum:1\""
 shutdown_when_empty
 wait_shutdown
+content_check "connection established with "
 content_check "closed by remote peer "
 exit_test


### PR DESCRIPTION
Add this both as module an input parameter. Complements already-existing
config param notifyonconnectionclose and mirrors the similar feature from
imptcp.

The module parameter acts as default, similarly to notifyonconnectionclose.

Note that in contrast to imptcp, we emit IP addresses and not host
names. This sticks with the traditional semantics of imtcp.

Thanks to John Chivian for suggesting the addition.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
