### PR TITLE
testbench: fix imfile-statefile-delete.sh (INOTIFY trigger)

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -854,13 +854,13 @@ detect_updates(fs_edge_t *const edge)
 				*  delay will never be reached and the file will be closed when the inode has changed.
 				*/
 				if (act->time_to_delete + FILE_DELETE_DELAY < ttNow) {
-					DBGPRINTF("detect_updates obj gone away, unlinking: '%s', ttDelete: %ld/%ld\n",
-						act->name, act->time_to_delete, ttNow);
+				DBGPRINTF("detect_updates obj gone away, unlinking: '%s', ttDelete: %lds, ttNow:%ld\n",
+					act->name, ttNow - (act->time_to_delete + FILE_DELETE_DELAY), ttNow);
 					act_obj_unlink(act);
 					restart = 1;
 				} else {
-					DBGPRINTF("detect_updates obj gone away, keep '%s' open: %ld/%ld/%lds!\n",
-						act->name, act->time_to_delete, ttNow, ttNow - act->time_to_delete);
+				DBGPRINTF("detect_updates obj gone away, keep '%s' open: %ld/%ld/%lds!\n",
+					act->name, act->time_to_delete, ttNow, ttNow - act->time_to_delete);
 					pollFile(act);
 				}
 			}

--- a/tests/imfile-statefile-delete.sh
+++ b/tests/imfile-statefile-delete.sh
@@ -5,6 +5,11 @@
 export TESTMESSAGES=1000
 export TESTMESSAGESFULL=999 
 export RETRIES=50
+
+# Uncomment fdor debuglogs
+#export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+#export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
+
 generate_conf
 add_conf '
 global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
@@ -22,8 +27,11 @@ wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
 rm $RSYSLOG_DYNNAME.input
 sleep_time_ms=0
 while ls $RSYSLOG_DYNNAME.spool/imfile-state:$inode:* 1> /dev/null 2>&1; do
-	./msleep 10
-	((sleep_time_ms+=10))
+	./msleep 100
+	((sleep_time_ms+=100))
+	if [ $sleep_time_ms -ge 6000 ]; then
+		touch $RSYSLOG_DYNNAME:.tmp
+	fi
 	if [ $sleep_time_ms -ge 30000 ]; then
 	        printf 'FAIL: state file still exists when it should have been deleted\nspool dir is:\n'
 	        ls -l $RSYSLOG_DYNNAME.spool


### PR DESCRIPTION
Due the patch in PR https://github.com/rsyslog/rsyslog/pull/4895 state files are deleted with a 5 second delay in order to fix missing or duplicated messages. However in INOTIFY mode, we need an INOTIFY event to trigger a poll_tree that triggers the delayed deletion. The testcase imfile-statefile-delete.sh will now create empty dummy files after 6 seconds delay in order to trigger INOTIFY events.

This fixes & closes https://github.com/rsyslog/rsyslog/issues/4958

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
