### PR TITLE
core bugfix: local hostname invalid if no global() config object given

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -1396,6 +1396,7 @@ glblDoneLoadCnf(void)
 		stddbg = -1;
 	}
 
+finalize_it:
 	/* we have now read the config. We need to query the local host name now
 	 * as it was set by the config.
 	 *
@@ -1404,8 +1405,7 @@ glblDoneLoadCnf(void)
 	 * are taken from that queue, the hostname will be adapted.
 	 */
 	queryLocalHostname();
-
-finalize_it:	RETiRet;
+	RETiRet;
 }
 
 


### PR DESCRIPTION
The local hostname is invalidly set to "[localhost]" on rsyslog startup if no global() config object is present in rsyslog.conf. Sending a HUP corrects the hostname.

This is a regression from ba00a9f25293f

closes https://github.com/rsyslog/rsyslog/issues/4975, https://github.com/rsyslog/rsyslog/issues/4825

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
