### PR TITLE
imjournal: add second fallback to the message identifier

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -452,6 +452,8 @@ readjournal(void)
 	/* Get message identifier, client pid and add ':' */
 	if (journalGetData("SYSLOG_IDENTIFIER", &get, &length) >= 0) {
 		CHKiRet(sanitizeValue(((const char *)get) + 18, length - 18, &sys_iden));
+	} else if (journalGetData("_COMM", &get, &length) >= 0) {
+		CHKiRet(sanitizeValue(((const char *)get) + 6, length - 6, &sys_iden));
 	} else {
 		CHKmalloc(sys_iden = strdup("journal"));
 	}


### PR DESCRIPTION
If SYSLOG_IDENTIFIER is not present in the journal message, then lookup the _COMM field, which stands for the name of the process the journal entry originates from [1]. This is needed in order to be in compliance with the journalctl output.

### Investigation
When I look at the journalctl output and compare it with the one produced by the imjournal module, the identifier is sometimes different. After doing some digging I found out that systemd-journal has an additional fallback(_COMM) when SYSLOG_IDENTIFIER is not specified.

[1] SYSTEMD.JOURNAL-FIELDS(7):
```
_COMM=, _EXE=, _CMDLINE=
           The name, the executable path, and the command line of the process the journal entry originates from.
```

Example:

- systemd: ```Sep 22 08:02:42 localhost gnome-shell[2202]: Adding device '/dev/dri/card0' (i915) using atomic mode setting.```
- rsylog ```Sep 22 08:02:42 localhost journal[2202]: Adding device '/dev/dri/card0' (i915) using atomic mode setting.```