### PR TITLE
configure.ac: remove bashisms

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1138,13 +1138,13 @@ AC_ARG_ENABLE(gnutls-tests,
           no) enable_gnutls_tests="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-gnutls-tests) ;;
          esac],
-        [if [[ "$enable_gnutls" == "yes" ]]; then
+        [if test "x$enable_gnutls" = "xyes"; then
 		enable_gnutls_tests=yes
 	else
 		enable_gnutls_tests=no
 	fi]
 )
-if  [[ "$enable_gnutls_tests" == "yes" ]] && [[ "$enable_gnutls" != "yes" ]]; then
+if test "x$enable_gnutls_tests" = "xyes" && test "x$enable_gnutls" != "xyes"; then
 		AC_MSG_WARN([gnutls-tests can not be enabled without gnutls support. Disabling gnutls tests...])
 		enable_gnutls_tests="no"
 fi
@@ -1852,7 +1852,7 @@ AC_ARG_ENABLE(imfile-tests,
          esac],
         [enable_imfile_tests=yes]
 )
-if  [[ "$enable_imfile_tests" == "yes" ]] && [[ "$enable_imfile" != "yes" ]]; then
+if  test "x$enable_imfile_tests" = "xyes" && test "x$enable_imfile" != "xyes"; then
 		AC_MSG_WARN([imfile-tests can not be enabled without imfile support. Disabling imfile tests...])
 		enable_imfile_tests="no"
 fi


### PR DESCRIPTION
replace `[[ ]]` (actually `[ ]` ) with `test` and `==` with `=`

Signed-off-by: Maciej Barć <xgqt@gentoo.org>

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
