### PR TITLE
kafka: fix building modules with static librdkafka

### DIFF
--- a/plugins/omkafka/Makefile.am
+++ b/plugins/omkafka/Makefile.am
@@ -6,13 +6,13 @@ omkafka_la_LDFLAGS = -module -avoid-version
 omkafka_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) -D MODNAME=omkafka
 else
 omkafka_la_SOURCES = omkafka.c
+if ENABLE_KAFKA_STATIC
+omkafka_la_LDFLAGS = -module -avoid-version -Wl,--whole-archive -l:librdkafka-static.a -Wl,--no-whole-archive -ldl -lresolv -lcurl -lssl -lpthread -lcrypto -lsasl2 -lz -llz4 -lrt -lm
+else
 omkafka_la_LDFLAGS = -module -avoid-version $(LIBRDKAFKA_LIBS) -lm
+endif
 omkafka_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
 endif
 
-if ENABLE_KAFKA_STATIC
-omkafka_la_LDFLAGS = -module -avoid-version -Wl,--whole-archive -l:librdkafka.a -Wl,--no-whole-archive -lssl -lpthread -lcrypto -lsasl2 -lz -llz4 -lrt -lm
-endif
 omkafka_la_LIBADD = 
-
 EXTRA_DIST = 


### PR DESCRIPTION
Because of changes in commit https://github.com/rsyslog/rsyslog/commit/7305c047dbb766e288ab83300d314ab324bd01c4, the kafka modules were not build with static librdkafka regarding of --enable-kafka-static.

Also added missing libraries needed for building with newer static librdkafka.

closes: https://github.com/rsyslog/rsyslog/issues/5025

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
