### PR TITLE
testbench: fix the wrong message injection object of instance 1

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -486,7 +486,7 @@ wait_startup() {
 	echo "$(tb_timestamp) rsyslogd$1 startup msg seen, pid " $(cat $RSYSLOG_PIDBASE$1.pid)
 	wait_file_exists $RSYSLOG_DYNNAME.imdiag$1.port
 	eval export IMDIAG_PORT$1=$(cat $RSYSLOG_DYNNAME.imdiag$1.port)
-	eval PORT=$IMDIAG_PORT$1
+	eval PORT='$IMDIAG_PORT'$1
 	echo "imdiag$1 port: $PORT"
 	if [ "$PORT" == "" ]; then
 		echo "TESTBENCH ERROR: imdiag port not found!"
@@ -649,8 +649,8 @@ injectmsg() {
 # inject messages in INSTANCE 2 via our inject interface (imdiag)
 injectmsg2() {
 	msgs=${2:-$NUMMESSAGES}
-	echo injecting $2 messages into instance 2
-	echo injectmsg "$1:-0" "$msgs" $3 $4 | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT2 || error_exit  $?
+	echo injecting $msgs messages into instance 2
+	echo injectmsg "${1:-0}" "$msgs" $3 $4 | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT2 || error_exit  $?
 	# TODO: some return state checking? (does it really make sense here?)
 }
 

--- a/tests/sndrcv.sh
+++ b/tests/sndrcv.sh
@@ -36,7 +36,7 @@ assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 # now it is time to stop the receiver as well

--- a/tests/sndrcv_failover.sh
+++ b/tests/sndrcv_failover.sh
@@ -44,7 +44,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_gzip.sh
+++ b/tests/sndrcv_gzip.sh
@@ -32,7 +32,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -84,7 +84,7 @@ local4.* action(	name="kafka-fwd"
 startup 2
 
 echo Inject messages into rsyslog sender instance
-injectmsg 1 $TESTMESSAGES
+injectmsg2 1 $TESTMESSAGES
 
 #echo Sleep to give rsyslog instances time to process data ...
 #sleep 5

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -101,7 +101,7 @@ startup 2
 # ---
 
 echo Inject messages into rsyslog sender instance
-injectmsg 1 $TESTMESSAGES
+injectmsg2 1 $TESTMESSAGES
 
 echo Starting kafka cluster instance
 start_kafka

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -93,7 +93,7 @@ startup 2
 # ---
 
 echo Inject messages into rsyslog sender instance
-injectmsg 1 $TESTMESSAGES
+injectmsg2 1 $TESTMESSAGES
 
 echo Stopping kafka cluster instance
 stop_kafka

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -41,7 +41,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg 1 50000
+injectmsg2 1 50000
 
 # shut down sender
 shutdown_when_empty 2

--- a/tests/sndrcv_relp_rebind.sh
+++ b/tests/sndrcv_relp_rebind.sh
@@ -35,7 +35,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg 1 1000
+injectmsg2 1 1000
 
 # shut down sender
 shutdown_when_empty 2

--- a/tests/sndrcv_relp_tls.sh
+++ b/tests/sndrcv_relp_tls.sh
@@ -30,7 +30,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg 1 50000
+injectmsg2 1 50000
 
 # shut down sender
 shutdown_when_empty 2

--- a/tests/sndrcv_relp_tls_certvalid.sh
+++ b/tests/sndrcv_relp_tls_certvalid.sh
@@ -52,7 +52,7 @@ fi
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg 1 50000
+injectmsg2 1 50000
 
 # shut down sender
 shutdown_when_empty 2

--- a/tests/sndrcv_relp_tls_prio.sh
+++ b/tests/sndrcv_relp_tls_prio.sh
@@ -31,7 +31,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg 1 50000
+injectmsg2 1 50000
 
 # shut down sender
 shutdown_when_empty 2

--- a/tests/sndrcv_tls_anon_hostname.sh
+++ b/tests/sndrcv_tls_anon_hostname.sh
@@ -50,7 +50,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_tls_anon_ipv4.sh
+++ b/tests/sndrcv_tls_anon_ipv4.sh
@@ -53,7 +53,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_tls_anon_ipv6.sh
+++ b/tests/sndrcv_tls_anon_ipv6.sh
@@ -54,7 +54,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2

--- a/tests/sndrcv_tls_certvalid.sh
+++ b/tests/sndrcv_tls_certvalid.sh
@@ -48,7 +48,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_tls_certvalid_expired.sh
+++ b/tests/sndrcv_tls_certvalid_expired.sh
@@ -49,7 +49,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2

--- a/tests/sndrcv_tls_certvalid_expired_defaultmode.sh
+++ b/tests/sndrcv_tls_certvalid_expired_defaultmode.sh
@@ -47,7 +47,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2

--- a/tests/sndrcv_tls_gtls_serveranon_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_serveranon_gtls_clientanon.sh
@@ -36,7 +36,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_tls_gtls_servercert_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_servercert_gtls_clientanon.sh
@@ -43,7 +43,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 wait_file_lines
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2

--- a/tests/sndrcv_tls_ossl_anon_ipv4.sh
+++ b/tests/sndrcv_tls_ossl_anon_ipv4.sh
@@ -54,7 +54,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_tls_ossl_anon_rebind.sh
+++ b/tests/sndrcv_tls_ossl_anon_rebind.sh
@@ -71,7 +71,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 shutdown_when_empty 2
 wait_shutdown 2
 # now it is time to stop the receiver as well

--- a/tests/sndrcv_tls_ossl_certvalid_expired.sh
+++ b/tests/sndrcv_tls_ossl_certvalid_expired.sh
@@ -48,7 +48,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2

--- a/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
+++ b/tests/sndrcv_tls_ossl_certvalid_tlscommand.sh
@@ -49,7 +49,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg 0 1
+injectmsg2 0 1
 shutdown_when_empty 2
 wait_shutdown 2
 # now it is time to stop the receiver as well

--- a/tests/sndrcv_udp_nonstdpt.sh
+++ b/tests/sndrcv_udp_nonstdpt.sh
@@ -8,7 +8,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
-export NUMMESSAGES=500
+export NUMMESSAGES=50
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 
 export RSYSLOG_DEBUGLOG="log"
@@ -24,17 +24,18 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 '
 startup
 export RSYSLOG_DEBUGLOG="log2"
+export PORT_RCVR="$TCPFLOOD_PORT"
 
 #valgrind="valgrind"
 generate_conf 2
 add_conf '
-*.*	@127.0.0.1:'$TCPFLOOD_PORT'
+*.*	@127.0.0.1:'$PORT_RCVR'
 ' 2
 startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg
+injectmsg2
 
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2


### PR DESCRIPTION
Somehow #4473, was closed when pushing the changes to the original PR. So I continue here with it. Thanks to @VincentZhu007 for the original patch.

In some client-server test cases, messages are supposed to be injected into the instance 2(client), but they are actually injected into instance 1(server), which may lead to false negative results. This patch fixed it by replacing 'injectmsg' with 'injectmsg2', and dealt with some minor issues.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
