### PR TITLE
omprog bugfix: invalid status handling at called program startup

### DIFF
--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -380,6 +380,7 @@ cleanupChild(instanceData *pData, childProcessCtx_t *pChildCtx)
 static void
 terminateChild(instanceData *pData, childProcessCtx_t *pChildCtx)
 {
+	DBGPRINTF("terminateChild called\n");
 	assert(pChildCtx->bIsRunning);
 
 	if (pData->bSignalOnClose) {
@@ -928,9 +929,6 @@ CODESTARTcreateWrkrInstance
 	}
 
 finalize_it:
-	if(iRet != RS_RET_OK && !pWrkrData->pData->bForceSingleInst) {
-		free(pWrkrData->pChildCtx);
-	}
 ENDcreateWrkrInstance
 
 


### PR DESCRIPTION
There is a bug when external program *startup* does not return "OK". This can also lead to a misadressing with potentially a segfault (very unlikely). Note that no problem exists once the initializiation phase of the external program is finished and regular message transfer runs.

The problem basically is that for a startup failure, the control data for that external program instance is freed on error. Unfortunately, that state data is needed later on to detect a suspended instance. We now keep the control data even on init failure (as we then need to do normal control options).

closes https://github.com/rsyslog/rsyslog/issues/4967

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
