### PR TITLE
testbench: make python http server based tests more reliable

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2311,7 +2311,7 @@ omhttp_start_server() {
     omhttp_server_logfile="${omhttp_work_dir}/omhttp_server.log"
     mkdir -p ${omhttp_work_dir}
 
-    server_args="-p $omhttp_server_port ${*:2}"
+    server_args="-p $omhttp_server_port ${*:2} --port-file $RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
 
     timeout 30m $PYTHON ${omhttp_server_py} ${server_args} >> ${omhttp_server_logfile} 2>&1 &
     if [ ! $? -eq 0 ]; then
@@ -2319,10 +2319,12 @@ omhttp_start_server() {
         rm -rf $omhttp_work_dir
         error_exit 1
     fi
-
     omhttp_server_pid=$!
+
+    wait_file_exists "$RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
+    omhttp_server_lstnport="$(cat $RSYSLOG_DYNNAME.omhttp_server_lstnport.file)"
     echo ${omhttp_server_pid} > ${omhttp_server_pidfile}
-    echo "Started omhttp test server with args ${server_args} with pid ${omhttp_server_pid}"
+    echo "Started omhttp test server with args ${server_args} with pid ${omhttp_server_pid}, port {$omhttp_server_lstnport}"
 }
 
 omhttp_stop_server() {

--- a/tests/errfile-basic.sh
+++ b/tests/errfile-basic.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=1000
 
-port=80
-omhttp_start_server $port
+omhttp_start_server 0
 
 echo "============================> RSYSLOG_DYNNAME:$RSYSLOG_DYNNAME <============================"
 
@@ -28,7 +27,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="off"
 
@@ -40,7 +39,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-auth.sh
+++ b/tests/omhttp-auth.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=100
 
-port="$(get_free_port)"
-omhttp_start_server $port --userpwd="bob:bobbackwards"
+omhttp_start_server 0 --userpwd="bob:bobbackwards"
 
 generate_conf
 add_conf '
@@ -25,7 +24,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="off"
 
@@ -39,7 +38,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-basic.sh
+++ b/tests/omhttp-basic.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=10000
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -25,7 +24,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="off"
 
@@ -37,7 +36,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-dynrestpath.sh
+++ b/tests/omhttp-batch-dynrestpath.sh
@@ -8,8 +8,7 @@ export NUMMESSAGES=10000
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -28,7 +27,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		dynrestpath = "on"
 		restpath="dynrestpath"
 
@@ -44,7 +43,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint jsonarray
+omhttp_get_data $omhttp_server_lstnport my/endpoint jsonarray
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-fail-with-400.sh
+++ b/tests/omhttp-batch-fail-with-400.sh
@@ -4,8 +4,7 @@
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-with-400-after 1000
+omhttp_start_server 0 --fail-with-400-after 1000
 
 generate_conf
 add_conf '
@@ -28,7 +27,7 @@ ruleset(name="ruleset_omhttp") {
         template="tpl"
 
         server="localhost"
-        serverport="'$port'"
+        serverport="'$omhttp_server_lstnport'"
         restpath="my/endpoint"
         batch="off"
 
@@ -46,7 +45,7 @@ startup
 injectmsg  0 10000
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check  0 999
 exit_test

--- a/tests/omhttp-batch-jsonarray-compress.sh
+++ b/tests/omhttp-batch-jsonarray-compress.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port --decompress
+omhttp_start_server 0 --decompress
 
 generate_conf
 add_conf '
@@ -27,7 +26,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="on"
 		batch.format="jsonarray"
@@ -42,7 +41,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint jsonarray
+omhttp_get_data $omhttp_server_lstnport my/endpoint jsonarray
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-jsonarray-retry.sh
+++ b/tests/omhttp-batch-jsonarray-retry.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-every 100
+omhttp_start_server 0 --fail-every 100
 
 generate_conf
 add_conf '
@@ -29,7 +28,7 @@ ruleset(name="ruleset_omhttp_retry") {
         template="tpl_echo"
 
         server="localhost"
-        serverport="'$port'"
+        serverport="'$omhttp_server_lstnport'"
         restpath="my/endpoint"
         batch="on"
         batch.maxsize="100"
@@ -51,7 +50,7 @@ ruleset(name="ruleset_omhttp") {
         template="tpl"
 
         server="localhost"
-        serverport="'$port'"
+        serverport="'$omhttp_server_lstnport'"
         restpath="my/endpoint"
         batch="on"
         batch.maxsize="100"
@@ -72,7 +71,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint jsonarray
+omhttp_get_data $omhttp_server_lstnport my/endpoint jsonarray
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-jsonarray.sh
+++ b/tests/omhttp-batch-jsonarray.sh
@@ -5,8 +5,7 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -26,7 +25,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="on"
 		batch.format="jsonarray"
@@ -40,7 +39,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint jsonarray
+omhttp_get_data $omhttp_server_lstnport my/endpoint jsonarray
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-kafkarest-retry.sh
+++ b/tests/omhttp-batch-kafkarest-retry.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-every 100
+omhttp_start_server 0 --fail-every 100
 
 generate_conf
 add_conf '
@@ -29,7 +28,7 @@ ruleset(name="ruleset_omhttp_retry") {
         template="tpl_echo"
 
         server="localhost"
-        serverport="'$port'"
+        serverport="'$omhttp_server_lstnport'"
         restpath="my/endpoint"
         batch="on"
         batch.maxsize="100"
@@ -51,7 +50,7 @@ ruleset(name="ruleset_omhttp") {
         template="tpl"
 
         server="localhost"
-        serverport="'$port'"
+        serverport="'$omhttp_server_lstnport'"
         restpath="my/endpoint"
         batch="on"
         batch.maxsize="100"
@@ -72,7 +71,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint kafkarest
+omhttp_get_data $omhttp_server_lstnport my/endpoint kafkarest
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-kafkarest.sh
+++ b/tests/omhttp-batch-kafkarest.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -27,7 +26,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="on"
 		batch.format="kafkarest"
@@ -41,7 +40,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint kafkarest
+omhttp_get_data $omhttp_server_lstnport my/endpoint kafkarest
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-lokirest-retry.sh
+++ b/tests/omhttp-batch-lokirest-retry.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-every 100
+omhttp_start_server 0 --fail-every 100
 
 generate_conf
 add_conf '
@@ -29,7 +28,7 @@ ruleset(name="ruleset_omhttp_retry") {
         template="tpl_echo"
 
         server="localhost"
-        serverport="'$port'"
+        serverport="'$omhttp_server_lstnport'"
         restpath="my/endpoint"
         batch="on"
         batch.maxsize="100"
@@ -51,7 +50,7 @@ ruleset(name="ruleset_omhttp") {
         template="tpl"
 
         server="localhost"
-        serverport="'$port'"
+        serverport="'$omhttp_server_lstnport'"
         restpath="my/endpoint"
         batch="on"
         batch.maxsize="100"
@@ -72,7 +71,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint lokirest
+omhttp_get_data $omhttp_server_lstnport my/endpoint lokirest
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-lokirest.sh
+++ b/tests/omhttp-batch-lokirest.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -27,7 +26,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="on"
 		batch.format="lokirest"
@@ -41,7 +40,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint lokirest
+omhttp_get_data $omhttp_server_lstnport my/endpoint lokirest
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-batch-newline.sh
+++ b/tests/omhttp-batch-newline.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -27,7 +26,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="on"
 		batch.format="newline"
@@ -41,7 +40,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint newline
+omhttp_get_data $omhttp_server_lstnport my/endpoint newline
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-dynrestpath.sh
+++ b/tests/omhttp-dynrestpath.sh
@@ -8,8 +8,7 @@ export NUMMESSAGES=10000
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -28,7 +27,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		dynrestpath = "on"
 		restpath="dynrestpath"
 		batch="off"
@@ -41,7 +40,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-httpheaderkey.sh
+++ b/tests/omhttp-httpheaderkey.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=1000
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -26,7 +25,7 @@ if $msg contains "msgnum:" then
 		httpheaderkey="X-Insert-Key"
 		httpheadervalue="dummy-value"
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="off"
 
@@ -38,7 +37,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-multiplehttpheaders.sh
+++ b/tests/omhttp-multiplehttpheaders.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=1000
 
-port="$(get_free_port)"
-omhttp_start_server $port
+omhttp_start_server 0
 
 generate_conf
 add_conf '
@@ -28,7 +27,7 @@ if $msg contains "msgnum:" then
 			"X-Event-Source: logs"
 		]
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		batch="off"
 
@@ -40,7 +39,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-retry.sh
+++ b/tests/omhttp-retry.sh
@@ -6,8 +6,7 @@
 
 export NUMMESSAGES=10000
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-every 1000
+omhttp_start_server 0 --fail-every 1000
 
 generate_conf
 add_conf '
@@ -28,7 +27,7 @@ if $msg contains "msgnum:" then
 		template="tpl"
 
 		server="localhost"
-		serverport="'$port'"
+		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
 		checkpath="ping"
 		batch="off"
@@ -41,7 +40,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $port my/endpoint
+omhttp_get_data $omhttp_server_lstnport my/endpoint
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp_server.py
+++ b/tests/omhttp_server.py
@@ -110,6 +110,7 @@ class MyHandler(BaseHTTPRequestHandler):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Archive and delete core app log files')
     parser.add_argument('-p', '--port', action='store', type=int, default=8080, help='port')
+    parser.add_argument('--port-file', action='store', type=str, default='', help='file to store listen port number')
     parser.add_argument('-i', '--interface', action='store', type=str, default='localhost', help='port')
     parser.add_argument('--fail-after', action='store', type=int, default=0, help='start failing after n posts')
     parser.add_argument('--fail-every', action='store', type=int, default=-1, help='fail every n posts')
@@ -123,7 +124,12 @@ if __name__ == '__main__':
     metadata['decompress'] = args.decompress
     metadata['userpwd'] = args.userpwd
     server = HTTPServer((args.interface, args.port), MyHandler)
+    lstn_port = server.server_address[1]
     pid = os.getpid()
     print('starting omhttp test server at {interface}:{port} with pid {pid}'
-          .format(interface=args.interface, port=args.port, pid=pid))
+          .format(interface=args.interface, port=lstn_port, pid=pid))
+    if args.port_file != '':
+        f = open(args.port_file, "w")
+        f.write(str(lstn_port))
+        f.close()
     server.serve_forever()


### PR DESCRIPTION
Harden them against races during server port assignment. Prevents testbench flakes.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
