### PR TITLE
Fix typos spotted by lintian

### DIFF
--- a/tools/rsyslog.conf.5
+++ b/tools/rsyslog.conf.5
@@ -220,9 +220,9 @@ The intent is to log all facilities at debug or higher, except for local6,
 which should only log at err or higher.
 
 Unfortunately, local6.err will permit error severity and higher, but will
-not exclude lower sevrity messages from facility local6.
+not exclude lower severity messages from facility local6.
 
-As an alternative, you can explicitely exclude all severities that you do
+As an alternative, you can explicitly exclude all severities that you do
 not want to match. For the above case, this selector is equivalent to the
 BSD syslog selector:
 


### PR DESCRIPTION
I: rsyslog: typo-in-manual-page explicitely explicitly [usr/share/man/man5/rsyslog.conf.5.gz:225]
I: rsyslog: typo-in-manual-page sevrity severity [usr/share/man/man5/rsyslog.conf.5.gz:223]

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
