### PR TITLE
Fixed wrong type conversion in cstrLen()

### DIFF
--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -144,7 +144,7 @@ rsRetVal cstrAppendCStr(cstr_t *pThis, cstr_t *pstrAppend);
 
 /* now come inline-like functions */
 #ifdef NDEBUG
-#	define cstrLen(x) ((int)((x)->iStrLen))
+#	define cstrLen(x) ((size_t)((x)->iStrLen))
 #else
 	int cstrLen(cstr_t *pThis);
 #endif


### PR DESCRIPTION
Segfaults can happen when getting the message length with cstrLen().

```
Core was generated by `/usr/sbin/rsyslogd -n'.
Program terminated with signal 11, Segmentation fault.
#0  __memcpy_ssse3_back () at ../sysdeps/x86_64/multiarch/memcpy-ssse3-back.S:1578
1578            movdqu  -16(%rsi), %xmm0

(gdb) bt 
#0  __memcpy_ssse3_back () at ../sysdeps/x86_64/multiarch/memcpy-ssse3-back.S:1578
#1  0x0000555b5dd293b4 in memcpy (__len=<optimized out>, __src=0x2afbf0000010, __dest=<optimized out>) at /usr/include/bits/string3.h:51
#2  MsgSetRawMsg (pThis=0x2afbe00346e0, pszRawMsg=0x2afbf0000010 "", lenMsg=lenMsg@entry=18446744072548766868) at msg.c:2884
#3  0x00002afbcb8c35f8 in enqLine (strtOffs=<optimized out>, cstrLine=0x2afbe00346c0, act=0x2afbe0032350) at imfile.c:1182
#4  pollFileReal (pCStr=0x2afbcd313a58, act=0x2afbe0032350) at imfile.c:1416
#5  pollFile (act=act@entry=0x2afbe0032350) at imfile.c:1447
#6  0x00002afbcb8c4be1 in act_obj_add (edge=edge@entry=0x555b5ece8e80, name=name@entry=0x2afbe0023510 "<MYFILE>", is_file=1, ino=<optimized out>, is_symlink=0, 
    source=source@entry=0x0) at imfile.c:608
#7  0x00002afbcb8c50a9 in poll_tree (chld=0x555b5ece8e80) at imfile.c:778
#8  0x00002afbcb8c084d in fs_node_walk (node=<optimized out>, f_usr=f_usr@entry=0x2afbcb8c4eb0 <poll_tree>) at imfile.c:957
#9  0x00002afbcb8c0859 in fs_node_walk (node=<optimized out>, f_usr=f_usr@entry=0x2afbcb8c4eb0 <poll_tree>) at imfile.c:958
#10 0x00002afbcb8c0859 in fs_node_walk (node=<optimized out>, f_usr=f_usr@entry=0x2afbcb8c4eb0 <poll_tree>) at imfile.c:958
#11 0x00002afbcb8c0859 in fs_node_walk (node=<optimized out>, f_usr=f_usr@entry=0x2afbcb8c4eb0 <poll_tree>) at imfile.c:958
#12 0x00002afbcb8c0859 in fs_node_walk (node=<optimized out>, f_usr=f_usr@entry=0x2afbcb8c4eb0 <poll_tree>) at imfile.c:958
#13 0x00002afbcb8c0859 in fs_node_walk (node=<optimized out>, f_usr=f_usr@entry=0x2afbcb8c4eb0 <poll_tree>) at imfile.c:958
#14 0x00002afbcb8c45d1 in doPolling () at imfile.c:1928
#15 runInput (pThrd=<optimized out>) at imfile.c:2155
#16 0x0000555b5dd4f524 in thrdStarter (arg=0x555b5ed31fd0) at ../threads.c:226
#17 0x00002afbc9c63ea5 in start_thread (arg=0x2afbcd315700) at pthread_create.c:307
#18 0x00002afbcabab9fd in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:111

(gdb) f 3
#3  0x00002afbcb8c35f8 in enqLine (strtOffs=<optimized out>, cstrLine=0x2afbe00346c0, act=0x2afbe0032350) at imfile.c:1182
1182                    MsgSetRawMsg(pMsg, (char*)rsCStrGetSzStrNoNULL(cstrLine), msgLen);

(gdb) l enqLine
1164            if(msgLen == 0) {
1165                    /* we do not process empty lines */
1166                    FINALIZE;
1167            }
1168
1169            CHKiRet(msgConstruct(&pMsg));
1170            MsgSetFlowControlType(pMsg, eFLOWCTL_FULL_DELAY);
1171            MsgSetInputName(pMsg, pInputName);
1172            if(inst->addCeeTag) {
1173                    /* Make sure we account for terminating null byte */
1174                    size_t ceeMsgSize = msgLen + CONST_LEN_CEE_COOKIE + 1;
1175                    char *ceeMsg;
1176                    CHKmalloc(ceeMsg = MALLOC(ceeMsgSize));
1177                    strcpy(ceeMsg, CONST_CEE_COOKIE);
1178                    strcat(ceeMsg, (char*)rsCStrGetSzStrNoNULL(cstrLine));
1179                    MsgSetRawMsg(pMsg, ceeMsg, ceeMsgSize);
1180                    free(ceeMsg);
1181            } else {
1182                    MsgSetRawMsg(pMsg, (char*)rsCStrGetSzStrNoNULL(cstrLine), msgLen);
1183            }

(gdb) p *cstrLine
$1 = {pBuf = 0x2afbf0000010 "", iBufSize = 4294967168, iStrLen = 3134182548}

(gdb) p (int)3134182548
$2 = -1160784748

(gdb) p (unsigned long)-1160784748
$3 = 18446744072548766868

(gdb) p msgLen
$4 = 18446744072548766868
```

This commit fixes the above issue.

Best regards,
Flos


