### PR TITLE
core bugfix: template system may generate invalid json

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -230,6 +230,7 @@ TESTS +=  \
 	privdropabortonidfail.sh \
 	privdropabortonidfaillegacy.sh \
 	json-nonstring.sh \
+        json-onempty-at-end.sh \
 	template-json.sh \
 	template-pure-json.sh \
 	template-pos-from-to.sh \
@@ -2047,6 +2048,7 @@ EXTRA_DIST= \
 	privdropabortonidfail.sh \
 	privdropabortonidfaillegacy.sh \
 	json-nonstring.sh \
+        json-onempty-at-end.sh \
 	template-json.sh \
 	template-pure-json.sh \
 	template-pos-from-to.sh \

--- a/tests/json-onempty-at-end.sh
+++ b/tests/json-onempty-at-end.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released  under ASL 2.0
+# written 2019-05-10 by Rainer Gerhards
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="json" type="list" option.jsonf="on") {
+	property(outname="empty_null" format="jsonf" name="$!empty" onEmpty="null")
+	property(outname="empty_skip" format="jsonf" name="$!empty" onEmpty="skip")
+}
+
+set $!val0 = 0;
+set $!val = 42;
+set $!empty = "";
+set $!string = "1.2.3.4";
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="json")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+content_check '{"empty_null":null}'
+check_not_present 'empty_skip'
+exit_test


### PR DESCRIPTION
When
- a list template
- is created with option.jsonf="on"
- and the last list element is a property with onEmpty="skip"
- and that property is actually empty invalid JSON is generated.

The JSON string in this case ends with ", " instead of "}\n". This patch fixes the issue.

closes https://github.com/rsyslog/rsyslog/issues/5050

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
