### PR TITLE
outchannel: eleminate type cast for compatibility reasons

### DIFF
--- a/outchannel.c
+++ b/outchannel.c
@@ -67,19 +67,19 @@ struct outchannel* ochConstruct(void)
 /* skips the next comma and any whitespace
  * in front and after it.
  */
-static void skip_Comma(char **pp)
+static void skip_Comma(uchar **pp)
 {
-	register char *p;
+	register uchar *p;
 
 	assert(pp != NULL);
 	assert(*pp != NULL);
 
 	p = *pp;
-	while(isspace((int)*p))
+	while(isspace(*p))
 		++p;
 	if(*p == ',')
 		++p;
-	while(isspace((int)*p))
+	while(isspace(*p))
 		++p;
 	*pp = p;
 }
@@ -98,7 +98,7 @@ static rsRetVal get_Field(uchar **pp, uchar **pField)
 	assert(*pp != NULL);
 	assert(pField != NULL);
 
-	skip_Comma((char**)pp);
+	skip_Comma(pp);
 	p = *pp;
 
 	CHKiRet(cstrConstruct(&pStrB));
@@ -135,7 +135,7 @@ static int get_off_t(uchar **pp, off_t *pOff_t)
 	assert(*pp != NULL);
 	assert(pOff_t != NULL);
 
-	skip_Comma((char**)pp);
+	skip_Comma(pp);
 	p = *pp;
 
 	val = 0;
@@ -166,7 +166,7 @@ static rsRetVal get_restOfLine(uchar **pp, uchar **pBuf)
 	assert(*pp != NULL);
 	assert(pBuf != NULL);
 
-	skip_Comma((char**)pp);
+	skip_Comma(pp);
 	p = *pp;
 
 	CHKiRet(cstrConstruct(&pStrB));


### PR DESCRIPTION
Fixes https://github.com/rsyslog/rsyslog/issues/5047

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
