### PR TITLE
omfile: add action parameters "rotation.*"

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1108,6 +1108,7 @@ TESTS +=  \
 	rscript_hash32.sh \
 	rscript_hash64.sh \
 	rscript_replace.sh \
+	omfile-sizelimitcmd-many.sh \
 	omfile-outchannel-many.sh
 if HAVE_VALGRIND
 TESTS +=  \
@@ -2001,6 +2002,7 @@ EXTRA_DIST= \
 	omfile-read-only.sh \
 	omfile-outchannel.sh \
 	omfile-outchannel-many.sh \
+	omfile-sizelimitcmd-many.sh \
 	omfile_both_files_set.sh \
 	omfile_hup.sh \
 	omrabbitmq_no_params.sh \

--- a/tests/omfile-sizelimitcmd-many.sh
+++ b/tests/omfile-sizelimitcmd-many.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# addd 2023-01-11 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=50000
+echo "ls -l $RSYSLOG_DYNNAME.channel.*
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.9 $RSYSLOG_DYNNAME.channel.log.prev.10 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.8 $RSYSLOG_DYNNAME.channel.log.prev.9 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.7 $RSYSLOG_DYNNAME.channel.log.prev.8 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.6 $RSYSLOG_DYNNAME.channel.log.prev.7 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.5 $RSYSLOG_DYNNAME.channel.log.prev.6 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.4 $RSYSLOG_DYNNAME.channel.log.prev.5 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.3 $RSYSLOG_DYNNAME.channel.log.prev.4 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.2 $RSYSLOG_DYNNAME.channel.log.prev.3 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev.1 $RSYSLOG_DYNNAME.channel.log.prev.2 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log.prev   $RSYSLOG_DYNNAME.channel.log.prev.1 2>/dev/null
+mv -f $RSYSLOG_DYNNAME.channel.log $RSYSLOG_DYNNAME.channel.log.prev
+"   > $RSYSLOG_DYNNAME.rotate.sh
+chmod +x $RSYSLOG_DYNNAME.rotate.sh
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then {
+	action(type="omfile" file="'$RSYSLOG_DYNNAME.channel.log'" template="outfmt"
+		rotation.sizeLimit="50k"
+		rotation.sizeLimitCommand="./'$RSYSLOG_DYNNAME.rotate.sh'")
+}
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+ls -l $RSYSLOG_DYNNAME.channel.*
+cat $RSYSLOG_DYNNAME.channel.* > $RSYSLOG_OUT_LOG
+seq_check
+exit_test

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -17,7 +17,7 @@
  * pipes. These have been moved to ompipe, to reduced the entanglement
  * between the two different functionalities. -- rgerhards
  *
- * Copyright 2007-2022 Adiscon GmbH.
+ * Copyright 2007-2023 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -282,6 +282,8 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "sig.provider", eCmdHdlrGetWord, 0 },
 	{ "cry.provider", eCmdHdlrGetWord, 0 },
 	{ "closetimeout", eCmdHdlrPositiveInt, 0 },
+	{ "rotation.sizelimit", eCmdHdlrSize, 0 },
+	{ "rotation.sizelimitcommand", eCmdHdlrString, 0 },
 	{ "template", eCmdHdlrGetWord, 0 }
 };
 static struct cnfparamblk actpblk =
@@ -1132,6 +1134,8 @@ setInstParamDefaults(instanceData *__restrict__ const pData)
 	pData->useSigprov = 0;
 	pData->useCryprov = 0;
 	pData->iCloseTimeout = -1;
+	pData->iSizeLimit = 0;
+	pData->pszSizeLimitCmd = NULL;
 }
 
 
@@ -1345,6 +1349,10 @@ CODESTARTnewActInst
 			pData->cryprovName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "closetimeout")) {
 			pData->iCloseTimeout = (int) pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "rotation.sizelimit")) {
+			pData->iSizeLimit = (int) pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "rotation.sizelimitcommand")) {
+			pData->pszSizeLimitCmd = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else {
 			dbgprintf("omfile: program error, non-handled "
 			  "param '%s'\n", actpblk.descr[i].name);


### PR DESCRIPTION
Add new action parameters
- rotation.sizeLimit
- rotation.sizeLimitCommand provide automatic output file rotation functionality feature-wise equivalent to legacy $outchannel. This finally permits to use this feature set in rscript.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
