### PR TITLE
substring function: enhancement and hardening

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2427,8 +2427,23 @@ doFunct_Substring(struct cnffunc *__restrict__ const func,
 	cnfexprEval(func->expr[1], &srcVal[1], usrptr, pWti);
 	cnfexprEval(func->expr[2], &srcVal[2], usrptr, pWti);
 	es_str_t *es = var2String(&srcVal[0], &bMustFree);
-	const int start = var2Number(&srcVal[1], NULL);
-	const int subStrLen = var2Number(&srcVal[2], NULL);
+	const int lenSrcStr = es_strlen(es);
+	int start = var2Number(&srcVal[1], NULL);
+	int subStrLen = var2Number(&srcVal[2], NULL);
+	if(start >= lenSrcStr) {
+		/* begin PAST the source string - ensure nothing is copied at all */
+		start = subStrLen = 0;
+	} else {
+		if(subStrLen < 0) {
+			subStrLen = lenSrcStr + subStrLen; /* "add" negative offset! */
+			if(subStrLen < 0) {
+				subStrLen = 0;
+			}
+		}
+		if(subStrLen > (lenSrcStr - start)) {
+			subStrLen = lenSrcStr - start;
+		}
+	}
 
 	ret->datatype = 'S';
 	ret->d.estr = es_newStrFromSubStr(es, (es_size_t)start, (es_size_t)subStrLen);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -184,6 +184,10 @@ TESTS +=  \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \
 	hostname-with-slash-dflt-invld.sh \
+	func-substring-invld-startpos.sh \
+	func-substring-large-endpos.sh \
+	func-substring-large-neg-endpos.sh \
+	func-substring-relative-endpos.sh \
 	hostname-with-slash-dflt-slash-valid.sh \
 	empty-app-name.sh \
 	stop-localvar.sh \
@@ -576,6 +580,7 @@ TESTS +=  \
 	badqi.sh \
 	threadingmq.sh \
 	threadingmqaq.sh \
+	func-substring-invld-startpos-vg.sh \
 	rscript_trim-vg.sh
 if ENABLE_LIBGCRYPT
 TESTS +=  \
@@ -1718,6 +1723,11 @@ EXTRA_DIST= \
 	config_enabled-off.sh \
 	empty-app-name.sh \
 	empty-hostname.sh \
+	func-substring-invld-startpos.sh \
+	func-substring-invld-startpos-vg.sh \
+	func-substring-large-endpos.sh \
+	func-substring-large-neg-endpos.sh \
+	func-substring-relative-endpos.sh \
 	hostname-with-slash-pmrfc5424.sh \
 	hostname-with-slash-pmrfc3164.sh \
 	pmrfc3164-msgFirstSpace.sh \

--- a/tests/func-substring-invld-startpos-vg.sh
+++ b/tests/func-substring-invld-startpos-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/func-substring-invld-startpos.sh

--- a/tests/func-substring-invld-startpos.sh
+++ b/tests/func-substring-invld-startpos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# addd 2023-01-13 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="data:%$!my_struc_data%\n")
+
+set $!my_struc_data = substring($STRUCTURED-DATA, 2000, -3);
+local4.debug action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z hostname1 sender - tag [tcpflood@32473 MSGNUM="0"] data'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='data:'
+cmp_exact
+exit_test

--- a/tests/func-substring-large-endpos.sh
+++ b/tests/func-substring-large-endpos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# addd 2023-01-13 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%$!my_struc_data%\n")
+
+set $!my_struc_data = substring($STRUCTURED-DATA, 1, 99999999);
+local4.debug action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z hostname1 sender - tag [tcpflood@32473 MSGNUM="0"] data'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='tcpflood@32473 MSGNUM="0"]'
+cmp_exact
+exit_test

--- a/tests/func-substring-large-neg-endpos.sh
+++ b/tests/func-substring-large-neg-endpos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# addd 2023-01-13 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="data:%$!my_struc_data%\n")
+
+set $!my_struc_data = substring($STRUCTURED-DATA, 1, -9999999);
+local4.debug action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z hostname1 sender - tag [tcpflood@32473 MSGNUM="0"] data'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='data:'
+cmp_exact
+exit_test

--- a/tests/func-substring-relative-endpos.sh
+++ b/tests/func-substring-relative-endpos.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# addd 2023-01-13 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%$!my_struc_data%\n")
+
+set $!my_struc_data = substring($STRUCTURED-DATA, 1, -2);
+local4.debug action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z hostname1 sender - tag [tcpflood@32473 MSGNUM="0"] data'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='tcpflood@32473 MSGNUM="0"'
+cmp_exact
+exit_test


### PR DESCRIPTION
Now, length can have a negative value -n to denote that the substring should be build between startpos and the character -n chars from the end. This is a shortcut for stripping charactes on "both ends" of the string.

Also, some hardening against invalid startpos and length has been added.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
