### PR TITLE
core/template: implement negative position.to

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4241,8 +4241,15 @@ uchar *MsgGetProp(smsg_t *__restrict__ const pMsg, struct templateEntry *__restr
 			/* need to zero-base to and from (they are 1-based!) */
 			if(iFrom > 0)
 				--iFrom;
-			if(iTo > 0)
+			if(iTo > 0) {
 				--iTo;
+			} else if(iTo < 0) {
+				/* note: we ADD negative value, 0-based (-1)! */
+				iTo = bufLen - 1 + iTo;
+				if(iTo < 0) {
+					iTo = 0;
+				}
+			}
 		}
 		if(iFrom >= bufLen) {
 			DBGPRINTF("msgGetProp: iFrom %d >= buflen %d, returning empty string\n",

--- a/template.c
+++ b/template.c
@@ -1471,7 +1471,8 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 	int spifno1stsp = 0;
 	int mandatory = 0;
 	int frompos = -1;
-	int topos = -1;
+	int topos = 0;
+	int topos_set = 0;
 	int fieldnum = -1;
 	int fielddelim = 9; /* default is HT (USACSII 9) */
 	int fixedwidth = 0;
@@ -1555,6 +1556,7 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 			bComplexProcessing = 1;
 		} else if(!strcmp(pblkProperty.descr[i].name, "position.to")) {
 			topos = pvals[i].val.d.n;
+			topos_set = 1;
 			bComplexProcessing = 1;
 		} else if(!strcmp(pblkProperty.descr[i].name, "position.relativetoend")) {
 			bPosRelativeToEnd = pvals[i].val.d.n;
@@ -1736,9 +1738,9 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 	}
 
 	/* sanity check */
-	if(topos == -1 && frompos != -1)
+	if(topos_set == 0 && frompos != -1)
 		topos = 2000000000; /* large enough ;) */
-	if(frompos == -1 && topos != -1)
+	if(frompos == -1 && topos_set != 0)
 		frompos = 0;
 	if(bPosRelativeToEnd) {
 		if(topos > frompos) {
@@ -1747,7 +1749,7 @@ createPropertyTpe(struct template *pTpl, struct cnfobj *o)
 			ABORT_FINALIZE(RS_RET_ERR);
 		}
 	} else {
-		if(topos < frompos) {
+		if((topos >= 0) && (topos < frompos)) {
 			LogError(0, RS_RET_ERR, "position.to=%d is lower than postion.from=%d\n",
 				topos, frompos);
 			ABORT_FINALIZE(RS_RET_ERR);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -243,6 +243,7 @@ TESTS +=  \
 	template-pos-from-to-oversize-lowercase.sh \
 	template-pos-from-to-missing-jsonvar.sh \
 	template-const-jsonf.sh \
+	template-topos-neg.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
 	fac_local7.sh \
@@ -2069,6 +2070,7 @@ EXTRA_DIST= \
 	template-pos-from-to-oversize-lowercase.sh \
 	template-pos-from-to-missing-jsonvar.sh \
 	template-const-jsonf.sh \
+	template-topos-neg.sh \
 	fac_authpriv.sh \
 	fac_local0.sh \
 	fac_local0-vg.sh \

--- a/tests/template-topos-neg.sh
+++ b/tests/template-topos-neg.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="out" type="list") {
+	property(name="STRUCTURED-DATA" position.from="2" position.to="-1")
+        constant(value="\n")
+}
+
+local4.debug action(type="omfile" template="out" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z hostname1 sender - tag [tcpflood@32473 MSGNUM="0"] msgnum:irrelevant'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='tcpflood@32473 MSGNUM="0"'
+cmp_exact
+exit_test


### PR DESCRIPTION
This will easily permit to drop the last n characters from a property without the need to know the exact length of the string. This is especially useful as the exact length is most often not known beforehand.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
