### PR TITLE
Fixed wrong type conversion in cstrLen() for debug mode as well

### DIFF
--- a/parse.h
+++ b/parse.h
@@ -56,7 +56,7 @@ struct rsParsObject
 	rsObjID OID;			/**< object ID */
 #endif
 	cstr_t *pCStr;		/**< pointer to the string object we are parsing */
-	int iCurrPos;			/**< current parsing position (char offset) */
+	size_t iCurrPos;	/**< current parsing position (char offset) */
 };
 typedef struct rsParsObject rsParsObj;
 

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1033,7 +1033,7 @@ strmReadMultiLine(strm_t *pThis, cstr_t **ppCStr, regex_t *start_preg, regex_t *
 	cstr_t *thisLine = NULL;
 	rsRetVal readCharRet;
 	const time_t tCurr = pThis->readTimeout ? getTime(NULL) : 0;
-	int maxMsgSize = glblGetMaxLine(runConf);
+	size_t maxMsgSize = glblGetMaxLine(runConf);
 	DEFiRet;
 
 	do {
@@ -1094,9 +1094,9 @@ strmReadMultiLine(strm_t *pThis, cstr_t **ppCStr, regex_t *start_preg, regex_t *
 					}
 
 
-					int currLineLen = cstrLen(thisLine);
+					size_t currLineLen = cstrLen(thisLine);
 					if(currLineLen > 0) {
-						int len;
+						size_t len;
 						if((len = cstrLen(pThis->prevMsgSegment) + currLineLen) <
 						maxMsgSize) {
 							CHKiRet(cstrAppendCStr(pThis->prevMsgSegment, thisLine));
@@ -1106,7 +1106,7 @@ strmReadMultiLine(strm_t *pThis, cstr_t **ppCStr, regex_t *start_preg, regex_t *
 								len = 0;
 							} else {
 								len = currLineLen-(len-maxMsgSize);
-								for(int z=0; z<len; z++) {
+								for(size_t z=0; z<len; z++) {
 									cstrAppendChar(pThis->prevMsgSegment,
 										thisLine->pBuf[z]);
 								}

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -474,7 +474,7 @@ finalize_it:
  * This is due to performance reasons.
  */
 #ifndef NDEBUG
-int cstrLen(cstr_t *pThis)
+size_t cstrLen(cstr_t *pThis)
 {
 	rsCHECKVALIDOBJECT(pThis, OIDrsCStr);
 	return(pThis->iStrLen);

--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -146,7 +146,7 @@ rsRetVal cstrAppendCStr(cstr_t *pThis, cstr_t *pstrAppend);
 #ifdef NDEBUG
 #	define cstrLen(x) ((size_t)((x)->iStrLen))
 #else
-	int cstrLen(cstr_t *pThis);
+	size_t cstrLen(cstr_t *pThis);
 #endif
 #define rsCStrLen(s) cstrLen((s))
 


### PR DESCRIPTION
Apply the type conversion correction added by PR
https://github.com/rsyslog/rsyslog/pull/5051 to both definitions of cstrLen().

Changed types from int to size_t in multiple occurrences (where cstrLen is used).

closes: https://github.com/rsyslog/rsyslog/issues/5073

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
