### PR TITLE
imptcp bugfix: spam log on oversize message

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1186,6 +1186,7 @@ processDataRcvd(ptcpsess_t *const __restrict__ pThis,
 					"max msg size; message will be split starting at: \"%.*s\"\n",
 					pThis->pLstn->pSrv->pszInputName, i, (i < 32) ? i : 32, *buff);
 				doSubmitMsg(pThis, stTime, ttGenTime, pMultiSub);
+				iMsg = 0;
 				++(*pnMsgs);
 				if(pThis->pLstn->pSrv->discardTruncatedMsg == 1) {
 					pThis->inputState = eInMsgTruncation;

--- a/tests/imptcp-oversize-message-display.sh
+++ b/tests/imptcp-oversize-message-display.sh
@@ -17,18 +17,25 @@ tcpflood -m1 -M "\"<120> 2011-03-01T11:22:12Z host tag: this is a way too long m
 shutdown_when_empty
 wait_shutdown
 
-grep "imptcp: message received.*150 byte larger.*will be split.*\"ghijkl"  $RSYSLOG_OUT_LOG > /dev/null
-if [ $? -ne 0 ]; then
+if ! grep "imptcp: message received.*150 byte larger.*will be split.*\"ghijkl"  $RSYSLOG_OUT_LOG > /dev/null
+then
         echo
         echo "FAIL: expected error message from imptcp truncation not found.  $RSYSLOG_OUT_LOG is:"
         cat $RSYSLOG_OUT_LOG
         error_exit 1
 fi
 
-grep "imptcp: message received.*22 byte larger.*will be split.*\"sstets"  $RSYSLOG_OUT_LOG > /dev/null
-if [ $? -ne 0 ]; then
+if ! grep "imptcp: message received.*22 byte larger.*will be split.*\"sstets"  $RSYSLOG_OUT_LOG > /dev/null
+then
         echo
         echo "FAIL: expected error message from imptcp truncation not found.  $RSYSLOG_OUT_LOG is:"
+        cat $RSYSLOG_OUT_LOG
+        error_exit 1
+fi
+if grep "imptcp: message received.*21 byte larger"  $RSYSLOG_OUT_LOG > /dev/null
+then
+        echo
+        echo "FAIL: UNEXPECTED error message from imptcp truncation found.  $RSYSLOG_OUT_LOG is:"
         cat $RSYSLOG_OUT_LOG
         error_exit 1
 fi


### PR DESCRIPTION
If an oversize message was received by imptcp, imptcp reported one error message for EACH oversize character. This could result in a potentially very large number of similar (and useless) messages.

This is a regression from commit f052717178.

closes https://github.com/rsyslog/rsyslog/issues/5078

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
