### PR TITLE
imjournal: Add FileCreateMode module parameter

### DIFF
--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -62,7 +62,7 @@ jobs:
             software-properties-common \
             valgrind \
             wget \
-	    zstd
+            zstd
 
       - name: git checkout project
         uses: actions/checkout@v1

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -35,6 +35,7 @@
 #include <sys/socket.h>
 #include <errno.h>
 #include <systemd/sd-journal.h>
+#include <fcntl.h>
 
 #include "dirty.h"
 #include "cfsysline.h"
@@ -73,6 +74,7 @@ struct modConfData_s {
 
 static struct configSettings_s {
 	char *stateFile;
+	int fCreateMode; /* default mode to use when creating new files, e.g. stateFile */
 	int iPersistStateInterval;
 	unsigned int ratelimitInterval;
 	unsigned int ratelimitBurst;
@@ -92,6 +94,7 @@ static rsRetVal facilityHdlr(uchar **pp, void *pVal);
 /* module-global parameters */
 static struct cnfparamdescr modpdescr[] = {
 	{ "statefile", eCmdHdlrGetWord, 0 },
+	{ "filecreatemode", eCmdHdlrFileCreateMode, 0 },
 	{ "ratelimit.interval", eCmdHdlrInt, 0 },
 	{ "ratelimit.burst", eCmdHdlrInt, 0 },
 	{ "persiststateinterval", eCmdHdlrInt, 0 },
@@ -523,8 +526,10 @@ static rsRetVal
 persistJournalState(void)
 {
 	DEFiRet;
-	FILE *sf = NULL; /* state file */
 	char tmp_sf[MAXFNAME];
+	int fd = -1;
+	size_t len;
+	ssize_t wr_ret;
 
 	DBGPRINTF("Persisting journal position, cursor: %s, at head? %d\n",
 			  journalContext.cursor, journalContext.atHead);
@@ -556,18 +561,19 @@ persistJournalState(void)
 			(int)(sizeof(tmp_sf) - sizeof(IM_SF_TMP_SUFFIX)),
 			cs.stateFile, IM_SF_TMP_SUFFIX);
 
-	sf = fopen(tmp_sf, "wb");
-	if (sf == NULL) {
-		LogError(errno, RS_RET_FOPEN_FAILURE, "imjournal: fopen() failed for path: '%s'", tmp_sf);
-		ABORT_FINALIZE(RS_RET_FOPEN_FAILURE);
+	fd = open((char*) tmp_sf, O_WRONLY|O_CREAT|O_CLOEXEC, cs.fCreateMode);
+	if (fd == -1) {
+		LogError(errno, RS_RET_FILE_OPEN_ERROR, "imjournal: open() failed for path: '%s'", tmp_sf);
+		ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
 	}
 
-	if(fputs(journalContext.cursor, sf) == EOF) {
-		LogError(errno, RS_RET_IO_ERROR, "imjournal: failed to save cursor to: '%s'", tmp_sf);
+	len = strlen(journalContext.cursor);
+	wr_ret = write(fd, journalContext.cursor, len);
+	if (wr_ret != (ssize_t)len) {
+		LogError(errno, RS_RET_IO_ERROR, "imjournal: failed to save cursor to: '%s',"
+			"write returned %zd, expected %zu", cs.stateFile, wr_ret, len);
 		ABORT_FINALIZE(RS_RET_IO_ERROR);
 	}
-
-	fflush(sf);
 
 	/* change the name of the file to the configured one */
 	if (rename(tmp_sf, cs.stateFile) < 0) {
@@ -576,7 +582,7 @@ persistJournalState(void)
 	}
 
 	if (cs.bFsync) {
-		if (fsync(fileno(sf)) != 0) {
+		if (fsync(fd) != 0) {
 			LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", cs.stateFile);
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
@@ -599,9 +605,9 @@ persistJournalState(void)
 	DBGPRINTF("Persisted journal to '%s'\n", cs.stateFile);
 
 finalize_it:
-	if (sf != NULL) {
-		if (fclose(sf) == EOF) {
-			LogError(errno, RS_RET_IO_ERROR, "imjournal: fclose() failed for path: '%s'", tmp_sf);
+	if (fd != -1) {
+		if (close(fd) == -1) {
+			LogError(errno, RS_RET_IO_ERROR, "imjournal: close() failed for path: '%s'", tmp_sf);
 			iRet = RS_RET_IO_ERROR;
 		}
 	}
@@ -898,6 +904,7 @@ CODESTARTbeginCnfLoad
 	cs.bIgnoreNonValidStatefile = 1;
 	cs.iPersistStateInterval = DFLT_persiststateinterval;
 	cs.stateFile = NULL;
+	cs.fCreateMode = -1;
 	cs.ratelimitBurst = 20000;
 	cs.ratelimitInterval = 600;
 	cs.iDfltSeverity = DFLT_SEVERITY;
@@ -1039,6 +1046,8 @@ CODESTARTsetModCnf
 			cs.iPersistStateInterval = (int) pvals[i].val.d.n;
 		} else if (!strcmp(modpblk.descr[i].name, "statefile")) {
 			cs.stateFile = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(modpblk.descr[i].name, "filecreatemode")) {
+			cs.fCreateMode = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "ratelimit.burst")) {
 			cs.ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "ratelimit.interval")) {
@@ -1072,6 +1081,14 @@ CODESTARTsetModCnf
 			dbgprintf("imjournal: program error, non-handled "
 				"param '%s' in beginCnfLoad\n", modpblk.descr[i].name);
 		}
+	}
+
+	/* File create mode is not set */
+	if (cs.fCreateMode == -1) {
+		const int fCreateMode = 0644;
+		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "imjournal: filecreatemode is not set, "
+			"using default %04o", fCreateMode);
+		cs.fCreateMode = fCreateMode;
 	}
 
 finalize_it:

--- a/tests/imjournal_filecreatemode.sh
+++ b/tests/imjournal_filecreatemode.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Test for checking the fileCreateMode imjournal parameter
+# Basically we set 3 different file creation modes for the state file
+# and test if those are really set
+# 
+. ${srcdir:=.}/diag.sh init
+
+# $1 - the file create mode that we set for the state file
+test_imjournal_filecreatemode() {
+  local EXPECTED=$1
+
+  generate_conf
+  add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(
+  load="../plugins/imjournal/.libs/imjournal"
+  StateFile="imjournal.state"
+  fileCreateMode="'$EXPECTED'"
+)
+'
+  startup
+
+  local ACTUAL="$(stat -c "%#a" "$RSYSLOG_DYNNAME.spool/imjournal.state")"
+  if [ "$ACTUAL" != "$EXPECTED" ]; then
+    echo "imjournal fileCreateMode failed, incorrect permissions on state file: expected($EXPECTED) != actual($ACTUAL)"
+    error_exit
+  fi
+  shutdown_when_empty
+  wait_shutdown
+  ls -l "$RSYSLOG_DYNNAME.spool/imjournal.state"
+}
+
+test_imjournal_filecreatemode "0600"
+test_imjournal_filecreatemode "0640"
+test_imjournal_filecreatemode "0644"
+
+exit_test


### PR DESCRIPTION
### Description
The parameter allows to set the default file mode bits when creating new files by the module. As of now, it has only impact on the state file. Other modules that create files such as omfile, imptcp, omprog provide a similar parameter.

If accepted, I can prepare a PR in rsyslog-doc to include it in the documentation part as well.
What do you think?

[UPDATE]
I've set the default permission of the state file to 0644 to provide the same results as we currently have but personally I would limit it to 0600. I appreciate the feedback :)