### PR TITLE
Send HUP on "systemctl reload rsyslog" on Debian.

### DIFF
--- a/platform/debian/rsyslog.service.10
+++ b/platform/debian/rsyslog.service.10
@@ -7,6 +7,7 @@ Documentation=https://www.rsyslog.com/doc/
 [Service]
 Type=notify
 ExecStart=/usr/sbin/rsyslogd -n -iNONE
+ExecReload=/bin/kill -HUP $MAINPID
 StandardOutput=null
 Restart=on-failure
 

--- a/platform/debian/rsyslog.service.8
+++ b/platform/debian/rsyslog.service.8
@@ -7,6 +7,7 @@ Documentation=http://www.rsyslog.com/doc/
 [Service]
 Type=notify
 ExecStart=/usr/sbin/rsyslogd -n
+ExecReload=/bin/kill -HUP $MAINPID
 StandardOutput=null
 Restart=on-failure
 

--- a/platform/debian/rsyslog.service.9
+++ b/platform/debian/rsyslog.service.9
@@ -7,6 +7,7 @@ Documentation=http://www.rsyslog.com/doc/
 [Service]
 Type=notify
 ExecStart=/usr/sbin/rsyslogd -n
+ExecReload=/bin/kill -HUP $MAINPID
 StandardOutput=null
 Restart=on-failure
 


### PR DESCRIPTION
Allow `systemctl reload rsyslog` to send HUP for log rotation. I'm not sure whether it's "right" semantic for reload operation that only reopens logs 

Tested on Debian9/10/11/12, I *assume* centos one would be same change but have no machine to test it so I don't include it in patch