### PR TITLE
core bugfix: potential segfault on busy systems

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2552,12 +2552,15 @@ tryEmulateTAG(smsg_t *const pM, const sbool bLockMutex)
 void ATTR_NONNULL(2,3)
 getTAG(smsg_t * const pM, uchar **const ppBuf, int *const piLen, const sbool bLockMutex)
 {
+	if(bLockMutex == LOCK_MUTEX)
+		MsgLock(pM);
+
 	if(pM == NULL) {
 		*ppBuf = UCHAR_CONSTANT("");
 		*piLen = 0;
 	} else {
 		if(pM->iLenTAG == 0)
-			tryEmulateTAG(pM, bLockMutex);
+			tryEmulateTAG(pM, MUTEX_ALREADY_LOCKED);
 		if(pM->iLenTAG == 0) {
 			*ppBuf = UCHAR_CONSTANT("");
 			*piLen = 0;
@@ -2566,6 +2569,9 @@ getTAG(smsg_t * const pM, uchar **const ppBuf, int *const piLen, const sbool bLo
 			*piLen = pM->iLenTAG;
 		}
 	}
+
+	if(bLockMutex == LOCK_MUTEX)
+		MsgUnlock(pM);
 }
 
 


### PR DESCRIPTION
This was discovered by Konstantin J. Chernov in a practicaly deployment. Here, msg object tag processing caused sporadic segfaults. We did not hear from similiar cases, but there clearly is potential for problems because a mutex lock had insufficient range, thus leading to a potential race.

The patch is directly from Konstantin J. Chernov, thanks for that.

Please note that the mutex lock could be minimized as it is not strictly needed for the pM == NULL case, but this cause is extremely exotic and the resulting code would be harder to understand. Thus we opt to do the locking on funtion level (as usual).

Descriptiond edited by Rainer Gerhards

closes: https://github.com/rsyslog/rsyslog/issues/5110

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
