### PR TITLE
Add the 'batchsize' parameter to imhiredis so we can configure the si…

### DIFF
--- a/contrib/imhiredis/README
+++ b/contrib/imhiredis/README
@@ -20,10 +20,10 @@ Following parameters are optional:
  - password: If set, the plugin will issue an "AUTH" command before calling xPOP
  - uselpop: If set to "1", LPOP will be used instead of default RPOP
 
-Redis pipelining is used inside the workerthread, with a hardcoded batch size of #10.
+Redis pipelining is used inside the worker thread. The dequeue batch size is configured with the "batchsize" parameter (default is 10).
 
 Imhiredis will query Redis every second to see if entries are in the list, if that's the case they will be dequeued
-continuously by batches of 10 until none remains.
+continuously by batches of "batchsize elements" until none remains.
 
 Due to its balance between polling interval and pipelining and its use of lists, this mode is quite performant and reliable.
 However, due to the 1 second polling frequency, one may consider using the `subscribe` mode instead if very low latency is required.
@@ -39,6 +39,7 @@ input(
     port="6379"
     uselpop="1"
     password="foobar"
+    batchsize="10"
 )
 ```
 
@@ -69,12 +70,12 @@ input(
     server="127.0.0.1"
     port="6379"
     password="foobar"
+    batchsize="10"
 )
 ```
 
 
 TODO
 * TLS support
-* detect master/replicas relationships and follow them
 
 

--- a/contrib/imhiredis/imhiredis.c
+++ b/contrib/imhiredis/imhiredis.c
@@ -94,6 +94,7 @@ struct instanceConf_s {
 	int streamAutoclaimIdleTime;
 	sbool streamConsumerACK;
 	int mode;
+	uint batchsize;
 	sbool useLPop;
 
 	struct {
@@ -182,6 +183,7 @@ static struct cnfparamdescr inppdescr[] = {
 	{ "port", eCmdHdlrInt, 0 },
 	{ "password", eCmdHdlrGetWord, 0 },
 	{ "mode", eCmdHdlrGetWord, 0 },
+	{ "batchsize", eCmdHdlrInt, 0 },
 	{ "key", eCmdHdlrGetWord, CNFPARAM_REQUIRED },
 	{ "uselpop", eCmdHdlrBinary, 0 },
 	{ "ruleset", eCmdHdlrString, 0 },
@@ -257,6 +259,7 @@ createInstance(instanceConf_t **pinst)
 	inst->password = NULL;
 	inst->key = NULL;
 	inst->mode = 0;
+	inst->batchsize = 0;
 	inst->useLPop = 0;
 	inst->streamConsumerGroup = NULL;
 	inst->streamConsumerName = NULL;
@@ -372,6 +375,15 @@ checkInstance(instanceConf_t *const inst)
 			LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'fields' "
 									"unused for mode != stream : ignored.");
 		}
+	}
+
+	if (inst->batchsize !=0 ) {
+		DBGPRINTF("imhiredis: batchsize is '%d'\n", inst->batchsize);
+	}
+	else {
+		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
+			"imhiredis: batchsize not set, setting to default (%d)",BATCH_SIZE);
+		inst->batchsize=BATCH_SIZE;
 	}
 
 	if (inst->password != NULL) {
@@ -490,6 +502,8 @@ CODESTARTnewInpInst
 						inst->fieldList.varname[j]);
 				free(param);
 			}
+		} else if(!strcmp(inppblk.descr[i].name, "batchsize")) {
+			inst->batchsize = (int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "key")) {
 			inst->key = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else {
@@ -1493,20 +1507,20 @@ rsRetVal redisDequeue(instanceConf_t *inst) {
 	DBGPRINTF("redisDequeue: beginning to dequeue key '%s'\n", inst->key);
 
 	do {
-		// append a batch of BATCH_SIZE POP commands (either LPOP or RPOP depending on conf)
+		// append a batch of inst->batchsize POP commands (either LPOP or RPOP depending on conf)
 		if (inst->useLPop == 1) {
 			DBGPRINTF("redisDequeue: Queuing #%d LPOP commands on key '%s' \n",
-					BATCH_SIZE,
+					inst->batchsize,
 					inst->key);
-			for (i=0; i<BATCH_SIZE; ++i ) {
+			for (i=0; i<inst->batchsize; ++i ) {
 				if (REDIS_OK != redisAppendCommand(inst->conn, "LPOP %s", inst->key))
 					break;
 			}
 		} else {
 			DBGPRINTF("redisDequeue: Queuing #%d RPOP commands on key '%s' \n",
-					BATCH_SIZE,
+					inst->batchsize,
 					inst->key);
-			for (i=0; i<BATCH_SIZE; i++) {
+			for (i=0; i<inst->batchsize; i++) {
 				if (REDIS_OK != redisAppendCommand(inst->conn, "RPOP %s", inst->key))
 					break;
 			}
@@ -1518,7 +1532,7 @@ rsRetVal redisDequeue(instanceConf_t *inst) {
 			if (REDIS_OK != redisGetReply(inst->conn, (void **) &reply)) {
 				// error getting reply, must stop
 				LogError(0, RS_RET_REDIS_ERROR, "redisDequeue: Error reading reply after POP #%d "
-								"on key '%s'", (BATCH_SIZE - i), inst->key);
+								"on key '%s'", (inst->batchsize - i), inst->key);
 				// close connection
 				redisFree(inst->conn);
 				inst->currentNode = NULL;


### PR DESCRIPTION
…ze of the batch dequeueing in pipelining operations with redis. Default value of '10' has been kept to avoid any side effect on existing configurations.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
