### PR TITLE
Fix quoting for omprog, improg, mmexternal

### DIFF
--- a/tests/omprog-defaults.sh
+++ b/tests/omprog-defaults.sh
@@ -26,7 +26,8 @@ template(name="outfmt" type="string" string="%msg%\n")
 :msg, contains, "msgnum:" {
     action(
         type="omprog"
-	    binary=`echo $srcdir/testsuites/omprog-defaults-bin.sh p1 p2 p3`
+	    binary="'$srcdir'/testsuites/omprog-defaults-bin.sh \"p1 with spaces\"'\
+' p2 \"\" --p4=\"middle quote\" \"--p6=\"proper middle quote\"\" \"p7 is last\""
         template="outfmt"
         name="omprog_action"
     )
@@ -37,7 +38,14 @@ injectmsg 0 10
 shutdown_when_empty
 wait_shutdown
 
-export EXPECTED="Starting with parameters: p1 p2 p3
+export EXPECTED="Starting with parameters: p1 with spaces p2  --p4=\"middle quote\" --p6=\"proper middle quote\" p7 is last
+Next parameter is \"p1 with spaces\"
+Next parameter is \"p2\"
+Next parameter is \"\"
+Next parameter is \"--p4=\"middle\"
+Next parameter is \"quote\"\"
+Next parameter is \"--p6=\"proper middle quote\"\"
+Next parameter is \"p7 is last\"
 Received msgnum:00000000:
 Received msgnum:00000001:
 Received msgnum:00000002:

--- a/tests/omprog-if-error.sh
+++ b/tests/omprog-if-error.sh
@@ -25,6 +25,9 @@ cat $RSYSLOG_DYNNAME.othermsg
 content_check 'must be terminated with \n' $RSYSLOG_DYNNAME.othermsg
 
 export EXPECTED="Starting with parameters: p1 p2 p3
+Next parameter is \"p1\"
+Next parameter is \"p2\"
+Next parameter is \"p3\"
 Received msgnum:00000000:
 Received msgnum:00000001:
 Received msgnum:00000002:

--- a/tests/testsuites/omprog-defaults-bin.sh
+++ b/tests/testsuites/omprog-defaults-bin.sh
@@ -3,6 +3,10 @@
 outfile=$RSYSLOG_OUT_LOG
 
 echo "Starting with parameters: $@" >> $outfile
+while [ $# -gt 0 ]; do
+    echo Next parameter is \""$1"\"
+    shift
+done >> $outfile
 
 read log_line
 while [[ -n "$log_line" ]]; do


### PR DESCRIPTION
This changes the current behaviour from honouring the double quotes in any part of the argument but leaving them in place and passing to the executed binary to requiring quotes exactly at the beginning and at the end of a multi-word argument, and not including them in the actual call.

Testcases added to ensure the expected results.

Fixes #4249.

I will send the corresponding change to rsyslog-doc repository later if you give the green light to this.