### PR TITLE
tests: mmexternal-SegFault-empty-jroot-vg.sh: fix typo

### DIFF
--- a/tests/mmexternal-SegFault-empty-jroot-vg.sh
+++ b/tests/mmexternal-SegFault-empty-jroot-vg.sh
@@ -14,7 +14,7 @@ if $msg contains "msgnum:" then {
 }
 '
 startup_vg
-injectmsg litteral "<129>Mar 10 01:00:00 172.20.245.8 tag:msgnum:1"
+injectmsg literal "<129>Mar 10 01:00:00 172.20.245.8 tag:msgnum:1"
 shutdown_when_empty
 wait_shutdown_vg
 check_exit_vg


### PR DESCRIPTION
Fix the typo that makes the test fail.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
