### PR TITLE
imjournal: Add option to freeze journal pointer

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -93,6 +93,7 @@ char** glblDbgFiles = NULL;
 size_t glblDbgFilesNum = 0;
 int glblDbgWhitelist = 1;
 int glblPermitCtlC = 0;
+int bJournalDisableForwarding = 0;		/* global switch that journal state should stop forwarding */
 
 pid_t glbl_ourpid;
 #ifndef HAVE_ATOMIC_BUILTINS
@@ -292,6 +293,15 @@ static void SetGlobalInputTermination(void)
 	ATOMIC_STORE_1_TO_INT(&bTerminateInputs, &mutTerminateInputs);
 }
 
+static int GetGlobalJournalDisableForwarding(void)
+{
+	return bJournalDisableForwarding;
+}
+
+static void SetGlobalJournalDisableForwarding(int val)
+{
+	bJournalDisableForwarding = val;
+}
 
 /* set the local host IP address to a specific string. Helper to
  * small set of functions. No checks done, caller must ensure it is
@@ -918,6 +928,8 @@ CODESTARTobjQueryInterface(glbl)
 	pIf->GetLocalHostIP = GetLocalHostIP;
 	pIf->SetGlobalInputTermination = SetGlobalInputTermination;
 	pIf->GetGlobalInputTermState = GetGlobalInputTermState;
+	pIf->GetGlobalJournalDisableForwarding = GetGlobalJournalDisableForwarding;
+	pIf->SetGlobalJournalDisableForwarding = SetGlobalJournalDisableForwarding;
 	pIf->GetSourceIPofLocalClient = GetSourceIPofLocalClient;	/* [ar] */
 	pIf->SetSourceIPofLocalClient = SetSourceIPofLocalClient;	/* [ar] */
 	pIf->GetDefPFFamily = getDefPFFamily;

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -63,6 +63,8 @@ BEGINinterface(glbl) /* name must also be changed in ENDinterface macro! */
 	/* added v4, 2009-07-20 */
 	int (*GetGlobalInputTermState)(void);
 	void (*SetGlobalInputTermination)(void);
+	int (*GetGlobalJournalDisableForwarding)(void);
+	void (*SetGlobalJournalDisableForwarding)(int);
 	/* added v5, 2009-11-03 */
 	/* note: v4, v5 are already used by more recent versions, so we need to skip them! */
 	/* added v6, 2009-11-16 as part of varmojfekoj's "unlimited select()" patch


### PR DESCRIPTION
Add `disableJournalForwarding` option in both imjournal and omfwd. If both imjournal and omfwd action is `on`, then freeze the journal pointer to avoid reading more data when we loose outgoing connection. Once the connection resumes then it should resume the pointer too.

Tested:

owfwrd:

- Disabled forwarding at boot up if no network connection
```
rsyslogd[23301]: cannot connect to 2002:ab1:c012:0:fd01:::32722: Connection
  refused [v8.2212.0 try https://www.rsyslog.com/e/2027 ]
rsyslogd[23301]: omfwd: Disable Journal Forwarding Logs... [v8.2212.0 try
  https://www.rsyslog.com/e/2027 ]
rsyslogd[23301]: action 'action-4-builtin:omfwd' suspended (module
  'builtin:omfwd'), retry 0. There should be messages before this one giving
  the reason for suspension. [v8.2212.0 try https://www.rsyslog.com/e/2007 ]
```

- Disabled forwarding after loosing connection
```
rsyslogd[22638]: omfwd: remote server at 2002:ab1:c012:0:fd01:::32722 seems to
  have closed connection. This often happens when the remote peer (or an interim
  system like a load balancer or firewall) shuts down or aborts a connection.
  Rsyslog will re-open the connection if configured to do so (we saw a generic
  IO Error, which usually goes along with that behaviour). [v8.2212.0 try
  https://www.rsyslog.com/e/2027 ]
rsyslogd[22638]: omfwd: Disable Journal Forwarding Logs...
  [v8.2212.0 try https://www.rsyslog.com/e/2007 ]
rsyslogd[22638]: action 'action-4-builtin:omfwd' suspended (module
  'builtin:omfwd'), retry 0. There should be messages before this one giving the
   reason for suspension. [v8.2212.0 try https://www.rsyslog.com/e/2007 ]
```

- Resume forwarding after reconnected.
```
rsyslogd[23301]: omfwd: Enable Journal Forwarding Logs... [v8.2212.0 try
  https://www.rsyslog.com/e/2359 ]
rsyslogd[23301]: action 'action-4-builtin:omfwd' resumed (module
  'builtin:omfwd') [v8.2212.0 try https://www.rsyslog.com/e/2359 ]
```

imjournal:

- Stop Journal pointer
```
SECONDS=0
expected="$(md5sum /var/log/state)"
echo "Expected state ${expected}"
while [ $SECONDS -lt 300 ];
do
  new_state="$(md5sum /var/log/state)"
  if [[ "${new_state}" != "${expected}" ]];
  then
    echo "Got state ${new_state} instead of ${expected}"
      exit 1
  fi
  sleep 5
done
echo "Passed"
exit 0
```

```
Expected state 309593de34bc095e4245c1ba07a7520c  /var/log/state
Passed
```

- Resume Journal Pointer

The state file changed after the connection resumed.
```
$ md5sum /var/log/state
d11c7e46fec4f86151df204608525d89  /var/log/state
```

The message send in when the connection was down is also sent out properly.

- Journal Pointer rotating out. Once the pointer rotates out it just goes to the top of the journal with no issue. I printed something in journal and waited for it to rotate out... and it was not send out after resuming pointer.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
