### PR TITLE
New Redis streams functionality + various fixes and improvements

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2461,6 +2461,17 @@ AC_ARG_ENABLE(omhiredis,
         [enable_omhiredis=no]
 )
 
+AC_ARG_ENABLE(redis_tests,
+        [AS_HELP_STRING([--enable-redis-tests],[Enable redis tests, needs redis-server @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_redis_tests="yes" ;;
+          no) enable_redis_tests="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-redis-tests) ;;
+         esac],
+        [enable_redis_tests=no]
+)
+AM_CONDITIONAL(ENABLE_REDIS_TESTS, test x$enable_redis_tests = xyes)
+
 if test "x$enable_omhiredis" = "xyes" -o "x$enable_imhiredis" = "xyes" ; then
     PKG_CHECK_MODULES(HIREDIS, hiredis >= 0.10.1, [],
         [AC_SEARCH_LIBS(redisConnectWithTimeout, hiredis,
@@ -2495,6 +2506,21 @@ if test "x$enable_imhiredis" = "xyes" ; then
         ],
         # libevent not found
         [AC_MSG_ERROR([no libevent >= 2.0 found with pthreads support, imhiredis cannot use pub/sub])])
+fi
+
+if test "x$enable_imhiredis" = "xyes" || test "x$enable_omhiredis" = "xyes"; then
+	if test "x$enable_redis_tests" = "xyes"; then
+		AC_CHECK_PROG(REDIS, [redis-server], [yes], [no])
+		if test "x${REDIS}" = "xno"; then
+			AC_MSG_FAILURE([redis-server, which is a redis-tests dependency, not found])
+		fi
+	fi
+else
+	if test "x$enable_redis_tests" = "xyes"; then
+		AC_MSG_WARN([redis-tests can not be enabled without imhiredis or omhiredis support.
+                        Disabling enable_redis_tests...])
+		enable_redis_tests="no"
+	fi
 fi
 
 AM_CONDITIONAL(ENABLE_OMHIREDIS, test x$enable_omhiredis = xyes)
@@ -2896,6 +2922,7 @@ echo "    Elasticsearch Tests:                      $enable_elasticsearch_tests"
 echo "    ClickHouse Tests:                         $enable_clickhouse_tests"
 echo "    PostgreSQL Tests enabled:                 $enable_pgsql_tests"
 echo "    Kafka Tests enabled:                      $enable_kafka_tests"
+echo "    Redis Tests enabled:                      $enable_redis_tests"
 echo "    Imdocker Tests enabled:                   $enable_imdocker_tests"
 echo "    gnutls tests enabled:                     $enable_gnutls_tests"
 echo "    imfile tests enabled:                     $enable_imfile_tests"

--- a/configure.ac
+++ b/configure.ac
@@ -2856,6 +2856,7 @@ echo "    omhttpfs module will be compiled:         $enable_omhttpfs"
 echo "    omamqp1 module will be compiled:          $enable_omamqp1"
 echo "    omtcl module will be compiled:            $enable_omtcl"
 echo "    omkafka module will be compiled:          $enable_omkafka"
+echo "    omhiredis module will be compiled:        $enable_omhiredis"
 echo
 echo "---{ parser modules }---"
 echo "    pmlastmsg module will be compiled:        $enable_pmlastmsg"

--- a/contrib/imhiredis/imhiredis.c
+++ b/contrib/imhiredis/imhiredis.c
@@ -63,8 +63,11 @@ MODULE_CNFNAME("imhiredis")
 /* static data */
 DEF_IMOD_STATIC_DATA
 #define BATCH_SIZE 10
+#define WAIT_TIME_MS 500
+#define STREAM_INDEX_STR_MAXLEN 44 // "18446744073709551615-18446744073709551615"
 #define IMHIREDIS_MODE_QUEUE 1
 #define IMHIREDIS_MODE_SUBSCRIBE 2
+#define IMHIREDIS_MODE_STREAM 3
 DEFobjCurrIf(prop)
 DEFobjCurrIf(ruleset)
 DEFobjCurrIf(glbl)
@@ -85,8 +88,20 @@ struct instanceConf_s {
 	uchar *password;
 	uchar *key;
 	uchar *modeDescription;
+	uchar *streamConsumerGroup;
+	uchar *streamConsumerName;
+	uchar *streamReadFrom;
+	int streamAutoclaimIdleTime;
+	sbool streamConsumerACK;
 	int mode;
 	sbool useLPop;
+
+	struct {
+		int     nmemb;
+		char **name;
+		char **varname;
+	} fieldList;
+
 	ruleset_t *pBindRuleset;	/* ruleset to bind listener to (use system default if unspecified) */
 	uchar *pszBindRuleset;		/* default name of Ruleset to bind to */
 
@@ -170,6 +185,12 @@ static struct cnfparamdescr inppdescr[] = {
 	{ "key", eCmdHdlrGetWord, CNFPARAM_REQUIRED },
 	{ "uselpop", eCmdHdlrBinary, 0 },
 	{ "ruleset", eCmdHdlrString, 0 },
+	{ "stream.consumerGroup", eCmdHdlrGetWord, 0 },
+	{ "stream.consumerName", eCmdHdlrGetWord, 0 },
+	{ "stream.readFrom", eCmdHdlrGetWord, 0 },
+	{ "stream.consumerACK", eCmdHdlrBinary, 0 },
+	{ "stream.autoclaimIdleTime", eCmdHdlrNonNegInt, 0 },
+	{ "fields", eCmdHdlrArray, 0 },
 };
 static struct cnfparamblk inppblk =
 	{ CNFPARAMBLK_VERSION,
@@ -187,7 +208,12 @@ struct timeval glblRedisConnectTimeout = { 3, 0 }; /* 3 seconds */
 static void redisAsyncRecvCallback (redisAsyncContext __attribute__((unused)) *c, void *reply, void *inst_obj);
 static void redisAsyncConnectCallback (const redisAsyncContext *c, int status);
 static void redisAsyncDisconnectCallback (const redisAsyncContext *c, int status);
+static struct json_object* _redisParseIntegerReply(const redisReply *reply);
+static struct json_object* _redisParseDoubleReply(const redisReply *reply);
+static struct json_object* _redisParseStringReply(const redisReply *reply);
+static struct json_object* _redisParseArrayReply(const redisReply *reply);
 static rsRetVal enqMsg(instanceConf_t *const inst, const char *message, size_t msgLen);
+static rsRetVal enqMsgJson(instanceConf_t *const inst, struct json_object *json, struct json_object *metadata);
 rsRetVal redisAuthentSynchronous(redisContext *conn, uchar *password);
 rsRetVal redisAuthentAsynchronous(redisAsyncContext *aconn, uchar *password);
 rsRetVal redisActualizeCurrentNode(instanceConf_t *inst);
@@ -200,6 +226,13 @@ rsRetVal redisConnectAsync(redisAsyncContext **aconn, redisNode *node);
 rsRetVal connectMasterAsync(instanceConf_t *inst);
 static sbool isConnectedAsync(instanceConf_t *inst);
 rsRetVal redisDequeue(instanceConf_t *inst);
+rsRetVal ensureConsumerGroupCreated(instanceConf_t *inst);
+rsRetVal ackStreamIndex(instanceConf_t *inst, uchar *stream, uchar *group, uchar *index);
+static rsRetVal enqueueRedisStreamReply(instanceConf_t *const inst, redisReply *reply);
+static rsRetVal handleRedisXREADReply(instanceConf_t *const inst, const redisReply *reply);
+static rsRetVal handleRedisXAUTOCLAIMReply(
+		instanceConf_t *const inst, const redisReply *reply, char **autoclaimIndex);
+rsRetVal redisStreamRead(instanceConf_t *inst);
 rsRetVal redisSubscribe(instanceConf_t *inst);
 void workerLoop(struct imhiredisWrkrInfo_s *me);
 static void *imhirediswrkr(void *myself);
@@ -225,8 +258,14 @@ createInstance(instanceConf_t **pinst)
 	inst->key = NULL;
 	inst->mode = 0;
 	inst->useLPop = 0;
+	inst->streamConsumerGroup = NULL;
+	inst->streamConsumerName = NULL;
+	CHKmalloc(inst->streamReadFrom = calloc(1, STREAM_INDEX_STR_MAXLEN));
+	inst->streamAutoclaimIdleTime = 0;
+	inst->streamConsumerACK = 1;
 	inst->pszBindRuleset = NULL;
 	inst->pBindRuleset = NULL;
+	inst->fieldList.nmemb = 0;
 
 	/* Redis objects */
 	inst->conn = NULL;
@@ -289,14 +328,50 @@ checkInstance(instanceConf_t *const inst)
 	}
 
 
-	if (inst->mode != IMHIREDIS_MODE_QUEUE && inst->mode != IMHIREDIS_MODE_SUBSCRIBE) {
-		LogError(0, RS_RET_CONFIG_ERROR, "imhiredis: invalid mode, please choose 'subscribe' or 'queue' mode.");
+	if (inst->mode < IMHIREDIS_MODE_QUEUE || inst->mode > IMHIREDIS_MODE_STREAM) {
+		LogError(0, RS_RET_CONFIG_ERROR, "imhiredis: invalid mode, please choose 'subscribe', "
+						"'queue' or 'stream' mode.");
 		ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 	}
 
 	if (inst->mode != IMHIREDIS_MODE_QUEUE && inst->useLPop) {
 		LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'uselpop' set with mode != queue : ignored.");
+	}
 
+	if (inst->mode == IMHIREDIS_MODE_STREAM) {
+		if(inst->streamConsumerGroup != NULL && inst->streamConsumerName == NULL) {
+			LogError(0, RS_RET_CONFIG_ERROR, "imhiredis: invalid configuration, "
+					"please set a consumer name when mode is 'stream' and a consumer group is set");
+			ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+		}
+		if(inst->streamAutoclaimIdleTime != 0 && inst->streamConsumerGroup == NULL) {
+			LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'stream.autoclaimIdleTime' "
+					"set with no consumer group set : ignored.");
+		}
+		if(inst->streamReadFrom[0] == '\0') {
+			inst->streamReadFrom[0] = '$';
+		}
+	} else {
+		if (inst->streamConsumerGroup != NULL) {
+			LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'stream.consumerGroup' "
+									"set with mode != stream : ignored.");
+		}
+		if (inst->streamConsumerName != NULL) {
+			LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'stream.consumerName' "
+									"set with mode != stream : ignored.");
+		}
+		if (inst->streamAutoclaimIdleTime != 0) {
+			LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'stream.autoclaimIdleTime' "
+									"set with mode != stream : ignored.");
+		}
+		if (inst->streamConsumerACK == 0) {
+			LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'stream.consumerACK' "
+									"disabled with mode != stream : ignored.");
+		}
+		if (inst->fieldList.nmemb > 0) {
+			LogMsg(0, RS_RET_CONFIG_ERROR, LOG_WARNING,"imhiredis: 'fields' "
+									"unused for mode != stream : ignored.");
+		}
 	}
 
 	if (inst->password != NULL) {
@@ -355,6 +430,20 @@ CODESTARTnewInpInst
 			inst->redisNodesList->port = (int) pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "password")) {
 			inst->password = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "stream.consumerGroup")) {
+			inst->streamConsumerGroup = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "stream.consumerName")) {
+			inst->streamConsumerName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "stream.consumerACK")) {
+			inst->streamConsumerACK = pvals[i].val.d.n;
+		} else if(!strcmp(inppblk.descr[i].name, "stream.readFrom")) {
+			// inst->streamReadFrom is already allocated, only copy contents
+			memcpy(inst->streamReadFrom,
+				es_getBufAddr(pvals[i].val.d.estr),
+				es_strlen(pvals[i].val.d.estr));
+			inst->streamReadFrom[es_strlen(pvals[i].val.d.estr)] = '\0';
+		} else if(!strcmp(inppblk.descr[i].name, "stream.autoclaimIdleTime")) {
+			inst->streamAutoclaimIdleTime = pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "uselpop")) {
 			inst->useLPop = pvals[i].val.d.n;
 		} else if(!strcmp(inppblk.descr[i].name, "mode")) {
@@ -363,10 +452,43 @@ CODESTARTnewInpInst
 				inst->mode = IMHIREDIS_MODE_QUEUE;
 			} else if (!strcmp((const char*)inst->modeDescription, "subscribe")) {
 				inst->mode = IMHIREDIS_MODE_SUBSCRIBE;
+			} else if (!strcmp((const char*)inst->modeDescription, "stream")) {
+				inst->mode = IMHIREDIS_MODE_STREAM;
 			} else {
 				LogMsg(0, RS_RET_PARAM_ERROR, LOG_ERR, "imhiredis: unsupported mode "
 					"'%s'", inst->modeDescription);
 				ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+			}
+		} else if (!strcmp(inppblk.descr[i].name, "fields")) {
+			inst->fieldList.nmemb = pvals[i].val.d.ar->nmemb;
+			CHKmalloc(inst->fieldList.name = calloc(inst->fieldList.nmemb, sizeof(char *)));
+			CHKmalloc(inst->fieldList.varname = calloc(inst->fieldList.nmemb, sizeof(char *)));
+			for (int j = 0; j <  pvals[i].val.d.ar->nmemb; ++j) {
+				char *const param = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+				char *varname = NULL;
+				char *name;
+				if(*param == ':') {
+					char *b = strchr(param+1, ':');
+					if(b == NULL) {
+						LogMsg(0, RS_RET_PARAM_ERROR, LOG_ERR,
+							"imhiredis: missing closing colon: '%s'", param);
+						ABORT_FINALIZE(RS_RET_ERR);
+					}
+					*b = '\0'; /* split name & varname */
+					varname = param+1;
+					name = b+1;
+				} else {
+					name = param;
+				}
+				CHKmalloc(inst->fieldList.name[j] = strdup(name));
+				char vnamebuf[1024];
+				snprintf(vnamebuf, sizeof(vnamebuf),
+					"!%s", (varname == NULL) ? name : varname);
+				CHKmalloc(inst->fieldList.varname[j] = strdup(vnamebuf));
+				DBGPRINTF("will map '%s' to '%s'\n",
+						inst->fieldList.name[j],
+						inst->fieldList.varname[j]);
+				free(param);
 			}
 		} else if(!strcmp(inppblk.descr[i].name, "key")) {
 			inst->key = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
@@ -481,7 +603,20 @@ CODESTARTfreeCnf
 			free(inst->password);
 		free(inst->modeDescription);
 		free(inst->key);
+		if(inst->streamConsumerGroup != NULL)
+			free(inst->streamConsumerGroup);
+		if(inst->streamConsumerName != NULL)
+			free(inst->streamConsumerName);
+		free(inst->streamReadFrom);
 		free(inst->pszBindRuleset);
+		if(inst->fieldList.name != NULL) {
+			for(int i = 0 ; i < inst->fieldList.nmemb ; ++i) {
+				free(inst->fieldList.name[i]);
+				free(inst->fieldList.varname[i]);
+			}
+			free(inst->fieldList.name);
+			free(inst->fieldList.varname);
+		}
 		if(inst->conn != NULL) {
 			redisFree(inst->conn);
 			inst->conn = NULL;
@@ -759,6 +894,61 @@ redisReply *getRole(redisContext *c) {
 }
 
 
+static struct json_object* _redisParseIntegerReply(const redisReply *reply) {
+	return json_object_new_int64(reply->integer);
+}
+
+static struct json_object* _redisParseDoubleReply(const redisReply *reply) {
+	return json_object_new_double_s(reply->dval, reply->str);
+}
+
+static struct json_object* _redisParseStringReply(const redisReply *reply) {
+	return json_object_new_string_len(reply->str, reply->len);
+}
+
+static struct json_object* _redisParseArrayReply(const redisReply *reply) {
+	struct json_object *result = NULL;
+	struct json_object *res = NULL;
+	char *key = NULL;
+
+	result = json_object_new_object(); // the redis type name is ARRAY, but represents a dict
+
+	if (result != NULL) {
+		for(size_t i = 0; i < reply->elements; i++) {
+			if (reply->element[i]->type == REDIS_REPLY_STRING && i % 2 == 0) {
+				key = reply->element[i]->str;
+			} else {
+				switch(reply->element[i]->type) {
+					case REDIS_REPLY_INTEGER:
+						res = _redisParseIntegerReply(reply->element[i]);
+						json_object_object_add(result, key, res);
+						break;
+					case REDIS_REPLY_DOUBLE:
+						res = _redisParseDoubleReply(reply->element[i]);
+						json_object_object_add(result, key, res);
+						break;
+					case REDIS_REPLY_STRING:
+						res = _redisParseStringReply(reply->element[i]);
+						json_object_object_add(result, key, res);
+						break;
+					case REDIS_REPLY_ARRAY:
+						res = _redisParseArrayReply(reply->element[i]);
+						json_object_object_add(result, key, res);
+						break;
+					default:
+						DBGPRINTF("Unhandled case!\n");
+						LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
+							"Redis reply object contains an unhandled type!");
+						break;
+				}
+			}
+		}
+	}
+
+	return result;
+}
+
+
 /*
  *	enqueue the hiredis message. The provided string is
  *	not freed - this must be done by the caller.
@@ -781,6 +971,80 @@ static rsRetVal enqMsg(instanceConf_t *const inst, const char *message, size_t m
 	MsgSetRuleset(pMsg, inst->pBindRuleset);
 	MsgSetMSGoffs(pMsg, 0);	/* we do not have a header... */
 	CHKiRet(submitMsg2(pMsg));
+
+finalize_it:
+	RETiRet;
+}
+
+
+static rsRetVal enqMsgJson(instanceConf_t *const inst, struct json_object *json, struct json_object *metadata) {
+	DEFiRet;
+	smsg_t *pMsg;
+	struct json_object *tempJson = NULL;
+
+	assert(json != NULL);
+
+	CHKiRet(msgConstruct(&pMsg)); // In case of allocation error -> needs to break
+	MsgSetInputName(pMsg, pInputName);
+	MsgSetRuleset(pMsg, inst->pBindRuleset);
+	MsgSetMSGoffs(pMsg, 0);	/* we do not have a header... */
+	if(RS_RET_OK != MsgSetFlowControlType(pMsg, eFLOWCTL_LIGHT_DELAY))
+		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
+			"Could not set Flow Control on message.");
+	if(inst->fieldList.nmemb != 0) {
+		for (int i = 0; i < inst->fieldList.nmemb; i++)
+		{
+			DBGPRINTF("processing field '%s'\n", inst->fieldList.name[i]);
+
+			/* case 1: static field. We simply forward it */
+			if (inst->fieldList.name[i][0] != '!' && inst->fieldList.name[i][0] != '.')
+			{
+				DBGPRINTF("field is static, taking it as it is...\n");
+				tempJson = json_object_new_string(inst->fieldList.name[i]);
+			}
+			/* case 2: dynamic field. We retrieve its value from the JSON logline and add it */
+			else
+			{
+				DBGPRINTF("field is dynamic, searching in root object...\n");
+				if (!json_object_object_get_ex(json, inst->fieldList.name[i]+1, &tempJson)) {
+
+					DBGPRINTF("Did not find value %s in message\n", inst->fieldList.name[i]);
+					continue;
+				}
+				// Getting object as it will not keep the same lifetime as its origin object
+				tempJson = json_object_get(tempJson);
+				// original object is put: no need for it anymore
+				json_object_put(json);
+			}
+
+			DBGPRINTF("got value of field '%s'\n", inst->fieldList.name[i]);
+			DBGPRINTF("will insert to '%s'\n", inst->fieldList.varname[i]);
+
+			if(RS_RET_OK != msgAddJSON(pMsg, (uchar *)inst->fieldList.varname[i], tempJson, 0, 0)) {
+				LogMsg(0, RS_RET_OBJ_CREATION_FAILED, LOG_ERR,
+					"Failed to add value to '%s'", inst->fieldList.varname[i]);
+			}
+
+			tempJson = NULL;
+		}
+	} else {
+		if(RS_RET_OK != msgAddJSON(pMsg, (uchar*)"!", json, 0, 0)) {
+			LogMsg(0, RS_RET_OBJ_CREATION_FAILED, LOG_ERR,
+				"Failed to add json info to message!");
+			ABORT_FINALIZE(RS_RET_OBJ_CREATION_FAILED);
+		}
+	}
+	if (metadata != NULL && RS_RET_OK != msgAddJSON(pMsg, (uchar*)".", metadata, 0, 0)) {
+		LogMsg(0, RS_RET_OBJ_CREATION_FAILED, LOG_ERR,
+			"Failed to add metadata to message!");
+		ABORT_FINALIZE(RS_RET_OBJ_CREATION_FAILED);
+	}
+	if(RS_RET_OK != submitMsg2(pMsg)) {
+		LogMsg(0, RS_RET_OBJ_CREATION_FAILED, LOG_ERR,
+			"Failed to submit message to main queue!");
+		ABORT_FINALIZE(RS_RET_OBJ_CREATION_FAILED);
+	}
+	DBGPRINTF("enqMsgJson: message enqueued!\n");
 
 finalize_it:
 	RETiRet;
@@ -1316,6 +1580,475 @@ finalize_it:
 }
 
 
+rsRetVal ensureConsumerGroupCreated(instanceConf_t *inst) {
+	DEFiRet;
+	redisReply *reply = NULL;
+
+	DBGPRINTF("ensureConsumerGroupCreated: Creating group %s on stream %s\n", inst->streamConsumerGroup, inst->key);
+
+	reply = (redisReply *)redisCommand(inst->conn, "XGROUP CREATE %s %s %s MKSTREAM",
+				inst->key,
+				inst->streamConsumerGroup,
+				inst->streamReadFrom);
+	if(reply != NULL) {
+		switch(reply->type) {
+			case REDIS_REPLY_STATUS:
+			case REDIS_REPLY_STRING:
+				if(0 == strncmp("OK", reply->str, reply->len))
+					DBGPRINTF("ensureConsumerGroupCreated: Consumer group %s created successfully "
+						"for stream %s\n",
+						inst->streamConsumerGroup,
+						inst->key);
+				break;
+			case REDIS_REPLY_ERROR:
+				if(strcasestr(reply->str, "BUSYGROUP") != NULL) {
+					DBGPRINTF("ensureConsumerGroupCreated: Consumer group %s already exists for "
+						"stream %s, ignoring\n",
+						inst->streamConsumerGroup,
+						inst->key);
+				} else {
+					LogError(0, RS_RET_ERR, "ensureConsumerGroupCreated: An unknown error "
+						"occurred while creating a Consumer group %s on stream %s -> %s",
+						inst->streamConsumerGroup,
+						inst->key,
+						reply->str);
+					ABORT_FINALIZE(RS_RET_ERR);
+				}
+				break;
+			default:
+				LogError(0, RS_RET_ERR, "ensureConsumerGroupCreated: An unknown reply was received "
+							"-> %s", REDIS_REPLIES[(reply->type)%15]);
+				ABORT_FINALIZE(RS_RET_ERR);
+		}
+	} else {
+		LogError(0, RS_RET_REDIS_ERROR, "ensureConsumerGroupCreated: Could not create group %s on stream %s!",
+						inst->streamConsumerGroup,
+						inst->key);
+		ABORT_FINALIZE(RS_RET_REDIS_ERROR);
+	}
+
+finalize_it:
+	if(reply != NULL)
+		freeReplyObject(reply);
+	RETiRet;
+}
+
+
+rsRetVal ackStreamIndex(instanceConf_t *inst, uchar *stream, uchar *group, uchar *index) {
+	DEFiRet;
+	redisReply *reply = NULL;
+
+	DBGPRINTF("ackStream: Acknowledging index '%s' in stream %s\n", index, stream);
+
+	reply = (redisReply *)redisCommand(inst->conn, "XACK %s %s %s",
+				stream,
+				group,
+				index);
+	if(reply != NULL) {
+		switch(reply->type) {
+			case REDIS_REPLY_INTEGER:
+				if(reply->integer == 1) {
+					DBGPRINTF("ackStreamIndex: index successfully acknowledged "
+						"for stream %s\n",
+						inst->key);
+				} else {
+					DBGPRINTF("ackStreamIndex: message was not acknowledged "
+						"-> already done?");
+				}
+				break;
+			case REDIS_REPLY_ERROR:
+				LogError(0, RS_RET_ERR, "ackStreamIndex: An error occurred "
+					"while trying to ACK message %s on %s[%s] -> %s",
+					index,
+					stream,
+					group,
+					reply->str);
+				ABORT_FINALIZE(RS_RET_ERR);
+			default:
+				LogError(0, RS_RET_ERR, "ackStreamIndex: unexpected reply type: %s",
+							REDIS_REPLIES[(reply->type)%15]);
+				ABORT_FINALIZE(RS_RET_ERR);
+		}
+
+	} else {
+		LogError(0, RS_RET_REDIS_ERROR, "ackStreamIndex: Could not ACK message with index %s for %s[%s]!",
+						index,
+						stream,
+						group);
+		ABORT_FINALIZE(RS_RET_REDIS_ERROR);
+	}
+
+finalize_it:
+	if(reply != NULL) {
+		freeReplyObject(reply);
+	}
+	RETiRet;
+}
+
+
+static rsRetVal enqueueRedisStreamReply(instanceConf_t *const inst, redisReply *reply) {
+	DEFiRet;
+	struct json_object *json = NULL, *metadata = NULL, *redis = NULL;
+
+	json = _redisParseArrayReply(reply->element[1]);
+
+	CHKmalloc(metadata = json_object_new_object());
+	CHKmalloc(redis = json_object_new_object());
+	json_object_object_add(redis, "stream", json_object_new_string((char *)inst->key));
+	json_object_object_add(redis, "index", _redisParseStringReply(reply->element[0]));
+	if(inst->streamConsumerGroup != NULL) {
+		json_object_object_add(redis, "group", json_object_new_string((char *)inst->streamConsumerGroup));
+	}
+	if(inst->streamConsumerName != NULL) {
+		json_object_object_add(redis, "consumer", json_object_new_string((char *)inst->streamConsumerName));
+	}
+
+	// ownership of redis object allocated by json_object_new_object() is taken by json
+	// no need to free/destroy/put redis object
+	json_object_object_add(metadata, "redis", redis);
+
+	CHKiRet(enqMsgJson(inst, json, metadata));
+	// enqueued message successfully, json and metadata objects are now owned by enqueued message
+	// no need to free/destroy/put json objects
+	json = NULL;
+	metadata = NULL;
+
+	if(inst->streamConsumerGroup != NULL && inst->streamConsumerACK) {
+		CHKiRet(ackStreamIndex(
+			inst,
+			(uchar *)inst->key,
+			inst->streamConsumerGroup,
+			(uchar *)reply->element[0]->str
+		));
+	}
+
+finalize_it:
+	// If that happens, there was an error during one of the steps and the json object is not enqueued
+	if(json != NULL) json_object_put(json);
+	if(metadata != NULL) json_object_put(metadata);
+	RETiRet;
+}
+
+
+/*
+ *	handle the hiredis Stream XREAD/XREADGROUP return objects. The provided reply is
+ *	not freed - this must be done by the caller.
+ *	example of stream to parse:
+ *	  1) 1) "mystream"			<- name of the stream indexes are from (list of streams requested)
+ *	     2) 1) 1) "1681749395006-0"		<- list of indexes returned for stream
+ *	           2) 1) "key1"
+ *	              2) "value1"
+ *	        2) 1) "1681749409349-0"
+ *	           2) 1) "key2"
+ *	              2) "value2"
+ *	              3) "key2.2"
+ *	              4) "value2.2"
+ *	json equivalent:
+ *	  [
+ *	    "mystream": [
+ *	      {
+ *	        "1681749395006-0": {
+ *	          "key1": "value1"
+ *	        }
+ *	      },
+ *	      {
+ *	        "1681749409349-0": {
+ *	          "key2": "value2",
+ *	          "key2.2": "value2.2"
+ *	        }
+ *	      }
+ *	    ]
+ *	  ]
+ */
+static rsRetVal handleRedisXREADReply(instanceConf_t *const inst, const redisReply *reply) {
+	DEFiRet;
+	redisReply *streamObj = NULL, *msgList = NULL, *msgObj = NULL;
+
+	if(reply == NULL || reply->type != REDIS_REPLY_ARRAY) {
+		/* we do not process empty or non-ARRAY lines */
+		DBGPRINTF("handleRedisXREADReply: object is not an array, ignoring\n");
+		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXREADReply: object is not an array, ignoring");
+		ABORT_FINALIZE(RS_RET_OK_WARN);
+	} else {
+		// iterating on streams
+		for(size_t i = 0; i < reply->elements; i++) {
+			streamObj = reply->element[i];
+			// object should contain the name of the stream, and an array containing the messages
+			if(streamObj->type != REDIS_REPLY_ARRAY || streamObj->elements != 2) {
+				LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXREADReply: wrong object format, "
+				"object should contain the name of the stream and an array of messages");
+				ABORT_FINALIZE(RS_RET_OK_WARN);
+			}
+			if(streamObj->element[0]->type != REDIS_REPLY_STRING) {
+				LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXREADReply: wrong field format, "
+				"first entry is not a string (supposed to be stream name)");
+				ABORT_FINALIZE(RS_RET_OK_WARN);
+			}
+
+			msgList = streamObj->element[1];
+
+			if(msgList->type != REDIS_REPLY_ARRAY) {
+				LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXREADReply: wrong field format, "
+				"second entry is not an array (supposed to be list of messages for stream)");
+				ABORT_FINALIZE(RS_RET_OK_WARN);
+			}
+
+			DBGPRINTF("handleRedisXREADReply: enqueuing messages for stream '%s'\n",
+				streamObj->element[0]->str);
+
+			for(size_t j = 0; j < msgList->elements; j++) {
+				msgObj = msgList->element[j];
+				// Object should contain the name of the index, and its content(s)
+				if(msgObj->type != REDIS_REPLY_ARRAY || msgObj->elements != 2) {
+					LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXREADReply: wrong object "
+						"format, object should contain the index and its content(s)");
+					ABORT_FINALIZE(RS_RET_OK_WARN);
+				}
+				if(msgObj->element[0]->type != REDIS_REPLY_STRING) {
+					LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXREADReply: wrong field "
+						"format, first entry should be a string (index name)");
+					ABORT_FINALIZE(RS_RET_OK_WARN);
+				}
+
+				if(msgObj->type != REDIS_REPLY_ARRAY) {
+					LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXREADReply: wrong field "
+						"format, second entry should be an array (index content(s))");
+					ABORT_FINALIZE(RS_RET_OK_WARN);
+				}
+
+				CHKiRet(enqueueRedisStreamReply(inst, msgObj));
+
+				// Update current stream index
+				memcpy(inst->streamReadFrom, msgObj->element[0]->str, msgObj->element[0]->len);
+				inst->streamReadFrom[msgObj->element[0]->len] = '\0';
+				DBGPRINTF("handleRedisXREADReply: current stream index is %s\n", inst->streamReadFrom);
+			}
+		}
+	}
+
+	DBGPRINTF("handleRedisXREADReply: finished enqueuing!\n");
+finalize_it:
+	RETiRet;
+}
+
+
+/*
+ *	handle the hiredis Stream XAUTOCLAIM return object. The provided reply is
+ *	not freed - this must be done by the caller.
+ *	example of stream to parse:
+ *	  1) "1681904437564-0"		<- next index to use for XAUTOCLAIM
+ *	  2)  1) 1) "1681904437525-0"	<- list of indexes reclaimed
+ *	         2) 1) "toto"
+ *	            2) "tata"
+ *	      2) 1) "1681904437532-0"
+ *	         2) 1) "titi"
+ *	            2) "tutu"
+ *	  3) (empty)			<- indexes that no longer exist, were deleted from the PEL
+ *	json equivalent:
+ *	  "1681904437564-0": [
+ *	    {
+ *	      "1681904437525-0": {
+ *	        "toto": "tata"
+ *	      }
+ *	    },
+ *	    {
+ *	      "1681904437532-0": {
+ *	        "titi": "tutu"
+ *	      }
+ *	    }
+ *	  ]
+ */
+static rsRetVal handleRedisXAUTOCLAIMReply(
+		instanceConf_t *const inst,
+		const redisReply *reply,
+		char **autoclaimIndex) {
+	DEFiRet;
+	redisReply *msgList = NULL, *msgObj = NULL;
+
+	if(reply == NULL || reply->type != REDIS_REPLY_ARRAY) {
+		/* we do not process empty or non-ARRAY lines */
+		DBGPRINTF("handleRedisXAUTOCLAIMReply: object is not an array, ignoring\n");
+		FINALIZE;
+	} else {
+		// Object should contain between 2 and 3 elements (depends on Redis server version)
+		if(reply->elements < 2 || reply->elements > 3) {
+			LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXAUTOCLAIMReply: wrong number of fields, "
+								"cannot process entry");
+			ABORT_FINALIZE(RS_RET_OK_WARN);
+		}
+		if(reply->element[0]->type != REDIS_REPLY_STRING) {
+			LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXAUTOCLAIMReply: the first element "
+								"is not a string, cannot process entry");
+			ABORT_FINALIZE(RS_RET_OK_WARN);
+		}
+
+		msgList = reply->element[1];
+
+		if(msgList->type != REDIS_REPLY_ARRAY) {
+			LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXAUTOCLAIMReply: the second element "
+								"is not an array, cannot process entry");
+			ABORT_FINALIZE(RS_RET_OK_WARN);
+		}
+
+		DBGPRINTF("handleRedisXAUTOCLAIMReply: re-claiming messages for stream '%s'\n", inst->key);
+
+		for(size_t j = 0; j < msgList->elements; j++) {
+			msgObj = msgList->element[j];
+			// Object should contain the name of the index, and its content(s)
+			if(msgObj->type != REDIS_REPLY_ARRAY || msgObj->elements != 2) {
+				LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXAUTOCLAIMReply: wrong message "
+									"format, cannot process");
+				ABORT_FINALIZE(RS_RET_OK_WARN);
+			}
+			if(msgObj->element[0]->type != REDIS_REPLY_STRING) {
+				LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXAUTOCLAIMReply: first message "
+									"element not a string, cannot process");
+				ABORT_FINALIZE(RS_RET_OK_WARN);
+			}
+
+			if(msgObj->type != REDIS_REPLY_ARRAY) {
+				LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "handleRedisXAUTOCLAIMReply: second message "
+									"element not an array, cannot process");
+				ABORT_FINALIZE(RS_RET_OK_WARN);
+			}
+
+			CHKiRet(enqueueRedisStreamReply(inst, msgObj));
+		}
+
+		// Update current stream index with next index from XAUTOCLAIM
+		// No message has to be claimed after that if value is "0-0"
+		memcpy(*autoclaimIndex, reply->element[0]->str, reply->element[0]->len);
+		(*autoclaimIndex)[reply->element[0]->len] = '\0';
+		DBGPRINTF("handleRedisXAUTOCLAIMReply: next stream index is %s\n", (*autoclaimIndex));
+	}
+
+	DBGPRINTF("handleRedisXAUTOCLAIMReply: finished re-claiming!\n");
+finalize_it:
+	RETiRet;
+}
+
+
+/*
+ *	Read Redis stream
+ */
+rsRetVal redisStreamRead(instanceConf_t *inst) {
+	DEFiRet;
+	redisReply *reply = NULL;
+	uint replyType = 0;
+	sbool mustClaimIdle = 0;
+	char *autoclaimIndex = NULL;
+
+	assert(inst != NULL);
+
+	// Ensure stream group is created before reading from it
+	if(inst->streamConsumerGroup != NULL) {
+		CHKiRet(ensureConsumerGroupCreated(inst));
+	}
+
+
+	if(inst->streamAutoclaimIdleTime != 0) {
+		DBGPRINTF("redisStreamRead: getting pending entries for stream '%s' from '%s', with idle time %d\n",
+			inst->key, inst->streamReadFrom, inst->streamAutoclaimIdleTime);
+		CHKmalloc(autoclaimIndex = calloc(1, STREAM_INDEX_STR_MAXLEN));
+		// Cannot claim from '$', will have to claim from the beginning of the stream
+		if(inst->streamReadFrom[0] == '$') {
+			LogMsg(0, RS_RET_OK, LOG_WARNING, "Cannot claim pending entries from '$', "
+				"will have to claim from the beginning of the stream");
+			memcpy(autoclaimIndex, "0-0", 4);
+		} else {
+			memcpy(autoclaimIndex, inst->streamReadFrom, STREAM_INDEX_STR_MAXLEN);
+		}
+		mustClaimIdle = 1;
+	} else {
+		DBGPRINTF("redisStreamRead: beginning to read stream '%s' from '%s'\n",
+			inst->key, inst->streamReadFrom);
+	}
+
+	do {
+		if(inst->streamConsumerGroup == NULL) {
+			reply = (redisReply *)redisCommand(inst->conn, "XREAD COUNT %d BLOCK %d STREAMS %s %s",
+						BATCH_SIZE,
+						WAIT_TIME_MS,
+						inst->key,
+						inst->streamReadFrom);
+		} else {
+			if(mustClaimIdle) {
+				reply = (redisReply *)redisCommand(inst->conn,
+							"XAUTOCLAIM %s %s %s %d %s COUNT %d",
+							inst->key,
+							inst->streamConsumerGroup,
+							inst->streamConsumerName,
+							inst->streamAutoclaimIdleTime,
+							autoclaimIndex,
+							BATCH_SIZE);
+			} else {
+
+				reply = (redisReply *)redisCommand(inst->conn,
+							"XREADGROUP GROUP %s %s COUNT %d BLOCK %d STREAMS %s >",
+							inst->streamConsumerGroup,
+							inst->streamConsumerName,
+							BATCH_SIZE,
+							WAIT_TIME_MS,
+							inst->key);
+			}
+		}
+		if(reply == NULL) {
+			LogError(0, RS_RET_REDIS_ERROR, "redisStreamRead: Error while trying to read stream '%s'",
+							inst->key);
+			ABORT_FINALIZE(RS_RET_REDIS_ERROR);
+		}
+
+		replyType = reply->type;
+		switch(replyType) {
+			case REDIS_REPLY_ARRAY:
+				DBGPRINTF("reply is an array, proceeding...\n");
+				if(mustClaimIdle) {
+					CHKiRet(handleRedisXAUTOCLAIMReply(inst, reply, &autoclaimIndex));
+					if(!strncmp(autoclaimIndex, "0-0", 4)) {
+						DBGPRINTF("redisStreamRead: Caught up with pending messages, "
+							"getting back to regular reads\n");
+						mustClaimIdle = 0;
+					}
+				} else {
+					CHKiRet(handleRedisXREADReply(inst, reply));
+				}
+				break;
+			case REDIS_REPLY_NIL:
+				// replies are dequeued but are empty = end of list
+				if(mustClaimIdle) mustClaimIdle = 0;
+				break;
+			case REDIS_REPLY_ERROR:
+				// There is a problem with the key or the Redis instance
+				LogMsg(0, RS_RET_REDIS_ERROR, LOG_ERR, "redisStreamRead: error "
+				"while reading stream(s) -> %s", reply->str);
+				srSleep(1, 0);
+				ABORT_FINALIZE(RS_RET_REDIS_ERROR);
+			default:
+				LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "redisStreamRead: unexpected "
+				"reply type: %s", REDIS_REPLIES[replyType%15]);
+		}
+		freeReplyObject(reply);
+		reply = NULL;
+
+	// while input can run, continue with a new batch
+	} while (glbl.GetGlobalInputTermState() == 0);
+
+	DBGPRINTF("redisStreamRead: finished to dequeue key '%s'\n", inst->key);
+
+finalize_it:
+	if(reply != NULL)
+		freeReplyObject(reply);
+	if(inst->conn != NULL) {
+		redisFree(inst->conn);
+		inst->conn = NULL;
+		inst->currentNode = NULL;
+	}
+	if(autoclaimIndex != NULL)
+		free(autoclaimIndex);
+	RETiRet;
+}
+
+
 /*
  *	Subscribe to Redis channel
  */
@@ -1414,6 +2147,11 @@ imhirediswrkr(void *myself)
 		me->fnConnectMaster = connectMasterSync;
 		me->fnIsConnected = isConnectedSync;
 		me->fnRun = redisDequeue;
+	}
+	else if (me->inst->mode == IMHIREDIS_MODE_STREAM) {
+		me->fnConnectMaster = connectMasterSync;
+		me->fnIsConnected = isConnectedSync;
+		me->fnRun = redisStreamRead;
 	}
 	else if (me->inst->mode == IMHIREDIS_MODE_SUBSCRIBE) {
 		me->fnConnectMaster = connectMasterAsync;

--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -30,6 +30,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <time.h>
+#include <math.h>
 #include <hiredis/hiredis.h>
 
 #include "rsyslog.h"
@@ -53,6 +54,7 @@ DEF_OMOD_STATIC_DATA
 #define OMHIREDIS_MODE_QUEUE 1
 #define OMHIREDIS_MODE_PUBLISH 2
 #define OMHIREDIS_MODE_SET 3
+#define OMHIREDIS_MODE_STREAM 4
 
 /* our instance data.
  * this will be accessable
@@ -64,10 +66,34 @@ typedef struct _instanceData {
 	uchar *tplName; /* template name */
 	char *modeDescription; /* mode description */
 	int mode; /* mode constant */
-	uchar *key; /* key for QUEUE and PUBLISH modes */
+	uchar *key; /* key for QUEUE, PUBLISH and STREAM modes */
+	uchar *streamKeyAck; /* key name for STREAM ACKs (when enabled) */
+	uchar *streamGroupAck; /* group name for STREAM ACKs (when enabled) */
+	uchar *streamIndexAck; /* index name for STREAM ACKs (when enabled) */
 	int expiration; /* expiration value for SET/SETEX mode */
 	sbool dynaKey; /* Should we treat the key as a template? */
+	sbool streamDynaKeyAck; /* Should we treat the groupAck as a template? */
+	sbool streamDynaGroupAck; /* Should we treat the groupAck as a template? */
+	sbool streamDynaIndexAck; /* Should we treat the IndexAck as a template? */
 	sbool useRPush; /* Should we use RPUSH instead of LPUSH? */
+	uchar *streamOutField; /* Field to place message into (for stream insertions only) */
+	uint streamCapacityLimit; /* zero means stream is not capped (default)
+				setting a non-zero value ultimately activates the approximate MAXLEN option '~'
+				(see Redis XADD docs)*/
+	sbool streamAck; /* Should the module send an XACK for each inserted message?
+				This feature requires that 3 infos are present in the '$.' object of the log:
+				- $.redis!stream
+				- $.redis!group
+				- $.redis!index
+				Those 3 infos can either be provided through usage of imhiredis
+				or set manually with Rainerscript */
+	sbool streamDel; /* Should the module send an XDEL for each inserted message?
+				This feature requires that 2 infos are present in the '$.' object of the log:
+				- $.redis!stream
+				- $.redis!index
+				Those 2 infos can either be provided through usage of imhiredis
+				or set manually with Rainerscript */
+
 } instanceData;
 
 typedef struct wrkrInstanceData {
@@ -86,6 +112,16 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "expiration", eCmdHdlrInt, 0 },
 	{ "dynakey", eCmdHdlrBinary, 0 },
 	{ "userpush", eCmdHdlrBinary, 0 },
+	{ "stream.outField", eCmdHdlrGetWord, 0 },
+	{ "stream.capacityLimit", eCmdHdlrNonNegInt, 0 },
+	{ "stream.ack", eCmdHdlrBinary, 0 },
+	{ "stream.del", eCmdHdlrBinary, 0 },
+	{ "stream.keyAck", eCmdHdlrGetWord, 0 },
+	{ "stream.groupAck", eCmdHdlrGetWord, 0 },
+	{ "stream.indexAck", eCmdHdlrGetWord, 0 },
+	{ "stream.dynaKeyAck", eCmdHdlrBinary, 0 },
+	{ "stream.dynaGroupAck", eCmdHdlrBinary, 0 },
+	{ "stream.dynaIndexAck", eCmdHdlrBinary, 0 },
 };
 
 static struct cnfparamblk actpblk = {
@@ -127,6 +163,11 @@ CODESTARTfreeInstance
 	free(pData->key);
 	free(pData->modeDescription);
 	free(pData->serverpassword);
+	free(pData->tplName);
+	free(pData->streamKeyAck);
+	free(pData->streamGroupAck);
+	free(pData->streamIndexAck);
+	free(pData->streamOutField);
 ENDfreeInstance
 
 BEGINfreeWrkrInstance
@@ -150,7 +191,7 @@ static rsRetVal initHiredis(wrkrInstanceData_t *pWrkrData, int bSilent)
 			(char*) pWrkrData->pData->server;
 	DBGPRINTF("omhiredis: trying connect to '%s' at port %d\n", server,
 			pWrkrData->pData->port);
-	
+
 	struct timeval timeout = { 1, 500000 }; /* 1.5 seconds */
 	pWrkrData->conn = redisConnectWithTimeout(server, pWrkrData->pData->port,
 			timeout);
@@ -257,6 +298,20 @@ static rsRetVal writeHiredis(uchar* key, uchar *message, wrkrInstanceData_t *pWr
 				rc = REDIS_ERR;
 			}
 			break;
+		case OMHIREDIS_MODE_STREAM:
+			if (pWrkrData->pData->streamCapacityLimit != 0) {
+				rc = redisAppendCommand(pWrkrData->conn, "XADD %s MAXLEN ~ %d * %s %s",
+								key,
+								pWrkrData->pData->streamCapacityLimit,
+								pWrkrData->pData->streamOutField,
+								message);
+			} else {
+				rc = redisAppendCommand(pWrkrData->conn, "XADD %s * %s %s",
+								key,
+								pWrkrData->pData->streamOutField,
+								message);
+			}
+			break;
 		default:
 			dbgprintf("omhiredis: mode %d is invalid something is really wrong\n",
 				pWrkrData->pData->mode);
@@ -273,6 +328,36 @@ static rsRetVal writeHiredis(uchar* key, uchar *message, wrkrInstanceData_t *pWr
 
 finalize_it:
 	free(formattedMsg);
+	RETiRet;
+}
+
+static rsRetVal ackHiredisStreamIndex(wrkrInstanceData_t *pWrkrData, uchar *key, uchar *group, uchar *index) {
+	DEFiRet;
+
+	if (REDIS_ERR == redisAppendCommand(pWrkrData->conn, "XACK %s %s %s", key, group, index)) {
+		LogError(0, NO_ERRCODE, "omhiredis: %s", pWrkrData->conn->errstr);
+		DBGPRINTF("omhiredis: %s\n", pWrkrData->conn->errstr);
+		ABORT_FINALIZE(RS_RET_ERR);
+	} else {
+		pWrkrData->count++;
+	}
+
+finalize_it:
+	RETiRet;
+}
+
+static rsRetVal delHiredisStreamIndex(wrkrInstanceData_t *pWrkrData, uchar *key, uchar *index) {
+	DEFiRet;
+
+	if (REDIS_ERR == redisAppendCommand(pWrkrData->conn, "XDEL %s %s", key, index)) {
+		LogError(0, NO_ERRCODE, "omhiredis: %s", pWrkrData->conn->errstr);
+		DBGPRINTF("omhiredis: %s\n", pWrkrData->conn->errstr);
+		ABORT_FINALIZE(RS_RET_ERR);
+	} else {
+		pWrkrData->count++;
+	}
+
+finalize_it:
 	RETiRet;
 }
 
@@ -303,13 +388,25 @@ ENDbeginTransaction
  * which appends it as a command to the
  * current pipeline */
 BEGINdoAction
+	uchar *message, *key, *keyNameAck, *groupNameAck, *IndexNameAck;
+	int inputIndex = 0;
 CODESTARTdoAction
-	if(pWrkrData->pData->dynaKey) {
-		CHKiRet(writeHiredis(ppString[1], ppString[0], pWrkrData));
+	// Don't change the order of conditions/assignations here without changing the end of the newActInst function!
+	message = ppString[inputIndex++];
+	key = pWrkrData->pData->dynaKey ? ppString[inputIndex++] : pWrkrData->pData->key;
+	keyNameAck = pWrkrData->pData->streamDynaKeyAck ? ppString[inputIndex++] : pWrkrData->pData->streamKeyAck;
+	groupNameAck = pWrkrData->pData->streamDynaGroupAck ? ppString[inputIndex++] : pWrkrData->pData->streamGroupAck;
+	IndexNameAck = pWrkrData->pData->streamDynaIndexAck ? ppString[inputIndex++] : pWrkrData->pData->streamIndexAck;
+
+	CHKiRet(writeHiredis(key, message, pWrkrData));
+
+	if(pWrkrData->pData->streamAck) {
+		CHKiRet(ackHiredisStreamIndex(pWrkrData, keyNameAck, groupNameAck, IndexNameAck));
 	}
-	else {
-		CHKiRet(writeHiredis(pWrkrData->pData->key, ppString[0], pWrkrData));
+	if(pWrkrData->pData->streamDel) {
+		CHKiRet(delHiredisStreamIndex(pWrkrData, keyNameAck, IndexNameAck));
 	}
+
 	iRet = RS_RET_DEFER_COMMIT;
 finalize_it:
 ENDdoAction
@@ -361,7 +458,18 @@ setInstParamDefaults(instanceData *pData)
 	pData->expiration = 0;
 	pData->modeDescription = NULL;
 	pData->key = NULL;
+	pData->dynaKey = 0;
 	pData->useRPush = 0;
+	pData->streamOutField = NULL;
+	pData->streamKeyAck = NULL;
+	pData->streamDynaKeyAck = 0;
+	pData->streamGroupAck = NULL;
+	pData->streamDynaGroupAck = 0;
+	pData->streamIndexAck = NULL;
+	pData->streamDynaIndexAck = 0;
+	pData->streamCapacityLimit = 0;
+	pData->streamAck = 0;
+	pData->streamDel = 0;
 }
 
 /* here is where the work to set up a new instance
@@ -372,7 +480,7 @@ BEGINnewActInst
 	struct cnfparamvals *pvals;
 	int i;
 	int iNumTpls;
-	uchar *keydup = NULL;
+	uchar *strDup = NULL;
 CODESTARTnewActInst
 	if((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL)
 		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -383,7 +491,7 @@ CODESTARTnewActInst
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
-	
+
 		if(!strcmp(actpblk.descr[i].name, "server")) {
 			pData->server = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "serverport")) {
@@ -396,6 +504,26 @@ CODESTARTnewActInst
 			pData->dynaKey = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "userpush")) {
 			pData->useRPush = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "stream.outField")) {
+			pData->streamOutField = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "stream.keyAck")) {
+			pData->streamKeyAck = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "stream.dynaKeyAck")) {
+			pData->streamDynaKeyAck = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "stream.groupAck")) {
+			pData->streamGroupAck = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "stream.dynaGroupAck")) {
+			pData->streamDynaGroupAck = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "stream.indexAck")) {
+			pData->streamIndexAck = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "stream.dynaIndexAck")) {
+			pData->streamDynaIndexAck = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "stream.capacityLimit")) {
+			pData->streamCapacityLimit = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "stream.ack")) {
+			pData->streamAck = pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "stream.del")) {
+			pData->streamDel = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "mode")) {
 			pData->modeDescription = es_str2cstr(pvals[i].val.d.estr, NULL);
 			if (!strcmp(pData->modeDescription, "template")) {
@@ -406,6 +534,8 @@ CODESTARTnewActInst
 				pData->mode = OMHIREDIS_MODE_PUBLISH;
 			} else if (!strcmp(pData->modeDescription, "set")) {
 				pData->mode = OMHIREDIS_MODE_SET;
+			} else if (!strcmp(pData->modeDescription, "stream")) {
+				pData->mode = OMHIREDIS_MODE_STREAM;
 			} else {
 				dbgprintf("omhiredis: unsupported mode %s\n", actpblk.descr[i].name);
 				ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -428,51 +558,167 @@ CODESTARTnewActInst
 		pData->mode = OMHIREDIS_MODE_TEMPLATE;
 	}
 
-	/* check config sanity for selected mode */
-	switch(pData->mode) {
-		case OMHIREDIS_MODE_QUEUE:
-		case OMHIREDIS_MODE_PUBLISH:
-		case OMHIREDIS_MODE_SET:
-			if (pData->key == NULL) {
-				dbgprintf("omhiredis: mode %s requires a key\n", pData->modeDescription);
-				ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
-			}
-			if (pData->tplName == NULL) {
-				dbgprintf("omhiredis: using default RSYSLOG_ForwardFormat template\n");
-				CHKmalloc(pData->tplName = ustrdup("RSYSLOG_ForwardFormat"));
-			}
-			if (pData->expiration && pData->mode != OMHIREDIS_MODE_SET) {
-				LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: expiration set but mode is not "\
-				"'set', expiration will be ignored");
-			}
-			break;
-		case OMHIREDIS_MODE_TEMPLATE:
-			if (pData->tplName == NULL) {
-				dbgprintf("omhiredis: selected mode requires template\n");
-				ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
-			}
-			break;
+	if (pData->mode == OMHIREDIS_MODE_STREAM && !pData->streamOutField) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: no stream.outField set, "\
+					"using 'msg' as default");
+		pData->streamOutField = ustrdup("msg");
 	}
-	
+
+	if (pData->tplName == NULL) {
+		if(pData->mode == OMHIREDIS_MODE_TEMPLATE) {
+			LogError(0, RS_RET_CONF_PARSE_ERROR, "omhiredis: selected mode requires a template");
+			ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+		} else {
+			CHKmalloc(pData->tplName = ustrdup("RSYSLOG_ForwardFormat"));
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: no template set, "\
+					"using RSYSLOG_ForwardFormat as default");
+		}
+	}
+
+	if (pData->mode != OMHIREDIS_MODE_TEMPLATE && pData->key == NULL) {
+
+		LogError(0, RS_RET_CONF_PARSE_ERROR,
+			"omhiredis: mode %s requires a key", pData->modeDescription);
+		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+	}
+
+	if (pData->expiration && pData->mode != OMHIREDIS_MODE_SET) {
+		LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: expiration set but mode is not "\
+		"'set', expiration will be ignored");
+	}
+
+	if (pData->mode != OMHIREDIS_MODE_STREAM) {
+		if (pData->streamOutField) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.outField set "\
+			"but mode is not 'stream', field will be ignored");
+		}
+		if (pData->streamAck) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.ack set "\
+			"but mode is not 'stream', XACK will be ignored");
+		}
+		if (pData->streamDel) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.del set "\
+			"but mode is not 'stream', XDEL will be ignored");
+		}
+		if (pData->streamCapacityLimit) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.capacityLimit set "\
+			"but mode is not 'stream', stream trimming will be ignored");
+		}
+		if (pData->streamKeyAck) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.keyAck set "\
+			"but mode is not 'stream', parameter will be ignored");
+		}
+		if (pData->streamDynaKeyAck) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.dynaKeyAck set "\
+			"but mode is not 'stream', parameter will be ignored");
+		}
+		if (pData->streamGroupAck) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.groupAck set "\
+			"but mode is not 'stream', parameter will be ignored");
+		}
+		if (pData->streamDynaGroupAck) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.dynaGroupAck set "\
+			"but mode is not 'stream', parameter will be ignored");
+		}
+		if (pData->streamIndexAck) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.indexAck set "\
+			"but mode is not 'stream', parameter will be ignored");
+		}
+		if (pData->streamDynaIndexAck) {
+			LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: stream.dynaIndexAck set "\
+			"but mode is not 'stream', parameter will be ignored");
+		}
+	} else {
+		if(pData->streamAck) {
+			if(!pData->streamKeyAck || !pData->streamGroupAck || !pData->streamIndexAck) {
+				LogError(0, RS_RET_CONF_PARSE_ERROR,
+					"omhiredis: 'stream.ack' is set but one of "\
+					"'stream.keyAck', 'stream.groupAck' or 'stream.indexAck' is missing");
+				ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+			}
+		}
+		if(pData->streamDel) {
+			if(!pData->streamKeyAck || !pData->streamIndexAck) {
+				LogError(0, RS_RET_CONF_PARSE_ERROR,
+					"omhiredis: 'stream.del' is set but one of "\
+					"'stream.keyAck' or 'stream.indexAck' is missing");
+				ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+			}
+		}
+	}
+
+	if (pData->streamDynaKeyAck && pData->streamKeyAck == NULL) {
+		LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: 'stream.dynaKeyAck' set "\
+				"but 'stream.keyAck' is empty, disabling");
+		pData->streamDynaKeyAck = 0;
+	}
+	if (pData->streamDynaGroupAck && pData->streamGroupAck == NULL) {
+		LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: 'stream.dynaGroupAck' set "\
+				"but 'stream.groupAck' is empty, disabling");
+		pData->streamDynaGroupAck = 0;
+	}
+	if (pData->streamDynaIndexAck && pData->streamIndexAck == NULL) {
+		LogError(0, RS_RET_CONF_PARSE_WARNING, "omhiredis: 'stream.dynaGroupAck' set "\
+				"but 'stream.indexAck' is empty, disabling");
+		pData->streamDynaIndexAck = 0;
+	}
+
 	iNumTpls = 1;
 
 	if (pData->dynaKey) {
 		assert(pData->key != NULL);
-		iNumTpls = 2;
+		iNumTpls += 1;
+	}
+	if (pData->streamDynaKeyAck) {
+		assert(pData->streamKeyAck != NULL);
+		iNumTpls += 1;
+	}
+	if (pData->streamDynaGroupAck) {
+		assert(pData->streamGroupAck != NULL);
+		iNumTpls += 1;
+	}
+	if (pData->streamDynaIndexAck) {
+		assert(pData->streamIndexAck != NULL);
+		iNumTpls += 1;
 	}
 	CODE_STD_STRING_REQUESTnewActInst(iNumTpls);
 
-	CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar*)pData->tplName, OMSR_NO_RQD_TPL_OPTS));
+	/* Insert templates in opposite order (keep in sync with doAction), order will be
+	 * - tplName
+	 * - key
+	 * - streamKeyAck
+	 * - streamGroupAck
+	 * - streamIndexAck
+	 */
+	if (pData->streamDynaIndexAck) {
+		CHKmalloc(strDup = ustrdup(pData->streamIndexAck));
+		CHKiRet(OMSRsetEntry(*ppOMSR, --iNumTpls, strDup, OMSR_NO_RQD_TPL_OPTS));
+		strDup = NULL; /* handed over */
+	}
+
+	if (pData->streamDynaGroupAck) {
+		CHKmalloc(strDup = ustrdup(pData->streamGroupAck));
+		CHKiRet(OMSRsetEntry(*ppOMSR, --iNumTpls, strDup, OMSR_NO_RQD_TPL_OPTS));
+		strDup = NULL; /* handed over */
+	}
+
+	if (pData->streamDynaKeyAck) {
+		CHKmalloc(strDup = ustrdup(pData->streamKeyAck));
+		CHKiRet(OMSRsetEntry(*ppOMSR, --iNumTpls, strDup, OMSR_NO_RQD_TPL_OPTS));
+		strDup = NULL; /* handed over */
+	}
 
 	if (pData->dynaKey) {
-		CHKmalloc(keydup = ustrdup(pData->key));
-		CHKiRet(OMSRsetEntry(*ppOMSR, 1, ustrdup(pData->key), OMSR_NO_RQD_TPL_OPTS));
-		keydup = NULL; /* handed over */
+		CHKmalloc(strDup = ustrdup(pData->key));
+		CHKiRet(OMSRsetEntry(*ppOMSR, --iNumTpls, strDup, OMSR_NO_RQD_TPL_OPTS));
+		strDup = NULL; /* handed over */
 	}
+
+	CHKiRet(OMSRsetEntry(*ppOMSR, --iNumTpls, ustrdup(pData->tplName), OMSR_NO_RQD_TPL_OPTS));
 
 CODE_STD_FINALIZERnewActInst
 	cnfparamvalsDestruct(pvals, &actpblk);
-	free(keydup);
+	free(strDup);
 ENDnewActInst
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1046,14 +1046,24 @@ TESTS +=  \
 	imhiredis-queue-lpop.sh \
 	imhiredis-redis-restart.sh \
 	imhiredis-redis-start-after.sh \
-	imhiredis-subscribe.sh
+	imhiredis-subscribe.sh \
+	imhiredis-stream.sh \
+	imhiredis-stream-from-beginning.sh \
+	imhiredis-stream-consumerGroup-ack.sh \
+	imhiredis-stream-consumerGroup-noack.sh \
+	imhiredis-stream-consumerGroup-reclaim.sh
 if HAVE_VALGRIND
 TESTS += \
 	imhiredis-queue-vg.sh \
 	imhiredis-queue-lpop-vg.sh \
 	imhiredis-redis-restart-vg.sh \
 	imhiredis-redis-start-after-vg.sh \
-	imhiredis-subscribe-vg.sh
+	imhiredis-subscribe-vg.sh \
+	imhiredis-stream-vg.sh \
+	imhiredis-stream-from-beginning-vg.sh \
+	imhiredis-stream-consumerGroup-ack-vg.sh \
+	imhiredis-stream-consumerGroup-noack-vg.sh \
+	imhiredis-stream-consumerGroup-reclaim-vg.sh
 endif # HAVE_VALGRIND
 endif # ENABLE_REDIS_TESTS
 
@@ -2036,7 +2046,17 @@ EXTRA_DIST= \
 	imhiredis-redis-start-after.sh \
 	imhiredis-redis-start-after-vg.sh \
 	imhiredis-subscribe.sh \
-	imhiredis-subscribe-vg.sh
+	imhiredis-subscribe-vg.sh \
+	imhiredis-stream.sh \
+	imhiredis-stream-vg.sh \
+	imhiredis-stream-from-beginning.sh \
+	imhiredis-stream-from-beginning-vg.sh \
+	imhiredis-stream-consumerGroup-ack.sh \
+	imhiredis-stream-consumerGroup-ack-vg.sh \
+	imhiredis-stream-consumerGroup-noack.sh \
+	imhiredis-stream-consumerGroup-noack-vg.sh \
+	imhiredis-stream-consumerGroup-reclaim.sh \
+	imhiredis-stream-consumerGroup-reclaim-vg.sh \
 	msgvar-concurrency.sh \
 	msgvar-concurrency-array.sh \
 	testsuites/msgvar-concurrency-array.rulebase \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1040,7 +1040,7 @@ endif # HAVE_VALGRIND
 endif # ENABLE_OMRABBITMQ
 
 if ENABLE_REDIS_TESTS
-
+if ENABLE_IMHIREDIS
 TESTS +=  \
 	imhiredis-queue.sh \
 	imhiredis-queue-lpop.sh \
@@ -1065,6 +1065,34 @@ TESTS += \
 	imhiredis-stream-consumerGroup-noack-vg.sh \
 	imhiredis-stream-consumerGroup-reclaim-vg.sh
 endif # HAVE_VALGRIND
+endif # ENABLE_IMHIREDIS
+
+if ENABLE_OMHIREDIS
+TESTS +=  \
+	mmdb-reload.sh \
+	omhiredis-dynakey.sh \
+	omhiredis-publish.sh \
+	omhiredis-queue-rpush.sh \
+	omhiredis-queue.sh \
+	omhiredis-set.sh \
+	omhiredis-setex.sh \
+	omhiredis-template.sh \
+	omhiredis-withpass.sh \
+	omhiredis-wrongpass.sh \
+if HAVE_VALGRIND
+TESTS += \
+	mmdb-reload-vg.sh \
+	omhiredis-dynakey-vg.sh \
+	omhiredis-publish-vg.sh \
+	omhiredis-queue-rpush-vg.sh \
+	omhiredis-queue-vg.sh \
+	omhiredis-set-vg.sh \
+	omhiredis-setex-vg.sh \
+	omhiredis-template-vg.sh \
+	omhiredis-withpass-vg.sh \
+	omhiredis-wrongpass-vg.sh \
+endif # HAVE_VALGRIND
+endif # ENABLE_OMHIREDIS
 endif # ENABLE_REDIS_TESTS
 
 if ENABLE_IMPSTATS

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1039,6 +1039,24 @@ TESTS += \
 endif # HAVE_VALGRIND
 endif # ENABLE_OMRABBITMQ
 
+if ENABLE_REDIS_TESTS
+
+TESTS +=  \
+	imhiredis-queue.sh \
+	imhiredis-queue-lpop.sh \
+	imhiredis-redis-restart.sh \
+	imhiredis-redis-start-after.sh \
+	imhiredis-subscribe.sh
+if HAVE_VALGRIND
+TESTS += \
+	imhiredis-queue-vg.sh \
+	imhiredis-queue-lpop-vg.sh \
+	imhiredis-redis-restart-vg.sh \
+	imhiredis-redis-start-after-vg.sh \
+	imhiredis-subscribe-vg.sh
+endif # HAVE_VALGRIND
+endif # ENABLE_REDIS_TESTS
+
 if ENABLE_IMPSTATS
 TESTS +=  \
 	impstats-hup.sh \
@@ -2009,6 +2027,16 @@ EXTRA_DIST= \
 	omrabbitmq_error_server3.sh \
 	omrabbitmq_json.sh \
 	omrabbitmq_raw.sh \
+	imhiredis-queue.sh \
+	imhiredis-queue-vg.sh \
+	imhiredis-queue-lpop.sh \
+	imhiredis-queue-lpop-vg.sh \
+	imhiredis-redis-restart.sh \
+	imhiredis-redis-restart-vg.sh \
+	imhiredis-redis-start-after.sh \
+	imhiredis-redis-start-after-vg.sh \
+	imhiredis-subscribe.sh \
+	imhiredis-subscribe-vg.sh
 	msgvar-concurrency.sh \
 	msgvar-concurrency-array.sh \
 	testsuites/msgvar-concurrency-array.rulebase \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1079,6 +1079,12 @@ TESTS +=  \
 	omhiredis-template.sh \
 	omhiredis-withpass.sh \
 	omhiredis-wrongpass.sh \
+	omhiredis-stream-ack.sh \
+	omhiredis-stream-capped.sh \
+	omhiredis-stream-del.sh \
+	omhiredis-stream-dynack.sh \
+	omhiredis-stream-outfield.sh \
+	omhiredis-stream.sh
 if HAVE_VALGRIND
 TESTS += \
 	mmdb-reload-vg.sh \
@@ -1091,6 +1097,12 @@ TESTS += \
 	omhiredis-template-vg.sh \
 	omhiredis-withpass-vg.sh \
 	omhiredis-wrongpass-vg.sh \
+	omhiredis-stream-ack-vg.sh \
+	omhiredis-stream-capped-vg.sh \
+	omhiredis-stream-del-vg.sh \
+	omhiredis-stream-dynack-vg.sh \
+	omhiredis-stream-outfield-vg.sh \
+	omhiredis-stream-vg.sh
 endif # HAVE_VALGRIND
 endif # ENABLE_OMHIREDIS
 endif # ENABLE_REDIS_TESTS

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1316,6 +1316,11 @@ error_exit() {
 	# Extended Exit handling for kafka / zookeeper instances 
 	kafka_exit_handling "false"
 
+	# Ensure redis instance is stopped
+	if [ -n "$REDIS_DYN_DIR" ]; then
+		stop_redis
+	fi
+
 	error_stats $1 # Report error to rsyslog testbench stats
 	do_cleanup
 
@@ -1527,6 +1532,9 @@ exit_test() {
 
 	# Extended Exit handling for kafka / zookeeper instances 
 	kafka_exit_handling "true"
+
+	# Ensure redis is stopped
+	stop_redis
 
 	printf '%s Test %s SUCCESSFUL (took %s seconds)\n' "$(tb_timestamp)" "$0" "$(( $(date +%s) - TB_STARTTEST ))"
 	echo  -------------------------------------------------------------------------------
@@ -2411,6 +2419,97 @@ mysql_cleanup_test() {
 		2>&1 | grep -iv "Using a password on the command line interface can be insecure."
 }
 
+
+start_redis() {
+	check_command_available redis-server
+
+	export REDIS_DYN_CONF="${RSYSLOG_DYNNAME}.redis.conf"
+	export REDIS_DYN_DIR="$(pwd)/${RSYSLOG_DYNNAME}-redis"
+
+	# Only set a random port if not set (useful when Redis must be restarted during a test)
+	if [ -z "$REDIS_RANDOM_PORT" ]; then
+		export REDIS_RANDOM_PORT="$(get_free_port)"
+	fi
+
+	cp $srcdir/testsuites/redis.conf $REDIS_DYN_CONF
+	mkdir -p $REDIS_DYN_DIR
+
+	sed -itemp "s+<tmpdir>+${REDIS_DYN_DIR}+g" $REDIS_DYN_CONF
+	sed -itemp "s+<rndport>+${REDIS_RANDOM_PORT}+g" $REDIS_DYN_CONF
+
+	# Start the server
+	echo "Starting redis with conf file $REDIS_DYN_CONF"
+	redis-server $REDIS_DYN_CONF &
+	$TESTTOOL_DIR/msleep 2000
+
+	# Wait for Redis to be fully up
+	timeoutend=10
+	until nc -w1 -z 127.0.0.1 $REDIS_RANDOM_PORT; do
+		echo "Waiting for Redis to start..."
+		$TESTTOOL_DIR/msleep 1000
+		(( timeseconds=timeseconds + 2 ))
+
+		if [ "$timeseconds" -gt "$timeoutend" ]; then
+			echo "--- TIMEOUT ( $timeseconds ) reached!!!"
+			if [ ! -d ${REDIS_DYN_DIR}/redis.log ]; then
+				echo "no Redis logs"
+			else
+				echo "Dumping ${REDIS_DYN_DIR}/redis.log"
+				echo "========================================="
+				cat ${REDIS_DYN_DIR}/redis.log
+				echo "========================================="
+			fi
+			error_exit 1
+		fi
+	done
+}
+
+cleanup_redis() {
+	if [ -d ${REDIS_DYN_DIR} ]; then
+		rm -rf ${REDIS_DYN_DIR}
+	fi
+	if [ -f ${REDIS_DYN_CONF} ]; then
+		rm -f ${REDIS_DYN_CONF}
+	fi
+}
+
+stop_redis() {
+	if [ -f "$REDIS_DYN_DIR/redis.pid" ]; then
+		redispid=$(cat $REDIS_DYN_DIR/redis.pid)
+		echo "Stopping Redis instance"
+		kill $redispid
+
+		i=0
+
+		# Check if redis instance went down!
+		while [ -f $REDIS_DYN_DIR/redis.pid ]; do
+			redispid=$(cat $REDIS_DYN_DIR/redis.pid)
+			if [[ "" !=  "$redispid" ]]; then
+				$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
+				if test $i -gt $TB_TIMEOUT_STARTSTOP; then
+					echo "redis server (PID $redispid) still running - Performing hard shutdown (-9)"
+					kill -9 $redispid
+					break
+				fi
+				(( i++ ))
+			else
+				# Break the loop
+				break
+			fi
+		done
+	fi
+}
+
+redis_command() {
+	check_command_available redis-cli
+
+	if [ -z "$1" ]; then
+		echo "redis_command: no command provided!"
+		error_exit 1
+	fi
+
+	printf "$1\n" | redis-cli -p "$REDIS_RANDOM_PORT"
+}
 
 # $1 - replacement string
 # $2 - start search string

--- a/tests/imhiredis-queue-lpop-vg.sh
+++ b/tests/imhiredis-queue-lpop-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-queue-lpop.sh

--- a/tests/imhiredis-queue-lpop.sh
+++ b/tests/imhiredis-queue-lpop.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+redis_command "RPUSH mykey message1"
+redis_command "RPUSH mykey message2"
+redis_command "RPUSH mykey message3"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mykey"
+        mode="queue"
+        uselpop="on"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+
+stop_redis
+
+# Same order
+content_check '1 message1'
+content_check '2 message2'
+content_check '3 message3'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-queue-vg.sh
+++ b/tests/imhiredis-queue-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-queue.sh

--- a/tests/imhiredis-queue.sh
+++ b/tests/imhiredis-queue.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+redis_command "RPUSH mykey message1"
+redis_command "RPUSH mykey message2"
+redis_command "RPUSH mykey message3"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mykey"
+        mode="queue"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+
+stop_redis
+
+# Opposite order
+content_check '1 message3'
+content_check '2 message2'
+content_check '3 message1'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-redis-restart-vg.sh
+++ b/tests/imhiredis-redis-restart-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-redis-restart.sh

--- a/tests/imhiredis-redis-restart.sh
+++ b/tests/imhiredis-redis-restart.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+# Start redis once to be able to generate configuration
+start_redis
+
+redis_command "RPUSH mykey message1"
+redis_command "RPUSH mykey message2"
+redis_command "RPUSH mykey message3"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mykey"
+        mode="queue"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+wait_content '3 message1'
+
+# Stop Redis and wait a short moment for imhiredis to notice Redis went down
+stop_redis
+rst_msleep 1500
+start_redis
+
+redis_command "RPUSH mykey message4"
+redis_command "RPUSH mykey message5"
+redis_command "RPUSH mykey message6"
+
+wait_content '4 message6'
+
+shutdown_when_empty
+wait_shutdown
+
+stop_redis
+
+content_check '1 message3'
+content_check '2 message2'
+content_check '3 message1'
+content_check 'sleeping 10 seconds before retrying'
+content_check '4 message6'
+content_check '5 message5'
+content_check '6 message4'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-redis-start-after-vg.sh
+++ b/tests/imhiredis-redis-start-after-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-redis-start-after.sh

--- a/tests/imhiredis-redis-start-after.sh
+++ b/tests/imhiredis-redis-start-after.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+. ${srcdir:=.}/diag.sh init
+
+# Start redis once to be able to generate configuration
+start_redis
+stop_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mykey"
+        mode="queue"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+start_redis
+redis_command "RPUSH mykey message1"
+redis_command "RPUSH mykey message2"
+redis_command "RPUSH mykey message3"
+
+wait_content '1 message3'
+
+shutdown_when_empty
+wait_shutdown
+
+stop_redis
+
+content_check '1 message3'
+content_check '2 message2'
+content_check '3 message1'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-stream-consumerGroup-ack-vg.sh
+++ b/tests/imhiredis-stream-consumerGroup-ack-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-stream-consumerGroup-ack.sh

--- a/tests/imhiredis-stream-consumerGroup-ack.sh
+++ b/tests/imhiredis-stream-consumerGroup-ack.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %$!msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mystream"
+        mode="stream"
+        stream.consumerGroup="mygroup"
+        stream.consumerName="myName"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+redis_command "XADD mystream * msg message1"
+redis_command "XADD mystream * msg message2"
+redis_command "XADD mystream * msg message3"
+
+shutdown_when_empty
+wait_shutdown
+
+output="$(redis_command 'hello 3\nXINFO groups mystream' | grep 'pending')"
+
+if [ -z "$output" ]; then
+    echo "Could not get group result from redis, cannot tell if entries ware acknowledged!"
+    error_exit 1
+fi
+
+if ! echo "$output" | grep -q "pending 0"; then
+    echo "ERROR: entries werent acknowledged!"
+    echo "ERROR: output from Redis is '$output'"
+    echo "ERROR: expected 'pending 0'"
+    error_exit 1
+fi
+
+stop_redis
+
+content_check '1 message1'
+content_check '2 message2'
+content_check '3 message3'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-stream-consumerGroup-noack-vg.sh
+++ b/tests/imhiredis-stream-consumerGroup-noack-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-stream-consumerGroup-noack.sh

--- a/tests/imhiredis-stream-consumerGroup-noack.sh
+++ b/tests/imhiredis-stream-consumerGroup-noack.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %$!msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mystream"
+        mode="stream"
+        stream.consumerGroup="mygroup"
+        stream.consumerName="myName"
+        stream.consumerACK="off"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+redis_command "XADD mystream * msg message1"
+redis_command "XADD mystream * msg message2"
+redis_command "XADD mystream * msg message3"
+
+shutdown_when_empty
+wait_shutdown
+
+output="$(redis_command 'hello 3\nXINFO groups mystream' | grep 'pending')"
+
+if [ -z "$output" ]; then
+    echo "Could not get group result from redis, cannot tell if entries ware acknowledged!"
+    error_exit 1
+fi
+
+if ! echo "$output" | grep -q "pending 3"; then
+    echo "ERROR: entries were acknowledged, they shouldn't have!"
+    echo "ERROR: output from Redis is '$output'"
+    echo "ERROR: expected 'pending 3'"
+    error_exit 1
+fi
+
+stop_redis
+
+content_check '1 message1'
+content_check '2 message2'
+content_check '3 message3'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-stream-consumerGroup-reclaim-vg.sh
+++ b/tests/imhiredis-stream-consumerGroup-reclaim-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-stream-consumerGroup-reclaim.sh

--- a/tests/imhiredis-stream-consumerGroup-reclaim.sh
+++ b/tests/imhiredis-stream-consumerGroup-reclaim.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %$!msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mystream"
+        mode="stream"
+        stream.consumerGroup="mygroup"
+        stream.consumerName="myName"
+        stream.autoclaimIdleTime="5000" #5 seconds
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+redis_command "XADD mystream * msg message1"
+redis_command "XADD mystream * msg message2"
+redis_command "XADD mystream * msg message3"
+redis_command "XADD mystream * msg message4"
+redis_command "XADD mystream * msg message5"
+redis_command "XADD mystream * msg message6"
+
+redis_command "XGROUP CREATE mystream mygroup 0-0"
+# Read and claim message1 and message2
+redis_command "XREADGROUP GROUP mygroup otherConsumer COUNT 2 STREAMS mystream >"
+rst_msleep 5500
+# Read and claim message3 and message4
+redis_command "XREADGROUP GROUP mygroup otherConsumer COUNT 2 STREAMS mystream >"
+
+startup
+
+shutdown_when_empty
+wait_shutdown
+
+output="$(redis_command 'hello 3\nXINFO groups mystream' | grep 'pending')"
+
+if [ -z "$output" ]; then
+    echo "Could not get group result from redis, cannot tell if entries ware acknowledged!"
+    error_exit 1
+fi
+
+# Should still have 2 pending messages: message3 and message4
+if ! echo "$output" | grep -q "pending 2"; then
+    echo "ERROR: entries weren't acknowledged!"
+    echo "ERROR: output from Redis is '$output'"
+    echo "ERROR: expected 'pending 2'"
+    error_exit 1
+fi
+
+stop_redis
+
+# Should reclaim message1 and message2
+# then claim and acknowledge message5 and message6 normally
+content_check '1 message1'
+content_check '2 message2'
+content_check '3 message5'
+content_check '4 message6'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-stream-from-beginning-vg.sh
+++ b/tests/imhiredis-stream-from-beginning-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-stream-from-beginning.sh

--- a/tests/imhiredis-stream-from-beginning.sh
+++ b/tests/imhiredis-stream-from-beginning.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+# WILL be logged by Rsyslog
+redis_command "XADD mystream * msg message1"
+redis_command "XADD mystream * msg message2"
+redis_command "XADD mystream * msg message3"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %$!msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mystream"
+        mode="stream"
+        stream.readFrom="0-0"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+redis_command "XADD mystream * msg message4"
+redis_command "XADD mystream * msg message5"
+redis_command "XADD mystream * msg message6"
+
+shutdown_when_empty
+wait_shutdown
+
+stop_redis
+
+content_check '1 message1'
+content_check '2 message2'
+content_check '3 message3'
+content_check '4 message4'
+content_check '5 message5'
+content_check '6 message6'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-stream-vg.sh
+++ b/tests/imhiredis-stream-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-stream.sh

--- a/tests/imhiredis-stream.sh
+++ b/tests/imhiredis-stream.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+# Won't be logged by Rsyslog
+redis_command "XADD mystream * msg message1"
+redis_command "XADD mystream * msg message2"
+redis_command "XADD mystream * msg message3"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %$!msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mystream"
+        mode="stream"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+redis_command "XADD mystream * msg message4"
+redis_command "XADD mystream * msg message5"
+redis_command "XADD mystream * msg message6"
+
+shutdown_when_empty
+wait_shutdown
+
+stop_redis
+
+check_not_present "message1"
+check_not_present "message2"
+check_not_present "message3"
+
+content_check '1 message4'
+content_check '2 message5'
+content_check '3 message6'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/imhiredis-subscribe-vg.sh
+++ b/tests/imhiredis-subscribe-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/imhiredis-subscribe.sh

--- a/tests/imhiredis-subscribe.sh
+++ b/tests/imhiredis-subscribe.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+# Won't be logged by Rsyslog
+redis_command "PUBLISH mychannel message1"
+redis_command "PUBLISH mychannel message2"
+redis_command "PUBLISH mychannel message3"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/imhiredis/.libs/imhiredis")
+template(name="outfmt" type="string" string="%$/num% %msg%\n")
+
+
+input(type="imhiredis"
+        server="127.0.0.1"
+        port="'$REDIS_RANDOM_PORT'"
+        key="mychannel"
+        mode="subscribe"
+        ruleset="redis")
+
+ruleset(name="redis") {
+  set $/num = cnum($/num + 1);
+  action(type="omfile"
+            file="'$RSYSLOG_OUT_LOG'"
+            template="outfmt")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+redis_command "PUBLISH mychannel message4"
+redis_command "PUBLISH mychannel message5"
+redis_command "PUBLISH mychannel message6"
+
+shutdown_when_empty
+wait_shutdown
+
+stop_redis
+
+check_not_present "message1"
+check_not_present "message2"
+check_not_present "message3"
+
+content_check '1 message4'
+content_check '2 message5'
+content_check '3 message6'
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-dynakey-vg.sh
+++ b/tests/omhiredis-dynakey-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-dynakey.sh

--- a/tests/omhiredis-dynakey.sh
+++ b/tests/omhiredis-dynakey.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+template(name="dynakey" type="string" string="%$!dynaKey%")
+
+local4.* {
+        set $!dynaKey = "myDynaKey";
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="set"
+                dynakey="on"
+                key="dynakey"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+# Should get nothing
+redis_command "GET myDynaKey" > $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+# Should get ' msgnum:00000001:'
+redis_command "GET myDynaKey" >> $RSYSLOG_OUT_LOG
+
+# The first get is before inserting, the second is after
+export EXPECTED="/usr/bin/redis-cli
+
+/usr/bin/redis-cli
+ msgnum:00000001:"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-publish-vg.sh
+++ b/tests/omhiredis-publish-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-publish.sh

--- a/tests/omhiredis-publish.sh
+++ b/tests/omhiredis-publish.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="publish"
+                key="myChannel"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+(redis_command "SUBSCRIBE myChannel" > $RSYSLOG_OUT_LOG) &
+
+startup
+
+# Inject 3 messages
+injectmsg 1 3
+
+shutdown_when_empty
+wait_shutdown
+
+# The SUBSCRIBE command gets the result of the subscribing and the 3 subsequent messages published by omhiredis
+export EXPECTED="/usr/bin/redis-cli
+subscribe
+myChannel
+1
+message
+myChannel
+ msgnum:00000001:
+message
+myChannel
+ msgnum:00000002:
+message
+myChannel
+ msgnum:00000003:"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-queue-rpush-vg.sh
+++ b/tests/omhiredis-queue-rpush-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-queue-rpush.sh

--- a/tests/omhiredis-queue-rpush.sh
+++ b/tests/omhiredis-queue-rpush.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="queue"
+                userpush="on"
+                key="myKey"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+startup
+
+# Inject 5 messages
+injectmsg 1 5
+
+shutdown_when_empty
+wait_shutdown
+
+redis_command "LLEN myKey" > $RSYSLOG_OUT_LOG
+# try to get 6 (should get only 5)
+redis_command "LPOP myKey 6" >> $RSYSLOG_OUT_LOG
+
+# Messages should be retrieved in order (as they were inserted using RPUSH)
+export EXPECTED="/usr/bin/redis-cli
+5
+/usr/bin/redis-cli
+ msgnum:00000001:
+ msgnum:00000002:
+ msgnum:00000003:
+ msgnum:00000004:
+ msgnum:00000005:"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-queue-vg.sh
+++ b/tests/omhiredis-queue-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-queue.sh

--- a/tests/omhiredis-queue.sh
+++ b/tests/omhiredis-queue.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="queue"
+                key="myKey"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+startup
+
+# Inject 10 messages
+injectmsg 1 10
+
+shutdown_when_empty
+wait_shutdown
+
+redis_command "LLEN myKey" > $RSYSLOG_OUT_LOG
+# try to get 11 (should get only 10)
+redis_command "LPOP myKey 11" >> $RSYSLOG_OUT_LOG
+
+# Messages should be retrieved in reverse order (as they were inserted using LPUSH)
+export EXPECTED="/usr/bin/redis-cli
+10
+/usr/bin/redis-cli
+ msgnum:00000010:
+ msgnum:00000009:
+ msgnum:00000008:
+ msgnum:00000007:
+ msgnum:00000006:
+ msgnum:00000005:
+ msgnum:00000004:
+ msgnum:00000003:
+ msgnum:00000002:
+ msgnum:00000001:"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-set-vg.sh
+++ b/tests/omhiredis-set-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-set.sh

--- a/tests/omhiredis-set.sh
+++ b/tests/omhiredis-set.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="set"
+                key="outKey"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+# Should get nothing
+redis_command "GET outKey" > $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+# Should get ' msgnum:00000001:'
+redis_command "GET outKey" >> $RSYSLOG_OUT_LOG
+
+# The first get is before inserting, the second is after
+export EXPECTED="/usr/bin/redis-cli
+
+/usr/bin/redis-cli
+ msgnum:00000001:"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-setex-vg.sh
+++ b/tests/omhiredis-setex-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-setex.sh

--- a/tests/omhiredis-setex.sh
+++ b/tests/omhiredis-setex.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+EXPIRATION="3"
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="set"
+                key="outKey"
+                expiration="'$EXPIRATION'"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+# Should get nothing
+redis_command "GET outKey" > $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+# Should get the remaining expiration time (over -1, under 5)
+ttl=$(redis_command "TTL outKey" | sed '1d')
+
+# Should get ' msgnum:00000001:'
+redis_command "GET outKey" >> $RSYSLOG_OUT_LOG
+
+sleep $EXPIRATION
+
+# Should get nothing
+redis_command "GET outKey" >> $RSYSLOG_OUT_LOG
+
+if [ $ttl -lt 0 ] || [ $ttl -gt $EXPIRATION ]; then
+    echo "ERROR: expiration is not in [0:$EXPIRATION] -> $ttl"
+    error_exit 1
+fi
+
+# The first get is before inserting
+# The third is while the key is still valid
+# The fourth is after the key expired
+export EXPECTED="/usr/bin/redis-cli
+
+/usr/bin/redis-cli
+ msgnum:00000001:
+/usr/bin/redis-cli
+"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-stream-ack-vg.sh
+++ b/tests/omhiredis-stream-ack-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-stream-ack.sh

--- a/tests/omhiredis-stream-ack.sh
+++ b/tests/omhiredis-stream-ack.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="stream"
+                key="outStream"
+                stream.ack="on"
+                stream.keyAck="inStream"
+                stream.groupAck="group"
+                stream.indexAck="1-0"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+redis_command "XGROUP CREATE inStream group 0 MKSTREAM" > $RSYSLOG_OUT_LOG
+redis_command "XADD inStream 1-0 key value" >> $RSYSLOG_OUT_LOG
+redis_command "XREADGROUP GROUP group consumerName COUNT 1 STREAMS inStream >" >> $RSYSLOG_OUT_LOG
+redis_command "XINFO GROUPS inStream" >> $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+redis_command "XINFO GROUPS inStream" >> $RSYSLOG_OUT_LOG
+
+# 1. create group and stream
+# 2. add entry to stream (with index 1-0)
+# 3. read it from a consumer group -> index is now pending
+# 4. show group infos -> pending shows 1 pending entry
+# 4.2. start Rsyslog and send message -> omhiredis acknowledges index 1-0 on group 'group' for stream 'inStream'
+# 5. show group infos again -> pending now shows 0 pending entries
+export EXPECTED="/usr/bin/redis-cli
+OK
+/usr/bin/redis-cli
+1-0
+/usr/bin/redis-cli
+inStream
+1-0
+key
+value
+/usr/bin/redis-cli
+name
+group
+consumers
+1
+pending
+1
+last-delivered-id
+1-0
+entries-read
+1
+lag
+0
+/usr/bin/redis-cli
+name
+group
+consumers
+1
+pending
+0
+last-delivered-id
+1-0
+entries-read
+1
+lag
+0"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-stream-capped-vg.sh
+++ b/tests/omhiredis-stream-capped-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-stream-capped.sh

--- a/tests/omhiredis-stream-capped.sh
+++ b/tests/omhiredis-stream-capped.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="stream"
+                key="outStream"
+                stream.capacityLimit="128"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+startup
+
+
+# Inject 1000 messages
+injectmsg 1 1000
+
+shutdown_when_empty
+wait_shutdown
+
+count=$(redis_command "XLEN outStream" | grep -o "[0-9]*")
+
+# Should be less than 1000 (close to 128, but not 128)
+# 500 still means that stream length was capped
+if [ ! "${count}" -le 500 ]; then
+    echo "error: stream has too much entries -> $count"
+    error_exit 1
+fi
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-stream-del-vg.sh
+++ b/tests/omhiredis-stream-del-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-stream-del.sh

--- a/tests/omhiredis-stream-del.sh
+++ b/tests/omhiredis-stream-del.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="stream"
+                key="outStream"
+                stream.del="on"
+                stream.keyAck="inStream"
+                stream.indexAck="1-0"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+redis_command "XADD inStream 1-0 key value" >> $RSYSLOG_OUT_LOG
+redis_command "XREAD STREAMS inStream 0" >> $RSYSLOG_OUT_LOG
+redis_command "XLEN inStream" >> $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+redis_command "XLEN inStream" >> $RSYSLOG_OUT_LOG
+
+# 2. add entry to stream (with index 1-0)
+# 3. read it -> index is read (but not deleted)
+# 4. show stream length -> should be 1
+# 4.2. start Rsyslog and send message -> omhiredis deletes index 1-0 on stream 'inStream'
+# 5.  show stream length again -> should be 0
+export EXPECTED="/usr/bin/redis-cli
+1-0
+/usr/bin/redis-cli
+inStream
+1-0
+key
+value
+/usr/bin/redis-cli
+1
+/usr/bin/redis-cli
+0"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-stream-dynack-vg.sh
+++ b/tests/omhiredis-stream-dynack-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-stream-dynack.sh

--- a/tests/omhiredis-stream-dynack.sh
+++ b/tests/omhiredis-stream-dynack.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+template(name="redis-key" type="string" string="%$.redis!key%")
+template(name="redis-group" type="string" string="%$.redis!group%")
+template(name="redis-index" type="string" string="%$.redis!index%")
+
+local4.* {
+        set $.redis!key = "inputStream";
+        set $.redis!group = "myGroup";
+        set $.redis!index = "2-0";
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="stream"
+                key="outStream"
+                stream.ack="on"
+                stream.dynaKeyAck="on"
+                stream.dynaGroupAck="on"
+                stream.dynaIndexAck="on"
+                stream.keyAck="redis-key"
+                stream.groupAck="redis-group"
+                stream.indexAck="redis-index"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+redis_command "XGROUP CREATE inputStream myGroup 0 MKSTREAM" > $RSYSLOG_OUT_LOG
+redis_command "XADD inputStream 2-0 key value" >> $RSYSLOG_OUT_LOG
+redis_command "XREADGROUP GROUP myGroup consumerName COUNT 1 STREAMS inputStream >" >> $RSYSLOG_OUT_LOG
+redis_command "XINFO GROUPS inputStream" >> $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+redis_command "XINFO GROUPS inputStream" >> $RSYSLOG_OUT_LOG
+
+# 1. create group and stream
+# 2. add entry to stream (with index 2-0)
+# 3. read it from a consumer group -> index is now pending
+# 4. show group infos -> pending shows 1 pending entry
+# 4.2. start Rsyslog and send message -> omhiredis acknowledges index 2-0 on group 'myGroup' for stream 'inputStream'
+# 5. show group infos again -> pending now shows 0 pending entries
+export EXPECTED="/usr/bin/redis-cli
+OK
+/usr/bin/redis-cli
+2-0
+/usr/bin/redis-cli
+inputStream
+2-0
+key
+value
+/usr/bin/redis-cli
+name
+myGroup
+consumers
+1
+pending
+1
+last-delivered-id
+2-0
+entries-read
+1
+lag
+0
+/usr/bin/redis-cli
+name
+myGroup
+consumers
+1
+pending
+0
+last-delivered-id
+2-0
+entries-read
+1
+lag
+0"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-stream-outfield-vg.sh
+++ b/tests/omhiredis-stream-outfield-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-stream-outfield.sh

--- a/tests/omhiredis-stream-outfield.sh
+++ b/tests/omhiredis-stream-outfield.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="stream"
+                key="outStream"
+                stream.outField="custom_field"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+startup
+
+# Inject 2 messages
+injectmsg 1 2
+
+shutdown_when_empty
+wait_shutdown
+
+# Should get '2'
+redis_command "XLEN outStream" >> $RSYSLOG_OUT_LOG
+# Should get 2 entries
+redis_command "XREAD COUNT 3 STREAMS outStream 0" >> $RSYSLOG_OUT_LOG
+
+# Cannot check for full reply as it includes entries' unix timestamp
+content_count_check "outStream" 1 $RSYSLOG_OUT_LOG
+content_count_check " msgnum:00000001:" 1 $RSYSLOG_OUT_LOG
+content_count_check " msgnum:00000002:" 1 $RSYSLOG_OUT_LOG
+# 2 data should be inserted in the 'custom_field' field inside every message
+content_count_check "custom_field" 2 $RSYSLOG_OUT_LOG
+content_count_check "msg" 2 $RSYSLOG_OUT_LOG
+content_count_check "msgnum" 2 $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-stream-vg.sh
+++ b/tests/omhiredis-stream-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-stream.sh

--- a/tests/omhiredis-stream.sh
+++ b/tests/omhiredis-stream.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="stream"
+                key="outStream"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+# Should get 'ERR no such key'
+redis_command "XINFO GROUPS outStream" > $RSYSLOG_OUT_LOG
+
+startup
+
+
+# Inject 2 messages
+injectmsg 1 2
+
+shutdown_when_empty
+wait_shutdown
+
+# Should get an empty string (no ERR)
+redis_command "XINFO GROUPS outStream" >> $RSYSLOG_OUT_LOG
+
+# Should get '2'
+redis_command "XLEN outStream" >> $RSYSLOG_OUT_LOG
+# Should get 2 entries
+redis_command "XREAD COUNT 3 STREAMS outStream 0" >> $RSYSLOG_OUT_LOG
+
+# Cannot check for full reply as it includes entries' unix timestamp
+content_count_check "ERR no such key" 1 $RSYSLOG_OUT_LOG
+content_count_check "outStream" 1 $RSYSLOG_OUT_LOG
+content_count_check " msgnum:00000001:" 1 $RSYSLOG_OUT_LOG
+content_count_check " msgnum:00000002:" 1 $RSYSLOG_OUT_LOG
+# 2 for the name of the field where the message was inserted, 2 for the 'msgnum' part
+content_count_check "msg" 4 $RSYSLOG_OUT_LOG
+content_count_check "msgnum" 2 $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-template-vg.sh
+++ b/tests/omhiredis-template-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-template.sh

--- a/tests/omhiredis-template.sh
+++ b/tests/omhiredis-template.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+template(name="redis_command" type="string" string="INCRBY counter 3")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="template"
+                template="redis_command")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+# Should get nothing
+redis_command "GET counter" > $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 3 messages
+injectmsg 1 3
+
+shutdown_when_empty
+wait_shutdown
+
+# Should get '9'
+redis_command "GET counter" >> $RSYSLOG_OUT_LOG
+
+# The first get is before inserting, the second is after
+export EXPECTED="/usr/bin/redis-cli
+
+/usr/bin/redis-cli
+9"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-withpass-vg.sh
+++ b/tests/omhiredis-withpass-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-withpass.sh

--- a/tests/omhiredis-withpass.sh
+++ b/tests/omhiredis-withpass.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+REDIS_PASSWORD="mySuperSecretPasswd"
+
+# Set a password on started Redis server
+redis_command "CONFIG SET requirepass ${REDIS_PASSWORD}"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                serverpassword="'${REDIS_PASSWORD}'"
+                mode="set"
+                key="outKey"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
+'
+
+# Client MUST authentiate here!
+redis_command "AUTH ${REDIS_PASSWORD} \n GET outKey" > $RSYSLOG_OUT_LOG
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+# Should get ' msgnum:00000001:'
+redis_command "AUTH ${REDIS_PASSWORD} \n GET outKey" >> $RSYSLOG_OUT_LOG
+
+# the "OK" replies are for authentication of the redis cli client
+export EXPECTED="/usr/bin/redis-cli
+OK
+
+/usr/bin/redis-cli
+OK
+ msgnum:00000001:"
+
+cmp_exact $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-wrongpass-vg.sh
+++ b/tests/omhiredis-wrongpass-vg.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+#export RS_REDIR=-d
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/omhiredis-wrongpass.sh

--- a/tests/omhiredis-wrongpass.sh
+++ b/tests/omhiredis-wrongpass.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# added 2023-04-20 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+REDIS_PASSWORD="mySuperSecretPasswd"
+
+# Set a password on started Redis server
+redis_command "CONFIG SET requirepass ${REDIS_PASSWORD}"
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                serverpassword="ThatsNotMyPassword"
+                mode="set"
+                key="outKey"
+                template="outfmt")
+        stop
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+
+# Inject 1 message
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "error while authenticating: WRONGPASS invalid username-password pair or user is disabled." $RSYSLOG_OUT_LOG
+
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/testsuites/redis.conf
+++ b/tests/testsuites/redis.conf
@@ -1,0 +1,26 @@
+daemonize no
+
+# PID file and port used
+pidfile "<tmpdir>/redis.pid"
+port <rndport>
+bind 127.0.0.1
+protected-mode no
+
+# Close the connection after a client is idle for 300 seconds
+timeout 300
+tcp-backlog 1024
+tcp-keepalive 15
+
+# Logging
+loglevel warning
+logfile "<tmpdir>/redis.log"
+
+databases 1
+
+# Do not save anything to disk
+dir "<tmpdir>/"
+save ""
+appendonly no
+
+maxmemory 1gb
+maxmemory-policy volatile-lru


### PR DESCRIPTION
### Added
- [TESTS] Implemented tests for existing functionalities
  - changed diag.sh to be able to start/stop/clean a redis server
  - added helper functions in diag.sh to be able to query a redis server instance
  - added new tests for imhiredis module to check
    - that the queue mode works, with both lpop and rpop
    - that the module is capable of handling a redis server going down
    - that the module is capable of handling a redis server that appears afterwards
    - that the subscribe mode works
- [IMHIREDIS] Missing redis replies' types in enumeration
- [IMHIREDIS] Add support for simple XREADs from Redis Streams (Redis >= 5.0 required)
- [IMHIREDIS] Add support for XREADGROUP from Redis Streams, allowing for user to define workers to dequeue logs in a stream
- [IMHIREDIS] stream mode can select fields to extract and insert in custom keys
- [IMHIREDIS] Add tests for the new 'stream' modes
- [OMHIREDIS] module is now able to insert entries to a Redis Stream
- [OMHIREDIS] in 'stream' mode, module can insert the message to a custom field in the entry ('msg' by default)
- [OMHIREDIS] in 'stream' mode, module can acknowledge an entry coming from imhiredis (if entry was claimed but not ACK'ed)
- [OMHIREDIS] in 'stream' mode, acknowledgements can be made from dynamic templates or static values
- [OMHIREDIS] in 'stream' mode, module can approximately cap the size of the output stream
- [OMHIREDIS] in 'stream' mode, module can delete an entry while inserting its message (useful to remove entry coming from another stream with imhiredis)
- [OMHIREDIS] new tests for 'stream' mode

### Changed
- [IMHIREDIS] factorize code for different modes
- [IMHIREDIS] Clean and improve logging lines
- [IMHIREDIS] Poll extinction state less frequently for main thread (less aggresive)
- [IMHIREDIS] Set 'key' action parameter to REQUIRED
- [IMHIREDIS] Use known message length instead of calculating it when enqueuing message

### Fixed
- [IMHIREDIS] Correctly initialize instance object, especially for redisNodesList
- [IMHIREDIS] Correctly print input mode's value in logs when set incorrectly
- [OMHIREDIS] Correctly authenticate to server before sending queries
- [OMHIREDIS] Properly ensure messages are successful in Redis, or suspend module
- [CONFIGURE.AC] Missing line to give omhiredis compilation status

--------------------------------------

associated PR for documentation : [rsyslog-doc PR #1008](https://github.com/rsyslog/rsyslog-doc/pull/1008)