### PR TITLE
Add new global config option "libcapng.default"

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -178,7 +178,8 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "parser.supportcompressionextension", eCmdHdlrBinary, 0 },
 	{ "shutdown.queue.doublesize", eCmdHdlrBinary, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
-	{ "debug.whitelist", eCmdHdlrBinary, 0 }
+	{ "debug.whitelist", eCmdHdlrBinary, 0 },
+	{ "libcapng.default", eCmdHdlrBinary, 0 }
 };
 static struct cnfparamblk paramblk =
 	{ CNFPARAMBLK_VERSION,
@@ -1183,6 +1184,13 @@ glblDoneLoadCnf(void)
 		if(!strcmp(paramblk.descr[i].name, "workdirectory")) {
 			cstr = (uchar*) es_str2cstr(cnfparamvals[i].val.d.estr, NULL);
 			setWorkDir(NULL, cstr);
+		} else if(!strcmp(paramblk.descr[i].name, "libcapng.default")) {
+#ifdef ENABLE_LIBCAPNG
+			loadConf->globals.bAbortOnFailedLibcapngSetup = (int) cnfparamvals[i].val.d.n;
+#else
+			LogError(0, RS_RET_ERR, "rsyslog wasn't "
+				"compiled with libcap-ng support.");
+#endif
 		} else if(!strcmp(paramblk.descr[i].name, "variables.casesensitive")) {
 			const int val = (int) cnfparamvals[i].val.d.n;
 			fjson_global_do_case_sensitive_comparison(val);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -159,6 +159,9 @@ int rsconfNeedDropPriv(rsconf_t *const cnf)
 
 static void cnfSetDefaults(rsconf_t *pThis)
 {
+#ifdef ENABLE_LIBCAPNG
+	pThis->globals.bAbortOnFailedLibcapngSetup = 1;
+#endif
 	pThis->globals.bAbortOnUncleanConfig = 0;
 	pThis->globals.bAbortOnFailedQueueStartup = 0;
 	pThis->globals.bReduceRepeatMsgs = 0;

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -84,6 +84,9 @@ struct parsercnf_s {
  * be re-set as often as the user likes).
  */
 struct globals_s {
+#ifdef ENABLE_LIBCAPNG
+	int bAbortOnFailedLibcapngSetup;
+#endif
 	int bDebugPrintTemplateList;
 	int bDebugPrintModuleList;
 	int bDebugPrintCfSysLineHandlerList;


### PR DESCRIPTION
The new global option defines how rsyslog should behave in case something went wrong when capabilities were to be dropped. Default value is "on", in which case rsyslog exits on a libcapng related error. If set to "off", an error message describing the problem appears at startup, nothing more. Default value is preserved for backwards compatibility.

The capability dropping had to be moved to a different place, where config parameters are already available.

Closes #5096
