### PR TITLE
imjournal: Support input module

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -33,6 +33,9 @@
 #include <time.h>
 #include <sys/poll.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include <errno.h>
 #include <systemd/sd-journal.h>
 #include <fcntl.h>
@@ -46,6 +49,7 @@
 #include "net.h"
 #include "glbl.h"
 #include "statsobj.h"
+#include "ruleset.h"
 #include "parser.h"
 #include "prop.h"
 #include "errmsg.h"
@@ -65,11 +69,23 @@ DEFobjCurrIf(glbl)
 DEFobjCurrIf(parser)
 DEFobjCurrIf(prop)
 DEFobjCurrIf(net)
+DEFobjCurrIf(ruleset)
 DEFobjCurrIf(statsobj)
+
+/* Module static data */
+typedef struct journal_etry_s {
+	pthread_t tid;	/* the worker's thread ID */
+	ruleset_t *pBindRuleset;
+	char* stateFile;
+	struct journalContext_s *journalContext;
+	struct journal_etry_s *next;
+} journal_etry_t;
+static journal_etry_t *journal_root = NULL;
+static int n_journal = 0;
 
 struct modConfData_s {
 	rsconf_t *pConf;
-	int bIgnPrevMsg;
+	instanceConf_t *root, *tail;
 };
 
 static struct configSettings_s {
@@ -114,6 +130,27 @@ static struct cnfparamblk modpblk =
 	  modpdescr
 	};
 
+/* input instance parameters */
+static struct cnfparamdescr inppdescr[] = {
+	{ "ruleset", eCmdHdlrString, 0 },
+	{ "main", eCmdHdlrBinary, 0 },
+};
+static struct cnfparamblk inppblk =
+	{ CNFPARAMBLK_VERSION,
+	  sizeof(inppdescr)/sizeof(struct cnfparamdescr),
+	  inppdescr
+	};
+
+struct instanceConf_s {
+	struct instanceConf_s *next;
+	char *stateFile;
+	uchar *pszBindRuleset;
+	ruleset_t *pBindRuleset; /* ruleset to bind listener to (use system default if unspecified) */
+	int bMain;
+};
+
+#include "im-helper.h" /* must be included AFTER the type definitions! */
+
 #define DFLT_persiststateinterval 10
 #define DFLT_SEVERITY pri2sev(LOG_NOTICE)
 #define DFLT_FACILITY pri2fac(LOG_USER)
@@ -144,54 +181,66 @@ struct journalContext_s { /* structure encapsulating all the journald_API-relate
 	sbool atHead; /* true if we are at start of journal (no seek was done) */
 	char *cursor; /* should point to last valid journald entry we processed */
 };
-static struct journalContext_s journalContext = {NULL, 0, 1, NULL};
+
+#define MAX_JOURNAL 8
+static struct journalContext_s journalContextArray[MAX_JOURNAL] = {
+	{NULL, 0, 1, NULL},
+	{NULL, 0, 1, NULL},
+	{NULL, 0, 1, NULL},
+	{NULL, 0, 1, NULL},
+	{NULL, 0, 1, NULL},
+	{NULL, 0, 1, NULL},
+	{NULL, 0, 1, NULL},
+	{NULL, 0, 1, NULL},
+};
 static modConfData_t *loadModConf = NULL;/* modConf ptr to use for the current load process */
 static modConfData_t *runModConf = NULL;/* modConf ptr to use for run process */
 
 #define J_PROCESS_PERIOD 1024  /* Call sd_journal_process() every 1,024 records */
 
-static rsRetVal persistJournalState(void);
-static rsRetVal loadJournalState(void);
+static rsRetVal persistJournalState(struct journalContext_s *journalContext, char* stateFile);
+static rsRetVal loadJournalState(struct journalContext_s *journalContext, char* stateFile);
 
-static rsRetVal openJournal(void) {
+static rsRetVal openJournal(struct journalContext_s *journalContext) {
+
 	int r;
 	DEFiRet;
 
-	if (journalContext.j) {
+	if (journalContext->j) {
 		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "imjournal: opening journal when already opened.\n");
 	}
-	if ((r = sd_journal_open(&journalContext.j, cs.bRemote? 0 : SD_JOURNAL_LOCAL_ONLY)) < 0) {
+	if ((r = sd_journal_open(&journalContext->j, cs.bRemote? 0 : SD_JOURNAL_LOCAL_ONLY)) < 0) {
 		LogError(-r, RS_RET_IO_ERROR, "imjournal: sd_journal_open() failed");
 		iRet = RS_RET_IO_ERROR;
 	}
-	if ((r = sd_journal_set_data_threshold(journalContext.j, glbl.GetMaxLine(runModConf->pConf))) < 0) {
+	if ((r = sd_journal_set_data_threshold(journalContext->j, glbl.GetMaxLine(runModConf->pConf))) < 0) {
 		LogError(-r, RS_RET_IO_ERROR, "imjournal: sd_journal_set_data_threshold() failed");
 		iRet = RS_RET_IO_ERROR;
 	}
-	journalContext.atHead = 1;
+	journalContext->atHead = 1;
 	RETiRet;
 }
 
 /* trySave shoulod only be true if there is no journald error preceeding this call */
-static void closeJournal(void) {
-	if (!journalContext.j) {
+static void closeJournal(struct journalContext_s *journalContext) {
+	if (!journalContext->j) {
 		LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "imjournal: closing NULL journal.\n");
 	}
-	sd_journal_close(journalContext.j);
-	journalContext.j = NULL; /* setting to NULL here as journald API will not do that for us... */
+	sd_journal_close(journalContext->j);
+	journalContext->j = NULL; /* setting to NULL here as journald API will not do that for us... */
 }
 
-static int journalGetData(const char *field, const void **data, size_t *length)
+static int journalGetData(struct journalContext_s *journalContext, const char *field, const void **data, size_t *length)
 {
 	int ret;
 
-	ret = sd_journal_get_data(journalContext.j, field, data, length);
+	ret = sd_journal_get_data(journalContext->j, field, data, length);
 	if (ret == -EADDRNOTAVAIL) {
 		LogError(-ret, RS_RET_ERR, "imjournal: Tried to get data without a 'next' call.\n");
-		if ((ret = sd_journal_next(journalContext.j)) < 0) {
+		if ((ret = sd_journal_next(journalContext->j)) < 0) {
 			LogError(-ret, RS_RET_ERR, "imjournal: sd_journal_next() failed\n");
 		} else {
-			ret = sd_journal_get_data(journalContext.j, field, data, length);
+			ret = sd_journal_get_data(journalContext->j, field, data, length);
 		}
 	}
 
@@ -260,7 +309,7 @@ finalize_it:
 /* Read JSON part of single journald message and return it as JSON object
  */
 static rsRetVal
-readJSONfromJournalMsg(struct fjson_object **json)
+readJSONfromJournalMsg(struct journalContext_s *journalContext, struct fjson_object **json)
 {
 	DEFiRet;
 	const void *get;
@@ -271,7 +320,7 @@ readJSONfromJournalMsg(struct fjson_object **json)
 
 	CHKmalloc(*json = fjson_object_new_object());
 
-	SD_JOURNAL_FOREACH_DATA(journalContext.j, get, l) {
+	SD_JOURNAL_FOREACH_DATA(journalContext->j, get, l) {
 		char *data;
 		char *name;
 
@@ -311,19 +360,19 @@ finalize_it:
 /* Try to obtain current journald cursor and save it to journalContext struct.
  */
 static rsRetVal
-updateJournalCursor(void)
+updateJournalCursor(struct journalContext_s *journalContext)
 {
 	DEFiRet;
 	char *c = NULL;
 	int r;
 
-	if ((r = sd_journal_get_cursor(journalContext.j, &c)) < 0) {
+	if ((r = sd_journal_get_cursor(journalContext->j, &c)) < 0) {
 		LogError(-r, RS_RET_ERR, "imjournal: Could not get journald cursor!\n");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	/* save journal cursor (at this point we can be sure it is valid) */
-	free(journalContext.cursor);
-	journalContext.cursor = c;
+	free(journalContext->cursor);
+	journalContext->cursor = c;
 finalize_it:
 	RETiRet;
 }
@@ -335,7 +384,7 @@ finalize_it:
  */
 static rsRetVal
 enqMsg(uchar *msg, uchar *pszTag, int iFacility, int iSeverity, struct timeval *tp, struct fjson_object *json,
-int sharedJsonProperties)
+int sharedJsonProperties, ruleset_t *pBindRuleset)
 {
 	struct syslogTime st;
 	smsg_t *pMsg;
@@ -362,6 +411,9 @@ int sharedJsonProperties)
 	MsgSetRcvFromIP(pMsg, pLocalHostIP);
 	MsgSetHOSTNAME(pMsg, glbl.GetLocalHostName(), ustrlen(glbl.GetLocalHostName()));
 	MsgSetTAG(pMsg, pszTag, ustrlen(pszTag));
+	if (pBindRuleset != NULL) {
+		MsgSetRuleset(pMsg, pBindRuleset);
+	}
 	pMsg->iFacility = iFacility;
 	pMsg->iSeverity = iSeverity;
 
@@ -386,7 +438,7 @@ finalize_it:
 /* Read journal log while data are available, each read() reads one journald record.
  */
 static rsRetVal
-readjournal(void)
+readjournal(struct journalContext_s *journalContext, ruleset_t *pBindRuleset)
 {
 	DEFiRet;
 
@@ -410,7 +462,7 @@ readjournal(void)
 	int facility = cs.iDfltFacility;
 
 	/* Get message text */
-	if (journalGetData("MESSAGE", &get, &length) < 0) {
+	if (journalGetData(journalContext, "MESSAGE", &get, &length) < 0) {
 		CHKmalloc(message = strdup(""));
 	} else {
 		CHKiRet(sanitizeValue(((const char *)get) + 8, length - 8, &message));
@@ -418,7 +470,7 @@ readjournal(void)
 	STATSCOUNTER_INC(statsCounter.ctrRead, statsCounter.mutCtrRead);
 
 	/* Get message severity ("priority" in journald's terminology) */
-	if (journalGetData("PRIORITY", &get, &length) >= 0) {
+	if (journalGetData(journalContext, "PRIORITY", &get, &length) >= 0) {
 		if (length == 10) {
 			severity = ((char *)get)[9] - '0';
 			if (severity < 0 || 7 < severity) {
@@ -433,7 +485,7 @@ readjournal(void)
 	}
 
 	/* Get syslog facility */
-	if (journalGetData("SYSLOG_FACILITY", &get, &length) >= 0) {
+	if (journalGetData(journalContext, "SYSLOG_FACILITY", &get, &length) >= 0) {
 		// Note: the journal frequently contains invalid facilities!
 		if (length == 17 || length == 18) {
 			facility = ((char *)get)[16] - '0';
@@ -453,16 +505,16 @@ readjournal(void)
 	}
 
 	/* Get message identifier, client pid and add ':' */
-	if (journalGetData("SYSLOG_IDENTIFIER", &get, &length) >= 0) {
+	if (journalGetData(journalContext, "SYSLOG_IDENTIFIER", &get, &length) >= 0) {
 		CHKiRet(sanitizeValue(((const char *)get) + 18, length - 18, &sys_iden));
-	} else if (journalGetData("_COMM", &get, &length) >= 0) {
+	} else if (journalGetData(journalContext, "_COMM", &get, &length) >= 0) {
 		CHKiRet(sanitizeValue(((const char *)get) + 6, length - 6, &sys_iden));
 	} else {
 		CHKmalloc(sys_iden = strdup("journal"));
 	}
 
 	/* trying to get PID, default is "SYSLOG_PID" property */
-	if (journalGetData(pidFieldName, &pidget, &pidlength) >= 0) {
+	if (journalGetData(journalContext, pidFieldName, &pidget, &pidlength) >= 0) {
 		char *sys_pid;
 		int val_ofs;
 
@@ -475,7 +527,7 @@ readjournal(void)
 		free (sys_pid);
 	} else {
 		/* this is fallback, "SYSLOG_PID" doesn't exist so trying to get "_PID" property */
-		if (bPidFallBack && journalGetData("_PID", &pidget, &pidlength) >= 0) {
+		if (bPidFallBack && journalGetData(journalContext, "_PID", &pidget, &pidlength) >= 0) {
 			char *sys_pid;
 			int val_ofs;
 
@@ -499,18 +551,18 @@ readjournal(void)
 		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
 	}
 
-	CHKiRet(readJSONfromJournalMsg(&json));
+	CHKiRet(readJSONfromJournalMsg(journalContext, &json));
 
 	/* calculate timestamp */
-	if (sd_journal_get_realtime_usec(journalContext.j, &timestamp) >= 0) {
+	if (sd_journal_get_realtime_usec(journalContext->j, &timestamp) >= 0) {
 		tv.tv_sec = timestamp / 1000000;
 		tv.tv_usec = timestamp % 1000000;
 	}
 
-	iRet = updateJournalCursor();
+	iRet = updateJournalCursor(journalContext);
 
 	/* submit message */
-	enqMsg((uchar *)message, (uchar *) sys_iden_help, facility, severity, &tv, json, 0);
+	enqMsg((uchar *)message, (uchar *) sys_iden_help, facility, severity, &tv, json, 0, pBindRuleset);
 
 finalize_it:
 	free(sys_iden_help);
@@ -523,7 +575,7 @@ finalize_it:
  * It must be checked that stateFile is configured prior to calling this.
  */
 static rsRetVal
-persistJournalState(void)
+persistJournalState(struct journalContext_s *journalContext, char* stateFile)
 {
 	DEFiRet;
 	char tmp_sf[MAXFNAME];
@@ -532,10 +584,10 @@ persistJournalState(void)
 	ssize_t wr_ret;
 
 	DBGPRINTF("Persisting journal position, cursor: %s, at head? %d\n",
-			  journalContext.cursor, journalContext.atHead);
+			  journalContext->cursor, journalContext->atHead);
 
 	/* first check that we have valid cursor */
-	if (!journalContext.cursor) {
+	if (!journalContext->cursor) {
 		DBGPRINTF("Journal cursor is not valid, ok...\n");
 		ABORT_FINALIZE(RS_RET_OK);
 	}
@@ -546,10 +598,10 @@ persistJournalState(void)
 	 * we use snprintf() to safely honor the boundaries
 	 * of the temporary state file name buffer by using
 	 * a precision specifier, which will limit the number
-	 * of bytes taken from cs.stateFile to what will fit
+	 * of bytes taken from stateFile to what will fit
 	 *
 	 * TODO: figure out a better way to avoid the PATH_MAX
-	 * problem. The truncated cs.stateFile with .tmp at the
+	 * problem. The truncated stateFile with .tmp at the
 	 * end is not optimal
 	 */
 #define IM_SF_TMP_SUFFIX ".tmp"
@@ -559,7 +611,7 @@ persistJournalState(void)
 			 * NUL terminator.
 			 */
 			(int)(sizeof(tmp_sf) - sizeof(IM_SF_TMP_SUFFIX)),
-			cs.stateFile, IM_SF_TMP_SUFFIX);
+			stateFile, IM_SF_TMP_SUFFIX);
 
 	fd = open((char*) tmp_sf, O_WRONLY|O_CREAT|O_CLOEXEC, cs.fCreateMode);
 	if (fd == -1) {
@@ -567,8 +619,8 @@ persistJournalState(void)
 		ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
 	}
 
-	len = strlen(journalContext.cursor);
-	wr_ret = write(fd, journalContext.cursor, len);
+	len = strlen(journalContext->cursor);
+	wr_ret = write(fd, journalContext->cursor, len);
 	if (wr_ret != (ssize_t)len) {
 		LogError(errno, RS_RET_IO_ERROR, "imjournal: failed to save cursor to: '%s',"
 			"write returned %zd, expected %zu", cs.stateFile, wr_ret, len);
@@ -576,14 +628,14 @@ persistJournalState(void)
 	}
 
 	/* change the name of the file to the configured one */
-	if (rename(tmp_sf, cs.stateFile) < 0) {
-		LogError(errno, iRet, "imjournal: rename() failed for new path: '%s'", cs.stateFile);
+	if (rename(tmp_sf, stateFile) < 0) {
+		LogError(errno, iRet, "imjournal: rename() failed for new path: '%s'", stateFile);
 		ABORT_FINALIZE(RS_RET_IO_ERROR);
 	}
 
 	if (cs.bFsync) {
 		if (fsync(fd) != 0) {
-			LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", cs.stateFile);
+			LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", stateFile);
 			ABORT_FINALIZE(RS_RET_IO_ERROR);
 		}
 		/* In order to guarantee physical write we need to force parent sync as well */
@@ -602,7 +654,7 @@ persistJournalState(void)
 		closedir(wd);
 	}
 
-	DBGPRINTF("Persisted journal to '%s'\n", cs.stateFile);
+	DBGPRINTF("Persisted journal to '%s'\n", stateFile);
 
 finalize_it:
 	if (fd != -1) {
@@ -615,67 +667,67 @@ finalize_it:
 }
 
 
-static rsRetVal skipOldMessages(void);
+static rsRetVal skipOldMessages(struct journalContext_s *journalContext);
 
 static rsRetVal
-handleRotation(void)
+handleRotation(struct journalContext_s *journalContext, char* stateFile)
 {
 	DEFiRet;
 	int r;
 
 	LogMsg(0, RS_RET_OK, LOG_NOTICE, "imjournal: journal files changed, reloading...\n");
 	STATSCOUNTER_INC(statsCounter.ctrRotations, statsCounter.mutCtrRotations);
-	closeJournal();
+	closeJournal(journalContext);
 
-	iRet = openJournal();
+	iRet = openJournal(journalContext);
 	if (iRet != RS_RET_OK) {
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 
 	/* outside error scenarios we should always have a cursor available at this point */
-	if (!journalContext.cursor)
+	if (!journalContext->cursor)
 	{
-		if (cs.stateFile) {
-			iRet = loadJournalState();
+		if (stateFile) {
+			iRet = loadJournalState(journalContext, stateFile);
 		}
 		else if (cs.bIgnorePrevious) {
 			/* Seek to the very end of the journal and ignore all older messages. */
-			iRet = skipOldMessages();
+			iRet = skipOldMessages(journalContext);
 		}
 		FINALIZE;
 	}
 
-	if (sd_journal_seek_cursor(journalContext.j, journalContext.cursor) != 0) {
+	if (sd_journal_seek_cursor(journalContext->j, journalContext->cursor) != 0) {
 		LogError(0, RS_RET_ERR, "imjournal: "
-			"couldn't seek to cursor `%s'\n", journalContext.cursor);
+			"couldn't seek to cursor `%s'\n", journalContext->cursor);
 		iRet = RS_RET_ERR;
 	}
-	journalContext.atHead = 0;
+	journalContext->atHead = 0;
 	/* Need to advance because cursor points at last processed message */
-	if ((r = sd_journal_next(journalContext.j)) < 0) {
+	if ((r = sd_journal_next(journalContext->j)) < 0) {
 		LogError(-r, RS_RET_ERR, "imjournal: sd_journal_next() failed");
 		iRet = RS_RET_ERR;
 	}
 
 finalize_it:
-	journalContext.reloaded = 1;
+	journalContext->reloaded = 1;
 	RETiRet;
 }
 
 #define POLL_TIMEOUT 900000 /* timeout for poll is 900ms */
 
 static rsRetVal
-pollJournal(void)
+pollJournal(struct journalContext_s *journalContext, char* stateFile)
 {
 	DEFiRet;
 	int err;
 
-	err = sd_journal_wait(journalContext.j, POLL_TIMEOUT);
-	if (err == SD_JOURNAL_INVALIDATE && !journalContext.reloaded) {
-		CHKiRet(handleRotation());
+	err = sd_journal_wait(journalContext->j, POLL_TIMEOUT);
+	if (err == SD_JOURNAL_INVALIDATE && !journalContext->reloaded) {
+		CHKiRet(handleRotation(journalContext, stateFile));
 	}
 	else {
-		journalContext.reloaded = 0;
+		journalContext->reloaded = 0;
 	}
 
 finalize_it:
@@ -684,18 +736,18 @@ finalize_it:
 
 
 static rsRetVal
-skipOldMessages(void)
+skipOldMessages(struct journalContext_s *journalContext)
 {
 	int r;
 	DEFiRet;
 
-	if ((r = sd_journal_seek_tail(journalContext.j)) < 0) {
+	if ((r = sd_journal_seek_tail(journalContext->j)) < 0) {
 		LogError(-r, RS_RET_ERR,
 			"imjournal: sd_journal_seek_tail() failed");
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
-	journalContext.atHead = 0;
-	if ((r = sd_journal_previous(journalContext.j)) < 0) {
+	journalContext->atHead = 0;
+	if ((r = sd_journal_previous(journalContext->j)) < 0) {
 		LogError(-r, RS_RET_ERR,
 			"imjournal: sd_journal_previous() failed");
 		ABORT_FINALIZE(RS_RET_ERR);
@@ -708,37 +760,37 @@ finalize_it:
 /* This function loads a journal cursor from the state file.
  */
 static rsRetVal
-loadJournalState(void)
+loadJournalState(struct journalContext_s *journalContext, char* stateFile)
 {
 	DEFiRet;
 	int r;
 	FILE *r_sf;
 
 	DBGPRINTF("Loading journal position, at head? %d, reloaded? %d\n",
-			  journalContext.atHead, journalContext.reloaded);
+			  journalContext->atHead, journalContext->reloaded);
 
 	/* if state file not exists (on very first run), skip */
-	if (access(cs.stateFile, F_OK|R_OK) == -1 && errno == ENOENT) {
+	if (access(stateFile, F_OK|R_OK) == -1 && errno == ENOENT) {
 		if (cs.bIgnorePrevious) {
 			/* Seek to the very end of the journal and ignore all older messages. */
-			skipOldMessages();
+			skipOldMessages(journalContext);
 		}
 		LogMsg(errno, RS_RET_FILE_NOT_FOUND, LOG_NOTICE, "imjournal: No statefile exists, "
-				"%s will be created (ignore if this is first run)", cs.stateFile);
+				"%s will be created (ignore if this is first run)", stateFile);
 		FINALIZE;
 	}
 
-	if ((r_sf = fopen(cs.stateFile, "rb")) != NULL) {
+	if ((r_sf = fopen(stateFile, "rb")) != NULL) {
 		char readCursor[128 + 1];
 		if (fscanf(r_sf, "%128s\n", readCursor) != EOF) {
-			if (sd_journal_seek_cursor(journalContext.j, readCursor) != 0) {
+			if (sd_journal_seek_cursor(journalContext->j, readCursor) != 0) {
 				LogError(0, RS_RET_ERR, "imjournal: "
 					"couldn't seek to cursor `%s'\n", readCursor);
 				iRet = RS_RET_ERR;
 			} else {
-				journalContext.atHead = 0;
+				journalContext->atHead = 0;
 				char * tmp_cursor = NULL;
-				sd_journal_next(journalContext.j);
+				sd_journal_next(journalContext->j);
 				/*
 				* This is resolving the situation when system is after reboot and boot_id
 				* doesn't match so cursor pointing into "future".
@@ -751,21 +803,21 @@ loadJournalState(void)
 				* but if cursor has been intentionally compromised it could stop logging even
 				* with persistent journal.
 				* */
-				if ((r = sd_journal_get_cursor(journalContext.j, &tmp_cursor)) < 0) {
+				if ((r = sd_journal_get_cursor(journalContext->j, &tmp_cursor)) < 0) {
 					LogError(-r, RS_RET_IO_ERROR, "imjournal: "
 					"loaded invalid cursor, seeking to the head of journal\n");
-					if ((r = sd_journal_seek_head(journalContext.j)) < 0) {
+					if ((r = sd_journal_seek_head(journalContext->j)) < 0) {
 						LogError(-r, RS_RET_ERR, "imjournal: "
 						"sd_journal_seek_head() failed, when cursor is invalid\n");
 						iRet = RS_RET_ERR;
 					}
-					journalContext.atHead = 1;
+					journalContext->atHead = 1;
 				}
 				free(tmp_cursor);
 			}
 		} else {
 			LogError(0, RS_RET_IO_ERROR, "imjournal: "
-				"fscanf on state file `%s' failed\n", cs.stateFile);
+				"fscanf on state file `%s' failed\n", stateFile);
 			iRet = RS_RET_IO_ERROR;
 		}
 
@@ -774,16 +826,16 @@ loadJournalState(void)
 		if (iRet != RS_RET_OK && cs.bIgnoreNonValidStatefile) {
 			/* ignore state file errors */
 			iRet = RS_RET_OK;
-			LogError(0, NO_ERRCODE, "imjournal: ignoring invalid state file %s", cs.stateFile);
+			LogError(0, NO_ERRCODE, "imjournal: ignoring invalid state file %s", stateFile);
 			if (cs.bIgnorePrevious) {
-				skipOldMessages();
+				skipOldMessages(journalContext);
 			}
 		}
 	} else {
-		LogError(0, RS_RET_FOPEN_FAILURE, "imjournal: open on state file `%s' failed\n", cs.stateFile);
+		LogError(0, RS_RET_FOPEN_FAILURE, "imjournal: open on state file `%s' failed\n", stateFile);
 		if (cs.bIgnorePrevious) {
 			/* Seek to the very end of the journal and ignore all older messages. */
-			skipOldMessages();
+			skipOldMessages(journalContext);
 		}
 	}
 
@@ -792,38 +844,59 @@ finalize_it:
 }
 
 static void
-tryRecover(void) {
+tryRecover(struct journalContext_s *journalContext) {
 	LogMsg(0, RS_RET_OK, LOG_INFO, "imjournal: trying to recover from journal error");
 	STATSCOUNTER_INC(statsCounter.ctrRecoveryAttempts, statsCounter.mutCtrRecoveryAttempts);
-	closeJournal();
+	closeJournal(journalContext);
 	srSleep(0, 200000);	// do not hammer machine with too-frequent retries
-	openJournal();
+	openJournal(journalContext);
+}
+
+static rsRetVal
+addListner(instanceConf_t *inst, u_int8_t index)
+{
+	DEFiRet;
+	if (index >= MAX_JOURNAL) {
+		iRet = RS_RET_NO_MORE_DATA;
+		RETiRet;
+	}
+
+	journal_etry_t *etry;
+	CHKmalloc(etry = (journal_etry_t*) calloc(1, sizeof(journal_etry_t)));
+	etry->journalContext = &journalContextArray[index];
+	if (inst) {
+		etry->pBindRuleset = inst->pBindRuleset;
+		etry->stateFile = inst->stateFile;
+	}
+	etry->next = journal_root;
+	journal_root = etry;
+	++n_journal;
+
+finalize_it:
+	if(iRet != RS_RET_OK) {
+		LogError(0, NO_ERRCODE, "imjournal: error %d trying to add listener", iRet);
+		free(etry);
+	}
+	RETiRet;
 }
 
 
-BEGINrunInput
+static rsRetVal
+doRun(journal_etry_t const* etry)
+{
+	DEFiRet;
 	uint64_t count = 0;
-CODESTARTrunInput
-	CHKiRet(ratelimitNew(&ratelimiter, "imjournal", NULL));
-	dbgprintf("imjournal: ratelimiting burst %u, interval %u\n", cs.ratelimitBurst,
-		  cs.ratelimitInterval);
-	ratelimitSetLinuxLike(ratelimiter, cs.ratelimitInterval, cs.ratelimitBurst);
-	ratelimitSetNoTimeCache(ratelimiter);
-
-	if (cs.stateFile) {
-		/* Load our position in the journal from the state file. */
-		CHKiRet(loadJournalState());
-	} else if (cs.bIgnorePrevious) {
-		/* Seek to the very end of the journal and ignore all older messages. */
-		skipOldMessages();
+	char* stateFile = cs.stateFile;
+	if (etry->stateFile) {
+		stateFile = etry->stateFile;
 	}
 
-	/* handling old "usepidfromsystem" option */
-	if (cs.bUseJnlPID != -1) {
-		free(cs.usePid);
-		cs.usePid = strdup("system");
-		LogError(0, RS_RET_DEPRECATED,
-			"\"usepidfromsystem\" is deprecated, use \"usepid\" instead");
+	if (stateFile) {
+		/* Load our position in the journal from the state file. */
+		CHKiRet(loadJournalState(etry->journalContext, stateFile));
+	} else if (cs.bIgnorePrevious) {
+		/* Seek to the very end of the journal and ignore all older messages. */
+		skipOldMessages(etry->journalContext);
 	}
 
 	if (cs.usePid && (strcmp(cs.usePid, "system") == 0)) {
@@ -841,28 +914,28 @@ CODESTARTrunInput
 		}
 	}
 
-
 	/* this is an endless loop - it is terminated when the thread is
 	 * signalled to do so. This, however, is handled by the framework.
 	 */
 	while (glbl.GetGlobalInputTermState() == 0) {
 		int r;
 
-		r = sd_journal_next(journalContext.j);
+		r = sd_journal_next(etry->journalContext->j);
 		if (r < 0) {
 			LogError(-r, RS_RET_ERR, "imjournal: sd_journal_next() failed");
-			tryRecover();
+			tryRecover(etry->journalContext);
 			continue;
 		}
 
 		if (r == 0) {
-			if (journalContext.atHead) {
+			if (etry->journalContext->atHead) {
 				LogMsg(0, RS_RET_OK, LOG_WARNING, "imjournal: "
 						"Journal indicates no msgs when positioned at head.\n");
 			}
 			/* No new messages, wait for activity. */
-			if (pollJournal() != RS_RET_OK && !journalContext.reloaded) {
-				tryRecover();
+			if (pollJournal(etry->journalContext, stateFile) != RS_RET_OK &&
+				!etry->journalContext->reloaded) {
+				tryRecover(etry->journalContext);
 			}
 			continue;
 		}
@@ -870,25 +943,113 @@ CODESTARTrunInput
 		/*
 		 * update journal disk usage before reading the new message.
 		 */
-		const int e = sd_journal_get_usage(journalContext.j, (uint64_t *)&statsCounter.diskUsageBytes);
+		const int e = sd_journal_get_usage(etry->journalContext->j, (uint64_t *)&statsCounter.diskUsageBytes);
 		if (e < 0) {
 			LogError(-e, RS_RET_ERR, "imjournal: sd_get_usage() failed");
 		}
 
-		if (readjournal() != RS_RET_OK) {
-			tryRecover();
+		if (readjournal(etry->journalContext, etry->pBindRuleset) != RS_RET_OK) {
+			tryRecover(etry->journalContext);
 			continue;
 		}
 
 		count++;
-		journalContext.atHead = 0;
-
-		if (cs.stateFile) { /* can't persist without a state file */
+		etry->journalContext->atHead = 0;
+		if (stateFile) { /* can't persist without a state file */
 			/* TODO: This could use some finer metric. */
 			if ((count % cs.iPersistStateInterval) == 0) {
-				persistJournalState();
+				persistJournalState(etry->journalContext, stateFile);
 			}
 		}
+	}
+finalize_it:
+	RETiRet;
+}
+
+static void *
+RunServerThread(void *myself)
+{
+	DEFiRet;
+	journal_etry_t *const etry = (journal_etry_t*) myself;
+	iRet = doRun(etry);
+	if(iRet != RS_RET_OK) {
+		LogError(0, iRet, "imjournal: error while stopping journal processing; "
+			"rsyslog may hang on shutdown");
+	}
+	return NULL;
+}
+
+/* support for running multiple servers on multiple threads (one server per thread) */
+static void
+startSrvWrkr(journal_etry_t *const etry)
+{
+	int r;
+	pthread_attr_t sessThrdAttr;
+
+	/* We need to temporarily block all signals because the new thread
+	 * inherits our signal mask. There is a race if we do not block them
+	 * now, and we have seen in practice that this race causes grief.
+	 * So we 1. save the current set, 2. block evertyhing, 3. start
+	 * threads, and 4 reset the current set to saved state.
+	 * rgerhards, 2019-08-16
+	 */
+	sigset_t sigSet, sigSetSave;
+	sigfillset(&sigSet);
+	/* enable signals we still need */
+	sigdelset(&sigSet, SIGTTIN);
+	sigdelset(&sigSet, SIGSEGV);
+	pthread_sigmask(SIG_SETMASK, &sigSet, &sigSetSave);
+
+	pthread_attr_init(&sessThrdAttr);
+	pthread_attr_setstacksize(&sessThrdAttr, 4096*1024);
+	r = pthread_create(&etry->tid, &sessThrdAttr, RunServerThread, etry);
+	if(r != 0) {
+		LogError(r, NO_ERRCODE, "imjournal: error creating imjournal thread");
+		/* we do NOT abort, as other servers may run - after all, we logged an error */
+	}
+	pthread_attr_destroy(&sessThrdAttr);
+	pthread_sigmask(SIG_SETMASK, &sigSetSave, NULL);
+}
+
+/* stop server worker thread
+ */
+static void
+stopSrvWrkr(journal_etry_t *const etry)
+{
+	DBGPRINTF("Wait for thread shutdown etry %p\n", etry);
+	pthread_kill(etry->tid, SIGTTIN);
+	pthread_join(etry->tid, NULL);
+	DBGPRINTF("input %p terminated\n", etry);
+}
+
+BEGINrunInput
+CODESTARTrunInput
+	CHKiRet(ratelimitNew(&ratelimiter, "imjournal", NULL));
+	dbgprintf("imjournal: ratelimiting burst %u, interval %u\n", cs.ratelimitBurst,
+		  cs.ratelimitInterval);
+	ratelimitSetLinuxLike(ratelimiter, cs.ratelimitInterval, cs.ratelimitBurst);
+	ratelimitSetNoTimeCache(ratelimiter);
+
+	/* handling old "usepidfromsystem" option */
+	if (cs.bUseJnlPID != -1) {
+		free(cs.usePid);
+		cs.usePid = strdup("system");
+		LogError(0, RS_RET_DEPRECATED,
+			"\"usepidfromsystem\" is deprecated, use \"usepid\" instead");
+	}
+
+	journal_etry_t *etry = journal_root->next;
+	while(etry != NULL) {
+		startSrvWrkr(etry);
+		etry = etry->next;
+	}
+
+	CHKiRet(doRun(journal_root));
+
+	etry = journal_root->next;
+	while(etry != NULL) {
+		stopSrvWrkr(etry);
+		etry = etry->next;
 	}
 
 finalize_it:
@@ -935,11 +1096,18 @@ ENDendCnfLoad
 
 
 BEGINcheckCnf
+	instanceConf_t *inst;
 CODESTARTcheckCnf
+	for(inst = pModConf->root ; inst != NULL ; inst = inst->next) {
+		std_checkRuleset(pModConf, inst);
+	}
 ENDcheckCnf
 
 
 BEGINactivateCnf
+	instanceConf_t *inst;
+	instanceConf_t *root_inst = NULL;
+	u_int8_t index = 0;
 CODESTARTactivateCnf
 	runModConf = pModConf;
 
@@ -975,31 +1143,122 @@ CODESTARTactivateCnf
 	CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));
 	/* end stats counter */
 
+	for(inst = runModConf->root ; inst != NULL ; inst = inst->next) {
+		if(cs.stateFile) {
+			char *new_stateFile;
+			if (-1 == asprintf(&new_stateFile, "%s/%s", cs.stateFile, inst->pszBindRuleset)) {
+					LogError(0, RS_RET_OUT_OF_MEMORY, "imjournal: asprintf failed\n");
+					ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+			}
+			free(inst->stateFile);
+			inst->stateFile = new_stateFile;;
+		}
+
+		// Only the first input module with main enabled will be treated as
+		// the main process.
+		if (inst->bMain && root_inst == NULL) {
+			root_inst = inst;
+		} else {
+			if (addListner(inst, index++) != RS_RET_OK) {
+				LogError(0, RS_RET_NO_MORE_DATA,
+				  "imjournal: Can only support up to %i journals\n",
+				  MAX_JOURNAL);
+				ABORT_FINALIZE(RS_RET_NO_MORE_DATA);
+			}
+		}
+	}
+
+	// Add all state files as a subfile of original cs.stateFile.
+	if(runModConf->root != NULL && cs.stateFile) {
+		char *new_stateFile;
+		if (-1 == asprintf(&new_stateFile, "%s/default", cs.stateFile)) {
+			LogError(0, RS_RET_OUT_OF_MEMORY, "imjournal: asprintf failed\n");
+			ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+		}
+
+		// TODO(need to delete old state file and create the folder.
+		DIR *stateDir;
+		if (!(stateDir = opendir(cs.stateFile))) {
+			remove(cs.stateFile);
+			mkdir(cs.stateFile, 0700);
+		} else {
+			closedir(stateDir);
+		}
+
+		free(cs.stateFile);
+		cs.stateFile = new_stateFile;;
+	}
+
+	// Default Handlers. Will be used as the main process if no `main`
+	// property is set in the input modules.
+	if (addListner(NULL, index++) != RS_RET_OK) {
+		LogError(0, RS_RET_NO_MORE_DATA,
+		  "imjournal: Can only support up to %i journals\n",
+		  MAX_JOURNAL);
+		ABORT_FINALIZE(RS_RET_NO_MORE_DATA);
+	}
+
+	// Main process will be the top of journal_root.
+	if (root_inst != NULL){
+		if (addListner(root_inst, index++) != RS_RET_OK) {
+			LogError(0, RS_RET_NO_MORE_DATA,
+			  "imjournal: Can only support up to %i journals\n",
+			  MAX_JOURNAL);
+			ABORT_FINALIZE(RS_RET_NO_MORE_DATA);
+		}
+	}
+
 finalize_it:
 ENDactivateCnf
 
 
 BEGINfreeCnf
+	instanceConf_t *inst, *del;
 CODESTARTfreeCnf
+	for(inst = pModConf->root ; inst != NULL ; ) {
+		free(inst->pszBindRuleset);
+		free(inst->stateFile);
+		del = inst;
+		inst = inst->next;
+		free(del);
+	}
 	free(cs.stateFile);
 	free(cs.usePid);
-	free(journalContext.cursor);
 	statsobj.Destruct(&(statsCounter.stats));
 ENDfreeCnf
 
 /* open journal */
 BEGINwillRun
+	journal_etry_t *etry = journal_root;
 CODESTARTwillRun
-	iRet = openJournal();
+	while(etry != NULL) {
+		CHKiRet(openJournal(etry->journalContext));
+		etry = etry->next;
+	}
+finalize_it:
 ENDwillRun
 
 /* close journal */
 BEGINafterRun
+	journal_etry_t *etry = journal_root;
+	journal_etry_t *del;
 CODESTARTafterRun
-	if (cs.stateFile) { /* can't persist without a state file */
-		persistJournalState();
+	while(etry != NULL) {
+		char *stateFile = cs.stateFile;
+		if (etry->stateFile) {
+			stateFile = etry->stateFile;
+		}
+		if (stateFile) { /* can't persist without a state file */
+			persistJournalState(etry->journalContext, stateFile);
+		}
+		closeJournal(etry->journalContext);
+		free(etry->journalContext->cursor);
+		// TODO: check iRet, reprot error
+		del = etry;
+		etry = etry->next;
+		free(del);
 	}
-	closeJournal();
+
 	if (ratelimiter) {
 		ratelimitDestruct(ratelimiter);
 	}
@@ -1020,6 +1279,7 @@ CODESTARTmodExit
 	objRelease(datetime, CORE_COMPONENT);
 	objRelease(parser, CORE_COMPONENT);
 	objRelease(prop, CORE_COMPONENT);
+	objRelease(ruleset, CORE_COMPONENT);
 ENDmodExit
 
 
@@ -1096,6 +1356,73 @@ finalize_it:
 		cnfparamvalsDestruct(pvals, &modpblk);
 ENDsetModCnf
 
+/* create input instance, set default parameters, and
+ * add it to the list of instances.
+ */
+static rsRetVal ATTR_NONNULL(1)
+createInstance(instanceConf_t **const pinst)
+{
+	instanceConf_t *inst;
+	DEFiRet;
+	CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
+	inst->next = NULL;
+	inst->pBindRuleset = NULL;
+	inst->pszBindRuleset = NULL;
+
+	/* node created, let's add to config */
+	if(loadModConf->tail == NULL) {
+		loadModConf->tail = loadModConf->root = inst;
+	} else {
+		loadModConf->tail->next = inst;
+		loadModConf->tail = inst;
+	}
+
+	*pinst = inst;
+finalize_it:
+	if(iRet != RS_RET_OK) {
+		free(inst);
+	}
+	RETiRet;
+}
+
+
+BEGINnewInpInst
+	struct cnfparamvals *pvals;
+	instanceConf_t *inst;
+	int i;
+CODESTARTnewInpInst
+	DBGPRINTF("newInpInst (imjournal)\n");
+
+	pvals = nvlstGetParams(lst, &inppblk, NULL);
+	if(pvals == NULL) {
+		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+	}
+
+	if(Debug) {
+		DBGPRINTF("input param blk in imjournal:\n");
+		cnfparamsPrint(&inppblk, pvals);
+	}
+
+	CHKiRet(createInstance(&inst));
+
+	for(i = 0 ; i < inppblk.nParams ; ++i) {
+		if(!pvals[i].bUsed)
+			continue;
+		if(!strcmp(inppblk.descr[i].name, "ruleset")) {
+			inst->pszBindRuleset = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(inppblk.descr[i].name, "main")) {
+			inst->bMain = (int) pvals[i].val.d.n;
+		} else {
+			DBGPRINTF("program error, non-handled "
+			  "param '%s'\n", inppblk.descr[i].name);
+		}
+	}
+finalize_it:
+CODE_STD_FINALIZERnewInpInst
+	if (pvals != NULL)
+		cnfparamvalsDestruct(pvals, &inppblk);
+ENDnewInpInst
+
 
 BEGINisCompatibleWithFeature
 CODESTARTisCompatibleWithFeature
@@ -1109,9 +1436,17 @@ CODESTARTqueryEtryPt
 CODEqueryEtryPt_STD_IMOD_QUERIES
 CODEqueryEtryPt_STD_CONF2_QUERIES
 CODEqueryEtryPt_STD_CONF2_setModCnf_QUERIES
+CODEqueryEtryPt_STD_CONF2_IMOD_QUERIES
 CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES
 ENDqueryEtryPt
 
+
+static inline void
+std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *inst)
+{
+	LogError(0, NO_ERRCODE, "imjournal: ruleset '%s' not found - "
+			"using default ruleset instead", inst->pszBindRuleset);
+}
 
 BEGINmodInit()
 CODESTARTmodInit
@@ -1123,6 +1458,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(prop, CORE_COMPONENT));
 	CHKiRet(objUse(net, CORE_COMPONENT));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
+	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 
 	/* we need to create the inputName property (only once during our lifetime) */
 	CHKiRet(prop.CreateStringProp(&pInputName, UCHAR_CONSTANT("imjournal"), sizeof("imjournal") - 1));


### PR DESCRIPTION
Allow us to bind the imjournal input to an output module. Thie enable us to block journal reading if the output module is failing. Note that we will only allow one input module for imjournal since we do not have multiple input sources. The memory usage can be high with multiple outputs.


The input module support the `main` argument to select the config to use in the main thread and will be stop stopped if the output source is not accepting data. Other rules in the background will continue.

Tested:

Example Config:
```
template(name="journal-format" type="string"
  string="%TIMESTAMP:::date-rfc3339% %HOSTNAME% %syslogtag% %msg%\n"
)

ruleset(name="remote" queue.type="direct"){
  action(
    type="omfwd"
    target="IP_ADDRESS"
    port="PORT"
    protocol="tcp"
    template="journal-format"
    StreamDriver="ossl"
    StreamDriverMode="0"
    StreamDriverAuthMode="anon"
    action.resumeRetryCount="-1"
  )
}

input(
 type="imjournal"
 ruleset="remote"
 main="on"
)
```

- Stop collector network -> Stop Journal pointer
```
SECONDS=0
expected="$(md5sum /var/log/state)"
echo "Expected state ${expected}"
while [ $SECONDS -lt 300 ];
do
  new_state="$(md5sum /var/log/state)"
  if [[ "${new_state}" != "${expected}" ]];
  then
    echo "Got state ${new_state} instead of ${expected}"
      exit 1
  fi
  sleep 5
done
echo "Passed"
exit 0
```

```
Expected state 309593de34bc095e4245c1ba07a7520c  /var/log/state
Passed
```

- Resume Journal Pointer

The state file changed after the connection resumed.
```
$ md5sum /var/log/state
d11c7e46fec4f86151df204608525d89  /var/log/state
```

The message send in when the connection was down is also sent out properly.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
