### PR TITLE
build system: more precise error message on too-old lib

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -389,10 +389,16 @@ AC_ARG_ENABLE(libcap-ng,
 
 if test "$enable_libcapng" = "yes"; then
         PKG_CHECK_MODULES(
+                [LIBCAPNG_PRESENT],
+                [libcap-ng],
+                [AC_DEFINE([ENABLE_LIBCAPNG_PRESENT], [1], [Indicator that libcap-ng is present])],
+                [AC_MSG_ERROR(libcap-ng is not present.)]
+        )
+        PKG_CHECK_MODULES(
                 [LIBCAPNG],
                 [libcap-ng >= 0.8.2],
                 [AC_DEFINE([ENABLE_LIBCAPNG], [1], [Indicator that libcap-ng is present])],
-                [AC_MSG_ERROR(libcap-ng is not present.)]
+                [AC_MSG_ERROR([libcap-ng is present, but outdated - need 0.8.2 or above.])]
         )
         CFLAGS="$CFLAGS $LIBCAPNG_CFLAGS"
         LIBS="$LIBS $LIBCAPNG_LIBS"

--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -40,10 +40,10 @@ fi
 printf '/rsyslog is mapped to %s \n' "$RSYSLOG_HOME"
 printf 'using container %s\n' "$RSYSLOG_DEV_CONTAINER"
 printf 'pulling container...\n'
+docker pull $RSYSLOG_DEV_CONTAINER
 printf 'user ids: %s:%s\n' $(id -u) $(id -g)
 printf 'container_uid: %s\n' ${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)}
 printf 'container cmd: %s\n' $*
-docker pull $RSYSLOG_DEV_CONTAINER
 docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e RSYSLOG_CONFIGURE_OPTIONS_EXTRA \
 	-e RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE \


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
