### PR TITLE
Clear undefined behavior in libgcry.c (GH #5167)

### DIFF
--- a/runtime/libgcry.c
+++ b/runtime/libgcry.c
@@ -575,7 +575,7 @@ seedIV(gcryfile gf, uchar **iv)
 		if(shift == 0) { /* need new random data? */
 			rndnum = randomNumber();
 		}
-		(*iv)[i] = 0xff & ((rndnum & (0xff << shift)) >> shift);
+		(*iv)[i] = 0xff & ((rndnum & (255u << shift)) >> shift);
 	}
 finalize_it:
 	RETiRet;


### PR DESCRIPTION
This commit clear some undefined behavior in libgcry.c. When testing with Undefined Behavior sanitizer, it led to 5 failed self tests.
