### PR TITLE
action.resumeintervalmax: the parameter was not respected

### DIFF
--- a/action.c
+++ b/action.c
@@ -2110,7 +2110,7 @@ actionApplyCnfParam(action_t * const pAction, struct cnfparamvals * const pvals)
 			pAction->bCopyMsg = (int) pvals[i].val.d.n;
 		} else if(!strcmp(pblk.descr[i].name, "action.resumeinterval")) {
 			pAction->iResumeInterval = pvals[i].val.d.n;
-		} else if(!strcmp(pblk.descr[i].name, "action.resumeintervalMax")) {
+		} else if(!strcmp(pblk.descr[i].name, "action.resumeintervalmax")) {
 			pAction->iResumeIntervalMax = pvals[i].val.d.n;
 		} else {
 			dbgprintf("action: program error, non-handled "


### PR DESCRIPTION
Unfortunately, defining ```action.resumeintervalmax``` in the configuration did not have any effect at all. Instead, the default value was used, which is ```1800```. This was caused by not having all the letters in lower-case. Fixes #5132

### Side note
If you start rsyslog with debug enabled, you can see that the parameter was detected correctly:
```
6038.749939940:main thread    : rainerscript.c: action.resumeintervalmax: 10
6038.749947294:main thread    : rainerscript.c: action.resumeinterval: 10
```

But it was not respected when it was assigned to internal variables:
```
6038.750271326:main thread    : ../action.c: Module builtin:omfwd processes this action.
6038.750275355:main thread    : ../action.c: action: program error, non-handled param 'action.resumeintervalmax'
```

I was not expecting this when I started debugging the problem :D