### PR TITLE
build system: make rsyslogd execute when --disable-inet is configured

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -677,7 +677,7 @@ fi
 
 # inet
 AC_ARG_ENABLE(inet,
-        [AS_HELP_STRING([--enable-inet],[Enable networking support @<:@default=yes@:>@])],
+        [AS_HELP_STRING([--enable-inet],[Enable automatic load of omfwd and limit build of networking libraries @<:@default=yes@:>@])],
         [case "${enableval}" in
          yes) enable_inet="yes" ;;
           no) enable_inet="no" ;;

--- a/parse.c
+++ b/parse.c
@@ -373,7 +373,6 @@ finalize_it:
  * full hostname (e.g.: localhost.localdomain) or hostname wildcard
  * (e.g.: *.localdomain).
  */
-#ifdef SYSLOG_INET
 rsRetVal parsAddrWithBits(rsParsObj *pThis, struct NetAddr **pIP, int *pBits)
 {
 	register uchar *pC;
@@ -509,7 +508,6 @@ finalize_it:
 	free(pszIP);
 	RETiRet;
 }
-#endif  /* #ifdef SYSLOG_INET */
 
 
 /* tell if the parsepointer is at the end of the

--- a/parse.h
+++ b/parse.h
@@ -100,10 +100,6 @@ rsRetVal rsParsDestruct(rsParsObj *pThis);
 int parsIsAtEndOfParseString(rsParsObj *pThis);
 int parsGetCurrentPosition(rsParsObj *pThis);
 char parsPeekAtCharAtParsPtr(rsParsObj *pThis);
-#ifdef SYSLOG_INET
 rsRetVal parsAddrWithBits(rsParsObj *pThis, netAddr_t **pIP, int *pBits);
-#endif
 
 #endif
-/* vim:set ai:
- */

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -160,16 +160,17 @@ lmzlibw_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)
 endif
 
 
-if ENABLE_INET
-pkglib_LTLIBRARIES += lmnet.la lmnetstrms.la
 #
-# network support
+# basic network support, needed for rsyslog startup (e.g. our own system name)
 #
+pkglib_LTLIBRARIES += lmnet.la
 lmnet_la_SOURCES = net.c net.h
 lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo
 lmnet_la_LIBADD =
 
+if ENABLE_INET
+pkglib_LTLIBRARIES += lmnetstrms.la
 if ENABLE_LIBLOGGING_STDLOG
 lmnet_la_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 lmnet_la_LDFLAGS += $(LIBLOGGING_STDLOG_LIBS)

--- a/runtime/conf.c
+++ b/runtime/conf.c
@@ -629,7 +629,7 @@ ENDObjClassExit(conf)
 BEGINAbstractObjClassInit(conf, 1, OBJ_IS_CORE_MODULE) /* class, version - CHANGE class also in END MACRO! */
 	/* request objects we use */
 	CHKiRet(objUse(module, CORE_COMPONENT));
-	CHKiRet(objUse(net, LM_NET_FILENAME)); /* TODO: make this dependcy go away! */
+	CHKiRet(objUse(net, LM_NET_FILENAME));
 	CHKiRet(objUse(ruleset, CORE_COMPONENT));
 
 	/* These commands will NOT be supported -- the new v6.3 config system provides
@@ -638,6 +638,3 @@ BEGINAbstractObjClassInit(conf, 1, OBJ_IS_CORE_MODULE) /* class, version - CHANG
 	CHKiRet(regCfSysLineHdlr((uchar *)"resetconfigvariables", 1, eCmdHdlrCustomHandler, resetConfigVariables,
 NULL, NULL));
 ENDObjClassInit(conf)
-
-/* vi:set ai:
- */


### PR DESCRIPTION
This option is mostly useless, as network functionality depends on the modules loaded by the config. The only real, and important, effect it has is to control auto-load of omfwd - a feature almost all installations depend in (backward compatibility).

This has been clarified in ./configure -help

Also, when --disable-inet is given, rsyslog now executes successfully. The reason for the abort was that previously building of the lmnet component was prevented, but that component is also needed by rsyslog startup itself to query its own (correct) hostname.

closes https://github.com/rsyslog/rsyslog/issues/5188

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
