### PR TITLE
testbench: make waiting for HUP processing more reliable

### DIFF
--- a/dirty.h
+++ b/dirty.h
@@ -5,7 +5,7 @@
  * yet a runtime library, because it depends on some functionality
  * residing somewhere else.
  *
- * Copyright 2007-2014 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2023 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -39,6 +39,7 @@ rsRetVal __attribute__((deprecated)) parseAndSubmitMessage(const uchar *hname,
 	const time_t ttGenTime, ruleset_t *pRuleset);
 rsRetVal createMainQueue(qqueue_t **ppQueue, uchar *pszQueueName, struct nvlst *lst);
 rsRetVal startMainQueue(rsconf_t *cnf, qqueue_t *pQueue);
+int get_bHadHUP(void);
 
 extern int MarkInterval;
 #define CONF_VERIFY_PARTIAL_CONF 0x02		/* bit: partial configuration to be checked */


### PR DESCRIPTION
The previous approach was more or less delay based. We have now changed the code to enable imdiag to detect if HUP is underway and wait until it is completed. The new method still employs some kind of timeout, but is now quite reliable. Most importantly, it works great with long-running HUP processing, which can happen e.g. when querying the system name takes long or some actions need longer time to persist their HUP processing.

The new approach will most likely reduce CI flakes and also speed up testbench runs. The speedup happens from not having to wait a full delay in cases where we detect HUP is completed (plus reduced timeout when we cannot clearly detect this - see code comments why the new method is still considered more reliable than the old one).

closes https://github.com/rsyslog/rsyslog/issues/5192

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
