### PR TITLE
openssl: Replaced depreceated method SSLv23_method with TLS_method

### DIFF
--- a/runtime/nsdsel_ptcp.c
+++ b/runtime/nsdsel_ptcp.c
@@ -158,6 +158,9 @@ IsReady(nsdsel_t *const pNsdsel, nsd_t *const pNsd, const nsdsel_waitOp_t waitOp
 	}
 
 	const short revent = pThis->fds[idx].revents;
+	if (revent & POLLNVAL) {
+		DBGPRINTF("ndssel_ptcp: revent & POLLNVAL is TRUE, something is wrong, revent = %d", revent);
+	}
 	assert(!(revent & POLLNVAL));
 	switch(waitOp) {
 		case NSDSEL_RD:

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1224,8 +1224,12 @@ initTLS(void)
 	ERR_load_BIO_strings();
 	ERR_load_crypto_strings();
 
-	/* Create main CTX Object */
+	/* Create main CTX Object. Use SSLv23_method for < Openssl 1.1.0 and TLS_method for all newer versions! */
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
 	ctx = SSL_CTX_new(SSLv23_method());
+#else
+	ctx = SSL_CTX_new(TLS_method());
+#endif
 
 	if(tlsCAFile != NULL && SSL_CTX_load_verify_locations(ctx, tlsCAFile, NULL) != 1) {
 		printf("tcpflood: Error, Failed loading CA certificate"


### PR DESCRIPTION
In OpenSSL 1.1.0 and higher, SSLv23_method causes some errors
in TLS handshake from time to time. As this method is depreceated
since 1.1.0, I have replaced it with the follow up method
TLS_method which is the most generic one.

It fixes the random test failures in tests like
- sndrcv_tls_ossl_anon_rebind.sh

Also added some debug output in OpenSSL error handling, which is
useful when analysing debug files.

closes: https://github.com/rsyslog/rsyslog/issues/5201
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
