### PR TITLE
lookup tables bugfix: reload on HUP did not work when backgrounded

### DIFF
--- a/runtime/lookup.h
+++ b/runtime/lookup.h
@@ -1,6 +1,6 @@
 /* header for lookup.c
  *
- * Copyright 2013 Adiscon GmbH.
+ * Copyright 2013-2023 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -111,5 +111,6 @@ void lookupDoHUP(void);
 rsRetVal lookupReload(lookup_ref_t *pThis, const uchar *stub_value_if_reload_fails);
 uint lookupPendingReloadCount(void);
 rsRetVal lookupClassInit(void);
+void lookupActivateConf(void);
 
 #endif /* #ifndef INCLUDED_LOOKUP_H */

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -2,7 +2,7 @@
  *
  * Module begun 2011-04-19 by Rainer Gerhards
  *
- * Copyright 2011-2022 Adiscon GmbH.
+ * Copyright 2011-2023 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -1038,6 +1038,7 @@ activate(rsconf_t *cnf)
 
 	CHKiRet(dropPrivileges(cnf));
 
+	lookupActivateConf();
 	tellModulesActivateConfig();
 	startInputModules();
 	CHKiRet(activateActions());

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -480,6 +480,7 @@ TESTS +=  \
 	incltest_dir_empty_wildcard.sh \
 	linkedlistqueue.sh \
 	lookup_table.sh \
+	lookup_table-hup-backgrounded.sh \
 	lookup_table_no_hup_reload.sh \
 	key_dereference_on_uninitialized_variable_space.sh \
 	array_lookup_table.sh \
@@ -2893,6 +2894,7 @@ EXTRA_DIST= \
 	rscript_re_match.sh \
 	rscript_re_match-dbl_quotes.sh \
 	lookup_table.sh \
+	lookup_table-hup-backgrounded.sh \
 	lookup_table_no_hup_reload.sh \
 	lookup_table_no_hup_reload-vg.sh \
 	lookup_table_rscript_reload.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -130,6 +130,20 @@ skip_platform() {
 
 }
 
+# function to skip a test if TSAN is enabled
+# This is necessary as TSAN does not properly handle thread creation
+# after fork() - which happens regularly in rsyslog if backgrounding
+# is activated.
+# $1 is the reason why TSAN is not supported
+# note: we depend on CFLAGS to properly reflect build options (what
+#       usually is the case when the testbench is run)
+skip_TSAN() {
+	if [[ "$CFLAGS" == *"sanitize=thread"* ]]; then
+		printf 'test incompatible with TSAN because of %s\n' "$1"
+		exit 77
+	fi
+}
+
 
 # a consistent format to output testbench timestamps
 tb_timestamp() {

--- a/tests/lookup_table-hup-backgrounded.sh
+++ b/tests/lookup_table-hup-backgrounded.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# test for lookup-table and HUP based reloading of it
+# added 2015-09-30 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_TSAN
+generate_conf
+add_conf '
+lookup_table(name="xlate" file="'$RSYSLOG_DYNNAME'.xlate.lkp_tbl" reloadOnHUP="on")
+
+template(name="outfmt" type="string" string="- %msg% %$.lkp%\n")
+
+set $.lkp = lookup("xlate", $msg);
+
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+cp -f $srcdir/testsuites/xlate.lkp_tbl $RSYSLOG_DYNNAME.xlate.lkp_tbl
+export RSTB_DAEMONIZE="YES"
+startup
+injectmsg  0 3
+wait_queueempty
+content_check "msgnum:00000000: foo_old"
+content_check "msgnum:00000001: bar_old"
+assert_content_missing "baz"
+cp -f $srcdir/testsuites/xlate_more.lkp_tbl $RSYSLOG_DYNNAME.xlate.lkp_tbl
+issue_HUP
+await_lookup_table_reload
+injectmsg  0 3
+wait_queueempty
+content_check "msgnum:00000000: foo_new"
+content_check "msgnum:00000001: bar_new"
+content_check "msgnum:00000002: baz"
+cp -f $srcdir/testsuites/xlate_more_with_duplicates_and_nomatch.lkp_tbl $RSYSLOG_DYNNAME.xlate.lkp_tbl
+issue_HUP
+await_lookup_table_reload
+injectmsg  0 10
+echo doing shutdown
+shutdown_when_empty
+echo wait on shutdown
+wait_shutdown
+content_check "msgnum:00000000: foo_latest"
+content_check "msgnum:00000001: quux"
+content_check "msgnum:00000002: baz_latest"
+content_check "msgnum:00000003: foo_latest"
+content_check "msgnum:00000004: foo_latest"
+content_check "msgnum:00000005: baz_latest"
+content_check "msgnum:00000006: foo_latest"
+content_check "msgnum:00000007: baz_latest"
+content_check "msgnum:00000008: baz_latest"
+content_check "msgnum:00000009: quux"
+exit_test

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1861,7 +1861,6 @@ finalize_it:
  */
 DEFFUNC_llExecFunc(doHUPActions)
 {
-	dbgprintf("doHUP called\n");
 	actionCallHUPHdlr((action_t*) pData);
 	return RS_RET_OK; /* we ignore errors, we can not do anything either way */
 }
@@ -1882,6 +1881,7 @@ doHUP(void)
 {
 	char buf[512];
 
+	DBGPRINTF("doHUP: doing modules\n");
 	if(ourConf->globals.bLogStatusMsgs) {
 		snprintf(buf, sizeof(buf),
 			 "[origin software=\"rsyslogd\" " "swVersion=\"" VERSION
@@ -1893,8 +1893,11 @@ doHUP(void)
 
 	queryLocalHostname(); /* re-read our name */
 	ruleset.IterateAllActions(ourConf, doHUPActions, NULL);
+	DBGPRINTF("doHUP: doing modules\n");
 	modDoHUP();
+	DBGPRINTF("doHUP: doing lookup tables\n");
 	lookupDoHUP();
+	DBGPRINTF("doHUP: doing errmsgs\n");
 	errmsgDoHUP();
 }
 


### PR DESCRIPTION
Lookup tables were only reloaded on HUP if the -n option was given and rsyslog no backgrounded. This patch fixes the issue.

closes: https://github.com/rsyslog/rsyslog/issues/4813

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
