### PR TITLE
Avoid crash on restart in imrelp SIGTTIN handler

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -839,7 +839,7 @@ static void
 doSIGTTIN(int __attribute__((unused)) sig)
 {
 	const int bTerminate = ATOMIC_FETCH_32BIT(&bTerminateInputs, &mutTerminateInputs);
-	if(bTerminate) {
+	if(bTerminate && (pRelpEngine != NULL)) {
 		relpEngineSetStop(pRelpEngine);
 	}
 }
@@ -882,6 +882,12 @@ ENDafterRun
 
 BEGINmodExit
 CODESTARTmodExit
+	struct sigaction newAct;
+	memset(&newAct, 0, sizeof (newAct));
+	sigemptyset(&newAct.sa_mask);
+	newAct.sa_handler = SIG_IGN;
+	sigaction(SIGTTIN, &newAct, NULL);
+
 	if(pRelpEngine != NULL)
 		iRet = relpEngineDestruct(&pRelpEngine);
 


### PR DESCRIPTION
While existing, if at specific time rsyslog receives a SIGTTIN, it crashes due to 2 issues.

1. debug.unloadModules="off" a double free of pRelpEngine
2. debug.unloadModules="on" it crashes because the signal handler has been unmapped from memory.

This patch covers both issues and fixes #5219.
