### PR TITLE
Add new global config option "libcapng.enable"

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -180,7 +180,8 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "shutdown.queue.doublesize", eCmdHdlrBinary, 0 },
 	{ "debug.files", eCmdHdlrArray, 0 },
 	{ "debug.whitelist", eCmdHdlrBinary, 0 },
-	{ "libcapng.default", eCmdHdlrBinary, 0 }
+	{ "libcapng.default", eCmdHdlrBinary, 0 },
+	{ "libcapng.enable", eCmdHdlrBinary, 0 },
 };
 static struct cnfparamblk paramblk =
 	{ CNFPARAMBLK_VERSION,
@@ -1211,6 +1212,13 @@ glblDoneLoadCnf(void)
 		} else if(!strcmp(paramblk.descr[i].name, "libcapng.default")) {
 #ifdef ENABLE_LIBCAPNG
 			loadConf->globals.bAbortOnFailedLibcapngSetup = (int) cnfparamvals[i].val.d.n;
+#else
+			LogError(0, RS_RET_ERR, "rsyslog wasn't "
+				"compiled with libcap-ng support.");
+#endif
+		} else if(!strcmp(paramblk.descr[i].name, "libcapng.enable")) {
+#ifdef ENABLE_LIBCAPNG
+			loadConf->globals.bCapabilityDropEnabled = (int) cnfparamvals[i].val.d.n;
 #else
 			LogError(0, RS_RET_ERR, "rsyslog wasn't "
 				"compiled with libcap-ng support.");

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -161,6 +161,7 @@ static void cnfSetDefaults(rsconf_t *pThis)
 {
 #ifdef ENABLE_LIBCAPNG
 	pThis->globals.bAbortOnFailedLibcapngSetup = 1;
+	pThis->globals.bCapabilityDropEnabled = 1;
 #endif
 	pThis->globals.bAbortOnUncleanConfig = 0;
 	pThis->globals.bAbortOnFailedQueueStartup = 0;

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -86,6 +86,7 @@ struct parsercnf_s {
 struct globals_s {
 #ifdef ENABLE_LIBCAPNG
 	int bAbortOnFailedLibcapngSetup;
+	int bCapabilityDropEnabled;
 #endif
 	int bDebugPrintTemplateList;
 	int bDebugPrintModuleList;


### PR DESCRIPTION
Defines whether rsyslog should drop capabilities at startup or not. By default, it is set to "on". Until this point, if the project was compiled with ```--enable-libcap-ng``` option, capabilities were automatically dropped. This is configurable now.
