### PR TITLE
Remove no longer used --with-systemdsystemunitdir configure switch

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -356,7 +356,6 @@ DISTCHECK_CONFIGURE_FLAGS=
 # in a make distcheck is so that we detect code that accidently was not updated
 # when some global update happened.
 DISTCHECK_CONFIGURE_FLAGS+= \
-	--with-systemdsystemunitdir=$$dc_install_base/$(systemdsystemunitdir) \
 	--enable-silent-rules \
 	--enable-rsyslogd \
 	--enable-omstdout \

--- a/configure.ac
+++ b/configure.ac
@@ -729,16 +729,6 @@ if test "$enable_unlimited_select" = "yes"; then
 fi
 
 
-# support for systemd unit files
-AC_ARG_WITH([systemdsystemunitdir],
-        AS_HELP_STRING([--with-systemdsystemunitdir=DIR], [Directory for systemd service files]),
-        [], [with_systemdsystemunitdir=$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
-if test "x$with_systemdsystemunitdir" != xno; then
-        AC_SUBST([systemdsystemunitdir], [$with_systemdsystemunitdir])
-fi
-AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
-
-
 # debug
 AC_ARG_ENABLE(debug,
         [AS_HELP_STRING([--enable-debug],[Enable debug mode @<:@default=auto@:>@])],


### PR DESCRIPTION
This is a clean up following the removal of the service unit in cfd07503ba055100a84d75d1a78a5c6cceb9fdab

