### PR TITLE
Netstreamdriver: deallocate certificate related resources

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -410,6 +410,7 @@ setDfltNetstrmDrvrCAF(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 	DEFiRet;
 	FILE *fp;
 	free(loadConf->globals.pszDfltNetstrmDrvrCAF);
+	loadConf->globals.pszDfltNetstrmDrvrCAF = pNewVal;
 	fp = fopen((const char*)pNewVal, "r");
 	if(fp == NULL) {
 		LogError(errno, RS_RET_NO_FILE_ACCESS,
@@ -417,7 +418,6 @@ setDfltNetstrmDrvrCAF(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 			"could not be accessed", pNewVal);
 	} else {
 		fclose(fp);
-		loadConf->globals.pszDfltNetstrmDrvrCAF = pNewVal;
 	}
 
 	RETiRet;
@@ -458,6 +458,7 @@ setDfltNetstrmDrvrCRLF(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 	DEFiRet;
 	FILE *fp;
 	free(loadConf->globals.pszDfltNetstrmDrvrCRLF);
+	loadConf->globals.pszDfltNetstrmDrvrCRLF = pNewVal;
 	fp = fopen((const char*)pNewVal, "r");
 	if(fp == NULL) {
 		LogError(errno, RS_RET_NO_FILE_ACCESS,
@@ -465,7 +466,6 @@ setDfltNetstrmDrvrCRLF(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 			"could not be accessed", pNewVal);
 	} else {
 		fclose(fp);
-		loadConf->globals.pszDfltNetstrmDrvrCRLF = pNewVal;
 	}
 
 	RETiRet;
@@ -478,6 +478,7 @@ setDfltNetstrmDrvrCertFile(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 	FILE *fp;
 
 	free(loadConf->globals.pszDfltNetstrmDrvrCertFile);
+	loadConf->globals.pszDfltNetstrmDrvrCertFile = pNewVal;
 	fp = fopen((const char*)pNewVal, "r");
 	if(fp == NULL) {
 		LogError(errno, RS_RET_NO_FILE_ACCESS,
@@ -485,7 +486,6 @@ setDfltNetstrmDrvrCertFile(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 			"could not be accessed", pNewVal);
 	} else {
 		fclose(fp);
-		loadConf->globals.pszDfltNetstrmDrvrCertFile = pNewVal;
 	}
 
 	RETiRet;
@@ -497,6 +497,7 @@ setDfltNetstrmDrvrKeyFile(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 	FILE *fp;
 
 	free(loadConf->globals.pszDfltNetstrmDrvrKeyFile);
+	loadConf->globals.pszDfltNetstrmDrvrKeyFile = pNewVal;
 	fp = fopen((const char*)pNewVal, "r");
 	if(fp == NULL) {
 		LogError(errno, RS_RET_NO_FILE_ACCESS,
@@ -504,7 +505,6 @@ setDfltNetstrmDrvrKeyFile(void __attribute__((unused)) *pVal, uchar *pNewVal) {
 			"could not be accessed", pNewVal);
 	} else {
 		fclose(fp);
-		loadConf->globals.pszDfltNetstrmDrvrKeyFile = pNewVal;
 	}
 
 	RETiRet;


### PR DESCRIPTION
Free resources when a certificate path has been typed in incorrectly. It will also trigger more information on the configuration problem including consequences.

### Problem
Default netstreamdriver related value, e.g. certificate was not specified correctly.

### Actual behavior 
```
rsyslogd: error: defaultnetstreamdriverkeyfile '/etc/rsyslogd.d/server-key.pema' could not be accessed: No such file or directory [v8.2312.0.master try https://www.rsyslog.com/e/2039 ]

=================================================================
==70902==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 32 byte(s) in 1 object(s) allocated from:
    #0 0x7fc1392d92ef in malloc (/lib64/libasan.so.8+0xd92ef) (BuildId: 542ad02088f38edfdba9d4bfa465b2299f512d3e)
    #1 0x7fc13995ab4f in es_str2cstr (/lib64/libestr.so.0+0x1b4f) (BuildId: 54dd8603dcca88b5ed5c139ab3cc31bb280c1c6e)
    #2 0x4d4c5f in glblDoneLoadCnf /home/alakatos/github/rsyslog/runtime/glbl.c:1236
    #3 0x4ed5e1 in tellCoreConfigLoadDone /home/alakatos/github/rsyslog/runtime/rsconf.c:762
    #4 0x4f43d7 in load /home/alakatos/github/rsyslog/runtime/rsconf.c:1521
    #5 0x41a621 in initAll /home/alakatos/github/rsyslog/tools/rsyslogd.c:1636
    #6 0x41da70 in main /home/alakatos/github/rsyslog/tools/rsyslogd.c:2337
    #7 0x7fc138849b89 in __libc_start_call_main (/lib64/libc.so.6+0x27b89) (BuildId: 7026fe8c129a523e07856d7c96306663ceab6e24)
    #8 0x7fc138849c4a in __libc_start_main_alias_2 (/lib64/libc.so.6+0x27c4a) (BuildId: 7026fe8c129a523e07856d7c96306663ceab6e24)
    #9 0x410394 in _start (/usr/local/sbin/rsyslogd+0x410394) (BuildId: 83c42335a5dcec7c42da7b2f9d987a995de2e95a)

SUMMARY: AddressSanitizer: 32 byte(s) leaked in 1 allocation(s).
```

With proposed patch:
```
rsyslogd: error: defaultnetstreamdriverkeyfile '/etc/rsyslogd.d/server-key.pema' could not be accessed: No such file or directory [v8.2312.0.master try https://www.rsyslog.com/e/2039 ]
rsyslogd: error reading file - a common cause is that the file  does not exist [v8.2312.0.master try https://www.rsyslog.com/e/2078 ]
rsyslogd: error adding our certificate. GnuTLS error -64, message: 'Error while reading file.', key: '/etc/rsyslogd.d/server-key.pema', cert: '/etc/rsyslogd.d/server-cert.pem' [v8.2312.0.master try https://www.rsyslog.com/e/2078 ]
rsyslogd: Could not create tcp listener, ignoring port 6514 bind-address **UNSPECIFIED**. [v8.2312.0.master try https://www.rsyslog.com/e/2078 ]
```

If you think the patch adds too much debug info, feel free to close this PR.