### PR TITLE
imfile: remove state file on file delete fix

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1153,6 +1153,7 @@ fs_node_destroy(fs_node_t *const node)
 	DBGPRINTF("node destroy: %p edges:\n", node);
 
 	for(edge = node->edges ; edge != NULL ; ) {
+		detect_updates(edge);
 		fs_node_destroy(edge->node);
 		fs_edge_t *const toDel = edge;
 		edge = edge->next;


### PR DESCRIPTION
The state file would remain in the working directory after shutdown, even though deleteStateOnfileDelete is set to "on" and the monitored file was removed. In case there was no other `inotify` event created that would trigger `detect_updates()`, the state file would remain in the system and would contain false information about a to be monitored file.

Fixes: #5258