### PR TITLE
imdocker: Add image name to metadata fields

### DIFF
--- a/doc/source/configuration/modules/imdocker.rst
+++ b/doc/source/configuration/modules/imdocker.rst
@@ -19,7 +19,7 @@ Other features include:
 
 - filter containers through the plugin options
 - handle long log lines (greater than 16kb) and obtain
-- container metadata, such as container id, name, image id, labels, etc.
+- container metadata, such as container id, name, image, image id, labels, etc.
 
 **Note**: Multiple docker instances are not supported at the time of this writing.
 
@@ -108,6 +108,8 @@ data items:
 
 - **Names** - the first container associated with the message.
 
+- **Image** - the image name and tag of the container associated with the message.
+
 - **ImageID** - the image id of the container associated with the message.
 
 - **Labels** - all the labels of the container associated with the message in json format.
@@ -174,6 +176,6 @@ An example of how to create a template with container metadata
 .. code-block:: none
 
   template (name="ImdockerFormat" type="string"
-  	string="program:%programname% tag:%syslogtag% id:%$!metadata!Id% name:%$!metadata!Names% imageid:%$!metadata!ImageID% labels:%$!metadata!Labels% msg: %msg%\n"
+  	string="program:%programname% tag:%syslogtag% id:%$!metadata!Id% name:%$!metadata!Names% image:%$!metadata!Image% imageid:%$!metadata!ImageID% labels:%$!metadata!Labels% msg: %msg%\n"
   )
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1098,12 +1098,14 @@ if ENABLE_IMDOCKER
 if ENABLE_IMDOCKER_TESTS
 TESTS += \
 	imdocker-basic.sh \
+	imdocker-image-name.sh \
 	imdocker-long-logline.sh \
 	imdocker-new-logs-from-start.sh \
 	imdocker-multi-line.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	imdocker-basic-vg.sh \
+	imdocker-image-name-vg.sh \
 	imdocker-long-logline-vg.sh \
 	imdocker-new-logs-from-start-vg.sh \
 	imdocker-multi-line-vg.sh

--- a/tests/imdocker-image-name-vg.sh
+++ b/tests/imdocker-image-name-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/imdocker-image-name.sh

--- a/tests/imdocker-image-name.sh
+++ b/tests/imdocker-image-name.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+# imdocker unit tests are enabled with --enable-imdocker-tests
+. ${srcdir:=.}/diag.sh init
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="image=%$!metadata!Image%\n")
+module(load="../contrib/imdocker/.libs/imdocker")
+if $!metadata!Names == "'$COOKIE'" then {
+  action(type="omfile" template="outfmt"  file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+# launch a docker runtime and generate an empty log
+docker run \
+   --name $COOKIE \
+   alpine:latest \
+   /bin/sh -c 'echo' > /dev/null
+
+#export RS_REDIR=-d
+startup
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "image=alpine:latest"
+
+docker container rm $COOKIE
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->

## What
Exposes the image name and tag of the source container (what the Docker API simply calls `Image`) as an additional metadata value alongside the existing ones.

## Why
While the ImageID is available today, a SHA hash is not a particularly user-friendly way to identify what is actually generating the logs.

The image name provides a simple, easy-to-read identifier for the common scenario where an unmodified application image is used.

## Testing
A test for this additional property has been written, however the `devtools/devcontainer.sh` environment does not include Docker, so attempting to run the test locally crashes with `docker: command not found`. 

Modifying this development environment to add Docker is probably beyond the scope of this PR, so I hope that the CI tests will suffice.

## Reference
Docker [API documentation](https://docs.docker.com/engine/api/v1.27/#tag/Container) reference.