### PR TITLE
omazureeventhubs: Corrected handling of transport closed failures

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -991,10 +991,13 @@ if ENABLE_OMAZUREEVENTHUBS
 if ENABLE_OMAZUREEVENTHUBS_TESTS
 TESTS += \
 	omazureeventhubs-basic.sh \
-	omazureeventhubs-list.sh
+	omazureeventhubs-list.sh \
+	omazureeventhubs-stress.sh \
+	omazureeventhubs-interrupt.sh
 if HAVE_VALGRIND
 TESTS += \
-	omazureeventhubs-stress.sh
+	omazureeventhubs-basic-vg.sh \
+	omazureeventhubs-interrupt-vg.sh
 endif
 endif
 endif
@@ -2809,6 +2812,9 @@ EXTRA_DIST= \
 	omazureeventhubs-basic.sh \
 	omazureeventhubs-list.sh \
 	omazureeventhubs-stress.sh \
+	omazureeventhubs-interrupt.sh \
+	omazureeventhubs-basic-vg.sh \
+	omazureeventhubs-interrupt-vg.sh \
 	mmpstrucdata.sh \
 	mmpstrucdata-escaping.sh \
 	mmpstrucdata-case.sh \

--- a/tests/omazureeventhubs-interrupt-vg.sh
+++ b/tests/omazureeventhubs-interrupt-vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
+export EXTRA_VALGRIND_SUPPRESSIONS="--suppressions=omazureeventhubs.supp"
+source ${srcdir:-.}/omazureeventhubs-interrupt.sh

--- a/tests/omazureeventhubs-interrupt.sh
+++ b/tests/omazureeventhubs-interrupt.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+echo This test must be run as root [raw socket access required]
+if [ "$EUID" -ne 0 ]; then
+    exit 77 # Not root, skip this test
+fi
+. ${srcdir:=.}/diag.sh init
+
+# ---	If test is needed, create helper script to store environment variables for 
+#	éventhubs access:
+#	export AZURE_HOST=""
+#	export AZURE_PORT=""
+#	export AZURE_KEY_NAME=""
+#	export AZURE_KEY=""
+#	export AZURE_CONTAINER=""
+# ---
+source omazureeventhubs-env.sh
+
+export NUMMESSAGES=10000
+export NUMMESSAGESFULL=$NUMMESSAGES
+export WAITTIMEOUT=60
+
+export QUEUESIZE=100000
+export DEQUEUESIZE=64
+export DEQUEUESIZEMIN=32
+export TESTWORKERTHREADS=3
+
+export interrupt_host="$AZURE_HOST"
+export interrupt_port="$AZURE_PORT"
+export interrupt_tick="10"
+
+
+# REQUIRES EXTERNAL ENVIRONMENT VARIABLES
+if [[ -z "${AZURE_HOST}" ]]; then
+	echo "SKIP: AZURE_HOST environment variable not SET! Example: <yourname>.servicebus.windows.net - SKIPPING"
+	exit 77
+fi
+if [[ -z "${AZURE_PORT}" ]]; then
+	echo "SKIP: AZURE_PORT environment variable not SET! Example: 5671 - SKIPPING"
+	exit 77
+fi
+if [[ -z "${AZURE_KEY_NAME}" ]]; then
+	echo "SKIP: AZURE_KEY_NAME environment variable not SET! Example: <yourkeyname> - SKIPPING"
+	exit 77
+fi
+if [[ -z "${AZURE_KEY}" ]]; then
+	echo "SKIP: AZURE_KEY environment variable not SET! Example: <yourlongkey> - SKIPPING"
+	exit 77
+fi
+if [[ -z "${AZURE_CONTAINER}" ]]; then
+	echo "SKIP: AZURE_CONTAINER environment variable not SET! Example: <youreventhubsname> - SKIPPING"
+	exit 77
+fi
+
+export AMQPS_ADRESS="amqps://$AZURE_KEY_NAME:$AZURE_KEY@$AZURE_HOST:$AZURE_PORT/$AZURE_NAME"
+export AZURE_ENDPOINT="Endpoint=sb://$AZURE_HOST/;SharedAccessKeyName=$AZURE_KEY_NAME;SharedAccessKey=$AZURE_KEY;EntityPath=$AZURE_NAME"
+
+# --- Create/Start omazureeventhubs sender config 
+
+generate_conf
+add_conf '
+global(
+#	debug.whitelist="on"
+#	debug.files=["omazureeventhubs.c", "modules.c", "errmsg.c", "action.c", "queue.c", "ruleset.c"]
+)
+
+# impstats in order to gain insight into error cases
+module(load="../plugins/impstats/.libs/impstats"
+	log.file="'$RSYSLOG_DYNNAME.pstats'"
+	interval="1" log.syslog="off")
+$imdiagInjectDelayMode full
+
+# Load mods
+module(load="../plugins/omazureeventhubs/.libs/omazureeventhubs")
+
+# templates
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+local4.* {
+	action(	name="omazureeventhubs"
+	type="omazureeventhubs"
+	azurehost="'$AZURE_HOST'"
+	azureport="'$AZURE_PORT'"
+	azure_key_name="'$AZURE_KEY_NAME'"
+	azure_key="'$AZURE_KEY'"
+	container="'$AZURE_CONTAINER'"
+#	amqp_address="amqps://'$AZURE_KEY_NAME':'$AZURE_KEY'@'$AZURE_HOST'/'$AZURE_NAME'"
+	template="outfmt"
+	queue.type="FixedArray"
+	queue.size="'$QUEUESIZE'"
+	queue.saveonshutdown="on"
+	queue.dequeueBatchSize="'$DEQUEUESIZE'"
+	queue.minDequeueBatchSize="'$DEQUEUESIZEMIN'"
+	queue.minDequeueBatchSize.timeout="1000" # 1 sec
+	queue.workerThreads="'$TESTWORKERTHREADS'"
+	queue.workerThreadMinimumMessages="'$DEQUEUESIZEMIN'"
+	queue.timeoutWorkerthreadShutdown="60000"
+	queue.timeoutEnqueue="2000"
+	queue.timeoutshutdown="1000"
+	action.resumeInterval="1"
+	action.resumeRetryCount="2"
+	)
+
+	action( type="omfile" file="'$RSYSLOG_OUT_LOG'")
+	stop
+}
+
+action( type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'")
+'
+echo Starting sender instance [omazureeventhubs]
+startup
+
+echo Inject messages into rsyslog sender instance  
+injectmsg 1 $NUMMESSAGES
+
+wait_file_lines --interrupt-connection $interrupt_host $interrupt_port $interrupt_tick $RSYSLOG_OUT_LOG $NUMMESSAGESFULL 100
+
+timeoutend=$WAITTIMEOUT
+timecounter=0
+lastcurrent_time=0
+
+echo "CHECK $RSYSLOG_DYNNAME.pstats"
+while [ $timecounter -lt $timeoutend ]; do
+	(( timecounter++ ))
+
+	if [ -f "$RSYSLOG_DYNNAME.pstats" ] ; then
+		# Read IMPSTATS for verification
+		IMPSTATSLINE=$(cat $RSYSLOG_DYNNAME.pstats | grep "origin\=omazureeventhubs" | tail -1 | cut -d: -f5)
+		SUBMITTED_MSG=$(echo $IMPSTATSLINE | grep "submitted" | cut -d" " -f2 | cut -d"=" -f2)
+		FAILED_MSG=$(echo $IMPSTATSLINE | grep "failures" | cut -d" " -f3 | cut -d"=" -f2)
+		ACCEPTED_MSG=$(echo $IMPSTATSLINE | grep "accepted" | cut -d" " -f4 | cut -d"=" -f2)
+
+		if ! [[ $SUBMITTED_MSG =~ $re ]] ; then
+			echo "**** omazureeventhubs WAITING FOR IMPSTATS"
+		else
+			if [ "$SUBMITTED_MSG" -ge "$NUMMESSAGESFULL" ]; then
+				if [ "$ACCEPTED_MSG" -ge "$NUMMESSAGESFULL" ]; then
+					echo "**** omazureeventhubs SUCCESS: NUMMESSAGESFULL: $NUMMESSAGESFULL, SUBMITTED_MSG:$SUBMITTED_MSG, ACCEPTED_MSG: $ACCEPTED_MSG, FAILED_MSG: $FAILED_MSG"
+					shutdown_when_empty
+					wait_shutdown
+					#cp $RSYSLOG_DEBUGLOG DEBUGDEBUG.log
+					exit_test
+				else
+					echo "**** omazureeventhubs FAIL: NUMMESSAGESFULL: $NUMMESSAGESFULL, SUBMITTED/WAITING: SUBMITTED_MSG:$SUBMITTED_MSG, ACCEPTED_MSG: $ACCEPTED_MSG, FAILED_MSG: $FAILED_MSG"
+				fi
+			else
+				echo "**** omazureeventhubs WAITING: SUBMITTED_MSG:$SUBMITTED_MSG, ACCEPTED_MSG: $ACCEPTED_MSG, FAILED_MSG: $FAILED_MSG"
+				current_time=$(date +%s)
+				if [ $interrupt_connection == "YES" ] && [ $current_time -gt $lastcurrent_time ] && [ $((current_time % $interrupt_tick)) -eq 0 ] && [ ${count} -gt 1 ]; then
+					# Interrupt Connection - requires root and linux kernel >= 4.9 in order to work!
+					echo "**** omazureeventhubs WAITING: Interrupt Connection on ${interrupt_host}:${interrupt_port}"
+					sudo ss -K dst ${interrupt_host} dport = ${interrupt_port}
+				fi
+				lastcurrent_time=$current_time
+			fi
+		fi
+	fi
+
+	$TESTTOOL_DIR/msleep 1000
+done
+unset count
+
+shutdown_when_empty
+wait_shutdown
+error_exit 1


### PR DESCRIPTION
- Added test for connection interrupts (requires root)
- Corrected handling of PN_TRANSPORT_CLOSED.
- Make sure Connection is being reestablished trough tryResume
- Enhanced Debug log output

closes: https://github.com/rsyslog/rsyslog/issues/5269

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
