### PR TITLE
imkmsg: add params "readMode" and "expectedBootCompleteSeconds"

### DIFF
--- a/contrib/imkmsg/imkmsg.h
+++ b/contrib/imkmsg/imkmsg.h
@@ -31,14 +31,21 @@ typedef enum _kernel_ts_parse_mods {
 		KMSG_PARSE_TS_STARTUP_ONLY = 2
 	} t_kernel_ts_parse_mode;
 
+typedef enum _kernel_readmode {
+		KMSG_READMODE_FULL_BOOT = 0,
+		KMSG_READMODE_FULL_ALWAYS = 1,
+		KMSG_READMODE_NEW_ONLY = 2
+	} t_kernel_readmode;
+
 /* we need to have the modConf type present in all submodules */
 struct modConfData_s {
 	rsconf_t *pConf;
 	int iFacilIntMsg;
 	uchar *pszPath;
 	int console_log_level;
+	int expected_boot_complete_secs;
 	t_kernel_ts_parse_mode parseKernelStamp;
-	sbool bFixKernelStamp;
+	t_kernel_readmode readMode;
 	sbool configSetViaV2Method;
 };
 


### PR DESCRIPTION
These parameters permit to control when imkmsg reads the full kernel log upon startup.

Parameter "readMode" provides the following options:

  * full-boot - (default) read full klog, but only "immediately" after boot. "Immediately" is hereby meant in seconds of system uptime given in "expectedBootCompleteSeconds"
  * full-always - read full klog on every rsyslog startup. Most probably causes messag duplication
  * new-only - never emit existing kernel log message, read only new ones.

Note that some message loss can happen if rsyslog is stopped in "full-boot" and "new-only" read mode. The longer rsyslog is inactive, the higher the message loss probability and potential number of messages lost. For typical restart scenarios, this should be minimal. On HUP, no message loss occurs as rsyslog is not actually stopped.

The default value for "expectedBootCompleteSeconds" is 90.

see also https://github.com/rsyslog/rsyslog/issues/5161

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
