### PR TITLE
core bugfix: rsyslog messages may not always have FQDN

### DIFF
--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -7,7 +7,7 @@
  *
  * Module begun 2008-04-16 by Rainer Gerhards
  *
- * Copyright 2008-2022 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2023 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -1447,7 +1447,7 @@ finalize_it:
 	 * hostname. These messages are currently in iminternal queue. Once they
 	 * are taken from that queue, the hostname will be adapted.
 	 */
-	queryLocalHostname();
+	queryLocalHostname(loadConf);
 	RETiRet;
 }
 

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1160,7 +1160,7 @@ cvthname(struct sockaddr_storage *f, prop_t **localName, prop_t **fqdn, prop_t *
  */
 #define EMPTY_HOSTNAME_REPLACEMENT "localhost-empty-hostname"
 static rsRetVal
-getLocalHostname(uchar **ppName)
+getLocalHostname(rsconf_t *const pConf, uchar **ppName)
 {
 	DEFiRet;
 	char hnbuf[8192];
@@ -1183,7 +1183,7 @@ getLocalHostname(uchar **ppName)
 
 	char *dot = strstr(hnbuf, ".");
 	struct addrinfo *res = NULL;
-	if(!empty_hostname && dot == NULL && runConf != NULL && !glbl.GetDisableDNS(runConf)) {
+	if(!empty_hostname && dot == NULL && pConf != NULL && !glbl.GetDisableDNS(pConf)) {
 		/* we need to (try) to find the real name via resolver */
 		struct addrinfo flags;
 		memset(&flags, 0, sizeof(flags));

--- a/runtime/net.h
+++ b/runtime/net.h
@@ -152,7 +152,7 @@ BEGINinterface(net) /* name must also be changed in ENDinterface macro! */
 		int ipfreebind, char *device);
 	void (*closeUDPListenSockets)(int *finet);
 	int (*isAllowedSender)(uchar *pszType, struct sockaddr *pFrom, const char *pszFromHost); /* deprecated! */
-	rsRetVal (*getLocalHostname)(uchar**);
+	rsRetVal (*getLocalHostname)(rsconf_t *const, uchar**);
 	int (*should_use_so_bsdcompat)(void);
 	/* permitted peer handling should be replaced by something better (see comments above) */
 	rsRetVal (*AddPermittedPeer)(permittedPeers_t **ppRootPeer, uchar *pszID);

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -1,6 +1,6 @@
 /* The rsconf object. It models a complete rsyslog configuration.
  *
- * Copyright 2011-2022 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2011-2023 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -3,7 +3,7 @@
  *
  * Begun 2005-09-15 RGerhards
  *
- * Copyright (C) 2005-2019 by Rainer Gerhards and Adiscon GmbH
+ * Copyright (C) 2005-2023 by Rainer Gerhards and Adiscon GmbH
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -782,7 +782,7 @@ rsRetVal rsrtExit(void);
 int rsrtIsInit(void);
 void rsrtSetErrLogger(void (*errLogger)(const int, const int, const uchar*));
 void dfltErrLogger(const int, const int, const uchar *errMsg);
-rsRetVal queryLocalHostname(void);
+rsRetVal queryLocalHostname(rsconf_t *const);
 
 
 /* this define below is (later) intended to be used to implement empty

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -253,15 +253,18 @@ get_bHadHUP(void)
 	return ret;
 }
 
+/* we need a pointer to the conf, because in early startup stage we
+ * need to use loadConf, later on runConf.
+ */
 rsRetVal
-queryLocalHostname(void)
+queryLocalHostname(rsconf_t *const pConf)
 {
 	uchar *LocalHostName = NULL;
 	uchar *LocalDomain = NULL;
 	uchar *LocalFQDNName;
 	DEFiRet;
 
-	CHKiRet(net.getLocalHostname(&LocalFQDNName));
+	CHKiRet(net.getLocalHostname(pConf, &LocalFQDNName));
 	uchar *dot = (uchar*) strstr((char*)LocalFQDNName, ".");
 	if(dot == NULL) {
 		CHKmalloc(LocalHostName = (uchar*) strdup((char*)LocalFQDNName));
@@ -1956,7 +1959,7 @@ doHUP(void)
 		logmsgInternal(NO_ERRCODE, LOG_SYSLOG|LOG_INFO, (uchar*)buf, 0);
 	}
 
-	queryLocalHostname(); /* re-read our name */
+	queryLocalHostname(runConf); /* re-read our name */
 	ruleset.IterateAllActions(ourConf, doHUPActions, NULL);
 	DBGPRINTF("doHUP: doing modules\n");
 	modDoHUP();


### PR DESCRIPTION
Even if hostname FQDN is configured, rsyslog internal messages generated after rsyslog startup and before the first HUP will not necessarily have FQDN but instead only the shortname of the local host. This commit fixes the situation.

Special thanks to github user eciii for doing a great bug analysis and helping us considerably to fix the issue.

closes https://github.com/rsyslog/rsyslog/issues/5218

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
