### PR TITLE
ommysql bugfix: potential segfault on database error

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -335,10 +335,15 @@ CODESTARTcommitTransaction
 		if(iRet != RS_RET_OK
 			&& iRet != RS_RET_DEFER_COMMIT
 			&& iRet != RS_RET_PREVIOUS_COMMITTED) {
-			if(mysql_rollback(pWrkrData->hmysql) != 0) {
-				DBGPRINTF("ommysql: server error: transaction could not be rolled back\n");
+			if(pWrkrData->hmysql == NULL) {
+				DBGPRINTF("ommysql: server error: hmysql is closed, transaction rollback "
+					  "willl not be tried (it probably already happened)\n");
+			} else {
+				if(mysql_rollback(pWrkrData->hmysql) != 0) {
+					DBGPRINTF("ommysql: server error: transaction could not be rolled back\n");
+				}
+				closeMySQL(pWrkrData);
 			}
-			closeMySQL(pWrkrData);
 			FINALIZE;
 		}
 	}


### PR DESCRIPTION
Due to an invalid code path, ommysql may cause a segfault if database transactions fail into a specific way. The main trigger is a totally irrecoverrable database error which can lead to premature connection close, which is not checked for in all recover code.

This was detected in a setting where a stored procedure is called that rolls back a transaction in itself.

This patch fixes the issue.

closes https://github.com/rsyslog/rsyslog/issues/5288

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
