### PR TITLE
ossl netstream driver: allow ephemeral Diffie-Hellman key exchange

### DIFF
--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -435,6 +435,11 @@ net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method)
 	SSL_CTX_set_timeout(pThis->ctx, 30);	/* Default Session Timeout, TODO: Make configureable */
 	SSL_CTX_set_mode(pThis->ctx, SSL_MODE_AUTO_RETRY);
 
+#if OPENSSL_VERSION_NUMBER >= 0x10100000L
+	/* Enable Support for automatic ephemeral/temporary DH parameter selection. */
+	SSL_CTX_set_dh_auto(pThis->ctx, 1);
+#endif
+
 #if OPENSSL_VERSION_NUMBER >= 0x10002000L
 #	if OPENSSL_VERSION_NUMBER <= 0x101010FFL
 	/* Enable Support for automatic EC temporary key parameter selection. */
@@ -638,7 +643,7 @@ net_ossl_chkonepeername(net_ossl_t *pThis, X509 *certpeer, uchar *pszPeerID, int
 #endif
 	char *x509name = NULL;
 	DEFiRet;
-	
+
 	if (certpeer == NULL) {
 		ABORT_FINALIZE(RS_RET_TLS_NO_CERT);
 	}


### PR DESCRIPTION
Use well known DH parameters that have built-in support in OpenSSL. From the man page: If "auto" DH parameters are switched on then the parameters will be selected to be consistent with the size of the key associated with the server's certificate.  If there is no certificate (e.g. for PSK ciphersuites), then it it will be consistent with the size of the negotiated symmetric cipher key.

### Current situation
Using the ossl netstream driver, I am not able to create an ```imtcp``` instance, which uses only the following cipher list (the highlight is on the ephemeral DH exchange part) :

- TLS_DHE_RSA_WITH_AES_128_GCM_SHA256
- TLS_DHE_RSA_WITH_AES_256_GCM_SHA384

Configuration snippet:
```
module(load="imtcp"
  StreamDriver.Mode="1"
  StreamDriver.AuthMode="anon"
  StreamDriver.Name="ossl"
  gnutlsPriorityString="Protocol=-ALL,TLSv1.2\nCipherString=DHE-RSA-AES128-GCM-SHA256:DHE-RSA-AES256-GCM-SHA384"
  MaxListeners="50")

input(type="imtcp" port="6514")

$DefaultNetstreamDriverCertFile /path/to/server-cert.pem
$DefaultNetstreamDriverKeyFile  /path/to/server-key.pem
```
The problem is that the requested ciphers are not available even if I delete the priorityString setting. This does not apply to the `gtls` driver. The following works as expected:
```
module(load="imtcp"
  StreamDriver.Mode="1"
  StreamDriver.AuthMode="anon"
  StreamDriver.Name="gtls"
  gnutlsPriorityString="SECURE128:+SECURE256:-VERS-ALL:+VERS-TLS1.2:-KX-ALL:+DHE-RSA:-CIPHER-ALL:+AES-256-GCM:+AES-128-GCM"
  MaxListeners="50")

input(type="imtcp" port="6514")

$DefaultNetstreamDriverCertFile /path/to/server-cert.pem
$DefaultNetstreamDriverKeyFile  /path/to/server-key.pem
```

After applying the patch, I used `nmap` to verify which ciphers are used by an `imtcp` connection. Using the first rsyslog snippet:
```
$ nmap --script +ssl-enum-ciphers -p 6514 localhost
Starting Nmap 7.92 ( https://nmap.org ) at 2024-02-09 09:41 EST
Nmap scan report for localhost (127.0.0.1)
Host is up (0.000059s latency).
Other addresses for localhost (not scanned): ::1

PORT     STATE SERVICE
6514/tcp open  syslog-tls
| ssl-enum-ciphers: 
|   TLSv1.2: 
|     ciphers: 
|       TLS_DHE_RSA_WITH_AES_128_GCM_SHA256 (dh 2048) - A
|       TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 (dh 2048) - A
|     compressors: 
|       NULL
|     cipher preference: client
|_  least strength: A

Nmap done: 1 IP address (1 host up) scanned in 0.59 seconds
```
