### PR TITLE
covscan: remove defects with type of RESOURCE_LEAK

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2943,7 +2943,7 @@ evalVar(struct cnfvar *__restrict__ const var, void *__restrict__ const usrptr,
 	unsigned short bMustBeFreed = 0;
 	rsRetVal localRet;
 	struct json_object *json;
-	uchar *cstr;
+	uchar *cstr = NULL;
 
 	if(var->prop.id == PROP_CEE        ||
 	   var->prop.id == PROP_LOCAL_VAR  ||
@@ -2962,8 +2962,8 @@ evalVar(struct cnfvar *__restrict__ const var, void *__restrict__ const usrptr,
 			ret->d.estr = (localRet != RS_RET_OK || cstr == NULL) ?
 					  es_newStr(1)
 					: es_newStrFromCStr((char*) cstr, strlen((char*) cstr));
-			free(cstr);
 		}
+		free(cstr);
 	} else {
 		ret->datatype = 'S';
 		pszProp = (uchar*) MsgGetProp((smsg_t*)usrptr, NULL, &var->prop, &propLen, &bMustBeFreed, NULL);

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1932,6 +1932,7 @@ lstnActivity(ptcplstn_t *const pLstn)
 		localRet = AcceptConnReq(pLstn, &newSock, &peerName, &peerIP);
 		DBGPRINTF("imptcp: AcceptConnReq on listen socket %d returned %d\n", pLstn->sock, localRet);
 		if(localRet == RS_RET_NO_MORE_DATA || glbl.GetGlobalInputTermState() == 1) {
+			close(newSock);
 			break;
 		}
 		CHKiRet(localRet);

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -993,6 +993,8 @@ gtlsChkPeerFingerprint(nsd_gtls_t *pThis, gnutls_x509_crt_t *pCert)
 finalize_it:
 	if(pstrFingerprint != NULL)
 		cstrDestruct(&pstrFingerprint);
+	if(pstrFingerprintSha256 != NULL)
+		cstrDestruct(&pstrFingerprintSha256);
 	RETiRet;
 }
 

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -725,6 +725,8 @@ osslChkPeerFingerprint(nsd_ossl_t *pThis, X509 *pCert)
 finalize_it:
 	if(pstrFingerprint != NULL)
 		cstrDestruct(&pstrFingerprint);
+	if(pstrFingerprintSha256 != NULL)
+		cstrDestruct(&pstrFingerprintSha256);
 	RETiRet;
 }
 

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -307,6 +307,7 @@ writePidFile(void)
 	DBGPRINTF("rsyslogd: writing pidfile '%s'.\n", tmpPidFile);
 	if((fp = fopen((char*) tmpPidFile, "w")) == NULL) {
 		perror("rsyslogd: error writing pid file (creation stage)\n");
+		free((char *)tmpPidFile);
 		ABORT_FINALIZE(RS_RET_ERR);
 	}
 	if(fprintf(fp, "%d", (int) glblGetOurPid()) < 0) {


### PR DESCRIPTION
Fix memory leaks when:
- it's not possible to create the temporary pidfile
- comparing peer's certificate SHA256 fingerprint in ossl
- comparing peer's certificate SHA256 fingerprint in gtls
- imptcp connection is accepted and right away rsyslog is stopped
- evaluating variable in rainerscript