### PR TITLE
MMDBLOOKUP::FIXED:: Don't suspend action on incompatible IP lookups

### DIFF
--- a/plugins/mmdblookup/mmdblookup.c
+++ b/plugins/mmdblookup/mmdblookup.c
@@ -412,6 +412,11 @@ CODESTARTdoAction
 		dbgprintf("Error from call to getaddrinfo for %s - %s\n", pszValue, gai_strerror(gai_err));
 		ABORT_FINALIZE(RS_RET_OK);
 	}
+	if (MMDB_IPV6_LOOKUP_IN_IPV4_DATABASE_ERROR == mmdb_err) {
+		LogMsg(0, NO_ERRCODE, LOG_INFO, "mmdblookup: Tried to search for an IPv6 address in an IPv4-only DB"
+		", ignoring");
+		ABORT_FINALIZE(RS_RET_OK);
+	}
 	if (MMDB_SUCCESS != mmdb_err) {
 		dbgprintf("Got an error from the maxminddb library: %s\n", MMDB_strerror(mmdb_err));
 		close_mmdb(&pWrkrData->mmdb);

--- a/tests/mmdb-lookup-wrong-ip-type-vg.sh
+++ b/tests/mmdb-lookup-wrong-ip-type-vg.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# released under ASL 2.0
+
+export USE_VALGRIND="YES"
+source ${srcdir:=.}/mmdb-lookup-wrong-ip-type.sh

--- a/tests/mmdb-lookup-wrong-ip-type.sh
+++ b/tests/mmdb-lookup-wrong-ip-type.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# added 2014-11-17 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[mmdb-lookup-wrong-ip-type.sh\]: test for mmdb
+# uncomment for debugging support:
+export RSYSLOG_DEBUG="debug"
+export RSYSLOG_DEBUGLOG="log"
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%$!iplocation%\n")
+
+module(load="../plugins/mmdblookup/.libs/mmdblookup")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+ruleset(name="testing") {
+	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)
+	action(type="mmdblookup" mmdbfile=`echo $srcdir/test.mmdb` key="$!ip" fields="city" )
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}'
+startup
+# This won't work, as the test.mmdb file is only IPv4-compatible
+tcpflood -m 1 -j "::1\ "
+# This MUST work, the test checks that the action is not suspended when encountering an IPv6 address
+tcpflood -m 1 -j "202.106.0.20\ "
+shutdown_when_empty
+wait_shutdown
+# If the second tcpflood worked, this sould be in the output file
+content_check '{ "city": "Beijing" }'
+exit_test


### PR DESCRIPTION
Mmdblookup module used to suspend after erroring on an IPv6 IP lookup on IPv4-only DBs
This commit replaces the suspension of the module by a simple log message, allowing it to keep working for future lookups
