### PR TITLE
NET-OSSL driver: Created interfaces for exported functions

### DIFF
--- a/plugins/imdtls/Makefile.am
+++ b/plugins/imdtls/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imdtls.la 
-imdtls_la_DEPENDENCIES = ../../runtime/lmnsd_ossl.la
+imdtls_la_DEPENDENCIES =
 imdtls_la_SOURCES = imdtls.c
 imdtls_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(OPENSSL_CFLAGS)
 imdtls_la_LDFLAGS = -module -avoid-version
-imdtls_la_LIBADD = $(OPENSSL_LIBS) ../../runtime/lmnsd_ossl.la
+imdtls_la_LIBADD = $(OPENSSL_LIBS)

--- a/plugins/omdtls/Makefile.am
+++ b/plugins/omdtls/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = omdtls.la 
-omdtls_la_DEPENDENCIES = ../../runtime/lmnsd_ossl.la
+omdtls_la_DEPENDENCIES =
 omdtls_la_SOURCES = omdtls.c
 omdtls_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(OPENSSL_CFLAGS)
 omdtls_la_LDFLAGS = -module -avoid-version
-omdtls_la_LIBADD = $(OPENSSL_LIBS) ../../runtime/lmnsd_ossl.la
+omdtls_la_LIBADD = $(OPENSSL_LIBS)

--- a/runtime/net_ossl.h
+++ b/runtime/net_ossl.h
@@ -83,6 +83,17 @@ BEGINinterface(net_ossl) /* name must also be changed in ENDinterface macro! */
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 	rsRetVal (*osslCtxInitCookie)(net_ossl_t *pThis);
 #endif // OPENSSL_VERSION_NUMBER >= 0x10100000L
+	// OpenSSL Helper function exports
+	rsRetVal (*osslChkpeername)(net_ossl_t *pThis, X509* certpeer, uchar *fromHostIP);
+	rsRetVal (*osslPeerfingerprint)(net_ossl_t *pThis, X509* certpeer, uchar *fromHostIP);
+	X509* (*osslGetpeercert)(net_ossl_t *pThis, SSL *ssl, uchar *fromHostIP);
+	rsRetVal (*osslChkpeercertvalidity)(net_ossl_t *pThis, SSL *ssl, uchar *fromHostIP);
+	rsRetVal (*osslApplyTlscgfcmd)(net_ossl_t *pThis, uchar *tlscfgcmd);
+	void (*osslSetBioCallback)(BIO *conn);
+	void (*osslSetCtxVerifyCallback)(SSL_CTX *pCtx, int flags);
+	void (*osslSetSslVerifyCallback)(SSL *pSsl, int flags);
+	void (*osslLastOpenSSLErrorMsg)(uchar *fromHost,
+		const int ret, SSL *ssl, int severity, const char* pszCallSource, const char* pszOsslApi);
 ENDinterface(net_ossl)
 
 #define net_osslCURR_IF_VERSION 1 /* increment whenever you change the interface structure! */
@@ -133,34 +144,6 @@ void osslGlblInit(void);
 void osslGlblExit(void);
 
 /*-----------------------------------------------------------------------------*/
-
-/* Prototypes for openssl helper functions */
-__attribute__((visibility("default"))) void net_ossl_lastOpenSSLErrorMsg
-	(uchar *fromHost, const int ret, SSL *ssl, int severity, const char* pszCallSource, const char* pszOsslApi);
-__attribute__((visibility("default"))) void net_ossl_set_ssl_verify_callback(SSL *pSsl, int flags);
-__attribute__((visibility("default"))) void net_ossl_set_ctx_verify_callback(SSL_CTX *pCtx, int flags);
-__attribute__((visibility("default"))) void net_ossl_set_bio_callback(BIO *conn);
-__attribute__((visibility("default"))) int net_ossl_verify_callback(int status, X509_STORE_CTX *store);
-__attribute__((visibility("default"))) rsRetVal net_ossl_apply_tlscgfcmd(net_ossl_t *pThis, uchar *tlscfgcmd);
-__attribute__((visibility("default"))) rsRetVal
-	net_ossl_chkpeercertvalidity(net_ossl_t *pThis, SSL *ssl, uchar *fromHostIP);
-__attribute__((visibility("default"))) X509*
-	net_ossl_getpeercert(net_ossl_t *pThis, SSL *ssl, uchar *fromHostIP);
-__attribute__((visibility("default"))) rsRetVal
-	net_ossl_peerfingerprint(net_ossl_t *pThis, X509* certpeer, uchar *fromHostIP);
-__attribute__((visibility("default"))) rsRetVal
-	net_ossl_chkpeername(net_ossl_t *pThis, X509* certpeer, uchar *fromHostIP);
-
-/*
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L && !defined(LIBRESSL_VERSION_NUMBER)
-long RSYSLOG_BIO_debug_callback_ex(BIO *bio, int cmd, const char __attribute__((unused)) *argp,
-			   size_t __attribute__((unused)) len, int argi, long __attribute__((unused)) argl,
-			   int ret, size_t __attribute__((unused)) *processed);
-#else
-long RSYSLOG_BIO_debug_callback(BIO *bio, int cmd, const char __attribute__((unused)) *argp,
-			int argi, long __attribute__((unused)) argl, long ret);
-#endif
-*/
 
 /* prototypes */
 PROTOTYPEObj(net_ossl);

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -80,7 +80,7 @@ void nsd_ossl_lastOpenSSLErrorMsg(nsd_ossl_t const *pThis, const int ret, SSL *s
 	}
 
 	// Call helper in net_ossl
-	net_ossl_lastOpenSSLErrorMsg(fromHost, ret, ssl, severity, pszCallSource, pszOsslApi);
+	net_ossl.osslLastOpenSSLErrorMsg(fromHost, ret, ssl, severity, pszCallSource, pszOsslApi);
 
 	free(fromHost);
 	errno = errno_store;
@@ -278,7 +278,8 @@ osslInitSession(nsd_ossl_t *pThis, osslSslState_t osslType) /* , nsd_ossl_t *pSe
 		dbgprintf("osslInitSession: enable certificate checking (Mode=%d, VerifyDepth=%d)\n",
 			pThis->pNetOssl->authMode, pThis->DrvrVerifyDepth);
 		/* Enable certificate valid checking */
-		net_ossl_set_ssl_verify_callback(pThis->pNetOssl->ssl, SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
+		net_ossl.osslSetSslVerifyCallback(pThis->pNetOssl->ssl,
+			SSL_VERIFY_PEER|SSL_VERIFY_FAIL_IF_NO_PEER_CERT);
 		if (pThis->DrvrVerifyDepth != 0) {
 			SSL_set_verify_depth(pThis->pNetOssl->ssl, pThis->DrvrVerifyDepth);
 		}
@@ -305,7 +306,7 @@ osslInitSession(nsd_ossl_t *pThis, osslSslState_t osslType) /* , nsd_ossl_t *pSe
 	dbgprintf("osslInitSession: Init conn BIO[%p] done\n", (void *)conn);
 
 	/* Set debug Callback for conn BIO as well! */
-	net_ossl_set_bio_callback(conn);
+	net_ossl.osslSetBioCallback(conn);
 
 	/* TODO: still needed? Set to NON blocking ! */
 	BIO_set_nbio( conn, 1 );
@@ -347,25 +348,25 @@ osslChkPeerAuth(nsd_ossl_t *pThis)
 	switch(pThis->pNetOssl->authMode) {
 		case OSSL_AUTH_CERTNAME:
 			/* if we check the name, we must ensure the cert is valid */
-			certpeer = net_ossl_getpeercert(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP);
+			certpeer = net_ossl.osslGetpeercert(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP);
 			dbgprintf("osslChkPeerAuth: Check peer certname[%p]=%s\n",
 				(void *)pThis->pNetOssl->ssl, (certpeer != NULL ? "VALID" : "NULL"));
-			CHKiRet(net_ossl_chkpeercertvalidity(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP));
-			CHKiRet(net_ossl_chkpeername(pThis->pNetOssl, certpeer, fromHostIP));
+			CHKiRet(net_ossl.osslChkpeercertvalidity(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP));
+			CHKiRet(net_ossl.osslChkpeername(pThis->pNetOssl, certpeer, fromHostIP));
 			break;
 		case OSSL_AUTH_CERTFINGERPRINT:
-			certpeer = net_ossl_getpeercert(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP);
+			certpeer = net_ossl.osslGetpeercert(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP);
 			dbgprintf("osslChkPeerAuth: Check peer fingerprint[%p]=%s\n",
 				(void *)pThis->pNetOssl->ssl, (certpeer != NULL ? "VALID" : "NULL"));
-			CHKiRet(net_ossl_chkpeercertvalidity(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP));
-			CHKiRet(net_ossl_peerfingerprint(pThis->pNetOssl, certpeer, fromHostIP));
+			CHKiRet(net_ossl.osslChkpeercertvalidity(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP));
+			CHKiRet(net_ossl.osslPeerfingerprint(pThis->pNetOssl, certpeer, fromHostIP));
 
 			break;
 		case OSSL_AUTH_CERTVALID:
-			certpeer = net_ossl_getpeercert(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP);
+			certpeer = net_ossl.osslGetpeercert(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP);
 			dbgprintf("osslChkPeerAuth: Check peer valid[%p]=%s\n",
 				(void *)pThis->pNetOssl->ssl, (certpeer != NULL ? "VALID" : "NULL"));
-			CHKiRet(net_ossl_chkpeercertvalidity(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP));
+			CHKiRet(net_ossl.osslChkpeercertvalidity(pThis->pNetOssl, pThis->pNetOssl->ssl, fromHostIP));
 			break;
 		case OSSL_AUTH_CERTANON:
 			FINALIZE;
@@ -1277,7 +1278,7 @@ applyGnutlsPriorityString(nsd_ossl_t *const pThis)
 	if(pThis->gnutlsPriorityString == NULL || pThis->pNetOssl->ctx == NULL) {
 		FINALIZE;
 	} else {
-		CHKiRet(net_ossl_apply_tlscgfcmd(pThis->pNetOssl, pThis->gnutlsPriorityString));
+		CHKiRet(net_ossl.osslApplyTlscgfcmd(pThis->pNetOssl, pThis->gnutlsPriorityString));
 	}
 #endif
 


### PR DESCRIPTION
Shared net_ossl_* functions are not available if loaded dynamically by module in imdtls or omdtls. The incorrect workarround was that I linked lmnsd_ossl.la into omdtls and imdtls. However that breaks make install when DTLS modules are enabled.

To fix the problem, all net_ossl_ functions are mapped to the net_ossl interface which is dynamically loaded on runtime.

This removes the lmnsd_ossl.la dependency from the omdtls and imdtls makefiles and fixes make install.

it also removes this build warning:
*** Warning: Linking the shared library omdtls.la against the loadable module *** lmnsd_ossl.so is not portable!

closes: https://github.com/rsyslog/rsyslog/issues/5340

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
