### PR TITLE
fix(lexer): typo and missing space when file can't be accessed

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -150,7 +150,7 @@ expand_backticks(char *const param)
 		const char *val = read_file(param+4);
 		if(val == NULL) {
 			parser_errmsg("file could not be accessed for `%s`", param);
-			const char *errmsg = "/* file cound not be accessed - see"
+			const char *errmsg = "/* file could not be accessed - see "
 				"error messages */";
 			estr = es_newStrFromCStr(errmsg, strlen(errmsg));
 		} else {


### PR DESCRIPTION
When using the backtick feature with cat and a file that does not exist, an error message is placed where the file content would be. This error message contained a typo in could as well as a missing space between see and error, which have now been fixed.

Fixes #5360 

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
