### PR TITLE
omfwd: implement native load balancing - phase 1

### DIFF
--- a/action.c
+++ b/action.c
@@ -802,6 +802,7 @@ actionSuspend(action_t * const pThis, wti_t * const pWti)
 	int suspendDuration;
 	char timebuf[32];
 
+	DBGPRINTF("actionSuspend: enter\n");
 	setSuspendMessageConfVars(pThis);
 
 	/* note: we can NOT use a cached timestamp, as time may have evolved
@@ -896,6 +897,7 @@ actionDoRetry(action_t * const pThis, wti_t * const pWti)
 			} else {
 				++iRetries;
 				iSleepPeriod = pThis->iResumeInterval;
+				DBGPRINTF("actionDoRetry: sleeping now %d seconds\n", iSleepPeriod);
 				srSleep(iSleepPeriod, 0);
 				if(*pWti->pbShutdownImmediate) {
 					ABORT_FINALIZE(RS_RET_FORCE_TERM);
@@ -1028,6 +1030,8 @@ actionTryResume(action_t * const pThis, wti_t * const pWti)
 	DEFiRet;
 	time_t ttNow = NO_TIME_PROVIDED;
 
+	DBGPRINTF("actionTryResume: enter\n");
+
 	if(getActionState(pWti, pThis) == ACT_STATE_SUSP) {
 		/* if we are suspended, we need to check if the timeout expired.
 		 * for this handling, we must always obtain a fresh timestamp. We used
@@ -1043,6 +1047,7 @@ actionTryResume(action_t * const pThis, wti_t * const pWti)
 	}
 
 	if(getActionState(pWti, pThis) == ACT_STATE_RTRY) {
+DBGPRINTF("actionTryResume calls actionDoRetry\n");
 		CHKiRet(actionDoRetry(pThis, pWti));
 	}
 
@@ -1072,6 +1077,8 @@ actionPrepare(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti
 DBGPRINTF("actionPrepare[%s]: enter\n", pThis->pszName);
 	CHKiRet(actionCheckAndCreateWrkrInstance(pThis, pWti));
 	CHKiRet(actionTryResume(pThis, pWti));
+
+DBGPRINTF("actionPrepare[%s]: after calling actionTryResume\n", pThis->pszName);
 
 	/* if we are now ready, we initialize the transaction and advance
 	 * action state accordingly
@@ -1332,6 +1339,7 @@ doTransaction(action_t *__restrict__ const pThis, wti_t *__restrict__ const pWti
 	int i;
 	DEFiRet;
 
+	DBGPRINTF("doTransaction[%s] enter\n", pThis->pszName);
 	wrkrInfo = &(pWti->actWrkrInfo[pThis->iActionNbr]);
 	if(pThis->pMod->mod.om.commitTransaction != NULL) {
 		DBGPRINTF("doTransaction: have commitTransaction IF, using that, pWrkrInfo %p\n", wrkrInfo);

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -7,7 +7,7 @@
  *
  * Module begun 2008-04-16 by Rainer Gerhards
  *
- * Copyright 2008-2023 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2024 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -89,6 +89,7 @@ static uchar *LocalDomain = NULL;/* our local domain name  - read-only after sta
 static int iMaxLine = 8096;
 int bTerminateInputs = 0;		/* global switch that inputs shall terminate ASAP (1=> terminate) */
 int glblUnloadModules = 1;
+int glblAbortOnProgramError = 0;
 char** glblDbgFiles = NULL;
 size_t glblDbgFilesNum = 0;
 int glblDbgWhitelist = 1;
@@ -113,6 +114,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "debug.onshutdown", eCmdHdlrBinary, 0 },
 	{ "debug.logfile", eCmdHdlrString, 0 },
 	{ "debug.gnutls", eCmdHdlrNonNegInt, 0 },
+	{ "debug.abortonprogramerror", eCmdHdlrBinary, 0 },
 	{ "debug.unloadmodules", eCmdHdlrBinary, 0 },
 	{ "defaultnetstreamdrivercafile", eCmdHdlrString, 0 },
 	{ "defaultnetstreamdrivercrlfile", eCmdHdlrString, 0 },
@@ -165,6 +167,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
 	{ "internalmsg.ratelimit.interval", eCmdHdlrPositiveInt, 0 },
 	{ "internalmsg.ratelimit.burst", eCmdHdlrPositiveInt, 0 },
 	{ "internalmsg.severity", eCmdHdlrSeverity, 0 },
+	{ "allmessagestostderr", eCmdHdlrBinary, 0 },
 	{ "errormessagestostderr.maxnumber", eCmdHdlrPositiveInt, 0 },
 	{ "shutdown.enable.ctlc", eCmdHdlrBinary, 0 },
 	{ "default.action.queue.timeoutshutdown", eCmdHdlrInt, 0 },
@@ -1302,6 +1305,8 @@ glblDoneLoadCnf(void)
 			LogError(0, RS_RET_OK, "debug: onShutdown set to %d", loadConf->globals.debugOnShutdown);
 		} else if(!strcmp(paramblk.descr[i].name, "debug.gnutls")) {
 			loadConf->globals.iGnuTLSLoglevel = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "debug.abortonprogramerror")) {
+			glblAbortOnProgramError = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "debug.unloadmodules")) {
 			glblUnloadModules = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "parser.controlcharacterescapeprefix")) {
@@ -1413,6 +1418,8 @@ glblDoneLoadCnf(void)
 			}
 		} else if(!strcmp(paramblk.descr[i].name, "errormessagestostderr.maxnumber")) {
 			loadConf->globals.maxErrMsgToStderr = (int) cnfparamvals[i].val.d.n;
+		} else if(!strcmp(paramblk.descr[i].name, "allmessagestostderr")) {
+			loadConf->globals.bAllMsgToStderr = (int) cnfparamvals[i].val.d.n;
 		} else if(!strcmp(paramblk.descr[i].name, "debug.files")) {
 			free(glblDbgFiles); /* "fix" Coverity false positive */
 			glblDbgFilesNum = cnfparamvals[i].val.d.ar->nmemb;

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -8,7 +8,7 @@
  * Please note that there currently is no glbl.c file as we do not yet
  * have any implementations.
  *
- * Copyright 2008-2022 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2024 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -123,6 +123,7 @@ extern char** glblDbgFiles;
 extern size_t glblDbgFilesNum;
 extern int glblDbgWhitelist;
 extern int glblPermitCtlC;
+extern int glblAbortOnProgramError;
 extern int bTerminateInputs;
 #ifndef HAVE_ATOMIC_BUILTINS
 extern DEF_ATOMIC_HELPER_MUT(mutTerminateInputs);

--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -78,8 +78,11 @@ ENDobjDestruct(netstrm)
 static rsRetVal
 netstrmConstructFinalize(netstrm_t *pThis)
 {
-	ISOBJ_TYPE_assert(pThis, netstrm);
-	return pThis->Drvr.Construct(&pThis->pDrvrData);
+	DEFiRet;
+	NULL_CHECK(pThis);
+	iRet = pThis->Drvr.Construct(&pThis->pDrvrData);
+finalize_it:
+	RETiRet;
 }
 
 /* abort a connection. This is much like Destruct(), but tries
@@ -89,13 +92,15 @@ static rsRetVal
 AbortDestruct(netstrm_t **ppThis)
 {
 	DEFiRet;
-	assert(ppThis != NULL);
-	ISOBJ_TYPE_assert((*ppThis), netstrm);
+	NULL_CHECK(ppThis);
+	NULL_CHECK(*ppThis);
 
 	/* we do NOT exit on error, because that would make things worse */
 	(*ppThis)->Drvr.Abort((*ppThis)->pDrvrData);
 	iRet = netstrmDestruct(ppThis);
 
+
+finalize_it:
 	RETiRet;
 }
 
@@ -113,7 +118,7 @@ AcceptConnReq(netstrm_t *pThis, netstrm_t **ppNew)
 	nsd_t *pNewNsd = NULL;
 	DEFiRet;
 
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	assert(ppNew != NULL);
 
 	/* accept the new connection */
@@ -170,8 +175,10 @@ static rsRetVal
 Rcv(netstrm_t *pThis, uchar *pBuf, ssize_t *pLenBuf, int *const oserr)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.Rcv(pThis->pDrvrData, pBuf, pLenBuf, oserr);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -187,8 +194,10 @@ static rsRetVal
 SetDrvrMode(netstrm_t *pThis, int iMode)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetMode(pThis->pDrvrData, iMode);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -199,8 +208,10 @@ static rsRetVal
 SetDrvrAuthMode(netstrm_t *pThis, uchar *mode)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetAuthMode(pThis->pDrvrData, mode);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -211,8 +222,10 @@ static rsRetVal
 SetDrvrPermitExpiredCerts(netstrm_t *pThis, uchar *mode)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetPermitExpiredCerts(pThis->pDrvrData, mode);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -221,8 +234,10 @@ static rsRetVal
 SetDrvrPermPeers(netstrm_t *pThis, permittedPeers_t *pPermPeers)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetPermPeers(pThis->pDrvrData, pPermPeers);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -231,8 +246,10 @@ static rsRetVal
 SetDrvrCheckExtendedKeyUsage(netstrm_t *pThis, int ChkExtendedKeyUsage)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetCheckExtendedKeyUsage(pThis->pDrvrData, ChkExtendedKeyUsage);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -241,8 +258,10 @@ static rsRetVal
 SetDrvrPrioritizeSAN(netstrm_t *pThis, int prioritizeSan)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetPrioritizeSAN(pThis->pDrvrData, prioritizeSan);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -251,8 +270,10 @@ static rsRetVal
 SetDrvrTlsVerifyDepth(netstrm_t *pThis, int verifyDepth)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetTlsVerifyDepth(pThis->pDrvrData, verifyDepth);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -260,8 +281,10 @@ static rsRetVal
 SetDrvrTlsCAFile(netstrm_t *const pThis, const uchar *const file)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetTlsCAFile(pThis->pDrvrData, file);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -269,8 +292,10 @@ static rsRetVal
 SetDrvrTlsCRLFile(netstrm_t *const pThis, const uchar *const file)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetTlsCRLFile(pThis->pDrvrData, file);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -278,8 +303,10 @@ static rsRetVal
 SetDrvrTlsKeyFile(netstrm_t *const pThis, const uchar *const file)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetTlsKeyFile(pThis->pDrvrData, file);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -287,8 +314,10 @@ static rsRetVal
 SetDrvrTlsCertFile(netstrm_t *const pThis, const uchar *const file)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetTlsCertFile(pThis->pDrvrData, file);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -306,8 +335,10 @@ static rsRetVal
 Send(netstrm_t *pThis, uchar *pBuf, ssize_t *pLenBuf)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.Send(pThis->pDrvrData, pBuf, pLenBuf);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -318,8 +349,10 @@ static rsRetVal
 EnableKeepAlive(netstrm_t *pThis)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.EnableKeepAlive(pThis->pDrvrData);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -329,8 +362,10 @@ static rsRetVal
 SetKeepAliveProbes(netstrm_t *pThis, int keepAliveProbes)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetKeepAliveProbes(pThis->pDrvrData, keepAliveProbes);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -340,8 +375,10 @@ static rsRetVal
 SetKeepAliveTime(netstrm_t *pThis, int keepAliveTime)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetKeepAliveTime(pThis->pDrvrData, keepAliveTime);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -351,8 +388,10 @@ static rsRetVal
 SetKeepAliveIntvl(netstrm_t *pThis, int keepAliveIntvl)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetKeepAliveIntvl(pThis->pDrvrData, keepAliveIntvl);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -361,8 +400,10 @@ static rsRetVal
 SetGnutlsPriorityString(netstrm_t *pThis, uchar *gnutlsPriorityString)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.SetGnutlsPriorityString(pThis->pDrvrData, gnutlsPriorityString);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -370,8 +411,11 @@ SetGnutlsPriorityString(netstrm_t *pThis, uchar *gnutlsPriorityString)
 static rsRetVal
 CheckConnection(netstrm_t *pThis)
 {
-	ISOBJ_TYPE_assert(pThis, netstrm);
-	return pThis->Drvr.CheckConnection(pThis->pDrvrData);
+	DEFiRet;
+	NULL_CHECK(pThis);
+	iRet = pThis->Drvr.CheckConnection(pThis->pDrvrData);
+finalize_it:
+	RETiRet;
 }
 
 
@@ -380,8 +424,10 @@ static rsRetVal
 GetRemoteHName(netstrm_t *pThis, uchar **ppsz)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.GetRemoteHName(pThis->pDrvrData, ppsz);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -391,8 +437,10 @@ static rsRetVal
 GetRemoteIP(netstrm_t *pThis, prop_t **ip)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.GetRemoteIP(pThis->pDrvrData, ip);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -402,8 +450,10 @@ static rsRetVal
 GetRemAddr(netstrm_t *pThis, struct sockaddr_storage **ppAddr)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	iRet = pThis->Drvr.GetRemAddr(pThis->pDrvrData, ppAddr);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -415,10 +465,12 @@ static rsRetVal
 Connect(netstrm_t *pThis, int family, uchar *port, uchar *host, char *device)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
+	NULL_CHECK(pThis);
 	assert(port != NULL);
 	assert(host != NULL);
 	iRet = pThis->Drvr.Connect(pThis->pDrvrData, family, port, host, device);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -432,9 +484,11 @@ static rsRetVal
 GetSock(netstrm_t *pThis, int *pSock)
 {
 	DEFiRet;
-	ISOBJ_TYPE_assert(pThis, netstrm);
-	assert(pSock != NULL);
+	NULL_CHECK(pThis);
+	NULL_CHECK(pSock);
 	iRet = pThis->Drvr.GetSock(pThis->pDrvrData, pSock);
+
+finalize_it:
 	RETiRet;
 }
 
@@ -504,5 +558,3 @@ BEGINAbstractObjClassInit(netstrm, 1, OBJ_IS_CORE_MODULE) /* class, version */
 
 	/* set our own handlers */
 ENDObjClassInit(netstrm)
-/* vi:set ai:
- */

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -170,6 +170,7 @@ static void cnfSetDefaults(rsconf_t *pThis)
 	pThis->globals.bDebugPrintModuleList = 0;
 	pThis->globals.bDebugPrintCfSysLineHandlerList = 0;
 	pThis->globals.bLogStatusMsgs = DFLT_bLogStatusMsgs;
+	pThis->globals.bAllMsgToStderr = 0;
 	pThis->globals.bErrMsgToStderr = 1;
 	pThis->globals.maxErrMsgToStderr = -1;
 	pThis->globals.umask = -1;

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -92,6 +92,7 @@ struct globals_s {
 	int bDebugPrintModuleList;
 	int bDebugPrintCfSysLineHandlerList;
 	int bLogStatusMsgs;	/* log rsyslog start/stop/HUP messages? */
+	int bAllMsgToStderr;	/* print all internal messages to stderr */
 	int bErrMsgToStderr;	/* print error messages to stderr
 				  (in addition to everything else)? */
 	int maxErrMsgToStderr;	/* how many messages to forward at most to stderr? */

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -150,6 +150,15 @@
 	#define PRAGMA_DIAGNOSTIC_POP
 #endif
 
+#define NULL_CHECK(ptr) \
+	do { \
+		if(unlikely(ptr == NULL)) { \
+			LogError(0, RS_RET_PROGRAM_ERROR, \
+				"%s:%d: prevented NULL pointer access", __FILE__, __LINE__); \
+			ABORT_FINALIZE(RS_RET_PROGRAM_ERROR); \
+		} \
+	} while(0);
+
 /* ############################################################# *
  * #                 Some constant values                      # *
  * ############################################################# */
@@ -621,6 +630,9 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_REDIS_AUTH_FAILED = -2453, /**< redis authentication failure */
 	RS_RET_FAUP_INIT_OPTIONS_FAILED = -2454, /**< could not initialize faup options */
 	RS_RET_LIBCAPNG_ERR = -2455, /**< error during dropping the capabilities */
+	RS_RET_NET_CONN_ABORTED = -2456, /**< error during dropping the capabilities */
+	RS_RET_PROGRAM_ERROR = -2457, /**< rsyslogd internal error, like tried NULL-ptr access */
+	RS_RET_DEBUG = -2458, /**< status messages primarily meant for debugging, no error */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */

--- a/runtime/tcpclt.c
+++ b/runtime/tcpclt.c
@@ -3,7 +3,7 @@
  * This is the implementation of TCP-based syslog clients (the counterpart
  * of the tcpsrv class).
  *
- * Copyright 2007-2018 Adiscon GmbH.
+ * Copyright 2007-2024 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -298,12 +298,6 @@ Send(tcpclt_t *pThis, void *pData, char *msg, size_t len)
 
 	CHKiRet(TCPSendBldFrame(pThis, &msg, &len, &bMsgMustBeFreed));
 
-	if(pThis->iRebindInterval > 0  && ++pThis->iNumMsgs == pThis->iRebindInterval) {
-		/* we need to rebind, and use the retry logic for this*/
-		CHKiRet(pThis->prepRetryFunc(pData)); /* try to recover */
-		pThis->iNumMsgs = 0;
-	}
-
 	while(!bDone) { /* loop is broken when send succeeds or error occurs */
 		CHKiRet(pThis->initFunc(pData));
 		iRet = pThis->sendFunc(pData, msg, len);
@@ -361,11 +355,10 @@ finalize_it:
 
 /* set functions */
 static rsRetVal
-SetResendLastOnRecon(tcpclt_t *pThis, int bResendLastOnRecon)
+SetResendLastOnRecon(tcpclt_t *pThis, const int bResendLastOnRecon)
 {
-	DEFiRet;
 	pThis->bResendLastOnRecon = (short) bResendLastOnRecon;
-	RETiRet;
+	return RS_RET_OK;
 }
 static rsRetVal
 SetSendInit(tcpclt_t *pThis, rsRetVal (*pCB)(void*))
@@ -402,14 +395,6 @@ SetFramingDelimiter(tcpclt_t *pThis, uchar tcp_framingDelimiter)
 	pThis->tcp_framingDelimiter = tcp_framingDelimiter;
 	RETiRet;
 }
-static rsRetVal
-SetRebindInterval(tcpclt_t *pThis, int iRebindInterval)
-{
-	DEFiRet;
-	pThis->iRebindInterval = iRebindInterval;
-	RETiRet;
-}
-
 
 /* Standard-Constructor
  */
@@ -468,7 +453,6 @@ CODESTARTobjQueryInterface(tcpclt)
 	pIf->SetSendPrepRetry = SetSendPrepRetry;
 	pIf->SetFraming = SetFraming;
 	pIf->SetFramingDelimiter = SetFramingDelimiter;
-	pIf->SetRebindInterval = SetRebindInterval;
 
 finalize_it:
 ENDobjQueryInterface(tcpclt)
@@ -518,8 +502,3 @@ CODESTARTmodInit
 	/* Initialize all classes that are in our module - this includes ourselfs */
 	CHKiRet(tcpcltClassInit(pModInfo)); /* must be done after tcps_sess, as we use it */
 ENDmodInit
-
-
-/*
- * vi:set ai:
- */

--- a/runtime/tcpclt.h
+++ b/runtime/tcpclt.h
@@ -36,7 +36,6 @@ typedef struct tcpclt_s {
 	short bResendLastOnRecon; /* should the last message be resent on a successful reconnect? */
 	size_t lenPrevMsg;
 	/* session specific callbacks */
-	int iRebindInterval;	/* how often should the send socket be rebound? */
 	int iNumMsgs;		/* number of messages during current "rebind session" */
 	rsRetVal (*initFunc)(void*);
 	rsRetVal (*sendFunc)(void*, char*, size_t);
@@ -57,12 +56,10 @@ BEGINinterface(tcpclt) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetSendFrame)(tcpclt_t*, rsRetVal (*)(void*, char*, size_t));
 	rsRetVal (*SetSendPrepRetry)(tcpclt_t*, rsRetVal (*)(void*));
 	rsRetVal (*SetFraming)(tcpclt_t*, TCPFRAMINGMODE framing);
-	/* v3, 2009-07-14*/
-	rsRetVal (*SetRebindInterval)(tcpclt_t*, int iRebindInterval);
 	/* v4, 2017-06-10*/
 	rsRetVal (*SetFramingDelimiter)(tcpclt_t*, uchar tcp_framingDelimiter);
 ENDinterface(tcpclt)
-#define tcpcltCURR_IF_VERSION 4 /* increment whenever you change the interface structure! */
+#define tcpcltCURR_IF_VERSION 5 /* increment whenever you change the interface structure! */
 
 
 /* prototypes */
@@ -72,5 +69,3 @@ PROTOTYPEObj(tcpclt);
 #define LM_TCPCLT_FILENAME "lmtcpclt"
 
 #endif /* #ifndef TCPCLT_H_INCLUDED */
-/* vim:set ai:
- */

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -355,9 +355,10 @@ if(dbgTimeoutToStderr) {
 	DBGPRINTF("%s: Worker thread %lx, terminated, num workers now %d\n",
 		wtpGetDbgHdr(pThis), (unsigned long) pWti, numWorkersNow);
 	if(numWorkersNow > 0) {
+		// TODO: did the thread ID experiment (pthread_self) work out? rgerhards, 2024-07-25
 		LogMsg(0, RS_RET_OPERATION_STATUS, LOG_INFO,
-			"%s: worker thread %lx terminated, now %d active worker threads",
-			wtpGetDbgHdr(pThis), (unsigned long) pWti, numWorkersNow);
+			"%s: worker thread %lx (%" PRIuPTR ") terminated, now %d active worker threads",
+			wtpGetDbgHdr(pThis), (unsigned long) pWti, (uintptr_t) pthread_self(), numWorkersNow);
 	}
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -207,6 +207,13 @@ TESTS +=  \
 	nested-call-shutdown.sh \
 	dnscache-TTL-0.sh \
 	invalid_nested_include.sh \
+	omfwd-lb-1target-retry-full_buf.sh \
+	omfwd-lb-1target-retry-1_byte_buf.sh \
+	omfwd-lb-1target-retry-1_byte_buf-TargetFail .sh \
+	omfwd-lb-susp.sh \
+	omfwd-lb-2target-basic.sh \
+	omfwd-lb-2target-retry.sh \
+	omfwd-lb-2target-one_fail.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omusrmsg-errmsg-no-params.sh \
@@ -1163,6 +1170,7 @@ TESTS +=  \
 	stats-json-es.sh \
 	dynstats_reset_without_pstats_reset.sh \
 	dynstats_prevent_premature_eviction.sh \
+	omfwd-lb-2target-impstats.sh \
 	omfwd_fast_imuxsock.sh \
 	omfwd_impstats-udp.sh \
 	omfwd_impstats-tcp.sh
@@ -2136,6 +2144,16 @@ EXTRA_DIST= \
 	rscript_set_modify.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
+	omfwd-lb-1target-retry-full_buf.sh \
+	omfwd-lb-1target-retry-1_byte_buf.sh \
+	omfwd-lb-1target-retry-test_skeleton.sh \
+	omfwd-lb-1target-retry-1_byte_buf-TargetFail .sh \
+	omfwd-lb-1target-retry-test_skeleton-TargetFail.sh \
+	omfwd-lb-susp.sh \
+	omfwd-lb-2target-basic.sh \
+	omfwd-lb-2target-impstats.sh \
+	omfwd-lb-2target-retry.sh \
+	omfwd-lb-2target-one_fail.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omfwd_fast_imuxsock.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+
 # 
 # this shell script provides commands to the common diag system. It enables
 # test scripts to wait for certain conditions and initiate certain actions.
@@ -231,7 +231,8 @@ generate_conf() {
 	echo 'module(load="../plugins/imdiag/.libs/imdiag")
 global(inputs.timeout.shutdown="'$RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT'"
        default.action.queue.timeoutshutdown="'$RSTB_ACTION_DEFAULT_Q_TO_SHUTDOWN'"
-       default.action.queue.timeoutEnqueue="'$RSTB_ACTION_DEFAULT_Q_TO_ENQUEUE'")
+       default.action.queue.timeoutEnqueue="'$RSTB_ACTION_DEFAULT_Q_TO_ENQUEUE'"
+       debug.abortOnProgramError="on")
 # use legacy-style for the following settings so that we can override if needed
 $MainmsgQueueTimeoutEnqueue 20000
 $MainmsgQueueTimeoutShutdown '$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT'
@@ -599,6 +600,22 @@ assign_file_content() {
 	fi
 	eval export $1="$content"
 	printf 'exported: %s=%s\n' $1 "$content"
+}
+
+# start a minitcpsrvr with the regular parameters
+# $1 is the output file name
+# $2 is the instance name (1, 2)
+start_minitcpsrvr() {
+	instance=${2:-1}
+	./minitcpsrv -t127.0.0.1 -p 0 -P "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance" -f "$1" $MINITCPSRV_EXTRA_OPTS &
+	BGPROCESS=$!
+	wait_file_exists "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance"
+	if [ "$instance" == "1" ]; then
+		export MINITCPSRVR_PORT1="$(cat $RSYSLOG_DYNNAME.minitcpsrvr_port$instance)"
+	else
+		export MINITCPSRVR_PORT2="$(cat $RSYSLOG_DYNNAME.minitcpsrvr_port$instance)"
+	fi
+	echo "### background minitcpsrv process id is $BGPROCESS port $(cat $RSYSLOG_DYNNAME.minitcpsrvr_port$instance) ###"
 }
 
 # same as startup_vg, BUT we do NOT wait on the startup message!

--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -1,6 +1,6 @@
 /* a very simplistic tcp receiver for the rsyslog testbench.
  *
- * Copyright 2016 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2016,2024 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog project.
  *
@@ -22,9 +22,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <errno.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
+#include <poll.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <arpa/inet.h>
@@ -32,41 +34,148 @@
 #include <netinet/in.h>
 #endif
 
+#define MAX_CONNECTIONS 10
+#define BUFFER_SIZE 1024
+
+/* OK, we use a lot of global. But after all, this is "just" a small
+ * testing ... that has evolved a bit ;-)
+ */
+char wrkBuf[4096];
+ssize_t nRead;
+size_t nRcv = 0;
+int nConnDrop; /* how often has the connection already been dropped? */
+int abortListener = 0; /* act like listener was totally aborted */
+int sleepAfterConnDrop = 0; /* number of seconds to sleep() when a connection was dropped */
+int dropConnection_NbrRcv = 0;
+int dropConnection_MaxTimes = 0;
+int opt;
+int sleepStartup = 0;
+char *targetIP = NULL;
+int targetPort = -1;
+char *portFileName = NULL;
+size_t totalWritten = 0;
+int listen_fd, conn_fd, fd, file_fd, nfds, port = 8080;
+struct sockaddr_in server_addr;
+struct pollfd fds[MAX_CONNECTIONS + 1]; // +1 for the listen socket
+char buffer[MAX_CONNECTIONS][BUFFER_SIZE];
+int buffer_offs[MAX_CONNECTIONS];
+
 static void
 errout(char *reason)
 {
 	perror(reason);
+	fprintf(stderr, "minitcpsrv ABORTS!!!\n\n\n");
 	exit(1);
 }
 
 static void
 usage(void)
 {
-	fprintf(stderr, "usage: minitcpsrvr -t ip-addr -p port -f outfile\n");
+	fprintf(stderr, "usage: minitcpsrv -t ip-addr -p port -P portFile -f outfile\n");
 	exit (1);
 }
+
+static void
+createListenSocket(void)
+{
+	struct sockaddr_in srvAddr;
+	unsigned int srvAddrLen;
+	static int portFileWritten = 0;
+	int r;
+
+	listen_fd = socket(AF_INET, SOCK_STREAM, 0);
+	if (listen_fd < 0) {
+		errout("Failed to create listen socket");
+	}
+	// Set SO_REUSEADDR and SO_REUSEPORT options
+	int opt = 1;
+	if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)) < 0) {
+		errout("setsockopt failed");
+	}
+
+	fprintf(stderr, "listen on target port %d\n", targetPort);
+	memset(&server_addr, 0, sizeof(server_addr));
+	server_addr.sin_family = AF_INET;
+	server_addr.sin_addr.s_addr = inet_addr(targetIP); //htonl(INADDR_ANY);
+	server_addr.sin_port = htons(targetPort);
+	srvAddrLen = sizeof(server_addr);
+
+
+	int sockBound = 0;
+	int try = 0;
+	do {
+		r = bind(listen_fd, (struct sockaddr *)&server_addr, sizeof(server_addr));
+		if(r < 0) {
+			if(errno == EADDRINUSE) {
+				perror("minitcpsrv bind listen socket");
+				if(try++ < 10) {
+					sleep(1);
+				} else {
+					fprintf(stderr, "minitcpsrv could not bind socket "
+						"after trying hard - terminating\n\n");
+					exit(2);
+				}
+			} else {
+				errout("bind");
+			}
+		} else {
+			sockBound = 1;
+		}
+	} while(!sockBound);
+
+	if (listen(listen_fd, MAX_CONNECTIONS) < 0) {
+		errout("Listen failed");
+	}
+
+	if (getsockname(listen_fd, (struct sockaddr*)&srvAddr, &srvAddrLen) == -1) {
+		errout("getsockname");
+	}
+	targetPort = ntohs(srvAddr.sin_port);
+
+	if(portFileName != NULL && !portFileWritten) {
+		FILE *fp;
+		if (getsockname(listen_fd, (struct sockaddr*)&srvAddr, &srvAddrLen) == -1) {
+			errout("getsockname");
+		}
+		if((fp = fopen(portFileName, "w+")) == NULL) {
+			errout(portFileName);
+		}
+		fprintf(fp, "%d", ntohs(srvAddr.sin_port));
+		fclose(fp);
+		portFileWritten= 1;
+	}
+
+	fds[0].fd = listen_fd;
+	fds[0].events = POLLIN;
+}
+
 
 int
 main(int argc, char *argv[])
 {
-	int fds;
 	int fdc;
 	int fdf = -1;
-	struct sockaddr_in srvAddr;
 	struct sockaddr_in cliAddr;
-	unsigned int srvAddrLen;
 	unsigned int cliAddrLen;
-	char wrkBuf[4096];
-	ssize_t nRead;
-	int opt;
-	int sleeptime = 0;
-	char *targetIP = NULL;
-	int targetPort = -1;
+	memset(fds, 0, sizeof(fds));
+	memset(buffer_offs, 0, sizeof(buffer_offs));
 
-	while((opt = getopt(argc, argv, "t:p:f:s:")) != -1) {
+	while((opt = getopt(argc, argv, "aB:D:t:p:P:f:s:S:")) != -1) {
 		switch (opt) {
-		case 's':
-			sleeptime = atoi(optarg);
+		case 'a': // abort listener: act like the server has died (shutdown and re-open listen socket)
+			abortListener = 1;
+			break;
+		case 'S': // sleep time after connection drop
+			sleepAfterConnDrop = atoi(optarg);
+			break;
+		case 's': // sleep time immediately after startup
+			sleepStartup = atoi(optarg);
+			break;
+		case 'B': // max number of time the connection shall be dropped
+			dropConnection_MaxTimes = atoi(optarg);
+			break;
+		case 'D': // drop connection after this number of recv() operations (not messages)
+			dropConnection_NbrRcv = atoi(optarg);
 			break;
 		case 't':
 			targetIP = optarg;
@@ -74,10 +183,14 @@ main(int argc, char *argv[])
 		case 'p':
 			targetPort = atoi(optarg);
 			break;
+		case 'P':
+			portFileName = optarg;
+			break;
 		case 'f':
 			if(!strcmp(optarg, "-")) {
 				fdf = 1;
 			} else {
+				fprintf(stderr, "writing to file %s\n", optarg);
 				fdf = open(optarg, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR|S_IWUSR);
 				if(fdf == -1) errout(argv[3]);
 			}
@@ -102,30 +215,134 @@ main(int argc, char *argv[])
 		usage();
 	}
 
-	if(sleeptime) {
-		printf("minitcpsrv: deliberate sleep of %d seconds\n", sleeptime);
-		sleep(sleeptime);
+	if(sleepStartup) {
+		printf("minitcpsrv: deliberate sleep of %d seconds\n", sleepStartup);
+		sleep(sleepStartup);
 		printf("minitcpsrv: end sleep\n");
 	}
 
-	fds = socket(AF_INET, SOCK_STREAM, 0);
-	srvAddr.sin_family = AF_INET;
-	srvAddr.sin_addr.s_addr = inet_addr(targetIP);
-	srvAddr.sin_port = htons(targetPort);
-	srvAddrLen = sizeof(srvAddr);
-	if(bind(fds, (struct sockaddr *)&srvAddr, srvAddrLen) != 0)
-		errout("bind");
-	if(listen(fds, 20) != 0) errout("listen");
-	cliAddrLen = sizeof(cliAddr);
 
-	fdc = accept(fds, (struct sockaddr *)&cliAddr, &cliAddrLen);
-	while(1) {
-		nRead = read(fdc, wrkBuf, sizeof(wrkBuf));
-		if(nRead == 0) break;
-		if(write(fdf, wrkBuf, nRead) != nRead)
-			errout("write");
+	createListenSocket();
+	nfds = 1;
+
+	int bKeepRunning;
+	while (1) {
+		int poll_count = poll(fds, nfds, -1); // -1 means no timeout
+		if (poll_count < 0) {
+			errout("poll");
+		}
+
+		bKeepRunning = 0;	/* terminate on last connection close */
+
+		for (int i = 0; i < nfds; i++) {
+			if (fds[i].revents == 0) continue;
+
+			if (fds[i].revents != POLLIN) {
+				fprintf(stderr, "Error! revents = %d\n", fds[i].revents);
+				exit(EXIT_FAILURE);
+			}
+
+			if (fds[i].fd == listen_fd) {
+				// Accept new connection
+				fprintf(stderr, "minitcpsrv: NEW CONNECT\n");
+				conn_fd = accept(listen_fd, (struct sockaddr *)NULL, NULL);
+				if (conn_fd < 0) {
+					perror("Accept failed");
+					continue;
+				}
+
+				fds[nfds].fd = conn_fd;
+				fds[nfds].events = POLLIN;
+				nfds++;
+			} else {
+				// Handle data from a client
+				fd = fds[i].fd;
+				const size_t bytes_to_read = sizeof(buffer[i]) - buffer_offs[i] - 1;
+				int read_bytes = read(fd, &(buffer[i][buffer_offs[i]]), bytes_to_read);
+				nRcv += read_bytes;
+				if (read_bytes < 0) {
+					perror("Read error");
+					close(fd);
+					fds[i].fd = -1; // Remove from poll set
+				} else if (read_bytes == 0) {
+						// Connection closed
+						close(fd);
+						fds[i].fd = -1; // Remove from poll set
+					} else {
+						// last valid char in rcv buffer
+						const int last_byte = read_bytes + buffer_offs[i] - 1;
+						int last_lf = last_byte;
+						while(last_lf > -1 && buffer[i][last_lf] != '\n') {
+							--last_lf;
+						}
+						if(last_lf == -1) { /* no LF found at all */
+							buffer_offs[i] = last_byte;
+						} else {
+							const int bytes_to_write = last_lf + 1;
+
+							const int written_bytes = write(fdf, buffer[i], bytes_to_write);
+							if(written_bytes != bytes_to_write)
+								errout("write");
+							totalWritten += bytes_to_write;
+							if(bytes_to_write == last_byte + 1) {
+								buffer_offs[i] = 0;
+							} else {
+								/* keep data in buffer, move it to start
+								 * and adjust offset.
+								 */
+								int unfinished_bytes = last_byte - bytes_to_write + 1;
+								memmove(buffer[i], &(buffer[i][bytes_to_write]),
+									unfinished_bytes);
+								buffer_offs[i] = unfinished_bytes;
+							}
+						}
+					}
+
+					/* simulate connection abort, if requested */
+					if((buffer_offs[i] == 0)
+					   && (dropConnection_NbrRcv > 0) && (nRcv >= dropConnection_NbrRcv)
+					   && (dropConnection_MaxTimes > 0) && (nConnDrop < dropConnection_MaxTimes)) {
+						nConnDrop++;
+						nRcv = 0;
+						if(abortListener) {
+							fprintf(stderr, "minitcpsrv: simulating died client\n");
+							shutdown(listen_fd, SHUT_RDWR);
+						}
+						close(fd);
+						fds[i].fd = -1; // Remove from poll set
+
+						if(sleepAfterConnDrop > 0) {
+							sleep(sleepAfterConnDrop);
+						}
+						if(abortListener) {
+							/* we hope that when we close and immediately re-open, we will
+							 * can use the some port again.
+							 */
+							close(listen_fd);
+							createListenSocket();
+							fprintf(stderr, "minitcpsrv: reactivated\n");
+						}
+						bKeepRunning = 1; /* do not abort if sole connection! */
+					}
+				}
+			}
+
+		// Compact the array of monitored file descriptors
+		for (int i = 0; i < nfds; i++) {
+			if (fds[i].fd == -1) {
+				for (int j = i; j < nfds - 1; j++) {
+				fds[j] = fds[j + 1];
+				}
+			i--;
+			nfds--;
+			}
+		}
+		// terminate if all connections have been closed
+		if(nfds == 1 && !bKeepRunning)
+			break;
 	}
+/* -------------------------------------------------- */
 	/* let the OS do the cleanup */
-	fprintf(stderr, "minitcpsrv terminates itself\n");
+	fprintf(stderr, "minitcpsrv on port %d terminates itself, %zu bytes written\n", targetPort, totalWritten);
 	return 0;
 }

--- a/tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh
+++ b/tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export OMFWD_IOBUF_SIZE=1000 # triggers edge cases
+source ${srcdir:-.}/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh

--- a/tests/omfwd-lb-1target-retry-1_byte_buf.sh
+++ b/tests/omfwd-lb-1target-retry-1_byte_buf.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export OMFWD_IOBUF_SIZE=10 # triggers edge cases
+source ${srcdir:-.}/omfwd-lb-1target-retry-test_skeleton.sh

--- a/tests/omfwd-lb-1target-retry-full_buf.sh
+++ b/tests/omfwd-lb-1target-retry-full_buf.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export OMFWD_IOBUF_SIZE=0 # full buffer size
+source ${srcdir:-.}/omfwd-lb-1target-retry-test_skeleton.sh

--- a/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
+++ b/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# added 2024-02-19 by rgerhards. Released under ASL 2.0
+# This test is not meant to be executed independetly. It just permits
+# to be called by different drivers with different io buffer sizes.
+# This in turn is needed to test some edge cases.
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS" "This test is currently not supported on solaris due to too-different timing"
+generate_conf
+export NUMMESSAGES=2000
+
+# starting minitcpsrvr receivers so that we can obtain their port
+# numbers
+export MINITCPSRV_EXTRA_OPTS="-D900 -B2 -a -S5"
+start_minitcpsrvr $RSYSLOG_OUT_LOG  1
+
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+$MainMsgQueueDequeueBatchSize 100
+
+global(allMessagesToStderr="on")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt" iobuffer.maxSize="'$OMFWD_IOBUF_SIZE'")
+
+if $msg contains "msgnum:" then {
+	action(type="omfwd" target=["127.0.0.1"] port="'$MINITCPSRVR_PORT1'" protocol="tcp"
+		pool.resumeInterval="2"
+		action.reportsuspensioncontinuation="on"
+		action.resumeRetryCount="-1" action.resumeInterval="3")
+}
+'
+echo Note: intentionally not started any local TCP receiver!
+
+# now do the usual run
+startup
+
+injectmsg
+shutdown_when_empty
+wait_shutdown
+# note: minitcpsrv shuts down automatically if the connection is closed!
+
+export SEQ_CHECK_OPTIONS=-d
+#permit 100 messages to be lost in this extreme test (-m 100)
+seq_check 0 $((NUMMESSAGES-1)) -m100
+exit_test

--- a/tests/omfwd-lb-1target-retry-test_skeleton.sh
+++ b/tests/omfwd-lb-1target-retry-test_skeleton.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# added 2024-02-19 by rgerhards. Released under ASL 2.0
+# This test is not meant to be executed independetly. It just permits
+# to be called by different drivers with different io buffer sizes.
+# This in turn is needed to test some edge cases.
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS" "This test is currently not supported on solaris due to too-different timing"
+generate_conf
+export NUMMESSAGES=2000
+
+# starting minitcpsrvr receivers so that we can obtain their port
+# numbers
+export MINITCPSRV_EXTRA_OPTS="-D900 -B2 -a -S3"
+start_minitcpsrvr $RSYSLOG_OUT_LOG  1
+
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+$MainMsgQueueDequeueBatchSize 100
+
+global(allMessagesToStderr="on")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt" iobuffer.maxSize="'$OMFWD_IOBUF_SIZE'")
+
+if $msg contains "msgnum:" then {
+	action(type="omfwd" target=["127.0.0.1"] port="'$MINITCPSRVR_PORT1'" protocol="tcp"
+		#extendedConnectionCheck="off"
+		pool.resumeInterval="1"
+		action.resumeRetryCount="-1" action.resumeInterval="1")
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt"
+	       action.ExecOnlyWhenPreviousIsSuspended="on")
+}
+'
+echo Note: intentionally not started any local TCP receiver!
+
+# now do the usual run
+startup
+
+injectmsg
+shutdown_when_empty
+wait_shutdown
+# note: minitcpsrv shuts down automatically if the connection is closed!
+
+export SEQ_CHECK_OPTIONS=-d
+#permit 100 messages to be lost in this extreme test (-m 100)
+seq_check 0 $((NUMMESSAGES-1)) -m100
+exit_test

--- a/tests/omfwd-lb-2target-basic.sh
+++ b/tests/omfwd-lb-2target-basic.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# added 2024-02-24 by rgerhards. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+export NUMMESSAGES=1000  # MUST be an EVEN number!
+
+# starting minitcpsrvr receives so that we can obtain their port
+# numbers
+start_minitcpsrvr $RSYSLOG_OUT_LOG  1
+start_minitcpsrvr $RSYSLOG2_OUT_LOG 2
+
+# regular startup
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt")
+
+if $msg contains "msgnum:" then {
+	action(type="omfwd" target=["127.0.0.1", "127.0.0.1"]
+	                    port=["'$MINITCPSRVR_PORT1'", "'$MINITCPSRVR_PORT2'"]
+		protocol="tcp"
+		pool.resumeInterval="10"
+		action.resumeRetryCount="-1" action.resumeInterval="5")
+}
+'
+
+# now do the usual run
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+if [ "$(wc -l < $RSYSLOG_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
+	echo "ERROR: RSYSLOG_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+	error_exit 100
+fi
+
+if [ "$(wc -l < $RSYSLOG2_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
+	echo "ERROR: RSYSLOG2_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+	error_exit 100
+fi
+
+# combine both files to check for correct message content
+export SEQ_CHECK_FILE="$RSYSLOG_DYNNAME.log-combined"
+cat "$RSYSLOG_OUT_LOG" "$RSYSLOG2_OUT_LOG" > "$SEQ_CHECK_FILE"
+
+seq_check
+exit_test

--- a/tests/omfwd-lb-2target-impstats.sh
+++ b/tests/omfwd-lb-2target-impstats.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# added 2024-02-24 by rgerhards. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+export NUMMESSAGES=1000  # MUST be an EVEN number!
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+
+# starting minitcpsrvr receives so that we can obtain their port
+# numbers
+start_minitcpsrvr $RSYSLOG_OUT_LOG  1
+start_minitcpsrvr $RSYSLOG2_OUT_LOG 2
+
+# regular startup
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'"
+	interval="1" ruleset="stats")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt")
+
+if $msg contains "msgnum:" then {
+	action(type="omfwd" target=["127.0.0.1", "127.0.0.1"]
+	                    port=["'$MINITCPSRVR_PORT1'", "'$MINITCPSRVR_PORT2'"]
+		protocol="tcp"
+		pool.resumeInterval="10"
+		action.resumeRetryCount="-1" action.resumeInterval="5")
+}
+'
+
+# now do the usual run
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+if [ "$(wc -l < $RSYSLOG_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
+	echo "ERROR: RSYSLOG_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+	error_exit 100
+fi
+
+if [ "$(wc -l < $RSYSLOG2_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
+	echo "ERROR: RSYSLOG2_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+	error_exit 100
+fi
+
+# combine both files to check for correct message content
+export SEQ_CHECK_FILE="$RSYSLOG_DYNNAME.log-combined"
+cat "$RSYSLOG_OUT_LOG" "$RSYSLOG2_OUT_LOG" > "$SEQ_CHECK_FILE"
+seq_check
+
+export MSGS_PER_TARGET="$((NUMMESSAGES / 2))"
+echo msg per target $MSGS_PER_TARGET
+# check pstats - that's our prime test target
+echo content_check --regex "TCP-.*origin=omfwd .*messages.sent=$MSGS_PER_TARGET" "$STATSFILE"
+content_check --regex "TCP-.*origin=omfwd .*messages.sent=$MSGS_PER_TARGET" "$STATSFILE"
+
+exit_test

--- a/tests/omfwd-lb-2target-one_fail.sh
+++ b/tests/omfwd-lb-2target-one_fail.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# added 2024-02-24 by rgerhards. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+export NUMMESSAGES=1000  # MUST be an EVEN number!
+
+# starting minitcpsrvr receives so that we can obtain their port
+# numbers
+start_minitcpsrvr $RSYSLOG_OUT_LOG  1
+
+# regular startup
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt")
+
+if $msg contains "msgnum:" then {
+	action(type="omfwd" target=["127.0.0.1", "127.0.0.1"]
+	                    port=["'$MINITCPSRVR_PORT1'", "'$TCPFLOOD_PORT'"]
+		protocol="tcp"
+		pool.resumeInterval="10"
+		action.resumeRetryCount="-1" action.resumeInterval="5")
+}
+'
+
+# now do the usual run
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+# combine both files to check for correct message content
+seq_check
+exit_test

--- a/tests/omfwd-lb-2target-retry.sh
+++ b/tests/omfwd-lb-2target-retry.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# added 2024-02-24 by rgerhards. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+export NUMMESSAGES=10000  # MUST be an EVEN number!
+
+# starting minitcpsrvr receivers so that we can obtain their port
+# numbers
+start_minitcpsrvr $RSYSLOG_OUT_LOG  1
+
+# regular startup
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+$MainMsgQueueWorkerThreads 2
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt")
+
+if $msg contains "msgnum:" then {
+	action(type="omfwd" target=["127.0.0.1", "127.0.0.1"]
+	                    port=["'$MINITCPSRVR_PORT1'", "'$TCPFLOOD_PORT'"]
+		protocol="tcp"
+		pool.resumeInterval="1"
+		action.resumeRetryCount="-1" action.resumeInterval="5")
+}
+'
+
+startup
+# we need special logic. In a first iteration, the second target is offline
+# so everything is expected to go the the first target, only.
+injectmsg
+# combine both files to check for correct message content
+#cat "$RSYSLOG_OUT_LOG" "$RSYSLOG2_OUT_LOG" > "$SEQ_CHECK_FILE"
+wait_queueempty
+wait_file_lines
+cp "$RSYSLOG_OUT_LOG" tmp.log
+seq_check
+printf "\nSUCCESS for part 1 of the test\n\n"
+
+echo WARNING: The next part of this test is flacky, because there is an
+echo inevitable race on the port number for minitcpsrvr. If another
+echo parallel test has aquired it in the interim, this test here will
+echo invalidly fail.
+./minitcpsrv -t127.0.0.1 -p $TCPFLOOD_PORT -f "$RSYSLOG2_OUT_LOG" \
+	-P "$RSYSLOG_DYNNAME.minitcpsrvr_port2"  &
+# Note: we use the port file just to make sure minitcpsrvr has initialized!
+wait_file_exists "$RSYSLOG_DYNNAME.minitcpsrvr_port2"
+BGPROCESS=$!
+echo "### background minitcpsrv process id is $BGPROCESS port $TCPFLOOD_PORT ###"
+echo "waiting a bit to ensure rsyslog retries the currently suspended pool member"
+
+sleep 3
+
+injectmsg $NUMMESSAGES $NUMMESSAGES
+
+shutdown_when_empty
+wait_shutdown
+
+if [ "$(wc -l < $RSYSLOG2_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
+	echo "ERROR: RSYSLOG2_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+	cat -n  $RSYSLOG2_OUT_LOG | head -10
+	error_exit 100
+fi
+
+# combine both files to check for correct message content
+export SEQ_CHECK_FILE="$RSYSLOG_DYNNAME.log-combined"
+export NUMMESSAGES=$((NUMMESSAGES*2))
+cat "$RSYSLOG_OUT_LOG" "$RSYSLOG2_OUT_LOG" > "$SEQ_CHECK_FILE"
+seq_check
+
+exit_test

--- a/tests/omfwd-lb-susp.sh
+++ b/tests/omfwd-lb-susp.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# added 2024-02-19 by rgerhards. Released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+module(load="builtin:omfwd" template="outfmt")
+
+if $msg contains "msgnum:" then {
+	action(type="omfwd" target=["xlocalhost", "127.0.0.1"] port="'$TCPFLOOD_PORT'" protocol="tcp")
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt"
+	       action.ExecOnlyWhenPreviousIsSuspended="on")
+}
+'
+echo Note: intentionally not started any local TCP receiver!
+
+# now do the usual run
+startup
+injectmsg 0 5000
+shutdown_when_empty
+wait_shutdown
+# note: minitcpsrv shuts down automatically if the connection is closed!
+
+seq_check 0 4999
+exit_test

--- a/tests/omfwd_impstats-tcp.sh
+++ b/tests/omfwd_impstats-tcp.sh
@@ -33,6 +33,7 @@ shutdown_when_empty
 wait_shutdown
 # note: minitcpsrv shuts down automatically if the connection is closed!
 
+cat -n $STATSFILE
 # check pstats - that's our prime test target
 content_check --regex "TCP-.*origin=omfwd .*bytes.sent=[1-9][0-9][0-9]" "$STATSFILE"
 

--- a/tests/rcvr_fail_restore.sh
+++ b/tests/rcvr_fail_restore.sh
@@ -164,5 +164,6 @@ if [ $NEWFILESIZE != $OLDFILESIZE ]; then
 	error_exit 1
 fi
 # do the final check
+export SEQ_CHECK_OPTIONS=-d
 seq_check 1 21010 -m 100
 exit_test

--- a/tests/sndrcv_tls_anon_rebind.sh
+++ b/tests/sndrcv_tls_anon_rebind.sh
@@ -3,6 +3,9 @@
 # rgerhards, 2011-04-04
 # This file is part of the rsyslog project, released  under GPLv3
 . ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=25000 #25000
+
 # uncomment for debugging support:
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
@@ -31,6 +34,7 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 startup
 export PORT_RCVR=$TCPFLOOD_PORT # save this, will be rewritten with next config
 
+#export RSYSLOG_DEBUG="debug nostdout"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -52,7 +56,7 @@ startup 2
 
 # now inject the messages into instance 2. It will connect to instance 1,
 # and that instance will record the data.
-injectmsg2 1 25000
+injectmsg2 1 $NUMMESSAGES
 # shut down sender when everything is sent, receiver continues to run concurrently
 shutdown_when_empty 2
 wait_shutdown 2
@@ -60,5 +64,5 @@ wait_shutdown 2
 shutdown_when_empty
 wait_shutdown
 
-seq_check 1 25000
+seq_check 1 $NUMMESSAGES
 exit_test

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -4,7 +4,7 @@
  * NOTE: read comments in module-template.h to understand how this file
  *       works!
  *
- * Copyright 2007-2021 Adiscon GmbH.
+ * Copyright 2007-2024 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -59,6 +59,7 @@
 #include "parserif.h"
 #include "ratelimit.h"
 #include "statsobj.h"
+#include "datetime.h"
 
 MODULE_TYPE_OUTPUT
 MODULE_TYPE_NOKEEP
@@ -73,11 +74,20 @@ DEFobjCurrIf(netstrms)
 DEFobjCurrIf(netstrm)
 DEFobjCurrIf(tcpclt)
 DEFobjCurrIf(statsobj)
+DEFobjCurrIf(datetime)
 
 
 /* some local constants (just) for better readybility */
 #define IS_FLUSH 1
 #define NO_FLUSH 0
+
+typedef struct _targetStats {
+	statsobj_t *stats;
+	intctr_t sentBytes;
+	intctr_t sentMsgs;
+	DEF_ATOMIC_HELPER_MUT64(mut_sentBytes)
+	DEF_ATOMIC_HELPER_MUT64(mut_sentMsgs)
+} targetStats_t;
 
 typedef struct _instanceData {
 	uchar 	*tplName;	/* name of assigned template */
@@ -93,11 +103,14 @@ typedef struct _instanceData {
 	const uchar *pszStrmDrvrCRLFile;
 	const uchar *pszStrmDrvrKeyFile;
 	const uchar *pszStrmDrvrCertFile;
-	char	*target;
+	int	nTargets;
+	int	nActiveTargets; /* how many targets have been active the last time? */
+	char	**target_name;
+	int	nPorts;
+	char	**ports;
 	char	*address;
 	char	*device;
 	int compressionLevel;	/* 0 - no compression, else level for zlib */
-	char *port;
 	int protocol;
 	char *networkNamespace;
 	int originalNamespace;
@@ -120,25 +133,27 @@ typedef struct _instanceData {
 	TCPFRAMINGMODE tcp_framing;
 	uchar tcp_framingDelimiter;
 	int bResendLastOnRecon; /* should the last message be re-sent on a successful reconnect? */
+	int bExtendedConnCheck;	/* do extended connection checking? */
 #	define COMPRESS_NEVER 0
 #	define COMPRESS_SINGLE_MSG 1	/* old, single-message compression */
 	/* all other settings are for stream-compression */
 #	define COMPRESS_STREAM_ALWAYS 2
 	uint8_t compressionMode;
-	int errsToReport;	/* max number of errors to report (per instance) */
 	sbool strmCompFlushOnTxEnd; /* flush stream compression on transaction end? */
+	unsigned poolResumeInterval;
 	unsigned int ratelimitInterval;
 	unsigned int ratelimitBurst;
 	ratelimit_t *ratelimiter;
-	statsobj_t *stats;		/* dynafile, primarily cache stats */
-	intctr_t sentBytes;
-	DEF_ATOMIC_HELPER_MUT64(mut_sentBytes)
+	targetStats_t *target_stats;
 } instanceData;
 
-typedef struct wrkrInstanceData {
+typedef struct targetData {
 	instanceData *pData;
+	struct wrkrInstanceData *pWrkrData; /* forward def of struct */
 	netstrms_t *pNS; /* netstream subsystem */
 	netstrm_t *pNetstrm; /* our output netstream */
+	char	*target_name;
+	char	*port;
 	struct addrinfo *f_addr;
 	int *pSockArray;	/* sockets to use for UDP */
 	int bIsConnected;  /* are we connected to remote host? 0 - no, 1 - yes, UDP means addr resolved */
@@ -146,10 +161,24 @@ typedef struct wrkrInstanceData {
 	tcpclt_t *pTCPClt;	/* our tcpclt object */
 	sbool bzInitDone; /* did we do an init of zstrm already? */
 	z_stream zstrm;	/* zip stream to use for tcp compression */
-	uchar sndBuf[16*1024];	/* this is intensionally fixed -- see no good reason to make configurable */
-	unsigned offsSndBuf;	/* next free spot in send buffer */
-	int errsToReport;	/* (remaining) number of errors to report */
+	/* we know int is sufficient, as we have the fixed buffer size above! so no need for size_t */
+	int maxLenSndBuf;	/* max usable length of sendbuf - primarily for testing */
+	int offsSndBuf;	/* next free spot in send buffer */
+	time_t ttResume;
+	targetStats_t *pTargetStats;
+	/* sndBuf buffer size is intensionally fixed -- see no good reason to make configurable */
+	#define SNDBUF_FIXED_BUFFER_SIZE (16*1024)
+	uchar sndBuf[SNDBUF_FIXED_BUFFER_SIZE];
+} targetData_t;
+
+typedef struct wrkrInstanceData {
+	instanceData *pData;
+	targetData_t *target;
+	int nXmit;		/* number of transmissions since last (re-)bind */
+	unsigned actualTarget;
+	unsigned wrkrID;	/* an internal monotonically increasing id for correlating worker messages */
 } wrkrInstanceData_t;
+static unsigned wrkrID = 0;
 
 /* config data */
 typedef struct configSettings_s {
@@ -174,7 +203,8 @@ static configSettings_t cs;
 /* tables for interfacing with the v6 config system */
 /* module-global parameters */
 static struct cnfparamdescr modpdescr[] = {
-	{ "template", eCmdHdlrGetWord, 0 },
+	{ "iobuffer.maxsize", eCmdHdlrNonNegInt, 0 },
+	{ "template", eCmdHdlrGetWord, 0 }
 };
 static struct cnfparamblk modpblk =
 	{ CNFPARAMBLK_VERSION,
@@ -184,10 +214,10 @@ static struct cnfparamblk modpblk =
 
 /* action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {
-	{ "target", eCmdHdlrGetWord, 0 },
+	{ "target", eCmdHdlrArray, CNFPARAM_REQUIRED },
 	{ "address", eCmdHdlrGetWord, 0 },
 	{ "device", eCmdHdlrGetWord, 0 },
-	{ "port", eCmdHdlrGetWord, 0 },
+	{ "port", eCmdHdlrArray, 0 },
 	{ "protocol", eCmdHdlrGetWord, 0 },
 	{ "networknamespace", eCmdHdlrGetWord, 0 },
 	{ "tcp_framing", eCmdHdlrGetWord, 0 },
@@ -217,10 +247,12 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "streamdriver.keyfile", eCmdHdlrString, 0 },
 	{ "streamdriver.certfile", eCmdHdlrString, 0 },
 	{ "resendlastmsgonreconnect", eCmdHdlrBinary, 0 },
+	{ "extendedconnectioncheck", eCmdHdlrBinary, 0 },
 	{ "udp.sendtoall", eCmdHdlrBinary, 0 },
 	{ "udp.senddelay", eCmdHdlrInt, 0 },
 	{ "udp.sendbuf", eCmdHdlrSize, 0 },
 	{ "template", eCmdHdlrGetWord, 0 },
+	{ "pool.resumeinterval", eCmdHdlrPositiveInt, 0 },
 	{ "ratelimit.interval", eCmdHdlrInt, 0 },
 	{ "ratelimit.burst", eCmdHdlrInt, 0 }
 };
@@ -233,6 +265,7 @@ static struct cnfparamblk actpblk =
 struct modConfData_s {
 	rsconf_t *pConf;	/* our overall config object */
 	uchar 	*tplName;	/* default template */
+	int maxLenSndBuf;	/* default max usable length of sendbuf - primarily for testing */
 };
 
 static modConfData_t *loadModConf = NULL;/* modConf ptr to use for the current load process */
@@ -255,8 +288,8 @@ CODESTARTinitConfVars
 ENDinitConfVars
 
 
-static rsRetVal doTryResume(wrkrInstanceData_t *);
-static rsRetVal doZipFinish(wrkrInstanceData_t *);
+static rsRetVal doTryResume(targetData_t *);
+static rsRetVal doZipFinish(targetData_t *);
 
 /* this function gets the default template. It coordinates action between
  * old-style and new-style configuration parts.
@@ -303,16 +336,38 @@ static rsRetVal
 closeUDPSockets(wrkrInstanceData_t *pWrkrData)
 {
 	DEFiRet;
-	if(pWrkrData->pSockArray != NULL) {
-		net.closeUDPListenSockets(pWrkrData->pSockArray);
-		pWrkrData->pSockArray = NULL;
-		freeaddrinfo(pWrkrData->f_addr);
-		pWrkrData->f_addr = NULL;
+	if(pWrkrData->target[0].pSockArray != NULL) {
+		net.closeUDPListenSockets(pWrkrData->target[0].pSockArray);
+		pWrkrData->target[0].pSockArray = NULL;
+		freeaddrinfo(pWrkrData->target[0].f_addr);
+		pWrkrData->target[0].f_addr = NULL;
 	}
-pWrkrData->bIsConnected = 0; // TODO: remove this variable altogether
+	pWrkrData->target[0].bIsConnected = 0;
 	RETiRet;
 }
 
+
+static void
+DestructTCPTargetData(targetData_t *const pTarget)
+{
+	// TODO: do we need to do a final send? if so, old bug!
+	doZipFinish(pTarget);
+
+	if(pTarget->pNetstrm != NULL) {
+		netstrm.Destruct(&pTarget->pNetstrm);
+	}
+	if(pTarget->pNS != NULL) {
+		netstrms.Destruct(&pTarget->pNS);
+	}
+
+	/* set resume time for interal retries */
+	datetime.GetTime(&pTarget->ttResume);
+	pTarget->ttResume += pTarget->pData->poolResumeInterval;
+	pTarget->bIsConnected = 0;
+	DBGPRINTF("omfwd: DestructTCPTargetData: %p %s:%s, connected %d, ttResume %lld\n",
+				&pTarget, pTarget->target_name, pTarget->port,
+				pTarget->bIsConnected, (long long) pTarget->ttResume);
+}
 
 /* destruct the TCP helper objects
  * This, for example, is needed after something went wrong.
@@ -326,11 +381,12 @@ pWrkrData->bIsConnected = 0; // TODO: remove this variable altogether
 static void
 DestructTCPInstanceData(wrkrInstanceData_t *pWrkrData)
 {
-	doZipFinish(pWrkrData);
-	if(pWrkrData->pNetstrm != NULL)
-		netstrm.Destruct(&pWrkrData->pNetstrm);
-	if(pWrkrData->pNS != NULL)
-		netstrms.Destruct(&pWrkrData->pNS);
+	LogMsg(0, RS_RET_DEBUG, LOG_DEBUG,
+		"omfwd: Destructing TCP target pool of %d targets (DestructTCPInstanceData)",
+		pWrkrData->pData->nTargets);
+	for(int j = 0 ; j <  pWrkrData->pData->nTargets ; ++j) {
+		DestructTCPTargetData(&(pWrkrData->target[j]));
+	}
 }
 
 
@@ -339,6 +395,7 @@ CODESTARTbeginCnfLoad
 	loadModConf = pModConf;
 	pModConf->pConf = pConf;
 	pModConf->tplName = NULL;
+	pModConf->maxLenSndBuf = -1;
 ENDbeginCnfLoad
 
 BEGINsetModCnf
@@ -364,9 +421,22 @@ CODESTARTsetModCnf
 						"was already set via legacy directive - may lead to inconsistent "
 						"results.");
 			}
+		} else if(!strcmp(modpblk.descr[i].name, "iobuffer.maxsize")) {
+			const int newLen = (int) pvals[i].val.d.n;
+			if(newLen > SNDBUF_FIXED_BUFFER_SIZE) {
+				LogMsg(0, RS_RET_PARAM_ERROR, LOG_WARNING,
+					"omfwd: module parameter \"iobuffer.maxsize\" specified larger "
+					"than actual buffer size (%d bytes) - ignored",
+					SNDBUF_FIXED_BUFFER_SIZE);
+			} else {
+				if(newLen > 0) {
+					loadModConf->maxLenSndBuf = newLen;
+				}
+			}
 		} else {
-			dbgprintf("omfwd: program error, non-handled "
-			  "param '%s' in beginCnfLoad\n", modpblk.descr[i].name);
+			LogMsg(0, RS_RET_INTERNAL_ERROR, LOG_ERR,
+				"omfwd: internal error, non-handled param '%s' in beginCnfLoad",
+				modpblk.descr[i].name);
 		}
 	}
 finalize_it:
@@ -398,6 +468,11 @@ ENDfreeCnf
 
 BEGINcreateInstance
 CODESTARTcreateInstance
+	/* We always have at least one target and port */
+	pData->nTargets = 1;
+	pData->nActiveTargets = 0;
+	pData->nPorts = 1;
+	pData->target_name = NULL;
 	if(cs.pszStrmDrvr != NULL)
 		CHKmalloc(pData->pszStrmDrvr = (uchar*)strdup((char*)cs.pszStrmDrvr));
 	if(cs.pszStrmDrvrAuthMode != NULL)
@@ -407,11 +482,38 @@ finalize_it:
 ENDcreateInstance
 
 
+/* Among others, all worker-specific targets are initialized here.
+*/
 BEGINcreateWrkrInstance
 CODESTARTcreateWrkrInstance
-	dbgprintf("DDDD: createWrkrInstance: pWrkrData %p\n", pWrkrData);
-	pWrkrData->offsSndBuf = 0;
+	time_t ttNow;
+
+	datetime.GetTime(&ttNow);
+	ttNow--; /* make sure it is expired */
+
+	assert(pData->nTargets > 0);
+	pWrkrData->actualTarget = 0;
+	pWrkrData->wrkrID = wrkrID++;
+	CHKmalloc(pWrkrData->target = (targetData_t *) calloc(pData->nTargets, sizeof(targetData_t)));
+	for(int i = 0 ; i <  pData->nTargets ; ++i) {
+		pWrkrData->target[i].pData = pWrkrData->pData;
+		pWrkrData->target[i].pWrkrData = pWrkrData;
+		pWrkrData->target[i].target_name = pData->target_name[i];
+		pWrkrData->target[i].pTargetStats = &(pData->target_stats[i]);
+		/* if insufficient ports are configured, we use ports[0] for the
+		 * missing ports.
+		 */
+		pWrkrData->target[i].port = pData->ports[(i < pData->nPorts) ? i : 0];
+		pWrkrData->target[i].maxLenSndBuf =
+			(runModConf->maxLenSndBuf == -1)
+				? SNDBUF_FIXED_BUFFER_SIZE
+				: runModConf->maxLenSndBuf;
+		pWrkrData->target[i].offsSndBuf = 0;
+		pWrkrData->target[i].ttResume = ttNow;
+	}
 	iRet = initTCP(pWrkrData);
+	LogMsg(0, RS_RET_DEBUG, LOG_DEBUG, "omfwd: worker with id %u initialized", pWrkrData->wrkrID);
+finalize_it:
 ENDcreateWrkrInstance
 
 
@@ -424,15 +526,26 @@ ENDisCompatibleWithFeature
 
 BEGINfreeInstance
 CODESTARTfreeInstance
-	if(pData->stats != NULL)
-		statsobj.Destruct(&(pData->stats));
 	free(pData->pszStrmDrvr);
 	free(pData->pszStrmDrvrAuthMode);
 	free(pData->pszStrmDrvrPermitExpiredCerts);
 	free(pData->gnutlsPriorityString);
-	free(pData->port);
 	free(pData->networkNamespace);
-	free(pData->target);
+	if(pData->ports != NULL) { /* could happen in error case (very unlikely) */
+		for(int j = 0 ; j <  pData->nPorts ; ++j) {
+			free(pData->ports[j]);
+		}
+		free(pData->ports);
+	}
+	if(pData->target_stats != NULL) {
+		for(int j = 0 ; j <  pData->nTargets ; ++j) {
+			free(pData->target_name[j]);
+			if(pData->target_stats[j].stats != NULL)
+				statsobj.Destruct(&(pData->target_stats[j].stats));
+		}
+		free(pData->target_stats);
+	}
+	free(pData->target_name);
 	free(pData->address);
 	free(pData->device);
 	free((void*)pData->pszStrmDrvrCAFile);
@@ -450,21 +563,24 @@ ENDfreeInstance
 
 BEGINfreeWrkrInstance
 CODESTARTfreeWrkrInstance
+	LogMsg(0, RS_RET_DEBUG, LOG_DEBUG, "omfwd: [wrkr %u/%" PRIuPTR "] Destructing worker instance",
+		pWrkrData->wrkrID, (uintptr_t) pthread_self());
+
 	DestructTCPInstanceData(pWrkrData);
 	closeUDPSockets(pWrkrData);
 
 	if(pWrkrData->pData->protocol == FORW_TCP) {
-		tcpclt.Destruct(&pWrkrData->pTCPClt);
+		for(int i = 0 ; i <  pWrkrData->pData->nTargets ; ++i) {
+			tcpclt.Destruct(&pWrkrData->target[i].pTCPClt);
+		}
 	}
+	free(pWrkrData->target); /* note: this frees all target memory,calloc()ed array! */
 ENDfreeWrkrInstance
 
 
 BEGINdbgPrintInstInfo
 CODESTARTdbgPrintInstInfo
 	dbgprintf("omfwd\n");
-	dbgprintf("\ttarget='%s'\n", pData->target);
-	dbgprintf("\tratelimit.interval='%u'\n", pData->ratelimitInterval);
-	dbgprintf("\tratelimit.burst='%u'\n", pData->ratelimitBurst);
 ENDdbgPrintInstInfo
 
 
@@ -484,18 +600,20 @@ static rsRetVal UDPSend(wrkrInstanceData_t *__restrict__ const pWrkrData,
 	sbool reInit = RSFALSE;
 	int lasterrno = ENOENT;
 	int lasterr_sock = -1;
+	targetData_t *const pTarget = &(pWrkrData->target[0]);
+	targetStats_t *const pTargetStats = &(pWrkrData->pData->target_stats[0]);
 
-	if(pWrkrData->pData->iRebindInterval && (pWrkrData->nXmit++ % pWrkrData->pData->iRebindInterval == 0)) {
+	if(pWrkrData->pData->iRebindInterval && (pTarget->nXmit++ % pWrkrData->pData->iRebindInterval == 0)) {
 		dbgprintf("omfwd dropping UDP 'connection' (as configured)\n");
-		pWrkrData->nXmit = 1;	/* else we have an addtl wrap at 2^31-1 */
+		pTarget->nXmit = 1;	/* else we have an addtl wrap at 2^31-1 */
 		CHKiRet(closeUDPSockets(pWrkrData));
 	}
 
-	if(pWrkrData->pSockArray == NULL) {
-		CHKiRet(doTryResume(pWrkrData));
+	if(pWrkrData->target[0].pSockArray == NULL) {
+		CHKiRet(doTryResume(pTarget)); /* for UDP, we have only a single tartget! */
 	}
 
-	if(pWrkrData->pSockArray == NULL) {
+	if(pTarget->pSockArray == NULL) {
 		FINALIZE;
 	}
 
@@ -515,18 +633,18 @@ static rsRetVal UDPSend(wrkrInstanceData_t *__restrict__ const pWrkrData,
 	 * the sendto() succeeded. -- rgerhards, 2007-06-22
 	 */
 	bSendSuccess = RSFALSE;
-	for (r = pWrkrData->f_addr; r; r = r->ai_next) {
+	for (r = pTarget->f_addr; r; r = r->ai_next) {
 		int runSockArrayLoop = 1;
-		for (i = 0; runSockArrayLoop && (i < *pWrkrData->pSockArray) ; i++) {
+		for (i = 0; runSockArrayLoop && (i < *pTarget->pSockArray) ; i++) {
 			int try_send = 1;
 			size_t lenThisTry = len;
 			while(try_send) {
-				lsent = sendto(pWrkrData->pSockArray[i+1], msg, lenThisTry, 0,
+				lsent = sendto(pTarget->pSockArray[i+1], msg, lenThisTry, 0,
 						r->ai_addr, r->ai_addrlen);
 				if (lsent == (ssize_t) lenThisTry) {
 					bSendSuccess = RSTRUE;
-					ATOMIC_ADD_uint64(&pWrkrData->pData->sentBytes,
-						&pWrkrData->pData->mut_sentBytes, lenThisTry);
+					ATOMIC_ADD_uint64(&pTargetStats->sentBytes,
+						&pTargetStats->mut_sentBytes, lenThisTry);
 					try_send = 0;
 					runSockArrayLoop = 0;
 				} else if(errno == EMSGSIZE) {
@@ -540,7 +658,7 @@ static rsRetVal UDPSend(wrkrInstanceData_t *__restrict__ const pWrkrData,
 				} else {
 					reInit = RSTRUE;
 					lasterrno = errno;
-					lasterr_sock = pWrkrData->pSockArray[i+1];
+					lasterr_sock = pTarget->pSockArray[i+1];
 					LogError(lasterrno, RS_RET_ERR_UDPSEND,
 						"omfwd/udp: socket %d: sendto() error",
 						lasterr_sock);
@@ -590,85 +708,127 @@ finalize_it:
 
 /* CODE FOR SENDING TCP MESSAGES */
 
+/* This is a common function so that we can emit consistent error
+ * messages whenever we have trouble with a connection, e.g. when
+ * sending or checking if it's broken.
+ */
+static void
+emitConnectionErrorMsg(const targetData_t *const pTarget, const rsRetVal iRet)
+{
+	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t *) pTarget->pWrkrData;
+
+	if(iRet == RS_RET_IO_ERROR || iRet == RS_RET_PEER_CLOSED_CONN) {
+		static unsigned int conErrCnt = 0;
+		const int skipFactor = pWrkrData->pData->iConErrSkip;
+
+		const char *actualErrMsg;
+		if(iRet == RS_RET_PEER_CLOSED_CONN) {
+			actualErrMsg = "remote server closed connection. ";
+		} else {
+			actualErrMsg = "we had a generic or IO error with the remote server. "
+				"The actual error message should already have been provided. ";
+		}
+		if (skipFactor <= 1)  {
+			/* All the connection errors are printed. */
+			LogError(0, iRet, "omfwd: [wrkr %u/%" PRIuPTR "] %s Server is %s:%s. "
+				"This can be caused by the remote server or an interim system like a load "
+				"balancer or firewall. Rsyslog will re-open the connection if configured "
+				"to do so.", pTarget->pWrkrData->wrkrID, (uintptr_t) pthread_self(),
+				actualErrMsg, pTarget->target_name, pTarget->port);
+		} else if ((conErrCnt++ % skipFactor) == 0) {
+			/* Every N'th error message is printed where N is a skipFactor. */
+			LogError(0, iRet, "omfwd: [wrkr %u] %s Server is %s:%s. "
+				"This can be caused by the remote server or an interim system like a load "
+				"balancer or firewall. Rsyslog will re-open the connection if configured "
+				"to do so. Note that the next %d connection error messages will be "
+				"skipped.", pTarget->pWrkrData->wrkrID,
+				actualErrMsg, pTarget->target_name, pTarget->port, skipFactor - 1);
+		}
+	} else {
+		LogError(0, iRet, "omfwd: TCPSendBuf error %d, destruct TCP Connection to %s:%s",
+			iRet, pTarget->target_name, pTarget->port);
+	}
+}
+
+
+/* hack to check connections for plain tcp syslog - see ptcp driver for details */
 static rsRetVal
-TCPSendBufUncompressed(wrkrInstanceData_t *pWrkrData, uchar *const buf, const unsigned len)
+CheckConnection(targetData_t *const pTarget)
+{
+	DEFiRet;
+
+	if((pTarget->pData->protocol == FORW_TCP) && (pTarget->pData->bExtendedConnCheck)) {
+		CHKiRet(netstrm.CheckConnection(pTarget->pNetstrm));
+	}
+
+finalize_it:
+	if(iRet != RS_RET_OK) {
+		emitConnectionErrorMsg(pTarget, iRet);
+		DestructTCPTargetData(pTarget);
+		iRet = RS_RET_SUSPENDED;
+	}
+	RETiRet;
+}
+
+
+static rsRetVal
+TCPSendBufUncompressed(targetData_t *const pTarget, uchar *const buf, const unsigned len)
 {
 	DEFiRet;
 	unsigned alreadySent;
 	ssize_t lenSend;
 
 	alreadySent = 0;
-	CHKiRet(netstrm.CheckConnection(pWrkrData->pNetstrm));
-	/* hack for plain tcp syslog - see ptcp driver for details */
+	if(pTarget->pData->bExtendedConnCheck) {
+		CHKiRet(netstrm.CheckConnection(pTarget->pNetstrm));
+		/* hack for plain tcp syslog - see ptcp driver for details */
+	}
 
 	while(alreadySent != len) {
 		lenSend = len - alreadySent;
-		CHKiRet(netstrm.Send(pWrkrData->pNetstrm, buf+alreadySent, &lenSend));
-		DBGPRINTF("omfwd: TCP sent %ld bytes, requested %u\n", (long) lenSend, len - alreadySent);
+		CHKiRet(netstrm.Send(pTarget->pNetstrm, buf+alreadySent, &lenSend));
+		DBGPRINTF("omfwd: TCP sent %zd bytes, requested %u\n", lenSend, len - alreadySent);
 		alreadySent += lenSend;
 	}
 
-	ATOMIC_ADD_uint64(&pWrkrData->pData->sentBytes, &pWrkrData->pData->mut_sentBytes, len);
+	ATOMIC_ADD_uint64(&pTarget->pTargetStats->sentBytes, &pTarget->pTargetStats->mut_sentBytes, len);
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		if(iRet == RS_RET_IO_ERROR) {
-			static unsigned int conErrCnt = 0;
-			const int skipFactor = pWrkrData->pData->iConErrSkip;
-			if (skipFactor <= 1)  {
-				/* All the connection errors are printed. */
-				LogError(0, iRet, "omfwd: remote server at %s:%s seems to have closed connection. "
-					"This often happens when the remote peer (or an interim system like a load "
-					"balancer or firewall) shuts down or aborts a connection. Rsyslog will "
-					"re-open the connection if configured to do so (we saw a generic IO Error, "
-					"which usually goes along with that behaviour).",
-					pWrkrData->pData->target, pWrkrData->pData->port);
-			} else if ((conErrCnt++ % skipFactor) == 0) {
-				/* Every N'th error message is printed where N is a skipFactor. */
-				LogError(0, iRet, "omfwd: remote server at %s:%s seems to have closed connection. "
-					"This often happens when the remote peer (or an interim system like a load "
-					"balancer or firewall) shuts down or aborts a connection. Rsyslog will "
-					"re-open the connection if configured to do so (we saw a generic IO Error, "
-					"which usually goes along with that behaviour). Note that the next %d "
-					"connection error messages will be skipped.",
-					pWrkrData->pData->target, pWrkrData->pData->port, skipFactor-1);
-			}
-		} else {
-			LogError(0, iRet, "omfwd: TCPSendBuf error %d, destruct TCP Connection to %s:%s",
-				iRet, pWrkrData->pData->target, pWrkrData->pData->port);
-		}
-		DestructTCPInstanceData(pWrkrData);
+		emitConnectionErrorMsg(pTarget, iRet);
+		DestructTCPTargetData(pTarget);
 		iRet = RS_RET_SUSPENDED;
 	}
 	RETiRet;
 }
 
 static rsRetVal
-TCPSendBufCompressed(wrkrInstanceData_t *pWrkrData, uchar *buf, unsigned len, sbool bIsFlush)
+TCPSendBufCompressed(targetData_t *pTarget, uchar *const buf, unsigned len, sbool bIsFlush)
 {
+	wrkrInstanceData_t *const pWrkrData = (wrkrInstanceData_t *) pTarget->pWrkrData;
 	int zRet;	/* zlib return state */
 	unsigned outavail;
 	uchar zipBuf[32*1024];
 	int op;
 	DEFiRet;
 
-	if(!pWrkrData->bzInitDone) {
+	if(!pTarget->bzInitDone) {
 		/* allocate deflate state */
-		pWrkrData->zstrm.zalloc = Z_NULL;
-		pWrkrData->zstrm.zfree = Z_NULL;
-		pWrkrData->zstrm.opaque = Z_NULL;
+		pTarget->zstrm.zalloc = Z_NULL;
+		pTarget->zstrm.zfree = Z_NULL;
+		pTarget->zstrm.opaque = Z_NULL;
 		/* see note in file header for the params we use with deflateInit2() */
-		zRet = deflateInit(&pWrkrData->zstrm, pWrkrData->pData->compressionLevel);
+		zRet = deflateInit(&pTarget->zstrm, pWrkrData->pData->compressionLevel);
 		if(zRet != Z_OK) {
 			DBGPRINTF("error %d returned from zlib/deflateInit()\n", zRet);
 			ABORT_FINALIZE(RS_RET_ZLIB_ERR);
 		}
-		pWrkrData->bzInitDone = RSTRUE;
+		pTarget->bzInitDone = RSTRUE;
 	}
 
 	/* now doing the compression */
-	pWrkrData->zstrm.next_in = (Bytef*) buf;
-	pWrkrData->zstrm.avail_in = len;
+	pTarget->zstrm.next_in = (Bytef*) buf;
+	pTarget->zstrm.avail_in = len;
 	if(pWrkrData->pData->strmCompFlushOnTxEnd && bIsFlush)
 		op = Z_SYNC_FLUSH;
 	else
@@ -676,29 +836,30 @@ TCPSendBufCompressed(wrkrInstanceData_t *pWrkrData, uchar *buf, unsigned len, sb
 	/* run deflate() on buffer until everything has been compressed */
 	do {
 		DBGPRINTF("omfwd: in deflate() loop, avail_in %d, total_in %ld, isFlush %d\n",
-			pWrkrData->zstrm.avail_in, pWrkrData->zstrm.total_in, bIsFlush);
-		pWrkrData->zstrm.avail_out = sizeof(zipBuf);
-		pWrkrData->zstrm.next_out = zipBuf;
-		zRet = deflate(&pWrkrData->zstrm, op);    /* no bad return value */
-		DBGPRINTF("after deflate, ret %d, avail_out %d\n", zRet, pWrkrData->zstrm.avail_out);
-		outavail = sizeof(zipBuf) - pWrkrData->zstrm.avail_out;
+			pTarget->zstrm.avail_in, pTarget->zstrm.total_in, bIsFlush);
+		pTarget->zstrm.avail_out = sizeof(zipBuf);
+		pTarget->zstrm.next_out = zipBuf;
+		zRet = deflate(&pTarget->zstrm, op);    /* no bad return value */
+		DBGPRINTF("after deflate, ret %d, avail_out %d\n", zRet, pTarget->zstrm.avail_out);
+		outavail = sizeof(zipBuf) - pTarget->zstrm.avail_out;
 		if(outavail != 0) {
-			CHKiRet(TCPSendBufUncompressed(pWrkrData, zipBuf, outavail));
+			CHKiRet(TCPSendBufUncompressed(pTarget, zipBuf, outavail));
 		}
-	} while (pWrkrData->zstrm.avail_out == 0);
+	} while (pTarget->zstrm.avail_out == 0);
 
 finalize_it:
 	RETiRet;
 }
 
 static rsRetVal
-TCPSendBuf(wrkrInstanceData_t *pWrkrData, uchar *buf, unsigned len, sbool bIsFlush)
+TCPSendBuf(targetData_t *pTarget, uchar *buf, unsigned len, sbool bIsFlush)
 {
+	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t *) pTarget->pWrkrData;
 	DEFiRet;
 	if(pWrkrData->pData->compressionMode >= COMPRESS_STREAM_ALWAYS)
-		iRet = TCPSendBufCompressed(pWrkrData, buf, len, bIsFlush);
+		iRet = TCPSendBufCompressed(pTarget, buf, len, bIsFlush);
 	else
-		iRet = TCPSendBufUncompressed(pWrkrData, buf, len);
+		iRet = TCPSendBufUncompressed(pTarget, buf, len);
 	RETiRet;
 }
 
@@ -706,53 +867,54 @@ TCPSendBuf(wrkrInstanceData_t *pWrkrData, uchar *buf, unsigned len, sbool bIsFlu
  * running in stream mode).
  */
 static rsRetVal
-doZipFinish(wrkrInstanceData_t *pWrkrData)
+doZipFinish(targetData_t *pTarget)
 {
 	int zRet;	/* zlib return state */
 	DEFiRet;
 	unsigned outavail;
 	uchar zipBuf[32*1024];
 
-	if(!pWrkrData->bzInitDone)
+	if(!pTarget->bzInitDone)
 		goto done;
 
 	// TODO: can we get this into a single common function?
-	pWrkrData->zstrm.avail_in = 0;
+	pTarget->zstrm.avail_in = 0;
 	/* run deflate() on buffer until everything has been compressed */
 	do {
-		DBGPRINTF("in deflate() loop, avail_in %d, total_in %ld\n", pWrkrData->zstrm.avail_in,
-			pWrkrData->zstrm.total_in);
-		pWrkrData->zstrm.avail_out = sizeof(zipBuf);
-		pWrkrData->zstrm.next_out = zipBuf;
-		zRet = deflate(&pWrkrData->zstrm, Z_FINISH);    /* no bad return value */
-		DBGPRINTF("after deflate, ret %d, avail_out %d\n", zRet, pWrkrData->zstrm.avail_out);
-		outavail = sizeof(zipBuf) - pWrkrData->zstrm.avail_out;
+		DBGPRINTF("in deflate() loop, avail_in %d, total_in %ld\n", pTarget->zstrm.avail_in,
+			pTarget->zstrm.total_in);
+		pTarget->zstrm.avail_out = sizeof(zipBuf);
+		pTarget->zstrm.next_out = zipBuf;
+		zRet = deflate(&pTarget->zstrm, Z_FINISH);    /* no bad return value */
+		DBGPRINTF("after deflate, ret %d, avail_out %d\n", zRet, pTarget->zstrm.avail_out);
+		outavail = sizeof(zipBuf) - pTarget->zstrm.avail_out;
 		if(outavail != 0) {
-			CHKiRet(TCPSendBufUncompressed(pWrkrData, zipBuf, outavail));
+			CHKiRet(TCPSendBufUncompressed(pTarget, zipBuf, outavail));
 		}
-	} while (pWrkrData->zstrm.avail_out == 0);
+	} while (pTarget->zstrm.avail_out == 0);
 
 finalize_it:
-	zRet = deflateEnd(&pWrkrData->zstrm);
+	zRet = deflateEnd(&pTarget->zstrm);
 	if(zRet != Z_OK) {
 		DBGPRINTF("error %d returned from zlib/deflateEnd()\n", zRet);
 	}
 
-	pWrkrData->bzInitDone = 0;
+	pTarget->bzInitDone = 0;
 done:	RETiRet;
 }
 
 
 /* Add frame to send buffer (or send, if requried)
  */
-static rsRetVal TCPSendFrame(void *pvData, char *msg, size_t len)
+static rsRetVal
+TCPSendFrame(void *pvData, char *msg, const size_t len)
 {
 	DEFiRet;
-	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t *) pvData;
+	targetData_t *pTarget = (targetData_t *) pvData;
 
-	DBGPRINTF("omfwd: add %u bytes to send buffer (curr offs %u)\n",
-		(unsigned) len, pWrkrData->offsSndBuf);
-	if(pWrkrData->offsSndBuf != 0 && pWrkrData->offsSndBuf + len >= sizeof(pWrkrData->sndBuf)) {
+	DBGPRINTF("omfwd: add %zu bytes to send buffer (curr offs %u, max len %d) msg: %*s\n",
+		len, pTarget->offsSndBuf, pTarget->maxLenSndBuf, (int) len, msg);
+	if(pTarget->offsSndBuf != 0 && (pTarget->offsSndBuf + len) >= (size_t) pTarget->maxLenSndBuf) {
 		/* no buffer space left, need to commit previous records. With the
 		 * current API, there unfortunately is no way to signal this
 		 * state transition to the upper layer.
@@ -760,19 +922,19 @@ static rsRetVal TCPSendFrame(void *pvData, char *msg, size_t len)
 		DBGPRINTF("omfwd: we need to do a tcp send due to buffer "
 			  "out of space. If the transaction fails, this will "
 			  "lead to duplication of messages");
-		CHKiRet(TCPSendBuf(pWrkrData, pWrkrData->sndBuf, pWrkrData->offsSndBuf, NO_FLUSH));
-		pWrkrData->offsSndBuf = 0;
+		CHKiRet(TCPSendBuf(pTarget, pTarget->sndBuf, pTarget->offsSndBuf, NO_FLUSH));
+		pTarget->offsSndBuf = 0;
 	}
 
 	/* check if the message is too large to fit into buffer */
-	if(len > sizeof(pWrkrData->sndBuf)) {
-		CHKiRet(TCPSendBuf(pWrkrData, (uchar*)msg, len, NO_FLUSH));
+	if(len > sizeof(pTarget->sndBuf)) {
+		CHKiRet(TCPSendBuf(pTarget, (uchar*)msg, len, NO_FLUSH));
 		ABORT_FINALIZE(RS_RET_OK);	/* committed everything so far */
 	}
 
 	/* we now know the buffer has enough free space */
-	memcpy(pWrkrData->sndBuf + pWrkrData->offsSndBuf, msg, len);
-	pWrkrData->offsSndBuf += len;
+	memcpy(pTarget->sndBuf + pTarget->offsSndBuf, msg, len);
+	pTarget->offsSndBuf += len;
 	iRet = RS_RET_DEFER_COMMIT;
 
 finalize_it:
@@ -780,87 +942,102 @@ finalize_it:
 }
 
 
-/* This function is called immediately before a send retry is attempted.
- * It shall clean up whatever makes sense.
- * rgerhards, 2007-12-28
+/* initializes a TCP session to a single Target
  */
-static rsRetVal TCPSendPrepRetry(void *pvData)
+static rsRetVal
+TCPSendInitTarget(targetData_t *const pTarget)
 {
 	DEFiRet;
-	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t *) pvData;
-
-	assert(pWrkrData != NULL);
-	DestructTCPInstanceData(pWrkrData);
-	RETiRet;
-}
+	wrkrInstanceData_t *const pWrkrData = (wrkrInstanceData_t *) pTarget->pWrkrData;
+	instanceData *pData = pWrkrData->pData;
 
 
-/* initializes everything so that TCPSend can work.
- * rgerhards, 2007-12-28
- */
-static rsRetVal TCPSendInit(void *pvData)
-{
-	DEFiRet;
-	wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t *) pvData;
-	instanceData *pData;
-
-	assert(pWrkrData != NULL);
-	pData = pWrkrData->pData;
-
-	if(pWrkrData->pNetstrm == NULL) {
-		dbgprintf("TCPSendInit CREATE\n");
-		CHKiRet(netstrms.Construct(&pWrkrData->pNS));
+	// TODO-RG: check error case - we need to make sure that we handle the situation correctly
+	//	    when SOME calls fails - else we may get into big trouble during de-init
+	if(pTarget->pNetstrm == NULL) {
+		dbgprintf("TCPSendInitTarget CREATE %s:%s, conn %d\n", pTarget->target_name,
+			pTarget->port, pTarget->bIsConnected);
+		CHKiRet(netstrms.Construct(&pTarget->pNS));
 		/* the stream driver must be set before the object is finalized! */
-		CHKiRet(netstrms.SetDrvrName(pWrkrData->pNS, pData->pszStrmDrvr));
-		CHKiRet(netstrms.ConstructFinalize(pWrkrData->pNS));
+		CHKiRet(netstrms.SetDrvrName(pTarget->pNS, pData->pszStrmDrvr));
+		CHKiRet(netstrms.ConstructFinalize(pTarget->pNS));
 
 		/* now create the actual stream and connect to the server */
-		CHKiRet(netstrms.CreateStrm(pWrkrData->pNS, &pWrkrData->pNetstrm));
-		CHKiRet(netstrm.ConstructFinalize(pWrkrData->pNetstrm));
-		CHKiRet(netstrm.SetDrvrMode(pWrkrData->pNetstrm, pData->iStrmDrvrMode));
-		CHKiRet(netstrm.SetDrvrCheckExtendedKeyUsage(pWrkrData->pNetstrm, pData->iStrmDrvrExtendedCertCheck));
-		CHKiRet(netstrm.SetDrvrPrioritizeSAN(pWrkrData->pNetstrm, pData->iStrmDrvrSANPreference));
-		CHKiRet(netstrm.SetDrvrTlsVerifyDepth(pWrkrData->pNetstrm, pData->iStrmTlsVerifyDepth));
+		CHKiRet(netstrms.CreateStrm(pTarget->pNS, &pTarget->pNetstrm));
+		CHKiRet(netstrm.ConstructFinalize(pTarget->pNetstrm));
+		CHKiRet(netstrm.SetDrvrMode(pTarget->pNetstrm, pData->iStrmDrvrMode));
+		CHKiRet(netstrm.SetDrvrCheckExtendedKeyUsage(pTarget->pNetstrm, pData->iStrmDrvrExtendedCertCheck));
+		CHKiRet(netstrm.SetDrvrPrioritizeSAN(pTarget->pNetstrm, pData->iStrmDrvrSANPreference));
+		CHKiRet(netstrm.SetDrvrTlsVerifyDepth(pTarget->pNetstrm, pData->iStrmTlsVerifyDepth));
 		/* now set optional params, but only if they were actually configured */
 		if(pData->pszStrmDrvrAuthMode != NULL) {
-			CHKiRet(netstrm.SetDrvrAuthMode(pWrkrData->pNetstrm, pData->pszStrmDrvrAuthMode));
+			CHKiRet(netstrm.SetDrvrAuthMode(pTarget->pNetstrm, pData->pszStrmDrvrAuthMode));
 		}
 		/* Call SetDrvrPermitExpiredCerts required
 		 * when param is NULL default handling for ExpiredCerts is set! */
-		CHKiRet(netstrm.SetDrvrPermitExpiredCerts(pWrkrData->pNetstrm,
+		CHKiRet(netstrm.SetDrvrPermitExpiredCerts(pTarget->pNetstrm,
 			pData->pszStrmDrvrPermitExpiredCerts));
-		CHKiRet(netstrm.SetDrvrTlsCAFile(pWrkrData->pNetstrm, pData->pszStrmDrvrCAFile));
-		CHKiRet(netstrm.SetDrvrTlsCRLFile(pWrkrData->pNetstrm, pData->pszStrmDrvrCRLFile));
-		CHKiRet(netstrm.SetDrvrTlsKeyFile(pWrkrData->pNetstrm, pData->pszStrmDrvrKeyFile));
-		CHKiRet(netstrm.SetDrvrTlsCertFile(pWrkrData->pNetstrm, pData->pszStrmDrvrCertFile));
+		CHKiRet(netstrm.SetDrvrTlsCAFile(pTarget->pNetstrm, pData->pszStrmDrvrCAFile));
+		CHKiRet(netstrm.SetDrvrTlsCRLFile(pTarget->pNetstrm, pData->pszStrmDrvrCRLFile));
+		CHKiRet(netstrm.SetDrvrTlsKeyFile(pTarget->pNetstrm, pData->pszStrmDrvrKeyFile));
+		CHKiRet(netstrm.SetDrvrTlsCertFile(pTarget->pNetstrm, pData->pszStrmDrvrCertFile));
 
 		if(pData->pPermPeers != NULL) {
-			CHKiRet(netstrm.SetDrvrPermPeers(pWrkrData->pNetstrm, pData->pPermPeers));
+			CHKiRet(netstrm.SetDrvrPermPeers(pTarget->pNetstrm, pData->pPermPeers));
 		}
 		/* params set, now connect */
 		if(pData->gnutlsPriorityString != NULL) {
-			CHKiRet(netstrm.SetGnutlsPriorityString(pWrkrData->pNetstrm, pData->gnutlsPriorityString));
+			CHKiRet(netstrm.SetGnutlsPriorityString(pTarget->pNetstrm, pData->gnutlsPriorityString));
 		}
-		CHKiRet(netstrm.Connect(pWrkrData->pNetstrm, glbl.GetDefPFFamily(runModConf->pConf),
-			(uchar*)pData->port, (uchar*)pData->target, pData->device));
+		CHKiRet(netstrm.Connect(pTarget->pNetstrm, glbl.GetDefPFFamily(runModConf->pConf),
+			(uchar*)pTarget->port, (uchar*)pTarget->target_name, pData->device));
 
 		/* set keep-alive if enabled */
 		if(pData->bKeepAlive) {
-			CHKiRet(netstrm.SetKeepAliveProbes(pWrkrData->pNetstrm, pData->iKeepAliveProbes));
-			CHKiRet(netstrm.SetKeepAliveIntvl(pWrkrData->pNetstrm, pData->iKeepAliveIntvl));
-			CHKiRet(netstrm.SetKeepAliveTime(pWrkrData->pNetstrm, pData->iKeepAliveTime));
-			CHKiRet(netstrm.EnableKeepAlive(pWrkrData->pNetstrm));
+			CHKiRet(netstrm.SetKeepAliveProbes(pTarget->pNetstrm, pData->iKeepAliveProbes));
+			CHKiRet(netstrm.SetKeepAliveIntvl(pTarget->pNetstrm, pData->iKeepAliveIntvl));
+			CHKiRet(netstrm.SetKeepAliveTime(pTarget->pNetstrm, pData->iKeepAliveTime));
+			CHKiRet(netstrm.EnableKeepAlive(pTarget->pNetstrm));
 		}
+
+		LogMsg(0, RS_RET_DEBUG, LOG_DEBUG,
+			"omfwd: [wrkr %u] TCPSendInitTarget established connection to %s:%s",
+			pTarget->pWrkrData->wrkrID, pTarget->target_name, pTarget->port);
 	}
 
 finalize_it:
 	if(iRet != RS_RET_OK) {
-		dbgprintf("TCPSendInit FAILED with %d.\n", iRet);
-		DestructTCPInstanceData(pWrkrData);
+		dbgprintf("TCPSendInitTarget FAILED with %d.\n", iRet);
+		DestructTCPTargetData(pTarget);
 	}
 
 	RETiRet;
 }
+
+
+/* Callback to initialize the provided target.
+ * rgerhards, 2007-12-28
+ */
+static rsRetVal
+TCPSendInit(void *pvData)
+{
+	return TCPSendInitTarget((targetData_t *) pvData);
+}
+
+/* This callback function is called immediately before a send retry is attempted.
+ * It shall clean up whatever makes sense.
+ * side-note: TCPSendInit() is called afterwards by the generic tcp client code.
+ */
+static rsRetVal TCPSendPrepRetry(void *pvData)
+{
+	DestructTCPTargetData((targetData_t *) pvData);
+	/* Even if the destruct fails, it does not help to provide this info to
+	 * the upper layer. Also, DestructTCPTargtData() does currently not
+	 * provide a return status.
+	 */
+	return RS_RET_OK;
+}
+
 
 
 /* change to network namespace pData->networkNamespace and keep the file
@@ -946,22 +1123,90 @@ finalize_it:
 }
 
 
+/* count the actual number of active targets.
+*/
+static void
+countActiveTargets(const wrkrInstanceData_t *const pWrkrData) {
+	int activeTargets = 0;
+	for(int j = 0 ; j <  pWrkrData->pData->nTargets ; ++j) {
+		if(pWrkrData->target[j].bIsConnected) {
+			activeTargets++;
+		}
+	}
+
+	if(activeTargets != pWrkrData->pData->nActiveTargets) {
+		LogMsg(0, RS_RET_DEBUG, LOG_DEBUG,
+			"omfwd: [wrkr %u] number of active targets changed from %d to %d",
+			pWrkrData->wrkrID, pWrkrData->pData->nActiveTargets, activeTargets);
+		pWrkrData->pData->nActiveTargets = activeTargets;
+	}
+}
+
+
+/* check if the action as while is working (one target is OK) or suspended.
+ * Try to resume initially not working targets along the way.
+ */
+static rsRetVal
+poolTryResume(wrkrInstanceData_t *const pWrkrData)
+{
+	DEFiRet;
+	int oneTargetOK = 0;
+	for(int j = 0 ; j <  pWrkrData->pData->nTargets ; ++j) {
+		if(pWrkrData->target[j].bIsConnected) {
+			if(CheckConnection(&(pWrkrData->target[j])) == RS_RET_OK) {
+				oneTargetOK = 1;
+			}
+		} else {
+			DBGPRINTF("omfwd: poolTryResume, calling tryResume, target %d\n", j);
+			iRet = doTryResume(&(pWrkrData->target[j]));
+			DBGPRINTF("omfwd: poolTryResume, done    tryResume, target %d, iRet %d\n", j, iRet);
+			if(iRet == RS_RET_OK) {
+				oneTargetOK = 1;
+			}
+		}
+	}
+	if(oneTargetOK) {
+		iRet = RS_RET_OK;
+	}
+	DBGPRINTF("poolTryResume: oneTargetOK %d, iRet %d\n", oneTargetOK, iRet);
+	RETiRet;
+}
+
 /* try to resume connection if it is not ready
+ * When done, we set the time of earliest resumption. This is to handle
+ * suspend and resume within the target connection pool.
  * rgerhards, 2007-08-02
  */
-static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
+static rsRetVal
+doTryResume(targetData_t *pTarget)
 {
+	wrkrInstanceData_t *const pWrkrData = (wrkrInstanceData_t *) pTarget->pWrkrData;
+	instanceData *const pData = pWrkrData->pData;;
 	int iErr;
 	struct addrinfo *res = NULL;
 	struct addrinfo hints;
-	instanceData *pData;
 	int bBindRequired = 0;
+	int bNeedReturnNs = 0;
 	const char *address;
 	DEFiRet;
 
-	if(pWrkrData->bIsConnected)
+	DBGPRINTF("doTryResume: isConnected: %d, ttResume %lld, LastActiveTargets: %d\n",
+		pTarget->bIsConnected, (long long) pTarget->ttResume, pTarget->pData->nActiveTargets);
+
+	if(pTarget->bIsConnected)
 		FINALIZE;
-	pData = pWrkrData->pData;
+	/* we look at the resume counter only if we have active targets at all - otherwise
+	 * rsyslog core handles the retry timing.
+	 */
+	if(pTarget->ttResume > 0 && pTarget->pData->nActiveTargets > 0) {
+		time_t ttNow;
+		datetime.GetTime(&ttNow);
+		if(ttNow < pTarget->ttResume) {
+			DBGPRINTF("omfwd: doTryResume: %s not yet time to retry, time %lld, ttResume %lld\n",
+				pTarget->target_name, (long long) ttNow, (long long) pTarget->ttResume);
+			ABORT_FINALIZE(RS_RET_SUSPENDED);
+		}
+	}
 
 	/* The remote address is not yet known and needs to be obtained */
 	if(pData->protocol == FORW_UDP) {
@@ -970,57 +1215,63 @@ static rsRetVal doTryResume(wrkrInstanceData_t *pWrkrData)
 		hints.ai_flags = AI_NUMERICSERV;
 		hints.ai_family = glbl.GetDefPFFamily(runModConf->pConf);
 		hints.ai_socktype = SOCK_DGRAM;
-		if((iErr = (getaddrinfo(pData->target, pData->port, &hints, &res))) != 0) {
+		if((iErr = (getaddrinfo(pTarget->target_name, pTarget->port, &hints, &res))) != 0) {
 			LogError(0, RS_RET_SUSPENDED,
 				"omfwd: could not get addrinfo for hostname '%s':'%s': %s",
-				pData->target, pData->port, gai_strerror(iErr));
+				pTarget->target_name, pTarget->port, gai_strerror(iErr));
 			ABORT_FINALIZE(RS_RET_SUSPENDED);
 		}
-		address = pData->target;
+		address = pTarget->target_name;
 		if(pData->address) {
 			struct addrinfo *addr;
 			/* The AF of the bind addr must match that of target */
 			hints.ai_family = res->ai_family;
 			hints.ai_flags |= AI_PASSIVE;
-			iErr = getaddrinfo(pData->address, pData->port, &hints, &addr);
+			iErr = getaddrinfo(pData->address, pTarget->port, &hints, &addr);
 			freeaddrinfo(addr);
 			if(iErr != 0) {
 				LogError(0, RS_RET_SUSPENDED,
 					 "omfwd: cannot use bind address '%s' for host '%s': %s",
-					 pData->address, pData->target, gai_strerror(iErr));
+					 pData->address, pTarget->target_name, gai_strerror(iErr));
 				ABORT_FINALIZE(RS_RET_SUSPENDED);
 			}
 			bBindRequired = 1;
 			address = pData->address;
 		}
-		DBGPRINTF("%s found, resuming.\n", pData->target);
-		pWrkrData->f_addr = res;
+		DBGPRINTF("%s found, resuming.\n", pTarget->target_name);
+		pTarget->f_addr = res;
 		res = NULL;
-		if(pWrkrData->pSockArray == NULL) {
+		if(pTarget->pSockArray == NULL) {
 			CHKiRet(changeToNs(pData));
-			pWrkrData->pSockArray = net.create_udp_socket((uchar*)address,
+			bNeedReturnNs = 1;
+			pTarget->pSockArray = net.create_udp_socket((uchar*)address,
 				NULL, bBindRequired, 0, pData->UDPSendBuf, pData->ipfreebind, pData->device);
 			CHKiRet(returnToOriginalNs(pData));
+			bNeedReturnNs = 0;
 		}
-		if(pWrkrData->pSockArray != NULL) {
-			pWrkrData->bIsConnected = 1;
+		if(pTarget->pSockArray != NULL) {
+			pTarget->bIsConnected = 1;
 		}
 	} else {
 		CHKiRet(changeToNs(pData));
-		CHKiRet(TCPSendInit((void*)pWrkrData));
+		bNeedReturnNs = 1;
+		CHKiRet(TCPSendInitTarget((void*)pTarget));
 		CHKiRet(returnToOriginalNs(pData));
+		bNeedReturnNs = 0;
+		pTarget->bIsConnected = 1;
 	}
 
 finalize_it:
-	DBGPRINTF("omfwd: doTryResume %s iRet %d\n", pWrkrData->pData->target, iRet);
 	if(res != NULL) {
 		freeaddrinfo(res);
 	}
 	if(iRet != RS_RET_OK) {
-		returnToOriginalNs(pData);
-		if(pWrkrData->f_addr != NULL) {
-			freeaddrinfo(pWrkrData->f_addr);
-			pWrkrData->f_addr = NULL;
+		if(bNeedReturnNs) {
+			returnToOriginalNs(pData);
+		}
+		if(pTarget->f_addr != NULL) {
+			freeaddrinfo(pTarget->f_addr);
+			pTarget->f_addr = NULL;
 		}
 		iRet = RS_RET_SUSPENDED;
 	}
@@ -1031,22 +1282,39 @@ finalize_it:
 
 BEGINtryResume
 CODESTARTtryResume
-	dbgprintf("omfwd: tryResume: pWrkrData %p\n", pWrkrData);
-	iRet = doTryResume(pWrkrData);
+	iRet = poolTryResume(pWrkrData);
+	countActiveTargets(pWrkrData);
+
+	LogMsg(0, RS_RET_DEBUG, LOG_DEBUG,
+		"omfwd: [wrkr %u/%" PRIuPTR "] tryResume was called by rsyslog core: "
+		"active targets: %d, overall return state %d",
+		pWrkrData->wrkrID, (uintptr_t) pthread_self(), pWrkrData->pData->nActiveTargets, iRet);
 ENDtryResume
 
 
 BEGINbeginTransaction
 CODESTARTbeginTransaction
 	dbgprintf("omfwd: beginTransaction\n");
-	iRet = doTryResume(pWrkrData);
+	/* note: we need to try resume so that we are at least at the start
+	 * of the transaction aware of target states. It is not useful to
+	 * start a transaction when we know it will most probably fail.
+	 */
+	iRet = poolTryResume(pWrkrData);
+
+	if(iRet == RS_RET_SUSPENDED) {
+		LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
+			"omfwd: [wrkr %d/%" PRIuPTR "] no working target servers in "
+			"pool available, suspending action (state: beginTx)",
+			pWrkrData->wrkrID, (uintptr_t) pthread_self());
+	}
 ENDbeginTransaction
 
 
 static rsRetVal
-processMsg(wrkrInstanceData_t *__restrict__ const pWrkrData,
+processMsg(targetData_t *__restrict__ const pTarget,
 	actWrkrIParams_t *__restrict__ const iparam)
 {
+	wrkrInstanceData_t *const pWrkrData = (wrkrInstanceData_t *) pTarget->pWrkrData;
 	uchar *psz; /* temporary buffering */
 	register unsigned l;
 	int iMaxLine;
@@ -1100,37 +1368,62 @@ processMsg(wrkrInstanceData_t *__restrict__ const pWrkrData,
 
 	if(pData->protocol == FORW_UDP) {
 		/* forward via UDP */
-		CHKiRet(UDPSend(pWrkrData, psz, l));
+		CHKiRet(UDPSend(pWrkrData, psz, l)); // TODO-RG: always add "actualTarget"!
 	} else {
 		/* forward via TCP */
-		iRet = tcpclt.Send(pWrkrData->pTCPClt, pWrkrData, (char *)psz, l);
+		iRet = tcpclt.Send(pTarget->pTCPClt, pTarget, (char *)psz, l);
 		if(iRet != RS_RET_OK && iRet != RS_RET_DEFER_COMMIT && iRet != RS_RET_PREVIOUS_COMMITTED) {
 			/* error! */
-			LogError(0, iRet, "omfwd: error forwarding via tcp to %s:%s, suspending action",
-				pWrkrData->pData->target, pWrkrData->pData->port);
-			DestructTCPInstanceData(pWrkrData);
+			LogError(0, iRet, "omfwd: error forwarding via tcp to %s:%s, suspending target",
+				pTarget->target_name, pTarget->port);
+			DestructTCPTargetData(pTarget);
 			iRet = RS_RET_SUSPENDED;
 		}
 	}
+
 finalize_it:
+	if(iRet == RS_RET_OK || iRet == RS_RET_DEFER_COMMIT || iRet == RS_RET_PREVIOUS_COMMITTED) {
+		ATOMIC_INC_uint64(&pTarget->pTargetStats->sentMsgs,
+			&pTarget->pTargetStats->mut_sentMsgs);
+	}
+
 	free(out); /* is NULL if it was never used... */
 	RETiRet;
 }
 
 BEGINcommitTransaction
 	unsigned i;
-	char namebuf[264]; /* 256 for FGDN, 5 for port and 3 for transport => 264 */
+	char namebuf[264]; /* 256 for FQDN, 5 for port and 3 for transport => 264 */
 CODESTARTcommitTransaction
-	CHKiRet(doTryResume(pWrkrData));
+	/* if needed, rebind first. This ensure we can deliver to the rebound addresses.
+	 * Note that rebind requires reconnect to the new targets. This is done by the
+	 * poolTryResume(), which needs to be made in any case.
+	 */
+	if(pWrkrData->pData->iRebindInterval && (pWrkrData->nXmit++ >= pWrkrData->pData->iRebindInterval)) {
+		dbgprintf("REBIND (sent %d, interval %d) - omfwd dropping target connection (as configured)\n",
+			pWrkrData->nXmit, pWrkrData->pData->iRebindInterval);
+		pWrkrData->nXmit = 0;	/* else we have an addtl wrap at 2^31-1 */
+		DestructTCPInstanceData(pWrkrData);
+		initTCP(pWrkrData);
+		LogMsg(0, RS_RET_PARAM_ERROR, LOG_WARNING,
+			"omfwd: dropped connections due to configured rebind interval");
+	}
 
-	DBGPRINTF(" %s:%s/%s\n", pWrkrData->pData->target, pWrkrData->pData->port,
+	CHKiRet(poolTryResume(pWrkrData));
+	countActiveTargets(pWrkrData);
+
+	DBGPRINTF("pool %s:%s/%s\n", pWrkrData->pData->target_name[0], pWrkrData->pData->ports[0],
 		 pWrkrData->pData->protocol == FORW_UDP ? "udp" : "tcp");
 
+	/* we use a rate-limiter based on the first pool members name. This looks
+	 * good enough. As an alternative, we may consider creating a special pool
+	 * name. But we leave this for when need actually arises.
+	 */
 	if(pWrkrData->pData->ratelimiter) {
 		snprintf(namebuf, sizeof namebuf, "%s:[%s]:%s",
 			pWrkrData->pData->protocol == FORW_UDP ? "udp" : "tcp",
-			pWrkrData->pData->target,
-			pWrkrData->pData->port);
+			pWrkrData->pData->target_name[0],
+			pWrkrData->pData->ports[0]);
 	}
 
 	for(i = 0 ; i < nParams ; ++i) {
@@ -1144,16 +1437,73 @@ CODESTARTcommitTransaction
 				LogError(0, RS_RET_ERR, "omfwd: error during rate limit : %d.\n",iRet);
 			}
 		}
-		iRet = processMsg(pWrkrData, &actParam(pParams, 1, i, 0));
-		if(iRet != RS_RET_OK && iRet != RS_RET_DEFER_COMMIT && iRet != RS_RET_PREVIOUS_COMMITTED)
-			FINALIZE;
+
+		int trynbr = 0;
+		int dotry = 1;
+		while(dotry && trynbr < pWrkrData->pData->nTargets) {
+			/* In the future we may consider if we would like to have targets on
+			   a per-worker or global basis. We now use worker because otherwise we
+			   have thread interdependence, which hurts performance. But this
+			   can lead to uneven distribution of messages when multiple workers run.
+			 */
+			const unsigned actualTarget = (pWrkrData->actualTarget++) % pWrkrData->pData->nTargets;
+			targetData_t *pTarget = &(pWrkrData->target[actualTarget]);
+			DBGPRINTF("load balancer: trying actualTarget %u [%u]: try %d, isConnected %d, wrkr %p\n",
+				actualTarget, (pWrkrData->actualTarget - 1), trynbr, pTarget->bIsConnected,
+				pWrkrData);
+			if(pTarget->bIsConnected) {
+				DBGPRINTF("RGER: sending to actualTarget %d: try %d\n", actualTarget,
+					  trynbr);
+				iRet = processMsg(pTarget, &actParam(pParams, 1, i, 0));
+				if(   iRet == RS_RET_OK || iRet == RS_RET_DEFER_COMMIT
+				   || iRet == RS_RET_PREVIOUS_COMMITTED) {
+					dotry = 0;
+				}
+			}
+			trynbr++;
+		}
+
+		if(dotry == 1) {
+			LogMsg(0, RS_RET_SUSPENDED, LOG_INFO,
+				"omfwd: [wrkr %u] found no working target server when trying to send "
+				"messages (main loop)", pWrkrData->wrkrID);
+			ABORT_FINALIZE(RS_RET_SUSPENDED);
+		}
+		pWrkrData->nXmit++;
 	}
 
-	if(pWrkrData->offsSndBuf != 0) {
-		iRet = TCPSendBuf(pWrkrData, pWrkrData->sndBuf, pWrkrData->offsSndBuf, IS_FLUSH);
-		pWrkrData->offsSndBuf = 0;
+	for(int j = 0 ; j <  pWrkrData->pData->nTargets ; ++j) {
+		if(pWrkrData->target[j].bIsConnected && pWrkrData->target[j].offsSndBuf != 0) {
+			iRet = TCPSendBuf(&(pWrkrData->target[j]), pWrkrData->target[j].sndBuf,
+				pWrkrData->target[j].offsSndBuf, IS_FLUSH);
+			if(iRet == RS_RET_OK || iRet == RS_RET_DEFER_COMMIT || iRet == RS_RET_PREVIOUS_COMMITTED) {
+				pWrkrData->target[j].offsSndBuf = 0;
+			} else {
+				LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
+					"omfwd: [wrkr %u] target %s:%s became unavailable during buffer flush. "
+					"Remaining messages will be sent when it is online again.",
+					pWrkrData->wrkrID, pWrkrData->target[j].target_name,
+					pWrkrData->target[j].port);
+				DestructTCPTargetData(&(pWrkrData->target[j]));
+				iRet = RS_RET_OK;
+			}
+		}
 	}
+
 finalize_it:
+	/* do pool stats */
+
+	countActiveTargets(pWrkrData);
+
+	if(pWrkrData->pData->nActiveTargets == 0) {
+		iRet= RS_RET_SUSPENDED;
+	}
+
+	if(iRet == RS_RET_SUSPENDED) {
+		LogMsg(0, RS_RET_SUSPENDED, LOG_WARNING,
+			"omfwd: [wrkr %d/%" PRIuPTR "] no working target servers in pool available, suspending action",
+			pWrkrData->wrkrID, (uintptr_t) pthread_self());
+	}
 ENDcommitTransaction
 
 
@@ -1185,16 +1535,17 @@ initTCP(wrkrInstanceData_t *pWrkrData)
 
 	pData = pWrkrData->pData;
 	if(pData->protocol == FORW_TCP) {
-		/* create our tcpclt */
-		CHKiRet(tcpclt.Construct(&pWrkrData->pTCPClt));
-		CHKiRet(tcpclt.SetResendLastOnRecon(pWrkrData->pTCPClt, pData->bResendLastOnRecon));
-		/* and set callbacks */
-		CHKiRet(tcpclt.SetSendInit(pWrkrData->pTCPClt, TCPSendInit));
-		CHKiRet(tcpclt.SetSendFrame(pWrkrData->pTCPClt, TCPSendFrame));
-		CHKiRet(tcpclt.SetSendPrepRetry(pWrkrData->pTCPClt, TCPSendPrepRetry));
-		CHKiRet(tcpclt.SetFraming(pWrkrData->pTCPClt, pData->tcp_framing));
-		CHKiRet(tcpclt.SetFramingDelimiter(pWrkrData->pTCPClt, pData->tcp_framingDelimiter));
-		CHKiRet(tcpclt.SetRebindInterval(pWrkrData->pTCPClt, pData->iRebindInterval));
+		for(int i = 0 ; i <  pData->nTargets ; ++i) {
+			/* create our tcpclt */
+			CHKiRet(tcpclt.Construct(&pWrkrData->target[i].pTCPClt));
+			CHKiRet(tcpclt.SetResendLastOnRecon(pWrkrData->target[i].pTCPClt, pData->bResendLastOnRecon));
+			CHKiRet(tcpclt.SetFraming(pWrkrData->target[i].pTCPClt, pData->tcp_framing));
+			CHKiRet(tcpclt.SetFramingDelimiter(pWrkrData->target[i].pTCPClt, pData->tcp_framingDelimiter));
+			/* and set callbacks */
+			CHKiRet(tcpclt.SetSendInit(pWrkrData->target[i].pTCPClt, TCPSendInit));
+			CHKiRet(tcpclt.SetSendFrame(pWrkrData->target[i].pTCPClt, TCPSendFrame));
+			CHKiRet(tcpclt.SetSendPrepRetry(pWrkrData->target[i].pTCPClt, TCPSendPrepRetry));
+		}
 	}
 finalize_it:
 	RETiRet;
@@ -1229,6 +1580,7 @@ setInstParamDefaults(instanceData *pData)
 	pData->iConErrSkip = 0;
 	pData->gnutlsPriorityString = NULL;
 	pData->bResendLastOnRecon = 0;
+	pData->bExtendedConnCheck = 1; /* traditionally enabled! */
 	pData->bSendToAll = -1;  /* unspecified */
 	pData->iUDPSendDelay = 0;
 	pData->UDPSendBuf = 0;
@@ -1237,31 +1589,57 @@ setInstParamDefaults(instanceData *pData)
 	pData->strmCompFlushOnTxEnd = 1;
 	pData->compressionMode = COMPRESS_NEVER;
 	pData->ipfreebind = IPFREEBIND_ENABLED_WITH_LOG;
+	pData->poolResumeInterval = 30;
 	pData->ratelimiter = NULL;
 	pData->ratelimitInterval = 0;
 	pData->ratelimitBurst = 200;
 }
 
 
+/* support statistics gathering - note: counter names are the same as for
+ * previous non-pool based code. This permits easy migration in our opinion.
+ */
 static rsRetVal
-setupInstStatsCtrs(instanceData *__restrict__ const pData)
+setupInstStatsCtrs(instanceData *const pData)
 {
 	uchar ctrName[512];
 	DEFiRet;
 
-	/* support statistics gathering */
-	snprintf((char*)ctrName, sizeof(ctrName), "%s-%s-%s",
-		(pData->protocol == FORW_TCP) ? "TCP" : "UDP",
-		pData->target, pData->port);
-	ctrName[sizeof(ctrName)-1] = '\0'; /* be on the save side */
-	CHKiRet(statsobj.Construct(&(pData->stats)));
-	CHKiRet(statsobj.SetName(pData->stats, ctrName));
-	CHKiRet(statsobj.SetOrigin(pData->stats, (uchar*)"omfwd"));
-	pData->sentBytes = 0;
-	INIT_ATOMIC_HELPER_MUT64(pData->mut_sentBytes);
-	CHKiRet(statsobj.AddCounter(pData->stats, UCHAR_CONSTANT("bytes.sent"),
-		ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pData->sentBytes)));
-	CHKiRet(statsobj.ConstructFinalize(pData->stats));
+	if(pData->target_name == NULL) {
+		/* This is primarily introduced to keep the static analyzer happy. We
+		 * do not understand how this situation could actually happen.
+		 */
+		LogError(0, RS_RET_INTERNAL_ERROR,
+			"internal error: target_name is NULL in setupInstStatsCtrs() -"
+			"statistics countes are disable. Report this error to the "
+			"rsyslog project please.");
+		ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+	}
+
+	CHKmalloc(pData->target_stats = (targetStats_t *) calloc(pData->nTargets, sizeof(targetStats_t)));
+
+	for(int i = 0 ; i < pData->nTargets ; ++i) {
+		/* if insufficient ports are configured, we use ports[0] for the * missing ports.  */
+		snprintf((char*)ctrName, sizeof(ctrName), "%s-%s-%s",
+			(pData->protocol == FORW_TCP) ? "TCP" : "UDP",
+			pData->target_name[i], pData->ports[(i < pData->nPorts) ? i : 0]);
+		ctrName[sizeof(ctrName)-1] = '\0'; /* be on the save side */
+		CHKiRet(statsobj.Construct(&(pData->target_stats[i].stats)));
+		CHKiRet(statsobj.SetName(pData->target_stats[i].stats, ctrName));
+		CHKiRet(statsobj.SetOrigin(pData->target_stats[i].stats, (uchar*)"omfwd"));
+
+		pData->target_stats[i].sentBytes = 0;
+		INIT_ATOMIC_HELPER_MUT64(pData->target_stats[i].mut_sentBytes);
+		CHKiRet(statsobj.AddCounter(pData->target_stats[i].stats, UCHAR_CONSTANT("bytes.sent"),
+			ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pData->target_stats[i].sentBytes)));
+
+		pData->target_stats[i].sentMsgs = 0;
+		INIT_ATOMIC_HELPER_MUT64(pData->target_stats[i].mut_sentMsgs);
+		CHKiRet(statsobj.AddCounter(pData->target_stats[i].stats, UCHAR_CONSTANT("messages.sent"),
+			ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(pData->target_stats[i].sentMsgs)));
+
+		CHKiRet(statsobj.ConstructFinalize(pData->target_stats[i].stats));
+	}
 
 finalize_it:
 	RETiRet;
@@ -1291,17 +1669,28 @@ CODESTARTnewActInst
 	CHKiRet(createInstance(&pData));
 	setInstParamDefaults(pData);
 
+	pData->nPorts = 0; /* we need this to detect missing port param */
+
 	for(i = 0 ; i < actpblk.nParams ; ++i) {
 		if(!pvals[i].bUsed)
 			continue;
 		if(!strcmp(actpblk.descr[i].name, "target")) {
-			pData->target = es_str2cstr(pvals[i].val.d.estr, NULL);
+			const int nTargets = pvals[i].val.d.ar->nmemb; /* keep static analyzer happy */
+			pData->nTargets = nTargets;
+			CHKmalloc(pData->target_name = (char**) calloc(pData->nTargets, sizeof(char*)));
+			for(int j = 0 ; j <  nTargets ; ++j) {
+				pData->target_name[j] = (char*) es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+			}
 		} else if(!strcmp(actpblk.descr[i].name, "address")) {
 			pData->address = es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "device")) {
 			pData->device = es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "port")) {
-			pData->port = es_str2cstr(pvals[i].val.d.estr, NULL);
+			pData->nPorts = pvals[i].val.d.ar->nmemb;
+			CHKmalloc(pData->ports = (char**) calloc(pData->nPorts, sizeof(char*)));
+			for(int j = 0 ; j < pData->nPorts ; ++j) {
+				pData->ports[j] = (char*) es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+			}
 		} else if(!strcmp(actpblk.descr[i].name, "protocol")) {
 			if(!es_strcasebufcmp(pvals[i].val.d.estr, (uchar*)"udp", 3)) {
 				pData->protocol = FORW_UDP;
@@ -1431,6 +1820,8 @@ CODESTARTnewActInst
 			pData->tcp_framingDelimiter = (uchar) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "resendlastmsgonreconnect")) {
 			pData->bResendLastOnRecon = (int) pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "extendedconnectioncheck")) {
+			pData->bExtendedConnCheck = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "udp.sendtoall")) {
 			pData->bSendToAll = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "udp.senddelay")) {
@@ -1458,6 +1849,8 @@ CODESTARTnewActInst
 			free(cstr);
 		} else if(!strcmp(actpblk.descr[i].name, "ipfreebind")) {
 			pData->ipfreebind = (int) pvals[i].val.d.n;
+		} else if(!strcmp(actpblk.descr[i].name, "pool.resumeinterval")) {
+			pData->poolResumeInterval = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "ratelimit.burst")) {
 			pData->ratelimitBurst = (unsigned int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
@@ -1469,9 +1862,28 @@ CODESTARTnewActInst
 		}
 	}
 
+	if(pData->protocol == FORW_UDP && pData->nTargets > 1) {
+		parser_warnmsg("you have defined %d targets. Multiple targets are ONLY "
+			"supported in TCP mode ignoring all but the first target in UDP mode",
+			pData->nTargets);
+	}
+
 	/* check if no port is set. If so, we use the IANA-assigned port of 514 */
-	if(pData->port == NULL) {
-		CHKmalloc(pData->port = strdup("514"));
+	if(pData->nPorts == 0) {
+		pData->nPorts = 1;
+		CHKmalloc(pData->ports = (char**) calloc(pData->nPorts, sizeof(char*)));
+		CHKmalloc(pData->ports[0] = strdup("514"));
+	}
+
+	if(pData->nPorts > pData->nTargets) {
+		parser_warnmsg("defined %d ports, but only %d targets - ignoring "
+			"extra ports", pData->nPorts, pData->nTargets);
+	}
+
+	if(pData->nPorts < pData->nTargets) {
+		parser_warnmsg("defined %d ports, but %d targets - using port %s "
+			"as default for the additional targets",
+			pData->nPorts, pData->nTargets, pData->ports[0]);
 	}
 
 	if(complevel != -1) {
@@ -1619,8 +2031,12 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	}
 
 	pData->tcp_framing = tcp_framing;
-	pData->port = NULL;
+	pData->ports = NULL;
 	pData->networkNamespace = NULL;
+
+	CHKmalloc(pData->target_name = (char**) malloc(sizeof(char*) * pData->nTargets));
+	CHKmalloc(pData->ports = (char**) calloc(pData->nTargets, sizeof(char*)));
+
 	if(*p == ':') { /* process port */
 		uchar * tmp;
 
@@ -1628,19 +2044,19 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 		tmp = ++p;
 		for(i=0 ; *p && isdigit((int) *p) ; ++p, ++i)
 			/* SKIP AND COUNT */;
-		pData->port = malloc(i + 1);
-		if(pData->port == NULL) {
+		pData->ports[0] = malloc(i + 1);
+		if(pData->ports[0] == NULL) {
 			LogError(0, NO_ERRCODE, "Could not get memory to store syslog forwarding port, "
 				 "using default port, results may not be what you intend");
 			/* we leave f_forw.port set to NULL, this is then handled below */
 		} else {
-			memcpy(pData->port, tmp, i);
-			*(pData->port + i) = '\0';
+			memcpy(pData->ports[0], tmp, i);
+			*(pData->ports[0] + i) = '\0';
 		}
 	}
 	/* check if no port is set. If so, we use the IANA-assigned port of 514 */
-	if(pData->port == NULL) {
-		CHKmalloc(pData->port = strdup("514"));
+	if(pData->ports[0] == NULL) {
+		CHKmalloc(pData->ports[0] = strdup("514"));
 	}
 
 	/* now skip to template */
@@ -1650,11 +2066,15 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 	if(*p == ';' || *p == '#' || isspace(*p)) {
 		uchar cTmp = *p;
 		*p = '\0'; /* trick to obtain hostname (later)! */
-		CHKmalloc(pData->target = strdup((char*) q));
+		CHKmalloc(pData->target_name[0] = strdup((char*) q));
 		*p = cTmp;
 	} else {
-		CHKmalloc(pData->target = strdup((char*) q));
+		CHKmalloc(pData->target_name[0] = strdup((char*) q));
 	}
+	/* We have a port at ports[0], so we must tell the module it is allocated.
+	 * Otherwise, the port would not be freed.
+	 */
+	pData->nPorts = 1;
 
 	/* copy over config data as needed */
 	pData->iRebindInterval = (pData->protocol == FORW_TCP) ?
@@ -1678,6 +2098,9 @@ CODE_STD_STRING_REQUESTparseSelectorAct(1)
 		}
 	}
 CODE_STD_FINALIZERparseSelectorAct
+	if(iRet == RS_RET_OK) {
+		setupInstStatsCtrs(pData);
+	}
 ENDparseSelectorAct
 
 
@@ -1692,7 +2115,7 @@ freeConfigVars(void)
 	free(cs.pszStrmDrvrAuthMode);
 	cs.pszStrmDrvrAuthMode = NULL;
 	free(cs.pPermPeers);
-	cs.pPermPeers = NULL; /* TODO: fix in older builds! */
+	cs.pPermPeers = NULL;
 }
 
 
@@ -1749,6 +2172,7 @@ CODEmodInit_QueryRegCFSLineHdlr
 	CHKiRet(objUse(glbl, CORE_COMPONENT));
 	CHKiRet(objUse(net,LM_NET_FILENAME));
 	CHKiRet(objUse(statsobj, CORE_COMPONENT));
+	CHKiRet(objUse(datetime, CORE_COMPONENT));
 
 	CHKiRet(regCfSysLineHdlr((uchar *)"actionforwarddefaulttemplate", 0, eCmdHdlrGetWord,
 		setLegacyDfltTpl, NULL, NULL));


### PR DESCRIPTION
This patch implements a very simple round-robin load balancer for omfwd. Its intent is to provide a solid base on which more elaborate functionality can be build.

That said, the load balancing basics will be in place, including the handling of failing load balancing targets and imporoved and adapted pstats counters.

The new functionality is fully backwards compatible with previous configuration settings.

New action() config params:
* pool.resumeinterval

New/"changed" rstats counters
Each target receives its own set of pstats counters. Most importantly this is the case for byte counts. That counter retains the same naming, but there may now be multiple of these counters, one for each target ip, port tuple.

New pstats message count to target
Among others, this can be used for checking that the load balancer works as intended. The so-far byte count emitted does not provide a clear indication of how many messages the targets had actually processed.

For obvious reasons, this message count makes most sense in advanced load balancing scenarios, but also provides additional insight into round-robin. Non-matches indicate that targets went offline, and we can now evaluate the impact this had on processing.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
