### PR TITLE
Fix memory leak in omazureeventhubs on accepted PN_DELIVERY event

### DIFF
--- a/plugins/omazureeventhubs/omazureeventhubs.c
+++ b/plugins/omazureeventhubs/omazureeventhubs.c
@@ -727,7 +727,7 @@ CODESTARTcommitTransaction
 		}
 		bDone = 1;
 
-		// Wait 100 microseconds
+		// Wait 100 milliseconds
 		srSleep(0, 100000);
 
 		// Verify if messages have been submitted successfully

--- a/plugins/omazureeventhubs/omazureeventhubs.c
+++ b/plugins/omazureeventhubs/omazureeventhubs.c
@@ -1283,6 +1283,7 @@ handleProton(wrkrInstanceData_t *const pWrkrData, pn_event_t *event) {
 						iQueueNum,
 						pWrkrData->nMaxProtonMsgs,
 						pWrkrData, pData->azurehost, pData->azureport, pData->container);
+					pn_delivery_settle(pDeliveryStatus); // free the delivered message
 					pMsgEntry->status = PROTON_ACCEPTED;
 
 					// Increment Stats Counter


### PR DESCRIPTION
According to https://issues.apache.org/jira/browse/PROTON-2709 the PN_DELIVERY event has to be settled when it is in state PN_ACCEPTED.

At the same time set good units in a comment.
