### PR TITLE
omfwd: fix segfault in UDP freeaddrinfo

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1247,13 +1247,13 @@ doTryResume(targetData_t *pTarget)
 			hints.ai_family = res->ai_family;
 			hints.ai_flags |= AI_PASSIVE;
 			iErr = getaddrinfo(pData->address, pTarget->port, &hints, &addr);
-			freeaddrinfo(addr);
 			if(iErr != 0) {
 				LogError(0, RS_RET_SUSPENDED,
 					 "omfwd: cannot use bind address '%s' for host '%s': %s",
 					 pData->address, pTarget->target_name, gai_strerror(iErr));
 				ABORT_FINALIZE(RS_RET_SUSPENDED);
 			}
+			freeaddrinfo(addr);
 			bBindRequired = 1;
 			address = pData->address;
 		}


### PR DESCRIPTION
This segfault occurred on an amd64 Debian 12 device, running rsyslog version 8.2302.0, though the bug seems to be present in the latest version.

When the omfwd module is configured with an IPv4 address as `Target` and an `Address` of IPv6 (or viceversa): 
```
if  prifilt("*.info")  then {
        action(type="omfwd" Target="8.8.8.8" Protocol="udp" Address="2001:db8:dead:beef:fe::8")
}
```

or when the Target is a FQDN that resolves to an IPv4 address and an `Address` of IPv6:

```
if  prifilt("*.info")  then {
        action(type="omfwd" Target="hola.com" Protocol="udp" Address="2001:db8:dead:beef:fe::8")
}
```

The following segmentation fault occurs:
```
Process 2353 (rsyslogd) of user 0 dumped core.
                                             
                                             Module libsystemd.so.0 from deb systemd-252.17-1~deb12u1.amd64
                                             Stack trace of thread 2356:
                                             #0  0x00007fb222dabc33 freeaddrinfo (libc.so.6 + 0xf1c33)
                                             #1  0x00005651df031e22 doTryResume (rsyslogd + 0x1de22)
                                             #2  0x00005651df07ecdb actionPrepare (rsyslogd + 0x6acdb)
                                             #3  0x00005651df080e03 actionPrepare (rsyslogd + 0x6ce03)
                                             #4  0x00005651df0810f9 processMsgMain (rsyslogd + 0x6d0f9)
                                             #5  0x00005651df07850f execAct (rsyslogd + 0x6450f)
                                             #6  0x00005651df07855d execPROPFILT (rsyslogd + 0x6455d)
                                             #7  0x00005651df0791d5 processBatch (rsyslogd + 0x651d5)
                                             #8  0x00005651df02bc5c msgConsumer (rsyslogd + 0x17c5c)
                                             #9  0x00005651df074002 ConsumerReg (rsyslogd + 0x60002)
                                             #10 0x00005651df070bb1 wtiWorker (rsyslogd + 0x5cbb1)
                                             #11 0x00005651df06f3aa wtpWorker (rsyslogd + 0x5b3aa)
                                             #12 0x00007fb222d43044 n/a (libc.so.6 + 0x89044)
                                             #13 0x00007fb222dc361c n/a (libc.so.6 + 0x10961c)
                                             
                                             Stack trace of thread 2354:
                                             #0  0x00007fb222db605f __poll (libc.so.6 + 0xfc05f)
                                             #1  0x00007fb222a1b8b0 poll (imuxsock.so + 0x48b0)
                                             #2  0x00005651df082a11 thrdStarter (rsyslogd + 0x6ea11)
                                             #3  0x00007fb222d43044 n/a (libc.so.6 + 0x89044)
                                             #4  0x00007fb222dc361c n/a (libc.so.6 + 0x10961c)
                                             
                                             Stack trace of thread 2355:
                                             #0  0x00007fb222dbb6e3 __mmap (libc.so.6 + 0x1016e3)
                                             #1  0x00007fb222d4f465 n/a (libc.so.6 + 0x95465)
                                             #2  0x00007fb222d4f982 n/a (libc.so.6 + 0x95982)
                                             #3  0x00007fb222d520fc n/a (libc.so.6 + 0x980fc)
                                             #4  0x00007fb222d5288e malloc (libc.so.6 + 0x9888e)
                                             #5  0x00007fb222d587fa __strdup (libc.so.6 + 0x9e7fa)
                                             #6  0x00005651df062749 dbgSetThrdName (rsyslogd + 0x4e749)
                                             #7  0x00007fb222a12c40 runInput (imklog.so + 0x2c40)
                                             #8  0x00005651df082a11 thrdStarter (rsyslogd + 0x6ea11)
                                             #9  0x00007fb222d43044 n/a (libc.so.6 + 0x89044)
                                             #10 0x00007fb222dc361c n/a (libc.so.6 + 0x10961c)
                                             
                                             Stack trace of thread 2353:
                                             #0  0x00007fb222db8941 pselect (libc.so.6 + 0xfe941)
                                             #1  0x00005651df02e31d wait_timeout (rsyslogd + 0x1a31d)
                                             #2  0x00005651df02b0f4 main (rsyslogd + 0x170f4)
                                             #3  0x00007fb222ce11ca n/a (libc.so.6 + 0x271ca)
                                             #4  0x00007fb222ce1285 __libc_start_main (libc.so.6 + 0x27285)
                                             #5  0x00005651df02b471 _start (rsyslogd + 0x17471)
                                             ELF object binary architecture: AMD x86-64

```

The following is the backtrace from the generated coredump:
```
(gdb) bt
#0  0x00007f029321cd4a in __GI___libc_free (mem=0x7f028400d) at ./malloc/malloc.c:3362
#1  0x00007f0293275c40 in __GI_freeaddrinfo (ai=0x87edbd183a9e4e97) at ../sysdeps/posix/getaddrinfo.c:2640
#2  0x000055adb6f64e22 in doTryResume (pWrkrData=0x7f0284009610) at ./tools/omfwd.c:982
#3  0x000055adb6fb1cdb in actionPrepare (pThis=pThis@entry=0x55adb786abd0, pWti=pWti@entry=0x55adb786e730)
    at ../action.c:1086
#4  0x000055adb6fb3e03 in actionPrepare (pWti=<optimized out>, pThis=<optimized out>) at ../action.c:1699
#5  processMsgMain (pAction=pAction@entry=0x55adb786abd0, pWti=pWti@entry=0x55adb786e730, ttNow=0x7f0292612840, 
    pMsg=<optimized out>) at ../action.c:1683
#6  0x000055adb6fb40f9 in processMsgMain (ttNow=0x7f0292612840, pMsg=<optimized out>, pWti=0x55adb786e730, 
    pAction=0x55adb786abd0) at ../action.c:1678
#7  doSubmitToActionQ (pAction=0x55adb786abd0, pWti=0x55adb786e730, pMsg=<optimized out>) at ../action.c:1855
#8  0x000055adb6fab50f in execAct (pWti=0x55adb786e730, pMsg=0x7f028c002b60, stmt=0x55adb786a250)
    at ./runtime/ruleset.c:209
#9  scriptExec (root=<optimized out>, pMsg=pMsg@entry=0x7f028c002b60, pWti=pWti@entry=0x55adb786e730)
    at ./runtime/ruleset.c:599
#10 0x000055adb6fab55d in execPROPFILT (pWti=<optimized out>, pMsg=<optimized out>, stmt=<optimized out>)
    at ./runtime/ruleset.c:546
#11 scriptExec (root=<optimized out>, pMsg=pMsg@entry=0x7f028c002b60, pWti=pWti@entry=0x55adb786e730)
    at ./runtime/ruleset.c:623
#12 0x000055adb6fac1d5 in processBatch (pBatch=0x55adb786e760, pWti=0x55adb786e730) at ./runtime/ruleset.c:660
--Type <RET> for more, q to quit, c to continue without paging-- 
#13 0x000055adb6f5ec5c in msgConsumer (notNeeded=<optimized out>, pBatch=0x55adb786e760, pWti=0x55adb786e730)
    at ./tools/rsyslogd.c:709
#14 0x000055adb6fa7002 in ConsumerReg (pThis=0x55adb785f960, pWti=0x55adb786e730) at ./runtime/queue.c:2158
#15 0x000055adb6fa3bb1 in wtiWorker (pThis=pThis@entry=0x55adb786e730) at ./runtime/wti.c:430
#16 0x000055adb6fa23aa in wtpWorker (arg=0x55adb786e730) at ./runtime/wtp.c:435
#17 0x00007f029320d044 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:442
#18 0x00007f029328d61c in clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:81
```

This seems to happen because the `getaddrinfo(pData->address, pData->port, &hints, &addr);` call returns a non-zero value and `freeaddrinfo(addr)` is called nevertheless.

The proposed fix is to call `freeaddrinfo(addr)` only when the value returned by `getaddrinfo(pData->address, pData->port, &hints, &addr);` is 0