### PR TITLE
Fix memory leak in omazureeventhubs on accepted PN_DELIVERY event

### DIFF
--- a/plugins/omazureeventhubs/omazureeventhubs.c
+++ b/plugins/omazureeventhubs/omazureeventhubs.c
@@ -727,7 +727,7 @@ CODESTARTcommitTransaction
 		}
 		bDone = 1;
 
-		// Wait 100 microseconds
+		// Wait 100 milliseconds
 		srSleep(0, 100000);
 
 		// Verify if messages have been submitted successfully
@@ -1283,6 +1283,7 @@ handleProton(wrkrInstanceData_t *const pWrkrData, pn_event_t *event) {
 						iQueueNum,
 						pWrkrData->nMaxProtonMsgs,
 						pWrkrData, pData->azurehost, pData->azureport, pData->container);
+					pn_delivery_settle(pDeliveryStatus); // free the delivered message
 					pMsgEntry->status = PROTON_ACCEPTED;
 
 					// Increment Stats Counter


### PR DESCRIPTION
- Fix units in a comment of omazureeventhubs

Replaces Original PR: https://github.com/rsyslog/rsyslog/pull/5398

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
