### PR TITLE
ossl: Fix #pragma GCC diagnostic not allowed inside functions

### DIFF
--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -220,8 +220,8 @@ osslGlblInit(void)
 	ERR_load_crypto_strings();
 #endif
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+PRAGMA_DIAGNOSTIC_PUSH
+PRAGMA_IGNORE_Wdeprecated_declarations
 
 	// Initialize OpenSSL engine library
 	ENGINE_load_builtin_engines();
@@ -243,7 +243,7 @@ osslGlblInit(void)
 	}
 	// Free the engine reference when done
 	ENGINE_free(osslEngine);
-#pragma GCC diagnostic pop
+PRAGMA_DIAGNOSTIC_POP
 }
 
 /* globally de-initialize OpenSSL */
@@ -1094,8 +1094,8 @@ RSYSLOG_BIO_debug_callback(BIO *bio, int cmd, const char __attribute__((unused))
 
 #if OPENSSL_VERSION_NUMBER >= 0x10100000L
 // Requires at least OpenSSL v1.1.1
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-parameter"
+PRAGMA_DIAGNOSTIC_PUSH
+PRAGMA_IGNORE_Wunused_parameter
 static int
 net_ossl_generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie_len)
 {
@@ -1118,7 +1118,7 @@ net_ossl_generate_cookie(SSL *ssl, unsigned char *cookie, unsigned int *cookie_l
 
 	return 1;
 }
-#pragma GCC diagnostic pop
+PRAGMA_DIAGNOSTIC_POP
 
 static int
 net_ossl_verify_cookie(SSL *ssl, const unsigned char *cookie, unsigned int cookie_len)
@@ -1149,8 +1149,8 @@ net_ossl_init_engine(__attribute__((unused)) net_ossl_t *pThis)
 	const char *engine_id = NULL;
 	const char *engine_name = NULL;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+PRAGMA_DIAGNOSTIC_PUSH
+PRAGMA_IGNORE_Wdeprecated_declarations
 	// Get the default RSA engine
 	ENGINE *default_engine = ENGINE_get_default_RSA();
 	if (default_engine) {
@@ -1188,7 +1188,7 @@ net_ossl_init_engine(__attribute__((unused)) net_ossl_t *pThis)
 	} else {
 		DBGPRINTF("net_ossl_init_engine: use openssl default Engine");
 	}
-#pragma GCC diagnostic pop
+PRAGMA_DIAGNOSTIC_POP
 
 	RETiRet;
 }

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -108,14 +108,18 @@
 						_Pragma("GCC diagnostic ignored \"-Wunknown-attribute\"")
 	#define PRAGMA_IGNORE_Wformat_nonliteral \
 						_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
-	#define PRAGMA_IGNORE_Wdeprecated_declarations \
-						_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
 	#if  __GNUC__ >= 5
+		#define PRAGMA_IGNORE_Wdeprecated_declarations \
+			_Pragma("GCC diagnostic ignored \"-Wdeprecated-declarations\"")
+		#define PRAGMA_IGNORE_Wunused_parameter \
+			_Pragma("GCC diagnostic ignored \"-Wunused-parameter\"")
 		#define PRAGMA_DIAGNOSTIC_PUSH \
 			_Pragma("GCC diagnostic push")
 		#define PRAGMA_DIAGNOSTIC_POP \
 			_Pragma("GCC diagnostic pop")
 	#else
+		#define PRAGMA_IGNORE_Wdeprecated_declarations
+		#define PRAGMA_IGNORE_Wunused_parameter
 		#define PRAGMA_DIAGNOSTIC_PUSH
 		#define PRAGMA_DIAGNOSTIC_POP
 	#endif


### PR DESCRIPTION
Some old compilers, eg. GCC 4.4.7 on el6 do not support #pragma GCC diagnostic in functions. Rsyslog has PRAGMA_* macros to handle those cases, so let's use them.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
