### PR TITLE
Refactor ossl crypto provider

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1131,7 +1131,9 @@ if test "x$enable_openssl" = "xyes"; then
 	AC_CHECK_LIB(
 		[crypto],
 		[EVP_CIPHER_get_block_size],
-		[enable_openssl_crypto_provider="yes"],
+		[enable_openssl_crypto_provider="yes"
+		AC_DEFINE([ENABLE_OPENSSL_CRYPTO_PROVIDER], [1], [Indicator that openssl(EVP_CIPHER_get_block_size) is present])
+		],
 		[AC_MSG_WARN([The ossl encryption provider will not be enabled (EVP_CIPHER_get_block_size is missing)])]
 	)
 fi

--- a/runtime/libcry_common.h
+++ b/runtime/libcry_common.h
@@ -22,6 +22,15 @@
 #define INCLUDED_LIBCRY_COMMON_H
 #include <stdint.h>
 
+/* error states */
+#define RSGCRYE_EI_OPEN 1 /* error opening .encinfo file */
+#define RSGCRYE_OOM 4 /* ran out of memory */
+
+#define EIF_MAX_RECTYPE_LEN 31 /* max length of record types */
+#define EIF_MAX_VALUE_LEN 1023 /* max length of value types */
+#define RSGCRY_FILETYPE_NAME "rsyslog-enrcyption-info"
+#define ENCINFO_SUFFIX ".encinfo"
+
 int cryGetKeyFromFile(const char* const fn, char** const key, unsigned* const keylen);
 
 int cryGetKeyFromProg(char* cmd, char** key, unsigned* keylen);

--- a/runtime/libgcry.c
+++ b/runtime/libgcry.c
@@ -52,6 +52,7 @@
 #include "srUtils.h"
 #include "debug.h"
 #include "libgcry.h"
+#include "libcry_common.h"
 
 #define READBUF_SIZE 4096	/* size of the read buffer */
 
@@ -703,7 +704,7 @@ rsgcryEncrypt(gcryfile pF, uchar *buf, size_t *len)
 {
 	int gcryError;
 	DEFiRet;
-	
+
 	if(*len == 0)
 		FINALIZE;
 
@@ -729,7 +730,7 @@ rsgcryDecrypt(gcryfile pF, uchar *buf, size_t *len)
 {
 	gcry_error_t gcryError;
 	DEFiRet;
-	
+
 	if(pF->bytesToBlkEnd != -1)
 		pF->bytesToBlkEnd -= *len;
 	gcryError = gcry_cipher_decrypt(pF->chd, buf, *len, NULL, 0);

--- a/runtime/libgcry.h
+++ b/runtime/libgcry.h
@@ -65,15 +65,6 @@ rsRetVal gcryfileGetBytesLeftInBlock(gcryfile gf, ssize_t *left);
 int rsgcryModename2Mode(char *const __restrict__ modename);
 int rsgcryAlgoname2Algo(char *const __restrict__ algoname);
 
-/* error states */
-#define RSGCRYE_EI_OPEN 1 	/* error opening .encinfo file */
-#define RSGCRYE_OOM 4	/* ran out of memory */
-
-#define EIF_MAX_RECTYPE_LEN 31 /* max length of record types */
-#define EIF_MAX_VALUE_LEN 1023 /* max length of value types */
-#define RSGCRY_FILETYPE_NAME "rsyslog-enrcyption-info"
-#define ENCINFO_SUFFIX ".encinfo"
-
 /* Note: gf may validly be NULL, e.g. if file has not yet been opened! */
 static inline void __attribute__((unused))
 gcryfileSetDeleteOnClose(gcryfile gf, const int val)

--- a/runtime/libossl.c
+++ b/runtime/libossl.c
@@ -52,6 +52,7 @@
 #include "srUtils.h"
 #include "debug.h"
 #include "libossl.h"
+#include "libcry_common.h"
 
 #define READBUF_SIZE 4096	/* size of the read buffer */
 static rsRetVal rsosslBlkBegin(osslfile gf);

--- a/runtime/libossl.h
+++ b/runtime/libossl.h
@@ -50,17 +50,6 @@ struct osslfile_s {
 				0 means -> end of block, new one must be started. */
 };
 
-
-/* error states */
-#define RSGCRYE_EI_OPEN 1 	/* error opening .encinfo file */
-#define RSGCRYE_OOM 4	/* ran out of memory */
-
-// FIXME refactor
-#define EIF_MAX_RECTYPE_LEN 31 /* max length of record types */
-#define EIF_MAX_VALUE_LEN 1023 /* max length of value types */
-#define RSGCRY_FILETYPE_NAME "rsyslog-enrcyption-info"
-#define ENCINFO_SUFFIX ".encinfo"
-
 osslctx osslCtxNew(void);
 void rsosslCtxDel(osslctx ctx);
 rsRetVal rsosslSetAlgoMode(osslctx ctx, uchar* algorithm);

--- a/runtime/lmcry_ossl.c
+++ b/runtime/lmcry_ossl.c
@@ -36,11 +36,6 @@
 #include "libossl.h"
 #include "lmcry_ossl.h"
 
-#pragma GCC diagnostic push // TODO REMOVE
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma GCC diagnostic ignored "-Wunused-variable"
-#pragma GCC diagnostic ignored "-Wunused-label"
-
 MODULE_TYPE_LIB
 MODULE_TYPE_NOKEEP
 
@@ -303,4 +298,3 @@ CODESTARTmodInit
 	CHKiRet(lmcry_osslClassInit(pModInfo)); /* must be done after tcps_sess, as we use it */
 ENDmodInit
 
-#pragma GCC diagnostic pop // TODO REMOVE


### PR DESCRIPTION
Very simple refactoring a use case, where `--enable-openssl` is defined but `--enable-libgcrypt` is not:

- Move common defines to a common file that is used by both `ossl` and `gcry`. I haven't realized it sooner, but some defines were put into a wrong file and if rsyslog was compiled without `gcry` support then those specific defines used by `ossl` were not present.