### PR TITLE
minor: flag function as OK for undefined behaviour

### DIFF
--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -97,8 +97,13 @@ hash_from_key_fn(void *k)
 			len = 0;
 			rkey = NULL;
 	}
-	while(len--)
-		hashval = hashval * 33 + *rkey++;
+	while(len--) {
+		/* the casts are done in order to prevent undefined behavior sanitizer
+		 * from triggering warnings. Actually, it would be OK if we have just
+		 * "random" truncation.
+		 */
+		hashval = (unsigned) (hashval * (unsigned long long) 33) + *rkey++;
+	}
 
 	return hashval;
 }

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -54,6 +54,11 @@
 		#pragma GCC diagnostic ignored "-Wjump-misses-init"
 	#endif /* if __GNUC__ >= 8 */
 
+	#if defined(__clang__)
+		#define ATTR_NO_SANITIZE_UNDEFINED __attribute__((no_sanitize("undefined")))
+	#else
+		#define ATTR_NO_SANITIZE_UNDEFINED
+	#endif
 	/* define a couple of attributes to improve cross-platform builds */
 	#if __GNUC__ > 6
 		#define CASE_FALLTHROUGH __attribute__((fallthrough));
@@ -104,8 +109,12 @@
 						_Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")
 	#define PRAGMA_IGNORE_Wunknown_warning_option \
 						_Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")
-	#define PRAGMA_IGNORE_Wunknown_attribute \
+	#if !defined(__clang__)
+		#define PRAGMA_IGNORE_Wunknown_attribute \
 						_Pragma("GCC diagnostic ignored \"-Wunknown-attribute\"")
+	#else
+		#define PRAGMA_IGNORE_Wunknown_attribute
+	#endif
 	#define PRAGMA_IGNORE_Wformat_nonliteral \
 						_Pragma("GCC diagnostic ignored \"-Wformat-nonliteral\"")
 	#if (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 2) || defined(__clang__)


### PR DESCRIPTION
The undefined bahavior sanitizer deteced an integer overflow inside some code. However, this is hash code and the interger overflow is perfectly fine.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
