### PR TITLE
Fix Solaris 10 compatibility issues

### DIFF
--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -89,7 +89,12 @@ createListenSocket(void)
 	}
 	// Set SO_REUSEADDR and SO_REUSEPORT options
 	int opt = 1;
-	if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR | SO_REUSEPORT, &opt, sizeof(opt)) < 0) {
+	int flags = SO_REUSEADDR;
+#ifdef SO_REUSEPORT
+	// If SO_REUSEPORT is available (Solaris 10 does not have SO_REUSEPORT)
+	flags |= SO_REUSEPORT;
+#endif
+	if (setsockopt(listen_fd, SOL_SOCKET, flags, &opt, sizeof(opt)) < 0) {
 		errout("setsockopt failed");
 	}
 


### PR DESCRIPTION
- Handle SO_REUSEPORT if not defined in minitcpsrvr.c

closes: https://github.com/rsyslog/rsyslog/issues/5440

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
