### PR TITLE
Fix runConf NULL pointer refence

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -2013,7 +2013,7 @@ rsyslogdDoDie(int sig)
 		abort();
 	}
 	bFinished = sig;
-	if(runConf->globals.debugOnShutdown) {
+	if(runConf && runConf->globals.debugOnShutdown) {
 		/* kind of hackish - set to 0, so that debug_swith will enable
 		 * and AND emit the "start debug log" message.
 		 */


### PR DESCRIPTION
`systemd restart rsyslog` in the early start of OS will let rsyslog segmentation fault. This cmd will send sigTerm to rsylogd, and rsyslogd will handle the signal in rsyslogdDoDie. If the rsyslogd havn't parse the conf, the runConf will be NULL So check the pointer before reference it.

#5453 