### PR TITLE
rainerscript: do not try to call a function if it does not exist

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2901,11 +2901,6 @@ doFuncCall(struct cnffunc *__restrict__ const func, struct svar *__restrict__ co
 		free(fname);
 	}
 	if(func->fPtr == NULL) {
-		char *fname = es_str2cstr(func->fname, NULL);
-		LogError(0, RS_RET_INTERNAL_ERROR,
-			"rainerscript: internal error: NULL pointer for function named '%s'\n",
-			fname);
-		free(fname);
 		ret->datatype = 'N';
 		ret->d.n = 0;
 	} else {
@@ -3802,7 +3797,7 @@ cnffuncDestruct(struct cnffunc *func)
 	char *cstr = es_str2cstr(func->fname, NULL);
 	struct scriptFunct *foundFunc = searchModList(cstr);
 	free(cstr);
-	if(foundFunc->destruct != NULL) {
+	if(foundFunc && foundFunc->destruct != NULL) {
 		foundFunc->destruct(func);
 	}
 
@@ -5300,7 +5295,7 @@ cnffuncNew(es_str_t *fname, struct cnffparamlst* paramlst)
 		}
 		/* some functions require special initialization */
 		struct scriptFunct *foundFunc = searchModList(cstr);
-		if(foundFunc->initFunc != NULL) {
+		if(foundFunc && foundFunc->initFunc != NULL) {
 			foundFunc->initFunc(func);
 		}
 		free(cstr);


### PR DESCRIPTION
Having a config snippet like the following causes **segmentation fault**, because the function can not be found.
```
if nonExistentFunction(1) then {
        stop
}
```
Output:
```
rsyslogd: version 8.2410.0.master, config validation run (level 1), master config /etc/rsyslog.conf
rsyslogd: error during parsing file /etc/rsyslog.d/crash.conf, on or before line 5: function 'nonExistentFunction' not found [v8.2410.0.master try https://www.rsyslog.com/e/2207 ]
rsyslogd: error during parsing file /etc/rsyslog.d/crash.conf, on or before line 5: Invalid function nonExistentFunction [v8.2410.0.master try https://www.rsyslog.com/e/2207 ]
[1]    123378 segmentation fault  ./tools/rsyslogd -N1
```

I intentionally removed the `rainerscript: internal error: NULL...` part because it was causing too much noise in the logs. If a function does not exist, it is reported to be missing when doing a config only check, so I think it's fine.
With patch applied, segfault does not happen on function call.