### PR TITLE
imjournal: Fix invalid memory READ issue

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -1379,6 +1379,7 @@ createInstance(instanceConf_t **const pinst)
 	inst->next = NULL;
 	inst->pBindRuleset = NULL;
 	inst->pszBindRuleset = NULL;
+	inst->stateFile = NULL;
 
 	/* node created, let's add to config */
 	if(loadModConf->tail == NULL) {


### PR DESCRIPTION
Initlize inst->stateFile to NULL to prevent it from having invalid address.

When running with ASAN on it will hit the following error.
```
$ /tmp/rsyslogd -n -iNONE
AddressSanitizer:DEADLYSIGNAL
=================================================================
==8588==ERROR: AddressSanitizer: SEGV on unknown address 0xbebebeae (pc 0xa6984f8c bp 0xaefb70cc sp 0xaefb6c68 T0)
==8588==The signal is caused by a READ memory access.
    #0 0xa6984f8c  (/usr/lib/libasan.so.8+0x20f8c) (BuildId: ee0b8a590de2b6d96c2138cdebb2499a90e6a07a)
    #1 0xa6a3b728  (/usr/lib/libasan.so.8+0xd7728) (BuildId: ee0b8a590de2b6d96c2138cdebb2499a90e6a07a)
    #2 0xa617c054  (/usr/lib/rsyslog/imjournal.so+0x6054) (BuildId: ca1c5d369cffa79029a75c06e0e18d62368c9bca)
    #3 0x4ff0e4  (/tmp/rsyslogd+0xa20e4) (BuildId: 14bec8475dcbac6b4061007eb0f4e4e3bab3aa38)
    #4 0x48f8bc  (/tmp/rsyslogd+0x328bc) (BuildId: 14bec8475dcbac6b4061007eb0f4e4e3bab3aa38)
    #5 0x488330 in main (/tmp/rsyslogd+0x2b330) (BuildId: 14bec8475dcbac6b4061007eb0f4e4e3bab3aa38)
    #6 0xa66a54ac  (/usr/lib/libc.so.6+0x1f4ac) (BuildId: c9c455a6e5b9355d2e08c2695ea6374f1ecc583c)
    #7 0xa66a5598 in __libc_start_main (/usr/lib/libc.so.6+0x1f598) (BuildId: c9c455a6e5b9355d2e08c2695ea6374f1ecc583c)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV (/usr/lib/libasan.so.8+0x20f8c) (BuildId: ee0b8a590de2b6d96c2138cdebb2499a90e6a07a)
==8588==ABORTING
```

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
