### PR TITLE
nsd_ptcp: remove debugging messages emited to stderr

### DIFF
--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -74,7 +74,6 @@ DEFobjCurrIf(prop)
 static void
 sockClose(int *pSock)
 {
-	fprintf(stderr, "nsd_ptcp: closing socket %d\n", *pSock);
 	if(*pSock >= 0) {
 		close(*pSock);
 		*pSock = -1;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -209,7 +209,7 @@ TESTS +=  \
 	invalid_nested_include.sh \
 	omfwd-lb-1target-retry-full_buf.sh \
 	omfwd-lb-1target-retry-1_byte_buf.sh \
-	omfwd-lb-1target-retry-1_byte_buf-TargetFail .sh \
+	omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh \
 	omfwd-lb-susp.sh \
 	omfwd-lb-2target-basic.sh \
 	omfwd-lb-2target-retry.sh \


### PR DESCRIPTION
fix regression introduced by 9ac56b286. This spits out a debug message to stderr. That message is removed by this patch here.

closes https://github.com/rsyslog/rsyslog/issues/5485

This also removes a typo in testbench settings which caused CI failures (second commit, done together for convenience).
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
