### PR TITLE
cleanup: remove variables that are no longer used

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -214,7 +214,6 @@ rsRetVal parsSkipAfterChar(rsParsObj *pThis, char c)
 rsRetVal parsSkipWhitespace(rsParsObj *pThis)
 {
 	register unsigned char *pC;
-	int numSkipped;
 	DEFiRet;
 
 
@@ -222,12 +221,10 @@ rsRetVal parsSkipWhitespace(rsParsObj *pThis)
 
 	pC = rsCStrGetBufBeg(pThis->pCStr);
 
-	numSkipped = 0;
 	while(pThis->iCurrPos < rsCStrLen(pThis->pCStr)) {
 		if(!isspace((int)*(pC+pThis->iCurrPos)))
 			break;
 		++pThis->iCurrPos;
-		++numSkipped;
 	}
 
 	RETiRet;

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -1095,7 +1095,6 @@ Load(uchar *const pModName, const sbool bConfLoad, struct nvlst *const lst)
 	cfgmodules_etry_t *pNew = NULL;
 	cfgmodules_etry_t *pLast = NULL;
 	uchar *pModDirCurr, *pModDirNext;
-	int iLoadCnt;
 	struct dlhandle_s *pHandle = NULL;
 	uchar pathBuf[PATH_MAX+1];
 	uchar *pPathBuf = pathBuf;
@@ -1156,7 +1155,6 @@ Load(uchar *const pModName, const sbool bConfLoad, struct nvlst *const lst)
 	pModDirCurr = (uchar *)((pModDir == NULL) ? _PATH_MODDIR : (char *)pModDir);
 	pModDirNext = NULL;
 	pModHdlr    = NULL;
-	iLoadCnt    = 0;
 	do {	/* now build our load module name */
 		if(*pModName == '/' || *pModName == '.') {
 			if(lenPathBuf < PATHBUF_OVERHEAD) {
@@ -1240,8 +1238,6 @@ Load(uchar *const pModName, const sbool bConfLoad, struct nvlst *const lst)
 				rsCStrAppendStr(load_err_msg, (uchar*)errmsg);
 			}
 		}
-
-		iLoadCnt++;
 
 	} while(pModHdlr == NULL && *pModName != '/' && pModDirNext);
 


### PR DESCRIPTION
detected by newer compiler builds

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
