### PR TITLE
gnutls bugfix: Avoid blocking sockets during TLS handshake

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -2204,6 +2204,7 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
 	int sock;
 	int gnuRet;
+	int flags;
 	const char *error_position;
 #	ifdef HAVE_GNUTLS_CERTIFICATE_TYPE_SET_PRIORITY
 	static const int cert_type_priority[2] = { GNUTLS_CRT_X509, 0 };
@@ -2305,9 +2306,16 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 		gnutls_dh_set_prime_bits(pThis->sess, dhMinBits);
 	}
 
-	/* assign the socket to GnuTls */
 	CHKiRet(nsd_ptcp.GetSock(pThis->pTcp, &sock));
+	/* Set the socket to non-blocking mode */
+	flags = fcntl(sock, F_GETFL, 0);
+	if (flags != -1) {
+		fcntl(sock, F_SETFL, flags | O_NONBLOCK);
+	}
+
+	/* assign the socket to GnuTls */
 	gtlsSetTransportPtr(pThis, sock);
+
 
 	/* we need to store the hostname as an alternate mean of authentication if no
 	 * permitted peer names are given. Using the hostname is quite useful. It permits

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -2204,7 +2204,6 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
 	int sock;
 	int gnuRet;
-	int flags;
 	const char *error_position;
 #	ifdef HAVE_GNUTLS_CERTIFICATE_TYPE_SET_PRIORITY
 	static const int cert_type_priority[2] = { GNUTLS_CRT_X509, 0 };
@@ -2307,11 +2306,6 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 	}
 
 	CHKiRet(nsd_ptcp.GetSock(pThis->pTcp, &sock));
-	/* Set the socket to non-blocking mode */
-	flags = fcntl(sock, F_GETFL, 0);
-	if (flags != -1) {
-		fcntl(sock, F_SETFL, flags | O_NONBLOCK);
-	}
 
 	/* assign the socket to GnuTls */
 	gtlsSetTransportPtr(pThis, sock);
@@ -2324,6 +2318,7 @@ Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device)
 	CHKmalloc(pThis->pszConnectHost = (uchar*)strdup((char*)host));
 
 	/* and perform the handshake */
+	gnutls_handshake_set_timeout(pThis->sess, 3000);
 	CHKgnutls(gnutls_handshake(pThis->sess));
 	dbgprintf("GnuTLS handshake succeeded\n");
 


### PR DESCRIPTION
When forwarding logs to a TLS server, using a blocking socket can lead to indefinite waiting during the gnutls_handshake() call if the server does not respond as expected.

This commit modifies the behavior to use non-blocking sockets, ensuring that the rsyslog client does not hang indefinitely waiting for a response.

Reproducer:
1. Start a dummy (fake) TLS server not doing any TLS handshake via
```
# ncat -4 -lkv 6514
```

2. Have rsyslog running with
```
*.* action(type="omfwd" protocol="tcp" target="127.0.0.1" port="6514"
       StreamDriver="gtls" StreamDriverMode="1" StreamDriverAuthMode="anon")
```

The gnutls_handshake call will block indefinitely. It will not return anything, so the client will not reinitiate the connection.