### PR TITLE
tcpsrv: move worker thread pool to server instance

### DIFF
--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -60,6 +60,18 @@ struct tcpLstnPortList_s {
 	tcpLstnPortList_t *pNext;	/**< next port or NULL */
 };
 
+struct tcpsrv_wrkrInfo_s {
+	pthread_t tid;	/* the worker's thread ID */
+	pthread_cond_t run;
+	int idx;
+	tcpsrv_t *pSrv; /* pSrv == NULL -> idle */
+	nspoll_t *pPoll;
+	void *pUsr;
+	sbool enabled;
+	long long unsigned numCalled;	/* how often was this called */
+	tcpsrv_t *mySrv;
+};
+
 #define TCPSRV_NO_ADDTL_DELIMITER -1 /* specifies that no additional delimiter is to be used in TCP framing */
 
 /* the tcpsrv object */
@@ -122,7 +134,16 @@ struct tcpsrv_s {
 	rsRetVal (*pOnSessAccept)(tcpsrv_t *, tcps_sess_t*);
 	rsRetVal (*OnSessConstructFinalize)(void*);
 	rsRetVal (*pOnSessDestruct)(void*);
+	pthread_t tid;	/* the worker's thread ID */
 	rsRetVal (*OnMsgReceive)(tcps_sess_t *, uchar *pszMsg, int iLenMsg); /* submit message callback */
+
+	/* support for multiple workers */
+	sbool bWrkrRunning; /* are the worker threads running? */
+	pthread_mutex_t wrkrMut;
+	pthread_cond_t wrkrIdle;
+	int wrkrMax;
+	int wrkrRunning;
+	struct tcpsrv_wrkrInfo_s wrkrInfo[4];
 };
 
 

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -67,7 +67,7 @@ export TB_ERR_TIMEOUT=101
 # CONFIG
 export ZOOPIDFILE="$(pwd)/zookeeper.pid"
 
-#valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
+valgrind="valgrind --malloc-fill=ff --free-fill=fe --log-fd=1"
 #valgrind="valgrind --tool=callgrind" # for kcachegrind profiling
 
 # **** use the line below for very hard to find leaks! *****
@@ -77,8 +77,8 @@ export ZOOPIDFILE="$(pwd)/zookeeper.pid"
 #valgrind="valgrind --tool=helgrind --log-fd=1 --suppressions=$srcdir/linux_localtime_r.supp --gen-suppressions=all"
 #valgrind="valgrind --tool=exp-ptrcheck --log-fd=1"
 #set -o xtrace
-#export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
-#export RSYSLOG_DEBUGLOG="log"
+export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
+export RSYSLOG_DEBUGLOG="log"
 TB_TIMEOUT_STARTSTOP=400 # timeout for start/stop rsyslogd in tenths (!) of a second 400 => 40 sec
 # note that 40sec for the startup should be sufficient even on very slow machines. we changed this from 2min on 2017-12-12
 TB_TEST_TIMEOUT=90  # number of seconds after which test checks timeout (eg. waits)

--- a/tests/imtcp-basic.sh
+++ b/tests/imtcp-basic.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=10000
+export NUMMESSAGES=4000 #10000
+#export NUMMESSAGES=10000
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '


### PR DESCRIPTION
The worker thread pool was a past experiment. It was kept inside the code and it "obviously" worked. However, it was now seen that the implementation with global variable interferes with multiple users of the tcpsrv object. Namely, it could theoretically cause issues between imtcp and imdiag, which routinely share this object inside the testbench.

To fix this, we have now moved the thread pool and its helper variables to the tcpsrv object instance. We preserve the very rough implementation for now.

In this commit are also some other changes to prep for an improved threading model (very early stage, experimental). However, they are currently disabled).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
