### PR TITLE
Fix legacy $ActionQueueDiscardMark parameter

### DIFF
--- a/action.c
+++ b/action.c
@@ -291,7 +291,7 @@ actionResetQueueParams(void)
 	cs.iActionQueueDeqBatchSize = 16;		/* default batch size */
 	cs.iActionQHighWtrMark = -1;			/* high water mark for disk-assisted queues */
 	cs.iActionQLowWtrMark = -1;			/* low water mark for disk-assisted queues */
-	cs.iActionQDiscardMark = 980;			/* begin to discard messages */
+	cs.iActionQDiscardMark = -1;			/* begin to discard messages */
 	cs.iActionQDiscardSeverity = 8;			/* discard warning and above */
 	cs.iActionQueueNumWorkers = 1;			/* number of worker threads for the mm queue above */
 	cs.iActionQueMaxFileSize = 1024*1024;

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -246,7 +246,7 @@ static void cnfSetDefaults(rsconf_t *pThis)
 	pThis->globals.mainQ.iMainMsgQueueSize = 100000;
 	pThis->globals.mainQ.iMainMsgQHighWtrMark = 80000;
 	pThis->globals.mainQ.iMainMsgQLowWtrMark = 20000;
-	pThis->globals.mainQ.iMainMsgQDiscardMark = 98000;
+	pThis->globals.mainQ.iMainMsgQDiscardMark = -1;
 	pThis->globals.mainQ.iMainMsgQDiscardSeverity = 8;
 	pThis->globals.mainQ.iMainMsgQueueNumWorkers = 2;
 	pThis->globals.mainQ.MainMsgQueType = QUEUETYPE_FIXED_ARRAY;


### PR DESCRIPTION
If the `$ActionQueueSize` legacy parameter was configured with a much higher value than the default, the `queueDiscardMark` option was not automatically adjusted to represent 98% of the actual queue size. This caused a misalignment issue, which does not occur when using the RainerScript syntax.

To reproduce:
Specify `$ActionQueueSize 10000` without altering `$ActionQueueDiscardMark`.

The documentation did not properly reflect the internal state, I created a doc PR as well: https://github.com/rsyslog/rsyslog-doc/pull/1068 