### PR TITLE
imdiag bugfix: racy network driver selection

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -623,6 +623,7 @@ addTCPListener(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	CHKiRet(tcpsrv.SetCBOpenLstnSocks(pOurTcpsrv, doOpenLstnSocks));
 	CHKiRet(tcpsrv.SetCBOnRegularClose(pOurTcpsrv, onRegularClose));
 	CHKiRet(tcpsrv.SetCBOnErrClose(pOurTcpsrv, onErrClose));
+	CHKiRet(tcpsrv.SetDrvrName(pOurTcpsrv, (uchar*) "ptcp")); /* imdiag always uses plain tcp */
 	CHKiRet(tcpsrv.SetDrvrMode(pOurTcpsrv, iStrmDrvrMode));
 	CHKiRet(tcpsrv.SetOnMsgReceive(pOurTcpsrv, OnMsgReceived));
 	/* now set optional params, but only if they were actually configured */


### PR DESCRIPTION
The testbench helper imdiag did not properly set the network stream driver to use but instead relyed on the default one. Depending on timing, this could mean that either ptcp or a configured default driver could be used, e.g. one of the TLS drivers. With TLS, processing did not happen correctly and could lead to abort.

In any case, imdiag was never meant to be used with any other driver than ptcp (plain tcp). It just uses the tcpsrv component in order to not implement another server.

The year-old problem is possibly the cause for some flakiness in some of the TLS tests, for which we could not find the root cause so far.

In any case, we now request the ptcp driver hardcoded, which not only solves the issue but is the proper thing to do.

Note: imdiag is a testbench tool and we do not expect that someone uses it in production.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
