### PR TITLE
mmkubernetes: nitfix

### DIFF
--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -305,8 +305,8 @@ static int init_annotationmatch(annotation_match_t *match, struct cnfarray *ar) 
 	DEFiRet;
 
 	match->nmemb = ar->nmemb;
-	CHKmalloc(match->patterns = calloc(sizeof(uchar*), match->nmemb));
-	CHKmalloc(match->regexps = calloc(sizeof(regex_t), match->nmemb));
+	CHKmalloc(match->patterns = calloc(match->nmemb, sizeof(uchar*)));
+	CHKmalloc(match->regexps = calloc(match->nmemb, sizeof(regex_t)));
 	for(int jj = 0; jj < ar->nmemb; ++jj) {
 		int rexret = 0;
 		match->patterns[jj] = (uchar*)es_str2cstr(ar->arr[jj], NULL);
@@ -334,7 +334,7 @@ static int copy_annotationmatch(annotation_match_t *src, annotation_match_t *des
 
 	dest->nmemb = src->nmemb;
 	CHKmalloc(dest->patterns = malloc(sizeof(uchar*) * dest->nmemb));
-	CHKmalloc(dest->regexps = calloc(sizeof(regex_t), dest->nmemb));
+	CHKmalloc(dest->regexps = calloc(dest->nmemb, sizeof(regex_t)));
 	for(int jj = 0 ; jj < src->nmemb ; ++jj) {
 		CHKmalloc(dest->patterns[jj] = (uchar*)strdup((char *)src->patterns[jj]));
 		/* assumes was already successfully compiled */


### PR DESCRIPTION
calloc() parameters were given in wrong order, which is incorrect but no problem in current practice. No need to update any old binaries.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
