### PR TITLE
imtcp support for NetworkNamespace

### DIFF
--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -47,6 +47,7 @@ struct tcpLstnParams_s {
     sbool bSPFramingFix; /**< support work-around for broken Cisco ASA framing? */
     sbool bPreserveCase; /**< preserve case in fromhost */
     const uchar *pszLstnPortFileName; /**< File in which the dynamic port is written */
+    char *pszNetworkNamespace; /**< network namespace to use */
     uchar *pszStrmDrvrName; /**< stream driver to use */
     uchar *pszInputName; /**< value to be used as input name */
     prop_t *pInputName;
@@ -280,8 +281,27 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
     /* added v28 */
     rsRetVal (*SetNumWrkr)(tcpsrv_t *pThis, int);
     rsRetVal (*SetStarvationMaxReads)(tcpsrv_t *pThis, unsigned int);
+    /* added v29 */
+    /*
+     * @brief Set the Network Namespace into the listener parameters
+     * @param pThis The associated TCP Server instance
+     * @param cnf_params The listener parameters to configure
+     * @param networkNamespace The namespace parameter to set into the
+     *                         listener configuration parameters
+     * @return RS_RET_OK on success, otherwise a failure code.
+     * @details For platforms that do not support network namespaces,
+     *          this function should fail for any non-null and non-empty
+     *          namespace passed.  Note that the empty string is treated
+     *          the same as a NULL, i.e. you are not allowed to actually
+     *          use a network namespace with the empty string.  So both
+     *          a NULL and an empty string "" both mean to use the
+     *          original startup network namespace.
+     */
+    rsRetVal (*SetNetworkNamespace)(tcpsrv_t *pThis, tcpLstnParams_t *const cnf_params,
+                                    const char *const networkNamespace);
+
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 28 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 29 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -628,6 +628,7 @@ TESTS +=  \
 	imtcp-maxFrameSize.sh \
 	imtcp-msg-truncation-on-number.sh \
 	imtcp-msg-truncation-on-number2.sh \
+	imtcp-netns.sh \
 	imtcp-NUL.sh \
 	imtcp-NUL-rawmsg.sh \
 	imtcp_incomplete_frame_at_end.sh \
@@ -1466,6 +1467,7 @@ TESTS +=  \
 	imptcp-oversize-message-display.sh \
 	imptcp-msg-truncation-on-number.sh \
 	imptcp-msg-truncation-on-number2.sh \
+	imtcp-netns.sh \
 	imptcp-maxFrameSize-parameter.sh \
 	mmjsonparse_cim.sh \
 	mmjsonparse_cim2.sh \
@@ -2442,6 +2444,7 @@ EXTRA_DIST= \
 	imptcp-oversize-message-display.sh \
 	imptcp-msg-truncation-on-number.sh \
 	imptcp-msg-truncation-on-number2.sh \
+	imtcp-netns.sh \
 	imptcp-maxFrameSize-parameter.sh \
 	mmjsonparse_cim.sh \
 	mmjsonparse_cim2.sh \
@@ -2528,6 +2531,7 @@ EXTRA_DIST= \
 	imtcp-maxFrameSize.sh \
 	imtcp-msg-truncation-on-number.sh \
 	imtcp-msg-truncation-on-number2.sh \
+	imtcp-netns.sh \
 	imtcp-NUL.sh \
 	imtcp-NUL-rawmsg.sh \
 	imtcp-tls-gtls-x509fingerprint-invld.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -627,7 +627,7 @@ startup_vg_waitpid_only() {
 	# add --keep-debuginfo=yes for hard to find cases; this cannot be used generally,
 	# because it is only supported by newer versions of valgrind (else CI will fail
 	# on older platforms).
-	LD_PRELOAD=$RSYSLOG_PRELOAD valgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/known_issues.supp ${EXTRA_VALGRIND_SUPPRESSIONS:-} --gen-suppressions=all --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=$RS_TESTBENCH_LEAK_CHECK ../tools/rsyslogd -C -n -i$RSYSLOG_PIDBASE$instance.pid -M../runtime/.libs:../.libs -f$CONF_FILE &
+	eval LD_PRELOAD=$RSYSLOG_PRELOAD valgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --suppressions=$srcdir/known_issues.supp ${EXTRA_VALGRIND_SUPPRESSIONS:-} --gen-suppressions=all --log-fd=1 --error-exitcode=10 --malloc-fill=ff --free-fill=fe --leak-check=$RS_TESTBENCH_LEAK_CHECK ../tools/rsyslogd -C -n -i$RSYSLOG_PIDBASE$instance.pid -M../runtime/.libs:../.libs -f$CONF_FILE $RS_REDIR &
 	wait_rsyslog_startup_pid $1
 }
 

--- a/tests/imtcp-netns-vg.sh
+++ b/tests/imtcp-netns-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/imtcp-netns.sh

--- a/tests/imtcp-netns.sh
+++ b/tests/imtcp-netns.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# This test tests listening on ports in another network namespace.
+echo ===============================================================================
+echo \[imtcp-netns.sh\]: test for listening in another network namespace
+echo This test must be run with CAP_SYS_ADMIN capabilities [network namespace creation/change required]
+if [ "$EUID" -ne 0 ]; then
+    exit 77 # Not root, skip this test
+fi
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+
+NS_PREFIX=$(basename ${RSYSLOG_DYNNAME})
+NS_DEFAULT="${NS_PREFIX}.rsyslog_ns_default"
+NS_FAIL=(
+   "${NS_PREFIX}.rsyslog_ns_a_fail"
+   "${NS_PREFIX}.rsyslog_ns_b_fail"
+)
+NS_GOOD=(
+   "${NS_PREFIX}.rsyslog_ns_c"
+   "${NS_PREFIX}.rsyslog_ns_d"
+)
+
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+module(
+    load="../plugins/imtcp/.libs/imtcp"
+    NetworkNamespace="'${NS_DEFAULT}'"
+)
+input(
+    Type="imtcp"
+    Port="0"
+    Address="127.0.0.1"
+    ListenPortFileName="'${NS_DEFAULT}'.port"
+)
+'
+
+for ns in "${NS_GOOD[@]}" "${NS_FAIL[@]}"; do
+    add_conf '
+        input(
+            Type="imtcp"
+            Port="0"
+            Address="127.0.0.1"
+            NetworkNamespace="'${ns}'"
+            ListenPortFileName="'${ns}'.port"
+        )
+    '
+done
+
+add_conf '
+input(
+    Type="imtcp"
+    Port="0"
+    Address="127.0.0.1"
+    NetworkNamespace=""
+    ListenPortFileName="'$RSYSLOG_DYNNAME'.port"
+)
+
+template(name="outfmt" type="string" string="%msg:%\n")
+:msg, contains, "imtcp-netns:" action(
+    type="omfile"
+    file="'${RSYSLOG_OUT_LOG}'"
+    template="outfmt"
+)
+'
+#
+# create network namespace and bring it up
+NS=(
+    "${NS_DEFAULT}"
+    "${NS_GOOD[@]}"
+)
+for ns in "${NS[@]}"; do
+    ip netns add "${ns}"
+    ip netns exec "${ns}" ip link set dev lo up
+done
+for ns in "${NS_FAIL[@]}"; do
+    ip netns delete "${ns}" > /dev/null 2>&1
+done
+
+# now do the usual run
+RS_REDIR="> ${RSYSLOG_DYNNAME}.log 2>&1"
+startup
+wait_file_exists "${RSYSLOG_DYNNAME}.port"
+for ns in "${NS[@]}"; do
+    wait_file_exists "${ns}.port"
+done
+
+MSGS=()
+function logmsg() {
+    local ns=$1
+    local msg=$2
+    local logger_cmd=()
+    local port_file=${RSYSLOG_DYNNAME}.port
+
+    if [[ -n "${ns}" ]]; then
+        logger_cmd+=(ip netns exec "${ns}")
+        port_file="${ns}.port"
+    fi
+    logger_cmd+=(
+        logger
+        --tcp
+        --server 127.0.0.1
+        --octet-count
+        --tag "$0"
+        --port "$(cat ${port_file})"
+        --
+        "imtcp-netns: ${msg}"
+    )
+    "${logger_cmd[@]}"
+    MSGS+=("imtcp-netns: ${msg}")
+}
+
+# Inject a few messages
+logmsg "" "start message from local namespace"
+for ns in "${NS[@]}"; do
+    logmsg "${ns}" "test message from namespace ${ns}"
+    # Try to keep them ordered
+    sleep 1
+done
+logmsg "" "end message from local namespace"
+
+shutdown_when_empty
+wait_shutdown
+
+# remove network namespaces
+for ns in "${NS[@]}"; do
+    ip netns delete "${ns}"
+done
+
+EXPECTED=$(printf "%s\n" "${MSGS[@]}")
+cmp_exact
+
+# Verify we have error messages for the missing namespaces
+for ns in "${NS_FAIL[@]}"; do
+    content_check "netns_switch: could not open namespace '${ns}':" ${RSYSLOG_DYNNAME}.log
+done
+exit_test


### PR DESCRIPTION
This adds a NetworkNamespace parameter to imtcp, based on the omfwd implementation.

This builds on "PR#6121 net: Add NetworkNamespace APIS" to add Network Namespace support to imtcp module.  This extends imtcp to support a wider range of Unix/Linux environments (or any environment supporting network namespaces).
    
The imtcp module is enhanced to accept a NetworkNamespace parameter, both as a default at the module level, and on a per-instance basis.
    
The tcpsrv module is enhanced to allow the NetworkNamespace to be applied to a listener's configuration parameters.
    
Finally, the netstrm module is enhanced to switch namespaces before invoking the downstream (driver specific) LstnInit function.
    
A new test imtcp-netns (and associated imtcp-netns-vg) is added to test this functionality.  This must be run as root (technically it must be run by a user with CAP_SYS_ADMIN capabilities, as network namespace creating/change is required).
    
A slight change to diag.sh is made to allow passing $RS_REDIR to valgrind (as $RS_REDIR is used in the imtcp-netns.sh test for some negative cases).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
