### PR TITLE
CI: remove libgrok-related codeql checks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,6 @@ jobs:
               libgcrypt20-dev \
               libglib2.0-dev \
               libgnutls28-dev \
-              libgrok1 libgrok-dev \
               libhiredis-dev \
               libkrb5-dev \
               liblz4-dev \
@@ -84,7 +83,7 @@ jobs:
         if: ${{ matrix.language == 'cpp' }}
         run: |
           autoreconf -fvi
-          ./configure --enable-imfile --enable-mysql --enable-usertools --enable-pgsql --enable-libdbi --enable-snmp --enable-elasticsearch --enable-gnutls --enable-mail --enable-imdiag --enable-mmjsonparse --enable-mmaudit --enable-mmanon --enable-mmrm1stspace --enable-mmutf8fix --enable-mmcount --enable-mmdblookup --enable-mmfields --enable-mmpstrucdata --enable-imptcp --enable-impstats --enable-omprog --enable-omudpspoof --enable-omstdout --enable-omjournal --enable-pmlastmsg --enable-pmcisconames --enable-pmciscoios --enable-pmnull --enable-pmaixforwardedfrom --enable-pmsnare --enable-pmpanngfw --enable-omuxsock --enable-omkafka --enable-imkafka --enable-ommongodb --enable-omhiredis --enable-omhttpfs --enable-gssapi-krb5 --enable-mmkubernetes --enable-relp --enable-mmnormalize --enable-pmnormalize --enable-openssl --enable-mmgrok --enable-omtcl --enable-omhttp --enable-improg --enable-imtuxedoulog --enable-mmtaghostname --enable-imbatchreport --enable-imdocker --enable-mmdarwin --enable-pmdb2diag --enable-omrabbitmq --enable-libzstd
+          ./configure --enable-imfile --enable-mysql --enable-usertools --enable-pgsql --enable-libdbi --enable-snmp --enable-elasticsearch --enable-gnutls --enable-mail --enable-imdiag --enable-mmjsonparse --enable-mmaudit --enable-mmanon --enable-mmrm1stspace --enable-mmutf8fix --enable-mmcount --enable-mmdblookup --enable-mmfields --enable-mmpstrucdata --enable-imptcp --enable-impstats --enable-omprog --enable-omudpspoof --enable-omstdout --enable-omjournal --enable-pmlastmsg --enable-pmcisconames --enable-pmciscoios --enable-pmnull --enable-pmaixforwardedfrom --enable-pmsnare --enable-pmpanngfw --enable-omuxsock --enable-omkafka --enable-imkafka --enable-ommongodb --enable-omhiredis --enable-omhttpfs --enable-gssapi-krb5 --enable-mmkubernetes --enable-relp --enable-mmnormalize --enable-pmnormalize --enable-openssl --disable-mmgrok --enable-omtcl --enable-omhttp --enable-improg --enable-imtuxedoulog --enable-mmtaghostname --enable-imbatchreport --enable-imdocker --enable-mmdarwin --enable-pmdb2diag --enable-omrabbitmq --enable-libzstd
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
libgrok1 seems to be no longer avaiblabe under Ubuntu 24.04, which now is being used for running codeql.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
