### PR TITLE
Replaced inet_aton with inet_pton for IPv4 address conversion.

### DIFF
--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -304,18 +304,17 @@ static rsRetVal omsnmp_sendsnmp(wrkrInstanceData_t *pWrkrData, uchar *psz, uchar
 
 		/* Set PDU SOurce property if available */
 		if (pszSource != NULL) {
-			if (inet_aton((const char *)pszSource, &srcAddr.sin_addr) != 0) {
-				pdu->agent_addr[0] = (srcAddr.sin_addr.s_addr) & 0xFF;
-				pdu->agent_addr[1] = (srcAddr.sin_addr.s_addr >> 8) & 0xFF;
-				pdu->agent_addr[2] = (srcAddr.sin_addr.s_addr >> 16) & 0xFF;
-				pdu->agent_addr[3] = (srcAddr.sin_addr.s_addr >> 24) & 0xFF;
-				dbgprintf( "omsnmp_sendsnmp: SNMPv1 Source Property set to %d.%d.%d.%d\n",
-					(srcAddr.sin_addr.s_addr) & 0xFF,
-					(srcAddr.sin_addr.s_addr >> 8) & 0xFF,
-					(srcAddr.sin_addr.s_addr >> 16) & 0xFF,
-					(srcAddr.sin_addr.s_addr >> 24) & 0xFF);
+			if (inet_pton(AF_INET, (const char *)pszSource, &srcAddr.sin_addr) == 1) {
+				uint32_t s_addr = ntohl(srcAddr.sin_addr.s_addr);
+				pdu->agent_addr[0] = (s_addr) & 0xFF;
+				pdu->agent_addr[1] = (s_addr >> 8) & 0xFF;
+				pdu->agent_addr[2] = (s_addr >> 16) & 0xFF;
+				pdu->agent_addr[3] = (s_addr >> 24) & 0xFF;
+
+				dbgprintf("omsnmp_sendsnmp: SNMPv1 Source Property set to %d.%d.%d.%d\n",
+					pdu->agent_addr[0], pdu->agent_addr[1], pdu->agent_addr[2], pdu->agent_addr[3]);
 			} else {
-				LogError(0, NO_ERRCODE, "omsnmp_sendsnmp: Failed to convert '%s' into a valid IPv4"
+				LogError(0, NO_ERRCODE, "omsnmp_sendsnmp: Failed to convert '%s' into a valid IPv4 "
 					"address\n", pszSource);
 			}
 		}


### PR DESCRIPTION
inet_pton is part of POSIX, whilst inet_aton is not. Moreover the function is marked as forbidden according to rpmlint: Forbidden function symbols found: inet_aton
I've been inspecting the following logs for all architectures we currently support on Fedora:
```
badfuncs
VERIFY /usr/lib64/rsyslog/omsnmp.so may use forbidden functions on aarch64 Anyone
Suggested remedy:

Forbidden symbols were found in an ELF file in the package. The configuration settings for rpminspect indicate the named symbols are forbidden in packages. If this is deliberate, you may want to disable the badfuncs inspection. If it is not deliberate, check the man pages for the named symbols to see what API functions have replaced the forbidden symbols. Usually a function is marked as deprecated but still provided in order to allow for backwards compatibility. Whenever possible the deprecated functions should not be used.
Forbidden function symbols found:
	inet_aton
```