### PR TITLE
Increase default backlog and adapt imptcp tests for connection loads

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1695,7 +1695,7 @@ createInstance(instanceConf_t **pinst)
 	inst->ratelimitInterval = 0; /* off */
 	inst->compressionMode = COMPRESS_SINGLE_MSG;
 	inst->multiLine = 0;
-	inst->socketBacklog = 5;
+	inst->socketBacklog = 64;
 	inst->pszLstnPortFileName = NULL;
 	inst->iTCPSessMax = -1;
 

--- a/tests/manyptcp.sh
+++ b/tests/manyptcp.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 $MaxOpenFiles 2000
 module(load="../plugins/imptcp/.libs/imptcp")
-input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+input(type="imptcp" SocketBacklog="1000" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")


### PR DESCRIPTION
### Increase default backlog and adapt imptcp tests for connection loads

This PR includes two commits aimed at improving the performance and reliability of the `imptcp` server and its associated test suite:

#### Commit 1: Increase default SYN backlog for imptcp server
- The default TCP SYN backlog for the `imptcp` server has been increased from 5 to 64.
- This change resolves potential connection instability and performance issues in scenarios with high connection loads, such as rapid bursts of concurrent client connections.
- The backlog can now be configured via the `SocketBacklog` parameter, which is recommended to be adjusted for workloads with:
  - High rates of concurrent connection openings.
  - Burst traffic scenarios.
  - Resource-intensive environments.

#### Commit 2: Adapt imptcp tests for large connection counts
- Updated the test suite to set the `SocketBacklog` parameter to a higher value to handle tests with a large number of concurrent connections.
- This change reduces CI flakes caused by SYN queue overflows and significantly improves test runtime by reducing delays during connection setup.
- The adjustment ensures better reliability and smoother handling of high connection counts during testing.

These changes collectively improve the stability, performance, and testing reliability of the `imptcp` server.
