### PR TITLE
imtcp: add "socketBacklog" parameter to configure TCP backlog size

### DIFF
--- a/runtime/netstrms.c
+++ b/runtime/netstrms.c
@@ -1,8 +1,8 @@
 /* netstrms.c
  *
- * Work on this module begung 2008-04-23 by Rainer Gerhards.
+ * Work on this module begun 2008-04-23 by Rainer Gerhards.
  *
- * Copyright 2008-2021 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2025 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -140,6 +140,16 @@ netstrmsConstructFinalize(netstrms_t *pThis)
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, netstrms);
 	iRet = loadDrvr(pThis);
+	RETiRet;
+}
+
+
+static rsRetVal
+SetSynBacklog(netstrms_t *pThis, const int iSynBacklog)
+{
+	DEFiRet;
+	ISOBJ_TYPE_assert(pThis, netstrms);
+	pThis->iSynBacklog = iSynBacklog;
 	RETiRet;
 }
 
@@ -473,6 +483,7 @@ CODESTARTobjQueryInterface(netstrms)
 	pIf->ConstructFinalize = netstrmsConstructFinalize;
 	pIf->Destruct = netstrmsDestruct;
 	pIf->CreateStrm = CreateStrm;
+	pIf->SetSynBacklog = SetSynBacklog;
 	pIf->SetDrvrName = SetDrvrName;
 	pIf->SetDrvrMode = SetDrvrMode;
 	pIf->GetDrvrMode = GetDrvrMode;

--- a/runtime/netstrms.h
+++ b/runtime/netstrms.h
@@ -1,6 +1,6 @@
-/* Definitions for the stream-based netstrmsworking class.
+/* Definitions for the stream-based netstrm sworking class.
  *
- * Copyright 2007-2021 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2025 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -42,6 +42,7 @@ struct netstrms_s {
 	const uchar *pszDrvrKeyFile;
 	const uchar *pszDrvrCertFile;
 	uchar *gnutlsPriorityString; /**< priorityString for connection */
+	int iSynBacklog;	/**< socket layer syn backlog for listen() */
 	permittedPeers_t *pPermPeers;/**< current driver's permitted peers */
 	rsRetVal(*fLstnInitDrvr)(netstrm_t*); /**< "late" driver-specific lstn init function NULL if none */
 
@@ -83,8 +84,11 @@ BEGINinterface(netstrms) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetDrvrTlsCRLFile)(netstrms_t *pThis, const uchar *);
 	const uchar* (*GetDrvrTlsCRLFile)(netstrms_t *pThis);
 
+	/* v4 */
+	rsRetVal (*SetSynBacklog)(netstrms_t *pThis, const int);
+
 ENDinterface(netstrms)
-#define netstrmsCURR_IF_VERSION 3 /* increment whenever you change the interface structure! */
+#define netstrmsCURR_IF_VERSION 4 /* increment whenever you change the interface structure! */
 
 /* prototypes */
 PROTOTYPEObj(netstrms);

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -688,7 +688,8 @@ LstnInit(netstrms_t *const pNS, void *pUsr, rsRetVal(*fAddLstn)(void*,netstrm_t*
 			}
 		}
 
-		if(listen(sock, iSessMax / 10 + 5) < 0) {
+		const int iSynBacklog = (pNS->iSynBacklog == 0) ? iSessMax / 10 + 5 : pNS->iSynBacklog;
+		if(listen(sock, iSynBacklog) < 0) {
 			/* If the listen fails, it most probably fails because we ask
 			 * for a too-large backlog. So in this case we first set back
 			 * to a fixed, reasonable, limit that should work. Only if

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -21,7 +21,7 @@
  * File begun on 2007-12-21 by RGerhards (extracted from syslogd.c[which was
  * licensed under BSD at the time of the rsyslog fork])
  *
- * Copyright 2007-2022 Adiscon GmbH.
+ * Copyright 2007-2025 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -1033,6 +1033,7 @@ BEGINobjConstruct(tcpsrv) /* be sure to specify the object type also in END macr
 	pThis->bUseFlowControl = 1;
 	pThis->pszDrvrName = NULL;
 	pThis->bPreserveCase = 1; /* preserve case in fromhost; default to true. */
+	pThis->iSynBacklog = 0; /* default: unset */
 	pThis->DrvrTlsVerifyDepth = 0;
 ENDobjConstruct(tcpsrv)
 
@@ -1046,6 +1047,7 @@ tcpsrvConstructFinalize(tcpsrv_t *pThis)
 
 	/* prepare network stream subsystem */
 	CHKiRet(netstrms.Construct(&pThis->pNS));
+	CHKiRet(netstrms.SetSynBacklog(pThis->pNS, pThis->iSynBacklog));
 	if(pThis->pszDrvrName != NULL)
 		CHKiRet(netstrms.SetDrvrName(pThis->pNS, pThis->pszDrvrName));
 	CHKiRet(netstrms.SetDrvrMode(pThis->pNS, pThis->iDrvrMode));
@@ -1581,6 +1583,14 @@ SetPreserveCase(tcpsrv_t *pThis, int bPreserveCase)
 }
 
 
+static rsRetVal
+SetSynBacklog(tcpsrv_t *pThis, const int iSynBacklog)
+{
+	pThis->iSynBacklog = iSynBacklog;
+	return RS_RET_OK;
+}
+
+
 /* queryInterface function
  * rgerhards, 2008-02-29
  */
@@ -1648,6 +1658,7 @@ CODESTARTobjQueryInterface(tcpsrv)
 	pIf->SetDrvrCheckExtendedKeyUsage = SetDrvrCheckExtendedKeyUsage;
 	pIf->SetDrvrPrioritizeSAN = SetDrvrPrioritizeSAN;
 	pIf->SetDrvrTlsVerifyDepth = SetDrvrTlsVerifyDepth;
+	pIf->SetSynBacklog = SetSynBacklog;
 
 finalize_it:
 ENDobjQueryInterface(tcpsrv)

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -1,6 +1,6 @@
 /* Definitions for tcpsrv class.
  *
- * Copyright 2008-2022 Adiscon GmbH.
+ * Copyright 2008-2025 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -106,6 +106,7 @@ struct tcpsrv_s {
 	int bDisableLFDelim;	/**< if 1, standard LF frame delimiter is disabled (*very dangerous*) */
 	int discardTruncatedMsg;/**< discard msg part that has been truncated*/
 	sbool bPreserveCase;	/**< preserve case in fromhost */
+	int iSynBacklog;
 	unsigned int ratelimitInterval;
 	unsigned int ratelimitBurst;
 	tcps_sess_t **pSessions;/**< array of all of our sessions */
@@ -213,8 +214,10 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetDrvrCertFile)(tcpsrv_t *pThis, uchar *pszMode);
 	/* added v26 -- Options for TLS CRL file */
 	rsRetVal (*SetDrvrCRLFile)(tcpsrv_t *pThis, uchar *pszMode);
+	/* added v27 -- sync backlog for listen() */
+	rsRetVal (*SetSynBacklog)(tcpsrv_t *pThis, int);
 ENDinterface(tcpsrv)
-#define tcpsrvCURR_IF_VERSION 26 /* increment whenever you change the interface structure! */
+#define tcpsrvCURR_IF_VERSION 27 /* increment whenever you change the interface structure! */
 /* change for v4:
  * - SetAddtlFrameDelim() added -- rgerhards, 2008-12-10
  * - SetInputName() added -- rgerhards, 2008-12-10

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2467,6 +2467,8 @@ EXTRA_DIST= \
 	imtcp-tls-ossl-error-key.sh \
 	imtcp-tls-ossl-error-key2.sh \
 	manytcp.sh \
+	imtcp-tls-gtls-manycon.sh \
+	imtcp-tls-ossl-manycon.sh \
 	manyptcp.sh \
 	imptcp-basic-hup.sh \
 	imptcp-NUL.sh \

--- a/tests/imtcp-tls-gtls-manycon.sh
+++ b/tests/imtcp-tls-gtls-manycon.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=100000
+ulimit -n 2048 # may or may not work ;-)
+generate_conf
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+#	debug.whitelist="on"
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="x509/name"
+	#PermittedPeer=["/CN=rsyslog-client/OU=Adiscon GmbH/O=Adiscon GmbH/L=Grossrinderfeld/ST=BW/C=DE/DC=rsyslog.com","rsyslog.com"]
+	PermittedPeer=["rsyslog-client"]
+     )
+input(type="imtcp" socketBacklog="1000" maxsessions="1000" port="0"
+	listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(	type="omfile" 
+					template="outfmt"
+					file=`echo $RSYSLOG_OUT_LOG`)
+'
+# Begin actual testcase
+startup
+tcpflood -c-1000 -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+wait_file_lines
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/imtcp-tls-ossl-manycon.sh
+++ b/tests/imtcp-tls-ossl-manycon.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=100000
+ulimit -n 2048 # may or may not work ;-)
+generate_conf
+add_conf '
+global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+#	debug.whitelist="on"
+#	debug.files=["net_ossl.c", "nsd_ossl.c", "nsd_ptcp.c", "tcpsrv.c", "nsdsel_ossl.c", "nsdpoll_ptcp.c", "dnscache.c"]
+)
+
+module(	load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="ossl"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="x509/name"
+	PermittedPeer=["/CN=rsyslog-client/OU=Adiscon GmbH/O=Adiscon GmbH/L=Grossrinderfeld/ST=BW/C=DE/DC=rsyslog.com","rsyslog.com"]
+     )
+input(type="imtcp" socketBacklog="1000" maxsessions="1000" port="0"
+	listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+:msg, contains, "msgnum:" action(	type="omfile" 
+					template="outfmt"
+					file=`echo $RSYSLOG_OUT_LOG`)
+'
+# Begin actual testcase
+startup
+tcpflood -c-1000 -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+wait_file_lines
+shutdown_when_empty
+wait_shutdown
+seq_check
+exit_test

--- a/tests/manytcp-too-few-tls-vg.sh
+++ b/tests/manytcp-too-few-tls-vg.sh
@@ -19,7 +19,7 @@ global(
 
 module(load="../plugins/imtcp/.libs/imtcp" maxSessions="1100"
        streamDriver.mode="1" streamDriver.authMode="anon")
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+input(type="imtcp" socketBacklog="1000" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!

--- a/tests/manytcp.sh
+++ b/tests/manytcp.sh
@@ -9,7 +9,7 @@ generate_conf
 add_conf '
 $MaxOpenFiles 2100
 module(load="../plugins/imtcp/.libs/imtcp" maxSessions="2100")
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+input(type="imtcp" socketBacklog="2000" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!


### PR DESCRIPTION
   A new "socketBacklog" parameter has been added to the imtcp module, allowing
   users to override the default TCP SYN backlog size. Previously, the backlog
    was set to roughly 10% of the configured max sessions, which remains the
    default if the parameter is not specified. This enhancement enables better
    configuration for high-performance servers. The parameter name aligns with
    the "socketBacklog" parameter in imptcp for consistency.
    
The "socketBacklog" parameter should be set based on the anticipated connection
rate and the server's ability to handle incoming connections. For high-performance
environments with heavy traffic, a larger value may be needed to avoid dropped
connections during bursts. If unsure, leave the parameter unset to use the default
(10% of max sessions), which is suitable for typical workloads.
