### PR TITLE
omfwd: align some parameters with imtcp names

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -235,8 +235,11 @@ static struct cnfparamdescr actpdescr[] = {
 	{ "conerrskip", eCmdHdlrNonNegInt, 0 },
 	{ "gnutlsprioritystring", eCmdHdlrString, 0 },
 	{ "streamdriver", eCmdHdlrGetWord, 0 },
+	{ "streamdriver.name", eCmdHdlrGetWord, 0 }, /* alias for streamdriver */
 	{ "streamdrivermode", eCmdHdlrInt, 0 },
+	{ "streamdriver.mode", eCmdHdlrInt, 0 },  /* alias for streamdrivermode */
 	{ "streamdriverauthmode", eCmdHdlrGetWord, 0 },
+	{ "streamdriver.authmode", eCmdHdlrGetWord, 0 }, /* alias for streamdriverauthmode */
 	{ "streamdriverpermittedpeers", eCmdHdlrGetWord, 0 },
 	{ "streamdriver.permitexpiredcerts", eCmdHdlrGetWord, 0 },
 	{ "streamdriver.CheckExtendedKeyPurpose", eCmdHdlrBinary, 0 },
@@ -1739,9 +1742,11 @@ CODESTARTnewActInst
 			pData->iConErrSkip = (int) pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "gnutlsprioritystring")) {
 			pData->gnutlsPriorityString = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
-		} else if(!strcmp(actpblk.descr[i].name, "streamdriver")) {
+		} else if(   !strcmp(actpblk.descr[i].name, "streamdriver")
+			  || !strcmp(actpblk.descr[i].name, "streamdriver.name")) {
 			pData->pszStrmDrvr = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
-		} else if(!strcmp(actpblk.descr[i].name, "streamdrivermode")) {
+		} else if(   !strcmp(actpblk.descr[i].name, "streamdrivermode")
+			  || !strcmp(actpblk.descr[i].name, "streamdrivermode")) {
 			pData->iStrmDrvrMode = pvals[i].val.d.n;
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.CheckExtendedKeyPurpose")) {
 			pData->iStrmDrvrExtendedCertCheck = pvals[i].val.d.n;
@@ -1754,7 +1759,8 @@ CODESTARTnewActInst
 				parser_errmsg("streamdriver.TlsVerifyDepth must be 2 or higher but is %d",
 									(int) pvals[i].val.d.n);
 			}
-		} else if(!strcmp(actpblk.descr[i].name, "streamdriverauthmode")) {
+		} else if(   !strcmp(actpblk.descr[i].name, "streamdriverauthmode")
+			  || !strcmp(actpblk.descr[i].name, "streamdriverauthmode")) {
 			pData->pszStrmDrvrAuthMode = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(actpblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
 			uchar *val = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);


### PR DESCRIPTION
Parameter names have historically evolved and are sometimes inconsistent between modules (while still having the same semantics and similiar name).

This commit creates three aliases in omfwd to keep stream driver parameter names consistent with the names used in imtcp. Note that we do not create an alias for
"streamdriverpermittedpeers" because the name differ more considerably and we would also need to create an alias in imtcp as well. We will do this only on request.

Note: aliases help, but are not a great solution. They may cause confusion if both names are used together in a single config. So care must be taken when using an alias.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
