### PR TITLE
testbench: Added new version of snmptrapreceiver.py for python 3.1x

### DIFF
--- a/tests/snmptrapreceiverv2.py
+++ b/tests/snmptrapreceiverv2.py
@@ -1,7 +1,8 @@
 # call this via "python[3] script name"
 import sys
+import importlib.util
 from pysnmp.entity import engine, config
-from pysnmp.carrier.asyncore.dgram import udp
+from pysnmp.carrier.asyncio.dgram import udp  # Changed from asyncore to asyncio
 from pysnmp.entity.rfc3413 import ntfrcv
 from pysnmp.smi import builder, view, compiler, rfc1902
 from pyasn1.type.univ import OctetString
@@ -61,44 +62,44 @@ logFile.flush()
 # Callback function for receiving notifications
 # noinspection PyUnusedLocal,PyUnusedLocal,PyUnusedLocal
 def cbReceiverSnmp(snmpEngine, stateReference, contextEngineId, contextName, varBinds, cbCtx):
-	transportDomain, transportAddress = snmpEngine.msgAndPduDsp.getTransportInfo(stateReference)
-	if (bDebug):
-		szDebug = str("Notification From: %s, Domain: %s, SNMP Engine: %s, Context: %s" %
-			(transportAddress, transportDomain, contextEngineId.prettyPrint(), contextName.prettyPrint()))
-		print(szDebug)
-		logFile.write(szDebug)
-		logFile.flush()
+    # Change getTransportInfo to get_transport_info
+    transportDomain, transportAddress = snmpEngine.msgAndPduDsp.get_transport_info(stateReference)
+    if (bDebug):
+        szDebug = str("Notification From: %s, Domain: %s, SNMP Engine: %s, Context: %s" %
+            (transportAddress, transportDomain, contextEngineId.prettyPrint(), contextName.prettyPrint()))
+        print(szDebug)
+        logFile.write(szDebug)
+        logFile.flush()
 
 	# Create output String
-	szOut = "Trap Source{}, Trap OID {}".format(transportAddress, transportDomain)
+    szOut = "Trap Source{}, Trap OID {}".format(transportAddress, transportDomain)
 
-	varBinds = [rfc1902.ObjectType(rfc1902.ObjectIdentity(x[0]), x[1]).resolveWithMib(mibViewController) for x in varBinds]
+    varBinds = [rfc1902.ObjectType(rfc1902.ObjectIdentity(x[0]), x[1]).resolveWithMib(mibViewController) for x in varBinds]
 
-	for name, val in varBinds:
-		# Append to output String
-		szOut = szOut + ", Oid: {}, Value: {}".format(name.prettyPrint(), val.prettyPrint())
+    for name, val in varBinds:
+        # Append to output String
+        szOut = szOut + ", Oid: {}, Value: {}".format(name.prettyPrint(), val.prettyPrint())
 
-		if isinstance(val, OctetString):
-			if (name.prettyPrint() != "SNMP-COMMUNITY-MIB::snmpTrapAddress.0"):
-				szOctets = val.asOctets()#.rstrip('\r').rstrip('\n')
-				szOut = szOut + ", Octets: {}".format(szOctets)
-		if (bDebug):
-			print('%s = %s' % (name.prettyPrint(), val.prettyPrint()))
-	outputFile.write(szOut)
-	if "\n" not in szOut:
-		outputFile.write("\n")
-	outputFile.flush()
+        if isinstance(val, OctetString):
+            if (name.prettyPrint() != "SNMP-COMMUNITY-MIB::snmpTrapAddress.0"):
+                szOctets = val.asOctets()#.rstrip('\r').rstrip('\n')
+                szOut = szOut + ", Octets: {}".format(szOctets)
+        if (bDebug):
+            print('%s = %s' % (name.prettyPrint(), val.prettyPrint()))
+    outputFile.write(szOut)
+    if "\n" not in szOut:
+        outputFile.write("\n")
+    outputFile.flush()
 
 
 # Register SNMP Application at the SNMP engine
 ntfrcv.NotificationReceiver(snmpEngine, cbReceiverSnmp)
 
-# this job would never finish
-snmpEngine.transportDispatcher.jobStarted(1)
-
 # Run I/O dispatcher which would receive queries and send confirmations
 try:
-	snmpEngine.transportDispatcher.runDispatcher()
-except:
-	snmpEngine.transportDispatcher.closeDispatcher()
-	raise
+    snmpEngine.transportDispatcher.runDispatcher()
+except KeyboardInterrupt:
+    snmpEngine.transportDispatcher.closeDispatcher()
+except Exception as e:
+    snmpEngine.transportDispatcher.closeDispatcher()
+    raise


### PR DESCRIPTION
The system packages on Ubuntu 24 appear to be broken for python3-pysnmp4. And when we update the package using
	pip install pyasn1 pysnmp --break-system-packages --upgrade

We need adapt the code, so a new version snmptrapreceiverv2.py has been added which will automatically been chosen if Python is >3.10

closes: https://github.com/rsyslog/rsyslog/issues/5554

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
