### PR TITLE
omamqp1: Fixed build on Ubuntu 24

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2751,7 +2751,7 @@ AC_ARG_ENABLE(omamqp1,
         [enable_omamqp1=no]
 )
 if test "x$enable_omamqp1" = "xyes"; then
-        PKG_CHECK_MODULES(PROTON, libqpid-proton >= 0.9)
+        PKG_CHECK_MODULES(PROTON, libqpid-proton >= 0.13)
         AC_SUBST(PROTON_CFLAGS)
         AC_SUBST(PROTON_LIBS)
 fi

--- a/contrib/omamqp1/Makefile.am
+++ b/contrib/omamqp1/Makefile.am
@@ -1,8 +1,13 @@
 pkglib_LTLIBRARIES = omamqp1.la
 
 omamqp1_la_SOURCES = omamqp1.c
-omamqp1_la_CPPFLAGS =  $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(PROTON_CFLAGS)
-omamqp1_la_LDFLAGS = -module -avoid-version
-omamqp1_la_LIBADD = $(PROTON_LIBS) $(PTHREADS_LIBS)
-
+if ENABLE_QPIDPROTON_STATIC
+omamqp1_la_LDFLAGS = -module -avoid-version $(PROTON_PROACTOR_LIBS) $(PTHREADS_LIBS) $(OPENSSL_LIBS) -lm
+omamqp1_la_LDFLAGS = -module -avoid-version -Wl,-whole-archive -l:libqpid-proton-proactor-static.a -l:libqpid-proton-core-static.a -Wl,--no-whole-archive $(PTHREADS_LIBS) $(OPENSSL_LIBS) ${RT_LIBS} -lsasl2
+omamqp1_la_LIBADD =
+else
+omamqp1_la_LDFLAGS = -module -avoid-version $(PROTON_PROACTOR_LIBS) $(PTHREADS_LIBS) $(OPENSSL_LIBS) -lm
+omamqp1_la_LIBADD =
+endif
+omamqp1_la_CPPFLAGS = $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(CURL_CFLAGS) $(PROTON_PROACTOR_CFLAGS) -Wno-error=switch
 EXTRA_DIST = 


### PR DESCRIPTION
Use same build parameters in makefile like omazureevents now.

closed: https://github.com/rsyslog/rsyslog/issues/5550

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
