### PR TITLE
omfwd bugfix: variable was not properly synced across threads

### DIFF
--- a/tests/action-tx-single-processing.sh
+++ b/tests/action-tx-single-processing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+skip_TSAN	# for some reason, this test is extremely slow under tsan, causing timeout fail
 export NUMMESSAGES=2000
 export SEQ_CHECK_OPTIONS=-i2
 check_sql_data_ready() {

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -138,6 +138,7 @@ skip_platform() {
 # note: we depend on CFLAGS to properly reflect build options (what
 #       usually is the case when the testbench is run)
 skip_TSAN() {
+	echo skip:_TSAN, CFLAGS $CFLAGS
 	if [[ "$CFLAGS" == *"sanitize=thread"* ]]; then
 		printf 'test incompatible with TSAN because of %s\n' "$1"
 		exit 77


### PR DESCRIPTION
While this could lead to some inefficiency, it should not have caused any real harm. But with data races it is never sure if more severe issues occur. However, here only very strange use cases can be envisioned where this might be the case.

In any case, the issue is now solved.

This also fixes some TSAN CI "flakes".

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
