### PR TITLE
testbench: Write started dummy file in python snmpreceiver script

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2713,22 +2713,24 @@ snmp_start_trapreceiver() {
         fi
     fi
     echo ${snmp_server_pid} > ${snmp_server_pidfile}
-	echo "Started snmptrapreceiver with ${SNMP_PYTHON} PID ${snmp_server_pid}."
+
+	while test ! -f ${snmp_server_logfile}.started; do
+		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
+		printf "."
+	done
 
     while test ! -s "${snmp_server_logfile}"; do
-	$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
-	if [ $(date +%s) -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
-	   printf '%s ABORT! Timeout waiting on startup (pid file %s)\n' "$(tb_timestamp)" "$1"
-	   ls -l "$1"
-	   ps -fp $(cat "$1")
-	   snmp_stop_trapreceiver
-	   error_exit 1
-#	else 
-#	   echo "waiting...${snmp_server_logfile}..."
-	fi
+		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
+		if [ $(date +%s) -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
+		printf '%s ABORT! Timeout waiting on startup (pid file %s)\n' "$(tb_timestamp)" "$1"
+		ls -l "$1"
+		ps -fp $(cat "$1")
+		snmp_stop_trapreceiver
+		error_exit 1
+		fi
     done
 
-    echo "Started snmptrapreceiver with args ${server_args} with pid ${snmp_server_pid}"
+    echo "Started snmptrapreceiver with ${SNMP_PYTHON} args ${server_args} with pid ${snmp_server_pid}"
 }
 
 snmp_stop_trapreceiver() {

--- a/tests/snmptrapreceiver.py
+++ b/tests/snmptrapreceiver.py
@@ -58,6 +58,11 @@ print("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOu
 logFile.write("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
 logFile.flush()
 
+# Add PID file creation after startup message
+import os
+with open(szSnmpLogfile + ".started", "w") as f:
+    f.write(str(os.getpid()))
+
 # Callback function for receiving notifications
 # noinspection PyUnusedLocal,PyUnusedLocal,PyUnusedLocal
 def cbReceiverSnmp(snmpEngine, stateReference, contextEngineId, contextName, varBinds, cbCtx):
@@ -98,7 +103,8 @@ snmpEngine.transportDispatcher.jobStarted(1)
 
 # Run I/O dispatcher which would receive queries and send confirmations
 try:
-	snmpEngine.transportDispatcher.runDispatcher()
+    snmpEngine.transportDispatcher.runDispatcher()
 except:
-	snmpEngine.transportDispatcher.closeDispatcher()
-	raise
+    os.remove(szOutputfile + ".started")  # Remove PID file on shutdown
+    snmpEngine.transportDispatcher.closeDispatcher()
+    raise

--- a/tests/snmptrapreceiverv2.py
+++ b/tests/snmptrapreceiverv2.py
@@ -59,6 +59,11 @@ print("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOu
 logFile.write("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
 logFile.flush()
 
+# Add PID file creation after startup message
+import os
+with open(szSnmpLogfile + ".started", "w") as f:
+    f.write(str(os.getpid()))
+
 # Callback function for receiving notifications
 # noinspection PyUnusedLocal,PyUnusedLocal,PyUnusedLocal
 def cbReceiverSnmp(snmpEngine, stateReference, contextEngineId, contextName, varBinds, cbCtx):
@@ -99,7 +104,9 @@ ntfrcv.NotificationReceiver(snmpEngine, cbReceiverSnmp)
 try:
     snmpEngine.transportDispatcher.runDispatcher()
 except KeyboardInterrupt:
+    os.remove(szOutputfile + ".started")  # Remove PID file on shutdown
     snmpEngine.transportDispatcher.closeDispatcher()
 except Exception as e:
+    os.remove(szOutputfile + ".started")  # Remove PID file on shutdown
     snmpEngine.transportDispatcher.closeDispatcher()
     raise


### PR DESCRIPTION
When the snmpreceiver is fully started and listening, the file is created. diag.sh checks for the .started file before proceeding with the textbench

see also: https://github.com/rsyslog/rsyslog/pull/5558

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
