### PR TITLE
openssl: check for ENGINE support in library

### DIFF
--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -223,6 +223,7 @@ osslGlblInit(void)
 PRAGMA_DIAGNOSTIC_PUSH
 PRAGMA_IGNORE_Wdeprecated_declarations
 
+#ifndef OPENSSL_NO_ENGINE
 	// Initialize OpenSSL engine library
 	ENGINE_load_builtin_engines();
 	/* Register all of them for every algorithm they collectively implement */
@@ -243,6 +244,10 @@ PRAGMA_IGNORE_Wdeprecated_declarations
 	}
 	// Free the engine reference when done
 	ENGINE_free(osslEngine);
+#else
+	DBGPRINTF("osslGlblInit: OpenSSL compiled without ENGINE support - ENGINE support disabled\n");
+#endif /* OPENSSL_NO_ENGINE */
+
 PRAGMA_DIAGNOSTIC_POP
 }
 
@@ -251,7 +256,9 @@ void
 osslGlblExit(void)
 {
 	DBGPRINTF("openssl: entering osslGlblExit\n");
+#ifndef OPENSSL_NO_ENGINE
 	ENGINE_cleanup();
+#endif
 	ERR_free_strings();
 	EVP_cleanup();
 	CRYPTO_cleanup_all_ex_data();
@@ -1150,7 +1157,10 @@ net_ossl_verify_cookie(SSL *ssl, const unsigned char *cookie, unsigned int cooki
 static rsRetVal
 net_ossl_init_engine(__attribute__((unused)) net_ossl_t *pThis)
 {
+	// OpenSSL Engine Support feature relies on an outdated version of OpenSSL and is
+	// strictly experimental. No support or guarantees are provided. Use at your own risk.
 	DEFiRet;
+#ifndef OPENSSL_NO_ENGINE
 	const char *engine_id = NULL;
 	const char *engine_name = NULL;
 
@@ -1194,6 +1204,9 @@ PRAGMA_IGNORE_Wdeprecated_declarations
 		DBGPRINTF("net_ossl_init_engine: use openssl default Engine");
 	}
 PRAGMA_DIAGNOSTIC_POP
+#else
+	DBGPRINTF("net_ossl_init_engine: OpenSSL compiled without ENGINE support - ENGINE support disabled\n");
+#endif /* OPENSSL_NO_ENGINE */
 
 	RETiRet;
 }

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -1473,7 +1473,9 @@ static void
 exitTLS(void)
 {
 	SSL_CTX_free(ctx);
+#ifndef OPENSSL_NO_ENGINE
 	ENGINE_cleanup();
+#endif
 	ERR_free_strings();
 	EVP_cleanup();
 	CRYPTO_cleanup_all_ex_data();


### PR DESCRIPTION
If openssl is compiled without support for openssl engines, do not include engine selection. The global option "defaultopensslengine" will not work in this case. It's support is depreciated in newer OpenSSL versions

OpenSSL Engine Support feature relies on an outdated version of OpenSSL and is strictly experimental.  No support or guarantees are provided. Use at your own risk.

closes: https://github.com/rsyslog/rsyslog/issues/5429

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
