### PR TITLE
CI: add compile check with atomic operations disabled

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -38,7 +38,7 @@ jobs:
         # note: we compile only with oldest and newest support compiler to
         # save ressources. Other important ones are used during the rest of
         # the check runs (most importantly the distro-default ones).
-        config: [clang9, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc14-gnu23-debug]
+        config: [clang9, clang18-noatomics, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc14-gnu23-debug]
 
     steps:
       - name: git checkout project
@@ -56,6 +56,11 @@ jobs:
               ;;
           'clang18-ndebug')
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=no'
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+              export CC='clang-18'
+              ;;
+          'clang18-noatomics')
+              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-atomic-operations=no'
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
               export CC='clang-18'
               ;;


### PR DESCRIPTION
The platforms that do not have support for atomic operations become more and more exoctic. Even more so, only Solaris builders now test that inside the rsyslog CI. To "harden" the CI system against a potential (temporary) unavailability of Solaris, we now also do a build where we intentionally disable atomics. This will trigger build issues on all platforms. This method also permits us to detect problems quicker, as the solaris builders are slow.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
