### PR TITLE
CI: use Ubuntu 24.04 for ASAN, UBSAN etc sanitizer runs

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -38,7 +38,7 @@ jobs:
         config: [centos_7, centos_8, debian_10, debian_11,
                  fedora_35, fedora_36,
                  ubuntu_18, ubuntu_20, ubuntu_24,
-                 ubuntu_22_san, ubuntu_24_tsan, ubuntu_22_codecov, ubuntu_22_distcheck,
+                 ubuntu_24_san, ubuntu_24_tsan, ubuntu_22_codecov, ubuntu_22_distcheck,
                  kafka_codecov, elasticsearch]
 
     steps:
@@ -114,9 +114,9 @@ jobs:
               export CI_CHECK_CMD='distcheck'
               export ABORT_ALL_ON_TEST_FAIL='YES'
               ;;
-          'ubuntu_22_san')
+          'ubuntu_24_san')
               export CI_SANITIZE_BLACKLIST='tests/asan.supp'
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
               export CC='clang'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                       --disable-libfaketime --without-valgrind-testbench --disable-valgrind \


### PR DESCRIPTION
Ensure we run the newest and most capable sanitizers.

This also fixes the issue of the current Ubuntu 22.04 environment not providing a proper symbolizer.

closes https://github.com/rsyslog/rsyslog/issues/5572

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
