### PR TITLE
CI: reduce parallel test runs

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -54,7 +54,7 @@ jobs:
           export CC='gcc'
           export USE_AUTO_DEBUG='off'
           export CI_MAKE_OPT='-j20'
-          export CI_MAKE_CHECK_OPT='-j6'
+          export CI_MAKE_CHECK_OPT='-j4'
           export CI_CHECK_CMD='check'
           case "${{ matrix.config }}" in
           'centos_7')
@@ -130,6 +130,7 @@ jobs:
               ;;
           'ubuntu_24_tsan')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+              export CI_MAKE_CHECK_OPT='-j3' # This is CPU-heavy due to tsan, so we need less concurrency to prevent flakes
               export CI_VALGRIND_SUPPRESSIONS="ubuntu22.04.supp"
               export CI_SANITIZE_BLACKLIST='tests/tsan.supp'
               export CC='clang'


### PR DESCRIPTION
We are seeing an increasing number of flaky tests with hard-to-explain failure conditions. Upon analysis it looks like this primarily stems back to overloaded CI VMs. This can be the case because we have performance enhanced rsyslog of the past month, which means the VMs have higher load (due to better parallel processing) at the same time. This is especially the case with CPU intense checks like TSAN.

In order to address this, we reduce the number of parallel tests.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
