### PR TITLE
queue: emit better warning messages on queue param mismatch

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3296,6 +3296,13 @@ qqueueCorrectParams(qqueue_t *pThis)
 		if(pThis->iHighWtrMrk == 0) { /* guard against very low max queue sizes! */
 			pThis->iHighWtrMrk = pThis->iMaxQueueSize;
 		}
+		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING,
+				"queue \"%s\": queue.highWaterMark "
+				"is set below queue size. It has been automatically been "
+				"adjusted to %d. In any case, we strongly recommend to review the "
+				"queue definition and resolve inconsistencies to guarantee "
+				"the config really matches your intent.",
+				obj.GetName((obj_t*) pThis), pThis->iHighWtrMrk);
 	}
 	if(   pThis->iLowWtrMrk < 2
 	   || pThis->iLowWtrMrk > pThis->iMaxQueueSize
@@ -3304,6 +3311,13 @@ qqueueCorrectParams(qqueue_t *pThis)
 		if(pThis->iLowWtrMrk == 0) {
 			pThis->iLowWtrMrk = 1;
 		}
+		LogMsg(0, RS_RET_CONF_PARSE_WARNING, LOG_WARNING,
+				"queue \"%s\": queue.lowWaterMark "
+				"is set below queue size or highWaterMark. It has been automatically been "
+				"adjusted to %d. In any case, we strongly recommend to review the "
+				"queue definition and resolve inconsistencies to guarantee "
+				"the config really matches your intent.",
+				obj.GetName((obj_t*) pThis), pThis->iHighWtrMrk);
 	}
 
 	if((pThis->iMinMsgsPerWrkr < 1


### PR DESCRIPTION
We silently adjust some queue parameters if they are set invalidly. At least for some important settings are now warning messages emitted.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
