### PR TITLE
omhttp: fix handling of httpProxy variable

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -411,7 +411,7 @@ CODESTARTdbgPrintInstInfo
 	dbgprintf("\trest path='%s'\n", pData->restPath);
 	dbgprintf("\tcheck path='%s'\n", pData->checkPath);
 	dbgprintf("\tdynamic rest path=%d\n", pData->dynRestPath);
-	dbgprintf("\tproxy host='%s'\n", pData->proxyHost);
+	dbgprintf("\tproxy host='%s'\n", (pData->proxyHost == NULL) ? "unset" : (char*) pData->proxyHost);
 	dbgprintf("\tproxy port='%d'\n", pData->proxyPort);
 	dbgprintf("\tuse https=%d\n", pData->useHttps);
 	dbgprintf("\tbatch=%d\n", pData->batchMode);
@@ -2180,10 +2180,12 @@ CODESTARTnewActInst
 	}
 
 	if (pData->proxyHost == NULL) {
-		if (getenv("http_proxy") != NULL) {
-			pData->proxyHost = ustrdup(getenv("http_proxy"));
-		} else if (getenv("HTTP_PROXY") != NULL) {
-			pData->proxyHost = ustrdup(getenv("HTTP_PROXY"));
+		const char *http_proxy;
+		if((http_proxy = getenv("http_proxy")) == NULL) {
+			http_proxy = getenv("HTTP_PROXY");
+		}
+		if(http_proxy != NULL) {
+			pData->proxyHost = ustrdup(http_proxy);
 		}
 	}
 


### PR DESCRIPTION
clang static analyzer effectively emitted a false positive, but the manual analysis showed a potential real issue (platform-dependend). We also restructured the code so that the false positive goes away.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
