### PR TITLE
rsyslog startup bugfix: cosmetic memory leak

### DIFF
--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -294,7 +294,7 @@ writePidFile(void)
 	FILE *fp;
 	DEFiRet;
 
-	const char *tmpPidFile;
+	const char *tmpPidFile = NULL;
 
 	if(!strcmp(PidFile, NO_PIDFILE)) {
 		FINALIZE;
@@ -304,6 +304,7 @@ writePidFile(void)
 	}
 	if(tmpPidFile == NULL)
 		tmpPidFile = PidFile;
+
 	DBGPRINTF("rsyslogd: writing pidfile '%s'.\n", tmpPidFile);
 	if((fp = fopen((char*) tmpPidFile, "w")) == NULL) {
 		perror("rsyslogd: error writing pid file (creation stage)\n");
@@ -317,9 +318,12 @@ writePidFile(void)
 		if(rename(tmpPidFile, PidFile) != 0) {
 			perror("rsyslogd: error writing pid file (rename stage)");
 		}
+	}
+
+finalize_it:
+	if(tmpPidFile != PidFile) {
 		free((void*)tmpPidFile);
 	}
-finalize_it:
 	RETiRet;
 }
 

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -2160,6 +2160,7 @@ mainloop(void)
 	sigaddset(&sigblockset, SIGHUP);
 
 	do {
+		sigemptyset(&origmask);
 		pthread_sigmask(SIG_BLOCK, &sigblockset, &origmask);
 		pthread_mutex_lock(&mutChildDied);
 		need_free_mutex = 1;


### PR DESCRIPTION
This was detected by Coverity Scan, and we "fix" it to keep Coverity silent. It is a < 100 byte mem leak that occurs once on startup.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
