### PR TITLE
testbench bugfix: do not execute tcpflood_wrong_option_output.sh with…

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -513,11 +513,19 @@ TESTS +=  \
 	queue-encryption-da.sh
 endif # ENABLE_LIBGCRYPT
 if HAVE_VALGRIND
+# note if the same test is added multiple times, it still is only executed once!
+if ENABLE_GNUTLS_TESTS
+TESTS +=  \
+	tcpflood_wrong_option_output.sh
+endif # ENABLE_GNUTLS_TESTS
+if ENABLE_OPENSSL
+TESTS +=  \
+	tcpflood_wrong_option_output.sh
+endif # ENABLE_OPENSSL
 TESTS +=  \
 	omusrmsg-noabort-vg.sh \
 	omfile_hup-vg.sh \
 	gzipwr_hup-vg.sh \
-	tcpflood_wrong_option_output.sh \
 	imtcp-octet-framing-too-long-vg.sh \
 	smtradfile-vg.sh \
 	dnscache-TTL-0-vg.sh \


### PR DESCRIPTION
…out TLS driver

when neither GTLS or OSSL TLS drivers are enabled, this test cannot pass. We now check for this condition and execute it only it at least one of the two is configured.

closes https://github.com/rsyslog/rsyslog/issues/5592

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
