### PR TITLE
Fix a buffer overflow when the argument to replace is empty

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1755,6 +1755,7 @@ doFuncReplace(struct svar *__restrict__ const operandVal, struct svar *__restric
 		if (j == lfind) {
 			lDst = lDst - lfind + lReplaceWith;
 			j = 0;
+			if (lfind == 0) break;
 		}
 		if (i == lSrc) break;
 		if (src_buff[i] == find[j]) {
@@ -1770,9 +1771,10 @@ doFuncReplace(struct svar *__restrict__ const operandVal, struct svar *__restric
 	uint k, s;
 	for(i = j = s = 0; i <= lSrc; i++, s++) {
 		if (j == lfind) {
-		s -= j;
-		for (k = 0; k < lReplaceWith; k++, s++) dest[s] = replaceWith[k];
+			s -= j;
+			for (k = 0; k < lReplaceWith; k++, s++) dest[s] = replaceWith[k];
 			j = 0;
+			if (lfind == 0) break;
 		}
 		if (i == lSrc) break;
 		if (src_buff[i] == find[j]) {


### PR DESCRIPTION
We have these expressions in rsyslogd.conf.

    set $!rsyslog_FileFormat = exec_template("RSYSLOG_FileFormat")
    set $!localheader = re_extract($!rsyslog_FileFormat, "[^ ]+.* +port[0-9]", 0, 0, "");
    set $!localpattern = re_extract($!rsyslog_FileFormat, " [^ ]+ +[^ ]+ +port[0-9]", 0, 0, "");
    set $!localheader = replace($!localheader, $!localpattern, " ");

We have a message like this arriving.

    <30>Feb 24 22:08:21 hostname port03 'label' RXDATA: \n

It was observed that when 2 of these messages arrive in a row, rsyslogd crashes. This is clearly due to memory corruption, as the crash comes from within calloc.

Unlike the crash, valgrind only complained about the first message. It reported that the 'find' variable was being accessed in the replace function, reading past allocated data.

The localpattern variable ends up "empty" (null?), because the pattern fails to match. This ends up passed into the replace function as an es_str_t with a length and buffer length of 0. There is no string data, not even a null terminator.

As a result, the 'find' pointer is invalid, and accessing it is an error. Protect against accessing the 'find' pointer when the buffer is empty by exiting the two loops when j == lfind and lfind == 0.

This removes the report from valgrind, and stops rsyslogd from crashing.
