### PR TITLE
rsyslog bugfix: fixes rsyslog segfault during shutdown when relp is configured with TLS

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -777,6 +777,8 @@ BEGINfreeCnf
     instanceConf_t *inst, *del;
     int i;
     CODESTARTfreeCnf;
+    if (pRelpEngine != NULL) iRet = relpEngineDestruct(&pRelpEngine);
+
     for (inst = pModConf->root; inst != NULL;) {
         free(inst->pszBindPort);
         if (inst->pszBindAddr != NULL) {
@@ -855,8 +857,6 @@ BEGINmodExit
     sigemptyset(&newAct.sa_mask);
     newAct.sa_handler = SIG_IGN;
     sigaction(SIGTTIN, &newAct, NULL);
-
-    if (pRelpEngine != NULL) iRet = relpEngineDestruct(&pRelpEngine);
 
     /* release objects we used */
     objRelease(statsobj, CORE_COMPONENT);


### PR DESCRIPTION
Hi,

I've been working on an issue where `rsyslog` generates a coredump. 

The problem occurs when `rsyslog` is using the `relp` module with TLS configured.

The issue arises when `rsyslog` is shutting down. As part of the shutdown, `rsyslog` starts unloading and destroying modules. Since we've configured the `relp` module, `rsyslog` calls `relpEngineDestruct()` from the `modExit()` function. This triggers the destruction of TCP sessions in the `relpTcpDestruct()` function, which then calls `relpTcpDestructTLS()` to handle the shutdown of SSL connections. In this case, the `relpTcpDestructTLS_ossl()` function is used to shut down SSL connections with OpenSSL.

During the shutdown process, if there is an issue with the connection, the SSL shutdown fails, causing an `SSL_ERROR_SSL` error to be logged by the `onErr()` function. By this point, the `freeCnf()` function has already freed variables like `pszBindPort`, which are needed for logging the error. This leads to a segfault when the `pszBindPort` variable is accessed, triggering a  coredump.

To resolve the issue, I added a check to prevent the segmentation fault. I introduced a global variable initialized to zero, which is set to one if the configuration has been freed. In the `onErr()` function, when an error is logged, the `pszBindPort` variable is omitted if the global variable indicates that the configuration has already been freed.

Thanks!

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
