### PR TITLE
tcpsrv: fix non-maintained stats counter "run"

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1050,7 +1050,7 @@ doAccept(tcpsrv_io_descr_t *const pioDescr, tcpsrvWrkrData_t *const wrkrData ATT
 	}
 #	if defined(ENABLE_IMTCP_EPOLL)
 	if(pioDescr->pSrv->workQueue.numWrkr > 1) {
-		STATSCOUNTER_ADD(wrkrData->ctrAccept, wrkrData->mutCtrRead, nAccept);
+		STATSCOUNTER_ADD(wrkrData->ctrAccept, wrkrData->mutCtrAccept, nAccept);
 	}
 	notifyReArm(pioDescr); /* listeners must ALWAYS be re-armed */
 #	endif
@@ -1249,6 +1249,7 @@ wrkr(void *arg)
 		 * case. Also, errors are reported inside processWorksetItem().
 		 */
 		processWorksetItem(pioDescr, wrkrData);
+		STATSCOUNTER_ADD(wrkrData->ctrRuns, wrkrData->mutCtrRuns, 1);
 	}
 
 	/**** de-init ****/


### PR DESCRIPTION
This affects primarily imtcp. The counter was not maintained at all, it now is incremented whenever a processing loop of the worker thread is completed. Note that, for busy senders, can mean a large number of iterations. The other counters tell the the details of operation. That also means that very busy threads can be detected by looking at the ratio of runs vs. actual operations.

This patch also fixes an invalid mutex being locked on systems that do not support atomic instructions (a copy&paste errror).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
