### PR TITLE
tcpsrv bugfix: input name was not properly propagated

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1195,7 +1195,8 @@ wrkr(void *arg)
 	tcpsrvWrkrData_t *const wrkrData = &(queue->wrkr_data[wrkrIdx]);
 
 	uchar thrdName[32];
-	snprintf((char*)thrdName, sizeof(thrdName), "tcpsrv/w%d", wrkrIdx);
+	snprintf((char*)thrdName, sizeof(thrdName), "w%d/%s", wrkrIdx,
+		(pThis->pszInputName == NULL) ? (uchar*)"tcpsrv" : pThis->pszInputName);
 	dbgSetThrdName(thrdName);
 
 	/* set thread name - we ignore if it fails, has no harsh consequences... */
@@ -1613,7 +1614,6 @@ CODESTARTobjDestruct(tcpsrv)
 	free(pThis->ppLstn);
 	free(pThis->ppLstnPort);
 	free(pThis->ppioDescrPtr);
-	free(pThis->pszInputName);
 	free(pThis->pszOrigin);
 ENDobjDestruct(tcpsrv)
 
@@ -1848,14 +1848,16 @@ SetOrigin(tcpsrv_t *pThis, uchar *origin)
 
 /* Set the input name to use -- rgerhards, 2008-12-10 */
 static rsRetVal
-SetInputName(tcpsrv_t *const pThis ATTR_UNUSED, tcpLstnParams_t *const cnf_params, const uchar *const name)
+SetInputName(tcpsrv_t *const pThis, tcpLstnParams_t *const cnf_params, const uchar *const name)
 {
 	DEFiRet;
 	ISOBJ_TYPE_assert(pThis, tcpsrv);
-	if(name == NULL)
+	if(name == NULL) {
 		cnf_params->pszInputName = NULL;
-	else
+	} else {
 		CHKmalloc(cnf_params->pszInputName = ustrdup(name));
+		pThis->pszInputName = cnf_params->pszInputName;
+	}
 
 	/* we need to create a property */
 	CHKiRet(prop.Construct(&cnf_params->pInputName));

--- a/tests/imtcp-impstats.sh
+++ b/tests/imtcp-impstats.sh
@@ -12,7 +12,7 @@ add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1")
 
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+input(type="imtcp" name="pstats-test" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
 	workerthreads="'$NUM_WORKERS'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
@@ -26,8 +26,8 @@ sleep 2
 shutdown_when_empty
 wait_shutdown
 
-cat -n $STATSFILE | grep 'tcpsrv/w'
-NUM_STATS=$(grep 'tcpsrv/w' "$STATSFILE" | wc -l)
+cat -n $STATSFILE | grep 'w./pstats-test'
+NUM_STATS=$(grep 'w./pstats-test' "$STATSFILE" | wc -l)
 if [ "$NUM_WORKERS" -gt 1 ]; then
     EXPECTED_COUNT=$NUM_WORKERS
 else

--- a/tests/manytcp.sh
+++ b/tests/manytcp.sh
@@ -9,7 +9,8 @@ generate_conf
 add_conf '
 $MaxOpenFiles 2100
 module(load="../plugins/imtcp/.libs/imtcp" maxSessions="2100")
-input(type="imtcp" socketBacklog="2000" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" workerthreads="8")
+input(type="imtcp" name="test-input"
+	socketBacklog="2000" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" workerthreads="8")
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!


### PR DESCRIPTION
As a result, it did not show up in pstats. Alos, we now use the input name in worker thread to easily identify where they belong to. As thread names have very limited length, the thread naming now is "w<worker-number>/<input-name>".

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
