### PR TITLE
add experimental stats for worker awaking via event notification

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -913,6 +913,11 @@ doReceive(tcpsrv_io_descr_t *const pioDescr, tcpsrvWrkrData_t *const wrkrData AT
 				do_run = 0;
 				break;
 			case RS_RET_RETRY:
+#	if defined(ENABLE_IMTCP_EPOLL)
+	if(pThis->workQueue.numWrkr > 1 && read_calls == 0) {
+		STATSCOUNTER_ADD(wrkrData->ctrEmptyRead, wrkrData->mutCtrEmptyRead, 1);
+	}
+#	endif
 				do_run = 0;
 				break;
 			case RS_RET_OK:
@@ -1222,6 +1227,10 @@ wrkr(void *arg)
 		STATSCOUNTER_INIT(wrkrData->ctrRead, wrkrData->mutCtrRead);
 		statsobj.AddCounter(wrkrData->stats, UCHAR_CONSTANT("read"),
 			ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(wrkrData->ctrRead));
+
+		STATSCOUNTER_INIT(wrkrData->ctrEmptyRead, wrkrData->mutCtrEmptyRead);
+		statsobj.AddCounter(wrkrData->stats, UCHAR_CONSTANT("emptyread"),
+			ctrType_IntCtr, CTR_FLAG_RESETTABLE, &(wrkrData->ctrEmptyRead));
 
 		STATSCOUNTER_INIT(wrkrData->ctrStarvation, wrkrData->mutCtrStarvation);
 		statsobj.AddCounter(wrkrData->stats, UCHAR_CONSTANT("starvation_protect"),

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -69,6 +69,7 @@ typedef struct tcpsrvWrkrData_s {
 	statsobj_t *stats;
 	STATSCOUNTER_DEF(ctrRuns, mutCtrRuns);
 	STATSCOUNTER_DEF(ctrRead, mutCtrRead);
+	STATSCOUNTER_DEF(ctrEmptyRead, mutCtrEmptyRead);
 	STATSCOUNTER_DEF(ctrStarvation, mutCtrStarvation);
 	STATSCOUNTER_DEF(ctrAccept, mutCtrAccept);
 } tcpsrvWrkrData_t;


### PR DESCRIPTION
It needs to be decided if this is a useful setting or not.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
