### PR TITLE
tcpsrv bugfix: do not busy wait on io events

### DIFF
--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -132,13 +132,13 @@ doOpenLstnSocks(tcpsrv_t *pSrv)
 
 
 static rsRetVal
-doRcvData(tcps_sess_t *pSess, char *buf, size_t lenBuf, ssize_t *piLenRcvd, int *oserr)
+doRcvData(tcps_sess_t *pSess, char *buf, size_t lenBuf, ssize_t *piLenRcvd, int *oserr, unsigned *nextIODirection)
 {
 	assert(pSess != NULL);
 	assert(piLenRcvd != NULL);
 
 	*piLenRcvd = lenBuf;
-	return netstrm.Rcv(pSess->pStrm, (uchar*) buf, piLenRcvd, oserr);
+	return netstrm.Rcv(pSess->pStrm, (uchar*) buf, piLenRcvd, oserr, nextIODirection);
 }
 
 static rsRetVal

--- a/plugins/imgssapi/imgssapi.c
+++ b/plugins/imgssapi/imgssapi.c
@@ -288,7 +288,8 @@ finalize_it:
 
 
 static rsRetVal
-doRcvData(tcps_sess_t *pSess, char *buf, size_t lenBuf, ssize_t *piLenRcvd, int *const oserr)
+doRcvData(tcps_sess_t *pSess, char *buf, size_t lenBuf, ssize_t *piLenRcvd, int *const oserr,
+	unsigned *const nextIODirection)
 {
 	DEFiRet;
 	int allowedMethods;
@@ -304,7 +305,7 @@ doRcvData(tcps_sess_t *pSess, char *buf, size_t lenBuf, ssize_t *piLenRcvd, int 
 		CHKiRet(TCPSessGSSRecv(pSess, buf, lenBuf, piLenRcvd));
 	} else {
 		*piLenRcvd = lenBuf;
-		CHKiRet(netstrm.Rcv(pSess->pStrm, (uchar*) buf, piLenRcvd, oserr));
+		CHKiRet(netstrm.Rcv(pSess->pStrm, (uchar*) buf, piLenRcvd, oserr, nextIODirection));
 	}
 
 finalize_it:

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -321,12 +321,12 @@ doOpenLstnSocks(tcpsrv_t *pSrv)
 
 
 static rsRetVal
-doRcvData(tcps_sess_t *pSess, char *buf, size_t lenBuf, ssize_t *piLenRcvd, int *const oserr)
+doRcvData(tcps_sess_t *pSess, char *buf, size_t lenBuf, ssize_t *piLenRcvd, int *const oserr, unsigned *nextIODirection)
 {
 	assert(pSess != NULL);
 	assert(piLenRcvd != NULL);
 	*piLenRcvd = lenBuf;
-	return netstrm.Rcv(pSess->pStrm, (uchar*) buf, piLenRcvd, oserr);
+	return netstrm.Rcv(pSess->pStrm, (uchar*) buf, piLenRcvd, oserr, nextIODirection);
 }
 
 static rsRetVal

--- a/runtime/netstrm.c
+++ b/runtime/netstrm.c
@@ -172,11 +172,11 @@ finalize_it:
  * rgerhards, 2008-03-17
  */
 static rsRetVal
-Rcv(netstrm_t *pThis, uchar *pBuf, ssize_t *pLenBuf, int *const oserr)
+Rcv(netstrm_t *pThis, uchar *pBuf, ssize_t *pLenBuf, int *const oserr, unsigned *nextIODirection)
 {
 	DEFiRet;
 	NULL_CHECK(pThis);
-	iRet = pThis->Drvr.Rcv(pThis->pDrvrData, pBuf, pLenBuf, oserr);
+	iRet = pThis->Drvr.Rcv(pThis->pDrvrData, pBuf, pLenBuf, oserr, nextIODirection);
 
 finalize_it:
 	RETiRet;

--- a/runtime/netstrm.h
+++ b/runtime/netstrm.h
@@ -45,7 +45,7 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*Destruct)(netstrm_t **ppThis);
 	rsRetVal (*AbortDestruct)(netstrm_t **ppThis);
 	rsRetVal (*AcceptConnReq)(netstrm_t *pThis, netstrm_t **ppNew);
-	rsRetVal (*Rcv)(netstrm_t *pThis, uchar *pRcvBuf, ssize_t *pLenBuf, int *oserr);
+	rsRetVal (*Rcv)(netstrm_t *pThis, uchar *pRcvBuf, ssize_t *pLenBuf, int *oserr, unsigned *nextIODirection);
 	rsRetVal (*Send)(netstrm_t *pThis, uchar *pBuf, ssize_t *pLenBuf);
 	rsRetVal (*Connect)(netstrm_t *pThis, int family, unsigned char *port, unsigned char *host, char *device);
 	rsRetVal (*GetRemoteHName)(netstrm_t *pThis, uchar **pszName);
@@ -93,7 +93,7 @@ BEGINinterface(netstrm) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetDrvrTlsKeyFile)(netstrm_t *pThis, const uchar* file);
 	rsRetVal (*SetDrvrTlsCertFile)(netstrm_t *pThis, const uchar* file);
 ENDinterface(netstrm)
-#define netstrmCURR_IF_VERSION 16 /* increment whenever you change the interface structure! */
+#define netstrmCURR_IF_VERSION 17 /* increment whenever you change the interface structure! */
 /* interface version 3 added GetRemAddr()
  * interface version 4 added EnableKeepAlive() -- rgerhards, 2009-06-02
  * interface version 5 changed return of CheckConnection from void to rsRetVal -- alorbach, 2012-09-06
@@ -103,6 +103,7 @@ ENDinterface(netstrm)
  * interface version 9 added SetGnutlsPriorityString -- PascalWithopf, 2017-08-08
  * interface version 10 added oserr parameter to Rcv() -- rgerhards, 2017-09-04
  * interface version 16 CRL file -- Oracle, 2022-01-16
+ * interface version 17 added nextIODirection parameter to Rcv() -- rgehards, 2025-04-17
  * */
 
 /* prototypes */

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -27,7 +27,7 @@
 
 #include <sys/socket.h>
 
-#if 0
+#if 0 //TODO: remove
 /**
  * The following structure is a descriptor for tcpsrv i/o. It is
  * primarily used together with epoll at the moment.
@@ -60,7 +60,7 @@ BEGINinterface(nsd) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*Construct)(nsd_t **ppThis);
 	rsRetVal (*Destruct)(nsd_t **ppThis);
 	rsRetVal (*Abort)(nsd_t *pThis);
-	rsRetVal (*Rcv)(nsd_t *pThis, uchar *pRcvBuf, ssize_t *pLenBuf, int *oserr);
+	rsRetVal (*Rcv)(nsd_t *pThis, uchar *pRcvBuf, ssize_t *pLenBuf, int *oserr, unsigned *nextIODirection);
 	rsRetVal (*Send)(nsd_t *pThis, uchar *pBuf, ssize_t *pLenBuf);
 	rsRetVal (*Connect)(nsd_t *pThis, int family, unsigned char *port, unsigned char *host, char *device);
 	rsRetVal (*AcceptConnReq)(nsd_t *pThis, nsd_t **ppThis);

--- a/runtime/nsd.h
+++ b/runtime/nsd.h
@@ -27,24 +27,6 @@
 
 #include <sys/socket.h>
 
-#if 0 //TODO: remove
-/**
- * The following structure is a descriptor for tcpsrv i/o. It is
- * primarily used together with epoll at the moment.
- */
-struct nsd_epworkset_s {
-	int id; // TODO: remove
-	//void *pUsr; // TODO: remove
-	enum {NSD_PTR_TYPE_LSTN, NSD_PTR_TYPE_SESS} ptrType;
-	union {
-		tcps_sess_t *pSess;
-		struct {
-			netstrm_t **ppLstn;	/**<  accept listener's netstream */
-		} lstn;
-	} ptr;
-};
-#endif
-
 enum nsdsel_waitOp_e {
 	NSDSEL_RD = 1,
 	NSDSEL_WR = 2,

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -603,7 +603,7 @@ uchar *gtlsStrerror(int error)
  * rgerhards, 2008-06-24
  */
 rsRetVal
-gtlsRecordRecv(nsd_gtls_t *pThis)
+gtlsRecordRecv(nsd_gtls_t *const pThis, unsigned int* nextIODirection)
 {
 	ssize_t lenRcvd;
 	DEFiRet;
@@ -647,18 +647,10 @@ gtlsRecordRecv(nsd_gtls_t *pThis)
 	} else if(lenRcvd == GNUTLS_E_AGAIN || lenRcvd == GNUTLS_E_INTERRUPTED) {
 sslerragain:
 		/* Check if the underlaying file descriptor needs to read or write data!*/
-		if (gnutls_record_get_direction(pThis->sess) == gtlsDir_READ) {
-			pThis->rtryCall = gtlsRtry_recv;
-			dbgprintf("GnuTLS receive requires a retry, this most probably is OK and no error condition\n");
-			ABORT_FINALIZE(RS_RET_RETRY);
-		} else {
-			uchar *pErr = gtlsStrerror(lenRcvd);
-			LogError(0, RS_RET_GNUTLS_ERR, "GnuTLS receive error %zd has wrong read direction(wants write) "
-				"- this could be caused by a broken connection. GnuTLS reports: %s\n",
-				lenRcvd, pErr);
-			free(pErr);
-			ABORT_FINALIZE(RS_RET_GNUTLS_ERR);
-		}
+		pThis->rtryCall = gtlsRtry_recv; /* _recv refers to the gnutls call, not socket layer! */
+		dbgprintf("GnuTLS receive requires a retry, this most probably is OK and no error condition\n");
+		*nextIODirection = (gnutls_record_get_direction(pThis->sess) == 0) ? NSDSEL_RD : NSDSEL_WR;
+		ABORT_FINALIZE(RS_RET_RETRY);
 	} else {
 		int gnuRet = lenRcvd;
 		ABORTgnutls;
@@ -2118,7 +2110,6 @@ Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf, int *const oserr, unsigned *cons
 	nsd_gtls_t *pThis = (nsd_gtls_t*) pNsd;
 	ISOBJ_TYPE_assert(pThis, nsd_gtls);
 
-DBGPRINTF("in gtls Rcv, bAbortConn %d\n", pThis->bAbortConn);
 	if(pThis->bAbortConn)
 		ABORT_FINALIZE(RS_RET_CONNECTION_ABORTREQ);
 
@@ -2153,7 +2144,7 @@ DBGPRINTF("in gtls Rcv, bAbortConn %d\n", pThis->bAbortConn);
 	 * the request from buffer contents.
 	 */
 	if(pThis->lenRcvBuf == -1) { /* no data present, must read */
-		CHKiRet(gtlsRecordRecv(pThis));
+		CHKiRet(gtlsRecordRecv(pThis, nextIODirection));
 	}
 
 	if(pThis->lenRcvBuf == 0) { /* EOS */
@@ -2174,8 +2165,7 @@ DBGPRINTF("in gtls Rcv, bAbortConn %d\n", pThis->bAbortConn);
 	*pLenBuf = iBytesCopy;
 
 finalize_it:
-	if (iRet != RS_RET_OK &&
-		iRet != RS_RET_RETRY) {
+	if (iRet != RS_RET_OK && iRet != RS_RET_RETRY) {
 		/* We need to free the receive buffer in error error case unless a retry is wanted. , if we
 		 * allocated one. -- rgerhards, 2008-12-03 -- moved here by alorbach, 2015-12-01
 		 */
@@ -2183,7 +2173,6 @@ finalize_it:
 		free(pThis->pszRcvBuf);
 		pThis->pszRcvBuf = NULL;
 	}
-	*nextIODirection = (gnutls_record_get_direction(pThis->sess) == 0) ? NSDSEL_RD : NSDSEL_WR;
 	dbgprintf("gtlsRcv return. nsd %p, iRet %d, lenRcvBuf %d, ptrRcvBuf %d\n", pThis,
 	iRet, pThis->lenRcvBuf, pThis->ptrRcvBuf);
 	RETiRet;

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -2111,7 +2111,7 @@ if (error_position != NULL) {
  * buffer. -- rgerhards, 2008-06-23
  */
 static rsRetVal
-Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf, int *const oserr)
+Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf, int *const oserr, unsigned *const nextIODirection)
 {
 	DEFiRet;
 	ssize_t iBytesCopy; /* how many bytes are to be copied to the client buffer? */
@@ -2123,7 +2123,7 @@ DBGPRINTF("in gtls Rcv, bAbortConn %d\n", pThis->bAbortConn);
 		ABORT_FINALIZE(RS_RET_CONNECTION_ABORTREQ);
 
 	if(pThis->iMode == 0) {
-		CHKiRet(nsd_ptcp.Rcv(pThis->pTcp, pBuf, pLenBuf, oserr));
+		CHKiRet(nsd_ptcp.Rcv(pThis->pTcp, pBuf, pLenBuf, oserr, nextIODirection));
 		FINALIZE;
 	}
 
@@ -2183,6 +2183,7 @@ finalize_it:
 		free(pThis->pszRcvBuf);
 		pThis->pszRcvBuf = NULL;
 	}
+	*nextIODirection = (gnutls_record_get_direction(pThis->sess) == 0) ? NSDSEL_RD : NSDSEL_WR;
 	dbgprintf("gtlsRcv return. nsd %p, iRet %d, lenRcvBuf %d, ptrRcvBuf %d\n", pThis,
 	iRet, pThis->lenRcvBuf, pThis->ptrRcvBuf);
 	RETiRet;

--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -103,7 +103,7 @@ PROTOTYPEObj(nsd_gtls);
 /* some prototypes for things used by our nsdsel_gtls helper class */
 uchar *gtlsStrerror(int error);
 rsRetVal gtlsChkPeerAuth(nsd_gtls_t *pThis);
-rsRetVal gtlsRecordRecv(nsd_gtls_t *pThis);
+rsRetVal gtlsRecordRecv(nsd_gtls_t *pThis, unsigned *);
 
 /* the name of our library binary */
 #define LM_NSD_GTLS_FILENAME "lmnsd_gtls"

--- a/runtime/nsd_ossl.h
+++ b/runtime/nsd_ossl.h
@@ -73,7 +73,7 @@ PROTOTYPEObj(nsd_ossl);
 /* some prototypes for things used by our nsdsel_ossl helper class */
 uchar *osslStrerror(int error);
 rsRetVal osslChkPeerAuth(nsd_ossl_t *pThis);
-rsRetVal osslRecordRecv(nsd_ossl_t *pThis);
+rsRetVal osslRecordRecv(nsd_ossl_t *pThis, unsigned*);
 rsRetVal osslHandshakeCheck(nsd_ossl_t *pNsd);
 void nsd_ossl_lastOpenSSLErrorMsg(nsd_ossl_t const *pThis, const int ret, SSL *ssl, int severity,
 	const char* pszCallSource, const char* pszOsslApi);

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -775,7 +775,7 @@ finalize_it:
  * rgerhards, 2008-03-17
  */
 static rsRetVal
-Rcv(nsd_t *pNsd, uchar *pRcvBuf, ssize_t *pLenBuf, int *const oserr)
+Rcv(nsd_t *pNsd, uchar *pRcvBuf, ssize_t *pLenBuf, int *const oserr, unsigned *const nextIODirection)
 {
 	char errStr[1024];
 	DEFiRet;
@@ -789,6 +789,7 @@ Rcv(nsd_t *pNsd, uchar *pRcvBuf, ssize_t *pLenBuf, int *const oserr)
 
 	*pLenBuf = recv(pThis->sock, pRcvBuf, *pLenBuf, MSG_DONTWAIT);
 	*oserr = errno;
+	*nextIODirection = NSDSEL_RD;
 
 	if(*pLenBuf == 0) {
 		ABORT_FINALIZE(RS_RET_CLOSED);

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -805,7 +805,6 @@ closeSess(tcpsrv_t *const pThis, tcpsrv_io_descr_t *const pioDescr)
 {
 	DEFiRet;
 	assert(pioDescr->ptrType == NSD_PTR_TYPE_SESS);
-dbgprintf("RGER: iodescr %p destructed via closeSess\n", pioDescr);
 	tcps_sess_t *pSess = pioDescr->ptr.pSess;
 	#if defined(ENABLE_IMTCP_EPOLL)
 		CHKiRet(epoll_Ctl(pThis, pioDescr, 0, EPOLL_CTL_DEL));
@@ -837,7 +836,6 @@ notifyReArm(tcpsrv_io_descr_t *const pioDescr)
 {
 	DEFiRet;
 
-dbgprintf("ReArm socket %d with %s\n", pioDescr->sock, (pioDescr->ioDirection == NSDSEL_RD) ? "EPOLLIN" : "EPOLLOUT");
 	const unsigned waitIOEvent = (pioDescr->ioDirection == NSDSEL_WR) ? EPOLLOUT : EPOLLIN;
 	pioDescr->event.events = waitIOEvent | EPOLLET | EPOLLONESHOT;
 	if(epoll_ctl(pioDescr->pSrv->evtdata.epoll.efd, EPOLL_CTL_MOD, pioDescr->sock, &pioDescr->event) < 0) {
@@ -1082,7 +1080,6 @@ processWorksetItem(tcpsrv_io_descr_t *const pioDescr, tcpsrvWrkrData_t *const wr
 		iRet = doReceive(pioDescr, wrkrData);
 	}
 
-DBGPRINTF("RGER: processWorksetItem returns %d\n", iRet);
 	RETiRet;
 }
 
@@ -1144,7 +1141,6 @@ dequeueWork(tcpsrv_t *pSrv)
 
 	pthread_mutex_lock(&queue->mut);
 	while((queue->head == NULL) && !glbl.GetGlobalInputTermState()) {
-dbgprintf("RGER: waiting on condition\n");
 		pthread_cond_wait(&queue->workRdy, &queue->mut);
 	}
 
@@ -1158,7 +1154,6 @@ dbgprintf("RGER: waiting on condition\n");
 	if(queue->head == NULL) {
 		queue->tail = NULL;
 	}
-DBGPRINTF("RGER: DEqueuWork done, sock %d\n", pioDescr->sock);
 
 finalize_it:
 	pthread_mutex_unlock(&queue->mut);
@@ -1181,7 +1176,6 @@ enqueueWork(tcpsrv_io_descr_t *const pioDescr)
 	}
 	queue->tail = pioDescr;
 
-DBGPRINTF("RGER: enqueuWork done, sock %d\n", pioDescr->sock);
 	pthread_cond_signal(&queue->workRdy);
 	pthread_mutex_unlock(&queue->mut);
 

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -91,6 +91,7 @@ typedef struct workQueue_s {
 struct tcpsrv_io_descr_s {
 	int id;		/* index into listener or session table, depending on ptrType */
 	int sock;	/* socket descriptor we need to "monitor" */
+	unsigned ioDirection;
 	enum {NSD_PTR_TYPE_LSTN, NSD_PTR_TYPE_SESS} ptrType;
 	union {
 		tcps_sess_t *pSess;
@@ -171,7 +172,7 @@ struct tcpsrv_s {
 	void *pUsr;		/**< a user-settable pointer (provides extensibility for "derived classes")*/
 	/* callbacks */
 	int      (*pIsPermittedHost)(struct sockaddr *addr, char *fromHostFQDN, void*pUsrSrv, void*pUsrSess);
-	rsRetVal (*pRcvData)(tcps_sess_t*, char*, size_t, ssize_t *, int*);
+	rsRetVal (*pRcvData)(tcps_sess_t*, char*, size_t, ssize_t *, int*, unsigned*);
 	rsRetVal (*OpenLstnSocks)(struct tcpsrv_s*);
 	rsRetVal (*pOnListenDeinit)(void*);
 	rsRetVal (*OnDestruct)(void*);
@@ -212,7 +213,8 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
 	rsRetVal (*SetUsrP)(tcpsrv_t*, void*);
 	rsRetVal (*SetCBIsPermittedHost)(tcpsrv_t*, int (*) (struct sockaddr *addr, char*, void*, void*));
 	rsRetVal (*SetCBOpenLstnSocks)(tcpsrv_t *, rsRetVal (*)(tcpsrv_t*));
-	rsRetVal (*SetCBRcvData)(tcpsrv_t *pThis, rsRetVal (*pRcvData)(tcps_sess_t*, char*, size_t, ssize_t*, int*));
+	rsRetVal (*SetCBRcvData)(tcpsrv_t *pThis, rsRetVal (*pRcvData)(tcps_sess_t*, char*, size_t, ssize_t*,
+		int*, unsigned*));
 	rsRetVal (*SetCBOnListenDeinit)(tcpsrv_t*, rsRetVal (*)(void*));
 	rsRetVal (*SetCBOnDestruct)(tcpsrv_t*, rsRetVal (*) (void*));
 	rsRetVal (*SetCBOnRegularClose)(tcpsrv_t*, rsRetVal (*) (tcps_sess_t*));


### PR DESCRIPTION
Depending on circumstances, tcpsrv worker threads did effectively busy-wait on io events to handle. Not always, but often. This was caused be improperly re-arming the inotify subsystem.

This effected overall system performance, but not general rsyslog stability. The bug was introduced on March 1st 2025 into the daily stable build.

closes https://github.com/rsyslog/rsyslog/issues/5623
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
