### PR TITLE
ossl tls driver: better error reporting

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -258,7 +258,7 @@ sslerr:
 			/* Output error and abort */
 			nsd_ossl_lastOpenSSLErrorMsg(pThis, lenRcvd, pThis->pNetOssl->ssl, LOG_INFO,
 				"osslRecordRecv", "SSL_read 1");
-			iRet = RS_RET_NO_ERRCODE;
+			iRet = RS_RET_TLS_ERR_SYSCALL;
 			/* Check for underlaying socket errors **/
 			if (	errno == ECONNRESET) {
 				DBGPRINTF("osslRecordRecv: SSL_ERROR_SYSCALL Errno %d, connection reset by peer\n",
@@ -308,7 +308,7 @@ osslInitSession(nsd_ossl_t *pThis, osslSslState_t osslType) /* , nsd_ossl_t *pSe
 	if(!(pThis->pNetOssl->ssl = SSL_new(pThis->pNetOssl->ctx))) {
 		pThis->pNetOssl->ssl = NULL;
 		nsd_ossl_lastOpenSSLErrorMsg(pThis, 0, pThis->pNetOssl->ssl, LOG_ERR, "osslInitSession", "SSL_new");
-		ABORT_FINALIZE(RS_RET_NO_ERRCODE);
+		ABORT_FINALIZE(RS_RET_TLS_BASEINIT_FAIL);
 	}
 
 	// Set SSL_MODE_AUTO_RETRY to SSL obj
@@ -1191,7 +1191,7 @@ Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf)
 				/* Output error and abort */
 				nsd_ossl_lastOpenSSLErrorMsg(pThis, iSent, pThis->pNetOssl->ssl, LOG_INFO,
 					"Send", "SSL_write");
-				iRet = RS_RET_NO_ERRCODE;
+				iRet = RS_RET_TLS_ERR_SYSCALL;
 				/* Check for underlaying socket errors **/
 				if (	errno == ECONNRESET) {
 					dbgprintf("Send: SSL_ERROR_SYSCALL Connection was reset by remote\n");

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -635,6 +635,8 @@ enum rsRetVal_				/** return value. All methods return this if not specified oth
 	RS_RET_NET_CONN_ABORTED = -2456, /**< error during dropping the capabilities */
 	RS_RET_PROGRAM_ERROR = -2457, /**< rsyslogd internal error, like tried NULL-ptr access */
 	RS_RET_DEBUG = -2458, /**< status messages primarily meant for debugging, no error */
+	RS_RET_TLS_BASEINIT_FAIL = -2459, /**< Basic TLS initialization step failed */
+	RS_RET_TLS_ERR_SYSCALL = -2460, /**< TLS lib had problem with syscall */
 
 	/* RainerScript error messages (range 1000.. 1999) */
 	RS_RET_SYSVAR_NOT_FOUND = 1001, /**< system variable could not be found (maybe misspelled) */


### PR DESCRIPTION
Replace some generic error codes with more specific counterparts. There is still some more work to do, but this covers important spots.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
