### PR TITLE
tcpsrv: ensure thread name set via pthread is max 15 char

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1198,6 +1198,9 @@ wrkr(void *arg)
 
 	tcpsrvWrkrData_t *const wrkrData = &(queue->wrkr_data[wrkrIdx]);
 
+	uchar shortThrdName[16];
+	snprintf((char*)shortThrdName, sizeof(shortThrdName), "w%d/%s", wrkrIdx,
+		(pThis->pszInputName == NULL) ? (uchar*)"tcpsrv" : pThis->pszInputName);
 	uchar thrdName[32];
 	snprintf((char*)thrdName, sizeof(thrdName), "w%d/%s", wrkrIdx,
 		(pThis->pszInputName == NULL) ? (uchar*)"tcpsrv" : pThis->pszInputName);
@@ -1209,7 +1212,7 @@ wrkr(void *arg)
 		DBGPRINTF("prctl failed, not setting thread name for '%s'\n", thrdName);
 	}
 #	elif defined(HAVE_PTHREAD_SETNAME_NP)
-	int r = pthread_setname_np(pthread_self(), (char*) thrdName);
+	int r = pthread_setname_np(pthread_self(), (char*) shortThrdName);
 	if(r != 0) {
 		DBGPRINTF("pthread_setname_np failed, not setting thread name for '%s'\n", thrdName);
 	}


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
