### PR TITLE
tls subsystem: generate better error message on accept failure

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -977,6 +977,42 @@ finalize_it:
 	RETiRet;
 }
 
+/**** TEMP for ehanced error message until better solution is found *****/
+static int get_socket_info(int sockfd, char *src_ip_str, int *src_port, char *dest_ip_str, int *dest_port) {
+    struct sockaddr_in local_addr;
+    socklen_t local_addr_len = sizeof(local_addr);
+
+    struct sockaddr_in remote_addr;
+    socklen_t remote_addr_len = sizeof(remote_addr);
+
+    // Get local socket information
+    if (getsockname(sockfd, (struct sockaddr *)&local_addr, &local_addr_len) == -1) {
+        perror("getsockname in get_socket_info");
+        return -1;
+    }
+
+    if (inet_ntop(AF_INET, &local_addr.sin_addr, src_ip_str, INET_ADDRSTRLEN) == NULL) {
+        perror("inet_ntop (local IP) in get_socket_info");
+        return -1;
+    }
+    *src_port = ntohs(local_addr.sin_port);
+
+    // Get remote peer information
+    if (getpeername(sockfd, (struct sockaddr *)&remote_addr, &remote_addr_len) == -1) {
+        perror("getpeername in get_socket_info");
+        return -1;
+    }
+
+    if (inet_ntop(AF_INET, &remote_addr.sin_addr, dest_ip_str, INET_ADDRSTRLEN) == NULL) {
+        perror("inet_ntop (remote IP) in get_socket_info");
+        return -1;
+    }
+    *dest_port = ntohs(remote_addr.sin_port);
+
+    return 0; // Success
+}
+/**** END TEMP for ehanced error message until better solution is found *****/
+
 /* accept an incoming connection request - here, we do the usual accept
  * handling. TLS specific handling is done thereafter (and if we run in TLS
  * mode at this time).
@@ -989,11 +1025,20 @@ AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew)
 	nsd_ossl_t *pNew = NULL;
 	nsd_ossl_t *pThis = (nsd_ossl_t*) pNsd;
 
+int have_ip = 0;
+char src_ip_str[INET_ADDRSTRLEN]; // Buffer to hold the IP address string
+int  src_port;
+char dest_ip_str[INET_ADDRSTRLEN]; // Buffer to hold the IP address string
+int  dest_port;
+
 	ISOBJ_TYPE_assert((pThis), nsd_ossl);
 	CHKiRet(nsd_osslConstruct(&pNew));
 	CHKiRet(nsd_ptcp.Destruct(&pNew->pTcp));
 	dbgprintf("AcceptConnReq for [%p]: Accepting connection ... \n", (void *)pThis);
 	CHKiRet(nsd_ptcp.AcceptConnReq(pThis->pTcp, &pNew->pTcp));
+
+
+have_ip = !get_socket_info(((nsd_ptcp_t*) pNew->pTcp)->sock, src_ip_str, &src_port, dest_ip_str, &dest_port);
 
 	if(pThis->iMode == 0) {
 		/*we are in non-TLS mode, so we are done */
@@ -1027,6 +1072,11 @@ finalize_it:
 			iRet, pNew, pNew->rtryCall);
 	}
 	if(iRet != RS_RET_OK) {
+if(have_ip) {
+	LogError(0, iRet, "nsd_ossl failed "
+		"to process incoming connection from remote peer %s:%d to %s:%d with error %d",
+		dest_ip_str, dest_port, src_ip_str, src_port, iRet);
+}
 		if(pNew != NULL) {
 			nsd_osslDestruct(&pNew);
 		}


### PR DESCRIPTION
Right now, the remote peer is not reported, even in cases where this would be possible. This patch provides a method to emit a second message with remote peer information in cases where it is possible. This is the case when the remote peer connects via plain tcp but TLS cannot be negotiated, especially because the connection breaks immediately. Most probably this behaviour can be created by load balancer and other tools healt checks.

This patch improves debugging network issues. So it is useful. However, it is far from perfect and if the method prooves to be useful in practice, further work is need to integrate it in a better way into the overall architecture. We may also be able to emit remote peer info in other cases. Stil, we can provide this patch as it offers sufficient value even in its current state.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
