### PR TITLE
imjournal: delete redundant lines in imklog.c

### DIFF
--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -339,7 +339,6 @@ CODESTARTbeginCnfLoad
 	pModConf->bParseKernelStamp = 0;
 	pModConf->bKeepKernelStamp = 0;
 	pModConf->console_log_level = -1;
-	pModConf->bKeepKernelStamp = 0;
 	pModConf->iFacilIntMsg = klogFacilIntMsg();
 	loadModConf->configSetViaV2Method = 0;
 	pModConf->ratelimiter = NULL;


### PR DESCRIPTION
The `bKeepKernelStamp` field assignment has been repeated twice,
This line of code is redundant,  need to be deleted and cleaned up.

fix issue: #5396