### PR TITLE
imhttp: add simple http health check functionality

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1108,7 +1108,9 @@ TESTS += \
 	imhttp-post-payload-multi.sh \
 	imhttp-post-payload-multi-lf.sh \
 	imhttp-post-payload-compress.sh \
-	imhttp-getrequest-file.sh
+	imhttp-getrequest-file.sh \
+	imhttp-healthcheck.sh \
+	imhttp-metrics.sh
 if HAVE_VALGRIND
 TESTS +=  \
 	imhttp-post-payload-vg.sh \
@@ -2714,6 +2716,8 @@ EXTRA_DIST= \
 	imhttp-post-payload-multi-lf-vg.sh \
 	imhttp-post-payload-compress.sh \
 	imhttp-post-payload-compress-vg.sh \
+	imhttp-healthcheck.sh \
+	imhttp-metrics.sh \
 	testsuites/docroot/file.txt \
 	testsuites/htpasswd \
 	omhttp-auth.sh \

--- a/tests/imhttp-healthcheck.sh
+++ b/tests/imhttp-healthcheck.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'"
+)
+'
+startup
+curl -s http://localhost:$IMHTTP_PORT/healthz > "$RSYSLOG_OUT_LOG"
+shutdown_when_empty
+wait_shutdown
+content_check "OK"
+exit_test

--- a/tests/imhttp-metrics.sh
+++ b/tests/imhttp-metrics.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+IMHTTP_PORT="$(get_free_port)"
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="'$IMHTTP_PORT'"
+       metricsPath="/metrics"
+)
+'
+startup
+curl -s http://localhost:$IMHTTP_PORT/metrics > "$RSYSLOG_OUT_LOG"
+shutdown_when_empty
+wait_shutdown
+content_check "imhttp_up 1"
+exit_test


### PR DESCRIPTION
This also includes a basic Prometheus scrape entry point, which currently can only be used for health checking.

We plan futher enhancement in this direction.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
