### PR TITLE
stats: add prometheus format to set of supported output formats

### DIFF
--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -395,6 +395,8 @@ CODESTARTsetModCnf
 				loadModConf->statsFmt = statsFmt_CEE;
 			} else if(!strcasecmp(mode, "legacy")) {
 				loadModConf->statsFmt = statsFmt_Legacy;
+			} else if(!strcasecmp(mode, "prometheus")) {
+				loadModConf->statsFmt = statsFmt_Prometheus;
 			} else {
 				LogError(0, RS_RET_ERR, "impstats: invalid format %s",
 						mode);

--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -48,7 +48,15 @@ typedef enum statsFmtType_e {
 	statsFmt_Legacy,
 	statsFmt_JSON,
 	statsFmt_JSON_ES,
-	statsFmt_CEE
+	statsFmt_CEE,
+	/**
+	* Prometheus text‐exposition format:
+	* For each counter, emit:
+	*   # HELP <obj>_<ctr> (optional generic text)
+	*   # TYPE <obj>_<ctr> counter
+	*   <obj>_<ctr> <value>
+	*/
+	statsFmt_Prometheus
 } statsFmtType_t;
 
 /* counter flags */

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -406,7 +406,6 @@ rsRetVal rsCStrSetSzStr(cstr_t *const __restrict__ pThis,
 uchar*
 cstrGetSzStrNoNULL(cstr_t *const __restrict__ pThis)
 {
-	rsCHECKVALIDOBJECT(pThis, OIDrsCStr);
 	assert(pThis->isFinalized);
 	return (pThis->pBuf == NULL) ? (uchar*) "" : pThis->pBuf;
 }

--- a/tests/stats-json-prometheus.sh
+++ b/tests/stats-json-prometheus.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# added 2016-03-30 by singh.janmejay
+# This file is part of the rsyslog project, released under ASL 2.0
+echo ===============================================================================
+echo \[stats-json-es.sh\]: test for verifying stats are reported correctly json-elasticsearch format
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+ruleset(name="stats") {
+  action(type="omfile" file="'${RSYSLOG_DYNNAME}'.out.stats.log")
+}
+
+module(load="../plugins/impstats/.libs/impstats" interval="1" severity="7" resetCounters="on" Ruleset="stats" bracketing="on" format="prometheus")
+
+if ($msg == "this condition will never match") then {
+  action(name="an_action_that_is_never_called" type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+}
+'
+startup
+injectmsg_file $srcdir/testsuites/dynstats_input_1
+wait_queueempty
+wait_for_stats_flush ${RSYSLOG_DYNNAME}.out.stats.log
+echo doing shutdown
+shutdown_when_empty
+echo wait on shutdown
+wait_shutdown
+custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_assert_content_missing '@cee' "${RSYSLOG_DYNNAME}.out.stats.log"
+exit_test


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
