### PR TITLE
docs: restructure contributor docs for clarity and AI agent readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,178 @@
+# AGENTS.md – rsyslog Repository Agent Guide
+
+This file defines guidelines and instructions for AI assistants (e.g., Codex, GitHub Copilot Workspace, ChatGPT agents) to understand and contribute effectively to the rsyslog codebase.
+
+---
+
+## 🧭 Repository Overview
+
+- **Primary Language**: C  
+- **Build System**: autotools (`autogen.sh`, `configure`, `make`)  
+- **Modules**: Dynamically loaded from `modules/`  
+- **Documentation**: Maintained in a separate repository ([rsyslog-doc](https://github.com/rsyslog/rsyslog-doc))  
+- **Child Projects**:
+  - [`rsyslog-docker`](https://github.com/rsyslog/rsyslog-docker): Provides prebuilt container environments for development and CI
+- **Side Libraries** (each in its own repo within the rsyslog GitHub org):
+  - [`liblognorm`](https://github.com/rsyslog/liblognorm)
+  - [`librelp`](https://github.com/rsyslog/librelp)
+  - [`libestr`](https://github.com/rsyslog/libestr)
+  - [`libfastjson`](https://github.com/rsyslog/libfastjson)
+
+---
+
+## 🔄 Development Workflow
+
+### Base Repository
+- URL: https://github.com/rsyslog/rsyslog
+- **Default base branch: `master`**  
+  > For technical reasons, `master` is still the default branch. Numerous scripts and CI workflows rely on this name.
+
+### Contributor Workflow
+1. Fork the repository (for personal development)
+2. Create a feature/fix branch
+3. Push changes to your fork
+4. Open a **pull request directly into `rsyslog/rsyslog:master`**
+
+> **Important**: AI-generated PRs must target the `rsyslog/rsyslog` repository directly.
+
+---
+
+## 🏷️ Branch Naming Conventions
+
+There are no strict naming rules, but these conventions are used frequently:
+
+- For issue-based work: `i-<issue-number>` (e.g., `i-2245`)
+- For features or refactoring: free-form is acceptable
+- For AI-generated work: prefix the branch name with the AI tool name  
+  (e.g., `gpt-i-2245-json-stats-export`)
+
+---
+
+## ✅ Coding Standards
+
+- **Use tabs, not spaces** for indentation — enforced via CI
+- Commit messages **must include all relevant information**, not just in the PR
+- Favor **self-documenting code** over excessive inline comments
+- Public functions should use Doxygen-style comments
+- Modules must implement and register `modInit()` and `modExit()`
+
+---
+
+## 🧪 Testing & Validation
+
+rsyslog uses a custom test driver and has complex build dependencies.
+
+### 🧰 Test Framework
+
+- All test definitions are located in the `/tests` directory.
+- The test execution framework is implemented in `tests/diag.sh`.
+- Tests are driven via `make check`, which wraps around `diag.sh`.
+
+> ⚠️ Test execution is resource-intensive. Limit concurrency (`make check -j4` or less) to avoid unreliable results.
+
+---
+
+### ✅ Recommended Test Environment
+
+Use prebuilt container environments provided by [`rsyslog-docker`](https://github.com/rsyslog/rsyslog-docker):
+
+- They contain all required libraries and tools
+- CI-like workflows can be reproduced locally
+- Support full configuration flexibility (Valgrind, tsan, sanitizers, etc.)
+
+> **If only a single test run is planned**, the best container to use is:  
+> `rsyslog/rsyslog_dev_base_ubuntu:24.04`
+
+GitHub Actions and other CI systems use these containers. Test execution typically takes 10–40 minutes per runner depending on the suite.
+
+---
+
+### ❗ Manual Setup (discouraged)
+
+Minimum setup requires:
+
+- Autotools toolchain: `autoconf`, `automake`, `libtool`, `make`, `gcc`
+- Side libraries: `libestr`, `librelp`, `libfastjson`, `liblognorm` (must be installed or built manually)
+
+Example commands:
+
+```bash
+./autogen.sh
+./configure --enable-debug
+make -j$(nproc)
+make check
+```
+
+Use `make check -j2` or `-j4` max for reliability.
+
+---
+
+## 📚 Documentation
+
+Main documentation is in a separate repo:  
+🔗 https://github.com/rsyslog/rsyslog-doc
+
+To build locally:
+
+```bash
+cd rsyslog-doc
+pip install -r requirements.txt
+make html
+```
+
+If a feature changes user-facing behavior or configuration:
+- Update the appropriate section in `rsyslog-doc`
+- Link it in your PR and commit message
+
+---
+
+## 📋 Pull Request & Commit Guidelines
+
+- PR title should be concise and informative  
+- PR body should describe what changed, why, how it was tested, and any caveats
+- **Commit messages must be complete** — assume the reader only has the git log
+- Link relevant GitHub issues (e.g., `Closes #1234`)
+- Use a single logical commit unless there's a clear need to split
+
+---
+
+## 💡 AI-Specific Hints
+
+- The `modules/` directory contains dynamically loaded input/output plugins  
+- `statsobj.c` implements the statistics interface  
+- `imhttp` provides HTTP input and optionally Prometheus metrics  
+- Use `doc/` only for legacy inline docs — modern documentation lives in `rsyslog-doc`
+- You may reference `rsyslog-docker` for dev/test environment setup
+- Side libraries are external GitHub repos, not subdirectories
+
+When generating or editing code, prefer:
+- Clean modular design  
+- Compatibility and backward safety  
+- Updating structured comments (e.g., Doxygen)
+
+---
+
+## 🤖 AI Agent Commit Convention
+
+If you are an AI agent contributing code or documentation:
+
+- Include a **commit footer tag** like:
+  ```
+  AI-Agent: Codex 2025-06
+  ```
+- PR descriptions should clearly identify that they were generated or co-authored by an AI tool.
+- Avoid generating multiple PRs for retries — reuse and update the original PR when possible.
+- Follow the same **commit message policy** as human contributors: describe what changed, why, and how it was validated.
+
+---
+
+## 🔐 Privacy, Trust & Permissions
+
+- AI agents **must not** push changes directly to user forks — always open PRs against `rsyslog/rsyslog`
+- Do not install third-party dependencies unless explicitly approved
+- PRs must pass standard CI and review checks
+- All code **must be reviewed manually**; AI output is subject to full review
+
+---
+
+End of `AGENTS.md`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,164 +1,101 @@
-# How to Contribute
+# Rsyslog Contribution Guide
 
-Rsyslog is a real open source project and open to contributions.
-By contributing, you help improve the state of logging as well as improve
-your own professional profile. Contributing is easy, and there are options
-for everyone - you do not need to be a developer.
+Rsyslog is a real open source project, welcoming contributions of all kinds—from code to documentation to community engagement. Whether you're an experienced developer or a first-time contributor, there are many ways to get involved.
 
-These are many ways to contribute to the project:
- * become a rsyslog ambassador and let other people know about rsyslog and how to utilize it for best results. Help rsyslog getting backlinks, be present on Internet news sites or at meetings you attend.
- * help others by offering support on
-   * the rsyslog's github home at https://github.com/rsyslog/rsyslog
-   * the rsyslog mailing list at http://lists.adiscon.net/mailman/listinfo/rsyslog
- * help with the documentation; you can either contribute
-   * to the [rsyslog doc directory](https://github.com/rsyslog/rsyslog-doc), which is shown on http://rsyslog.com/doc
-   * to the rsyslog project web site -- just ask us for account creation
- * become a bug-hunter and help with testing rsyslog development releases
- * help driving the rsyslog infrastructure with its web sites and the like
- * help creating packages
- * or, obviously, help with rsyslog code development
+---
 
-This list is not conclusive. There for sure are many more ways to contribute and if you find one, just let us know. We are very open to new suggestions and like to try out new things.
+## Ways to Contribute
 
-## When to submit Pull Requests?
+- **Be an ambassador**: Spread the word about rsyslog and how to best use it.
+- **Offer support**:
+  - On GitHub: [rsyslog repository](https://github.com/rsyslog/rsyslog)
+  - On the mailing list: [mailing list signup](http://lists.adiscon.net/mailman/listinfo/rsyslog)
+- **Improve documentation**:
+  - Contribute to [rsyslog-doc](https://github.com/rsyslog/rsyslog-doc)
+  - Help maintain [rsyslog.com/doc](http://rsyslog.com/doc)
+- **Maintain infrastructure**: Help with project websites, CI, or packaging.
+- **Develop code**: Implement new features, improve existing ones, or fix bugs.
 
-It is OK to submit PRs that are not yet fully ready for merging. You want to
-do this in order to get early CI system coverage for your patch. However,
-all patches should be reasonably complete and "work" in a sense.
+---
 
-If you submit such PRs, please flag them as "work in progress" by adding
-"WiP:" in front of the title. We will NOT merge these PRs before you tell us
-they are now ready for merging.
+## Pull Requests
 
-If you just want/need to do a temporary experiment, you may open a PR, flag it
-as "EXPERIMENT - DO NOT MERGE", let the CI tests run, check results and close
-the PR thereafter. This prevents unnecessary cluttering of the open PR list.
-We will take the liberty to close such PRs if they are left open for an
-extended period of time.
+### Drafts and Experiments
+- You may submit early PRs for CI testing. Mark them clearly as `WiP:`.
+- For experiments, use **draft pull requests**. Close them after testing.
 
-Please note, though, that the rsyslog repo is fully set up to use Travis CI.
-Travis covers about 95% of all essential testing. So we highly recommend
-that you use Travis to do initial checks on your work and create the PR
-only after this looks good. That saves both you and us some time.
+### Target Branch
+- All PRs must target the `master` branch (not `main`).
+- **Why `master`?** The `master` name is deeply integrated into our test and deployment infrastructure, across many legacy environments. Renaming would disrupt a wide ecosystem of automated tools and integrations.
 
-## Requirements for patches
+---
 
-In order to ensure good code quality, after applying the path the code must
+## Commit Guidelines for AI Agents
 
-- no legacy configuration statements ($someSetting) must be added,
-  all configuration must be in v6+ style (RainerScript)
-- compile cleanly without WARNING messages under both gcc and clang
-- pass clang static analyzer without any report
-- pass all CI tests
-- new functionality must have associated
-  * testbench tests
-  * doc additions in the rsyslog-doc sister project
-- be [sufficiently squashed](https://rainer.gerhards.net/2019/03/squash-your-pull-requests.html)
+If you use an AI agent (e.g. GitHub Copilot, ChatGPT, Codex), prefix your commit message with `AI:`.
+This helps us track and evaluate contributions and agent capabilities.
 
-### Testbench Coverage
+---
 
-If you fix a bug that is not detected by the current testbench, it is
-appreciated if you also add testbench test to make sure the problem does
-not re-occur in the future.
+## Patch Requirements
 
-In contrast to new feature PRs, this is not a hard requirement, but it
-helps to speed up merging. If there is no testbench test added, the
-core rsyslog developers will try to add one based on the patch. That
-means merging needs to wait until we have time to do this.
+All submissions must:
 
-### Compiler Diagnostics
+- Use RainerScript (no legacy `$...` config statements).
+- Compile cleanly with **no warnings** on both `gcc` and `clang`.
+- Pass `clang` static analysis with no findings.
+- Pass **all CI test jobs** (see below).
+- Include:
+  - Tests (for new features or bugfixes)
+  - Documentation updates (for new features)
+  - Squashed commits ([why it matters](https://rainer.gerhards.net/2019/03/squash-your-pull-requests.html))
 
-Note that both warning messages and static analyzer warnings may be false
-positives. We have decided to accept that fate and work around it (e.g. by
-re-arranging the code, etc). Otherwise, we cannot use these useful features.
+### Testbench Tips
 
-As a last resort, compiler warnings can be turned off via
-   #pragma diagnostic
-directives. This should really only be done if there is no other known
-way around it. If so, it should be applied to a single function, only and
-not to full source file. Be sure to re-enable the warning after the function
-in question. We have done this in some few cases ourselves, and if someone
-can fix the root cause, we would appreciate help. But, again, this is a
-last resort which should normally not be used.
+- Write small, focused tests.
+- Use similar existing tests as templates.
+- Test driver is `make check`, backed by `tests/diag.sh`.
+- Test concurrency is limited due to resource load.
 
-Please read [on the importance of static analysis and why we request you to work around false positives](https://rainer.gerhards.net/2018/06/why-static-code-analysis.html).
+### Compiler Warnings
+False positives must be resolved, not ignored. Only in extreme cases use:
+```c
+#pragma diagnostic push
+#pragma GCC diagnostic ignored "..."
+// ... function
+#pragma diagnostic pop
+```
+Apply to **single functions only**.
 
-### Continuous Integration Testing
+See: [Why static analysis matters](https://rainer.gerhards.net/2018/06/why-static-code-analysis.html)
 
-All patches are run though our continuous integration system, which ensures
-no regressions are inside the code as well as rsyslog project policies are
-followed (as far as we can check in an automated way).
+---
 
-For pull requests submitted via github, these two conditions are 
-verified automatically. See the PR for potential failures. For patches
-submitted otherwise, they will be verified semi-manually.
+## Continuous Integration (CI)
 
-Also, patches are requested to not break the testbench. Unfortunately, the
-current testbench has some racy tests, which are still useful enough so that
-we do not want to disable them until the root cause has been found. If your
-PR runs into something that you think is not related to your code, just sit
-back and relax. The rsyslog core developer team reviews PRs regularly and
-restarts tests which we know to look racy. If the problem persists, we will
-contact you.
+All PRs are tested via:
+- GitHub Actions workflows (including multi-platform docker-based tests)
+- Additional off-GitHub runners (Solaris, exotic distros)
 
-All PRs will be tested on a variety of systems, with the help of both Travis
-CI and buildbot. The core goal of this multi-platform testing is to find
-issues that surface only on some systems (e.g. 32bit related issues, etc).
-We continuously strive to update the CI system coverage. If you can provide
-a buildbot slave for a not-yet-supported test platform, please let us know.
-We will gladly add it.
+Build durations: 10–40 min per matrix job.
+Some known flaky tests exist; we re-run these manually if needed.
 
-Note that test coverage differs between platforms. For example, not all
-databases etc. are tested on each platform. Also note that due to resource
-constraints some very lengthy tests are only execute on some (maybe only
-a single) platform.
+---
 
-Note that we always try to merge with the most recent master branch and
-try a build from that version (if automatic merging is possible). If this
-test fails but no other, chances are good that there is an inter-PR issue.
-If this happens, it is suggested to rebase to git master branch and update
-the PR.
+## GDPR and Privacy
 
-## Note to developers
+By contributing, your name, email, commit hash, and timestamp become part of the git history.
+This is fundamental to git and public open source contribution. If you have privacy concerns, you may commit anonymously:
 
-Please address pull requests against the master branch.
+```bash
+git commit --author "anonymous <gdpr@example.com>"
+```
 
+Avoid `--gpg-sign` in that case.
 
-## Testbench coding Tips
+If you use your real identity, note:
+- We cannot delete commits retroactively without damaging project history.
+- Identity data is used only to maintain copyright tracking and audit trails.
+- Public commits may be copied by third parties and redistributed without control.
 
-- look for similar tests and use them as copy template. Be sure to update
-  comments as well.
-- see ./tests/diag.sh -- this is the base testing framework and it contains
-  many functions you can use inside your tests
-- keep test cases simple and focussed on one topic. Otherwise it is hard to
-  address test failures when they happen in the future.
-
--------------------------------------------------------------------------------------
-LEGAL GDPR NOTICE:
-According to the European data protection laws (GDPR), we would like to make you
-aware that contributing to rsyslog via git will permanently store the
-name and email address you provide as well as the actual commit and the
-time and date you made it inside git's version history. This is inevitable,
-because it is a main feature git. If you are concerned about your
-privacy, we strongly recommend to use
-
---author "anonymous <gdpr@example.com>"
-
-together with your commit. Also please do NOT sign your commit in this case,
-as that potentially could lead back to you. Please note that if you use your
-real identity, the GDPR grants you the right to have this information removed
-later. However, we have valid reasons why we cannot remove that information
-later on. The reasons are:
-
-* this would break git history and make future merges unworkable
-* the rsyslog projects has legitimate interest to keep a permanent record of the
-  contributor identity, once given, for
-  - copyright verification
-  - being able to provide proof should a malicious commit be made
-
-Please also note that your commit is public and as such will potentially be
-processed by many third-parties. Git's distributed nature makes it impossible
-to track where exactly your commit, and thus your personal data, will be stored
-and be processed. If you would not like to accept this risk, please do either
-commit anonymously or refrain from contributing to the rsyslog project.
--------------------------------------------------------------------------------------
+---

--- a/README.md
+++ b/README.md
@@ -1,188 +1,82 @@
-Rsyslog - what is it?
-=====================
+# Rsyslog - What is it?
 
 [![Help Contribute to Open Source](https://www.codetriage.com/rsyslog/rsyslog/badges/users.svg)](https://www.codetriage.com/rsyslog/rsyslog)
 
-Rsyslog is a **r**ocket-fast **sys**tem for **log** processing.
+**Rsyslog** is a **r**ocket-fast **sys**tem for **log** processing.
 
-It offers high-performance, great security features and a modular design.
-While it started as a regular syslogd, rsyslog has evolved into a kind of swiss
-army knife of logging, being able to accept inputs from a wide variety of sources,
-transform them, and output to the results to diverse destinations.
+It offers high-performance, advanced security features, and a modular design.
+Originally a regular syslogd, rsyslog has evolved into a highly versatile logging solution capable of ingesting data from numerous sources, transforming it, and outputting it to a wide variety of destinations.
 
-Rsyslog can deliver over one million messages per second  to local destinations
-when limited processing is applied (based on v7, December 2013). Even with
-remote destinations and more elaborate processing the performance is usually
-considered "stunning".
+Rsyslog can deliver over one million messages per second to local destinations under minimal processing (based on v7, Dec 2013). Even with complex routing and remote forwarding, performance remains excellent.
 
-Mailing List
-============
-http://lists.adiscon.net/mailman/listinfo/rsyslog
+---
 
-Installing rsyslog
-==================
-Most distributions carry rsyslog in their repository. So you usually just need
-to use the package manager to install it. Note that on non-systemd systems (most
-notably Ubuntu), rsyslog usually is already installed.
+## Getting Help
+- **Mailing List:** [rsyslog mailing list](http://lists.adiscon.net/mailman/listinfo/rsyslog)
+- **GitHub Issues:** [Open an issue](https://github.com/rsyslog/rsyslog/issues)
 
-Project-Provided Packages
-----------------------------
-Unfortunately, distributions often do not catch up with the pace of rsyslog
-development and as such only offer old versions. To solve that problem, we have
-created packages for current versions ourselves.
+---
 
-They are available for:
- * RPM-based systems: https://www.rsyslog.com/rhelcentos-rpms/
- * Ubuntu: https://www.rsyslog.com/ubuntu-repository/
- * Debian: https://www.rsyslog.com/debian-repository/
+## Installation
 
-Building from Source
---------------------
-Follow the instructions at: https://www.rsyslog.com/doc/v8-stable/installation/build_from_repo.html
+### Via Distribution Package Managers
+Rsyslog is available in the package repositories of most Linux distributions. On non-systemd systems (e.g., Ubuntu), rsyslog is often pre-installed.
 
-### Build Environment
+### Project-Provided Packages (for latest versions)
+Distributions often lag behind in packaging the latest rsyslog releases. Official builds for newer versions are available here:
 
-In general, you need
+- [RPM-based systems](https://www.rsyslog.com/rhelcentos-rpms/)
+- [Ubuntu](https://www.rsyslog.com/ubuntu-repository/)
+- [Debian](https://www.rsyslog.com/debian-repository/)
 
-* pkg-config
-* libestr
-* liblogging (stdlog component, for testbench)
+### Building from Source
+See: [Build Instructions](https://www.rsyslog.com/doc/v8-stable/installation/build_from_repo.html)
 
-It is best to build these from source.
+#### Build Environment Requirements
+- `pkg-config`
+- `libestr`
+- `liblogging` (stdlog component, for testbench)
 
-#### CentOS 6 / RHEL
+Build support libraries from source if you're working with the latest git master.
 
-For json-c, we need:
-```
-export PKG_CONFIG_PATH=/lib64/pkgconfig/
-```
+#### OS-specific Build Instructions
+Refer to the respective section in the original README for required packages on CentOS, Ubuntu, Debian, SUSE, etc.
 
-```
-sudo yum install git valgrind autoconf automake flex bison python-docutils python-sphinx json-c-devel libuuid-devel libgcrypt-devel zlib-devel openssl-devel libcurl-devel gnutls-devel mysql-devel postgresql-devel libdbi-dbd-mysql libdbi-devel net-snmp-devel
-```
+---
 
-#### Ubuntu
+## Contributing
+Rsyslog is a community-driven open-source project. Contributions are welcome and encouraged!
 
-Add Adiscon repository:
-```
-apt-get update && apt-get install -y software-properties-common
-add-apt-repository -y ppa:adiscon/v8-stable
-```
+- See [CONTRIBUTING.md](CONTRIBUTING.md) for detailed contribution guidelines.
+- To develop new output plugins in Python or Perl, see: [plugins/external/README.md](plugins/external/README.md)
 
-*Note:* if you are a developer who wants to work with git master branch,
-adding the Adiscon repository is probably not a good idea. It then
-is better to also compile the supporting libraries from source, because
-newer versions of rsyslog may need newer versions of the libraries than
-there are in the repositories.
-Libraries in question are at least: libestr, liblognorm, libfastjson.
+If you're working with AI coding agents (e.g. GitHub Copilot, OpenAI Codex), note that we support these workflows with agent-specific instructions in `AGENTS.md`.
 
-Needed packages to build with omhiredis support:
-```
-apt-get update && apt-get install -y build-essential pkg-config libestr-dev libfastjson-dev zlib1g-dev uuid-dev libgcrypt20-dev libhiredis-dev uuid-dev libgcrypt11-dev liblogging-stdlog-dev flex bison
-```
+---
 
-Aditional packages for other modules:
-```
-libdbi-dev libmysqlclient-dev postgresql-client libpq-dev libnet-dev librdkafka-dev libgrok-dev libgrok1 libgrok-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev
-```
+## Documentation
+The complete and current documentation is maintained in the separate [`rsyslog-doc`](https://github.com/rsyslog/rsyslog-doc) project.
 
-For KSI, from the Adiscon PPA:
-```
-sudo apt-get install libksi0 libksi-devel
-```
+Visit the latest version online:
+- [rsyslog.com/doc](https://www.rsyslog.com/doc/)
 
-#### Debian
+---
 
-```
-sudo apt install build-essential pkg-config libestr-dev libfastjson-dev zlib1g-dev uuid-dev libgcrypt20-dev libcurl4-gnutls-dev zlib1g-dev liblogging-stdlog-dev flex bison
-```
+## Project Philosophy
+Rsyslog development is driven by real-world use cases, open standards, and an active community. While sponsored primarily by Adiscon, technical decisions are made independently via mailing list consensus.
 
-*Note:* For certain libraries version requirements might be higher,
-in that case adding debian backports repositories might help.
-For example installing with apt libfastjson-dev -t stretch-backports.
+All contributors are welcome—there is no formal membership beyond participation.
 
+---
 
-Aditional packages for other modules:
-```
-libdbi-dev libmysqlclient-dev postgresql-client libpq-dev libnet-dev librdkafka-dev libgrok-dev libgrok1 libgrok-dev libpcre3-dev libtokyocabinet-dev libglib2.0-dev libmongo-client-dev
-```
+## Project Funding
+Adiscon GmbH supports rsyslog through:
+- Custom development services
+- Professional support contracts
 
+Third-party contributions, services, and integrations are welcome.
 
+---
 
-#### openSUSE 13
-
-```
-sudo zypper install gcc make autoconf automake libtool libcurl-devel flex bison valgrind python-docutils libjson-devel uuid-devel libgcrypt-devel libgnutls-devel libmysqlclient-devel libdbi-devel libnet-devel postgresql-devel net-snmp-devellibuuid-devel libdbi-drivers-dbd-mysql
-```
-
-For the testbench VMs:
-```
-sudo zypper install gvim mutt
-```
-
-#### SUSE LINUX Enterprise Server 11
-
-Available packages:
-```
-zypper install gcc make autoconf libtool flex bison
-```
-
-Missing packages:
-```
-libcurl-devel valgrind python-docutils uuid-devel libgcrypt-devel libgnutls-devel libmysqlclient-devel libdbi-devel postgresql-devel net-snmp-devel libdbi-drivers-dbd-mysql json-c zlib-dev libdbi
-```
-
-Reporting Bugs
-==============
-
-Talk to the mailing list if you think something is a bug. Often, it's just a
-matter of doing some config trickery.
-
-File bugs at: https://github.com/rsyslog/rsyslog/issues
-
-How to Contribute
-=================
-Contributions to rsyslog are very welcome. Fork and send us your Pull Requests.
-
-For more information about contributing, see the
-[CONTRIBUTING](CONTRIBUTING.md) file.
-
-Note that it is easy to add output plugins using languages like Python or
-Perl. So if you need to connect to a system which is not yet supported, you
-can easily do so via an external plugin. For more information see the
-[README](plugins/external/README.md) file in the external plugin directory.
-
-Documentation
-=============
-The main rsyslog documentation is available in HTML format. To read
-it, point your web browser to ./doc/manual.html. Alternatively,
-you can view the documentation for *the most recent rsyslog version*
-online at: https://www.rsyslog.com/doc/
-
-Project Philosophy
-==================
-We are an open source project in all aspects and very open to outside feedback
-and contribution. We base our work on standards and try to solve all real-world
-needs (of course, we occasionally fail tackling actually all needs ;)). While
-the project is primarily sponsored by Adiscon, technical development is
-independent from company goals and most decisions are solely based on mailing
-list discussion results. There is an active community around rsyslog.
-
-There is no such thing like being an official member of the rsyslog team. The
-closest to that is being subscribed to the mailing list:
-http://lists.adiscon.net/mailman/listinfo/rsyslog
-
-This method of open discussions is modelled after the IETF process, which is
-probably the best-known and most successive collaborative standards body.
-
-Project Funding
-===============
-Rsyslog's main sponsor Adiscon tries to fund rsyslog by selling custom
-development and support contracts. Adiscon does NOT license rsyslog under a
-commercial license (this is simply impossible for anyone due to rsyslog's
-license structure).
-
-Any third party is obviously also free to offer custom development, support
-and rsyslog consulting. We gladly merge results of such third-party work into
-the main repository (assuming it matches the few essential things written
-down in our contribution policy).
+## Legal Notice (GDPR)
+Contributions to rsyslog are stored in git history and publicly distributed. Please refer to `CONTRIBUTING.md` for detailed GDPR-related information.


### PR DESCRIPTION
This commit updates all contributor-facing documentation:

- **README.md**: Modernized structure and clarified installation/build sections. Removed obsolete local doc references and replaced with link to rsyslog-doc project.
- **CONTRIBUTING.md**: Refactored for clarity, added guidance for AI-generated code (e.g. commit prefix `AI:`), formalized use of draft PRs for experiments, and removed outdated advice on "testing new releases." Added rationale for continued use of `master` branch due to ecosystem dependencies.
- **AGENTS.md** (new): Introduces clear guidelines for AI-based agents contributing to rsyslog. Includes commit formatting, PR branch expectations, testing environment, and behavioral rules.

**Why now?**
Over the past two years, we've continuously evaluated the evolving capabilities of AI development agents. We now consider them mature enough to be integrated into the rsyslog development workflow—under careful human review. This documentation update provides the foundation to onboard such agents in a controlled, auditable, and high-quality manner.

All changes prioritize traceability and developer clarity—both human and AI.

closes: https://github.com/rsyslog/rsyslog/issues/5657

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
