### PR TITLE
Add optional PCRE match function

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,10 @@ This ensures Codex can build core components even in constrained environments. S
 ### `imkafka` and `omkafka`
 - Depends on: `librdkafka` (plus `liblz4` when linking statically)
 
+### `fmpcre`
+- Buildable: Yes when `libpcre3-dev` (or equivalent) is installed
+- Testable: Yes, simple regression test `ffmpcre-basic.sh` exercises `pcre_match()`
+
 ### `omhiredis` and `imhiredis`
 - Depends on: `hiredis`; `imhiredis` also needs `libevent`
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -206,6 +206,10 @@ if ENABLE_FMUNFLATTEN
 SUBDIRS += contrib/fmunflatten
 endif
 
+if ENABLE_FMPCRE
+SUBDIRS += plugins/fmpcre
+endif
+
 if ENABLE_FFAUP
 SUBDIRS += contrib/ffaup
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -464,6 +464,28 @@ AC_ARG_ENABLE(fmunflatten,
 )
 AM_CONDITIONAL(ENABLE_FMUNFLATTEN, test x$enable_fmunflatten = xyes)
 
+# PCRE function module
+AC_ARG_ENABLE(fmpcre,
+       [AS_HELP_STRING([--enable-fmpcre],[Enable PCRE based match function @<:@default=no@:>@])],
+       [case "${enableval}" in
+        yes) enable_fmpcre="yes" ;;
+         no) enable_fmpcre="no" ;;
+          *) AC_MSG_ERROR(bad value ${enableval} for --enable-fmpcre) ;;
+        esac],
+       [enable_fmpcre=no]
+)
+if test "x$enable_fmpcre" = "xyes"; then
+       AC_CHECK_LIB([pcre], [pcre_exec], [
+               AC_CHECK_HEADER([pcre.h], [
+                       PCRE_LIBS="-lpcre"
+                       PCRE_CFLAGS=""
+                       AC_SUBST(PCRE_LIBS)
+                       AC_SUBST(PCRE_CFLAGS)
+               ], [AC_MSG_ERROR([pcre headers not found])])
+       ], [AC_MSG_ERROR([libpcre not found])])
+fi
+AM_CONDITIONAL(ENABLE_FMPCRE, test x$enable_fmpcre = xyes)
+
 
 #gssapi
 AC_ARG_ENABLE(gssapi_krb5,
@@ -3020,9 +3042,10 @@ AC_CONFIG_FILES([Makefile \
 		plugins/omdtls/Makefile \
 		contrib/mmdarwin/Makefile \
 		contrib/omhttp/Makefile \
-		contrib/fmhash/Makefile \
-		contrib/fmunflatten/Makefile \
-		contrib/ffaup/Makefile \
+               contrib/fmhash/Makefile \
+               contrib/fmunflatten/Makefile \
+               plugins/fmpcre/Makefile \
+               contrib/ffaup/Makefile \
 		contrib/pmsnare/Makefile \
 		contrib/pmpanngfw/Makefile \
 		contrib/pmaixforwardedfrom/Makefile \
@@ -3182,6 +3205,7 @@ echo "    fmhttp enabled:                           $enable_fmhttp"
 echo "    fmhash enabled:                           $enable_fmhash"
 echo "    fmhash with xxhash enabled:               $enable_fmhash_xxhash"
 echo "    fmunflatten enabled:                      $enable_fmunflatten"
+echo "    fmpcre enabled:                          $enable_fmpcre"
 echo "    ffaup enabled:                            $enable_ffaup"
 echo
 echo "---{ debugging support }---"

--- a/plugins/fmpcre/Makefile.am
+++ b/plugins/fmpcre/Makefile.am
@@ -1,0 +1,5 @@
+pkglib_LTLIBRARIES = fmpcre.la
+fmpcre_la_SOURCES = fmpcre.c
+fmpcre_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(PCRE_CFLAGS)
+fmpcre_la_LDFLAGS = -module -avoid-version
+fmpcre_la_LIBADD = $(PCRE_LIBS)

--- a/plugins/fmpcre/README.md
+++ b/plugins/fmpcre/README.md
@@ -1,0 +1,23 @@
+# fmpcre - PCRE-based matching function
+
+This optional RainerScript function module provides `pcre_match()`. It allows
+checking whether a given string matches a PCRE regular expression.
+
+## Build
+
+Install the PCRE development library (e.g. `libpcre3-dev` on Debian/Ubuntu) and
+enable the module during configure:
+
+```bash
+./configure --enable-fmpcre
+make
+```
+
+## Usage
+
+Load the module and call `pcre_match()` inside RainerScript:
+
+```rsyslog
+module(load="fmpcre")
+set $.hit = pcre_match($msg, "^foo.*bar$");
+```

--- a/plugins/fmpcre/fmpcre.c
+++ b/plugins/fmpcre/fmpcre.c
@@ -1,0 +1,128 @@
+/*
+ * Prototype PCRE function module for rsyslog
+ *
+ * Copyright 2024 rsyslog
+ * Licensed under the Apache License, Version 2.0
+ * see COPYING.ASL20 in the source distribution
+ */
+#include "config.h"
+#include <stdint.h>
+#include <stddef.h>
+#ifndef _AIX
+#include <typedefs.h>
+#endif
+#include <sys/types.h>
+#include <pcre.h>
+#include <string.h>
+
+#include "rsyslog.h"
+#include "parserif.h"
+#include "module-template.h"
+#include "rainerscript.h"
+
+MODULE_TYPE_FUNCTION
+MODULE_TYPE_NOKEEP
+DEF_FMOD_STATIC_DATA
+
+struct pcre_state {
+        pcre *re;
+};
+
+static void ATTR_NONNULL()
+doFunc_pcre_match(struct cnffunc *__restrict__ const func,
+        struct svar *__restrict__ const ret,
+        void *__restrict__ const usrptr,
+        wti_t *__restrict__ const pWti)
+{
+        struct pcre_state *state = (struct pcre_state*)func->funcdata;
+        struct svar srcVal;
+        int bMustFree;
+        char *str;
+        int rc;
+
+        cnfexprEval(func->expr[0], &srcVal, usrptr, pWti);
+        str = (char*) var2CString(&srcVal, &bMustFree);
+        rc = pcre_exec(state->re, NULL, str, strlen(str), 0, 0, NULL, 0);
+        if(rc >= 0)
+                ret->d.n = 1;
+        else
+                ret->d.n = 0;
+        ret->datatype = 'N';
+        if(bMustFree)
+                free(str);
+        varFreeMembers(&srcVal);
+}
+
+static rsRetVal ATTR_NONNULL(1)
+initFunc_pcre_match(struct cnffunc *const func)
+{
+        DEFiRet;
+        const char *err;
+        int erroffset;
+       char *regex = NULL;
+        struct pcre_state *state;
+
+        if(func->nParams < 2) {
+                parser_errmsg("rsyslog logic error in line %d of file %s", __LINE__, __FILE__);
+                ABORT_FINALIZE(RS_RET_ERR);
+        }
+        if(func->expr[1]->nodetype != 'S') {
+                parser_errmsg("param 2 of pcre_match() must be a constant string");
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        CHKmalloc(state = calloc(1, sizeof(struct pcre_state)));
+        regex = es_str2cstr(((struct cnfstringval*) func->expr[1])->estr, NULL);
+        state->re = pcre_compile(regex, 0, &err, &erroffset, NULL);
+        if(state->re == NULL) {
+                parser_errmsg("pcre compilation failed at offset %d: %s", erroffset, err);
+                free(state);
+                ABORT_FINALIZE(RS_RET_ERR);
+        }
+        func->funcdata = state;
+        func->destructable_funcdata = 1;
+
+finalize_it:
+        free(regex);
+        RETiRet;
+}
+
+static void ATTR_NONNULL(1)
+destruct_pcre(struct cnffunc *const func)
+{
+        struct pcre_state *state = (struct pcre_state*)func->funcdata;
+        if(state != NULL) {
+                if(state->re != NULL)
+                        pcre_free(state->re);
+                free(state);
+        }
+}
+
+static struct scriptFunct functions[] = {
+        { "pcre_match", 2, 2, doFunc_pcre_match, initFunc_pcre_match, destruct_pcre },
+        { NULL, 0, 0, NULL, NULL, NULL }
+};
+
+BEGINgetFunctArray
+CODESTARTgetFunctArray
+        *version = 1;
+        *functArray = functions;
+ENDgetFunctArray
+
+BEGINmodExit
+CODESTARTmodExit
+ENDmodExit
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_FMOD_QUERIES
+ENDqueryEtryPt
+
+BEGINmodInit()
+CODESTARTmodInit
+        *ipIFVersProvided = CURR_MOD_IF_VERSION;
+CODEmodInit_QueryRegCFSLineHdlr
+        dbgprintf("rsyslog fmpcre init called, compiled with version %s\n", VERSION);
+ENDmodInit
+
+

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1353,6 +1353,11 @@ endif # HAVE_VALGRIND
 endif # ENABLE_FFAUP
 endif
 
+if ENABLE_FMPCRE
+TESTS +=  \
+	ffmpcre-basic.sh
+endif
+
 if ENABLE_MMPSTRUCDATA
 TESTS +=  \
 	mmpstrucdata.sh \

--- a/tests/ffmpcre-basic.sh
+++ b/tests/ffmpcre-basic.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# added 2025-06-07 by Codex, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/fmpcre/.libs/fmpcre")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+template(name="outfmt" type="string" string="%$.hit%\n")
+set $.hit = pcre_match($msg, "h.llo");
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+
+startup
+tcpflood -m1 -M "\"<13>Jan 1 00:00:00 host tag: hello\""
+tcpflood -m1 -M "\"<13>Jan 1 00:00:00 host tag: hallo\""
+shutdown_when_empty
+wait_shutdown
+echo '1
+1' | cmp - $RSYSLOG_OUT_LOG
+if [ $? -ne 0 ]; then
+  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
+  cat $RSYSLOG_OUT_LOG
+  error_exit 1
+fi
+
+exit_test
+


### PR DESCRIPTION
## Summary
- move prototype `fmpcre` module to `plugins/`
- document build steps in `README.md`
- mention dependency and test in `AGENTS.md`
- provide simple `ffmpcre-basic.sh` regression test

## Testing
- `./devtools/codex-setup.sh`
- `./autogen.sh`
- `./configure --enable-fmpcre`
- `make -j$(nproc)`


------
https://chatgpt.com/codex/tasks/task_e_68440efde2dc83329dbb4184a57f8d0b