### PR TITLE
lookup: add new table type for regex-matches

### DIFF
--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -38,11 +38,15 @@
 #include "rsconf.h"
 #include "dirty.h"
 #include "unicode-helper.h"
+#include "regexp.h"
 
 PRAGMA_IGNORE_Wdeprecated_declarations
 /* definitions for objects we access */
 DEFobjStaticHelpers
 DEFobjCurrIf(glbl)
+#ifdef FEATURE_REGEXP
+DEFobjCurrIf(regexp)
+#endif
 
 /* forward definitions */
 static rsRetVal lookupReadFile(lookup_t *pThis, const uchar* name, const uchar* filename);
@@ -208,9 +212,42 @@ destructTable_arr(lookup_t *pThis) {
 
 static void
 destructTable_sparseArr(lookup_t *pThis) {
-	free(pThis->table.sprsArr->entries);
-	free(pThis->table.sprsArr);
+       free(pThis->table.sprsArr->entries);
+       free(pThis->table.sprsArr);
 }
+
+#ifdef FEATURE_REGEXP
+static void
+destructTable_regex(lookup_t *pThis) {
+       uint32_t i;
+       int regfree_available = 0;
+       lookup_regex_tab_entry_t *entries;
+
+       if(pThis == NULL || pThis->table.regex == NULL)
+               return;
+
+       entries = pThis->table.regex->entries;
+       if(objUse(regexp, LM_REGEXP_FILENAME) == RS_RET_OK)
+               regfree_available = 1;
+
+       if(entries != NULL) {
+               for(i = 0; i < pThis->nmemb; ++i) {
+                       if(entries[i].is_compiled) {
+                               if(regfree_available) {
+                                       regexp.regfree(&entries[i].regex);
+                               } else {
+                                       LogError(0, RS_RET_INTERNAL_ERROR,
+                                               "regexp module missing; compiled regex cannot be freed");
+                               }
+                       }
+                       free(entries[i].regex_str);
+                       entries[i].regex_str = NULL;
+               }
+       }
+       free(entries);
+       free(pThis->table.regex);
+}
+#endif
 
 static void
 lookupDestruct(lookup_t *pThis) {
@@ -218,15 +255,19 @@ lookupDestruct(lookup_t *pThis) {
 
 	if (pThis == NULL) return;
 
-	if (pThis->type == STRING_LOOKUP_TABLE) {
-		destructTable_str(pThis);
-	} else if (pThis->type == ARRAY_LOOKUP_TABLE) {
-		destructTable_arr(pThis);
-	} else if (pThis->type == SPARSE_ARRAY_LOOKUP_TABLE) {
-		destructTable_sparseArr(pThis);
-	} else if (pThis->type == STUBBED_LOOKUP_TABLE) {
-		/*nothing to be done*/
-	}
+       if (pThis->type == STRING_LOOKUP_TABLE) {
+               destructTable_str(pThis);
+       } else if (pThis->type == ARRAY_LOOKUP_TABLE) {
+               destructTable_arr(pThis);
+       } else if (pThis->type == SPARSE_ARRAY_LOOKUP_TABLE) {
+               destructTable_sparseArr(pThis);
+#ifdef FEATURE_REGEXP
+       } else if (pThis->type == REGEX_LOOKUP_TABLE) {
+               destructTable_regex(pThis);
+#endif
+       } else if (pThis->type == STUBBED_LOOKUP_TABLE) {
+               /*nothing to be done*/
+       }
 
 	for (i = 0; i < pThis->interned_val_count; i++) {
 		free(pThis->interned_vals[i]);
@@ -416,6 +457,21 @@ lookupKey_sprsArr(lookup_t *pThis, lookup_key_t key) {
 	return es_newStrFromCStr(r, strlen(r));
 }
 
+#ifdef FEATURE_REGEXP
+static es_str_t*
+lookupKey_regex(lookup_t *pThis, lookup_key_t key) {
+       const char *r = defaultVal(pThis);
+       for (uint32_t i = 0; i < pThis->nmemb; ++i) {
+               if (regexp.regexec(&pThis->table.regex->entries[i].regex,
+                                       (char*)key.k_str, 0, NULL, 0) == 0) {
+                       r = (const char*)pThis->table.regex->entries[i].interned_val_ref;
+                       break;
+               }
+       }
+       return es_newStrFromCStr(r, strlen(r));
+}
+#endif
+
 /* builders for different table-types */
 
 #define NO_INDEX_ERROR(type, name)				\
@@ -579,6 +635,67 @@ finalize_it:
 	RETiRet;
 }
 
+#ifdef FEATURE_REGEXP
+static rsRetVal
+build_RegexTable(lookup_t *pThis, struct json_object *jtab, const uchar* name) {
+       uint32_t i;
+       struct json_object *jrow, *jregex, *jtag;
+       uchar *value, *canonicalValueRef;
+       const char *regex_str;
+       DEFiRet;
+
+       pThis->table.regex = NULL;
+       CHKmalloc(pThis->table.regex = calloc(1, sizeof(lookup_regex_tab_t)));
+       if (pThis->nmemb > 0) {
+               CHKmalloc(pThis->table.regex->entries = calloc(pThis->nmemb, sizeof(lookup_regex_tab_entry_t)));
+
+               for(i = 0; i < pThis->nmemb; i++) {
+                       jrow = json_object_array_get_idx(jtab, i);
+                       fjson_object_object_get_ex(jrow, "regex", &jregex);
+                       fjson_object_object_get_ex(jrow, "tag", &jtag);
+                       if (jregex == NULL || jtag == NULL || json_object_is_type(jregex, json_type_null) ||
+                                       json_object_is_type(jtag, json_type_null)) {
+                               LogError(0, RS_RET_INVALID_VALUE, "'regex' lookup table named: '%s' has record(s) without required fields", name);
+                               ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                       }
+                       regex_str = json_object_get_string(jregex);
+                       CHKmalloc(pThis->table.regex->entries[i].regex_str = ustrdup((const uchar*) regex_str));
+                       value = (uchar*) json_object_get_string(jtag);
+                       uchar *const *const canonicalValueRef_ptr = bsearch(value, pThis->interned_vals,
+                               pThis->interned_val_count, sizeof(uchar*), bs_arrcmp_str);
+                       if(canonicalValueRef_ptr == NULL) {
+                               LogError(0, RS_RET_ERR, "BUG: canonicalValueRef not found in build_RegexTable(), %s:%d", __FILE__, __LINE__);
+                               ABORT_FINALIZE(RS_RET_ERR);
+                       }
+                       canonicalValueRef = *canonicalValueRef_ptr;
+                       assert(canonicalValueRef != NULL);
+                       pThis->table.regex->entries[i].interned_val_ref = canonicalValueRef;
+
+                       int err;
+                       if(objUse(regexp, LM_REGEXP_FILENAME) == RS_RET_OK) {
+                               if((err = regexp.regcomp(&pThis->table.regex->entries[i].regex, regex_str, REG_EXTENDED | REG_NOSUB)) != 0) {
+                                       char errbuf[256];
+                                       regexp.regerror(err, &pThis->table.regex->entries[i].regex, errbuf, sizeof(errbuf));
+                                       LogError(0, RS_RET_INVALID_VALUE, "error compiling regex '%s' in lookup table '%s': %s", regex_str, name, errbuf);
+                                       ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                               } else {
+                                       pThis->table.regex->entries[i].is_compiled = 1;
+                               }
+                       } else {
+                               LogError(0, RS_RET_INTERNAL_ERROR, "regex library could not be loaded");
+                               ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+                       }
+               }
+       }
+
+       pThis->lookup = lookupKey_regex;
+       pThis->key_type = LOOKUP_KEY_TYPE_STRING;
+
+finalize_it:
+       RETiRet;
+}
+#endif
+
 static rsRetVal
 lookupBuildStubbedTable(lookup_t *pThis, const uchar* stub_val) {
 	DEFiRet;
@@ -595,9 +712,10 @@ finalize_it:
 static rsRetVal
 lookupBuildTable_v1(lookup_t *pThis, struct json_object *jroot, const uchar* name) {
 	struct json_object *jnomatch, *jtype, *jtab;
-	struct json_object *jrow, *jvalue;
-	const char *table_type, *nomatch_value;
-	const uchar **all_values;
+       struct json_object *jrow, *jvalue;
+       const char *table_type, *nomatch_value;
+       const char *value_key;
+       const uchar **all_values;
 	const uchar *curr, *prev;
 	uint32_t i, j;
 	uint32_t uniq_values;
@@ -613,20 +731,21 @@ lookupBuildTable_v1(lookup_t *pThis, struct json_object *jroot, const uchar* nam
 		ABORT_FINALIZE(RS_RET_INVALID_VALUE);
 	}
 	pThis->nmemb = json_object_array_length(jtab);
-	table_type = json_object_get_string(jtype);
-	if (table_type == NULL) {
-		table_type = "string";
-	}
+       table_type = json_object_get_string(jtype);
+       if (table_type == NULL) {
+               table_type = "string";
+       }
+       value_key = (strcmp(table_type, "regex") == 0) ? "tag" : "value";
 
 	CHKmalloc(all_values = malloc(pThis->nmemb * sizeof(uchar*)));
 
 	/* before actual table can be loaded, prepare all-value list and remove duplicates*/
-	for(i = 0; i < pThis->nmemb; i++) {
-		jrow = json_object_array_get_idx(jtab, i);
-		fjson_object_object_get_ex(jrow, "value", &jvalue);
-		if (jvalue == NULL || json_object_is_type(jvalue, json_type_null)) {
-			LogError(0, RS_RET_INVALID_VALUE, "'%s' lookup table named: '%s' has record(s) "
-			"without 'value' field", table_type, name);
+       for(i = 0; i < pThis->nmemb; i++) {
+               jrow = json_object_array_get_idx(jtab, i);
+               fjson_object_object_get_ex(jrow, value_key, &jvalue);
+               if (jvalue == NULL || json_object_is_type(jvalue, json_type_null)) {
+                        LogError(0, RS_RET_INVALID_VALUE, "'%s' lookup table named: '%s' has record(s) "
+                        "without '%s' field", table_type, name, value_key);
 			ABORT_FINALIZE(RS_RET_INVALID_VALUE);
 		}
 		all_values[i] = (const uchar*) json_object_get_string(jvalue);
@@ -661,16 +780,21 @@ lookupBuildTable_v1(lookup_t *pThis, struct json_object *jroot, const uchar* nam
 		CHKmalloc(pThis->nomatch = (uchar*) strdup(nomatch_value));
 	}
 
-	if (strcmp(table_type, "array") == 0) {
-		pThis->type = ARRAY_LOOKUP_TABLE;
-		CHKiRet(build_ArrayTable(pThis, jtab, name));
-	} else if (strcmp(table_type, "sparseArray") == 0) {
-		pThis->type = SPARSE_ARRAY_LOOKUP_TABLE;
-		CHKiRet(build_SparseArrayTable(pThis, jtab, name));
-	} else if (strcmp(table_type, "string") == 0) {
-		pThis->type = STRING_LOOKUP_TABLE;
-		CHKiRet(build_StringTable(pThis, jtab, name));
-	} else {
+       if (strcmp(table_type, "array") == 0) {
+               pThis->type = ARRAY_LOOKUP_TABLE;
+               CHKiRet(build_ArrayTable(pThis, jtab, name));
+       } else if (strcmp(table_type, "sparseArray") == 0) {
+               pThis->type = SPARSE_ARRAY_LOOKUP_TABLE;
+               CHKiRet(build_SparseArrayTable(pThis, jtab, name));
+#ifdef FEATURE_REGEXP
+       } else if (strcmp(table_type, "regex") == 0) {
+               pThis->type = REGEX_LOOKUP_TABLE;
+               CHKiRet(build_RegexTable(pThis, jtab, name));
+#endif
+       } else if (strcmp(table_type, "string") == 0) {
+               pThis->type = STRING_LOOKUP_TABLE;
+               CHKiRet(build_StringTable(pThis, jtab, name));
+       } else {
 		LogError(0, RS_RET_INVALID_VALUE, "lookup table named: '%s' uses unupported "
 				"type: '%s'", name, table_type);
 		ABORT_FINALIZE(RS_RET_INVALID_VALUE);

--- a/runtime/lookup.h
+++ b/runtime/lookup.h
@@ -21,11 +21,13 @@
 #ifndef INCLUDED_LOOKUP_H
 #define INCLUDED_LOOKUP_H
 #include <libestr.h>
+#include <regex.h>
 
 #define STRING_LOOKUP_TABLE 1
 #define ARRAY_LOOKUP_TABLE 2
 #define SPARSE_ARRAY_LOOKUP_TABLE 3
 #define STUBBED_LOOKUP_TABLE 4
+#define REGEX_LOOKUP_TABLE 5
 
 #define LOOKUP_KEY_TYPE_STRING 1
 #define LOOKUP_KEY_TYPE_UINT 2
@@ -56,7 +58,18 @@ struct lookup_string_tab_entry_s {
 };
 
 struct lookup_string_tab_s {
-	lookup_string_tab_entry_t *entries;
+        lookup_string_tab_entry_t *entries;
+};
+
+struct lookup_regex_tab_entry_s {
+       regex_t regex;
+       uchar *regex_str;
+       uchar *interned_val_ref;
+       uint8_t is_compiled;
+};
+
+struct lookup_regex_tab_s {
+       lookup_regex_tab_entry_t *entries;
 };
 
 struct lookup_ref_s {
@@ -84,11 +97,12 @@ struct lookup_s {
 	uint32_t nmemb;
 	uint8_t type;
 	uint8_t key_type;
-	union {
-		lookup_string_tab_t *str;
-		lookup_array_tab_t *arr;
-		lookup_sparseArray_tab_t *sprsArr;
-	} table;
+       union {
+               lookup_string_tab_t *str;
+               lookup_array_tab_t *arr;
+               lookup_sparseArray_tab_t *sprsArr;
+               lookup_regex_tab_t *regex;
+       } table;
 	uint32_t interned_val_count;
 	uchar **interned_vals;
 	uchar *nomatch;

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -112,7 +112,9 @@ typedef struct lookup_string_tab_s lookup_string_tab_t;
 typedef struct lookup_array_tab_s lookup_array_tab_t;
 typedef struct lookup_sparseArray_tab_s lookup_sparseArray_tab_t;
 typedef struct lookup_sparseArray_tab_entry_s lookup_sparseArray_tab_entry_t;
+typedef struct lookup_regex_tab_entry_s lookup_regex_tab_entry_t;
 typedef struct lookup_tables_s lookup_tables_t;
+typedef struct lookup_regex_tab_s lookup_regex_tab_t;
 typedef union lookup_key_u lookup_key_t;
 
 typedef struct lookup_s lookup_t;


### PR DESCRIPTION
While we do not like rexeg-matches for performance reasons, they are well known and appreciated by users. With the new table type, we add a lookup capability for partial matches, but at the price of much higher ressource use. It still is useful, e.g. to classify events as "noise" events in a simple manner.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
