### PR TITLE
ci: skip expensive workflows on doc-only changes

### DIFF
--- a/.github/workflows/ci.yml.template
+++ b/.github/workflows/ci.yml.template
@@ -26,6 +26,10 @@ name: CI PR runner
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   container_checks:

--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -26,6 +26,10 @@ name: compile check
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   run:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,16 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
   pull_request:
     branches: [ "master" ]
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
   schedule:
     - cron: "38 1 * * 3"
 

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -26,6 +26,10 @@ name: check
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   CI:

--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -26,6 +26,10 @@ name: check systemd journal
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   check_run:

--- a/.github/workflows/run_kafka_distcheck.yml
+++ b/.github/workflows/run_kafka_distcheck.yml
@@ -26,6 +26,10 @@ name: check kafka distcheck
 
 on:
   pull_request:
+    paths-ignore:
+      - 'ChangeLog'
+      - '**/*.md'
+      - '**/*.txt'
 
 jobs:
   check_run:


### PR DESCRIPTION
see also https://github.com/rsyslog/rsyslog/issues/5666

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
