### PR TITLE
imdocker: harden module buffer management

### DIFF
--- a/contrib/imdocker/imdocker.c
+++ b/contrib/imdocker/imdocker.c
@@ -862,14 +862,14 @@ CODESTARTsetModCnf
 		} else if(!strcmp(modpblk.descr[i].name, "listcontainersoptions")) {
 			loadModConf->listContainersOptions = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(modpblk.descr[i].name, "getcontainerlogoptions")) {
-			loadModConf->getContainerLogOptions = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+			CHKmalloc(loadModConf->getContainerLogOptions
+				= (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
 			/* also intialize the non-tail version */
 			size_t offset = 0;
-			char buf[256];
-			size_t buf_size = sizeof(buf);
-			strncpy(buf, (char*)loadModConf->getContainerLogOptions, buf_size-1);
 			size_t option_str_len = strlen((char*)loadModConf->getContainerLogOptions);
-			uchar *option_str = calloc(1, option_str_len);
+			char *buf = strdup((char*)loadModConf->getContainerLogOptions);
+			CHKmalloc(buf);
+			uchar *option_str = calloc(1, option_str_len + 1);
 			CHKmalloc(option_str);
 
 			const char *search_str = "tail=";
@@ -881,19 +881,20 @@ CODESTARTsetModCnf
 					token = strtok(NULL, "&");
 					continue;
 				}
-				int len = strlen(token);
-				if (offset + len + 1 >= option_str_len) {
-					break;
-				}
-				int bytes = snprintf((char*)option_str + offset,
-						(option_str_len - offset), "%s&", token);
-				if (bytes <= 0) {
-					break;
-				}
-				offset += bytes;
-				token = strtok(NULL, "&");
+			int len = strlen(token);
+			if (offset + len + 1 >= option_str_len + 1) {
+			break;
+			}
+			int bytes = snprintf((char*)option_str + offset,
+			(option_str_len + 1 - offset), "%s&", token);
+			if (bytes <= 0) {
+			break;
+			}
+			offset += bytes;
+			token = strtok(NULL, "&");
 			}
 			loadModConf->getContainerLogOptionsWithoutTail = option_str;
+			free(buf);
 		} else if(!strcmp(modpblk.descr[i].name, "dockerapiunixsockaddr")) {
 			loadModConf->dockerApiUnixSockAddr = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
 		} else if(!strcmp(modpblk.descr[i].name, "dockerapiaddr")) {


### PR DESCRIPTION
The imdocker configuration parser previously copied getcontainerlogoptions into a fixed buffer and allocated exactly the input length for a secondary options string. This risked truncation and missing termination. The new code allocates buffers dynamically and accounts for the trailing null byte.

Summary

Replaced the fixed 256‑byte buffer with a dynamically allocated copy of the configuration string and ensured room for a trailing null byte in option_str.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
