### PR TITLE
fix hashtable realloc memset range

### DIFF
--- a/runtime/hashtable.c
+++ b/runtime/hashtable.c
@@ -129,7 +129,8 @@ hashtable_expand(struct hashtable *h)
 		realloc(h->table, newsize * sizeof(struct entry *));
 		if (NULL == newtable) { (h->primeindex)--; return 0; }
 		h->table = newtable;
-		memset(newtable[h->tablelength], 0, newsize - h->tablelength);
+		memset(&newtable[h->tablelength], 0,
+		       (newsize - h->tablelength) * sizeof(struct entry *));
 		for (i = 0; i < h->tablelength; i++) {
 			for (pE = &(newtable[i]), e = *pE; e != NULL; e = *pE) {
 				idx = indexFor(newsize,e->h);


### PR DESCRIPTION
## Summary
- ensure new memory range in hashtable expand is cleared fully

## Testing
- `devtools/check-codestyle.sh runtime/hashtable.c`
- `./devtools/codex-setup.sh`
- `./autogen.sh`
- `./configure --enable-imdiag --enable-testbench --enable-omstdout`
- `make -j$(nproc)`
- `make check TESTS=tests/1.rstest` *(fails: failed to create tests/1.rstest.trs)*

------
https://chatgpt.com/codex/tasks/task_e_6847e23ccd54832bb4797f5b4db876c1