### PR TITLE
Fix race in notifyReArm

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -836,12 +836,14 @@ static rsRetVal
 notifyReArm(tcpsrv_io_descr_t *const pioDescr)
 {
 	DEFiRet;
-
 	const unsigned waitIOEvent = (pioDescr->ioDirection == NSDSEL_WR) ? EPOLLOUT : EPOLLIN;
-	pioDescr->event.events = waitIOEvent | EPOLLET | EPOLLONESHOT;
-	if(epoll_ctl(pioDescr->pSrv->evtdata.epoll.efd, EPOLL_CTL_MOD, pioDescr->sock, &pioDescr->event) < 0) {
-		LogError(errno, RS_RET_ERR_EPOLL_CTL, "epoll_ctl failed re-armed socket %d", pioDescr->sock);
-		ABORT_FINALIZE(RS_RET_ERR_EPOLL_CTL);
+	struct epoll_event event = {
+	.events = waitIOEvent | EPOLLET | EPOLLONESHOT,
+	.data   = { .ptr = pioDescr }
+	};
+	if(epoll_ctl(pioDescr->pSrv->evtdata.epoll.efd, EPOLL_CTL_MOD, pioDescr->sock, &event) < 0) {
+	LogError(errno, RS_RET_ERR_EPOLL_CTL, "epoll_ctl failed re-armed socket %d", pioDescr->sock);
+	ABORT_FINALIZE(RS_RET_ERR_EPOLL_CTL);
 	}
 
 finalize_it:


### PR DESCRIPTION
## Summary
- use local `struct epoll_event` in `notifyReArm`

## Testing
- `./devtools/check-codestyle.sh` *(fails: `rsyslog_stylecheck` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68456dc6d4288332bdedc6e8543fe058