### PR TITLE
Removed the redundant *_la_LDFLAGS

### DIFF
--- a/contrib/omamqp1/Makefile.am
+++ b/contrib/omamqp1/Makefile.am
@@ -2,7 +2,6 @@ pkglib_LTLIBRARIES = omamqp1.la
 
 omamqp1_la_SOURCES = omamqp1.c
 if ENABLE_QPIDPROTON_STATIC
-omamqp1_la_LDFLAGS = -module -avoid-version $(PROTON_PROACTOR_LIBS) $(PTHREADS_LIBS) $(OPENSSL_LIBS) -lm
 omamqp1_la_LDFLAGS = -module -avoid-version -Wl,-whole-archive -l:libqpid-proton-proactor-static.a -l:libqpid-proton-core-static.a -Wl,--no-whole-archive $(PTHREADS_LIBS) $(OPENSSL_LIBS) ${RT_LIBS} -lsasl2
 omamqp1_la_LIBADD =
 else

--- a/plugins/omazureeventhubs/Makefile.am
+++ b/plugins/omazureeventhubs/Makefile.am
@@ -2,7 +2,6 @@ pkglib_LTLIBRARIES = omazureeventhubs.la
 
 omazureeventhubs_la_SOURCES = omazureeventhubs.c
 if ENABLE_QPIDPROTON_STATIC
-omazureeventhubs_la_LDFLAGS = -module -avoid-version $(PROTON_PROACTOR_LIBS) $(PTHREADS_LIBS) $(OPENSSL_LIBS) -lm
 omazureeventhubs_la_LDFLAGS = -module -avoid-version -Wl,-whole-archive -l:libqpid-proton-proactor-static.a -l:libqpid-proton-core-static.a -Wl,--no-whole-archive $(PTHREADS_LIBS) $(OPENSSL_LIBS) ${RT_LIBS} -lsasl2
 omazureeventhubs_la_LIBADD =
 else


### PR DESCRIPTION
Whilst this did not cause issues when building the project, it produced warnings. Let's remove unnecessary code, so it becomes a bit more readable.