### PR TITLE
Fix unsafe sprintf use in Azure event hubs module

### DIFF
--- a/plugins/omazureeventhubs/omazureeventhubs.c
+++ b/plugins/omazureeventhubs/omazureeventhubs.c
@@ -242,7 +242,8 @@ static char* url_encode(const char *str) {
 			*str == '-' || *str == '_' || *str == '.' || *str == '~') {
 			*p++ = *str;
 		} else {
-			sprintf(p, "%%%02X", (unsigned char)*str);
+			/* use snprintf to avoid potential buffer overruns */
+			snprintf(p, 4, "%%%02X", (unsigned char)*str);
 			p += 3;
 		}
 		str++;


### PR DESCRIPTION
## Summary
- replace `sprintf` with `snprintf` in `url_encode`

## Testing
- `devtools/check-codestyle.sh`
- `make check TESTS=tests/errfile-basic.sh -j4` *(fails: fatal - cannot create tests/errfile-basic.trs)*

------
https://chatgpt.com/codex/tasks/task_e_684b2fef64f48332ba98d2f24e1d9f7d