### PR TITLE
Fix: Correct documentation location and update build guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ Rsyslog is a real open source project, welcoming contributions of all kinds—fr
   - On GitHub: [rsyslog repository](https://github.com/rsyslog/rsyslog)
   - On the mailing list: [mailing list signup](http://lists.adiscon.net/mailman/listinfo/rsyslog)
 - **Improve documentation**:
-  - Contribute to [rsyslog-doc](https://github.com/rsyslog/rsyslog-doc)
+  - Contributions to documentation should be made to the `doc/` directory of this repository.
   - Help maintain [rsyslog.com/doc](http://rsyslog.com/doc)
 - **Maintain infrastructure**: Help with project websites, CI, or packaging.
 - **Develop code**: Implement new features, improve existing ones, or fix bugs.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Please report any issues, false positives, or suggestions about the AI review pr
 ---
 
 ## Documentation
-The complete and current documentation is maintained in the separate [`rsyslog-doc`](https://github.com/rsyslog/rsyslog-doc) project.
+Documentation is located in the `doc/` directory of this repository. Contributions to the documentation should be made there.
 
 Visit the latest version online:
 - [rsyslog.com/doc](https://www.rsyslog.com/doc/)

--- a/doc/README.md
+++ b/doc/README.md
@@ -79,9 +79,7 @@ to Stack Exchange](https://serverfault.com/questions/ask?tags=rsyslog).
 
 ## Building the documentation
 
-These directions assume default installs of Python for Windows and Linux.
-Since the [Sphinx project recommends using Python 2.7](http://www.sphinx-doc.org/en/stable/install.html),
-that's what we'll show here.
+These directions assume a modern Python 3 environment (Python 3.6 or newer is recommended).
 
 ### Assumptions
 
@@ -110,10 +108,10 @@ later steps are identical, so we've covered those steps in one place.
 
 1.  Download the pip installer from https://bootstrap.pypa.io/get-pip.py.
 2.  Install `pip` locally instead of system-wide:
-    1.  `python ./get-pip.py --user`
+        1.  `python3 ./get-pip.py --user`
 3.  Install the `virtualenv` package and create a new virtual environment:
-    1.  `python -m pip install virtualenv --user`
-    1.  `python -m virtualenv rsyslog-docs-build`
+        1.  `python3 -m pip install virtualenv --user`
+        1.  `python3 -m virtualenv rsyslog-docs-build`
     1.  `source rsyslog-docs-build/bin/activate`
 4.  Install `git` for your distro. Since distros name the package differently,
     you may need to substitute the package name from the examples
@@ -137,17 +135,17 @@ later steps are identical, so we've covered those steps in one place.
 1.  Download the pip installer from https://bootstrap.pypa.io/get-pip.py.
 2.  Download and install Git for Windows from https://git-scm.com/download/win.
 3.  Install `pip` locally instead of system-wide:
-    1.  `c:\python27\python get-pip.py --user`
+        1.  `python get-pip.py --user`
 4.  Install the `virtualenv` package and create a new virtual environment:
-    1.  `c:\python27\python -m pip install virtualenv --user`
-    1.  `c:\python27\python -m virtualenv rsyslog-docs-build`
+        1.  `python -m pip install virtualenv --user`
+        1.  `python -m virtualenv rsyslog-docs-build`
     1.  `rsyslog-docs-build\Scripts\activate.bat`
 
 #### Windows and Linux
 
 1.  Install the `sphinx` package and any other project dependencies in our
     new virtual environment instead of system-wide:
-    1.  `pip install -r requirements.txt`
+        1.  `python -m pip install -r requirements.txt`
 2.  Clone the official Git repo:
     1.  `git clone https://github.com/rsyslog/rsyslog.git`
 3.  Check out either the current stable or development (aka, "master") branch:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -28,7 +28,7 @@ sys.path.insert(0, os.path.abspath('_ext'))
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '1.5.1'
+needs_sphinx = '4.5.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.

--- a/doc/source/configuration/modules/imfile.rst
+++ b/doc/source/configuration/modules/imfile.rst
@@ -869,24 +869,20 @@ the rsyslog process.
 WildCards
 =========
 
-**Before Version: 8.25.0**
-  Wildcards are only supported in the filename part, not in directory names.
+As of rsyslog version 8.25.0 and later, wildcards are fully supported in both directory names and filenames. This allows for flexible file monitoring configurations.
 
-* /var/log/\*.log **works**. *
-* /var/log/\*/syslog.log does **not work**. *
+Examples of supported wildcard usage:
 
+*   `/var/log/*.log` (all .log files in /var/log)
+*   `/var/log/*/*.log` (all .log files in immediate subdirectories of /var/log)
+*   `/var/log/app*/*/*.log` (all .log files in subdirectories of directories starting with "app" in /var/log)
 
-**Since Version: 8.25.0**
-  Wildcards are supported in filename and paths which means these samples will work:
+All matching files in all matching subfolders will be monitored.
 
-* /var/log/\*.log **works**. *
-* /var/log/\*/syslog.log **works**. *
-* /var/log/\*/\*.log **works**. *
+.. note::
+   Using complex wildcard patterns, especially those that match many directories and files, may have an impact on performance. It's advisable to use the most specific patterns possible.
 
-
-  All matching files in all matching subfolders will work.
-  Note that this may decrease performance in imfile depending on how
-  many directories and files are being watched dynamically.
+Historically, versions prior to 8.25.0 had limitations, supporting wildcards only in the filename part and not in directory paths.
 
 
 

--- a/doc/source/configuration/modules/omczmq.rst
+++ b/doc/source/configuration/modules/omczmq.rst
@@ -1,0 +1,30 @@
+.. _omczmq:
+
+******************************
+omczmq: Output module for ZeroMQ
+******************************
+
+.. index:: ! omczmq
+
+===========================  ===========================================================================
+**Module Name:**             **omczmq**
+**Author:**                  Brian Knox <bknox@digitalocean.com>
+===========================  ===========================================================================
+
+.. warning::
+   This module is currently not documented. The documentation needs to be written.
+
+Purpose
+=======
+
+(To be completed)
+
+Configuration Parameters
+========================
+
+(To be completed)
+
+Examples
+========
+
+(To be completed)


### PR DESCRIPTION
This commit addresses several documentation inconsistencies and updates:

- Corrected `README.md` and `CONTRIBUTING.md` to accurately state that documentation is located in the `doc/` directory of this repository, not in a separate `rsyslog-doc` project.
- Added a placeholder file for the `omczmq` module documentation at `doc/source/configuration/modules/omczmq.rst`, as it was previously missing.
- Updated `doc/README.md` to recommend Python 3 and a modern Sphinx version for building documentation, removing outdated Python 2.7 references.
- Updated `doc/source/conf.py` to set `needs_sphinx = '4.5.0'` (from '1.5.1').
- Clarified the "WildCards" section in `doc/source/configuration/modules/imfile.rst` to better reflect current functionality regarding wildcard usage in paths and filenames.

These changes aim to improve the accuracy and maintainability of the project's documentation.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
