### PR TITLE
doc: add lexer for rsyslog config language

### DIFF
--- a/doc/source/_ext/rsyslog_lexer.py
+++ b/doc/source/_ext/rsyslog_lexer.py
@@ -1,0 +1,122 @@
+import re
+
+from pygments.lexer import RegexLexer, bygroups
+from pygments.token import (
+    Text, Comment, Operator, Keyword, Name, String, Number, Punctuation,
+    Error
+)
+
+__all__ = ['RainerScriptLexer']
+
+
+class RainerScriptLexer(RegexLexer):
+    """
+    Pygments lexer for Rsyslog's RainerScript.
+    """
+    name = 'RainerScript'
+    aliases = ['rsyslog', 'rainerscript']
+    filenames = ['*.conf', '*.rs', '*.rainerscript']
+    mimetypes = ['text/x-rainerscript']
+
+    # Keywords from the lexer file
+    keywords = [
+        'if', 'then', 'else', 'call', 'call_indirect', 'set', 'unset',
+        'reset', 'stop', 'continue', 'foreach', 'do', 'return'
+    ]
+
+    # Object definition keywords
+    objects = [
+        'action', 'input', 'module', 'template', 'ruleset', 'parser',
+        'global', 'property', 'constant', 'lookup_table', 'main_queue',
+        'dyn_stats', 'percentile_stats', 'timezone', 'include',
+        'reload_lookup_table'
+    ]
+    
+    # Built-in functions and system properties
+    builtins = [
+        'exec_template', 'lookup', 're_match', 're_extract', 'field', 'dyn_inc',
+        'http_request', 'getenv', 'uuid', 'random', 'get_metadata',
+        'set_metadata', 'unset_metadata', 'exists', 'int', 'string',
+        'get_var', 'hostname', 'ip', 'programname', 'msg', 'rawmsg',
+        'syslogtag', 'protocol-version', 'structured-data', 'app-name',
+        'procid', 'msgid', 'pri', 'pri-text', 'syslogfacility',
+        'syslogfacility-text', 'syslogseverity', 'syslogseverity-text',
+        'fromhost', 'fromhost-ip', 'remotehost', 'remotehost-ip', 'timereported',
+        'timegenerated', 'timestamp', 'json', 'jsonmesg', 'jsonf'
+    ]
+
+    tokens = {
+        'root': [
+            (r'\s+', Text),
+            (r'#.*?\n', Comment.Single),
+            (r'/\*', Comment.Multiline, 'comment'),
+            
+            # Legacy syslog selectors at the start of a line
+            (r'^\s*([a-zA-Z0-9\.\*]+;)?([a-zA-Z0-9\.\*]+)\.(=|!=|=,!=)?([a-zA-Z0-9\*]+)\s+',
+             bygroups(Keyword.Namespace, Keyword.Namespace, Operator, Keyword.Namespace), 'legacy_action'),
+            (r'^\s*:([a-zA-Z0-9_-]+),\s*(==|!=|<>|contains|startswith|re_match|re_extract)\s*"[^"]*"\s+',
+             bygroups(Name.Tag, Operator.Word, String.Double), 'legacy_action'),
+            
+            # RainerScript Keywords
+            (r'\b(%s)\b' % '|'.join(keywords), Keyword.Reserved),
+            (r'\b(%s)\b' % '|'.join(objects), Keyword.Declaration),
+            (r'\b(on|off|yes|no|true|false)\b', Keyword.Constant),
+            
+            # Operators
+            (r'(&&|\|\||and|or|not)\b', Operator.Word),
+            (r'(=|==|!=|<>|<=|>=|<|>|:=|contains_i|startswith_i|contains|startswith)', Operator),
+
+            # Variables and Properties
+            (r'\$[a-zA-Z0-9_.-]+', Name.Variable),
+            (r'\$\![\w\.-]+', Name.Variable.Instance),
+            (r'\$\.[\w\.-]+', Name.Variable.Global),
+
+            # Built-in functions
+            (r'\b(%s)\b' % '|'.join(builtins), Name.Builtin),
+
+            # Strings
+            (r'"', String.Double, 'double_string'),
+            (r"'", String.Single, 'single_string'),
+            (r'`', String.Backtick, 'backtick_string'),
+
+            # Numbers
+            (r'\b(0x[0-9a-fA-F]+)\b', Number.Hex),
+            (r'\b\d+\b', Number.Integer),
+            
+            # Punctuation
+            (r'[{}(),;\[\].&]', Punctuation),
+            
+            # Identifiers
+            (r'[a-zA-Z_][a-zA-Z0-9_]*', Name),
+            
+            # Legacy Directives
+            (r'^\$\w+', Keyword.Pseudo),
+        ],
+        'comment': [
+            (r'[^*/]+', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline),
+        ],
+        'double_string': [
+            (r'\\"', String.Escape),
+            (r'[^"]+', String.Double),
+            (r'"', String.Double, '#pop'),
+        ],
+        'single_string': [
+            (r"\\'", String.Escape),
+            (r"[^']+", String.Single),
+            (r"'", String.Single, '#pop'),
+        ],
+        'backtick_string': [
+            (r"\\`", String.Escape),
+            (r"[^`]+", String.Backtick),
+            (r"`", String.Backtick, '#pop'),
+        ],
+        'legacy_action': [
+            (r'~', Operator, '#pop'),
+            (r'-?/[^;\s]+', Name.Constant, '#pop'),
+            (r'\S+', Name.Constant),
+            (r'.*?\n', Text, '#pop'),
+        ],
+    }

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,12 +18,12 @@ import sys
 sys.path.append(os.getcwd())
 import conf_helpers
 
-
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('_ext'))
+
+from rsyslog_lexer import RainerScriptLexer
 
 # -- General configuration -----------------------------------------------------
 
@@ -421,3 +421,4 @@ epub_description = u'Documentation for the rsyslog project'
 # Include our custom stylesheet in addition to specified theme
 def setup(app):
     app.add_css_file('rsyslog.css')
+    app.add_lexer('rsyslog', RainerScriptLexer)


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
