### PR TITLE
CI: do not run github actions for compile check if only doc updated

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Rainer Gerhards and Others
+# Copyright 2025 Rainer Gerhards and Others
 #
 # https://github.com/rsyslog/rsyslog-pkg-ubuntu
 #
@@ -30,6 +30,7 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
 
 jobs:
   run:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,12 +7,14 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
   schedule:
     - cron: "38 1 * * 3"
 

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -30,6 +30,7 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
 
 jobs:
   CI:

--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -30,6 +30,7 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
 
 jobs:
   check_run:

--- a/.github/workflows/run_kafka_distcheck.yml
+++ b/.github/workflows/run_kafka_distcheck.yml
@@ -30,6 +30,7 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
 
 jobs:
   check_run:


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
