### PR TITLE
CI: Optimize compile check for doc-only changes

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Rainer Gerhards and Others
+# Copyright 2024-2025 Rainer Gerhards and Others
 #
 # https://github.com/rsyslog/rsyslog-pkg-ubuntu
 #
@@ -6,7 +6,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     https://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -20,33 +20,88 @@
 # https://github.com/settings/notifications
 # https://software.opensuse.org//download.html?project=home%3Argerhards&package=rsyslog
 
-
+# ---
+# This GitHub Actions workflow performs a compile check of the project across
+# various compiler configurations. It's designed to ensure code quality and
+# compatibility.
+#
+# The workflow features intelligent skipping for Pull Requests that *only*
+# involve documentation or other non-source code changes (e.g., ChangeLog,
+# .md, .txt files, or files within the 'doc/' directory).
+#
+# How it works:
+# 1. A preliminary job checks the changed files in the Pull Request.
+# 2. If *only* documentation or designated ignored files are modified, a quick,
+#    succeeding job runs to satisfy branch protection rules. The main
+#    compilation job is then skipped.
+# 3. If any source code changes are detected, the full compilation matrix
+#    executes to thoroughly test the changes.
+# This approach ensures efficient CI resource usage while maintaining robust
+# code quality gates.
 ---
 name: compile check
 
 on:
   pull_request:
-    paths-ignore:
-      - 'ChangeLog'
-      - '**/*.md'
-      - '**/*.txt'
 
 jobs:
+  # This job identifies if the PR only contains changes to documentation or other ignored files.
+  # It will output 'true' if only such files were modified, and 'false' otherwise.
+  determine_changes_type:
+    runs-on: ubuntu-latest
+    outputs:
+      # 'true' if no files *outside* the ignored list have changed
+      only_documentation_or_ignored: ${{ steps.check_files.outputs.any_changed == 'false' }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4 # Recommended to use v4 for security and features
+        with:
+          fetch-depth: 2 # Essential for 'tj-actions/changed-files' to accurately compare branches
+
+      - name: Get changed files (excluding specified documentation/ignored paths)
+        id: check_files
+        uses: tj-actions/changed-files@v4
+        with:
+          # These are the patterns that, if *only* they change, should skip compilation.
+          files_ignore: |
+            ChangeLog
+            AGENTS.md
+            **/*.md
+            **/*.txt
+            doc/**
+          # This 'files' pattern ensures we look for changes in anything else
+          files: |
+            *
+
+  # This job runs and succeeds ONLY if the 'determine_changes_type' job
+  # indicated that only documentation or ignored files were modified.
+  # This job will fulfill the branch protection requirement for doc-only PRs.
+  doc_only_success_check:
+    needs: determine_changes_type
+    if: ${{ needs.determine_changes_type.outputs.only_documentation_or_ignored == 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Confirm documentation-only changes
+        run: echo "No relevant source code changes detected. Skipping full compilation checks."
+
+  # This job will ONLY execute if 'determine_changes_type' found that actual source code or
+  # other non-ignored files were part of the PR.
   run:
+    needs: determine_changes_type # Ensure this job waits for the change detection to complete
+    # This 'if' condition ensures the compilation only runs for actual code changes.
+    # If 'only_documentation_or_ignored' is 'true', this job will be skipped,
+    # and GitHub Actions treats skipped jobs (due to 'if') as successful for branch protection.
+    if: ${{ needs.determine_changes_type.outputs.only_documentation_or_ignored == 'false' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
-      # When set to true, cancel all in-progress jobs if any matrix job fails.
       fail-fast: false
       matrix:
-        # note: we compile only with oldest and newest support compiler to
-        # save ressources. Other important ones are used during the rest of
-        # the check runs (most importantly the distro-default ones).
         config: [clang9, clang18-noatomics, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc14-gnu23-debug]
 
     steps:
       - name: git checkout project
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4 # Recommended to use v4 for security and features
 
       - name: run compile check (container)
         run: |
@@ -55,42 +110,42 @@ jobs:
           export CFLAGS='-g'
           case "${{ matrix.config }}" in
           'clang9')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:20.04'
-              export CC='clang-9'
-              ;;
+            export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:20.04'
+            export CC='clang-9'
+            ;;
           'clang18-ndebug')
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=no'
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
-              export CC='clang-18'
-              ;;
+            export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=no'
+            export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+            export CC='clang-18'
+            ;;
           'clang18-noatomics')
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-atomic-operations=no'
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
-              export CC='clang-18'
-              ;;
+            export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-atomic-operations=no'
+            export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+            export CC='clang-18'
+            ;;
           'gcc8-debug')
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=yes'
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:18.04'
-              export CC='gcc-8'
-              ;;
+            export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=yes'
+            export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:18.04'
+            export CC='gcc-8'
+            ;;
           'gcc-11-ndebug')
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=no'
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
-              export CC='gcc-11'
-              ;;
+            export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=no'
+            export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
+            export CC='gcc-11'
+            ;;
           'gcc14-gnu23-debug')
-              # omamqp1 seems to have an issue with the build system - exclude it for now
-              # rgerhards, 2024-12-06
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=yes --disable-omamqp1'
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
-              export CFLAGS="-g -std=gnu23"
-              export CC='gcc-14'
-              ;;
+            # omamqp1 seems to have an issue with the build system - exclude it for now
+            # rgerhards, 2024-12-06
+            export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=yes --disable-omamqp1'
+            export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
+            export CFLAGS="-g -std=gnu23"
+            export CC='gcc-14'
+            ;;
           *)
-              echo "unknown configuration "
-              echo "error-terminating this check run"
-              exit 1
-              ;;
+            echo "unknown configuration "
+            echo "error-terminating this check run"
+            exit 1
+            ;;
           esac
           devtools/devcontainer.sh --rm devtools/run-configure.sh
           devtools/devcontainer.sh --rm make -j20

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -7,12 +7,15 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
+
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
   schedule:
     - cron: "38 1 * * 3"
 

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -30,6 +30,7 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
 
 jobs:
   CI:

--- a/.github/workflows/run_journal.yml
+++ b/.github/workflows/run_journal.yml
@@ -30,6 +30,7 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
 
 jobs:
   check_run:

--- a/.github/workflows/run_kafka_distcheck.yml
+++ b/.github/workflows/run_kafka_distcheck.yml
@@ -30,6 +30,7 @@ on:
       - 'ChangeLog'
       - '**/*.md'
       - '**/*.txt'
+      - 'doc/**'
 
 jobs:
   check_run:


### PR DESCRIPTION
Enhances the 'compile check' GitHub Actions workflow to intelligently skip resource-intensive compilation when Pull Requests (PRs) only involve documentation or other non-source code modifications.

This optimization improves CI efficiency and reduces build times for documentation-only changes, while still enforcing full compilation for actual code modifications.

Key changes include:
- **Removed `paths-ignore`**: The workflow now always triggers, allowing for granular job control.
- **Introduced `determine_changes_type` job**: This job uses `tj-actions/changed-files` to accurately detect if a PR consists solely of ignored files (e.g., `ChangeLog`, `*.md`, `*.txt`, `doc/**`).
- **Conditional `doc_only_success_check` job**: A lightweight job that runs and passes quickly when only documentation changes are present, satisfying branch protection requirements.
- **Conditional `run` job**: The main compilation job now only executes if actual source code changes are detected, preventing unnecessary builds.

This ensures that all required status checks for branch protection are met, whether the PR touches code or just documentation.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
