### PR TITLE
Add omsendertrack statefile tests

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -498,10 +498,14 @@ TESTS +=  \
 
 if ENABLE_OMSENDERTRACK
 TESTS +=  \
-	omsendertrack-basic.sh
+        omsendertrack-basic.sh
+TESTS +=  \
+        omsendertrack-statefile.sh
 if HAVE_VALGRIND
 TESTS += \
-	omsendertrack-basic-vg.sh
+        omsendertrack-basic-vg.sh
+TESTS += \
+        omsendertrack-statefile-vg.sh
 endif # if HAVE_VALGRIND
 endif
 
@@ -2218,12 +2222,14 @@ EXTRA_DIST= \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omfwd_fast_imuxsock.sh \
-	omfile_hup-vg.sh \
-	omsendertrack-basic.sh \
-	omsendertrack-basic-vg.sh \
-	zstd.sh \
-	zstd-vg.sh \
-	gzipwr_hup-vg.sh \
+        omfile_hup-vg.sh \
+        omsendertrack-basic.sh \
+        omsendertrack-basic-vg.sh \
+        omsendertrack-statefile.sh \
+        omsendertrack-statefile-vg.sh \
+        zstd.sh \
+        zstd-vg.sh \
+        gzipwr_hup-vg.sh \
 	omusrmsg-errmsg-no-params.sh \
 	omusrmsg-noabort.sh \
 	omusrmsg-noabort-vg.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -497,15 +497,15 @@ TESTS +=  \
 	parsertest-snare_ccoff_udp2.sh
 
 if ENABLE_OMSENDERTRACK
-TESTS +=  \
-        omsendertrack-basic.sh
-TESTS +=  \
-        omsendertrack-statefile.sh
+TESTS += \
+	omsendertrack-basic.sh
+TESTS += \
+	omsendertrack-statefile.sh
 if HAVE_VALGRIND
 TESTS += \
-        omsendertrack-basic-vg.sh
+	omsendertrack-basic-vg.sh
 TESTS += \
-        omsendertrack-statefile-vg.sh
+	omsendertrack-statefile-vg.sh
 endif # if HAVE_VALGRIND
 endif
 
@@ -2222,14 +2222,14 @@ EXTRA_DIST= \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omfwd_fast_imuxsock.sh \
-        omfile_hup-vg.sh \
-        omsendertrack-basic.sh \
-        omsendertrack-basic-vg.sh \
-        omsendertrack-statefile.sh \
-        omsendertrack-statefile-vg.sh \
-        zstd.sh \
-        zstd-vg.sh \
-        gzipwr_hup-vg.sh \
+	omfile_hup-vg.sh \
+	omsendertrack-basic.sh \
+	omsendertrack-basic-vg.sh \
+	omsendertrack-statefile.sh \
+	omsendertrack-statefile-vg.sh \
+	zstd.sh \
+	zstd-vg.sh \
+	gzipwr_hup-vg.sh \
 	omusrmsg-errmsg-no-params.sh \
 	omusrmsg-noabort.sh \
 	omusrmsg-noabort-vg.sh \

--- a/tests/omsendertrack-statefile-vg.sh
+++ b/tests/omsendertrack-statefile-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/omsendertrack-statefile.sh

--- a/tests/omsendertrack-statefile.sh
+++ b/tests/omsendertrack-statefile.sh
@@ -12,8 +12,6 @@ JSON
 generate_conf
 add_conf '
 module(load="../plugins/omsendertrack/.libs/omsendertrack")
-module(load="../plugins/imtcp/.libs/imtcp")
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="hostname" type="string" string="%hostname%")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
@@ -22,7 +20,8 @@ action(type="omsendertrack" template="hostname" statefile="'$RSYSLOG_DYNNAME'.se
 '
 
 startup
-tcpflood -h sender1.example.net -m $NUMMESSAGES
+injectmsg_literal '<167>Mar  1 01:00:00 sender1.example.net tag msgnum:00000000:'
+injectmsg_literal '<167>Mar  1 01:00:00 sender1.example.net tag msgnum:00000001:'
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/omsendertrack-statefile.sh
+++ b/tests/omsendertrack-statefile.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=2
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+cat > $RSYSLOG_DYNNAME.sendertrack <<'JSON'
+[
+ {"sender":"sender1.example.net","messages":5,"firstseen":1600000000,"lastseen":1600000000}
+]
+JSON
+
+generate_conf
+add_conf '
+module(load="../plugins/omsendertrack/.libs/omsendertrack")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="hostname" type="string" string="%hostname%")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+action(type="omsendertrack" template="hostname" statefile="'$RSYSLOG_DYNNAME'.sendertrack")
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+
+startup
+tcpflood -h sender1.example.net -m $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+
+grep '"sender":"sender1.example.net"' $RSYSLOG_DYNNAME.sendertrack
+grep '"messages":7' $RSYSLOG_DYNNAME.sendertrack
+
+exit_test


### PR DESCRIPTION
## Summary
- add a new `omsendertrack-statefile.sh` test verifying state file loading
- provide a valgrind wrapper
- register the new tests in `Makefile.am`

## Testing
- `make check TESTS=omsendertrack-statefile.sh`


------
https://chatgpt.com/codex/tasks/task_e_6850f78b5d588332b16de443181a7f00