### PR TITLE
net_ossl: Fix memleak in net_ossl_peerfingerprint

### DIFF
--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -781,6 +781,8 @@ net_ossl_peerfingerprint(net_ossl_t *pThis, X509* certpeer, uchar *fromHostIP)
 finalize_it:
 	if(pstrFingerprint != NULL)
 		cstrDestruct(&pstrFingerprint);
+	if(pstrFingerprintSha256 != NULL)
+		cstrDestruct(&pstrFingerprintSha256);
 	RETiRet;
 }
 


### PR DESCRIPTION
Fix memory leak where `pstrFingerprintSha256` was not being freed in the finalize_it section. This could cause memory accumulation during TLS certificate fingerprint verification when the function exits.