### PR TITLE
tests: skip kafka tests when download fails

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1807,15 +1807,16 @@ download_kafka() {
 			wget -q $dep_zk_url -O $dep_zk_cached_file
 			if [ $? -ne 0 ]
 			then
-				echo error during wget, retry:
-				wget $dep_zk_url -O $dep_zk_cached_file
-				if [ $? -ne 0 ]
-				then
-					error_exit 1
-				fi
-			fi
-		fi
-	fi
+                                echo error during wget, retry:
+                                wget $dep_zk_url -O $dep_zk_cached_file
+                                if [ $? -ne 0 ]
+                                then
+                                        echo "Skipping test - unable to download zookeeper"
+                                        error_exit 77
+                                fi
+                        fi
+                fi
+        fi
 	if [ ! -f $dep_kafka_cached_file ]; then
 		if [ -f /local_dep_cache/$RS_KAFKA_DOWNLOAD ]; then
 			printf 'Kafka: satisfying dependency %s from system cache.\n' "$RS_KAFKA_DOWNLOAD"
@@ -1826,15 +1827,16 @@ download_kafka() {
 			if [ $? -ne 0 ]
 			then
 				echo error during wget, retry:
-				wget $dep_kafka_url -O $dep_kafka_cached_file
-				if [ $? -ne 0 ]
-				then
-					rm $dep_kafka_cached_file # a 0-size file may be left over
-					error_exit 1
-				fi
-			fi
-		fi
-	fi
+                                wget $dep_kafka_url -O $dep_kafka_cached_file
+                                if [ $? -ne 0 ]
+                                then
+                                        rm $dep_kafka_cached_file # a 0-size file may be left over
+                                        echo "Skipping test - unable to download kafka"
+                                        error_exit 77
+                                fi
+                        fi
+                fi
+        fi
 }
 
 stop_kafka() {


### PR DESCRIPTION
Network restrictions can prevent fetching Kafka or Zookeeper packages. When both download attempts fail, skip the test by exiting with code 77 instead of reporting an error.

AI-Agent: Codex 2025-06

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
