### PR TITLE
CI: (try to) fix running compile checks only on code file changes

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -50,28 +50,33 @@ jobs:
   determine_changes_type:
     runs-on: ubuntu-latest
     outputs:
-      # 'true' if no files *outside* the ignored list have changed
-      only_documentation_or_ignored: ${{ steps.check_files.outputs.any_changed == 'false' }}
+      # 'true' if no files *outside* the ignored list (i.e., no code files) have changed
+      only_documentation_or_ignored: ${{ steps.check_non_doc_files.outputs.any_changed == 'false' }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4 # Recommended to use v4 for security and features
         with:
           fetch-depth: 2 # Essential for 'tj-actions/changed-files' to accurately compare branches
 
-      - name: Get changed files (excluding specified documentation/ignored paths)
-        id: check_files
+      - name: Get changed non-documentation/source files
+        id: check_non_doc_files
         uses: tj-actions/changed-files@v46
         with:
-          # These are the patterns that, if *only* they change, should skip compilation.
-          files_ignore: |
-            ChangeLog
-            AGENTS.md
-            **/*.md
-            **/*.txt
-            doc/**
-          # This 'files' pattern ensures we look for changes in anything else
+          # Define patterns for files that, if changed, should *NOT* result in skipping compilation.
+          # These are primarily source code files and critical build system files.
+          # If any of these change, 'any_changed' will be true, indicating a code change.
           files: |
-            *
+            **/*.c
+            **/*.h
+            **/Makefile.am
+            grammar/*.l
+            grammar/*.y
+            configure.ac
+            autogen.sh
+            .github/workflows/*.yml
+            # Add other critical build or configuration files here that should trigger a compile
+            # if they change. Avoid including documentation files here.
+
 
   # This job runs and succeeds ONLY if the 'determine_changes_type' job
   # indicated that only documentation or ignored files were modified.


### PR DESCRIPTION
Previously, they never ran. Trying now a more robust method.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
