### PR TITLE
Introduce new imfile module parameter: deleteStateOnFileMove

### DIFF
--- a/doc/source/configuration/modules/imfile.rst
+++ b/doc/source/configuration/modules/imfile.rst
@@ -110,6 +110,20 @@ This sets the default value for input *timeout* parameters. See there
 for exact meaning. Parameter value is the number of seconds.
 
 
+deleteStateOnFileMove
+^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+If set to **on**, the state file for a monitored file is removed when that file
+is moved or rotated away. By default the state file is kept.
+
+
 timeoutGranularity
 ^^^^^^^^^^^^^^^^^^
 

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -252,6 +252,7 @@ struct modConfData_s {
 	instanceConf_t *root, *tail;
 	fs_node_t *conf_tree;
 	uint8_t opMode;
+	sbool deleteStateOnFileMove;
 	sbool configSetViaV2Method;
 	uchar *stateFileDirectory;
 	sbool sortFiles;
@@ -309,7 +310,8 @@ static struct cnfparamdescr modpdescr[] = {
 	{ "sortfiles", eCmdHdlrBinary, 0 },
 	{ "statefile.directory", eCmdHdlrString, 0 },
 	{ "normalizepath", eCmdHdlrBinary, 0 },
-	{ "mode", eCmdHdlrGetWord, 0 }
+	{ "mode", eCmdHdlrGetWord, 0 },
+	{ "deletestateonfilemove", eCmdHdlrBinary, 0 },
 };
 static struct cnfparamblk modpblk =
 	{ CNFPARAMBLK_VERSION,
@@ -839,7 +841,7 @@ detect_updates(fs_edge_t *const edge)
 				*/
 				sbool is_file = act->edge->is_file;
 				if (!is_file || act->time_to_delete + FILE_DELETE_DELAY < ttNow) {
-				DBGPRINTF("detect_updates obj gone away, unlinking: "
+					DBGPRINTF("detect_updates obj gone away, unlinking: "
 					"'%s', ttDelete: %"PRId64"s, ttNow:%"PRId64" isFile: %d\n",
 					act->name, (int64_t) ttNow - (act->time_to_delete + FILE_DELETE_DELAY),
 					(int64_t) ttNow, is_file);
@@ -1044,8 +1046,18 @@ act_obj_destroy(act_obj_t *const act, const int is_deleted)
 		}
 		persistStrmState(act);
 		strm.Destruct(&act->pStrm);
-		/* we delete state file after destruct in case strm obj initiated a write */
-		if(is_deleted && !act->in_move && inst->bRMStateOnDel) {
+
+		/*
+		 * We delete the state file after the destruct operation to ensure that any pending
+		 * writes initiated by the stream object are completed before removal. The state file
+		 * is deleted in the following scenarios:
+		 *   - If the file has not been moved and we are configured to delete the state file
+		 *     when the original file is removed.
+		 *   - If the configuration specifies not to preserve the state file after the file
+		 *     has been renamed.
+		 * The second one ensures proper cleanup and prevents orphaned state files.
+		 */
+		if(is_deleted && ((!act->in_move && inst->bRMStateOnDel) || runModConf->deleteStateOnFileMove)) {
 			DBGPRINTF("act_obj_destroy: deleting state file %s\n", statefn);
 			unlink((char*)statefn);
 		}
@@ -1914,7 +1926,7 @@ addInstance(void __attribute__((unused)) *pVal, uchar *pNewVal)
 	inst->reopenOnTruncate = 0;
 	inst->addMetadata = 0;
 	inst->addCeeTag = 0;
-	inst->bRMStateOnDel = 0;
+	inst->bRMStateOnDel = 1;
 	inst->readTimeout = loadModConf->readTimeout;
 	inst->msgFlag = 0;
 
@@ -2071,6 +2083,7 @@ CODESTARTbeginCnfLoad
 	/* init our settings */
 	loadModConf->opMode = OPMODE_POLLING;
 	loadModConf->iPollInterval = DFLT_PollInterval;
+	loadModConf->deleteStateOnFileMove = 0;
 	loadModConf->configSetViaV2Method = 0;
 	loadModConf->readTimeout = 0; /* default: no timeout */
 	loadModConf->timeoutGranularity = 1000; /* default: 1 second */
@@ -2124,6 +2137,8 @@ CODESTARTsetModCnf
 			continue;
 		if(!strcmp(modpblk.descr[i].name, "pollinginterval")) {
 			loadModConf->iPollInterval = (int) pvals[i].val.d.n;
+		} else if(!strcmp(modpblk.descr[i].name, "deletestateonfilemove")) {
+			loadModConf->deleteStateOnFileMove = (sbool) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "readtimeout")) {
 			loadModConf->readTimeout = (int) pvals[i].val.d.n;
 		} else if(!strcmp(modpblk.descr[i].name, "timeoutgranularity")) {
@@ -2791,7 +2806,8 @@ persistStrmState(act_obj_t *const act)
 	uchar *const statefn = getStateFileName(act, statefile, sizeof(statefile));
 	getFileID(act);
 	getFullStateFileName(statefn, act->file_id, statefname, sizeof(statefname));
-	DBGPRINTF("persisting state for '%s', state file '%s'\n", act->name, statefname);
+	DBGPRINTF("persisting state for '%s', state file '%s', file-id: '%s', file_id_prev: '%s', ino: %lu\n",
+		act->name, statefname, act->file_id, act->file_id_prev, act->ino);
 
 	struct json_object *jval = NULL;
 	struct json_object *json = NULL;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1774,6 +1774,7 @@ TESTS += \
 	imfile-logrotate-multiple.sh \
 	imfile-logrotate-copytruncate.sh \
 	imfile-logrotate-nocopytruncate.sh \
+	imfile-logrotate-state-files.sh \
 	imfile-growing-file-id.sh \
 	imfile-ignore-old-file-1.sh \
 	imfile-ignore-old-file-2.sh \
@@ -2870,6 +2871,7 @@ EXTRA_DIST= \
 	imfile-logrotate-copytruncate.sh \
 	imfile-logrotate-nocopytruncate.sh \
 	imfile-logrotate-multiple.sh \
+	imfile-logrotate-state-files.sh \
 	imfile-growing-file-id.sh \
 	imfile-ignore-old-file-1.sh \
 	imfile-ignore-old-file-2.sh \

--- a/tests/imfile-logrotate-state-files.sh
+++ b/tests/imfile-logrotate-state-files.sh
@@ -1,0 +1,180 @@
+. $srcdir/diag.sh check-inotify-only
+. ${srcdir:=.}/diag.sh init
+export TESTMESSAGES=1000
+export RETRIES=50
+export TESTMESSAGESFULL=$((3 * $TESTMESSAGES - 1))
+export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
+export RSYSLOG_DEBUGLOG="log"
+
+generate_conf
+add_conf '
+$WorkDirectory '$RSYSLOG_DYNNAME'.spool
+
+# Enable debug for state file operations
+global(
+	debug.whitelist="on"
+	debug.files=["imfile.c"]
+)
+
+module(	load="../plugins/imfile/.libs/imfile" 
+	mode="inotify" 
+	deleteStateOnFileMove="on"
+)
+
+input(type="imfile"
+	File="./'$RSYSLOG_DYNNAME'.input.log"
+	Tag="file:"
+	Severity="error"
+	Facility="local7"
+	addMetadata="on"
+	PersistStateInterval="100"
+)
+
+$template outfmt,"%msg:F,58:2%\n"
+if $msg contains "msgnum:" then
+ action(
+   type="omfile"
+   file=`echo $RSYSLOG_OUT_LOG`
+   template="outfmt"
+ )
+'
+
+print_state_files() {
+	local round=$1
+	echo "=== State files after round $round ==="
+	if [ -d "$RSYSLOG_DYNNAME.spool" ]; then
+		echo "State files in spool directory:"
+		local state_count=$(ls -1 "$RSYSLOG_DYNNAME.spool/"imfile-state* 2>/dev/null | wc -l)
+		echo "Total state files found: $state_count"
+		
+		if [ $state_count -eq 0 ]; then
+			echo "No state files found"
+		else
+			ls -la "$RSYSLOG_DYNNAME.spool/"imfile-state* 2>/dev/null
+			echo ""
+			
+			for statefile in "$RSYSLOG_DYNNAME.spool/"imfile-state*; do
+				if [ -f "$statefile" ]; then
+					echo "State file: $(basename "$statefile")"
+					echo "  Size: $(stat -c%s "$statefile" 2>/dev/null || echo "unknown") bytes"
+					echo "  Modified: $(stat -c%y "$statefile" 2>/dev/null || echo "unknown")"
+					echo "  Contents:"
+					if [ -r "$statefile" ]; then
+						cat "$statefile" 2>/dev/null | jq . 2>/dev/null | sed 's/^/    /' || {
+							echo "    Raw contents (not valid JSON):"
+							cat "$statefile" 2>/dev/null | sed 's/^/    /'
+						}
+					else
+						echo "    Cannot read file (permissions?)"
+					fi
+					echo ""
+				fi
+			done
+		fi
+	else
+		echo "Spool directory does not exist"
+	fi
+	echo ""
+}
+
+print_inode_info() {
+	local round=$1
+	echo "=== Inode information after round $round ==="
+	for file in "$RSYSLOG_DYNNAME".input.log*; do
+		if [ -f "$file" ]; then
+			local inode=$(stat -c%i "$file" 2>/dev/null || echo "N/A")
+			local size=$(stat -c%s "$file" 2>/dev/null || echo "N/A")
+			echo "File: $file - Inode: $inode - Size: $size bytes"
+		fi
+	done
+	echo ""
+}
+
+write_log_lines() {
+	local round=$1
+	local start_num=$((($round - 1) * $TESTMESSAGES))
+	echo "Writing $TESTMESSAGES log lines for round $round (starting from msgnum $start_num)"
+	./inputfilegen -m $TESTMESSAGES -i $start_num >> "$RSYSLOG_DYNNAME.input.log"
+}
+
+rotate_logs() {
+	echo "Rotating logs..."
+	if [ -f "$RSYSLOG_DYNNAME.input.log.3" ]; then
+		echo "  Removing $RSYSLOG_DYNNAME.input.log.3"
+		rm -f "$RSYSLOG_DYNNAME.input.log.3"
+	fi
+	if [ -f "$RSYSLOG_DYNNAME.input.log.2" ]; then
+		echo "  Moving $RSYSLOG_DYNNAME.input.log.2 to $RSYSLOG_DYNNAME.input.log.3"
+		mv "$RSYSLOG_DYNNAME.input.log.2" "$RSYSLOG_DYNNAME.input.log.3"
+	fi
+	if [ -f "$RSYSLOG_DYNNAME.input.log.1" ]; then
+		echo "  Moving $RSYSLOG_DYNNAME.input.log.1 to $RSYSLOG_DYNNAME.input.log.2"
+		mv "$RSYSLOG_DYNNAME.input.log.1" "$RSYSLOG_DYNNAME.input.log.2"
+	fi
+	if [ -f "$RSYSLOG_DYNNAME.input.log" ]; then
+		echo "  Moving $RSYSLOG_DYNNAME.input.log to $RSYSLOG_DYNNAME.input.log.1"
+		mv "$RSYSLOG_DYNNAME.input.log" "$RSYSLOG_DYNNAME.input.log.1"
+	fi
+}
+
+# Create initial empty input file
+touch "$RSYSLOG_DYNNAME.input.log"
+
+startup
+echo "Started rsyslog, waiting 1 second for initialization..."
+./msleep 1000
+
+# Perform 3 rounds of write->rotate cycle
+for round in 1 2 3; do
+	echo ""
+	echo "=== ROUND $round ==="
+	
+	# Write log lines
+	write_log_lines $round
+	
+	# Print inode information
+	print_inode_info "round $round (after write)"
+	
+	# Wait for processing
+	echo "Waiting 1 second for processing..."
+	./msleep 1000
+	
+	# Rotate logs
+	rotate_logs
+	
+	# Wait after rotation
+	echo "Waiting 1 second after rotation..."
+	./msleep 1000
+	
+	# Check state files
+	print_state_files $round
+	
+	# Print inode information after rotation
+	print_inode_info "round $round (after rotation)"
+done
+
+# Verify we got the expected number of messages
+expected_messages=$((3 * $TESTMESSAGES))
+wait_file_lines $RSYSLOG_OUT_LOG $expected_messages $RETRIES
+shutdown_when_empty
+wait_shutdown
+
+seq_check 0 $TESTMESSAGESFULL
+print_state_files "after shutdown"
+
+# Validate that there is exactly one state file after shutdown
+state_count=$(ls -1 "$RSYSLOG_DYNNAME.spool/"imfile-state* 2>/dev/null | wc -l)
+if [ $state_count -gt 1 ]; then
+	echo "FAIL: Multiple state files found ($state_count) - expected exactly one"
+	error_exit 1
+fi
+
+# Cleanup
+echo ""
+echo "=== CLEANUP ==="
+echo "Removing generated files..."
+rm -f "$RSYSLOG_DYNNAME".input.log*
+rm -rf "$RSYSLOG_DYNNAME.spool"
+echo "Cleanup completed"
+
+exit_test


### PR DESCRIPTION
When set to on, this parameter ensures that the state file associated with a monitored file is deleted if the file is moved or rotated. By default, the state file is retained. Enabling this option prevents leftover state files from accumulating in the spool directory when monitored files are rotated and later deleted, which is important for many use cases, e.g. to not fill up spool directory with obsolete state files.

I attached a test case as well. If you turn off this new parameter, then the state file is not deleted at exit.