### PR TITLE
scripting: add endswith operator to property filters and RainerScript

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,7 +87,7 @@ When fixing compiler warnings like `stringop-overread`, explain in the commit me
 > Mixed indentation styles (e.g., spaces in C files, tabs in Python) will be **rejected automatically** by style checks.
 > When generating C code, always simulate a tab width of 8 spaces for proper alignment of tabbed content.
 
-### Code Style Rules Enforced by `devtools/check-whitespace`:
+### Code Style Rules Enforced by `devtools/rsyslog_stylecheck.py`
 
 - Lines **must end with a single LF** (no missing or extra newlines)
 - **Maximum line length**: 120 columns (tab width = 8 spaces)

--- a/doc/source/_ext/rsyslog_lexer.py
+++ b/doc/source/_ext/rsyslog_lexer.py
@@ -54,7 +54,7 @@ class RainerScriptLexer(RegexLexer):
             # Legacy syslog selectors at the start of a line
             (r'^\s*([a-zA-Z0-9\.\*]+;)?([a-zA-Z0-9\.\*]+)\.(=|!=|=,!=)?([a-zA-Z0-9\*]+)\s+',
              bygroups(Keyword.Namespace, Keyword.Namespace, Operator, Keyword.Namespace), 'legacy_action'),
-            (r'^\s*:([a-zA-Z0-9_-]+),\s*(==|!=|<>|contains|startswith|re_match|re_extract)\s*"[^"]*"\s+',
+            (r'^\s*:([a-zA-Z0-9_-]+),\s*(==|!=|<>|contains|startswith|endswith|re_match|re_extract)\s*"[^"]*"\s+',
              bygroups(Name.Tag, Operator.Word, String.Double), 'legacy_action'),
             
             # RainerScript Keywords
@@ -64,7 +64,7 @@ class RainerScriptLexer(RegexLexer):
             
             # Operators
             (r'(&&|\|\||and|or|not)\b', Operator.Word),
-            (r'(=|==|!=|<>|<=|>=|<|>|:=|contains_i|startswith_i|contains|startswith)', Operator),
+            (r'(=|==|!=|<>|<=|>=|<|>|:=|contains_i|startswith_i|contains|startswith|endswith)', Operator),
 
             # Variables and Properties
             (r'\$[a-zA-Z0-9_.-]+', Name.Variable),

--- a/doc/source/configuration/filters.rst
+++ b/doc/source/configuration/filters.rst
@@ -145,6 +145,11 @@ The following **compare-operations** are currently supported:
   implemented, it can make very much sense (performance-wise) to use
   "startswith".
 
+**endswith**
+  Checks if the value appears exactly at the end of the property value.
+  For example, ``:programname, endswith, "_foo"`` matches if the program name
+  ends with ``_foo``.
+
 **regex**
   Compares the property against the provided POSIX BRE regular expression.
 

--- a/doc/source/rainerscript/expressions.rst
+++ b/doc/source/rainerscript/expressions.rst
@@ -10,7 +10,7 @@ in the list, e.g. multiplications are done before additions.
 -  not, unary minus
 -  \*, /, % (modulus, as in C)
 -  +, -, & (string concatenation)
--  ==, !=, <>, <, >, <=, >=, contains (strings!), startswith (strings!)
+-  ==, !=, <>, <, >, <=, >=, contains (strings!), startswith (strings!), endswith (strings!)
 -  and
 -  or
 

--- a/grammar/grammar.y
+++ b/grammar/grammar.y
@@ -107,6 +107,7 @@ extern int yyerror(const char*);
 %token CMP_CONTAINSI
 %token CMP_STARTSWITH
 %token CMP_STARTSWITHI
+%token CMP_ENDSWITH
 
 %type <nvlst> nv nvlst value
 %type <obj> obj property constant
@@ -118,7 +119,7 @@ extern int yyerror(const char*);
 %type <arr> array arrayelt
 
 %left AND OR
-%left CMP_EQ CMP_NE CMP_LE CMP_GE CMP_LT CMP_GT CMP_CONTAINS CMP_CONTAINSI CMP_STARTSWITH CMP_STARTSWITHI
+%left CMP_EQ CMP_NE CMP_LE CMP_GE CMP_LT CMP_GT CMP_CONTAINS CMP_CONTAINSI CMP_STARTSWITH CMP_STARTSWITHI CMP_ENDSWITH
 %left '+' '-' '&'
 %left '*' '/' '%'
 %nonassoc UMINUS NOT
@@ -211,6 +212,7 @@ expr:	  expr AND expr			{ $$ = cnfexprNew(AND, $1, $3); }
 	| expr CMP_CONTAINSI expr	{ $$ = cnfexprNew(CMP_CONTAINSI, $1, $3); }
 	| expr CMP_STARTSWITH expr	{ $$ = cnfexprNew(CMP_STARTSWITH, $1, $3); }
 	| expr CMP_STARTSWITHI expr	{ $$ = cnfexprNew(CMP_STARTSWITHI, $1, $3); }
+        | expr CMP_ENDSWITH expr        { $$ = cnfexprNew(CMP_ENDSWITH, $1, $3); }
 	| expr '&' expr			{ $$ = cnfexprNew('&', $1, $3); }
 	| expr '+' expr			{ $$ = cnfexprNew('+', $1, $3); }
 	| expr '-' expr			{ $$ = cnfexprNew('-', $1, $3); }

--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -321,6 +321,7 @@ int fileno(FILE *stream);
 <EXPR>"contains_i"		{ cnfPrintToken(yytext); return CMP_CONTAINSI; }
 <EXPR>"startswith"		{ cnfPrintToken(yytext); return CMP_STARTSWITH; }
 <EXPR>"startswith_i"		{ cnfPrintToken(yytext); return CMP_STARTSWITHI; }
+<EXPR>"endswith"              { cnfPrintToken(yytext); return CMP_ENDSWITH; }
 <EXPR>0[0-7]+ |			/* octal number */
 <EXPR>0x[0-9a-f]+ |		/* hex number, following rule is dec; strtoll handles all! */
 <EXPR>([1-9][0-9]*|0)		{ cnfPrintToken(yytext); yylval.n = strtoll(yytext, NULL, 0); return NUMBER; }

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -11,7 +11,7 @@
  *
  * Module begun 2009-06-10 by Rainer Gerhards
  *
- * Copyright 2009-2021 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2009-2025 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -473,8 +473,11 @@ evalPROPFILT(struct cnfstmt *stmt, smsg_t *pMsg)
 			bRet = 1; /* process message! */
 		break;
 	case FIOP_STARTSWITH:
-		if(rsCStrSzStrStartsWithCStr(stmt->d.s_propfilt.pCSCompValue,
-				  pszPropVal, propLen) == 0)
+		if(rsCStrSzStrStartsWithCStr(stmt->d.s_propfilt.pCSCompValue, pszPropVal, propLen) == 0)
+			bRet = 1; /* process message! */
+		break;
+	case FIOP_ENDSWITH:
+		if(rsCStrSzStrEndsWithCStr(stmt->d.s_propfilt.pCSCompValue, pszPropVal, propLen) == 0)
 			bRet = 1; /* process message! */
 		break;
 	case FIOP_REGEX:

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -11,7 +11,7 @@
  * e.g. search. Further refactoring and simplificytin may make
  * sense.
  *
- * Copyright (C) 2005-2019 Adiscon GmbH
+ * Copyright (C) 2005-2025 Adiscon GmbH
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -554,9 +554,7 @@ rsCStrCStrCmp(cstr_t *const __restrict__ pCS1, cstr_t *const __restrict__ pCS2)
  * rgerhards 2005-10-19
  */
 int
-rsCStrSzStrStartsWithCStr(cstr_t *const __restrict__ pCS1,
-	uchar *const __restrict__ psz,
-	const size_t iLenSz)
+rsCStrSzStrStartsWithCStr(cstr_t *const __restrict__ pCS1, uchar *const __restrict__ psz, const size_t iLenSz)
 {
 	rsCHECKVALIDOBJECT(pCS1, OIDrsCStr);
 	assert(psz != NULL);
@@ -568,6 +566,28 @@ rsCStrSzStrStartsWithCStr(cstr_t *const __restrict__ pCS1,
 			return memcmp(psz, pCS1->pBuf, pCS1->iStrLen);
 	} else {
 		return -1; /* pCS1 is less then psz */
+	}
+}
+
+/* check if a sz-type string ends with a CStr object. This helper mirrors
+ * rsCStrSzStrStartsWithCStr and is primarily intended for the new
+ * "endswith" property-filter operation.
+ * returns 0 if the string ends with the pattern, -1 otherwise.
+ */
+int
+rsCStrSzStrEndsWithCStr(cstr_t *const __restrict__ pCS1, uchar *const __restrict__ psz, const size_t iLenSz)
+{
+	rsCHECKVALIDOBJECT(pCS1, OIDrsCStr);
+	assert(psz != NULL);
+	assert(iLenSz == strlen((char*)psz));
+	if(iLenSz >= pCS1->iStrLen) {
+		if(pCS1->iStrLen == 0) {
+			return 0; /* yes, it ends with a zero-sized string ;) */
+		} else {
+			return memcmp(psz + iLenSz - pCS1->iStrLen, pCS1->pBuf, pCS1->iStrLen);
+		}
+	} else {
+		return -1;
 	}
 }
 

--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -135,6 +135,7 @@ int rsCStrOffsetSzStrCmp(cstr_t *pCS1, size_t iOffset, uchar *psz, size_t iLenSz
 int rsCStrLocateSzStr(cstr_t *pCStr, uchar *sz);
 int rsCStrLocateInSzStr(cstr_t *pThis, uchar *sz);
 int rsCStrSzStrStartsWithCStr(cstr_t *pCS1, uchar *psz, size_t iLenSz);
+int rsCStrSzStrEndsWithCStr(cstr_t *pCS1, uchar *psz, size_t iLenSz);
 rsRetVal rsCStrSzStrMatchRegex(cstr_t *pCS1, uchar *psz, int iType, void *cache);
 void rsCStrRegexDestruct(void *rc);
 

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -172,9 +172,10 @@ typedef enum {
 	FIOP_CONTAINS  = 1,	/* contains string? */
 	FIOP_ISEQUAL  = 2,	/* is (exactly) equal? */
 	FIOP_STARTSWITH = 3,	/* starts with a string? */
-	FIOP_REGEX = 4,		/* matches a (BRE) regular expression? */
-	FIOP_EREREGEX = 5,	/* matches a ERE regular expression? */
-	FIOP_ISEMPTY = 6	/* string empty <=> strlen(s) == 0 ?*/
+	FIOP_ENDSWITH = 4,    /* ends with a string? */
+	FIOP_REGEX = 5,		/* matches a (BRE) regular expression? */
+	FIOP_EREREGEX = 6,	/* matches a ERE regular expression? */
+	FIOP_ISEMPTY = 7	/* string empty <=> strlen(s) == 0 ?*/
 } fiop_t;
 
 #ifndef HAVE_LSEEK64

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -188,6 +188,7 @@ TESTS +=  \
 	func-substring-relative-endpos.sh \
 	hostname-with-slash-dflt-slash-valid.sh \
 	empty-app-name.sh \
+	endswith-basic.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
 	glbl-ruleset-queue-defaults.sh \
@@ -1921,6 +1922,7 @@ EXTRA_DIST= \
 	config_enabled-off.sh \
 	empty-app-name.sh \
 	empty-hostname.sh \
+	endswith-basic.sh \
 	func-substring-invld-startpos.sh \
 	func-substring-invld-startpos-vg.sh \
 	func-substring-large-endpos.sh \

--- a/tests/endswith-basic.sh
+++ b/tests/endswith-basic.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%programname% %msg%\n")
+if $programname endswith ["_foo", "-bar", ".baz"] then {
+        action(type="omfile" template="outfmt" file="'${RSYSLOG_OUT_LOG}'")
+}
+'
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host service_foo - - - test1'
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host service-bar - - - test2'
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host service.baz - - - test3'
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host otherprog - - - test4'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED="service_foo test1
+service-bar test2
+service.baz test3"
+cmp_exact
+exit_test


### PR DESCRIPTION
This Implements suffix comparison similar to startswith. Note that we do intentionally not use libestr functions in order to speed up adaption. It would otherwise probably take years for distros to upgrade libestr.

With some help of the Codex AI Agent.

closes https://github.com/rsyslog/rsyslog/issues/1255

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
