### PR TITLE
imtcp: prevent double-enqueue of descriptors via inQueue flag

### DIFF
--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -99,12 +99,14 @@ struct tcpsrv_io_descr_s {
 	} ptr;
 	int isInError; /* boolean, if set, subsystem indicates we need to close because we had an
 			* unrecoverable error at the network layer. */
+	int inQueue;	/**< flag: descriptor queued */
 	tcpsrv_t *pSrv;	/* our server object */
 	tcpsrv_io_descr_t *next; /* for use in workQueue_t */
 	#if defined(ENABLE_IMTCP_EPOLL)
 	struct epoll_event event; /* to re-enable EPOLLONESHOT */
 	#endif
 	DEF_ATOMIC_HELPER_MUT(mut_isInError);
+	DEF_ATOMIC_HELPER_MUT(mut_inQueue);
 };
 
 #define TCPSRV_NO_ADDTL_DELIMITER -1 /* specifies that no additional delimiter is to be used in TCP framing */


### PR DESCRIPTION
This patch adds an inQueue flag with its own mutex to each tcpsrv_io_descr_t structure. The flag prevents multiple worker threads from processing the same descriptor at the same time.

The change was motivated by segmentation faults reported in production systems after commit ad1fd21, which introduced a worker thread pool to imtcp. We could not reproduce the faults ourselves, but code analysis suggests several race conditions may exist.

In particular:

- epoll_wait may return the same descriptor multiple times. If it gets enqueued more than once, multiple threads may process and free it in parallel, causing use-after-free errors.

- closeSess releases the session mutex before destroying the session and descriptor. A second thread might still be waiting to acquire the mutex and access the now-freed memory.

- shutdown is unordered: stopWrkrPool waits for threads to join, but the work queue may still contain descriptors that will be processed after their memory has been freed.

- pending epoll events for a socket may still be processed after epoll_ctl(..., DEL) was called, leading to access to invalid memory.

The patch:

- Adds an inQueue flag to each descriptor and a mutex to protect it.
- Prevents enqueueWork from queuing a descriptor already in queue.
- Clears the flag when dequeueing the descriptor.
- Initializes and destroys the new mutex at listener startup/cleanup.

While unverified, we believe this patch is a safe and helpful change. It may fix the reported crashes and in general improves correctness.

The analysis and draft of this patch were created with help from a Codex-based AI agent. Final review and edits were done by a human.

Performance will be evaluated during PR review.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
