### PR TITLE
imkmsg fix: Handle EAGAIN/EWOULDBLOCK check portably

### DIFF
--- a/contrib/imkmsg/kmsg.c
+++ b/contrib/imkmsg/kmsg.c
@@ -4,7 +4,7 @@
  * For a general overview, see head comment in imkmsg.c.
  * This is heavily based on imklog bsd.c file.
  *
- * Copyright 2008-2023 Adiscon GmbH
+ * Copyright 2008-2025 Adiscon GmbH
  *
  * This file is part of rsyslog.
  *
@@ -268,11 +268,17 @@ readkmsg(modConfData_t *const pModConf)
 			continue;
 		} else {
 			/* something went wrong - error or zero length message */
-			if(i < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
-				DBGPRINTF("imkmsg: initial read done, changing to blocking mode\n");
-				change_reads_to_blocking(fklog);
-				bInInitialReading = 0;
-				continue;
+			if(i < 0) {
+			#if EAGAIN != EWOULDBLOCK
+				if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			#else
+				if (errno == EAGAIN) {
+			#endif
+					DBGPRINTF("imkmsg: initial read done, changing to blocking mode\n");
+					change_reads_to_blocking(fklog);
+					bInInitialReading = 0;
+					continue;
+				}
 			}
 			if(i < 0 && errno != EINTR && errno != EAGAIN) {
 				/* error occurred */


### PR DESCRIPTION
On some systems, EAGAIN and EWOULDBLOCK are defined to the same value, causing a `-Wlogical-op` warning for the redundant logical 'or' in the errno check.

While portable code must check for both cases, this warning is unwanted.

This change uses a preprocessor directive to conditionally compile the check for `errno == EWOULDBLOCK` only on platforms where its value differs from EAGAIN. This silences the warning without affecting portability.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
