### PR TITLE
nsd_ptcp fix: misleading error messages (regression from ad1fd21)

### DIFF
--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -932,7 +932,7 @@ EnableKeepAlive(nsd_t *pNsd)
 	ret = -1;
 #	endif
 	if(ret < 0) {
-		LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive probes - ignored");
+		LogError(ret, NO_ERRCODE, "nsd_ptcp cannot set keepalive probes - ignored");
 	}
 
 #	if defined(IPPROTO_TCP) && defined(TCP_KEEPIDLE)
@@ -947,7 +947,7 @@ EnableKeepAlive(nsd_t *pNsd)
 	ret = -1;
 #	endif
 	if(ret < 0) {
-		LogError(ret, NO_ERRCODE, "imptcp cannot set keepalive time - ignored");
+		LogError(ret, NO_ERRCODE, "nsd_ptcp cannot set keepalive time - ignored");
 	}
 
 #	if defined(IPPROTO_TCP) && defined(TCP_KEEPCNT)
@@ -962,7 +962,7 @@ EnableKeepAlive(nsd_t *pNsd)
 	ret = -1;
 #	endif
 	if(ret < 0) {
-		LogError(errno, NO_ERRCODE, "imptcp cannot set keepalive intvl - ignored");
+		LogError(errno, NO_ERRCODE, "nsd_ptcp cannot set keepalive intvl - ignored");
 	}
 
 	dbgprintf("KEEPALIVE enabled for socket %d\n", pThis->sock);


### PR DESCRIPTION
We received reports of log messages incorrectly referring to "imptcp" even though the imptcp module was not loaded on the system. This caused confusion during troubleshooting.

One such message was:

  rsyslogd: imptcp cannot set keepalive intvl - ignored: Bad file descriptor

This message originated from the nsd_ptcp module, but the LogError() calls in EnableKeepAlive() still used "imptcp" as the source name.

This is a regression introduced in commit ad1fd21, which restructured TCP input handling and moved responsibility for keepalive setup to nsd_ptcp, but did not update the associated log messages.

This patch corrects the affected log strings to use "nsd_ptcp", accurately reflecting the code path that emits them.

There is no functional change; the patch improves clarity of log output and prevents misleading diagnostics.

The actual error shown could be related to a different issue, see also https://github.com/rsyslog/rsyslog/pull/5749

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
