### PR TITLE
Add mmaitag plugin with real Gemini provider

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -294,6 +294,10 @@ if ENABLE_MMPSTRUCDATA
 SUBDIRS += plugins/mmpstrucdata
 endif
 
+if ENABLE_MMAITAG
+SUBDIRS += plugins/mmaitag
+endif
+
 if ENABLE_MMRFC5424ADDHMAC
 SUBDIRS += contrib/mmrfc5424addhmac
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -1649,6 +1649,21 @@ AC_ARG_ENABLE(mmpstrucdata,
 )
 AM_CONDITIONAL(ENABLE_MMPSTRUCDATA, test x$enable_mmpstrucdata = xyes)
 
+# mmaitag
+AC_ARG_ENABLE(mmaitag,
+        [AS_HELP_STRING([--enable-mmaitag],[Enable AI tagging module @<:@default=yes@:>@])],
+        [case "${enableval}" in
+         yes) enable_mmaitag="yes" ;;
+          no) enable_mmaitag="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-mmaitag) ;;
+         esac],
+        [enable_mmaitag=yes]
+)
+if test "x$enable_mmaitag" = "xyes"; then
+        PKG_CHECK_MODULES([CURL], [libcurl])
+fi
+AM_CONDITIONAL(ENABLE_MMAITAG, test x$enable_mmaitag = xyes)
+
 
 # mmrfc5424addhmac
 AC_ARG_ENABLE(mmrfc5424addhmac,
@@ -3030,9 +3045,10 @@ AC_CONFIG_FILES([Makefile \
 		plugins/mmanon/Makefile \
 		plugins/mmrm1stspace/Makefile \
 		plugins/mmutf8fix/Makefile \
-		plugins/mmfields/Makefile \
-		plugins/mmpstrucdata/Makefile \
-		plugins/omelasticsearch/Makefile \
+                plugins/mmfields/Makefile \
+                plugins/mmpstrucdata/Makefile \
+                plugins/mmaitag/Makefile \
+                plugins/omelasticsearch/Makefile \
 		plugins/omclickhouse/Makefile \
 		plugins/mmsnmptrapd/Makefile \
 		plugins/pmlastmsg/Makefile \
@@ -3181,6 +3197,7 @@ echo "    mmdarwin enabled:                         $enable_mmdarwin"
 echo "    mmfields enabled:                         $enable_mmfields"
 echo "    mmrm1stspace module enabled:              $enable_mmrm1stspace"
 echo "    mmkubernetes enabled:                     $enable_mmkubernetes"
+echo "    mmaitag enabled:                          $enable_mmaitag"
 echo "    mmtaghostname enabled:                    $enable_mmtaghostname"
 echo
 echo "---{ database support }---"

--- a/doc/source/configuration/modules/mmaitag.rst
+++ b/doc/source/configuration/modules/mmaitag.rst
@@ -1,0 +1,55 @@
+.. index:: ! mmaitag
+
+****************************
+AI-based classification (mmaitag)
+****************************
+
+================  ================================
+**Module Name:**  mmaitag
+**Author:**       Adiscon
+**Available:**    9.0+
+================  ================================
+
+Purpose
+=======
+
+The **mmaitag** module enriches log messages with classification tags
+obtained from an external AI service. Each message is sent to the provider
+individually and the resulting tag is stored in a custom variable.
+
+Default labels
+--------------
+
+| Label     | Description                                                |
+| --------- | ---------------------------------------------------------- |
+| NOISE     | Can be ignored, redundant, or irrelevant for most purposes |
+| REGULAR   | Normal messages of operational interest                    |
+| IMPORTANT | Should be logged and may indicate early signs of issues    |
+| CRITICAL  | Indicates immediate or serious problems                    |
+
+Configuration Parameters
+=======================
+
+- ``provider``: which backend to use (``gemini`` or ``gemini_mock``)
+- ``tag``: message variable name for the classification
+- ``model``: AI model identifier (provider specific)
+- ``expert.initial_prompt``: optional custom prompt text. If unset, the
+  following default is used::
+
+  You are a tool that classifies log messages. Given an array of log
+  messages, respond with a JSON array of labels: 'NOISE', 'REGULAR',
+  'IMPORTANT', or 'CRITICAL' — one per message, in order. Do not
+  include explanations or additional formatting.
+- ``inputproperty``: which message property to classify
+- ``apikey``: API key for the provider
+- ``apikey_file``: file containing the API key
+
+Example
+=======
+
+.. code-block:: none
+
+   module(load="mmaitag")
+   action(type="mmaitag" provider="gemini" apikey="ABC" tag="$.aitag")
+
+

--- a/plugins/mmaitag/Makefile.am
+++ b/plugins/mmaitag/Makefile.am
@@ -1,0 +1,8 @@
+pkglib_LTLIBRARIES = mmaitag.la
+
+mmaitag_la_SOURCES = mmaitag.c ai_provider.h ai_provider_gemini.c ai_provider_gemini_mock.c
+mmaitag_la_CPPFLAGS = $(RSRT_CFLAGS) $(PTHREADS_CFLAGS) $(CURL_CFLAGS)
+mmaitag_la_LDFLAGS = -module -avoid-version
+mmaitag_la_LIBADD = $(CURL_LIBS)
+
+EXTRA_DIST =

--- a/plugins/mmaitag/ai_provider.h
+++ b/plugins/mmaitag/ai_provider.h
@@ -1,0 +1,74 @@
+/**
+ * @file ai_provider.h
+ * @brief Defines the interface for AI classification providers.
+ *
+ * This header defines an abstraction layer for different AI backends.
+ * The mmaitag module uses this interface to classify messages without
+ * needing to know the specifics of the chosen AI service (e.g., Gemini,
+ * OpenAI). Each provider implements the functions defined here and
+ * exposes its implementation via a global ai_provider_t struct.
+ */
+#ifndef AI_PROVIDER_H
+#define AI_PROVIDER_H
+
+#include "rsyslog.h"
+
+typedef struct ai_provider_s ai_provider_t;
+
+/**
+ * @brief Function pointer type for initializing a provider.
+ *
+ * @param[in] prov The provider instance to initialize.
+ * @param[in] model The specific AI model name to use.
+ * @param[in] apikey The API key for service authentication.
+ * @param[in] prompt The base system/initial prompt to use for classification.
+ * @return RS_RET_OK on success, or an error code.
+ */
+typedef rsRetVal (*ai_provider_init_t)(ai_provider_t *prov, const char *model,
+	const char *apikey, const char *prompt);
+
+/**
+ * @brief Function pointer type for classifying a batch of messages.
+ *
+ * @param[in]  prov The provider instance.
+ * @param[in]  messages An array of message strings to classify.
+ * @param[in]  n The number of messages in the array.
+ * @param[out] tags A pointer to a string array that will be allocated by the
+ * implementation and filled with the resulting classification tags.
+ *
+ * @note The provider's implementation MUST allocate memory for the `tags`
+ * array and each string within it. The caller is responsible for
+ * freeing this memory.
+ *
+ * @return RS_RET_OK on success, or an error code.
+ */
+typedef rsRetVal (*ai_provider_classify_t)(ai_provider_t *prov,
+	const char **messages, size_t n, char ***tags);
+
+/**
+ * @brief Function pointer type for cleaning up a provider's resources.
+ *
+ * @param[in] prov The provider instance to clean up.
+ */
+typedef void (*ai_provider_cleanup_t)(ai_provider_t *prov);
+
+
+/**
+ * @brief The central struct defining a provider's implementation.
+ */
+struct ai_provider_s {
+	void *data;                     ///< Pointer to provider-specific private state data.
+	ai_provider_init_t init;        ///< Pointer to the provider's init function.
+	ai_provider_classify_t classify;///< Pointer to the provider's classification function.
+	ai_provider_cleanup_t cleanup;  ///< Pointer to the provider's cleanup function.
+};
+
+/*
+ * Extern declarations for the global provider instances.
+ * These make the provider singletons, defined in their respective .c files,
+ * available to the main mmaitag module.
+ */
+extern ai_provider_t gemini_provider;
+extern ai_provider_t gemini_mock_provider;
+
+#endif /* AI_PROVIDER_H */

--- a/plugins/mmaitag/ai_provider_gemini.c
+++ b/plugins/mmaitag/ai_provider_gemini.c
@@ -1,0 +1,288 @@
+/**
+ * @file ai_provider_gemini.c
+ * @brief An AI provider that uses the Google Gemini REST API.
+ *
+ * This file provides a concrete implementation of the ai_provider.h
+ * interface. It handles the specifics of formatting requests for
+ * and parsing responses from the Google Gemini API to classify
+ * log messages.
+ */
+#include "config.h"
+#include "ai_provider.h"
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <unistd.h>      /* for sleep() */
+#include <ctype.h>       /* for isspace() */
+#include <curl/curl.h>
+#include <json.h>
+
+/**
+ * @brief Holds the private state for the Gemini provider.
+ *
+ * This struct contains all provider-specific configuration, such as
+ * the model name and API key. An instance of this is stored in the
+ * generic `ai_provider_t->data` void pointer.
+ */
+typedef struct gemini_data_s {
+	char *model;
+	char *apikey;
+	char *prompt;
+} gemini_data_t;
+
+/**
+ * @brief A simple buffer to accumulate the HTTP response from libcurl.
+ */
+struct curl_resp {
+	char *buf;
+	size_t len;
+};
+
+/**
+ * @brief Strips trailing whitespace from a string in-place.
+ *
+ * @note This is a critical step because LLMs often add trailing
+ * newlines or other whitespace to their responses. Client-side
+ * cleaning is necessary for robust parsing.
+ *
+ * @param[in,out] str The string to be trimmed.
+ */
+static void
+strip_trailing_whitespace(char *str)
+{
+	if (str == NULL) return;
+
+	// Strip any true whitespace characters, including LF, CR, space, etc.
+	int len = strlen(str);
+	while (len > 0 && isspace((unsigned char)str[len - 1])) {
+		str[--len] = '\0';
+	}
+}
+
+
+/**
+ * @brief libcurl callback function for writing received data.
+ * @see CURLOPT_WRITEFUNCTION
+ *
+ * This function is called by libcurl whenever new data is received from
+ * the server. It appends the new data chunk to our curl_resp buffer.
+ */
+static size_t
+write_cb(char *ptr, size_t size, size_t nmemb, void *data)
+{
+	struct curl_resp *r = (struct curl_resp*)data;
+	size_t tot = size * nmemb;
+	char *tmp = realloc(r->buf, r->len + tot + 1);
+	if(tmp == NULL)
+		return 0;
+	r->buf = tmp;
+	memcpy(r->buf + r->len, ptr, tot);
+	r->len += tot;
+	r->buf[r->len] = '\0';
+	return tot;
+}
+
+/**
+ * @brief Implements the ai_provider_cleanup_t interface function.
+ *
+ * Frees all resources allocated by this provider, namely the
+ * private gemini_data_t state object.
+ */
+static void
+gemini_cleanup(ai_provider_t *prov)
+{
+	gemini_data_t *d = (gemini_data_t*)prov->data;
+	if(d == NULL)
+		return;
+	free(d->model);
+	free(d->apikey);
+	free(d->prompt);
+	free(d);
+	prov->data = NULL;
+}
+
+/**
+ * @brief Implements the ai_provider_init_t interface function.
+ *
+ * Allocates and populates the provider-specific gemini_data_t state
+ * struct and attaches it to the generic provider's `data` pointer.
+ *
+ * @param[in] prov The generic provider instance to initialize.
+ */
+static rsRetVal
+gemini_init(ai_provider_t *prov, const char *model, const char *key, const char *prompt)
+{
+	gemini_data_t *d;
+	DEFiRet;
+	d = calloc(1, sizeof(*d));
+	if(d == NULL)
+		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+	if(model)  d->model = strdup(model);
+	if(key)    d->apikey = strdup(key);
+	if(prompt) d->prompt = strdup(prompt);
+	prov->data = d;
+	prov->cleanup = gemini_cleanup;
+finalize_it:
+	RETiRet;
+}
+
+/**
+ * @brief Implements the ai_provider_classify_t interface function for Gemini.
+ *
+ * @note This function iterates through the message batch and sends
+ * **one API request per message**. This is inefficient for production
+ * but suitable for a proof-of-concept. A future optimization
+ * would be to construct a single request for the entire batch.
+ *
+ * @note The prompt is constructed by combining the configured initial_prompt
+ * with the log message, separated by a newline.
+ *
+ * @param[in]  prov The provider instance, used to access private data.
+ * @param[in]  msgs Array of C-strings, each a log message to classify.
+ * @param[in]  n    The number of messages in the `msgs` array.
+ * @param[out] tags A pointer to an array of C-strings. This function will
+ * allocate this array and fill it with the resulting tags.
+ * The caller is responsible for freeing the array and each
+ * string within it.
+ */
+static rsRetVal
+gemini_classify_batch(ai_provider_t *prov, const char **msgs, size_t n, char ***tags)
+{
+	gemini_data_t *d = (gemini_data_t*)prov->data;
+	DEFiRet;
+	char *url = NULL;
+	CURL *curl = NULL;
+
+	if(d == NULL || d->apikey == NULL)
+		ABORT_FINALIZE(RS_RET_ERR);
+
+	CHKmalloc(*tags = calloc(n, sizeof(char*)));
+
+	curl = curl_easy_init();
+	if(curl == NULL)
+		ABORT_FINALIZE(RS_RET_ERR);
+
+	if(asprintf(&url,
+		"https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent",
+		d->model ? d->model : "gemini-2.0-flash") == -1) {
+		ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+	}
+
+	for (size_t i = 0; i < n; ++i) {
+		struct curl_slist *headers = NULL;
+		struct curl_resp resp = {0};
+		struct json_object *req = NULL;
+		char *full_prompt = NULL;
+		char *api_key_header = NULL;
+
+		if (asprintf(&full_prompt, "%s\n%s", d->prompt ? d->prompt : "", msgs[i]) == -1) {
+			(*tags)[i] = strdup("REGULAR");
+			continue;
+		}
+		
+		// ✅ Dynamically allocate header to prevent buffer overflow
+		if (asprintf(&api_key_header, "x-goog-api-key: %s", d->apikey) == -1) {
+			(*tags)[i] = strdup("REGULAR");
+			free(full_prompt);
+			continue;
+		}
+
+		req = json_object_new_object();
+		struct json_object *contents = json_object_new_array();
+		struct json_object *user_turn = json_object_new_object();
+		struct json_object *parts = json_object_new_array();
+		struct json_object *text_part = json_object_new_object();
+
+		json_object_object_add(text_part, "text", json_object_new_string(full_prompt));
+		json_object_array_add(parts, text_part);
+		json_object_object_add(user_turn, "role", json_object_new_string("user"));
+		json_object_object_add(user_turn, "parts", parts);
+		json_object_array_add(contents, user_turn);
+		json_object_object_add(req, "contents", contents);
+
+		const char *body = json_object_to_json_string(req);
+
+		curl_easy_setopt(curl, CURLOPT_URL, url);
+		curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body);
+		
+		headers = curl_slist_append(NULL, "Content-Type: application/json");
+		headers = curl_slist_append(headers, api_key_header);
+		curl_easy_setopt(curl, CURLOPT_HTTPHEADER, headers);
+
+		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
+		curl_easy_setopt(curl, CURLOPT_WRITEDATA, &resp);
+		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+
+		long http_code = 0;
+		CURLcode cc = curl_easy_perform(curl);
+		curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
+
+		if (cc == CURLE_OK && http_code == 200) {
+			struct json_object *parsed = json_tokener_parse(resp.buf);
+			struct json_object *candidates = NULL;
+			struct json_object *first_candidate = NULL;
+			struct json_object *content = NULL;
+			struct json_object *parts_array = NULL;
+			struct json_object *part_obj = NULL;
+			struct json_object *text_obj = NULL;
+			const char *raw_tag = NULL;
+
+			// This chain of checks ensures we don't dereference a NULL pointer.
+			if (parsed &&
+				json_object_object_get_ex(parsed, "candidates", &candidates) &&
+				(first_candidate = json_object_array_get_idx(candidates, 0)) != NULL &&
+				json_object_object_get_ex(first_candidate, "content", &content) &&
+				json_object_object_get_ex(content, "parts", &parts_array) &&
+				(part_obj = json_object_array_get_idx(parts_array, 0)) != NULL &&
+				json_object_object_get_ex(part_obj, "text", &text_obj)) {
+
+				raw_tag = json_object_get_string(text_obj);
+			}
+
+			if (raw_tag) {
+				char *mutable_tag = strdup(raw_tag);
+				strip_trailing_whitespace(mutable_tag);
+				(*tags)[i] = mutable_tag;
+			} else {
+				(*tags)[i] = strdup("REGULAR");
+			}
+
+			if (parsed) {
+				json_object_put(parsed);
+			}
+		} else {
+			(*tags)[i] = strdup("REGULAR");
+			char err_details[1024];
+			snprintf(err_details, sizeof(err_details), "HTTP %ld - %s", http_code, resp.buf ? resp.buf : curl_easy_strerror(cc));
+			LogError(0, RS_RET_ERR, "mmaitag: gemini request for a message failed: %s", err_details);
+		}
+
+		// Cleanup for this loop iteration
+		curl_slist_free_all(headers);
+		free(api_key_header); // ✅ Free the dynamically allocated header
+		free(full_prompt);
+		free(resp.buf);
+		json_object_put(req);
+	}
+
+finalize_it:
+	if(curl)
+		curl_easy_cleanup(curl);
+	free(url);
+	RETiRet;
+}
+
+
+/**
+ * @brief The global instance of the Gemini provider.
+ *
+ * This struct "plugs" the static gemini_* functions into the interface
+ * defined in ai_provider.h. It is declared `extern` in `ai_provider.h`
+ * so that mmaitag.c can find and use it at runtime.
+ */
+ai_provider_t gemini_provider = {
+	.data     = NULL,
+	.init     = gemini_init,
+	.classify = gemini_classify_batch,
+	.cleanup  = gemini_cleanup
+};

--- a/plugins/mmaitag/ai_provider_gemini_mock.c
+++ b/plugins/mmaitag/ai_provider_gemini_mock.c
@@ -1,0 +1,140 @@
+/**
+ * @file ai_provider_gemini_mock.c
+ * @brief Mock provider used for mmaitag tests.
+ *
+ * This provider implements the ai_provider.h interface but does not
+ * contact any external service. It is designed to make test runs
+ * deterministic by returning predefined labels.
+ */
+#include "config.h"
+#include "ai_provider.h"
+#include <stdlib.h>
+#include <string.h>
+#include <curl/curl.h>
+#include <json.h>
+
+/**
+ * @brief Fulfills the private data requirement for the provider interface.
+ *
+ * While the mock classification logic does not use this state, it is
+ * allocated and freed to ensure the provider interface is correctly
+ * exercised during tests.
+ */
+typedef struct gemini_data_s {
+	char *model;
+	char *apikey;
+	char *prompt;
+} gemini_data_t;
+
+/**
+ * @brief Implements the standard cleanup function for the mock provider.
+ */
+static void
+gemini_cleanup(ai_provider_t *prov)
+{
+	gemini_data_t *data = (gemini_data_t*)prov->data;
+	if(data == NULL)
+		return;
+	free(data->model);
+	free(data->apikey);
+	free(data->prompt);
+	free(data);
+	prov->data = NULL;
+}
+
+/**
+ * @brief Implements the standard init function for the mock provider.
+ */
+static rsRetVal
+gemini_init(ai_provider_t *prov, const char *model, const char *apikey,
+	const char *prompt)
+{
+	gemini_data_t *data;
+	DEFiRet;
+	CHKmalloc(data = calloc(1, sizeof(*data)));
+	if(model)
+		data->model = strdup(model);
+	if(apikey)
+		data->apikey = strdup(apikey);
+	if(prompt)
+		data->prompt = strdup(prompt);
+	prov->data = data;
+	prov->cleanup = gemini_cleanup;
+finalize_it:
+	RETiRet;
+}
+
+/**
+ * @brief Mock implementation of the ai_provider_classify_t function.
+ *
+ * @note This function simulates an API call by parsing a comma-separated
+ * string from the `GEMINI_MOCK_RESPONSE` environment variable
+ * (e.g., "NOISE,CRITICAL,REGULAR").
+ *
+ * @note It is stateful across calls within a single test run. It uses a
+ * static counter to return subsequent tags from the list on
+ * subsequent calls, allowing for testing of sequential message
+ * processing.
+ *
+ * @note If the environment variable is not set or runs out of tags, it
+ * returns "REGULAR" as a default fallback value.
+ */
+static rsRetVal
+gemini_classify_batch(ai_provider_t *prov, const char **messages, size_t n,
+char ***tags)
+{
+	static size_t next = 0;
+	const char *mock = getenv("GEMINI_MOCK_RESPONSE");
+	(void)prov;
+	(void)messages;
+	char *tmp;
+	char *tok;
+	char *saveptr = NULL;
+	char **out;
+	size_t idx = 0;
+	DEFiRet;
+
+	if(mock == NULL) {
+		LogError(0, RS_RET_ERR, "mmaitag: mock provider requires "
+		"GEMINI_MOCK_RESPONSE environment variable to be set.");
+		ABORT_FINALIZE(RS_RET_ERR);
+	}
+
+	CHKmalloc(tmp = strdup(mock));
+
+	// Advance to the correct starting position in the token list
+	tok = strtok_r(tmp, ",", &saveptr);
+	for(size_t i = 0; i < next && tok != NULL; ++i)
+		tok = strtok_r(NULL, ",", &saveptr);
+
+	CHKmalloc(out = calloc(n, sizeof(char*)));
+	for(idx = 0 ; idx < n ; ++idx) {
+		if(tok != NULL) {
+			out[idx] = strdup(tok);
+			tok = strtok_r(NULL, ",", &saveptr);
+		} else {
+			// Fallback if we run out of mock tags
+			out[idx] = strdup("REGULAR");
+		}
+	}
+	next += n; // Update state for the next call
+
+	free(tmp);
+	*tags = out;
+
+finalize_it:
+	RETiRet;
+}
+
+/**
+ * @brief The global instance of the mock Gemini provider.
+ *
+ * This struct plugs the mock functions into the ai_provider.h interface
+ * for use in testing environments.
+ */
+ai_provider_t gemini_mock_provider = {
+	.data = NULL,
+	.init = gemini_init,
+	.classify = gemini_classify_batch,
+	.cleanup = gemini_cleanup
+};

--- a/plugins/mmaitag/mmaitag.c
+++ b/plugins/mmaitag/mmaitag.c
@@ -1,0 +1,270 @@
+/**
+ * @file mmaitag.c
+ * @brief AI-based message classification plugin.
+ *
+ * This module contacts an external AI service to classify log
+ * messages. The result of the classification is stored in a
+ * message variable (defaults to `$.aitag`). Messages are processed
+ * one by one through a pluggable provider interface. The
+ * initial implementation contains a Gemini provider as well as a
+ * mock backend used for testing.
+ *
+ * Copyright 2025 Adiscon GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * -or-
+ * see COPYING.ASL20 in the source distribution
+ */
+#include "config.h"
+#include "rsyslog.h"
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>      /* For strerror() */
+#include <json.h>
+#include "conf.h"
+#include "syslogd-types.h"
+#include "module-template.h"
+#include "msg.h"
+#include "cfsysline.h"
+#include "ai_provider.h"
+
+MODULE_TYPE_OUTPUT
+MODULE_TYPE_NOKEEP
+MODULE_CNFNAME("mmaitag")
+
+DEF_OMOD_STATIC_DATA
+
+static struct cnfparamdescr actpdescr[] = {
+	{ "provider", eCmdHdlrString, 0 },
+	{ "tag", eCmdHdlrString, 0 },
+	{ "model", eCmdHdlrString, 0 },
+	{ "expert.initial_prompt", eCmdHdlrString, 0 },
+	{ "inputproperty", eCmdHdlrString, 0 },
+	{ "apikey", eCmdHdlrString, 0 },
+	{ "apikey_file", eCmdHdlrString, 0 }
+};
+static struct cnfparamblk actpblk = {
+	CNFPARAMBLK_VERSION,
+	sizeof(actpdescr)/sizeof(struct cnfparamdescr),
+	actpdescr
+};
+
+typedef struct _instanceData {
+	char *provider_name;
+	char *tag;
+	char *model;
+	char *prompt;
+	msgPropDescr_t *inputProp;
+	char *apikey;
+	char *apikey_file;
+	ai_provider_t *provider;
+} instanceData;
+
+typedef struct wrkrInstanceData {
+	instanceData *pData;
+} wrkrInstanceData_t;
+
+static ai_provider_t *get_provider(const char *name); // Forward declaration
+
+BEGINcreateInstance
+CODESTARTcreateInstance
+ENDcreateInstance
+
+BEGINfreeInstance
+CODESTARTfreeInstance
+	free(pData->provider_name);
+	free(pData->tag);
+	free(pData->model);
+	free(pData->prompt);
+	free(pData->apikey);
+	free(pData->apikey_file);
+	if(pData->inputProp) {
+		msgPropDescrDestruct(pData->inputProp);
+		free(pData->inputProp);
+	}
+	if(pData->provider && pData->provider->cleanup)
+		pData->provider->cleanup(pData->provider);
+ENDfreeInstance
+
+BEGINcreateWrkrInstance
+CODESTARTcreateWrkrInstance
+	pWrkrData->pData = pData;
+ENDcreateWrkrInstance
+
+BEGINfreeWrkrInstance
+CODESTARTfreeWrkrInstance
+ENDfreeWrkrInstance
+
+BEGINdbgPrintInstInfo
+CODESTARTdbgPrintInstInfo
+	dbgprintf("mmaitag provider=%s tag=%s\n", pData->provider_name, pData->tag);
+ENDdbgPrintInstInfo
+
+BEGINtryResume
+CODESTARTtryResume
+ENDtryResume
+
+BEGINisCompatibleWithFeature
+CODESTARTisCompatibleWithFeature
+	if(eFeat == sFEATURERepeatedMsgReduction)
+		iRet = RS_RET_OK;
+ENDisCompatibleWithFeature
+
+static void
+setInstParamDefaults(instanceData *pData)
+{
+	pData->provider_name = strdup("gemini");
+	pData->tag = strdup(".aitag");
+	pData->model = strdup("gemini-2.0-flash");
+	pData->prompt = strdup(
+		"Task: Classify the log message that follows. "
+		"Output: Exactly one label from this list: NOISE, REGULAR, IMPORTANT, CRITICAL. "
+		"Restrictions: No other text, explanations, formatting, or newline characters.");
+	pData->inputProp = NULL;
+	pData->apikey = NULL;
+	pData->apikey_file = NULL;
+	pData->provider = NULL;
+}
+
+BEGINdoAction_NoStrings
+	smsg_t **ppMsg = (smsg_t**)pMsgData;
+	smsg_t *pMsg = ppMsg[0];
+	const char *msgs[1];
+	char **tags = NULL;
+	uchar *val;
+	rs_size_t len;
+	unsigned short freeBuf = 0;
+	instanceData *const pData = pWrkrData->pData;
+CODESTARTdoAction
+	if(pData->inputProp == NULL)
+		getRawMsg(pMsg, &val, &len);
+	else
+		val = MsgGetProp(pMsg, NULL, pData->inputProp, &len, &freeBuf, NULL);
+	msgs[0] = strndup((char*)val, len);
+	if(freeBuf)
+		free(val);
+	if(pData->provider && pData->provider->classify)
+		CHKiRet(pData->provider->classify(pData->provider, msgs, 1, &tags));
+	if(tags && tags[0]) {
+		struct json_object *j = json_object_new_string(tags[0]);
+		msgAddJSON(pMsg, (uchar*)pData->tag, j, 0, 0);
+	}
+finalize_it:
+	if(msgs[0])
+		free((void*)msgs[0]);
+	if(tags && tags[0])
+		free(tags[0]);
+	free(tags);
+ENDdoAction
+
+
+BEGINnewActInst
+	struct cnfparamvals *pvals;
+	int i;
+CODESTARTnewActInst
+	if((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
+		ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+	}
+	CODE_STD_STRING_REQUESTnewActInst(1);
+	CHKiRet(OMSRsetEntry(*ppOMSR, 0, NULL, OMSR_TPL_AS_MSG));
+	CHKiRet(createInstance(&pData));
+	setInstParamDefaults(pData);
+	for(i = 0 ; i < actpblk.nParams ; ++i) {
+		if(!pvals[i].bUsed)
+			continue;
+		if(!strcmp(actpblk.descr[i].name, "provider")) {
+			free(pData->provider_name);
+			pData->provider_name = es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "tag")) {
+			free(pData->tag);
+			pData->tag = es_str2cstr(pvals[i].val.d.estr, NULL);
+			if(pData->tag[0] == '$')
+				memmove(pData->tag, pData->tag+1, strlen(pData->tag));
+		} else if(!strcmp(actpblk.descr[i].name, "model")) {
+			free(pData->model);
+			pData->model = es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "expert.initial_prompt")) {
+			free(pData->prompt);
+			pData->prompt = es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "inputproperty")) {
+			char *c = es_str2cstr(pvals[i].val.d.estr, NULL);
+			CHKmalloc(pData->inputProp = malloc(sizeof(msgPropDescr_t)));
+			CHKiRet(msgPropDescrFill(pData->inputProp, (uchar*)c, strlen(c)));
+			free(c);
+		} else if(!strcmp(actpblk.descr[i].name, "apikey")) {
+			free(pData->apikey);
+			pData->apikey = es_str2cstr(pvals[i].val.d.estr, NULL);
+		} else if(!strcmp(actpblk.descr[i].name, "apikey_file")) {
+			free(pData->apikey_file);
+			pData->apikey_file = es_str2cstr(pvals[i].val.d.estr, NULL);
+		}
+	}
+	
+	// ✅ --- Robust API Key File Reading ---
+	if(pData->apikey == NULL && pData->apikey_file != NULL) {
+		FILE *fp = fopen(pData->apikey_file, "r");
+		if(fp == NULL) {
+			LogError(0, RS_RET_ERR, "mmaitag: could not open apikey_file '%s': %s",
+				pData->apikey_file, strerror(errno));
+		} else {
+			char *line = NULL;
+			size_t len = 0;
+			if(getline(&line, &len, fp) != -1) {
+				// Strip trailing newline characters
+				line[strcspn(line, "\r\n")] = '\0';
+				pData->apikey = line; // Transfer ownership of allocated buffer
+			} else {
+				free(line); // Free buffer if getline failed or file was empty
+			}
+			fclose(fp);
+		}
+	}
+
+	if(pData->provider == NULL) {
+		pData->provider = get_provider(pData->provider_name);
+		if(pData->provider == NULL) {
+			LogError(0, RS_RET_ERR, "mmaitag: unknown provider '%s'", pData->provider_name);
+			ABORT_FINALIZE(RS_RET_ERR);
+		}
+		if(pData->provider->init)
+			CHKiRet(pData->provider->init(pData->provider, pData->model, pData->apikey, pData->prompt));
+	}
+CODE_STD_FINALIZERnewActInst
+	cnfparamvalsDestruct(pvals, &actpblk);
+ENDnewActInst
+
+static ai_provider_t *
+get_provider(const char *name)
+{
+	// This function will need to be defined based on which providers are compiled in.
+	// For now, it's just a placeholder. You will need to provide the actual
+	// gemini_provider and gemini_mock_provider objects.
+	if(!strcmp(name, "gemini"))
+		return &gemini_provider;
+	if(!strcmp(name, "gemini_mock"))
+		return &gemini_mock_provider;
+	return NULL;
+}
+
+NO_LEGACY_CONF_parseSelectorAct
+
+BEGINmodExit
+CODESTARTmodExit
+ENDmodExit
+
+BEGINqueryEtryPt
+CODESTARTqueryEtryPt
+CODEqueryEtryPt_STD_OMOD_QUERIES
+CODEqueryEtryPt_STD_OMOD8_QUERIES
+CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES
+ENDqueryEtryPt
+
+BEGINmodInit()
+CODESTARTmodInit;
+	*ipIFVersProvided = CURR_MOD_IF_VERSION;
+CODEmodInit_QueryRegCFSLineHdlr
+ENDmodInit

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -665,8 +665,14 @@ endif # if ENABLE_SNMP
 
 if ENABLE_MMUTF8FIX
 TESTS +=  \
-	mmutf8fix_no_error.sh
+        mmutf8fix_no_error.sh
 endif # if ENABLE_MAIL
+
+if ENABLE_MMAITAG
+TESTS +=  \
+        mmaitag-basic.sh \
+        mmaitag-invalid-key.sh
+endif
 
 if ENABLE_MAIL
 TESTS +=  \
@@ -2365,9 +2371,11 @@ EXTRA_DIST= \
 	timegenerated-utc-legacy.sh \
 	timereported-utc.sh \
 	timereported-utc-legacy.sh \
-	timereported-utc-vg.sh \
-	mmrm1stspace-basic.sh \
-	mmnormalize_parsesuccess.sh \
+        timereported-utc-vg.sh \
+        mmrm1stspace-basic.sh \
+        mmaitag-basic.sh \
+        mmaitag-invalid-key.sh \
+        mmnormalize_parsesuccess.sh \
 	mmnormalize_parsesuccess-vg.sh \
 	mmnormalize_rule_from_string.sh \
 	mmnormalize_rule_from_array.sh \

--- a/tests/mmaitag-basic.sh
+++ b/tests/mmaitag-basic.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+## basic test for mmaitag plugin
+. ${srcdir:=.}/diag.sh init
+export GEMINI_MOCK_RESPONSE="NOISE,NOISE,REGULAR"
+
+generate_conf
+add_conf '
+module(load="../plugins/mmaitag/.libs/mmaitag")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg% %$.aitag%\n")
+
+
+if($msg contains "msgnum:00") then {
+	action(type="mmaitag" provider="gemini_mock" apikey="dummy")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+tcpflood -m 3
+shutdown_when_empty
+wait_shutdown
+content_check "msgnum:00000000: NOISE"
+content_check "msgnum:00000001: NOISE"
+content_check "msgnum:00000002: REGULAR"
+exit_test

--- a/tests/mmaitag-invalid-key.sh
+++ b/tests/mmaitag-invalid-key.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+## test gemini provider with invalid API key
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmaitag/.libs/mmaitag")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%msg% [%$.aitag%]\n")
+
+if($msg contains "msgnum:00") then {
+	action(type="mmaitag" provider="gemini" apikey="dummy")
+}
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+tcpflood -m 1
+shutdown_when_empty
+wait_shutdown
+content_check "request for a message failed" "$RSYSLOG_OUT_LOG"
+exit_test


### PR DESCRIPTION
## Summary
- add real Gemini provider implementation
- rename mock provider and update references
- include doc for mmaitag usage
- update test to use gemini_mock provider

## Testing
- `python3 devtools/rsyslog_stylecheck.py plugins/mmaitag/mmaitag.c plugins/mmaitag/ai_provider_gemini.c plugins/mmaitag/ai_provider_gemini_mock.c plugins/mmaitag/Makefile.am tests/mmaitag-basic.sh doc/source/configuration/modules/mmaitag.rst`

------
https://chatgpt.com/codex/tasks/task_e_686b6feb58f48332b3b53f2f557dcbb8