### PR TITLE
Fix imfile inode check

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -824,7 +824,7 @@ detect_updates(fs_edge_t *const edge)
 			       e.g. file has been closed, so we will never have old inode (but
 			            why was it closed then? --> check)
 			 */
-			r = fstat(act->ino, &fileInfo);
+			r = fstat(act->fd, &fileInfo);
 			if(r == -1) {
 				time_t ttNow;
 				time(&ttNow);


### PR DESCRIPTION
## Summary
- imfile: check file descriptor when verifying inode

Fixes issue https://github.com/rsyslog/rsyslog/issues/5176

## Testing
- `python3 devtools/rsyslog_stylecheck.py plugins/imfile/imfile.c`


------
https://chatgpt.com/codex/tasks/task_e_6871640d371883328778c0871905c1fc