### PR TITLE
Document GTLS certificate chain behavior

### DIFF
--- a/doc/source/configuration/modules/imtcp.rst
+++ b/doc/source/configuration/modules/imtcp.rst
@@ -500,6 +500,15 @@ https://docs.openssl.org/1.1.1/man3/SSL_CTX_set_verify/
 For GnuTLS, the default is 5 - see the doc for more:
 https://www.gnutls.org/manual/gnutls.html
 
+.. note::
+
+   The GnuTLS driver sends all certificates contained in the file
+   specified via ``StreamDriver.CertFile`` (or
+   ``$DefaultNetstreamDriverCertFile``) to connecting clients.  To
+   expose intermediate certificates, the file must contain the server
+   certificate first, followed by the intermediate certificates.
+   This capability was added in rsyslog version 8.36.0.
+
 
 PermittedPeer
 ^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary
- clarify that the GTLS driver sends all certificates in the configured cert file
- note this resolves [issue #2547](https://github.com/rsyslog/rsyslog/issues/2547)

## Testing
- `python3 devtools/rsyslog_stylecheck.py doc/source/configuration/modules/imtcp.rst`

------
https://chatgpt.com/codex/tasks/task_e_68716f81b39c8332bafeabccf7516389