### PR TITLE
Add Doxygen headers for statsobj

### DIFF
--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -21,6 +21,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * @file statsobj.c
+ * @brief Implementation of the rsyslog statistics object
+ *
+ * Each statsobj_t instance maintains a name, origin and a set of counters.
+ * All instances are linked together so that GetAllStatsLines() can iterate
+ * through them and emit their values. Counters may be 64 bit integers or
+ * plain ints and are modified with atomic helpers when required.
+ *
+ * The module can output collected counters in several formats:
+ *  - legacy key=value lines
+ *  - JSON or JSON-ES (Elasticsearch compatible)
+ *  - CEE / lumberjack records
+ *  - Prometheus text exposition
+ *
+ * Statistics gathering is controlled by the ::GatherStats flag and can be
+ * enabled via EnableStats().
+ */
 
 #include "config.h"
 #include <stdio.h>

--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -18,6 +18,30 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+/**
+ * @file statsobj.h
+ * @brief Interface of the rsyslog statistics object
+ *
+ * A statistics object (statsobj_t) represents a set of counters that
+ * describe activity within a subsystem. Each object keeps a doubly
+ * linked list of counters and all objects are maintained in a global
+ * list protected by a mutex. The counters are either 64 bit integers
+ * (ctrType_IntCtr) or plain int values (ctrType_Int) and can be marked
+ * resettable. Statistics are only gathered while the global
+ * ::GatherStats flag is non-zero.
+ *
+ * Counters can be reported in multiple formats via the GetAllStatsLines()
+ * interface:
+ *  - ::statsFmt_Legacy     classic key=value pairs
+ *  - ::statsFmt_JSON       valid JSON structures
+ *  - ::statsFmt_JSON_ES    JSON with dot replacement for Elasticsearch
+ *  - ::statsFmt_CEE        Project Lumberjack / CEE format
+ *  - ::statsFmt_Prometheus Prometheus text exposition format
+ *
+ * The caller supplies a callback that receives each generated line.
+ * After emission counters flagged with CTR_FLAG_RESETTABLE may be
+ * cleared if requested.
+ */
 #ifndef INCLUDED_STATSOBJ_H
 #define INCLUDED_STATSOBJ_H
 


### PR DESCRIPTION
## Summary
- document stats object architecture and usage
- list output formats supported by stats subsystem

## Testing
- `python3 devtools/rsyslog_stylecheck.py runtime/statsobj.h runtime/statsobj.c`

------
https://chatgpt.com/codex/tasks/task_e_68726b3cd44c833288fdf551b84e7ab0