### PR TITLE
AI support: relax indention rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,42 +69,37 @@ When fixing compiler warnings like `stringop-overread`, explain in the commit me
 ### Indentation Rules (Language-Specific)
 
 - **C / Header / Makefiles**:
-  - Use **tabs only** for indentation (`\t`) (1 tab = 1 indent level)
-  - Do **not** use spaces for indentation or alignment
+  - Preferred: **tabs only** for indentation (`\t`)
+  - Acceptable: **spaces** may be used if required by the generation tool
+  - Do **not** mix tabs and spaces in the same block
   - The **only allowed space at column 1** is for multiline comments starting with ` *`, e.g.:
     ```c
     /*
      * This is a valid Doxygen or traditional comment.
      */
     ```
-  - This rule is strictly enforced by CI and `devtools/rsyslog_stylecheck.py`
 
 - **Python**:
   - Follow [PEP 8](https://peps.python.org/pep-0008/): **4 spaces per indent level**
   - Do **not** use tabs in `.py` files
 
 > AI Agent Note:
-> Mixed indentation styles (e.g., spaces in C files, tabs in Python) will be **rejected automatically** by style checks.
-> When generating C code, always simulate a tab width of 8 spaces for proper alignment of tabbed content.
+> When generating C code, tabs are preferred. If your environment requires spaces,
+> simulate tab width of 8 spaces for proper alignment.
 
-### Code Style Rules Enforced by `devtools/rsyslog_stylecheck.py`
+---
 
-- Lines **must end with a single LF** (no missing or extra newlines)
-- **Maximum line length**: 120 columns (tab width = 8 spaces)
-- **No leading space** at beginning of line (except for ` *` in comments)
-- **No trailing whitespace** at line end
-- **DOS CRLF format is not permitted**
+## Build & Test Expectations
 
-### Structured Error Handling Convention
+Whenever `.c` or `.h` files are modified, a build should be performed using `make`.
+If new functionality is introduced, at least a basic test should be created and run.
 
-- Use `ABORT_FINALIZE(code);` to both set `iRet = code` and jump to `finalize`.
-- Use `FINALIZE;` when exiting with the current `iRet` value.
-- Use `DEFiRet` at the beginning of a function to define `iRet`.
-- Use the label `finalize_it:` to mark the exception return point.
-- Return using `RETiRet`.
-- Use `CHKiRet()` to check a function's return and jump to `finalize_it` on failure.
-- Use `CHKmalloc()` and similar macros to verify allocations or calls.
-- `localRet` is a temporary `rsRetVal` for intermediate error evaluation.
+If possible, agents should:
+- Build the project using `./configure` and `make`
+- Run an individual test using the instructions below
+
+> In restricted environments, a build may not be possible. In such cases, ensure the
+> generated code is clear and well-commented to aid review.
 
 ---
 


### PR DESCRIPTION
Strict rules break a lot of AI Agent capabilites as we have seen. Repo will most probably soon moved to space-indention.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
