### PR TITLE
Update README and unify dev container builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Build support libraries from source if you're working with the latest git master
 Refer to the respective section in the original README for required packages on CentOS, Ubuntu, Debian, SUSE, etc.
 
 #### Development Containers & Testing
-For a ready-to-use environment, use the images from [rsyslog-docker](https://github.com/rsyslog/rsyslog-docker). They contain all build dependencies. Run the test suite with `make check` (limit to `-j4`).
+Ready-to-use build environments are provided in `packaging/docker/dev_env`. These images were previously built in the separate [rsyslog-docker](https://github.com/rsyslog/rsyslog-docker) repository and are now maintained here. See `packaging/docker/README.md` for details. Runtime container definitions are in `packaging/docker/rsyslog`. Run the test suite inside the container with `make check` (limit to `-j4`).
 
 ---
 

--- a/packaging/docker/dev_env/Makefile
+++ b/packaging/docker/dev_env/Makefile
@@ -1,0 +1,41 @@
+# ============================================================================
+# Makefile for building rsyslog development environment containers
+#
+# Each directory containing a build.sh script is automatically exposed
+# as a make target. The target name mirrors the directory path with
+# slashes replaced by dashes. For example:
+#   make ubuntu-base-22.04
+#   make fedora-buildbot-31
+#
+# Additional arguments can be passed to the underlying build.sh via
+# the DOCKER_ARGS variable, e.g.:
+#   make ubuntu-base-22.04 DOCKER_ARGS="--no-cache"
+# ============================================================================
+
+SHELL := /bin/bash
+
+# Discover build scripts
+BUILD_SCRIPTS := $(shell find . -name build.sh | sort)
+TARGET_PATHS  := $(dir $(BUILD_SCRIPTS))
+TARGET_NAMES  := $(patsubst ./%,%,$(subst /,-,$(TARGET_PATHS)))
+
+.PHONY: $(TARGET_NAMES) all list help
+
+all: $(TARGET_NAMES)
+
+$(TARGET_NAMES):
+	@script="$(subst -,/,$@)/build.sh"; \
+	dir="$$(dirname $$script)"; \
+	if [ ! -f $$script ]; then \
+	echo "Unknown target: $@"; exit 1; \
+	fi; \
+	echo "--- Building $$script ---"; \
+	(cd $$dir && bash ./build.sh $(DOCKER_ARGS))
+
+list:
+	@for t in $(TARGET_NAMES); do echo $$t; done
+
+help: list
+	@echo
+	@echo "Use 'make <target>' to build the corresponding dev container."
+	@echo "Pass extra Docker build flags via DOCKER_ARGS."


### PR DESCRIPTION
## Summary
- document Docker images now in-tree
- add Makefile to simplify `dev_env` container builds

## Testing
- `python3 devtools/rsyslog_stylecheck.py README.md packaging/docker/dev_env/Makefile`

------
https://chatgpt.com/codex/tasks/task_e_6872b22e502083328e0630afe94620a5