### PR TITLE
fix: Prevent redefinition warnings for syslog macros

### DIFF
--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -26,6 +26,7 @@
 #include <regex.h>
 #include "typedefs.h"
 
+#undef LOG_NFACILITIES
 #define LOG_NFACILITIES 24+1 /* we copy&paste this as including rsyslog.h gets us in off64_t trouble... :-( */
 #define CNFFUNC_MAX_ARGS 32
 	/**< maximum number of arguments that any function can have (among

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -219,7 +219,38 @@
 /* make sure we uses consistent macros, no matter what the
  * platform gives us.
  */
-#undef LOG_NFACILITIES /* may be system defined, override */
+#undef LOG_EMERG
+#undef LOG_ALERT
+#undef LOG_CRIT
+#undef LOG_ERR
+#undef LOG_WARNING
+#undef LOG_NOTICE
+#undef LOG_INFO
+#undef LOG_DEBUG
+
+#undef LOG_KERN
+#undef LOG_USER
+#undef LOG_MAIL
+#undef LOG_DAEMON
+#undef LOG_AUTH
+#undef LOG_SYSLOG
+#undef LOG_LPR
+#undef LOG_NEWS
+#undef LOG_UUCP
+#undef LOG_CRON
+#undef LOG_AUTHPRIV
+#undef LOG_FTP
+#undef LOG_LOCAL0
+#undef LOG_LOCAL1
+#undef LOG_LOCAL2
+#undef LOG_LOCAL3
+#undef LOG_LOCAL4
+#undef LOG_LOCAL5
+#undef LOG_LOCAL6
+#undef LOG_LOCAL7
+#undef LOG_FAC_INVLD
+#undef LOG_INVLD
+#undef LOG_NFACILITIES
 #define LOG_NFACILITIES 24+1 /* plus one for our special "invld" facility! */
 #define LOG_MAXPRI 191	/* highest supported valid PRI value --> RFC3164, RFC5424 */
 #undef LOG_MAKEPRI


### PR DESCRIPTION
Undefine common syslog severity and facility macros before redefining them in rsyslog.h. As rsyslog, we need consistent definitions. This resolves "redefined" warnings when other system headers are included. LOG_CRON remains guarded. Improves build cleanliness.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
