### PR TITLE
Fix srUtilItoA type inconsistencies

### DIFF
--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -323,25 +323,25 @@ SerializeProp(strm_t *pStrm, uchar *pszPropName, propType_t propType, void *pUsr
 			vType = VARTYPE_STR;
 			break;
 		case PROPTYPE_SHORT:
-			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), (long) *((short*) pUsr)));
+			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), (int64_t) *((short*) pUsr)));
 			pszBuf = szBuf;
 			lenBuf = ustrlen(szBuf);
 			vType = VARTYPE_NUMBER;
 			break;
 		case PROPTYPE_INT:
-			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), (long) *((int*) pUsr)));
+			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), (int64_t) *((int*) pUsr)));
 			pszBuf = szBuf;
 			lenBuf = ustrlen(szBuf);
 			vType = VARTYPE_NUMBER;
 			break;
 		case PROPTYPE_LONG:
-			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), *((long*) pUsr)));
+			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), (int64_t) *((long*) pUsr)));
 			pszBuf = szBuf;
 			lenBuf = ustrlen(szBuf);
 			vType = VARTYPE_NUMBER;
 			break;
 		case PROPTYPE_INT64:
-			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), *((int64*) pUsr)));
+			CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), *((int64_t*) pUsr)));
 			pszBuf = szBuf;
 			lenBuf = ustrlen(szBuf);
 			vType = VARTYPE_NUMBER;

--- a/runtime/srUtils.h
+++ b/runtime/srUtils.h
@@ -63,7 +63,7 @@ extern syslogName_t syslogFacNames[];
  *
  * \param iToConv The integer to be converted.
  */
-rsRetVal srUtilItoA(char *pBuf, int iLenBuf, number_t iToConv);
+rsRetVal srUtilItoA(char *pBuf, int iLenBuf, int64_t iToConv);
 
 /**
  * A method to duplicate a string for which the length is known.

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -132,7 +132,7 @@ syslogName_t	syslogFacNames[] = {
  * public members                                                    *
  * ################################################################# */
 
-rsRetVal srUtilItoA(char *pBuf, int iLenBuf, number_t iToConv)
+rsRetVal srUtilItoA(char *pBuf, int iLenBuf, int64_t iToConv)
 {
 	int i;
 	int bIsNegative;

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -2014,7 +2014,7 @@ static rsRetVal strmWriteLong(strm_t *__restrict__ const pThis, const long i)
 
 	assert(pThis != NULL);
 
-	CHKiRet(srUtilItoA((char*)szBuf, sizeof(szBuf), i));
+	    CHKiRet(srUtilItoA((char*)szBuf, sizeof(szBuf), (int64_t)i));
 	CHKiRet(strmWrite(pThis, szBuf, strlen((char*)szBuf)));
 
 finalize_it:

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -357,7 +357,7 @@ rsRetVal rsCStrAppendInt(cstr_t *pThis, long i)
 
 	rsCHECKVALIDOBJECT(pThis, OIDrsCStr);
 
-	CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), i));
+	CHKiRet(srUtilItoA((char*) szBuf, sizeof(szBuf), (int64_t)i));
 
 	iRet = rsCStrAppendStr(pThis, szBuf);
 finalize_it:


### PR DESCRIPTION
## Summary
- use `int64_t` for srUtilItoA parameter
- cast callers to ensure consistent interface

## Testing
- `python3 devtools/rsyslog_stylecheck.py runtime/srUtils.h runtime/srutils.c runtime/stringbuf.c runtime/stream.c runtime/obj.c`

------
https://chatgpt.com/codex/tasks/task_e_687652cc77808332bc90d18d7f86395e