### PR TITLE
build: mmaitag in configure disabled by default

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1651,13 +1651,13 @@ AM_CONDITIONAL(ENABLE_MMPSTRUCDATA, test x$enable_mmpstrucdata = xyes)
 
 # mmaitag
 AC_ARG_ENABLE(mmaitag,
-        [AS_HELP_STRING([--enable-mmaitag],[Enable AI tagging module @<:@default=yes@:>@])],
+        [AS_HELP_STRING([--enable-mmaitag],[Enable AI tagging module @<:@default=no@:>@])],
         [case "${enableval}" in
          yes) enable_mmaitag="yes" ;;
           no) enable_mmaitag="no" ;;
            *) AC_MSG_ERROR(bad value ${enableval} for --enable-mmaitag) ;;
          esac],
-        [enable_mmaitag=yes]
+        [enable_mmaitag=no]
 )
 if test "x$enable_mmaitag" = "xyes"; then
         PKG_CHECK_MODULES([CURL], [libcurl])


### PR DESCRIPTION
This was originally intended, but for testing it was set to enabled by default. This is now corrected. Not all CI workers support the necessary dependencies.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
