### PR TITLE
Fix auth error reporting in omelasticsearch

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -170,6 +170,7 @@ typedef struct wrkrInstanceData {
     int replyLen;
     size_t replyBufLen;
     char *reply;
+    long httpStatusCode; /* http status code of response */
     CURL *curlCheckConnHandle; /* libcurl session handle for checking the server connection */
     CURL *curlPostHandle; /* libcurl session handle for posting data to the server */
     HEADER *curlHeader; /* json POST request info */
@@ -270,6 +271,7 @@ BEGINcreateWrkrInstance
     pWrkrData->reply = NULL;
     pWrkrData->replyLen = 0;
     pWrkrData->replyBufLen = 0;
+    pWrkrData->httpStatusCode = 0;
     iRet = curlSetup(pWrkrData);
 ENDcreateWrkrInstance
 
@@ -1572,6 +1574,7 @@ static rsRetVal ATTR_NONNULL(1, 2)
     curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, msglen);
     curl_easy_setopt(curl, CURLOPT_ERRORBUFFER, errbuf);
     code = curl_easy_perform(curl);
+    curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &pWrkrData->httpStatusCode);
     DBGPRINTF("curl returned %lld\n", (long long)code);
     if (code != CURLE_OK && code != CURLE_HTTP_RETURNED_ERROR) {
         STATSCOUNTER_INC(indexHTTPReqFail, mutIndexHTTPReqFail);
@@ -1580,6 +1583,13 @@ static rsRetVal ATTR_NONNULL(1, 2)
                  "omelasticsearch: we are suspending ourselfs due "
                  "to server failure %lld: %s",
                  (long long)code, errbuf);
+        ABORT_FINALIZE(RS_RET_SUSPENDED);
+    }
+
+    if (pWrkrData->httpStatusCode == 401 || pWrkrData->httpStatusCode == 403) {
+        STATSCOUNTER_INC(indexHTTPFail, mutIndexHTTPFail);
+        LogError(0, RS_RET_SUSPENDED, "omelasticsearch: authentication failed with status %ld",
+                 pWrkrData->httpStatusCode);
         ABORT_FINALIZE(RS_RET_SUSPENDED);
     }
 


### PR DESCRIPTION
## Summary
- track HTTP status in omelasticsearch worker data
- detect 401/403 responses after posting and log an auth failure

## Testing
- `./devtools/format-code.sh`
- `python3 devtools/rsyslog_stylecheck.py -f`
- `python3 devtools/rsyslog_stylecheck.py -f plugins/omelasticsearch/omelasticsearch.c`


------
https://chatgpt.com/codex/tasks/task_e_6877c5c1aa2c83329a908c7d650811a9