### PR TITLE
doc: fix "edit on github" repo link

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -33,8 +33,8 @@ needs_sphinx = '4.5.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['edit_on_github', 'sphinx.ext.todo']
-edit_on_github_project = 'rsyslog/rsyslog-doc'
-edit_on_github_branch = 'master'
+edit_on_github_project = 'https://github.com/rsyslog/rsyslog'
+edit_on_github_branch = 'main'
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/source/containers/index.rst
+++ b/doc/source/containers/index.rst
@@ -9,7 +9,7 @@ All versions of rsyslog work well in containers. Versions beginning with
 extra features that are useful inside containers.
 
 Note: the sources for docker containers created by the rsyslog project
-can be found at https://github.com/rsyslog/rsyslog-docker - these may
+can be found at https://github.com/rsyslog/rsyslog/tree/main/packaging/docker - these may
 be useful as a starting point for similar efforts. Feedback, bug
 reports and pull requests are also appreciated for this project.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -67,7 +67,7 @@ Contributing to the docs
 ------------------------
 
 This documentation is hosted on `github
-<https://github.com/rsyslog/rsyslog-doc>`_. If you find something to be
+<https://github.com/rsyslog/rsyslog/tree/main/doc>`_. If you find something to be
 improved, please feel free to fork and file a patch request with your
 improvements. There is also a Button 'Edit in GitHub' on every documentation
 page beginning with the main `docs page

--- a/doc/source/proposals/big_restructuring/documentation_review.rst
+++ b/doc/source/proposals/big_restructuring/documentation_review.rst
@@ -61,7 +61,6 @@ Some resources worth taking a look.
 
     * https://docs.redhat.com/en/documentation/Red_Hat_Enterprise_Linux/7/html/system_administrators_guide/ch-viewing_and_managing_log_files
 	* https://www.usenix.org/system/files/login/articles/06_lang-online.pdf
-	* https://rsyslog.readthedocs.io/_/downloads/en/latest/pdf/
 	* http://download.rsyslog.com/rainerscript2_rsyslog.conf
 	* https://people.redhat.com/pvrabec/rpms/rsyslog/rsyslog-example.conf
 	* http://www.rsyslog.com/doc/syslog_parsing.html


### PR DESCRIPTION
and some other places with outdated repo link

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
