### PR TITLE
core: unify srUtilItoA calling sequence

### DIFF
--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -308,13 +308,13 @@ static rsRetVal SerializeProp(strm_t *pStrm, uchar *pszPropName, propType_t prop
             vType = VARTYPE_STR;
             break;
         case PROPTYPE_SHORT:
-            CHKiRet(srUtilItoA((char *)szBuf, sizeof(szBuf), (long)*((short *)pUsr)));
+            CHKiRet(srUtilItoA((char *)szBuf, sizeof(szBuf), (int64_t)*((short *)pUsr)));
             pszBuf = szBuf;
             lenBuf = ustrlen(szBuf);
             vType = VARTYPE_NUMBER;
             break;
         case PROPTYPE_INT:
-            CHKiRet(srUtilItoA((char *)szBuf, sizeof(szBuf), (long)*((int *)pUsr)));
+            CHKiRet(srUtilItoA((char *)szBuf, sizeof(szBuf), (int64_t)*((int *)pUsr)));
             pszBuf = szBuf;
             lenBuf = ustrlen(szBuf);
             vType = VARTYPE_NUMBER;

--- a/runtime/srUtils.h
+++ b/runtime/srUtils.h
@@ -63,7 +63,7 @@ extern syslogName_t syslogFacNames[];
  *
  * \param iToConv The integer to be converted.
  */
-rsRetVal srUtilItoA(char *pBuf, int iLenBuf, number_t iToConv);
+rsRetVal srUtilItoA(char *pBuf, size_t iLenBuf, int64_t iToConv);
 
 /**
  * A method to duplicate a string for which the length is known.

--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -123,8 +123,8 @@ syslogName_t syslogFacNames[] = {
  * public members                                                    *
  * ################################################################# */
 
-rsRetVal srUtilItoA(char *pBuf, int iLenBuf, number_t iToConv) {
-    int i;
+rsRetVal srUtilItoA(char *pBuf, const size_t iLenBuf, int64_t iToConv) {
+    ssize_t i;
     int bIsNegative;
     char szBuf[64]; /* sufficiently large for my lifespan and those of my children... ;) */
 

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -1916,7 +1916,7 @@ static rsRetVal strmWriteLong(strm_t *__restrict__ const pThis, const long i) {
 
     assert(pThis != NULL);
 
-    CHKiRet(srUtilItoA((char *)szBuf, sizeof(szBuf), i));
+    CHKiRet(srUtilItoA((char *)szBuf, sizeof(szBuf), (int64_t) i));
     CHKiRet(strmWrite(pThis, szBuf, strlen((char *)szBuf)));
 
 finalize_it:

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -327,7 +327,7 @@ finalize_it:
 }
 
 
-rsRetVal rsCStrAppendInt(cstr_t *pThis, long i) {
+rsRetVal rsCStrAppendInt(cstr_t *pThis, const int64_t i) {
     DEFiRet;
     uchar szBuf[32];
 

--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -121,7 +121,7 @@ rsRetVal rsCStrAppendStrf(cstr_t *pThis, const char *fmt, ...) __attribute__((fo
  * Append an integer to the string. No special formatting is
  * done.
  */
-rsRetVal rsCStrAppendInt(cstr_t *pThis, long i);
+rsRetVal rsCStrAppendInt(cstr_t *pThis, const int64_t i);
 
 
 rsRetVal strExit(void);


### PR DESCRIPTION
This helps against improper propagation.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
