### PR TITLE
Fix imtcp close-session race condition

### DIFF
--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -67,6 +67,8 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     pThis->iMaxLine = glbl.GetMaxLine(runConf);
     pThis->inputState = eAtStrtFram; /* indicate frame header expected */
     pThis->eFraming = TCP_FRAMING_OCTET_STUFFING; /* just make sure... */
+    pThis->being_closed = 0;
+    INIT_ATOMIC_HELPER_MUT(pThis->mut_being_closed);
     pthread_mutex_init(&pThis->mut, NULL);
     /* now allocate the message reception buffer */
     CHKmalloc(pThis->pMsg = (uchar *)malloc(pThis->iMaxLine + 1));
@@ -96,6 +98,7 @@ BEGINobjDestruct(tcps_sess) /* be sure to specify the object type also in END an
     if (pThis->pSrv->pOnSessDestruct != NULL) {
         pThis->pSrv->pOnSessDestruct(&pThis->pUsr);
     }
+    DESTROY_ATOMIC_HELPER_MUT(pThis->mut_being_closed);
     pthread_mutex_destroy(&pThis->mut);
     /* now destruct our own properties */
     if (pThis->fromHost != NULL) CHKiRet(prop.Destruct(&pThis->fromHost));

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -47,7 +47,9 @@ struct tcps_sess_s {
         void *pUsr; /* a user-pointer */
         rsRetVal (*DoSubmitMessage)(tcps_sess_t *, uchar *, int); /* submit message callback */
         int iMaxLine; /* fast lookup buffer for config property */
+        int being_closed; /**< flag: session is currently being closed */
         pthread_mutex_t mut;
+        DEF_ATOMIC_HELPER_MUT(mut_being_closed);
 };
 
 

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -760,6 +760,9 @@ static rsRetVal closeSess(tcpsrv_t *const pThis, tcpsrv_io_descr_t *const pioDes
     DEFiRet;
     assert(pioDescr->ptrType == NSD_PTR_TYPE_SESS);
     tcps_sess_t *pSess = pioDescr->ptr.pSess;
+    if (!ATOMIC_CAS(&pSess->being_closed, 0, 1, &pSess->mut_being_closed)) {
+        return RS_RET_OK;
+    }
 #if defined(ENABLE_IMTCP_EPOLL)
     CHKiRet(epoll_Ctl(pThis, pioDescr, 0, EPOLL_CTL_DEL));
 #endif


### PR DESCRIPTION
## Summary
- avoid closing the same TCP session multiple times
- add `being_closed` flag to `tcps_sess_t`

## Testing
- `./tests/imtcp-basic.sh`

------
https://chatgpt.com/codex/tasks/task_e_6877d1f63b148332998272f148e0e676