### PR TITLE
pmrfc3164: add optional headerless‐message detection and handling

### DIFF
--- a/doc/source/configuration/modules/pmrfc3164.rst
+++ b/doc/source/configuration/modules/pmrfc3164.rst
@@ -134,6 +134,140 @@ hostnames with numbers as their name can still be recognized correctly. But
 everything in this range will be detected as a year.
 
 
+detect.headerless
+^^^^^^^^^^^^^^^^^
+
+.. meta::
+   :tag: parameter:detect.headerless
+   :tag: category:advanced
+   :tag: keywords: pmrfc3164, syslog, headerless, detection
+
+Enables extended detection of messages that lack a standard syslog header.
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+.. note::
+   Messages beginning with ``{`` or ``[`` are treated as structured syslog
+   (e.g. JSON) and **not** classified as headerless.
+
+When set to ``on``, a message is classified as “headerless” only
+if **all** of the following are true:
+
+- It has **no** PRI header (facility/severity).
+- It does **not** start with an accepted timestamp.
+- It does **not** begin with whitespace followed by ``{`` or ``[``.
+
+Related Parameters
+------------------
+Other action parameters prefixed with ``headerless.`` can be used to further customize
+processing of messages identified as headerless (for example, writing them to an
+"error file").
+
+headerless.hostname
+^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "<ip-address of sender>", "no", "none"
+
+By default, rsyslog uses the IP address from the system it received the
+message from as a hostname replacement. This can be overridden by the
+hostname configured here.
+
+
+headerless.tag
+^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "headerless", "no", "none"
+
+Specifies the tag to assign to detected headerless messages.
+
+
+headerless.ruleset
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "none"
+
+If set, detected headerless messages are routed to the given ruleset for
+further processing (e.g. writing to a dedicated error log or discarding).
+
+headerless.errorfile
+^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "none", "no", "none"
+
+If specified, raw headerless input will be appended to this file before any
+further processing. The file is created if it does not yet exist.
+
+headerless.drop
+^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "binary", "off", "no", "none"
+
+When set to ``on``, headerless messages are discarded after optional logging to
+``headerless.errorfile`` and are not processed by subsequent rules.
+
+
+Signal Handling
+===============
+
+HUP Signal Support
+------------------
+
+This parser module supports the HUP signal for log rotation when using the
+``headerless.errorfile`` parameter. When rsyslog receives a HUP signal, the
+module will:
+
+1. Close the current headerless error file
+2. Automatically reopen it on the next write operation
+
+This allows external log rotation tools (like ``logrotate``) to safely rotate
+the headerless error file by moving/renaming it and then sending a HUP signal
+to rsyslog.
+
+**Example log rotation configuration:**
+
+.. code-block:: none
+
+   /var/log/rsyslog-headerless.log {
+       daily
+       rotate 7
+       compress
+       delaycompress
+       postrotate
+           /bin/kill -HUP `cat /var/run/rsyslogd.pid 2> /dev/null` 2> /dev/null || true
+       endscript
+   }
+
+
 Examples
 ========
 
@@ -156,6 +290,5 @@ sections and parse them accordingly.
    	 detect.YearAfterTimestamp="on")
 
    ruleset(name="customparser" parser="custom.rfc3164") {
-   	 ... do processing here ...
+    ... do processing here...
    }
-

--- a/runtime/module-template.h
+++ b/runtime/module-template.h
@@ -1059,6 +1059,22 @@
     RETiRet;     \
     }
 
+/* doHUPParser()
+ */
+#define CODEqueryEtryPt_doHUPParser       \
+    if (!strcmp((char *)name, "doHUP")) { \
+        *pEtryPoint = doHUP;              \
+    }
+#define BEGINdoHUPParser                                                    \
+    static rsRetVal doHUP(instanceConf_t __attribute__((unused)) * pData) { \
+        DEFiRet;
+
+#define CODESTARTdoHUPParser
+
+#define ENDdoHUPParser \
+    RETiRet;           \
+    }
+
 
 /* doHUPWrkr()
  * This is like doHUP(), but on an action worker level.

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -3,7 +3,7 @@
  *
  * File begun on 2007-07-13 by RGerhards (extracted from syslogd.c)
  *
- * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2025 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -271,6 +271,8 @@ TESTS +=  \
 	pmrfc3164-AtSignsInHostname_off.sh \
 	pmrfc3164-tagEndingByColon.sh \
 	pmrfc3164-defaultTag.sh \
+	pmrfc3164-headerless.sh \
+	pmrfc3164-drop.sh \
 	pmrfc3164-json.sh \
 	tcp_forwarding_tpl.sh \
 	tcp_forwarding_dflt_tpl.sh \
@@ -901,7 +903,7 @@ endif
 
 # see comments in configure.ac on flaky tests for important details!!!
 if ENABLE_FLAKY_TESTS
-#TESTS += 
+#TESTS +=
 #
 if ENABLE_OMHTTP
 TESTS +=  \
@@ -1951,6 +1953,8 @@ EXTRA_DIST= \
 	pmrfc3164-tagEndingByColon.sh \
 	pmrfc3164-defaultTag.sh \
 	pmrfc3164-json.sh \
+	pmrfc3164-headerless.sh \
+	pmrfc3164-drop.sh \
 	hostname-with-slash-dflt-invld.sh \
 	hostname-with-slash-dflt-slash-valid.sh \
 	glbl-umask.sh \

--- a/tests/pmrfc3164-drop.sh
+++ b/tests/pmrfc3164-drop.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# added 2025-07-18 by Codex, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="input")
+parser(name="p3164" type="pmrfc3164"
+  detect.headerless="on" headerless.errorfile="'$RSYSLOG_OUT_LOG'.err"
+  headerless.drop="on")
+
+ruleset(name="input" parser="p3164") {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+
+tcpflood -p $TCPFLOOD_PORT -m1 -M "\"this is not syslog\""
+tcpflood -p $TCPFLOOD_PORT -m1 -M "\"<13>Oct 11 22:14:15 host tag: normal\""
+
+shutdown_when_empty
+wait_shutdown
+
+! grep -q 'this is not syslog' $RSYSLOG_OUT_LOG
+grep -q 'normal' $RSYSLOG_OUT_LOG || { cat $RSYSLOG_OUT_LOG; error_exit 1; }
+grep -q 'this is not syslog' ${RSYSLOG_OUT_LOG}.err || { cat ${RSYSLOG_OUT_LOG}.err; error_exit 1; }
+
+exit_test

--- a/tests/pmrfc3164-headerless.sh
+++ b/tests/pmrfc3164-headerless.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# added 2025-07-18 by Codex, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="input")
+parser(name="p3164" type="pmrfc3164" detect.headerless="on" headerless.hostname="n/a" headerless.tag="hdr" headerless.ruleset="hdrules")
+
+ruleset(name="input" parser="p3164") {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'.ok")
+}
+ruleset(name="hdrules") {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+
+tcpflood -p $TCPFLOOD_PORT -m1 -M "\"this is not syslog\""
+tcpflood -p $TCPFLOOD_PORT -m1 -M "\"<13>Oct 11 22:14:15 host tag: normal\""
+
+shutdown_when_empty
+wait_shutdown
+
+grep -q 'this is not syslog' $RSYSLOG_OUT_LOG || { cat $RSYSLOG_OUT_LOG; error_exit 1; }
+grep -q 'normal' ${RSYSLOG_OUT_LOG}.ok || { cat ${RSYSLOG_OUT_LOG}.ok; error_exit 1; }
+
+exit_test


### PR DESCRIPTION
This patch enhances the legacy RFC3164 parser by introducing:

- **Headerless detection toggle**
  - New `detect.headerless` boolean parameter (default: off)
  - When enabled, any message lacking a PRI header and a valid
    timestamp is treated as headerless
  - Defaults injected via `headerless.hostname`/`headerless.tag`
  - Optional routing/logging/discard via `headerless.ruleset`,
    `headerless.errorfile`, `headerless.drop`
  - Downstream `HEADERLESS_MSG` flag for filtering

- **Thread‐safe ruleset resolution**
  - Adds `ATOMIC_CAS_VOIDPTR` in `atomic.h` for void‐pointer CAS
  - Lazy, atomic lookup of `headerless.ruleset` at runtime

- **HUP signal support**
  - New `doHUPParser` entry point to close/reopen the headerless
    error file on SIGHUP
  - Enables safe log rotation when using `headerless.errorfile`

- **Test coverage**
  - Adds `pmrfc3164-headerless.sh` and `pmrfc3164-drop.sh`
  - Updates `tests/Makefile.am` to include new tests

- **Maintenance**
  - Bump copyright years to 2025 in `atomic.h`, `msg.h`,
    `pmrfc3164.c`
  - Minor cleanup of includes and formatting

Why?  
We needed a lightweight, opt‐in way to bypass full header parsing for  
non‐syslog input—improving throughput in high‐volume setups—while  
preserving existing behavior by default. Thread safety, HUP‐based
log rotation, and test coverage round out the feature.  
