### PR TITLE
Add docs build CI workflow

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -1,0 +1,40 @@
+name: documentation build
+
+on:
+  pull_request:
+
+jobs:
+  build_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check for doc changes
+        id: doc_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            doc/**/*.rst
+
+      - name: Setup Python
+        if: steps.doc_changes.outputs.any_changed == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install Sphinx
+        if: steps.doc_changes.outputs.any_changed == 'true'
+        run: python -m pip install -r doc/requirements.txt
+
+      - name: Build documentation
+        if: steps.doc_changes.outputs.any_changed == 'true'
+        run: |
+          cd doc
+          make html SPHINXOPTS="-W --keep-going"
+
+      - name: Skip build
+        if: steps.doc_changes.outputs.any_changed == 'false'
+        run: echo "No doc changes detected. Skipping build."


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds the docs
- run `make html` when `doc/*.rst` files change
- exit fast when no documentation files changed

## Testing
- `make -C doc html SPHINXOPTS="-W --keep-going"`


------
https://chatgpt.com/codex/tasks/task_e_687c86e2030483329086c683b914459b