### PR TITLE
Add canonical link to Sphinx docs

### DIFF
--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends "!layout.html" %}
+
+{% block extrahead %}
+  {{ super() }}
+  <link rel="canonical" href="https://www.rsyslog.com/doc{{ pathto('', 1) }}" />
+{% endblock %}


### PR DESCRIPTION
## Summary
- extend default Sphinx layout in `_templates/layout.html`
- inject a `<link rel="canonical">` element for docs.rsyslog.com

## Testing
- `pip install sphinx`
- `make -C doc html`

------
https://chatgpt.com/codex/tasks/task_e_687d451585a8833299a18f4aaeea37d9