### PR TITLE
Add canonical links and schema.org metadata to docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 
 # Need at least 1.5.1 due to some of the features we are using
 sphinx >=1.5.1
+sphinxcontrib-schemaorg

--- a/doc/source/_templates/layout.html
+++ b/doc/source/_templates/layout.html
@@ -1,0 +1,6 @@
+{% extends "!layout.html" %}
+{% block extrahead %}
+  {{ super() }}
+  <link rel="canonical" href="https://docs.rsyslog.com{{ pathto('', 1) }}" />
+  {{ schemaorg_script() }}
+{% endblock %}

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -30,7 +30,8 @@ needs_sphinx = '4.5.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
-extensions = ['edit_on_github', 'sphinx.ext.todo','rsyslog_lexer']
+extensions = ['edit_on_github', 'sphinx.ext.todo', 'rsyslog_lexer']
+extensions += ['sphinxcontrib.schemaorg']
 edit_on_github_project = 'https://github.com/rsyslog/rsyslog'
 edit_on_github_branch = 'main'
 
@@ -270,7 +271,17 @@ html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
-#html_last_updated_fmt = '%b %d, %Y'
+html_last_updated_fmt = '%Y-%m-%d'
+
+# Schema.org metadata configuration for sphinxcontrib-schemaorg
+schemaorg_context = {
+    "@type": "TechArticle",
+    "headline": "{{ title }}",
+    "description": "{{ meta.description }}",
+    "url": "https://docs.rsyslog.com{{ pathto('', 1) }}",
+    "author": {"@type": "Organization", "name": "rsyslog.com"},
+    "dateModified": "{{ last_updated }}",
+}
 
 # If true, SmartyPants will be used to convert quotes and dashes to
 # typographically correct entities.


### PR DESCRIPTION
## Summary
- generate canonical URLs and embed JSON-LD metadata via `sphinxcontrib-schemaorg`
- hook the canonical link and schemaorg script into a custom layout
- update doc requirements

## Testing
- `devtools/format-code.sh`

------
https://chatgpt.com/codex/tasks/task_e_687d45812c6c8332a9b3e7fe8cb171ff