### PR TITLE
Enable anchor IDs in docs

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,4 @@
 
 # Need at least 1.5.1 due to some of the features we are using
 sphinx >=1.5.1
+sphinxcontrib-anchors

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -31,6 +31,11 @@ needs_sphinx = '4.5.0'
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['edit_on_github', 'sphinx.ext.todo','rsyslog_lexer']
+extensions += ["sphinxcontrib.anchors"]
+anchors_options = {
+    "selector": "p, li, h1, h2, h3, h4, h5, h6",
+    "permalink": False
+}
 edit_on_github_project = 'https://github.com/rsyslog/rsyslog'
 edit_on_github_branch = 'main'
 


### PR DESCRIPTION
## Summary
- enable sphinxcontrib-anchors in Sphinx config
- add dependency in doc requirements

## Testing
- `devtools/format-code.sh`
- `python3 -m pip install -r doc/requirements.txt` *(fails: no matching distribution)*

------
https://chatgpt.com/codex/tasks/task_e_687d4621d92c83329d393cdaa46d8cb1