### PR TITLE
Add JSON build targets

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -6,7 +6,7 @@ SPHINXBUILD ?= sphinx-build
 SOURCEDIR = source
 BUILDDIR = build
 
-.PHONY: help clean html singlehtml
+.PHONY: help clean html singlehtml json alljson
 
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -21,6 +21,12 @@ singlehtml:  # -t minimal_build triggers stripped-down config in conf.py
 	@$(SPHINXBUILD) -M singlehtml "$(SOURCEDIR)" "$(BUILDDIR)" -t minimal_build $(SPHINXOPTS) -D rst_epilog='' $(O)
 	@echo
 	@echo "Build finished. The minimal single page HTML is in $(BUILDDIR)/singlehtml."
+
+json:
+	@$(SPHINXBUILD) -b json "$(SOURCEDIR)" "$(BUILDDIR)/json" $(SPHINXOPTS) $(O)
+
+alljson: json
+	@$(SPHINXBUILD) -b json "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 %:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)


### PR DESCRIPTION
## Summary
- expand `.PHONY` list in `doc/Makefile`
- add `json` and `alljson` build targets for Sphinx JSON output

## Testing
- `make -f doc/Makefile json`

------
https://chatgpt.com/codex/tasks/task_e_687d467f12808332adad436eed97a184