### PR TITLE
Add ChatGPT plugin manifest

### DIFF
--- a/doc/_static/.well-known/ai-plugin.json
+++ b/doc/_static/.well-known/ai-plugin.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": "v1",
+  "name_for_human": "rsyslog Docs",
+  "name_for_model": "rsyslog_docs",
+  "description_for_human": "Official rsyslog configuration and API reference",
+  "description_for_model": "Plugin to look up rsyslog docs and config examples by topic",
+  "auth": { "type": "none" },
+  "api": {
+    "type": "openapi",
+    "url": "https://docs.rsyslog.com/.well-known/openapi.json",
+    "is_user_authenticated": false
+  },
+  "logo_url": "https://docs.rsyslog.com/logo.png",
+  "contact_email": "support@rsyslog.com",
+  "legal_info_url": "https://rsyslog.com/legal"
+}

--- a/doc/_static/.well-known/openapi.json
+++ b/doc/_static/.well-known/openapi.json
@@ -1,0 +1,108 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "rsyslog Docs API",
+    "version": "1.0.0"
+  },
+  "servers": [
+    { "url": "https://docs.rsyslog.com" }
+  ],
+  "paths": {
+    "/topics": {
+      "get": {
+        "summary": "List available documentation topics",
+        "responses": {
+          "200": {
+            "description": "List of topics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Topic" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/topics/{id}": {
+      "get": {
+        "summary": "Retrieve a specific topic",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A JSON document for the topic",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search": {
+      "post": {
+        "summary": "Search within documentation",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/SearchRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/SearchResult" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Topic": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" }
+        },
+        "required": ["id", "title"]
+      },
+      "SearchRequest": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string" }
+        },
+        "required": ["query"]
+      },
+      "SearchResult": {
+        "type": "object",
+        "properties": {
+          "topicId": { "type": "string" },
+          "anchor": { "type": "string" },
+          "text": { "type": "string" },
+          "score": { "type": "number" }
+        },
+        "required": ["topicId", "anchor", "text", "score"]
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add ai-plugin manifest and OpenAPI spec for docs.rsyslog.com
- allow a ChatGPT plugin to query topics and search docs

## Testing
- `make -C doc html`

------
https://chatgpt.com/codex/tasks/task_e_687d484df5108332ad928077765ae6e5