### PR TITLE
Investigate and resolve rsyslog issue 1254

### DIFF
--- a/doc/source/configuration/modules/imptcp.rst
+++ b/doc/source/configuration/modules/imptcp.rst
@@ -432,7 +432,7 @@ Enable of disable keep-alive packets at the tcp socket layer. The
 default is to disable them.
 
 
-KeepAlive.Probes
+keepalive.probes
 ^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -449,7 +449,7 @@ effect if keep-alive is enabled. The functionality may not be
 available on all platforms.
 
 
-KeepAlive.Interval
+keepalive.interval
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -466,7 +466,7 @@ effect if keep-alive is enabled. The functionality may not be
 available on all platforms.
 
 
-KeepAlive.Time
+keepalive.time
 ^^^^^^^^^^^^^^
 
 .. csv-table::

--- a/doc/source/configuration/modules/imrelp.rst
+++ b/doc/source/configuration/modules/imrelp.rst
@@ -423,7 +423,7 @@ Enable or disable keep-alive packets at the TCP socket layer. By
 default keep-alives are disabled.
 
 
-KeepAlive.Probes
+keepalive.probes
 ^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -440,7 +440,7 @@ effect if keep-alives are enabled. The functionality may not be
 available on all platforms.
 
 
-KeepAlive.Interval
+keepalive.interval
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -457,7 +457,7 @@ if keep-alive is enabled. The functionality may not be available on all
 platforms.
 
 
-KeepAlive.Time
+keepalive.time
 ^^^^^^^^^^^^^^
 
 .. csv-table::

--- a/doc/source/configuration/modules/imtcp.rst
+++ b/doc/source/configuration/modules/imtcp.rst
@@ -189,7 +189,7 @@ Enable or disable keep-alive packets at the tcp socket layer. The
 default is to disable them.
 
 
-KeepAlive.Probes
+keepalive.probes
 ^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -206,7 +206,7 @@ effect if keep-alive is enabled. The functionality may not be
 available on all platforms.
 
 
-KeepAlive.Time
+keepalive.time
 ^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -224,7 +224,7 @@ This has only effect if keep-alive is enabled. The functionality may
 not be available on all platforms.
 
 
-KeepAlive.Interval
+keepalive.interval
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -1168,7 +1168,7 @@ This permits to override the equally-named module parameter on the input()
 level. For further details, see the module parameter.
 
 
-KeepAlive.Probes
+keepalive.probes
 ^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -1184,7 +1184,7 @@ This permits to override the equally-named module parameter on the input()
 level. For further details, see the module parameter.
 
 
-KeepAlive.Time
+keepalive.time
 ^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -1200,7 +1200,7 @@ This permits to override the equally-named module parameter on the input()
 level. For further details, see the module parameter.
 
 
-KeepAlive.Interval
+keepalive.interval
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -432,7 +432,7 @@ Enable or disable keep-alive packets at the tcp socket layer. The
 default is to disable them.
 
 
-KeepAlive.Probes
+keepalive.probes
 ^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -449,7 +449,7 @@ effect if keep-alive is enabled. The functionality may not be
 available on all platforms.
 
 
-KeepAlive.Interval
+keepalive.interval
 ^^^^^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -466,7 +466,7 @@ effect if keep-alive is enabled. The functionality may not be
 available on all platforms.
 
 
-KeepAlive.Time
+keepalive.time
 ^^^^^^^^^^^^^^
 
 .. csv-table::
@@ -930,3 +930,14 @@ syslogs to remote servers in different namespaces specify them as separate actio
    action(type="omfwd" Target="192.168.1.13" Port="10514" Protocol="tcp" NetworkNamespace="ns_eth0.0")
    action(type="omfwd" Target="192.168.2.24" Port="10514" Protocol="tcp" NetworkNamespace="ns_eth0.1")
    action(type="omfwd" Target="192.168.3.38" Port="10514" Protocol="tcp" NetworkNamespace="ns_eth0.2")
+
+
+Example 3
+---------
+
+TCP forwarding with keepalive settings enabled. This helps detect broken connections.
+
+.. code-block:: none
+
+   action(type="omfwd" Target="192.168.1.100" Port="514" Protocol="tcp" 
+          KeepAlive="on" keepalive.time="60" keepalive.probes="3" keepalive.interval="10")


### PR DESCRIPTION
## Fix keepalive parameter names in documentation

### Problem
The documentation incorrectly showed keepalive parameters with uppercase names (`KeepAlive.Probes`, `KeepAlive.Interval`, `KeepAlive.Time`) when the actual working parameter names are lowercase with dots (`keepalive.probes`, `keepalive.interval`, `keepalive.time`).

This discrepancy has been causing user confusion and configuration errors, as reported in:
- [Issue #1254](https://github.com/rsyslog/rsyslog/issues/1254) 
- [Issue #916](https://github.com/rsyslog/rsyslog/issues/916) (already closed)

### Solution
- ✅ Corrected parameter names from uppercase to lowercase format across all affected documentation
- ✅ Added practical configuration example showing correct usage
- ✅ Ensures documentation matches actual code implementation

### Files Changed
- `doc/source/configuration/modules/omfwd.rst` - Fixed parameter names + added usage example
- `doc/source/configuration/modules/imptcp.rst` - Fixed parameter names  
- `doc/source/configuration/modules/imtcp.rst` - Fixed parameter names (module and action level)
- `doc/source/configuration/modules/imrelp.rst` - Fixed parameter names

### Example Usage (now documented correctly)
```bash
action(type="omfwd" Target="192.168.1.100" Port="514" Protocol="tcp" 
       KeepAlive="on" keepalive.time="60" keepalive.probes="3" keepalive.interval="10")
```

### Testing
- ✅ Verified against existing test case `tests/omfwd-keepalive.sh` which uses correct parameter names
- ✅ Confirmed code implementation expects lowercase dot notation since 2016 (commit 9d839634)

### Impact
- 🔧 **Fixes user confusion** - documentation now matches working code
- 📚 **Improves user experience** - clear examples provided
- 🚫 **No breaking changes** - only documentation updates

closes: https://github.com/rsyslog/rsyslog/issues/1254