### PR TITLE
CI: Enhance PR validation and update branch name

### DIFF
--- a/.github/workflows/commit_style_check.yml
+++ b/.github/workflows/commit_style_check.yml
@@ -1,0 +1,40 @@
+# This workflow is responsible for validating Pull Requests (PRs)
+# against specific quality and hygiene standards for the rsyslog project.
+#
+# It automatically runs a custom validation script to ensure PRs meet
+# requirements like commit structure and count before merging.
+name: PR Validation
+
+# Triggers the workflow on pull request events.
+# When 'types:' is not specified, the workflow defaults to triggering on:
+# - 'opened': When a new pull request is created.
+# - 'synchronize': When new commits are pushed to the PR branch.
+# - 'reopened': When a previously closed PR is reopened.
+# This covers the essential scenarios for validating PRs based on their
+# content and commit history.
+on:
+  pull_request: # Defaults to opened, synchronize, reopened
+
+jobs:
+  validate-pr:
+    runs-on: ubuntu-latest # 'ubuntu-latest' provides a virtual machine with the latest Ubuntu OS.
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          # 'fetch-depth: 0' is crucial here. It fetches the entire commit history
+          # of the repository, not just the latest commit. This is necessary
+          # for the PR_validation.sh script to accurately analyze commit counts,
+          # commit messages, and ensure proper squashing.
+          fetch-depth: 0
+
+      - name: Run PR Validation Script
+        run: ./tests/CI/PR_validation.sh
+        # This script is responsible for implementing the specific validation logic,
+        # such as:
+        # - Checking if the PR's commits are squashed.
+        # - Ensuring a maximum of two commits (one for change, one for testing commit).
+        # - Any other custom rules defined by the rsyslog project.
+        #
+        # If the script exits with a non-zero status code, this step (and thus the job)
+        # will fail, indicating that the PR does not meet the specified requirements.

--- a/tests/CI/PR_validation.sh
+++ b/tests/CI/PR_validation.sh
@@ -2,10 +2,10 @@
 # This script "validates" a PR from a git PoV. We check that best
 # practices are kept which most importantly means we try to detect
 # fixup commits. These should not be part of a PR and squashed into
-# the main commit.
+# the primary commit.
 # Copyright (C) 2019 by Rainer Gerhards
 exitcode=0;
-git log  --oneline HEAD...origin/master >gitlog
+git log  --oneline HEAD...origin/main >gitlog
 if head -1 gitlog | grep -q "Merge " gitlog; then
 	printf 'This looks like a github merge branch. Removing first commit:\n'
 	head -1 gitlog
@@ -59,7 +59,7 @@ if grep -q "Merge " gitlog; then
 	cat >&2 <<- EOF
 	This feature branch contains merge commits. This almost always indicates that it
 	contains unwanted merges where a rebase should have been applied.
-	Please consider squashing the branch and/or rebasing it to current master.
+	Please consider squashing the branch and/or rebasing it to current default branch.
 
 	You possibly wonder why this CI check complains. See
 	    https://rainer.gerhards.net/2019/03/squash-your-pull-requests.html


### PR DESCRIPTION
This patch improves the GitHub Actions PR validation workflow:
- Added comprehensive inline documentation for clarity.
- Corrected branch reference from 'master' to 'main' in `tests/CI/PR_validation.sh`.

These changes enhance CI/CD clarity and maintainability.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
