### PR TITLE
Add sphinxcontrib-mermaid to Dockerfile

### DIFF
--- a/packaging/docker/dev_env/ubuntu/doc_base/22.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/doc_base/22.04/Dockerfile
@@ -29,7 +29,7 @@ RUN	apt-get install -y \
 	texlive-luatex \
 	texlive-xetex \
 	latexmk
-RUN	pip install sphinx sphinx_rtd_theme rst2pdf furo
+RUN	pip install sphinx sphinx_rtd_theme rst2pdf furo sphinxcontrib-mermaid
 VOLUME	/rsyslog
 RUN	groupadd rsyslog \
 	&& useradd -g rsyslog -s /bin/bash rsyslog \


### PR DESCRIPTION
Add sphinxcontrib-mermaid to documentation Docker image

This package is required to build `txt` and `singlehtml` documentation formats, enabling Mermaid diagram rendering in Sphinx documentation.
