### PR TITLE
omhttp: Switch to commitTransaction to fix deferred message retry

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -2290,6 +2290,9 @@ CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES;
 CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES;
 CODEqueryEtryPt_doHUP CODEqueryEtryPt_doHUPWrkr /* Load the worker HUP handling code */
     CODEqueryEtryPt_TXIF_OMOD_QUERIES /* we support the transactional interface! */
+    if (!strcmp((char *)name, "commitTransaction")) { /* export commitTransaction for new transaction interface */
+        *pEtryPoint = commitTransaction;
+    }
         CODEqueryEtryPt_STD_CONF2_QUERIES;
 ENDqueryEtryPt
 

--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -1525,6 +1525,13 @@ ENDbeginTransaction
 
 
 
+BEGINdoAction
+    CODESTARTdoAction;
+    /* When using transactions (which we always do), defer all work to commitTransaction */
+    iRet = RS_RET_DEFER_COMMIT;
+finalize_it:
+ENDdoAction
+
 BEGINendTransaction
     CODESTARTendTransaction;
     /* End Transaction only if batch data is not empty */

--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -1528,7 +1528,9 @@ ENDbeginTransaction
 BEGINdoAction
     CODESTARTdoAction;
     /* When using transactions (which we always do), defer all work to commitTransaction */
+    (void)ppString; /* unused but required by macro */
     iRet = RS_RET_DEFER_COMMIT;
+    goto finalize_it; /* ensure label is used */
 finalize_it:
 ENDdoAction
 


### PR DESCRIPTION
This PR replaces the `doAction` interface with `commitTransaction` in the `omhttp` plugin.

**Why this change%3F**
This change addresses GitHub Issue %232420, where messages deferred within a transaction (by returning `RS_RET_DEFER_COMMIT` from `doAction`) were not properly retried if a subsequent message in the same transaction failed.

The `commitTransaction` interface processes the entire batch of messages atomically. If any message within the batch fails, the entire transaction is retried, ensuring that all messages (including those previously deferred) are reprocessed as expected.

**Compatibility:**
The existing batching logic, dynamic REST path handling, and support for single-message/non-batch modes within `omhttp` are fully compatible with `commitTransaction` and have been preserved. This change maintains backward compatibility.

closes: https://github.com/rsyslog/rsyslog/issues/2420
