### PR TITLE
doc: Restructure omfwd documentation

### DIFF
--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -73,13 +73,14 @@ The most common forwarding examples:
        StreamDriverPermittedPeers="logs.example.com"
    )
 
+Outdated Legacy Methods
+=======================
 
-Avoiding Legacy Antipatterns
-============================
-
-Old tutorials often show legacy directives like `@server` or `@@server`.  
-These are still supported but are **not recommended** because they lack queues 
-and modern flexibility.
+Many distro defaults and popular online tutorials still use `@server`/`@@server`.
+These shorter forms bypass queues and lack back‑pressure control, misleading
+users about delivery guarantees and ranking high in search results.
+Although longer and seemingly complex, modern RainerScript variants
+are explicit, configurable, and robust—preventing hidden pitfalls.
 
 **TCP Forwarding**
 
@@ -140,114 +141,23 @@ Configuration Parameters
 
    Parameter names are case-insensitive.
 
-Module Parameters
------------------
+Basic Parameters
+----------------
 
+.. toctree::
+   :maxdepth: 2
 
-Template
-^^^^^^^^
+   omfwd/parameters/basic
+   omfwd/parameters/module
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
+Action Parameters (omfwd)
+-------------------------
 
-   "word", "RSYSLOG_TraditionalForwardFormat", "no", "``$ActionForwardDefaultTemplate``"
-
-Sets a custom default template for this module.
-
-iobuffer.maxSize
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "full size", "no", "none"
-
-The iobuffer.maxSize parameter sets the maximum size of the I/O buffer
-used by rsyslog when submitting messages to the TCP send API. This
-parameter allows limiting the buffer size to a specific value and is
-primarily intended for testing purposes, such as within an automated
-testbench. By default, the full size of the I/O buffer is used, which
-depends on the rsyslog version. If the specified size is too large, an
-error is emitted, and rsyslog reverts to using the full size.
+Action parameters define how a specific forwarding action behaves.  
+They apply to each `action(type="omfwd" ...)` statement.
 
 .. note::
-    The I/O buffer has a fixed upper size limit for performance reasons. This limitation
-    allows saving one ``malloc()`` call and indirect addressing. Therefore, the ``iobuffer.maxSize``
-    parameter cannot be set to a value higher than this fixed limit.
-
-.. note::
-    This parameter should usually not be used in production environments.
-
-Example
-.......
-
-.. code-block:: rsyslog
-
-  module(load="builtin:omfwd" iobuffer.maxSize="8")
-
-In this example, a very small buffer size is used. This setting helps
-force rsyslog to execute code paths that are rarely used in normal
-operations. It allows testing edge cases that typically cannot be
-tested automatically.
-
-**Note that contrary to most other modules, omfwd is a built-in module. As such,
-you cannot "normally" load it just by name but need to prefix it with
-"builtin:" as can be seen above!**
-
-
-Action Parameters
------------------
-
-Target
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array/word", "none", "no", "none"
-
-Name or IP address of the system to receive messages. Any resolvable name is fine.
-Here either a single target or an array of targets can be provided.
-
-If an array is provided, rsyslog forms a "target pool". Inside the pool, it
-performs equal load-balancing among them. Targets are changed for
-each message being sent. If targets become unreachable, they will temporarily not
-participate in load balancing. If all targets become offline (then and only then)
-the action itself is suspended. Unreachable targets are automatically retried
-by omfwd.
-
-NOTE: target pools are ONLY available for TCP transport. If UDP is selected, an
-error message is emitted and only the first target used.
-
-Single target: Target="syslog.example.net"
-
-Array of targets: Target=["syslog1.example.net", "syslog2.example.net", "syslog3.example.net"]
-
-Port
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array/word", "514", "no", "none"
-
-Name or numerical value of the port to use when connecting to the target.
-If multiple targets are defined, different ports can be defined for each target.
-To do so, use array mode. The first port will be used for the first target, the
-second for the second target and so on. If fewer ports than targets are defined,
-the remaining targets will use the first port configured. This also means that you
-also need to define a single port, if all targets should use the same port.
-
-Note: if more ports than targets are defined, the remaining ports are ignored and
-an error message is emitted.
+   Parameter names are case-insensitive.
 
 
 pool.resumeinterval
@@ -271,23 +181,6 @@ on a try-by-try basis because of other ongoing activity inside rsyslog.
 Warning: we do NOT recommend to set this interval below 10 seconds, as it can lead
 DoS-like reconnection behaviour. Actually, the default of 30 seconds is quite short
 and should be extended if the use case permits.
-
-Protocol
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "udp", "no", "none"
-
-Type of protocol to use for forwarding. Note that ``tcp`` includes both legacy 
-plain TCP syslog and 
-`RFC5425 <https://datatracker.ietf.org/doc/html/rfc5425>`_-based TLS-encrypted 
-syslog. The selection depends on the StreamDriver parameter. If StreamDriver is 
-set to "ossl" or "gtls", it will use TLS-encrypted syslog.
-
 
 NetworkNamespace
 ^^^^^^^^^^^^^^^^
@@ -867,7 +760,7 @@ single message in such cases. This is caused by an
 and there is no way rsyslog could prevent this from happening
 (if you read the detail description, be sure to follow the link
 to the follow-up posting). In order to prevent these problems,
-we recommend the use of :doc:`omrelp <omrelp>`.
+we recommend the use of :doc:`omrelp<omrelp>`.
 
 
 udp.SendToAll
@@ -992,7 +885,6 @@ is unlikely to bring real benefits in such scenarios.
 
 Note: If you need reliable delivery, do NOT use plain TCP syslog transport.
 Use RELP instead.
-
 
 Statistic Counter
 =================

--- a/doc/source/configuration/modules/omfwd/parameters/basic.rst
+++ b/doc/source/configuration/modules/omfwd/parameters/basic.rst
@@ -1,0 +1,144 @@
+.. meta::
+   :tag: module:omfwd
+   :tag: category:basic
+
+Basic Parameters
+################
+
+These settings apply either when loading the `omfwd` module (global defaults)
+or on individual `action(type="omfwd")` instances.
+
+Target
+======
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "array/word", "none", "no", "none"
+
+Description
+~~~~~~~~~~~
+
+Specifies the **name or IP address** of the system(s) receiving logs.  
+You can configure:
+
+- A **single target** (hostname or IP).  
+- An **array of targets**, forming a *target pool* for load‑balancing.
+
+Target Pools (Load‑Balancing)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you specify multiple targets, rsyslog forms a **target pool**:
+
+- Round‑robin delivery among all **online** targets.  
+- Unreachable hosts are removed and retried every 30 s.  
+- If **all** targets fail, the action suspends until one recovers.  
+- **Note:** Pools require TCP; UDP sends only to the first target.
+
+Examples
+~~~~~~~~
+
+**Single‑Target Action**
+
+.. code-block:: rsyslog
+
+   action(
+       type="omfwd"              # forwarding module
+       target="syslog.example.net"
+       port="10514"              # custom TCP port
+       protocol="tcp"            # reliable transport
+       queue.type="linkedList"   # prevent blocking
+   )
+
+**Target‑Pool Action**
+
+.. code-block:: rsyslog
+
+   action(
+       type="omfwd"
+       target=[
+           "syslog1.example.net",
+           "syslog2.example.net",
+           "syslog3.example.net"
+       ]
+       port="10514"              # same custom port for all
+       protocol="tcp"
+       queue.type="linkedList"
+   )
+
+Visual Flow
+~~~~~~~~~~~
+
+.. mermaid::
+
+   flowchart LR
+       LogGen[Log Generator] --> OMFWD[omfwd Action]
+       OMFWD --> T1[syslog1.example.net]
+       OMFWD --> T2[syslog2.example.net]
+       OMFWD --> T3[syslog3.example.net]
+
+
+Port
+====
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "array/word", "514", "no", "none"
+
+Name or numerical value of the port to use when connecting to the target.
+If multiple targets are defined, different ports can be defined for each target.
+To do so, use array mode. The first port will be used for the first target, the
+second for the second target and so on. If fewer ports than targets are defined,
+the remaining targets will use the first port configured. This also means that you
+also need to define a single port, if all targets should use the same port.
+
+Note: if more ports than targets are defined, the remaining ports are ignored and
+an error message is emitted.
+
+Protocol
+========
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "word", "udp", "no", "none"
+
+Type of protocol to use for forwarding. Note that ``tcp`` includes both legacy 
+plain TCP syslog and 
+`RFC5425 <https://datatracker.ietf.org/doc/html/rfc5425>`_-based TLS-encrypted 
+syslog. The selection depends on the StreamDriver parameter. If StreamDriver is 
+set to "ossl" or "gtls", it will use TLS-encrypted syslog.
+
+Template
+========
+
+**Type**: word  
+
+**Default**: inherited from module default  
+
+**Mandatory**: no  
+
+When used inside an `action(type="omfwd" ...)`, `template=` overrides the
+global template only for that action instance. This lets you customize
+message formatting per destination.
+
+Example
+~~~~~~~
+
+.. code-block:: rsyslog
+
+   action(
+       type="omfwd"
+       target="syslog.example.net"
+       port="10514"
+       protocol="tcp"
+       template="JsonFormat"       # Overrides the default with a JSON layout
+       queue.type="linkedList"
+   )

--- a/doc/source/configuration/modules/omfwd/parameters/module.rst
+++ b/doc/source/configuration/modules/omfwd/parameters/module.rst
@@ -1,0 +1,69 @@
+Module Parameters
+#################
+
+The following parameters define **default settings** for the `omfwd` module.  
+These values are used by all `omfwd` actions unless explicitly overridden 
+by action parameters.
+
+.. note::
+   - Module parameters are configured by loading the built-in module with 
+     ``module(load="builtin:omfwd" ...)``.
+   - Action parameters (inside ``action(type="omfwd" ...)``) take precedence 
+     over these defaults when both are set.
+
+List of Module Parameters
+=========================
+
+Template
+^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "word", "RSYSLOG_TraditionalForwardFormat", "no", "``$ActionForwardDefaultTemplate``"
+
+Sets a custom default template for this module.
+
+iobuffer.maxSize
+^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "full size", "no", "none"
+
+The iobuffer.maxSize parameter sets the maximum size of the I/O buffer
+used by rsyslog when submitting messages to the TCP send API. This
+parameter allows limiting the buffer size to a specific value and is
+primarily intended for testing purposes, such as within an automated
+testbench. By default, the full size of the I/O buffer is used, which
+depends on the rsyslog version. If the specified size is too large, an
+error is emitted, and rsyslog reverts to using the full size.
+
+.. note::
+    The I/O buffer has a fixed upper size limit for performance reasons. This limitation
+    allows saving one ``malloc()`` call and indirect addressing. Therefore, the ``iobuffer.maxSize``
+    parameter cannot be set to a value higher than this fixed limit.
+
+.. note::
+    This parameter should usually not be used in production environments.
+
+Example
+.......
+
+.. code-block:: rsyslog
+
+  module(load="builtin:omfwd" iobuffer.maxSize="8")
+
+In this example, a very small buffer size is used. This setting helps
+force rsyslog to execute code paths that are rarely used in normal
+operations. It allows testing edge cases that typically cannot be
+tested automatically.
+
+**Note that contrary to most other modules, omfwd is a built-in module. As such,
+you cannot "normally" load it just by name but need to prefix it with
+"builtin:" as can be seen above!**

--- a/doc/source/development/doc_reference_section_guidelines.rst
+++ b/doc/source/development/doc_reference_section_guidelines.rst
@@ -1,0 +1,181 @@
+Documentation Reference Section Structure Guidelines
+====================================================
+
+This page describes the **ultimate desired layout** for all _reference_ pages
+(e.g. modules under Configuration → Output Modules), balancing both:
+
+- **Human UX** under the Furo theme  
+- **AI/RAG ingestion** needs for fine-grained, semantically focused chunks
+
+Overview
+--------
+
+Each reference module (e.g., ``omfwd``) is defined by its master RST file and
+an optional set of category pages for related parameters. **Do not move or rename
+existing module files** (e.g., ``source/configuration/modules/omfwd.rst``) to
+preserve SEO, bookmarks, and inter-document links.
+
+Directory Layout
+----------------
+
+Modules remain at top level; parameter group pages live in a new sub-folder.
+
+.. code-block:: text
+
+   source/configuration/modules/
+   ├── omfwd.rst                    # master reference page (unchanged)
+   ├── imfile.rst                   # other modules (unchanged)
+   └── omfwd/                       # new subdirectory for parameter categories
+       └── parameters/
+           ├── basic.rst            # core parameters (target, port, protocol)
+           ├── transport.rst        # networking params (Address, NetworkNamespace)
+           ├── security.rst         # TLS/auth params (StreamDriver, AuthMode)
+           └── advanced.rst         # compression, framing, keep-alive, etc.
+
+Master Page ("<module>.rst")
+----------------------------
+
+Enhance the existing master file (e.g., ``omfwd.rst``) with these sections:
+
+#. **Introduction** and **Best Practices** (concise overview).  
+#. **Common Pitfalls** of legacy syntax with minimal before/after snippets.  
+#. **Parameters at a Glance** — two tables:
+   - **Module-Load Parameters** (e.g., ``iobuffer.maxSize``)  
+   - **Action-Instance Parameters** (e.g., ``target``, ``queue.type``)  
+#. A hidden ``.. toctree::`` pulling in the category pages:
+
+   .. code-block:: rst
+
+      .. toctree::
+         :hidden:
+         :maxdepth: 1
+
+         omfwd/parameters/basic
+         omfwd/parameters/transport
+         omfwd/parameters/security
+         omfwd/parameters/advanced
+
+**Example Parameters at a Glance:**
+
+.. code-block:: rst
+
+   **Module-Load Parameters**
+
+   .. csv-table::
+      :header: "Parameter", "Default", "Description", "Page"
+      :widths: 20 15 50 25
+
+      "iobuffer.maxSize", "full size", "Max TCP API buffer.", :doc:`module <omfwd/parameters/module>`
+
+   **Action-Instance Parameters**
+
+   .. csv-table::
+      :header: "Parameter", "Default", "Description", "Page"
+      :widths: 20 15 50 25
+
+      "target", "none", "Remote host(s).", :doc:`action <omfwd/parameters/action>`
+      "port", "514", "Destination port.", :doc:`action <omfwd/parameters/action>`
+      "protocol", "udp", "Transport protocol (udp/tcp/TLS).", :doc:`action <omfwd/parameters/action>`
+      "queue.type", "linkedList", "Per-action queue type.", :doc:`action <omfwd/parameters/action>`
+
+Category Pages ("parameters/\*.rst")
+------------------------------------
+
+Group related parameters into 3–8 per category. Example structure for "basic.rst":
+
+.. code-block:: rst
+
+   Basic Parameters
+   ================
+
+   .. meta::
+      :tag: module:omfwd
+      :tag: category:basic
+
+   Core settings for forwarding.
+
+   ---
+
+   target
+   ~~~~~~
+
+   **Summary:** Name or IP of the remote syslog server.
+
+   :type: array/word  
+   :default: none  
+   :mandatory: no  
+
+   .. code-block:: rsyslog
+
+      action(
+        type="omfwd"
+        target="logs.example.com"
+        port="514"
+        protocol="tcp"
+        queue.type="linkedList"
+      )
+
+   .. toggle::
+      :caption: Deep dive: How target pools work
+
+      .. include:: ../../../concepts/queues.inc
+
+Repeat for transport, security, and advanced categories.
+
+Concept Snippets
+----------------
+
+Centralize deep theory under ``source/concepts/``:
+
+- ``<topic>.inc`` — conceptual snippet content  
+- ``<topic>.rst`` — standalone concept page including the snippet
+
+Include snippets in parameter pages via:
+
+.. code-block:: rst
+
+   .. toggle::
+      :caption: Deep dive: How target pools work
+
+      .. include:: ../../../concepts/queues.inc
+
+Metadata & Tags
+---------------
+
+At the top of every page (master, category, concept), include:
+
+.. code-block:: rst
+
+   .. meta::
+      :tag: module:<module-name>
+      :tag: category:<category-name>    # category pages only
+      :tag: parameter:<parameter-name>  # if desired on parameter sections
+      :tag: concept:<topic-name>        # on concept pages
+
+These tags drive precise AI/RAG filtering.
+
+TOC Integration
+---------------
+
+**In Doc Writing → Development** (``source/development/doc_style_guide.rst``):
+
+.. code-block:: rst
+
+   .. toctree::
+      :maxdepth: 1
+
+      doc_style_guide
+      reference_section_guidelines
+
+**In Configuration → Output Modules** (``source/configuration/modules/index.rst``):
+
+.. code-block:: rst
+
+   .. toctree::
+      :maxdepth: 2
+
+      omfwd
+      omrelp
+      omfile
+      …
+


### PR DESCRIPTION
This commit reorganizes the `omfwd` module documentation for improved clarity and maintainability.

The large `omfwd.rst` file has been split into smaller, more focused documents:
* `omfwd/parameters/module/index.rst`: Contains parameters that apply globally to the omfwd module.
* `omfwd/parameters/action/index.rst`: Contains parameters specific to individual omfwd actions.
* `omfwd/parameters/action/target.rst`: Extracts the "Target" parameter into its own file. This serves as a proof-of-concept for future parameter-specific pages.

This restructuring is part of an ongoing effort to enhance the `omfwd` documentation. Further improvements to the page are planned.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
