### PR TITLE
imjournal: fix vulnerability in state file creation

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -1039,7 +1039,7 @@ BEGINbeginCnfLoad
     cs.bIgnoreNonValidStatefile = 1;
     cs.iPersistStateInterval = DFLT_persiststateinterval;
     cs.stateFile = NULL;
-    cs.fCreateMode = -1;
+    cs.fCreateMode = 0644;
     cs.ratelimitBurst = 20000;
     cs.ratelimitInterval = 600;
     cs.iDfltSeverity = DFLT_SEVERITY;
@@ -1314,16 +1314,6 @@ BEGINsetModCnf
                 "param '%s' in beginCnfLoad\n",
                 modpblk.descr[i].name);
         }
-    }
-
-    /* File create mode is not set */
-    if (cs.fCreateMode == -1) {
-        const int fCreateMode = 0644;
-        LogMsg(0, RS_RET_OK_WARN, LOG_WARNING,
-               "imjournal: filecreatemode is not set, "
-               "using default %04o",
-               fCreateMode);
-        cs.fCreateMode = fCreateMode;
     }
 
 finalize_it:


### PR DESCRIPTION
Initialize cs.fCreateMode to 0644 instead of -1 to prevent state files from being created with all permission bits set when legacy configuration is used. The setModCnf function is only called with modern configuration, leaving cs.fCreateMode at -1 for legacy configs, which results in wrong open() calls.

By default, the state file will now use a hardcoded permission of 0644 for legacy syntax, while remaining configurable through the new syntax. Since rsyslog is the sole consumer of this file (at least should be), I will maintain FileCreateMode at 0644 to avoid introducing additional issues.

Side note: another approach would be to introduce the legacy version of this parameter via:
```
CHKiRet(omsdRegCFSLineHdlr((uchar *)"filecreatemode", 0, eCmdHdlrFileCreateMode, NULL, &cs.fCreateMode, STD_LOADABLE_MODULE_ID));
```
However, adding new legacy options is not being considered.

What do you think? (for some reason I am not able to mention anyone who left a comment in #5375)
Fixes #5375 
Fixes https://github.com/rsyslog/rsyslog/issues/5864