### PR TITLE
gtls: log missing certificate/key only once

### DIFF
--- a/runtime/nsd_gtls.h
+++ b/runtime/nsd_gtls.h
@@ -83,6 +83,7 @@ struct nsd_gtls_s {
         gnutls_x509_privkey_t ourKey; /**< our private key, if in client mode (unused in server mode) */
         short bOurCertIsInit; /**< 1 if our certificate is initialized and must be deinit on destruction */
         short bOurKeyIsInit; /**< 1 if our private key is initialized and must be deinit on destruction */
+        unsigned short loggedWarnings; /**< bitfield of logged warnings */
         char *pszRcvBuf;
         int lenRcvBuf;
         /**< -1: empty, 0: connection closed, 1..NSD_GTLS_MAX_RCVBUF-1: data of that size present */


### PR DESCRIPTION
When no TLS certificate or key is configured for forwarding actions, repeated connection attempts produced the same warning messages over and over. `gtlsInitCred()` and `gtlsAddOurCert()` now log these warnings only during the initial setup.
Without the patch, they log these messages every time the connection is being reestabilished:
```
Jul 26 13:31:01 vm-tls rsyslogd[6101]: warning: certificate file is not set [v8.2412.0-1.el9 try https://www.rsyslog.com/e/2330 ]
Jul 26 13:31:01 vm-tls rsyslogd[6101]: warning: key file is not set [v8.2412.0-1.el9 try https://www.rsyslog.com/e/2331 ]
Jul 26 13:31:01 vm-tls rsyslogd[6101]: warning: certificate file is not set [v8.2412.0-1.el9 try https://www.rsyslog.com/e/2330 ]
Jul 26 13:31:01 vm-tls rsyslogd[6101]: warning: key file is not set [v8.2412.0-1.el9 try https://www.rsyslog.com/e/2331 ]
...
```