### PR TITLE
ossl: Add support for PrioritizeSAN option to OpenSSL network stream driver

### DIFF
--- a/doc/source/concepts/ns_ossl.rst
+++ b/doc/source/concepts/ns_ossl.rst
@@ -74,3 +74,14 @@ Supported Authentication Modes
       anon cipher will be used.
 
 
+PrioritizeSAN
+=============
+
+-  **off** - by default this binary argument is turned off, which means
+   that validation of names in certificates goes per older RFC 5280 and either
+   Subject Alternative Name or Common Name match is good and connection is
+   allowed.
+
+-  **on** - if you turn this option on, it will perform stricter name checking
+   as per newer RFC 6125, where, if any SAN is found, contents of CN are 
+   completely ignored and name validity is decided based on SAN only. 

--- a/runtime/net_ossl.h
+++ b/runtime/net_ossl.h
@@ -67,6 +67,7 @@ struct net_ossl_s {
         int bReportAuthErr; /* only the first auth error is to be reported, this var triggers it. Initially, it is
                              * set to 1 and changed to 0 after the first report. It is changed back to 1 after
                              * one successful authentication. */
+        int bSANpriority; /* if true, we do stricter checking (if any SAN present we do not check CN) */
         /* Open SSL objects */
         BIO *bio; /* OpenSSL main BIO obj */
         int ctx_is_copy;


### PR DESCRIPTION
<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->

Add OpenSSL equivalent of existing GnuTLS prioritizeSAN functionality implemented in https://github.com/rsyslog/rsyslog/commit/937e278fdf51c3e21ebd3acf05f9d1b8649ce2c5

https://docs.openssl.org/1.1.1/man3/X509_check_host/#description
> The X509_CHECK_FLAG_NEVER_CHECK_SUBJECT flag causes the function to never consider the subject DN even if the certificate contains no subject alternative names of the right type (DNS name or email address as appropriate); the default is to use the subject DN when no corresponding subject alternative names are present.

`0x10100004L` corresponds to OpenSSL 1.1.0-pre4 in which `X509_CHECK_FLAG_NEVER_CHECK_SUBJECT` first appeared, unsure if it would be better to compare against the official 1.1.0 release
