### PR TITLE
CI: add code style check

### DIFF
--- a/.github/workflows/ci_codestyle_check.yml
+++ b/.github/workflows/ci_codestyle_check.yml
@@ -1,0 +1,39 @@
+name: "Code Style Check"
+
+on:
+  pull_request:
+
+jobs:
+  style-check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Detect changed files
+        id: code_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            **/*.c
+            **/*.h
+            devtools/format-code.sh
+
+      - name: Enforce code style
+        run: |
+          if [ "${{ steps.code_changes.outputs.any_changed }}" != "true" ]; then
+            echo "No code changes detected; skipping style check."
+            exit 0
+          fi
+          chmod +x devtools/format-code.sh
+          ./devtools/format-code.sh
+          if ! git diff --exit-code; then
+            echo "::error ::Code style violations detected."
+            echo "Contributors: to fix this, run './devtools/format-code.sh' locally"
+            echo "and push the updated commit to your branch."
+            echo "Ensure 'Allow edits from maintainers' is enabled on this PR so maintainers"
+            echo "can help apply formatting fixes if needed."
+            exit 1
+          fi
+


### PR DESCRIPTION
Introduce a GitHub Actions workflow that automatically runs devtools/format-code.sh on every pull request touching source files. If formatting changes are detected, the check fails and provides clear instructions for contributors—run the formatter locally and enable “Allow edits from maintainers” so fixes can be applied.

This prevents code‑style drift and eliminates style‑only update noise.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
