### PR TITLE
doc fix: remove doc for debug options that no longer exits

### DIFF
--- a/doc/source/troubleshooting/debug.rst
+++ b/doc/source/troubleshooting/debug.rst
@@ -36,19 +36,6 @@ There are two environment variables that set several debug settings:
    The "RSYSLOG\_DEBUG" environment variable contains an option string
    with the following options possible (all are case insensitive):
 
-   -  **LogFuncFlow** - print out the logical flow of functions
-      (entering and exiting them)
-   -  **FileTrace** - specifies which files to trace LogFuncFlow. If
-      **not** set (the default), a LogFuncFlow trace is provided for all
-      files. Set to limit it to the files specified. FileTrace may be
-      specified multiple times, one file each (e.g. export
-      RSYSLOG\_DEBUG="LogFuncFlow FileTrace=vm.c FileTrace=expr.c"
-   -  **PrintFuncDB** - print the content of the debug function database
-      whenever debug information is printed (e.g. abort case)!
-   -  **PrintAllDebugInfoOnExit** - print all debug information
-      immediately before rsyslogd exits (currently not implemented!)
-   -  **PrintMutexAction** - print mutex action as it happens. Useful
-      for finding deadlocks and such.
    -  **NoLogTimeStamp** - do not prefix log lines with a timestamp
       (default is to do that).
    -  **NoStdOut** - do not emit debug messages to stdout. If


### PR DESCRIPTION
Some debug options were removed several years ago but unfortunately not removed from the doc. This is now done.

closes: https://github.com/rsyslog/rsyslog/issues/4817

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
