### PR TITLE
testbench: fix some omfwd-lb-1target* tests - they were very flaky

### DIFF
--- a/tests/omfwd-lb-1target-retry-test_skeleton.sh
+++ b/tests/omfwd-lb-1target-retry-test_skeleton.sh
@@ -24,24 +24,22 @@ module(load="builtin:omfwd" template="outfmt" iobuffer.maxSize="'$OMFWD_IOBUF_SI
 
 if $msg contains "msgnum:" then {
 	action(type="omfwd" target=["127.0.0.1"] port="'$MINITCPSRVR_PORT1'" protocol="tcp"
-		#extendedConnectionCheck="off"
+		extendedConnectionCheck="off"
 		pool.resumeInterval="1"
 		action.resumeRetryCount="-1" action.resumeInterval="1")
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt"
-	       action.ExecOnlyWhenPreviousIsSuspended="on")
 }
 '
-echo Note: intentionally not started any local TCP receiver!
 
 # now do the usual run
 startup
 
 injectmsg
+sleep 20 # This is just an experiment! TODO: remove or adjust after experiment.
 shutdown_when_empty
 wait_shutdown
 # note: minitcpsrv shuts down automatically if the connection is closed!
 
 export SEQ_CHECK_OPTIONS=-d
 #permit 500 messages to be lost in this extreme test (-m 100)
-seq_check 0 $((NUMMESSAGES-1)) -m500
+seq_check 0 $((NUMMESSAGES-1)) -m100
 exit_test


### PR DESCRIPTION
It looks like at some point a change purely intend for local testing went into git, rendering the test incorrect. Still needs to be finally confirmed.

potentially fixes https://github.com/rsyslog/rsyslog/issues/5880

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
