### PR TITLE
core: migrate callback invocations to type-safe signatures

### DIFF
--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -871,9 +871,9 @@ rsRetVal objDeserializeWithMethods(void *ppObj,
                                    strm_t *pStrm,
                                    rsRetVal (*fFixup)(obj_t *, void *),
                                    void *pUsr,
-                                   rsRetVal (*objConstruct)(void *, ...),
-                                   rsRetVal (*objConstructFinalize)(void *, ...),
-                                   rsRetVal (*objDeserialize)(void *, ...)) {
+                                   rsRetVal (*objConstruct)(void **),
+                                   rsRetVal (*objConstructFinalize)(void *),
+                                   rsRetVal (*objDeserialize)(void *, strm_t *)) {
     DEFiRet;
     rsRetVal iRetLocal;
     obj_t *pObj = NULL;
@@ -904,7 +904,7 @@ rsRetVal objDeserializeWithMethods(void *ppObj,
 
     if (rsCStrSzStrCmp(pstrID, pszTypeExpected, lenTypeExpected)) ABORT_FINALIZE(RS_RET_INVALID_OID);
 
-    CHKiRet(objConstruct(&pObj));
+    CHKiRet(objConstruct((void **)&pObj));
 
     /* we got the object, now we need to fill the properties */
     CHKiRet(objDeserialize(pObj, pStrm));

--- a/runtime/obj.h
+++ b/runtime/obj.h
@@ -122,9 +122,9 @@ rsRetVal objDeserializeWithMethods(void *ppObj,
                                    strm_t *pStrm,
                                    rsRetVal (*fFixup)(obj_t *, void *),
                                    void *pUsr,
-                                   rsRetVal (*objConstruct)(void *, ...),
-                                   rsRetVal (*objConstructFinalize)(void *, ...),
-                                   rsRetVal (*objDeserialize)(void *, ...));
+                                   rsRetVal (*objConstruct)(void **),
+                                   rsRetVal (*objConstructFinalize)(void *),
+                                   rsRetVal (*objDeserialize)(void *, strm_t *));
 rsRetVal objDeserializeProperty(var_t *pProp, strm_t *pStrm);
 uchar *objGetName(obj_t *pThis);
 

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1140,11 +1140,18 @@ finalize_it:
 }
 
 
+static rsRetVal msgConstructFromVoid(void **ppThis) {
+    return msgConstructForDeserializer((smsg_t **)ppThis);
+}
+
+static rsRetVal msgDeserializeFromVoid(void *pObj, strm_t *pStrm) {
+    return MsgDeserialize((smsg_t *)pObj, pStrm);
+}
+
 static rsRetVal qDeqDisk(qqueue_t *pThis, smsg_t **ppMsg) {
     DEFiRet;
-    iRet = objDeserializeWithMethods(ppMsg, (uchar *)"msg", 3, pThis->tVars.disk.pReadDeq, NULL, NULL,
-                                     (rsRetVal(*)(void *, ...))msgConstructForDeserializer, NULL,
-                                     (rsRetVal(*)(void *, ...))MsgDeserialize);
+    iRet = objDeserializeWithMethods(ppMsg, (uchar *)"msg", sizeof("msg") - 1, pThis->tVars.disk.pReadDeq, NULL, NULL,
+                                     msgConstructFromVoid, NULL, msgDeserializeFromVoid);
     if (iRet != RS_RET_OK) {
         LogError(0, iRet, "%s: qDeqDisk error happened at around offset %lld", obj.GetName((obj_t *)pThis),
                  (long long)pThis->tVars.disk.pReadDeq->iCurrOffs);


### PR DESCRIPTION
Replace opaque/variadic callback usage with explicit, type-safe function signatures to reduce undefined behavior and clarify intent. Adapter helpers bridge the existing APIs without raw variadic casts, enabling the transition incrementally. Callback setup sites are standardized for consistent readability. This tightens the contract on callbacks, eases future refactoring, and makes their roles more self-documenting.

Inspired by https://github.com/rsyslog/rsyslog/pull/5882

With AI support: Codex

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
