### PR TITLE
doc: refactor imdocker module param docs into structured ref pages

### DIFF
--- a/doc/source/configuration/modules/imdocker.rst
+++ b/doc/source/configuration/modules/imdocker.rst
@@ -32,7 +32,7 @@ the behavior of imdocker.
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; CamelCase is recommended for readability.
 
 .. note::
 
@@ -43,150 +43,61 @@ the behavior of imdocker.
 Module Parameters
 -----------------
 
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-DockerApiUnixSockAddr
-^^^^^^^^^^^^^^^^^^^^^
+   * - Parameter
+     - Summary
+   * - :ref:`param-imdocker-dockerapiunixsockaddr`
+     - .. include:: ../../reference/parameters/imdocker-dockerapiunixsockaddr.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-apiversionstr`
+     - .. include:: ../../reference/parameters/imdocker-apiversionstr.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-pollinginterval`
+     - .. include:: ../../reference/parameters/imdocker-pollinginterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-listcontainersoptions`
+     - .. include:: ../../reference/parameters/imdocker-listcontainersoptions.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-getcontainerlogoptions`
+     - .. include:: ../../reference/parameters/imdocker-getcontainerlogoptions.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-retrievenewlogsfromstart`
+     - .. include:: ../../reference/parameters/imdocker-retrievenewlogsfromstart.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-defaultfacility`
+     - .. include:: ../../reference/parameters/imdocker-defaultfacility.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-defaultseverity`
+     - .. include:: ../../reference/parameters/imdocker-defaultseverity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imdocker-escapelf`
+     - .. include:: ../../reference/parameters/imdocker-escapelf.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
+.. toctree::
+   :hidden:
 
-   "string", "/var/run/docker.sock", "no", "none"
-
-Specifies the Docker unix socket address to use.
-
-ApiVersionStr
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "v1.27", "no", "none"
-
-Specifies the version of Docker API to use. Must be in the format specified by the
-Docker api, e.g. similar to the default above (v1.27, v1.28, etc).
-
-
-PollingInterval
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "60", "no", "none"
-
-Specifies the polling interval in seconds, imdocker will poll for new containers by
-calling the 'List containers' API from the Docker engine.
-
-
-ListContainersOptions
-^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "", "no", "none"
-
-Specifies the HTTP query component of the a 'List Containers' HTTP API request.
-See Docker API for more information about available options.
-**Note**: It is not necessary to prepend the string with '?'.
-
-
-GetContainerLogOptions
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "timestamp=0&follow=1&stdout=1&stderr=1&tail=1", "no", "none"
-
-Specifies the HTTP query component of the a 'Get container logs' HTTP API request.
-See Docker API for more information about available options.
-**Note**: It is not necessary to prepend the string with '?'.
-
-
-RetrieveNewLogsFromStart
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "1", "no", "none"
-
-This option specifies the whether imdocker will process newly found container logs from the beginning.
-The exception is for containers found on start-up. The container logs for containers
-that were active at imdocker start-up are controlled via 'GetContainerLogOptions', the
-'tail' in particular.
-
-
-DefaultFacility
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer or string (preferred)", "user", "no", ""
-
-The syslog facility to be assigned to log messages received. Specified as numbers.
-
-.. seealso::
-
-   https://en.wikipedia.org/wiki/Syslog
-
-
-DefaultSeverity
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer or string (preferred)", "info", "no", ""
-
-The syslog severity to be assigned to log messages received. Specified as numbers (e.g. 6
-for ``info``). Textual form is suggested. Default is ``notice``.
-
-.. seealso::
-
-   https://en.wikipedia.org/wiki/Syslog
-
-
-escapeLF
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-This is only meaningful if multi-line messages are to be processed.
-LF characters embedded into syslog messages cause a lot of trouble,
-as most tools and even the legacy syslog TCP protocol do not expect
-these. If set to "on", this option avoid this trouble by properly
-escaping LF characters to the 4-byte sequence "#012". This is
-consistent with other rsyslog control character escaping. By default,
-escaping is turned on. If you turn it off, make sure you test very
-carefully with all associated tools. Please note that if you intend
-to use plain TCP syslog with embedded LF characters, you need to
-enable octet-counted framing.
-For more details, see Rainer's blog posting on imfile LF escaping.
-
+   ../../reference/parameters/imdocker-dockerapiunixsockaddr
+   ../../reference/parameters/imdocker-apiversionstr
+   ../../reference/parameters/imdocker-pollinginterval
+   ../../reference/parameters/imdocker-listcontainersoptions
+   ../../reference/parameters/imdocker-getcontainerlogoptions
+   ../../reference/parameters/imdocker-retrievenewlogsfromstart
+   ../../reference/parameters/imdocker-defaultfacility
+   ../../reference/parameters/imdocker-defaultseverity
+   ../../reference/parameters/imdocker-escapelf
 
 Metadata
 ========

--- a/doc/source/reference/parameters/imdocker-apiversionstr.rst
+++ b/doc/source/reference/parameters/imdocker-apiversionstr.rst
@@ -1,0 +1,43 @@
+.. _param-imdocker-apiversionstr:
+.. _imdocker.parameter.module.apiversionstr:
+
+ApiVersionStr
+=============
+
+.. index::
+   single: imdocker; ApiVersionStr
+   single: ApiVersionStr
+
+.. summary-start
+
+Docker API version string like ``v1.27``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: ApiVersionStr
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=v1.27
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+Specifies the version of Docker API to use. The value must match the format
+required by the Docker API, such as ``v1.27``.
+
+Module usage
+------------
+.. _param-imdocker-module-apiversionstr:
+.. _imdocker.parameter.module.apiversionstr-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" ApiVersionStr="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-defaultfacility.rst
+++ b/doc/source/reference/parameters/imdocker-defaultfacility.rst
@@ -1,0 +1,48 @@
+.. _param-imdocker-defaultfacility:
+.. _imdocker.parameter.module.defaultfacility:
+
+DefaultFacility
+===============
+
+.. index::
+   single: imdocker; DefaultFacility
+   single: DefaultFacility
+
+.. summary-start
+
+Syslog facility assigned to received messages; default ``user``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: DefaultFacility
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=user
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+The syslog facility to be assigned to log messages. Textual names such as
+``user`` are suggested, though numeric values are also accepted.
+
+Module usage
+------------
+.. _param-imdocker-module-defaultfacility:
+.. _imdocker.parameter.module.defaultfacility-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" DefaultFacility="...")
+
+Notes
+-----
+- Numeric facility values are accepted but textual names are recommended.
+- See https://en.wikipedia.org/wiki/Syslog.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-defaultseverity.rst
+++ b/doc/source/reference/parameters/imdocker-defaultseverity.rst
@@ -1,0 +1,48 @@
+.. _param-imdocker-defaultseverity:
+.. _imdocker.parameter.module.defaultseverity:
+
+DefaultSeverity
+===============
+
+.. index::
+   single: imdocker; DefaultSeverity
+   single: DefaultSeverity
+
+.. summary-start
+
+Syslog severity assigned to received messages; default ``info``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: DefaultSeverity
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=info
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+The syslog severity to be assigned to log messages. Textual names such as
+``info`` are suggested, though numeric values are also accepted.
+
+Module usage
+------------
+.. _param-imdocker-module-defaultseverity:
+.. _imdocker.parameter.module.defaultseverity-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" DefaultSeverity="...")
+
+Notes
+-----
+- Numeric severity values are accepted but textual names are recommended.
+- See https://en.wikipedia.org/wiki/Syslog.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-dockerapiunixsockaddr.rst
+++ b/doc/source/reference/parameters/imdocker-dockerapiunixsockaddr.rst
@@ -1,0 +1,42 @@
+.. _param-imdocker-dockerapiunixsockaddr:
+.. _imdocker.parameter.module.dockerapiunixsockaddr:
+
+DockerApiUnixSockAddr
+=====================
+
+.. index::
+   single: imdocker; DockerApiUnixSockAddr
+   single: DockerApiUnixSockAddr
+
+.. summary-start
+
+Unix socket path for Docker API connections; default ``/var/run/docker.sock``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: DockerApiUnixSockAddr
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=/var/run/docker.sock
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+Specifies the Docker unix socket address to use.
+
+Module usage
+------------
+.. _param-imdocker-module-dockerapiunixsockaddr:
+.. _imdocker.parameter.module.dockerapiunixsockaddr-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" DockerApiUnixSockAddr="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-escapelf.rst
+++ b/doc/source/reference/parameters/imdocker-escapelf.rst
@@ -1,0 +1,48 @@
+.. _param-imdocker-escapelf:
+.. _imdocker.parameter.module.escapelf:
+
+escapeLF
+========
+
+.. index::
+   single: imdocker; escapeLF
+   single: escapeLF
+
+.. summary-start
+
+Escapes line feeds as ``#012`` in multi-line messages; default ``on``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: escapeLF
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+If enabled, line feed characters embedded in messages are escaped to the
+sequence ``#012``. This avoids issues with tools that do not expect embedded LF
+characters.
+
+Module usage
+------------
+.. _param-imdocker-module-escapelf:
+.. _imdocker.parameter.module.escapelf-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" escapeLF="...")
+
+Notes
+-----
+- The original documentation described this as a binary option; it is a boolean parameter.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-getcontainerlogoptions.rst
+++ b/doc/source/reference/parameters/imdocker-getcontainerlogoptions.rst
@@ -1,0 +1,43 @@
+.. _param-imdocker-getcontainerlogoptions:
+.. _imdocker.parameter.module.getcontainerlogoptions:
+
+GetContainerLogOptions
+======================
+
+.. index::
+   single: imdocker; GetContainerLogOptions
+   single: GetContainerLogOptions
+
+.. summary-start
+
+HTTP query options for ``Get container logs`` requests; default ``timestamps=0&follow=1&stdout=1&stderr=1&tail=1``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: GetContainerLogOptions
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=timestamps=0&follow=1&stdout=1&stderr=1&tail=1
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+Specifies the HTTP query component of a ``Get container logs`` API request. See
+the Docker API for available options. It is not necessary to prepend ``?``.
+
+Module usage
+------------
+.. _param-imdocker-module-getcontainerlogoptions:
+.. _imdocker.parameter.module.getcontainerlogoptions-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" GetContainerLogOptions="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-listcontainersoptions.rst
+++ b/doc/source/reference/parameters/imdocker-listcontainersoptions.rst
@@ -1,0 +1,43 @@
+.. _param-imdocker-listcontainersoptions:
+.. _imdocker.parameter.module.listcontainersoptions:
+
+ListContainersOptions
+=====================
+
+.. index::
+   single: imdocker; ListContainersOptions
+   single: ListContainersOptions
+
+.. summary-start
+
+HTTP query options appended to ``List Containers`` requests; omit leading ``?``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: ListContainersOptions
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+Specifies the HTTP query component of a ``List Containers`` API request. See the
+Docker API for available options. It is not necessary to prepend ``?``.
+
+Module usage
+------------
+.. _param-imdocker-module-listcontainersoptions:
+.. _imdocker.parameter.module.listcontainersoptions-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" ListContainersOptions="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-pollinginterval.rst
+++ b/doc/source/reference/parameters/imdocker-pollinginterval.rst
@@ -1,0 +1,43 @@
+.. _param-imdocker-pollinginterval:
+.. _imdocker.parameter.module.pollinginterval:
+
+PollingInterval
+===============
+
+.. index::
+   single: imdocker; PollingInterval
+   single: PollingInterval
+
+.. summary-start
+
+Seconds between ``List Containers`` polls for new containers; default ``60``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: PollingInterval
+:Scope: module
+:Type: integer
+:Default: module=60
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+Specifies the polling interval in seconds. imdocker polls for new containers by
+calling the ``List containers`` Docker API.
+
+Module usage
+------------
+.. _param-imdocker-module-pollinginterval:
+.. _imdocker.parameter.module.pollinginterval-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" PollingInterval="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+

--- a/doc/source/reference/parameters/imdocker-retrievenewlogsfromstart.rst
+++ b/doc/source/reference/parameters/imdocker-retrievenewlogsfromstart.rst
@@ -1,0 +1,48 @@
+.. _param-imdocker-retrievenewlogsfromstart:
+.. _imdocker.parameter.module.retrievenewlogsfromstart:
+
+RetrieveNewLogsFromStart
+========================
+
+.. index::
+   single: imdocker; RetrieveNewLogsFromStart
+   single: RetrieveNewLogsFromStart
+
+.. summary-start
+
+Whether to read newly discovered container logs from start; default ``on``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdocker`.
+
+:Name: RetrieveNewLogsFromStart
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: 8.41.0
+
+Description
+-----------
+Specifies whether imdocker processes newly found container logs from the
+beginning. Containers that exist when imdocker starts are controlled by
+``GetContainerLogOptions`` and its ``tail`` option.
+
+Module usage
+------------
+.. _param-imdocker-module-retrievenewlogsfromstart:
+.. _imdocker.parameter.module.retrievenewlogsfromstart-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdocker" RetrieveNewLogsFromStart="...")
+
+Notes
+-----
+- The original documentation described this as a binary option; it is a boolean parameter.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdocker`.
+


### PR DESCRIPTION
Migrates all imdocker module parameter descriptions from the monolithic module page into individual parameter reference files under doc/source/reference/parameters/. Each parameter now has:

- A stable Sphinx label and cross-references
- A concise summary section for use in tables and AI ingestion
- Clear metadata (scope, type, default, introduced version)
- RainerScript usage examples
- "See also" links back to the main module page

The imdocker.rst page now uses a compact parameter list-table with embedded summaries and a hidden toctree linking to full parameter pages. This aligns with the new documentation structure for better maintainability, human readability, and machine ingestion (e.g. for RAG-based assistants).

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
