### PR TITLE
doc: reference AI module map in AGENTS.md and DEVELOPING.md

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,65 @@
+# Developing rsyslog (v8 engine essentials)
+
+This short guide is the **canonical entry point** for humans and AI coding agents.
+It captures the v8 worker model and locking rules that module code must follow.
+
+## v8 worker model (normative)
+* The framework may run **multiple workers per action**.
+* `wrkrInstanceData_t` (WID) is **per-worker, thread-local** → **no locks needed** inside WID.
+* `pData` (per-action/shared) may be touched by multiple workers and/or extra threads → **guard mutable/shared members**.
+* **Inherently serial resources** (e.g., a FILE/strm shared in pData) **must be serialized** inside the module using a mutex in pData.
+* **Direct queues** do **not** remove the need to serialize serial resources.
+
+### Where state goes
+| Kind of state                         | Put it in           | Locking                                            |
+|--------------------------------------|---------------------|----------------------------------------------------|
+| Config, shared counters, streams     | `pData` (per-action)| Guard if mutated or not thread-safe                |
+| Live handles, sockets, buffers       | `wrkrInstanceData_t`| No locks (WID is owned by exactly one worker)      |
+| Library thread + callbacks (I/O)     | `pData` + rwlock    | Define who reads/writes; document in comments      |
+
+### Locking rules (quick)
+1. Never share a WID across workers.
+2. Any shared mutable `pData` member → protect with `pthread_mutex_t`
+   (or `pthread_rwlock_t` if a background thread is involved).
+3. If a module uses an external/library thread, document **who takes read/write**.
+4. Transactions follow the same rules as `doAction`.
+5. Test with workerThreads > 1.
+
+## Canonical examples (start here)
+* `plugins/omfile/*` → inherently serial: uses a pData mutex to guard write/flush.
+* `plugins/omfwd/*`  → per-worker sockets in WID, typically no additional locks.
+* `plugins/omelasticsearch/*` → per-worker curl & batch in WID.
+* `plugins/omazureeventhubs/*` → two-thread model (rsyslog worker + Proton): needs an rwlock across threads (fix in progress).
+* `contrib/omhttp/*` → per-worker curl & buffers in WID.
+* `contrib/mmkubernetes/*` → WID is per-thread; shared caches live in pData and
+  must be guarded (see code).
+
+## Entry points (what modules implement)
+* `createWrkrInstance` / `freeWrkrInstance` — allocate/free WID (thread-local).
+* `doAction` — may run concurrently across workers of the same action.
+* `beginTransaction` / `commitTransaction` / `rollbackTransaction` — same concurrency rules as `doAction`.
+
+> **Rule of thumb:** if multiple workers could touch it, it lives in `pData` and must be protected.
+
+## Notes on current code
+* `ommysql`: a global RW-lock was introduced historically; it will be refactored soon.
+  Consider it a historical note, not a pattern to copy.
+* `omazureeventhubs`: ensure all Proton callbacks take the read lock and worker paths
+  that mutate handles take the write lock. A follow-up patch will address this.
+
+## Coding style
+* US-ASCII, subject ≤ 65 chars (aim 62), see `COMMENTING_STYLE.md` and `CONTRIBUTING.md`.
+
+## Safe starter tasks for agents
+* Add a **“Concurrency & Locking”** comment block at the top of output modules.
+* Ensure inherently serial modules guard pData streams with a mutex.
+* Verify modules with external threads hold the documented read/write locks on **all** callback paths (TSAN already runs in CI).
+
+## Pointers
+* Developer docs: `doc/` (Sphinx).
+* Tests: `tests/`.
+* Module sources: `plugins/` and `contrib/`.
+* AI module map: `doc/ai/module_map.yaml` (per-module paths & locking hints).
+
+---
+_This file is intentionally brief and normative. Longer background belongs in Sphinx._

--- a/MODULE_AUTHOR_CHECKLIST.md
+++ b/MODULE_AUTHOR_CHECKLIST.md
@@ -1,0 +1,25 @@
+# Module author checklist (v8)
+
+**State placement**
+- [ ] Config/static/shared data in **pData** (per-action).
+- [ ] Live handles/buffers in **wrkrInstanceData_t** (per-worker).
+- [ ] No sharing of WID across workers.
+
+**Serialization**
+- [ ] Inherently serial resources (e.g., a shared stream) guarded by a **mutex in pData**.
+- [ ] If any library thread or callback touches shared state, define a **pthread_rwlock_t**
+      and document who reads/writes.
+
+**Entry points**
+- [ ] `createWrkrInstance`/`freeWrkrInstance` allocate/free WID only.
+- [ ] `doAction`/tx callbacks may run concurrently across workers; they **never** share WID.
+
+**Docs in code**
+- [ ] Top-of-file “Concurrency & Locking” block explains the above for this module.
+- [ ] Doxygen comments on pData/WID typedefs describe lifetime & locking rules.
+
+**Testing**
+- [ ] Run with `queue.workerThreads > 1`. CI already runs TSAN on the full suite.
+
+**Style**
+- [ ] Commit subject ≤ 65 chars; aim for 62. ASCII only. See `CONTRIBUTING.md`.

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -1,0 +1,34 @@
+# Seed map for AI agents; keep minimal and truthful. Extend over time.
+omfile:
+  paths: ["plugins/omfile/"]
+  requires_serialization: true
+  locks:
+    - type: mutex
+      field: pData.mutWrite
+
+omfwd:
+  paths: ["plugins/omfwd/"]
+  requires_serialization: false
+
+omelasticsearch:
+  paths: ["plugins/omelasticsearch/"]
+  requires_serialization: false
+
+omazureeventhubs:
+  paths: ["plugins/omazureeventhubs/"]
+  requires_serialization: true
+  locks:
+    - type: rwlock
+      field: pData.pnLock
+      writer: rsyslog_worker
+      reader: proton_thread
+
+contrib_omhttp:
+  paths: ["contrib/omhttp/"]
+  requires_serialization: false
+
+contrib_mmkubernetes:
+  paths: ["contrib/mmkubernetes/"]
+  requires_serialization: false
+  notes:
+    - WID is per-thread; shared caches in pData must be guarded.


### PR DESCRIPTION
Added cross-references to doc/ai/module_map.yaml in both developer- facing guides:

- AGENTS.md:
  * Mentioned the AI module map in the Repository Overview and Quickstart sections.
  * Added a common task instructing contributors to consult the map before making edits.

- DEVELOPING.md:
  * Updated “Pointers” to include the AI module map as a source for per-module paths and known locking hints.

This improves discoverability of module locations and expected locking patterns for both AI agents (e.g., Codex) and human contributors, reducing time spent locating code and relevant design notes.

No functional changes; documentation only.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
