### PR TITLE
docs: extract imjournal parameter pages

### DIFF
--- a/doc/source/configuration/modules/imjournal.rst
+++ b/doc/source/configuration/modules/imjournal.rst
@@ -47,313 +47,115 @@ Notable Features
 - statistics counters
 
 
-Configuration Parameters
-========================
-
-.. note::
-
-   Parameter names are case-insensitive.
-
-
 Module Parameters
 =================
 
-
-PersistStateInterval
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "10", "no", "``$imjournalPersistStateInterval``"
-
-This is a global setting. It specifies how often should the journal
-state be persisted. The persists happens after each *number-of-messages*.
-This option is useful for rsyslog to start reading from the last journal
-message it read.
-
-FileCreateMode
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "octalNumber", "0644", "no", "none"
-
-Set the access permissions for the state file. The value given must
-always be a 4-digit octal number, with the initial digit being zero.
-Please note that the actual permission depend on rsyslogd's process
-umask. If in doubt, use "$umask 0000" right at the beginning of the
-configuration file to remove any restrictions. The state file's only
-consumer is rsyslog, so it's recommended to adjust the value according
-to that.
-
-
-StateFile
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "``$imjournalStateFile``"
-
-This is a global setting. It specifies where the state file for
-persisting journal state is located. If a full path name is given
-(starting with "/"), that path is used. Otherwise the given name
-is created inside the working directory.
-
-
-Ratelimit.Interval
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "600", "no", "``$imjournalRatelimitInterval``"
-
-Specifies the interval in seconds onto which rate-limiting is to be
-applied. If more than ratelimit.burst messages are read during that
-interval, further messages up to the end of the interval are
-discarded. The number of messages discarded is emitted at the end of
-the interval (if there were any discards).
-
-**Setting this value to 0 turns off ratelimiting.**
-
-Note that it is *not recommended to turn off ratelimiting*,
-except that you know for
-sure journal database entries will never be corrupted. Without
-ratelimiting, a corrupted systemd journal database may cause a kind
-of denial of service We are stressing this point as multiple users
-have reported us such problems with the journal database - in June
-of 2013 and occasionally also after this time (up until the time of
-this writing in January 2019).
-
-
-Ratelimit.Burst
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "20000", "no", "``$imjournalRatelimitBurst``"
-
-Specifies the maximum number of messages that can be emitted within
-the ratelimit.interval interval. For further information, see
-description there.
-
-
-IgnorePreviousMessages
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$ImjournalIgnorePreviousMessages``"
-
-This option specifies whether imjournal should ignore messages
-currently in journal and read only new messages. This option is only
-used when there is no StateFile to avoid message loss.
-
-
-DefaultSeverity
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "severity", "5", "no", "``$ImjournalDefaultSeverity``"
-
-Some messages coming from journald don't have the SYSLOG_PRIORITY
-field. These are typically the messages logged through journald's
-native API. This option specifies the default severity for these
-messages. Can be given either as a name or a number. Defaults to 'notice'.
-
-
-DefaultFacility
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "facility", "LOG_USER", "no", "``$ImjournalDefaultFacility``"
-
-Some messages coming from journald don't have the SYSLOG_FACILITY
-field. These are typically the messages logged through journald's
-native API. This option specifies the default facility for these
-messages. Can be given either as a name or a number. Defaults to 'user'.
-
-
-UsePidFromSystem
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "0", "no", "none"
-
-Retrieves the trusted systemd parameter, _PID, instead of the user
-systemd parameter, SYSLOG_PID, which is the default.
-This option override the "usepid" option.
-This is now deprecated. It is better to use usepid="syslog" instead.
-
-
-UsePid
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "both", "no", "none"
-
-Sets the PID source from journal.
-
-*syslog*
-   *imjournal* retrieves SYSLOG_PID from journal as PID number.
-
-*system*
-   *imjournal* retrieves _PID from journal as PID number.
-
-*both*
-   *imjournal* trying to retrieve SYSLOG_PID first. When it is not
-   available, it is also trying to retrieve _PID. When none of them is available,
-   message is parsed without PID number.
-
-
-IgnoreNonValidStatefile
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-When a corrupted statefile is read imjournal ignores the statefile and continues
-with logging from the beginning of the journal (from its end if IgnorePreviousMessages
-is on). After PersistStateInterval or when rsyslog is stopped invalid statefile
-is overwritten with a new valid cursor.
-
-
-WorkAroundJournalBug
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-.. versionadded:: 8.37.0
-
-**Deprecated.** This option was intended as temporary and has no effect now
-(since 8.1910.0). Left for backwards compatibility only.
-
-
-FSync
-^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.1908.0
-
-When there is a hard crash, power loss or similar abrupt end of rsyslog process,
-there is a risk of state file not being written to persistent storage or possibly
-being corrupted. This then results in imjournal starting reading elsewhere then 
-desired and most probably message duplication. To mitigate this problem you can 
-turn this option on which will force state file writes to persistent physical 
-storage. Please note that fsync calls are costly, so especially with lower 
-PersistStateInterval value, this may present considerable performance hit.
-
-
-Remote
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.1910.0
-
-When this option is turned on, imjournal will pull not only all local journal
-files (default behavior), but also any journal files on machine originating from
-remote sources.
-
-defaultTag
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.2312.0
-
-The DefaultTag option specifies the default value for the tag field.
-In imjournal, this can happen when one of the following is missing:
-
-* identifier string provided by the application (SYSLOG_IDENTIFIER) or
-* name of the process the journal entry originates from (_COMM)
-
-Under normal circumstances, at least one of the previously mentioned fields
-is always part of the journal message. But there are some corner cases
-where this is not the case. This parameter provides the ability to alter
-the content of the tag field.
-
-
-Input Module Parameters
-=======================
+.. note::
+   Parameter names are case-insensitive; CamelCase is recommended for readability.
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imjournal-persiststateinterval`
+     - .. include:: ../../reference/parameters/imjournal-persiststateinterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-filecreatemode`
+     - .. include:: ../../reference/parameters/imjournal-filecreatemode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-statefile`
+     - .. include:: ../../reference/parameters/imjournal-statefile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-ratelimit-interval`
+     - .. include:: ../../reference/parameters/imjournal-ratelimit-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-ratelimit-burst`
+     - .. include:: ../../reference/parameters/imjournal-ratelimit-burst.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-ignorepreviousmessages`
+     - .. include:: ../../reference/parameters/imjournal-ignorepreviousmessages.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-defaultseverity`
+     - .. include:: ../../reference/parameters/imjournal-defaultseverity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-defaultfacility`
+     - .. include:: ../../reference/parameters/imjournal-defaultfacility.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-usepidfromsystem`
+     - .. include:: ../../reference/parameters/imjournal-usepidfromsystem.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-usepid`
+     - .. include:: ../../reference/parameters/imjournal-usepid.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-ignorenonvalidstatefile`
+     - .. include:: ../../reference/parameters/imjournal-ignorenonvalidstatefile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-workaroundjournalbug`
+     - .. include:: ../../reference/parameters/imjournal-workaroundjournalbug.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-fsync`
+     - .. include:: ../../reference/parameters/imjournal-fsync.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-remote`
+     - .. include:: ../../reference/parameters/imjournal-remote.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imjournal-defaulttag`
+     - .. include:: ../../reference/parameters/imjournal-defaulttag.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+
+Input Parameters
+================
 
 Parameters specific to the input module.
 
-Main
-^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
+   * - Parameter
+     - Summary
+   * - :ref:`param-imjournal-main`
+     - .. include:: ../../reference/parameters/imjournal-main.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
-   "word", "journal", "no", "none"
+.. toctree::
+   :hidden:
 
-.. versionadded:: 8.2312.0
-
-When this option is turned on within the input module, imjournal will run the
-target ruleset in the main thread and will be stop taking input if the output
-module is not accepting data. If multiple input modules set `main` to true, only
-the first one will be affected. The non `main` rulesets will run in the
-background thread and not affected by the output state.
+   ../../reference/parameters/imjournal-persiststateinterval
+   ../../reference/parameters/imjournal-filecreatemode
+   ../../reference/parameters/imjournal-statefile
+   ../../reference/parameters/imjournal-ratelimit-interval
+   ../../reference/parameters/imjournal-ratelimit-burst
+   ../../reference/parameters/imjournal-ignorepreviousmessages
+   ../../reference/parameters/imjournal-defaultseverity
+   ../../reference/parameters/imjournal-defaultfacility
+   ../../reference/parameters/imjournal-usepidfromsystem
+   ../../reference/parameters/imjournal-usepid
+   ../../reference/parameters/imjournal-ignorenonvalidstatefile
+   ../../reference/parameters/imjournal-workaroundjournalbug
+   ../../reference/parameters/imjournal-fsync
+   ../../reference/parameters/imjournal-remote
+   ../../reference/parameters/imjournal-defaulttag
+   ../../reference/parameters/imjournal-main
 
 
 

--- a/doc/source/reference/parameters/imjournal-defaultfacility.rst
+++ b/doc/source/reference/parameters/imjournal-defaultfacility.rst
@@ -1,0 +1,55 @@
+.. _param-imjournal-defaultfacility:
+.. _imjournal.parameter.module.defaultfacility:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:DefaultFacility
+
+DefaultFacility
+===============
+
+.. index::
+   single: imjournal; DefaultFacility
+   single: DefaultFacility
+
+.. summary-start
+
+Fallback facility used if a journal entry lacks ``SYSLOG_FACILITY``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: DefaultFacility
+:Scope: module
+:Type: word
+:Default: module=LOG_USER
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Specifies the facility assigned to messages missing the ``SYSLOG_FACILITY``
+field. Values may be given as facility names or numbers.
+
+Module usage
+------------
+.. _param-imjournal-module-defaultfacility:
+.. _imjournal.parameter.module.defaultfacility-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" DefaultFacility="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _imjournal.parameter.legacy.imjournaldefaultfacility:
+
+- $ImjournalDefaultFacility — maps to DefaultFacility (status: legacy)
+
+.. index::
+   single: imjournal; $ImjournalDefaultFacility
+   single: $ImjournalDefaultFacility
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-defaultseverity.rst
+++ b/doc/source/reference/parameters/imjournal-defaultseverity.rst
@@ -1,0 +1,55 @@
+.. _param-imjournal-defaultseverity:
+.. _imjournal.parameter.module.defaultseverity:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:DefaultSeverity
+
+DefaultSeverity
+===============
+
+.. index::
+   single: imjournal; DefaultSeverity
+   single: DefaultSeverity
+
+.. summary-start
+
+Fallback severity used if a journal entry lacks ``SYSLOG_PRIORITY``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: DefaultSeverity
+:Scope: module
+:Type: word
+:Default: module=notice
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Specifies the severity assigned to messages that do not provide the
+``SYSLOG_PRIORITY`` field. Values may be given as names or numbers.
+
+Module usage
+------------
+.. _param-imjournal-module-defaultseverity:
+.. _imjournal.parameter.module.defaultseverity-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" DefaultSeverity="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _imjournal.parameter.legacy.imjournaldefaultseverity:
+
+- $ImjournalDefaultSeverity — maps to DefaultSeverity (status: legacy)
+
+.. index::
+   single: imjournal; $ImjournalDefaultSeverity
+   single: $ImjournalDefaultSeverity
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-defaulttag.rst
+++ b/doc/source/reference/parameters/imjournal-defaulttag.rst
@@ -1,0 +1,49 @@
+.. _param-imjournal-defaulttag:
+.. _imjournal.parameter.module.defaulttag:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:defaultTag
+
+defaultTag
+==========
+
+.. index::
+   single: imjournal; defaultTag
+   single: defaultTag
+
+.. summary-start
+
+Provides a default tag when both ``SYSLOG_IDENTIFIER`` and ``_COMM`` are missing.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: defaultTag
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=journal
+:Required?: no
+:Introduced: 8.2312.0
+
+Description
+-----------
+Defines the tag value used when neither an identifier string nor process name is
+available in the journal entry.
+
+Module usage
+------------
+.. _param-imjournal-module-defaulttag:
+.. _imjournal.parameter.module.defaulttag-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" defaultTag="...")
+
+Notes
+-----
+- Earlier documentation incorrectly described this option as ``binary``.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-filecreatemode.rst
+++ b/doc/source/reference/parameters/imjournal-filecreatemode.rst
@@ -1,0 +1,51 @@
+.. _param-imjournal-filecreatemode:
+.. _imjournal.parameter.module.filecreatemode:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:FileCreateMode
+
+FileCreateMode
+==============
+
+.. index::
+   single: imjournal; FileCreateMode
+   single: FileCreateMode
+
+.. summary-start
+
+Sets the octal permission mode for the state file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: FileCreateMode
+:Scope: module
+:Type: integer
+:Default: module=0644
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Defines access permissions for the state file using a four-digit octal value.
+Actual permissions also depend on the process ``umask``. If in doubt, use
+``global(umask="0000")`` at the beginning of the configuration file to remove
+any restrictions.
+
+Module usage
+------------
+.. _param-imjournal-module-filecreatemode:
+.. _imjournal.parameter.module.filecreatemode-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" FileCreateMode="...")
+
+Notes
+-----
+- Value is interpreted as an octal number.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-fsync.rst
+++ b/doc/source/reference/parameters/imjournal-fsync.rst
@@ -1,0 +1,51 @@
+.. _param-imjournal-fsync:
+.. _imjournal.parameter.module.fsync:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:FSync
+
+FSync
+=====
+
+.. index::
+   single: imjournal; FSync
+   single: FSync
+
+.. summary-start
+
+Force ``fsync()`` on the state file to guard against crash corruption.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: FSync
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.1908.0
+
+Description
+-----------
+When enabled, the module synchronizes the state file to persistent storage after
+each write. This reduces the risk of duplicate messages after abrupt shutdowns
+at the cost of additional I/O.
+
+Module usage
+------------
+.. _param-imjournal-module-fsync:
+.. _imjournal.parameter.module.fsync-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" FSync="...")
+
+Notes
+-----
+- Historic documentation called this a ``binary`` option; it is boolean.
+- May significantly impact performance with low ``PersistStateInterval`` values.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-ignorenonvalidstatefile.rst
+++ b/doc/source/reference/parameters/imjournal-ignorenonvalidstatefile.rst
@@ -1,0 +1,51 @@
+.. _param-imjournal-ignorenonvalidstatefile:
+.. _imjournal.parameter.module.ignorenonvalidstatefile:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:IgnoreNonValidStatefile
+
+IgnoreNonValidStatefile
+=======================
+
+.. index::
+   single: imjournal; IgnoreNonValidStatefile
+   single: IgnoreNonValidStatefile
+
+.. summary-start
+
+Ignores corrupt state files and restarts reading from the beginning.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: IgnoreNonValidStatefile
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When a corrupted state file is encountered, the module discards it and continues
+reading from the start of the journal (or from the end if ``IgnorePreviousMessages``
+is enabled). A new valid state file is written after the next state persistence
+or shutdown.
+
+Module usage
+------------
+.. _param-imjournal-module-ignorenonvalidstatefile:
+.. _imjournal.parameter.module.ignorenonvalidstatefile-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" IgnoreNonValidStatefile="...")
+
+Notes
+-----
+- Historic documentation called this a ``binary`` option; it is boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-ignorepreviousmessages.rst
+++ b/doc/source/reference/parameters/imjournal-ignorepreviousmessages.rst
@@ -1,0 +1,60 @@
+.. _param-imjournal-ignorepreviousmessages:
+.. _imjournal.parameter.module.ignorepreviousmessages:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:IgnorePreviousMessages
+
+IgnorePreviousMessages
+======================
+
+.. index::
+   single: imjournal; IgnorePreviousMessages
+   single: IgnorePreviousMessages
+
+.. summary-start
+
+Starts reading only new journal entries when no state file exists.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: IgnorePreviousMessages
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+If enabled and no state file is present, messages already stored in the journal
+are skipped and only new entries are processed, preventing reprocessing of old
+logs.
+
+Module usage
+------------
+.. _param-imjournal-module-ignorepreviousmessages:
+.. _imjournal.parameter.module.ignorepreviousmessages-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" IgnorePreviousMessages="...")
+
+Notes
+-----
+- Historic documentation called this a ``binary`` option; it is boolean.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _imjournal.parameter.legacy.imjournalignorepreviousmessages:
+
+- $ImjournalIgnorePreviousMessages — maps to IgnorePreviousMessages (status: legacy)
+
+.. index::
+   single: imjournal; $ImjournalIgnorePreviousMessages
+   single: $ImjournalIgnorePreviousMessages
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-main.rst
+++ b/doc/source/reference/parameters/imjournal-main.rst
@@ -1,0 +1,50 @@
+.. _param-imjournal-main:
+.. _imjournal.parameter.input.main:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:Main
+
+Main
+====
+
+.. index::
+   single: imjournal; Main
+   single: Main
+
+.. summary-start
+
+Runs the input's ruleset on the main thread and stops reading if outputs block.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: Main
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2312.0
+
+Description
+-----------
+When enabled, the input module executes its bound ruleset in the main thread and
+pauses ingestion if the output side cannot accept data. Only the first input with
+``Main="on"`` is treated as such; others run in background threads.
+
+Input usage
+-----------
+.. _param-imjournal-input-main:
+.. _imjournal.parameter.input.main-usage:
+.. code-block:: rsyslog
+
+   input(type="imjournal" Main="...")
+
+Notes
+-----
+- Earlier documentation misclassified this option; it is boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-persiststateinterval.rst
+++ b/doc/source/reference/parameters/imjournal-persiststateinterval.rst
@@ -1,0 +1,56 @@
+.. _param-imjournal-persiststateinterval:
+.. _imjournal.parameter.module.persiststateinterval:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:PersistStateInterval
+
+PersistStateInterval
+====================
+
+.. index::
+   single: imjournal; PersistStateInterval
+   single: PersistStateInterval
+
+.. summary-start
+
+Saves the journal cursor after every N messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: PersistStateInterval
+:Scope: module
+:Type: integer
+:Default: module=10
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Defines how often the module writes its position in the journal to the state file.
+The cursor is saved after each ``PersistStateInterval`` messages so rsyslog resumes
+from the last processed entry on restart.
+
+Module usage
+------------
+.. _param-imjournal-module-persiststateinterval:
+.. _imjournal.parameter.module.persiststateinterval-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" PersistStateInterval="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _imjournal.parameter.legacy.imjournalpersiststateinterval:
+
+- $imjournalPersistStateInterval — maps to PersistStateInterval (status: legacy)
+
+.. index::
+   single: imjournal; $imjournalPersistStateInterval
+   single: $imjournalPersistStateInterval
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/imjournal-ratelimit-burst.rst
@@ -1,0 +1,55 @@
+.. _param-imjournal-ratelimit-burst:
+.. _imjournal.parameter.module.ratelimit-burst:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:Ratelimit.Burst
+
+Ratelimit.Burst
+===============
+
+.. index::
+   single: imjournal; Ratelimit.Burst
+   single: Ratelimit.Burst
+
+.. summary-start
+
+Maximum messages accepted within each rate-limit window.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: Ratelimit.Burst
+:Scope: module
+:Type: integer
+:Default: module=20000
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Specifies how many messages are permitted during each ``Ratelimit.Interval``
+period. Messages beyond this threshold are discarded until the interval expires.
+
+Module usage
+------------
+.. _param-imjournal-module-ratelimit-burst:
+.. _imjournal.parameter.module.ratelimit-burst-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" Ratelimit.Burst="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _imjournal.parameter.legacy.imjournalratelimitburst:
+
+- $imjournalRatelimitBurst — maps to Ratelimit.Burst (status: legacy)
+
+.. index::
+   single: imjournal; $imjournalRatelimitBurst
+   single: $imjournalRatelimitBurst
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/imjournal-ratelimit-interval.rst
@@ -1,0 +1,60 @@
+.. _param-imjournal-ratelimit-interval:
+.. _imjournal.parameter.module.ratelimit-interval:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:Ratelimit.Interval
+
+Ratelimit.Interval
+==================
+
+.. index::
+   single: imjournal; Ratelimit.Interval
+   single: Ratelimit.Interval
+
+.. summary-start
+
+Time window in seconds for rate limiting; 0 disables the limit.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: Ratelimit.Interval
+:Scope: module
+:Type: integer
+:Default: module=600
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Defines the interval over which message rate limiting is applied. If more than
+``Ratelimit.Burst`` messages arrive during this interval, additional messages are
+silently discarded and a discard notice is emitted at the end of the interval.
+
+Module usage
+------------
+.. _param-imjournal-module-ratelimit-interval:
+.. _imjournal.parameter.module.ratelimit-interval-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" Ratelimit.Interval="...")
+
+Notes
+-----
+- Setting the value to ``0`` disables rate limiting and is generally not recommended.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _imjournal.parameter.legacy.imjournalratelimitinterval:
+
+- $imjournalRatelimitInterval — maps to Ratelimit.Interval (status: legacy)
+
+.. index::
+   single: imjournal; $imjournalRatelimitInterval
+   single: $imjournalRatelimitInterval
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-remote.rst
+++ b/doc/source/reference/parameters/imjournal-remote.rst
@@ -1,0 +1,49 @@
+.. _param-imjournal-remote:
+.. _imjournal.parameter.module.remote:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:Remote
+
+Remote
+======
+
+.. index::
+   single: imjournal; Remote
+   single: Remote
+
+.. summary-start
+
+Also read journal files from remote sources.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: Remote
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.1910.0
+
+Description
+-----------
+When enabled, the module processes not only local journal files but also those
+originating from remote systems stored on the host.
+
+Module usage
+------------
+.. _param-imjournal-module-remote:
+.. _imjournal.parameter.module.remote-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" Remote="...")
+
+Notes
+-----
+- Historic documentation called this a ``binary`` option; it is boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-statefile.rst
+++ b/doc/source/reference/parameters/imjournal-statefile.rst
@@ -1,0 +1,56 @@
+.. _param-imjournal-statefile:
+.. _imjournal.parameter.module.statefile:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:StateFile
+
+StateFile
+=========
+
+.. index::
+   single: imjournal; StateFile
+   single: StateFile
+
+.. summary-start
+
+Specifies path to the state file holding the journal cursor.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: StateFile
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Defines where the module stores its persistent position in the journal. A relative
+path is created inside rsyslog's working directory; an absolute path is used as
+is.
+
+Module usage
+------------
+.. _param-imjournal-module-statefile:
+.. _imjournal.parameter.module.statefile-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" StateFile="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _imjournal.parameter.legacy.imjournalstatefile:
+
+- $imjournalStateFile — maps to StateFile (status: legacy)
+
+.. index::
+   single: imjournal; $imjournalStateFile
+   single: $imjournalStateFile
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-usepid.rst
+++ b/doc/source/reference/parameters/imjournal-usepid.rst
@@ -1,0 +1,56 @@
+.. _param-imjournal-usepid:
+.. _imjournal.parameter.module.usepid:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:UsePid
+
+UsePid
+======
+
+.. index::
+   single: imjournal; UsePid
+   single: UsePid
+
+.. summary-start
+
+Selects which journal PID field to use: ``syslog``, ``system``, or ``both``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: UsePid
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=both
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Determines the journal field that supplies the process identifier.
+
+``syslog``
+    Use ``SYSLOG_PID``.
+``system``
+    Use ``_PID``.
+``both``
+    Try ``SYSLOG_PID`` first and fall back to ``_PID``. If neither is available,
+    the message is parsed without a PID.
+
+Module usage
+------------
+.. _param-imjournal-module-usepid:
+.. _imjournal.parameter.module.usepid-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" UsePid="...")
+
+Notes
+-----
+- Case-insensitive values are accepted.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-usepidfromsystem.rst
+++ b/doc/source/reference/parameters/imjournal-usepidfromsystem.rst
@@ -1,0 +1,51 @@
+.. _param-imjournal-usepidfromsystem:
+.. _imjournal.parameter.module.usepidfromsystem:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:UsePidFromSystem
+
+UsePidFromSystem
+================
+
+.. index::
+   single: imjournal; UsePidFromSystem
+   single: UsePidFromSystem
+
+.. summary-start
+
+Use ``_PID`` instead of ``SYSLOG_PID`` as the process identifier.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: UsePidFromSystem
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Retrieves the trusted ``_PID`` field from the journal instead of ``SYSLOG_PID``.
+This option overrides ``UsePid`` and is deprecated; use ``UsePid="system"``
+for equivalent behavior.
+
+Module usage
+------------
+.. _param-imjournal-module-usepidfromsystem:
+.. _imjournal.parameter.module.usepidfromsystem-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" UsePidFromSystem="...")
+
+Notes
+-----
+- Legacy documentation referred to this as a ``binary`` option.
+- Deprecated; prefer ``UsePid``.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.

--- a/doc/source/reference/parameters/imjournal-workaroundjournalbug.rst
+++ b/doc/source/reference/parameters/imjournal-workaroundjournalbug.rst
@@ -1,0 +1,50 @@
+.. _param-imjournal-workaroundjournalbug:
+.. _imjournal.parameter.module.workaroundjournalbug:
+
+.. meta::
+   :tag: module:imjournal
+   :tag: parameter:WorkAroundJournalBug
+
+WorkAroundJournalBug
+====================
+
+.. index::
+   single: imjournal; WorkAroundJournalBug
+   single: WorkAroundJournalBug
+
+.. summary-start
+
+Legacy flag with no current effect; retained for compatibility.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imjournal`.
+
+:Name: WorkAroundJournalBug
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: 8.37.0
+
+Description
+-----------
+Originally enabled a workaround for a journald bug. The option has had no effect
+since version 8.1910.0 and remains only for backward compatibility.
+
+Module usage
+------------
+.. _param-imjournal-module-workaroundjournalbug:
+.. _imjournal.parameter.module.workaroundjournalbug-usage:
+.. code-block:: rsyslog
+
+   module(load="imjournal" WorkAroundJournalBug="...")
+
+Notes
+-----
+- Historic documentation called this a ``binary`` option; it is boolean.
+- Deprecated; enabling or disabling changes nothing.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imjournal`.


### PR DESCRIPTION
## Summary
- split imjournal parameter documentation into individual reference pages
- replace module page parameters with summary table and hidden toctree

## Testing
- `./devtools/format-code.sh`
- `python3 -m sphinx -b html doc/source doc/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_689b740465b08332b66549f64efd9903