### PR TITLE
docs: split pmrfc3164 parameters into structured reference pages

### DIFF
--- a/doc/source/configuration/modules/pmrfc3164.rst
+++ b/doc/source/configuration/modules/pmrfc3164.rst
@@ -16,225 +16,77 @@ syslog standard :rfc:`3164`
 
 It is part of the default parser chain.
 
+.. note::
+   ``pmrfc3164`` is built into rsyslog and must not be loaded with
+   ``module(load="pmrfc3164")``. Configure parameters via the
+   ``parser`` directive.
+
 The parser can also be customized to allow the parsing of specific formats,
 if they occur.
-
 
 Configuration Parameters
 ========================
 
 .. note::
-
-   Parameter names are case-insensitive.
-
+   Parameter names are case-insensitive; CamelCase is recommended for readability.
 
 Parser Parameters
 -----------------
 
-permit.squareBracketsInHostname
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-This setting tells the parser that hostnames that are enclosed by brackets
-should omit the brackets.
-
-
-permit.slashesInHostname
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.20.0
-
-This setting tells the parser that hostnames may contain slashes. This
-is useful when messages e.g. from a syslog-ng relay chain are received.
-Syslog-ng puts the various relay hosts via slashes into the hostname
-field.
-
-
-permit.AtSignsInHostname
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.25.0
-
-This setting tells the parser that hostnames may contain at-signs. This
-is useful when messages are relayed from a syslog-ng server in rfc3164
-format. The hostname field sent by syslog-ng may be prefixed by the source
-name followed by an at-sign character.
-
-
-force.tagEndingByColon
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.25.0
-
-This setting tells the parser that tag need to be ending by colon to be
-valid.  In others case, the tag is set to dash ("-") without changing
-message.
-
-
-remove.msgFirstSpace
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.25.0
-
-Rfc3164 tell message is directly after tag including first white space.
-This option tell to remove the first white space in message just after
-reading. It make rfc3164 & rfc5424 syslog messages working in a better way.
-
-
-detect.YearAfterTimestamp
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Some devices send syslog messages in a format that is similar to RFC3164,
-but they also attach the year to the timestamp (which is not compliant to
-the RFC). With regular parsing, the year would be recognized to be the
-hostname and the hostname would become the syslogtag. This setting should
-prevent this. It is also limited to years between 2000 and 2099, so
-hostnames with numbers as their name can still be recognized correctly. But
-everything in this range will be detected as a year.
-
-
-detect.headerless
-^^^^^^^^^^^^^^^^^
-
-.. meta::
-   :tag: parameter:detect.headerless
-   :tag: category:advanced
-   :tag: keywords: pmrfc3164, syslog, headerless, detection
-
-Enables extended detection of messages that lack a standard syslog header.
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. note::
-   Messages beginning with ``{`` or ``[`` are treated as structured syslog
-   (e.g. JSON) and **not** classified as headerless.
-
-When set to ``on``, a message is classified as “headerless” only
-if **all** of the following are true:
-
-- It has **no** PRI header (facility/severity).
-- It does **not** start with an accepted timestamp.
-- It does **not** begin with whitespace followed by ``{`` or ``[``.
-
-Related Parameters
-------------------
-Other action parameters prefixed with ``headerless.`` can be used to further customize
-processing of messages identified as headerless (for example, writing them to an
-"error file").
-
-headerless.hostname
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "<ip-address of sender>", "no", "none"
-
-By default, rsyslog uses the IP address from the system it received the
-message from as a hostname replacement. This can be overridden by the
-hostname configured here.
-
-
-headerless.tag
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "headerless", "no", "none"
-
-Specifies the tag to assign to detected headerless messages.
-
-
-headerless.ruleset
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-If set, detected headerless messages are routed to the given ruleset for
-further processing (e.g. writing to a dedicated error log or discarding).
-
-headerless.errorfile
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-If specified, raw headerless input will be appended to this file before any
-further processing. The file is created if it does not yet exist.
-
-headerless.drop
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-When set to ``on``, headerless messages are discarded after optional logging to
-``headerless.errorfile`` and are not processed by subsequent rules.
-
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-pmrfc3164-permit-squarebracketsinhostname`
+     - .. include:: ../../reference/parameters/pmrfc3164-permit-squarebracketsinhostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-permit-slashesinhostname`
+     - .. include:: ../../reference/parameters/pmrfc3164-permit-slashesinhostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-permit-atsignsinhostname`
+     - .. include:: ../../reference/parameters/pmrfc3164-permit-atsignsinhostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-force-tagendingbycolon`
+     - .. include:: ../../reference/parameters/pmrfc3164-force-tagendingbycolon.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-remove-msgfirstspace`
+     - .. include:: ../../reference/parameters/pmrfc3164-remove-msgfirstspace.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-detect-yearaftertimestamp`
+     - .. include:: ../../reference/parameters/pmrfc3164-detect-yearaftertimestamp.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-detect-headerless`
+     - .. include:: ../../reference/parameters/pmrfc3164-detect-headerless.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-headerless-hostname`
+     - .. include:: ../../reference/parameters/pmrfc3164-headerless-hostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-headerless-tag`
+     - .. include:: ../../reference/parameters/pmrfc3164-headerless-tag.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-headerless-ruleset`
+     - .. include:: ../../reference/parameters/pmrfc3164-headerless-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-headerless-errorfile`
+     - .. include:: ../../reference/parameters/pmrfc3164-headerless-errorfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-pmrfc3164-headerless-drop`
+     - .. include:: ../../reference/parameters/pmrfc3164-headerless-drop.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 Signal Handling
 ===============
@@ -285,10 +137,27 @@ sections and parse them accordingly.
    input(type="imtcp" port="514" ruleset="customparser")
 
    parser(name="custom.rfc3164"
-   	 type="pmrfc3164"
-   	 permit.squareBracketsInHostname="on"
-   	 detect.YearAfterTimestamp="on")
+         type="pmrfc3164"
+         permit.squareBracketsInHostname="on"
+         detect.YearAfterTimestamp="on")
 
    ruleset(name="customparser" parser="custom.rfc3164") {
     ... do processing here...
    }
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/pmrfc3164-permit-squarebracketsinhostname.rst
+   ../../reference/parameters/pmrfc3164-permit-slashesinhostname.rst
+   ../../reference/parameters/pmrfc3164-permit-atsignsinhostname.rst
+   ../../reference/parameters/pmrfc3164-force-tagendingbycolon.rst
+   ../../reference/parameters/pmrfc3164-remove-msgfirstspace.rst
+   ../../reference/parameters/pmrfc3164-detect-yearaftertimestamp.rst
+   ../../reference/parameters/pmrfc3164-detect-headerless.rst
+   ../../reference/parameters/pmrfc3164-headerless-hostname.rst
+   ../../reference/parameters/pmrfc3164-headerless-tag.rst
+   ../../reference/parameters/pmrfc3164-headerless-ruleset.rst
+   ../../reference/parameters/pmrfc3164-headerless-errorfile.rst
+   ../../reference/parameters/pmrfc3164-headerless-drop.rst
+

--- a/doc/source/reference/parameters/pmrfc3164-detect-headerless.rst
+++ b/doc/source/reference/parameters/pmrfc3164-detect-headerless.rst
@@ -1,0 +1,52 @@
+.. _param-pmrfc3164-detect-headerless:
+.. _pmrfc3164.parameter.module.detect-headerless:
+.. _pmrfc3164.parameter.module.detect.headerless:
+
+detect.headerless
+=================
+
+.. index::
+   single: pmrfc3164; detect.headerless
+   single: detect.headerless
+
+.. summary-start
+
+Enable detection of messages lacking standard syslog headers.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: detect.headerless
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+When enabled, rsyslog applies extra heuristics to classify messages without a syslog header. A message is considered headerless only if:
+
+- It has no PRI header (facility/severity).
+- It does not start with an accepted timestamp.
+- It does not begin with whitespace followed by ``{`` or ``[``.
+
+Messages starting with ``{`` or ``[`` are treated as structured data (e.g., JSON) instead.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-detect-headerless:
+.. _pmrfc3164.parameter.module.detect-headerless-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" detect.headerless="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-detect-yearaftertimestamp.rst
+++ b/doc/source/reference/parameters/pmrfc3164-detect-yearaftertimestamp.rst
@@ -1,0 +1,46 @@
+.. _param-pmrfc3164-detect-yearaftertimestamp:
+.. _pmrfc3164.parameter.module.detect-yearaftertimestamp:
+.. _pmrfc3164.parameter.module.detect.YearAfterTimestamp:
+
+detect.YearAfterTimestamp
+=========================
+
+.. index::
+   single: pmrfc3164; detect.YearAfterTimestamp
+   single: detect.YearAfterTimestamp
+
+.. summary-start
+
+Treat a year following the timestamp as part of the timestamp instead of the hostname.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: detect.YearAfterTimestamp
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Some devices append the year directly after the timestamp, which would otherwise be parsed as the hostname. When enabled, years between 2000 and 2099 are treated as part of the timestamp.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-detect-yearaftertimestamp:
+.. _pmrfc3164.parameter.module.detect-yearaftertimestamp-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" detect.YearAfterTimestamp="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-force-tagendingbycolon.rst
+++ b/doc/source/reference/parameters/pmrfc3164-force-tagendingbycolon.rst
@@ -1,0 +1,46 @@
+.. _param-pmrfc3164-force-tagendingbycolon:
+.. _pmrfc3164.parameter.module.force-tagendingbycolon:
+.. _pmrfc3164.parameter.module.force.tagEndingByColon:
+
+force.tagEndingByColon
+======================
+
+.. index::
+   single: pmrfc3164; force.tagEndingByColon
+   single: force.tagEndingByColon
+
+.. summary-start
+
+Require tags to end with a colon or set the tag to ``-``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: force.tagEndingByColon
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+When enabled, tags must end with a colon to be valid. Otherwise the tag is replaced with ``-`` without modifying the message.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-force-tagendingbycolon:
+.. _pmrfc3164.parameter.module.force-tagendingbycolon-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" force.tagEndingByColon="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-headerless-drop.rst
+++ b/doc/source/reference/parameters/pmrfc3164-headerless-drop.rst
@@ -1,0 +1,46 @@
+.. _param-pmrfc3164-headerless-drop:
+.. _pmrfc3164.parameter.module.headerless-drop:
+.. _pmrfc3164.parameter.module.headerless.drop:
+
+headerless.drop
+===============
+
+.. index::
+   single: pmrfc3164; headerless.drop
+   single: headerless.drop
+
+.. summary-start
+
+Discard headerless messages after optional logging.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: headerless.drop
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+When enabled, headerless messages are discarded after optional logging to ``headerless.errorfile`` and are not processed by later rules.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-headerless-drop:
+.. _pmrfc3164.parameter.module.headerless-drop-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" headerless.drop="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-headerless-errorfile.rst
+++ b/doc/source/reference/parameters/pmrfc3164-headerless-errorfile.rst
@@ -1,0 +1,42 @@
+.. _param-pmrfc3164-headerless-errorfile:
+.. _pmrfc3164.parameter.module.headerless-errorfile:
+.. _pmrfc3164.parameter.module.headerless.errorfile:
+
+headerless.errorfile
+====================
+
+.. index::
+   single: pmrfc3164; headerless.errorfile
+   single: headerless.errorfile
+
+.. summary-start
+
+Append raw headerless input to a file before other processing.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: headerless.errorfile
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=none
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+If specified, raw headerless input is appended to this file before further processing. The file is created if it does not already exist.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-headerless-errorfile:
+.. _pmrfc3164.parameter.module.headerless-errorfile-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" headerless.errorfile="/var/log/rsyslog-headerless.log")
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-headerless-hostname.rst
+++ b/doc/source/reference/parameters/pmrfc3164-headerless-hostname.rst
@@ -1,0 +1,42 @@
+.. _param-pmrfc3164-headerless-hostname:
+.. _pmrfc3164.parameter.module.headerless-hostname:
+.. _pmrfc3164.parameter.module.headerless.hostname:
+
+headerless.hostname
+===================
+
+.. index::
+   single: pmrfc3164; headerless.hostname
+   single: headerless.hostname
+
+.. summary-start
+
+Override the hostname assigned to headerless messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: headerless.hostname
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=<ip-address of sender>
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+By default, rsyslog uses the sender's IP address as the hostname for headerless messages. Set this option to provide a different hostname.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-headerless-hostname:
+.. _pmrfc3164.parameter.module.headerless-hostname-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" headerless.hostname="example.local")
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-headerless-ruleset.rst
+++ b/doc/source/reference/parameters/pmrfc3164-headerless-ruleset.rst
@@ -1,0 +1,42 @@
+.. _param-pmrfc3164-headerless-ruleset:
+.. _pmrfc3164.parameter.module.headerless-ruleset:
+.. _pmrfc3164.parameter.module.headerless.ruleset:
+
+headerless.ruleset
+==================
+
+.. index::
+   single: pmrfc3164; headerless.ruleset
+   single: headerless.ruleset
+
+.. summary-start
+
+Route headerless messages to a specific ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: headerless.ruleset
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=none
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+If set, detected headerless messages are sent to the given ruleset for further processing, such as writing to a dedicated error log or discarding.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-headerless-ruleset:
+.. _pmrfc3164.parameter.module.headerless-ruleset-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" headerless.ruleset="errorhandler")
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-headerless-tag.rst
+++ b/doc/source/reference/parameters/pmrfc3164-headerless-tag.rst
@@ -1,0 +1,42 @@
+.. _param-pmrfc3164-headerless-tag:
+.. _pmrfc3164.parameter.module.headerless-tag:
+.. _pmrfc3164.parameter.module.headerless.tag:
+
+headerless.tag
+==============
+
+.. index::
+   single: pmrfc3164; headerless.tag
+   single: headerless.tag
+
+.. summary-start
+
+Set the tag used for headerless messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: headerless.tag
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=headerless
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+Specifies the tag to assign to detected headerless messages.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-headerless-tag:
+.. _pmrfc3164.parameter.module.headerless-tag-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" headerless.tag="missing")
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-permit-atsignsinhostname.rst
+++ b/doc/source/reference/parameters/pmrfc3164-permit-atsignsinhostname.rst
@@ -1,0 +1,46 @@
+.. _param-pmrfc3164-permit-atsignsinhostname:
+.. _pmrfc3164.parameter.module.permit-atsignsinhostname:
+.. _pmrfc3164.parameter.module.permit.AtSignsInHostname:
+
+permit.AtSignsInHostname
+=========================
+
+.. index::
+   single: pmrfc3164; permit.AtSignsInHostname
+   single: permit.AtSignsInHostname
+
+.. summary-start
+
+Allow ``@`` in hostnames, typically from syslog-ng relays.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: permit.AtSignsInHostname
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+This option allows hostnames to include at-sign characters, which is useful when syslog-ng relays prefix source names with ``@``.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-permit-atsignsinhostname:
+.. _pmrfc3164.parameter.module.permit-atsignsinhostname-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" permit.AtSignsInHostname="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-permit-slashesinhostname.rst
+++ b/doc/source/reference/parameters/pmrfc3164-permit-slashesinhostname.rst
@@ -1,0 +1,46 @@
+.. _param-pmrfc3164-permit-slashesinhostname:
+.. _pmrfc3164.parameter.module.permit-slashesinhostname:
+.. _pmrfc3164.parameter.module.permit.slashesInHostname:
+
+permit.slashesInHostname
+========================
+
+.. index::
+   single: pmrfc3164; permit.slashesInHostname
+   single: permit.slashesInHostname
+
+.. summary-start
+
+Allow ``/`` in hostnames, useful for syslog-ng relay chains.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: permit.slashesInHostname
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.20.0
+
+Description
+-----------
+This option allows hostnames to include slash characters.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-permit-slashesinhostname:
+.. _pmrfc3164.parameter.module.permit-slashesinhostname-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" permit.slashesInHostname="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-permit-squarebracketsinhostname.rst
+++ b/doc/source/reference/parameters/pmrfc3164-permit-squarebracketsinhostname.rst
@@ -1,0 +1,46 @@
+.. _param-pmrfc3164-permit-squarebracketsinhostname:
+.. _pmrfc3164.parameter.module.permit-squarebracketsinhostname:
+.. _pmrfc3164.parameter.module.permit.squareBracketsInHostname:
+
+permit.squareBracketsInHostname
+================================
+
+.. index::
+   single: pmrfc3164; permit.squareBracketsInHostname
+   single: permit.squareBracketsInHostname
+
+.. summary-start
+
+Accept hostnames enclosed in ``[]``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: permit.squareBracketsInHostname
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This option allows hostnames wrapped in square brackets to be parsed without the brackets.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-permit-squarebracketsinhostname:
+.. _pmrfc3164.parameter.module.permit-squarebracketsinhostname-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" permit.squareBracketsInHostname="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.

--- a/doc/source/reference/parameters/pmrfc3164-remove-msgfirstspace.rst
+++ b/doc/source/reference/parameters/pmrfc3164-remove-msgfirstspace.rst
@@ -1,0 +1,46 @@
+.. _param-pmrfc3164-remove-msgfirstspace:
+.. _pmrfc3164.parameter.module.remove-msgfirstspace:
+.. _pmrfc3164.parameter.module.remove.msgFirstSpace:
+
+remove.msgFirstSpace
+====================
+
+.. index::
+   single: pmrfc3164; remove.msgFirstSpace
+   single: remove.msgFirstSpace
+
+.. summary-start
+
+Remove the first space after the tag to improve RFC3164/RFC5424 interoperability.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/pmrfc3164`.
+
+:Name: remove.msgFirstSpace
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.2508.0
+
+Description
+-----------
+RFC3164 places a space after the tag. When enabled, this option removes that first space so RFC3164 and RFC5424 messages can mix more easily.
+
+Module usage
+------------
+
+.. _param-pmrfc3164-module-remove-msgfirstspace:
+.. _pmrfc3164.parameter.module.remove-msgfirstspace-usage:
+.. code-block:: rsyslog
+
+   parser(name="custom.rfc3164" type="pmrfc3164" remove.msgFirstSpace="on")
+
+Notes
+-----
+- Legacy docs referred to this as a ``binary`` option, which maps to a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/pmrfc3164`.


### PR DESCRIPTION
Refactored pmrfc3164.rst to move individual parameter descriptions into dedicated files under doc/source/reference/parameters/, one per parameter. Each new page contains:

- Consistent metadata (Name, Scope, Type, Default, Required?, Introduced)
- Concise summary blocks for inclusion in overview tables
- Corrected and clarified type info (boolean/string)
- Usage examples for parser configuration
- Legacy/alternate name mappings

pmrfc3164.rst now presents parameters via a list-table with :ref: links and inline summaries, plus a hidden toctree for the new reference pages.

This brings pmrfc3164 documentation in line with the structured parameter format used in other modules, improving maintainability, readability, and navigation.

No functional changes; documentation only.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
