### PR TITLE
docs: split omelasticsearch params into individual pages

### DIFF
--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -26,766 +26,205 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; CamelCase is recommended for readability.
 
+.. note::
+
+   This module supports action parameters, only.
 
 Action Parameters
 -----------------
-
-Server
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "none", "no", "none"
-
-An array of Elasticsearch servers in the specified format. If no scheme
-is specified, it will be chosen according to usehttps_. If no port is
-specified, serverport_ will be used. Defaults to "localhost".
-
-Requests to Elasticsearch will be load-balanced between all servers in
-round-robin fashion.
-
-.. code-block:: none
-
-  Examples:
-       server="localhost:9200"
-       server=["elasticsearch1", "elasticsearch2"]
-
-
-.. _serverport:
-
-Serverport
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "9200", "no", "none"
-
-Default HTTP port to use to connect to Elasticsearch if none is specified
-on a server_. Defaults to 9200
-
-
-.. _healthchecktimeout:
-
-HealthCheckTimeout
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "3500", "no", "none"
-
-Specifies the number of milliseconds to wait for a successful health check
-on a server_. Before trying to submit events to Elasticsearch, rsyslog will
-execute an *HTTP HEAD* to ``/_cat/health`` and expect an *HTTP OK* within
-this timeframe. Defaults to 3500.
-
-*Note, the health check is verifying connectivity only, not the state of
-the Elasticsearch cluster.*
-
-
-.. _esVersion_major:
-
-esVersion.major
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-ElasticSearch is notoriously bad at maintaining backwards compatibility. For this
-reason, the setting can be used to configure the server's major version number (e.g. 7, 8, ...).
-As far as we know breaking changes only happen with major version changes.
-As of now, only value 8 triggers API changes. All other values select
-pre-version-8 API usage.
-
-.. _searchIndex:
-
-searchIndex
-^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-`Elasticsearch
-index <http://www.elasticsearch.org/guide/appendix/glossary.html#index>`_
-to send your logs to. Defaults to "system"
-
-
-.. _dynSearchIndex:
-
-dynSearchIndex
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Whether the string provided for searchIndex_ should be taken as a
-`rsyslog template <http://www.rsyslog.com/doc/rsyslog_conf_templates.html>`_.
-Defaults to "off", which means the index name will be taken
-literally. Otherwise, it will look for a template with that name, and
-the resulting string will be the index name. For example, let's
-assume you define a template named "date-days" containing
-"%timereported:1:10:date-rfc3339%". Then, with dynSearchIndex="on",
-if you say searchIndex="date-days", each log will be sent to and
-index named after the first 10 characters of the timestamp, like
-"2013-03-22".
-
-
-.. _searchType:
-
-searchType
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-`Elasticsearch
-type <http://www.elasticsearch.org/guide/appendix/glossary.html#type>`_
-to send your index to. Defaults to "events".
-Setting this parameter to an empty string will cause the type to be omitted,
-which is required since Elasticsearch 7.0. See
-`Elasticsearch documentation <https://www.elastic.co/guide/en/elasticsearch/reference/current/removal-of-types.html>`_
-for more information.
-
-
-.. _dynSearchType:
-
-dynSearchType
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Like dynSearchIndex_, it allows you to specify a
-`rsyslog template <http://www.rsyslog.com/doc/rsyslog_conf_templates.html>`_
-for searchType_, instead of a static string.
-
-
-.. _pipelineName:
-
-pipelineName
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-The `ingest node <https://www.elastic.co/guide/en/elasticsearch/reference/current/ingest.html>`_
-pipeline name to be included in the request. This allows pre processing
-of events before indexing them. By default, events are not send to a pipeline.
-
-
-.. _dynPipelineName:
-
-dynPipelineName
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Like dynSearchIndex_, it allows you to specify a
-`rsyslog template <http://www.rsyslog.com/doc/rsyslog_conf_templates.html>`_
-for pipelineName_, instead of a static string.
-
-
-.. _skipPipelineIfEmpty:
-
-skipPipelineIfEmpty
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-When POST'ing a document, Elasticsearch does not allow an empty pipeline
-parameter value. If boolean option skipPipelineIfEmpty is set to `"on"`, the
-pipeline parameter won't be posted. Default is `"off"`.
-
-
-.. _asyncrepl:
-
-asyncrepl
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-No longer supported as ElasticSearch no longer supports it.
-
-
-.. _usehttps:
-
-usehttps
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Default scheme to use when sending events to Elasticsearch if none is
-specified on a  server_. Good for when you have
-Elasticsearch behind Apache or something else that can add HTTPS.
-Note that if you have a self-signed certificate, you'd need to install
-it first. This is done by copying the certificate to a trusted path
-and then running *update-ca-certificates*. That trusted path is
-typically */usr/local/share/ca-certificates* but check the man page of
-*update-ca-certificates* for the default path of your distro
-
-
-.. _timeout:
-
-timeout
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "1m", "no", "none"
-
-How long Elasticsearch will wait for a primary shard to be available
-for indexing your log before sending back an error. Defaults to "1m".
-
-
-.. _indextimeout:
-
-indexTimeout
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-.. versionadded:: 8.2204.0
-
-Specifies the number of milliseconds to wait for a successful log indexing
-request on a server_. By default there is no timeout.
-
-
-.. _template:
-
-template
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "see below", "no", "none"
-
-This is the JSON document that will be indexed in Elasticsearch. The
-resulting string needs to be a valid JSON, otherwise Elasticsearch
-will return an error. Defaults to:
-
-.. code-block:: none
-
-    $template StdJSONFmt, "{\"message\":\"%msg:::json%\",\"fromhost\":\"%HOSTNAME:::json%\",\"facility\":\"%syslogfacility-text%\",\"priority\":\"%syslogpriority-text%\",\"timereported\":\"%timereported:::date-rfc3339%\",\"timegenerated\":\"%timegenerated:::date-rfc3339%\"}"
-
-Which will produce this sort of documents (pretty-printed here for
-readability):
-
-.. code-block:: none
-
-    {
-        "message": " this is a test message",
-        "fromhost": "test-host",
-        "facility": "user",
-        "priority": "info",
-        "timereported": "2013-03-12T18:05:01.344864+02:00",
-        "timegenerated": "2013-03-12T18:05:01.344864+02:00"
-    }
-
-Another template, FullJSONFmt, is available that includes more fields including programname, PROCID (usually the process ID), and MSGID.
-
-.. _bulkmode:
-
-bulkmode
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-The default "off" setting means logs are shipped one by one. Each in
-its own HTTP request, using the `Index
-API <http://www.elasticsearch.org/guide/reference/api/index_.html>`_.
-Set it to "on" and it will use Elasticsearch's `Bulk
-API <http://www.elasticsearch.org/guide/reference/api/bulk.html>`_ to
-send multiple logs in the same request. The maximum number of logs
-sent in a single bulk request depends on your maxbytes_
-and queue settings -
-usually limited by the `dequeue batch
-size <http://www.rsyslog.com/doc/node35.html>`_. More information
-about queues can be found
-`here <http://www.rsyslog.com/doc/node32.html>`_.
-
-
-.. _maxbytes:
-
-maxbytes
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "100m", "no", "none"
-
-.. versionadded:: 8.23.0
-
-When shipping logs with bulkmode_ **on**, maxbytes specifies the maximum
-size of the request body sent to Elasticsearch. Logs are batched until
-either the buffer reaches maxbytes or the `dequeue batch
-size <http://www.rsyslog.com/doc/node35.html>`_ is reached. In order to
-ensure Elasticsearch does not reject requests due to content length, verify
-this value is set according to the `http.max_content_length
-<https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html>`_
-setting in Elasticsearch. Defaults to 100m.
-
-
-.. _parent:
-
-parent
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Specifying a string here will index your logs with that string the
-parent ID of those logs. Please note that you need to define the
-`parent
-field <http://www.elasticsearch.org/guide/reference/mapping/parent-field.html>`_
-in your
-`mapping <http://www.elasticsearch.org/guide/reference/mapping/>`_
-for that to work. By default, logs are indexed without a parent.
-
-
-.. _dynParent:
-
-dynParent
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Using the same parent for all the logs sent in the same action is
-quite unlikely. So you'd probably want to turn this "on" and specify
-a
-`rsyslog template <http://www.rsyslog.com/doc/rsyslog_conf_templates.html>`_
-that will provide meaningful parent IDs for your logs.
-
-
-.. _uid:
-
-uid
-^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-If you have basic HTTP authentication deployed (eg through the
-`elasticsearch-basic
-plugin <https://github.com/Asquera/elasticsearch-http-basic>`_), you
-can specify your user-name here.
-
-
-.. _pwd:
-
-pwd
-^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Password for basic authentication.
-
-
-.. _errorfile:
-
-errorFile
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-If specified, records failed in bulk mode are written to this file, including
-their error cause. Rsyslog itself does not process the file any more, but the
-idea behind that mechanism is that the user can create a script to periodically
-inspect the error file and react appropriately. As the complete request is
-included, it is possible to simply resubmit messages from that script.
-
-*Please note:* when rsyslog has problems connecting to elasticsearch, a general
-error is assumed and the submit is retried. However, if we receive negative
-responses during batch processing, we assume an error in the data itself
-(like a mandatory field is not filled in, a format error or something along
-those lines). Such errors cannot be solved by simply resubmitting the record.
-As such, they are written to the error file so that the user (script) can
-examine them and act appropriately. Note that e.g. after search index
-reconfiguration (e.g. dropping the mandatory attribute) a resubmit may
-be successful.
-
-.. _omelasticsearch-tls.cacert:
-
-tls.cacert
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-This is the full path and file name of the file containing the CA cert for the
-CA that issued the Elasticsearch server cert.  This file is in PEM format.  For
-example: `/etc/rsyslog.d/es-ca.crt`
-
-.. _tls.mycert:
-
-tls.mycert
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-This is the full path and file name of the file containing the client cert for
-doing client cert auth against Elasticsearch.  This file is in PEM format.  For
-example: `/etc/rsyslog.d/es-client-cert.pem`
-
-.. _tls.myprivkey:
-
-tls.myprivkey
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-This is the full path and file name of the file containing the private key
-corresponding to the cert `tls.mycert` used for doing client cert auth against
-Elasticsearch.  This file is in PEM format, and must be unencrypted, so take
-care to secure it properly.  For example: `/etc/rsyslog.d/es-client-key.pem`
-
-.. _omelasticsearch-allowunsignedcerts:
-
-allowunsignedcerts
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "boolean", "off", "no", "none"
-
-If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYPEER` option to
-`0`.  You are strongly discouraged to set this to `"on"`.  It is
-primarily useful only for debugging or testing.
-
-.. _omelasticsearch-skipverifyhost:
-
-skipverifyhost
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "boolean", "off", "no", "none"
-
-If `"on"`, this will set the curl `CURLOPT_SSL_VERIFYHOST` option to
-`0`.  You are strongly discouraged to set this to `"on"`.  It is
-primarily useful only for debugging or testing.
-
-.. _omelasticsearch-bulkid:
-
-bulkid
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-This is the unique id to assign to the record.  The `bulk` part is misleading - this
-can be used in both bulk mode :ref:`bulkmode` or in index
-(record at a time) mode.  Although you can specify a static value for this
-parameter, you will almost always want to specify a *template* for the value of
-this parameter, and set `dynbulkid="on"` :ref:`omelasticsearch-dynbulkid`.  NOTE:
-you must use `bulkid` and `dynbulkid` in order to use `writeoperation="create"`
-:ref:`omelasticsearch-writeoperation`.
-
-.. _omelasticsearch-dynbulkid:
-
-dynbulkid
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-If this parameter is set to `"on"`, then the `bulkid` parameter :ref:`omelasticsearch-bulkid`
-specifies a *template* to use to generate the unique id value to assign to the record.  If
-using `bulkid` you will almost always want to set this parameter to `"on"` to assign
-a different unique id value to each record.  NOTE:
-you must use `bulkid` and `dynbulkid` in order to use `writeoperation="create"`
-:ref:`omelasticsearch-writeoperation`.
-
-.. _omelasticsearch-writeoperation:
-
-writeoperation
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "index", "no", "none"
-
-The value of this parameter is either `"index"` (the default) or `"create"`.  If `"create"` is
-used, this means the bulk action/operation will be `create` - create a document only if the
-document does not already exist.  The record must have a unique id in order to use `create`.
-See :ref:`omelasticsearch-bulkid` and :ref:`omelasticsearch-dynbulkid`.  See
-:ref:`omelasticsearch-writeoperation-example` for an example.
-
-.. _omelasticsearch-retryfailures:
-
-retryfailures
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-If this parameter is set to `"on"`, then the module will look for an
-`"errors":true` in the bulk index response.  If found, each element in the
-response will be parsed to look for errors, since a bulk request may have some
-records which are successful and some which are failures.  Failed requests will
-be converted back into records and resubmitted back to rsyslog for
-reprocessing.  Each failed request will be resubmitted with a local variable
-called `$.omes`.  This is a hash consisting of the fields from the metadata
-header in the original request, and the fields from the response.  If the same
-field is in the request and response, the value from the field in the *request*
-will be used, to facilitate retries that want to send the exact same request,
-and want to know exactly what was sent.
-See below :ref:`omelasticsearch-retry-example` for an example of how retry
-processing works.
-*NOTE* The retried record will be resubmitted at the "top" of your processing
-pipeline.  If your processing pipeline is not idempotent (that is, your
-processing pipeline expects "raw" records), then you can specify a ruleset to
-redirect retries to.  See :ref:`omelasticsearch-retryruleset` below.
-
-`$.omes` fields:
-
-* writeoperation - the operation used to submit the request - for rsyslog
-  omelasticsearch this currently means either `"index"` or `"create"`
-* status - the HTTP status code - typically an error will have a `4xx` or `5xx`
-  code - of particular note is `429` - this means Elasticsearch was unable to
-  process this bulk record request due to a temporary condition e.g. the bulk
-  index thread pool queue is full, and rsyslog should retry the operation.
-* _index, _type, _id, pipeline, _parent - the metadata associated with the
-  request - not all of these fields will be present with every request - for
-  example, if you do not use `"pipelinename"` or `"dynpipelinename"`, there
-  will be no `$.omes!pipeline` field.
-* error - a hash containing one or more, possibly nested, fields containing
-  more detailed information about a failure.  Typically there will be fields
-  `$.omes!error!type` (a keyword) and `$.omes!error!reason` (a longer string)
-  with more detailed information about the rejection.  NOTE: The format is
-  apparently not described in great detail, so code must not make any
-  assumption about the availability of `error` or any specific sub-field.
-
-There may be other fields too - the code just copies everything in the
-response.  Here is an example of a detailed error response, in JSON format, from
-Elasticsearch 5.6.9:
-
-.. code-block:: json
-
-    {"omes":
-      {"writeoperation": "create",
-       "_index": "rsyslog_testbench",
-       "_type": "test-type",
-       "_id": "92BE7AF79CD44305914C7658AF846A08",
-       "status": 400,
-       "error":
-         {"type": "mapper_parsing_exception",
-          "reason": "failed to parse [msgnum]",
-          "caused_by":
-            {"type": "number_format_exception",
-             "reason": "For input string: \"x00000025\""}}}}
-
-Reference: https://www.elastic.co/guide/en/elasticsearch/guide/current/bulk.html#bulk
-
-.. _omelasticsearch-retryruleset:
-
-retryruleset
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "", "no", "none"
-
-If `retryfailures` is not `"on"` (:ref:`omelasticsearch-retryfailures`) then
-this parameter has no effect.  This parameter specifies the name of a ruleset
-to use to route retries.  This is useful if you do not want retried messages to
-be processed starting from the top of your processing pipeline, or if you have
-multiple outputs but do not want to send retried Elasticsearch failures to all
-of your outputs, and you do not want to clutter your processing pipeline with a
-lot of conditionals.  See below :ref:`omelasticsearch-retry-example` for an
-example of how retry processing works.
-
-.. _omelasticsearch-ratelimit.interval:
-
-ratelimit.interval
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "600", "no", "none"
-
-If `retryfailures` is not `"on"` (:ref:`omelasticsearch-retryfailures`) then
-this parameter has no effect.  Specifies the interval in seconds onto which
-rate-limiting is to be applied. If more than ratelimit.burst messages are read
-during that interval, further messages up to the end of the interval are
-discarded. The number of messages discarded is emitted at the end of the
-interval (if there were any discards).
-Setting this to value zero turns off ratelimiting.
-
-.. _omelasticsearch-ratelimit.burst:
-
-ratelimit.burst
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "20000", "no", "none"
-
-If `retryfailures` is not `"on"` (:ref:`omelasticsearch-retryfailures`) then
-this parameter has no effect.  Specifies the maximum number of messages that
-can be emitted within the ratelimit.interval interval. For further information,
-see description there.
-
-.. _omelasticsearch-rebindinterval:
-
-rebindinterval
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "-1", "no", "none"
-
-This parameter tells omelasticsearch to close the connection and reconnect
-to Elasticsearch after this many operations have been submitted.  The default
-value `-1` means that omelasticsearch will not reconnect.  A value greater
-than `-1` tells omelasticsearch, after this many operations have been
-submitted to Elasticsearch, to drop the connection and establish a new
-connection.  This is useful when rsyslog connects to multiple Elasticsearch
-nodes through a router or load balancer, and you need to periodically drop
-and reestablish connections to help the router balance the connections.  Use
-the counter `rebinds` to monitor the number of times this has happened.
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-omelasticsearch-server`
+     - .. include:: ../../reference/parameters/omelasticsearch-server.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-serverport`
+     - .. include:: ../../reference/parameters/omelasticsearch-serverport.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-healthchecktimeout`
+     - .. include:: ../../reference/parameters/omelasticsearch-healthchecktimeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-esversion-major`
+     - .. include:: ../../reference/parameters/omelasticsearch-esversion-major.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-searchindex`
+     - .. include:: ../../reference/parameters/omelasticsearch-searchindex.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-dynsearchindex`
+     - .. include:: ../../reference/parameters/omelasticsearch-dynsearchindex.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-searchtype`
+     - .. include:: ../../reference/parameters/omelasticsearch-searchtype.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-dynsearchtype`
+     - .. include:: ../../reference/parameters/omelasticsearch-dynsearchtype.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-pipelinename`
+     - .. include:: ../../reference/parameters/omelasticsearch-pipelinename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-dynpipelinename`
+     - .. include:: ../../reference/parameters/omelasticsearch-dynpipelinename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-skippipelineifempty`
+     - .. include:: ../../reference/parameters/omelasticsearch-skippipelineifempty.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-asyncrepl`
+     - .. include:: ../../reference/parameters/omelasticsearch-asyncrepl.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-usehttps`
+     - .. include:: ../../reference/parameters/omelasticsearch-usehttps.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-timeout`
+     - .. include:: ../../reference/parameters/omelasticsearch-timeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-indextimeout`
+     - .. include:: ../../reference/parameters/omelasticsearch-indextimeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-template`
+     - .. include:: ../../reference/parameters/omelasticsearch-template.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-bulkmode`
+     - .. include:: ../../reference/parameters/omelasticsearch-bulkmode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-maxbytes`
+     - .. include:: ../../reference/parameters/omelasticsearch-maxbytes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-parent`
+     - .. include:: ../../reference/parameters/omelasticsearch-parent.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-dynparent`
+     - .. include:: ../../reference/parameters/omelasticsearch-dynparent.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-uid`
+     - .. include:: ../../reference/parameters/omelasticsearch-uid.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-pwd`
+     - .. include:: ../../reference/parameters/omelasticsearch-pwd.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-errorfile`
+     - .. include:: ../../reference/parameters/omelasticsearch-errorfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-tls-cacert`
+     - .. include:: ../../reference/parameters/omelasticsearch-tls-cacert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-tls-mycert`
+     - .. include:: ../../reference/parameters/omelasticsearch-tls-mycert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-tls-myprivkey`
+     - .. include:: ../../reference/parameters/omelasticsearch-tls-myprivkey.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-allowunsignedcerts`
+     - .. include:: ../../reference/parameters/omelasticsearch-allowunsignedcerts.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-skipverifyhost`
+     - .. include:: ../../reference/parameters/omelasticsearch-skipverifyhost.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-bulkid`
+     - .. include:: ../../reference/parameters/omelasticsearch-bulkid.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-dynbulkid`
+     - .. include:: ../../reference/parameters/omelasticsearch-dynbulkid.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-writeoperation`
+     - .. include:: ../../reference/parameters/omelasticsearch-writeoperation.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-retryfailures`
+     - .. include:: ../../reference/parameters/omelasticsearch-retryfailures.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-retryruleset`
+     - .. include:: ../../reference/parameters/omelasticsearch-retryruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-ratelimit-interval`
+     - .. include:: ../../reference/parameters/omelasticsearch-ratelimit-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-ratelimit-burst`
+     - .. include:: ../../reference/parameters/omelasticsearch-ratelimit-burst.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-rebindinterval`
+     - .. include:: ../../reference/parameters/omelasticsearch-rebindinterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/omelasticsearch-server
+   ../../reference/parameters/omelasticsearch-serverport
+   ../../reference/parameters/omelasticsearch-healthchecktimeout
+   ../../reference/parameters/omelasticsearch-esversion-major
+   ../../reference/parameters/omelasticsearch-searchindex
+   ../../reference/parameters/omelasticsearch-dynsearchindex
+   ../../reference/parameters/omelasticsearch-searchtype
+   ../../reference/parameters/omelasticsearch-dynsearchtype
+   ../../reference/parameters/omelasticsearch-pipelinename
+   ../../reference/parameters/omelasticsearch-dynpipelinename
+   ../../reference/parameters/omelasticsearch-skippipelineifempty
+   ../../reference/parameters/omelasticsearch-asyncrepl
+   ../../reference/parameters/omelasticsearch-usehttps
+   ../../reference/parameters/omelasticsearch-timeout
+   ../../reference/parameters/omelasticsearch-indextimeout
+   ../../reference/parameters/omelasticsearch-template
+   ../../reference/parameters/omelasticsearch-bulkmode
+   ../../reference/parameters/omelasticsearch-maxbytes
+   ../../reference/parameters/omelasticsearch-parent
+   ../../reference/parameters/omelasticsearch-dynparent
+   ../../reference/parameters/omelasticsearch-uid
+   ../../reference/parameters/omelasticsearch-pwd
+   ../../reference/parameters/omelasticsearch-errorfile
+   ../../reference/parameters/omelasticsearch-tls-cacert
+   ../../reference/parameters/omelasticsearch-tls-mycert
+   ../../reference/parameters/omelasticsearch-tls-myprivkey
+   ../../reference/parameters/omelasticsearch-allowunsignedcerts
+   ../../reference/parameters/omelasticsearch-skipverifyhost
+   ../../reference/parameters/omelasticsearch-bulkid
+   ../../reference/parameters/omelasticsearch-dynbulkid
+   ../../reference/parameters/omelasticsearch-writeoperation
+   ../../reference/parameters/omelasticsearch-retryfailures
+   ../../reference/parameters/omelasticsearch-retryruleset
+   ../../reference/parameters/omelasticsearch-ratelimit-interval
+   ../../reference/parameters/omelasticsearch-ratelimit-burst
+   ../../reference/parameters/omelasticsearch-rebindinterval
 
 .. _omelasticsearch-statistic-counter:
 
@@ -860,7 +299,7 @@ equivalent to "failed.http".
 How Retries Are Handled
 =======================
 
-When using `retryfailures="on"` (:ref:`omelasticsearch-retryfailures`), the
+When using `retryfailures="on"` (:ref:`param-omelasticsearch-retryfailures`), the
 original `Message` object (that is, the original `smsg_t *msg` object) **is not
 available**.  This means none of the metadata associated with that object, such
 as various timestamps, hosts/ip addresses, etc. are not available for the retry
@@ -939,7 +378,7 @@ The following sample does the following:
 .. code-block:: none
 
     module(load="omelasticsearch")
-    *.*     action(type="omelasticsearch")
+    action(type="omelasticsearch")
 
 
 Example 2
@@ -953,7 +392,7 @@ The following sample does the following:
 .. code-block:: none
 
     module(load="omelasticsearch")
-    *.*     action(type="omelasticsearch" template="FullJSONFmt")
+    action(type="omelasticsearch" template="FullJSONFmt")
 
 
 Example 3
@@ -1019,8 +458,8 @@ The following sample does the following:
 Example 4
 ---------
 
-The following sample shows how to use :ref:`omelasticsearch-writeoperation`
-with :ref:`omelasticsearch-dynbulkid` and :ref:`omelasticsearch-bulkid`.  For
+The following sample shows how to use :ref:`param-omelasticsearch-writeoperation`
+with :ref:`param-omelasticsearch-dynbulkid` and :ref:`param-omelasticsearch-bulkid`.  For
 simplicity, it assumes rsyslog has been built with `--enable-libuuid` which
 provides the `uuid` property for each record:
 
@@ -1042,7 +481,7 @@ provides the `uuid` property for each record:
 Example 5
 ---------
 
-The following sample shows how to use :ref:`omelasticsearch-retryfailures` to
+The following sample shows how to use :ref:`param-omelasticsearch-retryfailures` to
 process, discard, or retry failed operations.  This uses
 `writeoperation="create"` with a unique `bulkid` so that we can check for and
 discard duplicate messages as successful.  The `try_es` ruleset is used both

--- a/doc/source/reference/parameters/omelasticsearch-allowunsignedcerts.rst
+++ b/doc/source/reference/parameters/omelasticsearch-allowunsignedcerts.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-allowunsignedcerts:
+.. _omelasticsearch.parameter.module.allowunsignedcerts:
+
+allowunsignedcerts
+==================
+
+.. index::
+   single: omelasticsearch; allowunsignedcerts
+   single: allowunsignedcerts
+
+.. summary-start
+
+Disable TLS peer verification (insecure, for testing only).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: allowunsignedcerts
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Sets the curl `CURLOPT_SSL_VERIFYPEER` option to `0`. Strongly discouraged outside of testing.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-allowunsignedcerts:
+.. _omelasticsearch.parameter.action.allowunsignedcerts:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" allowunsignedcerts="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-asyncrepl.rst
+++ b/doc/source/reference/parameters/omelasticsearch-asyncrepl.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-asyncrepl:
+.. _omelasticsearch.parameter.module.asyncrepl:
+
+asyncrepl
+=========
+
+.. index::
+   single: omelasticsearch; asyncrepl
+   single: asyncrepl
+
+.. summary-start
+
+Deprecated option formerly enabling asynchronous replication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: asyncrepl
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Kept for compatibility; Elasticsearch removed support for asynchronous replication so this setting has no effect.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-asyncrepl:
+.. _omelasticsearch.parameter.action.asyncrepl:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" asyncrepl="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-bulkid.rst
+++ b/doc/source/reference/parameters/omelasticsearch-bulkid.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-bulkid:
+.. _omelasticsearch.parameter.module.bulkid:
+
+bulkid
+======
+
+.. index::
+   single: omelasticsearch; bulkid
+   single: bulkid
+
+.. summary-start
+
+Unique identifier assigned to each record.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: bulkid
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Specifies a static value or template used as the document `_id`. Required with `writeoperation="create"`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-bulkid:
+.. _omelasticsearch.parameter.action.bulkid:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" bulkid="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-bulkmode.rst
+++ b/doc/source/reference/parameters/omelasticsearch-bulkmode.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-bulkmode:
+.. _omelasticsearch.parameter.module.bulkmode:
+
+bulkmode
+========
+
+.. index::
+   single: omelasticsearch; bulkmode
+   single: bulkmode
+
+.. summary-start
+
+Use the Elasticsearch Bulk API to send batched events.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: bulkmode
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+If enabled, events are buffered and sent in bulk requests. Without it, each event is sent individually.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-bulkmode:
+.. _omelasticsearch.parameter.action.bulkmode:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" bulkmode="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-dynbulkid.rst
+++ b/doc/source/reference/parameters/omelasticsearch-dynbulkid.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-dynbulkid:
+.. _omelasticsearch.parameter.module.dynbulkid:
+
+dynbulkid
+=========
+
+.. index::
+   single: omelasticsearch; dynbulkid
+   single: dynbulkid
+
+.. summary-start
+
+Treat `bulkid` as a template that generates per-record IDs.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: dynbulkid
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Enables interpreting `bulkid` as a template, producing a unique identifier for each record.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-dynbulkid:
+.. _omelasticsearch.parameter.action.dynbulkid:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" dynbulkid="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-dynparent.rst
+++ b/doc/source/reference/parameters/omelasticsearch-dynparent.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-dynparent:
+.. _omelasticsearch.parameter.module.dynparent:
+
+dynParent
+=========
+
+.. index::
+   single: omelasticsearch; dynParent
+   single: dynParent
+
+.. summary-start
+
+Treat `parent` as a template for per-record parent IDs.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: dynParent
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When enabled, `parent` names a template that produces the parent ID for each record.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-dynparent:
+.. _omelasticsearch.parameter.action.dynparent:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" dynParent="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-dynpipelinename.rst
+++ b/doc/source/reference/parameters/omelasticsearch-dynpipelinename.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-dynpipelinename:
+.. _omelasticsearch.parameter.module.dynpipelinename:
+
+dynPipelineName
+===============
+
+.. index::
+   single: omelasticsearch; dynPipelineName
+   single: dynPipelineName
+
+.. summary-start
+
+Treat `pipelineName` as a template name.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: dynPipelineName
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+If enabled, the value of `pipelineName` is taken as a template whose result selects the pipeline.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-dynpipelinename:
+.. _omelasticsearch.parameter.action.dynpipelinename:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" dynPipelineName="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-dynsearchindex.rst
+++ b/doc/source/reference/parameters/omelasticsearch-dynsearchindex.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-dynsearchindex:
+.. _omelasticsearch.parameter.module.dynsearchindex:
+
+dynSearchIndex
+==============
+
+.. index::
+   single: omelasticsearch; dynSearchIndex
+   single: dynSearchIndex
+
+.. summary-start
+
+Treat `searchIndex` as a template name instead of a literal.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: dynSearchIndex
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+If enabled, the value of `searchIndex` is interpreted as the name of a template whose expansion becomes the index name.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-dynsearchindex:
+.. _omelasticsearch.parameter.action.dynsearchindex:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" dynSearchIndex="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-dynsearchtype.rst
+++ b/doc/source/reference/parameters/omelasticsearch-dynsearchtype.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-dynsearchtype:
+.. _omelasticsearch.parameter.module.dynsearchtype:
+
+dynSearchType
+=============
+
+.. index::
+   single: omelasticsearch; dynSearchType
+   single: dynSearchType
+
+.. summary-start
+
+Treat `searchType` as a template name.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: dynSearchType
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When enabled, `searchType` references a template whose expansion becomes the type.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-dynsearchtype:
+.. _omelasticsearch.parameter.action.dynsearchtype:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" dynSearchType="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-errorfile.rst
+++ b/doc/source/reference/parameters/omelasticsearch-errorfile.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-errorfile:
+.. _omelasticsearch.parameter.module.errorfile:
+
+errorFile
+=========
+
+.. index::
+   single: omelasticsearch; errorFile
+   single: errorFile
+
+.. summary-start
+
+File that receives records rejected during bulk mode.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: errorFile
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Failed bulk records are appended to this file with error details for later inspection or resubmission.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-errorfile:
+.. _omelasticsearch.parameter.action.errorfile:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" errorFile="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-esversion-major.rst
+++ b/doc/source/reference/parameters/omelasticsearch-esversion-major.rst
@@ -1,0 +1,41 @@
+.. _param-omelasticsearch-esversion-major:
+.. _omelasticsearch.parameter.module.esversion-major:
+.. _omelasticsearch.parameter.module.esVersion.major:
+
+esVersion.major
+===============
+
+.. index::
+   single: omelasticsearch; esVersion.major
+   single: esVersion.major
+
+.. summary-start
+
+Elasticsearch major version used to select compatible APIs.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: esVersion.major
+:Scope: action
+:Type: integer
+:Default: action=0
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Value indicates the Elasticsearch major version (e.g. 7 or 8) and guides which API variant is used. Only value 8 currently changes behaviour.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-esversion-major:
+.. _omelasticsearch.parameter.action.esversion-major:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" esVersion.major="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-healthchecktimeout.rst
+++ b/doc/source/reference/parameters/omelasticsearch-healthchecktimeout.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-healthchecktimeout:
+.. _omelasticsearch.parameter.module.healthchecktimeout:
+
+HealthCheckTimeout
+==================
+
+.. index::
+   single: omelasticsearch; HealthCheckTimeout
+   single: HealthCheckTimeout
+
+.. summary-start
+
+Milliseconds to wait for an HTTP health check before sending events.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: HealthCheckTimeout
+:Scope: action
+:Type: integer
+:Default: action=3500
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Before logging begins, rsyslog issues an HTTP HEAD to `/_cat/health` and waits up to this many milliseconds for `HTTP OK`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-healthchecktimeout:
+.. _omelasticsearch.parameter.action.healthchecktimeout:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" HealthCheckTimeout="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-indextimeout.rst
+++ b/doc/source/reference/parameters/omelasticsearch-indextimeout.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-indextimeout:
+.. _omelasticsearch.parameter.module.indextimeout:
+
+indexTimeout
+============
+
+.. index::
+   single: omelasticsearch; indexTimeout
+   single: indexTimeout
+
+.. summary-start
+
+Milliseconds to wait for an indexing request to complete.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: indexTimeout
+:Scope: action
+:Type: integer
+:Default: action=0
+:Required?: no
+:Introduced: 8.2204.0
+
+Description
+-----------
+Sets the client-side timeout for a log indexing request. `0` means no timeout.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-indextimeout:
+.. _omelasticsearch.parameter.action.indextimeout:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" indexTimeout="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-maxbytes.rst
+++ b/doc/source/reference/parameters/omelasticsearch-maxbytes.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-maxbytes:
+.. _omelasticsearch.parameter.module.maxbytes:
+
+maxbytes
+========
+
+.. index::
+   single: omelasticsearch; maxbytes
+   single: maxbytes
+
+.. summary-start
+
+Maximum size of a bulk request body when bulkmode is enabled.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: maxbytes
+:Scope: action
+:Type: word
+:Default: action=100m
+:Required?: no
+:Introduced: 8.23.0
+
+Description
+-----------
+Events are batched until this size or the dequeue batch size is reached. Set to match Elasticsearch `http.max_content_length`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-maxbytes:
+.. _omelasticsearch.parameter.action.maxbytes:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" maxbytes="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-parent.rst
+++ b/doc/source/reference/parameters/omelasticsearch-parent.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-parent:
+.. _omelasticsearch.parameter.module.parent:
+
+parent
+======
+
+.. index::
+   single: omelasticsearch; parent
+   single: parent
+
+.. summary-start
+
+Parent document ID assigned to indexed events.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: parent
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Adds a parent ID to each record. The mapping must define a corresponding parent field.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-parent:
+.. _omelasticsearch.parameter.action.parent:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" parent="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-pipelinename.rst
+++ b/doc/source/reference/parameters/omelasticsearch-pipelinename.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-pipelinename:
+.. _omelasticsearch.parameter.module.pipelinename:
+
+pipelineName
+============
+
+.. index::
+   single: omelasticsearch; pipelineName
+   single: pipelineName
+
+.. summary-start
+
+Ingest pipeline to run before indexing.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: pipelineName
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Adds an ingest pipeline name to the request so events are pre-processed before indexing. By default no pipeline is used.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-pipelinename:
+.. _omelasticsearch.parameter.action.pipelinename:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" pipelineName="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-pwd.rst
+++ b/doc/source/reference/parameters/omelasticsearch-pwd.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-pwd:
+.. _omelasticsearch.parameter.module.pwd:
+
+pwd
+===
+
+.. index::
+   single: omelasticsearch; pwd
+   single: pwd
+
+.. summary-start
+
+Password for basic HTTP authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: pwd
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Supplies the password when Elasticsearch requires basic authentication.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-pwd:
+.. _omelasticsearch.parameter.action.pwd:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" pwd="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/omelasticsearch-ratelimit-burst.rst
@@ -1,0 +1,41 @@
+.. _param-omelasticsearch-ratelimit-burst:
+.. _omelasticsearch.parameter.module.ratelimit-burst:
+.. _omelasticsearch.parameter.module.ratelimit.burst:
+
+ratelimit.burst
+===============
+
+.. index::
+   single: omelasticsearch; ratelimit.burst
+   single: ratelimit.burst
+
+.. summary-start
+
+Maximum messages allowed in a rate-limit interval.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: ratelimit.burst
+:Scope: action
+:Type: integer
+:Default: action=20000
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Specifies the burst size permitted within `ratelimit.interval` when retry limiting is active.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-ratelimit-burst:
+.. _omelasticsearch.parameter.action.ratelimit-burst:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" ratelimit.burst="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/omelasticsearch-ratelimit-interval.rst
@@ -1,0 +1,41 @@
+.. _param-omelasticsearch-ratelimit-interval:
+.. _omelasticsearch.parameter.module.ratelimit-interval:
+.. _omelasticsearch.parameter.module.ratelimit.interval:
+
+ratelimit.interval
+==================
+
+.. index::
+   single: omelasticsearch; ratelimit.interval
+   single: ratelimit.interval
+
+.. summary-start
+
+Seconds over which retry rate limiting is calculated.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: ratelimit.interval
+:Scope: action
+:Type: integer
+:Default: action=600
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Defines the interval for rate limiting when `retryfailures` is enabled. Set to `0` to disable.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-ratelimit-interval:
+.. _omelasticsearch.parameter.action.ratelimit-interval:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" ratelimit.interval="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-rebindinterval.rst
+++ b/doc/source/reference/parameters/omelasticsearch-rebindinterval.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-rebindinterval:
+.. _omelasticsearch.parameter.module.rebindinterval:
+
+rebindinterval
+==============
+
+.. index::
+   single: omelasticsearch; rebindinterval
+   single: rebindinterval
+
+.. summary-start
+
+Operations after which to reconnect; `-1` disables periodic reconnect.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: rebindinterval
+:Scope: action
+:Type: integer
+:Default: action=-1
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+After this many operations the module drops and re-establishes the connection. Useful behind load balancers.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-rebindinterval:
+.. _omelasticsearch.parameter.action.rebindinterval:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" rebindinterval="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-retryfailures.rst
+++ b/doc/source/reference/parameters/omelasticsearch-retryfailures.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-retryfailures:
+.. _omelasticsearch.parameter.module.retryfailures:
+
+retryfailures
+=============
+
+.. index::
+   single: omelasticsearch; retryfailures
+   single: retryfailures
+
+.. summary-start
+
+Resubmit failed bulk items back into rsyslog for retry.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: retryfailures
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When enabled, bulk responses are scanned for errors and failed entries are resubmitted with metadata under `$.omes`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-retryfailures:
+.. _omelasticsearch.parameter.action.retryfailures:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" retryfailures="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-retryruleset.rst
+++ b/doc/source/reference/parameters/omelasticsearch-retryruleset.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-retryruleset:
+.. _omelasticsearch.parameter.module.retryruleset:
+
+retryruleset
+============
+
+.. index::
+   single: omelasticsearch; retryruleset
+   single: retryruleset
+
+.. summary-start
+
+Ruleset used when processing retried records.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: retryruleset
+:Scope: action
+:Type: word
+:Default: none (unset)
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Names a ruleset to handle records requeued by `retryfailures`. If unset, retries start at the default ruleset.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-retryruleset:
+.. _omelasticsearch.parameter.action.retryruleset:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" retryruleset="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-searchindex.rst
+++ b/doc/source/reference/parameters/omelasticsearch-searchindex.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-searchindex:
+.. _omelasticsearch.parameter.module.searchindex:
+
+searchIndex
+===========
+
+.. index::
+   single: omelasticsearch; searchIndex
+   single: searchIndex
+
+.. summary-start
+
+Elasticsearch index where events are written.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: searchIndex
+:Scope: action
+:Type: word
+:Default: action=system
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Name of the target Elasticsearch index. When unset it defaults to `system`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-searchindex:
+.. _omelasticsearch.parameter.action.searchindex:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" searchIndex="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-searchtype.rst
+++ b/doc/source/reference/parameters/omelasticsearch-searchtype.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-searchtype:
+.. _omelasticsearch.parameter.module.searchtype:
+
+searchType
+==========
+
+.. index::
+   single: omelasticsearch; searchType
+   single: searchType
+
+.. summary-start
+
+Elasticsearch type to use; empty string omits the type.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: searchType
+:Scope: action
+:Type: word
+:Default: action=events
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Specifies the document type. Set to an empty string to omit the type which is required for Elasticsearch 7 and later.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-searchtype:
+.. _omelasticsearch.parameter.action.searchtype:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" searchType="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-server.rst
+++ b/doc/source/reference/parameters/omelasticsearch-server.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-server:
+.. _omelasticsearch.parameter.module.server:
+
+Server
+======
+
+.. index::
+   single: omelasticsearch; Server
+   single: Server
+
+.. summary-start
+
+List of Elasticsearch servers to send events to.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: Server
+:Scope: action
+:Type: array[string]
+:Default: action=localhost
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Defines one or more Elasticsearch servers. If no scheme is given, it is chosen based on `usehttps`. Missing ports use `serverport`. Requests are load-balanced in round-robin order.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-server:
+.. _omelasticsearch.parameter.action.server:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" Server="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-serverport.rst
+++ b/doc/source/reference/parameters/omelasticsearch-serverport.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-serverport:
+.. _omelasticsearch.parameter.module.serverport:
+
+Serverport
+==========
+
+.. index::
+   single: omelasticsearch; Serverport
+   single: Serverport
+
+.. summary-start
+
+Default port used when server URLs omit a port.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: Serverport
+:Scope: action
+:Type: integer
+:Default: action=9200
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Port applied to entries in `server` that lack an explicit port number.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-serverport:
+.. _omelasticsearch.parameter.action.serverport:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" Serverport="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-skippipelineifempty.rst
+++ b/doc/source/reference/parameters/omelasticsearch-skippipelineifempty.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-skippipelineifempty:
+.. _omelasticsearch.parameter.module.skippipelineifempty:
+
+skipPipelineIfEmpty
+===================
+
+.. index::
+   single: omelasticsearch; skipPipelineIfEmpty
+   single: skipPipelineIfEmpty
+
+.. summary-start
+
+Omit the pipeline parameter when `pipelineName` expands to an empty string.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: skipPipelineIfEmpty
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When enabled and the pipeline name resolves to an empty value, the parameter is not sent to Elasticsearch to avoid errors.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-skippipelineifempty:
+.. _omelasticsearch.parameter.action.skippipelineifempty:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" skipPipelineIfEmpty="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-skipverifyhost.rst
+++ b/doc/source/reference/parameters/omelasticsearch-skipverifyhost.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-skipverifyhost:
+.. _omelasticsearch.parameter.module.skipverifyhost:
+
+skipverifyhost
+==============
+
+.. index::
+   single: omelasticsearch; skipverifyhost
+   single: skipverifyhost
+
+.. summary-start
+
+Disable TLS host name verification (insecure, for testing).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: skipverifyhost
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Sets the curl `CURLOPT_SSL_VERIFYHOST` option to `0`. Use only for debugging.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-skipverifyhost:
+.. _omelasticsearch.parameter.action.skipverifyhost:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" skipverifyhost="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-template.rst
+++ b/doc/source/reference/parameters/omelasticsearch-template.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-template:
+.. _omelasticsearch.parameter.module.template:
+
+template
+========
+
+.. index::
+   single: omelasticsearch; template
+   single: template
+
+.. summary-start
+
+Template used to render the JSON document sent to Elasticsearch.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: template
+:Scope: action
+:Type: word
+:Default: action=StdJSONFmt
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Defines the rsyslog template that generates the JSON payload. The default `StdJSONFmt` includes common fields.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-template:
+.. _omelasticsearch.parameter.action.template:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" template="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-timeout.rst
+++ b/doc/source/reference/parameters/omelasticsearch-timeout.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-timeout:
+.. _omelasticsearch.parameter.module.timeout:
+
+timeout
+=======
+
+.. index::
+   single: omelasticsearch; timeout
+   single: timeout
+
+.. summary-start
+
+How long Elasticsearch waits for a primary shard before failing.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: timeout
+:Scope: action
+:Type: word
+:Default: action=1m
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Controls the `timeout` query parameter for index operations. Example values use time units such as `1m`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-timeout:
+.. _omelasticsearch.parameter.action.timeout:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" timeout="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-tls-cacert.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-cacert.rst
@@ -1,0 +1,41 @@
+.. _param-omelasticsearch-tls-cacert:
+.. _omelasticsearch.parameter.module.tls-cacert:
+.. _omelasticsearch.parameter.module.tls.cacert:
+
+tls.cacert
+==========
+
+.. index::
+   single: omelasticsearch; tls.cacert
+   single: tls.cacert
+
+.. summary-start
+
+CA certificate file used to verify the Elasticsearch server.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: tls.cacert
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Path to a PEM file containing the CA certificate that issued the server certificate.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-tls-cacert:
+.. _omelasticsearch.parameter.action.tls-cacert:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" tls.cacert="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-tls-mycert.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-mycert.rst
@@ -1,0 +1,41 @@
+.. _param-omelasticsearch-tls-mycert:
+.. _omelasticsearch.parameter.module.tls-mycert:
+.. _omelasticsearch.parameter.module.tls.mycert:
+
+tls.mycert
+==========
+
+.. index::
+   single: omelasticsearch; tls.mycert
+   single: tls.mycert
+
+.. summary-start
+
+Client certificate for mutual TLS authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: tls.mycert
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+PEM file containing the client certificate presented to Elasticsearch.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-tls-mycert:
+.. _omelasticsearch.parameter.action.tls-mycert:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" tls.mycert="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-tls-myprivkey.rst
+++ b/doc/source/reference/parameters/omelasticsearch-tls-myprivkey.rst
@@ -1,0 +1,41 @@
+.. _param-omelasticsearch-tls-myprivkey:
+.. _omelasticsearch.parameter.module.tls-myprivkey:
+.. _omelasticsearch.parameter.module.tls.myprivkey:
+
+tls.myprivkey
+=============
+
+.. index::
+   single: omelasticsearch; tls.myprivkey
+   single: tls.myprivkey
+
+.. summary-start
+
+Unencrypted private key for `tls.mycert`.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: tls.myprivkey
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+PEM file containing the private key corresponding to the client certificate. The key must not be encrypted.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-tls-myprivkey:
+.. _omelasticsearch.parameter.action.tls-myprivkey:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" tls.myprivkey="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-uid.rst
+++ b/doc/source/reference/parameters/omelasticsearch-uid.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-uid:
+.. _omelasticsearch.parameter.module.uid:
+
+uid
+===
+
+.. index::
+   single: omelasticsearch; uid
+   single: uid
+
+.. summary-start
+
+User name for basic HTTP authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: uid
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Supplies the user name when Elasticsearch requires basic authentication.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-uid:
+.. _omelasticsearch.parameter.action.uid:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" uid="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-usehttps.rst
+++ b/doc/source/reference/parameters/omelasticsearch-usehttps.rst
@@ -1,0 +1,44 @@
+.. _param-omelasticsearch-usehttps:
+.. _omelasticsearch.parameter.module.usehttps:
+
+usehttps
+========
+
+.. index::
+   single: omelasticsearch; usehttps
+   single: usehttps
+
+.. summary-start
+
+Default scheme for servers missing one.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: usehttps
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+If enabled, URLs in `server` without an explicit scheme use HTTPS; otherwise HTTP is assumed.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-usehttps:
+.. _omelasticsearch.parameter.action.usehttps:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" usehttps="...")
+
+Notes
+-----
+- Previously documented as a "binary" option.
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-writeoperation.rst
+++ b/doc/source/reference/parameters/omelasticsearch-writeoperation.rst
@@ -1,0 +1,40 @@
+.. _param-omelasticsearch-writeoperation:
+.. _omelasticsearch.parameter.module.writeoperation:
+
+writeoperation
+==============
+
+.. index::
+   single: omelasticsearch; writeoperation
+   single: writeoperation
+
+.. summary-start
+
+Bulk action type: `index` (default) or `create` to avoid overwrites.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: writeoperation
+:Scope: action
+:Type: word
+:Default: action=index
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Controls the operation sent in bulk requests. Use `create` to only add documents that do not yet exist. Requires `bulkid` and `dynbulkid`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-writeoperation:
+.. _omelasticsearch.parameter.action.writeoperation:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" writeoperation="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.


### PR DESCRIPTION
## Summary
- split omelasticsearch parameters into standalone reference pages
- summarize parameters in omelasticsearch module docs via table includes

## Testing
- `sphinx-build -b html -a -E -D html_theme=alabaster doc/source doc/_build/html`

------
https://chatgpt.com/codex/tasks/task_e_689b7455c3508332823051bdf9419013