### PR TITLE
doc: add v8 locking note

### DIFF
--- a/doc/source/development/dev_action_threads.rst
+++ b/doc/source/development/dev_action_threads.rst
@@ -58,6 +58,14 @@ Thread and Queue Topology
      A1W --> A1Out["Action A1: omfile"];
      A2W --> A2Out["Action A2: omfwd"];
 
+Concurrency & Locking
+---------------------
+- The framework may run **multiple workers per action**.
+- ``wrkrInstanceData_t`` (WID) is **per-worker**; do not share it; no locks needed inside WID.
+- Shared per-action state (``pData``/``instanceData``) **must be protected by the module** (mutex/rwlock).
+- **Direct** mode does **not** remove the need to serialize inherently serial resources in the module.
+
+
 Message Processing Lifecycle (Action Queue)
 -------------------------------------------
 1. Enqueue


### PR DESCRIPTION
Add "Concurrency & Locking" to dev_action_threads.rst: multiple workers per action; WID is per-worker; shared pData must be mutex/rwlock-protected; direct mode still needs module-side serialization for inherently serial resources.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
