### PR TITLE
docs: split omkafka action parameters into pages

### DIFF
--- a/doc/source/configuration/modules/omkafka.rst
+++ b/doc/source/configuration/modules/omkafka.rst
@@ -21,334 +21,116 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; CamelCase is recommended for readability.
 
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/omkafka-broker
+   ../../reference/parameters/omkafka-topic
+   ../../reference/parameters/omkafka-key
+   ../../reference/parameters/omkafka-dynakey
+   ../../reference/parameters/omkafka-dynatopic
+   ../../reference/parameters/omkafka-dynatopic-cachesize
+   ../../reference/parameters/omkafka-partitions-auto
+   ../../reference/parameters/omkafka-partitions-number
+   ../../reference/parameters/omkafka-partitions-usefixed
+   ../../reference/parameters/omkafka-errorfile
+   ../../reference/parameters/omkafka-statsfile
+   ../../reference/parameters/omkafka-confparam
+   ../../reference/parameters/omkafka-topicconfparam
+   ../../reference/parameters/omkafka-template
+   ../../reference/parameters/omkafka-closetimeout
+   ../../reference/parameters/omkafka-resubmitonfailure
+   ../../reference/parameters/omkafka-keepfailedmessages
+   ../../reference/parameters/omkafka-failedmsgfile
+   ../../reference/parameters/omkafka-statsname
 
 Action Parameters
 -----------------
 
-Note that omkafka supports some *Array*-type parameters. While the parameter
-name can only be set once, it is possible to set multiple values with that
-single parameter. See the :ref:`omkafka-examples-label` section for details.
-
-
-Broker
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "localhost:9092", "no", "none"
-
-Specifies the broker(s) to use.
-
-
-Topic
-^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "yes", "none"
-
-Specifies the topic to produce to.
-
-
-Key
-^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-Kafka key to be used for all messages.
-
-If a key is provided and partitions.auto="on" is set, then all messages will
-be assigned to a partition based on the key.
-
-
-DynaKey
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive", "Available since"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none", v8.1903
-
-If set, the key parameter becomes a template for the key to base the
-partitioning on. 
-
-
-DynaTopic
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-If set, the topic parameter becomes a template for which topic to
-produce messages to. The cache is cleared on HUP.
-
-
-DynaTopic.Cachesize
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "50", "no", "none"
-
-If set, defines the number of topics that will be kept in the dynatopic
-cache.
-
-
-Partitions.Auto
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Librdkafka provides an automatic partitioning function that will
-automatically distribute the produced messages into all partitions
-configured for that topic.
-
-To use, set partitions.auto="on". This is instead of specifying the
-number of partitions on the producer side, where it would be easier
-to change the kafka configuration on the cluster for number of
-partitions/topic vs on every machine talking to Kafka via rsyslog.
-
-If no key is set, messages will be distributed randomly across partitions.
-This results in a very even load on all partitions, but does not preserve
-ordering between the messages.
-
-If a key is set, a partition will be chosen automatically based on it. All
-messages with the same key will be sorted into the same partition,
-preserving their ordering. For example, by setting the key to the hostname,
-messages from a specific host will be written to one partition and ordered,
-but messages from different nodes will be distributed across different
-partitions. This distribution is essentially random, but stable. If the
-number of different keys is much larger than the number of partitions on the
-topic, load will be distributed fairly evenly.
-
-If set, it will override any other partitioning scheme configured.
-
-
-Partitions.number
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "none", "no", "none"
-
-If set, specifies how many partitions exists **and** activates
-load-balancing among them. Messages are distributed more or
-less evenly between the partitions. Note that the number specified
-must be correct. Otherwise, some errors may occur or some partitions
-may never receive data.
-
-
-Partitions.useFixed
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "none", "no", "none"
-
-If set, specifies the partition to which data is produced. All
-data goes to this partition, no other partition is ever involved
-for this action.
-
-
-errorFile
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-If set, messages that could not be sent and caused an error
-messages are written to the file specified. This file is in JSON
-format, with a single record being written for each message in
-error. The entry contains the full message, as well as Kafka
-error number and reason string.
-
-The idea behind the error file is that the admin can periodically
-run a script that reads the error file and reacts on it. Note that
-the error file is kept open from when the first error occurred up
-until rsyslog is terminated or received a HUP signal.
-
-
-statsFile
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-If set, the contents of the JSON object containing the full librdkafka
-statistics will be written to the file specified. The file will be
-updated based on the statistics.interval.ms confparam value, which must
-also be set.
-
-
-ConfParam
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "none", "no", "none"
-
-Permits to specify Kafka options. Rather than offering a myriad of
-config settings to match the Kafka parameters, we provide this setting
-here as a vehicle to set any Kafka parameter. This has the big advantage
-that Kafka parameters that come up in new releases can immediately be used.
-
-Note that we use librdkafka for the Kafka connection, so the parameters
-are actually those that librdkafka supports. As of our understanding, this
-is a superset of the native Kafka parameters.
-
-
-TopicConfParam
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "none", "no", "none"
-
-In essence the same as *confParam*, but for the Kafka topic.
-
-
-Template
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "template set via template module parameter", "no", "none"
-
-Sets the template to be used for this action.
-
-
-closeTimeout
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "2000", "no", "none"
-
-Sets the time to wait in ms (milliseconds) for draining messages submitted to kafka-handle
-(provided by librdkafka) before closing it.
-
-The maximum value of closeTimeout used across all omkafka action instances
-is used as librdkafka unload-timeout while unloading the module
-(for shutdown, for instance).
-
-
-resubmitOnFailure
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.28.0
-
-If enabled, failed messages will be resubmit automatically when kafka is able to send
-messages again. To prevent message loss, this option should be enabled.
-
-**Note:** Messages that are rejected by kafka due to exceeding the maximum configured
-message size, are automatically dropped. These errors are not retriable.
-
-KeepFailedMessages
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-If enabled, failed messages will be saved and loaded on shutdown/startup and resend after startup if
-the kafka server is able to receive messages again. This setting requires resubmitOnFailure to be enabled as well.
-
-
-failedMsgFile
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-.. versionadded:: 8.28.0
-
-Filename where the failed messages should be stored into.
-Needs to be set when keepFailedMessages is enabled, otherwise failed messages won't be saved.
-
-
-statsName
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "none"
-
-.. versionadded:: 8.2108.0
-
-The name assigned to statistics specific to this action instance. The supported set of
-statistics tracked for this action instance are **submitted**, **acked**, **failures**.
-See the :ref:`statistics-counter_label` section for more details.
-
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-omkafka-broker`
+     - .. include:: ../../reference/parameters/omkafka-broker.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-topic`
+     - .. include:: ../../reference/parameters/omkafka-topic.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-key`
+     - .. include:: ../../reference/parameters/omkafka-key.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-dynakey`
+     - .. include:: ../../reference/parameters/omkafka-dynakey.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-dynatopic`
+     - .. include:: ../../reference/parameters/omkafka-dynatopic.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-dynatopic-cachesize`
+     - .. include:: ../../reference/parameters/omkafka-dynatopic-cachesize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-partitions-auto`
+     - .. include:: ../../reference/parameters/omkafka-partitions-auto.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-partitions-number`
+     - .. include:: ../../reference/parameters/omkafka-partitions-number.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-partitions-usefixed`
+     - .. include:: ../../reference/parameters/omkafka-partitions-usefixed.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-errorfile`
+     - .. include:: ../../reference/parameters/omkafka-errorfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-statsfile`
+     - .. include:: ../../reference/parameters/omkafka-statsfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-confparam`
+     - .. include:: ../../reference/parameters/omkafka-confparam.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-topicconfparam`
+     - .. include:: ../../reference/parameters/omkafka-topicconfparam.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-template`
+     - .. include:: ../../reference/parameters/omkafka-template.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-closetimeout`
+     - .. include:: ../../reference/parameters/omkafka-closetimeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-resubmitonfailure`
+     - .. include:: ../../reference/parameters/omkafka-resubmitonfailure.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-keepfailedmessages`
+     - .. include:: ../../reference/parameters/omkafka-keepfailedmessages.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-failedmsgfile`
+     - .. include:: ../../reference/parameters/omkafka-failedmsgfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omkafka-statsname`
+     - .. include:: ../../reference/parameters/omkafka-statsname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. _statistics-counter_label:
 

--- a/doc/source/reference/parameters/omkafka-broker.rst
+++ b/doc/source/reference/parameters/omkafka-broker.rst
@@ -1,0 +1,44 @@
+.. _param-omkafka-broker:
+.. _omkafka.parameter.module.broker:
+
+Broker
+======
+
+.. index::
+   single: omkafka; Broker
+   single: Broker
+
+.. summary-start
+
+List of Kafka brokers in `host:port` form.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: Broker
+:Scope: action
+:Type: array[string]
+:Default: action=localhost:9092
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+Specifies the broker(s) to use.
+
+Action usage
+------------
+
+.. _param-omkafka-action-broker:
+.. _omkafka.parameter.action.broker:
+.. code-block:: rsyslog
+
+   action(type="omkafka" Broker=["host1:9092","host2:9092"])
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-closetimeout.rst
+++ b/doc/source/reference/parameters/omkafka-closetimeout.rst
@@ -1,0 +1,46 @@
+.. _param-omkafka-closetimeout:
+.. _omkafka.parameter.module.closetimeout:
+
+closeTimeout
+============
+
+.. index::
+   single: omkafka; closeTimeout
+   single: closeTimeout
+
+.. summary-start
+
+Milliseconds to wait for pending messages on shutdown.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: closeTimeout
+:Scope: action
+:Type: integer
+:Default: action=2000
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+Sets the time to wait in ms for draining messages submitted to the
+Kafka handle before closing it. The maximum across all actions is used
+as librdkafka's unload timeout.
+
+Action usage
+------------
+
+.. _param-omkafka-action-closetimeout:
+.. _omkafka.parameter.action.closetimeout:
+.. code-block:: rsyslog
+
+   action(type="omkafka" closeTimeout="2000")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-confparam.rst
+++ b/doc/source/reference/parameters/omkafka-confparam.rst
@@ -1,0 +1,50 @@
+.. _param-omkafka-confparam:
+.. _omkafka.parameter.module.confparam:
+
+ConfParam
+=========
+
+.. index::
+   single: omkafka; ConfParam
+   single: ConfParam
+
+.. summary-start
+
+Arbitrary librdkafka producer options `name=value`.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: ConfParam
+:Scope: action
+:Type: array[string]
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+Permits specifying Kafka options using ``name=value`` strings.
+Parameters are passed directly to librdkafka and support all its producer settings.
+
+Action usage
+------------
+
+.. _param-omkafka-action-confparam:
+.. _omkafka.parameter.action.confparam:
+.. code-block:: rsyslog
+
+   action(type="omkafka" confParam=["compression.codec=snappy"])
+
+Notes
+-----
+
+- Multiple values may be set using array syntax.
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-dynakey.rst
+++ b/doc/source/reference/parameters/omkafka-dynakey.rst
@@ -1,0 +1,50 @@
+.. _param-omkafka-dynakey:
+.. _omkafka.parameter.module.dynakey:
+
+DynaKey
+=======
+
+.. index::
+   single: omkafka; DynaKey
+   single: DynaKey
+
+.. summary-start
+
+Treat `key` as a template for dynamic partition keys.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: DynaKey
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: 8.1903
+
+Description
+-----------
+
+If set, the key parameter becomes a template for the key to base the
+partitioning on.
+
+Action usage
+------------
+
+.. _param-omkafka-action-dynakey:
+.. _omkafka.parameter.action.dynakey:
+.. code-block:: rsyslog
+
+   action(type="omkafka" DynaKey="on" Key="keytemplate")
+
+Notes
+-----
+
+- Originally documented as "binary"; uses boolean values.
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-dynatopic-cachesize.rst
+++ b/doc/source/reference/parameters/omkafka-dynatopic-cachesize.rst
@@ -1,0 +1,44 @@
+.. _param-omkafka-dynatopic-cachesize:
+.. _omkafka.parameter.module.dynatopic-cachesize:
+
+DynaTopic.Cachesize
+===================
+
+.. index::
+   single: omkafka; DynaTopic.Cachesize
+   single: DynaTopic.Cachesize
+
+.. summary-start
+
+Number of dynamic topics kept in cache.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: DynaTopic.Cachesize
+:Scope: action
+:Type: integer
+:Default: action=50
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+If set, defines the number of topics that will be kept in the dynatopic cache.
+
+Action usage
+------------
+
+.. _param-omkafka-action-dynatopic-cachesize:
+.. _omkafka.parameter.action.dynatopic-cachesize:
+.. code-block:: rsyslog
+
+   action(type="omkafka" DynaTopic.Cachesize="100")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-dynatopic.rst
+++ b/doc/source/reference/parameters/omkafka-dynatopic.rst
@@ -1,0 +1,50 @@
+.. _param-omkafka-dynatopic:
+.. _omkafka.parameter.module.dynatopic:
+
+DynaTopic
+=========
+
+.. index::
+   single: omkafka; DynaTopic
+   single: DynaTopic
+
+.. summary-start
+
+Treat `topic` as a template for dynamic topic names.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: DynaTopic
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+If set, the topic parameter becomes a template for which topic to
+produce messages to. The cache is cleared on HUP.
+
+Action usage
+------------
+
+.. _param-omkafka-action-dynatopic:
+.. _omkafka.parameter.action.dynatopic:
+.. code-block:: rsyslog
+
+   action(type="omkafka" DynaTopic="on" Topic="topic.template")
+
+Notes
+-----
+
+- Originally documented as "binary"; uses boolean values.
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-errorfile.rst
+++ b/doc/source/reference/parameters/omkafka-errorfile.rst
@@ -1,0 +1,45 @@
+.. _param-omkafka-errorfile:
+.. _omkafka.parameter.module.errorfile:
+
+errorFile
+=========
+
+.. index::
+   single: omkafka; errorFile
+   single: errorFile
+
+.. summary-start
+
+Write failed messages to this JSON file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: errorFile
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+If set, messages that could not be sent are written to the specified file.
+Each entry is JSON and contains the full message plus the Kafka error number and reason.
+
+Action usage
+------------
+
+.. _param-omkafka-action-errorfile:
+.. _omkafka.parameter.action.errorfile:
+.. code-block:: rsyslog
+
+   action(type="omkafka" errorFile="/var/log/omkafka-error.json")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-failedmsgfile.rst
+++ b/doc/source/reference/parameters/omkafka-failedmsgfile.rst
@@ -1,0 +1,47 @@
+.. _param-omkafka-failedmsgfile:
+.. _omkafka.parameter.module.failedmsgfile:
+
+failedMsgFile
+=============
+
+.. index::
+   single: omkafka; failedMsgFile
+   single: failedMsgFile
+
+.. summary-start
+
+File that stores messages saved by `KeepFailedMessages`.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: failedMsgFile
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: 8.28.0
+
+Description
+-----------
+
+.. versionadded:: 8.28.0
+
+Filename where the failed messages should be stored. Must be set when
+``KeepFailedMessages`` is enabled.
+
+Action usage
+------------
+
+.. _param-omkafka-action-failedmsgfile:
+.. _omkafka.parameter.action.failedmsgfile:
+.. code-block:: rsyslog
+
+   action(type="omkafka" failedMsgFile="/var/spool/rsyslog/failed.kafkamsgs")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-keepfailedmessages.rst
+++ b/doc/source/reference/parameters/omkafka-keepfailedmessages.rst
@@ -1,0 +1,51 @@
+.. _param-omkafka-keepfailedmessages:
+.. _omkafka.parameter.module.keepfailedmessages:
+
+KeepFailedMessages
+==================
+
+.. index::
+   single: omkafka; KeepFailedMessages
+   single: KeepFailedMessages
+
+.. summary-start
+
+Persist failed messages for resending after restart.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: KeepFailedMessages
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+If enabled, failed messages will be saved and loaded on shutdown/startup and
+resent after startup when Kafka is available. This setting requires
+``resubmitOnFailure`` to be enabled.
+
+Action usage
+------------
+
+.. _param-omkafka-action-keepfailedmessages:
+.. _omkafka.parameter.action.keepfailedmessages:
+.. code-block:: rsyslog
+
+   action(type="omkafka" KeepFailedMessages="on")
+
+Notes
+-----
+
+- Originally documented as "binary"; uses boolean values.
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-key.rst
+++ b/doc/source/reference/parameters/omkafka-key.rst
@@ -1,0 +1,46 @@
+.. _param-omkafka-key:
+.. _omkafka.parameter.module.key:
+
+Key
+===
+
+.. index::
+   single: omkafka; Key
+   single: Key
+
+.. summary-start
+
+Key used for partitioning messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: Key
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+Kafka key to be used for all messages. If a key is provided and
+``partitions.auto="on"`` is set, then all messages will be assigned to
+a partition based on the key.
+
+Action usage
+------------
+
+.. _param-omkafka-action-key:
+.. _omkafka.parameter.action.key:
+.. code-block:: rsyslog
+
+   action(type="omkafka" Key="mykey")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-partitions-auto.rst
+++ b/doc/source/reference/parameters/omkafka-partitions-auto.rst
@@ -1,0 +1,51 @@
+.. _param-omkafka-partitions-auto:
+.. _omkafka.parameter.module.partitions-auto:
+
+Partitions.Auto
+===============
+
+.. index::
+   single: omkafka; Partitions.Auto
+   single: Partitions.Auto
+
+.. summary-start
+
+Use librdkafka's automatic partitioning.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: Partitions.Auto
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+Librdkafka provides an automatic partitioning function that distributes
+messages into all partitions configured for a topic.
+
+Action usage
+------------
+
+.. _param-omkafka-action-partitions-auto:
+.. _omkafka.parameter.action.partitions-auto:
+.. code-block:: rsyslog
+
+   action(type="omkafka" Partitions.Auto="on")
+
+Notes
+-----
+
+- Originally documented as "binary"; uses boolean values.
+- Overrides other partitioning settings when enabled.
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-partitions-number.rst
+++ b/doc/source/reference/parameters/omkafka-partitions-number.rst
@@ -1,0 +1,45 @@
+.. _param-omkafka-partitions-number:
+.. _omkafka.parameter.module.partitions-number:
+
+Partitions.number
+=================
+
+.. index::
+   single: omkafka; Partitions.number
+   single: Partitions.number
+
+.. summary-start
+
+Number of partitions to load-balance across.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: Partitions.number
+:Scope: action
+:Type: integer
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+If set, specifies how many partitions exist and activates load-balancing among them.
+The number must match the topic's partition count.
+
+Action usage
+------------
+
+.. _param-omkafka-action-partitions-number:
+.. _omkafka.parameter.action.partitions-number:
+.. code-block:: rsyslog
+
+   action(type="omkafka" Partitions.number="3")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-partitions-usefixed.rst
+++ b/doc/source/reference/parameters/omkafka-partitions-usefixed.rst
@@ -1,0 +1,45 @@
+.. _param-omkafka-partitions-usefixed:
+.. _omkafka.parameter.module.partitions-usefixed:
+
+Partitions.useFixed
+===================
+
+.. index::
+   single: omkafka; Partitions.useFixed
+   single: Partitions.useFixed
+
+.. summary-start
+
+Send all messages to a specific partition.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: Partitions.useFixed
+:Scope: action
+:Type: integer
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+If set, specifies the partition to which data is produced. All data goes to
+this partition; no other partition is used.
+
+Action usage
+------------
+
+.. _param-omkafka-action-partitions-usefixed:
+.. _omkafka.parameter.action.partitions-usefixed:
+.. code-block:: rsyslog
+
+   action(type="omkafka" Partitions.useFixed="1")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-resubmitonfailure.rst
+++ b/doc/source/reference/parameters/omkafka-resubmitonfailure.rst
@@ -1,0 +1,53 @@
+.. _param-omkafka-resubmitonfailure:
+.. _omkafka.parameter.module.resubmitonfailure:
+
+resubmitOnFailure
+=================
+
+.. index::
+   single: omkafka; resubmitOnFailure
+   single: resubmitOnFailure
+
+.. summary-start
+
+Retry failed messages when Kafka becomes available.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: resubmitOnFailure
+:Scope: action
+:Type: boolean
+:Default: action=off
+:Required?: no
+:Introduced: 8.28.0
+
+Description
+-----------
+
+.. versionadded:: 8.28.0
+
+If enabled, failed messages will be resubmitted automatically when Kafka can
+send messages again. Messages rejected because they exceed the maximum size
+are dropped.
+
+Action usage
+------------
+
+.. _param-omkafka-action-resubmitonfailure:
+.. _omkafka.parameter.action.resubmitonfailure:
+.. code-block:: rsyslog
+
+   action(type="omkafka" resubmitOnFailure="on")
+
+Notes
+-----
+
+- Originally documented as "binary"; uses boolean values.
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-statsfile.rst
+++ b/doc/source/reference/parameters/omkafka-statsfile.rst
@@ -1,0 +1,45 @@
+.. _param-omkafka-statsfile:
+.. _omkafka.parameter.module.statsfile:
+
+statsFile
+=========
+
+.. index::
+   single: omkafka; statsFile
+   single: statsFile
+
+.. summary-start
+
+Write librdkafka statistics JSON to this file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: statsFile
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+If set, the JSON statistics from librdkafka are written to the specified file.
+Updates occur based on the ``statistics.interval.ms`` `confParam` value.
+
+Action usage
+------------
+
+.. _param-omkafka-action-statsfile:
+.. _omkafka.parameter.action.statsfile:
+.. code-block:: rsyslog
+
+   action(type="omkafka" statsFile="/var/log/omkafka-stats.json")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-statsname.rst
+++ b/doc/source/reference/parameters/omkafka-statsname.rst
@@ -1,0 +1,47 @@
+.. _param-omkafka-statsname:
+.. _omkafka.parameter.module.statsname:
+
+statsName
+=========
+
+.. index::
+   single: omkafka; statsName
+   single: statsName
+
+.. summary-start
+
+Name of statistics instance for this action.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: statsName
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: 8.2108.0
+
+Description
+-----------
+
+.. versionadded:: 8.2108.0
+
+The name assigned to statistics specific to this action instance. Counters
+include ``submitted``, ``acked`` and ``failures``.
+
+Action usage
+------------
+
+.. _param-omkafka-action-statsname:
+.. _omkafka.parameter.action.statsname:
+.. code-block:: rsyslog
+
+   action(type="omkafka" statsName="producer-1")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-template.rst
+++ b/doc/source/reference/parameters/omkafka-template.rst
@@ -1,0 +1,44 @@
+.. _param-omkafka-template:
+.. _omkafka.parameter.module.template:
+
+Template
+========
+
+.. index::
+   single: omkafka; Template
+   single: Template
+
+.. summary-start
+
+Template used to format messages for this action.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: Template
+:Scope: action
+:Type: word
+:Default: action=inherits module
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+Sets the template to be used for this action.
+
+Action usage
+------------
+
+.. _param-omkafka-action-template:
+.. _omkafka.parameter.action.template:
+.. code-block:: rsyslog
+
+   action(type="omkafka" Template="MyTemplate")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-topic.rst
+++ b/doc/source/reference/parameters/omkafka-topic.rst
@@ -1,0 +1,44 @@
+.. _param-omkafka-topic:
+.. _omkafka.parameter.module.topic:
+
+Topic
+=====
+
+.. index::
+   single: omkafka; Topic
+   single: Topic
+
+.. summary-start
+
+Kafka topic to produce to.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: Topic
+:Scope: action
+:Type: string
+:Default: action=none
+:Required?: yes
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+Specifies the topic to produce to.
+
+Action usage
+------------
+
+.. _param-omkafka-action-topic:
+.. _omkafka.parameter.action.topic:
+.. code-block:: rsyslog
+
+   action(type="omkafka" Topic="mytopic")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+

--- a/doc/source/reference/parameters/omkafka-topicconfparam.rst
+++ b/doc/source/reference/parameters/omkafka-topicconfparam.rst
@@ -1,0 +1,49 @@
+.. _param-omkafka-topicconfparam:
+.. _omkafka.parameter.module.topicconfparam:
+
+TopicConfParam
+==============
+
+.. index::
+   single: omkafka; TopicConfParam
+   single: TopicConfParam
+
+.. summary-start
+
+Arbitrary librdkafka topic options `name=value`.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omkafka`.
+
+:Name: TopicConfParam
+:Scope: action
+:Type: array[string]
+:Default: action=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+
+In essence the same as ``ConfParam``, but for Kafka topic options.
+
+Action usage
+------------
+
+.. _param-omkafka-action-topicconfparam:
+.. _omkafka.parameter.action.topicconfparam:
+.. code-block:: rsyslog
+
+   action(type="omkafka" topicConfParam=["acks=all"])
+
+Notes
+-----
+
+- Multiple values may be set using array syntax.
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omkafka`.
+


### PR DESCRIPTION
## Summary
- split omkafka action parameters into standalone reference pages
- link omkafka.rst to new parameter pages with a summary table and toctree
- document resubmitOnFailure and other booleans with normalized types

## Testing
- `/root/.pyenv/versions/3.12.10/bin/sphinx-build -b html doc/source doc/_build/html doc/source/configuration/modules/omkafka.rst`

------
https://chatgpt.com/codex/tasks/task_e_689ca136f0848332a2ab5b6bbfda6342