### PR TITLE
doc: clarify reverse DNS cache TTL parameters

### DIFF
--- a/doc/source/configuration/global/index.rst
+++ b/doc/source/configuration/global/index.rst
@@ -93,7 +93,8 @@ True Global Directives
 -  **$PreserveFQDN** [on/**off**) - if set to off (legacy default to remain
    compatible to sysklogd), the domain part from a name that is within
    the same domain as the receiving system is stripped. If set to on,
-   full names are always used.
+   full names are always used. Reverse lookup results are cached; see
+   :ref:`reverse_dns_cache` for controlling cache refresh.
 -  **$WorkDirectory** <name> (directory for spool and other work files. Do
    **not** use trailing slashes)
 -  `$PrivDropToGroup <droppriv.html>`_

--- a/doc/source/configuration/input_directives/rsconf1_allowedsender.rst
+++ b/doc/source/configuration/input_directives/rsconf1_allowedsender.rst
@@ -60,8 +60,9 @@ syslog, make sure that you do proper egress and ingress filtering at the
 firewall and router level.
 
 Rsyslog also detects some kind of malicious reverse DNS entries. In any
-case, using DNS names adds an extra layer of vulnerability. We recommend
-to stick with hard-coded IP addresses wherever possible.
+case, using DNS names adds an extra layer of vulnerability. Reverse lookup
+results are cached; see :ref:`reverse_dns_cache` for ways to refresh cached
+names. We recommend to stick with hard-coded IP addresses wherever possible.
 
 **Sample:**
 

--- a/doc/source/configuration/input_directives/rsconf1_dropmsgswithmaliciousdnsptrrecords.rst
+++ b/doc/source/configuration/input_directives/rsconf1_dropmsgswithmaliciousdnsptrrecords.rst
@@ -14,7 +14,8 @@ Rsyslog can detect those cases. It will log an error message in any
 case. If this option here is set to "on", the malicious message will be
 completely dropped from your logs. If the option is set to "off", the
 message will be logged, but the original IP will be used instead of the
-DNS name.
+DNS name. Reverse lookup results are cached; see :ref:`reverse_dns_cache`
+for controlling cache timeout and refresh.
 
 **Sample:**
 

--- a/doc/source/configuration/modules/imptcp.rst
+++ b/doc/source/configuration/modules/imptcp.rst
@@ -20,6 +20,9 @@ provide TLS services. Encryption can be provided by using
 This module has no limit on the number of listeners and sessions that
 can be used.
 
+.. note::
+   Reverse DNS lookups for remote senders are cached. Set the TTL via
+   :ref:`reverse_dns_cache`.
 
 Notable Features
 ================

--- a/doc/source/configuration/modules/imtcp.rst
+++ b/doc/source/configuration/modules/imtcp.rst
@@ -16,6 +16,9 @@ natively provided by selecting the appropriate network stream driver
 and can also be provided by using `stunnel <rsyslog_stunnel.html>`_ (an
 alternative is the use the `imgssapi <imgssapi.html>`_ module).
 
+.. note::
+   Reverse DNS lookups for remote senders are cached. To control refresh
+   intervals, see :ref:`reverse_dns_cache`.
 
 Notable Features
 ================

--- a/doc/source/configuration/modules/imudp.rst
+++ b/doc/source/configuration/modules/imudp.rst
@@ -21,6 +21,9 @@ statements.
 Note that in order to enable UDP reception, Firewall rules probably
 need to be modified as well. Also, SELinux may need additional rules.
 
+.. note::
+   Reverse DNS lookups for remote senders are cached. To control how long
+   cached hostnames persist, see :ref:`reverse_dns_cache`.
 
 Notable Features
 ================

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -8,8 +8,13 @@ It is **built-in** and does not require explicit loading.
 To configure global defaults, use ``builtin:omfwd``.
 
 .. note::
-   For modern deployments, prefer **TCP with TLS** over plain TCP or UDP.  
+   For modern deployments, prefer **TCP with TLS** over plain TCP or UDP.
    If reliable delivery is critical, consider :doc:`omrelp <omrelp>`.
+
+.. note::
+   Hostnames in ``target`` are resolved on each connection attempt using the
+   system resolver. Reverse lookup cache settings (:ref:`reverse_dns_cache`)
+   do not affect outbound name resolution.
 
 Best Practices
 ==============

--- a/doc/source/configuration/properties.rst
+++ b/doc/source/configuration/properties.rst
@@ -57,7 +57,10 @@ The following message properties exist:
   hostname of the system the message was received from (in a relay chain,
   this is the system immediately in front of us and not necessarily the
   original sender). This is a DNS-resolved name, except if that is not
-  possible or DNS resolution has been disabled.
+  possible or DNS resolution has been disabled. Reverse lookup results are
+  cached; see :ref:`reverse_dns_cache` for controlling cache timeout. Forward
+  lookups for outbound connections are not cached by rsyslog and are resolved
+  via the system resolver whenever a connection is made.
 
 **fromhost-ip**
   The same as fromhost, but always as an IP address. Local inputs (like

--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -42,6 +42,11 @@ The following parameters can be set:
   Permits to overwrite the local host hostname.
 
 - **preserveFQDN**
+
+  Keep fully qualified hostnames instead of stripping the local domain.
+  The default is "off" for sysklogd compatibility. Reverse lookup results
+  are cached; see :ref:`reverse_dns_cache` for options to refresh cached
+  names.
 - **defaultNetstreamDriverCAFile**
 
   For `TLS syslog <http://www.rsyslog.com/doc/rsyslog_secure_tls.html>`_,
@@ -204,7 +209,9 @@ The following parameters can be set:
 
   **Default:** on
 
-  Can be used to turn DNS name resolution on or off.
+  Can be used to turn DNS name resolution on or off. When disabled, no
+  reverse lookups are performed and the cache described in
+  :ref:`reverse_dns_cache` is bypassed.
 
 - **net.permitACLWarning** [on/off] available 8.6.0+
 

--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -585,28 +585,54 @@ The following parameters can be set:
 
   These parameters set global queue defaults for the respective queue settings.
 
-- **reverselookup.cache.ttl.default** [numeric, seconds] available 8.1904.0+
+.. _reverse_dns_cache:
 
-  Rsyslog includes a cache for ip-address-to-hostname lookups. This is most
-  useful for inputs without a connection. imudp is the prime example.
-  This settings permits to specify after which period (in seconds) an
-  entry expires. Upon expiration the entry will be discarded and re-queried.
-  The **default** value is 24 hours.
-  To never cache entries, set the parameter to 0, which will make cache
-  entries expire immediately. Note that especially with imudp this can
-  cause huge performance degradation and potentially also message loss.
+Reverse DNS caching
+-------------------
 
-  Note: for many years rsyslog did **not** timeout cache entries at all. This
-  only occasionally caused issues. We assume that the once-every-24-hrs
-  default value is a very good compromise between performance and
-  keeping reverse lookup information current.
+.. index::
+   single: reverse DNS cache
+   single: dnsCacheTTL
+   single: dnscacheEnableTTL
+   single: dnscacheDefaultTTL
+   single: reverse DNS refresh
+   single: DNS lookup cache timeout
+
+Rsyslog caches results from reverse DNS lookups. When TTL expiry is disabled
+(*reverselookup.cache.ttl.enable*="off", the default), cache entries remain
+valid for the lifetime of the process. Enabling the TTL mechanism permits
+automatic refresh after a fixed interval. These controls apply **only** to
+reverse lookups of inbound messages. Forward lookups for outbound connections
+(for example, resolving `server.example.net` for *omfwd*) use the system
+resolver each time and are not cached by rsyslog, so no TTL setting exists for
+them.
 
 - **reverselookup.cache.ttl.enable** [boolean (on/off)] available 8.1904.0+
 
-  This configures whether rsyslog expires DNS cache entries (setting "on") or
-  not (setting "off", the default). If configured to "off",
-  *reverselookup.cache.default.ttl* is not in effect. Note that this is the
-  **default**.
+  Controls whether cached hostnames expire. If set to "on", entries expire
+  after the duration specified by *reverselookup.cache.ttl.default*. When set
+  to "off" the cache never expires.
+
+- **reverselookup.cache.ttl.default** [numeric, seconds] available 8.1904.0+
+
+  Fixed time-to-live for cached reverse lookup results. The **default** value
+  is 24 hours. Setting this parameter to ``0`` effectively disables caching,
+  which can severely degrade performance, especially for UDP inputs.
+
+These settings interact with ``preserveFQDN`` and ``net.enableDNS``. If DNS
+resolution is disabled globally, no caching occurs.
+
+Example:
+
+.. code-block:: none
+
+   global(
+     reverselookup.cache.ttl.enable="on"
+     reverselookup.cache.ttl.default="3600"    # seconds
+   )
+
+Historically these options were referenced in source code and change logs as
+``dnscacheEnableTTL`` and ``dnscacheDefaultTTL``.
 
 - **security.abortOnIDResolutionFail** [boolean (on/off)], default "on", available 8.2002.0+
 

--- a/doc/source/troubleshooting/troubleshoot.rst
+++ b/doc/source/troubleshooting/troubleshoot.rst
@@ -37,6 +37,16 @@ but rather use the host that sent the message (taken from the socket
 layer). Of course, this does not work over NAT or relay chains, where
 the only cure is to make sure senders emit well-formed messages.
 
+Stale reverse DNS entries
+-------------------------
+
+If logged hostnames appear outdated, rsyslog may have cached reverse DNS
+results. The cache persists for the process lifetime unless a time-to-live
+is configured. See :ref:`reverse_dns_cache` for settings that control cache
+expiry and refresh. Forward lookups for outbound connections are not cached;
+if a target hostname resolves to a new address, rsyslog picks it up the next
+time a connection is established.
+
 Configuration Problems
 ----------------------
 


### PR DESCRIPTION
## Summary
- document reverse DNS cache behavior and TTL options
- cross-link from properties, directives, and troubleshooting
- note dnscache* aliases in change log
- clarify TTL applies only to reverse lookups, not outbound name resolution

## Testing
- `devtools/format-code.sh`
- `./autogen.sh`
- `./configure`
- `make check`


------
https://chatgpt.com/codex/tasks/task_e_689cb6b37e088332945e6d51e0e03936