### PR TITLE
docs: split imfile parameters into reference pages

### DIFF
--- a/doc/source/configuration/modules/imfile.rst
+++ b/doc/source/configuration/modules/imfile.rst
@@ -53,926 +53,202 @@ Configuration
 =============
 
 .. note::
-
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; CamelCase is recommended for readability.
 
 
 Module Parameters
 -----------------
 
-Mode
-^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "inotify", "no", "none"
-
-.. versionadded:: 8.1.5
-
-This specifies if imfile is shall run in inotify ("inotify") or polling
-("polling") mode. Traditionally, imfile used polling mode, which is
-much more resource-intense (and slower) than inotify mode. It is
-suggested that users turn on "polling" mode only if they experience
-strange problems in inotify mode. In theory, there should never be a
-reason to enable "polling" mode and later versions will most probably
-remove it.
-
-Note: if a legacy "$ModLoad" statement is used, the default is *polling*.
-This default was kept to prevent problems with old configurations. It
-might change in the future.
-
-.. versionadded:: 8.32.0
-
-On Solaris, the FEN API is used instead of INOTIFY. You can set the mode
-to fen or inotify (which is automatically mapped to fen on Solaris OS).
-Please note that the FEN is limited compared to INOTIFY. Deep wildcard
-matches may not work because of the API limits for now.
-
-
-readTimeout
-^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-*Default: 0 (no timeout)*
-
-.. versionadded:: 8.23.0
-
-This sets the default value for input *timeout* parameters. See there
-for exact meaning. Parameter value is the number of seconds.
-
-
-deleteStateOnFileMove
-^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-If set to **on**, the state file for a monitored file is removed when that file
-is moved or rotated away. By default the state file is kept.
-
-
-timeoutGranularity
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "1", "no", "none"
-
-.. versionadded:: 8.23.0
-
-This sets the interval in which multi-line-read timeouts are checked.
-The interval is specified in seconds. Note that
-this establishes a lower limit on the length of the timeout. For example, if
-a timeoutGranularity of 60 seconds is selected and a readTimeout value of 10 seconds
-is used, the timeout is nevertheless only checked every 60 seconds (if there is
-no other activity in imfile). This means that the readTimeout is also only
-checked every 60 seconds, which in turn means a timeout can occur only after 60
-seconds.
-
-Note that timeGranularity has some performance implication. The more frequently
-timeout processing is triggered, the more processing time is needed. This
-effect should be negligible, except if a very large number of files is being
-monitored.
-
-
-sortFiles
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.32.0
-
-If this parameter is set to on, the files will be processed in sorted order, else
-not. However, due to the inherent asynchronicity of the whole operations involved
-in tracking files, it is not possible to guarantee this sorted order, as it also
-depends on operation mode and OS timing.
-
-
-PollingInterval
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "10", "no", "none"
-
-This setting specifies how often files are to be
-polled for new data. For obvious reasons, it has effect only if
-imfile is running in polling mode.
-The time specified is in seconds. During each
-polling interval, all files are processed in a round-robin fashion.
-
-A short poll interval provides more rapid message forwarding, but
-requires more system resources. While it is possible, we strongly
-recommend not to set the polling interval to 0 seconds. That will
-make rsyslogd become a CPU hog, taking up considerable resources. It
-is supported, however, for the few very unusual situations where this
-level may be needed. Even if you need quick response, 1 seconds
-should be well enough. Please note that imfile keeps reading files as
-long as there is any data in them. So a "polling sleep" will only
-happen when nothing is left to be processed.
-
-**We recommend to use inotify mode.**
-
-
-statefile.directory
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "global(WorkDirectory) value", "no", "none"
-
-.. versionadded:: 8.1905.0
-
-This parameter permits to specify a dedicated directory for the storage of
-imfile state files. An absolute path name should be specified (e.g.
-`/var/rsyslog/imfilestate`). This permits to keep imfile state files separate
-from other rsyslog work items.
-
-If not specified the global `workDirectory` setting is used.
-
-**Important: The directory must exist before rsyslog is started.** Also,
-rsyslog needs write permissions to work correctly. Keep in mind that this
-also might require SELinux definitions (or similar for other enhanced security
-systems).
-
+   * - Parameter
+     - Summary
+   * - :ref:`param-imfile-mode`
+     - .. include:: ../../reference/parameters/imfile-mode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-readtimeout`
+     - .. include:: ../../reference/parameters/imfile-readtimeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-deletestateonfilemove`
+     - .. include:: ../../reference/parameters/imfile-deletestateonfilemove.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-timeoutgranularity`
+     - .. include:: ../../reference/parameters/imfile-timeoutgranularity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-sortfiles`
+     - .. include:: ../../reference/parameters/imfile-sortfiles.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-pollinginterval`
+     - .. include:: ../../reference/parameters/imfile-pollinginterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-statefile-directory`
+     - .. include:: ../../reference/parameters/imfile-statefile-directory.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 Input Parameters
 ----------------
 
-File
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "yes", "``$InputFileName``"
-
-The file being monitored. So far, this must be an absolute name (no
-macros or templates). Note that wildcards are supported at the file
-name level (see **WildCards** below for more details).
-
-
-Tag
-^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "yes", "``$InputFileTag``"
-
-The tag to be assigned to messages read from this file. If you would like to
-see the colon after the tag, you need to include it when you assign a tag
-value, like so: ``tag="myTagValue:"``.
-
-
-Facility
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer or string (preferred)", "local0", "no", "``$InputFileFacility``"
-
-The syslog facility to be assigned to messages read from this file. Can be
-specified in textual form (e.g. ``local0``, ``local1``, ...) or as numbers (e.g.
-16 for ``local0``). Textual form is suggested. Default  is ``local0``.
-
-.. seealso::
-
-   https://en.wikipedia.org/wiki/Syslog
-
-
-Severity
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer or string (preferred)", "notice", "no", "``$InputFileSeverity``"
-
-The syslog severity to be assigned to lines read. Can be specified
-in textual   form (e.g. ``info``, ``warning``, ...) or as numbers (e.g. 6
-for ``info``). Textual form is suggested. Default is ``notice``.
-
-.. seealso::
-
-   https://en.wikipedia.org/wiki/Syslog
-
-
-PersistStateInterval
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "``$InputFilePersistStateInterval``"
-
-Specifies how often the state file shall be written when processing
-the input file. The **default** value is 0, which means a new state
-file is at least being written when the monitored files is being closed (end of
-rsyslogd execution). Any other value n means that the state file is
-written at least every time n file lines have been processed. This setting can
-be used to guard against message duplication due to fatal errors
-(like power fail). Note that this setting affects imfile performance,
-especially when set to a low value. Frequently writing the state file
-is very time consuming.
-
-Note further that rsyslog may write state files
-more frequently. This happens if rsyslog has some reason to do so.
-There is intentionally no more precise description of when state files
-are being written, as this is an implementation detail and may change
-as needed.
-
-**Note: If this parameter is not set, state files are not created.**
-
-
-startmsg.regex
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-.. versionadded:: 8.10.0
-
-This permits the processing of multi-line messages. When set, a
-messages is terminated when the next one begins, and
-``startmsg.regex`` contains the regex that identifies the start
-of a message. As this parameter is using regular expressions, it
-is more flexible than ``readMode`` but at the cost of lower
-performance.
-Note that ``readMode`` and ``startmsg.regex`` and ``endmsg.regex`` cannot all be
-defined for the same input.
-
-
-endmsg.regex
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-.. versionadded:: 8.38.0
-
-This permits the processing of multi-line messages. When set, a message is
-terminated when ``endmsg.regex`` matches the line that
-identifies the end of a message. As this parameter is using regular
-expressions, it is more flexible than ``readMode`` but at the cost of lower
-performance.
-Note that ``readMode`` and ``startmsg.regex`` and ``endmsg.regex`` cannot all be
-defined for the same input.
-The primary use case for this is multiline container log files which look like
-this:
-
-.. code-block:: none
-
-    date stdout P start of message
-    date stdout P  middle of message
-    date stdout F  end of message
-
-The `F` means this is the line which contains the final part of the message.
-The fully assembled message should be `start of message middle of message end of
-message`.  `endmsg.regex="^[^ ]+ stdout F "` will match.
-
-readTimeout
-^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-.. versionadded:: 8.23.0
-
-This can be used with *startmsg.regex* (but not *readMode*). If specified,
-partial multi-line reads are timed out after the specified timeout interval.
-That means the current message fragment is being processed and the next
-message fragment arriving is treated as a completely new message. The
-typical use case for this parameter is a file that is infrequently being
-written. In such cases, the next message arrives relatively late, maybe hours
-later. Specifying a readTimeout will ensure that those "last messages" are
-emitted in a timely manner. In this use case, the "partial" messages being
-processed are actually full messages, so everything is fully correct.
-
-To guard against accidental too-early emission of a (partial) message, the
-timeout should be sufficiently large (5 to 10 seconds or more recommended).
-Specifying a value of zero turns off timeout processing. Also note the
-relationship to the *timeoutGranularity* global parameter, which sets the
-lower bound of *readTimeout*.
-
-Setting timeout values slightly increases processing time requirements; the
-effect should only be visible of a very large number of files is being
-monitored.
-
-
-readMode
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "``$InputFileReadMode``"
-
-This provides support for processing some standard types of multiline
-messages. It is less flexible than ``startmsg.regex`` or ``endmsg.regex`` but
-offers higher performance than regex processing. Note that ``readMode`` and
-``startmsg.regex`` and ``endmsg.regex`` cannot all be defined for the same
-input.
-
-The value can range from 0-2 and determines the multiline
-detection method.
-
-0 - (**default**) line based (each line is a new message)
-
-1 - paragraph (There is a blank line between log messages)
-
-2 - indented (new log messages start at the beginning of a line. If a
-line starts with a space or tab "\t" it is part of the log message before it)
-
-
-escapeLF
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "1", "no", "none"
-
-This is only meaningful if multi-line messages are to be processed.
-LF characters embedded into syslog messages cause a lot of trouble,
-as most tools and even the legacy syslog TCP protocol do not expect
-these. If set to "on", this option avoid this trouble by properly
-escaping LF characters to the 4-byte sequence "#012". This is
-consistent with other rsyslog control character escaping. By default,
-escaping is turned on. If you turn it off, make sure you test very
-carefully with all associated tools. Please note that if you intend
-to use plain TCP syslog with embedded LF characters, you need to
-enable octet-counted framing. For more details, see
-`Rainer Gerhards' blog posting on imfile LF escaping <https://rainer.gerhards.net/2013/09/imfile-multi-line-messages.html>`_.
-
-
-escapeLF.replacement
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "depending on use", "no", "none"
-
-.. versionadded:: 8.2001.0
-
-This parameter works in conjunction with `escapeLF`. It is only
-honored if `escapeLF="on"`.
-
-It permits to replace the default escape sequence by a different character
-sequence. The default historically is inconsistent and depends on which
-functionality is used to read the file. It can be either "#012" or "\\n". If
-you want to retain that default, do not configure this parameter.
-
-If it is configured, any sequence may be used. For example, to replace an LF
-with a simple space, use::
-
-   escapeLF.replacement=" "
-
-It is also possible to configure longer replacements. An example for this is::
-
-   escapeLF.replacement="[LF]"
-
-Finally, it is possible to completely remove the LF. This is done by specifying
-an empty replacement sequence::
-
-   escapeLF.replacement=""
-
-
-MaxLinesAtOnce
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "``$InputFileMaxLinesAtOnce``"
-
-This is a legacy setting that only is supported in *polling* mode.
-In *inotify* mode, it is fixed at 0 and all attempts to configure
-a different value will be ignored, but will generate an error
-message.
-
-Please note that future versions of imfile may not support this
-parameter at all. So it is suggested to not use it.
-
-In *polling* mode, if set to 0, each file will be fully processed and
-then processing switches to the next file. If it is set to any other
-value, a maximum of [number] lines is processed in sequence for each file,
-and then the file is switched. This provides a kind of multiplexing
-the load of multiple files and probably leads to a more natural
-distribution of events when multiple busy files are monitored. For
-*polling* mode, the **default** is 10240.
-
-
-MaxSubmitAtOnce
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "1024", "no", "none"
-
-This is an expert option. It can be used to set the maximum input
-batch size that imfile can generate. The **default** is 1024, which
-is suitable for a wide range of applications. Be sure to understand
-rsyslog message batch processing before you modify this option. If
-you do not know what this doc here talks about, this is a good
-indication that you should NOT modify the default.
-
-
-deleteStateOnFileDelete
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-This parameter controls if state files are deleted if their associated
-main file is deleted. Usually, this is a good idea, because otherwise
-problems would occur if a new file with the same name is created. In
-that case, imfile would pick up reading from the last position in
-the **deleted** file, which usually is not what you want.
-
-However, there is one situation where not deleting associated state
-file makes sense: this is the case if a monitored file is modified
-with an editor (like vi or gedit). Most editors write out modifications
-by deleting the old file and creating a new now. If the state file
-would be deleted in that case, all of the file would be reprocessed,
-something that's probably not intended in most case. As a side-note,
-it is strongly suggested *not* to modify monitored files with
-editors. In any case, in such a situation, it makes sense to
-disable state file deletion. That also applies to similar use
-cases.
-
-In general, this parameter should only by set if the users
-knows exactly why this is required.
-
-For historical reasons, this parameter has an alias called
-`removeStateOnDelete`. This is to provide backward compatibility.
-Newer installations should use `deleteStateOnFileDelete` only.
-
-deleteStateOnFileMove
-^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "inherits from module parameter", "no", "none"
-
-This parameter controls if state files are deleted when their associated
-main file is moved or renamed. By default, this parameter inherits its
-value from the module-level `deleteStateOnFileMove` parameter. When set
-to "on", the state file will be automatically cleaned up when the file
-is moved, preventing orphaned state files.
-
-
-Ruleset
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "``$InputFileBindRuleset``"
-
-Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
-
-
-addMetadata
-^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "-1", "no", "none"
-
-**Default: see intro section on Metadata**
-
-This is used to turn on or off the addition of metadata to the
-message object.
-
-
-addCeeTag
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-This is used to turn on or off the addition of the "@cee:" cookie to the
-message object.
-
-
-reopenOnTruncate
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-This is an **experimental** feature that tells rsyslog to reopen input file
-when it was truncated (inode unchanged but file size on disk is less than
-current offset in memory).
-
-
-MaxLinesPerMinute
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-Instructs rsyslog to enqueue up to the specified maximum number of lines
-as messages per minute. Lines above this value are discarded.
-
-The **default** value is 0, which means that no lines are discarded.
-
-
-MaxBytesPerMinute
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-Instructs rsyslog to enqueue a maximum number of bytes as messages per
-minute. Once MaxBytesPerMinute is reached, subsequent messages are
-discarded.
-
-Note that messages are not truncated as a result of MaxBytesPerMinute,
-rather the entire message is discarded if part of it would be above the
-specified maximum bytes per minute.
-
-The **default** value is 0, which means that no messages are discarded.
-
-
-trimLineOverBytes
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-This is used to tell rsyslog to truncate the line which length is greater
-than specified bytes. If it is positive number, rsyslog truncate the line
-at specified bytes. Default value of 'trimLineOverBytes' is 0, means never
-truncate line.
-
-This option can be used when ``readMode`` is 0 or 2.
-
-
-freshStartTail
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-This is used to tell rsyslog to seek to the end/tail of input files
-(discard old logs) **at its first start(freshStart)** and process only new
-log messages.
-
-When deploy rsyslog to a large number of servers, we may only care about
-new log messages generated after the deployment. set **freshstartTail**
-to **on** will discard old logs. Otherwise, there may be vast useless
-message burst on the remote central log receiver
-
-This parameter only applies to files that are already existing during
-rsyslog's initial processing of the file monitors.
-
-.. warning::
-
-   Depending on the number and location of existing files, this initial
-   startup processing may take some time as well. If another process
-   creates a new file at exactly the time of startup processing and writes
-   data to it, rsyslog might detect this file and it's data as preexisting
-   and may skip it. This race is inevitable. So when freshStartTail is used,
-   some risk of data loss exists. The same holds true if between the last
-   shutdown of rsyslog and its restart log file content has been added.
-   As such, the rsyslog team advises against activating the freshStartTail
-   option.
-
-
-discardTruncatedMsg
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-When messages are too long they are truncated and the following part is
-processed as a new message. When this parameter is turned on the
-truncated part is not processed but discarded.
-
-
-msgDiscardingError
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-Upon truncation an error is given. When this parameter is turned off, no
-error will be shown upon truncation.
-
-
-needParse
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.1903.0
-
-By default, read message are sent to output modules without passing through
-parsers. This parameter informs rsyslog to use also defined parser module(s).
-
-
-
-persistStateAfterSubmission
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 8.2006.0
-
-This setting makes imfile persist state file information after a batch of
-messages has been submitted. It can be activated (switched to "on") in order
-to provide enhanced robustness against unclean shutdowns. Depending on the
-configuration of the rest of rsyslog (most importantly queues), persisting
-the state file after each message submission prevents message loss
-when reading files and the system is shutdown in an unclean way (e.g.
-loss of power).
-
-Please note that this setting may cause frequent state file writes and
-as such may cause some performance degradation.
-
-
-ignoreOlderThan
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-.. versionadded:: 8.2108.0
-
-Instructs imfile to ignore a discovered file that has not been modified in the
-specified number of seconds. Once a file is discovered, the file is no longer
-ignored and new data will be read. This option is disabled (set to 0) by default.
-
-
-
-.. _Metadata:
-
-Metadata
-========
-The imfile module supports message metadata. It supports the following
-data items:
-
-- filename
-
-  Name of the file where the message originated from. This is most
-  useful when using wildcards inside file monitors, because it then
-  is the only way to know which file the message originated from.
-  The value can be accessed using the %$!metadata!filename% property.
-  **Note**: For symlink-ed files this does **not** contain name of the
-  actual file (source of the data) but name of the symlink (file which
-  matched configured input).
-
-- fileoffset
-
-  Offset of the file in bytes at the time the message was read. The
-  offset reported is from the **start** of the line.
-  This information can be useful when recreating multi-line files
-  that may have been accessed or transmitted non-sequentially.
-  The value can be accessed using the %$!metadata!fileoffset% property.
-
-Metadata is only present if enabled. By default it is enabled for
-input() statements that contain wildcards. For all others, it is
-disabled by default. It can explicitly be turned on or off via the
-*addMetadata* input() parameter, which always overrides the default.
-
-
-.. _State-Files:
-
-State Files
-===========
-Rsyslog must keep track of which parts of the monitored file
-are already processed. This is done in so-called "state files" that
-are created in the rsyslog working directory and are read on startup to
-resume monitoring after a shutdown. The location of the rsyslog
-working directory is configurable via the ``global(workDirectory)``
-|FmtAdvancedName| format parameter.
-
-**Note**: The ``PersistStateInterval`` parameter must be set, otherwise state
-files will NOT be created.
-
-Rsyslog automatically generates state file names. These state file
-names will begin with the string ``imfile-state:`` and be followed
-by some suffix rsyslog generates.
-
-There is intentionally no more precise description of when state file
-naming, as this is an implementation detail and may change as needed.
-
-Note that it is possible to set a fixed state file name via the
-deprecated ``stateFile`` parameter. It is suggested to avoid this, as
-the user must take care of name clashes. Most importantly, if
-"stateFile" is set for file monitors with wildcards, the **same**
-state file is used for all occurrences of these files. In short,
-this will usually not work and cause confusion. Upon startup,
-rsyslog tries to detect these cases and emit warning messages.
-However, the detection simply checks for the presence of "*"
-and as such it will not cover more complex cases.
-
-Note that when the ``global(workDirectory)`` |FmtAdvancedName| format
-parameter is points to a non-writable location, the state file
-**will not be generated**. In those cases, the file content will always
-be completely re-sent by imfile, because the module does not know that it
-already processed parts of that file. if The parameter is not set to all, it
-defaults to the file system root, which may or may not be writable by
-the rsyslog process.
-
-
-.. _WildCards:
-
-WildCards
-=========
-
-As of rsyslog version 8.25.0 and later, wildcards are fully supported in both directory names and filenames. This allows for flexible file monitoring configurations.
-
-Examples of supported wildcard usage:
-
-*   `/var/log/*.log` (all .log files in /var/log)
-*   `/var/log/*/*.log` (all .log files in immediate subdirectories of /var/log)
-*   `/var/log/app*/*/*.log` (all .log files in subdirectories of directories starting with "app" in /var/log)
-
-All matching files in all matching subfolders will be monitored.
-
-.. note::
-   Using complex wildcard patterns, especially those that match many directories and files, may have an impact on performance. It's advisable to use the most specific patterns possible.
-
-Historically, versions prior to 8.25.0 had limitations, supporting wildcards only in the filename part and not in directory paths.
-
-
-
-
-Caveats/Known Bugs
-==================
-
-* symlink may not always be properly processed
-
-Configuration Examples
-======================
-
-The following sample monitors two files. If you need just one, remove
-the second one. If you need more, add them according to the sample ;).
-This code must be placed in /etc/rsyslog.conf (or wherever your distro
-puts rsyslog's config files). Note that only commands actually needed
-need to be specified. The second file uses less commands and uses
-defaults instead.
-
-.. code-block:: none
-
-  module(load="imfile" PollingInterval="10") #needs to be done just once
-
-  # File 1
-  input(type="imfile"
-        File="/path/to/file1"
-        Tag="tag1"
-        Severity="error"
-        Facility="local7")
-
-  # File 2
-  input(type="imfile"
-        File="/path/to/file2"
-        Tag="tag2")
-
-  # ... and so on ... #
-
-
-Deprecated parameters
-=====================
-
-**Note:** While these parameters are still accepted, they should no longer be
-used for newly created configurations.
-
-stateFile
----------
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "``$InputFileStateFile``"
-
-This is the name of this file's state file. This parameter should
-usually **not** be used. Check the section on "State Files" above
-for more details.
-
-
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imfile-file`
+     - .. include:: ../../reference/parameters/imfile-file.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-tag`
+     - .. include:: ../../reference/parameters/imfile-tag.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-facility`
+     - .. include:: ../../reference/parameters/imfile-facility.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-severity`
+     - .. include:: ../../reference/parameters/imfile-severity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-persiststateinterval`
+     - .. include:: ../../reference/parameters/imfile-persiststateinterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-startmsg-regex`
+     - .. include:: ../../reference/parameters/imfile-startmsg-regex.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-endmsg-regex`
+     - .. include:: ../../reference/parameters/imfile-endmsg-regex.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-readtimeout`
+     - .. include:: ../../reference/parameters/imfile-readtimeout.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-readmode`
+     - .. include:: ../../reference/parameters/imfile-readmode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-escapelf`
+     - .. include:: ../../reference/parameters/imfile-escapelf.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-escapelf-replacement`
+     - .. include:: ../../reference/parameters/imfile-escapelf-replacement.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-maxlinesatonce`
+     - .. include:: ../../reference/parameters/imfile-maxlinesatonce.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-maxsubmitatonce`
+     - .. include:: ../../reference/parameters/imfile-maxsubmitatonce.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-deletestateonfiledelete`
+     - .. include:: ../../reference/parameters/imfile-deletestateonfiledelete.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-deletestateonfilemove`
+     - .. include:: ../../reference/parameters/imfile-deletestateonfilemove.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-ruleset`
+     - .. include:: ../../reference/parameters/imfile-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-addmetadata`
+     - .. include:: ../../reference/parameters/imfile-addmetadata.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-addceetag`
+     - .. include:: ../../reference/parameters/imfile-addceetag.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-reopenontruncate`
+     - .. include:: ../../reference/parameters/imfile-reopenontruncate.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-maxlinesperminute`
+     - .. include:: ../../reference/parameters/imfile-maxlinesperminute.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-maxbytesperminute`
+     - .. include:: ../../reference/parameters/imfile-maxbytesperminute.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-trimlineoverbytes`
+     - .. include:: ../../reference/parameters/imfile-trimlineoverbytes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-freshstarttail`
+     - .. include:: ../../reference/parameters/imfile-freshstarttail.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-discardtruncatedmsg`
+     - .. include:: ../../reference/parameters/imfile-discardtruncatedmsg.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-msgdiscardingerror`
+     - .. include:: ../../reference/parameters/imfile-msgdiscardingerror.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-needparse`
+     - .. include:: ../../reference/parameters/imfile-needparse.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-persiststateaftersubmission`
+     - .. include:: ../../reference/parameters/imfile-persiststateaftersubmission.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfile-ignoreolderthan`
+     - .. include:: ../../reference/parameters/imfile-ignoreolderthan.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imfile-mode
+   ../../reference/parameters/imfile-readtimeout
+   ../../reference/parameters/imfile-deletestateonfilemove
+   ../../reference/parameters/imfile-timeoutgranularity
+   ../../reference/parameters/imfile-sortfiles
+   ../../reference/parameters/imfile-pollinginterval
+   ../../reference/parameters/imfile-statefile-directory
+   ../../reference/parameters/imfile-file
+   ../../reference/parameters/imfile-tag
+   ../../reference/parameters/imfile-facility
+   ../../reference/parameters/imfile-severity
+   ../../reference/parameters/imfile-persiststateinterval
+   ../../reference/parameters/imfile-startmsg-regex
+   ../../reference/parameters/imfile-endmsg-regex
+   ../../reference/parameters/imfile-readmode
+   ../../reference/parameters/imfile-escapelf
+   ../../reference/parameters/imfile-escapelf-replacement
+   ../../reference/parameters/imfile-maxlinesatonce
+   ../../reference/parameters/imfile-maxsubmitatonce
+   ../../reference/parameters/imfile-deletestateonfiledelete
+   ../../reference/parameters/imfile-ruleset
+   ../../reference/parameters/imfile-addmetadata
+   ../../reference/parameters/imfile-addceetag
+   ../../reference/parameters/imfile-reopenontruncate
+   ../../reference/parameters/imfile-maxlinesperminute
+   ../../reference/parameters/imfile-maxbytesperminute
+   ../../reference/parameters/imfile-trimlineoverbytes
+   ../../reference/parameters/imfile-freshstarttail
+   ../../reference/parameters/imfile-discardtruncatedmsg
+   ../../reference/parameters/imfile-msgdiscardingerror
+   ../../reference/parameters/imfile-needparse
+   ../../reference/parameters/imfile-persiststateaftersubmission
+   ../../reference/parameters/imfile-ignoreolderthan

--- a/doc/source/reference/parameters/imfile-addceetag.rst
+++ b/doc/source/reference/parameters/imfile-addceetag.rst
@@ -1,0 +1,45 @@
+.. _param-imfile-addceetag:
+.. _imfile.parameter.module.addceetag:
+
+addCeeTag
+=========
+
+.. index::
+   single: imfile; addCeeTag
+   single: addCeeTag
+
+.. summary-start
+
+This is used to turn on or off the addition of the "@cee:" cookie to the message object.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: addCeeTag
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This is used to turn on or off the addition of the "@cee:" cookie to the
+message object.
+
+Input usage
+-----------
+.. _param-imfile-input-addceetag:
+.. _imfile.parameter.input.addceetag:
+.. code-block:: rsyslog
+
+   input(type="imfile" addCeeTag="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-addmetadata.rst
+++ b/doc/source/reference/parameters/imfile-addmetadata.rst
@@ -1,0 +1,47 @@
+.. _param-imfile-addmetadata:
+.. _imfile.parameter.module.addmetadata:
+
+addMetadata
+===========
+
+.. index::
+   single: imfile; addMetadata
+   single: addMetadata
+
+.. summary-start
+
+**Default: see intro section on Metadata**  This is used to turn on or off the addition of metadata to the message object.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: addMetadata
+:Scope: input
+:Type: boolean
+:Default: input=-1
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+**Default: see intro section on Metadata**
+
+This is used to turn on or off the addition of metadata to the
+message object.
+
+Input usage
+-----------
+.. _param-imfile-input-addmetadata:
+.. _imfile.parameter.input.addmetadata:
+.. code-block:: rsyslog
+
+   input(type="imfile" addMetadata="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-addmetadata.rst
+++ b/doc/source/reference/parameters/imfile-addmetadata.rst
@@ -10,7 +10,7 @@ addMetadata
 
 .. summary-start
 
-**Default: see intro section on Metadata**  This is used to turn on or off the addition of metadata to the message object.
+Controls whether file-related metadata is added to messages. By default, this is automatically enabled when wildcards are used in the file path.
 
 .. summary-end
 
@@ -18,17 +18,16 @@ This parameter applies to :doc:`../../configuration/modules/imfile`.
 
 :Name: addMetadata
 :Scope: input
-:Type: boolean
-:Default: input=-1
+:Type: word
+:Default: input=auto (enabled for wildcards, disabled otherwise)
 :Required?: no
 :Introduced: at least 8.x, possibly earlier
 
 Description
 -----------
-**Default: see intro section on Metadata**
-
-This is used to turn on or off the addition of metadata to the
-message object.
+This parameter controls whether file-related metadata is attached to each
+message. If left unspecified, metadata is automatically added when wildcards
+appear in the ``File`` setting; otherwise it is disabled.
 
 Input usage
 -----------
@@ -40,7 +39,7 @@ Input usage
 
 Notes
 -----
-- Legacy docs describe this as a binary option; it is a boolean.
+- Allowed values: ``on`` or ``off``. If omitted, the value is ``auto``.
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-deletestateonfiledelete.rst
+++ b/doc/source/reference/parameters/imfile-deletestateonfiledelete.rst
@@ -1,0 +1,77 @@
+.. _param-imfile-deletestateonfiledelete:
+.. _imfile.parameter.module.deletestateonfiledelete:
+
+deleteStateOnFileDelete
+=======================
+
+.. index::
+   single: imfile; deleteStateOnFileDelete
+   single: deleteStateOnFileDelete
+
+.. summary-start
+
+This parameter controls if state files are deleted if their associated main file is deleted.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: deleteStateOnFileDelete
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+This parameter controls if state files are deleted if their associated
+main file is deleted. Usually, this is a good idea, because otherwise
+problems would occur if a new file with the same name is created. In
+that case, imfile would pick up reading from the last position in
+the **deleted** file, which usually is not what you want.
+
+However, there is one situation where not deleting associated state
+file makes sense: this is the case if a monitored file is modified
+with an editor (like vi or gedit). Most editors write out modifications
+by deleting the old file and creating a new now. If the state file
+would be deleted in that case, all of the file would be reprocessed,
+something that's probably not intended in most case. As a side-note,
+it is strongly suggested *not* to modify monitored files with
+editors. In any case, in such a situation, it makes sense to
+disable state file deletion. That also applies to similar use
+cases.
+
+In general, this parameter should only by set if the users
+knows exactly why this is required.
+
+For historical reasons, this parameter has an alias called
+`removeStateOnDelete`. This is to provide backward compatibility.
+Newer installations should use `deleteStateOnFileDelete` only.
+
+Input usage
+-----------
+.. _param-imfile-input-deletestateonfiledelete:
+.. _imfile.parameter.input.deletestateonfiledelete:
+.. code-block:: rsyslog
+
+   input(type="imfile" deleteStateOnFileDelete="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.removestateondelete:
+- removeStateOnDelete — maps to deleteStateOnFileDelete (status: legacy)
+
+.. index::
+   single: imfile; removeStateOnDelete
+   single: removeStateOnDelete
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-deletestateonfilemove.rst
+++ b/doc/source/reference/parameters/imfile-deletestateonfilemove.rst
@@ -1,0 +1,59 @@
+.. _param-imfile-deletestateonfilemove:
+.. _imfile.parameter.module.deletestateonfilemove:
+
+deleteStateOnFileMove
+=====================
+
+.. index::
+   single: imfile; deleteStateOnFileMove
+   single: deleteStateOnFileMove
+
+.. summary-start
+
+If set to **on**, the state file for a monitored file is removed when that file is moved or rotated away.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: deleteStateOnFileMove
+:Scope: module | input
+:Type: boolean
+:Default: module=off; input=inherits module
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+If set to **on**, the state file for a monitored file is removed when that file
+is moved or rotated away. By default the state file is kept.
+
+This parameter controls if state files are deleted when their associated
+main file is moved or renamed. By default, this parameter inherits its
+value from the module-level `deleteStateOnFileMove` parameter. When set
+to "on", the state file will be automatically cleaned up when the file
+is moved, preventing orphaned state files.
+
+Module usage
+------------
+.. _param-imfile-module-deletestateonfilemove:
+.. _imfile.parameter.module.deletestateonfilemove-usage:
+.. code-block:: rsyslog
+
+   module(load="imfile" deleteStateOnFileMove="...")
+
+Input usage
+-----------
+.. _param-imfile-input-deletestateonfilemove:
+.. _imfile.parameter.input.deletestateonfilemove:
+.. code-block:: rsyslog
+
+   input(type="imfile" deleteStateOnFileMove="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-discardtruncatedmsg.rst
+++ b/doc/source/reference/parameters/imfile-discardtruncatedmsg.rst
@@ -10,7 +10,7 @@ discardTruncatedMsg
 
 .. summary-start
 
-When messages are too long they are truncated and the following part is processed as a new message.
+Controls whether the truncated part of an overly long message is discarded instead of being processed as a new message.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-discardtruncatedmsg.rst
+++ b/doc/source/reference/parameters/imfile-discardtruncatedmsg.rst
@@ -1,0 +1,46 @@
+.. _param-imfile-discardtruncatedmsg:
+.. _imfile.parameter.module.discardtruncatedmsg:
+
+discardTruncatedMsg
+===================
+
+.. index::
+   single: imfile; discardTruncatedMsg
+   single: discardTruncatedMsg
+
+.. summary-start
+
+When messages are too long they are truncated and the following part is processed as a new message.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: discardTruncatedMsg
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When messages are too long they are truncated and the following part is
+processed as a new message. When this parameter is turned on the
+truncated part is not processed but discarded.
+
+Input usage
+-----------
+.. _param-imfile-input-discardtruncatedmsg:
+.. _imfile.parameter.input.discardtruncatedmsg:
+.. code-block:: rsyslog
+
+   input(type="imfile" discardTruncatedMsg="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-endmsg-regex.rst
+++ b/doc/source/reference/parameters/imfile-endmsg-regex.rst
@@ -1,0 +1,61 @@
+.. _param-imfile-endmsg-regex:
+.. _imfile.parameter.module.endmsg-regex:
+.. _imfile.parameter.module.endmsg.regex:
+
+endmsg.regex
+============
+
+.. index::
+   single: imfile; endmsg.regex
+   single: endmsg.regex
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: endmsg.regex
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: 8.38.0
+
+Description
+-----------
+.. versionadded:: 8.38.0
+
+This permits the processing of multi-line messages. When set, a message is
+terminated when ``endmsg.regex`` matches the line that
+identifies the end of a message. As this parameter is using regular
+expressions, it is more flexible than ``readMode`` but at the cost of lower
+performance.
+Note that ``readMode`` and ``startmsg.regex`` and ``endmsg.regex`` cannot all be
+defined for the same input.
+The primary use case for this is multiline container log files which look like
+this:
+
+.. code-block:: none
+
+    date stdout P start of message
+    date stdout P  middle of message
+    date stdout F  end of message
+
+The `F` means this is the line which contains the final part of the message.
+The fully assembled message should be `start of message middle of message end of
+message`.  `endmsg.regex="^[^ ]+ stdout F "` will match.
+
+Input usage
+-----------
+.. _param-imfile-input-endmsg-regex:
+.. _imfile.parameter.input.endmsg-regex:
+.. code-block:: rsyslog
+
+   input(type="imfile" endmsg.regex="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-endmsg-regex.rst
+++ b/doc/source/reference/parameters/imfile-endmsg-regex.rst
@@ -11,7 +11,7 @@ endmsg.regex
 
 .. summary-start
 
-.
+Specifies a regular expression to detect the end of a multi-line message.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-escapelf-replacement.rst
+++ b/doc/source/reference/parameters/imfile-escapelf-replacement.rst
@@ -10,7 +10,7 @@ escapeLF.replacement
 
 .. summary-start
 
-.
+Specifies a custom replacement string for escaped line feed characters in multi-line messages.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-escapelf-replacement.rst
+++ b/doc/source/reference/parameters/imfile-escapelf-replacement.rst
@@ -1,0 +1,62 @@
+.. _param-imfile-escapelf-replacement:
+.. _imfile.parameter.module.escapelf-replacement:
+
+escapeLF.replacement
+====================
+
+.. index::
+   single: imfile; escapeLF.replacement
+   single: escapeLF.replacement
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: escapeLF.replacement
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=depending on use
+:Required?: no
+:Introduced: 8.2001.0
+
+Description
+-----------
+.. versionadded:: 8.2001.0
+
+This parameter works in conjunction with `escapeLF`. It is only
+honored if `escapeLF="on"`.
+
+It permits to replace the default escape sequence by a different character
+sequence. The default historically is inconsistent and depends on which
+functionality is used to read the file. It can be either "#012" or "\\n". If
+you want to retain that default, do not configure this parameter.
+
+If it is configured, any sequence may be used. For example, to replace an LF
+with a simple space, use::
+
+   escapeLF.replacement=" "
+
+It is also possible to configure longer replacements. An example for this is::
+
+   escapeLF.replacement="[LF]"
+
+Finally, it is possible to completely remove the LF. This is done by specifying
+an empty replacement sequence::
+
+   escapeLF.replacement=""
+
+Input usage
+-----------
+.. _param-imfile-input-escapelf-replacement:
+.. _imfile.parameter.input.escapelf-replacement:
+.. code-block:: rsyslog
+
+   input(type="imfile" escapeLF.replacement="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-escapelf.rst
+++ b/doc/source/reference/parameters/imfile-escapelf.rst
@@ -1,0 +1,54 @@
+.. _param-imfile-escapelf:
+.. _imfile.parameter.module.escapelf:
+
+escapeLF
+========
+
+.. index::
+   single: imfile; escapeLF
+   single: escapeLF
+
+.. summary-start
+
+This is only meaningful if multi-line messages are to be processed.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: escapeLF
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This is only meaningful if multi-line messages are to be processed.
+LF characters embedded into syslog messages cause a lot of trouble,
+as most tools and even the legacy syslog TCP protocol do not expect
+these. If set to "on", this option avoid this trouble by properly
+escaping LF characters to the 4-byte sequence "#012". This is
+consistent with other rsyslog control character escaping. By default,
+escaping is turned on. If you turn it off, make sure you test very
+carefully with all associated tools. Please note that if you intend
+to use plain TCP syslog with embedded LF characters, you need to
+enable octet-counted framing. For more details, see
+`Rainer Gerhards' blog posting on imfile LF escaping <https://rainer.gerhards.net/2013/09/imfile-multi-line-messages.html>`_.
+
+Input usage
+-----------
+.. _param-imfile-input-escapelf:
+.. _imfile.parameter.input.escapelf:
+.. code-block:: rsyslog
+
+   input(type="imfile" escapeLF="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-facility.rst
+++ b/doc/source/reference/parameters/imfile-facility.rst
@@ -1,0 +1,61 @@
+.. _param-imfile-facility:
+.. _imfile.parameter.module.facility:
+
+Facility
+========
+
+.. index::
+   single: imfile; Facility
+   single: Facility
+
+.. summary-start
+
+The syslog facility to be assigned to messages read from this file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: Facility
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=local0
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+The syslog facility to be assigned to messages read from this file. Can be
+specified in textual form (e.g. ``local0``, ``local1``, ...) or as numbers (e.g.
+16 for ``local0``). Textual form is suggested. Default  is ``local0``.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog
+
+Input usage
+-----------
+.. _param-imfile-input-facility:
+.. _imfile.parameter.input.facility:
+.. code-block:: rsyslog
+
+   input(type="imfile" Facility="...")
+
+Notes
+-----
+- Can be given as numeric code instead of name.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfilefacility:
+- $InputFileFacility — maps to Facility (status: legacy)
+
+.. index::
+   single: imfile; $InputFileFacility
+   single: $InputFileFacility
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-file.rst
+++ b/doc/source/reference/parameters/imfile-file.rst
@@ -1,0 +1,53 @@
+.. _param-imfile-file:
+.. _imfile.parameter.module.file:
+
+File
+====
+
+.. index::
+   single: imfile; File
+   single: File
+
+.. summary-start
+
+The file being monitored.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: File
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: yes
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+The file being monitored. So far, this must be an absolute name (no
+macros or templates). Note that wildcards are supported at the file
+name level (see **WildCards** below for more details).
+
+Input usage
+-----------
+.. _param-imfile-input-file:
+.. _imfile.parameter.input.file:
+.. code-block:: rsyslog
+
+   input(type="imfile" File="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfilename:
+- $InputFileName — maps to File (status: legacy)
+
+.. index::
+   single: imfile; $InputFileName
+   single: $InputFileName
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-freshstarttail.rst
+++ b/doc/source/reference/parameters/imfile-freshstarttail.rst
@@ -1,0 +1,66 @@
+.. _param-imfile-freshstarttail:
+.. _imfile.parameter.module.freshstarttail:
+
+freshStartTail
+==============
+
+.. index::
+   single: imfile; freshStartTail
+   single: freshStartTail
+
+.. summary-start
+
+This is used to tell rsyslog to seek to the end/tail of input files (discard old logs) **at its first start(freshStart)** and process only new log messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: freshStartTail
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This is used to tell rsyslog to seek to the end/tail of input files
+(discard old logs) **at its first start(freshStart)** and process only new
+log messages.
+
+When deploy rsyslog to a large number of servers, we may only care about
+new log messages generated after the deployment. set **freshstartTail**
+to **on** will discard old logs. Otherwise, there may be vast useless
+message burst on the remote central log receiver
+
+This parameter only applies to files that are already existing during
+rsyslog's initial processing of the file monitors.
+
+.. warning::
+
+   Depending on the number and location of existing files, this initial
+   startup processing may take some time as well. If another process
+   creates a new file at exactly the time of startup processing and writes
+   data to it, rsyslog might detect this file and it's data as preexisting
+   and may skip it. This race is inevitable. So when freshStartTail is used,
+   some risk of data loss exists. The same holds true if between the last
+   shutdown of rsyslog and its restart log file content has been added.
+   As such, the rsyslog team advises against activating the freshStartTail
+   option.
+
+Input usage
+-----------
+.. _param-imfile-input-freshstarttail:
+.. _imfile.parameter.input.freshstarttail:
+.. code-block:: rsyslog
+
+   input(type="imfile" freshStartTail="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-ignoreolderthan.rst
+++ b/doc/source/reference/parameters/imfile-ignoreolderthan.rst
@@ -9,7 +9,9 @@ ignoreOlderThan
    single: ignoreOlderThan
 
 .. summary-start
-Ignores files untouched for the given number of seconds.
+
+Instructs imfile to ignore discovered files that have not been modified within a specified time. Once a file is being monitored, it is no longer ignored.
+
 .. summary-end
 
 This parameter applies to :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-ignoreolderthan.rst
+++ b/doc/source/reference/parameters/imfile-ignoreolderthan.rst
@@ -1,0 +1,44 @@
+.. _param-imfile-ignoreolderthan:
+.. _imfile.parameter.module.ignoreolderthan:
+
+ignoreOlderThan
+===============
+
+.. index::
+   single: imfile; ignoreOlderThan
+   single: ignoreOlderThan
+
+.. summary-start
+Ignores files untouched for the given number of seconds.
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: ignoreOlderThan
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: 8.2108.0
+
+Description
+-----------
+.. versionadded:: 8.2108.0
+
+Instructs imfile to ignore a discovered file that has not been modified in the
+specified number of seconds. Once a file is discovered, the file is no longer
+ignored and new data will be read. This option is disabled (set to 0) by default.
+
+
+
+Input usage
+-----------
+.. _param-imfile-input-ignoreolderthan:
+.. _imfile.parameter.input.ignoreolderthan:
+.. code-block:: rsyslog
+
+   input(type="imfile" ignoreOlderThan="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-maxbytesperminute.rst
+++ b/doc/source/reference/parameters/imfile-maxbytesperminute.rst
@@ -1,0 +1,48 @@
+.. _param-imfile-maxbytesperminute:
+.. _imfile.parameter.module.maxbytesperminute:
+
+MaxBytesPerMinute
+=================
+
+.. index::
+   single: imfile; MaxBytesPerMinute
+   single: MaxBytesPerMinute
+
+.. summary-start
+
+Instructs rsyslog to enqueue a maximum number of bytes as messages per minute.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: MaxBytesPerMinute
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Instructs rsyslog to enqueue a maximum number of bytes as messages per
+minute. Once MaxBytesPerMinute is reached, subsequent messages are
+discarded.
+
+Note that messages are not truncated as a result of MaxBytesPerMinute,
+rather the entire message is discarded if part of it would be above the
+specified maximum bytes per minute.
+
+The **default** value is 0, which means that no messages are discarded.
+
+Input usage
+-----------
+.. _param-imfile-input-maxbytesperminute:
+.. _imfile.parameter.input.maxbytesperminute:
+.. code-block:: rsyslog
+
+   input(type="imfile" MaxBytesPerMinute="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-maxlinesatonce.rst
+++ b/doc/source/reference/parameters/imfile-maxlinesatonce.rst
@@ -1,0 +1,65 @@
+.. _param-imfile-maxlinesatonce:
+.. _imfile.parameter.module.maxlinesatonce:
+
+MaxLinesAtOnce
+==============
+
+.. index::
+   single: imfile; MaxLinesAtOnce
+   single: MaxLinesAtOnce
+
+.. summary-start
+
+This is a legacy setting that only is supported in *polling* mode.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: MaxLinesAtOnce
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+This is a legacy setting that only is supported in *polling* mode.
+In *inotify* mode, it is fixed at 0 and all attempts to configure
+a different value will be ignored, but will generate an error
+message.
+
+Please note that future versions of imfile may not support this
+parameter at all. So it is suggested to not use it.
+
+In *polling* mode, if set to 0, each file will be fully processed and
+then processing switches to the next file. If it is set to any other
+value, a maximum of [number] lines is processed in sequence for each file,
+and then the file is switched. This provides a kind of multiplexing
+the load of multiple files and probably leads to a more natural
+distribution of events when multiple busy files are monitored. For
+*polling* mode, the **default** is 10240.
+
+Input usage
+-----------
+.. _param-imfile-input-maxlinesatonce:
+.. _imfile.parameter.input.maxlinesatonce:
+.. code-block:: rsyslog
+
+   input(type="imfile" MaxLinesAtOnce="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfilemaxlinesatonce:
+- $InputFileMaxLinesAtOnce — maps to MaxLinesAtOnce (status: legacy)
+
+.. index::
+   single: imfile; $InputFileMaxLinesAtOnce
+   single: $InputFileMaxLinesAtOnce
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-maxlinesperminute.rst
+++ b/doc/source/reference/parameters/imfile-maxlinesperminute.rst
@@ -1,0 +1,43 @@
+.. _param-imfile-maxlinesperminute:
+.. _imfile.parameter.module.maxlinesperminute:
+
+MaxLinesPerMinute
+=================
+
+.. index::
+   single: imfile; MaxLinesPerMinute
+   single: MaxLinesPerMinute
+
+.. summary-start
+
+Instructs rsyslog to enqueue up to the specified maximum number of lines as messages per minute.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: MaxLinesPerMinute
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Instructs rsyslog to enqueue up to the specified maximum number of lines
+as messages per minute. Lines above this value are discarded.
+
+The **default** value is 0, which means that no lines are discarded.
+
+Input usage
+-----------
+.. _param-imfile-input-maxlinesperminute:
+.. _imfile.parameter.input.maxlinesperminute:
+.. code-block:: rsyslog
+
+   input(type="imfile" MaxLinesPerMinute="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-maxsubmitatonce.rst
+++ b/doc/source/reference/parameters/imfile-maxsubmitatonce.rst
@@ -1,0 +1,45 @@
+.. _param-imfile-maxsubmitatonce:
+.. _imfile.parameter.module.maxsubmitatonce:
+
+MaxSubmitAtOnce
+===============
+
+.. index::
+   single: imfile; MaxSubmitAtOnce
+   single: MaxSubmitAtOnce
+
+.. summary-start
+
+This is an expert option.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: MaxSubmitAtOnce
+:Scope: input
+:Type: integer
+:Default: input=1024
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This is an expert option. It can be used to set the maximum input
+batch size that imfile can generate. The **default** is 1024, which
+is suitable for a wide range of applications. Be sure to understand
+rsyslog message batch processing before you modify this option. If
+you do not know what this doc here talks about, this is a good
+indication that you should NOT modify the default.
+
+Input usage
+-----------
+.. _param-imfile-input-maxsubmitatonce:
+.. _imfile.parameter.input.maxsubmitatonce:
+.. code-block:: rsyslog
+
+   input(type="imfile" MaxSubmitAtOnce="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-mode.rst
+++ b/doc/source/reference/parameters/imfile-mode.rst
@@ -10,7 +10,7 @@ Mode
 
 .. summary-start
 
-.
+Specifies if imfile shall run in inotify ("inotify") or polling ("polling") mode.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-mode.rst
+++ b/doc/source/reference/parameters/imfile-mode.rst
@@ -1,0 +1,59 @@
+.. _param-imfile-mode:
+.. _imfile.parameter.module.mode:
+
+Mode
+====
+
+.. index::
+   single: imfile; Mode
+   single: Mode
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: Mode
+:Scope: module
+:Type: word
+:Default: module=inotify
+:Required?: no
+:Introduced: 8.1.5
+
+Description
+-----------
+.. versionadded:: 8.1.5
+
+This specifies if imfile is shall run in inotify ("inotify") or polling
+("polling") mode. Traditionally, imfile used polling mode, which is
+much more resource-intense (and slower) than inotify mode. It is
+suggested that users turn on "polling" mode only if they experience
+strange problems in inotify mode. In theory, there should never be a
+reason to enable "polling" mode and later versions will most probably
+remove it.
+
+Note: if a legacy "$ModLoad" statement is used, the default is *polling*.
+This default was kept to prevent problems with old configurations. It
+might change in the future.
+
+.. versionadded:: 8.32.0
+
+On Solaris, the FEN API is used instead of INOTIFY. You can set the mode
+to fen or inotify (which is automatically mapped to fen on Solaris OS).
+Please note that the FEN is limited compared to INOTIFY. Deep wildcard
+matches may not work because of the API limits for now.
+
+Module usage
+------------
+.. _param-imfile-module-mode:
+.. _imfile.parameter.module.mode-usage:
+.. code-block:: rsyslog
+
+   module(load="imfile" Mode="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-msgdiscardingerror.rst
+++ b/doc/source/reference/parameters/imfile-msgdiscardingerror.rst
@@ -10,7 +10,7 @@ msgDiscardingError
 
 .. summary-start
 
-Upon truncation an error is given.
+Controls whether an error is logged when a message is truncated.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-msgdiscardingerror.rst
+++ b/doc/source/reference/parameters/imfile-msgdiscardingerror.rst
@@ -1,0 +1,45 @@
+.. _param-imfile-msgdiscardingerror:
+.. _imfile.parameter.module.msgdiscardingerror:
+
+msgDiscardingError
+==================
+
+.. index::
+   single: imfile; msgDiscardingError
+   single: msgDiscardingError
+
+.. summary-start
+
+Upon truncation an error is given.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: msgDiscardingError
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Upon truncation an error is given. When this parameter is turned off, no
+error will be shown upon truncation.
+
+Input usage
+-----------
+.. _param-imfile-input-msgdiscardingerror:
+.. _imfile.parameter.input.msgdiscardingerror:
+.. code-block:: rsyslog
+
+   input(type="imfile" msgDiscardingError="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-needparse.rst
+++ b/doc/source/reference/parameters/imfile-needparse.rst
@@ -1,0 +1,47 @@
+.. _param-imfile-needparse:
+.. _imfile.parameter.module.needparse:
+
+needParse
+=========
+
+.. index::
+   single: imfile; needParse
+   single: needParse
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: needParse
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.1903.0
+
+Description
+-----------
+.. versionadded:: 8.1903.0
+
+By default, read message are sent to output modules without passing through
+parsers. This parameter informs rsyslog to use also defined parser module(s).
+
+Input usage
+-----------
+.. _param-imfile-input-needparse:
+.. _imfile.parameter.input.needparse:
+.. code-block:: rsyslog
+
+   input(type="imfile" needParse="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-needparse.rst
+++ b/doc/source/reference/parameters/imfile-needparse.rst
@@ -10,7 +10,7 @@ needParse
 
 .. summary-start
 
-.
+Instructs rsyslog to process messages from this file through configured parser modules.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-persiststateaftersubmission.rst
+++ b/doc/source/reference/parameters/imfile-persiststateaftersubmission.rst
@@ -10,7 +10,7 @@ persistStateAfterSubmission
 
 .. summary-start
 
-.
+Ensures state file information is written after each batch of messages has been submitted for improved robustness.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-persiststateaftersubmission.rst
+++ b/doc/source/reference/parameters/imfile-persiststateaftersubmission.rst
@@ -1,0 +1,55 @@
+.. _param-imfile-persiststateaftersubmission:
+.. _imfile.parameter.module.persiststateaftersubmission:
+
+persistStateAfterSubmission
+===========================
+
+.. index::
+   single: imfile; persistStateAfterSubmission
+   single: persistStateAfterSubmission
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: persistStateAfterSubmission
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2006.0
+
+Description
+-----------
+.. versionadded:: 8.2006.0
+
+This setting makes imfile persist state file information after a batch of
+messages has been submitted. It can be activated (switched to "on") in order
+to provide enhanced robustness against unclean shutdowns. Depending on the
+configuration of the rest of rsyslog (most importantly queues), persisting
+the state file after each message submission prevents message loss
+when reading files and the system is shutdown in an unclean way (e.g.
+loss of power).
+
+Please note that this setting may cause frequent state file writes and
+as such may cause some performance degradation.
+
+Input usage
+-----------
+.. _param-imfile-input-persiststateaftersubmission:
+.. _imfile.parameter.input.persiststateaftersubmission:
+.. code-block:: rsyslog
+
+   input(type="imfile" persistStateAfterSubmission="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-persiststateinterval.rst
+++ b/doc/source/reference/parameters/imfile-persiststateinterval.rst
@@ -1,0 +1,67 @@
+.. _param-imfile-persiststateinterval:
+.. _imfile.parameter.module.persiststateinterval:
+
+PersistStateInterval
+====================
+
+.. index::
+   single: imfile; PersistStateInterval
+   single: PersistStateInterval
+
+.. summary-start
+
+Specifies how often the state file shall be written when processing the input file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: PersistStateInterval
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Specifies how often the state file shall be written when processing
+the input file. The **default** value is 0, which means a new state
+file is at least being written when the monitored files is being closed (end of
+rsyslogd execution). Any other value n means that the state file is
+written at least every time n file lines have been processed. This setting can
+be used to guard against message duplication due to fatal errors
+(like power fail). Note that this setting affects imfile performance,
+especially when set to a low value. Frequently writing the state file
+is very time consuming.
+
+Note further that rsyslog may write state files
+more frequently. This happens if rsyslog has some reason to do so.
+There is intentionally no more precise description of when state files
+are being written, as this is an implementation detail and may change
+as needed.
+
+**Note: If this parameter is not set, state files are not created.**
+
+Input usage
+-----------
+.. _param-imfile-input-persiststateinterval:
+.. _imfile.parameter.input.persiststateinterval:
+.. code-block:: rsyslog
+
+   input(type="imfile" PersistStateInterval="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfilepersiststateinterval:
+- $InputFilePersistStateInterval — maps to PersistStateInterval (status: legacy)
+
+.. index::
+   single: imfile; $InputFilePersistStateInterval
+   single: $InputFilePersistStateInterval
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-pollinginterval.rst
+++ b/doc/source/reference/parameters/imfile-pollinginterval.rst
@@ -1,0 +1,56 @@
+.. _param-imfile-pollinginterval:
+.. _imfile.parameter.module.pollinginterval:
+
+PollingInterval
+===============
+
+.. index::
+   single: imfile; PollingInterval
+   single: PollingInterval
+
+.. summary-start
+
+This setting specifies how often files are to be polled for new data.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: PollingInterval
+:Scope: module
+:Type: integer
+:Default: module=10
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This setting specifies how often files are to be
+polled for new data. For obvious reasons, it has effect only if
+imfile is running in polling mode.
+The time specified is in seconds. During each
+polling interval, all files are processed in a round-robin fashion.
+
+A short poll interval provides more rapid message forwarding, but
+requires more system resources. While it is possible, we strongly
+recommend not to set the polling interval to 0 seconds. That will
+make rsyslogd become a CPU hog, taking up considerable resources. It
+is supported, however, for the few very unusual situations where this
+level may be needed. Even if you need quick response, 1 seconds
+should be well enough. Please note that imfile keeps reading files as
+long as there is any data in them. So a "polling sleep" will only
+happen when nothing is left to be processed.
+
+**We recommend to use inotify mode.**
+
+Module usage
+------------
+.. _param-imfile-module-pollinginterval:
+.. _imfile.parameter.module.pollinginterval-usage:
+.. code-block:: rsyslog
+
+   module(load="imfile" PollingInterval="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-readmode.rst
+++ b/doc/source/reference/parameters/imfile-readmode.rst
@@ -1,0 +1,65 @@
+.. _param-imfile-readmode:
+.. _imfile.parameter.module.readmode:
+
+readMode
+========
+
+.. index::
+   single: imfile; readMode
+   single: readMode
+
+.. summary-start
+
+This provides support for processing some standard types of multiline messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: readMode
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+This provides support for processing some standard types of multiline
+messages. It is less flexible than ``startmsg.regex`` or ``endmsg.regex`` but
+offers higher performance than regex processing. Note that ``readMode`` and
+``startmsg.regex`` and ``endmsg.regex`` cannot all be defined for the same
+input.
+
+The value can range from 0-2 and determines the multiline
+detection method.
+
+0 - (**default**) line based (each line is a new message)
+
+1 - paragraph (There is a blank line between log messages)
+
+2 - indented (new log messages start at the beginning of a line. If a
+line starts with a space or tab "\t" it is part of the log message before it)
+
+Input usage
+-----------
+.. _param-imfile-input-readmode:
+.. _imfile.parameter.input.readmode:
+.. code-block:: rsyslog
+
+   input(type="imfile" readMode="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfilereadmode:
+- $InputFileReadMode — maps to readMode (status: legacy)
+
+.. index::
+   single: imfile; $InputFileReadMode
+   single: $InputFileReadMode
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-readtimeout.rst
+++ b/doc/source/reference/parameters/imfile-readtimeout.rst
@@ -1,0 +1,75 @@
+.. _param-imfile-readtimeout:
+.. _imfile.parameter.module.readtimeout:
+
+readTimeout
+===========
+
+.. index::
+   single: imfile; readTimeout
+   single: readTimeout
+
+.. summary-start
+
+This sets the default value for input *timeout* parameters.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: readTimeout
+:Scope: module | input
+:Type: integer
+:Default: module=0; input=inherits module
+:Required?: no
+:Introduced: 8.23.0
+
+Description
+-----------
+*Default: 0 (no timeout)*
+
+.. versionadded:: 8.23.0
+
+This sets the default value for input *timeout* parameters. See there
+for exact meaning. Parameter value is the number of seconds.
+
+.. versionadded:: 8.23.0
+
+This can be used with *startmsg.regex* (but not *readMode*). If specified,
+partial multi-line reads are timed out after the specified timeout interval.
+That means the current message fragment is being processed and the next
+message fragment arriving is treated as a completely new message. The
+typical use case for this parameter is a file that is infrequently being
+written. In such cases, the next message arrives relatively late, maybe hours
+later. Specifying a readTimeout will ensure that those "last messages" are
+emitted in a timely manner. In this use case, the "partial" messages being
+processed are actually full messages, so everything is fully correct.
+
+To guard against accidental too-early emission of a (partial) message, the
+timeout should be sufficiently large (5 to 10 seconds or more recommended).
+Specifying a value of zero turns off timeout processing. Also note the
+relationship to the *timeoutGranularity* global parameter, which sets the
+lower bound of *readTimeout*.
+
+Setting timeout values slightly increases processing time requirements; the
+effect should only be visible of a very large number of files is being
+monitored.
+
+Module usage
+------------
+.. _param-imfile-module-readtimeout:
+.. _imfile.parameter.module.readtimeout-usage:
+.. code-block:: rsyslog
+
+   module(load="imfile" readTimeout="...")
+
+Input usage
+-----------
+.. _param-imfile-input-readtimeout:
+.. _imfile.parameter.input.readtimeout:
+.. code-block:: rsyslog
+
+   input(type="imfile" readTimeout="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-reopenontruncate.rst
+++ b/doc/source/reference/parameters/imfile-reopenontruncate.rst
@@ -1,0 +1,46 @@
+.. _param-imfile-reopenontruncate:
+.. _imfile.parameter.module.reopenontruncate:
+
+reopenOnTruncate
+================
+
+.. index::
+   single: imfile; reopenOnTruncate
+   single: reopenOnTruncate
+
+.. summary-start
+
+This is an **experimental** feature that tells rsyslog to reopen input file when it was truncated (inode unchanged but file size on disk is less than current...
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: reopenOnTruncate
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This is an **experimental** feature that tells rsyslog to reopen input file
+when it was truncated (inode unchanged but file size on disk is less than
+current offset in memory).
+
+Input usage
+-----------
+.. _param-imfile-input-reopenontruncate:
+.. _imfile.parameter.input.reopenontruncate:
+.. code-block:: rsyslog
+
+   input(type="imfile" reopenOnTruncate="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-reopenontruncate.rst
+++ b/doc/source/reference/parameters/imfile-reopenontruncate.rst
@@ -10,7 +10,7 @@ reopenOnTruncate
 
 .. summary-start
 
-This is an **experimental** feature that tells rsyslog to reopen input file when it was truncated (inode unchanged but file size on disk is less than current...
+This is an **experimental** feature that tells rsyslog to reopen the input file when it was truncated (inode unchanged but file size on disk is less than current offset in memory).
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-ruleset.rst
+++ b/doc/source/reference/parameters/imfile-ruleset.rst
@@ -1,0 +1,51 @@
+.. _param-imfile-ruleset:
+.. _imfile.parameter.module.ruleset:
+
+Ruleset
+=======
+
+.. index::
+   single: imfile; Ruleset
+   single: Ruleset
+
+.. summary-start
+
+Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: Ruleset
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
+
+Input usage
+-----------
+.. _param-imfile-input-ruleset:
+.. _imfile.parameter.input.ruleset:
+.. code-block:: rsyslog
+
+   input(type="imfile" Ruleset="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfilebindruleset:
+- $InputFileBindRuleset — maps to Ruleset (status: legacy)
+
+.. index::
+   single: imfile; $InputFileBindRuleset
+   single: $InputFileBindRuleset
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-severity.rst
+++ b/doc/source/reference/parameters/imfile-severity.rst
@@ -1,0 +1,61 @@
+.. _param-imfile-severity:
+.. _imfile.parameter.module.severity:
+
+Severity
+========
+
+.. index::
+   single: imfile; Severity
+   single: Severity
+
+.. summary-start
+
+The syslog severity to be assigned to lines read.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: Severity
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=notice
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+The syslog severity to be assigned to lines read. Can be specified
+in textual   form (e.g. ``info``, ``warning``, ...) or as numbers (e.g. 6
+for ``info``). Textual form is suggested. Default is ``notice``.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog
+
+Input usage
+-----------
+.. _param-imfile-input-severity:
+.. _imfile.parameter.input.severity:
+.. code-block:: rsyslog
+
+   input(type="imfile" Severity="...")
+
+Notes
+-----
+- Can be given as numeric code instead of name.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfileseverity:
+- $InputFileSeverity — maps to Severity (status: legacy)
+
+.. index::
+   single: imfile; $InputFileSeverity
+   single: $InputFileSeverity
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-sortfiles.rst
+++ b/doc/source/reference/parameters/imfile-sortfiles.rst
@@ -10,7 +10,7 @@ sortFiles
 
 .. summary-start
 
-.
+If enabled, files are processed in sorted order.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-sortfiles.rst
+++ b/doc/source/reference/parameters/imfile-sortfiles.rst
@@ -1,0 +1,49 @@
+.. _param-imfile-sortfiles:
+.. _imfile.parameter.module.sortfiles:
+
+sortFiles
+=========
+
+.. index::
+   single: imfile; sortFiles
+   single: sortFiles
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: sortFiles
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.32.0
+
+Description
+-----------
+.. versionadded:: 8.32.0
+
+If this parameter is set to on, the files will be processed in sorted order, else
+not. However, due to the inherent asynchronicity of the whole operations involved
+in tracking files, it is not possible to guarantee this sorted order, as it also
+depends on operation mode and OS timing.
+
+Module usage
+------------
+.. _param-imfile-module-sortfiles:
+.. _imfile.parameter.module.sortfiles-usage:
+.. code-block:: rsyslog
+
+   module(load="imfile" sortFiles="...")
+
+Notes
+-----
+- Legacy docs describe this as a binary option; it is a boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-startmsg-regex.rst
+++ b/doc/source/reference/parameters/imfile-startmsg-regex.rst
@@ -11,7 +11,7 @@ startmsg.regex
 
 .. summary-start
 
-.
+Specifies a regular expression that marks the beginning of a multi-line message.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-startmsg-regex.rst
+++ b/doc/source/reference/parameters/imfile-startmsg-regex.rst
@@ -1,0 +1,50 @@
+.. _param-imfile-startmsg-regex:
+.. _imfile.parameter.module.startmsg-regex:
+.. _imfile.parameter.module.startmsg.regex:
+
+startmsg.regex
+==============
+
+.. index::
+   single: imfile; startmsg.regex
+   single: startmsg.regex
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: startmsg.regex
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: 8.10.0
+
+Description
+-----------
+.. versionadded:: 8.10.0
+
+This permits the processing of multi-line messages. When set, a
+messages is terminated when the next one begins, and
+``startmsg.regex`` contains the regex that identifies the start
+of a message. As this parameter is using regular expressions, it
+is more flexible than ``readMode`` but at the cost of lower
+performance.
+Note that ``readMode`` and ``startmsg.regex`` and ``endmsg.regex`` cannot all be
+defined for the same input.
+
+Input usage
+-----------
+.. _param-imfile-input-startmsg-regex:
+.. _imfile.parameter.input.startmsg-regex:
+.. code-block:: rsyslog
+
+   input(type="imfile" startmsg.regex="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-statefile-directory.rst
+++ b/doc/source/reference/parameters/imfile-statefile-directory.rst
@@ -1,0 +1,53 @@
+.. _param-imfile-statefile-directory:
+.. _imfile.parameter.module.statefile-directory:
+.. _imfile.parameter.module.statefile.directory:
+
+statefile.directory
+===================
+
+.. index::
+   single: imfile; statefile.directory
+   single: statefile.directory
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: statefile.directory
+:Scope: module
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: module=global(WorkDirectory) value
+:Required?: no
+:Introduced: 8.1905.0
+
+Description
+-----------
+.. versionadded:: 8.1905.0
+
+This parameter permits to specify a dedicated directory for the storage of
+imfile state files. An absolute path name should be specified (e.g.
+`/var/rsyslog/imfilestate`). This permits to keep imfile state files separate
+from other rsyslog work items.
+
+If not specified the global `workDirectory` setting is used.
+
+**Important: The directory must exist before rsyslog is started.** Also,
+rsyslog needs write permissions to work correctly. Keep in mind that this
+also might require SELinux definitions (or similar for other enhanced security
+systems).
+
+Module usage
+------------
+.. _param-imfile-module-statefile-directory:
+.. _imfile.parameter.module.statefile-directory-usage:
+.. code-block:: rsyslog
+
+   module(load="imfile" statefile.directory="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-statefile-directory.rst
+++ b/doc/source/reference/parameters/imfile-statefile-directory.rst
@@ -11,7 +11,7 @@ statefile.directory
 
 .. summary-start
 
-.
+Sets a dedicated directory for storing imfile state files.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-tag.rst
+++ b/doc/source/reference/parameters/imfile-tag.rst
@@ -1,0 +1,53 @@
+.. _param-imfile-tag:
+.. _imfile.parameter.module.tag:
+
+Tag
+===
+
+.. index::
+   single: imfile; Tag
+   single: Tag
+
+.. summary-start
+
+The tag to be assigned to messages read from this file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: Tag
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: yes
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+The tag to be assigned to messages read from this file. If you would like to
+see the colon after the tag, you need to include it when you assign a tag
+value, like so: ``tag="myTagValue:"``.
+
+Input usage
+-----------
+.. _param-imfile-input-tag:
+.. _imfile.parameter.input.tag:
+.. code-block:: rsyslog
+
+   input(type="imfile" Tag="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imfile.parameter.legacy.inputfiletag:
+- $InputFileTag — maps to Tag (status: legacy)
+
+.. index::
+   single: imfile; $InputFileTag
+   single: $InputFileTag
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-timeoutgranularity.rst
+++ b/doc/source/reference/parameters/imfile-timeoutgranularity.rst
@@ -1,0 +1,54 @@
+.. _param-imfile-timeoutgranularity:
+.. _imfile.parameter.module.timeoutgranularity:
+
+timeoutGranularity
+==================
+
+.. index::
+   single: imfile; timeoutGranularity
+   single: timeoutGranularity
+
+.. summary-start
+
+.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: timeoutGranularity
+:Scope: module
+:Type: integer
+:Default: module=1
+:Required?: no
+:Introduced: 8.23.0
+
+Description
+-----------
+.. versionadded:: 8.23.0
+
+This sets the interval in which multi-line-read timeouts are checked.
+The interval is specified in seconds. Note that
+this establishes a lower limit on the length of the timeout. For example, if
+a timeoutGranularity of 60 seconds is selected and a readTimeout value of 10 seconds
+is used, the timeout is nevertheless only checked every 60 seconds (if there is
+no other activity in imfile). This means that the readTimeout is also only
+checked every 60 seconds, which in turn means a timeout can occur only after 60
+seconds.
+
+Note that timeGranularity has some performance implication. The more frequently
+timeout processing is triggered, the more processing time is needed. This
+effect should be negligible, except if a very large number of files is being
+monitored.
+
+Module usage
+------------
+.. _param-imfile-module-timeoutgranularity:
+.. _imfile.parameter.module.timeoutgranularity-usage:
+.. code-block:: rsyslog
+
+   module(load="imfile" timeoutGranularity="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.

--- a/doc/source/reference/parameters/imfile-timeoutgranularity.rst
+++ b/doc/source/reference/parameters/imfile-timeoutgranularity.rst
@@ -10,7 +10,7 @@ timeoutGranularity
 
 .. summary-start
 
-.
+Sets the interval in which multi-line-read timeouts are checked.
 
 .. summary-end
 

--- a/doc/source/reference/parameters/imfile-trimlineoverbytes.rst
+++ b/doc/source/reference/parameters/imfile-trimlineoverbytes.rst
@@ -1,0 +1,45 @@
+.. _param-imfile-trimlineoverbytes:
+.. _imfile.parameter.module.trimlineoverbytes:
+
+trimLineOverBytes
+=================
+
+.. index::
+   single: imfile; trimLineOverBytes
+   single: trimLineOverBytes
+
+.. summary-start
+
+This is used to tell rsyslog to truncate the line which length is greater than specified bytes.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfile`.
+
+:Name: trimLineOverBytes
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This is used to tell rsyslog to truncate the line which length is greater
+than specified bytes. If it is positive number, rsyslog truncate the line
+at specified bytes. Default value of 'trimLineOverBytes' is 0, means never
+truncate line.
+
+This option can be used when ``readMode`` is 0 or 2.
+
+Input usage
+-----------
+.. _param-imfile-input-trimlineoverbytes:
+.. _imfile.parameter.input.trimlineoverbytes:
+.. code-block:: rsyslog
+
+   input(type="imfile" trimLineOverBytes="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfile`.


### PR DESCRIPTION
## Summary
- factor imfile module docs into per-parameter reference pages
- add summary tables and hidden toctree on the imfile module page

## Testing
- `sphinx-build -b html doc/source doc/_build/html` *(fails: invalid option block fixed, final run emits warnings about incomplete search index)*

------
https://chatgpt.com/codex/tasks/task_e_689cc8debea88332b10d1b01fbf1b3fb