### PR TITLE
ommysql: remove long-standing non-needed TODO item

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -465,10 +465,7 @@ BEGINparseSelectorAct
      * We specify that the SQL option must be present in the template.
      * This is for your own protection (prevent sql injection).
      */
-    if (*(p - 1) == ';')
-        --p; /* TODO: the whole parsing of the MySQL module needs to be re-thought - but this here
-              *       is clean enough for the time being -- rgerhards, 2007-07-30
-              */
+    if (*(p - 1) == ';') --p; /* point back to the delimiter for cflineParseTemplateName */
     CHKiRet(cflineParseTemplateName(&p, *ppOMSR, 0, OMSR_RQD_TPL_OPT_SQL, (uchar *)" StdDBFmt"));
 
     /* If we detect invalid properties, we disable logging,


### PR DESCRIPTION
This item was create in 2007 and has proven in ~20yrs of practice to be no issue. Even more so, this is now in legacy code that will no longer be updated at all. So the TODO no longer applies and could be removed.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
