### PR TITLE
docs: refactor imudp parameter docs

### DIFF
--- a/doc/source/configuration/modules/imudp.rst
+++ b/doc/source/configuration/modules/imudp.rst
@@ -33,7 +33,7 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; CamelCase is recommended for readability.
 
 .. index:: imudp; module parameters
 
@@ -41,128 +41,36 @@ Configuration Parameters
 Module Parameters
 -----------------
 
-TimeRequery
-^^^^^^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "2", "no", "``$UDPServerTimeRequery``"
-
-This is a performance optimization. Getting the system time is very
-costly. With this setting, imudp can be instructed to obtain the
-precise time only once every n-times. This logic is only activated if
-messages come in at a very fast rate, so doing less frequent time
-calls should usually be acceptable. The default value is two, because
-we have seen that even without optimization the kernel often returns
-twice the identical time. You can set this value as high as you like,
-but do so at your own risk. The higher the value, the less precise
-the timestamp.
-
-**Note:** the timeRequery is done based on executed system calls
-(**not** messages received). So when batch sizes are used, multiple
-messages are received with one system call. All of these messages
-always receive the same timestamp, as they are effectively received
-at the same time. When there is very high traffic and successive
-system calls immediately return the next batch of messages, the time
-requery logic kicks in, which means that by default time is only
-queried for every second batch. Again, this should not cause a
-too-much deviation as it requires messages to come in very rapidly.
-However, we advise not to set the "timeRequery" parameter to a large
-value (larger than 10) if input batches are used.
-
-
-SchedulingPolicy
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "``$IMUDPSchedulingPolicy``"
-
-Can be used the set the scheduler priority, if the necessary
-functionality is provided by the platform. Most useful to select
-"fifo" for real-time processing under Linux (and thus reduce chance
-of packet loss). Other options are "rr" and "other".
-
-
-SchedulingPriority
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "none", "no", "``$IMUDPSchedulingPriority``"
-
-Scheduling priority to use.
-
-
-BatchSize
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "32", "no", "none"
-
-This parameter is only meaningful if the system support recvmmsg()
-(newer Linux OSs do this). The parameter is silently ignored if the
-system does not support it. If supported, it sets the maximum number
-of UDP messages that can be obtained with a single OS call. For
-systems with high UDP traffic, a relatively high batch size can
-reduce system overhead and improve performance. However, this
-parameter should not be overdone. For each buffer, max message size
-bytes are statically required. Also, a too-high number leads to
-reduced efficiency, as some structures need to be completely
-initialized before the OS call is done. We would suggest to not set
-it above a value of 128, except if experimental results show that
-this is useful.
-
-
-Threads
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "1", "no", "none"
-
-.. versionadded:: 7.5.5
-
-Number of worker threads to process incoming messages. These threads
-are utilized to pull data off the network. On a busy system,
-additional threads (but not more than there are CPUs/Cores) can help
-improving performance and avoiding message loss. Note that with too
-many threads, performance can suffer. There is a hard upper limit on
-the number of threads that can be defined. Currently, this limit is
-set to 32. It may increase in the future when massive multicore
-processors become available.
-
-
-PreserveCase
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "boolean", "off", "no", "none"
-
-.. versionadded:: 8.37.0
-
-This parameter is for controlling the case in fromhost.  If preservecase is set to "on", the case in fromhost is preserved.  E.g., 'Host1.Example.Org' when the message was received from 'Host1.Example.Org'.  Default to "off" for the backward compatibility.
-
+   * - Parameter
+     - Summary
+   * - :ref:`param-imudp-timerequery`
+     - .. include:: ../../reference/parameters/imudp-timerequery.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-schedulingpolicy`
+     - .. include:: ../../reference/parameters/imudp-schedulingpolicy.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-schedulingpriority`
+     - .. include:: ../../reference/parameters/imudp-schedulingpriority.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-batchsize`
+     - .. include:: ../../reference/parameters/imudp-batchsize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-threads`
+     - .. include:: ../../reference/parameters/imudp-threads.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-preservecase`
+     - .. include:: ../../reference/parameters/imudp-preservecase.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. index:: imudp; input parameters
 
@@ -170,224 +78,77 @@ This parameter is for controlling the case in fromhost.  If preservecase is set 
 Input Parameters
 ----------------
 
-.. index:: imudp; address (input parameter)
-
-Address
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "``$UDPServerAddress``"
-
-Local IP address (or name) the UDP server should bind to. Use "*"
-to bind to all of the machine's addresses.
-
-
-Port
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "514", "yes", "``$UDPServerRun``"
-
-Specifies the port the server shall listen to.. Either a single port can
-be specified or an array of ports. If multiple ports are specified, a
-listener will be automatically started for each port. Thus, no
-additional inputs need to be configured.
-
-Single port: Port="514"
-
-Array of ports: Port=["514","515","10514","..."]
-
-
-IpFreeBind
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "2", "no", "none"
-
-.. versionadded:: 8.18.0
-
-Manages the IP_FREEBIND option on the UDP socket, which allows binding it to
-an IP address that is nonlocal or not (yet) associated to any network interface.
-
-The parameter accepts the following values:
-
--  0 - does not enable the IP_FREEBIND option on the
-   UDP socket. If the *bind()* call fails because of *EADDRNOTAVAIL* error,
-   socket initialization fails.
-
--  1 - silently enables the IP_FREEBIND socket
-   option if it is required to successfully bind the socket to a nonlocal address.
-
--  2 - enables the IP_FREEBIND socket option and
-   warns when it is used to successfully bind the socket to a nonlocal address.
-
-
-Device
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-Bind socket to given device (e.g., eth0)
-
-For Linux with VRF support, the Device option can be used to specify the
-VRF for the Address.
-
-
-Ruleset
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "RSYSLOG_DefaultRuleset", "no", "``$InputUDPServerBindRuleset``"
-
-Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
-
-
-RateLimit.Interval
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-.. versionadded:: 7.3.1
-
-The rate-limiting interval in seconds. Value 0 turns off rate limiting.
-Set it to a number of seconds (5 recommended) to activate rate-limiting.
-
-
-RateLimit.Burst
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "10000", "no", "none"
-
-.. versionadded:: 7.3.1
-
-Specifies the rate-limiting burst in number of messages.
-
-
-Name
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "imudp", "no", "none"
-
-.. versionadded:: 8.3.3
-
-Specifies the value of the inputname property. In older versions,
-this was always "imudp" for all
-listeners, which still is the default. Starting with 7.3.9 it can be
-set to different values for each listener. Note that when a single
-input statement defines multiple listener ports, the inputname will be
-the same for all of them. If you want to differentiate in that case,
-use "name.appendPort" to make them unique. Note that the
-"name" parameter can be an empty string. In that case, the
-corresponding inputname property will obviously also be the empty
-string. This is primarily meant to be used together with
-"name.appendPort" to set the inputname equal to the port.
-
-
-Name.appendPort
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 7.3.9
-
-Appends the port the inputname property. Note that when no "name" is
-specified, the default of "imudp" is used and the port is appended to
-that default. So, for example, a listener port of 514 in that case
-will lead to an inputname of "imudp514". The ability to append a port
-is most useful when multiple ports are defined for a single input and
-each of the inputnames shall be unique. Note that there currently is
-no differentiation between IPv4/v6 listeners on the same port.
-
-
-DefaultTZ
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-This is an **experimental** parameter; details may change at any
-time and it may also be discontinued without any early warning.
-Permits to set a default timezone for this listener. This is useful
-when working with legacy syslog (RFC3164 et al) residing in different
-timezones. If set it will be used as timezone for all messages **that
-do not contain timezone info**. Currently, the format **must** be
-"+/-hh:mm", e.g. "-05:00", "+01:30". Other formats, including TZ
-names (like EST) are NOT yet supported. Note that consequently no
-daylight saving settings are evaluated when working with timezones.
-If an invalid format is used, "interesting" things can happen, among
-them malformed timestamps and rsyslogd segfaults. This will obviously
-be changed at the time this feature becomes non-experimental.
-
-
-RcvBufSize
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "size", "none", "no", "none"
-
-.. versionadded:: 7.3.9
-
-This request a socket receive buffer of specific size from the operating system. It
-is an expert parameter, which should only be changed for a good reason.
-Note that setting this parameter disables Linux auto-tuning, which
-usually works pretty well. The default value is 0, which means "keep
-the OS buffer size unchanged". This is a size value. So in addition
-to pure integer values, sizes like "256k", "1m" and the like can be
-specified. Note that setting very large sizes may require root or
-other special privileges. Also note that the OS may slightly adjust
-the value or shrink it to a system-set max value if the user is not
-sufficiently privileged. Technically, this parameter will result in a
-setsockopt() call with SO\_RCVBUF (and SO\_RCVBUFFORCE if it is
-available). (Maximum Value: 1G)
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imudp-address`
+     - .. include:: ../../reference/parameters/imudp-address.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-port`
+     - .. include:: ../../reference/parameters/imudp-port.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ipfreebind`
+     - .. include:: ../../reference/parameters/imudp-ipfreebind.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-device`
+     - .. include:: ../../reference/parameters/imudp-device.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ruleset`
+     - .. include:: ../../reference/parameters/imudp-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ratelimit-interval`
+     - .. include:: ../../reference/parameters/imudp-ratelimit-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ratelimit-burst`
+     - .. include:: ../../reference/parameters/imudp-ratelimit-burst.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-name`
+     - .. include:: ../../reference/parameters/imudp-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-name-appendport`
+     - .. include:: ../../reference/parameters/imudp-name-appendport.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-defaulttz`
+     - .. include:: ../../reference/parameters/imudp-defaulttz.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-rcvbufsize`
+     - .. include:: ../../reference/parameters/imudp-rcvbufsize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imudp-timerequery
+   ../../reference/parameters/imudp-schedulingpolicy
+   ../../reference/parameters/imudp-schedulingpriority
+   ../../reference/parameters/imudp-batchsize
+   ../../reference/parameters/imudp-threads
+   ../../reference/parameters/imudp-preservecase
+   ../../reference/parameters/imudp-address
+   ../../reference/parameters/imudp-port
+   ../../reference/parameters/imudp-ipfreebind
+   ../../reference/parameters/imudp-device
+   ../../reference/parameters/imudp-ruleset
+   ../../reference/parameters/imudp-ratelimit-interval
+   ../../reference/parameters/imudp-ratelimit-burst
+   ../../reference/parameters/imudp-name
+   ../../reference/parameters/imudp-name-appendport
+   ../../reference/parameters/imudp-defaulttz
+   ../../reference/parameters/imudp-rcvbufsize
 
 
 .. _imudp-statistic-counter:

--- a/doc/source/reference/parameters/imudp-address.rst
+++ b/doc/source/reference/parameters/imudp-address.rst
@@ -1,0 +1,53 @@
+.. _param-imudp-address:
+.. _imudp.parameter.module.address:
+
+Address
+=======
+
+.. index::
+   single: imudp; Address
+   single: Address
+
+.. summary-start
+
+Local IP address or name the UDP socket binds to; use ``*`` for all addresses.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Address
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Specifies the local IP address or host name to which the UDP server binds. A
+value of ``*`` binds to all addresses on the machine.
+
+Input usage
+-----------
+.. _param-imudp-input-address:
+.. _imudp.parameter.input.address:
+.. code-block:: rsyslog
+
+   input(type="imudp" Address="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.udpserveraddress:
+- $UDPServerAddress — maps to Address (status: legacy)
+
+.. index::
+   single: imudp; $UDPServerAddress
+   single: $UDPServerAddress
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-batchsize.rst
+++ b/doc/source/reference/parameters/imudp-batchsize.rst
@@ -1,0 +1,49 @@
+.. _param-imudp-batchsize:
+.. _imudp.parameter.module.batchsize:
+
+BatchSize
+=========
+
+.. index::
+   single: imudp; BatchSize
+   single: BatchSize
+
+.. summary-start
+
+Maximum number of UDP messages read with one ``recvmmsg()`` call when batching is supported.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: BatchSize
+:Scope: module
+:Type: integer
+:Default: module=32
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+If the platform supports ``recvmmsg()``, this sets how many UDP messages can be
+obtained with a single OS call. Larger batches reduce system overhead for high
+traffic but require preallocated buffers for each potential message. Too-high
+values lead to inefficiency because structures must be initialized before the
+call. Values above 128 are generally not recommended.
+
+Module usage
+------------
+.. _param-imudp-module-batchsize:
+.. _imudp.parameter.module.batchsize-usage:
+.. code-block:: rsyslog
+
+   module(load="imudp" BatchSize="...")
+
+Notes
+-----
+- Ignored silently if ``recvmmsg()`` is not supported by the system.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-defaulttz.rst
+++ b/doc/source/reference/parameters/imudp-defaulttz.rst
@@ -1,0 +1,49 @@
+.. _param-imudp-defaulttz:
+.. _imudp.parameter.module.defaulttz:
+
+DefaultTZ
+=========
+
+.. index::
+   single: imudp; DefaultTZ
+   single: DefaultTZ
+
+.. summary-start
+
+Experimental setting that applies a fallback timezone to legacy messages lacking one.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: DefaultTZ
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Sets a default timezone for messages without timezone information, useful with
+legacy syslog formats like RFC3164. The format must be ``+/-hh:mm`` such as
+``-05:00`` or ``+01:30``. Timezone names (for example ``EST``) and daylight
+saving adjustments are not supported.
+
+Input usage
+-----------
+.. _param-imudp-input-defaulttz:
+.. _imudp.parameter.input.defaulttz:
+.. code-block:: rsyslog
+
+   input(type="imudp" DefaultTZ="...")
+
+Notes
+-----
+- Experimental: syntax and behavior may change or disappear without notice.
+- Invalid formats may lead to malformed timestamps or even ``rsyslogd`` crashes.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-device.rst
+++ b/doc/source/reference/parameters/imudp-device.rst
@@ -1,0 +1,43 @@
+.. _param-imudp-device:
+.. _imudp.parameter.module.device:
+
+Device
+======
+
+.. index::
+   single: imudp; Device
+   single: Device
+
+.. summary-start
+
+Bind the UDP socket to a specific network device or VRF.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Device
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Specifies the network interface to which the socket should bind, for example
+``eth0``. On Linux with VRF support, the device value can specify the VRF for the
+configured address.
+
+Input usage
+-----------
+.. _param-imudp-input-device:
+.. _imudp.parameter.input.device:
+.. code-block:: rsyslog
+
+   input(type="imudp" Device="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-ipfreebind.rst
+++ b/doc/source/reference/parameters/imudp-ipfreebind.rst
@@ -1,0 +1,49 @@
+.. _param-imudp-ipfreebind:
+.. _imudp.parameter.module.ipfreebind:
+
+IpFreeBind
+==========
+
+.. index::
+   single: imudp; IpFreeBind
+   single: IpFreeBind
+
+.. summary-start
+
+Controls the ``IP_FREEBIND`` socket option when binding to nonlocal addresses.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: IpFreeBind
+:Scope: input
+:Type: integer
+:Default: input=2
+:Required?: no
+:Introduced: 8.18.0
+
+Description
+-----------
+Manages the ``IP_FREEBIND`` option on the UDP socket, allowing binding to an IP
+address that is nonlocal or not yet configured on any interface.
+
+The parameter accepts these values:
+
+- ``0`` – do not enable ``IP_FREEBIND``; binding fails if the address is
+  not available.
+- ``1`` – silently enable ``IP_FREEBIND`` only when needed to bind.
+- ``2`` – enable ``IP_FREEBIND`` and emit a warning when it was required.
+
+Input usage
+-----------
+.. _param-imudp-input-ipfreebind:
+.. _imudp.parameter.input.ipfreebind:
+.. code-block:: rsyslog
+
+   input(type="imudp" IpFreeBind="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-name-appendport.rst
+++ b/doc/source/reference/parameters/imudp-name-appendport.rst
@@ -1,0 +1,48 @@
+.. _param-imudp-name-appendport:
+.. _imudp.parameter.module.name-appendport:
+
+Name.appendPort
+===============
+
+.. index::
+   single: imudp; Name.appendPort
+   single: Name.appendPort
+
+.. summary-start
+
+Appends the listener's port number to the ``inputname`` value.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Name.appendPort
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 7.3.9
+
+Description
+-----------
+When enabled, the port number is appended to the ``inputname`` property. If no
+explicit ``name`` is set, the default ``imudp`` is used before the port, yielding
+values like ``imudp514``. This helps make input names unique when multiple ports
+are defined. IPv4 and IPv6 listeners on the same port are not distinguished.
+
+Input usage
+-----------
+.. _param-imudp-input-name-appendport:
+.. _imudp.parameter.input.name-appendport:
+.. code-block:: rsyslog
+
+   input(type="imudp" Name.appendPort="...")
+
+Notes
+-----
+- Historic documentation called this a ``binary`` option; it is boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-name.rst
+++ b/doc/source/reference/parameters/imudp-name.rst
@@ -1,0 +1,49 @@
+.. _param-imudp-name:
+.. _imudp.parameter.module.name:
+
+Name
+====
+
+.. index::
+   single: imudp; Name
+   single: Name
+
+.. summary-start
+
+Sets the ``inputname`` property for messages received by this listener.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Name
+:Scope: input
+:Type: word
+:Default: input=imudp
+:Required?: no
+:Introduced: 8.3.3
+
+Description
+-----------
+Defines the value of the ``inputname`` property. By default all listeners report
+``imudp``. When multiple ports are configured within a single input, all share
+the same name unless ``name.appendPort`` is also set. The name may be an empty
+string, which is mainly useful together with ``name.appendPort`` to use the port
+number itself.
+
+Input usage
+-----------
+.. _param-imudp-input-name:
+.. _imudp.parameter.input.name:
+.. code-block:: rsyslog
+
+   input(type="imudp" Name="...")
+
+Notes
+-----
+- Earlier examples referred to this parameter as ``inputname``.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-port.rst
+++ b/doc/source/reference/parameters/imudp-port.rst
@@ -1,0 +1,59 @@
+.. _param-imudp-port:
+.. _imudp.parameter.module.port:
+
+Port
+====
+
+.. index::
+   single: imudp; Port
+   single: Port
+
+.. summary-start
+
+Port number or array of ports the UDP server listens on.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Port
+:Scope: input
+:Type: array[string]
+:Default: input=514
+:Required?: yes
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Defines the UDP port or ports to listen to. Either a single port can be
+specified or an array of ports. When multiple ports are given, a listener is
+started automatically for each one.
+
+Examples:
+
+- Single port: ``Port="514"``
+- Array of ports: ``Port=["514","515","10514","..."]``
+
+Input usage
+-----------
+.. _param-imudp-input-port:
+.. _imudp.parameter.input.port:
+.. code-block:: rsyslog
+
+   input(type="imudp" Port="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.udpserverrun:
+- $UDPServerRun — maps to Port (status: legacy)
+
+.. index::
+   single: imudp; $UDPServerRun
+   single: $UDPServerRun
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-preservecase.rst
+++ b/doc/source/reference/parameters/imudp-preservecase.rst
@@ -1,0 +1,43 @@
+.. _param-imudp-preservecase:
+.. _imudp.parameter.module.preservecase:
+
+PreserveCase
+============
+
+.. index::
+   single: imudp; PreserveCase
+   single: PreserveCase
+
+.. summary-start
+
+Preserves the exact letter case of the ``fromhost`` value instead of lowering it.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: PreserveCase
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.37.0
+
+Description
+-----------
+Controls the case of the ``fromhost`` property. When set to ``on`` the host name
+is kept exactly as received, for example ``Host1.Example.Org``. The default
+``off`` keeps historical behavior of lowercasing for backward compatibility.
+
+Module usage
+------------
+.. _param-imudp-module-preservecase:
+.. _imudp.parameter.module.preservecase-usage:
+.. code-block:: rsyslog
+
+   module(load="imudp" PreserveCase="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/imudp-ratelimit-burst.rst
@@ -1,0 +1,42 @@
+.. _param-imudp-ratelimit-burst:
+.. _imudp.parameter.module.ratelimit-burst:
+
+RateLimit.Burst
+===============
+
+.. index::
+   single: imudp; RateLimit.Burst
+   single: RateLimit.Burst
+
+.. summary-start
+
+Maximum number of messages permitted within one rate-limiting interval.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: RateLimit.Burst
+:Scope: input
+:Type: integer
+:Default: input=10000
+:Required?: no
+:Introduced: 7.3.1
+
+Description
+-----------
+Sets the number of messages allowed to pass within the current rate-limiting
+interval before excess messages are discarded or delayed.
+
+Input usage
+-----------
+.. _param-imudp-input-ratelimit-burst:
+.. _imudp.parameter.input.ratelimit-burst:
+.. code-block:: rsyslog
+
+   input(type="imudp" RateLimit.Burst="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/imudp-ratelimit-interval.rst
@@ -1,0 +1,43 @@
+.. _param-imudp-ratelimit-interval:
+.. _imudp.parameter.module.ratelimit-interval:
+
+RateLimit.Interval
+==================
+
+.. index::
+   single: imudp; RateLimit.Interval
+   single: RateLimit.Interval
+
+.. summary-start
+
+Length of the rate-limiting window in seconds; ``0`` disables rate limiting.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: RateLimit.Interval
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: 7.3.1
+
+Description
+-----------
+Defines the interval in seconds used for rate limiting. A value of ``0`` turns
+off rate limiting; setting it to a positive value such as ``5`` activates the
+mechanism.
+
+Input usage
+-----------
+.. _param-imudp-input-ratelimit-interval:
+.. _imudp.parameter.input.ratelimit-interval:
+.. code-block:: rsyslog
+
+   input(type="imudp" RateLimit.Interval="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-rcvbufsize.rst
+++ b/doc/source/reference/parameters/imudp-rcvbufsize.rst
@@ -1,0 +1,46 @@
+.. _param-imudp-rcvbufsize:
+.. _imudp.parameter.module.rcvbufsize:
+
+RcvBufSize
+==========
+
+.. index::
+   single: imudp; RcvBufSize
+   single: RcvBufSize
+
+.. summary-start
+
+Requests a specific socket receive buffer size from the operating system.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: RcvBufSize
+:Scope: input
+:Type: size
+:Default: input=0
+:Required?: no
+:Introduced: 7.3.9
+
+Description
+-----------
+Asks the OS to allocate a receive buffer of the given size for the UDP socket.
+Setting this disables Linux auto-tuning and should be done only when necessary.
+Sizes can be specified as plain numbers or with units such as ``256k`` or ``1m``.
+Very large values may require root privileges, and the OS may adjust or shrink
+them to system limits. Internally, ``setsockopt()`` with ``SO_RCVBUF`` (and
+``SO_RCVBUFFORCE`` if available) is used. Maximum value is 1G.
+
+Input usage
+-----------
+.. _param-imudp-input-rcvbufsize:
+.. _imudp.parameter.input.rcvbufsize:
+.. code-block:: rsyslog
+
+   input(type="imudp" RcvBufSize="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-ruleset.rst
+++ b/doc/source/reference/parameters/imudp-ruleset.rst
@@ -1,0 +1,53 @@
+.. _param-imudp-ruleset:
+.. _imudp.parameter.module.ruleset:
+
+Ruleset
+=======
+
+.. index::
+   single: imudp; Ruleset
+   single: Ruleset
+
+.. summary-start
+
+Binds the listener to a specific rsyslog ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Ruleset
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=RSYSLOG_DefaultRuleset
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Associates the listener with the given :doc:`ruleset <../../concepts/multi_ruleset>`.
+Messages received on this input are directed to that ruleset for processing.
+
+Input usage
+-----------
+.. _param-imudp-input-ruleset:
+.. _imudp.parameter.input.ruleset:
+.. code-block:: rsyslog
+
+   input(type="imudp" Ruleset="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.inputudpserverbindruleset:
+- $InputUDPServerBindRuleset — maps to Ruleset (status: legacy)
+
+.. index::
+   single: imudp; $InputUDPServerBindRuleset
+   single: $InputUDPServerBindRuleset
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-schedulingpolicy.rst
+++ b/doc/source/reference/parameters/imudp-schedulingpolicy.rst
@@ -1,0 +1,58 @@
+.. _param-imudp-schedulingpolicy:
+.. _imudp.parameter.module.schedulingpolicy:
+
+SchedulingPolicy
+================
+
+.. index::
+   single: imudp; SchedulingPolicy
+   single: SchedulingPolicy
+
+.. summary-start
+
+Selects the thread scheduling policy such as ``fifo`` for real-time processing.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: SchedulingPolicy
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Can set the scheduler policy if the platform supports it. "fifo" is most useful
+for real-time processing under Linux to reduce packet loss. Other valid options
+are "rr" and "other".
+
+Module usage
+------------
+.. _param-imudp-module-schedulingpolicy:
+.. _imudp.parameter.module.schedulingpolicy-usage:
+.. code-block:: rsyslog
+
+   module(load="imudp" SchedulingPolicy="...")
+
+Notes
+-----
+- Scheduling parameters are set after privilege drop and may fail without sufficient privileges.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.imudpschedulingpolicy:
+- $IMUDPSchedulingPolicy — maps to SchedulingPolicy (status: legacy)
+
+.. index::
+   single: imudp; $IMUDPSchedulingPolicy
+   single: $IMUDPSchedulingPolicy
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-schedulingpriority.rst
+++ b/doc/source/reference/parameters/imudp-schedulingpriority.rst
@@ -1,0 +1,57 @@
+.. _param-imudp-schedulingpriority:
+.. _imudp.parameter.module.schedulingpriority:
+
+SchedulingPriority
+==================
+
+.. index::
+   single: imudp; SchedulingPriority
+   single: SchedulingPriority
+
+.. summary-start
+
+Specifies the scheduler priority value when a policy like ``fifo`` is used.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: SchedulingPriority
+:Scope: module
+:Type: integer
+:Default: module=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Defines the scheduler priority to apply when a real-time scheduling policy is
+selected.
+
+Module usage
+------------
+.. _param-imudp-module-schedulingpriority:
+.. _imudp.parameter.module.schedulingpriority-usage:
+.. code-block:: rsyslog
+
+   module(load="imudp" SchedulingPriority="...")
+
+Notes
+-----
+- Scheduling parameters are set after privilege drop and may fail without sufficient privileges.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.imudpschedulingpriority:
+- $IMUDPSchedulingPriority — maps to SchedulingPriority (status: legacy)
+
+.. index::
+   single: imudp; $IMUDPSchedulingPriority
+   single: $IMUDPSchedulingPriority
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-threads.rst
+++ b/doc/source/reference/parameters/imudp-threads.rst
@@ -1,0 +1,44 @@
+.. _param-imudp-threads:
+.. _imudp.parameter.module.threads:
+
+Threads
+=======
+
+.. index::
+   single: imudp; Threads
+   single: Threads
+
+.. summary-start
+
+Number of worker threads that pull UDP data from the network.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Threads
+:Scope: module
+:Type: integer
+:Default: module=1
+:Required?: no
+:Introduced: 7.5.5
+
+Description
+-----------
+Specifies how many worker threads process incoming UDP messages. Additional
+threads can improve performance on busy systems but should not exceed the number
+of CPU cores. A hard upper limit of 32 applies. Too many threads can actually
+reduce performance.
+
+Module usage
+------------
+.. _param-imudp-module-threads:
+.. _imudp.parameter.module.threads-usage:
+.. code-block:: rsyslog
+
+   module(load="imudp" Threads="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+

--- a/doc/source/reference/parameters/imudp-timerequery.rst
+++ b/doc/source/reference/parameters/imudp-timerequery.rst
@@ -1,0 +1,62 @@
+.. _param-imudp-timerequery:
+.. _imudp.parameter.module.timerequery:
+
+TimeRequery
+===========
+
+.. index::
+   single: imudp; TimeRequery
+   single: TimeRequery
+
+.. summary-start
+
+Number of system calls before querying precise time again to optimize performance.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: TimeRequery
+:Scope: module
+:Type: integer
+:Default: module=2
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Retrieving system time is costly. This parameter controls how often imudp obtains
+the precise system time. A higher value reduces expensive time queries when
+messages arrive very rapidly but lowers timestamp accuracy. Time is requested only
+once per the specified number of system calls, not per message. When input batches
+are used, all messages in a batch share the same timestamp. The default of 2
+reflects that kernels often return the same time twice. Avoid values larger than
+10 when batching.
+
+Module usage
+------------
+.. _param-imudp-module-timerequery:
+.. _imudp.parameter.module.timerequery-usage:
+.. code-block:: rsyslog
+
+   module(load="imudp" TimeRequery="...")
+
+Notes
+-----
+- Setting very large values can cause significant timestamp deviations.
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.udpservertimerequery:
+- $UDPServerTimeRequery — maps to TimeRequery (status: legacy)
+
+.. index::
+   single: imudp; $UDPServerTimeRequery
+   single: $UDPServerTimeRequery
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.
+


### PR DESCRIPTION
## Summary
- restructure imudp configuration docs
- move each imudp parameter to its own reference page
- link parameter tables from module page

## Testing
- `devtools/format-code.sh`
- `make -C doc html` *(fails: sphinx-build: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d97b780ec833298be6103919b7501