### PR TITLE
doc: split imudp parameter docs

### DIFF
--- a/doc/source/configuration/modules/imudp.rst
+++ b/doc/source/configuration/modules/imudp.rst
@@ -33,7 +33,9 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+     Parameter names are case-insensitive. In examples we recommend **camelCase**
+     (lowercase first word; each subsequent word capitalized). Dotted parameters
+     keep camelCase per segment (e.g., ``name.appendPort``, ``rateLimit.interval``).
 
 .. index:: imudp; module parameters
 
@@ -41,355 +43,91 @@ Configuration Parameters
 Module Parameters
 -----------------
 
-TimeRequery
-^^^^^^^^^^^
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
 
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "2", "no", "``$UDPServerTimeRequery``"
-
-This is a performance optimization. Getting the system time is very
-costly. With this setting, imudp can be instructed to obtain the
-precise time only once every n-times. This logic is only activated if
-messages come in at a very fast rate, so doing less frequent time
-calls should usually be acceptable. The default value is two, because
-we have seen that even without optimization the kernel often returns
-twice the identical time. You can set this value as high as you like,
-but do so at your own risk. The higher the value, the less precise
-the timestamp.
-
-**Note:** the timeRequery is done based on executed system calls
-(**not** messages received). So when batch sizes are used, multiple
-messages are received with one system call. All of these messages
-always receive the same timestamp, as they are effectively received
-at the same time. When there is very high traffic and successive
-system calls immediately return the next batch of messages, the time
-requery logic kicks in, which means that by default time is only
-queried for every second batch. Again, this should not cause a
-too-much deviation as it requires messages to come in very rapidly.
-However, we advise not to set the "timeRequery" parameter to a large
-value (larger than 10) if input batches are used.
-
-
-SchedulingPolicy
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "none", "no", "``$IMUDPSchedulingPolicy``"
-
-Can be used the set the scheduler priority, if the necessary
-functionality is provided by the platform. Most useful to select
-"fifo" for real-time processing under Linux (and thus reduce chance
-of packet loss). Other options are "rr" and "other".
-
-
-SchedulingPriority
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "none", "no", "``$IMUDPSchedulingPriority``"
-
-Scheduling priority to use.
-
-
-BatchSize
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "32", "no", "none"
-
-This parameter is only meaningful if the system support recvmmsg()
-(newer Linux OSs do this). The parameter is silently ignored if the
-system does not support it. If supported, it sets the maximum number
-of UDP messages that can be obtained with a single OS call. For
-systems with high UDP traffic, a relatively high batch size can
-reduce system overhead and improve performance. However, this
-parameter should not be overdone. For each buffer, max message size
-bytes are statically required. Also, a too-high number leads to
-reduced efficiency, as some structures need to be completely
-initialized before the OS call is done. We would suggest to not set
-it above a value of 128, except if experimental results show that
-this is useful.
-
-
-Threads
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "1", "no", "none"
-
-.. versionadded:: 7.5.5
-
-Number of worker threads to process incoming messages. These threads
-are utilized to pull data off the network. On a busy system,
-additional threads (but not more than there are CPUs/Cores) can help
-improving performance and avoiding message loss. Note that with too
-many threads, performance can suffer. There is a hard upper limit on
-the number of threads that can be defined. Currently, this limit is
-set to 32. It may increase in the future when massive multicore
-processors become available.
-
-
-PreserveCase
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "boolean", "off", "no", "none"
-
-.. versionadded:: 8.37.0
-
-This parameter is for controlling the case in fromhost.  If preservecase is set to "on", the case in fromhost is preserved.  E.g., 'Host1.Example.Org' when the message was received from 'Host1.Example.Org'.  Default to "off" for the backward compatibility.
-
-
+   * - Parameter
+     - Summary
+   * - :ref:`param-imudp-timerequery`
+     - .. include:: ../../reference/parameters/imudp-timerequery.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-schedulingpolicy`
+     - .. include:: ../../reference/parameters/imudp-schedulingpolicy.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-schedulingpriority`
+     - .. include:: ../../reference/parameters/imudp-schedulingpriority.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-batchsize`
+     - .. include:: ../../reference/parameters/imudp-batchsize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-threads`
+     - .. include:: ../../reference/parameters/imudp-threads.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-preservecase`
+     - .. include:: ../../reference/parameters/imudp-preservecase.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 .. index:: imudp; input parameters
-
 
 Input Parameters
 ----------------
 
-.. index:: imudp; address (input parameter)
-
-Address
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "``$UDPServerAddress``"
-
-Local IP address (or name) the UDP server should bind to. Use "*"
-to bind to all of the machine's addresses.
-
-
-Port
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "array", "514", "yes", "``$UDPServerRun``"
-
-Specifies the port the server shall listen to.. Either a single port can
-be specified or an array of ports. If multiple ports are specified, a
-listener will be automatically started for each port. Thus, no
-additional inputs need to be configured.
-
-Single port: Port="514"
-
-Array of ports: Port=["514","515","10514","..."]
-
-
-IpFreeBind
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "2", "no", "none"
-
-.. versionadded:: 8.18.0
-
-Manages the IP_FREEBIND option on the UDP socket, which allows binding it to
-an IP address that is nonlocal or not (yet) associated to any network interface.
-
-The parameter accepts the following values:
-
--  0 - does not enable the IP_FREEBIND option on the
-   UDP socket. If the *bind()* call fails because of *EADDRNOTAVAIL* error,
-   socket initialization fails.
-
--  1 - silently enables the IP_FREEBIND socket
-   option if it is required to successfully bind the socket to a nonlocal address.
-
--  2 - enables the IP_FREEBIND socket option and
-   warns when it is used to successfully bind the socket to a nonlocal address.
-
-
-Device
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-Bind socket to given device (e.g., eth0)
-
-For Linux with VRF support, the Device option can be used to specify the
-VRF for the Address.
-
-
-Ruleset
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "RSYSLOG_DefaultRuleset", "no", "``$InputUDPServerBindRuleset``"
-
-Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
-
-
-RateLimit.Interval
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "no", "none"
-
-.. versionadded:: 7.3.1
-
-The rate-limiting interval in seconds. Value 0 turns off rate limiting.
-Set it to a number of seconds (5 recommended) to activate rate-limiting.
-
-
-RateLimit.Burst
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "10000", "no", "none"
-
-.. versionadded:: 7.3.1
-
-Specifies the rate-limiting burst in number of messages.
-
-
-Name
-^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "imudp", "no", "none"
-
-.. versionadded:: 8.3.3
-
-Specifies the value of the inputname property. In older versions,
-this was always "imudp" for all
-listeners, which still is the default. Starting with 7.3.9 it can be
-set to different values for each listener. Note that when a single
-input statement defines multiple listener ports, the inputname will be
-the same for all of them. If you want to differentiate in that case,
-use "name.appendPort" to make them unique. Note that the
-"name" parameter can be an empty string. In that case, the
-corresponding inputname property will obviously also be the empty
-string. This is primarily meant to be used together with
-"name.appendPort" to set the inputname equal to the port.
-
-
-Name.appendPort
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. versionadded:: 7.3.9
-
-Appends the port the inputname property. Note that when no "name" is
-specified, the default of "imudp" is used and the port is appended to
-that default. So, for example, a listener port of 514 in that case
-will lead to an inputname of "imudp514". The ability to append a port
-is most useful when multiple ports are defined for a single input and
-each of the inputnames shall be unique. Note that there currently is
-no differentiation between IPv4/v6 listeners on the same port.
-
-
-DefaultTZ
-^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "none"
-
-This is an **experimental** parameter; details may change at any
-time and it may also be discontinued without any early warning.
-Permits to set a default timezone for this listener. This is useful
-when working with legacy syslog (RFC3164 et al) residing in different
-timezones. If set it will be used as timezone for all messages **that
-do not contain timezone info**. Currently, the format **must** be
-"+/-hh:mm", e.g. "-05:00", "+01:30". Other formats, including TZ
-names (like EST) are NOT yet supported. Note that consequently no
-daylight saving settings are evaluated when working with timezones.
-If an invalid format is used, "interesting" things can happen, among
-them malformed timestamps and rsyslogd segfaults. This will obviously
-be changed at the time this feature becomes non-experimental.
-
-
-RcvBufSize
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "size", "none", "no", "none"
-
-.. versionadded:: 7.3.9
-
-This request a socket receive buffer of specific size from the operating system. It
-is an expert parameter, which should only be changed for a good reason.
-Note that setting this parameter disables Linux auto-tuning, which
-usually works pretty well. The default value is 0, which means "keep
-the OS buffer size unchanged". This is a size value. So in addition
-to pure integer values, sizes like "256k", "1m" and the like can be
-specified. Note that setting very large sizes may require root or
-other special privileges. Also note that the OS may slightly adjust
-the value or shrink it to a system-set max value if the user is not
-sufficiently privileged. Technically, this parameter will result in a
-setsockopt() call with SO\_RCVBUF (and SO\_RCVBUFFORCE if it is
-available). (Maximum Value: 1G)
-
-
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imudp-address`
+     - .. include:: ../../reference/parameters/imudp-address.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-port`
+     - .. include:: ../../reference/parameters/imudp-port.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ipfreebind`
+     - .. include:: ../../reference/parameters/imudp-ipfreebind.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-device`
+     - .. include:: ../../reference/parameters/imudp-device.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ruleset`
+     - .. include:: ../../reference/parameters/imudp-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ratelimit-interval`
+     - .. include:: ../../reference/parameters/imudp-ratelimit-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-ratelimit-burst`
+     - .. include:: ../../reference/parameters/imudp-ratelimit-burst.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-name`
+     - .. include:: ../../reference/parameters/imudp-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-name-appendport`
+     - .. include:: ../../reference/parameters/imudp-name-appendport.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-defaulttz`
+     - .. include:: ../../reference/parameters/imudp-defaulttz.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imudp-rcvbufsize`
+     - .. include:: ../../reference/parameters/imudp-rcvbufsize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 .. _imudp-statistic-counter:
 
 Statistic Counter
@@ -598,3 +336,23 @@ Additional Resources
    counters <http://www.rsyslog.com/rsyslog-statistic-counter/>`_.
    This also describes all imudp counters.
 
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imudp-timerequery
+   ../../reference/parameters/imudp-schedulingpolicy
+   ../../reference/parameters/imudp-schedulingpriority
+   ../../reference/parameters/imudp-batchsize
+   ../../reference/parameters/imudp-threads
+   ../../reference/parameters/imudp-preservecase
+   ../../reference/parameters/imudp-address
+   ../../reference/parameters/imudp-port
+   ../../reference/parameters/imudp-ipfreebind
+   ../../reference/parameters/imudp-device
+   ../../reference/parameters/imudp-ruleset
+   ../../reference/parameters/imudp-ratelimit-interval
+   ../../reference/parameters/imudp-ratelimit-burst
+   ../../reference/parameters/imudp-name
+   ../../reference/parameters/imudp-name-appendport
+   ../../reference/parameters/imudp-defaulttz
+   ../../reference/parameters/imudp-rcvbufsize

--- a/doc/source/reference/parameters/imudp-address.rst
+++ b/doc/source/reference/parameters/imudp-address.rst
@@ -1,0 +1,54 @@
+.. _param-imudp-address:
+.. _imudp.parameter.input.address:
+
+Address
+=======
+
+.. index::
+   single: imudp; Address
+   single: Address
+
+.. summary-start
+
+Local address that UDP server binds to; ``*`` uses all interfaces.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Address
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Local IP address (or name) the UDP server should bind to. Use ``*`` to bind to
+all of the machine's addresses.
+
+Input usage
+-----------
+.. _param-imudp-input-address:
+.. _imudp.parameter.input.address-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" Address="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.udpserveraddress:
+
+- $UDPServerAddress — maps to Address (status: legacy)
+
+.. index::
+   single: imudp; $UDPServerAddress
+   single: $UDPServerAddress
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-batchsize.rst
+++ b/doc/source/reference/parameters/imudp-batchsize.rst
@@ -1,0 +1,50 @@
+.. _param-imudp-batchsize:
+.. _imudp.parameter.module.batchsize:
+
+BatchSize
+=========
+
+.. index::
+   single: imudp; BatchSize
+   single: BatchSize
+
+.. summary-start
+
+Maximum messages retrieved per ``recvmmsg()`` call when available.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: BatchSize
+:Scope: module
+:Type: integer
+:Default: module=32
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This parameter is only meaningful if the system supports ``recvmmsg()`` (newer
+Linux systems do this). The parameter is silently ignored if the system does not
+support it. If supported, it sets the maximum number of UDP messages that can be
+obtained with a single OS call. For systems with high UDP traffic, a relatively
+high batch size can reduce system overhead and improve performance. However,
+this parameter should not be overdone. For each buffer, max message size bytes
+are statically required. Also, a too-high number leads to reduced efficiency, as
+some structures need to be completely initialized before the OS call is done. We
+would suggest to not set it above a value of 128, except if experimental results
+show that this is useful.
+
+Module usage
+------------
+.. _param-imudp-module-batchsize:
+.. _imudp.parameter.module.batchsize-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imudp" BatchSize="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-defaulttz.rst
+++ b/doc/source/reference/parameters/imudp-defaulttz.rst
@@ -1,0 +1,51 @@
+.. _param-imudp-defaulttz:
+.. _imudp.parameter.input.defaulttz:
+
+DefaultTZ
+=========
+
+.. index::
+   single: imudp; DefaultTZ
+   single: DefaultTZ
+
+.. summary-start
+
+Experimental default timezone applied when none present.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: DefaultTZ
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+This is an **experimental** parameter; details may change at any time and it may
+also be discontinued without any early warning. Permits to set a default
+timezone for this listener. This is useful when working with legacy syslog
+(RFC3164 et al) residing in different timezones. If set it will be used as
+timezone for all messages **that do not contain timezone info**. Currently, the
+format **must** be ``+/-hh:mm``, e.g. ``-05:00``, ``+01:30``. Other formats,
+including TZ names (like EST) are NOT yet supported. Note that consequently no
+daylight saving settings are evaluated when working with timezones. If an
+invalid format is used, "interesting" things can happen, among them malformed
+timestamps and ``rsyslogd`` segfaults. This will obviously be changed at the time
+this feature becomes non-experimental.
+
+Input usage
+-----------
+.. _param-imudp-input-defaulttz:
+.. _imudp.parameter.input.defaulttz-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" DefaultTZ="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-device.rst
+++ b/doc/source/reference/parameters/imudp-device.rst
@@ -1,0 +1,51 @@
+.. _param-imudp-device:
+.. _imudp.parameter.input.device:
+
+Device
+======
+
+.. index::
+   single: imudp; Device
+   single: Device
+
+.. summary-start
+
+Binds UDP socket to a specific network device or VRF.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Device
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+Bind socket to given device (e.g., ``eth0``).
+
+For Linux with VRF support, the ``Device`` option can be used to specify the VRF
+for the ``Address``.
+
+Examples:
+
+.. code-block:: rsyslog
+
+   module(load="imudp") # needs to be done just once
+   input(type="imudp" port="514" device="eth0")
+
+Input usage
+-----------
+.. _param-imudp-input-device:
+.. _imudp.parameter.input.device-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" Device="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-ipfreebind.rst
+++ b/doc/source/reference/parameters/imudp-ipfreebind.rst
@@ -1,0 +1,52 @@
+.. _param-imudp-ipfreebind:
+.. _imudp.parameter.input.ipfreebind:
+
+IpFreeBind
+==========
+
+.. index::
+   single: imudp; IpFreeBind
+   single: IpFreeBind
+
+.. summary-start
+
+Controls Linux ``IP_FREEBIND`` socket option for nonlocal binds.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: IpFreeBind
+:Scope: input
+:Type: integer
+:Default: input=2
+:Required?: no
+:Introduced: 8.18.0
+
+Description
+-----------
+Manages the ``IP_FREEBIND`` option on the UDP socket, which allows binding it to
+an IP address that is nonlocal or not (yet) associated to any network interface.
+
+The parameter accepts the following values:
+
+- 0 - does not enable the ``IP_FREEBIND`` option on the UDP socket. If the
+  ``bind()`` call fails because of ``EADDRNOTAVAIL`` error, socket initialization
+  fails.
+- 1 - silently enables the ``IP_FREEBIND`` socket option if it is required to
+  successfully bind the socket to a nonlocal address.
+- 2 - enables the ``IP_FREEBIND`` socket option and warns when it is used to
+  successfully bind the socket to a nonlocal address.
+
+Input usage
+-----------
+.. _param-imudp-input-ipfreebind:
+.. _imudp.parameter.input.ipfreebind-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" IpFreeBind="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-name-appendport.rst
+++ b/doc/source/reference/parameters/imudp-name-appendport.rst
@@ -1,0 +1,65 @@
+.. _param-imudp-name-appendport:
+.. _imudp.parameter.input.name-appendport:
+
+Name.appendPort
+===============
+
+.. index::
+   single: imudp; Name.appendPort
+   single: Name.appendPort
+
+.. summary-start
+
+Appends listener port number to ``inputname``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Name.appendPort
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 7.3.9
+
+Description
+-----------
+Appends the port to the ``inputname`` property. Note that when no ``name`` is
+specified, the default of ``imudp`` is used and the port is appended to that
+default. So, for example, a listener port of 514 in that case will lead to an
+``inputname`` of ``imudp514``. The ability to append a port is most useful when
+multiple ports are defined for a single input and each of the ``inputname``
+values shall be unique. Note that there currently is no differentiation between
+IPv4/v6 listeners on the same port.
+
+Examples:
+
+.. code-block:: rsyslog
+
+   module(load="imudp")
+   input(type="imudp" port=["10514","10515","10516"]
+         name="udp" name.appendPort="on")
+
+.. code-block:: rsyslog
+
+   module(load="imudp")
+   input(type="imudp" port=["10514","10515","10516"]
+         name="" name.appendPort="on")
+
+Input usage
+-----------
+.. _param-imudp-input-name-appendport:
+.. _imudp.parameter.input.name-appendport-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" Name.appendPort="...")
+
+Notes
+-----
+- Earlier documentation described the type as ``binary``; this maps to boolean.
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-name.rst
+++ b/doc/source/reference/parameters/imudp-name.rst
@@ -1,0 +1,63 @@
+.. _param-imudp-name:
+.. _imudp.parameter.input.name:
+
+Name
+====
+
+.. index::
+   single: imudp; Name
+   single: Name
+
+.. summary-start
+
+Value assigned to ``inputname`` property for this listener.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Name
+:Scope: input
+:Type: word
+:Default: input=imudp
+:Required?: no
+:Introduced: 8.3.3
+
+Description
+-----------
+Specifies the value of the ``inputname`` property. In older versions, this was
+always ``imudp`` for all listeners, which still is the default. Starting with
+7.3.9 it can be set to different values for each listener. Note that when a
+single input statement defines multiple listener ports, the ``inputname`` will be
+the same for all of them. If you want to differentiate in that case, use
+``name.appendPort`` to make them unique. Note that the ``name`` parameter can be
+an empty string. In that case, the corresponding ``inputname`` property will
+obviously also be the empty string. This is primarily meant to be used together
+with ``name.appendPort`` to set the ``inputname`` equal to the port.
+
+Examples:
+
+.. code-block:: rsyslog
+
+   module(load="imudp")
+   input(type="imudp" port=["10514","10515","10516"]
+         name="udp" name.appendPort="on")
+
+.. code-block:: rsyslog
+
+   module(load="imudp")
+   input(type="imudp" port=["10514","10515","10516"]
+         name="" name.appendPort="on")
+
+Input usage
+-----------
+.. _param-imudp-input-name:
+.. _imudp.parameter.input.name-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" Name="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-port.rst
+++ b/doc/source/reference/parameters/imudp-port.rst
@@ -1,0 +1,68 @@
+.. _param-imudp-port:
+.. _imudp.parameter.input.port:
+
+Port
+====
+
+.. index::
+   single: imudp; Port
+   single: Port
+
+.. summary-start
+
+Port or array of ports for the UDP listener.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Port
+:Scope: input
+:Type: array[string]
+:Default: input=514
+:Required?: yes
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Specifies the port the server shall listen to. Either a single port can be
+specified or an array of ports. If multiple ports are specified, a listener will
+be automatically started for each port. Thus, no additional inputs need to be
+configured.
+
+Examples:
+
+.. code-block:: rsyslog
+
+   module(load="imudp") # needs to be done just once
+   input(type="imudp" port="514")
+
+.. code-block:: rsyslog
+
+   module(load="imudp")
+   input(type="imudp" port=["514","515","10514"])
+
+Input usage
+-----------
+.. _param-imudp-input-port:
+.. _imudp.parameter.input.port-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" Port="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.udpserverrun:
+
+- $UDPServerRun — maps to Port (status: legacy)
+
+.. index::
+   single: imudp; $UDPServerRun
+   single: $UDPServerRun
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-preservecase.rst
+++ b/doc/source/reference/parameters/imudp-preservecase.rst
@@ -1,0 +1,44 @@
+.. _param-imudp-preservecase:
+.. _imudp.parameter.module.preservecase:
+
+PreserveCase
+============
+
+.. index::
+   single: imudp; PreserveCase
+   single: PreserveCase
+
+.. summary-start
+
+Controls whether ``fromhost`` preserves original case.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: PreserveCase
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.37.0
+
+Description
+-----------
+This parameter is for controlling the case in ``fromhost``. If
+``PreserveCase`` is set to "on", the case in ``fromhost`` is preserved, e.g.,
+``Host1.Example.Org`` when the message was received from
+``Host1.Example.Org``. Default is "off" for backward compatibility.
+
+Module usage
+------------
+.. _param-imudp-module-preservecase:
+.. _imudp.parameter.module.preservecase-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imudp" PreserveCase="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/imudp-ratelimit-burst.rst
@@ -1,0 +1,41 @@
+.. _param-imudp-ratelimit-burst:
+.. _imudp.parameter.input.ratelimit-burst:
+
+RateLimit.Burst
+===============
+
+.. index::
+   single: imudp; RateLimit.Burst
+   single: RateLimit.Burst
+
+.. summary-start
+
+Maximum messages permitted per rate-limiting burst.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: RateLimit.Burst
+:Scope: input
+:Type: integer
+:Default: input=10000
+:Required?: no
+:Introduced: 7.3.1
+
+Description
+-----------
+Specifies the rate-limiting burst in number of messages.
+
+Input usage
+-----------
+.. _param-imudp-input-ratelimit-burst:
+.. _imudp.parameter.input.ratelimit-burst-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" RateLimit.Burst="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/imudp-ratelimit-interval.rst
@@ -1,0 +1,42 @@
+.. _param-imudp-ratelimit-interval:
+.. _imudp.parameter.input.ratelimit-interval:
+
+RateLimit.Interval
+==================
+
+.. index::
+   single: imudp; RateLimit.Interval
+   single: RateLimit.Interval
+
+.. summary-start
+
+Rate-limiting interval in seconds; ``0`` disables throttling.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: RateLimit.Interval
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: 7.3.1
+
+Description
+-----------
+The rate-limiting interval in seconds. Value 0 turns off rate limiting. Set it to
+a number of seconds (5 recommended) to activate rate-limiting.
+
+Input usage
+-----------
+.. _param-imudp-input-ratelimit-interval:
+.. _imudp.parameter.input.ratelimit-interval-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" RateLimit.Interval="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-rcvbufsize.rst
+++ b/doc/source/reference/parameters/imudp-rcvbufsize.rst
@@ -1,0 +1,58 @@
+.. _param-imudp-rcvbufsize:
+.. _imudp.parameter.input.rcvbufsize:
+
+RcvBufSize
+==========
+
+.. index::
+   single: imudp; RcvBufSize
+   single: RcvBufSize
+
+.. summary-start
+
+Requests specific socket receive buffer size; disables auto-tuning.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: RcvBufSize
+:Scope: input
+:Type: size
+:Default: input=0
+:Required?: no
+:Introduced: 7.3.9
+
+Description
+-----------
+This requests a socket receive buffer of specific size from the operating
+system. It is an expert parameter, which should only be changed for a good
+reason. Note that setting this parameter disables Linux auto-tuning, which
+usually works pretty well. The default value is 0, which means "keep the OS
+buffer size unchanged". This is a size value. So in addition to pure integer
+values, sizes like ``256k``, ``1m`` and the like can be specified. Note that
+setting very large sizes may require root or other special privileges. Also note
+that the OS may slightly adjust the value or shrink it to a system-set max value
+if the user is not sufficiently privileged. Technically, this parameter will
+result in a ``setsockopt()`` call with ``SO_RCVBUF`` (and ``SO_RCVBUFFORCE`` if it
+is available). (Maximum Value: 1G)
+
+Examples:
+
+.. code-block:: rsyslog
+
+   module(load="imudp") # needs to be done just once
+   input(type="imudp" port="514" rcvbufSize="1m")
+
+Input usage
+-----------
+.. _param-imudp-input-rcvbufsize:
+.. _imudp.parameter.input.rcvbufsize-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" RcvBufSize="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-ruleset.rst
+++ b/doc/source/reference/parameters/imudp-ruleset.rst
@@ -1,0 +1,53 @@
+.. _param-imudp-ruleset:
+.. _imudp.parameter.input.ruleset:
+
+Ruleset
+=======
+
+.. index::
+   single: imudp; Ruleset
+   single: Ruleset
+
+.. summary-start
+
+Assigns incoming messages to a specified ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Ruleset
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=RSYSLOG_DefaultRuleset
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Binds the listener to a specific :doc:`ruleset <../../concepts/multi_ruleset>`.
+
+Input usage
+-----------
+.. _param-imudp-input-ruleset:
+.. _imudp.parameter.input.ruleset-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" Ruleset="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.inputudpserverbindruleset:
+
+- $InputUDPServerBindRuleset — maps to Ruleset (status: legacy)
+
+.. index::
+   single: imudp; $InputUDPServerBindRuleset
+   single: $InputUDPServerBindRuleset
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-schedulingpolicy.rst
+++ b/doc/source/reference/parameters/imudp-schedulingpolicy.rst
@@ -1,0 +1,56 @@
+.. _param-imudp-schedulingpolicy:
+.. _imudp.parameter.module.schedulingpolicy:
+
+SchedulingPolicy
+================
+
+.. index::
+   single: imudp; SchedulingPolicy
+   single: SchedulingPolicy
+
+.. summary-start
+
+Selects OS scheduler policy like ``fifo`` for real-time handling.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: SchedulingPolicy
+:Scope: module
+:Type: word
+:Default: module=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Can be used to set the scheduler priority, if the necessary functionality is
+provided by the platform. Most useful to select ``fifo`` for real-time processing
+under Linux (and thus reduce chance of packet loss). Other options are ``rr`` and
+``other``.
+
+Module usage
+------------
+.. _param-imudp-module-schedulingpolicy:
+.. _imudp.parameter.module.schedulingpolicy-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imudp" SchedulingPolicy="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.imudpschedulingpolicy:
+
+- $IMUDPSchedulingPolicy — maps to SchedulingPolicy (status: legacy)
+
+.. index::
+   single: imudp; $IMUDPSchedulingPolicy
+   single: $IMUDPSchedulingPolicy
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-schedulingpriority.rst
+++ b/doc/source/reference/parameters/imudp-schedulingpriority.rst
@@ -1,0 +1,53 @@
+.. _param-imudp-schedulingpriority:
+.. _imudp.parameter.module.schedulingpriority:
+
+SchedulingPriority
+==================
+
+.. index::
+   single: imudp; SchedulingPriority
+   single: SchedulingPriority
+
+.. summary-start
+
+Scheduler priority value when ``SchedulingPolicy`` is used.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: SchedulingPriority
+:Scope: module
+:Type: integer
+:Default: module=none
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+Scheduling priority to use.
+
+Module usage
+------------
+.. _param-imudp-module-schedulingpriority:
+.. _imudp.parameter.module.schedulingpriority-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imudp" SchedulingPriority="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.imudpschedulingpriority:
+
+- $IMUDPSchedulingPriority — maps to SchedulingPriority (status: legacy)
+
+.. index::
+   single: imudp; $IMUDPSchedulingPriority
+   single: $IMUDPSchedulingPriority
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-threads.rst
+++ b/doc/source/reference/parameters/imudp-threads.rst
@@ -1,0 +1,47 @@
+.. _param-imudp-threads:
+.. _imudp.parameter.module.threads:
+
+Threads
+=======
+
+.. index::
+   single: imudp; Threads
+   single: Threads
+
+.. summary-start
+
+Number of worker threads receiving data; upper limit 32.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: Threads
+:Scope: module
+:Type: integer
+:Default: module=1
+:Required?: no
+:Introduced: 7.5.5
+
+Description
+-----------
+Number of worker threads to process incoming messages. These threads are
+utilized to pull data off the network. On a busy system, additional threads
+(but not more than there are CPUs/Cores) can help improving performance and
+avoiding message loss. Note that with too many threads, performance can suffer.
+There is a hard upper limit on the number of threads that can be defined.
+Currently, this limit is set to 32. It may increase in the future when massive
+multicore processors become available.
+
+Module usage
+------------
+.. _param-imudp-module-threads:
+.. _imudp.parameter.module.threads-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imudp" Threads="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/doc/source/reference/parameters/imudp-timerequery.rst
+++ b/doc/source/reference/parameters/imudp-timerequery.rst
@@ -1,0 +1,66 @@
+.. _param-imudp-timerequery:
+.. _imudp.parameter.module.timerequery:
+
+TimeRequery
+===========
+
+.. index::
+   single: imudp; TimeRequery
+   single: TimeRequery
+
+.. summary-start
+
+Frequency of system time queries; lower values yield more precise timestamps.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: TimeRequery
+:Scope: module
+:Type: integer
+:Default: module=2
+:Required?: no
+:Introduced: at least 5.x, possibly earlier
+
+Description
+-----------
+This is a performance optimization. Getting the system time is very costly. With
+this setting, imudp can be instructed to obtain the precise time only once every
+n-times. This logic is only activated if messages come in at a very fast rate, so
+doing less frequent time calls should usually be acceptable. The default value is
+two, because we have seen that even without optimization the kernel often returns
+twice the identical time. You can set this value as high as you like, but do so at
+your own risk. The higher the value, the less precise the timestamp.
+
+.. note::
+   The time requery is based on executed system calls, not messages received.
+   When batch sizes are used, multiple messages are obtained with one system
+   call and all receive the same timestamp. At very high traffic the requery
+   logic means time is queried only for every second batch by default. Do not
+   set ``TimeRequery`` above 10 when input batches are used.
+
+Module usage
+------------
+.. _param-imudp-module-timerequery:
+.. _imudp.parameter.module.timerequery-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imudp" TimeRequery="...")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imudp.parameter.legacy.udpservertimerequery:
+
+- $UDPServerTimeRequery — maps to TimeRequery (status: legacy)
+
+.. index::
+   single: imudp; $UDPServerTimeRequery
+   single: $UDPServerTimeRequery
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.


### PR DESCRIPTION
## Summary
- split `imudp` documentation into dedicated parameter pages
- replace inline parameter docs with summary tables and hidden toctree

## Testing
- `devtools/format-code.sh`
- `sphinx-build -b html doc/source doc/_build/html`


------
https://chatgpt.com/codex/tasks/task_e_689db886f28c8332b931f60df5b35ce0