### PR TITLE
testbench fix: $srcdir was not always exported

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2794,7 +2794,9 @@ file_size_check() {
 }
 
 case $1 in
-   'init')	$srcdir/killrsyslog.sh # kill rsyslogd if it runs for some reason
+  'init')
+    export srcdir # in case it was not yet in environment
+    $srcdir/killrsyslog.sh # kill rsyslogd if it runs for some reason
 		source set-envvars
 		# for (solaris) load debugging, uncomment next 2 lines:
 		#export LD_DEBUG=all


### PR DESCRIPTION
If the srcdir variable was not defined, all tests initialize it to ".". While this is fine, if srcdrv was not previously exported the newly set variable was local to the execution shell and did not promote to rsyslog environment.

However, srcdir is granted to be in environment, many processes in testbench depend on this. We now ensure this by doing an explicit export of srcdir during script init phase.

replaces https://github.com/rsyslog/rsyslog/pull/5912 because it sets srcdir right as first thing in init

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
