### PR TITLE
omhttp: migrate to OMODTX commitTransaction

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -1512,94 +1512,75 @@ finalize_it:
     RETiRet;
 }
 
-BEGINbeginTransaction
-    CODESTARTbeginTransaction;
-    if (!pWrkrData->pData->batchMode) {
-        FINALIZE;
+BEGINcommitTransaction
+    instanceData *const pData = pWrkrData->pData;
+    size_t nBytes;
+    unsigned i;
+    sbool submit;
+    uchar *restPath = NULL;
+    uchar *tpls[2];
+    int const nTpls = pData->dynRestPath ? 2 : 1;
+    CODESTARTcommitTransaction;
+
+    if (pData->batchMode) {
+        initializeBatch(pWrkrData);
     }
 
-    initializeBatch(pWrkrData);
-finalize_it:
-ENDbeginTransaction
+    for (i = 0; i < nParams; ++i) {
+        tpls[0] = actParam(pParams, nTpls, i, 0).param;
+        if (pData->dynRestPath) tpls[1] = actParam(pParams, nTpls, i, 1).param;
 
-BEGINdoAction
-    size_t nBytes;
-    sbool submit;
-    CODESTARTdoAction;
-    instanceData *const pData = pWrkrData->pData;
-    uchar *restPath = NULL;
-    STATSCOUNTER_INC(ctrMessagesSubmitted, mutCtrMessagesSubmitted);
+        STATSCOUNTER_INC(ctrMessagesSubmitted, mutCtrMessagesSubmitted);
 
-    if (pWrkrData->pData->batchMode) {
-        if (pData->dynRestPath) {
-            /* Get copy of restpath in batch mode if dynRestPath enabled */
-            getRestPath(pData, ppString, &restPath);
-            if (pWrkrData->batch.restPath == NULL) {
-                pWrkrData->batch.restPath = (uchar *)strdup((char *)restPath);
-            } else if (strcmp((char *)pWrkrData->batch.restPath, (char *)restPath) != 0) {
-                /* Check if the restPath changed - if yes submit the current batch first*/
-                CHKiRet(submitBatch(pWrkrData, NULL));
+        if (pData->batchMode) {
+            if (pData->dynRestPath) {
+                getRestPath(pData, tpls, &restPath);
+                if (pWrkrData->batch.restPath == NULL) {
+                    pWrkrData->batch.restPath = (uchar *)strdup((char *)restPath);
+                } else if (strcmp((char *)pWrkrData->batch.restPath, (char *)restPath) != 0) {
+                    CHKiRet(submitBatch(pWrkrData, NULL));
+                    initializeBatch(pWrkrData);
+                }
+            }
+
+            if (pData->maxBatchSize == 1) {
+                initializeBatch(pWrkrData);
+                CHKiRet(buildBatch(pWrkrData, tpls[0]));
+                CHKiRet(submitBatch(pWrkrData, tpls));
+                continue;
+            }
+
+            nBytes = actParam(pParams, nTpls, i, 0).lenStr - 1;
+            submit = 0;
+
+            if (pWrkrData->batch.nmemb >= pData->maxBatchSize) {
+                submit = 1;
+                DBGPRINTF("omhttp: maxbatchsize limit reached submitting batch of %zd elements.\n",
+                          pWrkrData->batch.nmemb);
+            } else if (computeBatchSize(pWrkrData) + nBytes > pData->maxBatchBytes) {
+                submit = 1;
+                DBGPRINTF("omhttp: maxbytes limit reached submitting partial batch of %zd elements.\n",
+                          pWrkrData->batch.nmemb);
+            }
+
+            if (submit) {
+                CHKiRet(submitBatch(pWrkrData, tpls));
                 initializeBatch(pWrkrData);
             }
+
+            CHKiRet(buildBatch(pWrkrData, tpls[0]));
+        } else {
+            const size_t msgLen = actParam(pParams, nTpls, i, 0).lenStr - 1;
+            CHKiRet(curlPost(pWrkrData, tpls[0], (int)msgLen, tpls, 1));
         }
-
-        /* If the maxbatchsize is 1, then build and immediately post a batch with 1 element.
-         * This mode will play nicely with rsyslog's action.resumeRetryCount logic.
-         */
-        if (pWrkrData->pData->maxBatchSize == 1) {
-            initializeBatch(pWrkrData);
-            CHKiRet(buildBatch(pWrkrData, ppString[0]));
-            CHKiRet(submitBatch(pWrkrData, ppString));
-            FINALIZE;
-        }
-
-        /* We should submit if any of these conditions are true
-         * 1. Total batch size > pWrkrData->pData->maxBatchSize
-         * 2. Total bytes > pWrkrData->pData->maxBatchBytes
-         */
-        nBytes = ustrlen((char *)ppString[0]) - 1;
-        submit = 0;
-
-        if (pWrkrData->batch.nmemb >= pWrkrData->pData->maxBatchSize) {
-            submit = 1;
-            DBGPRINTF("omhttp: maxbatchsize limit reached submitting batch of %zd elements.\n", pWrkrData->batch.nmemb);
-        } else if (computeBatchSize(pWrkrData) + nBytes > pWrkrData->pData->maxBatchBytes) {
-            submit = 1;
-            DBGPRINTF("omhttp: maxbytes limit reached submitting partial batch of %zd elements.\n",
-                      pWrkrData->batch.nmemb);
-        }
-
-        if (submit) {
-            CHKiRet(submitBatch(pWrkrData, ppString));
-            initializeBatch(pWrkrData);
-        }
-
-        CHKiRet(buildBatch(pWrkrData, ppString[0]));
-
-        /* If there is only one item in the batch, all previous items have been
-         * submitted or this is the first item for this transaction. Return previous
-         * committed so that all items leading up to the current (exclusive)
-         * are not replayed should a failure occur anywhere else in the transaction. */
-        iRet = pWrkrData->batch.nmemb == 1 ? RS_RET_PREVIOUS_COMMITTED : RS_RET_DEFER_COMMIT;
-    } else {
-        CHKiRet(curlPost(pWrkrData, ppString[0], strlen((char *)ppString[0]), ppString, 1));
     }
-finalize_it:
-ENDdoAction
 
-
-BEGINendTransaction
-    CODESTARTendTransaction;
-    /* End Transaction only if batch data is not empty */
-    if (pWrkrData->batch.nmemb > 0) {
+    if (pData->batchMode && pWrkrData->batch.nmemb > 0) {
         CHKiRet(submitBatch(pWrkrData, NULL));
-    } else {
-        dbgprintf(
-            "omhttp: endTransaction, pWrkrData->batch.nmemb = 0, "
-            "nothing to send. \n");
     }
+
 finalize_it:
-ENDendTransaction
+ENDcommitTransaction
 
 /* Creates authentication header uid:pwd
  */
@@ -2254,13 +2235,12 @@ ENDmodExit
 NO_LEGACY_CONF_parseSelectorAct
 
     BEGINqueryEtryPt CODESTARTqueryEtryPt;
-CODEqueryEtryPt_STD_OMOD_QUERIES;
+CODEqueryEtryPt_STD_OMODTX_QUERIES;
 CODEqueryEtryPt_STD_OMOD8_QUERIES;
 CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES;
 CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES;
 CODEqueryEtryPt_doHUP CODEqueryEtryPt_doHUPWrkr /* Load the worker HUP handling code */
-    CODEqueryEtryPt_TXIF_OMOD_QUERIES /* we support the transactional interface! */
-        CODEqueryEtryPt_STD_CONF2_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_QUERIES;
 ENDqueryEtryPt
 
 


### PR DESCRIPTION
## Summary
- switch omhttp from legacy TXIF begin/do/end to OMODTX commitTransaction
- maintain batching and dynamic REST path semantics
- update query entry points to OMODTX macros

## Testing
- `./autogen.sh`
- `./configure`
- `make -j4`


------
https://chatgpt.com/codex/tasks/task_e_689f0406c1e0833283c7a720cf7b46ec