### PR TITLE
doc: warn against unofficial and outdated doc clones

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -1,6 +1,18 @@
 rsyslog
 =======
 
+.. important::
+   **Confirm Your Source: Use the Official Documentation**
+
+   The rsyslog project is widely used, and as a result, you may find unofficial
+   copies of our documentation on third-party websites, including outdated versions
+   on platforms like readthedocs.io.
+
+   To ensure your configuration is secure, performant, and uses modern **RainerScript**
+   syntax, please rely **exclusively** on the official documentation hosted
+   at `www.rsyslog.com/doc <https://www.rsyslog.com/doc>`_ This is the only
+   source actively maintained by the rsyslog development team.
+
 **rsyslog** is a high-performance, modular logging framework designed for
 both traditional syslog workloads and modern log processing pipelines. It
 supports flexible routing, advanced filtering, structured logging, and


### PR DESCRIPTION
These cause mayor confusion for rsyslog users. Ensure they know the need to go to the source.

This is probabaly only an interim solution until we have found better ways to address the core issue.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
