### PR TITLE
doc: set html_baseurl to emit canonical tags

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -233,7 +233,8 @@ suppress_warnings = ['epub.unknown_project_files']
 
 # The base URL which points to the root of the HTML documentation.
 # It is used to indicate the location of document like canonical_url.
-html_baseurl = 'https://www.rsyslog.com/doc/'
+RSYSLOG_BASE_URL = 'https://www.rsyslog.com'
+html_baseurl = f'{RSYSLOG_BASE_URL}/doc/'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -231,6 +231,10 @@ suppress_warnings = ['epub.unknown_project_files']
 
 # -- Options for HTML output ---------------------------------------------------
 
+# The base URL which points to the root of the HTML documentation.
+# It is used to indicate the location of document like canonical_url.
+html_baseurl = 'https://www.rsyslog.com/doc/'
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'furo'


### PR DESCRIPTION
Add html_baseurl to Sphinx config; set to
'https://www.rsyslog.com/doc/'.
Sphinx will add a canonical link per page, reducing duplicate content in search and consolidating ranking.

The URL matches the production docs root (trailing slash kept). No behavior change for local/offline builds.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
