### PR TITLE
doc: add per-container docker pages with env defaults

### DIFF
--- a/doc/source/containers/collector.rst
+++ b/doc/source/containers/collector.rst
@@ -1,0 +1,26 @@
+.. _containers-user-collector:
+
+rsyslog/rsyslog-collector
+=========================
+
+Built on the standard image, ``rsyslog-collector`` adds modules for
+centralised log aggregation. It exposes TCP and UDP syslog ports and can
+forward data to storage backends.
+
+Environment Variables
+---------------------
+
+Runtime behaviour can be tuned with the following variables:
+
+- ``ENABLE_UDP`` – enable UDP syslog reception. Default ``on``.
+- ``ENABLE_TCP`` – enable TCP syslog reception. Default ``on``.
+- ``WRITE_ALL_FILE`` – write all messages to ``/var/log/all.log`` when
+  ``on`` (default).
+- ``WRITE_JSON_FILE`` – write JSON formatted messages to
+  ``/var/log/all-json.log`` when ``on`` (default).
+- ``RSYSLOG_HOSTNAME`` – hostname used inside rsyslog. Defaults to the
+  value of ``/etc/hostname`` when unset.
+- ``PERMIT_UNCLEAN_START`` – skip configuration validation when set. By
+  default ``rsyslogd -N1`` validates the configuration.
+- ``RSYSLOG_ROLE`` – role name consumed by the entrypoint. Defaults to
+  ``collector``.

--- a/doc/source/containers/dockerlogs.rst
+++ b/doc/source/containers/dockerlogs.rst
@@ -1,0 +1,21 @@
+.. _containers-user-dockerlogs:
+
+rsyslog/rsyslog-dockerlogs
+==========================
+
+This variant includes the ``imdocker`` module to read logs from the
+Docker daemon and forward them to a central rsyslog instance.
+
+Environment Variables
+---------------------
+
+- ``REMOTE_SERVER_NAME`` – required hostname or IP of the collector to
+  forward logs to.
+- ``REMOTE_SERVER_PORT`` – TCP port on the collector. Defaults to ``514``
+  when unset.
+- ``RSYSLOG_HOSTNAME`` – hostname used inside rsyslog. Defaults to the
+  value of ``/etc/hostname`` when unset.
+- ``PERMIT_UNCLEAN_START`` – skip configuration validation when set. By
+  default ``rsyslogd -N1`` validates the configuration.
+- ``RSYSLOG_ROLE`` – role name consumed by the entrypoint. Defaults to
+  ``docker``.

--- a/doc/source/containers/minimal.rst
+++ b/doc/source/containers/minimal.rst
@@ -1,0 +1,21 @@
+.. _containers-user-minimal:
+
+rsyslog/rsyslog-minimal
+=======================
+
+A lean Ubuntu-based image containing the rsyslog core and a tiny
+configuration that writes logs to standard output. It serves as the
+foundation for the other rsyslog images and is suitable when you want to
+add your own modules or configuration.
+
+Environment Variables
+---------------------
+
+The entrypoint script recognises the following variables:
+
+- ``RSYSLOG_HOSTNAME`` – hostname used inside rsyslog. If unset the
+  script reads ``/etc/hostname``.
+- ``PERMIT_UNCLEAN_START`` – skip ``rsyslogd -N1`` configuration check
+  when set. By default the configuration is validated.
+- ``RSYSLOG_ROLE`` – role name consumed by the entrypoint. Defaults to
+  ``minimal`` and normally does not need to be changed.

--- a/doc/source/containers/standard.rst
+++ b/doc/source/containers/standard.rst
@@ -1,0 +1,20 @@
+.. _containers-user-standard:
+
+rsyslog/rsyslog
+===============
+
+The general-purpose image builds on ``rsyslog-minimal`` and adds commonly
+used modules such as ``imhttp`` and ``omhttp``. Use it when you need a
+ready-to-run rsyslog with HTTP ingestion or forwarding capabilities.
+
+Environment Variables
+---------------------
+
+The same entrypoint variables as the minimal image are available:
+
+- ``RSYSLOG_HOSTNAME`` – hostname used inside rsyslog. Defaults to the
+  value of ``/etc/hostname`` when unset.
+- ``PERMIT_UNCLEAN_START`` – skip configuration validation when set. By
+  default ``rsyslogd -N1`` validates the configuration.
+- ``RSYSLOG_ROLE`` – role name consumed by the entrypoint. Defaults to
+  ``standard``.

--- a/doc/source/containers/user_images.rst
+++ b/doc/source/containers/user_images.rst
@@ -14,14 +14,22 @@ the ``YYYY-MM`` rsyslog release.
 
 Available variants include:
 
-* ``rsyslog/rsyslog-minimal`` – rsyslog core only.
-* ``rsyslog/rsyslog`` – standard image with common modules such as
-  ``imhttp`` and ``omhttp``.
-* ``rsyslog/rsyslog-collector`` – adds modules for centralized log
-  collection (``elasticsearch``, ...).
-* ``rsyslog/rsyslog-dockerlogs`` – includes ``imdocker`` to process
-  logs from the Docker daemon.
+* :doc:`rsyslog/rsyslog-minimal <minimal>` – rsyslog core only.
+* :doc:`rsyslog/rsyslog <standard>` – standard image with common modules
+  such as ``imhttp`` and ``omhttp``.
+* :doc:`rsyslog/rsyslog-collector <collector>` – adds modules for
+  centralized log collection (``elasticsearch``, ...).
+* :doc:`rsyslog/rsyslog-dockerlogs <dockerlogs>` – includes ``imdocker``
+  to process logs from the Docker daemon.
 * ``rsyslog/rsyslog-debug`` – planned variant with troubleshooting tools.
+
+.. toctree::
+   :maxdepth: 1
+
+   minimal
+   standard
+   collector
+   dockerlogs
 
 Images are built using the layered ``Makefile`` in
 ``packaging/docker/rsyslog``::


### PR DESCRIPTION
## Summary
- document individual Docker images (minimal, standard, collector, dockerlogs)
- list environment variables and default values for each image
- link new pages from the user-focused container overview

## Testing
- `./devtools/format-code.sh`
- `make -C doc html`

------
https://chatgpt.com/codex/tasks/task_e_68a1bcc5f0148332b7b0ef3046c40a47