### PR TITLE
runtime: fix NetstreamDriverCAExtraFiles parsing

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -69,7 +69,8 @@ jobs:
           case "${{ matrix.config }}" in
           'centos_7')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_centos:7'
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--disable-elasticsearch-tests --disable-kafka-tests --disable-snmp-tests'
+              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
+                     --disable-kafka-tests --disable-snmp-tests"
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               ;;
           'centos_8')
@@ -131,7 +132,8 @@ jobs:
               # TODO: enable disabled components when the issues are fixed
               # It is better to run at least the majority of checks than to postpone that
               # any longer. 2025-01-31 RGerhards
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--enable-omazureeventhubs --enable-imdtls --enable-omdtls --disable-omamqp1 --disable-snmp --disable-elasticsearch-tests"
+              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--enable-omazureeventhubs --enable-imdtls \
+                     --enable-omdtls --disable-omamqp1 --disable-snmp --disable-elasticsearch-tests"
               ;;
           'ubuntu_22_distcheck')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
@@ -155,7 +157,8 @@ jobs:
               ;;
           'ubuntu_24_tsan')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
-              export CI_MAKE_CHECK_OPT='-j2' # This is CPU-heavy due to tsan, so we need less concurrency to prevent flakes
+              # This is CPU-heavy due to tsan, so we need less concurrency to prevent flakes
+              export CI_MAKE_CHECK_OPT='-j2'
               export CI_VALGRIND_SUPPRESSIONS="ubuntu22.04.supp"
               export CI_SANITIZE_BLACKLIST='tests/tsan.supp'
               export CC='clang'

--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -43,7 +43,7 @@ printf 'pulling container...\n'
 docker pull $RSYSLOG_DEV_CONTAINER
 printf 'user ids: %s:%s\n' $(id -u) $(id -g)
 printf 'container_uid: %s\n' ${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)}
-printf 'container cmd: %s\n' $*
+printf 'container cmd: %s\n' "$*"
 docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e RSYSLOG_CONFIGURE_OPTIONS_EXTRA \
 	-e RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE \
@@ -68,4 +68,4 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	--cap-add SYS_PTRACE \
 	${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)} \
 	$DOCKER_RUN_EXTRA_FLAGS \
-	-v "$RSYSLOG_HOME":/rsyslog $RSYSLOG_DEV_CONTAINER $*
+	-v "$RSYSLOG_HOME":/rsyslog $RSYSLOG_DEV_CONTAINER "$@"

--- a/packaging/docker/dev_env/fedora/base/41/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/41/Dockerfile
@@ -51,6 +51,7 @@ RUN	dnf -y install \
 	nc \
 	net-snmp-devel \
 	net-tools \
+	openssl \
 	openssl-devel \
 	openssl-devel-engine \
 	postgresql-devel \

--- a/packaging/docker/dev_env/fedora/base/42/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/42/Dockerfile
@@ -49,6 +49,7 @@ RUN	dnf -y install \
 	nc \
 	net-snmp-devel \
 	net-tools \
+	openssl \
 	openssl-devel \
 	openssl-devel-engine \
 	postgresql-devel \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1561,6 +1561,7 @@ TESTS +=  \
 	sndrcv_tls_ossl_certvalid_tlscommand.sh \
 	sndrcv_tls_ossl_certvalid_ciphers.sh \
 	sndrcv_tls_ossl_certvalid_revoked.sh \
+	sndrcv_tls_ossl_intermediate_ca_chain.sh \
 	imtcp-tls-ossl-x509valid.sh \
 	imtcp-tls-ossl-x509name.sh \
 	imtcp-tls-ossl-x509fingerprint.sh \
@@ -3165,6 +3166,7 @@ EXTRA_DIST= \
 	sndrcv_tls_gtls_serveranon_ossl_clientanon.sh \
 	sndrcv_tls_client_missing_cert.sh \
 	sndrcv_ossl_cert_chain.sh \
+	sndrcv_tls_ossl_intermediate_ca_chain.sh \
 	omtcl.sh \
 	omtcl.tcl \
 	pmsnare-default.sh \

--- a/tests/sndrcv_tls_ossl_intermediate_ca_chain.sh
+++ b/tests/sndrcv_tls_ossl_intermediate_ca_chain.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# Test for issue #5207: multiple intermediate CA certificates
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1000
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="log"
+
+# Prepare certificate workspace (dynamic, auto-cleaned by testbench)
+CERTDIR="$RSYSLOG_DYNNAME.certwork"
+mkdir -p "$CERTDIR"
+
+# Create minimal OpenSSL extfiles
+cat >"$CERTDIR/ca_ext.cnf" <<'EOF'
+[v3_ca]
+subjectKeyIdentifier=hash
+authorityKeyIdentifier=keyid:always,issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, cRLSign, keyCertSign
+EOF
+
+cat >"$CERTDIR/leaf_ext.cnf" <<'EOF'
+[server_cert]
+basicConstraints = CA:false
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = serverAuth
+
+[client_cert]
+basicConstraints = CA:false
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+EOF
+
+# Generate root CA
+openssl genpkey -algorithm RSA -out "$CERTDIR/ca-root-key.pem" >/dev/null 2>&1
+openssl req -new -key "$CERTDIR/ca-root-key.pem" -out "$CERTDIR/ca-root.csr" -subj "/C=US/ST=State/L=City/O=Org/OU=Unit/CN=Root-CA" >/dev/null 2>&1
+openssl x509 -req -in "$CERTDIR/ca-root.csr" -signkey "$CERTDIR/ca-root-key.pem" -days 3650 \
+  -extfile "$CERTDIR/ca_ext.cnf" -extensions v3_ca -out "$CERTDIR/ca-root-cert.pem" >/dev/null 2>&1
+
+# Create intermediate CA 1
+openssl genpkey -algorithm RSA -out "$CERTDIR/intermediate-ca1-key.pem" >/dev/null 2>&1
+openssl req -new -key "$CERTDIR/intermediate-ca1-key.pem" -out "$CERTDIR/intermediate-ca1.csr" -subj "/C=US/ST=State/L=City/O=Org/OU=Unit/CN=Intermediate-CA1" >/dev/null 2>&1
+openssl x509 -req -in "$CERTDIR/intermediate-ca1.csr" -CA "$CERTDIR/ca-root-cert.pem" -CAkey "$CERTDIR/ca-root-key.pem" -CAcreateserial -days 1825 \
+  -extfile "$CERTDIR/ca_ext.cnf" -extensions v3_ca -out "$CERTDIR/intermediate-ca1-cert.pem" >/dev/null 2>&1
+
+# Create intermediate CA 2
+openssl genpkey -algorithm RSA -out "$CERTDIR/intermediate-ca2-key.pem" >/dev/null 2>&1
+openssl req -new -key "$CERTDIR/intermediate-ca2-key.pem" -out "$CERTDIR/intermediate-ca2.csr" -subj "/C=US/ST=State/L=City/O=Org/OU=Unit/CN=Intermediate-CA2" >/dev/null 2>&1
+openssl x509 -req -in "$CERTDIR/intermediate-ca2.csr" -CA "$CERTDIR/ca-root-cert.pem" -CAkey "$CERTDIR/ca-root-key.pem" -CAcreateserial -days 1825 \
+  -extfile "$CERTDIR/ca_ext.cnf" -extensions v3_ca -out "$CERTDIR/intermediate-ca2-cert.pem" >/dev/null 2>&1
+
+# Create server certificate signed by intermediate CA 1
+openssl genpkey -algorithm RSA -out "$CERTDIR/server-int1-key.pem" >/dev/null 2>&1
+openssl req -new -key "$CERTDIR/server-int1-key.pem" -out "$CERTDIR/server-int1.csr" -subj "/C=US/ST=State/L=City/O=Org/OU=Unit/CN=rsyslogserver" >/dev/null 2>&1
+openssl x509 -req -in "$CERTDIR/server-int1.csr" -CA "$CERTDIR/intermediate-ca1-cert.pem" -CAkey "$CERTDIR/intermediate-ca1-key.pem" -CAcreateserial -days 365 \
+  -extfile "$CERTDIR/leaf_ext.cnf" -extensions server_cert -out "$CERTDIR/server-int1-cert.pem" >/dev/null 2>&1
+cat "$CERTDIR/server-int1-cert.pem" "$CERTDIR/intermediate-ca1-cert.pem" > "$CERTDIR/server-int1-chain.pem"
+
+# Create client certificate signed by intermediate CA 2
+openssl genpkey -algorithm RSA -out "$CERTDIR/client-int2-key.pem" >/dev/null 2>&1
+openssl req -new -key "$CERTDIR/client-int2-key.pem" -out "$CERTDIR/client-int2.csr" -subj "/C=US/ST=State/L=City/O=Org/OU=Unit/CN=rsyslogclient" >/dev/null 2>&1
+openssl x509 -req -in "$CERTDIR/client-int2.csr" -CA "$CERTDIR/intermediate-ca2-cert.pem" -CAkey "$CERTDIR/intermediate-ca2-key.pem" -CAcreateserial -days 365 \
+  -extfile "$CERTDIR/leaf_ext.cnf" -extensions client_cert -out "$CERTDIR/client-int2-cert.pem" >/dev/null 2>&1
+cat "$CERTDIR/client-int2-cert.pem" "$CERTDIR/intermediate-ca2-cert.pem" > "$CERTDIR/client-int2-chain.pem"
+
+# Debug: dump generated certificates and verify chains
+{
+  echo "==== CERT DEBUG: Subjects/Issuers/Dates/Fingerprints ===="
+  echo "-- Root CA --";
+  openssl x509 -in "$CERTDIR/ca-root-cert.pem" -noout -subject -issuer -dates -serial -fingerprint -sha256;
+  echo "-- Intermediate CA 1 --";
+  openssl x509 -in "$CERTDIR/intermediate-ca1-cert.pem" -noout -subject -issuer -dates -serial -fingerprint -sha256;
+  echo "-- Intermediate CA 2 --";
+  openssl x509 -in "$CERTDIR/intermediate-ca2-cert.pem" -noout -subject -issuer -dates -serial -fingerprint -sha256;
+  echo "-- Server leaf --";
+  openssl x509 -in "$CERTDIR/server-int1-cert.pem" -noout -subject -issuer -dates -serial -fingerprint -sha256;
+  echo "-- Server chain (top of file) --";
+  openssl x509 -in "$CERTDIR/server-int1-chain.pem" -noout -subject -issuer -dates -serial -fingerprint -sha256;
+  echo "-- Client leaf --";
+  openssl x509 -in "$CERTDIR/client-int2-cert.pem" -noout -subject -issuer -dates -serial -fingerprint -sha256;
+  echo "-- Client chain (top of file) --";
+  openssl x509 -in "$CERTDIR/client-int2-chain.pem" -noout -subject -issuer -dates -serial -fingerprint -sha256;
+  echo "==== OPENSSL VERIFY ===="
+  echo "Verify server leaf against Root + Intermediate1";
+  openssl verify -CAfile "$CERTDIR/ca-root-cert.pem" -untrusted "$CERTDIR/intermediate-ca1-cert.pem" "$CERTDIR/server-int1-cert.pem";
+  echo "Verify client leaf against Root + Intermediate2";
+  openssl verify -CAfile "$CERTDIR/ca-root-cert.pem" -untrusted "$CERTDIR/intermediate-ca2-cert.pem" "$CERTDIR/client-int2-cert.pem";
+}
+
+generate_conf
+export PORT_RCVR="$(get_free_port)"
+export SERVER_CN="rsyslogserver"
+export CLIENT_CN="rsyslogclient"
+
+add_conf '
+global(
+    DefaultNetstreamDriver="ossl"
+    DefaultNetstreamDriverCAFile="'$CERTDIR'/ca-root-cert.pem"
+    DefaultNetstreamDriverCertFile="'$CERTDIR'/server-int1-chain.pem"
+    DefaultNetstreamDriverKeyFile="'$CERTDIR'/server-int1-key.pem"
+    NetstreamDriverCAExtraFiles="'$CERTDIR'/intermediate-ca1-cert.pem,'$CERTDIR'/intermediate-ca2-cert.pem"
+)
+
+module(  load="../plugins/imtcp/.libs/imtcp"
+        StreamDriver.Name="ossl"
+        StreamDriver.Mode="1"
+        PermittedPeer="'$CLIENT_CN'"
+        StreamDriver.AuthMode="x509/name" )
+input(  type="imtcp" port="'$PORT_RCVR'" )
+
+$template outfmt,"%msg:F,58:2%\n"
+$template dynfile,"'$RSYSLOG_OUT_LOG'"
+:msg, contains, "msgnum:" ?dynfile;outfmt
+'
+
+startup
+export RSYSLOG_DEBUGLOG="log2"
+
+generate_conf 2
+export TCPFLOOD_PORT="$(get_free_port)"
+add_conf '
+global(
+    defaultNetstreamDriverCAFile="'$CERTDIR'/ca-root-cert.pem"
+    defaultNetstreamDriverCertFile="'$CERTDIR'/client-int2-chain.pem"
+    defaultNetstreamDriverKeyFile="'$CERTDIR'/client-int2-key.pem"
+)
+
+$ModLoad ../plugins/imtcp/.libs/imtcp
+input(  type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" )
+
+action( type="omfwd"
+    protocol="tcp"
+    target="127.0.0.1"
+    port="'$PORT_RCVR'"
+    StreamDriver="ossl"
+    StreamDriverMode="1"
+    StreamDriverAuthMode="x509/name"
+    StreamDriverPermittedPeers="'$SERVER_CN'"
+)
+' 2
+
+startup 2
+
+tcpflood -m$NUMMESSAGES -i1
+wait_file_lines
+
+shutdown_when_empty 2
+wait_shutdown 2
+shutdown_when_empty
+wait_shutdown
+
+seq_check 1 $NUMMESSAGES
+exit_test
+


### PR DESCRIPTION
Multiple intermediate CAs were not honored because strtok() modified
the original config value at the first comma. This led to only the
first file being considered. This change preserves the original value
and validates files using a duplicate buffer.

Impact: Users can reliably specify multiple CA intermediates via
NetstreamDriverCAExtraFiles; TLS chains that require intermediates
now validate as expected. Tests added.

Before: parsing mutated the stored string, effectively truncating at
the first comma and ignoring subsequent CA files.

After: we strdup() for validation, leave the original string intact,
and set it only if all files are accessible. Error handling follows
existing RS_RET patterns; temporary buffer is freed on all paths.

Additionally, add a test (OpenSSL backend) that generates a root,
two intermediates, and leaf certs on both client and server. The test
verifies chains with openssl, aligns CN/PermittedPeer, and exercises
a full send/receive path to guard against regressions. Makefile is
updated to include the new test in TESTS and EXTRA_DIST.

Additionally, in devtools/devcontainer.sh, switched printing to
printf 'container cmd: %s\n' \"$*\" and, most importantly, passed
the command as \"$@\" to preserve argument boundaries and
embedded quotes/newlines.

Fixes: https://github.com/rsyslog/rsyslog/issues/5207
