### PR TITLE
docs: streamline contrib templates and commit guidance

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,45 @@
 <!--
-LEGAL GDPR NOTICE:
-According to the European data protection laws (GDPR), we would like to make you
-aware that contributing to rsyslog via git will permanently store the
-name and email address you provide as well as the actual commit and the
-time and date you made it inside git's version history. This is inevitable,
-because it is a main feature git. If you are concerned about your
-privacy, we strongly recommend to use
+Thanks for your PR!
 
---author "anonymous <gdpr@example.com>"
+Commit Assistant (recommended for the commit message):
+- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
+- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt
 
-together with your commit. Also please do NOT sign your commit in this case,
-as that potentially could lead back to you. Please note that if you use your
-real identity, the GDPR grants you the right to have this information removed
-later. However, we have valid reasons why we cannot remove that information
-later on. The reasons are:
-
-* this would break git history and make future merges unworkable
-* the rsyslog projects has legitimate interest to keep a permanent record of the
-  contributor identity, once given, for
-  - copyright verification
-  - being able to provide proof should a malicious commit be made
-
-Please also note that your commit is public and as such will potentially be
-processed by many third-parties. Git's distributed nature makes it impossible
-to track where exactly your commit, and thus your personal data, will be stored
-and be processed. If you would not like to accept this risk, please do either
-commit anonymously or refrain from contributing to the rsyslog project.
+Important: put the substance into the **commit message** (not only here).
+If needed, amend first (`git commit --amend`) and then open the PR.
 -->
+
+### Summary (non-technical, complete)
+<!-- Why this change matters: modernization, maintainability, perf/security,
+     Docker/CI readiness, or user value. This text should mirror the commit’s
+     non-technical intro. -->
+
+### References
+<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
+Refs: https://github.com/rsyslog/rsyslog/issues/<id>
+
+### Notes (optional)
+<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
+     ensure the commit body has a one-line Impact and a one-line Before/After. -->
+
+---
+
+#### Quick check (optional)
+- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
+- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
+  and a one-line Before/After when behavior changed.
+- Used the Commit Assistant or mirrored its structure.
+
+---
+
+#### Git workflow tips (optional, but helps reviews)
+- Start by crafting the commit message locally (use the Assistant).
+- If you already committed, improve it with:
+  ```
+  git commit --amend
+  ```
+- Squash related commits before PR where appropriate.
+- Push your branch and then open the PR.
+- If key info is only in the PR text, maintainers may ask you to move it
+  into the commit message for a clean history.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,8 +79,8 @@ There are no strict naming rules, but these conventions are used frequently:
 ## Coding Standards
 
   - Commit messages **must include all relevant information**, not just in the PR
-  - Commit message titles **must not exceed 65 characters** (aim for 62)
-  - commit message text must be plain US ASCII, line length must not exceed 86 characters
+  - Commit message titles **must not exceed 62 characters**
+  - commit message text must be plain US ASCII, line length must not exceed 72 characters
   - When referencing GitHub issues, use the **full GitHub URL** to assist in `git log`-based reviews
   - Favor **self-documenting code** over excessive inline comments
   - Public functions should use Doxygen-style comments
@@ -352,6 +352,9 @@ If you are an AI agent contributing code or documentation:
       - Note any impact on existing versions or behaviors (especially for bug fixes).
   - Commit message descriptions should clearly identify that they were generated or co-authored by an AI tool.
   - Include a **commit footer tag** like "AI-Agent: Codex"
+  - **Use the canonical commit-message base prompt** to draft/lint messages (ASCII, 62/72 wrap, `<component>:` title, non-tech “why”, Impact, Before/After, full-URL Fixes/Refs):
+    ai/rsyslog_commit_assistant/base_prompt.txt
+  - **Commit-first:** ensure the substance is in the commit body (not only the PR). If needed, amend before opening the PR (`git commit --amend`).
 
 -----
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Rsyslog is a real open source project, welcoming contributions of all kinds—fr
 - For experiments, use **draft pull requests**. Close them after testing.
 
 ### Target Branch
-- All PRs must target the `main` branch (not `main`).
+- All PRs must target the `main` branch.
 
 ---
 
@@ -51,6 +51,32 @@ AI-Agent: Codex 2025-06
 ```
 
 This helps us track and evaluate contributions and agent capabilities.
+
+---
+
+## Commit Messages & Commit Assistant
+
+To speed up reviews and keep history consistent, please follow these rules for commit messages. You can use our assistant to generate compliant messages.
+
+- **Commit Assistant (web, for humans):**
+  https://www.rsyslog.com/tool_rsyslog-commit-assistant
+- **Base prompt (canonical, in-repo; for agents/offline):**
+  `ai/rsyslog_commit_assistant/base_prompt.txt`
+
+**Rules (must):**
+- ASCII only.
+- Title ≤ **62** characters; body lines ≤ **72** characters.
+- Title format: `<component>: <concise action>`
+  Examples: `omhttp: migrate to OMODTX`, `docs: clarify imfile wildcards`.
+- Lead with a brief **non-technical “why”** (modernization, maintainability, performance, security, Docker/CI readiness, user value).
+- Include **Impact:** one line when tests or user-visible behavior change.
+- Add a one-line **Before/After** behavior summary.
+- Provide a **technical overview** (conceptual, not line-by-line) in 4–12 lines.
+- Footer with full-URL reference(s):
+  - `Fixes: https://github.com/rsyslog/rsyslog/issues/<id>` (only if conclusively fixed)
+  - otherwise `Refs: https://github.com/rsyslog/rsyslog/issues/<id>`
+
+Do **not** include secrets/tokens or paste sensitive data from diffs.
 
 ---
 
@@ -81,7 +107,7 @@ False positives must be resolved, not ignored. Only in extreme cases use:
 ```c
 #pragma diagnostic push
 #pragma GCC diagnostic ignored "..."
-// ... function
+/* ... function ... */
 #pragma diagnostic pop
 ```
 
@@ -117,3 +143,4 @@ If you use your real identity, note:
 - We cannot delete commits retroactively without damaging project history.
 - Identity data is used only to maintain copyright tracking and audit trails.
 - Public commits may be copied by third parties and redistributed without control.
+

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ Rsyslog is a community-driven open-source project. Contributions are welcome and
 
 If you're working with AI coding agents (e.g. GitHub Copilot, OpenAI Codex), note that we support these workflows with agent-specific instructions in `AGENTS.md`.
 
+**Commit Assistant (recommended):** Draft compliant commit messages with
+https://www.rsyslog.com/tool_rsyslog-commit-assistant (see rules in
+[CONTRIBUTING.md](CONTRIBUTING.md)). Put the substance into the **commit
+message** (amend before PR if needed).
+
 ---
 
 ### AI-Based Code Review (Experimental)
@@ -111,4 +116,4 @@ Third-party contributions, services, and integrations are welcome.
 ---
 
 ## Legal Notice (GDPR)
-Contributions to rsyslog are stored in git history and publicly distributed. Please refer to `CONTRIBUTING.md` for detailed GDPR-related information.
+Contributions to rsyslog are stored in git history and publicly distributed.

--- a/ai/rsyslog_commit_assistant/base_prompt.txt
+++ b/ai/rsyslog_commit_assistant/base_prompt.txt
@@ -38,7 +38,7 @@ WORKFLOW
    - Test changes implying behavior shifts (e.g., retry/duplicates).
    - Config parameter semantics, defaults, deprecations.
    - Packaging/CI/doc changes.
-   If behavior or tests changed OR you suspect risk, output **Findings**
+   If behavior or tests changed OR you suspect risk, output **Findings:**
    with 3–7 bullets (MANDATORY in those cases). Proceed with the commit
    message regardless (do not block output).
 

--- a/tests/CI/check_commit_text.py
+++ b/tests/CI/check_commit_text.py
@@ -9,7 +9,7 @@ f = open(sys.argv[1], "r")
 for line in f:
    len_line = len(line) - len_hash
    if len_line > max_line_length:
-       sys.stderr.write("This commit title is {} characters too long (maximum is {}, line len is {}):\n".format(
+       sys.stderr.write("This commit line is {} characters too long (maximum is {}, line len is {}):\n".format(
            len_line - max_line_length, max_line_length, len_line))
        sys.stderr.write(line)
        rc = 1


### PR DESCRIPTION
This modernizes contributor experience by simplifying PR templates and removing the lengthy GDPR disclaimer that often discouraged or confused new contributors. The update encourages more participation and shows how responsible AI can be used to improve open source workflows.

Impact: none on runtime behavior; contributor workflow improved.

Before: PR template included long GDPR block; commit message rules were scattered and partly implicit.
After: PR template is concise, GDPR text removed, and commit assistant usage is documented across README, CONTRIBUTING, and AGENTS.md.

Technical changes include:
- PR template: drop GDPR notice, add commit-assistant references.
- CONTRIBUTING.md: add explicit commit rules and workflow guidance.
- AGENTS.md: require canonical base prompt and commit-first workflow.
- README.md: point to assistant and updated guidance.
- base_prompt.txt: enforce "Findings:" colon format.
- Minor formatting corrections in comments.

<!--
LEGAL GDPR NOTICE:
According to the European data protection laws (GDPR), we would like to make you
aware that contributing to rsyslog via git will permanently store the
name and email address you provide as well as the actual commit and the
time and date you made it inside git's version history. This is inevitable,
because it is a main feature git. If you are concerned about your
privacy, we strongly recommend to use

--author "anonymous <gdpr@example.com>"

together with your commit. Also please do NOT sign your commit in this case,
as that potentially could lead back to you. Please note that if you use your
real identity, the GDPR grants you the right to have this information removed
later. However, we have valid reasons why we cannot remove that information
later on. The reasons are:

* this would break git history and make future merges unworkable
* the rsyslog projects has legitimate interest to keep a permanent record of the
  contributor identity, once given, for
  - copyright verification
  - being able to provide proof should a malicious commit be made

Please also note that your commit is public and as such will potentially be
processed by many third-parties. Git's distributed nature makes it impossible
to track where exactly your commit, and thus your personal data, will be stored
and be processed. If you would not like to accept this risk, please do either
commit anonymously or refrain from contributing to the rsyslog project.
-->
