### PR TITLE
omsendertrack: fix "template" parameter after PoC phase

### DIFF
--- a/doc/source/configuration/modules/omsendertrack.rst
+++ b/doc/source/configuration/modules/omsendertrack.rst
@@ -139,13 +139,6 @@ For instance:
 overall throughput, especially if complex templates are used. Choose your
 template wisely based on your tracking needs and performance considerations.
 
-.. important::
-
-   The current Proof-of-Concept implementation of the ``omsendertrack`` module
-   might still refer to this parameter as ``template`` instead of ``senderid``.
-   Please use ``template`` if ``senderid`` is not recognized by your rsyslog
-   version, and be aware that this will be harmonized in future releases.
-
 interval
 ^^^^^^^^
 

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -132,6 +132,8 @@ static uchar template_StdClickHouseFmt[] =
     "\"INSERT INTO rsyslog.SystemEvents (severity, facility, "
     "timestamp, hostname, tag, message) VALUES (%syslogseverity%, %syslogfacility%, "
     "'%timereported:::date-unixtimestamp%', '%hostname%', '%syslogtag%', '%msg%')\",STDSQL";
+static uchar template_StdOmSenderTrack_senderid[] =
+    "\"%fromhost-ip%\""; /* default template for omsendertrack "senderid" parameter*/
 /* end templates */
 
 /* tables for interfacing with the v6 config system (as far as we need to) */
@@ -1329,6 +1331,8 @@ static rsRetVal initLegacyConf(void) {
     tplAddLine(ourConf, " FullJSONFmt", &pTmp);
     pTmp = template_StdClickHouseFmt;
     tplAddLine(ourConf, " StdClickHouseFmt", &pTmp);
+    pTmp = template_StdOmSenderTrack_senderid;
+    tplAddLine(ourConf, " StdOmSenderTrack-senderid", &pTmp);
     pTmp = template_spoofadr;
     tplLastStaticInit(ourConf, tplAddLine(ourConf, "RSYSLOG_omudpspoofDfltSourceTpl", &pTmp));
 

--- a/tests/omsendertrack-basic.sh
+++ b/tests/omsendertrack-basic.sh
@@ -10,7 +10,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 template(name="hostname" type="string" string="%hostname%")
-action(type="omsendertrack" template="hostname" statefile="'$RSYSLOG_DYNNAME'.sendertrack")
+action(type="omsendertrack" senderid="hostname" statefile="'$RSYSLOG_DYNNAME'.sendertrack")
 
 # The following is just to find a terminating condition for message injection
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/omsendertrack-statefile.sh
+++ b/tests/omsendertrack-statefile.sh
@@ -15,7 +15,7 @@ module(load="../plugins/omsendertrack/.libs/omsendertrack")
 
 template(name="hostname" type="string" string="%hostname%")
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
-action(type="omsendertrack" template="hostname" statefile="'$RSYSLOG_DYNNAME'.sendertrack")
+action(type="omsendertrack" senderid="hostname" statefile="'$RSYSLOG_DYNNAME'.sendertrack")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
 '
 


### PR DESCRIPTION
parameter name was a bug, see original featrure request:
   https://github.com/rsyslog/rsyslog/issues/5599

we kept it during PoC, but change to senderid for final code.

No need for backward compatibility. While in daily and scheduled stable, users were warned the omsendertrack was in PoC and things may change. Potentially affected user base is slime, known PoC users have been notified.

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

