### PR TITLE
omhttp: add profile support and revise HTTP retry semantics @#5957

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1006,6 +1006,7 @@ TESTS +=  \
 	omhttp-batch-kafkarest.sh \
 	omhttp-batch-lokirest-retry.sh \
 	omhttp-batch-lokirest.sh \
+	omhttp-profile-loki.sh \
 	omhttp-batch-newline.sh \
 	omhttp-retry.sh \
 	omhttp-retry-timeout.sh \
@@ -2748,6 +2749,7 @@ EXTRA_DIST= \
 	omhttp-batch-lokirest-retry.sh \
 	omhttp-batch-lokirest.sh \
 	omhttp-batch-lokirest-vg.sh \
+	omhttp-profile-loki.sh \
 	omhttp-batch-newline.sh \
 	omhttp-batch-retry-metadata.sh \
 	omhttp-retry-timeout.sh \

--- a/tests/omhttp-profile-loki.sh
+++ b/tests/omhttp-profile-loki.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+# Test the profile="loki" configuration
+
+#  Starting actual testbench
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=100
+
+# Start a mock Loki server (enable decompression as profile enables compression)
+omhttp_start_server 0 --decompress
+
+generate_conf
+add_conf '
+module(load="../contrib/omhttp/.libs/omhttp")
+
+# Simplified loki payload to match test harness lokirest parser
+template(name="loki_template" type="string" string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+ruleset(name="ruleset_omhttp_loki") {
+    action(
+        name="action_omhttp_loki"
+        type="omhttp"
+
+        # Use the Loki profile
+        profile="loki"
+
+        template="loki_template"
+        server="localhost"
+        serverport="'$omhttp_server_lstnport'"
+
+        # The profile should set these defaults:
+        # - batch.format="lokirest"
+        # - restpath="loki/api/v1/push"
+        # - batch="on"
+        # - compress="on"
+
+        # Our mock server is plain HTTP
+        usehttps="off"
+    ) & stop
+}
+
+if $msg contains "msgnum:" then
+    call ruleset_omhttp_loki
+'
+startup
+injectmsg  0 $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+
+# Verify data was sent to the Loki endpoint; parse as lokirest
+omhttp_get_data $omhttp_server_lstnport loki/api/v1/push lokirest
+
+omhttp_stop_server
+
+# Verify all messages were sent
+seq_check 0 $(( NUMMESSAGES - 1 ))
+exit_test


### PR DESCRIPTION
This change introduces profile-based configuration for omhttp. Profiles
simplify setup for common backends such as Grafana Loki and Splunk HEC by
applying recommended defaults for batching, paths, formats, and retry codes.
This improves usability and avoids error-prone manual tuning.

Impact: HTTP error handling semantics are changed; retry behavior for
3xx and 4xx differs from previous releases.

Technically, HTTP status handling is refactored: transport errors and 5xx
remain retriable, while 3xx (redirection) and 4xx (client errors) are now
treated as permanent failures (`RS_RET_DATAFAIL`). Retry ruleset logic in
batch mode is clarified: if a retry ruleset is configured, messages are
queued there; otherwise, core retry is used. In single-message mode, core
retry is always used.

The new `profile` parameter applies bundled settings. The `loki` profile
enables batching, lokirest formatting, compression, and a default path of
`loki/api/v1/push`. The `hec:splunk` profile sets HEC-specific defaults
including newline batching and size limits. A new test validates the Loki
profile end-to-end. Documentation typo in imptcp parameter reference is
also fixed.

Refs: https://github.com/rsyslog/rsyslog/issues/5957
Refs: https://github.com/rsyslog/rsyslog/pull/5972
