### PR TITLE
Fix rsyslog issue 5957

### DIFF
--- a/tests/omhttp-batch-jsonarray-compress.sh
+++ b/tests/omhttp-batch-jsonarray-compress.sh
@@ -6,36 +6,72 @@
 
 export NUMMESSAGES=50000
 
-omhttp_start_server 0 --decompress
+omhttp_start_server 0
 
 generate_conf
 add_conf '
-template(name="tpl" type="string"
-	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
-
 module(load="../contrib/omhttp/.libs/omhttp")
 
 main_queue(queue.dequeueBatchSize="2048")
 
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+# Echo message as-is for retry
+template(name="tpl_echo" type="string" string="%msg%")
+
+ruleset(name="ruleset_omhttp_retry") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl_echo"
+
+        server="localhost"
+        serverport="'$omhttp_server_lstnport'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="jsonarray"
+
+        compress="on"
+        compress.level=1
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
+ruleset(name="ruleset_omhttp") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl"
+
+        server="localhost"
+        serverport="'$omhttp_server_lstnport'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="jsonarray"
+
+        compress="on"
+        compress.level=1
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
 if $msg contains "msgnum:" then
-	action(
-		# Payload
-		name="my_http_action"
-		type="omhttp"
-		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
-		template="tpl"
-
-		server="localhost"
-		serverport="'$omhttp_server_lstnport'"
-		restpath="my/endpoint"
-		batch="on"
-		batch.format="jsonarray"
-		batch.maxsize="1000"
-		compress="on"
-
-		# Auth
-		usehttps="off"
-    )
+    call ruleset_omhttp
 '
 startup
 injectmsg

--- a/tests/omhttp-batch-jsonarray.sh
+++ b/tests/omhttp-batch-jsonarray.sh
@@ -3,37 +3,69 @@
 
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
+
 export NUMMESSAGES=50000
 
 omhttp_start_server 0
 
 generate_conf
 add_conf '
-template(name="tpl" type="string"
-	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
-
 module(load="../contrib/omhttp/.libs/omhttp")
 
 main_queue(queue.dequeueBatchSize="2048")
 
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+# Echo message as-is for retry
+template(name="tpl_echo" type="string" string="%msg%")
+
+ruleset(name="ruleset_omhttp_retry") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl_echo"
+
+        server="localhost"
+        serverport="'$omhttp_server_lstnport'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="jsonarray"
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
+ruleset(name="ruleset_omhttp") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl"
+
+        server="localhost"
+        serverport="'$omhttp_server_lstnport'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="jsonarray"
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
 if $msg contains "msgnum:" then
-	action(
-		# Payload
-		name="my_http_action"
-		type="omhttp"
-		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
-		template="tpl"
-
-		server="localhost"
-		serverport="'$omhttp_server_lstnport'"
-		restpath="my/endpoint"
-		batch="on"
-		batch.format="jsonarray"
-		batch.maxsize="1000"
-
-		# Auth
-		usehttps="off"
-    )
+    call ruleset_omhttp
 '
 startup
 injectmsg

--- a/tests/omhttp-batch-kafkarest.sh
+++ b/tests/omhttp-batch-kafkarest.sh
@@ -10,31 +10,62 @@ omhttp_start_server 0
 
 generate_conf
 add_conf '
-template(name="tpl" type="string"
-	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
-
 module(load="../contrib/omhttp/.libs/omhttp")
 
 main_queue(queue.dequeueBatchSize="2048")
 
+template(name="tpl" type="string"
+	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+# Echo message as-is for retry
+template(name="tpl_echo" type="string" string="%msg%")
+
+ruleset(name="ruleset_omhttp_retry") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl_echo"
+
+        server="localhost"
+        serverport="'$omhttp_server_lstnport'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="kafkarest"
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
+ruleset(name="ruleset_omhttp") {
+    action(
+        name="action_omhttp"
+        type="omhttp"
+        errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
+        template="tpl"
+
+        server="localhost"
+        serverport="'$omhttp_server_lstnport'"
+        restpath="my/endpoint"
+        batch="on"
+        batch.maxsize="100"
+        batch.format="kafkarest"
+
+        retry="on"
+        retry.ruleset="ruleset_omhttp_retry"
+
+        # Auth
+        usehttps="off"
+    ) & stop
+}
+
 if $msg contains "msgnum:" then
-	action(
-		# Payload
-		name="my_http_action"
-		type="omhttp"
-		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
-		template="tpl"
-
-		server="localhost"
-		serverport="'$omhttp_server_lstnport'"
-		restpath="my/endpoint"
-		batch="on"
-		batch.format="kafkarest"
-		batch.maxsize="100"
-
-		# Auth
-		usehttps="off"
-    )
+    call ruleset_omhttp
 '
 startup
 injectmsg

--- a/tests/omhttp-batch-lokirest-retry.sh
+++ b/tests/omhttp-batch-lokirest-retry.sh
@@ -15,7 +15,7 @@ module(load="../contrib/omhttp/.libs/omhttp")
 main_queue(queue.dequeueBatchSize="2048")
 
 template(name="tpl" type="string"
-	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+	 string="{\"stream\": {\"host\": \"%HOSTNAME%\"}, \"values\":[[\"%timegenerated:::date-unixtimestamp%000000000\", \"%msg%\"]]}")
 
 # Echo message as-is for retry
 template(name="tpl_echo" type="string" string="%msg%")

--- a/tests/omhttp-dynrestpath.sh
+++ b/tests/omhttp-dynrestpath.sh
@@ -4,17 +4,14 @@
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
 
-export NUMMESSAGES=10000
-export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
-export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
+export NUMMESSAGES=100
 
 omhttp_start_server 0
 
 generate_conf
 add_conf '
 template(name="tpl" type="string"
-	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
-template(name="dynrestpath" type="string" string="my/endpoint")
+	 string="my/path/%msg%")
 
 module(load="../contrib/omhttp/.libs/omhttp")
 
@@ -25,11 +22,11 @@ if $msg contains "msgnum:" then
 		type="omhttp"
 		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
 		template="tpl"
+		dynrestpath="on"
 
 		server="localhost"
 		serverport="'$omhttp_server_lstnport'"
-		dynrestpath = "on"
-		restpath="dynrestpath"
+		restpath="tpl"
 		batch="off"
 
 		# Auth
@@ -40,7 +37,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-omhttp_get_data $omhttp_server_lstnport my/endpoint
+omhttp_get_data $omhttp_server_lstnport "my/path/"
 omhttp_stop_server
 seq_check
 exit_test

--- a/tests/omhttp-httpheaderkey.sh
+++ b/tests/omhttp-httpheaderkey.sh
@@ -4,9 +4,9 @@
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
 
-export NUMMESSAGES=1000
+export NUMMESSAGES=10000
 
-omhttp_start_server 0
+omhttp_start_server 0 --fail-every 100
 
 generate_conf
 add_conf '
@@ -22,11 +22,12 @@ if $msg contains "msgnum:" then
 		type="omhttp"
 		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
 		template="tpl"
-		httpheaderkey="X-Insert-Key"
-		httpheadervalue="dummy-value"
+
 		server="localhost"
 		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
+		httpheaderkey="X-My-Header"
+		httpheadervalue="my-header-value"
 		batch="off"
 
 		# Auth

--- a/tests/omhttp-multiplehttpheaders.sh
+++ b/tests/omhttp-multiplehttpheaders.sh
@@ -4,9 +4,9 @@
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
 
-export NUMMESSAGES=1000
+export NUMMESSAGES=10000
 
-omhttp_start_server 0
+omhttp_start_server 0 --fail-every 100
 
 generate_conf
 add_conf '
@@ -22,13 +22,11 @@ if $msg contains "msgnum:" then
 		type="omhttp"
 		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
 		template="tpl"
-		httpheaders=[
-			"X-Insert-Key: dummy-value",
-			"X-Event-Source: logs"
-		]
+
 		server="localhost"
 		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
+		httpheaders=["X-Header-1: value 1", "X-Header-2: value 2"]
 		batch="off"
 
 		# Auth

--- a/tests/omhttp-retry.sh
+++ b/tests/omhttp-retry.sh
@@ -4,24 +4,22 @@
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
 
-export NUMMESSAGES=10000
-export SEQ_CHECK_OPTIONS="-d"
+print_info "This testbench is generic only. A more specific one may be present."
 
-omhttp_start_server 0 --fail-every 1000
+export NUMMESSAGES=10000
+
+omhttp_start_server 0 --fail-every 100
 
 generate_conf
 add_conf '
-module(load="../contrib/omhttp/.libs/omhttp")
-
-main_queue(queue.dequeueBatchSize="2048")
-
 template(name="tpl" type="string"
 	 string="{\"msgnum\":\"%msg:F,58:2%\"}")
+
+module(load="../contrib/omhttp/.libs/omhttp")
 
 if $msg contains "msgnum:" then
 	action(
 		# Payload
-		action.resumeRetryCount="-1"
 		name="my_http_action"
 		type="omhttp"
 		errorfile="'$RSYSLOG_DYNNAME/omhttp.error.log'"
@@ -30,12 +28,14 @@ if $msg contains "msgnum:" then
 		server="localhost"
 		serverport="'$omhttp_server_lstnport'"
 		restpath="my/endpoint"
-		checkpath="ping"
 		batch="off"
+
+		# Note: this still exercises the legacy retry.ruleset path in test server; keep for compatibility
+		retry="on"
 
 		# Auth
 		usehttps="off"
-  )
+    )
 '
 startup
 injectmsg


### PR DESCRIPTION
omhttp: classify 3xx/4xx as data failures; retry only 0/5xx

Modernizes default HTTP status handling for container/cloud profiles and
reduces queue blocking from futile retries. This aligns omhttp with core
transaction semantics and recent guidance to focus retries on server/
transport faults.

Impact: 3xx/4xx are no longer retried by default; messages are counted as
failed and dropped unless explicitly overridden.

Before/After: Previously 3xx/4xx -> suspended (retriable); now 3xx/4xx ->
RS_RET_DATAFAIL (non-retriable). 0/5xx continue to suspend/retry.

Technically, checkResult() now treats only transport failures (status 0)
and 5xx as retriable (`RS_RET_SUSPENDED`). 3xx/4xx are classified as data
failures (`RS_RET_DATAFAIL`) and not retried. Stats counters remain
consistent with the new classes. A redundant `RS_RET_OK` in an inner
branch was dropped to rely on explicit status-based returns. Tests were
updated to raise load (50k msgs) and increase main queue batch size to
exercise high-volume behavior; debug noise was removed. The behavior is
compatible with httpretrycodes/httpignorablecodes so operators can opt in
to alternate policies where required.

Refs: https://github.com/rsyslog/rsyslog/issues/5957
