### PR TITLE
doc/imfile: add File and Tag to parameter samples

### DIFF
--- a/doc/source/reference/parameters/imfile-addceetag.rst
+++ b/doc/source/reference/parameters/imfile-addceetag.rst
@@ -36,7 +36,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" addCeeTag="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         addCeeTag="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-addmetadata.rst
+++ b/doc/source/reference/parameters/imfile-addmetadata.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" addMetadata="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         addMetadata="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-deletestateonfiledelete.rst
+++ b/doc/source/reference/parameters/imfile-deletestateonfiledelete.rst
@@ -39,7 +39,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" deleteStateOnFileDelete="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         deleteStateOnFileDelete="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-deletestateonfilemove.rst
+++ b/doc/source/reference/parameters/imfile-deletestateonfilemove.rst
@@ -50,7 +50,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" deleteStateOnFileMove="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         deleteStateOnFileMove="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-discardtruncatedmsg.rst
+++ b/doc/source/reference/parameters/imfile-discardtruncatedmsg.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" discardTruncatedMsg="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         discardTruncatedMsg="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-endmsg-regex.rst
+++ b/doc/source/reference/parameters/imfile-endmsg-regex.rst
@@ -50,7 +50,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" endmsg.regex="pattern")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         endmsg.regex="pattern")
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-escapelf-replacement.rst
+++ b/doc/source/reference/parameters/imfile-escapelf-replacement.rst
@@ -46,7 +46,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" escapeLF="on" escapeLF.replacement="[LF]")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         escapeLF="on" escapeLF.replacement="[LF]")
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-escapelf.rst
+++ b/doc/source/reference/parameters/imfile-escapelf.rst
@@ -39,7 +39,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" escapeLF="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         escapeLF="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-facility.rst
+++ b/doc/source/reference/parameters/imfile-facility.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" Facility="local0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         Facility="local0")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-file.rst
+++ b/doc/source/reference/parameters/imfile-file.rst
@@ -37,7 +37,9 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" File="/path/to/logfile")
+   input(type="imfile"
+         File="/path/to/logfile"
+         Tag="example")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imfile-freshstarttail.rst
+++ b/doc/source/reference/parameters/imfile-freshstarttail.rst
@@ -47,7 +47,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" freshStartTail="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         freshStartTail="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-ignoreolderthan.rst
+++ b/doc/source/reference/parameters/imfile-ignoreolderthan.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" ignoreOlderThan="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         ignoreOlderThan="0")
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-maxbytesperminute.rst
+++ b/doc/source/reference/parameters/imfile-maxbytesperminute.rst
@@ -38,7 +38,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" MaxBytesPerMinute="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         MaxBytesPerMinute="0")
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-maxlinesatonce.rst
+++ b/doc/source/reference/parameters/imfile-maxlinesatonce.rst
@@ -42,7 +42,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" MaxLinesAtOnce="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         MaxLinesAtOnce="0")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imfile-maxlinesperminute.rst
+++ b/doc/source/reference/parameters/imfile-maxlinesperminute.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" MaxLinesPerMinute="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         MaxLinesPerMinute="0")
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-maxsubmitatonce.rst
+++ b/doc/source/reference/parameters/imfile-maxsubmitatonce.rst
@@ -38,7 +38,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" MaxSubmitAtOnce="1024")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         MaxSubmitAtOnce="1024")
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-msgdiscardingerror.rst
+++ b/doc/source/reference/parameters/imfile-msgdiscardingerror.rst
@@ -36,7 +36,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" msgDiscardingError="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         msgDiscardingError="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-needparse.rst
+++ b/doc/source/reference/parameters/imfile-needparse.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" needParse="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         needParse="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-persiststateaftersubmission.rst
+++ b/doc/source/reference/parameters/imfile-persiststateaftersubmission.rst
@@ -38,7 +38,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" persistStateAfterSubmission="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         persistStateAfterSubmission="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-persiststateinterval.rst
+++ b/doc/source/reference/parameters/imfile-persiststateinterval.rst
@@ -43,7 +43,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" PersistStateInterval="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         PersistStateInterval="0")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imfile-readmode.rst
+++ b/doc/source/reference/parameters/imfile-readmode.rst
@@ -42,7 +42,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" readMode="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         readMode="0")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imfile-readtimeout.rst
+++ b/doc/source/reference/parameters/imfile-readtimeout.rst
@@ -53,7 +53,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" readTimeout="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         readTimeout="0")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-reopenontruncate.rst
+++ b/doc/source/reference/parameters/imfile-reopenontruncate.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" reopenOnTruncate="on")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         reopenOnTruncate="on")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-ruleset.rst
+++ b/doc/source/reference/parameters/imfile-ruleset.rst
@@ -35,7 +35,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" Ruleset="myrules")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         Ruleset="myrules")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imfile-severity.rst
+++ b/doc/source/reference/parameters/imfile-severity.rst
@@ -37,7 +37,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" Severity="notice")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         Severity="notice")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-startmsg-regex.rst
+++ b/doc/source/reference/parameters/imfile-startmsg-regex.rst
@@ -40,7 +40,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" startmsg.regex="^start")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         startmsg.regex="^start")
 
 See also
 --------

--- a/doc/source/reference/parameters/imfile-statefile.rst
+++ b/doc/source/reference/parameters/imfile-statefile.rst
@@ -41,7 +41,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" stateFile="/path/to/state")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         stateFile="/path/to/state")
 
 Notes
 -----

--- a/doc/source/reference/parameters/imfile-tag.rst
+++ b/doc/source/reference/parameters/imfile-tag.rst
@@ -37,7 +37,9 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" Tag="app:")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="app:")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imfile-trimlineoverbytes.rst
+++ b/doc/source/reference/parameters/imfile-trimlineoverbytes.rst
@@ -38,7 +38,10 @@ Input usage
 
 .. code-block:: rsyslog
 
-   input(type="imfile" trimLineOverBytes="0")
+   input(type="imfile"
+         File="/var/log/example.log"
+         Tag="example"
+         trimLineOverBytes="0")
 
 See also
 --------


### PR DESCRIPTION
## Summary
- include required `File` and `Tag` lines in imfile parameter examples
- update dedicated File and Tag parameter docs to show both required fields

## Testing
- `devtools/format-code.sh`
- `make -C doc html`


------
https://chatgpt.com/codex/tasks/task_e_68a31a8d4ae88332ba477ef0df3d7b68