### PR TITLE
imuxsock: split input parameter docs into reference pages

### DIFF
--- a/doc/source/configuration/modules/imuxsock.rst
+++ b/doc/source/configuration/modules/imuxsock.rst
@@ -36,7 +36,7 @@ Configuration Parameters
 
 .. note::
 
-   Parameter names are case-insensitive.
+   Parameter names are case-insensitive; camelCase is recommended for readability.
 
 Module Parameters
 -----------------
@@ -48,588 +48,150 @@ Module Parameters
    details.
 
 
-SysSock.IgnoreTimestamp
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "``$SystemLogSocketIgnoreMsgTimestamp``"
-
-Ignore timestamps included in the messages, applies to messages received via
-the system log socket.
-
-
-SysSock.IgnoreOwnMessages
-^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-Ignores messages that originated from the same instance of rsyslogd.
-There usually is no reason to receive messages from ourselves. This
-setting is vital when writing messages to the systemd journal.
-
-.. versionadded:: 7.3.7
-
-.. seealso::
-
-   See :doc:`omjournal <omjournal>` module documentation for a more
-   in-depth description.
-
-
-SysSock.Use
-^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "``$OmitLocalLogging``"
-
-Listen on the default local log socket (``/dev/log``) or, if provided, use
-the log socket value assigned to the ``SysSock.Name`` parameter instead
-of the default. This is most useful if you run multiple instances of
-rsyslogd where only one shall handle the system log socket.  Unless
-disabled by the ``SysSock.Unlink`` setting, this socket is created
-upon rsyslog startup and deleted upon shutdown, according to
-traditional syslogd behavior.
-
-The behavior of this parameter is different for systemd systems. For those
-systems, ``SysSock.Use`` still needs to be enabled, but the value of
-``SysSock.Name`` is ignored and the socket provided by systemd is used
-instead. If this parameter is *not* enabled, then imuxsock will only be
-of use if a custom input is configured.
-
-See the :ref:`imuxsock-systemd-details-label` section for details.
-
-
-SysSock.Name
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "word", "/dev/log", "no", "``$SystemLogSocketName``"
-
-Specifies an alternate log socket to be used instead of the default system
-log socket, traditionally ``/dev/log``. Unless disabled by the
-``SysSock.Unlink`` setting, this socket is created upon rsyslog startup
-and deleted upon shutdown, according to traditional syslogd behavior.
-
-The behavior of this parameter is different for systemd systems. See the
- :ref:`imuxsock-systemd-details-label` section for details.
-
-
-SysSock.FlowControl
-^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$SystemLogFlowControl``"
-
-Specifies if flow control should be applied to the system log socket.
-
-
-SysSock.UsePIDFromSystem
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$SystemLogUsePIDFromSystem``"
-
-Specifies if the pid being logged shall be obtained from the log socket
-itself. If so, the TAG part of the message is rewritten. It is recommended
-to turn this option on, but the default is "off" to keep compatible
-with earlier versions of rsyslog.
-
-.. versionadded:: 5.7.0
-
-
-SysSock.RateLimit.Interval
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "", "no", "``$SystemLogRateLimitInterval``"
-
-Specifies the rate-limiting interval in seconds. Default value is 0,
-which turns off rate limiting. Set it to a number of seconds (5
-recommended) to activate rate-limiting. The default of 0 has been
-chosen as people experienced problems with this feature activated
-by default. Now it needs an explicit opt-in by setting this parameter.
-
-
-SysSock.RateLimit.Burst
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "200", "(2^31)-1", "no", "``$SystemLogRateLimitBurst``"
-
-Specifies the rate-limiting burst in number of messages.
-
-.. versionadded:: 5.7.1
-
-
-SysSock.RateLimit.Severity
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "1", "", "no", "``$SystemLogRateLimitSeverity``"
-
-Specifies the severity of messages that shall be rate-limited.
-
-.. seealso::
-
-   https://en.wikipedia.org/wiki/Syslog#Severity_level
-
-
-SysSock.UseSysTimeStamp
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "``$SystemLogUseSysTimeStamp``"
-
-The same as the input parameter ``UseSysTimeStamp``, but for the system log
-socket. This parameter instructs ``imuxsock`` to obtain message time from
-the system (via control messages) instead of using time recorded inside
-the message. This may be most useful in combination with systemd. Due to
-the usefulness of this functionality, we decided to enable it by default.
-As such, the behavior is slightly different than previous versions.
-However, we do not see how this could negatively affect existing environments.
-
-.. versionadded:: 5.9.1
-
-
-SysSock.Annotate
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$SystemLogSocketAnnotate``"
-
-Turn on annotation/trusted properties for the system log socket. See
-the :ref:`imuxsock-trusted-properties-label` section for more info.
-
-
-SysSock.ParseTrusted
-^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$SystemLogParseTrusted``"
-
-If ``SysSock.Annotation`` is turned on, create JSON/lumberjack properties
-out of the trusted properties (which can be accessed via |FmtAdvancedName|
-JSON Variables, e.g. ``$!pid``) instead of adding them to the message.
-
-.. versionadded:: 7.2.7
-   |FmtAdvancedName| directive introduced
-
-.. versionadded:: 7.3.8
-   |FmtAdvancedName| directive introduced
-
-.. versionadded:: 6.5.0
-   |FmtObsoleteName| directive introduced
-
-
-SysSock.Unlink
-^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-If turned on (default), the system socket is unlinked and re-created
-when opened and also unlinked when finally closed. Note that this
-setting has no effect when running under systemd control (because
-systemd handles the socket. See the :ref:`imuxsock-systemd-details-label`
-section for details.
-
-.. versionadded:: 7.3.9
-
-
-SysSock.UseSpecialParser
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-The equivalent of the ``UseSpecialParser`` input parameter, but
-for the system socket. If turned on (the default) a special parser is
-used that parses the format that is usually used
-on the system log socket (the one :manpage:`syslog(3)` creates). If set to
-"off", the regular parser chain is used, in which case the format on the
-log socket can be arbitrary.
-
-.. note::
-
-   When the special parser is used, rsyslog is able to inject a more precise
-   timestamp into the message (it is obtained from the log socket). If the
-   regular parser chain is used, this is not possible.
-
-.. versionadded:: 8.9.0
-   The setting was previously hard-coded "on"
-
-
-SysSock.ParseHostname
-^^^^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-.. note::
-
-   This option only has an effect if ``SysSock.UseSpecialParser`` is
-   set to "off".
-
-Normally, the local log sockets do *not* contain hostnames. If set
-to on, parsers will expect hostnames just like in regular formats. If
-set to off (the default), the parser chain is instructed to not expect
-them.
-
-.. versionadded:: 8.9.0
-
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imuxsock-syssock-ignoretimestamp`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-ignoretimestamp.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-ignoreownmessages`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-ignoreownmessages.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-use`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-use.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-name`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-flowcontrol`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-flowcontrol.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-usepidfromsystem`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-usepidfromsystem.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-ratelimit-interval`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-ratelimit-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-ratelimit-burst`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-ratelimit-burst.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-ratelimit-severity`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-ratelimit-severity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-usesystimestamp`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-usesystimestamp.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-annotate`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-annotate.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-parsetrusted`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-parsetrusted.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-unlink`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-unlink.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-usespecialparser`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-usespecialparser.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-parsehostname`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-parsehostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 Input Parameters
 ----------------
 
-Ruleset
-^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "default ruleset", "no", "none"
-
-Binds specified ruleset to this input. If not set, the default
-ruleset is bound.
-
-.. versionadded:: 8.17.0
-
-
-IgnoreTimestamp
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "``$InputUnixListenSocketIgnoreMsgTimestamp``"
-
-Ignore timestamps included in messages received from the input being
-defined.
-
-
-IgnoreOwnMessages
-^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-Ignore messages that originated from the same instance of rsyslogd.
-There usually is no reason to receive messages from ourselves. This
-setting is vital when writing messages to the systemd journal.
-
-.. versionadded:: 7.3.7
-
-.. seealso::
-
-   See :doc:`omjournal <omjournal>` module documentation for a more
-   in-depth description.
-
-
-
-
-FlowControl
-^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$InputUnixListenSocketFlowControl``"
-
-Specifies if flow control should be applied to the input being defined.
-
-
-RateLimit.Interval
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "0", "", "no", "``$IMUXSockRateLimitInterval``"
-
-Specifies the rate-limiting interval in seconds. Default value is 0, which
-turns off rate limiting. Set it to a number of seconds (5 recommended)
-to activate rate-limiting. The default of 0 has been chosen as people
-experienced problems with this feature activated by default. Now it
-needs an explicit opt-in by setting this parameter.
-
-
-RateLimit.Burst
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "200", "(2^31)-1", "no", "``$IMUXSockRateLimitBurst``"
-
-Specifies the rate-limiting burst in number of messages.
-
-.. versionadded:: 5.7.1
-
-
-RateLimit.Severity
-^^^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "max", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "integer", "1", "", "no", "``$IMUXSockRateLimitSeverity``"
-
-Specifies the severity of messages that shall be rate-limited.
-
-.. seealso::
-
-   https://en.wikipedia.org/wiki/Syslog#Severity_level
-
-
-UsePIDFromSystem
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$InputUnixListenSocketUsePIDFromSystem``"
-
-Specifies if the pid being logged shall be obtained from the log socket
-itself. If so, the TAG part of the message is rewritten. It is
-recommended to turn this option on, but the default is "off" to keep
-compatible with earlier versions of rsyslog.
-
-
-UseSysTimeStamp
-^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "``$InputUnixListenSocketUseSysTimeStamp``"
-
-This parameter instructs ``imuxsock`` to obtain message time from
-the system (via control messages) instead of using time recorded inside
-the message. This may be most useful in combination with systemd. Due to
-the usefulness of this functionality, we decided to enable it by default.
-As such, the behavior is slightly different than previous versions.
-However, we do not see how this could negatively affect existing environments.
-
-.. versionadded:: 5.9.1
-
-
-CreatePath
-^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$InputUnixListenSocketCreatePath``"
-
-Create directories in the socket path if they do not already exist.
-They are created with 0755 permissions with the owner being the
-process under which rsyslogd runs. The default is not to create
-directories. Keep in mind, though, that rsyslogd always creates
-the socket itself if it does not exist (just not the directories
-by default).
-
-This option is primarily considered useful for defining additional
-sockets that reside on non-permanent file systems. As rsyslogd probably
-starts up before the daemons that create these sockets, it is a vehicle
-to enable rsyslogd to listen to those sockets even though their directories
-do not yet exist.
-
-.. versionadded:: 4.7.0
-.. versionadded:: 5.3.0
-
-
-Socket
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "none", "no", "``$AddUnixListenSocket``"
-
-Adds additional unix socket. Formerly specified with the ``-a`` option.
-
-
-HostName
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "string", "NULL", "no", "``$InputUnixListenSocketHostName``"
-
-Allows overriding the hostname that shall be used inside messages
-taken from the input that is being defined.
-
-
-Annotate
-^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$InputUnixListenSocketAnnotate``"
-
-Turn on annotation/trusted properties for the input that is being defined.
-See the :ref:`imuxsock-trusted-properties-label` section for more info.
-
-
-ParseTrusted
-^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "``$ParseTrusted``"
-
-Equivalent to the ``SysSock.ParseTrusted`` module parameter, but applies
-to the input that is being defined.
-
-
-Unlink
-^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "``none``"
-
-If turned on (default), the socket is unlinked and re-created when opened
-and also unlinked when finally closed. Set it to off if you handle socket
-creation yourself.
-
-.. note::
-
-   Note that handling socket creation oneself has the
-   advantage that a limited amount of messages may be queued by the OS
-   if rsyslog is not running.
-
-.. versionadded:: 7.3.9
-
-
-UseSpecialParser
-^^^^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "on", "no", "none"
-
-Equivalent to the ``SysSock.UseSpecialParser`` module parameter, but applies
-to the input that is being defined.
-
-.. versionadded:: 8.9.0
-   The setting was previously hard-coded "on"
-
-
-ParseHostname
-^^^^^^^^^^^^^
-
-.. csv-table::
-   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
-   :widths: auto
-   :class: parameter-table
-
-   "binary", "off", "no", "none"
-
-Equivalent to the ``SysSock.ParseHostname`` module parameter, but applies
-to the input that is being defined.
-
-.. versionadded:: 8.9.0
-
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imuxsock-ruleset`
+     - .. include:: ../../reference/parameters/imuxsock-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-ignoretimestamp`
+     - .. include:: ../../reference/parameters/imuxsock-ignoretimestamp.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-ignoreownmessages`
+     - .. include:: ../../reference/parameters/imuxsock-ignoreownmessages.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-flowcontrol`
+     - .. include:: ../../reference/parameters/imuxsock-flowcontrol.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-ratelimit-interval`
+     - .. include:: ../../reference/parameters/imuxsock-ratelimit-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-ratelimit-burst`
+     - .. include:: ../../reference/parameters/imuxsock-ratelimit-burst.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-ratelimit-severity`
+     - .. include:: ../../reference/parameters/imuxsock-ratelimit-severity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-usepidfromsystem`
+     - .. include:: ../../reference/parameters/imuxsock-usepidfromsystem.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-usesystimestamp`
+     - .. include:: ../../reference/parameters/imuxsock-usesystimestamp.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-createpath`
+     - .. include:: ../../reference/parameters/imuxsock-createpath.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-socket`
+     - .. include:: ../../reference/parameters/imuxsock-socket.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-hostname`
+     - .. include:: ../../reference/parameters/imuxsock-hostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-annotate`
+     - .. include:: ../../reference/parameters/imuxsock-annotate.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-parsetrusted`
+     - .. include:: ../../reference/parameters/imuxsock-parsetrusted.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-unlink`
+     - .. include:: ../../reference/parameters/imuxsock-unlink.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-usespecialparser`
+     - .. include:: ../../reference/parameters/imuxsock-usespecialparser.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-parsehostname`
+     - .. include:: ../../reference/parameters/imuxsock-parsehostname.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. _imuxsock-rate-limiting-label:
 
@@ -963,4 +525,41 @@ system log socket.
 
    module(load="imuxsock" # needs to be done just once
             SysSock.RateLimit.Interval="0") # turn off rate limiting
+
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imuxsock-syssock-ignoretimestamp
+   ../../reference/parameters/imuxsock-syssock-ignoreownmessages
+   ../../reference/parameters/imuxsock-syssock-use
+   ../../reference/parameters/imuxsock-syssock-name
+   ../../reference/parameters/imuxsock-syssock-flowcontrol
+   ../../reference/parameters/imuxsock-syssock-usepidfromsystem
+   ../../reference/parameters/imuxsock-syssock-ratelimit-interval
+   ../../reference/parameters/imuxsock-syssock-ratelimit-burst
+   ../../reference/parameters/imuxsock-syssock-ratelimit-severity
+   ../../reference/parameters/imuxsock-syssock-usesystimestamp
+   ../../reference/parameters/imuxsock-syssock-annotate
+   ../../reference/parameters/imuxsock-syssock-parsetrusted
+   ../../reference/parameters/imuxsock-syssock-unlink
+   ../../reference/parameters/imuxsock-syssock-usespecialparser
+   ../../reference/parameters/imuxsock-syssock-parsehostname
+   ../../reference/parameters/imuxsock-ruleset
+   ../../reference/parameters/imuxsock-ignoretimestamp
+   ../../reference/parameters/imuxsock-ignoreownmessages
+   ../../reference/parameters/imuxsock-flowcontrol
+   ../../reference/parameters/imuxsock-ratelimit-interval
+   ../../reference/parameters/imuxsock-ratelimit-burst
+   ../../reference/parameters/imuxsock-ratelimit-severity
+   ../../reference/parameters/imuxsock-usepidfromsystem
+   ../../reference/parameters/imuxsock-usesystimestamp
+   ../../reference/parameters/imuxsock-createpath
+   ../../reference/parameters/imuxsock-socket
+   ../../reference/parameters/imuxsock-hostname
+   ../../reference/parameters/imuxsock-annotate
+   ../../reference/parameters/imuxsock-parsetrusted
+   ../../reference/parameters/imuxsock-unlink
+   ../../reference/parameters/imuxsock-usespecialparser
+   ../../reference/parameters/imuxsock-parsehostname
 

--- a/doc/source/reference/parameters/imuxsock-annotate.rst
+++ b/doc/source/reference/parameters/imuxsock-annotate.rst
@@ -40,8 +40,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.inputunixlistensocketannotate:
+
 - $InputUnixListenSocketAnnotate — maps to Annotate (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-annotate.rst
+++ b/doc/source/reference/parameters/imuxsock-annotate.rst
@@ -1,0 +1,53 @@
+.. _param-imuxsock-annotate:
+.. _imuxsock.parameter.input.annotate:
+
+Annotate
+========
+
+.. index::
+   single: imuxsock; Annotate
+   single: Annotate
+
+.. summary-start
+
+Enables annotation and trusted properties for this input.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: Annotate
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Turn on annotation/trusted properties for the input that is being defined.
+See the :ref:`imuxsock-trusted-properties-label` section for more info.
+
+Input usage
+-----------
+.. _param-imuxsock-input-annotate:
+.. _imuxsock.parameter.input.annotate-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" annotate="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.inputunixlistensocketannotate:
+- $InputUnixListenSocketAnnotate — maps to Annotate (status: legacy)
+
+.. index::
+   single: imuxsock; $InputUnixListenSocketAnnotate
+   single: $InputUnixListenSocketAnnotate
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-createpath.rst
+++ b/doc/source/reference/parameters/imuxsock-createpath.rst
@@ -1,0 +1,66 @@
+.. _param-imuxsock-createpath:
+.. _imuxsock.parameter.input.createpath:
+
+CreatePath
+==========
+
+.. index::
+   single: imuxsock; CreatePath
+   single: CreatePath
+
+.. summary-start
+
+Creates missing directories for the specified socket path.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: CreatePath
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 4.7.0
+
+Description
+-----------
+Create directories in the socket path if they do not already exist.
+They are created with 0755 permissions with the owner being the
+process under which rsyslogd runs. The default is not to create
+directories. Keep in mind, though, that rsyslogd always creates
+the socket itself if it does not exist (just not the directories
+by default).
+
+This option is primarily considered useful for defining additional
+sockets that reside on non-permanent file systems. As rsyslogd probably
+starts up before the daemons that create these sockets, it is a vehicle
+to enable rsyslogd to listen to those sockets even though their directories
+do not yet exist.
+
+.. versionadded:: 4.7.0
+.. versionadded:: 5.3.0
+
+Input usage
+-----------
+.. _param-imuxsock-input-createpath:
+.. _imuxsock.parameter.input.createpath-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" createPath="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.inputunixlistensocketcreatepath:
+- $InputUnixListenSocketCreatePath — maps to CreatePath (status: legacy)
+
+.. index::
+   single: imuxsock; $InputUnixListenSocketCreatePath
+   single: $InputUnixListenSocketCreatePath
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-createpath.rst
+++ b/doc/source/reference/parameters/imuxsock-createpath.rst
@@ -39,7 +39,6 @@ to enable rsyslogd to listen to those sockets even though their directories
 do not yet exist.
 
 .. versionadded:: 4.7.0
-.. versionadded:: 5.3.0
 
 Input usage
 -----------
@@ -53,8 +52,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.inputunixlistensocketcreatepath:
+
 - $InputUnixListenSocketCreatePath — maps to CreatePath (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-flowcontrol.rst
+++ b/doc/source/reference/parameters/imuxsock-flowcontrol.rst
@@ -1,0 +1,52 @@
+.. _param-imuxsock-flowcontrol:
+.. _imuxsock.parameter.input.flowcontrol:
+
+FlowControl
+===========
+
+.. index::
+   single: imuxsock; FlowControl
+   single: FlowControl
+
+.. summary-start
+
+Enables flow control on this input's socket.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: FlowControl
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies if flow control should be applied to the input being defined.
+
+Input usage
+-----------
+.. _param-imuxsock-input-flowcontrol:
+.. _imuxsock.parameter.input.flowcontrol-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" flowControl="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.inputunixlistensocketflowcontrol:
+- $InputUnixListenSocketFlowControl — maps to FlowControl (status: legacy)
+
+.. index::
+   single: imuxsock; $InputUnixListenSocketFlowControl
+   single: $InputUnixListenSocketFlowControl
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-flowcontrol.rst
+++ b/doc/source/reference/parameters/imuxsock-flowcontrol.rst
@@ -39,8 +39,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.inputunixlistensocketflowcontrol:
+
 - $InputUnixListenSocketFlowControl — maps to FlowControl (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-hostname.rst
+++ b/doc/source/reference/parameters/imuxsock-hostname.rst
@@ -1,0 +1,53 @@
+.. _param-imuxsock-hostname:
+.. _imuxsock.parameter.input.hostname:
+
+HostName
+========
+
+.. index::
+   single: imuxsock; HostName
+   single: HostName
+
+.. summary-start
+
+Overrides the hostname used inside messages from this input.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: HostName
+:Scope: input
+:Type: string
+:Default: input=NULL
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Allows overriding the hostname that shall be used inside messages
+taken from the input that is being defined.
+
+Input usage
+-----------
+.. _param-imuxsock-input-hostname:
+.. _imuxsock.parameter.input.hostname-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" hostName="jail1.example.net")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.inputunixlistensockethostname:
+- $InputUnixListenSocketHostName — maps to HostName (status: legacy)
+
+.. index::
+   single: imuxsock; $InputUnixListenSocketHostName
+   single: $InputUnixListenSocketHostName
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-hostname.rst
+++ b/doc/source/reference/parameters/imuxsock-hostname.rst
@@ -40,8 +40,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.inputunixlistensockethostname:
+
 - $InputUnixListenSocketHostName — maps to HostName (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-ignoreownmessages.rst
+++ b/doc/source/reference/parameters/imuxsock-ignoreownmessages.rst
@@ -1,0 +1,48 @@
+.. _param-imuxsock-ignoreownmessages:
+.. _imuxsock.parameter.input.ignoreownmessages:
+
+IgnoreOwnMessages
+=================
+
+.. index::
+   single: imuxsock; IgnoreOwnMessages
+   single: IgnoreOwnMessages
+
+.. summary-start
+
+Suppresses messages that originated from the same rsyslog instance.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: IgnoreOwnMessages
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: 7.3.7
+
+Description
+-----------
+Ignore messages that originated from the same instance of rsyslogd.
+There usually is no reason to receive messages from ourselves. This
+setting is vital when writing messages to the systemd journal.
+
+.. seealso::
+
+   See :doc:`omjournal <omjournal>` module documentation for a more
+   in-depth description.
+
+Input usage
+-----------
+.. _param-imuxsock-input-ignoreownmessages:
+.. _imuxsock.parameter.input.ignoreownmessages-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" ignoreOwnMessages="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-ignoreownmessages.rst
+++ b/doc/source/reference/parameters/imuxsock-ignoreownmessages.rst
@@ -31,8 +31,8 @@ setting is vital when writing messages to the systemd journal.
 
 .. seealso::
 
-   See :doc:`omjournal <omjournal>` module documentation for a more
-   in-depth description.
+   See :doc:`omjournal <../../configuration/modules/omjournal>` module
+   documentation for a more in-depth description.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/imuxsock-ignoretimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-ignoretimestamp.rst
@@ -1,0 +1,53 @@
+.. _param-imuxsock-ignoretimestamp:
+.. _imuxsock.parameter.input.ignoretimestamp:
+
+IgnoreTimestamp
+===============
+
+.. index::
+   single: imuxsock; IgnoreTimestamp
+   single: IgnoreTimestamp
+
+.. summary-start
+
+Ignores timestamps included in messages from this input.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: IgnoreTimestamp
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Ignore timestamps included in messages received from the input being
+defined.
+
+Input usage
+-----------
+.. _param-imuxsock-input-ignoretimestamp:
+.. _imuxsock.parameter.input.ignoretimestamp-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" ignoreTimestamp="off")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.inputunixlistensocketignoremsgtimestamp:
+- $InputUnixListenSocketIgnoreMsgTimestamp — maps to IgnoreTimestamp (status: legacy)
+
+.. index::
+   single: imuxsock; $InputUnixListenSocketIgnoreMsgTimestamp
+   single: $InputUnixListenSocketIgnoreMsgTimestamp
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-ignoretimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-ignoretimestamp.rst
@@ -40,8 +40,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.inputunixlistensocketignoremsgtimestamp:
+
 - $InputUnixListenSocketIgnoreMsgTimestamp — maps to IgnoreTimestamp (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-parsehostname.rst
+++ b/doc/source/reference/parameters/imuxsock-parsehostname.rst
@@ -1,0 +1,44 @@
+.. _param-imuxsock-parsehostname:
+.. _imuxsock.parameter.input.parsehostname:
+
+ParseHostname
+=============
+
+.. index::
+   single: imuxsock; ParseHostname
+   single: ParseHostname
+
+.. summary-start
+
+Expects hostnames in messages when the special parser is disabled.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: ParseHostname
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.9.0
+
+Description
+-----------
+Equivalent to the ``SysSock.ParseHostname`` module parameter, but applies
+to the input that is being defined.
+
+.. versionadded:: 8.9.0
+
+Input usage
+-----------
+.. _param-imuxsock-input-parsehostname:
+.. _imuxsock.parameter.input.parsehostname-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" parseHostname="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-parsetrusted.rst
+++ b/doc/source/reference/parameters/imuxsock-parsetrusted.rst
@@ -40,8 +40,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.parsetrusted:
+
 - $ParseTrusted — maps to ParseTrusted (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-parsetrusted.rst
+++ b/doc/source/reference/parameters/imuxsock-parsetrusted.rst
@@ -1,0 +1,53 @@
+.. _param-imuxsock-parsetrusted:
+.. _imuxsock.parameter.input.parsetrusted:
+
+ParseTrusted
+============
+
+.. index::
+   single: imuxsock; ParseTrusted
+   single: ParseTrusted
+
+.. summary-start
+
+Turns annotation data into JSON fields when annotation is enabled.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: ParseTrusted
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Equivalent to the ``SysSock.ParseTrusted`` module parameter, but applies
+to the input that is being defined.
+
+Input usage
+-----------
+.. _param-imuxsock-input-parsetrusted:
+.. _imuxsock.parameter.input.parsetrusted-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" parseTrusted="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.parsetrusted:
+- $ParseTrusted — maps to ParseTrusted (status: legacy)
+
+.. index::
+   single: imuxsock; $ParseTrusted
+   single: $ParseTrusted
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/imuxsock-ratelimit-burst.rst
@@ -40,8 +40,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.imuxsockratelimitburst:
+
 - $IMUXSockRateLimitBurst — maps to RateLimit.Burst (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/imuxsock-ratelimit-burst.rst
@@ -1,0 +1,53 @@
+.. _param-imuxsock-ratelimit-burst:
+.. _imuxsock.parameter.input.ratelimit-burst:
+
+RateLimit.Burst
+===============
+
+.. index::
+   single: imuxsock; RateLimit.Burst
+   single: RateLimit.Burst
+
+.. summary-start
+
+Sets the rate-limiting burst size in messages for this input.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: RateLimit.Burst
+:Scope: input
+:Type: integer
+:Default: input=200
+:Required?: no
+:Introduced: 5.7.1
+
+Description
+-----------
+Specifies the rate-limiting burst in number of messages. The maximum is
+``(2^31)-1``.
+
+Input usage
+-----------
+.. _param-imuxsock-input-ratelimit-burst:
+.. _imuxsock.parameter.input.ratelimit-burst-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" rateLimit.burst="500")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.imuxsockratelimitburst:
+- $IMUXSockRateLimitBurst — maps to RateLimit.Burst (status: legacy)
+
+.. index::
+   single: imuxsock; $IMUXSockRateLimitBurst
+   single: $IMUXSockRateLimitBurst
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/imuxsock-ratelimit-interval.rst
@@ -43,8 +43,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.imuxsockratelimitinterval:
+
 - $IMUXSockRateLimitInterval — maps to RateLimit.Interval (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/imuxsock-ratelimit-interval.rst
@@ -1,0 +1,56 @@
+.. _param-imuxsock-ratelimit-interval:
+.. _imuxsock.parameter.input.ratelimit-interval:
+
+RateLimit.Interval
+==================
+
+.. index::
+   single: imuxsock; RateLimit.Interval
+   single: RateLimit.Interval
+
+.. summary-start
+
+Sets the rate-limiting interval in seconds for this input.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: RateLimit.Interval
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies the rate-limiting interval in seconds. Default value is 0,
+which turns off rate limiting. Set it to a number of seconds (5
+recommended) to activate rate-limiting. The default of 0 has been
+chosen as people experienced problems with this feature activated
+by default. Now it needs an explicit opt-in by setting this parameter.
+
+Input usage
+-----------
+.. _param-imuxsock-input-ratelimit-interval:
+.. _imuxsock.parameter.input.ratelimit-interval-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" rateLimit.interval="5")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.imuxsockratelimitinterval:
+- $IMUXSockRateLimitInterval — maps to RateLimit.Interval (status: legacy)
+
+.. index::
+   single: imuxsock; $IMUXSockRateLimitInterval
+   single: $IMUXSockRateLimitInterval
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-ratelimit-severity.rst
+++ b/doc/source/reference/parameters/imuxsock-ratelimit-severity.rst
@@ -1,0 +1,56 @@
+.. _param-imuxsock-ratelimit-severity:
+.. _imuxsock.parameter.input.ratelimit-severity:
+
+RateLimit.Severity
+==================
+
+.. index::
+   single: imuxsock; RateLimit.Severity
+   single: RateLimit.Severity
+
+.. summary-start
+
+Defines the severity level at or below which messages are rate-limited.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: RateLimit.Severity
+:Scope: input
+:Type: integer
+:Default: input=1
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies the severity of messages that shall be rate-limited.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog#Severity_level
+
+Input usage
+-----------
+.. _param-imuxsock-input-ratelimit-severity:
+.. _imuxsock.parameter.input.ratelimit-severity-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" rateLimit.severity="5")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.imuxsockratelimitseverity:
+- $IMUXSockRateLimitSeverity — maps to RateLimit.Severity (status: legacy)
+
+.. index::
+   single: imuxsock; $IMUXSockRateLimitSeverity
+   single: $IMUXSockRateLimitSeverity
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-ratelimit-severity.rst
+++ b/doc/source/reference/parameters/imuxsock-ratelimit-severity.rst
@@ -43,8 +43,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.imuxsockratelimitseverity:
+
 - $IMUXSockRateLimitSeverity — maps to RateLimit.Severity (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-ruleset.rst
+++ b/doc/source/reference/parameters/imuxsock-ruleset.rst
@@ -1,0 +1,42 @@
+.. _param-imuxsock-ruleset:
+.. _imuxsock.parameter.input.ruleset:
+
+Ruleset
+=======
+
+.. index::
+   single: imuxsock; Ruleset
+   single: Ruleset
+
+.. summary-start
+
+Binds a specified ruleset to the input instead of the default ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: Ruleset
+:Scope: input
+:Type: string
+:Default: input=default ruleset
+:Required?: no
+:Introduced: 8.17.0
+
+Description
+-----------
+Binds specified ruleset to this input. If not set, the default
+ruleset is bound.
+
+Input usage
+-----------
+.. _param-imuxsock-input-ruleset:
+.. _imuxsock.parameter.input.ruleset-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" ruleset="myRuleset")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-socket.rst
+++ b/doc/source/reference/parameters/imuxsock-socket.rst
@@ -39,8 +39,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.addunixlistensocket:
+
 - $AddUnixListenSocket — maps to Socket (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-socket.rst
+++ b/doc/source/reference/parameters/imuxsock-socket.rst
@@ -1,0 +1,52 @@
+.. _param-imuxsock-socket:
+.. _imuxsock.parameter.input.socket:
+
+Socket
+======
+
+.. index::
+   single: imuxsock; Socket
+   single: Socket
+
+.. summary-start
+
+Adds an additional UNIX socket for this input to listen on.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: Socket
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Adds additional unix socket. Formerly specified with the ``-a`` option.
+
+Input usage
+-----------
+.. _param-imuxsock-input-socket:
+.. _imuxsock.parameter.input.socket-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" socket="/path/to/socket")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.addunixlistensocket:
+- $AddUnixListenSocket — maps to Socket (status: legacy)
+
+.. index::
+   single: imuxsock; $AddUnixListenSocket
+   single: $AddUnixListenSocket
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-annotate.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-annotate.rst
@@ -40,7 +40,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogsockannotate:
 
 - $SystemLogSocketAnnotate — maps to SysSock.Annotate (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-annotate.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-annotate.rst
@@ -1,0 +1,54 @@
+.. _param-imuxsock-syssock-annotate:
+.. _imuxsock.parameter.module.syssock-annotate:
+
+SysSock.Annotate
+================
+
+.. index::
+   single: imuxsock; SysSock.Annotate
+   single: SysSock.Annotate
+
+.. summary-start
+
+Enables annotation or trusted properties on the system log socket.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.Annotate
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Turn on annotation/trusted properties for the system log socket. See
+the :ref:`imuxsock-trusted-properties-label` section for more info.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-annotate:
+.. _imuxsock.parameter.module.syssock-annotate-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.annotate="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogsockannotate:
+
+- $SystemLogSocketAnnotate — maps to SysSock.Annotate (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogSocketAnnotate
+   single: $SystemLogSocketAnnotate
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-flowcontrol.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-flowcontrol.rst
@@ -39,7 +39,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogflowcontrol:
 
 - $SystemLogFlowControl — maps to SysSock.FlowControl (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-flowcontrol.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-flowcontrol.rst
@@ -1,0 +1,53 @@
+.. _param-imuxsock-syssock-flowcontrol:
+.. _imuxsock.parameter.module.syssock-flowcontrol:
+
+SysSock.FlowControl
+===================
+
+.. index::
+   single: imuxsock; SysSock.FlowControl
+   single: SysSock.FlowControl
+
+.. summary-start
+
+Applies flow control to the system log socket.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.FlowControl
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies if flow control should be applied to the system log socket.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-flowcontrol:
+.. _imuxsock.parameter.module.syssock-flowcontrol-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.flowControl="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogflowcontrol:
+
+- $SystemLogFlowControl — maps to SysSock.FlowControl (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogFlowControl
+   single: $SystemLogFlowControl
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-ignoreownmessages.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ignoreownmessages.rst
@@ -1,0 +1,48 @@
+.. _param-imuxsock-syssock-ignoreownmessages:
+.. _imuxsock.parameter.module.syssock-ignoreownmessages:
+
+SysSock.IgnoreOwnMessages
+=========================
+
+.. index::
+   single: imuxsock; SysSock.IgnoreOwnMessages
+   single: SysSock.IgnoreOwnMessages
+
+.. summary-start
+
+Ignores messages that originate from the same rsyslogd instance.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.IgnoreOwnMessages
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: 7.3.7
+
+Description
+-----------
+Ignores messages that originated from the same instance of rsyslogd.
+There usually is no reason to receive messages from ourselves.
+This setting is vital when writing messages to the systemd journal.
+
+.. seealso::
+
+   See :doc:`omjournal <../../configuration/modules/omjournal>` module documentation for a more
+   in-depth description.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-ignoreownmessages:
+.. _imuxsock.parameter.module.syssock-ignoreownmessages-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.ignoreOwnMessages="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-ignoretimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ignoretimestamp.rst
@@ -40,7 +40,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogsocketignoremsgtimestamp:
 
 - $SystemLogSocketIgnoreMsgTimestamp — maps to SysSock.IgnoreTimestamp (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-ignoretimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ignoretimestamp.rst
@@ -1,0 +1,54 @@
+.. _param-imuxsock-syssock-ignoretimestamp:
+.. _imuxsock.parameter.module.syssock-ignoretimestamp:
+
+SysSock.IgnoreTimestamp
+=======================
+
+.. index::
+   single: imuxsock; SysSock.IgnoreTimestamp
+   single: SysSock.IgnoreTimestamp
+
+.. summary-start
+
+Ignores timestamps included in messages from the system log socket.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.IgnoreTimestamp
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Ignore timestamps included in the messages, applies to messages received via
+the system log socket.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-ignoretimestamp:
+.. _imuxsock.parameter.module.syssock-ignoretimestamp-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.ignoreTimestamp="off")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogsocketignoremsgtimestamp:
+
+- $SystemLogSocketIgnoreMsgTimestamp — maps to SysSock.IgnoreTimestamp (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogSocketIgnoreMsgTimestamp
+   single: $SystemLogSocketIgnoreMsgTimestamp
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-name.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-name.rst
@@ -1,0 +1,59 @@
+.. _param-imuxsock-syssock-name:
+.. _imuxsock.parameter.module.syssock-name:
+
+SysSock.Name
+============
+
+.. index::
+   single: imuxsock; SysSock.Name
+   single: SysSock.Name
+
+.. summary-start
+
+Selects an alternate log socket instead of the default ``/dev/log``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.Name
+:Scope: module
+:Type: word
+:Default: module=/dev/log
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies an alternate log socket to be used instead of the default system
+log socket, traditionally ``/dev/log``. Unless disabled by the
+``SysSock.Unlink`` setting, this socket is created upon rsyslog startup
+and deleted upon shutdown, according to traditional syslogd behavior.
+
+The behavior of this parameter is different for systemd systems. See the
+:ref:`imuxsock-systemd-details-label` section for details.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-name:
+.. _imuxsock.parameter.module.syssock-name-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.name="/var/run/rsyslog/devlog")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogsockname:
+
+- $SystemLogSocketName — maps to SysSock.Name (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogSocketName
+   single: $SystemLogSocketName
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-name.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-name.rst
@@ -45,7 +45,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogsockname:
 
 - $SystemLogSocketName — maps to SysSock.Name (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-parsehostname.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-parsehostname.rst
@@ -1,0 +1,49 @@
+.. _param-imuxsock-syssock-parsehostname:
+.. _imuxsock.parameter.module.syssock-parsehostname:
+
+SysSock.ParseHostname
+=====================
+
+.. index::
+   single: imuxsock; SysSock.ParseHostname
+   single: SysSock.ParseHostname
+
+.. summary-start
+
+Expects hostnames on the system log socket when special parsing is disabled.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.ParseHostname
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 8.9.0
+
+Description
+-----------
+.. note::
+
+   This option only has an effect if ``SysSock.UseSpecialParser`` is
+   set to "off".
+
+Normally, the local log sockets do *not* contain hostnames. If set
+to on, parsers will expect hostnames just like in regular formats. If
+set to off (the default), the parser chain is instructed to not expect
+them.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-parsehostname:
+.. _imuxsock.parameter.module.syssock-parsehostname-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.parseHostname="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-parsetrusted.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-parsetrusted.rst
@@ -1,0 +1,64 @@
+.. _param-imuxsock-syssock-parsetrusted:
+.. _imuxsock.parameter.module.syssock-parsetrusted:
+
+SysSock.ParseTrusted
+====================
+
+.. index::
+   single: imuxsock; SysSock.ParseTrusted
+   single: SysSock.ParseTrusted
+
+.. summary-start
+
+Turns trusted properties into JSON fields when annotation is enabled.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.ParseTrusted
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 6.5.0
+
+Description
+-----------
+If ``SysSock.Annotation`` is turned on, create JSON/lumberjack properties
+out of the trusted properties (which can be accessed via |FmtAdvancedName|
+JSON Variables, e.g. ``$!pid``) instead of adding them to the message.
+
+.. versionadded:: 7.2.7
+   |FmtAdvancedName| directive introduced
+
+.. versionadded:: 7.3.8
+   |FmtAdvancedName| directive introduced
+
+.. versionadded:: 6.5.0
+   |FmtObsoleteName| directive introduced
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-parsetrusted:
+.. _imuxsock.parameter.module.syssock-parsetrusted-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.parseTrusted="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogparsetrusted:
+
+- $SystemLogParseTrusted — maps to SysSock.ParseTrusted (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogParseTrusted
+   single: $SystemLogParseTrusted
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-parsetrusted.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-parsetrusted.rst
@@ -29,14 +29,11 @@ If ``SysSock.Annotation`` is turned on, create JSON/lumberjack properties
 out of the trusted properties (which can be accessed via |FmtAdvancedName|
 JSON Variables, e.g. ``$!pid``) instead of adding them to the message.
 
-.. versionadded:: 7.2.7
-   |FmtAdvancedName| directive introduced
-
-.. versionadded:: 7.3.8
-   |FmtAdvancedName| directive introduced
-
 .. versionadded:: 6.5.0
-   |FmtObsoleteName| directive introduced
+   As ``$SystemLogParseTrusted``.
+
+.. versionchanged:: 7.2.7
+   Support for the advanced format was added.
 
 Module usage
 ------------
@@ -50,7 +47,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogparsetrusted:
 
 - $SystemLogParseTrusted — maps to SysSock.ParseTrusted (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ratelimit-burst.rst
@@ -40,7 +40,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogratelimitburst:
 
 - $SystemLogRateLimitBurst — maps to SysSock.RateLimit.Burst (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-ratelimit-burst.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ratelimit-burst.rst
@@ -1,0 +1,54 @@
+.. _param-imuxsock-syssock-ratelimit-burst:
+.. _imuxsock.parameter.module.syssock-ratelimit-burst:
+
+SysSock.RateLimit.Burst
+=======================
+
+.. index::
+   single: imuxsock; SysSock.RateLimit.Burst
+   single: SysSock.RateLimit.Burst
+
+.. summary-start
+
+Sets the rate-limiting burst size in messages for the system log socket.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.RateLimit.Burst
+:Scope: module
+:Type: integer
+:Default: module=200
+:Required?: no
+:Introduced: 5.7.1
+
+Description
+-----------
+Specifies the rate-limiting burst in number of messages. The maximum is
+``(2^31)-1``.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-ratelimit-burst:
+.. _imuxsock.parameter.module.syssock-ratelimit-burst-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.rateLimit.burst="100")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogratelimitburst:
+
+- $SystemLogRateLimitBurst — maps to SysSock.RateLimit.Burst (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogRateLimitBurst
+   single: $SystemLogRateLimitBurst
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ratelimit-interval.rst
@@ -1,0 +1,57 @@
+.. _param-imuxsock-syssock-ratelimit-interval:
+.. _imuxsock.parameter.module.syssock-ratelimit-interval:
+
+SysSock.RateLimit.Interval
+==========================
+
+.. index::
+   single: imuxsock; SysSock.RateLimit.Interval
+   single: SysSock.RateLimit.Interval
+
+.. summary-start
+
+Sets the rate-limiting interval in seconds for the system log socket.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.RateLimit.Interval
+:Scope: module
+:Type: integer
+:Default: module=0
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies the rate-limiting interval in seconds. Default value is 0,
+which turns off rate limiting. Set it to a number of seconds (5
+recommended) to activate rate-limiting. The default of 0 has been
+chosen as people experienced problems with this feature activated
+by default. Now it needs an explicit opt-in by setting this parameter.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-ratelimit-interval:
+.. _imuxsock.parameter.module.syssock-ratelimit-interval-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.rateLimit.interval="5")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogratelimitinterval:
+
+- $SystemLogRateLimitInterval — maps to SysSock.RateLimit.Interval (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogRateLimitInterval
+   single: $SystemLogRateLimitInterval
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-ratelimit-interval.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ratelimit-interval.rst
@@ -43,7 +43,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogratelimitinterval:
 
 - $SystemLogRateLimitInterval — maps to SysSock.RateLimit.Interval (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-ratelimit-severity.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ratelimit-severity.rst
@@ -43,7 +43,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogratelimitseverity:
 
 - $SystemLogRateLimitSeverity — maps to SysSock.RateLimit.Severity (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-ratelimit-severity.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ratelimit-severity.rst
@@ -1,0 +1,57 @@
+.. _param-imuxsock-syssock-ratelimit-severity:
+.. _imuxsock.parameter.module.syssock-ratelimit-severity:
+
+SysSock.RateLimit.Severity
+==========================
+
+.. index::
+   single: imuxsock; SysSock.RateLimit.Severity
+   single: SysSock.RateLimit.Severity
+
+.. summary-start
+
+Specifies which message severity levels are rate-limited on the system log socket.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.RateLimit.Severity
+:Scope: module
+:Type: integer
+:Default: module=1
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies the severity of messages that shall be rate-limited.
+
+.. seealso::
+
+   https://en.wikipedia.org/wiki/Syslog#Severity_level
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-ratelimit-severity:
+.. _imuxsock.parameter.module.syssock-ratelimit-severity-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.rateLimit.severity="5")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogratelimitseverity:
+
+- $SystemLogRateLimitSeverity — maps to SysSock.RateLimit.Severity (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogRateLimitSeverity
+   single: $SystemLogRateLimitSeverity
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-unlink.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-unlink.rst
@@ -1,0 +1,45 @@
+.. _param-imuxsock-syssock-unlink:
+.. _imuxsock.parameter.module.syssock-unlink:
+
+SysSock.Unlink
+==============
+
+.. index::
+   single: imuxsock; SysSock.Unlink
+   single: SysSock.Unlink
+
+.. summary-start
+
+Controls whether the system socket is unlinked and recreated on start and stop.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.Unlink
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: 7.3.9
+
+Description
+-----------
+If turned on (default), the system socket is unlinked and re-created
+when opened and also unlinked when finally closed. Note that this
+setting has no effect when running under systemd control (because
+systemd handles the socket. See the :ref:`imuxsock-systemd-details-label`
+section for details.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-unlink:
+.. _imuxsock.parameter.module.syssock-unlink-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.unlink="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-use.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-use.rst
@@ -53,7 +53,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.omitlocallogging:
 
 - $OmitLocalLogging — maps to SysSock.Use (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-use.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-use.rst
@@ -1,0 +1,67 @@
+.. _param-imuxsock-syssock-use:
+.. _imuxsock.parameter.module.syssock-use:
+
+SysSock.Use
+===========
+
+.. index::
+   single: imuxsock; SysSock.Use
+   single: SysSock.Use
+
+.. summary-start
+
+Enables listening on the system log socket or the path set by SysSock.Name.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.Use
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Listen on the default local log socket (``/dev/log``) or, if provided, use
+the log socket value assigned to the ``SysSock.Name`` parameter instead
+of the default. This is most useful if you run multiple instances of
+rsyslogd where only one shall handle the system log socket. Unless
+disabled by the ``SysSock.Unlink`` setting, this socket is created
+upon rsyslog startup and deleted upon shutdown, according to
+traditional syslogd behavior.
+
+The behavior of this parameter is different for systemd systems. For those
+systems, ``SysSock.Use`` still needs to be enabled, but the value of
+``SysSock.Name`` is ignored and the socket provided by systemd is used
+instead. If this parameter is *not* enabled, then imuxsock will only be
+of use if a custom input is configured.
+
+See the :ref:`imuxsock-systemd-details-label` section for details.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-use:
+.. _imuxsock.parameter.module.syssock-use-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.use="off")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.omitlocallogging:
+
+- $OmitLocalLogging — maps to SysSock.Use (status: legacy)
+
+.. index::
+   single: imuxsock; $OmitLocalLogging
+   single: $OmitLocalLogging
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-usepidfromsystem.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-usepidfromsystem.rst
@@ -1,0 +1,56 @@
+.. _param-imuxsock-syssock-usepidfromsystem:
+.. _imuxsock.parameter.module.syssock-usepidfromsystem:
+
+SysSock.UsePIDFromSystem
+========================
+
+.. index::
+   single: imuxsock; SysSock.UsePIDFromSystem
+   single: SysSock.UsePIDFromSystem
+
+.. summary-start
+
+Obtains the logged PID from the log socket itself.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.UsePIDFromSystem
+:Scope: module
+:Type: boolean
+:Default: module=off
+:Required?: no
+:Introduced: 5.7.0
+
+Description
+-----------
+Specifies if the pid being logged shall be obtained from the log socket
+itself. If so, the TAG part of the message is rewritten. It is recommended
+to turn this option on, but the default is "off" to keep compatible
+with earlier versions of rsyslog.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-usepidfromsystem:
+.. _imuxsock.parameter.module.syssock-usepidfromsystem-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.usePIDFromSystem="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogusepidfromsystem:
+
+- $SystemLogUsePIDFromSystem — maps to SysSock.UsePIDFromSystem (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogUsePIDFromSystem
+   single: $SystemLogUsePIDFromSystem
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-usepidfromsystem.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-usepidfromsystem.rst
@@ -42,7 +42,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogusepidfromsystem:
 
 - $SystemLogUsePIDFromSystem — maps to SysSock.UsePIDFromSystem (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-usespecialparser.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-usespecialparser.rst
@@ -1,0 +1,52 @@
+.. _param-imuxsock-syssock-usespecialparser:
+.. _imuxsock.parameter.module.syssock-usespecialparser:
+
+SysSock.UseSpecialParser
+========================
+
+.. index::
+   single: imuxsock; SysSock.UseSpecialParser
+   single: SysSock.UseSpecialParser
+
+.. summary-start
+
+Uses a specialized parser for the typical system log socket format.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.UseSpecialParser
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: 8.9.0
+
+Description
+-----------
+The equivalent of the ``UseSpecialParser`` input parameter, but
+for the system socket. If turned on (the default) a special parser is
+used that parses the format that is usually used
+on the system log socket (the one :manpage:`syslog(3)` creates). If set to
+"off", the regular parser chain is used, in which case the format on the
+log socket can be arbitrary.
+
+.. note::
+
+   When the special parser is used, rsyslog is able to inject a more precise
+   timestamp into the message (it is obtained from the log socket). If the
+   regular parser chain is used, this is not possible.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-usespecialparser:
+.. _imuxsock.parameter.module.syssock-usespecialparser-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.useSpecialParser="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-syssock-usesystimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-usesystimestamp.rst
@@ -45,7 +45,6 @@ Module usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.systemlogusesystimestamp:
 
 - $SystemLogUseSysTimeStamp — maps to SysSock.UseSysTimeStamp (status: legacy)

--- a/doc/source/reference/parameters/imuxsock-syssock-usesystimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-usesystimestamp.rst
@@ -1,0 +1,59 @@
+.. _param-imuxsock-syssock-usesystimestamp:
+.. _imuxsock.parameter.module.syssock-usesystimestamp:
+
+SysSock.UseSysTimeStamp
+=======================
+
+.. index::
+   single: imuxsock; SysSock.UseSysTimeStamp
+   single: SysSock.UseSysTimeStamp
+
+.. summary-start
+
+Obtains message time from the system instead of the message content.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: SysSock.UseSysTimeStamp
+:Scope: module
+:Type: boolean
+:Default: module=on
+:Required?: no
+:Introduced: 5.9.1
+
+Description
+-----------
+The same as the input parameter ``UseSysTimeStamp``, but for the system log
+socket. This parameter instructs ``imuxsock`` to obtain message time from
+the system (via control messages) instead of using time recorded inside
+the message. This may be most useful in combination with systemd. Due to
+the usefulness of this functionality, we decided to enable it by default.
+As such, the behavior is slightly different than previous versions.
+However, we do not see how this could negatively affect existing environments.
+
+Module usage
+------------
+.. _param-imuxsock-module-syssock-usesystimestamp:
+.. _imuxsock.parameter.module.syssock-usesystimestamp-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imuxsock" sysSock.useSysTimeStamp="off")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.systemlogusesystimestamp:
+
+- $SystemLogUseSysTimeStamp — maps to SysSock.UseSysTimeStamp (status: legacy)
+
+.. index::
+   single: imuxsock; $SystemLogUseSysTimeStamp
+   single: $SystemLogUseSysTimeStamp
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-unlink.rst
+++ b/doc/source/reference/parameters/imuxsock-unlink.rst
@@ -1,0 +1,51 @@
+.. _param-imuxsock-unlink:
+.. _imuxsock.parameter.input.unlink:
+
+Unlink
+======
+
+.. index::
+   single: imuxsock; Unlink
+   single: Unlink
+
+.. summary-start
+
+Controls whether the socket is unlinked on open and close.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: Unlink
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: 7.3.9
+
+Description
+-----------
+If turned on (default), the socket is unlinked and re-created when opened
+and also unlinked when finally closed. Set it to off if you handle socket
+creation yourself.
+
+.. note::
+
+   Note that handling socket creation oneself has the
+   advantage that a limited amount of messages may be queued by the OS
+   if rsyslog is not running.
+
+.. versionadded:: 7.3.9
+
+Input usage
+-----------
+.. _param-imuxsock-input-unlink:
+.. _imuxsock.parameter.input.unlink-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" unlink="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-usepidfromsystem.rst
+++ b/doc/source/reference/parameters/imuxsock-usepidfromsystem.rst
@@ -1,0 +1,55 @@
+.. _param-imuxsock-usepidfromsystem:
+.. _imuxsock.parameter.input.usepidfromsystem:
+
+UsePIDFromSystem
+================
+
+.. index::
+   single: imuxsock; UsePIDFromSystem
+   single: UsePIDFromSystem
+
+.. summary-start
+
+Obtains the process ID from the log socket instead of the message.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: UsePIDFromSystem
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: at least 7.0.0, possibly earlier
+
+Description
+-----------
+Specifies if the pid being logged shall be obtained from the log socket
+itself. If so, the TAG part of the message is rewritten. It is
+recommended to turn this option on, but the default is "off" to keep
+compatible with earlier versions of rsyslog.
+
+Input usage
+-----------
+.. _param-imuxsock-input-usepidfromsystem:
+.. _imuxsock.parameter.input.usepidfromsystem-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" usePidFromSystem="on")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.inputunixlistensocketusepidfromsystem:
+- $InputUnixListenSocketUsePIDFromSystem — maps to UsePIDFromSystem (status: legacy)
+
+.. index::
+   single: imuxsock; $InputUnixListenSocketUsePIDFromSystem
+   single: $InputUnixListenSocketUsePIDFromSystem
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-usepidfromsystem.rst
+++ b/doc/source/reference/parameters/imuxsock-usepidfromsystem.rst
@@ -42,8 +42,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.inputunixlistensocketusepidfromsystem:
+
 - $InputUnixListenSocketUsePIDFromSystem — maps to UsePIDFromSystem (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-usespecialparser.rst
+++ b/doc/source/reference/parameters/imuxsock-usespecialparser.rst
@@ -1,0 +1,45 @@
+.. _param-imuxsock-usespecialparser:
+.. _imuxsock.parameter.input.usespecialparser:
+
+UseSpecialParser
+================
+
+.. index::
+   single: imuxsock; UseSpecialParser
+   single: UseSpecialParser
+
+.. summary-start
+
+Selects the special parser tailored for default UNIX socket format.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: UseSpecialParser
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: 8.9.0
+
+Description
+-----------
+Equivalent to the ``SysSock.UseSpecialParser`` module parameter, but applies
+to the input that is being defined.
+
+.. versionadded:: 8.9.0
+   The setting was previously hard-coded "on"
+
+Input usage
+-----------
+.. _param-imuxsock-input-usespecialparser:
+.. _imuxsock.parameter.input.usespecialparser-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" useSpecialParser="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.

--- a/doc/source/reference/parameters/imuxsock-usesystimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-usesystimestamp.rst
@@ -46,8 +46,8 @@ Input usage
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Historic names/directives for compatibility. Do not use in new configs.
-
 .. _imuxsock.parameter.legacy.inputunixlistensocketusesystimestamp:
+
 - $InputUnixListenSocketUseSysTimeStamp — maps to UseSysTimeStamp (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/imuxsock-usesystimestamp.rst
+++ b/doc/source/reference/parameters/imuxsock-usesystimestamp.rst
@@ -1,0 +1,59 @@
+.. _param-imuxsock-usesystimestamp:
+.. _imuxsock.parameter.input.usesystimestamp:
+
+UseSysTimeStamp
+===============
+
+.. index::
+   single: imuxsock; UseSysTimeStamp
+   single: UseSysTimeStamp
+
+.. summary-start
+
+Takes message timestamps from the system instead of the message itself.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imuxsock`.
+
+:Name: UseSysTimeStamp
+:Scope: input
+:Type: boolean
+:Default: input=on
+:Required?: no
+:Introduced: 5.9.1
+
+Description
+-----------
+This parameter instructs ``imuxsock`` to obtain message time from
+the system (via control messages) instead of using time recorded inside
+the message. This may be most useful in combination with systemd. Due to
+the usefulness of this functionality, we decided to enable it by default.
+As such, the behavior is slightly different than previous versions.
+However, we do not see how this could negatively affect existing environments.
+
+.. versionadded:: 5.9.1
+
+Input usage
+-----------
+.. _param-imuxsock-input-usesystimestamp:
+.. _imuxsock.parameter.input.usesystimestamp-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imuxsock" useSysTimeStamp="off")
+
+Legacy names (for reference)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Historic names/directives for compatibility. Do not use in new configs.
+
+.. _imuxsock.parameter.legacy.inputunixlistensocketusesystimestamp:
+- $InputUnixListenSocketUseSysTimeStamp — maps to UseSysTimeStamp (status: legacy)
+
+.. index::
+   single: imuxsock; $InputUnixListenSocketUseSysTimeStamp
+   single: $InputUnixListenSocketUseSysTimeStamp
+
+See also
+--------
+See also :doc:`../../configuration/modules/imuxsock`.


### PR DESCRIPTION
## Summary
- split imuxsock input parameters into individual reference pages
- replace inline input parameter documentation with summary list-table
- extend hidden toctree with new parameter references

## Testing
- `devtools/format-code.sh`
- `make -C doc html` *(interrupted at ~32%: doc build long)*

------
https://chatgpt.com/codex/tasks/task_e_68a334d2738483328d1d686746238545