### PR TITLE
template: fix missing lenStr in subtree templates

### DIFF
--- a/template.c
+++ b/template.c
@@ -154,6 +154,7 @@ rsRetVal tplToString(struct template *__restrict__ const pTpl,
         if (iLenVal >= (rs_size_t)iparam->lenBuf) /* we reserve one char for the final \0! */
             CHKiRet(ExtendBuf(iparam, iLenVal + 1));
         memcpy(iparam->param, pVal, iLenVal + 1);
+        iparam->lenStr = iLenVal;
         FINALIZE;
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -215,6 +215,7 @@ TESTS +=  \
 	omfwd-lb-2target-one_fail.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
+	omfwd-subtree-tpl.sh \
 	omusrmsg-errmsg-no-params.sh \
 	omusrmsg-noabort.sh \
 	omfile-module-params.sh \
@@ -239,7 +240,7 @@ TESTS +=  \
 	privdropabortonidfail.sh \
 	privdropabortonidfaillegacy.sh \
 	json-nonstring.sh \
-        json-onempty-at-end.sh \
+	json-onempty-at-end.sh \
 	template-json.sh \
 	template-pure-json.sh \
 	template-pos-from-to.sh \
@@ -2243,12 +2244,13 @@ EXTRA_DIST= \
 	omfwd-lb-2target-basic.sh \
 	omfwd-lb-2target-impstats.sh \
 	omfwd-lb-2target-retry.sh \
-	omfwd-lb-2target-one_fail.sh \
-	omfwd-tls-invalid-permitExpiredCerts.sh \
-	omfwd-keepalive.sh \
-	omfwd_fast_imuxsock.sh \
-	omfile_hup-vg.sh \
-	omsendertrack-basic.sh \
+        omfwd-lb-2target-one_fail.sh \
+        omfwd-tls-invalid-permitExpiredCerts.sh \
+        omfwd-keepalive.sh \
+        omfwd-subtree-tpl.sh \
+        omfwd_fast_imuxsock.sh \
+        omfile_hup-vg.sh \
+        omsendertrack-basic.sh \
 	omsendertrack-basic-vg.sh \
 	omsendertrack-statefile.sh \
 	omsendertrack-statefile-vg.sh \

--- a/tests/omfwd-subtree-tpl.sh
+++ b/tests/omfwd-subtree-tpl.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Verify omfwd forwards messages when using subtree-type templates
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+template(name="csl-subtree" type="subtree" subtree="$!csl")
+
+if $msg contains "msgnum:" then {
+    set $!csl!foo = "bar";
+    action(type="omfwd" template="csl-subtree"
+           target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp")
+}
+'
+
+./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
+BGPROCESS=$!
+
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+content_check '{ "foo": "bar" }' "$RSYSLOG_OUT_LOG"
+exit_test
+


### PR DESCRIPTION
## Summary
- ensure subtree-type templates set `lenStr`
- add regression test for omfwd with subtree templates

## Testing
- `make`
- `make check TESTS=omfwd-subtree-tpl.sh` *(fails: missing msleep/minitcpsrv tools in build)*

------
https://chatgpt.com/codex/tasks/task_e_68a36a8810408332902abc161520c65a