### PR TITLE
ci: add clang static analyzer workflow

### DIFF
--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -7,6 +7,13 @@ name: "Clang Static Analyzer"
 jobs:
   clang-analyzer:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy-report.outputs.page_url }}
 
     steps:
       - name: Checkout repository
@@ -36,14 +43,33 @@ jobs:
           path: scan-build-report
           retention-days: 7
 
+      - name: Upload HTML report for Pages
+        if: always()
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: scan-build-report
+
+      - name: Deploy report to GitHub Pages
+        if: always()
+        id: deploy-report
+        uses: actions/deploy-pages@v4  # publish HTML report online
+
       - name: Show clang static analyzer report link
         if: always()
         run: |
-          url=${{ steps.upload-report.outputs.artifact-url }}
-          echo "Clang static analyzer HTML report:" >> $GITHUB_STEP_SUMMARY
-          echo "$url" >> $GITHUB_STEP_SUMMARY
-          echo "Clang static analyzer HTML report:"
-          echo "$url"
+          artifact=${{ steps.upload-report.outputs.artifact-url }}
+          pages=${{ steps.deploy-report.outputs.page_url }}
+          cat >> $GITHUB_STEP_SUMMARY <<EOF
+          Clang static analyzer HTML report (download):
+          $artifact
+
+          Clang static analyzer HTML report (browse online):
+          $pages
+          EOF
+          echo "Clang static analyzer HTML report (download):"
+          echo "$artifact"
+          echo "Clang static analyzer HTML report (browse online):"
+          echo "$pages"
 
       - name: Fail if analysis failed
         if: steps.run-clang.outputs.exitcode != '0'

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -1,0 +1,48 @@
+---
+name: "Clang Static Analyzer"
+
+'on':
+  pull_request: {}
+
+jobs:
+  clang-analyzer:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run clang static analyzer
+        id: run-clang
+        env:
+          RSYSLOG_DEV_CONTAINER: rsyslog/rsyslog_dev_base_ubuntu:24.04
+          SCAN_BUILD: scan-build
+          SCAN_BUILD_CC: clang
+          SCAN_BUILD_REPORT_DIR: scan-build-report
+        run: |
+          chmod -R go+rw .
+          set +e
+          devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh
+          echo "exitcode=$?" >> $GITHUB_OUTPUT
+
+      - name: Upload clang static analyzer report
+        if: always()
+        id: upload-report
+        uses: actions/upload-artifact@v4
+        with:
+          name: clang-static-analyzer-report
+          path: scan-build-report
+          retention-days: 7
+
+      - name: Show clang static analyzer report link
+        if: always()
+        run: |
+          url=${{ steps.upload-report.outputs.artifact-url }}
+          echo "Clang static analyzer HTML report:" >> $GITHUB_STEP_SUMMARY
+          echo "$url" >> $GITHUB_STEP_SUMMARY
+          echo "Clang static analyzer HTML report:"
+          echo "$url"
+
+      - name: Fail if analysis failed
+        if: steps.run-clang.outputs.exitcode != '0'
+        run: exit 1

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -31,8 +31,9 @@ jobs:
         run: |
           chmod -R go+rw .
           set +e
-          devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh
-          echo "exitcode=$?" >> $GITHUB_OUTPUT
+            devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh 2>&1 \
+              | tee clang-analyzer.log
+          echo "exitcode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
 
       - name: Upload clang static analyzer report
         if: always()
@@ -73,4 +74,12 @@ jobs:
 
       - name: Fail if analysis failed
         if: steps.run-clang.outputs.exitcode != '0'
-        run: exit 1
+        run: |
+          artifact="${{ steps.upload-report.outputs.artifact-url }}"
+          pages="${{ steps.deploy-report.outputs.page_url }}"
+          echo "clang static analyzer detected issues:" >&2
+          tail -n 200 clang-analyzer.log >&2 || true
+          echo >&2
+          echo "Clang static analyzer HTML report (download): $artifact" >&2
+          echo "Clang static analyzer HTML report (browse online): $pages" >&2
+          exit 1

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -19,6 +19,8 @@ jobs:
           SCAN_BUILD: scan-build
           SCAN_BUILD_CC: clang
           SCAN_BUILD_REPORT_DIR: scan-build-report
+          DOCKER_RUN_EXTRA_OPTS: >-
+            -e SCAN_BUILD -e SCAN_BUILD_CC -e SCAN_BUILD_REPORT_DIR
         run: |
           chmod -R go+rw .
           set +e

--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -9,11 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy-report.outputs.page_url }}
 
     steps:
       - name: Checkout repository
@@ -35,6 +30,8 @@ jobs:
               | tee clang-analyzer.log
           echo "exitcode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
 
+      # GitHub Pages deployment is disabled due to setup issues; reports remain
+      # available as downloadable artifacts
       - name: Upload clang static analyzer report
         if: always()
         id: upload-report
@@ -44,42 +41,23 @@ jobs:
           path: scan-build-report
           retention-days: 7
 
-      - name: Upload HTML report for Pages
-        if: always()
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: scan-build-report
-
-      - name: Deploy report to GitHub Pages
-        if: always()
-        id: deploy-report
-        uses: actions/deploy-pages@v4  # publish HTML report online
-
       - name: Show clang static analyzer report link
         if: always()
         run: |
           artifact=${{ steps.upload-report.outputs.artifact-url }}
-          pages=${{ steps.deploy-report.outputs.page_url }}
           cat >> $GITHUB_STEP_SUMMARY <<EOF
           Clang static analyzer HTML report (download):
           $artifact
-
-          Clang static analyzer HTML report (browse online):
-          $pages
           EOF
           echo "Clang static analyzer HTML report (download):"
           echo "$artifact"
-          echo "Clang static analyzer HTML report (browse online):"
-          echo "$pages"
 
       - name: Fail if analysis failed
         if: steps.run-clang.outputs.exitcode != '0'
         run: |
           artifact="${{ steps.upload-report.outputs.artifact-url }}"
-          pages="${{ steps.deploy-report.outputs.page_url }}"
           echo "clang static analyzer detected issues:" >&2
           tail -n 200 clang-analyzer.log >&2 || true
           echo >&2
           echo "Clang static analyzer HTML report (download): $artifact" >&2
-          echo "Clang static analyzer HTML report (browse online): $pages" >&2
           exit 1


### PR DESCRIPTION
## Summary
- run clang static analyzer in a devcontainer on pull requests
- upload scan-build HTML reports as artifacts for seven days
- log and summarize the artifact URL for easy access

## Testing
- `yamllint .github/workflows/clang-analyzer.yml`
- `./devtools/format-code.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a452aca78c83328356a5f03dac95eb