### PR TITLE
atomic: remove trailing semicolons from helper macros

### DIFF
--- a/action.h
+++ b/action.h
@@ -94,7 +94,7 @@ struct action_s {
     qqueue_t *pQueue; /* action queue */
     pthread_mutex_t mutAction; /* primary action mutex */
     uchar *pszName; /* action name */
-    DEF_ATOMIC_HELPER_MUT(mutCAS)
+    DEF_ATOMIC_HELPER_MUT(mutCAS);
     /* error file */
     const char *pszErrFile;
     int fdErrFile;

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -319,7 +319,7 @@ struct ptcplstn_s {
     STATSCOUNTER_DEF(ctrSessOpen, mutCtrSessOpen)
     STATSCOUNTER_DEF(ctrSessOpenErr, mutCtrSessOpenErr)
     STATSCOUNTER_DEF(ctrSessClose, mutCtrSessClose)
-    DEF_ATOMIC_HELPER_MUT64(mut_rcvdBytes)
+    DEF_ATOMIC_HELPER_MUT64(mut_rcvdBytes);
 };
 
 

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -203,9 +203,9 @@ static inline void ATOMIC_SUB_unsigned(unsigned *data, int val, pthread_mutex_t 
     (*data) -= val;
     pthread_mutex_unlock(phlpmut);
 }
-    #define DEF_ATOMIC_HELPER_MUT(x) pthread_mutex_t x;
-    #define INIT_ATOMIC_HELPER_MUT(x) pthread_mutex_init(&(x), NULL);
-    #define DESTROY_ATOMIC_HELPER_MUT(x) pthread_mutex_destroy(&(x));
+    #define DEF_ATOMIC_HELPER_MUT(x) pthread_mutex_t x
+    #define INIT_ATOMIC_HELPER_MUT(x) pthread_mutex_init(&(x), NULL)
+    #define DESTROY_ATOMIC_HELPER_MUT(x) pthread_mutex_destroy(&(x))
 
     #define PREFER_ATOMIC_INC(data) ((void)++data)
     #define PREFER_FETCH_32BIT(data) ((unsigned)(data))
@@ -254,7 +254,7 @@ static inline unsigned ATOMIC_INC_AND_FETCH_uint64(uint64 *data, pthread_mutex_t
     return (val);
 }
 
-    #define DEF_ATOMIC_HELPER_MUT64(x) pthread_mutex_t x;
+    #define DEF_ATOMIC_HELPER_MUT64(x) pthread_mutex_t x
     #define INIT_ATOMIC_HELPER_MUT64(x) pthread_mutex_init(&(x), NULL)
     #define DESTROY_ATOMIC_HELPER_MUT64(x) pthread_mutex_destroy(&(x))
 #endif /* #ifdef HAVE_ATOMIC_BUILTINS64 */

--- a/runtime/prop.h
+++ b/runtime/prop.h
@@ -34,7 +34,7 @@ struct prop_s {
             uchar sz[CONF_PROP_BUFSIZE];
         } szVal;
         int len; /* we use int intentionally, otherwise we may get some troubles... */
-        DEF_ATOMIC_HELPER_MUT(mutRefCount)
+        DEF_ATOMIC_HELPER_MUT(mutRefCount);
 };
 
 /* interfaces */

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -203,8 +203,8 @@ struct queue_s {
         cryprov_if_t cryprov; /* ptr to crypto provider interface */
         void *cryprovData; /* opaque data ptr for provider use */
         uchar *cryprovNameFull; /* full internal crypto provider name */
-        DEF_ATOMIC_HELPER_MUT(mutQueueSize)
-        DEF_ATOMIC_HELPER_MUT(mutLogDeq)
+        DEF_ATOMIC_HELPER_MUT(mutQueueSize);
+        DEF_ATOMIC_HELPER_MUT(mutLogDeq);
         /* for statistics subsystem */
         statsobj_t *statsobj;
         STATSCOUNTER_DEF(ctrEnqueued, mutCtrEnqueued)

--- a/runtime/statsobj.h
+++ b/runtime/statsobj.h
@@ -203,7 +203,7 @@ void checkGoneAwaySenders(time_t);
  */
 #define STATSCOUNTER_DEF(ctr, mut) \
     intctr_t ctr;                  \
-    DEF_ATOMIC_HELPER_MUT64(mut)
+    DEF_ATOMIC_HELPER_MUT64(mut);
 
 #define STATSCOUNTER_INIT(ctr, mut) \
     INIT_ATOMIC_HELPER_MUT64(mut);  \

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -79,7 +79,7 @@ struct wti_s {
         actWrkrInfo_t *actWrkrInfo; /* *array* of action wrkr infos for all actions
                           (sized for max nbr of actions in config!) */
         pthread_cond_t pcondBusy; /* condition to wake up the worker, protected by pmutUsr in wtp */
-        DEF_ATOMIC_HELPER_MUT(mutIsRunning)
+        DEF_ATOMIC_HELPER_MUT(mutIsRunning);
         struct {
             uint8_t script_errno; /* errno-type interface for RainerScript functions */
             uint8_t bPrevWasSuspended;

--- a/runtime/wtp.h
+++ b/runtime/wtp.h
@@ -70,8 +70,8 @@ struct wtp_s {
         rsRetVal (*pfDoWork)(void *pUsr, void *pWti);
         /* end user objects */
         uchar *pszDbgHdr; /* header string for debug messages */
-        DEF_ATOMIC_HELPER_MUT(mutCurNumWrkThrd)
-        DEF_ATOMIC_HELPER_MUT(mutWtpState)
+        DEF_ATOMIC_HELPER_MUT(mutCurNumWrkThrd);
+        DEF_ATOMIC_HELPER_MUT(mutWtpState);
 };
 
 /* some symbolic constants for easier reference */

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -78,8 +78,8 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(netstrms) DEFobjCurrIf(netstrm
     statsobj_t *stats;
     intctr_t sentBytes;
     intctr_t sentMsgs;
-    DEF_ATOMIC_HELPER_MUT64(mut_sentBytes)
-    DEF_ATOMIC_HELPER_MUT64(mut_sentMsgs)
+    DEF_ATOMIC_HELPER_MUT64(mut_sentBytes);
+    DEF_ATOMIC_HELPER_MUT64(mut_sentMsgs);
 } targetStats_t;
 
 typedef struct _instanceData {

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -94,7 +94,7 @@ struct instanceConf_s {
     uchar* pszHeaderlessTag; /** < TAG to use for headerless messages */
     uchar* pszHeaderlessRulesetName; /** < name of Ruleset to use for headerless messages */
     ruleset_t* pHeaderlessRuleset; /**< Ruleset to use for headerless messages */
-    DEF_ATOMIC_HELPER_MUT(mutHeaderlessRuleset) /**< mutex for atomic operations on pHeaderlessRuleset */
+    DEF_ATOMIC_HELPER_MUT(mutHeaderlessRuleset); /**< mutex for atomic operations on pHeaderlessRuleset */
     uchar* pszHeaderlessErrFile; /**< name of error file for headerless messages */
     FILE* fpHeaderlessErr; /**< file pointer for error file (headerless) */
     pthread_mutex_t mutErrFile;


### PR DESCRIPTION
## Summary
- drop trailing semicolons from DEF/INIT/DESTROY atomic helper macros
- add missing semicolons at call sites and in STATSCOUNTER_DEF

## Testing
- `./devtools/format-code.sh`
- `make` *(fails: ../libtool: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a47de42c30833285429b5d0158aa62