### PR TITLE
imhttp: expose stats via Prometheus endpoint

### DIFF
--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -99,6 +99,8 @@ struct modConfData_s {
     int nOptions;
     char *pszHealthCheckPath;
     char *pszMetricsPath;
+    char *pszHealthCheckAuthFile;
+    char *pszMetricsAuthFile;
 };
 
 struct instanceConf_s {
@@ -145,7 +147,9 @@ static struct cnfparamdescr modpdescr[] = {{"ports", eCmdHdlrString, 0},
                                            {"documentroot", eCmdHdlrString, 0},
                                            {"liboptions", eCmdHdlrArray, 0},
                                            {"healthcheckpath", eCmdHdlrString, 0},
-                                           {"metricspath", eCmdHdlrString, 0}};
+                                           {"metricspath", eCmdHdlrString, 0},
+                                           {"healthcheckbasicauthfile", eCmdHdlrString, 0},
+                                           {"metricsbasicauthfile", eCmdHdlrString, 0}};
 
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
 
@@ -777,24 +781,23 @@ static int authorize(struct mg_connection *conn, FILE *filep) {
     see also: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization
 */
 static int basicAuthHandler(struct mg_connection *conn, void *cbdata) {
-    const instanceConf_t *inst = (const instanceConf_t *)cbdata;
+    const char *authFile = (const char *)cbdata;
     char errStr[512];
     FILE *fp = NULL;
     int ret = 1;
 
-    if (!inst->pszBasicAuthFile) {
+    if (!authFile) {
         mg_cry(conn, "warning: 'BasicAuthFile' not configured.\n");
         ret = 0;
         goto finalize;
     }
 
-    fp = fopen((const char *)inst->pszBasicAuthFile, "r");
+    fp = fopen(authFile, "r");
     if (fp == NULL) {
         if (strerror_r(errno, errStr, sizeof(errStr)) == 0) {
-            mg_cry(conn, "error: 'BasicAuthFile' file '%s' could not be accessed: %s\n", inst->pszBasicAuthFile,
-                   errStr);
+            mg_cry(conn, "error: 'BasicAuthFile' file '%s' could not be accessed: %s\n", authFile, errStr);
         } else {
-            mg_cry(conn, "error: 'BasicAuthFile' file '%s' could not be accessed: %d\n", inst->pszBasicAuthFile, errno);
+            mg_cry(conn, "error: 'BasicAuthFile' file '%s' could not be accessed: %d\n", authFile, errno);
         }
         ret = 0;
         goto finalize;
@@ -916,22 +919,59 @@ static int health_check_handler(struct mg_connection *conn, ATTR_UNUSED void *cb
 
 /*
  * prometheus_metrics_handler
- * Responds with a single, constant Prometheus metric indicating the module is up.
+ * Export rsyslog statistics in Prometheus text format.
  */
+struct stats_buf {
+    char *buf;
+    size_t len;
+    size_t cap;
+};
+
+static rsRetVal prom_stats_collect(void *usrptr, const char *line) {
+    struct stats_buf *sb = (struct stats_buf *)usrptr;
+    const size_t line_len = strlen(line);
+    if (sb->len + line_len + 1 >= sb->cap) {
+        size_t newcap = sb->cap ? sb->cap * 2 : 1024;
+        while (newcap <= sb->len + line_len + 1) {
+            newcap *= 2;
+        }
+        char *tmp = realloc(sb->buf, newcap);
+        if (tmp == NULL) {
+            return RS_RET_OUT_OF_MEMORY;
+        }
+        sb->buf = tmp;
+        sb->cap = newcap;
+    }
+    memcpy(sb->buf + sb->len, line, line_len);
+    sb->len += line_len;
+    sb->buf[sb->len] = '\0';
+    return RS_RET_OK;
+}
+
 static int prometheus_metrics_handler(struct mg_connection *conn, ATTR_UNUSED void *cbdata) {
-    // Prometheus text exposition format
-    const char *metrics_body =
-        "# HELP imhttp_up Indicates if the imhttp module is operational (1 for up, 0 for down).\n"
-        "# TYPE imhttp_up gauge\n"
-        "imhttp_up 1\n";
+    struct stats_buf sb = {.buf = NULL, .len = 0, .cap = 0};
+    rsRetVal ret = statsobj.GetAllStatsLines(prom_stats_collect, &sb, statsFmt_Prometheus, 0);
+    if (ret != RS_RET_OK) {
+        LogError(0, ret, "imhttp: failed to retrieve statistics");
+        mg_printf(conn, "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\n\r\n");
+        free(sb.buf);
+        return 500;
+    }
 
-    // Send HTTP OK with Prometheus content type
-    mg_send_http_ok(conn, "text/plain; version=0.0.4; charset=utf-8", strlen(metrics_body));
+    mg_printf(conn,
+              "HTTP/1.1 200 OK\r\n"
+              "Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n"
+              "Connection: close\r\n"
+              "\r\n");
 
-    // Write the metrics body
-    mg_write(conn, metrics_body, strlen(metrics_body));
+    mg_printf(conn,
+              "# HELP imhttp_up Indicates if the imhttp module is operational (1 for up, 0 for down).\n"
+              "# TYPE imhttp_up gauge\n"
+              "imhttp_up 1\n");
 
-    return 200;  // HTTP 200 OK (signals to CivetWeb that the request was handled)
+    mg_write(conn, sb.buf, sb.len);
+    free(sb.buf);
+    return 200; /* HTTP 200 OK */
 }
 
 
@@ -945,7 +985,8 @@ static int runloop(void) {
             dbgprintf("setting request handler: '%s'\n", inst->pszEndpoint);
             mg_set_request_handler(s_httpserv->ctx, (char *)inst->pszEndpoint, postHandler, inst);
             if (inst->pszBasicAuthFile) {
-                mg_set_auth_handler(s_httpserv->ctx, (char *)inst->pszEndpoint, basicAuthHandler, inst);
+                mg_set_auth_handler(s_httpserv->ctx, (char *)inst->pszEndpoint, basicAuthHandler,
+                                    inst->pszBasicAuthFile);
             }
         }
     }
@@ -953,12 +994,20 @@ static int runloop(void) {
     if (runModConf->pszHealthCheckPath && runModConf->pszHealthCheckPath[0] != '\0') {
         dbgprintf("imhttp: setting request handler for global health check: '%s'\n", runModConf->pszHealthCheckPath);
         mg_set_request_handler(s_httpserv->ctx, runModConf->pszHealthCheckPath, health_check_handler, NULL);
+        if (runModConf->pszHealthCheckAuthFile) {
+            mg_set_auth_handler(s_httpserv->ctx, runModConf->pszHealthCheckPath, basicAuthHandler,
+                                runModConf->pszHealthCheckAuthFile);
+        }
     }
 
     if (runModConf->pszMetricsPath && runModConf->pszMetricsPath[0] != '\0') {
         dbgprintf("imhttp: setting request handler for Prometheus metrics: '%s'\n", runModConf->pszMetricsPath);
         mg_set_request_handler(s_httpserv->ctx, runModConf->pszMetricsPath, prometheus_metrics_handler,
                                NULL /* cbdata, not used */);
+        if (runModConf->pszMetricsAuthFile) {
+            mg_set_auth_handler(s_httpserv->ctx, runModConf->pszMetricsPath, basicAuthHandler,
+                                runModConf->pszMetricsAuthFile);
+        }
     }
 
     /* Wait until the server should be closed */
@@ -1038,6 +1087,8 @@ BEGINbeginCnfLoad
     loadModConf->docroot.name = NULL;
     loadModConf->nOptions = 0;
     loadModConf->options = NULL;
+    loadModConf->pszHealthCheckAuthFile = NULL;
+    loadModConf->pszMetricsAuthFile = NULL;
 ENDbeginCnfLoad
 
 
@@ -1087,6 +1138,16 @@ BEGINsetModCnf
             val_str = es_str2cstr(pvals[i].val.d.estr, NULL);
             free(loadModConf->pszMetricsPath);  // Free previous if any
             loadModConf->pszMetricsPath = strdup(val_str);
+            free(val_str);
+        } else if (!strcmp(modpblk.descr[i].name, "healthcheckbasicauthfile")) {
+            val_str = es_str2cstr(pvals[i].val.d.estr, NULL);
+            free(loadModConf->pszHealthCheckAuthFile);
+            loadModConf->pszHealthCheckAuthFile = strdup(val_str);
+            free(val_str);
+        } else if (!strcmp(modpblk.descr[i].name, "metricsbasicauthfile")) {
+            val_str = es_str2cstr(pvals[i].val.d.estr, NULL);
+            free(loadModConf->pszMetricsAuthFile);
+            loadModConf->pszMetricsAuthFile = strdup(val_str);
             free(val_str);
         } else {
             dbgprintf(
@@ -1280,6 +1341,8 @@ BEGINfreeCnf
     free((void *)pModConf->docroot.val);
     free((void *)pModConf->pszHealthCheckPath);
     free((void *)pModConf->pszMetricsPath);
+    free((void *)pModConf->pszHealthCheckAuthFile);
+    free((void *)pModConf->pszMetricsAuthFile);
 
     if (statsCounter.stats) {
         statsobj.Destruct(&statsCounter.stats);

--- a/doc/source/configuration/modules/imhttp.rst
+++ b/doc/source/configuration/modules/imhttp.rst
@@ -25,6 +25,7 @@ Notable Features
 
 - :ref:`imhttp-statistic-counter`
 - :ref:`imhttp-error-messages`
+- :ref:`imhttp-prometheus-metrics`
 
 
 Configuration Parameters
@@ -86,6 +87,75 @@ Configures civetweb library "Options".
 
 - `Civetweb Options <https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md#options-from-civetwebc>`_
 
+
+.. _imhttp-healthcheckpath:
+
+healthCheckPath
+^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "mandatory", "format", "default"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "no", "path that begins with '/'", "/healthz"
+
+Configures the request path for a simple HTTP health probe that returns
+``200`` when the module is running.
+The endpoint is unauthenticated unless :ref:`healthCheckBasicAuthFile
+<imhttp-healthcheckbasicauthfile>` is set. Otherwise, bind the server to
+``localhost`` or use CivetWeb access controls if external access is not
+desired.
+
+.. _imhttp-healthcheckbasicauthfile:
+
+healthCheckBasicAuthFile
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "mandatory", "format", "default"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "no", "path to htpasswd file", "none"
+
+Protects the health probe with HTTP Basic Authentication using a file in
+`htpasswd` format.
+
+.. _imhttp-metricspath:
+
+metricsPath
+^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "mandatory", "format", "default"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "no", "path that begins with '/'", "/metrics"
+
+Exposes rsyslog statistics in Prometheus text format at the specified
+path. The endpoint emits counters such as ``imhttp_submitted_total`` and
+``imhttp_failed_total``.
+By default the endpoint does not enforce authentication, but it can be
+protected with :ref:`metricsBasicAuthFile <imhttp-metricsbasicauthfile>`.
+Leaving the default paths enabled creates user-visible URLs as soon as
+the module is loaded, so review firewall and access-control settings.
+
+.. _imhttp-metricsbasicauthfile:
+
+metricsBasicAuthFile
+^^^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "mandatory", "format", "default"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "no", "path to htpasswd file", "none"
+
+Protects the metrics endpoint with HTTP Basic Authentication using a
+file in `htpasswd` format.
 
 Input Parameters
 ----------------
@@ -276,6 +346,26 @@ accumulated for all inputs. The statistic has the following counters:
 -  **discarded** - Total number of messages discarded since startup, due to rate limiting or similar.
 
 
+.. _imhttp-prometheus-metrics:
+
+Prometheus Metrics
+==================
+
+If :ref:`metricspath <imhttp-metricspath>` is configured (default
+``/metrics``), imhttp exposes rsyslog statistics in the Prometheus
+text exposition format. The endpoint provides counters such as
+``imhttp_submitted_total``, ``imhttp_failed_total`` and
+``imhttp_discarded_total``.
+
+The handler streams data without a ``Content-Length`` header and closes
+the connection, which most Prometheus scrapers handle. Proxies or load
+balancers must allow such responses. An ``imhttp_up`` gauge is exported
+alongside the full rsyslog statistics. Name collisions with other
+exporters are unlikely but should be documented in monitoring setups.
+To expose only the metrics endpoint, load the module without configuring
+any ``input()`` statements.
+
+
 .. _imhttp-error-messages:
 
 Error Messages
@@ -367,3 +457,38 @@ imhttp can also support the underlying options of `Civetweb <https://github.com/
          endpoint="/postrequest"
          ruleset="postrequest_rs"
          )
+
+
+Example 4
+---------
+
+Expose a Prometheus metrics endpoint alongside an input path:
+
+.. code-block:: none
+
+   module(load="imhttp" ports="8080" metricspath="/metrics")
+   input(type="imhttp" endpoint="/postrequest")
+
+   # scrape statistics
+   # curl http://localhost:8080/metrics
+   # HELP imhttp_up Indicates if the imhttp module is operational (1 for up, 0 for down).
+   # TYPE imhttp_up gauge
+   imhttp_up 1
+   # HELP imhttp_submitted_total rsyslog stats: origin="imhttp" object="imhttp", counter="submitted"
+   # TYPE imhttp_submitted_total counter
+   imhttp_submitted_total 0
+
+Example 5
+---------
+
+Expose only a Prometheus metrics endpoint secured with Basic
+Authentication:
+
+.. code-block:: none
+
+   module(load="imhttp" ports="8080"
+          metricspath="/metrics"
+          metricsbasicauthfile="/etc/rsyslog/htpasswd")
+
+   # scrape statistics with credentials
+   # curl -u user:password http://localhost:8080/metrics


### PR DESCRIPTION
## Summary
- export rsyslog statistics in Prometheus text format
- document metricsPath/healthCheckPath options, security notes, and usage example
- handle stats retrieval failures by returning HTTP 500
- add optional Basic Auth for metrics and health endpoints and describe metrics-only setups

## Testing
- `autoreconf -i`
- `./configure`
- `make -C contrib/imhttp CFLAGS="-I/usr/include/apr-1.0"`


------
https://chatgpt.com/codex/tasks/task_e_68a47b513b70833298b4d17baa9da363