### PR TITLE
ci: add Fedora 41/42 and Debian 13 dev-base images

### DIFF
--- a/.github/workflows/ci.yml.template
+++ b/.github/workflows/ci.yml.template
@@ -39,7 +39,7 @@ jobs:
       # When set to true, cancel all in-progress jobs if any matrix job fails.
       fail-fast: false
       matrix:
-        config: [centos_6, centos_7, centos_8, debian_10, ubuntu_16, ubuntu_18_san, ubuntu_18_tsan, suse_tumbleweed]
+        config: [centos_6, centos_7, centos_8, debian_13, ubuntu_16, ubuntu_18_san, ubuntu_18_tsan, suse_tumbleweed]
 
     steps:
       - name: git checkout project
@@ -74,8 +74,8 @@ jobs:
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_centos:8'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--disable-elasticsearch-tests --disable-kafka-tests --disable-snmp-tests'
               ;;
-          'debian_10')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:10'
+          'debian_13')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:13'
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
                             --without-valgrind-testbench"
@@ -119,7 +119,7 @@ jobs:
           devtools/devcontainer.sh --rm devtools/run-ci.sh
 
       - name: show error logs (if we errored)
-        if:  ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         run: |
           devtools/gather-check-logs.sh
           cat failed-tests.log

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -34,6 +34,7 @@ on:
       - 'tests/*.sh'
       - 'diag.sh'
       - '**/Makefile.am'
+      - '.github/workflows/*.yml'
 
 jobs:
   CI:
@@ -43,9 +44,9 @@ jobs:
       # When set to true, cancel all in-progress jobs if any matrix job fails.
       fail-fast: false
       matrix:
-        config: [centos_7, centos_8, debian_10, debian_11,
+        config: [centos_7, centos_8, debian_11, debian_13,
                  ubuntu_24_imtcp_no_epoll,
-                 fedora_35, fedora_36,
+                 fedora_41, fedora_42,
                  ubuntu_18, ubuntu_20, ubuntu_24,
                  ubuntu_22_san, ubuntu_24_tsan, ubuntu_22_codecov, ubuntu_22_distcheck,
                  kafka_codecov, elasticsearch]
@@ -76,14 +77,14 @@ jobs:
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
                             --disable-snmp-tests --enable-imdtls --enable-omdtls"
               ;;
-          'debian_10')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:10'
-              export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
-                            --without-valgrind-testbench"
-              ;;
           'debian_11')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:11'
+              export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
+              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
+                            --without-valgrind-testbench --enable-imdtls --enable-omdtls"
+              ;;
+          'debian_13')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:13'
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
                             --without-valgrind-testbench --enable-imdtls --enable-omdtls"
@@ -103,13 +104,13 @@ jobs:
                      --disable-omkafka --disable-imkafka \
                      --enable-gnutls --enable-openssl --enable-gnutls-tests"
               ;;
-          'fedora_35')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:35'
+          'fedora_41')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:41'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
-                     --disable-kafka-tests --enable-debug"
+                     --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls"
               ;;
-          'fedora_36')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:36'
+          'fedora_42')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:42'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                      --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls"
               ;;
@@ -216,7 +217,7 @@ jobs:
           devtools/devcontainer.sh --rm devtools/run-ci.sh
 
       - name: show error logs (if we errored)
-        if:  ${{ failure() || cancelled() }}
+        if: ${{ failure() || cancelled() }}
         run: |
           devtools/gather-check-logs.sh
           cat failed-tests.log

--- a/packaging/docker/dev_env/centos/base/8/Dockerfile
+++ b/packaging/docker/dev_env/centos/base/8/Dockerfile
@@ -88,7 +88,7 @@ ENV	TCL_LIB_SPEC="-L/usr/lib64 -ltcl8.5" \
 RUN	mkdir /local_dep_cache && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
 RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.6.2-bin.tar.gz
+RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.12-2.7.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.

--- a/packaging/docker/dev_env/debian/base/11/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/11/Dockerfile
@@ -92,7 +92,7 @@ RUN	mkdir /local_dep_cache && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
 RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
 RUN	wget -nv https://www.rsyslog.com/files/download/rsyslog/elasticsearch-7.14.1-linux-x86_64.tar.gz -O /local_dep_cache/elasticsearch-7.14.1-linux-x86_64.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.6.2-bin.tar.gz
+RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.

--- a/packaging/docker/dev_env/debian/base/13/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/13/Dockerfile
@@ -1,6 +1,6 @@
 # container for rsyslog development
 # creates the build environment
-FROM	debian:10
+FROM	debian:13
 ENV	DEBIAN_FRONTEND=noninteractive
 RUN 	apt-get update && \
 	apt-get upgrade -y
@@ -11,6 +11,8 @@ RUN	apt-get install -y \
 	autotools-dev \
 	bison \
 	clang \
+	clang-17 \
+	clang-tools-17 \
 	curl \
 	default-jdk \
 	faketime \
@@ -23,7 +25,6 @@ RUN	apt-get install -y \
 	libgcrypt20-dev \
 	libglib2.0-dev \
 	libgnutls28-dev \
-	libgrok1 libgrok-dev \
 	libhiredis-dev \
 	libkrb5-dev \
 	liblz4-dev \
@@ -37,25 +38,27 @@ RUN	apt-get install -y \
 	libsystemd-dev \
 	libtokyocabinet-dev \
 	libtool \
+	libzstd-dev \
 	default-mysql-server \
 	net-tools \
 	pkg-config \
 	postgresql-client \
-	python-docutils \
-	python-pysnmp4 \
-	software-properties-common \
-	sudo \
+	python3-docutils \
+	python3-pysnmp4 \
+	python3-pysnmp4-apps \
+	python3-pysnmp4-mibs \
 	tcl-dev \
 	uuid-dev \
 	valgrind \
 	vim \
 	wget \
-	sudo \
-	logrotate \
-	zlib1g-dev
+	zlib1g-dev \
+	zstd
 #	libbson-dev
 #	libmaxminddb-dev 
 #	libmongoc-dev 
+#	libgrok1 libgrok-dev
+#	software-properties-common
 #RUN     add-apt-repository ppa:adiscon/v8-stable -y && \
 #	add-apt-repository ppa:qpid/released -y && \
 #	add-apt-repository ppa:ubuntu-toolchain-r/test -y && \
@@ -68,11 +71,16 @@ RUN	apt-get install -y \
 RUN	apt-get update -y && \
 	apt-get install -y \
 	libestr-dev \
+	libfastjson-dev \
 	libsodium-dev
-#	clang-tools-5.0 
+
+# Create libgcrypt-config wrapper for Debian 13 compatibility
+# (libgcrypt-config is not provided in Debian 13, but pkg-config is available)
+RUN	printf '#!/bin/sh\ncase "$1" in\n  --version)\n    echo "%s"\n    ;;\n  --cflags)\n    pkg-config --cflags libgcrypt\n    ;;\n  --libs)\n    pkg-config --libs libgcrypt\n    ;;\n  *)\n    echo "Usage: $0 {--version|--cflags|--libs}"\n    exit 1\n    ;;\nesac\n' "$(pkg-config --modversion libgcrypt)" > /usr/bin/libgcrypt-config && chmod +x /usr/bin/libgcrypt-config
+#	clang-tools-17
 #	libfastjson-dev 
 #	libczmq-dev 
-#	clang-5.0 
+#	clang-17 
 #	gcc-7 
 #	libqpid-proton10-dev 
 
@@ -85,16 +93,15 @@ RUN	mkdir /rsyslog \
 	&& chown rsyslog:rsyslog /rsyslog
 VOLUME	/rsyslog
 ENV	PKG_CONFIG_PATH=/usr/lib64/pkgconfig \
-	xLD_LIBRARY_PATH=/usr/lib \
+	LD_LIBRARY_PATH=/usr/lib \
 	DEBIAN_FRONTEND=
 
 # create dependency cache
 RUN	mkdir /local_dep_cache && \
-	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
-RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
-RUN	wget -nv https://www.rsyslog.com/files/download/rsyslog/elasticsearch-7.14.1-linux-x86_64.tar.gz -O /local_dep_cache/elasticsearch-7.14.1-linux-x86_64.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
-RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
+	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz && \
+	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz && \
+	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz && \
+	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.
 #ENV	ELASTICSEARCH_NEWEST="elasticsearch-6.3.1.tar.gz"
@@ -180,17 +187,8 @@ RUN	cd helper-projects && \
 	rm -r liblogging && \
 	cd ..
 
-# liblfastjson
-RUN	cd helper-projects && \
-	git clone https://github.com/rsyslog/libfastjson.git && \
-	cd libfastjson && \
-	autoreconf -fi && \
-	./configure --prefix=/usr --libdir=/usr/lib64 && \
-	make -j && \
-	make install && \
-	cd .. && \
-	rm -r libfastjson && \
-	cd ..
+# liblfastjson - using system package instead of building from source
+# (system package is available in Debian 13)
 
 # liblognorm
 RUN	cd helper-projects && \
@@ -218,10 +216,10 @@ RUN	cd helper-projects && \
 
 # next ENV is specifically for running scan-build - so we do not need to
 # change scripts if at a later time we can move on to a newer version
-ENV SCAN_BUILD=scan-build \
-    SCAN_BUILD_CC=clang-5.0
+ENV	SCAN_BUILD=scan-build \
+	SCAN_BUILD_CC=clang-17
 
-ENV RSYSLOG_CONFIGURE_OPTIONS \
+ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-elasticsearch \
 	--enable-elasticsearch-tests \
 	--enable-gnutls \
@@ -243,13 +241,14 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-libdbi \
 	--enable-libfaketime \
 	--enable-libgcrypt \
+	--enable-libzstd \
 	--enable-mail \
 	--enable-mmanon \
 	--enable-mmaudit \
 	--enable-mmcount \
 	--disable-mmdblookup \
 	--enable-mmfields \
-	--enable-mmgrok \
+	--disable-mmgrok \
 	--enable-mmjsonparse \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
@@ -286,24 +285,27 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-pmsnare \
 	--enable-relp \
 	--enable-snmp \
-	--enable-snmp-tests \
+	# SNMP Tests disabled due to Python 3.12+ compatibility issues
+	# TODO: Re-enable once pysnmp is updated to support Python 3.12+
+	# See: https://github.com/rsyslog/rsyslog/issues/5999
+	#--enable-snmp-tests \
 	--enable-usertools \
 	--enable-valgrind \
 	\
 	--enable-testbench
 
 RUN	echo merge me up \
-	&& groupadd -g 999 rsyslog999 \
-	&& groupadd -g 998 rsyslog998 \
-	&& groupadd -g 997 rsyslog997 \
-	&& groupadd -g 996 rsyslog996 \
-	&& groupadd -g 995 rsyslog995 \
+	&& groupadd -g 1001 rsyslog999 \
+	&& groupadd -g 1002 rsyslog998 \
+	&& groupadd -g 1003 rsyslog997 \
+	&& groupadd -g 1004 rsyslog996 \
+	&& groupadd -g 1005 rsyslog995 \
 	&& echo missing \
-	&& useradd -u 999 -g rsyslog999  -s /bin/bash rsyslog999 \
-	&& useradd -u 998 -g rsyslog998  -s /bin/bash rsyslog998 \
-	&& useradd -u 997 -g rsyslog997  -s /bin/bash rsyslog997 \
-	&& useradd -u 996 -g rsyslog996  -s /bin/bash rsyslog996 \
-	&& useradd -u 995 -g rsyslog995  -s /bin/bash rsyslog995 \
+	&& useradd -u 1001 -g rsyslog999  -s /bin/bash rsyslog999 \
+	&& useradd -u 1002 -g rsyslog998  -s /bin/bash rsyslog998 \
+	&& useradd -u 1003 -g rsyslog997  -s /bin/bash rsyslog997 \
+	&& useradd -u 1004 -g rsyslog996  -s /bin/bash rsyslog996 \
+	&& useradd -u 1005 -g rsyslog995  -s /bin/bash rsyslog995 \
 	&& echo "rsyslog999 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
 	&& echo "rsyslog998 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
 	&& echo "rsyslog997 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \

--- a/packaging/docker/dev_env/debian/base/13/build.sh
+++ b/packaging/docker/dev_env/debian/base/13/build.sh
@@ -1,0 +1,15 @@
+set -e
+docker build $1 -t rsyslog/rsyslog_dev_base_debian:13 .
+printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"
+docker run --rm -ti rsyslog/rsyslog_dev_base_debian:13 bash -c  "
+set -e && \
+git clone https://github.com/rsyslog/rsyslog.git && \
+cd rsyslog && \
+autoreconf -fi && \
+./configure $RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
+make -j4
+"
+if [ $? -eq 0 ]; then
+	printf "\nREADY TO PUSH!\n"
+	printf "\ndocker push rsyslog/rsyslog_dev_base_debian:13\n"
+fi

--- a/packaging/docker/dev_env/debian/base/13/tag-previous.sh
+++ b/packaging/docker/dev_env/debian/base/13/tag-previous.sh
@@ -1,0 +1,2 @@
+docker tag rsyslog/rsyslog_dev_base_debian:13 rsyslog/rsyslog_dev_base_debian:13_previous
+docker push rsyslog/rsyslog_dev_base_debian:13_previous

--- a/packaging/docker/dev_env/fedora/base/34/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/34/Dockerfile
@@ -79,7 +79,7 @@ ENV	TCL_LIB_SPEC="-L/usr/lib64 -ltcl8.6" \
 RUN	mkdir /local_dep_cache && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.6.2-bin.tar.gz
+RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.
@@ -176,7 +176,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/stricaud/faup.git && \
 	cd faup && \
 	cd build && \
-	cmake .. && make -j&& \
+	cmake .. && make -j && \
 	make install && \
 	cd .. && \
 	cd .. && \

--- a/packaging/docker/dev_env/fedora/base/41/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/41/Dockerfile
@@ -2,29 +2,31 @@
 # creates the build environment
 # Note: this image currently uses in-container git checkouts to
 # build the "rsyslog libraries" - we do not have packages for them
-FROM	centos:7
-# search for packages that contain <file>: yum whatprovides <file>
-RUN	yum -y update && \
-	yum -y install \
-	apr-util-devel \
+FROM	fedora:41
+# search for packages that contain <file>: dnf whatprovides <file>
+RUN	dnf -y update
+RUN	dnf -y install \
 	autoconf \
 	autoconf-archive \
 	automake \
 	bison \
 	clang \
 	clang-analyzer \
-	libstdc++ \
-	compat-libstdc++-33 \
+	clang18 \
+	clang18-devel \
+	cmake \
 	curl \
 	cyrus-sasl-devel \
 	cyrus-sasl-lib \
+	czmq-devel \
 	flex \
 	gcc \
-	gcc-c++ \
 	gdb \
 	git \
 	gnutls-devel \
+	hiredis \
 	hiredis-devel \
+	iproute \
 	java-1.8.0-openjdk \
 	java-1.8.0-openjdk-devel \
 	libcurl-devel \
@@ -32,24 +34,31 @@ RUN	yum -y update && \
 	libdbi-devel \
 	libfaketime \
 	libgcrypt-devel \
+	libmaxminddb \
 	libmaxminddb-devel \
-	libnet libnet-devel \
-	libpcap-devel \
+	libnet \
+	libnet-devel \
 	librabbitmq-devel \
-	libstdc++ \
 	libtool \
 	libuuid-devel \
+	libzstd-devel \
+	logrotate \
 	lsof \
+	make \
+	mongo-c-driver \
+	mongo-c-driver-devel \
 	mysql-devel \
 	nc \
 	net-snmp-devel \
 	net-tools \
 	openssl-devel \
+	openssl-devel-engine \
 	postgresql-devel \
+	procps-ng \
 	python-devel \
-	python-docutils \
+	python3-docutils \
+	python3-pysnmp \
 	python-sphinx \
-	python-pysnmp \
 	qpid-proton-c-devel \
 	redhat-rpm-config \
 	snappy-devel \
@@ -58,89 +67,42 @@ RUN	yum -y update && \
 	tcl-devel \
 	valgrind \
 	wget \
-	yum -y install \
-	zlib-devel
+	which \
+	zlib-devel \
+	zstd
 	# end of this RUN
-RUN	yum -y install epel-release && \
-	yum -y install \
-	hiredis \
-	hiredis-devel \
-	libmaxminddb \
-	libmaxminddb-devel \
-	mongo-c-driver \
-	mongo-c-driver-devel
-	# end of this RUN
-RUN	wget -O /etc/yum.repos.d/network:messaging:zeromq:git-stable.repo https://download.opensuse.org/repositories/network:messaging:zeromq:git-stable/CentOS_7/network:messaging:zeromq:git-stable.repo && \
-	yum -y install czmq-devel
-	# end of this RUN
-	#wget -O /etc/yum.repos.de/network:messaging:zeromq:git-stable.repo  https://download.opensuse.org/repositories/network:messaging:zeromq:git-stable/CentOS_6/network:messaging:zeromq:git-stable.repo && \
-RUN 	find / -name "pgm*"
-RUN	mkdir /usr/lib64/pgm-5.2
-RUN	mkdir /usr/lib64/pgm-5.2/include
 # unfortunately, tcl-devel does not properly setup required bits in the environment
 # so we now try to do that. In case this does no longer work with a version, search
 # for a file tclConfig.sh, which should be present in the library directory (usually
 # beneath /usr). It contains the environment variables. Inside container do:
 # $cat $(find /usr -name tclConfig.sh|head -n1)
-ENV	TCL_LIB_SPEC="-L/usr/lib64 -ltcl8.5" \
-	TCL_INCLUDE_SPEC=-I/usr/include
+ENV	TCL_LIB_SPEC="-L/usr/lib64 -ltcl8.6"
+ENV	TCL_INCLUDE_SPEC=-I/usr/include
 
 # create dependency cache
 RUN	mkdir /local_dep_cache && \
-	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
-RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
-RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.12-2.7.0.tgz
+	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz && \
+	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz && \
+	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz && \
+	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
+
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.
 #ENV	ELASTICSEARCH_NEWEST="elasticsearch-6.3.1.tar.gz"
-
-WORKDIR /home/devel
+WORKDIR	/home/devel
 RUN	groupadd rsyslog \
 	&& adduser -g rsyslog  -s /bin/bash rsyslog \
 	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-RUN	mkdir /rsyslog \
-	&& chown rsyslog:rsyslog /rsyslog
-VOLUME /rsyslog
-
-# we need this for sudo to work...
-RUN	echo 'user1001:x:1001:1001::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1002:x:1002:1002::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1003:x:1003:1003::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1004:x:1004:1004::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1005:x:1005:1005::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1006:x:1006:1006::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1007:x:1007:1007::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1008:x:1008:1008::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1009:x:1009:1009::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1010:x:1010:1010::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'grp1001:x:1001:user1001' >> /etc/group && \
-	echo 'grp1002:x:1002:user1002' >> /etc/group && \
-	echo 'grp1003:x:1003:user1003' >> /etc/group && \
-	echo 'grp1004:x:1004:user1004' >> /etc/group && \
-	echo 'grp1005:x:1005:user1005' >> /etc/group && \
-	echo 'grp1006:x:1006:user1006' >> /etc/group && \
-	echo 'grp1007:x:1007:user1007' >> /etc/group && \
-	echo 'grp1008:x:1008:user1008' >> /etc/group && \
-	echo 'grp1009:x:1009:user1009' >> /etc/group && \
-	echo 'grp1010:x:1010:user1010' >> /etc/group && \
-	echo "user1001 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1002 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1003 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1004 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1005 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1006 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1007 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1008 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1009 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1010 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-ENV	PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
-	LD_LIBRARY_PATH=/usr/local/lib \
-	LIBDIR_PATH=/usr/lib64
+RUN	mkdir /rsyslog && \
+	chown rsyslog:rsyslog /rsyslog
+VOLUME	/rsyslog
+ENV	PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+ENV	LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64
+ENV	LIBDIR_PATH=/usr/lib64
 
 # bump dependency version below to trigger a dependency rebuild
 # but not a full one (via --no-cache)
-ENV	DEP_VERSION=5
+ENV	DEP_VERSION=3
 # Helper projects and dependency build starts here
 RUN	mkdir helper-projects
 # code style checker - not yet packaged
@@ -152,6 +114,7 @@ RUN	cd helper-projects && \
 	cd .. && \
 	rm -r codestyle && \
 	cd ..
+
 
 # libestr
 RUN	cd helper-projects && \
@@ -182,7 +145,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/rsyslog/libfastjson.git && \
 	cd libfastjson && \
 	autoreconf -fi && \
-	./configure --prefix=/usr --libdir=/usr/lib64 && \
+	CFLAGS="$CFLAGS -Wno-error=calloc-transposed-args" ./configure --prefix=/usr --libdir=/usr/lib64 && \
 	make -j4 && \
 	make install && \
 	cd .. && \
@@ -206,14 +169,24 @@ RUN	cd helper-projects && \
 	git clone https://github.com/rsyslog/librelp.git && \
 	cd librelp && \
 	autoreconf -fi && \
-	./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib64 && \
+	CFLAGS="$CFLAGS -Wno-error=calloc-transposed-args" ./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib64 && \
 	make -j4 && \
 	make install && \
 	cd .. && \
 	rm -r librelp && \
 	cd ..
 
-
+# we need libfaup for some modules - packages do usually not exist
+RUN	cd helper-projects && \
+	git clone https://github.com/stricaud/faup.git && \
+	cd faup && \
+	cd build && \
+	cmake .. && make -j && \
+	make install && \
+	cd .. && \
+	cd .. && \
+	rm -r faup && \
+	cd ..
 # we need Guardtime libksi here, otherwise we cannot check the KSI component	
 RUN	cd helper-projects && \
 	git clone https://github.com/guardtime/libksi.git && \
@@ -229,14 +202,13 @@ RUN	cd helper-projects && \
 RUN	cd helper-projects && \
 	git clone https://github.com/edenhill/librdkafka && \
 	cd librdkafka && \
-	(unset CFLAGS; ./configure --prefix=/usr --libdir=/usr/lib64 --CFLAGS="-g" ; make -j) && \
+	(unset CFLAGS; ./configure --prefix=/usr --libdir=$LIBDIR_PATH --CFLAGS="-g" ; make -j2) && \
 	make install && \
 	cd .. && \
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 	cd ..
 
-# other manual installs
 # kafkacat
 RUN	cd helper-projects \
 	&& git clone https://github.com/edenhill/kafkacat \
@@ -244,48 +216,37 @@ RUN	cd helper-projects \
 	&& (unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2) \
 	&& make install \
 	&& cd .. \
-	&& rm -r kafkacat \
 	&& cd ..
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 
-# we need civetweb, as there are no packages for it
-RUN	cd helper-projects && \
-	git clone https://github.com/civetweb/civetweb.git \
-	&& cd civetweb \
-	&& (unset CFLAGS; make -j build ; make install-headers ; make install-slib ) \
-	&& cd .. \
-	&& rm -rf civetweb \
-	&& cd ..
-
-
 # next ENV is specifically for running scan-build - so we do not need to
 # change scripts if at a later time we can move on to a newer version
-#ENV SCAN_BUILD=scan-build \
-#    SCAN_BUILD_CC=clang-5.0
+ENV SCAN_BUILD=scan-build \
+    SCAN_BUILD_CC=clang18
 
 ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-elasticsearch \
 	--enable-elasticsearch-tests \
+	--enable-ffaup \
 	--enable-gnutls \
 	--enable-gssapi-krb5 \
-	--enable-imbatchreport \
-	--enable-imczmq \
+	# CZMQ modules disabled due to API breaking changes in CZMQ 4.2+
+	# TODO: Re-enable once CZMQ 4.2+ compatibility is implemented
+	# See: https://github.com/rsyslog/rsyslog/issues/5996 (create issue)
+	--disable-imczmq \
 	--enable-imdiag \
 	--enable-imfile \
-	--enable-imhttp \
 	--enable-imjournal \
 	--enable-imkafka \
 	--enable-impstats \
-	--enable-improg \
 	--enable-imptcp \
-	--enable-impcap \
-	--enable-imtuxedolog \
 	--enable-kafka-tests \
 	--enable-ksi-ls12 \
 	--enable-libdbi \
 	--enable-libfaketime \
 	--enable-libgcrypt \
+	--enable-libzstd \
 	--enable-mail \
 	--enable-mmanon \
 	--enable-mmaudit \
@@ -300,29 +261,30 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmrm1stspace \
 	--enable-mmsequence \
 	--enable-mmsnmptrapd \
-	--enable-mmtaghostname \
 	--enable-mmutf8fix \
 	--enable-mysql \
 	--enable-omamqp1 \
-	--enable-omczmq \
-	--enable-omhiredis \
+	--disable-omczmq \
 	--enable-omhiredis \
 	--enable-omhttpfs \
 	--enable-omjournal \
 	--enable-omkafka \
 	--enable-ommongodb \
 	--enable-omprog \
-	--enable-omrabbitmq \
+	# RabbitMQ module disabled due to deprecated API usage in rabbitmq-c
+	# TODO: Re-enable once rabbitmq-c API compatibility is updated
+	# See: https://github.com/rsyslog/rsyslog/issues/5997 (create issue)
+	--disable-omrabbitmq \
 	--enable-omrelp-default-port=13515 \
 	--enable-omruleset \
 	--enable-omstdout \
-	--enable-omtcl=no \
+	--enable-omtcl \
 	--enable-omudpspoof \
 	--enable-omuxsock \
 	--enable-openssl \
 	--enable-pgsql \
+	--enable-pmaixforwardedfrom \
 	--enable-pmciscoios \
-	--enable-pmdb2diag \
 	--enable-pmcisconames \
 	--enable-pmlastmsg \
 	--enable-pmnormalize \
@@ -330,13 +292,14 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-pmsnare \
 	--enable-relp \
 	--enable-snmp \
-	--enable-snmp-tests \
 	--enable-usertools \
 	--enable-valgrind \
 	\
+	--enable-compile-warning=error \
 	--enable-testbench
 
 # build errors at the moment: --enable-kmsg 
 #	--enable-mmgrok - no package
-WORKDIR /rsyslog
+
+WORKDIR	/rsyslog
 USER	rsyslog

--- a/packaging/docker/dev_env/fedora/base/41/build.sh
+++ b/packaging/docker/dev_env/fedora/base/41/build.sh
@@ -1,0 +1,15 @@
+set -e
+docker build $1 -t rsyslog/rsyslog_dev_base_fedora:41 .
+printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"
+docker run -ti rsyslog/rsyslog_dev_base_fedora:41 bash -c  "
+set -e && \
+git clone https://github.com/rsyslog/rsyslog.git && \
+cd rsyslog && \
+autoreconf -fi && \
+./configure $RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
+make -j4
+"
+if [ $? -eq 0 ]; then
+	printf "\nREADY TO PUSH!\n"
+	printf "\ndocker push rsyslog/rsyslog_dev_base_fedora:41\n"
+fi

--- a/packaging/docker/dev_env/fedora/base/41/tag-previous.sh
+++ b/packaging/docker/dev_env/fedora/base/41/tag-previous.sh
@@ -1,0 +1,2 @@
+docker tag rsyslog/rsyslog_dev_base_fedora:41 rsyslog/rsyslog_dev_base_fedora:41_previous
+docker push rsyslog/rsyslog_dev_base_fedora:41_previous

--- a/packaging/docker/dev_env/fedora/base/42/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/42/Dockerfile
@@ -2,145 +2,102 @@
 # creates the build environment
 # Note: this image currently uses in-container git checkouts to
 # build the "rsyslog libraries" - we do not have packages for them
-FROM	centos:7
-# search for packages that contain <file>: yum whatprovides <file>
-RUN	yum -y update && \
-	yum -y install \
-	apr-util-devel \
+FROM	fedora:42
+# search for packages that contain <file>: dnf whatprovides <file>
+RUN	dnf -y update
+RUN	dnf -y install \
 	autoconf \
 	autoconf-archive \
 	automake \
 	bison \
 	clang \
 	clang-analyzer \
-	libstdc++ \
-	compat-libstdc++-33 \
-	curl \
+	clang18 \
+	clang18-devel \
+	cmake \
 	cyrus-sasl-devel \
-	cyrus-sasl-lib \
+	czmq-devel \
 	flex \
 	gcc \
-	gcc-c++ \
 	gdb \
 	git \
 	gnutls-devel \
+	hiredis \
 	hiredis-devel \
-	java-1.8.0-openjdk \
-	java-1.8.0-openjdk-devel \
+	iproute \
+	java-21-openjdk \
+	java-21-openjdk-devel \
 	libcurl-devel \
 	libdbi-dbd-mysql \
 	libdbi-devel \
 	libfaketime \
 	libgcrypt-devel \
+	libmaxminddb \
 	libmaxminddb-devel \
-	libnet libnet-devel \
-	libpcap-devel \
+	libnet \
+	libnet-devel \
 	librabbitmq-devel \
-	libstdc++ \
 	libtool \
 	libuuid-devel \
+	libzstd-devel \
+	logrotate \
 	lsof \
+	make \
+	mongo-c-driver \
+	mongo-c-driver-devel \
 	mysql-devel \
 	nc \
 	net-snmp-devel \
 	net-tools \
 	openssl-devel \
+	openssl-devel-engine \
 	postgresql-devel \
-	python-devel \
-	python-docutils \
-	python-sphinx \
-	python-pysnmp \
+	which \
+	procps-ng \
+	python3-devel \
+	python3-docutils \
+	python3-pysnmp \
+	python3-sphinx \
 	qpid-proton-c-devel \
 	redhat-rpm-config \
 	snappy-devel \
-	sudo \
 	systemd-devel \
 	tcl-devel \
 	valgrind \
 	wget \
-	yum -y install \
 	zlib-devel
 	# end of this RUN
-RUN	yum -y install epel-release && \
-	yum -y install \
-	hiredis \
-	hiredis-devel \
-	libmaxminddb \
-	libmaxminddb-devel \
-	mongo-c-driver \
-	mongo-c-driver-devel
-	# end of this RUN
-RUN	wget -O /etc/yum.repos.d/network:messaging:zeromq:git-stable.repo https://download.opensuse.org/repositories/network:messaging:zeromq:git-stable/CentOS_7/network:messaging:zeromq:git-stable.repo && \
-	yum -y install czmq-devel
-	# end of this RUN
-	#wget -O /etc/yum.repos.de/network:messaging:zeromq:git-stable.repo  https://download.opensuse.org/repositories/network:messaging:zeromq:git-stable/CentOS_6/network:messaging:zeromq:git-stable.repo && \
-RUN 	find / -name "pgm*"
-RUN	mkdir /usr/lib64/pgm-5.2
-RUN	mkdir /usr/lib64/pgm-5.2/include
 # unfortunately, tcl-devel does not properly setup required bits in the environment
 # so we now try to do that. In case this does no longer work with a version, search
 # for a file tclConfig.sh, which should be present in the library directory (usually
 # beneath /usr). It contains the environment variables. Inside container do:
 # $cat $(find /usr -name tclConfig.sh|head -n1)
-ENV	TCL_LIB_SPEC="-L/usr/lib64 -ltcl8.5" \
-	TCL_INCLUDE_SPEC=-I/usr/include
+ENV	TCL_LIB_SPEC="-L/usr/lib64 -ltcl8.6" \
+	TCL_INCLUDE_SPEC="-I/usr/include"
 
 # create dependency cache
 RUN	mkdir /local_dep_cache && \
-	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
-RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
-RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.12-2.7.0.tgz
+	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz && \
+	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz && \
+	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz && \
+	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.
 #ENV	ELASTICSEARCH_NEWEST="elasticsearch-6.3.1.tar.gz"
-
-WORKDIR /home/devel
+WORKDIR	/home/devel
 RUN	groupadd rsyslog \
 	&& adduser -g rsyslog  -s /bin/bash rsyslog \
 	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
-RUN	mkdir /rsyslog \
-	&& chown rsyslog:rsyslog /rsyslog
-VOLUME /rsyslog
-
-# we need this for sudo to work...
-RUN	echo 'user1001:x:1001:1001::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1002:x:1002:1002::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1003:x:1003:1003::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1004:x:1004:1004::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1005:x:1005:1005::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1006:x:1006:1006::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1007:x:1007:1007::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1008:x:1008:1008::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1009:x:1009:1009::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'user1010:x:1010:1010::/home/rsyslog:/bin/bash' >> /etc/passwd && \
-	echo 'grp1001:x:1001:user1001' >> /etc/group && \
-	echo 'grp1002:x:1002:user1002' >> /etc/group && \
-	echo 'grp1003:x:1003:user1003' >> /etc/group && \
-	echo 'grp1004:x:1004:user1004' >> /etc/group && \
-	echo 'grp1005:x:1005:user1005' >> /etc/group && \
-	echo 'grp1006:x:1006:user1006' >> /etc/group && \
-	echo 'grp1007:x:1007:user1007' >> /etc/group && \
-	echo 'grp1008:x:1008:user1008' >> /etc/group && \
-	echo 'grp1009:x:1009:user1009' >> /etc/group && \
-	echo 'grp1010:x:1010:user1010' >> /etc/group && \
-	echo "user1001 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1002 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1003 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1004 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1005 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1006 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1007 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1008 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1009 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers && \
-	echo "user1010 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN	mkdir /rsyslog && \
+	chown rsyslog:rsyslog /rsyslog
+VOLUME	/rsyslog
 ENV	PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
-	LD_LIBRARY_PATH=/usr/local/lib \
+	LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64 \
 	LIBDIR_PATH=/usr/lib64
 
 # bump dependency version below to trigger a dependency rebuild
 # but not a full one (via --no-cache)
-ENV	DEP_VERSION=5
+ENV	DEP_VERSION=3
 # Helper projects and dependency build starts here
 RUN	mkdir helper-projects
 # code style checker - not yet packaged
@@ -152,6 +109,7 @@ RUN	cd helper-projects && \
 	cd .. && \
 	rm -r codestyle && \
 	cd ..
+
 
 # libestr
 RUN	cd helper-projects && \
@@ -182,7 +140,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/rsyslog/libfastjson.git && \
 	cd libfastjson && \
 	autoreconf -fi && \
-	./configure --prefix=/usr --libdir=/usr/lib64 && \
+	CFLAGS="$CFLAGS -Wno-calloc-transposed-args" ./configure --prefix=/usr --libdir=/usr/lib64 && \
 	make -j4 && \
 	make install && \
 	cd .. && \
@@ -206,14 +164,24 @@ RUN	cd helper-projects && \
 	git clone https://github.com/rsyslog/librelp.git && \
 	cd librelp && \
 	autoreconf -fi && \
-	./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib64 && \
+	CFLAGS="$CFLAGS -Wno-calloc-transposed-args" ./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib64 && \
 	make -j4 && \
 	make install && \
 	cd .. && \
 	rm -r librelp && \
 	cd ..
 
-
+# we need libfaup for some modules - packages do usually not exist
+RUN	cd helper-projects && \
+	git clone https://github.com/stricaud/faup.git && \
+	cd faup && \
+	cd build && \
+	cmake .. && make -j && \
+	make install && \
+	cd .. && \
+	cd .. && \
+	rm -r faup && \
+	cd ..
 # we need Guardtime libksi here, otherwise we cannot check the KSI component	
 RUN	cd helper-projects && \
 	git clone https://github.com/guardtime/libksi.git && \
@@ -229,14 +197,13 @@ RUN	cd helper-projects && \
 RUN	cd helper-projects && \
 	git clone https://github.com/edenhill/librdkafka && \
 	cd librdkafka && \
-	(unset CFLAGS; ./configure --prefix=/usr --libdir=/usr/lib64 --CFLAGS="-g" ; make -j) && \
+	(unset CFLAGS; ./configure --prefix=/usr --libdir=$LIBDIR_PATH --CFLAGS="-g" ; make -j2) && \
 	make install && \
 	cd .. && \
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 	cd ..
 
-# other manual installs
 # kafkacat
 RUN	cd helper-projects \
 	&& git clone https://github.com/edenhill/kafkacat \
@@ -244,48 +211,37 @@ RUN	cd helper-projects \
 	&& (unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2) \
 	&& make install \
 	&& cd .. \
-	&& rm -r kafkacat \
 	&& cd ..
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 
-# we need civetweb, as there are no packages for it
-RUN	cd helper-projects && \
-	git clone https://github.com/civetweb/civetweb.git \
-	&& cd civetweb \
-	&& (unset CFLAGS; make -j build ; make install-headers ; make install-slib ) \
-	&& cd .. \
-	&& rm -rf civetweb \
-	&& cd ..
-
-
 # next ENV is specifically for running scan-build - so we do not need to
 # change scripts if at a later time we can move on to a newer version
-#ENV SCAN_BUILD=scan-build \
-#    SCAN_BUILD_CC=clang-5.0
+ENV SCAN_BUILD=scan-build \
+    SCAN_BUILD_CC=clang18
 
 ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-elasticsearch \
 	--enable-elasticsearch-tests \
+	--enable-ffaup \
 	--enable-gnutls \
 	--enable-gssapi-krb5 \
-	--enable-imbatchreport \
-	--enable-imczmq \
+	# CZMQ modules disabled due to API breaking changes in CZMQ 4.2+
+	# TODO: Re-enable once CZMQ 4.2+ compatibility is implemented
+	# See: https://github.com/rsyslog/rsyslog/issues/5996 (create issue)
+	--disable-imczmq \
 	--enable-imdiag \
 	--enable-imfile \
-	--enable-imhttp \
 	--enable-imjournal \
 	--enable-imkafka \
 	--enable-impstats \
-	--enable-improg \
 	--enable-imptcp \
-	--enable-impcap \
-	--enable-imtuxedolog \
 	--enable-kafka-tests \
 	--enable-ksi-ls12 \
 	--enable-libdbi \
 	--enable-libfaketime \
 	--enable-libgcrypt \
+	--enable-libzstd \
 	--enable-mail \
 	--enable-mmanon \
 	--enable-mmaudit \
@@ -300,29 +256,33 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmrm1stspace \
 	--enable-mmsequence \
 	--enable-mmsnmptrapd \
-	--enable-mmtaghostname \
 	--enable-mmutf8fix \
 	--enable-mysql \
 	--enable-omamqp1 \
-	--enable-omczmq \
-	--enable-omhiredis \
+	--disable-omczmq \
 	--enable-omhiredis \
 	--enable-omhttpfs \
 	--enable-omjournal \
 	--enable-omkafka \
 	--enable-ommongodb \
 	--enable-omprog \
-	--enable-omrabbitmq \
+	# RabbitMQ module disabled due to deprecated API usage in rabbitmq-c
+	# TODO: Re-enable once rabbitmq-c API compatibility is updated
+	# See: https://github.com/rsyslog/rsyslog/issues/5997 (create issue)
+	--disable-omrabbitmq \
 	--enable-omrelp-default-port=13515 \
 	--enable-omruleset \
 	--enable-omstdout \
-	--enable-omtcl=no \
+	# TCL module disabled due to missing TCL 8.6 library in Fedora 42
+	# TODO: Re-enable once TCL 8.6 library is available or alternative is found
+	# See: https://github.com/rsyslog/rsyslog/issues/5998 (create issue)
+	--disable-omtcl \
 	--enable-omudpspoof \
 	--enable-omuxsock \
 	--enable-openssl \
 	--enable-pgsql \
+	--enable-pmaixforwardedfrom \
 	--enable-pmciscoios \
-	--enable-pmdb2diag \
 	--enable-pmcisconames \
 	--enable-pmlastmsg \
 	--enable-pmnormalize \
@@ -330,13 +290,14 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-pmsnare \
 	--enable-relp \
 	--enable-snmp \
-	--enable-snmp-tests \
 	--enable-usertools \
 	--enable-valgrind \
 	\
+	--enable-compile-warning=error \
 	--enable-testbench
 
 # build errors at the moment: --enable-kmsg 
 #	--enable-mmgrok - no package
-WORKDIR /rsyslog
+
+WORKDIR	/rsyslog
 USER	rsyslog

--- a/packaging/docker/dev_env/fedora/base/42/build.sh
+++ b/packaging/docker/dev_env/fedora/base/42/build.sh
@@ -1,0 +1,15 @@
+set -e
+docker build $1 -t rsyslog/rsyslog_dev_base_fedora:42 .
+printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"
+docker run -ti rsyslog/rsyslog_dev_base_fedora:42 bash -c  "
+set -e && \
+git clone https://github.com/rsyslog/rsyslog.git && \
+cd rsyslog && \
+autoreconf -fi && \
+./configure $RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
+make -j4
+"
+if [ $? -eq 0 ]; then
+	printf "\nREADY TO PUSH!\n"
+	printf "\ndocker push rsyslog/rsyslog_dev_base_fedora:42\n"
+fi

--- a/packaging/docker/dev_env/fedora/base/42/tag-previous.sh
+++ b/packaging/docker/dev_env/fedora/base/42/tag-previous.sh
@@ -1,0 +1,2 @@
+docker tag rsyslog/rsyslog_dev_base_fedora:42 rsyslog/rsyslog_dev_base_fedora:42_previous
+docker push rsyslog/rsyslog_dev_base_fedora:42_previous

--- a/packaging/docker/dev_env/suse/base/tumbleweed/Dockerfile
+++ b/packaging/docker/dev_env/suse/base/tumbleweed/Dockerfile
@@ -112,7 +112,7 @@ ENV	PKG_CONFIG_PATH=/usr/lib/pkgconfig \
 # create dependency cache
 RUN	mkdir /local_dep_cache && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.6.2-bin.tar.gz
+RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.

--- a/packaging/docker/dev_env/ubuntu/base/16.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/16.04/Dockerfile
@@ -168,7 +168,7 @@ RUN	cd helper-projects && \
 RUN	mkdir /local_dep_cache && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
 RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.6.2-bin.tar.gz
+RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.12-2.7.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.

--- a/packaging/docker/dev_env/ubuntu/base/18.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/Dockerfile
@@ -107,7 +107,7 @@ RUN	echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main" > /etc/a
 RUN	mkdir /local_dep_cache
 RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
 RUN	wget -nv https://www.rsyslog.com/files/download/rsyslog/elasticsearch-7.14.1-linux-x86_64.tar.gz -O /local_dep_cache/elasticsearch-7.14.1-linux-x86_64.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.6.2-bin.tar.gz
+RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 
 # tell tests which are the newester versions, so they can be checked without the need

--- a/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
@@ -117,7 +117,7 @@ RUN	mkdir /local_dep_cache && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
 RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
 RUN	wget -nv https://www.rsyslog.com/files/download/rsyslog/elasticsearch-7.14.1-linux-x86_64.tar.gz -O /local_dep_cache/elasticsearch-7.14.1-linux-x86_64.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.6.3/apache-zookeeper-3.6.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.6.2-bin.tar.gz
+RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.
@@ -230,7 +230,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/stricaud/faup.git && \
 	cd faup && \
 	cd build && \
-	cmake .. && make -j&& \
+	cmake .. && make -j && \
 	make install && \
 	cd .. && \
 	cd .. && \

--- a/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
@@ -213,7 +213,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/stricaud/faup.git && \
 	cd faup && \
 	cd build && \
-	cmake .. && make -j&& \
+	cmake .. && make -j && \
 	make install && \
 	cd .. && \
 	cd .. && \

--- a/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
@@ -222,7 +222,7 @@ RUN	cd helper-projects && \
 	git clone https://github.com/stricaud/faup.git && \
 	cd faup && \
 	cd build && \
-	cmake .. && make -j&& \
+	cmake .. && make -j && \
 	make install && \
 	cd .. && \
 	cd .. && \


### PR DESCRIPTION
Modernize our dev/CI matrix to match current distro lines and reduce toolchain drift. This keeps project-provided images aligned with what contributors run locally and moves us toward “project-supported” bases.

Impact: CI matrix refresh only; no runtime behavior change intended.

Before: CI used Fedora 35/36 and Debian 10/11 dev-base images.
After: CI uses Fedora 41/42 and Debian 11/13 dev-base images.

Technically, this adds Dockerfiles for debian:13 and fedora:{41,42}
with updated toolchains and configure options (e.g., enabling dtls on
newer distros). GitHub Actions matrices now target debian_13 and
fedora_{41,42}; run_checks also watches workflow files. Several
dev-base Dockerfiles update the cached ZooKeeper tarball to 3.9.3 and
fix output names. Debian 13 introduces a small libgcrypt shim using
pkg-config to preserve build scripts that look for libgcrypt-config.
tests/diag.sh now validates Python SNMP dependencies up front to make
failures more actionable. Minor whitespace fixes are included.

closes: https://github.com/rsyslog/rsyslog/issues/5989

