### PR TITLE
tcpsrv: revert PR 5806 because it was ineffective

### DIFF
--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -68,8 +68,6 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     pThis->inputState = eAtStrtFram; /* indicate frame header expected */
     pThis->eFraming = TCP_FRAMING_OCTET_STUFFING; /* just make sure... */
     pthread_mutex_init(&pThis->mut, NULL);
-    pThis->being_closed = 0;
-    INIT_ATOMIC_HELPER_MUT(pThis->mut_being_closed);
     /* now allocate the message reception buffer */
     CHKmalloc(pThis->pMsg = (uchar *)malloc(pThis->iMaxLine + 1));
 finalize_it:
@@ -99,7 +97,6 @@ BEGINobjDestruct(tcps_sess) /* be sure to specify the object type also in END an
         pThis->pSrv->pOnSessDestruct(&pThis->pUsr);
     }
     pthread_mutex_destroy(&pThis->mut);
-    DESTROY_ATOMIC_HELPER_MUT(pThis->mut_being_closed);
     /* now destruct our own properties */
     if (pThis->fromHost != NULL) CHKiRet(prop.Destruct(&pThis->fromHost));
     if (pThis->fromHostIP != NULL) CHKiRet(prop.Destruct(&pThis->fromHostIP));

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -24,7 +24,6 @@
 
 #include "obj.h"
 #include "prop.h"
-#include "atomic.h"
 
 /* a forward-definition, we are somewhat cyclic */
 struct tcpsrv_s;
@@ -49,8 +48,6 @@ struct tcps_sess_s {
         rsRetVal (*DoSubmitMessage)(tcps_sess_t *, uchar *, int); /* submit message callback */
         int iMaxLine; /* fast lookup buffer for config property */
         pthread_mutex_t mut;
-        int being_closed;
-        pthread_mutex_t mut_being_closed;
 };
 
 


### PR DESCRIPTION
While at the time of merge I was confident it would fix a data race, the root cause has now surfaced to be a simple state advancement (single-threaded) bug. See commit c5fd73499 for details. As such I revert this patch. it caused no harm, but complicates code, adds a bit of computation and is no longer needed.

I cannot 100% outrule it might have addressed some edge cases. I know an environment where we can verify this within the next month or so. If, unexpectedly, this shows regressions, we can re-enable the patch. But I am 99.99% sure it is not needed.

see also: https://github.com/rsyslog/rsyslog/pull/5806
see also: https://github.com/rsyslog/rsyslog/pull/5993
