### PR TITLE
imjournal: initialize instance fields to avoid invalid free

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -1333,10 +1333,7 @@ ENDsetModCnf
 static rsRetVal ATTR_NONNULL(1) createInstance(instanceConf_t **const pinst) {
     instanceConf_t *inst;
     DEFiRet;
-    CHKmalloc(inst = malloc(sizeof(instanceConf_t)));
-    inst->next = NULL;
-    inst->pBindRuleset = NULL;
-    inst->pszBindRuleset = NULL;
+    CHKmalloc(inst = calloc(1, sizeof(instanceConf_t)));
 
     /* node created, let's add to config */
     if (loadModConf->tail == NULL) {


### PR DESCRIPTION
## Summary
- initialize `stateFile` and `bMain` in `createInstance`
- prevent `free(): invalid pointer` when a statefile is configured

## Testing
- `./autogen.sh`
- `make -j4`
- `make check -j4`


------
https://chatgpt.com/codex/tasks/task_e_68a84843a25483328f74849dd88ac80c

closes https://github.com/rsyslog/rsyslog/issues/5730