### PR TITLE
immark: release configuration strings on unload

### DIFF
--- a/plugins/immark/immark.c
+++ b/plugins/immark/immark.c
@@ -220,6 +220,11 @@ ENDactivateCnf
 
 BEGINfreeCnf
     CODESTARTfreeCnf;
+    /* free configuration strings allocated during load to avoid leaks */
+    free((char *)pModConf->pszMarkMsgText);
+    pModConf->pszMarkMsgText = NULL;
+    free(pModConf->pszBindRuleset);
+    pModConf->pszBindRuleset = NULL;
 ENDfreeCnf
 
 


### PR DESCRIPTION
## Summary
- free and null immark's mark text and ruleset strings when configuration is freed

## Testing
- `make` *(fails: /bin/bash: ../libtool: No such file or directory)*
- `./immark-ruleset.sh` *(fails: ./diag.sh: line 2881: set-envvars: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a95de9302c833289d54e2ed3b1a6ce