### PR TITLE
imdocker: free temp buffer after option parse

### DIFF
--- a/contrib/imdocker/imdocker.c
+++ b/contrib/imdocker/imdocker.c
@@ -860,6 +860,8 @@ BEGINsetModCnf
                 token = strtok(NULL, "&");
             }
             loadModConf->getContainerLogOptionsWithoutTail = option_str;
+            free(buf);
+            buf = NULL;
         } else if (!strcmp(modpblk.descr[i].name, "dockerapiunixsockaddr")) {
             loadModConf->dockerApiUnixSockAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
         } else if (!strcmp(modpblk.descr[i].name, "dockerapiaddr")) {


### PR DESCRIPTION
## Summary
- free temporary buffer after parsing getContainerLogOptions to avoid leak

## Testing
- `./autogen.sh`
- `./configure`
- `make -j4` *(fails: /bin/bash: ../libtool: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a95ed7cae083328dd33560aba927c1