### PR TITLE
imdiag: allow specifying payload size in injectmsg

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -666,15 +666,18 @@ startup_vgthread() {
 }
 
 
-# inject messages via our inject interface (imdiag)
-# $1 is start message number, env var NUMMESSAGES is number of messages to inject
+## inject messages via our inject interface (imdiag)
+## $1: start message number
+## $2: number of messages to inject
+## $3: optional payload size, unpadded if unset
 injectmsg() {
-	if [ "$3" != "" ] ; then
-		printf 'error: injectmsg only has two arguments, extra arg is %s\n' "$3"
-	fi
-	msgs=${2:-$NUMMESSAGES}
-	echo injecting $msgs messages
-	echo injectmsg "${1:-0}" "$msgs" | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
+        msgs=${2:-$NUMMESSAGES}
+        echo injecting $msgs messages
+        if [ -n "$3" ]; then
+                echo injectmsg "${1:-0}" "$msgs" "$3" | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
+        else
+                echo injectmsg "${1:-0}" "$msgs" | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
+        fi
 }
 
 # inject messages in INSTANCE 2 via our inject interface (imdiag)


### PR DESCRIPTION
## Summary
- allow injectmsg commands to specify payload size
- document payload size parameter in imdiag and test helper
- note default unpadded behavior in diag test helper

## Testing
- `devtools/format-code.sh`
- `./autogen.sh`
- `./configure`
- `make -j4`
- `bash -n tests/diag.sh`
- `shellcheck tests/diag.sh` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa0f66a9948332bf9fa80a8ec2f2aa