### PR TITLE
CI: fix doc_build check which was not always built

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 8
 
       - name: Check for doc changes
         id: doc_changes


### PR DESCRIPTION
Too shallow fetch from github made trigger condition unreliable.
