### PR TITLE
doc: correct PermittedPeer example for ns_ossl driver

### DIFF
--- a/doc/source/concepts/ns_ossl.rst
+++ b/doc/source/concepts/ns_ossl.rst
@@ -38,11 +38,21 @@ Supported Authentication Modes
 -  **x509/fingerprint** - certificate fingerprint authentication as
    described in IETF's draft-ietf-syslog-transport-tls-12 Internet draft.
    The fingerprint must be provided as the SHA1 or the SHA256 hex string of
-   the certificate. Multiple values must be separated by comma (,).
-   A valid configuration would be e.G.
+   the certificate. Multiple values must be separated by a comma (,).
+   A sample configuration might look like:
    ::
 
-      StreamDriverPermittedPeers="SHA256:10:C4:26:1D:CB:3C:AB:12:DB:1A:F0:47:37:AE:6D:D2:DE:66:B5:71:B7:2E:5B:BB:AE:0C:7E:7F:5F:0D:E9:64,SHA1:DD:23:E3:E7:70:F5:B4:13:44:16:78:A5:5A:8C:39:48:53:A6:DD:25"
+      module(load="imtcp")
+      input(type="imtcp"
+            port="6514"
+            StreamDriver="ossl"
+            StreamDriverMode="1"
+            StreamDriverAuthMode="x509/fingerprint"
+            PermittedPeer=[
+              "SHA256:10:C4:26:1D:CB:3C:AB:12:DB:1A:F0:47:37:AE:6D:D2:DE:66:B5:71:B7:2E:5B:BB:AE:0C:7E:7F:5F:0D:E9:64",
+              "SHA1:DD:23:E3:E7:70:F5:B4:13:44:16:78:A5:5A:8C:39:48:53:A6:DD:25"
+            ]
+      )
 
 -  **x509/certvalid** - certificate validation only. x509/certvalid is
    a nonstandard mode. It validates the remote peers certificate, but


### PR DESCRIPTION
## Summary
- replace incorrect StreamDriverPermittedPeers line with a full example using PermittedPeer
- clarify fingerprint description for the OpenSSL network stream driver

## Testing
- `pip install -r doc/requirements.txt`
- `make -C doc html`
- `./devtools/format-code.sh`


------
https://chatgpt.com/codex/tasks/task_e_68af50502dac83328de6f961f758ca00