### PR TITLE
Potential fix for code scanning alert no. 44: Commented-out code

### DIFF
--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -44,11 +44,6 @@
     #include <sys/prctl.h>
 #endif
 
-/// TODO: check on solaris if this is any longer needed - I don't think so - rgerhards, 2009-09-20
-// #ifdef OS_SOLARIS
-// #	include <sched.h>
-// #endif
-
 #include "rsyslog.h"
 #include "stringbuf.h"
 #include "srUtils.h"


### PR DESCRIPTION
Potential fix for [https://github.com/rsyslog/rsyslog/security/code-scanning/44](https://github.com/rsyslog/rsyslog/security/code-scanning/44)

To fix the problem, remove the commented-out code and the related TODO comment. This will eliminate confusion about whether the code is still needed and prevent readers from being distracted by unused blocks. Only the lines within the flagged region (the TODO comment and the commented-out Solaris code) are to be removed, leaving all actual functioning code (including the #includes above and below) intact. No changes to imports, definitions, or methods are needed, as the code is simply being removed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
