### PR TITLE
CI: ensure static analyzer script only runs when actually needed

### DIFF
--- a/.github/workflows/clang-analyzer.yml
+++ b/.github/workflows/clang-analyzer.yml
@@ -1,12 +1,18 @@
----
 name: "Clang Static Analyzer"
 
-"on":
+on:
   pull_request:
-    paths-ignore:
-      - "**/*.rst"
-      - "**/*.md"
-      - "**/*.txt"
+    paths:
+      - '**/*.c'
+      - '**/*.h'
+      - 'grammar/lexer.l'
+      - 'grammar/grammar.y'
+      - 'devtools/run-static-analyzer.sh' # run on change of analyzer script itself
+      - '.github/workflows/clang-analyzer.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   clang-analyzer:
@@ -30,12 +36,9 @@ jobs:
         run: |
           chmod -R go+rw .
           set +e
-            devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh 2>&1 \
-              | tee clang-analyzer.log
+          devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh 2>&1 | tee clang-analyzer.log
           echo "exitcode=${PIPESTATUS[0]}" >> $GITHUB_OUTPUT
 
-      # GitHub Pages deployment is disabled due to setup issues; reports remain
-      # available as downloadable artifacts
       - name: Upload clang static analyzer report
         if: always()
         id: upload-report
@@ -44,6 +47,7 @@ jobs:
           name: clang-static-analyzer-report
           path: scan-build-report
           retention-days: 7
+          if-no-files-found: ignore   # optional: prevents failure if dir absent
 
       - name: Show clang static analyzer report link
         if: always()
@@ -65,3 +69,4 @@ jobs:
           echo >&2
           echo "Clang static analyzer HTML report (download): $artifact" >&2
           exit 1
+


### PR DESCRIPTION
Also
- auto-abort on re-push
- some minor tweaks

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

