### PR TITLE
tools/rsyslog.conf.5: fix example Port= value

### DIFF
--- a/tools/rsyslog.conf.5
+++ b/tools/rsyslog.conf.5
@@ -295,7 +295,7 @@ the omfwd module.
 
 .B Example:
 .RS
-action(type="omfwd" Target="192.168.0.1" Device="eth0" Port=514 Protocol="udp")
+action(type="omfwd" Target="192.168.0.1" Device="eth0" Port="514" Protocol="udp")
 .RE
 .sp
 In the example above, messages are forwarded via UDP to the machine 192.168.0.1 at port 514 over


### PR DESCRIPTION
This will fix the example given where a Port number is configured. The Port number (514) should be configured as a string value: "514".