### PR TITLE
CI: change zookeeper version to latest stable

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1735,9 +1735,9 @@ presort() {
 
 #START: ext kafka config
 #dep_cache_dir=$(readlink -f .dep_cache)
-export RS_ZK_DOWNLOAD=apache-zookeeper-3.9.3-bin.tar.gz
+export RS_ZK_DOWNLOAD=apache-zookeeper-3.8.4-bin.tar.gz
 dep_cache_dir=$(pwd)/.dep_cache
-dep_zk_url=https://downloads.apache.org/zookeeper/zookeeper-3.9.3/$RS_ZK_DOWNLOAD
+dep_zk_url=https://downloads.apache.org/zookeeper/zookeeper-3.8.4/$RS_ZK_DOWNLOAD
 dep_zk_cached_file=$dep_cache_dir/$RS_ZK_DOWNLOAD
 
 export RS_KAFKA_DOWNLOAD=kafka_2.13-2.8.0.tgz


### PR DESCRIPTION
Previosly, dev build was targeted, where download also expired. This resulted in CI failures as we could no longer set up kafka environment.
