### PR TITLE
CI: reconfigure gemmini code review bot

### DIFF
--- a/.gemini/config.yml
+++ b/.gemini/config.yml
@@ -1,33 +1,21 @@
 # Gemini Code Assist for GitHub Configuration File
-#
-# This configuration disables all automatic actions from the Gemini bot.
-# The bot will only be activated when manually called in a pull request comment.
-#
+# This file enables automatic pull request summaries and code reviews
+# when a pull request is opened.
+
 # For documentation, see: https://developers.google.com/gemini-code-assist/docs/customize-gemini-behavior-github
 
 version: 1
 
-# Disable all automatic review triggers.
-review_triggers:
-  # Do not trigger a review when a pull request is opened.
-  pull_request_opened: true
-  # Do not trigger a review when a new commit is pushed to the PR branch.
-  pull_request_commit_added: true
-  # Do trigger a review when the bot is added as a reviewer.
-  reviewer_added: true
+code_review:
+  # Disables Gemini from acting on pull requests, set to 'false' to enable.
+  disable: false
 
-# Disable automatic summary generation.
-# This prevents the bot from posting a summary of changes when a PR is opened.
-summarize_on_pull_request_open: false
+  pull_request_opened:
+    # Posts a pull request summary when the PR is opened.
+    summary: true
+    # Posts a code review when the PR is opened.
+    code_review: true
 
-# You can leave 'review_comments' enabled. This section controls WHAT the bot
-# comments on (e.g., security, code style) when it's called, not WHEN it's called.
-# Disabling triggers above is sufficient to control its activation.
-review_comments:
-  # Enable all categories of comments for when a manual review is requested.
-  security: true
-  performance: true
-  style: false
-  code_understanding: true
-  test_coverage: true
-  custom_instructions: true # This allows you to provide extra instructions in a PR comment if needed.
+  # Other settings that control the content of the review
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1


### PR DESCRIPTION
It looks like our previous config was either for a pre-release or did work albeit not following the (current) published schema.

Now changed it to current form.
