### PR TITLE
runtime: fix Darwin build regressionsa

### DIFF
--- a/runtime/cfsysline.c
+++ b/runtime/cfsysline.c
@@ -776,7 +776,6 @@ static rsRetVal cslchCallHdlr(cslCmdHdlr_t *pThis, uchar **ppConfLine) {
             goto finalize_it;
     }
 
-
 finalize_it:
     RETiRet;
 }

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1322,7 +1322,11 @@ static void ATTR_NONNULL() * wrkr(void *arg) {
         DBGPRINTF("prctl failed, not setting thread name for '%s'\n", thrdName);
     }
 #elif defined(HAVE_PTHREAD_SETNAME_NP)
+    #if defined(__APPLE__)
+    int r = pthread_setname_np((char *)shortThrdName);
+    #else
     int r = pthread_setname_np(pthread_self(), (char *)shortThrdName);
+    #endif
     if (r != 0) {
         DBGPRINTF("pthread_setname_np failed, not setting thread name for '%s'\n", thrdName);
     }

--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -72,6 +72,9 @@
 #ifdef HAVE_PATHS_H
     #include <paths.h>
 #endif
+#ifndef _PATH_UTMP
+    #define _PATH_UTMP "/var/run/utmp"
+#endif
 #ifdef HAVE_LIBSYSTEMD
     #include <systemd/sd-daemon.h>
     #include <systemd/sd-login.h>


### PR DESCRIPTION
# Fix Darwin build regressions

## Summary
This PR addresses compilation issues on macOS/Darwin systems that prevent rsyslog from building successfully.

## Changes Made

### runtime/tcpsrv.c
- **Darwin pthread_setname_np compatibility**: Added conditional compilation for macOS systems
- Darwin's `pthread_setname_np` only takes the thread name parameter, unlike Linux/glibc which requires both thread ID and name
- This prevents build failures when setting thread names on macOS

### tools/omusrmsg.c  
- **PATH_UTMP fallback**: Added fallback definition for `_PATH_UTMP` when `paths.h` is missing or doesn't define it
- Sets default path to `/var/run/utmp` for systems without proper paths.h support
- Ensures consistent behavior across different Unix-like systems

### runtime/cfsysline.c
- **Code cleanup**: Removed trailing empty line for consistency

## Testing
- Builds successfully on macOS/Darwin systems
- Maintains compatibility with Linux and other Unix-like platforms
- No functional changes to runtime behavior

## Impact
- **Positive**: Enables rsyslog to build and run on macOS systems
- **Neutral**: No impact on existing Linux/Unix functionality
- **Backward compatible**: All changes are conditional and don't affect other platforms

## Related
Fixes build issues on macOS systems where rsyslog previously failed to compile due to Darwin-specific API differences.