### PR TITLE
core: add fromhost-port message property

### DIFF
--- a/doc/source/_ext/rsyslog_lexer.py
+++ b/doc/source/_ext/rsyslog_lexer.py
@@ -43,7 +43,7 @@ class RainerScriptLexer(RegexLexer):
         'syslogtag', 'protocol-version', 'structured-data', 'app-name',
         'procid', 'msgid', 'pri', 'pri-text', 'syslogfacility',
         'syslogfacility-text', 'syslogseverity', 'syslogseverity-text',
-        'fromhost', 'fromhost-ip', 'remotehost', 'remotehost-ip', 'timereported',
+        'fromhost', 'fromhost-ip', 'fromhost-port', 'remotehost', 'remotehost-ip', 'timereported',
         'timegenerated', 'timestamp', 'json', 'jsonmesg', 'jsonf'
     ]
 

--- a/doc/source/configuration/properties.rst
+++ b/doc/source/configuration/properties.rst
@@ -66,6 +66,10 @@ The following message properties exist:
   The same as fromhost, but always as an IP address. Local inputs (like
   imklog) use 127.0.0.1 in this property.
 
+**fromhost-port**
+  The same as fromhost, but contains the numeric source port of the
+  sender. Local inputs provide an empty string.
+
 **syslogtag**
   TAG from the message
 

--- a/plugins/external/INTERFACE.md
+++ b/plugins/external/INTERFACE.md
@@ -327,6 +327,7 @@ Most message properties can be modified. Modifiable are:
 * hostname (aliased "source")
 * fromhost
 * fromhost-ip
+* fromhost-port
 * all message variable ("$!" tree)
 
 If the message variable tree is modified, new variables may also be *added*. Deletion

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -95,6 +95,7 @@ struct msg {
         cstr_t *pCSMSGID; /* MSGID */
         prop_t *pInputName; /* input name property */
         prop_t *pRcvFromIP; /* IP of system message was received from */
+        prop_t *pRcvFromPort; /* port of system message was received from */
         union {
             prop_t *pRcvFrom; /* name of system message was received from */
             struct sockaddr_storage *pfrominet; /* unresolved name */
@@ -194,6 +195,8 @@ void MsgSetRcvFrom(smsg_t *pMsg, prop_t *);
 void MsgSetRcvFromStr(smsg_t *const pMsg, const uchar *pszRcvFrom, const int, prop_t **);
 rsRetVal MsgSetRcvFromIP(smsg_t *pMsg, prop_t *);
 rsRetVal MsgSetRcvFromIPStr(smsg_t *const pThis, const uchar *psz, const int len, prop_t **ppProp);
+rsRetVal MsgSetRcvFromPort(smsg_t *pMsg, prop_t *);
+rsRetVal MsgSetRcvFromPortStr(smsg_t *const pThis, const uchar *psz, const int len, prop_t **ppProp);
 void MsgSetHOSTNAME(smsg_t *pMsg, const uchar *pszHOSTNAME, const int lenHOSTNAME);
 rsRetVal MsgSetAfterPRIOffs(smsg_t *pMsg, int offs);
 void MsgSetMSGoffs(smsg_t *pMsg, int offs);

--- a/runtime/tcps_sess.h
+++ b/runtime/tcps_sess.h
@@ -44,6 +44,7 @@ struct tcps_sess_s {
         uchar *pMsg; /* message (fragment) received */
         prop_t *fromHost; /* host name we received messages from */
         prop_t *fromHostIP;
+        prop_t *fromHostPort;
         void *pUsr; /* a user-pointer */
         rsRetVal (*DoSubmitMessage)(tcps_sess_t *, uchar *, int); /* submit message callback */
         int iMaxLine; /* fast lookup buffer for config property */
@@ -66,17 +67,20 @@ BEGINinterface(tcps_sess) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*SetUsrP)(tcps_sess_t *, void *);
     rsRetVal (*SetHost)(tcps_sess_t *pThis, uchar *);
     rsRetVal (*SetHostIP)(tcps_sess_t *pThis, prop_t *);
+    rsRetVal (*SetHostPort)(tcps_sess_t *pThis, prop_t *);
     rsRetVal (*SetStrm)(tcps_sess_t *pThis, netstrm_t *);
     rsRetVal (*SetMsgIdx)(tcps_sess_t *pThis, int);
     rsRetVal (*SetOnMsgReceive)(tcps_sess_t *pThis, rsRetVal (*OnMsgReceive)(tcps_sess_t *, uchar *, int));
 ENDinterface(tcps_sess)
-#define tcps_sessCURR_IF_VERSION 3 /* increment whenever you change the interface structure! */
+#define tcps_sessCURR_IF_VERSION 4 /* increment whenever you change the interface structure! */
 /* interface changes
  * to version v2, rgerhards, 2009-05-22
  * - Data structures changed
  * - SetLstnInfo entry point added
  * version 3, rgerhards, 2013-01-21:
  * - signature of SetHostIP() changed
+ * version 4, 2025-01-??:
+ * - SetHostPort() entry point added
  */
 
 

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -216,6 +216,7 @@ typedef uintTiny propid_t;
 #define PROP_PARSESUCCESS 23
 #define PROP_JSONMESG 24
 #define PROP_RAWMSG_AFTER_PRI 25
+#define PROP_FROMHOST_PORT 26
 #define PROP_SYS_NOW 150
 #define PROP_SYS_YEAR 151
 #define PROP_SYS_MONTH 152

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -612,7 +612,9 @@ endif # ENABLE_DEFAULT_TESTS
 
 if ENABLE_IMTCP_TESTS
 TESTS +=  \
-	imtcp-listen-port-file-2.sh \
+	fromhost-port.sh \
+	fromhost-port-tuple.sh \
+	fromhost-port-async-ruleset.sh \
 	allowed-sender-tcp-ok.sh \
 	allowed-sender-tcp-fail.sh \
 	allowed-sender-tcp-hostname-ok.sh \
@@ -2506,6 +2508,9 @@ EXTRA_DIST= \
 	msgdup_props.sh \
 	empty-ruleset.sh \
 	ruleset-direct-queue.sh \
+	fromhost-port.sh \
+	fromhost-port-tuple.sh \
+	fromhost-port-async-ruleset.sh \
 	imtcp-listen-port-file-2.sh \
 	allowed-sender-tcp-ok.sh \
 	allowed-sender-tcp-fail.sh \

--- a/tests/fromhost-port-async-ruleset.sh
+++ b/tests/fromhost-port-async-ruleset.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+## fromhost-port.sh
+## Check that fromhost-port property records sender port and that it
+## can properly be carried over to a second asnc ruleset.
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="list") {
+    property(name="fromhost-port")
+    constant(value="\n")
+}
+
+call async
+
+# Note: a disk-type queue is selected to test even more rsyslog core features
+ruleset(name="async" queue.type="disk") {
+  :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file="'$RSYSLOG_OUT_LOG'")
+}
+'
+startup
+tcpflood -m $NUMMESSAGES -w "${RSYSLOG_DYNNAME}.tcpflood-port"
+shutdown_when_empty
+wait_shutdown
+export EXPECTED="$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+cmp_exact
+exit_test

--- a/tests/fromhost-port-tuple.sh
+++ b/tests/fromhost-port-tuple.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+## fromhost-port.sh
+## Check that fromhost-port property records sender port
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="list") {
+    property(name="$.ip_port")
+    constant(value="\n")
+}
+
+set $.ip_port = $fromhost-ip & ":" & $fromhost-port;
+
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+tcpflood -m $NUMMESSAGES -w "${RSYSLOG_DYNNAME}.tcpflood-port"
+shutdown_when_empty
+wait_shutdown
+export EXPECTED="127.0.0.1:$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+cmp_exact
+exit_test

--- a/tests/fromhost-port.sh
+++ b/tests/fromhost-port.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+## fromhost-port.sh
+## Check that fromhost-port property records sender port
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="list") {
+    property(name="fromhost-port")
+    constant(value="\n")
+}
+
+:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
+			         file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+tcpflood -m $NUMMESSAGES -w "${RSYSLOG_DYNNAME}.tcpflood-port"
+shutdown_when_empty
+wait_shutdown
+export EXPECTED="$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+cmp_exact
+exit_test


### PR DESCRIPTION
Some deployments need to disambiguate multiple senders sharing an IP, for example autossh or similar tunnel setups. Exposing the source port improves observability and lets pipelines key on a stable tuple.

Impact: new property/JSON field; tcps_sess IF v4; out-of-tree modules must rebuild.

Before: messages exposed fromhost and fromhost-ip only.
After:  messages also expose fromhost-port and jsonmesg includes it.

Introduce PROP_FROMHOST_PORT and wire it through msg.{h,c}. For TCP, capture the remote port on accept, store it in tcps_sess, and attach it to the msg on submit. For other inputs, resolveDNS derives the port from the sockaddr when available; local inputs return an empty string. Add a getter, duplication and destructor handling, and name<->ID mapping. Add the field to jsonmesg output. Update docs, lexer keywords, and the external plugin interface doc (property is modifiable). Bump tcps_sessCURR_IF_VERSION to 4 and add SetHostPort() to the interface. Include a focused test (fromhost-port.sh) that verifies the property.

Non-technical rationale: allow identification by (fromhost-ip, fromhost-port) where IP alone is shared across systems (e.g., autossh).

With help from AI-Agents: ChatGPT
