### PR TITLE
CI: add gcc 15 to compile checks

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -42,7 +42,7 @@ jobs:
         # note: we compile only with the oldest and newest supported compilers to
         # save resources. Other important ones are used during the rest of
         # the check runs (most importantly the distro-default ones).
-        config: [clang9, clang18-noatomics, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc14-gnu23-debug]
+        config: [clang9, clang18-noatomics, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc15]
 
     steps:
       - name: git checkout project
@@ -92,13 +92,13 @@ jobs:
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
               export CC='gcc-11'
               ;;
-          'gcc14-gnu23-debug')
+          'gcc15')
               # omamqp1 seems to have an issue with the build system - exclude it for now
               # rgerhards, 2024-12-06
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:42'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--enable-debug=yes --disable-omamqp1'
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
-              export CFLAGS="-g -std=gnu23"
-              export CC='gcc-14'
+              export CFLAGS="-g -Werror"
+              export CC='gcc'
               ;;
           *)
               echo "unknown configuration "

--- a/action.c
+++ b/action.c
@@ -1,3 +1,4 @@
+/*REMOVEME*/
 /**
  * @file action.c
  * @brief Implementation of the action object.


### PR DESCRIPTION
This shall detect gcc 15 specific warnings, which will cause the build to error out.

see also: https://github.com/rsyslog/rsyslog/issues/5566
