### PR TITLE
devtools: use codecov uploader in CI script

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -63,6 +63,8 @@ jobs:
       - name: run container CI pipeline
         run: |
           chmod -R go+rw .
+          export CODECOV_repo_slug="$(git config --get remote.origin.url | sed -E 's#.*[:/]([^/]+/[^/.]+)(\\.git)?$#\1#')"
+          export CODECOV_commit_sha="$(git rev-parse HEAD)"
           export RSYSLOG_CONTAINER_UID="" # use default
           export RSYSLOG_STATSURL='http://build.rsyslog.com/testbench-failedtest.php'
           export CFLAGS='-g'

--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -63,6 +63,8 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e ABORT_ALL_ON_TEST_FAIL \
 	-e USE_AUTO_DEBUG \
 	-e RSYSLOG_STATSURL \
+	-e CODECOV_commit_sha \
+	-e CODECOV_repo_slug \
 	-e VCS_SLUG \
 	--cap-add SYS_ADMIN \
 	--cap-add SYS_PTRACE \

--- a/devtools/run-ci.sh
+++ b/devtools/run-ci.sh
@@ -58,8 +58,9 @@ if [ "$CI_CODECOV_TOKEN" != "" ]; then
         curl -Os https://uploader.codecov.io/latest/linux/codecov
         curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
         if ! sha256sum -c codecov.SHA256SUM; then
-                echo 'SHA256 verification for Codecov uploader failed'
+                echo 'SHA256 verification for Codecov uploader failed' >&2
                 rm -f codecov codecov.SHA256SUM
+                exit 1
         else
                 chmod +x codecov
                 printf "repo slug %s, commit_sha %s\n" "$CODECOV_repo_slug" "$CODECOV_commit_sha"

--- a/devtools/run-ci.sh
+++ b/devtools/run-ci.sh
@@ -1,12 +1,16 @@
 #!/bin/bash
-# script for generic CI runs via container
+## run-ci.sh
+## Run generic CI tasks inside a container.
+##
+## This script is used by multiple CI systems and must remain
+## independent of any specific CI provider.
 printf 'running CI with\n'
-printf 'container: %s\n' $RSYSLOG_DEV_CONTAINER
+printf 'container: %s\n' "$RSYSLOG_DEV_CONTAINER"
 printf 'CC:\t%s\n' "$CC"
 printf 'CFLAGS:\t%s:\n' "$CFLAGS"
 printf 'RSYSLOG_CONFIGURE_OPTIONS:\t%s\n' "$RSYSLOG_CONFIGURE_OPTIONS"
 printf 'working directory: %s\n' "$(pwd)"
-printf 'user ids: %s:%s\n' $(id -u) $(id -g)
+printf 'user ids: %s:%s\n' "$(id -u)" "$(id -g)"
 if [ "$SUDO" != "" ]; then
 	printf 'check sudo'
 	$SUDO echo sudo works!
@@ -31,30 +35,57 @@ fi
 printf 'STEP: make %s ==============================================================\n', \
 	"$CI_CHECK_CMD"
 set +e
-echo CI_CHECK_CMD: $CI_CHECK_CMD
-make $CI_MAKE_CHECK_OPT ${CI_CHECK_CMD:-check}
+echo CI_CHECK_CMD: "$CI_CHECK_CMD"
+make $CI_MAKE_CHECK_OPT "${CI_CHECK_CMD:-check}"
 rc=$?
 
 printf 'STEP: find failing tests ====================================================\n'
 echo calling gather-check-logs
 devtools/gather-check-logs.sh
 
+## Upload coverage results to Codecov using the official uploader
 printf 'STEP: Codecov upload =======================================================\n'
 if [ "$CI_CODECOV_TOKEN" != "" ]; then
-	curl -s https://codecov.io/bash >codecov.sh
-	chmod +x codecov.sh
-	./codecov.sh -t "$CI_CODECOV_TOKEN" -n 'rsyslog buildbot PR' &> codecov_log
-	rm codecov.sh
-	lines="$(wc -l < codecov_log)"
-	if (( lines > 3000 )); then
-		printf 'codecov log file is very large (%d lines), showing parts\n' $lines
-		head -n 1500 < codecov_log
-		printf '\n\n... snip ...\n\n'
-		tail -n 1500 < codecov_log
-	else
-		cat codecov_log
-	fi
-	rm codecov_log
+        coverage_file=""
+        ## Prefer lcov for aggregated coverage info; warn if unavailable
+        if command -v lcov >/dev/null 2>&1; then
+                lcov --capture --directory . --output-file coverage.info >/dev/null 2>&1
+                coverage_file="coverage.info"
+        else
+                printf 'warning: lcov not found; using gcov\n' >&2
+                find . -name '*.gcno' -exec gcov -pb {} + >/dev/null 2>&1
+        fi
+        curl -Os https://uploader.codecov.io/latest/linux/codecov
+        curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+        if ! sha256sum -c codecov.SHA256SUM; then
+                echo 'SHA256 verification for Codecov uploader failed'
+                rm -f codecov codecov.SHA256SUM
+        else
+                chmod +x codecov
+                printf "repo slug %s, commit_sha %s\n" "$CODECOV_repo_slug" "$CODECOV_commit_sha"
+                if [ -n "$coverage_file" ]; then
+                      ./codecov -f "$coverage_file" -C "$CODECOV_commit_sha" -r "$CODECOV_repo_slug" -t "$CI_CODECOV_TOKEN" -n 'rsyslog PR' -Z &> codecov_log
+                else
+                        ./codecov -C "$CODECOV_commit_sha" -r "$CODECOV_repo_slug" -t "$CI_CODECOV_TOKEN" -n 'rsyslog PR' -Z &> codecov_log
+                fi
+                cov_rc=$?
+                rm codecov codecov.SHA256SUM
+                [ -n "$coverage_file" ] && rm "$coverage_file"
+                find . -name '*.gcov' -delete
+                lines="$(wc -l < codecov_log)"
+                if (( lines > 3000 )); then
+                        printf 'codecov log file is very large (%d lines), showing parts\n' "$lines"
+                        head -n 1500 < codecov_log
+                        printf '\n\n... snip ...\n\n'
+                        tail -n 1500 < codecov_log
+                else
+                        cat codecov_log
+                fi
+                rm codecov_log
+                if [ "$rc" -eq 0 ]; then
+                        rc=$cov_rc
+                fi
+        fi
 fi
 
 exit $rc


### PR DESCRIPTION
Replace deprecated bash uploader with Codecov's official uploader. The script now downloads the uploader binary, verifies its SHA256 checksum, and runs it to submit coverage results.

The change keeps run-ci.sh CI-agnostic.

With the help of AI-Agent: ChatGPT
