### PR TITLE
doc: restore missing doc files in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3025,6 +3025,10 @@ rst_files=`cd "$srcdir" && find doc/source -type f -name '*.rst' -print 2>/dev/n
 # assemble; keep paths relative to top (we cd into $srcdir above)
 DOC_FILES="$rst_files
 doc/source/conf.py
+doc/source/conf_helpers.py
+doc/source/_ext/edit_on_github.py
+doc/source/_ext/rsyslog_lexer.py
+doc/source/_static/rsyslog.css
 doc/requirements.txt
 doc/README.md
 doc/STRATEGY.md


### PR DESCRIPTION
The Sphinx docs build has been failing because conf.py imports
doc/source/conf_helpers.py, which was removed. This PR restores the
helper module so documentation builds succeed again.

Regression introduced by:
https://github.com/rsyslog/rsyslog/commit/ba762b653331f3c97ba2da91cf6a0ab602e6243c

Impact:
- Restores local and CI documentation builds
- No runtime or ABI changes

Before:
- sphinx-build failed with ImportError/ModuleNotFoundError for conf_helpers

After:
- sphinx-build succeeds

Testing:
- sphinx-build -b html doc/source doc/build/html completes locally
- .github/workflows/doc_build.yml expected to pass

AI-Agent: Codex