### PR TITLE
devtools: Specify usage of clang-format-18 to pin v18

### DIFF
--- a/devtools/format-code.sh
+++ b/devtools/format-code.sh
@@ -30,19 +30,22 @@
 #   parentheses `\( ... \)` to ensure that `clang-format` is executed for
 #   both `.c` and `.h` files as intended.
 #
-#   Before running, ensure 'clang-format' is installed on your system.
+#   Before running, ensure 'clang-format-18' is installed on your system.
 #   It is highly recommended to commit your current changes or create a backup
 #   before executing this script, as it modifies files directly.
 #
 # Exit Codes:
 #   0: Overall formatting process completed successfully.
-#   1: 'clang-format' is not found or not executable.
+#   1: 'clang-format-18' is not found or not executable.
 #   2: A critical error occurred during the 'find -exec' command.
 
 # --- Script Start ---
 
 # Set sensible defaults for shell options
 set -euo pipefail # Exit on error, unset variables, and pipefail
+
+# --- Configuration ---
+readonly CLANG_FORMAT="clang-format-18"  # Specify the clang-format version to use
 
 # --- Functions ---
 
@@ -69,9 +72,9 @@ done
 # --- Pre-checks ---
 
 # Check if clang-format is installed and executable
-if ! command -v clang-format &> /dev/null; then
-  echo "Error: 'clang-format' command not found." >&2
-  echo "Please install it. On Ubuntu, you can run: sudo apt install clang-format" >&2
+if ! command -v "$CLANG_FORMAT" &> /dev/null; then
+  echo "Error: '$CLANG_FORMAT' command not found." >&2
+  echo "Please install it. On Ubuntu, you can run: sudo apt install $CLANG_FORMAT" >&2
   exit 1
 fi
 
@@ -84,9 +87,9 @@ if ! find . -maxdepth 2 -name ".clang-format" -print -quit | grep -q .; then
 fi
 
 echo "Starting code formatting for .c and .h files using 'find -exec ... +'..."
-echo "Using clang-format -i -style=file"
+echo "Using $CLANG_FORMAT -i -style=file"
 echo "This may take a moment. Any clang-format errors for individual files will be printed directly."
-echo "Note: 'clang-format' only modifies files that deviate from the specified style."
+echo "Note: '$CLANG_FORMAT' only modifies files that deviate from the specified style."
 echo ""
 
 # --- Formatting Logic ---
@@ -94,7 +97,7 @@ echo ""
 # The '{} +' syntax passes multiple filenames to a single clang-format invocation,
 # which is more efficient.
 # The parentheses '\( ... \)' are crucial for correctly grouping the -name conditions.
-if ! find . \( -name "*.c" -o -name "*.h" \) -exec clang-format -i -style=file {} +; then
+if ! find . \( -name "*.c" -o -name "*.h" \) -exec "$CLANG_FORMAT" -i -style=file {} +; then
   echo "Error: The overall code formatting process failed." >&2
   echo "Please review the output above for any specific clang-format errors." >&2
   exit 2


### PR DESCRIPTION
<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

This PR modifies the behaviour of `devtools/format-code.sh` to use a configurable version of `clang-format`, and sets it to use `clang-format-18`.

This avoids version ambiguity, which has become a problem due to later versions of the tool typically being installed by more recent versions of Linux distributions.

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->

Ref: https://github.com/rsyslog/rsyslog/pull/5268#issuecomment-3252118980

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

