### PR TITLE
rainerscript: add toupper() function

### DIFF
--- a/doc/source/rainerscript/functions/rs-toupper.rst
+++ b/doc/source/rainerscript/functions/rs-toupper.rst
@@ -1,0 +1,21 @@
+*********
+toupper()
+*********
+
+Purpose
+=======
+
+toupper(str)
+
+Converts the provided string into uppercase.
+
+
+Example
+=======
+
+The following example shows the syslogtag being converted to upper case.
+
+.. code-block:: none
+
+   toupper($syslogtag)
+

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -2115,6 +2115,31 @@ static void ATTR_NONNULL() doFunct_ToLower(struct cnffunc *__restrict__ const fu
     varFreeMembers(&srcVal);
 }
 
+static void ATTR_NONNULL() doFunct_ToUpper(struct cnffunc *__restrict__ const func,
+                                           struct svar *__restrict__ const ret,
+                                           void *__restrict__ const usrptr,
+                                           wti_t *__restrict__ const pWti) {
+    struct svar srcVal;
+    es_str_t *estr;
+    int bMustFree;
+    uchar *p;
+    int i, len;
+
+    cnfexprEval(func->expr[0], &srcVal, usrptr, pWti);
+    estr = var2String(&srcVal, &bMustFree);
+    if (!bMustFree) { /* let caller handle that M) */
+        estr = es_strdup(estr);
+    }
+    p = es_getBufAddr(estr);
+    len = es_strlen(estr);
+    for (i = 0; i < len; ++i) {
+        p[i] = toupper((int)p[i]);
+    }
+    ret->datatype = 'S';
+    ret->d.estr = estr;
+    varFreeMembers(&srcVal);
+}
+
 static void ATTR_NONNULL() doFunct_CStr(struct cnffunc *__restrict__ const func,
                                         struct svar *__restrict__ const ret,
                                         void *__restrict__ const usrptr,
@@ -3614,6 +3639,7 @@ static struct scriptFunct functions[] = {
     {"ltrim", 1, 1, doFunct_LTrim, NULL, NULL},
     {"rtrim", 1, 1, doFunct_RTrim, NULL, NULL},
     {"tolower", 1, 1, doFunct_ToLower, NULL, NULL},
+    {"toupper", 1, 1, doFunct_ToUpper, NULL, NULL},
     {"cstr", 1, 1, doFunct_CStr, NULL, NULL},
     {"cnum", 1, 1, doFunct_CNum, NULL, NULL},
     {"ip42num", 1, 1, doFunct_Ipv42num, NULL, NULL},

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -442,6 +442,7 @@ TESTS +=  \
 	rscript_int2Hex.sh \
 	rscript_trim.sh \
 	rscript_substring.sh \
+	rscript_toupper.sh \
 	rscript_format_time.sh \
 	rscript_parse_time.sh \
 	rscript_is_time.sh \
@@ -2151,6 +2152,7 @@ EXTRA_DIST= \
 	rscript_int2Hex.sh \
 	rscript_trim.sh \
 	rscript_substring.sh \
+	rscript_toupper.sh \
 	rscript_format_time.sh \
 	rscript_parse_time.sh \
 	rscript_parse_time_get-ts.py \

--- a/tests/rscript_tolower.sh
+++ b/tests/rscript_tolower.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+set $!str!var1 = tolower("test");
+set $!str!var2 = tolower("TeSt");
+set $!str!var3 = tolower("");
+
+template(name="outfmt" type="string" string="%!str%\n")
+local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m1 -y
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='{ "var1": "test", "var2": "test", "var3": "" }'
+cmp_exact
+exit_test
+

--- a/tests/rscript_toupper.sh
+++ b/tests/rscript_toupper.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+set $!str!var1 = toupper("test");
+set $!str!var2 = toupper("TeSt");
+set $!str!var3 = toupper("");
+
+template(name="outfmt" type="string" string="%!str%\n")
+local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m1 -y
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='{ "var1": "TEST", "var2": "TEST", "var3": "" }'
+cmp_exact
+exit_test
+


### PR DESCRIPTION
Add a RainerScript function to convert strings to uppercase. The implementation mirrors tolower() but operates per-byte using toupper(). Tests demonstrate the new function, documentation and ChangeLog entries added.

closes: https://github.com/rsyslog/rsyslog/issues/3666

With the help of AI-Agent: ChatGPT
