### PR TITLE
net: Add NetworkNamespace APIs

### DIFF
--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -165,7 +165,7 @@ endif
 # basic network support, needed for rsyslog startup (e.g. our own system name)
 #
 pkglib_LTLIBRARIES += lmnet.la
-lmnet_la_SOURCES = net.c net.h
+lmnet_la_SOURCES = net.c net.h netns_socket.c netns_socket.h
 lmnet_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
 lmnet_la_LDFLAGS = -module -avoid-version ../compat/compat_la-getifaddrs.lo
 lmnet_la_LIBADD =

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1628,6 +1628,11 @@ BEGINobjQueryInterface(net)
     pIf->CmpHost = CmpHost;
     pIf->HasRestrictions = HasRestrictions;
     pIf->GetIFIPAddr = getIFIPAddr;
+
+    pIf->netns_save = netns_save;
+    pIf->netns_restore = netns_restore;
+    pIf->netns_switch = netns_switch;
+    pIf->netns_socket = netns_socket;
 finalize_it:
 ENDobjQueryInterface(net)
 

--- a/runtime/netns_socket.c
+++ b/runtime/netns_socket.c
@@ -1,0 +1,166 @@
+/* Implementation for netns_socket API
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include <stdio.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <sched.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include "rsyslog.h"
+#include "debug.h"
+#include "errmsg.h"
+#include "netns_socket.h"
+
+
+/* Change to the given network namespace.
+ * This function based on previous implementation
+ * of tools/omfwd.c function changeToNs.
+ */
+rsRetVal netns_switch(const char *ns) {
+    DEFiRet;
+#ifdef HAVE_SETNS
+    int ns_fd = -1;
+    char *nsPath = NULL;
+
+    if (ns && *ns) {
+        /* Build network namespace path */
+        if (asprintf(&nsPath, "/var/run/netns/%s", ns) == -1) {
+            // Some implementations say nsPath would be undefined on failure
+            nsPath = NULL;
+            LogError(0, RS_RET_OUT_OF_MEMORY, "%s: asprintf failed", __func__);
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+
+        /* Open file descriptor of destination network namespace */
+        ns_fd = open(nsPath, O_RDONLY);
+        if (ns_fd < 0) {
+            LogError(errno, RS_RET_IO_ERROR, "%s: could not open namespace '%s'", __func__, ns);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        /* Change to the destination network namespace */
+        if (setns(ns_fd, CLONE_NEWNET) != 0) {
+            LogError(errno, RS_RET_IO_ERROR, "%s: could not change to namespace '%s'", __func__, ns);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        dbgprintf("%s: changed to network namespace '%s'\n", __func__, ns);
+    }
+finalize_it:
+    free(nsPath);
+    if ((ns_fd >= 0) && (close(ns_fd) != 0)) {
+        LogError(errno, RS_RET_IO_ERROR, "%s: failed to close namespace '%s'", __func__, ns);
+    }
+#else  // ndef HAVE_SETNS
+    if (ns && *ns) {
+        LogError(ENOSYS, RS_RET_VALUE_NOT_SUPPORTED, "%s: could not change to namespace '%s'", __func__, ns);
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+finalize_it:
+#endif  // ndef HAVE_SETNS
+    RETiRet;
+}
+
+
+/* Return to the startup network namespace.
+ * This function based on code in tools/omfwd.c
+ */
+rsRetVal ATTR_NONNULL() netns_restore(int *fd) {
+    DEFiRet;
+
+#ifdef HAVE_SETNS
+    if (*fd >= 0) {
+        if (setns(*fd, CLONE_NEWNET) != 0) {
+            LogError(errno, RS_RET_IO_ERROR, "%s: could not return to startup namespace", __func__);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        dbgprintf("%s: returned to startup network namespace\n", __func__);
+    }
+
+finalize_it:
+#endif  // def HAVE_SETNS
+    if (*fd >= 0 && close(*fd) != 0) {
+        LogError(errno, RS_RET_IO_ERROR, "%s: could not close startup namespace fd", __func__);
+    }
+    *fd = -1;
+    RETiRet;
+}
+
+/* Save the current network namespace fd
+ */
+rsRetVal ATTR_NONNULL() netns_save(int *fd) {
+    DEFiRet;
+
+    /*
+     * The fd must always point to either a valid fd
+     * or to -1.  We expect it to be -1 on entry here.
+     * To avoid bugs, or possible descriptor leaks,
+     * check that it is always -1 on entry.
+     */
+#ifdef HAVE_SETNS
+    if (*fd != -1) {
+        LogError(0, RS_RET_CODE_ERR, "%s: called with uninitialized descriptor", __func__);
+        ABORT_FINALIZE(RS_RET_CODE_ERR);
+    }
+    *fd = open("/proc/self/ns/net", O_RDONLY);
+    if (*fd == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "%s: could not access startup namespace", __func__);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    dbgprintf("%s: saved startup network namespace\n", __func__);
+finalize_it:
+#endif  // def HAVE_SETNS
+    RETiRet;
+}
+
+rsRetVal netns_socket(int *fdp, int domain, int type, int protocol, const char *ns) {
+    DEFiRet;
+    int fd = -1;
+
+#ifndef HAVE_SETNS
+    if (ns && *ns) {
+        LogError(0, RS_RET_VALUE_NOT_SUPPORTED, "Network namespaces are not supported");
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+#else /* def HAVE_SETNS */
+    rsRetVal iRet_restore;
+    int ns_fd = -1;
+
+    if (ns && *ns) {
+        CHKiRet(netns_save(&ns_fd));
+        CHKiRet(netns_switch(ns));
+    }
+#endif /* def HAVE_SETNS */
+    *fdp = fd = socket(domain, type, protocol);
+    if (fd == -1) {
+        LogError(errno, RS_RET_NO_SOCKET, "%s: socket(%d, %d, %d) failed", __func__, domain, type, protocol);
+        ABORT_FINALIZE(RS_RET_NO_SOCKET);
+    }
+finalize_it:
+#ifdef HAVE_SETNS
+    iRet_restore = netns_restore(&ns_fd);
+    if (iRet == RS_RET_OK) iRet = iRet_restore;
+#endif /* def HAVE_SETNS */
+    if (iRet != RS_RET_OK && fd != -1) {
+        (void)close(fd);
+        *fdp = -1;
+    }
+    RETiRet;
+}

--- a/runtime/netns_socket.h
+++ b/runtime/netns_socket.h
@@ -1,0 +1,40 @@
+/* Definitions for netns_socket API
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef INCLUDED_NETNS_SOCKET_H
+#define INCLUDED_NETNS_SOCKET_H
+
+#include "rsyslog.h"
+
+/*
+ * Open a socket in the named network namespace
+ */
+rsRetVal netns_socket(int *fdp, int domain, int type, int protocol, const char *ns);
+
+/*
+ * Switch to the named networknamespace
+ */
+rsRetVal netns_switch(const char *ns);
+
+/*
+ * Save and restore our current network namespace
+ */
+rsRetVal ATTR_NONNULL() netns_save(int *fd);
+rsRetVal ATTR_NONNULL() netns_restore(int *fd);
+
+#endif /* #ifndef INCLUDED_NETNS_SOCKET_H */

--- a/tests/known_issues.supp
+++ b/tests/known_issues.supp
@@ -71,3 +71,21 @@
    fun:exit
    fun:(below main)
 }
+{
+   <glibc 2.4[01] failures for fc4[12].aarch64>
+   Memcheck:Leak
+   match-leak-kinds: definite
+   fun:malloc
+   fun:UnknownInlinedFun
+   fun:_dl_map_object_deps
+   fun:dl_open_worker_begin
+   fun:_dl_catch_exception
+   fun:dl_open_worker
+   fun:_dl_catch_exception
+   fun:_dl_open
+   fun:do_dlopen
+   fun:_dl_catch_exception
+   fun:_dl_catch_error
+   fun:dlerror_run
+   fun:__libc_dlopen_mode
+}

--- a/tests/tcp_forwarding_ns_tpl.sh
+++ b/tests/tcp_forwarding_ns_tpl.sh
@@ -26,7 +26,7 @@ ip netns add rsyslog_test_ns
 ip netns exec rsyslog_test_ns ip link set dev lo up
 
 # run server in namespace
-ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p'$TCPFLOOD_PORT' -f $RSYSLOG_OUT_LOG &
+ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p"$TCPFLOOD_PORT" -f $RSYSLOG_OUT_LOG &
 BGPROCESS=$!
 echo background minitcpsrvr process id is $BGPROCESS
 


### PR DESCRIPTION
<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

This moves NetworkNamespace functionality into the net module. This allows the same code to be reused across multiple tools and plugins. The first usage is with omfwd, which is changed to use the common net implementation.  Note the net implementation is based on the original omfwd implementation.  Subsequent PRs will be opened for integrating this into omuxsock and imtcp.

### Notes
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

The original test case tcp_forwarding_ns_tpl.sh was broken due to use of single quotes rather than double quotes, thus preventing the proper port number argument to be passed to the listener.  Note this test must be run as root.

Development has occurred across Fedora41 and Fedora42, which uses glibc 2.40 and glibc2.41 respectively.  The valgrind suppressions are updated to handle new glibc issues accordingly.

Four new functions are callable through the net module. These allow one to save a handle to the current namespace, switch to a new namespace by name, and restore the namespace from the saved handle.  A fourth higher level wrapper is used to open a socket in a named network namespace, and handles the invocation of the lower level functions. Ideally this would be the only public function, however it simplifies integration into imtcp in the future (which doesn't directly open sockets).  This may change in the future as network namespaces are integrated into more modules and plugins.
