### PR TITLE
docker: fix collector, udp and tcp could not be enabled individually

### DIFF
--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -1,8 +1,8 @@
 # reception of network messages. Comment out unneeded functionality
 # NOTE: this is unencrypted config!
 
-module(load="imtcp" config.enabled=`echo $ENABLE_UDP`)
-module(load="imudp" config.enabled=`echo $ENABLE_TCP`)
+module(load="imudp" config.enabled=`echo $ENABLE_UDP`)
+module(load="imtcp" config.enabled=`echo $ENABLE_TCP`)
 module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
 input(	config.enabled=`echo $ENABLE_UDP`


### PR DESCRIPTION
If either one was disabled, so was the other one as well.
