### PR TITLE
docs/getting_started: add AI assistants page

### DIFF
--- a/doc/source/getting_started/ai-assistants.rst
+++ b/doc/source/getting_started/ai-assistants.rst
@@ -1,0 +1,70 @@
+.. _ai-assistants:
+
+AI Assistants
+=============
+
+.. meta::
+   :audience: beginner
+   :tier: entry
+   :keywords: rsyslog AI assistant, chatgpt, configuration help, troubleshooting, documentation, development
+
+.. summary-start
+
+Specialized AI helpers for rsyslog tasks: configuration, troubleshooting,
+documentation, and development.
+
+.. summary-end
+
+As part of rsyslog’s :doc:`../about/ai_first` strategy, we provide several AI
+assistants to make setup, configuration, and contribution easier.  
+They are currently implemented as **OpenAI ChatGPT custom GPTs**, which means
+you need a free OpenAI account to use them. Most users will find the free tier
+sufficient, but availability may depend on your subscription.  
+The platform may change in the future.
+
+General-purpose assistant
+-------------------------
+
+- **Rsyslog Assistant** – the first stop for all usage, configuration, and
+  troubleshooting questions.  
+  🌐 https://rsyslog.ai  
+
+  It can generate working config snippets, explain errors, and guide you through
+  common tasks. While accuracy is usually high, always **verify the results**.
+  Like any AI tool, it can occasionally produce mistakes.
+
+Other assistants
+----------------
+
+These are more specialized, and mainly interesting for contributors:
+
+- **Rsyslog Doc Assistant**  
+  Helps documentation writers maintain consistent style and structure.  
+  🌐 https://www.rsyslog.com/tool_rsyslog-doc-assistant
+
+- **Rsyslog Dev Assistant**  
+  For developers, focused on onboarding and codebase exploration. Still
+  experimental (as of Sept 2025).  
+  🌐 https://www.rsyslog.com/tool_rsyslog-dev-assistant
+
+- **Rsyslog Commit Assistant**  
+  Guides developers in crafting commit messages that follow rsyslog’s conventions.  
+  🌐 https://www.rsyslog.com/tool_rsyslog-commit-assistant
+
+Community feedback
+------------------
+
+We are continuously improving these assistants. Suggestions and feedback are
+very welcome in the `GitHub Discussions
+<https://github.com/rsyslog/rsyslog/discussions>`_.  
+
+If you would like to see a new assistant for a specific use case, please let us
+know there.
+
+Video tips
+----------
+
+Some tutorials reference short “🎬 video tips”. These will be added over time.
+If you would like to contribute tutorial videos to the project, please contact
+**rgerhards@adiscon.com** or post in the GitHub discussions.
+

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -15,6 +15,7 @@ This guide helps you get up and running quickly. It includes:
    :maxdepth: 1
 
    beginner_tutorials/index
+   ai-assistants
    installation
    basic_configuration
    understanding_default_config


### PR DESCRIPTION
Improve discoverability of rsyslog-specific AI helpers for users and contributors. This supports onboarding and troubleshooting and aligns with the project's AI-first strategy.

Impact: docs-only; adds a new page under Getting Started navigation.
