### PR TITLE
CI: fix zookeeper install errors

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1734,9 +1734,9 @@ presort() {
 
 #START: ext kafka config
 #dep_cache_dir=$(readlink -f .dep_cache)
-export RS_ZK_DOWNLOAD=apache-zookeeper-3.8.4-bin.tar.gz
+export RS_ZK_DOWNLOAD=apache-zookeeper-3.8.4.tar.gz
 dep_cache_dir=$(pwd)/.dep_cache
-dep_zk_url=https://downloads.apache.org/zookeeper/zookeeper-3.8.4/$RS_ZK_DOWNLOAD
+dep_zk_url=https://www.rsyslog.com/files/download/rsyslog/$RS_ZK_DOWNLOAD
 dep_zk_cached_file=$dep_cache_dir/$RS_ZK_DOWNLOAD
 
 export RS_KAFKA_DOWNLOAD=kafka_2.13-2.8.0.tgz


### PR DESCRIPTION
Provide different file name for zookeeper tar - it looks like apache changed the name (not sure, but it worked previously).

Also now cached the file on rsyslog.com, so that we have reliable access even on name change or apache download rate-limiting.
