### PR TITLE
CI: remove outdated ElasticSearch v6 testing

### DIFF
--- a/tests/diskqueue-multithread-es.sh
+++ b/tests/diskqueue-multithread-es.sh
@@ -11,7 +11,7 @@
 # messages actually went to the DA queue.
 # Copyright (C) 2019-10-28 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 . ${srcdir:=.}/diag.sh init
 export ES_PORT=19200
 export NUMMESSAGES=25000

--- a/tests/es-basic-errfile-empty.sh
+++ b/tests/es-basic-errfile-empty.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 export ES_PORT=19200
 export NUMMESSAGES=1500 # slow test, thus low number - large number is NOT necessary
 export QUEUE_EMPTY_CHECK_FUNC=es_shutdown_empty_check

--- a/tests/es-basic-errfile-popul.sh
+++ b/tests/es-basic-errfile-popul.sh
@@ -1,48 +1,63 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
-. ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
-export ES_PORT=19200
-export NUMMESSAGES=1000 # slow test, thus low number - large number is NOT necessary
-ensure_elasticsearch_ready
 
+. ${srcdir:=.}/diag.sh init
+
+# --- ElasticSearch test parameters ---
+export ES_PORT=19200
+export NUMMESSAGES=1000    # slow test, thus low number - large number is NOT necessary
+
+ensure_elasticsearch_ready
 init_elasticsearch
-curl -H 'Content-Type: application/json' -XPUT localhost:19200/rsyslog_testbench/ -d '{
-  "mappings": {
-    "test-type": {
-      "properties": {
-        "msgnum": {
-          "type": "integer"
+
+# Create index with ES 7+ typeless mapping (no legacy type wrapper)
+http_code=$(curl -sS -o /tmp/es_mapping_resp.json -w "%{http_code}" \
+  -H 'Content-Type: application/json' \
+  -X PUT "http://localhost:${ES_PORT}/rsyslog_testbench" \
+  -d '{
+        "mappings": {
+          "properties": {
+            "msgnum": { "type": "integer" }
+          }
         }
-      }
-    }
-  }
-}'
+      }')
+
+# Accept 200 (updated) or 201 (created); otherwise fail fast so test result is meaningful
+if [ "$http_code" != "200" ] && [ "$http_code" != "201" ]; then
+  echo "ERROR: failed to create mapping (HTTP $http_code). Response:"
+  cat /tmp/es_mapping_resp.json
+  error_exit 1
+fi
+
 generate_conf
-add_conf '
+add_conf "
 # Note: we must mess up with the template, because we can not
 # instruct ES to put further constraints on the data type and
 # values. So we require integer and make sure it is none.
-template(name="tpl" type="string"
-	 string="{\"msgnum\":\"x%msg:F,58:2%\"}")
+template(name=\"tpl\" type=\"string\"
+         string=\"{\\\"msgnum\\\":\\\"x%msg:F,58:2%\\\"}\")
 
+module(load=\"../plugins/omelasticsearch/.libs/omelasticsearch\")
+:msg, contains, \"msgnum:\" action(
+  type=\"omelasticsearch\"
+  template=\"tpl\"
+  searchIndex=\"rsyslog_testbench\"
+  searchType=\"_doc\"            # ES 7+: use _doc (or drop this param if module build supports typeless)
+  serverport=\"${ES_PORT}\"
+  bulkmode=\"off\"
+  errorFile=\"./${RSYSLOG_DYNNAME}.errorfile\"
+)
+"
 
-module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
-:msg, contains, "msgnum:" action(type="omelasticsearch"
-				 template="tpl"
-				 searchIndex="rsyslog_testbench"
-				 searchType="test-type"
-				 serverport="19200"
-				 bulkmode="off"
-				 errorFile="./'${RSYSLOG_DYNNAME}'.errorfile")
-'
 startup
 injectmsg
 shutdown_when_empty
-wait_shutdown 
-if [ ! -f ${RSYSLOG_DYNNAME}.errorfile ]
-then
-    echo "error: error file does not exist!"
-    error_exit 1
+wait_shutdown
+
+if [ ! -f "${RSYSLOG_DYNNAME}.errorfile" ]; then
+  echo "error: error file does not exist!"
+  error_exit 1
 fi
+
 exit_test
+

--- a/tests/es-basic-ha-vg.sh
+++ b/tests/es-basic-ha-vg.sh
@@ -2,7 +2,8 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=100
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 export ES_PORT=19200
 ensure_elasticsearch_ready
 

--- a/tests/es-basic-ha.sh
+++ b/tests/es-basic-ha.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 ensure_elasticsearch_ready
 generate_conf
 add_conf '

--- a/tests/es-bulk-errfile-empty.sh
+++ b/tests/es-bulk-errfile-empty.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 export ES_PORT=19200
 export NUMMESSAGES=10000
 export QUEUE_EMPTY_CHECK_FUNC=es_shutdown_empty_check

--- a/tests/es-bulk-errfile-popul-def-format.sh
+++ b/tests/es-bulk-errfile-popul-def-format.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 ensure_elasticsearch_ready
 
 init_elasticsearch

--- a/tests/es-bulk-errfile-popul-def-interleaved.sh
+++ b/tests/es-bulk-errfile-popul-def-interleaved.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 ensure_elasticsearch_ready
 
 init_elasticsearch

--- a/tests/es-bulk-errfile-popul-erronly-interleaved.sh
+++ b/tests/es-bulk-errfile-popul-erronly-interleaved.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 ensure_elasticsearch_ready
 
 init_elasticsearch

--- a/tests/es-bulk-errfile-popul-erronly.sh
+++ b/tests/es-bulk-errfile-popul-erronly.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 ensure_elasticsearch_ready
 
 init_elasticsearch

--- a/tests/es-bulk-errfile-popul.sh
+++ b/tests/es-bulk-errfile-popul.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 ensure_elasticsearch_ready
 
 init_elasticsearch

--- a/tests/es-maxbytes-bulk.sh
+++ b/tests/es-maxbytes-bulk.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+#export ES_DOWNLOAD=elasticsearch-6.0.0.tar.gz
+export ES_DOWNLOAD=elasticsearch-6.8.23.tar.gz
 export ES_PORT=19200
 export NUMMESSAGES=10000
 export QUEUE_EMPTY_CHECK_FUNC=es_shutdown_empty_check


### PR DESCRIPTION
This is a first step in getting the omelasticsearch testbench in better shape. For now, the ES 6 download requirements are just commented out, to check if that is at least a feasible measure. We also need a quick fix to get CI running again.

Once the initial problem is solved, follow-up patches will be used to modernize the omelasticsearch testbench.
