### PR TITLE
Clarify agent build and test documentation

### DIFF
--- a/tests/README
+++ b/tests/README
@@ -3,6 +3,21 @@ evolving. New tests are always welcome. So far, most tests check
 out the functionality of a single module. More complex tests are
 welcome.
 
+Quick Start (Modern Harness)
+============================
+
+-   To run a single test script from the repository root, execute
+    `./tests/<test-name>.sh`. The root-level `diag.sh` stub will
+    automatically run `autoreconf`, invoke `./configure --enable-testbench`
+    with the default feature set, and build any missing helper binaries
+    before forwarding to `tests/diag.sh`.
+-   For the full suite, run `make check -j4` after configuration. Inspect
+    `tests/test-suite.log` if a failure occurs.
+-   When introducing a new test, mirror an existing script, source
+    `${srcdir:=.}/diag.sh`, and register the script inside `tests/Makefile.am`
+    so the autotools harness is aware of it. See `AGENTS.md` for additional
+    guidance aimed at AI contributors.
+
 For a simple sample, see rtinit.c, which does a simple
 init/deinit check of the runtime system.
 


### PR DESCRIPTION
## Summary
- expand the agent build instructions to mention running `autogen.sh` and the preferred configure flags before executing tests
- add concrete guidance for registering new test scripts and helper binaries in the harness
- refresh `tests/README` with a modern quick-start that highlights the root `diag.sh` bootstrapping and points back to AGENTS.md

## Testing
- devtools/format-code.sh *(fails: missing clang-format-18 in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d010d894848332bfc23f174d881afb