### PR TITLE
CI: fix invalid download name for zookeeper

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1904,7 +1904,7 @@ presort() {
 
 #START: ext kafka config
 #dep_cache_dir=$(readlink -f .dep_cache)
-export RS_ZK_DOWNLOAD=apache-zookeeper-3.8.4.tar.gz
+export RS_ZK_DOWNLOAD=apache-zookeeper-3.8.5-bin.tar.gz
 dep_cache_dir=$(pwd)/.dep_cache
 dep_zk_url=https://www.rsyslog.com/files/download/rsyslog/$RS_ZK_DOWNLOAD
 dep_zk_cached_file=$dep_cache_dir/$RS_ZK_DOWNLOAD

--- a/tests/kafka-selftest.sh
+++ b/tests/kafka-selftest.sh
@@ -2,12 +2,9 @@
 # added 2018-10-26 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-set -v -x
 check_command_available kcat
 export KEEP_KAFKA_RUNNING="YES"
-
 export TESTMESSAGES=100000
-
 export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.


### PR DESCRIPTION
We invalidly specified the source distribution, which does not include the necessary class files. This lead to zookeeper start failure and thus no kafka tests being executed.
