### PR TITLE
docs: add agent guides and module metadata scaffolding

### DIFF
--- a/ai/rsyslog_code_doc_builder/base_prompt.txt
+++ b/ai/rsyslog_code_doc_builder/base_prompt.txt
@@ -1,0 +1,45 @@
+# rsyslog code agent doc builder – base prompt
+
+You are assisting with updates to rsyslog's AI-facing documentation (e.g.
+AGENTS.md files, module metadata notes, onboarding checklists). Follow these
+principles:
+
+## 1. Gather context first
+- Read the repository-level `AGENTS.md` plus any directory-scoped guides that
+  cover the files in scope (plugins/, contrib/, doc/, tools/, etc.).
+- Inspect existing `MODULE_METADATA.yaml` or `tools/MODULE_METADATA.json` entries
+  for the modules touched so ownership, maturity, and support channels remain in
+  sync with the prose.
+- Collect relevant user-facing docs (`doc/` subtree) to ensure cross-references
+  stay accurate.
+
+## 2. Document actionable workflows
+- Prefer concise step-by-step instructions that an AI agent can execute without
+  improvising (e.g. when to run `./autogen.sh`, which tests to prefer, how to
+  skip heavy integration suites).
+- Note sandbox-friendly defaults (like using GitHub Discussions & Issues as the
+  primary contact) and explain how to override them when a dedicated maintainer
+  exists.
+- Highlight runtime or tooling costs (approximate durations, external service
+  requirements) so agents can plan work within resource limits.
+
+## 3. Keep structure consistent
+- Reuse existing headings and bullet patterns from sibling AGENTS guides.
+- Update quick links or templates when adding new documentation so future agents
+  can discover it quickly.
+- When introducing new metadata keys, refresh both the schema description and any
+  templates/examples in the tree.
+
+## 4. Validate and cross-link
+- Ensure every instruction you add references the exact filenames or scripts
+  needed (`./tests/<name>.sh`, `devtools/codex-setup.sh`, etc.).
+- Cross-link user docs and AI docs when behavior changes, and mention
+  coordination requirements for other teams/modules.
+- Provide a summary in the commit message that explains what changed and why it
+  helps future AI contributors.
+
+## 5. Output expectations
+- Produce well-structured Markdown that mirrors the repository style
+  (sentence-case headings, wrapped paragraphs, consistent indentation).
+- Prefer American English spellings.
+- Call out when no tests are required and why (documentation-only changes).

--- a/contrib/AGENTS.md
+++ b/contrib/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md – Contrib modules subtree
+
+These instructions apply to everything under `contrib/`.
+
+## Expectations for contrib work
+- Contrib modules are not part of the core support contract.  Changes should
+  preserve backward compatibility for existing users and clearly call out
+  behavior shifts in commit messages and documentation.
+- Many contrib modules depend on third-party SDKs or services that are not
+  available in CI.  Document any manual setup that reviewers must perform.
+
+## Build & bootstrap reminders
+- Run `./autogen.sh` before your first build in a fresh checkout and whenever
+  you modify autotools inputs (`configure.ac`, `Makefile.am`, files under `m4/`).  Expect
+  the bootstrap step to take up to about 2 minutes; you can skip it when the
+  task does not require building (for example, documentation-only changes).
+- Configure with the switches needed to include the contrib module.  Some
+  modules are disabled unless their dependencies are detected.  Use
+  `./configure --help` and the module's `MODULE_METADATA.yaml` to identify
+  the relevant `--enable`/`--with` flags.
+- Build with `make -j$(nproc)` and execute the most relevant smoke test
+  directly (for example `./tests/imtcp-basic.sh` or a module-specific script).
+  Reserve `make check` for cases where you must mirror CI or diagnose harness
+  behavior.
+
+## Metadata required for every module
+Each contrib module directory (for example `contrib/mmkubernetes/`) must contain
+`MODULE_METADATA.yaml`.  Contrib metadata uses the same schema as core plugins,
+with different default expectations.
+
+### Required keys
+```yaml
+support_status: contributor-supported | stalled
+maturity_level: fully-mature | mature | fresh | experimental | deprecated
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: YYYY-MM-DD
+```
+
+- Default `support_status` is `contributor-supported` unless the core team has
+  formally adopted the module.
+- Use `stalled` if no maintainer is known.  Do not set `core-supported` unless
+  the module has moved to `plugins/`.
+
+### Optional keys
+Use the optional keys from the template to document build/runtime
+requirements, CI coverage, and reviewer notes.  Copy
+`contrib/MODULE_METADATA_TEMPLATE.yaml` when creating the file.
+
+- `build_dependencies`: List library or tool requirements (match configure
+  options when possible).
+- `runtime_dependencies`: Libraries or services the module needs at runtime.
+- `ci_targets`: Names of CI jobs or scripts that exercise this module.
+- `documentation`: Links into `doc/` or external references.
+- `support_channels`: Overrides or supplements the default GitHub Discussions
+  and Issues flow when a module has a bespoke support process.
+- `notes`: Free-form guidance for reviewers and contributors.
+
+Replace `primary_contact` with a specific maintainer string when a contrib
+module has an active owner outside the standard GitHub Discussions and Issues
+queue, and record any bespoke escalation path via the optional
+`support_channels` array if needed.
+
+## Testing expectations
+- Prefer smoke tests that can run directly via `./tests/<script>.sh` without
+  proprietary services.  If that is impossible, provide script stubs in `tests/`
+  that mock or skip the integration but keep API coverage verifiable, and note
+  any CI limitations in the metadata.
+- Record any external test environments (container images, cloud resources) in
+  the module metadata so reviewers understand the manual steps required.
+
+## Documentation touchpoints
+- Update `doc/` to mention new or changed contrib modules, especially when the
+  module has prerequisites or manual installation steps.
+- When a contrib module becomes core-supported, move it under `plugins/`, update
+  the metadata accordingly, and inform maintainers via the changelog.

--- a/contrib/MODULE_METADATA_TEMPLATE.yaml
+++ b/contrib/MODULE_METADATA_TEMPLATE.yaml
@@ -1,0 +1,12 @@
+# Copy this file into a contrib module directory and adjust values.
+support_status: contributor-supported  # contributor-supported | stalled
+maturity_level: fresh                  # fully-mature | mature | fresh | experimental | deprecated
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2024-01-01
+build_dependencies: []
+runtime_dependencies: []
+ci_targets: []
+documentation: []
+support_channels: []
+notes: |-
+  Document manual setup steps and any missing CI coverage here.

--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md – Documentation subtree
+
+This guide applies to everything under `doc/`.
+
+## Purpose & scope
+- The `doc/` tree contains the Sphinx documentation sources plus helper tools.
+- Use this file together with the top-level `AGENTS.md` instructions.
+
+## Editing guidelines
+- Prefer reStructuredText (`*.rst`) for content; Markdown files exist for historical reasons.
+- Keep headings consistent with the existing `doc/README.md` conventions.
+- Cross-link new material from `doc/README.md` or the relevant `index.rst` so it is discoverable.
+- When touching shared style guidance, update `doc/STRATEGY.md` if needed.
+- Prime new contributors with the doc-builder base prompt at
+  `ai/rsyslog_code_doc_builder/base_prompt.txt` when scoping AI-driven documentation
+  work.
+
+## Build & validation
+- After content changes, run `./doc/tools/build-doc-linux.sh --clean --format html` locally when possible to catch Sphinx errors.
+- For quick linting without rebuilding everything, run `make -C doc html` (uses the repo's virtualenv if already set up).
+- Document-only changes generally do not require running the full C test suite.
+
+## Commit messaging
+- Summarize the reader impact (new topics, reorganized structure, typo fixes) in the commit body.
+- Include the `AI-Agent: ChatGPT` trailer as requested by the repository guidelines.
+
+## Coordination
+- If a change affects module-specific docs, check `doc/ai/module_map.yaml` for component details and mention any locking or
+  runtime considerations in the documentation where relevant.

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -1,4 +1,7 @@
 # Seed map for AI agents; keep minimal and truthful. Extend over time.
+# Per-module metadata (support status, maturity, contacts) lives in each module
+# directory as `MODULE_METADATA.yaml`; update both the metadata file and this map
+# when concurrency guidance changes.
 omfile:
   paths: ["plugins/omfile/"]
   requires_serialization: true

--- a/plugins/AGENTS.md
+++ b/plugins/AGENTS.md
@@ -1,0 +1,109 @@
+# AGENTS.md – Core plugins subtree
+
+These instructions apply to everything under `plugins/` (except `plugins/external`,
+which vendors third-party code; do not modify it unless specifically requested).
+
+## Build & bootstrap reminders
+- Run `./autogen.sh` before your **first** build in a fresh checkout and
+  whenever you touch `configure.ac`, any `Makefile.am`, or files under `m4/`.
+  The bootstrap step can take up to ~2 minutes, so skip it for pure
+  documentation or metadata-only edits when no build is required.
+- Configure with the options needed for the module you are touching.  The
+  defaults build all modules whose dependencies are present.  Use
+  `./configure --help` to discover `--enable`/`--disable` switches if you need
+  to constrain the build.
+- Keep the testbench enabled with `./configure --enable-testbench` so
+  module-specific tests continue to compile.
+- Build with `make -j$(nproc)` and execute the most relevant smoke/regression
+  test directly (for example `./tests/imtcp-basic.sh` or a module-specific
+  script).  Direct invocation keeps stdout/stderr visible.  Use `make check`
+  only when mirroring CI or chasing harness-specific failures.
+
+## Module-level agent guides
+High-complexity modules benefit from their own `AGENTS.md` living directly
+inside the module directory (for example `plugins/omelasticsearch/AGENTS.md`).
+Use them to capture:
+
+- A short overview plus links to user-facing docs.
+- Build or dependency switches that only affect this module.
+- Smoke/regression tests to run locally and any helper scripts to prepare
+  external services.
+- Common troubleshooting tips (log messages, stats counters, error files).
+- Coordination notes when touching shared helpers or cross-module contracts.
+- References to `MODULE_METADATA.yaml` and other metadata that must stay in
+  sync.
+
+Copy `plugins/MODULE_AGENTS_TEMPLATE.md` when creating a new module guide and
+update it whenever workflows or dependencies change.
+
+## Metadata required for every module
+Each module directory (for example `plugins/omfile/`) must contain a
+`MODULE_METADATA.yaml` file.  The file communicates ownership and expectations
+for both humans and agents.
+
+### Required keys
+```yaml
+support_status: core-supported | contributor-supported | stalled
+maturity_level: fully-mature | mature | fresh | experimental | deprecated
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: YYYY-MM-DD
+```
+
+#### Support status values
+- `core-supported`: Maintained by the rsyslog core team.
+- `contributor-supported`: Maintained primarily by a community contributor; the
+  core team reviews but does not lead feature work.
+- `stalled`: No active maintainer; use extra caution before changing behavior.
+
+#### Maturity level values
+- `fully-mature`: Long-standing module with well-established interfaces.
+- `mature`: Stable but with medium deployment footprint or recent major changes.
+- `fresh`: Recently added or lightly used; expect feedback-driven revisions.
+- `experimental`: Works, but explicitly needs broader testing feedback before it
+  can be considered stable.
+- `deprecated`: Kept only for backward compatibility; avoid new feature work and
+  document migration paths in user-facing docs.
+
+### Optional keys
+Add keys as needed to help future contributors:
+- `build_dependencies`: List library or tool requirements (match configure
+  options when possible).
+- `runtime_dependencies`: Libraries or services the module needs at runtime.
+- `ci_targets`: Names of CI jobs or scripts that exercise this module.
+- `documentation`: Links into `doc/` or external references.
+- `support_channels`: Overrides or supplements the default GitHub Discussions
+  and Issues flow when a module has a bespoke support process.
+- `notes`: Free-form guidance for reviewers and contributors.
+
+Replace `primary_contact` with a specific maintainer string (e.g.
+`"Full Name <email@example.com>"`) when a module has an active owner outside the
+standard GitHub Discussions and Issues queue.
+
+### Template
+Copy `plugins/MODULE_METADATA_TEMPLATE.yaml` when creating or updating
+module metadata.  Keep values accurate and review them whenever ownership or
+support expectations change.
+
+## Coding expectations
+- Follow `MODULE_AUTHOR_CHECKLIST.md` for concurrency and documentation tasks.
+- Update the module's top-of-file "Concurrency & Locking" comment when
+  behavior changes.
+- Update `doc/ai/module_map.yaml` if concurrency expectations change.
+- When adding a new module, update `plugins/Makefile.am`, `configure.ac`, and
+  provide tests under `tests/` to cover the new behavior.
+
+## Testing expectations
+- Prefer module-focused tests in `tests/` named after the module (e.g.
+  `omxyz-basic.sh`).
+- Ensure new tests run cleanly when invoked directly via `./tests/<script>.sh`.
+  When reviewers request a CI reproduction, confirm the test also passes under
+  `make check`.
+- When a module requires external services (databases, message queues, etc.),
+  document setup steps in the module metadata and reference any helper scripts
+  placed under `tests/`.
+
+## Documentation touchpoints
+- Mention significant behavior or dependency changes in `doc/` (for example,
+  module reference guides or changelog entries).
+- Cross-link any new documentation from the appropriate `index.rst` so users
+  can discover it easily.

--- a/plugins/MODULE_AGENTS_TEMPLATE.md
+++ b/plugins/MODULE_AGENTS_TEMPLATE.md
@@ -1,0 +1,29 @@
+# AGENTS.md – <module name>
+
+## Module overview
+- Purpose of the module and key user documentation links.
+- Support status & maturity (mirror `MODULE_METADATA.yaml`).
+
+## Build & dependencies
+- Configure flags to enable the module (e.g. `--enable-foo`).
+- Library/tool prerequisites and how to install them inside the sandbox.
+- Reminders about rerunning `./autogen.sh` or `configure` when touching build
+  inputs.
+
+## Local testing
+- Smoke tests (`make foo-basic.log`) and longer scenarios.
+- Helpers or environment variables required to provision external services.
+- Notes about test runtime or resource requirements.
+
+## Diagnostics & troubleshooting
+- Key log messages, stats counters, or generated files that validate success.
+- Typical failure signatures and quick triage steps.
+
+## Cross-component coordination
+- Shared helpers or configuration formats that must stay aligned.
+- Other modules or docs to update when behavior changes.
+
+## Metadata & housekeeping
+- Remind contributors to update `MODULE_METADATA.yaml`.
+- Call out any templates or automation that need refreshing alongside code
+  changes.

--- a/plugins/MODULE_METADATA_TEMPLATE.yaml
+++ b/plugins/MODULE_METADATA_TEMPLATE.yaml
@@ -1,0 +1,17 @@
+# Copy this file into a module directory (e.g. plugins/omfile/) and adjust values.
+# Keep the keys ordered as shown so diffs stay readable.
+support_status: core-supported        # core-supported | contributor-supported | stalled
+maturity_level: mature                # fully-mature | mature | fresh | experimental | deprecated
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+                                      # Use "Full Name <email>" when a dedicated maintainer exists.
+last_reviewed: 2024-01-01             # Update whenever metadata changes.
+build_dependencies: []                # Optional: list pkg-config names or tools.
+runtime_dependencies: []              # Optional: list services or daemons.
+ci_targets: []                        # Optional: list CI jobs or scripts.
+documentation: []                     # Optional: list doc/*.rst paths or URLs.
+support_channels: []                  # Optional: alternative escalation paths.
+notes: |-
+  Replace this block with free-form context such as:
+  - Known limitations
+  - Links to design documents
+  - How to run module-focused smoke tests

--- a/plugins/imkafka/AGENTS.md
+++ b/plugins/imkafka/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md – imkafka input module
+
+## Module overview
+- Consumes events from Apache Kafka topics via librdkafka.
+- User documentation: `doc/source/configuration/modules/imkafka.rst`.
+- Support status: contributor-supported. Maturity: mature.
+
+## Build & dependencies
+- Configure with `--enable-imkafka` (pair with `--enable-omkafka` for combined pipelines).
+- `./devtools/codex-setup.sh` installs librdkafka headers inside the sandbox when available.
+- Re-run `./configure` after toggling Kafka-related flags; rerun `./autogen.sh` if you touch `configure.ac`, any `Makefile.am`, or files under `m4/`.
+
+## Local testing
+- **Skip the Kafka integration tests when working in the sandbox.** They rely on downloading and running Kafka plus ZooKeeper, which is too resource intensive for agent runs.
+- Build-only validation is acceptable: run `./configure --enable-imkafka` (optionally `--enable-omkafka`) and `make modules` to confirm the plugin links.
+- Maintainers can enable `--enable-kafka-tests` and invoke scripts like `./tests/imkafka.sh` or `./tests/imkafka_multi_group.sh`, but should expect several minutes of setup time for the Kafka cluster.
+
+## Diagnostics & troubleshooting
+- `impstats` exposes the `imkafka` counter set (submitted, failed, and lag metrics). Monitor it to confirm offsets advance as expected.
+- The helper `./tests/diag.sh dump-kafka-topic <topic>` retrieves topic contents when diagnosing ingestion issues.
+
+## Cross-component coordination
+- Coordinate changes with `omkafka` to keep shared Kafka helpers, configuration parameters, and documentation aligned.
+- Update `doc/source/configuration/modules/imkafka.rst` whenever defaults or supported features change.
+
+## Metadata & housekeeping
+- Keep `plugins/imkafka/MODULE_METADATA.yaml` accurate and refresh `last_reviewed` when updating ownership or support status.
+- Update `doc/ai/module_map.yaml` if concurrency or state-handling behavior changes.

--- a/plugins/imkafka/MODULE_METADATA.yaml
+++ b/plugins/imkafka/MODULE_METADATA.yaml
@@ -1,0 +1,16 @@
+support_status: contributor-supported
+maturity_level: mature
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2025-09-26
+build_dependencies:
+  - librdkafka development headers (`./devtools/codex-setup.sh`)
+runtime_dependencies:
+  - Apache Kafka cluster reachable over TCP
+ci_targets:
+  - imkafka.sh
+  - imkafka_multi_group.sh
+  - imkafka-hang-on-no-kafka.sh
+documentation:
+  - doc/source/configuration/modules/imkafka.rst
+notes:
+  - Integration tests launch Kafka and ZooKeeper; agents usually skip them and rely on build-only validation.

--- a/plugins/omelasticsearch/AGENTS.md
+++ b/plugins/omelasticsearch/AGENTS.md
@@ -1,0 +1,47 @@
+# AGENTS.md – omelasticsearch output module
+
+## Module overview
+- Ships events to Elasticsearch via HTTP bulk requests using libcurl.
+- User documentation: `doc/source/configuration/modules/omelasticsearch.rst`.
+- Support status: core-supported. Maturity: fully-mature.
+
+## Build & dependencies
+- Configure with `--enable-elasticsearch` to compile this plugin.
+- `./devtools/codex-setup.sh` installs the required libcurl development headers
+  inside the sandbox.
+- Re-run `./configure` after toggling the flag; rerun `./autogen.sh` if you touch
+  `configure.ac`, any `Makefile.am`, or files under `m4/`.
+
+## Local testing
+- **Do not run the integration tests during routine agent work.** They require
+  downloading and launching an Elasticsearch node, which is too heavy for the
+  sandbox environment.
+- Compiling the module is sufficient validation. Rebuild the tree with
+  `./configure --enable-elasticsearch` followed by `make modules` to ensure the
+  plugin links correctly.
+- Maintainers who need full coverage can enable the suite with
+  `--enable-elasticsearch-tests=minimal` and run `make es-basic.log` (additional
+  scenarios live beside it), but expect multi-minute startup overhead for the
+  embedded Elasticsearch instance.
+
+## Diagnostics & troubleshooting
+- impstats exposes the `omelasticsearch` counter set (submitted, fail.http,
+  fail.httprequests, fail.es, and the retry-focused `response.*` metrics when
+  `retryfailures="on"`).
+- Configure `errorfile="/path/to/errors.json"` while testing to capture raw
+  Elasticsearch responses for triage.
+- Watch for `writeoperation` validation failures; tests like
+  `es-writeoperation.sh` enforce accepted values.
+
+## Cross-component coordination
+- Template changes that alter JSON structure must be mirrored in
+  `doc/source/configuration/modules/omelasticsearch.rst` and in the
+  parameter reference snippets under `doc/source/reference/parameters/`.
+- Updates that touch the curl helper patterns should be reviewed alongside
+  other HTTP-based plugins (e.g., `contrib/omhttp`).
+
+## Metadata & housekeeping
+- Keep `plugins/omelasticsearch/MODULE_METADATA.yaml` current when ownership or
+  maturity changes.
+- Update `doc/ai/module_map.yaml` and relevant tests if new configuration
+  options or diagnostics are introduced.

--- a/plugins/omelasticsearch/MODULE_METADATA.yaml
+++ b/plugins/omelasticsearch/MODULE_METADATA.yaml
@@ -1,0 +1,17 @@
+support_status: core-supported
+maturity_level: fully-mature
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2024-06-22
+build_dependencies:
+  - libcurl development headers (`./devtools/codex-setup.sh`)
+runtime_dependencies:
+  - Elasticsearch 7.x or later reachable over HTTP(S)
+ci_targets:
+  - es-basic.sh
+  - es-bulk-errfile-popul.sh
+  - es-bulk-retry.sh
+documentation:
+  - doc/source/configuration/modules/omelasticsearch.rst
+notes:
+  - Tests require launching Elasticsearch; agents typically skip them and only build the module.
+  - Testbench downloads Elasticsearch via `tests/diag.sh`; set ES_DOWNLOAD to pin versions when maintaining the suite.

--- a/plugins/omkafka/AGENTS.md
+++ b/plugins/omkafka/AGENTS.md
@@ -1,0 +1,28 @@
+# AGENTS.md – omkafka output module
+
+## Module overview
+- Ships events to Apache Kafka topics via librdkafka.
+- User documentation: `doc/source/configuration/modules/omkafka.rst`.
+- Support status: contributor-supported. Maturity: mature.
+
+## Build & dependencies
+- Configure with `--enable-omkafka` (optionally pair with `--enable-imkafka` for end-to-end tests).
+- `./devtools/codex-setup.sh` installs librdkafka headers inside the sandbox when available.
+- Re-run `./configure` after toggling Kafka-related flags; rerun `./autogen.sh` if you touch `configure.ac`, any `Makefile.am`, or files under `m4/`.
+
+## Local testing
+- **Skip the Kafka integration tests for routine agent tasks.** They download and run Kafka plus ZooKeeper, which exceeds the sandbox resource budget.
+- Build validation is sufficient: run `./configure --enable-omkafka` (and `--enable-imkafka` if desired) followed by `make modules` to confirm the plugin links.
+- Maintainers who must exercise the suite can enable `--enable-kafka-tests` and run scripts such as `./tests/omkafka.sh`, but expect multi-minute startup time for the embedded Kafka cluster.
+
+## Diagnostics & troubleshooting
+- `impstats` exposes the `omkafka` counter set (submitted, failed, retry metrics); enable the module and inspect `impstats` output for delivery issues.
+- Kafka-side diagnostics live in the working directory under `.dep_wrk/`; the helper `./tests/diag.sh dump-kafka-topic <topic>` extracts queued messages for debugging.
+
+## Cross-component coordination
+- Changes to shared Kafka helpers in `runtime/` or `tests/diag.sh` must also be reviewed by `imkafka` maintainers.
+- Align parameter documentation with `doc/source/configuration/modules/omkafka.rst` and update examples when defaults change.
+
+## Metadata & housekeeping
+- Keep `plugins/omkafka/MODULE_METADATA.yaml` current (support status, maturity, contacts).
+- Update `doc/ai/module_map.yaml` if the concurrency model or locking guidance changes.

--- a/plugins/omkafka/MODULE_METADATA.yaml
+++ b/plugins/omkafka/MODULE_METADATA.yaml
@@ -1,0 +1,16 @@
+support_status: contributor-supported
+maturity_level: mature
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2025-09-26
+build_dependencies:
+  - librdkafka development headers (`./devtools/codex-setup.sh`)
+runtime_dependencies:
+  - Apache Kafka cluster reachable over TCP
+ci_targets:
+  - omkafka.sh
+  - omkafkadynakey.sh
+  - omkafka-headers.sh
+documentation:
+  - doc/source/configuration/modules/omkafka.rst
+notes:
+  - Integration tests start Kafka and ZooKeeper; agents typically skip them and perform build-only validation.

--- a/plugins/omruleset/AGENTS.md
+++ b/plugins/omruleset/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md – omruleset compatibility module
+
+## Module overview
+- Historical helper that forwards a message to another ruleset.
+- Replaced by the RainerScript `call` statement; retained only for backward compatibility.
+- User documentation: `doc/source/configuration/modules/omruleset.rst`.
+- Support status: core-supported. Maturity: deprecated.
+
+## Build & dependencies
+- Built automatically when plugins are enabled; no extra configure flags or external dependencies.
+- Follow the repository-wide autotools guidance (rerun `./autogen.sh` only when autotools inputs change).
+
+## Local testing
+- There is no standalone test suite for `omruleset`. Building rsyslog with `make` is sufficient validation.
+- When refactoring, rely on configuration-level tests that exercise ruleset chaining rather than new module-specific scripts.
+
+## Diagnostics & troubleshooting
+- Failures typically stem from queueing semantics or recursion in user configurations. Encourage migrating to the `call` statement where possible.
+- Review `doc/source/configuration/modules/omruleset.rst` for historical caveats around queue saturation and message loss.
+
+## Cross-component coordination
+- Document any behavior-affecting changes in `doc/source/configuration/modules/omruleset.rst` and update migration notes that point to the `call` statement.
+- Audit related examples in `doc/source/configuration/modules/omfile.rst` and `doc/source/rainerscript/` if you touch shared queue guidance.
+
+## Metadata & housekeeping
+- Keep `plugins/omruleset/MODULE_METADATA.yaml` marked as `deprecated` and refresh the review date when compatibility fixes land.
+- If the module is ever removed, update the documentation and release notes to highlight the required migration.

--- a/plugins/omruleset/MODULE_METADATA.yaml
+++ b/plugins/omruleset/MODULE_METADATA.yaml
@@ -1,0 +1,11 @@
+support_status: core-supported
+maturity_level: deprecated
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2025-09-26
+build_dependencies: []
+runtime_dependencies: []
+ci_targets: []
+documentation:
+  - doc/source/configuration/modules/omruleset.rst
+notes:
+  - Retained solely for backward compatibility; prefer the RainerScript `call` statement.

--- a/tools/AGENTS.md
+++ b/tools/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md – Built-in tool modules
+
+The `tools/` directory holds historic built-in modules that share code with the
+core but are compiled directly into the rsyslog binary:
+
+- `omfile.c`
+- `omusrmsg.c`
+- `omfwd.c`
+- `ompipe.c`
+- `omshell.c`
+- `omdiscard.c`
+
+## Build & testing expectations
+- These modules are always built as part of the default configuration; no
+  additional `./configure` flags are required.
+- Follow the top-level build workflow: run `./autogen.sh` only when autotools
+  inputs change, configure with the options your change requires, and rebuild via
+  `make`.
+- There are no standalone regression scripts for these built-in modules. When
+  modifying them, rely on targeted configuration tests under `tests/` (e.g.
+  `./tests/omfile-basic.sh`) or add new ones as needed.
+
+## Metadata
+- Shared metadata lives in `tools/MODULE_METADATA.json` so we do not duplicate
+  YAML files beside each source.
+- Keep the JSON array sorted by module name and update the `last_reviewed` field
+  whenever support status, maturity, or contacts change.
+- The default `primary_contact` points at the rsyslog GitHub Discussions and
+  Issues queue; replace it with a specific maintainer only when a new owner is
+  explicitly assigned.
+
+## Documentation touchpoints
+- Most of these modules have reference guides under
+  `doc/source/configuration/modules/`. Update the relevant `.rst` files when you
+  change defaults or add features.
+- Cross-reference changes in `doc/ai/module_map.yaml` if the concurrency or
+  locking guidance shifts.

--- a/tools/MODULE_METADATA.json
+++ b/tools/MODULE_METADATA.json
@@ -1,0 +1,76 @@
+[
+  {
+    "module": "omdiscard",
+    "support_status": "core-supported",
+    "maturity_level": "mature",
+    "primary_contact": "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>",
+    "last_reviewed": "2025-09-26",
+    "documentation": [],
+    "notes": [
+      "No standalone tests; verify behavior via configuration-based discard scenarios."
+    ]
+  },
+  {
+    "module": "omfile",
+    "support_status": "core-supported",
+    "maturity_level": "fully-mature",
+    "primary_contact": "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>",
+    "last_reviewed": "2025-09-26",
+    "documentation": [
+      "doc/source/configuration/modules/omfile.rst"
+    ],
+    "notes": [
+      "High-traffic path; update doc/ai/module_map.yaml when locking changes."
+    ]
+  },
+  {
+    "module": "omfwd",
+    "support_status": "core-supported",
+    "maturity_level": "fully-mature",
+    "primary_contact": "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>",
+    "last_reviewed": "2025-09-26",
+    "documentation": [
+      "doc/source/configuration/modules/omfwd.rst"
+    ],
+    "notes": [
+      "Shares code with network stack; coordinate with imtcp/omtcp owners when changing defaults."
+    ]
+  },
+  {
+    "module": "ompipe",
+    "support_status": "core-supported",
+    "maturity_level": "mature",
+    "primary_contact": "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>",
+    "last_reviewed": "2025-09-26",
+    "documentation": [
+      "doc/source/configuration/modules/ompipe.rst"
+    ],
+    "notes": [
+      "Ensure platform-specific pipe handling stays in sync with runtime/.*pipe helpers."
+    ]
+  },
+  {
+    "module": "omshell",
+    "support_status": "core-supported",
+    "maturity_level": "mature",
+    "primary_contact": "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>",
+    "last_reviewed": "2025-09-26",
+    "documentation": [],
+    "notes": [
+      "Primarily used for legacy shell pipelines; document security implications when changing behavior."
+    ]
+  },
+  {
+    "module": "omusrmsg",
+    "support_status": "core-supported",
+    "maturity_level": "mature",
+    "primary_contact": "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>",
+    "last_reviewed": "2025-09-26",
+    "documentation": [
+      "doc/source/configuration/modules/omusrmsg.rst"
+    ],
+    "notes": [
+      "Interacts with user accounting facilities; exercise sudo/write permissions when testing."
+    ]
+  }
+]


### PR DESCRIPTION
Improve AI-facing documentation to speed up contributor onboarding after the gpt5-codex agent update. The guides clarify bootstrap, testing, and where to find module ownership so agents can work predictably and avoid expensive CI-only paths.

Impact: documentation-only; no runtime changes. Clarifies when to use direct test scripts vs. the autotools harness.

This introduces repository-wide AGENTS guides (root, plugins/, contrib/, tools/, doc/) plus module-focused guides for omelasticsearch, imkafka, omkafka, and omruleset. It adds metadata templates for core and contrib modules, initial MODULE_METADATA.yaml files for the Kafka and ES modules, and a tools/MODULE_METADATA.json for built-ins. The top-level guide now includes quick links, “priming a fresh AI session,” and explicit autotools bootstrap instructions (run ./autogen.sh when autotools inputs change). Testing guidance asks agents to prefer invoking ./tests/*.sh directly, reserving `make check` for CI reproductions. The doc subtree gains its own AGENTS.md and an AI doc-builder base prompt to keep edits consistent. doc/ai/module_map.yaml was annotated to reference per-module metadata.

Before: scattered or missing agent guidance; unclear when to bootstrap autotools or run the full harness. After: structured, discoverable docs, templates, and metadata that align contributor workflow across modules.
