### PR TITLE
ci: add openEuler 24.03 LTS container and CI job

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1,4 +1,4 @@
-# Copyright 2024 Rainer Gerhards and Others
+# Copyright 2024-2025 Rainer Gerhards and Others
 #
 # https://github.com/rsyslog/rsyslog-pkg-ubuntu
 #
@@ -54,7 +54,7 @@ jobs:
                  fedora_41, fedora_42,
                  ubuntu_20, ubuntu_24,
                  ubuntu_22_san, ubuntu_24_tsan, ubuntu_22_distcheck,
-                 elasticsearch]
+                 openeuler, elasticsearch]
 
     steps:
       - name: git checkout project
@@ -112,6 +112,11 @@ jobs:
                      --disable-helgrind --disable-default-tests --disable-kafka-tests \
                      --disable-omkafka --disable-imkafka \
                      --enable-gnutls --enable-openssl --enable-gnutls-tests"
+              ;;
+          'openeuler')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_openeuler:24.03-lts'
+              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
+                     --disable-kafka-tests"
               ;;
           'fedora_41')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:41'

--- a/packaging/docker/dev_env/README.md
+++ b/packaging/docker/dev_env/README.md
@@ -2,5 +2,14 @@ These images are used for rsyslog CI and development testing. Each contains all
 build dependencies so that the full feature set can be exercised. They are
 intentionally large (1-3 GB) and do not attempt to optimize layers; easy
 addition of build components takes precedence over size. As such they are not
-intended for general production use. Developers working on rsyslog may use
-them to reproduce the CI environment.
+intended for general production use. Developers working on rsyslog may use them
+to reproduce the CI environment.
+
+## Directory layout
+
+- `ubuntu/`, `debian/`, `fedora/`, `centos/`, `suse/`, and `alpine/` mirror the
+  long-standing container definitions used in CI.
+- `openeuler/` contains development images based on the openEuler distribution.
+  The initial `base/24.03-lts` image installs the full set of dependencies
+  required to build rsyslog with the same feature coverage we exercise on other
+  RPM-based platforms.

--- a/packaging/docker/dev_env/openeuler/base/24.03-lts/Dockerfile
+++ b/packaging/docker/dev_env/openeuler/base/24.03-lts/Dockerfile
@@ -1,0 +1,182 @@
+# container for rsyslog development
+# creates the build environment for openEuler
+FROM    openeuler/openeuler:24.03-lts
+
+# czmq is not packaged on openEuler 24.03 LTS, so the related modules are
+# omitted from the build options below. The distro also ships rpm macros by
+# default, so there is no separate redhat-rpm-config package to install.
+
+RUN     dnf -y update && \
+        dnf -y install dnf-plugins-core && \
+        (dnf config-manager --set-enabled everything || true) && \
+        (dnf config-manager --set-enabled EPOL || true)
+
+RUN     dnf -y install \
+        apr-util-devel \
+        autoconf \
+        autoconf-archive \
+        automake \
+        bison \
+        ca-certificates \
+        clang \
+        cmake \
+        cyrus-sasl \
+        cyrus-sasl-devel \
+        diffutils \
+        flex \
+        gcc \
+        gcc-c++ \
+        gdb \
+        git \
+        gnutls-devel \
+        hiredis \
+        hiredis-devel \
+        iproute \
+        java-11-openjdk \
+        java-11-openjdk-devel \
+        krb5-devel \
+        libbson-devel \
+        libcap-ng-devel \
+        libcurl-devel \
+        libdbi-devel \
+        libestr-devel \
+        libfastjson-devel \
+        libgcrypt-devel \
+        lz4-devel \
+        libmaxminddb-devel \
+        mongo-c-driver-devel \
+        libnet \
+        libnet-devel \
+        liblognorm-devel \
+        libpcap-devel \
+        librabbitmq-devel \
+        librdkafka-devel \
+        libstdc++ \
+        libtool \
+        libuuid-devel \
+        libxml2-devel \
+        libzstd-devel \
+        logrotate \
+        lsof \
+        make \
+        mariadb-connector-c-devel \
+        mariadb-server \
+        net-snmp-devel \
+        net-tools \
+        openssl-devel \
+        patch \
+        pkgconf-pkg-config \
+        postgresql \
+        postgresql-devel \
+        python3 \
+        python3-devel \
+        python3-docutils \
+        python3-pip \
+        python3-setuptools \
+        python3-sphinx \
+        qpid-proton-c-devel \
+        sudo \
+        swig \
+        systemd-devel \
+        tcl-devel \
+        valgrind \
+        wget \
+        which \
+        zeromq-devel \
+        zlib-devel \
+        && dnf clean all
+
+RUN     set -euxo pipefail; \
+        # openEuler ships MariaDB client libraries that install mysql_config but
+        # only expose libmariadb.so. Ensure compatibility symlinks exist so the
+        # rsyslog configure checks that still look for libmysqlclient succeed.
+        libdir="$(pkg-config --variable=libdir libmariadb 2>/dev/null || echo /usr/lib64)"; \
+        if [ -d "$libdir" ]; then \
+            cd "$libdir"; \
+            if [ -e libmariadb.so.3 ] && [ ! -e libmariadb.so ]; then \
+                ln -s libmariadb.so.3 libmariadb.so; \
+            fi; \
+            if [ -e libmariadb.so ] && [ ! -e libmysqlclient.so ]; then \
+                ln -s libmariadb.so libmysqlclient.so; \
+            fi; \
+            if [ -e libmariadb.so.3 ] && [ ! -e libmysqlclient.so.21 ]; then \
+                ln -s libmariadb.so.3 libmysqlclient.so.21; \
+            fi; \
+        fi
+
+RUN     pip3 install --no-cache-dir pysnmp
+
+RUN     mkdir /local_dep_cache
+
+ENV     RSYSLOG_CONFIGURE_OPTIONS=" \
+        --enable-compile-warning=error \
+        --enable-elasticsearch \
+        --disable-elasticsearch-tests \
+        --disable-ffaup \
+        --enable-gnutls \
+        --enable-gssapi-krb5 \
+        --enable-imbatchreport \
+        --enable-imdiag \
+        --enable-imfile \
+        --disable-imhttp \
+        --enable-imjournal \
+        --enable-imkafka \
+        --enable-impstats \
+        --enable-impcap \
+        --enable-imptcp \
+        --enable-kafka-tests \
+        --enable-libdbi \
+        --enable-libgcrypt \
+        --enable-libzstd \
+        --enable-mmanon \
+        --enable-mmcount \
+        --enable-mmdblookup \
+        --enable-mmfields \
+        --enable-mmjsonparse \
+        --enable-mmkubernetes \
+        --enable-mmnormalize \
+        --enable-mmpstrucdata \
+        --enable-mmrm1stspace \
+        --enable-mmsequence \
+        --enable-mmsnmptrapd \
+        --enable-mmutf8fix \
+        --disable-mysql \
+        --enable-omamqp1 \
+        --enable-omhiredis \
+        --enable-omhttpfs \
+        --enable-omjournal \
+        --enable-omkafka \
+        --enable-ommongodb \
+        --enable-omprog \
+        --disable-omrabbitmq \
+        --enable-omrelp-default-port=13515 \
+        --enable-omruleset \
+        --enable-omstdout \
+        --disable-omtcl \
+        --enable-omudpspoof \
+        --enable-omuxsock \
+        --enable-openssl \
+        --enable-pgsql \
+        --enable-pmciscoios \
+        --enable-pmlastmsg \
+        --enable-pmnormalize \
+        --enable-pmnull \
+        --enable-pmsnare \
+        --disable-relp \
+        --enable-snmp \
+        --disable-snmp-tests \
+        --enable-usertools \
+        --disable-valgrind \
+	--without-valgrind-testbench \
+        --enable-testbench \
+        "
+
+RUN     groupadd -g 1000 rsyslog && \
+        useradd -u 1000 -g rsyslog -m -s /bin/bash rsyslog && \
+        echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+RUN     mkdir /rsyslog && \
+        chown rsyslog:rsyslog /rsyslog
+
+WORKDIR /rsyslog
+USER    rsyslog

--- a/packaging/docker/dev_env/openeuler/base/24.03-lts/build.sh
+++ b/packaging/docker/dev_env/openeuler/base/24.03-lts/build.sh
@@ -1,0 +1,17 @@
+OPEN_EULER_VERSION=24.03-lts
+set -e
+docker build $1 -t rsyslog/rsyslog_dev_base_openeuler:$OPEN_EULER_VERSION . --progress=plain
+printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"
+docker run -ti -u $(id -u):$(id -g) rsyslog/rsyslog_dev_base_openeuler:$OPEN_EULER_VERSION bash -c  "
+set -e && \
+git clone https://github.com/rsyslog/rsyslog.git && \
+cd rsyslog && \
+autoreconf -fi && \
+./configure \$RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
+make -j4
+"
+if [ $? -eq 0 ]; then
+        printf "\nREADY TO PUSH!\n"
+        printf "\ndocker push rsyslog/rsyslog_dev_base_openeuler:$OPEN_EULER_VERSION\n"
+fi
+rm -rf ./rsyslog

--- a/packaging/docker/dev_env/openeuler/base/24.03-lts/tag-previous.sh
+++ b/packaging/docker/dev_env/openeuler/base/24.03-lts/tag-previous.sh
@@ -1,0 +1,2 @@
+docker tag rsyslog/rsyslog_dev_base_openeuler:24.03-lts rsyslog/rsyslog_dev_base_openeuler:24.03-lts_previous
+docker push rsyslog/rsyslog_dev_base_openeuler:24.03-lts_previous


### PR DESCRIPTION
Add an openEuler 24.03 LTS development container and wire it into CI to validate builds on that platform.

Why: expand RPM-based coverage and catch distro-specific build issues early.

Impact: CI-only. No runtime or API changes.

Before: no openEuler container or CI job; build breakage went unnoticed. After: dedicated container and matrix entry compile and run unit tests on openEuler.

Notes: module and test coverage may differ on openEuler; track gaps in follow-up issues.
