### PR TITLE
imdiag/tests/docs: use RFC5737 test IP in samples

### DIFF
--- a/doc/source/reference/templates/templates-examples.rst
+++ b/doc/source/reference/templates/templates-examples.rst
@@ -111,7 +111,7 @@ Produces output similar to:
 
 .. code-block:: none
 
-    {"@timestamp":"2018-03-01T01:00:00+00:00", "host":"172.20.245.8", "severity":7, "facility":20, "syslog-tag":"tag", "source":"tag", "message":" msgnum:00000000:"}
+    {"@timestamp":"2018-03-01T01:00:00+00:00", "host":"192.0.2.8", "severity":7, "facility":20, "syslog-tag":"tag", "source":"tag", "message":" msgnum:00000000:"}
 
 Pretty-printed:
 
@@ -119,7 +119,7 @@ Pretty-printed:
 
     {
       "@timestamp": "2018-03-01T01:00:00+00:00",
-      "host": "172.20.245.8",
+      "host": "192.0.2.8",
       "severity": 7,
       "facility": 20,
       "syslog-tag": "tag",
@@ -131,7 +131,7 @@ If ``onEmpty="null"`` is used and ``source`` is empty:
 
 .. code-block:: none
 
-    {"@timestamp":"2018-03-01T01:00:00+00:00", "host":"172.20.245.8", "severity":7, "facility":20, "syslog-tag":"tag", "source":null, "message":" msgnum:00000000:"}
+    {"@timestamp":"2018-03-01T01:00:00+00:00", "host":"192.0.2.8", "severity":7, "facility":20, "syslog-tag":"tag", "source":null, "message":" msgnum:00000000:"}
 
 .. note:: The output is not pretty-printed in actual use to avoid waste of resources.
 

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -227,10 +227,17 @@ finalize_it:
 
 /* submit a generated numeric-suffix message to the rsyslog core
  */
+/** The hostname inserted into generated diagnostic messages.
+ * 192.0.2.0/24 (TEST-NET-1) is reserved for documentation and examples per
+ * RFC 5737, so using 192.0.2.8 avoids collisions with real-world systems.
+ */
+static const char diagDefaultHostname[] = "192.0.2.8";
+
 static rsRetVal doInjectNumericSuffixMsg(int iNum, ratelimit_t *ratelimiter) {
     uchar szMsg[1024];
     DEFiRet;
-    snprintf((char *)szMsg, sizeof(szMsg) / sizeof(uchar), "<167>Mar  1 01:00:00 172.20.245.8 tag msgnum:%8.8d:", iNum);
+    snprintf((char *)szMsg, sizeof(szMsg) / sizeof(uchar),
+             "<167>Mar  1 01:00:00 %s tag msgnum:%8.8d:", diagDefaultHostname, iNum);
     iRet = doInjectMsg(szMsg, ratelimiter);
     RETiRet;
 }

--- a/tests/clickhouse-dflt-tpl.sh
+++ b/tests/clickhouse-dflt-tpl.sh
@@ -19,6 +19,6 @@ wait_shutdown
 clickhouse-client --query="SELECT * FROM rsyslog.SystemEvents FORMAT CSV" > $RSYSLOG_OUT_LOG
 
 clickhouse-client --query="DROP TABLE rsyslog.SystemEvents"
-content_check --regex '7,20,"20..-03-01 01:00:00","172.20.245.8","tag"," msgnum:00000000:"'
+content_check --regex '7,20,"20..-03-01 01:00:00","192.0.2.8","tag"," msgnum:00000000:"'
 
 exit_test

--- a/tests/mmexternal-SegFault-empty-jroot-vg.sh
+++ b/tests/mmexternal-SegFault-empty-jroot-vg.sh
@@ -14,7 +14,7 @@ if $msg contains "msgnum:" then {
 }
 '
 startup_vg
-injectmsg literal "<129>Mar 10 01:00:00 172.20.245.8 tag:msgnum:1"
+injectmsg literal "<129>Mar 10 01:00:00 192.0.2.8 tag:msgnum:1"
 shutdown_when_empty
 wait_shutdown_vg
 check_exit_vg

--- a/tests/mmexternal-SegFault.sh
+++ b/tests/mmexternal-SegFault.sh
@@ -16,7 +16,7 @@ if $msg contains "msgnum:" then {
 }
 '
 startup
-injectmsg literal "<129>Mar 10 01:00:00 172.20.245.8 tag:msgnum:1"
+injectmsg literal "<129>Mar 10 01:00:00 192.0.2.8 tag:msgnum:1"
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/omrabbitmq_data_1server.sh
+++ b/tests/omrabbitmq_data_1server.sh
@@ -30,10 +30,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 server tag - - -  msgrmq')
+export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 server tag - - -  msgrmq')
 echo $EXPECTED | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_data_2servers.sh
+++ b/tests/omrabbitmq_data_2servers.sh
@@ -32,10 +32,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 172.20.245.8 tag - - -  msgrmq')
+export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 192.0.2.8 tag - - -  msgrmq')
 echo $EXPECTED | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_error_server0.sh
+++ b/tests/omrabbitmq_error_server0.sh
@@ -33,10 +33,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq'
 cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "exchange declare failed PRECONDITION_FAILED"
 exit_test

--- a/tests/omrabbitmq_error_server1.sh
+++ b/tests/omrabbitmq_error_server1.sh
@@ -33,10 +33,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq'
 cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "disconnected while exchange declare"
 exit_test

--- a/tests/omrabbitmq_error_server2.sh
+++ b/tests/omrabbitmq_error_server2.sh
@@ -33,10 +33,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq'
 cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "Connection closed : reconnect"
 exit_test

--- a/tests/omrabbitmq_error_server3.sh
+++ b/tests/omrabbitmq_error_server3.sh
@@ -32,10 +32,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq'
 cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "Connection closed : reconnect"
 exit_test

--- a/tests/omrabbitmq_json.sh
+++ b/tests/omrabbitmq_json.sh
@@ -27,10 +27,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-expected=$(printf 'Exchange:in, routing-key:myrouting, content-type:application/json, delivery-mode:transient, expiration:5000, msg:{\"message\":\" msgrmq\",\"fromhost\":\"172.20.245.8\",\"facility\":\"local4\",\"priority\":\"debug\",\"timereported\":.*}')
+expected=$(printf 'Exchange:in, routing-key:myrouting, content-type:application/json, delivery-mode:transient, expiration:5000, msg:{\"message\":\" msgrmq\",\"fromhost\":\"192.0.2.8\",\"facility\":\"local4\",\"priority\":\"debug\",\"timereported\":.*}')
 grep -E "${expected}" $RSYSLOG_DYNNAME.amqp.log > /dev/null 2>&1
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_raw.sh
+++ b/tests/omrabbitmq_raw.sh
@@ -31,10 +31,10 @@ if $msg contains "msgrmq" then {
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
-injectmsg literal "<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq"
+injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:172.20.245.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 172.20.245.8 tag msgrmq'
+export EXPECTED='Exchange:in, routing-key:tag.local4.debug, content-type:plain/text, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq'
 cmp_exact $RSYSLOG_DYNNAME.amqp.log
 content_check "server localhost port"
 exit_test

--- a/tests/omtcl.sh
+++ b/tests/omtcl.sh
@@ -8,7 +8,7 @@ $template tcldict, "message \"%msg:::json%\" fromhost \"%HOSTNAME:::json%\" faci
 add_conf "*.* :omtcl:$srcdir/omtcl.tcl,doAction;tcldict
 "
 startup
-echo 'injectmsg literal <167>Mar  1 01:00:00 172.20.245.8 tag hello world' | \
+echo 'injectmsg literal <167>Mar  1 01:00:00 192.0.2.8 tag hello world' | \
 	./diagtalker -p$IMDIAG_PORT || error_exit $?
 echo doing shutdown
 shutdown_when_empty

--- a/tests/perctile-simple.sh
+++ b/tests/perctile-simple.sh
@@ -32,11 +32,11 @@ if $msg startswith " msgnum:" then {
 startup
 wait_for_stats_flush ${RSYSLOG_DYNNAME}.out.stats.log
 . $srcdir/diag.sh block-stats-flush
-shuf -i 1-1000 | sed -e 's/^/injectmsg literal <167>Mar  1 01:00:00 172.20.245.8 tag msgnum:/g' | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
+shuf -i 1-1000 | sed -e 's/^/injectmsg literal <167>Mar  1 01:00:00 192.0.2.8 tag msgnum:/g' | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
 wait_queueempty
 . $srcdir/diag.sh allow-single-stats-flush-after-block-and-wait-for-it
 
-shuf -i 1001-2000 | sed -e 's/^/injectmsg literal <167>Mar  1 01:00:00 172.20.245.8 tag msgnum:/g' | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
+shuf -i 1001-2000 | sed -e 's/^/injectmsg literal <167>Mar  1 01:00:00 192.0.2.8 tag msgnum:/g' | $TESTTOOL_DIR/diagtalker -p$IMDIAG_PORT || error_exit  $?
 . $srcdir/diag.sh await-stats-flush-after-block
 wait_queueempty
 wait_for_stats_flush ${RSYSLOG_DYNNAME}.out.stats.log

--- a/tests/smtradfile.sh
+++ b/tests/smtradfile.sh
@@ -10,5 +10,5 @@ startup
 injectmsg 0 1
 shutdown_when_empty
 wait_shutdown
-content_check "Mar  1 01:00:00 172.20.245.8 tag msgnum:00000000:"
+content_check "Mar  1 01:00:00 192.0.2.8 tag msgnum:00000000:"
 exit_test


### PR DESCRIPTION
Use a documentation-only IP to avoid confusion and follow best practice. This prevents irritation when users or scanners see a private address in samples and wonder if rsyslog is trying to contact it.

Impact: Visible change in sample payloads, tests, and docs (host field).

Technical: Replace the hardcoded "172.20.245.8" in imdiag's generated messages with a constant default hostname "192.0.2.8" from RFC 5737 (TEST-NET-1). Update tests (e.g., omrabbitmq, perctile, mmexternal, clickhouse) and template examples to match. No API/ABI change; no effect on action queues, OMODTX, retry/duplicate semantics, or HUP behavior. This is purely about sample message contents emitted by the diag tool.

Before/After: samples used 172.20.245.8 -> now 192.0.2.8.

See also: https://gitee.com/src-openeuler/rsyslog/issues/I7V4I8

Fixes: https://github.com/rsyslog/rsyslog/issues/6190
