### PR TITLE
mmexternal: add missing scoped usage anchors

### DIFF
--- a/doc/source/reference/parameters/mmexternal-binary.rst
+++ b/doc/source/reference/parameters/mmexternal-binary.rst
@@ -32,6 +32,7 @@ included in the string.
 
 Input usage
 -----------
+.. _param-mmexternal-input-binary:
 .. _mmexternal.parameter.input.binary-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/mmexternal-forcesingleinstance.rst
+++ b/doc/source/reference/parameters/mmexternal-forcesingleinstance.rst
@@ -44,6 +44,7 @@ This parameter is equivalent to the
 
 Input usage
 -----------
+.. _param-mmexternal-input-forcesingleinstance:
 .. _mmexternal.parameter.input.forcesingleinstance-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/mmexternal-interface-input.rst
+++ b/doc/source/reference/parameters/mmexternal-interface-input.rst
@@ -46,6 +46,7 @@ external plugin documentation for what needs to be used.
 
 Input usage
 -----------
+.. _param-mmexternal-input-interface-input:
 .. _mmexternal.parameter.input.interface-input-usage:
 
 .. code-block:: rsyslog

--- a/doc/source/reference/parameters/mmexternal-output.rst
+++ b/doc/source/reference/parameters/mmexternal-output.rst
@@ -41,6 +41,7 @@ processing that happens between plugin and rsyslog core.
 
 Input usage
 -----------
+.. _param-mmexternal-input-output:
 .. _mmexternal.parameter.input.output-usage:
 
 .. code-block:: rsyslog


### PR DESCRIPTION
- Add param-mmexternal-input anchors beside each usage block to meet reference conventions
- Preserve existing summaries, descriptions, and usage examples

AI-Agent: ChatGPT

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

