### PR TITLE
AI: align AGENTS.md and README; expand harness tips

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -34,7 +34,7 @@ agents.
 
 ## Running tests locally
 - Build rsyslog first (`./autogen.sh`, `./configure --enable-testbench`,
-  `make -j$(nproc)`") so the testbench can load freshly built binaries and
+  `make -j$(nproc)`) so the testbench can load freshly built binaries and
   modules. The same bootstrap commands are called out in `tests/README` under
   “Quickstart”.
 - Execute individual scenarios directly for quick feedback

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,7 +1,10 @@
 # AGENTS.md – Testbench subtree
 
 This guide covers everything under `tests/`, including shell test cases,
-helpers, suppressions, and supporting binaries.
+helpers, suppressions, and supporting binaries. Pair it with
+[`tests/README`](./README) for human- and CI-facing run instructions; this
+document focuses on authoring guidance and the knobs that matter most to AI
+agents.
 
 ## Purpose & scope
 - The directory implements the Automake testbench that exercises rsyslog.
@@ -13,19 +16,27 @@ helpers, suppressions, and supporting binaries.
 ## Writing & updating tests
 - Base new shell tests on existing ones; include `. $srcdir/diag.sh` to gain the
   helper functions (timeouts, Valgrind integration, rsyslogd launch helpers).
+- Prefer harness helpers such as `cmp_exact`, `command_deny`, and
+  `require_plugin` over ad-hoc shell to keep diagnostics uniform.
 - Name Valgrind-enabled wrappers with the `-vg.sh` suffix and toggle Valgrind by
-  exporting `USE_VALGRIND` before sourcing the non-`vg` script.
+  exporting `USE_VALGRIND` before sourcing the non-`vg` script. Use
+  `tests/timereported-utc-vg.sh` as the reference layout: it sources the base
+  scenario instead of copying it and demonstrates paring back emitted messages
+  when the underlying test is slow—especially important under Valgrind. Older
+  wrappers still duplicate logic; prefer the modern pattern when touching them.
 - Put auxiliary binaries next to their scripts (e.g. `*.c` programs compiled via
   the Automake harness) and list them in `tests/Makefile.am`.
 - Keep long-lived configuration snippets in `tests/testsuites/` and reuse them
   instead of copying large config blocks into multiple scripts.
 - Document new environment flags or helper functions inside `diag.sh` so other
-  tests can discover them.
+  tests can discover them. Mention the addition in `tests/README` if operators
+  should know about the new knob.
 
 ## Running tests locally
 - Build rsyslog first (`./autogen.sh`, `./configure --enable-testbench`,
-  `make -j$(nproc)`) so the testbench can load freshly built binaries and
-  modules.
+  `make -j$(nproc)`") so the testbench can load freshly built binaries and
+  modules. The same bootstrap commands are called out in `tests/README` under
+  “Quickstart”.
 - Execute individual scenarios directly for quick feedback
   (`./tests/imfile-basic.sh`).
 - Use `make check TESTS='script.sh'` when you need Automake logging,
@@ -38,7 +49,8 @@ helpers, suppressions, and supporting binaries.
 ## Debugging & environment control
 - `tests/diag.sh` documents environment variables such as `SUDO`,
   `USE_VALGRIND`, `RSYSLOG_DEBUG`, and timeout overrides; prefer these knobs over
-  ad-hoc `sleep` loops.
+  ad-hoc `sleep` loops. `tests/README` mirrors the operator-facing knobs so
+  tooling and human docs stay aligned.
 - Use `USE_GDB=1 make <test>.log` to pause execution and attach a debugger as
   described in `tests/README`.
 - Keep suppression files (e.g. `*.supp`) current when adding new Valgrind noise;

--- a/tests/README
+++ b/tests/README
@@ -1,102 +1,105 @@
-This directory contains the rsyslog testbench. It is slowly
-evolving. New tests are always welcome. So far, most tests check
-out the functionality of a single module. More complex tests are
-welcome.
+# rsyslog testbench quick reference
 
-For a simple sample, see rtinit.c, which does a simple
-init/deinit check of the runtime system.
+This directory houses the rsyslog Automake test suite. The
+[`tests/AGENTS.md`](./AGENTS.md) file gives AI agents authoring guidance and
+conventions; this README focuses on operators and contributors who need to run
+the suite.
 
-Test Naming
-===========
+Most scripts validate a single module, but complex end-to-end scenarios are
+welcome. For a minimal example, examine `rtinit.c`, which performs a simple
+runtime init/deinit cycle.
 
-Test that use valgrind shall end in "-vg.sh".
-Test that use valgrind's helgrind thread debugger shall end in "-vgthread.sh".
+## Quickstart
 
-Setting up Test Environments
-============================
+Bootstrap the build tree before attempting to run tests:
 
-Setting up MariaDB/MySQL
-------------------------
-to create the necessary user:
+```sh
+./autogen.sh
+./configure --enable-testbench
+make -j$(nproc)
+make check
+```
 
+`make check` compiles the helper binaries, prepares fixtures, and then executes
+the entire suite. Use <kbd>Ctrl</kbd>+<kbd>C</kbd> to stop an ongoing run.
+
+## Running individual scenarios
+
+```
+make <test-name>.log
+```
+
+For example, `make imfile-basic.log` produces `imfile-basic.log` and
+`imfile-basic.trs`. Remove those files before re-running to clear cached
+results. When you need Automake’s logging but do not want to type the `.log`
+suffix, use:
+
+```
+make check TESTS='imfile-basic.sh'
+```
+
+You can also execute scripts directly (`./tests/imfile-basic.sh`) for quicker
+iteration, though Automake will not capture transcripts.
+
+## Harness conventions
+
+- Source `diag.sh` at the top of every shell test: `. "$srcdir/diag.sh"`.
+- Prefer helpers such as `cmp_exact` and `require_plugin` over ad-hoc shell so
+  diagnostics stay consistent. See `tests/AGENTS.md` for a longer checklist.
+- Name Valgrind-enabled wrappers with the `-vg.sh` suffix and Helgrind-enabled
+  scripts with `-vgthread.sh`. `tests/timereported-utc-vg.sh` illustrates how to
+  source the base scenario rather than duplicating it and how to trim emitted
+  messages when a slow test would otherwise become prohibitively long under
+  Valgrind. Some legacy wrappers predate this pattern; follow the newer style
+  when adding or refactoring coverage.
+
+## Environment setup snippets
+
+### MariaDB/MySQL
+
+```
 echo "create user 'rsyslog'@'localhost' identified by 'testbench';" | mysql -u root
 mysql -u root < ../plugins/ommysql/createDB.sql
 echo "grant all on Syslog.* to 'rsyslog'@'localhost';" | mysql -u root
+```
 
-openSUSE
---------
-To configure system properties like hostname and firewall, use the
-graphical "yast2" administration tool. Note the ssh-access by default
-is disable in the firewall!
+### openSUSE tips
 
-Before running tests
-====================
-make check - this will compile all of the C code used in the tests, as well as
-do any other preparations, and will start running all of the tests.  Ctrl-C to
-stop running all of the tests.
+Use the graphical `yast2` tool to adjust hostname and firewall rules. SSH
+access is disabled in the firewall by default.
 
-Running all tests
-=================
-make check
+## Debugging aids
 
-Running named tests
-===================
-make testname.log
+To pause a test and attach a debugger, add the following guard:
 
-For example, to run the imfile-basic.sh test, use
+```sh
+. "$srcdir/diag.sh" startup
+if [ -n "${USE_GDB:-}" ]; then
+    echo "attach gdb here"
+    sleep 54321 || :
+fi
+```
 
-    make imfile-basic.log
+Run the scenario in the background, wait for the prompt, and attach GDB:
 
-Test output is in imfile-basic.log
+```
+USE_GDB=1 make mytest.sh.log &
+tail -f mytest.sh.log  # wait for "attach gdb here"
+gdb ../tools/rsyslogd <rsyslogd-pid>
+```
 
-To re-run the test, first remove imfile-basic.log then make again
+After continuing in GDB, terminate the `sleep` with `pkill -f 54321` (or locate
+the PID via `ps -ef | grep 54321`).
 
-Or an alternative option is to run
+## Core dump analysis
 
-    make check TESTS='imfile-basic.sh'
+The harness can inspect core dumps automatically. Ensure the operating system
+allows them to be written:
 
-* Using gdb to debug rsyslog during a test run
+1. Set `ulimit -c unlimited` (you might need to adjust `/etc/security/limits.conf`
+   to raise `soft core unlimited`).
+2. Confirm `/proc/sys/kernel/core_pattern` is set to `core`. Systemd-based
+   distributions often redirect cores elsewhere; revert to the classic format
+   with `sudo bash -c 'echo core > /proc/sys/kernel/core_pattern'`.
 
-Edit your test like this:
-
-    . $srcdir/diag.sh startup
-    if [ -n "${USE_GDB:-}" ] ; then
-        echo attach gdb here
-        sleep 54321 || :
-    fi
-
-Run your test in the background:
-
-    USE_GDB=1 make mytest.sh.log &
-
-Tail mytest.sh.log until you see 'attach gdb here'.  The log should also
-tell you what is the rsyslogd pid.
-
-   gdb ../tools/rsyslogd $rsyslogd_pid
-
-Set breakpoints, whatever, then 'continue'
-
-In another window, do ps -ef|grep 54321, then kill that pid
-
-Core Dump Analysis
-==================
-The testbench contains some limited (yet useful) support for automatically
-analyzing core dumps. In order for this to work, obviously core files need
-to be generated. This often doesn't work as intended. If you hit this problem,
-check
-
-1. ulimit -c unlimited (or a reasonable limit)
-   Note that root may need to increase a system-wide limit, which is
-   usually recorded in /etc/security/limits.conf
-   You need:
-   *     soft    core      unlimited
-
-2. cat  /proc/sys/kernel/core_pattern"
-   On systemd systems (and some others), the pattern is changed to save
-   core files so that systemd can import them -- with the result that the
-   testbench doesn't see them any longer. We require classic format, which
-   can be set via
-   $ sudo bash -c "echo \"core\" > /proc/sys/kernel/core_pattern"
-
-Note that you probably want to do neither of these changes to a production
-system.
+Avoid applying these tweaks on production hosts.


### PR DESCRIPTION
This refines testbench docs for both AI agents and human operators. Goal: clearer authoring guidance and a smoother quickstart so agents produce higher-quality tests and contributors run them reliably.

Before/After: scattered guidance across files -> cross-linked docs with explicit helper usage, Valgrind wrapper patterns, and quickstart.

Non-technical rationale:
This improves maintainability and AI readiness by giving agents concrete patterns and reducing duplicate boilerplate. It also aligns operator docs with the harness so CI and local runs behave consistently.
