### PR TITLE
Fix: Subtree Templates Generate Empty Output

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -214,6 +214,7 @@ TESTS +=  \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omfwd-subtree-tpl.sh \
+	omfile-subtree-jsonf.sh \
 	omusrmsg-errmsg-no-params.sh \
 	omusrmsg-noabort.sh \
 	omfile-module-params.sh \
@@ -2269,6 +2270,7 @@ EXTRA_DIST= \
         omfwd-tls-invalid-permitExpiredCerts.sh \
         omfwd-keepalive.sh \
         omfwd-subtree-tpl.sh \
+		omfile-subtree-jsonf.sh \ 
         omfwd_fast_imuxsock.sh \
         omfile_hup-vg.sh \
 	omrelp-keepalive.sh \

--- a/tests/omfile-subtree-jsonf.sh
+++ b/tests/omfile-subtree-jsonf.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# Validate that subtree templates provide data to jsonf list templates
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+$MainMsgQueueTimeoutShutdown 10000
+
+template(name="eventSubtree" type="subtree" subtree="$!event")
+template(name="jsonfList" type="list" option.jsonf="on") {
+        property(outname="message" name="$.payload" format="jsonf")
+}
+
+if $msg contains "msgnum:" then {
+        set $!event!level = "error";
+        set $!event!code = 500;
+        set $.payload = exec_template("eventSubtree");
+        action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="jsonfList")
+}
+'
+
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+python3 - "$RSYSLOG_OUT_LOG" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], 'r', encoding='utf-8') as fh:
+    payload = json.load(fh)
+
+expected_message = '{ "level": "error", "code": 500 }'
+if payload.get("message") != expected_message:
+    print('invalid JSON generated')
+    print('################# actual JSON is:')
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    print('################# expected JSON was:')
+    print(json.dumps({"message": expected_message}, indent=2, sort_keys=True))
+    sys.exit(1)
+PY
+
+exit_test
+


### PR DESCRIPTION
### Summary

This PR fixes a bug where `type="subtree"` templates produce empty output when used with modules like `omfwd` that rely on the `lenStr` field to determine message length.

### Problem Description

The `tplToString()` function in `template.c` correctly extracts and copies JSON subtree data into the output buffer, but fails to set `iparam->lenStr` to record the actual data length. This causes downstream modules to believe the buffer is empty (lenStr=0), resulting in empty frames being sent over the network or written to files.

### Impact

**Before this fix:**
- Configurations using `type="subtree"` templates with `omfwd` send **empty TCP/UDP frames**
- Data is correctly extracted but silently dropped due to lenStr=0
- Affects any module that checks lenStr before processing (omfwd, potentially others)
- No error messages are generated, making this a silent data loss bug

**After this fix:**
- Subtree templates work correctly with all output modules
- lenStr is properly set to match the actual JSON data length
- Network forwarding delivers complete JSON content as expected

### Example Scenario

**Configuration:**
```conf
template(name="eventSubtree" type="subtree" subtree="$!event")

if $msg contains "error" then {
    set $!event!level = "error";
    set $!event!code = 500;
    action(type="omfwd" template="eventSubtree" 
           target="192.168.1.100" port="10514" protocol="tcp")
}
```

**Before:** Receiver gets empty frame (lenStr=0)  
**After:** Receiver gets `{"level":"error","code":500}`

### Technical Details

**File:** `template.c`  
**Function:** `tplToString()`  
**Change:** Added `iparam->lenStr = iLenVal;` after the subtree memcpy() operation

The fix is a single line that ensures the length metadata matches the copied data. Other template code paths (regular templates, jsonftree, string generators) already set lenStr correctly; the subtree branch was simply overlooked.