### PR TITLE
tests: stabilize omfwd-lb-1target-retry-1_byte_buf-TargetFail by raising loss tolerance

### DIFF
--- a/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
+++ b/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
@@ -40,6 +40,6 @@ wait_shutdown
 # note: minitcpsrv shuts down automatically if the connection is closed!
 
 export SEQ_CHECK_OPTIONS=-d
-#permit 100 messages to be lost in this extreme test (-m 100)
-seq_check 0 $((NUMMESSAGES-1)) -m100
+#permit 250 messages to be lost in this extreme test (-m 250)
+seq_check 0 $((NUMMESSAGES-1)) -m250
 exit_test


### PR DESCRIPTION
Summary:
- Intermittent failures caused by two intentional TCP drops (-B2 -D900 -a -S5) leading to >100 lost messages due to byte-based drop timing and kernel buffering.
- Increase allowed loss to keep stress characteristics while avoiding flakiness.

What changed:
- tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
  - seq_check 0 $((NUMMESSAGES-1)) -m100 -> seq_check 0 $((NUMMESSAGES-1)) -m250

Rationale:
- minitcpsrvr drops on bytes-read thresholds and reopens after a 5s outage; actual loss varies. Two drops can exceed 100 lines. 250 provides sufficient headroom without masking ordering validation.

Raise the allowed loss from -m100 to -m250 in tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh to stabilize the test while still verifying ordering.
