### PR TITLE
tests: raise startup timeout for manytcp-too-few-tls-vg

### DIFF
--- a/tests/manytcp-too-few-tls-vg.sh
+++ b/tests/manytcp-too-few-tls-vg.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # test many concurrent tcp connections
 # released under ASL 2.0
+export USE_VALGRIND="YES"
 . ${srcdir:=.}/diag.sh init
 skip_platform "FreeBSD"  "This test does not work on FreeBSD"
 export NUMMESSAGES=40000 # we unfortunately need many messages as we have many connections


### PR DESCRIPTION
## Summary
- Export USE_VALGRIND before sourcing diag.sh in
  tests/manytcp-too-few-tls-vg.sh so the harness applies the 240s startup
  timeout under valgrind.
- Addresses intermittent 60s startup timeouts on slower CentOS 8 runners.
- Test-only change; no impact on rsyslog functionality.

## Rationale
The harness sets TB_STARTUP_MAX_RUNTIME to 240s when USE_VALGRIND=YES. This
test sourced diag.sh before setting the variable, leaving the default 60s
timeout and causing rare startup aborts under valgrind on CentOS 8.