### PR TITLE
mmjsonparse: add find-json mode to parse embedded JSON

### DIFF
--- a/doc/source/configuration/modules/mmjsonparse.rst
+++ b/doc/source/configuration/modules/mmjsonparse.rst
@@ -15,17 +15,25 @@ Purpose
 =======
 
 This module provides support for parsing structured log messages that
-follow the CEE/lumberjack spec. The so-called "CEE cookie" is checked
-and, if present, the JSON-encoded structured message content is parsed.
+follow the CEE/lumberjack spec or contain embedded JSON content.
+
+In the legacy **cookie mode** (default), the module checks for the CEE cookie
+and, if present, parses the JSON-encoded structured message content.
 The properties are then available as original message properties.
 
+In the **find-json mode**, the module scans the message content to locate
+the first valid top-level JSON object "{...}" and parses it, regardless
+of its position in the message. This mode is useful for processing logs
+that contain JSON embedded within other text, such as application logs
+with prefixes.
+
 As a convenience, mmjsonparse will produce a valid CEE/lumberjack log
-message if passed a message without the CEE cookie.  A JSON structure
+message if passed a message without the CEE cookie or valid JSON.  A JSON structure
 will be created and the "msg" field will be the only field and it will
 contain the message. Note that in this case, mmjsonparse will
 nonetheless return that the JSON parsing has failed.
 
-The "CEE cookie" is the character sequence "@cee:" which must prepend the
+In **cookie mode**, the "CEE cookie" is the character sequence "@cee:" which must prepend the
 actual JSON. Note that the JSON must be valid and MUST NOT be followed
 by any non-JSON message. If either of these conditions is not true,
 mmjsonparse will **not** parse the associated JSON. This is based on the
@@ -33,10 +41,9 @@ cookie definition used in CEE/project lumberjack and is meant to aid
 against an erroneous detection of a message as being CEE where it is
 not.
 
-This also means that mmjsonparse currently is NOT a generic JSON parser
-that picks up JSON from wherever it may occur in the message. This is
-intentional, but future versions may support config parameters to relax
-the format requirements.
+**Note:** Cookie mode is NOT a generic JSON parser that picks up JSON from
+wherever it may occur in the message. This is intentional, but the new
+find-json mode provides this capability.
 
 
 Notable Features
@@ -63,8 +70,20 @@ Action Parameters
 
    * - Parameter
      - Summary
+   * - :ref:`param-mmjsonparse-mode`
+     - .. include:: ../../reference/parameters/mmjsonparse-mode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-mmjsonparse-cookie`
      - .. include:: ../../reference/parameters/mmjsonparse-cookie.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmjsonparse-max_scan_bytes`
+     - .. include:: ../../reference/parameters/mmjsonparse-max_scan_bytes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmjsonparse-allow_trailing`
+     - .. include:: ../../reference/parameters/mmjsonparse-allow_trailing.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-mmjsonparse-userawmsg`
@@ -96,18 +115,97 @@ message by reading the $parsesuccess variable :
    }
 
 
-Examples
-========
+Statistics Counters
+===================
 
-Apply default normalization
----------------------------
+When using find-json mode, mmjsonparse provides detailed statistics about JSON scanning performance and results. These counters are available through rsyslog's statistics interface and can be viewed using ``rsyslogctl stats`` or through the impstats module.
 
-This activates the module and applies normalization to all messages.
+Available Counters
+------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 75
+
+   * - Counter Name
+     - Description
+   * - ``scan.attempted``
+     - Total number of messages processed in find-json mode. Incremented for every message that enters find-json scanning, regardless of whether JSON is found.
+   * - ``scan.found``
+     - Number of messages where valid JSON objects were successfully located during scanning. This includes cases where JSON was found but later rejected due to trailing data restrictions.
+   * - ``scan.failed``
+     - Number of messages where JSON objects were found during scanning but failed to parse properly. This indicates malformed JSON content.
+   * - ``scan.truncated``
+     - Number of messages where the JSON scan was terminated due to reaching the ``max_scan_bytes`` limit before finding a complete JSON object.
+
+Counter Usage Examples
+----------------------
+
+View current statistics:
+
+.. code-block:: bash
+
+   # View all rsyslog statistics including mmjsonparse
+   rsyslogctl stats
+
+   # Example output:
+   {
+     "name": "mmjsonparse",
+     "origin": "mmjsonparse",
+     "scan.attempted": 1523,
+     "scan.found": 1456,
+     "scan.failed": 42,
+     "scan.truncated": 25
+   }
+
+Configure automatic statistics reporting:
 
 .. code-block:: none
 
-  module(load="mmjsonparse")
-  action(type="mmjsonparse")
+   # Report statistics every 60 seconds
+   module(load="impstats" interval="60" severity="6")
+
+   # Statistics will appear in rsyslog's main log
+
+Performance Analysis
+--------------------
+
+The statistics counters help analyze JSON processing performance:
+
+- **Success Rate**: ``scan.found / scan.attempted`` indicates how often JSON is successfully located
+- **Parse Quality**: ``scan.failed / scan.found`` shows the rate of malformed JSON
+- **Scan Efficiency**: ``scan.truncated / scan.attempted`` indicates if ``max_scan_bytes`` should be increased
+
+Example analysis:
+
+.. code-block:: none
+
+   # High truncation rate suggests increasing max_scan_bytes
+   if scan.truncated > (scan.attempted * 0.1) then {
+       # Consider increasing max_scan_bytes parameter
+   }
+
+   # High failure rate suggests data quality issues
+   if scan.failed > (scan.found * 0.05) then {
+       # Investigate JSON formatting in source logs
+   }
+
+**Note**: Statistics counters are only active when using ``mode="find-json"``. Cookie mode does not generate these scanning-specific statistics.
+
+
+Examples
+========
+
+Apply default normalization (legacy cookie mode)
+------------------------------------------------
+
+This activates the module and applies normalization to all messages using
+the legacy CEE cookie mode.
+
+.. code-block:: none
+
+   module(load="mmjsonparse")
+   action(type="mmjsonparse")
 
 
 Permit parsing messages without cookie
@@ -117,13 +215,51 @@ To permit parsing messages without cookie, use this action statement
 
 .. code-block:: none
 
-  action(type="mmjsonparse" cookie="")
+   action(type="mmjsonparse" cookie="")
+
+
+Find-JSON mode for embedded JSON content
+-----------------------------------------
+
+To parse JSON content embedded anywhere in the message, use find-json mode:
+
+.. code-block:: none
+
+   # Basic find-json mode with defaults
+   action(type="mmjsonparse" mode="find-json")
+
+   # Find-json mode with custom limits and strict trailing control
+   action(type="mmjsonparse"
+          mode="find-json"
+          max_scan_bytes="32768"
+          allow_trailing="off")
+
+
+Mixed mode processing
+---------------------
+
+Different message types can be processed with different modes:
+
+.. code-block:: none
+
+   # Legacy CEE messages
+   if $msg startswith "@cee:" then {
+       action(type="mmjsonparse" mode="cookie")
+   }
+
+   # Modern logs with embedded JSON
+   else if $msg contains "{" then {
+       action(type="mmjsonparse" mode="find-json")
+   }
 
 
 .. toctree::
    :hidden:
 
+   ../../reference/parameters/mmjsonparse-mode
    ../../reference/parameters/mmjsonparse-cookie
+   ../../reference/parameters/mmjsonparse-max_scan_bytes
+   ../../reference/parameters/mmjsonparse-allow_trailing
    ../../reference/parameters/mmjsonparse-userawmsg
    ../../reference/parameters/mmjsonparse-container
 

--- a/doc/source/development/engine_overview.rst
+++ b/doc/source/development/engine_overview.rst
@@ -1,0 +1,79 @@
+.. _dev-main-overview:
+
+Developer Overview: rsyslog Engine
+==================================
+
+.. page-summary-start
+
+Comprehensive technical overview of rsyslog’s core engine, queue types, concurrency handling,
+and worker thread model, aimed at contributors and advanced users.
+
+.. page-summary-end
+
+Overview
+--------
+rsyslog processes messages through a modular architecture built around queues, rulesets, and actions.
+The design enables high throughput, flexible routing, and resilience under load or failure conditions.
+
+Key Components
+--------------
+- **Inputs**: Modules that receive messages from various sources (e.g., imtcp, imudp).
+- **Rulesets**: Contain filters and actions; can be invoked by inputs or other rulesets.
+- **Actions**: Output or processing steps (e.g., omfile, omfwd).
+- **Queues**: Decouple producers from consumers, manage flow control, and ensure durability.
+
+Queue Types
+-----------
+- **direct**: No buffering; messages are handed directly to the action. Lowest latency but action must keep pace.
+- **in-memory**: Stored in RAM (LinkedList or FixedArray); volatile but fast.
+- **disk-assisted (DA)**: Combination of in-memory (primary) and on-disk spillover when memory fills.
+- **disk-only**: Persistent on-disk storage; highest durability, higher latency.
+
+Concurrency Model
+-----------------
+- Each action may have its own queue and multiple worker threads.
+- Worker threads dequeue messages in batches and execute the action logic.
+- Thread safety is enforced via locks or atomic operations where state is shared.
+- Avoid blocking operations in action workers; prefer non-blocking I/O.
+
+Concurrency Handling in Detail
+------------------------------
+- **Worker threads per action** are configured with ``queue.workerThreads``.
+- **Batching** improves throughput but may introduce reordering between batches.
+- **Synchronization primitives** (mutexes, RW locks) are used only when necessary for shared state in pData.
+- **Atomic counters** and memory barriers ensure correctness without excessive locking.
+- Actions must clearly signal transient vs. permanent failures to allow the queue engine to handle retries or discards appropriately.
+
+Queue Flow (Mermaid Diagram)
+----------------------------
+.. mermaid::
+
+   flowchart LR
+     Inputs[Inputs] --> MainQ[Main Queue]
+     MainQ --> Rules[Rulesets]
+     Rules -->|Filter match| ActQ1[Action Queue 1]
+     Rules -->|Filter match| ActQ2[Action Queue 2]
+     ActQ1 --> W1[Workers 1]
+     ActQ2 --> W2[Workers 2]
+     W1 --> A1[Action 1]
+     W2 --> A2[Action 2]
+
+Backpressure & Flow Control
+---------------------------
+- **High-water mark**: When reached, producers block or slow down.
+- **Low-water mark**: Normal operation resumes below this threshold.
+- **Discard policy**: Drop lower-priority messages first when full.
+- **Timeouts**: Control enqueue blocking and shutdown grace periods.
+
+Error Handling
+--------------
+- **Transient errors**: Retries with exponential backoff.
+- **Persistent errors**: Drop, dead-letter queue, or keep retrying based on configuration.
+- **DA/disk queues**: Preserve messages across restarts.
+
+Cross-References
+----------------
+- :doc:`dev_action_threads`
+- :doc:`../concepts/queues`
+- :doc:`../rainerscript/queue_parameters`
+

--- a/doc/source/reference/parameters/mmjsonparse-allow_trailing.rst
+++ b/doc/source/reference/parameters/mmjsonparse-allow_trailing.rst
@@ -1,0 +1,53 @@
+.. _param-mmjsonparse-allow_trailing:
+.. _mmjsonparse.parameter.allow_trailing:
+
+allow_trailing
+==============
+
+.. index::
+   single: mmjsonparse; allow_trailing
+   single: allow_trailing
+   single: trailing data
+
+.. summary-start
+
+Whether to allow non-whitespace data after the JSON object in find-json mode.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmjsonparse`.
+
+:Name: allow_trailing
+:Scope: action
+:Type: boolean
+:Default: on
+:Required?: no
+:Introduced: 8.2506.0
+
+Description
+-----------
+Controls whether trailing non-whitespace characters are permitted after the parsed JSON object in find-json mode.
+
+- **on** (default): Allow trailing data after the JSON object. The JSON portion will be parsed and the trailing content ignored.
+- **off**: Reject messages with trailing non-whitespace content after the JSON object. Such messages will be treated as non-JSON.
+
+Whitespace characters (spaces, tabs, newlines) are always allowed after the JSON object regardless of this setting.
+
+This parameter is only effective when mode="find-json".
+
+Input usage
+-----------
+.. _mmjsonparse.parameter.allow_trailing-usage:
+
+.. code-block:: rsyslog
+
+   # Allow trailing data (default)
+   action(type="mmjsonparse" mode="find-json" allow_trailing="on")
+   
+   # Reject messages with trailing data
+   action(type="mmjsonparse" mode="find-json" allow_trailing="off")
+
+See also
+--------
+See also the :doc:`main mmjsonparse module documentation
+<../../configuration/modules/mmjsonparse>`.

--- a/doc/source/reference/parameters/mmjsonparse-max_scan_bytes.rst
+++ b/doc/source/reference/parameters/mmjsonparse-max_scan_bytes.rst
@@ -1,0 +1,50 @@
+.. _param-mmjsonparse-max_scan_bytes:
+.. _mmjsonparse.parameter.max_scan_bytes:
+
+max_scan_bytes
+==============
+
+.. index::
+   single: mmjsonparse; max_scan_bytes
+   single: max_scan_bytes
+   single: scan limit
+
+.. summary-start
+
+Maximum number of bytes to scan when searching for JSON content in find-json mode.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmjsonparse`.
+
+:Name: max_scan_bytes
+:Scope: action
+:Type: positive integer
+:Default: 65536
+:Required?: no
+:Introduced: 8.2506.0
+
+Description
+-----------
+Sets the maximum number of bytes to scan when searching for JSON objects in find-json mode. This prevents performance issues with very large messages by limiting the amount of data that will be examined.
+
+When the scan limit is reached without finding a complete JSON object, the message is treated as non-JSON and processed through the fallback path (creating a simple JSON object with the original message as the "msg" field).
+
+This parameter is only effective when mode="find-json".
+
+Input usage
+-----------
+.. _mmjsonparse.parameter.max_scan_bytes-usage:
+
+.. code-block:: rsyslog
+
+   # Scan up to 32KB for JSON content
+   action(type="mmjsonparse" mode="find-json" max_scan_bytes="32768")
+   
+   # Use default 64KB scan limit
+   action(type="mmjsonparse" mode="find-json")
+
+See also
+--------
+See also the :doc:`main mmjsonparse module documentation
+<../../configuration/modules/mmjsonparse>`.

--- a/doc/source/reference/parameters/mmjsonparse-mode.rst
+++ b/doc/source/reference/parameters/mmjsonparse-mode.rst
@@ -1,0 +1,49 @@
+.. _param-mmjsonparse-mode:
+.. _mmjsonparse.parameter.mode:
+
+mode
+====
+
+.. index::
+   single: mmjsonparse; mode
+   single: mode
+   single: parsing mode
+
+.. summary-start
+
+Specifies the parsing mode for JSON content detection.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmjsonparse`.
+
+:Name: mode
+:Scope: action
+:Type: string
+:Default: cookie
+:Required?: no
+:Introduced: 8.2506.0
+
+Description
+-----------
+Sets the parsing mode to determine how JSON content is detected and processed.
+
+- **cookie** (default): Legacy CEE cookie mode. Expects messages to begin with the configured cookie (default "@cee:") followed by JSON content. This preserves backward compatibility with existing configurations.
+- **find-json**: Scans the message to locate the first valid top-level JSON object "{...}" regardless of its position. The module uses a tokenizer-aware scanner that respects quotes and escapes to find complete JSON objects.
+
+Input usage
+-----------
+.. _mmjsonparse.parameter.mode-usage:
+
+.. code-block:: rsyslog
+
+   # Legacy CEE cookie mode (default)
+   action(type="mmjsonparse" mode="cookie")
+   
+   # Find-JSON scanning mode
+   action(type="mmjsonparse" mode="find-json")
+
+See also
+--------
+See also the :doc:`main mmjsonparse module documentation
+<../../configuration/modules/mmjsonparse>`.

--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -6,7 +6,7 @@
  *
  * File begun on 2012-02-20 by RGerhards
  *
- * Copyright 2012-2018 Adiscon GmbH.
+ * Copyright 2012-2025 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -43,8 +43,8 @@
 #include "module-template.h"
 #include "errmsg.h"
 #include "cfsysline.h"
-#include "parserif.h"
 #include "dirty.h"
+#include "statsobj.h"
 
 MODULE_TYPE_OUTPUT;
 MODULE_TYPE_NOKEEP;
@@ -57,18 +57,38 @@ static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __
 /* internal structures
  */
 DEF_OMOD_STATIC_DATA;
+DEFobjCurrIf(glbl) DEFobjCurrIf(statsobj)
+
+    /* parsing modes */
+    typedef enum {
+        PARSE_MODE_COOKIE = 0, /**< legacy CEE cookie mode (default) */
+        PARSE_MODE_FIND_JSON = 1 /**< find first JSON object mode */
+    } parse_mode_t;
 
 typedef struct _instanceData {
     sbool bUseRawMsg; /**< use %rawmsg% instead of %msg% */
     char *cookie;
     uchar *container;
     int lenCookie;
-    /* REMOVE dummy when real data items are to be added! */
+    parse_mode_t mode; /**< parsing mode: cookie or find-json */
+    int max_scan_bytes; /**< max bytes to scan in find-json mode */
+    sbool allow_trailing; /**< allow trailing data after JSON in find-json mode */
+    /* TODO: add start_regex support in future enhancement */
 } instanceData;
 
 typedef struct wrkrInstanceData {
     instanceData *pData;
     struct json_tokener *tokener;
+    /* Statistics counters - manually expanded from STATSCOUNTER_DEF */
+    intctr_t ctrScanAttempted;
+    DEF_ATOMIC_HELPER_MUT64(mutCtrScanAttempted);
+    intctr_t ctrScanFound;
+    DEF_ATOMIC_HELPER_MUT64(mutCtrScanFound);
+    intctr_t ctrScanFailed;
+    DEF_ATOMIC_HELPER_MUT64(mutCtrScanFailed);
+    intctr_t ctrScanTruncated;
+    DEF_ATOMIC_HELPER_MUT64(mutCtrScanTruncated);
+    statsobj_t *statsobj;
 } wrkrInstanceData_t;
 
 struct modConfData_s {
@@ -80,7 +100,8 @@ static modConfData_t *runModConf = NULL; /* modConf ptr to use for the current e
 /* tables for interfacing with the v6 config system */
 /* action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {
-    {"cookie", eCmdHdlrString, 0}, {"container", eCmdHdlrString, 0}, {"userawmsg", eCmdHdlrBinary, 0}};
+    {"cookie", eCmdHdlrString, 0}, {"container", eCmdHdlrString, 0},           {"userawmsg", eCmdHdlrBinary, 0},
+    {"mode", eCmdHdlrString, 0},   {"max_scan_bytes", eCmdHdlrPositiveInt, 0}, {"allow_trailing", eCmdHdlrBinary, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 
@@ -113,6 +134,9 @@ BEGINcreateInstance
     CHKmalloc(pData->container = (uchar *)strdup("!"));
     CHKmalloc(pData->cookie = strdup(CONST_CEE_COOKIE));
     pData->lenCookie = CONST_LEN_CEE_COOKIE;
+    pData->mode = PARSE_MODE_COOKIE; /* default to legacy behavior */
+    pData->max_scan_bytes = 65536; /* default scan limit */
+    pData->allow_trailing = 1; /* default allow trailing data */
 finalize_it:
 ENDcreateInstance
 
@@ -125,6 +149,27 @@ BEGINcreateWrkrInstance
                  "tokener, cannot activate instance");
         ABORT_FINALIZE(RS_RET_ERR);
     }
+
+    /* Initialize statistics counters */
+    STATSCOUNTER_INIT(pWrkrData->ctrScanAttempted, pWrkrData->mutCtrScanAttempted);
+    STATSCOUNTER_INIT(pWrkrData->ctrScanFound, pWrkrData->mutCtrScanFound);
+    STATSCOUNTER_INIT(pWrkrData->ctrScanFailed, pWrkrData->mutCtrScanFailed);
+    STATSCOUNTER_INIT(pWrkrData->ctrScanTruncated, pWrkrData->mutCtrScanTruncated);
+
+    /* Create stats object for this worker instance */
+    CHKiRet(statsobj.Construct(&(pWrkrData->statsobj)));
+    CHKiRet(statsobj.SetName(pWrkrData->statsobj, (uchar *)"mmjsonparse"));
+    CHKiRet(statsobj.SetOrigin(pWrkrData->statsobj, (uchar *)"mmjsonparse"));
+    CHKiRet(statsobj.AddCounter(pWrkrData->statsobj, (uchar *)"scan.attempted", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrScanAttempted)));
+    CHKiRet(statsobj.AddCounter(pWrkrData->statsobj, (uchar *)"scan.found", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrScanFound)));
+    CHKiRet(statsobj.AddCounter(pWrkrData->statsobj, (uchar *)"scan.failed", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrScanFailed)));
+    CHKiRet(statsobj.AddCounter(pWrkrData->statsobj, (uchar *)"scan.truncated", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrScanTruncated)));
+    CHKiRet(statsobj.ConstructFinalize(pWrkrData->statsobj));
+
 finalize_it:
 ENDcreateWrkrInstance
 
@@ -143,6 +188,9 @@ ENDfreeInstance
 BEGINfreeWrkrInstance
     CODESTARTfreeWrkrInstance;
     if (pWrkrData->tokener != NULL) json_tokener_free(pWrkrData->tokener);
+    if (pWrkrData->statsobj != NULL) {
+        statsobj.Destruct(&pWrkrData->statsobj);
+    }
 ENDfreeWrkrInstance
 
 
@@ -157,7 +205,110 @@ BEGINtryResume
 ENDtryResume
 
 
-static rsRetVal processJSON(wrkrInstanceData_t *pWrkrData, smsg_t *pMsg, char *buf, size_t lenBuf) {
+/**
+ * Find the first valid JSON object in a message buffer using the actual JSON parser.
+ * This function scans for '{' characters and uses json_tokener to validate complete objects.
+ *
+ * @param pWrkrData Worker instance data (contains tokener)
+ * @param msg       Message buffer to scan
+ * @param len       Length of message buffer
+ * @param start_off Starting offset for scan
+ * @param max_scan  Maximum bytes to scan
+ * @param obj_off   [OUT] Offset where JSON object starts
+ * @param obj_len   [OUT] Length of JSON object
+ * @param parsed_json [OUT] Already parsed JSON object (caller must release)
+ * @param allow_trailing Whether trailing data after JSON is allowed
+ * @return 0 on success, 1 if no JSON found, 2 if scan truncated, 3 if trailing data not allowed
+ */
+static int find_first_json_object(wrkrInstanceData_t *pWrkrData,
+                                  const uchar *msg,
+                                  size_t len,
+                                  size_t start_off,
+                                  size_t max_scan,
+                                  size_t *obj_off,
+                                  size_t *obj_len,
+                                  struct json_object **parsed_json,
+                                  sbool allow_trailing) {
+    size_t i = start_off;
+    size_t scan_end = start_off + max_scan;
+    if (scan_end > len) scan_end = len;
+
+    *parsed_json = NULL;
+
+    /* Find potential JSON start positions ('{' characters) */
+    while (i < scan_end) {
+        /* Find the next '{' */
+        const uchar *p = memchr(msg + i, '{', scan_end - i);
+        if (p == NULL) {
+            i = scan_end;
+        } else {
+            i = p - msg;
+        }
+
+        if (i >= scan_end) {
+            return (i >= len) ? 1 : 2; /* no JSON found or scan truncated */
+        }
+
+        /* Try to parse JSON starting from this position */
+        size_t remaining = len - i;
+        json_tokener_reset(pWrkrData->tokener);
+
+        struct json_object *json = json_tokener_parse_ex(pWrkrData->tokener, (const char *)(msg + i), remaining);
+
+        if (json != NULL && json_object_is_type(json, json_type_object)) {
+            /* Valid JSON object found */
+            size_t parsed_len = pWrkrData->tokener->char_offset;
+
+            /* Check for trailing data if allow_trailing is false */
+            if (!allow_trailing && parsed_len < remaining) {
+                size_t check_pos = i + parsed_len;
+                while (check_pos < len && isspace(msg[check_pos])) {
+                    check_pos++;
+                }
+                if (check_pos < len) {
+                    json_object_put(json); /* release the object */
+                    return 3; /* trailing data not allowed */
+                }
+            }
+
+            *obj_off = i;
+            *obj_len = parsed_len;
+            *parsed_json = json; /* pass ownership to caller */
+            return 0; /* success */
+        }
+
+        /* Clean up if parsing failed */
+        if (json != NULL) {
+            json_object_put(json);
+        }
+
+        /* Move to next potential start position */
+        i++;
+    }
+
+    return 2; /* scan truncated or no valid JSON found */
+}
+
+
+static rsRetVal processJSON(wrkrInstanceData_t *pWrkrData, smsg_t *pMsg, struct json_object *json) {
+    DEFiRet;
+
+    DBGPRINTF("mmjsonparse: processing already parsed JSON object\n");
+
+    /* JSON is already parsed and validated, just add it to the message */
+    CHKiRet(msgAddJSON(pMsg, pWrkrData->pData->container, json, 0, 0));
+    /* Note: msgAddJSON takes ownership of the json object on success,
+     * but we need to clean up on failure */
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        /* msgAddJSON failed, we need to clean up the JSON object */
+        json_object_put(json);
+    }
+    RETiRet;
+}
+
+static rsRetVal processJSONBuffer(wrkrInstanceData_t *pWrkrData, smsg_t *pMsg, char *buf, size_t lenBuf) {
     struct json_object *json;
     const char *errMsg;
     DEFiRet;
@@ -210,26 +361,77 @@ BEGINdoAction_NoStrings
     instanceData *pData;
     CODESTARTdoAction;
     pData = pWrkrData->pData;
-    /* note that we can performance-optimize the interface, but this also
-     * requires changes to the libraries. For now, we accept message
-     * duplication. -- rgerhards, 2010-12-01
-     */
+
+    /* Get message buffer */
     if (pWrkrData->pData->bUseRawMsg)
         getRawMsg(pMsg, &buf, &len);
-    else
+    else {
         buf = getMSG(pMsg);
-
-    while (*buf && isspace(*buf)) {
-        ++buf;
+        len = getMSGLen(pMsg);
     }
 
-    if (*buf == '\0' || strncmp((char *)buf, pData->cookie, pData->lenCookie)) {
-        DBGPRINTF("mmjsonparse: no JSON cookie: '%s'\n", buf);
-        ABORT_FINALIZE(RS_RET_NO_CEE_MSG);
+    /* Handle different parsing modes */
+    if (pData->mode == PARSE_MODE_COOKIE) {
+        /* Legacy CEE cookie mode */
+        size_t remaining = len;
+
+        /* Skip leading whitespace - length-aware */
+        while (remaining > 0 && isspace(*buf)) {
+            ++buf;
+            --remaining;
+        }
+
+        /* Check for cookie presence - length-aware */
+        if (remaining == 0 || remaining < (size_t)pData->lenCookie ||
+            memcmp(buf, pData->cookie, pData->lenCookie) != 0) {
+            DBGPRINTF("mmjsonparse: no JSON cookie found\n");
+            ABORT_FINALIZE(RS_RET_NO_CEE_MSG);
+        }
+
+        buf += pData->lenCookie;
+        remaining -= pData->lenCookie;
+
+        CHKiRet(processJSONBuffer(pWrkrData, pMsg, (char *)buf, remaining));
+        bSuccess = 1;
+    } else if (pData->mode == PARSE_MODE_FIND_JSON) {
+        /* Find-JSON mode */
+        size_t obj_off, obj_len;
+        int scan_result;
+        struct json_object *parsed_json = NULL;
+
+        STATSCOUNTER_INC(pWrkrData->ctrScanAttempted, pWrkrData->mutCtrScanAttempted);
+
+        scan_result = find_first_json_object(pWrkrData, buf, len, 0, pData->max_scan_bytes, &obj_off, &obj_len,
+                                             &parsed_json, pData->allow_trailing);
+
+        if (scan_result == 0) {
+            /* JSON object found and already parsed */
+            STATSCOUNTER_INC(pWrkrData->ctrScanFound, pWrkrData->mutCtrScanFound);
+            iRet = processJSON(pWrkrData, pMsg, parsed_json);
+            if (iRet == RS_RET_OK) {
+                bSuccess = 1;
+            } else {
+                /* JSON was found but processing failed */
+                STATSCOUNTER_INC(pWrkrData->ctrScanFailed, pWrkrData->mutCtrScanFailed);
+                /* Will be handled in finalize_it */
+            }
+        } else {
+            /* Handle scan failures */
+            if (scan_result == 2) {
+                STATSCOUNTER_INC(pWrkrData->ctrScanTruncated, pWrkrData->mutCtrScanTruncated);
+                DBGPRINTF("mmjsonparse: JSON scan truncated at max_scan_bytes=%d\n", pData->max_scan_bytes);
+            } else if (scan_result == 3) {
+                STATSCOUNTER_INC(pWrkrData->ctrScanFound,
+                                 pWrkrData->mutCtrScanFound); /* JSON was found but trailing data rejected */
+                DBGPRINTF("mmjsonparse: trailing data found but allow_trailing=off\n");
+                /* Note: find_first_json_object already cleaned up the JSON object for error case 3 */
+            } else {
+                DBGPRINTF("mmjsonparse: no JSON object found in message\n");
+            }
+            ABORT_FINALIZE(RS_RET_NO_CEE_MSG);
+        }
     }
-    buf += pData->lenCookie;
-    CHKiRet(processJSON(pWrkrData, pMsg, (char *)buf, strlen((char *)buf)));
-    bSuccess = 1;
+
 finalize_it:
     if (iRet == RS_RET_NO_CEE_MSG) {
         /* add buf as msg */
@@ -282,14 +484,36 @@ BEGINnewActInst
             }
             if ((lenvar == 0) ||
                 (!(pData->container[0] == '!' || pData->container[0] == '.' || pData->container[0] == '/'))) {
-                parser_errmsg(
-                    "mmjsonparse: invalid container name '%s', name must "
-                    "start with either '$!', '$.', or '$/'",
-                    pData->container);
+                LogError(0, RS_RET_INVALID_VAR,
+                         "mmjsonparse: invalid container name '%s', name must "
+                         "start with either '$!', '$.', or '$/'",
+                         pData->container);
                 ABORT_FINALIZE(RS_RET_INVALID_VAR);
             }
         } else if (!strcmp(actpblk.descr[i].name, "userawmsg")) {
             pData->bUseRawMsg = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "mode")) {
+            char *mode_str = es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (!strcmp(mode_str, "cookie")) {
+                pData->mode = PARSE_MODE_COOKIE;
+            } else if (!strcmp(mode_str, "find-json")) {
+                pData->mode = PARSE_MODE_FIND_JSON;
+            } else {
+                LogError(0, RS_RET_CONF_PARAM_INVLD, "mmjsonparse: invalid mode '%s', must be 'cookie' or 'find-json'",
+                         mode_str);
+                free(mode_str);
+                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+            }
+            free(mode_str);
+        } else if (!strcmp(actpblk.descr[i].name, "max_scan_bytes")) {
+            pData->max_scan_bytes = (int)pvals[i].val.d.n;
+            if (pData->max_scan_bytes <= 0) {
+                LogError(0, RS_RET_CONF_PARAM_INVLD, "mmjsonparse: max_scan_bytes must be positive, got %d",
+                         pData->max_scan_bytes);
+                ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+            }
+        } else if (!strcmp(actpblk.descr[i].name, "allow_trailing")) {
+            pData->allow_trailing = (int)pvals[i].val.d.n;
         } else {
             dbgprintf("mmjsonparse: program error, non-handled param '%s'\n", actpblk.descr[i].name);
         }
@@ -353,7 +577,10 @@ BEGINmodInit()
     CODESTARTmodInit;
     *ipIFVersProvided = CURR_MOD_IF_VERSION;
     /* we only support the current interface specification */
-    CODEmodInit_QueryRegCFSLineHdlr DBGPRINTF("mmjsonparse: module compiled with rsyslog version %s.\n", VERSION);
+    CODEmodInit_QueryRegCFSLineHdlr;
+    CHKiRet(objUse(glbl, CORE_COMPONENT));
+    CHKiRet(objUse(statsobj, CORE_COMPONENT));
+    DBGPRINTF("mmjsonparse: module compiled with rsyslog version %s.\n", VERSION);
     /* check if the rsyslog core supports parameter passing code */
     bMsgPassingSupported = 0;
     localRet = pHostQueryEtryPt((uchar *)"OMSRgetSupportedTplOpts", &pomsrGetSupportedTplOpts);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1483,7 +1483,13 @@ endif
 if ENABLE_MMJSONPARSE
 TESTS += \
         mmjsonparse-w-o-cookie.sh \
-        mmjsonparse-w-o-cookie-multi-spaces.sh
+        mmjsonparse-w-o-cookie-multi-spaces.sh \
+        mmjsonparse-find-json-basic.sh \
+        mmjsonparse-find-json-trailing.sh \
+        mmjsonparse-find-json-scan-limit.sh \
+        mmjsonparse-find-json-invalid.sh \
+        mmjsonparse-find-json-invalid-mode.sh \
+        mmjsonparse-find-json-parser-validation.sh
 if ENABLE_IMPSTATS
 TESTS += \
 	mmjsonparse-invalid-containerName.sh \
@@ -2485,6 +2491,12 @@ EXTRA_DIST= \
 	mmleefparse_basic.sh \
 	mmjsonparse-w-o-cookie.sh \
 	mmjsonparse-w-o-cookie-multi-spaces.sh \
+        mmjsonparse-find-json-basic.sh \
+        mmjsonparse-find-json-trailing.sh \
+        mmjsonparse-find-json-scan-limit.sh \
+        mmjsonparse-find-json-invalid.sh \
+        mmjsonparse-find-json-invalid-mode.sh \
+        mmjsonparse-find-json-parser-validation.sh \
 	mmjsonparse_simple.sh \
 	mmjsonparse-invalid-containerName.sh \
 	wtpShutdownAll-assertionFailure.sh \

--- a/tests/mmjsonparse-find-json-basic.sh
+++ b/tests/mmjsonparse-find-json-basic.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Test mmjsonparse find-json mode basic functionality
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+
+template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% json=%$!%\n")
+
+# Legacy cookie mode (default) - should NOT parse text with JSON
+if $msg contains "LEGACY" then {
+    action(type="mmjsonparse")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+
+# Find-JSON mode - should parse text with embedded JSON
+if $msg contains "FINDJSON" then {
+    action(type="mmjsonparse" mode="find-json")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+'
+startup
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: LEGACY prefix {"field":"value"}'
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: FINDJSON prefix {"field":"value"}'
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' LEGACY prefix {"field":"value"} parsesuccess=FAIL json={ "msg": "LEGACY prefix {\"field\":\"value\"}" }
+ FINDJSON prefix {"field":"value"} parsesuccess=OK json={ "field": "value" }'
+cmp_exact
+exit_test

--- a/tests/mmjsonparse-find-json-invalid-mode.sh
+++ b/tests/mmjsonparse-find-json-invalid-mode.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Test mmjsonparse invalid mode parameter error handling
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+action(type="mmjsonparse" mode="INVALID")
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+
+startup
+shutdown_when_empty
+wait_shutdown
+content_check --regex "mmjsonparse: invalid mode 'INVALID'"
+exit_test

--- a/tests/mmjsonparse-find-json-invalid.sh
+++ b/tests/mmjsonparse-find-json-invalid.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Test mmjsonparse find-json mode with invalid JSON
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+
+template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% json=%$!%\n")
+
+# Test invalid JSON
+if $msg contains "INVALID" then {
+    action(type="mmjsonparse" mode="find-json")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+
+# Test no JSON present
+if $msg contains "NOJSON" then {
+    action(type="mmjsonparse" mode="find-json")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+'
+startup
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: INVALID prefix {invalid json'
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: NOJSON just plain text without any json'
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' INVALID prefix {invalid json parsesuccess=FAIL json={ "msg": " INVALID prefix {invalid json" }
+ NOJSON just plain text without any json parsesuccess=FAIL json={ "msg": " NOJSON just plain text without any json" }'
+cmp_exact
+exit_test

--- a/tests/mmjsonparse-find-json-parser-validation.sh
+++ b/tests/mmjsonparse-find-json-parser-validation.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Test mmjsonparse find-json mode with improved JSON parser validation
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+
+template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% json=%$!%\n")
+
+# Test various JSON edge cases that manual brace counting might miss
+if $msg contains "TEST" then {
+    action(type="mmjsonparse" mode="find-json")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+'
+startup
+# Valid JSON with nested objects and arrays
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TEST1 prefix {"key": {"nested": ["a", "b"]}, "num": 123}'
+# JSON with escaped quotes in strings
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TEST2 prefix {"message": "He said \"hello\" to me"}'
+# JSON with braces in string values (should not confuse parser)
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TEST3 prefix {"code": "if (x > 0) { return true; }"}'
+# Invalid JSON that looks like it might work with brace counting
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TEST4 prefix {"invalid": json}'
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' TEST1 prefix {"key": {"nested": ["a", "b"]}, "num": 123} parsesuccess=OK json={ "key": { "nested": [ "a", "b" ] }, "num": 123 }
+ TEST2 prefix {"message": "He said \"hello\" to me"} parsesuccess=OK json={ "message": "He said \"hello\" to me" }
+ TEST3 prefix {"code": "if (x > 0) { return true; }"} parsesuccess=OK json={ "code": "if (x > 0) { return true; }" }
+ TEST4 prefix {"invalid": json} parsesuccess=FAIL json={ "msg": " TEST4 prefix {\"invalid\": json}" }'
+cmp_exact
+exit_test

--- a/tests/mmjsonparse-find-json-scan-limit.sh
+++ b/tests/mmjsonparse-find-json-scan-limit.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Test mmjsonparse find-json mode with max_scan_bytes limit
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+
+template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% json=%$!%\n")
+
+# Test with very small max_scan_bytes to force truncation
+if $msg contains "SCAN_LIMIT" then {
+    action(type="mmjsonparse" mode="find-json" max_scan_bytes="10")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+
+# Test with sufficient max_scan_bytes
+if $msg contains "SCAN_OK" then {
+    action(type="mmjsonparse" mode="find-json" max_scan_bytes="100")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+'
+startup
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: SCAN_LIMIT this is a long prefix before {"test":"value"}'
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: SCAN_OK short {"test":"value"}'
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' SCAN_LIMIT this is a long prefix before {"test":"value"} parsesuccess=FAIL json={ "msg": " SCAN_LIMIT this is a long prefix before {\"test\":\"value\"}" }
+ SCAN_OK short {"test":"value"} parsesuccess=OK json={ "test": "value" }'
+cmp_exact
+exit_test

--- a/tests/mmjsonparse-find-json-trailing.sh
+++ b/tests/mmjsonparse-find-json-trailing.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Test mmjsonparse find-json mode with trailing data and allow_trailing parameter
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+
+template(name="outfmt" type="string" string="%msg% parsesuccess=%parsesuccess% json=%$!%\n")
+
+# Test allow_trailing=on (default)
+if $msg contains "TRAILING_ON" then {
+    action(type="mmjsonparse" mode="find-json" allow_trailing="on")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+
+# Test allow_trailing=off
+if $msg contains "TRAILING_OFF" then {
+    action(type="mmjsonparse" mode="find-json" allow_trailing="off")
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    stop
+}
+'
+startup
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TRAILING_ON {"test":1} garbage after'
+injectmsg_literal '<167>Jan 16 16:57:54 host.example.net TAG: TRAILING_OFF {"test":2} garbage after'
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED=' TRAILING_ON {"test":1} garbage after parsesuccess=OK json={ "test": 1 }
+ TRAILING_OFF {"test":2} garbage after parsesuccess=FAIL json={ "msg": " TRAILING_OFF {\"test\":2} garbage after" }'
+cmp_exact
+exit_test


### PR DESCRIPTION
Plain JSON (often with short textual prefixes) is mainstream in real deployments. This change lets mmjsonparse handle such logs natively, reducing friction compared to the CEE/lumberjack cookie flow.

Impact: Default behavior is unchanged; new mode and parameters are opt-in.

Before: cookie-only JSON. After: find-json parses first top-level {}.

Technical details:
- Add action parameter `mode` with `cookie` (default) and `find-json`. The new mode scans the message for the first `{` and validates a full top-level JSON object using json_tokener; quotes/escapes are respected.
- Add `max_scan_bytes` (default 65536) to bound scanning work and `allow_trailing` (default on) to accept or reject non-whitespace after the JSON object. When scanning fails or is rejected, we keep legacy behavior: return NO_CEE_MSG and wrap the full message into {"msg":...}.
- Keep legacy cookie flow intact; `cookie=""` remains usable but `mode` is the clearer switch for generic JSON.
- Introduce per-worker scan counters (attempted/found/failed/truncated) for future observability; no external stats wiring yet.
- Update docs: module overview, new parameter reference pages, and examples including mixed-mode routing; add a developer engine overview.
- Add tests covering basic scanning, trailing handling, scan limits, invalid JSON, invalid mode, and parser validation.

