### PR TITLE
CI: enhance doc workflow to check tarball completeness

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -40,6 +40,60 @@ jobs:
           files: |
             doc/**/*.rst
 
+      # we build from tarball to ensure no missing files!
+      - name: setup make dist build env
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libestr-dev \
+            libglib2.0-dev \
+            libgnutls28-dev \
+            liblognorm-dev \
+            liblz4-dev \
+            libnet1-dev \
+            librelp-dev \
+            libssl-dev \
+            libsystemd-dev \
+            libtool \
+            libtool-bin \
+            libzstd-dev \
+            lsof \
+            make \
+            net-tools \
+            pkg-config \
+            python3-docutils  \
+            software-properties-common \
+            zstd
+
+      - name: create tarball
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
+        run: |
+          autoreconf -fvi
+          ./configure --enable-silent-rules --disable-testbench \
+             --disable-imdiag --disable-imdocker --disable-imfile --disable-default-tests\
+             --disable-impstats --disable-imptcp --disable-mmanon --disable-mmaudit --disable-mmfields \
+             --disable-mmjsonparse --disable-mmpstrucdata --disable-mmsequence --disable-mmutf8fix \
+             --disable-mail --disable-omprog --disable-improg --disable-omruleset --disable-omstdout \
+             --disable-omuxsock --disable-pmaixforwardedfrom --disable-pmciscoios --disable-pmcisconames \
+             --disable-pmlastmsg --disable-pmsnare --disable-libgcrypt --disable-mmnormalize \
+             --disable-omudpspoof --disable-relp --disable-mmsnmptrapd --disable-gnutls --disable-usertools \
+             --disable-mysql --disable-valgrind --disable-omjournal --enable-libsystemd \
+             --disable-mmkubernetes --disable-imjournal --disable-omkafka --disable-imkafka \
+             --disable-ommongodb --disable-omrabbitmq --disable-journal-tests --disable-mmdarwin \
+             --disable-helgrind --disable-uuid --disable-fmhttp
+          make dist
+
+      - name: unpack tarball for build
+        if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
+        run: |
+          mkdir doc-builder
+          cd doc-builder
+          tar -xf ../rsyslog-8*.tar.gz --strip-components=1
+          pwd
+          ls -l
+          cd ..
+
       - name: Setup Python
         if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
         uses: actions/setup-python@v5
@@ -53,7 +107,7 @@ jobs:
       - name: Build documentation
         if: ${{ (github.event_name != 'pull_request' && github.event_name != 'pull_request_target') || steps.doc_changes.outputs.any_changed == 'true' }}
         run: |
-          cd doc
+          cd doc-builder/doc
           make html SPHINXOPTS="-W -q --keep-going"
 
       - name: Upload build artifact
@@ -61,7 +115,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs-html
-          path: doc/build/html
+          path: doc-builder/doc/build/html
 
 
   publish_pr_preview:

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,6 @@ EXTRA_DIST = \
 	contrib/gnutls/ca.pem \
 	contrib/gnutls/cert.pem \
 	contrib/gnutls/key.pem \
-	doc/ai/module_map.yaml \
 	$(DOC_FILES)
 
 SUBDIRS = compat runtime grammar . plugins/immark plugins/imuxsock plugins/imtcp plugins/imudp plugins/omtesting

--- a/configure.ac
+++ b/configure.ac
@@ -3074,20 +3074,23 @@ fi
 
 dnl ---- gather doc files for EXTRA_DIST ----
 # .rst files
-rst_files=`cd "$srcdir" && find doc/source -type f -name '*.rst' -print 2>/dev/null | LC_ALL=C sort`
+doc_src_files=`cd "$srcdir" && find doc/source -type f \( -name '*.rst' -o -name '*.conf' -o -name '*.jpg' -o -name '*.png' \) -print 2>/dev/null | LC_ALL=C sort`
 
 # assemble; keep paths relative to top (we cd into $srcdir above)
-DOC_FILES="$rst_files
+DOC_FILES="$doc_src_files
 doc/source/conf.py
 doc/source/conf_helpers.py
 doc/source/_ext/edit_on_github.py
 doc/source/_ext/rsyslog_lexer.py
 doc/source/_static/rsyslog.css
+doc/source/tutorials/cert-script.tar.gz
+doc/ai/module_map.yaml
 doc/requirements.txt
 doc/README.md
 doc/STRATEGY.md
 doc/CONTRIBUTING.md
 doc/LICENSE
+doc/Makefile
 $ai_files"
 
 # collapse newlines and extra whitespace to single spaces


### PR DESCRIPTION
Real-world tarballs must be self-contained for doc builds. This change verifies release completeness by building the docs from the tarball, not the checkout.
    
Impact: Release tarballs now include additional doc assets; CI fails early if a doc-required file is missing.
    
Before: CI built Sphinx docs directly from the repo tree. Missing files could be masked by in-tree paths. After: CI creates a 'make dist' tarball, unpacks it, and builds docs from that tree to catch omissions.
    
Technically, the doc workflow installs build deps, runs autoreconf and a minimal './configure', issues 'make dist', unpacks into
'doc-builder/', and runs 'make html' under 'doc-builder/doc'. The artifact path is updated accordingly.
    
For distribution, 'configure.ac' now composes DOC_FILES from 'doc/source' (*.rst, *.conf, *.jpg, *.png) and explicitly adds 'tutorials/cert-script.tar.gz', 'doc/Makefile', and 'doc/ai/module_map.yaml'. The duplicate listing of  'doc/ai/module_map.yaml' is removed from 'Makefile.am' EXTRA_DIST to avoid drift; DOC_FILES remains the single source of truth for doc payloads.
