### PR TITLE
CI: fix imtcp-tls-gibberish being executed in non-TLS builds

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -293,7 +293,6 @@ TESTS +=  \
 	msgdup_props.sh \
 	empty-ruleset.sh \
 	ruleset-direct-queue.sh \
-	imtcp-tls-gibberish.sh \
 	imtcp-listen-port-file-2.sh \
 	allowed-sender-tcp-ok.sh \
 	allowed-sender-tcp-fail.sh \
@@ -1554,6 +1553,7 @@ TESTS +=  \
 	imtcp-tls-input-2certs.sh \
 	imtcp-tls-basic-verifydepth.sh \
 	imtcp_conndrop_tls.sh \
+	imtcp-tls-gibberish.sh \
 	sndrcv_tls_anon_rebind.sh \
 	sndrcv_tls_anon_hostname.sh \
 	sndrcv_tls_anon_ipv4.sh \


### PR DESCRIPTION
This tool requires rsyslog to build with TLS support. If not present, the test will always fail. This is solved by executing it only if gnutls is enabled. As this is a fequently tested environment, this does not reduce test coverage. It is easier to do then checking for both gnutls and openssl.

Many thanks to Michael Biebl for bringing this to our attention.

closes https://github.com/rsyslog/rsyslog/issues/6224
