### PR TITLE
feat: Trigger macOS workflow on relevant file changes

### DIFF
--- a/.github/workflows/run_macos.yml
+++ b/.github/workflows/run_macos.yml
@@ -25,6 +25,16 @@ name: check_run_macos
 
 'on':
   pull_request:
+    paths:
+      - '**/*.c'
+      - '**/*.h'
+      - 'grammar/lexer.l'
+      - 'grammar/grammar.y'
+      - 'tests/*.sh'
+      - 'diag.sh'
+      - '**/Makefile.am'
+      - 'configure.ac'
+      - '.github/workflows/*.yml'
 
 jobs:
   check_run:


### PR DESCRIPTION
## Summary
- Align macOS workflow trigger with the main Linux workflow.
- Add pull_request paths list to `.github/workflows/run_macos.yml` matching `run_checks.yml`.
- Reduce unnecessary macOS CI runs on non-relevant changes.

## Impact
- No changes to build or test steps; only trigger conditions updated.
- CI runs faster and cheaper while preserving relevant coverage.
