### PR TITLE
tests: fix macOS tr illegal byte sequence in RSYSLOG_DYNNAME

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -3515,7 +3515,11 @@ case $1 in
 			echo "hint: was init accidentally called twice?"
 			exit 2
 		fi
-		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))$(tr -dc 'a-zA-Z0-9' < /dev/urandom | head --bytes 4)"
+		# Generate a short ASCII-only random suffix in a POSIX/portable way.
+		# On macOS, BSD tr with UTF-8 locales can error with "Illegal byte sequence"
+		# when fed /dev/urandom. Force C locale and use head -c (portable) instead of
+		# GNU head --bytes to avoid flaky failures in GitHub Actions runners.
+		export RSYSLOG_DYNNAME="rstb_$(./test_id $(basename $0))$(LC_ALL=C tr -dc 'a-zA-Z0-9' < /dev/urandom | head -c 4)"
 		export RSYSLOG_OUT_LOG="${RSYSLOG_DYNNAME}.out.log"
 		export RSYSLOG2_OUT_LOG="${RSYSLOG_DYNNAME}_2.out.log"
 		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!


### PR DESCRIPTION
## Summary
- Fix flaky macOS failures caused by `tr: Illegal byte sequence`
- Make test harness random name generation portable across platforms
- No functional changes to rsyslog or tests, only harness robustness

## Context
Occasional macOS CI failures in tests like `tests/imtcp-connection-msg-recieved.sh`
due to BSD `tr` under UTF-8 locales erroring on `/dev/urandom`:
  tr: Illegal byte sequence

## Changes
- In `tests/diag.sh`, generate `RSYSLOG_DYNNAME` with:
  - `LC_ALL=C` for `tr` to avoid multibyte decoding
  - Replace GNU-only `head --bytes` with POSIX `head -c`

## Rationale
- C locale treats input as single-byte; avoids BSD `tr` errors
- `head -c` is portable and avoids GNU-specific options

## Impact
- Stabilizes macOS CI jobs (`run_macos.yml`) across macOS 13/14/15
- Linux behavior remains unchanged
- Only the ephemeral test name suffix generation is affected

## Test plan
- Configure and build:
  - `autoreconf -fvi`
  - `./configure --enable-imdiag --enable-testbench`
  - `make -j`
- Run representative tests on macOS and Linux:
  - `./tests/imtcp-connection-msg-recieved.sh`
  - A small spot-check of other tests that rely on `RSYSLOG_DYNNAME`
- Verify no occurrences of `tr: Illegal byte sequence` in logs