### PR TITLE
Fix GCC 14 -Wnull-dereference build failure in imptcp by guarding

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1499,7 +1499,8 @@ finalize_it:
                  "imptcp: failed to fully accept session from remote peer %s[%s]. "
                  "This can be caused by a peer that closed the session immediately after "
                  "connect, like during a security or health check port probe.",
-                 propGetSzStr(peerName), propGetSzStr(peerIP));
+                 propGetSzStrOrDefault(peerName, "(unknown)"),
+                 propGetSzStrOrDefault(peerIP, "(unknown)"));
         if (pSess != NULL) {
             if (pSess->next != NULL) {
                 unlinkSess(pSess);


### PR DESCRIPTION
## Summary
Fix GCC 14 -Wnull-dereference build failure in imptcp by guarding
error-path logging against NULL properties.

## What changed
- In plugins/imptcp/imptcp.c (addSess error path), replace
  propGetSzStr(peerName)/propGetSzStr(peerIP) with
  propGetSzStrOrDefault(..., "(unknown)").

## Why
- GCC 14.2 with -Werror flags a potential NULL dereference because
  peerName/peerIP can be NULL on failed/partial accepts, while
  propGetSzStr dereferences pThis->len and is annotated nonnull.

## Impact
- Unblocks builds on newer compilers.
- No behavior change when values are present.
- When absent, logs "(unknown)" for peer fields instead of risking UB.

## Risk
- Low. Affects only error logging; normal paths unchanged.

## Notes
- Audited imptcp for similar use; other call sites operate on
  initialized session fields. If GCC reports more sites, we can apply
  the same safe helper.
