### PR TITLE
Add agent chat keywords for FINISH and SUMMARIZE

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,25 @@ component notes that apply to your task.
 
 -----
 
+## Agent Chat Keywords
+
+The following chat codewords instruct AI assistants to perform standardized actions in this repository.
+
+### `FINISH`
+
+When the user says the codeword "FINISH", do the following:
+
+- Review all changes
+
+### `SUMMARIZE`
+
+When the user says the codeword "SUMMARIZE", do the following:
+
+- Create a summary for the pull request and print it in the Agent chat in a TEXTBOX field ready to copy
+- Create a summary for a squashed commit message and print it in the Agent chat in a TEXTBOX field ready to copy
+
+-----
+
 ## Priming a fresh AI session
 
 When starting a new AI-assisted coding session (for example after a PR merges or


### PR DESCRIPTION
docs: add Agent Chat Keywords to AGENTS.md

Add a new "Agent Chat Keywords" section documenting FINISH and
SUMMARIZE codewords to standardize agent end-of-session actions.

FINISH: review all changes.
SUMMARIZE: produce ready-to-copy PR and squashed commit summaries.

Doc-only change; no runtime or test impact.
