### PR TITLE
imptcp: fix null pointer dereference in error logging

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1499,7 +1499,7 @@ finalize_it:
                  "imptcp: failed to fully accept session from remote peer %s[%s]. "
                  "This can be caused by a peer that closed the session immediately after "
                  "connect, like during a security or health check port probe.",
-                 propGetSzStr(peerName), propGetSzStr(peerIP));
+                 propGetSzStrOrDefault(peerName, "(hostname unknown)"), propGetSzStrOrDefault(peerIP, "(IP unknown)"));
         if (pSess != NULL) {
             if (pSess->next != NULL) {
                 unlinkSess(pSess);


### PR DESCRIPTION
### Summary (non-technical, complete)
  
When compiling with -Werror=null-dereference, the compiler detected that peerName and peerIP parameters could be NULL when the error logging code executes:

```
  CC       imptcp_la-imptcp.lo
In file included from ../../runtime/glbl.h:38,
                 from ../../runtime/stream.h:75,
                 from ../../runtime/obj.h:48,
                 from ../../runtime/rsyslog.h:889,
                 from imptcp.c:65:
In function 'propGetSzStr',
    inlined from 'addSess' at imptcp.c:1498:9,
    inlined from 'lstnActivity' at imptcp.c:1861:20,
    inlined from 'processWorkItem' at imptcp.c:1937:13:
../../runtime/prop.h:66:18: error: potential null pointer dereference [-Werror=null-dereference]
   66 |     return (pThis->len < CONF_PROP_BUFSIZE) ? pThis->szVal.sz : pThis->szVal.psz;
      |             ~~~~~^~~~~
cc1: all warnings being treated as errors
make[2]: *** [Makefile:565: imptcp_la-imptcp.lo] Error 1

```

The issue occurs because `NULL_CHECK()` macros at the function start can cause an early jump to finalize_it: when parameters are NULL, but the error logging code still tries to use those NULL pointers.

### Notes (optional)
gcc-15.2.1-1.fc42
