### PR TITLE
ossl bugfix: ensure peer cert is freed in osslChkPeerAuth

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -353,7 +353,7 @@ finalize_it:
  */
 rsRetVal osslChkPeerAuth(nsd_ossl_t *pThis) {
     DEFiRet;
-    X509 *certpeer;
+    X509 *certpeer = NULL;
 
     ISOBJ_TYPE_assert(pThis, nsd_ossl);
     uchar *fromHostIP = NULL;
@@ -388,6 +388,9 @@ rsRetVal osslChkPeerAuth(nsd_ossl_t *pThis) {
             break;
     }
 finalize_it:
+    if (certpeer != NULL) {
+        X509_free(certpeer);
+    }
     if (fromHostIP != NULL) {
         free(fromHostIP);
     }


### PR DESCRIPTION
Ensure `osslChkPeerAuth` starts with a null peer-certificate pointer and frees any retrieved X509 certificate so OpenSSL allocations from `SSL_get_peer_certificate` do not leak after TLS handshakes.