### PR TITLE
core: stop busy-loop when action disables itself

### DIFF
--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -167,7 +167,7 @@ rsRetVal activateRulesetQueues(void) {
 
 static rsRetVal execAct(struct cnfstmt *stmt, smsg_t *pMsg, wti_t *pWti) {
     DEFiRet;
-    if (stmt->d.act->bDisabled) {
+    if (actionIsDisabled(stmt->d.act)) {
         DBGPRINTF("action %d died, do NOT execute\n", stmt->d.act->iActionNbr);
         FINALIZE;
     }

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -40,6 +40,9 @@
 questions needs to be dropped as it will always fail. The             \
 action must still do a "normal" retry in order to bring               \
 it back to regular state. */
+#define ACT_STATE_DISABLED                                  \
+    6 /* action encountered an unrecoverable failure and is \
+         permanently disabled for this process lifetime */
 /* note: 3 bit bit field --> highest value is 7! */
 
 typedef struct actWrkrInfo {


### PR DESCRIPTION
In the field, an action that disables itself could leave workers in a tight retry/commit cycle, pegging a CPU core. This change makes the engine recognize and short-circuit disabled actions promptly, avoiding spin and wasted work.

Before/After: disabled action could spin in retry/commit ->
disabled action is marked and skipped with a clear return code.

Impact: CPU spikes from disabled actions are eliminated. Messages for that action are no longer retried once disabled (unchanged intent).

Technical details:
- Add ACT_STATE_DISABLED and surface it via getActStateName("disabled").
- Map disabled state and flag to RS_RET_DISABLE_ACTION in getReturnCode().
- New helper actionDisableForWorker(): calls actionDisable() and sets the per-worker state to DISABLED if needed.
- Gate all hot paths on !bDisabled and/or DISABLED state: processMsgMain/processBatchMain, actionPrepare/tryResume, doRetry and doRetry_extFile loops, actionCommit, actionCommitAllDirect, doSubmitToActionQ, actionWriteToAction. Loops now break on disable.
- Treat RS_RET_DISABLE_ACTION like a terminal outcome in commit/execute flows; callers transition to DISABLED and stop rescheduling work.

Fixes: https://github.com/rsyslog/rsyslog/issues/5423
