### PR TITLE
doc: enable parallel Sphinx builds; silence edit_on_github

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,32 +1,43 @@
 # Makefile for rsyslog-doc
 #
 # You can set these variables from the command line.
-SPHINXOPTS ?=
+SPHINXOPTS := $(SPHINXOPTS)
 SPHINXBUILD ?= sphinx-build
 SOURCEDIR = source
 BUILDDIR = build
 
+# Function to add parallel jobs from MAKEFLAGS to SPHINXOPTS
+define add_parallel_jobs
+	$(eval SPHINXOPTS += $(if $(filter -j%,$(SPHINXOPTS)),,$(filter -j%,$(MAKEFLAGS))))
+endef
+
 .PHONY: help clean html singlehtml json alljson
 
 help:
+	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
 	rm -rf "$(BUILDDIR)"
 
 html:
+	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 singlehtml:  # -t minimal_build triggers stripped-down config in conf.py
+	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -M singlehtml "$(SOURCEDIR)" "$(BUILDDIR)" -t minimal_build $(SPHINXOPTS) -D rst_epilog='' $(O)
 	@echo
 	@echo "Build finished. The minimal single page HTML is in $(BUILDDIR)/singlehtml."
 
 json:
+	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -b json "$(SOURCEDIR)" "$(BUILDDIR)/json" $(SPHINXOPTS) $(O)
 
 alljson: json
+	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -b json "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 %:
+	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/_ext/edit_on_github.py
+++ b/doc/source/_ext/edit_on_github.py
@@ -40,4 +40,12 @@ def setup(app):
     app.add_config_value('edit_on_github_project', '', True)
     app.add_config_value('edit_on_github_branch', 'master', True)
     app.connect('html-page-context', html_page_context)
+    # Declare the extension as safe for Sphinx parallel reading/writing.
+    # This extension does not maintain global mutable state and only
+    # augments per-page rendering context, so it is safe.
+    return {
+        'version': '1.0',
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }
 


### PR DESCRIPTION
## Summary
Enable true parallel Sphinx docs builds and remove the warning about
edit_on_github not declaring parallel safety.

## Changes
- Mark doc/source/_ext/edit_on_github.py as parallel read/write safe.
- Propagate GNU make’s -j to sphinx-build in doc/Makefile (respects an
  explicit -j in SPHINXOPTS; bare -j maps to -j auto).

## Impact
- `make -C doc html -jN` now parallelizes Sphinx and runs warning-free.
- No changes to generated content or theme.

Fixes: https://github.com/rsyslog/rsyslog/issues/6254