### PR TITLE
Enable Sphinx Sitemap Generation for HTML Documentation

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,3 +3,4 @@
 sphinx>=4.5.0
 furo
 sphinxcontrib.mermaid
+sphinx-sitemap

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,7 @@ extensions = ['edit_on_github',
               'sphinx.ext.todo',
               'rsyslog_lexer',
               'sphinxcontrib.mermaid',
+              'sphinx_sitemap',
              ]
 edit_on_github_project = 'https://github.com/rsyslog/rsyslog'
 edit_on_github_branch = 'main'
@@ -235,6 +236,11 @@ suppress_warnings = ['epub.unknown_project_files']
 # It is used to indicate the location of document like canonical_url.
 RSYSLOG_BASE_URL = 'https://www.rsyslog.com'
 html_baseurl = f'{RSYSLOG_BASE_URL}/doc/'
+
+# Sitemap configuration to remove language/version from URLs
+sitemap_url_scheme = "{link}"
+sitemap_localtolinks = False
+sitemap_filename = "sitemap.xml"
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.


### PR DESCRIPTION
This PR adds sitemap generation capability to the rsyslog documentation build process, allowing search engines and other automated tools to better discover and index the documentation pages.

### Changes Made

- **doc/requirements.txt**: Added `sphinx-sitemap` dependency
- **doc/source/conf.py**: Added `sphinx_sitemap` extension and configured sitemap settings:
  - `sitemap_url_scheme = "{link}"` - Uses clean URLs without language/version prefixes
  - `sitemap_localtolinks = False` - Generates absolute URLs for production use  
  - `sitemap_filename = "sitemap.xml"` - Standard sitemap filename

### Configuration Details

The sitemap is configured to generate URLs under the existing base URL `https://www.rsyslog.com/doc/` and will include all documentation pages in a format suitable for search engine indexing.

### Testing

Successfully built the documentation with `make html`, confirming that `sitemap.xml` is generated in `build/html/sitemap.xml` as expected.

This enhancement improves the discoverability of the rsyslog documentation for users and search engines.