### PR TITLE
action.c: reordered actionDestruc

### DIFF
--- a/action.c
+++ b/action.c
@@ -314,8 +314,6 @@ rsRetVal actionDestruct(action_t *const pThis) {
      */
     if (pThis->statsobj != NULL) statsobj.Destruct(&pThis->statsobj);
 
-    if (pThis->pModData != NULL) pThis->pMod->freeInstance(pThis->pModData);
-
     if (pThis->fdErrFile != -1) close(pThis->fdErrFile);
     pthread_mutex_destroy(&pThis->mutErrFile);
     pthread_mutex_destroy(&pThis->mutAction);
@@ -326,6 +324,12 @@ rsRetVal actionDestruct(action_t *const pThis) {
     free(pThis->ppTpl);
     free(pThis->peParamPassing);
     freeWrkrDataTable(pThis);
+
+    /* The module's instance data must be freed after the worker data table,
+     * as workers may need to access the shared module data during their
+     * cleanup.
+     */
+    if (pThis->pModData != NULL) pThis->pMod->freeInstance(pThis->pModData);
 
 finalize_it:
     free(pThis);


### PR DESCRIPTION
This is intended to be a question rather than a complete fix.

### Problem description
When shutting down an action (for example omfwd), rsyslog first frees the shared configuration data, then tries to free each worker's data. The problem is that workers need to read the shared configuration during their cleanup, for example, to check how many TCP connections to close. Since the shared data was already freed, the workers end up reading from deallocated memory, which is a use-after-free bug.

In `actionDestruct`, we have 
```
...
if (pThis->pModData != NULL) pThis->pMod->freeInstance(pThis->pModData);
...
freeWrkrDataTable(pThis);
```

In omfwd, the wrkrInstanceData_t structure contains `instanceData *pData` (pointer to shared data). When `freeInstance` finishes, it will free `pModData(pData)`. But that pointer is also used in  `freeWrkrInstance`, which is called from `freeWrkrDataTable`.

I am not entirely sure if the fix will not have any consequences, that's why I am marking it as a DRAFT.