### PR TITLE
imfile: ensure state files are deleted correctly on log rotation

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -237,6 +237,7 @@ static void ATTR_NONNULL() act_obj_unlink(act_obj_t *act);
 static uchar *ATTR_NONNULL(1, 2) getStateFileName(const act_obj_t *, uchar *, const size_t);
 static int ATTR_NONNULL()
     getFullStateFileName(const uchar *const, const char *const, uchar *const pszout, const size_t ilenout);
+static void ATTR_NONNULL(1) getFileID(act_obj_t *const act);
 
 
 #define OPMODE_POLLING 0
@@ -983,6 +984,7 @@ static void act_obj_destroy(act_obj_t *const act, const int is_deleted) {
         pollFile(act); /* get any left-over data */
         if (inst->bRMStateOnDel) {
             statefn = getStateFileName(act, statefile, sizeof(statefile));
+	    getFileID(act);
             getFullStateFileName(statefn, act->file_id, toDel, sizeof(toDel));  // TODO: check!
             statefn = toDel;
         }


### PR DESCRIPTION
Problem:
When log rotation occurs, imfile sometimes fails to delete the old state files. The issue arises because detect_updates() notices that the inode of a monitored file has changed and calls:

    detect_updates() -> act_obj_unlink() -> act_obj_destroy()

However, act_obj_destroy() does not initialize the fileId by calling getFileID(). As a result, the fileId may be uninitialized, and getFullStateFileName() cannot generate the correct state file path.

Solution:
This patch ensures that fileId is always properly initialized when act_obj_destroy() attempts to construct and delete the state file name. This guarantees that state files are correctly removed during log rotation.

Before Fix:
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263637931:imfile.c       : imfile.c: file '/var/log/hitCount4.log' inode changed from 55 to 41, unlinking from internal lists
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263640672:imfile.c       : imfile.c: act_obj_unlink 0x7ff7440010b0: /var/log/hitCount4.log, pStrm 0x7ff7440011e0, ttDelete: 1761334184
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263644137:imfile.c       : imfile.c: act_obj_destroy: act 0x7ff7440010b0 '/var/log/hitCount4.log' (source '---'), wd 8, pStrm 0x7ff7440011e0, is_deleted 1, in_move 0
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263646925:imfile.c       : imfile.c: pollFileReal enter, act 0x7ff7440010b0, pStrm 0x7ff7440011e0, name '/var/log/hitCount4.log'
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263649009:imfile.c       : imfile.c: pollFileReal enter, edge 0x252f0bc0
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263650903:imfile.c       : imfile.c: pollFileReal enter, edge->instarr 0x252d6b80
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263655125:imfile.c       : imfile.c: getStateFileName for '/var/log/hitCount4.log'
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263657750:imfile.c       : imfile.c: getStateFileName:  state file name now is imfile-state:55
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263661051:imfile.c       : imfile.c: getStateFileName for '/var/log/hitCount4.log'
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263663059:imfile.c       : imfile.c: getStateFileName:  state file name now is imfile-state:55
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263669715:imfile.c       : imfile.c: getFileID for '/var/log/hitCount4.log', file_id_hash '2d133e8aa64d6735'
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263672153:imfile.c       : imfile.c: persisting state for '/var/log/hitCount4.log', state file '/var/lib/rsyslog/imfile-state:55:2d133e8aa64d6735'
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263759513:imfile.c       : imfile.c: removing old state file: '/var/lib/rsyslog/imfile-state:55'
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263765848:imfile.c       : imfile.c: trying to delete no longer valid statefile '/var/lib/rsyslog/imfile-state:55' which no longer exists (probably already deleted)
Oct 24 19:29:45 radovid01-2 rsyslogd[2390292]: 4185.263771427:imfile.c       : imfile.c: act_obj_destroy: deleting state file /var/lib/rsyslog/imfile-state:55

After Fix:
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314921539:imfile.c       : imfile.c: file '/var/log/hitCount4.log' inode changed from 55 to 41, unlinking from internal lists
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314924253:imfile.c       : imfile.c: act_obj_unlink 0x7f429c014d70: /var/log/hitCount4.log, pStrm 0x7f429c001120, ttDelete: 1761334567
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314927752:imfile.c       : imfile.c: act_obj_destroy: act 0x7f429c014d70 '/var/log/hitCount4.log' (source '---'), wd 8, pStrm 0x7f429c001120, is_deleted 1, in_move 0
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314930721:imfile.c       : imfile.c: pollFileReal enter, act 0x7f429c014d70, pStrm 0x7f429c001120, name '/var/log/hitCount4.log'
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314932482:imfile.c       : imfile.c: pollFileReal enter, edge 0x6230bc0
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314934251:imfile.c       : imfile.c: pollFileReal enter, edge->instarr 0x6216b80
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314940752:imfile.c       : imfile.c: getStateFileName for '/var/log/hitCount4.log'
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314943133:imfile.c       : imfile.c: getStateFileName:  state file name now is imfile-state:55
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314950074:imfile.c       : imfile.c: getFileID for '/var/log/hitCount4.log', file_id_hash '787806325d372188'
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314953173:imfile.c       : imfile.c: getStateFileName for '/var/log/hitCount4.log'
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314955852:imfile.c       : imfile.c: getStateFileName:  state file name now is imfile-state:55
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314961204:imfile.c       : imfile.c: getFileID for '/var/log/hitCount4.log', file_id_hash '787806325d372188'
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.314963948:imfile.c       : imfile.c: persisting state for '/var/log/hitCount4.log', state file '/var/lib/rsyslog/imfile-state:55:787806325d372188'
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.315059771:imfile.c       : imfile.c: removing old state file: '/var/lib/rsyslog/imfile-state:55'
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.315066002:imfile.c       : imfile.c: trying to delete no longer valid statefile '/var/lib/rsyslog/imfile-state:55' which no longer exists (probably already deleted)
Oct 24 19:36:08 radovid01-2 rsyslogd[2424935]: 4568.315071242:imfile.c       : imfile.c: act_obj_destroy: deleting state file /var/lib/rsyslog/imfile-state:55:787806325d372188

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

