### PR TITLE
Add API key authentication to omelasticsearch

### DIFF
--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -145,6 +145,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/omelasticsearch-pwd.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-apikey`
+     - .. include:: ../../reference/parameters/omelasticsearch-apikey.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omelasticsearch-errorfile`
      - .. include:: ../../reference/parameters/omelasticsearch-errorfile.rst
         :start-after: .. summary-start
@@ -228,6 +232,7 @@ Action Parameters
    ../../reference/parameters/omelasticsearch-dynparent
    ../../reference/parameters/omelasticsearch-uid
    ../../reference/parameters/omelasticsearch-pwd
+   ../../reference/parameters/omelasticsearch-apikey
    ../../reference/parameters/omelasticsearch-errorfile
    ../../reference/parameters/omelasticsearch-tls-cacert
    ../../reference/parameters/omelasticsearch-tls-mycert

--- a/doc/source/reference/parameters/omelasticsearch-apikey.rst
+++ b/doc/source/reference/parameters/omelasticsearch-apikey.rst
@@ -1,0 +1,45 @@
+.. _param-omelasticsearch-apikey:
+.. _omelasticsearch.parameter.module.apikey:
+
+apikey
+======
+
+.. index::
+   single: omelasticsearch; apikey
+   single: apikey
+
+.. summary-start
+
+Supplies the value for the ``Authorization: ApiKey`` HTTP header.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: apikey
+:Scope: action
+:Type: word
+:Default: action=none
+:Required?: no
+:Introduced: 8.2406.0
+
+Description
+-----------
+Accepts the API key material expected by Elasticsearch's ``ApiKey`` authentication scheme.
+The configured value is appended to the ``Authorization: ApiKey`` header without modification,
+so provide the base64-encoded ``<id>:<api_key>`` string exactly as documented by Elasticsearch.
+
+The API key setting cannot be combined with :ref:`param-omelasticsearch-uid` or
+:ref:`param-omelasticsearch-pwd`.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-apikey:
+.. _omelasticsearch.parameter.action.apikey:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" apikey="...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`.

--- a/doc/source/reference/parameters/omelasticsearch-pwd.rst
+++ b/doc/source/reference/parameters/omelasticsearch-pwd.rst
@@ -26,6 +26,7 @@ This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
 Description
 -----------
 Supplies the password when Elasticsearch requires basic authentication.
+This parameter cannot be combined with :ref:`param-omelasticsearch-apikey`.
 
 Action usage
 ------------

--- a/doc/source/reference/parameters/omelasticsearch-uid.rst
+++ b/doc/source/reference/parameters/omelasticsearch-uid.rst
@@ -26,6 +26,7 @@ This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
 Description
 -----------
 Supplies the user name when Elasticsearch requires basic authentication.
+This parameter cannot be combined with :ref:`param-omelasticsearch-apikey`.
 
 Action usage
 ------------


### PR DESCRIPTION
## Summary
- add an `apikey` action parameter so omelasticsearch can send an `Authorization: ApiKey` header
- reject configurations that mix API keys with basic-auth credentials and plumb the header into curl setup
- document the new parameter and cross-link the mutual exclusion with the existing `uid`/`pwd` options

## Testing
- devtools/format-code.sh


------
https://chatgpt.com/codex/tasks/task_e_6901eb747ebc8332a9773d5444de8ae7