### PR TITLE
CI: skip a potentially buggy test

### DIFF
--- a/tests/imrelp-tls-cfgcmd.sh
+++ b/tests/imrelp-tls-cfgcmd.sh
@@ -2,6 +2,9 @@
 # addd 2019-11-14 by alorbach, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 require_relpEngineSetTLSLibByName
+echo This test seems to have problems with a tcpflood segfault on some platforms, thus skipping
+echo see https://github.com/rsyslog/rsyslog/issues/6267
+skip_test
 export NUMMESSAGES=1000
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"


### PR DESCRIPTION
Test imrelp-tls-cfgcmd.sh seems to fail but still report success, which can create a false impression.

Suspected root cause is in librelp. It may also be that the test actually succeeds, where it just looks like it failed because of abort of tcpflood testing tool (due to librelp bug).

The whole point of the test is that an error is generated, and this may very well happen. And only tcpflood aborts because of the librelp bug. Core file detection than jumps in, and invalidly treats the tcpflood core file as a test failure.

While this is investigated, the test will be skipped. Highly like that this needs to be forwarded either to librelp or is a native tcpflood bug.

Thanks to Santiago Vila for reporting the bug and Michael Biebl for forwarding it upstream.

see also: https://github.com/rsyslog/rsyslog/issues/6267
