### PR TITLE
mmsnareparse: add Sysmon event support via JSON definition file

### DIFF
--- a/plugins/mmsnareparse/Makefile.am
+++ b/plugins/mmsnareparse/Makefile.am
@@ -5,4 +5,4 @@ mmsnareparse_la_CPPFLAGS = $(RSRT_CFLAGS) $(PTHREADS_CFLAGS)
 mmsnareparse_la_LDFLAGS = -module -avoid-version $(LIBFASTJSON_LIBS)
 mmsnareparse_la_LIBADD =
 
-EXTRA_DIST =
+EXTRA_DIST = sysmon_definitions.json

--- a/plugins/mmsnareparse/sysmon_definitions.json
+++ b/plugins/mmsnareparse/sysmon_definitions.json
@@ -1,0 +1,804 @@
+{
+  "events": [
+    {
+      "event_id": 1,
+      "category": "Process",
+      "subtype": "Creation",
+      "outcome": "success"
+    },
+    {
+      "event_id": 2,
+      "category": "File",
+      "subtype": "TimeChange",
+      "outcome": "success"
+    },
+    {
+      "event_id": 3,
+      "category": "Network",
+      "subtype": "Connection",
+      "outcome": "success"
+    },
+    {
+      "event_id": 4,
+      "category": "System",
+      "subtype": "ServiceStateChange",
+      "outcome": "success"
+    },
+    {
+      "event_id": 5,
+      "category": "Process",
+      "subtype": "Termination",
+      "outcome": "success"
+    },
+    {
+      "event_id": 6,
+      "category": "Driver",
+      "subtype": "Load",
+      "outcome": "success"
+    },
+    {
+      "event_id": 7,
+      "category": "Image",
+      "subtype": "Load",
+      "outcome": "success"
+    },
+    {
+      "event_id": 8,
+      "category": "Process",
+      "subtype": "RemoteThread",
+      "outcome": "success"
+    },
+    {
+      "event_id": 9,
+      "category": "File",
+      "subtype": "RawAccessRead",
+      "outcome": "success"
+    },
+    {
+      "event_id": 10,
+      "category": "Process",
+      "subtype": "Access",
+      "outcome": "success"
+    },
+    {
+      "event_id": 11,
+      "category": "File",
+      "subtype": "Create",
+      "outcome": "success"
+    },
+    {
+      "event_id": 12,
+      "category": "Registry",
+      "subtype": "ObjectCreateDelete",
+      "outcome": "success"
+    },
+    {
+      "event_id": 13,
+      "category": "Registry",
+      "subtype": "ValueSet",
+      "outcome": "success"
+    },
+    {
+      "event_id": 14,
+      "category": "Registry",
+      "subtype": "KeyValueRename",
+      "outcome": "success"
+    },
+    {
+      "event_id": 15,
+      "category": "File",
+      "subtype": "StreamHash",
+      "outcome": "success"
+    },
+    {
+      "event_id": 16,
+      "category": "System",
+      "subtype": "ConfigStateChange",
+      "outcome": "success"
+    },
+    {
+      "event_id": 17,
+      "category": "Pipe",
+      "subtype": "Created",
+      "outcome": "success"
+    },
+    {
+      "event_id": 18,
+      "category": "Pipe",
+      "subtype": "Connected",
+      "outcome": "success"
+    },
+    {
+      "event_id": 19,
+      "category": "WMI",
+      "subtype": "EventFilter",
+      "outcome": "success"
+    },
+    {
+      "event_id": 20,
+      "category": "WMI",
+      "subtype": "EventConsumer",
+      "outcome": "success"
+    },
+    {
+      "event_id": 21,
+      "category": "WMI",
+      "subtype": "ConsumerToFilter",
+      "outcome": "success"
+    },
+    {
+      "event_id": 22,
+      "category": "Network",
+      "subtype": "DNS",
+      "outcome": "success"
+    },
+    {
+      "event_id": 23,
+      "category": "File",
+      "subtype": "Delete",
+      "outcome": "success"
+    },
+    {
+      "event_id": 24,
+      "category": "Clipboard",
+      "subtype": "Change",
+      "outcome": "success"
+    },
+    {
+      "event_id": 25,
+      "category": "Process",
+      "subtype": "Tampering",
+      "outcome": "success"
+    },
+    {
+      "event_id": 26,
+      "category": "File",
+      "subtype": "DeleteLogged",
+      "outcome": "success"
+    },
+    {
+      "event_id": 27,
+      "category": "File",
+      "subtype": "BlockExecutable",
+      "outcome": "success"
+    },
+    {
+      "event_id": 28,
+      "category": "File",
+      "subtype": "BlockShredding",
+      "outcome": "success"
+    },
+    {
+      "event_id": 29,
+      "category": "File",
+      "subtype": "ExecutableDetected",
+      "outcome": "success"
+    }
+  ],
+  "fields": [
+    {
+      "pattern": "UtcTime",
+      "canonical": "UtcTime",
+      "value_type": "timestamp",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ProcessGuid",
+      "canonical": "ProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ProcessId",
+      "canonical": "ProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Image",
+      "canonical": "Image",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "FileVersion",
+      "canonical": "FileVersion",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Description",
+      "canonical": "Description",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Product",
+      "canonical": "Product",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Company",
+      "canonical": "Company",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "OriginalFileName",
+      "canonical": "OriginalFileName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CommandLine",
+      "canonical": "CommandLine",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CurrentDirectory",
+      "canonical": "CurrentDirectory",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "User",
+      "canonical": "User",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "LogonGuid",
+      "canonical": "LogonGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "LogonId",
+      "canonical": "LogonId",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TerminalSessionId",
+      "canonical": "TerminalSessionId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "IntegrityLevel",
+      "canonical": "IntegrityLevel",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Hashes",
+      "canonical": "Hashes",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentProcessGuid",
+      "canonical": "ParentProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentProcessId",
+      "canonical": "ParentProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentImage",
+      "canonical": "ParentImage",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentCommandLine",
+      "canonical": "ParentCommandLine",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ParentUser",
+      "canonical": "ParentUser",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceIp",
+      "canonical": "SourceIp",
+      "value_type": "ip_address",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourcePort",
+      "canonical": "SourcePort",
+      "value_type": "int64",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationIp",
+      "canonical": "DestinationIp",
+      "value_type": "ip_address",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationPort",
+      "canonical": "DestinationPort",
+      "value_type": "int64",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Protocol",
+      "canonical": "Protocol",
+      "value_type": "string",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Initiated",
+      "canonical": "Initiated",
+      "value_type": "bool",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceIsIpv6",
+      "canonical": "SourceIsIpv6",
+      "value_type": "bool",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceHostname",
+      "canonical": "SourceHostname",
+      "value_type": "string",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationIsIpv6",
+      "canonical": "DestinationIsIpv6",
+      "value_type": "bool",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "DestinationPortName",
+      "canonical": "DestinationPortName",
+      "value_type": "string",
+      "section": "Network",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetFilename",
+      "canonical": "TargetFilename",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CreationUtcTime",
+      "canonical": "CreationUtcTime",
+      "value_type": "timestamp",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "PreviousCreationUtcTime",
+      "canonical": "PreviousCreationUtcTime",
+      "value_type": "timestamp",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "State",
+      "canonical": "State",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Version",
+      "canonical": "Version",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SchemaVersion",
+      "canonical": "SchemaVersion",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "ImageLoaded",
+      "canonical": "ImageLoaded",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Signed",
+      "canonical": "Signed",
+      "value_type": "bool",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Signature",
+      "canonical": "Signature",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SignatureStatus",
+      "canonical": "SignatureStatus",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceProcessGuid",
+      "canonical": "SourceProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceProcessId",
+      "canonical": "SourceProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceThreadId",
+      "canonical": "SourceThreadId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "SourceImage",
+      "canonical": "SourceImage",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetProcessGuid",
+      "canonical": "TargetProcessGuid",
+      "value_type": "guid",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetProcessId",
+      "canonical": "TargetProcessId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetImage",
+      "canonical": "TargetImage",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "NewThreadId",
+      "canonical": "NewThreadId",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "StartAddress",
+      "canonical": "StartAddress",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "StartModule",
+      "canonical": "StartModule",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "StartFunction",
+      "canonical": "StartFunction",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Device",
+      "canonical": "Device",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "GrantedAccess",
+      "canonical": "GrantedAccess",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "CallTrace",
+      "canonical": "CallTrace",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Configuration",
+      "canonical": "Configuration",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "PipeName",
+      "canonical": "PipeName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "EventType",
+      "canonical": "EventType",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Operation",
+      "canonical": "Operation",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "EventNamespace",
+      "canonical": "EventNamespace",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Name",
+      "canonical": "Name",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Query",
+      "canonical": "Query",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Type",
+      "canonical": "Type",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Destination",
+      "canonical": "Destination",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Consumer",
+      "canonical": "Consumer",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Filter",
+      "canonical": "Filter",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "QueryName",
+      "canonical": "QueryName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "QueryStatus",
+      "canonical": "QueryStatus",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "QueryResults",
+      "canonical": "QueryResults",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "IsExecutable",
+      "canonical": "IsExecutable",
+      "value_type": "bool",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Archived",
+      "canonical": "Archived",
+      "value_type": "bool",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Session",
+      "canonical": "Session",
+      "value_type": "int64",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Client Info",
+      "canonical": "ClientInfo",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "TargetObject",
+      "canonical": "TargetObject",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "NewName",
+      "canonical": "NewName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "Details",
+      "canonical": "Details",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    },
+    {
+      "pattern": "RuleName",
+      "canonical": "RuleName",
+      "value_type": "string",
+      "section": "EventData",
+      "priority": 10,
+      "sensitivity": "case_sensitive"
+    }
+  ]
+}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -510,6 +510,7 @@ TESTS += \
 	mmsnareparse-comprehensive.sh \
 	mmsnareparse-value-types.sh \
 	mmsnareparse-enhanced-validation.sh \
+	mmsnareparse-sysmon.sh \
 	mmsnareparse-kerberos.sh \
 	mmsnareparse-custom.sh \
 	mmsnareparse-realworld-4624-4634-5140.sh
@@ -2089,6 +2090,7 @@ EXTRA_DIST= \
         mmsnareparse-custom.sh \
         mmsnareparse-enhanced-validation.sh \
         mmsnareparse-json.sh \
+        mmsnareparse-sysmon.sh \
         mmsnareparse-kerberos.sh \
         mmsnareparse-realworld-4624-4634-5140.sh \
         mmsnareparse-syslog.sh \

--- a/tests/mmsnareparse-sysmon.sh
+++ b/tests/mmsnareparse-sysmon.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Validate mmsnareparse parsing against Microsoft Sysmon events using definition file.
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmsnareparse/.libs/mmsnareparse")
+
+template(name="outfmt" type="list") {
+    property(name="$!win!Event!EventID")
+    constant(value=",")
+    property(name="$!win!Event!Channel")
+    constant(value=",")
+    property(name="$!win!Event!Category")
+    constant(value=",")
+    property(name="$!win!Event!Subtype")
+    constant(value=",")
+    property(name="$!win!EventData!ProcessId")
+    constant(value=",")
+    property(name="$!win!EventData!Image")
+    constant(value=",")
+    property(name="$!win!EventData!CommandLine")
+    constant(value=",")
+    property(name="$!win!EventData!User")
+    constant(value=",")
+    property(name="$!win!Network!SourceIp")
+    constant(value=",")
+    property(name="$!win!Network!SourcePort")
+    constant(value=",")
+    property(name="$!win!Network!DestinationIp")
+    constant(value=",")
+    property(name="$!win!Network!DestinationPort")
+    constant(value=",")
+    property(name="$!win!Network!Protocol")
+    constant(value="\n")
+}
+
+action(type="mmsnareparse"
+       definition.file="../plugins/mmsnareparse/sysmon_definitions.json")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+cat <<'MSG' > ${RSYSLOG_DYNNAME}.input
+<14>Nov 25 05:54:32 DC-01 MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	10448	Tue Nov 25 05:54:32 2025	1	Windows	SYSTEM	User	Information	DC-01	CORP\NETWORK SERVICE	Process creation	Sysmon  Event ID 1 - Process creation: UtcTime: 2024-04-28 22:08:22.025 ProcessGuid: {b34fbf9a-ce67-6a14-1111-1121f0a06f11} ProcessId: 6228 Image: C:\Windows\System32\wbem\WmiPrvSE.exe FileVersion: 10.0.22621.1 (WinBuild.160101.0800) Description: WMI Provider Host Product: Microsoft® Windows® Operating System Company: Microsoft Corporation OriginalFileName: Wmiprvse.exe CommandLine: C:\Windows\system32\wbem\wmiprvse.exe -secured -Embedding CurrentDirectory: C:\Windows\system32\ User: CORP\NETWORK SERVICE LogonGuid: {d56hdh1c-eg89-8c36-3333-3343h2c28h33} LogonId: 0x7EB05 TerminalSessionId: 1 IntegrityLevel: System Hashes: SHA1=A3F7B2C8D9E1F4A5B6C7D8E9F0A1B2C3D4E5F6A7,MD5=8E4F2A1B3C5D6E7F8A9B0C1D2E3F4A5,SHA256=7B9C2D4E5F6A7B8C9D0E1F2A3B4C5D6E7F8A9B0C1D2E3F4A5B6C7D8E9F0A1B2C3D4,IMPHASH=6A5B4C3D2E1F0A9B8C7D6E5F4A3B2C1D0E9F8A7B6C5 ParentProcessGuid: {c45gcg0b-df78-7b25-2222-2232g1b17g22} ParentProcessId: 580 ParentImage: C:\Windows\System32\svchost.exe ParentCommandLine: C:\Windows\system32\svchost.exe -k DcomLaunch -p ParentUser: NT INTERNAL\SYSTEM	10448
+<14>Mar 10 22:36:54 SQL-01 MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	30692	Mon Mar 10 22:36:54 2025	3	Windows	SYSTEM	User	Information	SQL-01	LAB\Administrator	Network connection detected	Sysmon  Event ID 3 - Network connection detected: RuleName: RDP UtcTime: 2017-04-28 22:12:22.557 ProcessGuid: {c45gcg0b-df78-7b25-2222-2232g1b17g22} ProcessId: 13220 Image: C:\Program Files (x86)\Google\Chrome\Application\chrome.exe Description: Sysmon  Event ID 3 User: LAB\Administrator SourceIp: 10.0.0.20 SourcePort: 3328 DestinationIp: 192.168.1.20 DestinationPort: 3389 Protocol: tcp Initiated: true SourceIsIpv6: 192.168.1.20 SourceHostname: DC-03 DestinationIsIpv6: 10.0.0.20 DestinationPortName: ms-wbt-server	30692
+<14>Jun 27 04:55:00 SERVER-01 MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	50518	Fri Jun 27 04:55:00 2025	5	Windows	SYSTEM	User	Information	SERVER-01		Process terminated	Sysmon  Event ID 5 - Process terminated: UtcTime: 2017-04-28 22:13:20.895 ProcessGuid: {02de4fd3-bd56-5903-0000-0010e9d95e00} ProcessId: 12684 Image: C:\Program Files (x86)\Google\Chrome\Application\chrome.exe Description: Sysmon  Event ID 5	50518
+MSG
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+
+shutdown_when_empty
+wait_shutdown
+
+# Test Event ID 1 (Process Creation)
+content_check '1,Microsoft-Windows-Sysmon/Operational,Process,Creation,6228,C:\Windows\System32\wbem\WmiPrvSE.exe,C:\Windows\system32\wbem\wmiprvse.exe -secured -Embedding,CORP\NETWORK SERVICE,,,,,' $RSYSLOG_OUT_LOG
+
+# Test Event ID 3 (Network Connection)
+content_check '3,Microsoft-Windows-Sysmon/Operational,Network,Connection,13220,C:\Program Files (x86)\Google\Chrome\Application\chrome.exe,,LAB\Administrator,10.0.0.20,,192.168.1.20,,tcp' $RSYSLOG_OUT_LOG
+
+# Test Event ID 5 (Process Termination)
+content_check '5,Microsoft-Windows-Sysmon/Operational,Process,Termination,12684,C:\Program Files (x86)\Google\Chrome\Application\chrome.exe,,,,,,' $RSYSLOG_OUT_LOG
+
+exit_test


### PR DESCRIPTION
### Overview
Adds support for Microsoft Sysinternals Sysmon events to the `mmsnareparse` plugin using a JSON definition file, enabling generic parsing of Sysmon events without hardcoding.

### Changes Made

**Core Functionality:**
- Modified `locate_snare_payload()` to detect Sysmon events when MSWinEventLog is in the syslog tag (RFC3164 parsing)
- Updated `populate_event_metadata()` to extract Channel, EventID, Category, and Subtype from RFC3164-formatted messages
- Enhanced channel extraction to use the raw message when MSWinEventLog is moved to the syslog tag
- Fixed key-value parsing to handle single-space-separated pairs in Sysmon descriptions
- Improved pattern selection to prefer EventData section patterns when sectionName is NULL

**Files Modified:**
- `plugins/mmsnareparse/mmsnareparse.c`: Core parsing logic for Sysmon events
- `plugins/mmsnareparse/sysmon_definitions.json`: JSON definition file for Sysmon event types and field patterns
- `tests/mmsnareparse-sysmon.sh`: New test case validating Sysmon event parsing

**Key Technical Details:**
- Generic parsing: no Sysmon-specific hardcoding; extensible via JSON definitions
- RFC3164 support: handles cases where MSWinEventLog is moved to the syslog tag
- Pattern matching: fixes User field storage in EventData section instead of WDAC section
- Value extraction: correctly extracts multi-word values like "CORP\NETWORK SERVICE"

### Testing
- New test case `mmsnareparse-sysmon.sh` validates Event IDs 1, 3, and 5
- All test cases pass successfully
- Validates EventID, Channel, Category, Subtype, ProcessId, Image, CommandLine, User, and Network fields
