### PR TITLE
Add conceptual model summaries to documentation

### DIFF
--- a/doc/source/concepts/janitor.rst
+++ b/doc/source/concepts/janitor.rst
@@ -39,3 +39,15 @@ this takes up some system resources and is not considered useful, we
 have not implemented it that way. If the HUP/janitor interaction causes
 problems, let the rsyslog team know and we can change the implementation.
 
+
+.. _concept-model-concepts-janitor:
+
+Conceptual model
+----------------
+
+- The janitor is a periodic scheduler that runs maintenance jobs such as closing inactive files.
+- All time-based actions are NET (no earlier than) relative to the janitor interval, so deadlines are approximate windows.
+- Frequency tuning trades precision for power usage: shorter intervals reduce latency but increase wakeups.
+- A HUP signal triggers an immediate janitor run, potentially bunching cleanup work with configuration reloads.
+- Janitor work currently reuses existing threads; a dedicated thread is avoided to conserve resources unless needed.
+

--- a/doc/source/concepts/log_pipeline/design_patterns.rst
+++ b/doc/source/concepts/log_pipeline/design_patterns.rst
@@ -171,3 +171,16 @@ See also
 - :doc:`../../configuration/modules/omfile`
 - :doc:`../../configuration/modules/omrelp`
 - :doc:`../../configuration/modules/mmjsonparse`
+
+
+.. _concept-model-concepts-log_pipeline-design_patterns:
+
+Conceptual model
+----------------
+
+- The pipeline is a DAG of rulesets: actions hang off nodes and can be branched (fan-out) or chained (call) to form stages.
+- Each ruleset executes independently on queued messages, so slow or failing actions do not block sibling branches.
+- Fan-out duplicates the same message stream to multiple actions, relying on per-action queues for backpressure isolation.
+- Chained rulesets decompose processing into composable stages, enabling reuse and clearer failure boundaries.
+- Binding inputs to distinct rulesets with dedicated queues partitions workloads and prevents noisy sources from starving others.
+- Queue sizing and worker-thread counts tune throughput vs. isolation; impstats telemetry is needed to monitor backlogs.

--- a/doc/source/concepts/log_pipeline/stages.rst
+++ b/doc/source/concepts/log_pipeline/stages.rst
@@ -145,3 +145,17 @@ See also
 - :doc:`../../configuration/modules/imtcp`
 - :doc:`../../configuration/modules/mmjsonparse`
 - :doc:`../../configuration/modules/omfile`
+
+
+.. _concept-model-concepts-log_pipeline-stages:
+
+Conceptual model
+----------------
+
+- The pipeline is a staged flow: inputs ingest, rulesets transform, actions emit, and queues buffer between each boundary.
+- Inputs can bind to specific rulesets, selecting both processing logic and queue isolation per ingress path.
+- Rulesets encapsulate deterministic filtering and transformation; ``call`` composes them into multi-stage flows.
+- Actions execute within a ruleset context, with optional per-action queues to absorb destination latency.
+- Queue types govern durability and throughput: direct for synchronous handoff, memory for speed, disk-assisted for reliability.
+- Worker threads and queue sizing shape concurrency and backpressure, preventing slow consumers from halting ingestion.
+- Impstats telemetry and queue tuning are essential to maintain predictable latency under varying workloads.

--- a/doc/source/concepts/messageparser.rst
+++ b/doc/source/concepts/messageparser.rst
@@ -302,3 +302,16 @@ and also offer some interesting ideas that may be explored in the future
 - up to full message normalization capabilities. It is strongly
 recommended that anyone with a heterogeneous environment take a look at
 message parser capabilities.
+
+
+.. _concept-model-concepts-messageparser:
+
+Conceptual model
+----------------
+
+- Message parsers operate on already-framed syslog messages, leaving transport framing to input/output modules.
+- Parsers are loadable modules arranged in ordered chains; the first parser that recognizes a format produces the canonical internal representation.
+- Parser ordering encodes precedence, ensuring specific formats (e.g., RFC5424) are matched before permissive fallbacks (e.g., RFC3164).
+- Each ruleset carries its own parser chain, and binding an input to a ruleset selects the parsing semantics for that traffic.
+- Failure to match any parser causes message drop with guardrails to avoid loops, so configurations should end chains with a catch-all parser when loss is unacceptable.
+- Custom parsers extend the system by translating malformed or proprietary formats into rsyslog's internal schema for downstream processing.

--- a/doc/source/concepts/multi_ruleset.rst
+++ b/doc/source/concepts/multi_ruleset.rst
@@ -310,3 +310,17 @@ By default, rulesets do **not** have their own queue. It must be
 activated via the
 :doc:`$RulesetCreateMainQueue <../configuration/ruleset/rsconf1_rulesetcreatemainqueue>`
 directive.
+
+
+.. _concept-model-concepts-multi_ruleset:
+
+Conceptual model
+----------------
+
+- A ruleset is an isolated rule pipeline: filters and actions run only for messages explicitly bound to that ruleset.
+- Inputs bind to rulesets, so routing decisions happen at ingest time rather than through in-pipeline filtering.
+- Parser chains are scoped per ruleset, enabling device-specific parsing semantics alongside routing.
+- Each ruleset can optionally own a dedicated queue, decoupling its work from the global queue and enabling parallel ingestion.
+- Binding listeners to distinct rulesets partitions traffic, reducing filter overhead and improving throughput on multicore hosts.
+- Default ruleset binding applies when no explicit ruleset is provided, but custom bindings override it per input.
+- Queue-enabled rulesets process asynchronously, so message mutations inside them do not propagate back to callers.

--- a/doc/source/concepts/queues.rst
+++ b/doc/source/concepts/queues.rst
@@ -522,3 +522,19 @@ includes data elements there were begun being processed by workers that
 needed to be cancelled due to too-long processing. For a large queue,
 this operation may be lengthy. No timeout applies to a required shutdown
 save.
+
+
+.. _concept-model-concepts-queues:
+
+Conceptual model
+----------------
+
+- Queues decouple producers and consumers so message flow continues even when downstream actions stall.
+- Each queue instance is typed (direct, memory, disk, disk-assisted) to trade throughput, latency, and durability.
+- Direct queues act as synchronous pass-through channels, enabling return-code propagation for backup actions.
+- Memory queues prioritize low latency and throughput, with LinkedList vs. FixedArray implementations balancing footprint and CPU cost.
+- Disk queues persist every element to chunked files, favoring durability over performance and bypassing in-memory buffering.
+- Disk-assisted queues layer a memory primary queue with a spillover disk queue, governed by high/low watermarks to avoid unnecessary writes.
+- Worker thread pools dequeue elements in batches, scaling concurrency based on backlog while respecting configured limits.
+- Flow control uses enqueue timeouts, discard watermarks, and optional rate limiting to bound resource use under pressure.
+- Shutdown sequencing uses timeouts and optional save-on-shutdown persistence to minimize data loss during termination.

--- a/doc/source/whitepapers/queues_analogy.rst
+++ b/doc/source/whitepapers/queues_analogy.rst
@@ -362,3 +362,16 @@ also far from trivial and a real joy for an implementer to work on ;).
 If you have not done so before, it may be worth reading
 :doc:`Understanding rsyslog Queues <../concepts/queues>`, which most
 importantly lists all the knobs you can turn to tweak queue operation.
+
+
+.. _concept-model-whitepapers-queues_analogy:
+
+Conceptual model
+----------------
+
+- rsyslog message flow mirrors traffic: the main queue drives processing and pushes work to passive consumers.
+- Every action conceptually has a queue; "direct" mode is equivalent to a zero-capacity turning lane that still gates flow.
+- Non-direct queues duplicate messages for parallel delivery, isolating slow actions from the main path.
+- Queue workers are the active agents pulling from queues and invoking parsers or actions; consumers never request data.
+- Queue capacity and worker counts bound concurrency: more lanes/queues increase parallelism, while zero-capacity queues serialize.
+- Shutdown, error handling, and timeouts are governed by the queue, which decides completion and can cancel long-running actions.

--- a/doc/source/whitepapers/reliable_logging.rst
+++ b/doc/source/whitepapers/reliable_logging.rst
@@ -79,3 +79,17 @@ why traditional syslog had a reputation for being very slow.
 See Also
 --------
 * https://rainer.gerhards.net/2008/04/on-unreliability-of-plain-tcp-syslog.html
+
+
+.. _concept-model-whitepapers-reliable_logging:
+
+Conceptual model
+----------------
+
+- Reliability is a policy choice: block the application when logging stalls or drop messages to keep workloads running.
+- rsyslog decouples applications via in-memory queues, only halting writers when queues saturate.
+- Disk-assisted queues extend buffer capacity and persistence but introduce latency and eventual disk exhaustion risks.
+- Per-action queues isolate unreliable destinations so other actions can continue during outages.
+- High/low watermarks and severity-based discard policies bound backlog growth under sustained failures.
+- Transport choice defines delivery guarantees: UDP sacrifices reliability; TCP reduces loss window but can drop in-flight data; RELP adds application-level acknowledgements.
+- Absolute durability is limited by OS and disk flush semantics; stronger guarantees trade away throughput by orders of magnitude.

--- a/doc/source/whitepapers/syslog_parsing.rst
+++ b/doc/source/whitepapers/syslog_parsing.rst
@@ -279,3 +279,16 @@ I hope this is a useful guide. You may also have a look at the `rsyslog
 troubleshooting guide <troubleshoot.html>`_ for further help and places
 where to ask questions.
 
+
+.. _concept-model-whitepapers-syslog_parsing:
+
+Conceptual model
+----------------
+
+- Legacy syslog message format is underspecified; parsers must tolerate malformed inputs and often rely on heuristics.
+- RFC3164 provides only informational guidance, so vendors emit divergent formats that can blur hostname, tag, and message boundaries.
+- Parser ambiguity arises when tokens can represent multiple fields; without clear delimiters, deterministic recovery is impossible.
+- rsyslog exposes internal properties (e.g., fromhost, timegenerated, rawmsg) to rebuild structured output when parsing fails.
+- Custom C parsers can be bound per ruleset to normalize proprietary formats efficiently, avoiding heavy regex-based workarounds.
+- The safest path is to configure senders to emit well-formed messages, reducing guesswork and preserving semantic fidelity.
+

--- a/doc/source/whitepapers/syslog_protocol.rst
+++ b/doc/source/whitepapers/syslog_protocol.rst
@@ -214,5 +214,18 @@ be discussed ;)
 -  The implications of the current syslog/tcp industry standard on
    syslog-protocol should be further evaluated and be fully understood
 
+
+.. _concept-model-whitepapers-syslog_protocol:
+
+Conceptual model
+----------------
+
+- syslog-protocol introduces a structured header (PRI, VERSION, TIMESTAMP, HOSTNAME, APP-NAME, PROCID, MSGID, SD, MSG) to standardize message framing.
+- rsyslog auto-detects legacy vs. protocol messages, mapping missing fields (e.g., TAG to APP-NAME/PROCID) to maintain compatibility during transition.
+- Parsing focuses on minimal validation for performance; structured data may be accepted without strict checks to avoid drop-induced data loss.
+- Message transport (UDP/TCP) imposes limits: UDP fragmentation and LF-delimited TCP can truncate or split protocol frames.
+- Encoding and NUL handling are implementation challenges; messages are often forwarded as-is because source encoding is unknown.
+- Rules for discarding malformed messages are relaxed in practice; marking and routing invalid messages preserves observability.
+
  
 


### PR DESCRIPTION
## Summary
- add conceptual model sections to queue, parser, ruleset, and pipeline concept pages
- capture core reliability and syslog protocol semantics for quick ingestion

## Testing
- not run (documentation changes only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691b6419cc308332a596b153a23cbf6f)