### PR TITLE
mmsnareparse: add ignoreTrailingPattern parameter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -274,14 +274,84 @@ Minimum setup requires:
   - Autotools toolchain: `autoconf`, `automake`, `libtool`, `make`, `gcc`
   - Side libraries: `libestr`, `librelp`, `libfastjson`, `liblognorm` (must be installed or built manually)
 
-Example commands (swap the final step for the most relevant smoke test):
+### Complete Dependency Installation (Ubuntu/Debian WSL)
+
+For a full development environment with all common dependencies:
 
 ```bash
-./autogen.sh
-./configure --enable-debug --enable-testbench
-make -j$(nproc)
+sudo apt-get update
+sudo apt-get install -y \
+    autoconf autoconf-archive automake autotools-dev \
+    bison flex gcc \
+    libcurl4-gnutls-dev libdbi-dev libgcrypt20-dev \
+    libglib2.0-dev libgnutls28-dev \
+    libtool libtool-bin libzstd-dev make \
+    libestr-dev python3-docutils libfastjson-dev \
+    liblognorm-dev libcurl4-gnutls-dev \
+    libaprutil1-dev libcivetweb-dev \
+    valgrind clang-format
+```
+
+Mark the environment as configured (optional, for tracking):
+```bash
+touch /tmp/rsyslog_base_env.flag
+```
+
+### Build Process
+
+1. **Generate configure script** (required after fresh checkout or changes to build files):
+   ```bash
+   ./autogen.sh
+   ```
+
+2. **Configure with testbench and required modules**:
+   ```bash
+   # Basic configuration
+   ./configure --enable-testbench --enable-imdiag --enable-omstdout
+   
+   # For specific module testing, add the module's enable flag:
+   ./configure --enable-testbench --enable-imdiag --enable-omstdout \
+       --enable-mmsnareparse
+   
+   # For multiple modules:
+   ./configure --enable-testbench --enable-imdiag --enable-omstdout \
+       --enable-mmsnareparse \
+       --enable-omotlp \
+       --enable-imhttp
+   ```
+
+3. **Build the project**:
+   ```bash
+   make -j$(nproc)
+   ```
+
+### Running Tests
+
+#### Example 1: Run a single test directly (recommended for debugging)
+```bash
 ./tests/imtcp-basic.sh
 ```
+
+#### Example 2: Run a single test through make check
+```bash
+make check -j16 TESTS="imtcp-basic.sh"
+```
+
+#### Example 3: Run module-specific tests
+```bash
+# mmsnareparse test
+make check -j16 TESTS="mmsnareparse-sysmon.sh"
+
+# Multiple tests
+make check -j16 TESTS="mmsnareparse-sysmon.sh mmsnareparse-trailing-extradata.sh"
+```
+
+#### Example 4: Run all tests (CI-style, time-consuming)
+```bash
+make check -j4
+```
+
+**Note:** The `-j` flag controls parallelism. Use `-j2` or `-j4` for reliability on resource-constrained systems, or `-j16` for faster execution on powerful machines.
 
 Reserve `make check` for cases where you must mirror CI or chase harness-only failures. When you do run it, prefer `make check -j2` or `-j4` for reliability.
 

--- a/doc/source/configuration/modules/mmsnareparse.rst
+++ b/doc/source/configuration/modules/mmsnareparse.rst
@@ -285,6 +285,7 @@ Parameters
    "``definition.json``", "string", "``unset``", "Inline JSON descriptor following the same schema as ``definition.file``. Processed after the file-based overrides."
    "``runtime.config``", "string", "``unset``", "Persistent runtime configuration file. Supports the definition schema plus ``options`` such as ``enable_debug`` and ``enable_fallback``."
    "``validation.mode`` / ``validation_mode``", "string", "``permissive``", "Selects parser strictness: ``permissive`` ignores issues, ``moderate`` records warnings, ``strict`` aborts when thresholds are exceeded."
+   "``ignoreTrailingPattern``", "string", "``unset``", "Pattern that marks the start of a trailing extra-data section to be ignored during parsing. When set, the parser searches for this pattern in trailing positions (after the last tab-separated token). If found, the message is truncated at that point before parsing, and the truncated extra-data section is stored in the ``!extradata_section`` message property. This is useful for removing non-standard trailing enrichment data that may be added by third-party enrichers. The pattern is a literal string match (not a regex)."
 
 Extracted fields
 ----------------

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -513,7 +513,8 @@ TESTS += \
 	mmsnareparse-sysmon.sh \
 	mmsnareparse-kerberos.sh \
 	mmsnareparse-custom.sh \
-	mmsnareparse-realworld-4624-4634-5140.sh
+	mmsnareparse-realworld-4624-4634-5140.sh \
+	mmsnareparse-trailing-extradata.sh
 if HAVE_VALGRIND
 TESTS += \
 	mmsnareparse-comprehensive-vg.sh
@@ -2095,6 +2096,7 @@ EXTRA_DIST= \
         mmsnareparse-realworld-4624-4634-5140.sh \
         mmsnareparse-syslog.sh \
         mmsnareparse-value-types.sh \
+        mmsnareparse-trailing-extradata.sh \
         mmexternal-InvldProg-vg.sh \
 	nested-call-shutdown.sh \
 	1.rstest 2.rstest 3.rstest err1.rstest \

--- a/tests/mmsnareparse-trailing-extradata.sh
+++ b/tests/mmsnareparse-trailing-extradata.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Validate mmsnareparse parsing with trailing extra-data section truncation.
+# This test verifies both the with-tabs code path and documents the bug fix for the no-tabs path.
+unset RSYSLOG_DYNNAME
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmsnareparse/.libs/mmsnareparse")
+
+template(name="outfmt" type="list") {
+    property(name="$!win!Event!EventID")
+    constant(value=",")
+    property(name="$!win!Event!Channel")
+    constant(value=",")
+    property(name="$!win!EventData!EventType")
+    constant(value=",")
+    property(name="$!win!EventData!TargetObject")
+    constant(value=",")
+    property(name="$!win!EventData!User")
+    constant(value=",")
+    property(name="$!extradata_section")
+    constant(value="\n")
+}
+
+action(type="mmsnareparse"
+       definition.file="../plugins/mmsnareparse/sysmon_definitions.json"
+       ignoreTrailingPattern="enrichment_section:")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+cat <<'MSG' > ${RSYSLOG_DYNNAME}.input
+<14>Mar 22 08:47:23 testhost MSWinEventLog	1	Microsoft-Windows-Sysmon/Operational	20977	Mon Mar 22 08:47:23 2025	13	Windows	SYSTEM	User	SetValue	testhost	Registry value set (rule: RegistryEvent)		Registry value set:  RuleName: Default RegistryEvent  EventType: SetValue  UtcTime: 2025-03-22 08:47:23.284  ProcessGuid: {fd4d0da6-d589-6916-eb03-000000000000}  ProcessId: 4  Image: System  TargetObject: HKLM\System\CurrentControlSet\Services\TestService\ImagePath  Details: "C:\Program Files\TestAgent\TestService.exe"  User: NT AUTHORITY\SYSTEM	3385599 enrichment_section: fromhost-ip=192.168.45.217
+MSG
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+
+shutdown_when_empty
+wait_shutdown
+
+# Test that Event ID 13 (Registry value set) is parsed correctly
+# The ignoreTrailingPattern should remove "enrichment_section: fromhost-ip=192.168.45.217" 
+# from the message before parsing, so it should NOT appear in any parsed fields.
+# However, the truncated content is stored in the !extradata_section property.
+# This test verifies:
+# 1. Parsing works correctly (EventID=13, Channel, EventType=SetValue, TargetObject, User)
+# 2. The enrichment section is removed from parsing (doesn't affect parsed fields)
+# 3. The truncated content is stored in !extradata_section property (tests with-tabs code path)
+#
+# NOTE: A critical bug in the no-tabs code path (lines 5111-5121 in mmsnareparse.c) was fixed
+# where strdup was called AFTER truncation, resulting in an empty string. The fix reverses
+# the order: copy first, then truncate. This is now consistent with the with-tabs path.
+content_check '13,Microsoft-Windows-Sysmon/Operational,SetValue,HKLM\System\CurrentControlSet\Services\TestService\ImagePath,NT AUTHORITY\SYSTEM,3385599 enrichment_section: fromhost-ip=192.168.45.217' $RSYSLOG_OUT_LOG
+
+exit_test


### PR DESCRIPTION
Add `ignoreTrailingPattern` parameter to mmsnareparse for removing trailing extra-data sections

**Description:**

Adds a configurable parameter to the `mmsnareparse` plugin to detect and remove trailing extra-data sections from messages before parsing. This addresses cases where third-party enrichers append non-standard data (e.g., `enrichment_section: fromhost-ip=...`) that can interfere with parsing.

**Changes:**
- Added `ignoreTrailingPattern` parameter at both module and action levels (action-level overrides module default)
- Implemented trailing pattern detection that only matches patterns appearing after the last tab-separated token
- When a pattern is found, the message is truncated at the start of the last token (after the last tab), removing the entire trailing section including any preceding content in that token
- The truncated extra-data section is optionally exposed as a `!extradata_section` message property for downstream use
- Added test case `mmsnareparse-trailing-extradata.sh` validating the feature with anonymized sample data
- Updated documentation in `doc/source/configuration/modules/mmsnareparse.rst` with parameter description

**Technical Details:**
- Pattern matching is literal string-based (not regex)
- Truncation only occurs when pattern appears in trailing positions (after last tab or in trailing portion for non-tab messages)
- Existing parsing behavior is unchanged when parameter is not set
- Memory management: proper allocation and cleanup of pattern strings and extra-data sections

**Testing:**
- New test case validates correct parsing of Event ID 13 (Registry value set) with trailing enrichment section
- Verifies enrichment section is removed from parsed fields but stored in `!extradata_section` property
- Test passes successfully
