### PR TITLE
build: Add code coverage targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ tools/logctl
 tools/rscryutil
 tools/rscryutil.1
 /bin/
+# Coverage artifacts
+*.gcda
+*.gcno
+coverage*

--- a/Makefile.am
+++ b/Makefile.am
@@ -658,3 +658,45 @@ dist-hook:
 	$(AM_V_GEN)echo $(VERSION) > $(distdir)/.tarball-version
 
 ACLOCAL_AMFLAGS = -I m4
+
+COVERAGE_INFO = $(top_builddir)/coverage.info
+COVERAGE_DIR =  coverage
+
+LCOV_FLAGS =	--capture \
+	--config-file "$(top_srcdir)/lcovrc" \
+	--directory "$(abs_top_builddir)" \
+	--ignore-errors mismatch \
+	--output-file $(COVERAGE_INFO)
+
+GENHTML_FLAGS = --legend \
+	--title "$(PACKAGE_NAME)-$(PACKAGE_VERSION) Code Coverage" \
+	--output-directory $(top_builddir)/$(COVERAGE_DIR)
+
+check-coverage: reset-coverage-stats
+if ENABLE_COVERAGE
+	$(MAKE) check || true
+	$(MAKE) coverage
+
+reset-coverage-stats:
+	$(LCOV) --zerocounters --directory "$(abs_top_builddir)"
+
+coverage: clean-coverage-local distclean-coverage-local
+	@echo "Aggregating coverage files and generating HTML summary..."
+	$(LCOV) $(LCOV_FLAGS) > /dev/null
+	$(GENHTML) $(GENHTML_FLAGS) $(COVERAGE_INFO) > /dev/null
+	@echo "Coverage HTML page result file://$(abs_builddir)/$(COVERAGE_DIR)/index.html"
+else
+	@echo "Code coverage not enabled; to enable:"
+	@echo
+	@echo "    ./configure --enable-coverage"
+endif
+
+clean-local: clean-coverage-local
+
+clean-coverage-local:
+	rm -f $(COVERAGE_INFO)
+
+distclean-local: distclean-coverage-local
+
+distclean-coverage-local:
+	rm -rf $(COVERAGE_DIR)

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,8 @@ AC_DEFINE(VERSION_MONTH, 12, [month part of real rsyslog version]) # UPDATE on r
 
 AM_INIT_AUTOMAKE([tar-pax subdir-objects])
 
+AM_EXTRA_RECURSIVE_TARGETS([clean-coverage distclean-coverage])
+
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])
 
 unamestr=$(uname)
@@ -806,6 +808,36 @@ AC_ARG_ENABLE(debug_symbols,
         [enable_debug_symbols="yes"]
 )
 
+# coverage
+AC_ARG_ENABLE([coverage],
+        [AS_HELP_STRING([--enable-coverage], [Enable code coverage @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_coverage="yes" ;;
+          no) enable_coverage="no" ;;
+           *) AC_MSG_ERROR([bad value ${enableval} for --enable-coverage]) ;;
+         esac],
+        [enable_coverage="no"]
+)
+if test "$enable_coverage" = "yes"; then
+        AC_CHECK_TOOL([GCOV], [gcov], [no])
+        AS_IF(
+                [test "x$GCOV" = "xno"],
+                [AC_MSG_ERROR([required program "gcov" for code coverage not found])]
+        )
+        AC_CHECK_PROG([LCOV], [lcov], [lcov], [no])
+        AS_IF(
+                [test "x$LCOV" = "xno"],
+                [AC_MSG_ERROR([required program "lcov" for code coverage not found])]
+        )
+        AC_CHECK_PROG([GENHTML], [genhtml], [genhtml], [no])
+        AS_IF(
+                [test "x$GENHTML" = "xno"],
+                [AC_MSG_ERROR([required program "genhtml" for code coverage not found])]
+        )
+        AC_DEFINE([ENABLE_COVERAGE], [1], [Define to 1 if code coverage is enabled.])
+fi
+AM_CONDITIONAL([ENABLE_COVERAGE], [test "x$enable_coverage" = xyes])
+
 
 # total debugless: highest performance, but no way at all to enable debug
 # logging
@@ -1370,6 +1402,10 @@ if test "$GCC" = "yes"; then
 
   if test "x$enable_debug_symbols" = "xyes"; then
     RSRT_CFLAGS="$RSRT_CFLAGS -g"
+  fi
+  if test "x$enable_coverage" = "xyes"; then
+    RSRT_CFLAGS="$RSRT_CFLAGS --coverage -g -O0"
+    LDFLAGS="$LDFLAGS --coverage"
   fi
 fi
 RSRT_CFLAGS="$RSRT_CFLAGS $WARN_CFLAGS"
@@ -3395,4 +3431,5 @@ echo "    (total) debugless mode enabled:           $enable_debugless"
 echo "    Diagnostic tools enabled:                 $enable_diagtools"
 echo "    End-User tools enabled:                   $enable_usertools"
 echo "    Valgrind support settings enabled:        $enable_valgrind"
+echo "    Code coverage using gcov/lcov enabled:    $enable_coverage"
 echo

--- a/lcovrc
+++ b/lcovrc
@@ -1,0 +1,2 @@
+geninfo_external = 0
+lcov_excl_line   = LCOV_EXCL_LINE|unreachable


### PR DESCRIPTION
<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

- Add new configure flag to enable code coverage using gcc and lcov/genhtml
- Add Makefile targets to run coverage after or during checks, as well as cleaning coverage artefacts

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
None

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

