### PR TITLE
Add agent task keywords SETUP, BUILD, and TEST to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,85 @@ When the user says the codeword "SUMMARIZE", do the following:
   - A summary for the pull request
   - A summary for a squashed commit message
 
+### `SETUP`
+
+When the user says the codeword "SETUP", do the following:
+
+- Install all necessary development dependencies for the rsyslog workspace
+- Run the complete dependency installation command for Ubuntu/Debian systems:
+  ```bash
+  sudo apt-get update
+  sudo apt-get install -y \
+      autoconf autoconf-archive automake autotools-dev \
+      bison flex gcc \
+      libcurl4-gnutls-dev libdbi-dev libgcrypt20-dev \
+      libglib2.0-dev libgnutls28-dev \
+      libtool libtool-bin libzstd-dev make \
+      libestr-dev python3-docutils libfastjson-dev \
+      liblognorm-dev libcurl4-gnutls-dev \
+      libaprutil1-dev libcivetweb-dev \
+      valgrind clang-format
+  ```
+- Mark the environment as configured (optional): `touch /tmp/rsyslog_base_env.flag`
+- Note: This keyword is intended for local Ubuntu/Debian environments (including WSL). In containerized or pre-configured environments, skip this step.
+
+### `BUILD [configure-options]`
+
+When the user says the codeword "BUILD" optionally followed by configure options, do the following:
+
+1. **Generate the autotools build system** (if not already done):
+   ```bash
+   ./autogen.sh
+   ```
+
+2. **Configure the project**:
+   - If configure options are provided after "BUILD", use them:
+     ```bash
+     ./configure [user-provided-options]
+     ```
+   - If no options are provided, use the default testbench configuration:
+     ```bash
+     ./configure --enable-testbench --enable-imdiag --enable-omstdout
+     ```
+
+3. **Build the project**:
+   ```bash
+   make -j$(nproc)
+   ```
+
+Examples:
+- `BUILD` - Uses default testbench configuration
+- `BUILD --enable-testbench --enable-mmsnareparse` - Custom configuration with mmsnareparse module
+- `BUILD --enable-testbench --enable-imdiag --enable-omstdout --enable-mmsnareparse --enable-omotlp` - Multiple modules
+
+### `TEST [test-script-names]`
+
+When the user says the codeword "TEST" optionally followed by test script names, do the following:
+
+1. **Ensure the project is built** (if not already built, run BUILD first)
+
+2. **Run tests**:
+   - If test script names are provided after "TEST", run those specific tests:
+     ```bash
+     ./tests/<test-script-name>.sh
+     ```
+     For multiple tests, run each one:
+     ```bash
+     ./tests/<test-script-1>.sh
+     ./tests/<test-script-2>.sh
+     ```
+   - If no test names are provided, run the default smoke test:
+     ```bash
+     ./tests/imtcp-basic.sh
+     ```
+
+Examples:
+- `TEST` - Runs the default smoke test (`imtcp-basic.sh`)
+- `TEST mmsnareparse-sysmon.sh` - Runs the mmsnareparse-sysmon test
+- `TEST mmsnareparse-sysmon.sh mmsnareparse-trailing-extradata.sh` - Runs multiple specific tests
+
+Note: Tests are run directly (not via `make check`) to provide unfiltered stdout/stderr output.
+
 -----
 
 ## Priming a fresh AI session


### PR DESCRIPTION
This PR extends the "Agent Chat Keywords" section in AGENTS.md with three
new standardized task keywords that enable AI agents to automate common
development workflows:

1. SETUP - Automates installation of all development dependencies for
   Ubuntu/Debian environments (including WSL)

2. BUILD [configure-options] - Automates the autotools build process:
   - Runs ./autogen.sh if needed
   - Configures with provided options or sensible defaults
   - Builds the project with make

3. TEST [test-script-names] - Automates test execution:
   - Ensures project is built first
   - Runs specific test scripts or defaults to smoke test
   - Supports multiple test scripts

These keywords follow the same pattern as existing FINISH and SUMMARIZE
keywords, providing clear instructions and usage examples.

**Use Case: Agent Cloud Tasks Environments**

These keywords are particularly valuable when agents operate in workspace
environments within Agent Cloud Tasks. They enable agents to:

- Automatically set up development environments from scratch
- Build and configure rsyslog with appropriate module flags
- Run tests to verify fixes and validate solutions

This automation allows agents to debug and solve issues autonomously by:
- Reproducing build failures in clean environments
- Testing code changes immediately after implementation
- Validating fixes against the test suite without manual intervention
- Iterating on solutions with rapid build-test cycles

Impact:
- Agents can now use simple keywords instead of manually following
  multi-step instructions
- Reduces errors from incomplete setup or build procedures
- Makes agent workflows more consistent and reproducible
- Enables fully automated debugging workflows in Cloud Tasks environments