### PR TITLE
doc: add TLS example for omelasticsearch

### DIFF
--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -475,9 +475,35 @@ The following sample does the following:
            action.resumeretrycount="-1")
 
 
+Example 4
+---------
+
+The following sample sends events to Elasticsearch over TLS:
+
+-  loads the omelasticsearch module
+-  enables HTTPS for a cluster that presents a trusted certificate
+-  demonstrates how to supply the CA bundle and (optionally) client
+   authentication material
+
+.. code-block:: none
+
+    module(load="omelasticsearch")
+    action(type="omelasticsearch"
+           server="es01.example.net:9200"
+           usehttps="on"
+           tls.cacert="/etc/ssl/certs/ca-bundle.crt"
+           # Uncomment the following lines if client auth is required
+           # tls.mycert="/etc/rsyslog/keys/es-client.crt"
+           # tls.myprivkey="/etc/rsyslog/keys/es-client.key")
+
+The ``server`` value accepts hostnames with optional ports (or explicit
+``https://`` URLs) and is normalized to include the chosen scheme and
+port. Avoid malformed host strings such as ``https://server.example:net:9200``;
+the hostname must be valid when passed directly to libcurl.
+
 .. _omelasticsearch-writeoperation-example:
 
-Example 4
+Example 5
 ---------
 
 The following sample shows how to use :ref:`param-omelasticsearch-writeoperation`
@@ -500,7 +526,7 @@ provides the `uuid` property for each record:
 
 .. _omelasticsearch-retry-example:
 
-Example 5
+Example 6
 ---------
 
 The following sample shows how to use :ref:`param-omelasticsearch-retryfailures` to

--- a/doc/source/reference/parameters/omelasticsearch-server.rst
+++ b/doc/source/reference/parameters/omelasticsearch-server.rst
@@ -25,7 +25,7 @@ This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
 
 Description
 -----------
-Defines one or more Elasticsearch servers. If no scheme is given, it is chosen based on `usehttps`. Missing ports use `serverport`. Requests are load-balanced in round-robin order.
+Defines one or more Elasticsearch servers. Each entry may be a bare hostname or an ``http``/``https`` URL without a trailing slash or path component. If no scheme is given, one is selected based on `usehttps`, otherwise the provided scheme is honored. Missing ports use `serverport`. Requests are load-balanced in round-robin order.
 
 Action usage
 ------------

--- a/doc/source/reference/parameters/omelasticsearch-usehttps.rst
+++ b/doc/source/reference/parameters/omelasticsearch-usehttps.rst
@@ -25,7 +25,7 @@ This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
 
 Description
 -----------
-If enabled, URLs in `server` without an explicit scheme use HTTPS; otherwise HTTP is assumed.
+If enabled, entries in `server` without an explicit scheme use HTTPS; otherwise HTTP is assumed. Servers that already specify ``http`` or ``https`` keep their declared scheme.
 
 Action usage
 ------------


### PR DESCRIPTION
## Summary
- add a TLS connection example for omelasticsearch and clarify valid server values
- document how server entries are normalized and how usehttps interacts with explicit schemes
- reinforce hostname requirements in the TLS guidance

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69273c7a1244833285f477ee87d7efc2)