### PR TITLE
imtcp: add NetworkNamespace to documentation

### DIFF
--- a/doc/source/configuration/modules/imtcp.rst
+++ b/doc/source/configuration/modules/imtcp.rst
@@ -183,6 +183,10 @@ Module Parameters
      - .. include:: ../../reference/parameters/imtcp-preservecase.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imtcp-networknamespace`
+     - .. include:: ../../reference/parameters/imtcp-networknamespace.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 .. toctree::
    :hidden:
@@ -225,6 +229,7 @@ Module Parameters
    ../../reference/parameters/imtcp-streamdriver-crlfile
    ../../reference/parameters/imtcp-streamdriver-keyfile
    ../../reference/parameters/imtcp-streamdriver-certfile
+   ../../reference/parameters/imtcp-networknamespace
 
 Input Parameters
 ----------------
@@ -375,6 +380,10 @@ Input Parameters
      - .. include:: ../../reference/parameters/imtcp-keepalive-interval.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imtcp-networknamespace`
+     - .. include:: ../../reference/parameters/imtcp-networknamespace.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 .. _imtcp-statistic-counter:
 
 Statistic Counter
@@ -493,6 +502,33 @@ connections:
 
 Note that the global parameters (here: max sessions) need to be set when
 the module is loaded. Otherwise, the parameters will not apply.
+
+Example 2
+---------
+
+A single rsyslogd instance can accept messages from multiple network namespaces. This example sets up a TCP server on port 514 in three named namespaces, plus one in the default startup namespace. Note that these namespaces must be created before rsyslogd starts. For example, this can be done using the `ExecStartPre` option in a systemd service file.
+
+.. code-block:: none
+
+   module(load="imtcp" MaxSessions="500")
+   input(type="imtcp" port="514" NetworkNamespace="ns_eth0.0")
+   input(type="imtcp" port="514" NetworkNamespace="ns_eth0.1")
+   input(type="imtcp" port="514" NetworkNamespace="ns_eth0.2")
+   input(type="imtcp" port="514")
+
+
+Example 3
+---------
+
+This example sets a default `NetworkNamespace` at the module level. Multiple TCP servers are then started within that namespace. It also shows that setting `NetworkNamespace` to an empty string (`""`) makes an input listen in the startup namespace instead. The `Address` parameter is used to bind listeners to specific interfaces within their namespaces. This can be combined with a `PermittedPeer` list to control which peers can connect to these ports.
+
+.. code-block:: none
+
+   module(load="imtcp" MaxSessions="500" NetworkNamespace="ns_eth0")
+   input(type="imtcp" Address="172.0.0.1" port="514")
+   input(type="imtcp" Address="172.0.1.1" port="514")
+   input(type="imtcp" Address="172.0.2.1" port="514")
+   input(type="imtcp" port="514" NetworkNamespace="")
 
 
 Additional Resources

--- a/doc/source/reference/parameters/imtcp-networknamespace.rst
+++ b/doc/source/reference/parameters/imtcp-networknamespace.rst
@@ -1,0 +1,53 @@
+.. _param-imtcp-networknamespace:
+.. _imtcp.parameter.input.networknamespace:
+
+NetworkNamespace
+================
+
+.. index::
+   single: imtcp; NetworkNamespace
+   single: NetworkNamespace
+
+.. summary-start
+
+Sets the value for the ``networknamespace`` property.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imtcp`.
+
+:Name: NetworkNamespace
+:Scope: module, input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: v8.2512
+
+Description
+-----------
+Sets the network namespace for the listener.
+
+- If not set, the listener operates in the default (startup) network namespace.
+- The specified namespace must exist before rsyslogd starts (e.g., created via ``ip netns add <name>``).
+- This feature requires rsyslog to be built with ``setns()`` support. An error will be logged if a namespace is configured but support is missing.
+- The underlying operating system must also support network namespaces.
+
+Input usage
+-----------
+.. _param-imtcp-input-networknamespace:
+.. _imtcp.parameter.input.networknamespace-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imtcp" port="514" NetworkNamespace="routing")
+   input(type="imtcp" port="514" NetworkNamespace="management")
+
+.. code-block:: rsyslog
+
+   module(load="imtcp" NetworkNamespace="routing")
+   input(type="imtcp" port="514")
+   input(type="imtcp" port="514" NetworkNamespace="management")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imtcp`.


### PR DESCRIPTION
<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

Update documentation to add NetworkNamespace parameter to imtcp input module

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: [imtcp support for NetworkNamespace](https://github.com/rsyslog/rsyslog/pull/5519)

<!-- ### Notes (optional) -->
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---
<!--
#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.
-->
