### PR TITLE
Handle backslash continuations in rsyslog lexer

### DIFF
--- a/doc/source/_ext/rsyslog_lexer.py
+++ b/doc/source/_ext/rsyslog_lexer.py
@@ -86,7 +86,7 @@ class RainerScriptLexer(RegexLexer):
             (r'\b\d+\b', Number.Integer),
             
             # Punctuation
-            (r'[{}(),;\[\].&]', Punctuation),
+            (r'[{}(),;\\\[\].&]', Punctuation),
             
             # Identifiers
             (r'[a-zA-Z_][a-zA-Z0-9_-]*', Name), # <<<--- THIS IS THE CHANGE: Added '-' to allowed identifier characters


### PR DESCRIPTION
## Summary
- include the backslash character in the RainerScript punctuation class so lexer accepts line continuations used in docs

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ecc895864833295791fe9e3d90655)