### PR TITLE
Add TLS support to rsyslog collector Docker image using OpenSSL

### DIFF
--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -1,13 +1,35 @@
 # reception of network messages. Comment out unneeded functionality
-# NOTE: this is unencrypted config!
+# Supports both unencrypted and TLS-encrypted (OpenSSL) configurations.
+# TLS is disabled by default (ENABLE_TLS=off) for backward compatibility.
 
+# Load input modules
 module(load="imudp" config.enabled=`echo $ENABLE_UDP`)
 module(load="imtcp" config.enabled=`echo $ENABLE_TCP`)
 module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
+# UDP input (unencrypted, port 514)
 input(	config.enabled=`echo $ENABLE_UDP`
 	type="imudp" port="514" ruleset="rs-main")
+
+# TCP input (plain/unencrypted, port 514)
 input(	config.enabled=`echo $ENABLE_TCP`
 	type="imtcp" port="514" ruleset="rs-main")
+
+# TLS TCP input (encrypted via OpenSSL, port 6514, RFC 5425)
+# Requires ENABLE_TLS=on and TLS certificate files to be configured via environment variables:
+# TLS_CA_FILE, TLS_CERT_FILE, TLS_KEY_FILE
+# Certificates are set per-input to avoid warnings when TLS is disabled
+input(	config.enabled=`echo $ENABLE_TLS`
+	type="imtcp"
+	port="6514"
+	ruleset="rs-main"
+	streamDriver.Name="ossl"
+	streamDriver.Mode="1"
+	streamDriver.AuthMode=`echo $TLS_AUTH_MODE`
+	streamDriver.caFile=`echo $TLS_CA_FILE`
+	streamDriver.certFile=`echo $TLS_CERT_FILE`
+	streamDriver.keyFile=`echo $TLS_KEY_FILE`)
+
+# RELP input (port 2514)
 input(	config.enabled=`echo $ENABLE_RELP`
 	type="imrelp" port="2514" ruleset="rs-main")

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -29,11 +29,13 @@ LABEL com.adiscon.rsyslog.base.image="${BASE_IMAGE_TAG}"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install additional rsyslog modules/packages specific to the collector's role.
+# Includes TLS support via OpenSSL (rsyslog-openssl) for secure log collection.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         rsyslog-elasticsearch \
         rsyslog-omhttp \
         rsyslog-relp \
+        rsyslog-openssl \
     && apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -44,16 +46,24 @@ COPY 10-collector.conf 80-file-output.conf /etc/rsyslog.d/
 
 # Expose standard syslog ports.
 # These ports will be exposed by default for UDP and TCP syslog reception.
+# Port 6514/tcp is the standard port for syslog over TLS (RFC 5425).
 EXPOSE 514/udp
 EXPOSE 514/tcp
 EXPOSE 2514/tcp
+EXPOSE 6514/tcp
 
 # Default config toggles for an entrypoint script to use
 ENV ENABLE_UDP=on
 ENV ENABLE_TCP=on
 ENV ENABLE_RELP=off
+ENV ENABLE_TLS=off
 ENV WRITE_ALL_FILE=on
 ENV WRITE_JSON_FILE=on
+# TLS configuration paths (can be overridden via volume mounts or environment)
+ENV TLS_CA_FILE=""
+ENV TLS_CERT_FILE=""
+ENV TLS_KEY_FILE=""
+ENV TLS_AUTH_MODE="anon"
 
 # Define the container role for the entrypoint script
 ENV RSYSLOG_ROLE=collector


### PR DESCRIPTION
This PR adds TLS/SSL support to the rsyslog collector Docker image
using OpenSSL, enabling secure log collection over encrypted
connections while maintaining full backward compatibility.

Changes:
- Added rsyslog-openssl package installation in Dockerfile
- Added TLS TCP input on port 6514 (RFC 5425 standard)
- Configured OpenSSL StreamDriver for TLS connections
- Added environment variables for TLS configuration:
  * ENABLE_TLS (default: off)
  * TLS_CA_FILE, TLS_CERT_FILE, TLS_KEY_FILE
  * TLS_AUTH_MODE (default: anon)
- Exposed port 6514/tcp for TLS connections

Backward Compatibility:
- TLS is disabled by default (ENABLE_TLS=off)
- All existing environment variables unchanged
- Plain TCP/UDP/RELP inputs remain unchanged
- Existing configurations continue to work without modification

Implementation Details:
- Certificates configured per-input to avoid warnings when TLS
  is disabled
- Follows Docker best practices (combined RUN, cleanup, comments)
- Uses standard RFC 5425 port 6514 for syslog over TLS

Impact:
- No breaking changes - fully backward compatible
- Users can opt-in to TLS by setting ENABLE_TLS=on and providing
  certificate paths
- No warnings when TLS is disabled (default state)