### PR TITLE
Fix: Always load imtcp module in Docker collector image

### DIFF
--- a/packaging/docker/rsyslog/collector/10-collector.conf
+++ b/packaging/docker/rsyslog/collector/10-collector.conf
@@ -4,7 +4,9 @@
 
 # Load input modules
 module(load="imudp" config.enabled=`echo $ENABLE_UDP`)
-module(load="imtcp" config.enabled=`echo $ENABLE_TCP`)
+# Always load imtcp module - it's required for both plain TCP (port 514) and TLS (port 6514).
+# The module is lightweight and harmless if not used (inputs are controlled separately).
+module(load="imtcp")
 module(load="imrelp" config.enabled=`echo $ENABLE_RELP`)
 
 # UDP input (unencrypted, port 514)


### PR DESCRIPTION
The Docker collector image configuration had a bug where the imtcp module
was only loaded when ENABLE_TCP=on. However, the TLS input (port 6514)
also uses type="imtcp" and requires the module to be loaded. This caused
TLS to fail when ENABLE_TCP=off, even if ENABLE_TLS=on.

The initial fix attempted to use a complex bash expression in rsyslog
backticks to conditionally load imtcp when either ENABLE_TCP or ENABLE_TLS
is enabled. However, rsyslog's backtick feature only supports simple
commands like echo $VAR, not complex shell expressions with conditionals.

The final fix always loads the imtcp module unconditionally. This is safe
because:
- The module is lightweight and harmless if not used
- Individual inputs are still controlled independently by ENABLE_TCP and
  ENABLE_TLS environment variables
- This avoids the need for complex entrypoint script modifications

This allows configurations where:
- ENABLE_TCP=off, ENABLE_TLS=on: TLS works, plain TCP port 514 not exposed
- ENABLE_TCP=on, ENABLE_TLS=on: Both work
- ENABLE_TCP=on, ENABLE_TLS=off: Plain TCP works, TLS disabled

Files changed:
- packaging/docker/rsyslog/collector/10-collector.conf