### PR TITLE
omotlp: native OpenTelemetry (OTLP/HTTP JSON) log export

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -145,8 +145,8 @@ jobs:
               # It is better to run at least the majority of checks than to postpone that
               # any longer. 2025-01-31 RGerhards
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--enable-omazureeventhubs --enable-imdtls \
-                     --enable-omdtls --disable-omamqp1 --disable-snmp --disable-kafka-tests \
-                     --disable-elasticsearch-tests --enable-mmsnareparse"
+                    --enable-omdtls --enable-omotlp --disable-omamqp1 --disable-snmp --disable-kafka-tests \
+                    --disable-elasticsearch-tests --enable-mmsnareparse"
               ;;
           'ubuntu_22_distcheck')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
@@ -161,6 +161,7 @@ jobs:
               export CC='clang'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                       --disable-libfaketime --without-valgrind-testbench --disable-valgrind \
+                      --enable-omotlp \
                       --disable-kafka-tests --enable-imdtls --enable-omdtls \
                       --enable-mmsnareparse"
               export CFLAGS="-fstack-protector -D_FORTIFY_SOURCE=2 \
@@ -182,6 +183,7 @@ jobs:
               # imhttp disabled because of race in civetweb (need to consider different lib)
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --enable-imfile-tests \
                     --disable-impstats --disable-kafka-tests --disable-mmpstrucdata \
+                    --enable-omotlp \
                     --disable-clickhouse --disable-clickhouse-tests --disable-kafka-tests \
                     --disable-libfaketime --disable-imhttp \
                     --without-valgrind-testbench --disable-valgrind \

--- a/Makefile.am
+++ b/Makefile.am
@@ -147,6 +147,10 @@ if ENABLE_OMHDFS
 SUBDIRS += plugins/omhdfs
 endif
 
+if ENABLE_OMOTLP
+SUBDIRS += plugins/omotlp
+endif
+
 if ENABLE_OMJOURNAL
 SUBDIRS += plugins/omjournal
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -2514,9 +2514,27 @@ AC_ARG_ENABLE(omhdfs,
         [enable_omhdfs=no]
 )
 if test "x$enable_omhdfs"; then
-	AC_CHECK_HEADERS([hdfs.h hadoop/hdfs.h])
+        AC_CHECK_HEADERS([hdfs.h hadoop/hdfs.h])
 fi
 AM_CONDITIONAL(ENABLE_OMHDFS, test x$enable_omhdfs = xyes)
+
+AC_ARG_ENABLE(omotlp,
+        [AS_HELP_STRING([--enable-omotlp],[Enable OpenTelemetry output module @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_omotlp="yes" ;;
+          no) enable_omotlp="no" ;;
+            *) AC_MSG_ERROR(bad value ${enableval} for --enable-omotlp) ;;
+         esac],
+        [enable_omotlp=no]
+)
+OMOTLP_HTTP_CFLAGS=""
+OMOTLP_HTTP_LIBS=""
+if test "x$enable_omotlp" = "xyes"; then
+        PKG_CHECK_MODULES([OMOTLP_HTTP], [libcurl libfastjson])
+fi
+AC_SUBST([OMOTLP_HTTP_CFLAGS])
+AC_SUBST([OMOTLP_HTTP_LIBS])
+AM_CONDITIONAL(ENABLE_OMOTLP, test x$enable_omotlp = xyes)
 
 # support for kafka input output
 AC_ARG_ENABLE(omkafka,
@@ -3145,8 +3163,9 @@ AC_CONFIG_FILES([Makefile \
 		plugins/imjournal/Makefile \
 		plugins/immark/Makefile \
 		plugins/imklog/Makefile \
-		plugins/omhdfs/Makefile \
-		plugins/omkafka/Makefile \
+                plugins/omhdfs/Makefile \
+                plugins/omotlp/Makefile \
+                plugins/omkafka/Makefile \
 		plugins/omprog/Makefile \
 		plugins/mmexternal/Makefile \
 		plugins/omstdout/Makefile \
@@ -3294,6 +3313,7 @@ echo "    omstdout module will be compiled:         $enable_omstdout"
 echo "    omsendertrack module will be compiled:    $enable_omsendertrack"
 echo "    omjournal module will be compiled:        $enable_omjournal"
 echo "    omhdfs module will be compiled:           $enable_omhdfs"
+echo "    omotlp module will be compiled:           $enable_omotlp"
 echo "    omelasticsearch module will be compiled:  $enable_elasticsearch"
 echo "    omclickhouse module will be compiled:     $enable_clickhouse"
 echo "    omhttp module will be compiled:           $enable_omhttp"

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -60,3 +60,9 @@ mmjsonrewrite:
   notes:
     - Expands dotted JSON property names into nested containers per message.
 
+omotlp:
+  paths: ["plugins/omotlp/"]
+  requires_serialization: false
+  notes:
+    - Transport resources are not yet active; introduce pData locking once they appear.
+

--- a/doc/source/configuration/modules/omotlp.rst
+++ b/doc/source/configuration/modules/omotlp.rst
@@ -1,0 +1,522 @@
+.. _module-omotlp:
+
+.. meta::
+   :description: Scaffolding for the omotlp OpenTelemetry output module.
+   :keywords: omotlp, otlp, opentelemetry, rsyslog module
+
+.. summary-start
+
+Phase 1 of the omotlp output plugin streams OpenTelemetry logs over
+OTLP/HTTP JSON with configurable batching, gzip compression, retry/backoff
+controls, TLS/mTLS support for secure HTTPS connections, and HTTP proxy
+support for corporate networks and firewalled environments.
+
+.. summary-end
+
+omotlp: OpenTelemetry output module (preview)
+=============================================
+
+.. warning::
+
+   The OTLP/HTTP JSON transport is ready for preview deployments. The optional
+   OTLP/gRPC façade and HTTP/protobuf fast-path remain under development, so
+   keep action queues enabled and plan future upgrades accordingly.
+
+Overview
+--------
+
+``omotlp`` prepares rsyslog for native :abbr:`OTLP (OpenTelemetry Log Protocol)`
+exports. Phase 1 focuses on the OTLP/HTTP JSON transport path: the module maps
+rsyslog metadata into the canonical OTLP JSON structure, joins the configured
+endpoint and path, and posts batches of rendered payloads via ``libcurl`` using
+``application/json`` semantics. Batching thresholds, gzip compression, retry and
+backoff policies, custom headers, TLS/mTLS authentication, and HTTP proxy support
+are all configurable. Subsequent phases will extend the module with the gRPC
+façade and, optionally, HTTP/protobuf support.
+
+Availability
+------------
+
+The module is built only when ``./configure`` is invoked with
+``--enable-omotlp=yes`` and both ``libcurl`` and ``libfastjson`` are present.
+The default ``--enable-omotlp`` setting is ``no``, so you must opt in
+explicitly. The HTTP transport depends on ``libcurl`` at runtime.
+
+Configuration
+-------------
+
+The action parameters listed below mirror the current transport design. All
+parameters are optional and fall back to sensible defaults inspired by the
+`OTLP specification <https://opentelemetry.io/docs/specs/otlp/>`_.
+
+.. csv-table:: ``omotlp`` action parameters
+   :header: "Parameter", "Type", "Default", "Description"
+   :widths: auto
+
+   "endpoint", "string", "http://127.0.0.1:4318", "Base OTLP collector URL"
+   "path", "string", "/v1/logs", "Request path appended to the endpoint"
+   "protocol", "word", "http/json", "Transport variant"
+   "template", "word", "RSYSLOG_FileFormat", "Message template used for the log body"
+   "timeout.ms", "integer", "10000", "HTTP request timeout in milliseconds"
+   "compression", "word", "none", "Request payload compression (``none`` or ``gzip``)"
+   "batch.max_items", "integer", "512", "Flush the batch after this many records (``0`` disables the limit)"
+   "batch.max_bytes", "integer", "524288", "Approximate uncompressed payload threshold in bytes (``0`` disables the limit)"
+   "batch.timeout.ms", "integer", "5000", "Flush the oldest batch after this idle period in milliseconds (``0`` disables the user-configured timer, but a short safety flush still runs periodically to avoid indefinite buffering)"
+   "retry.initial.ms", "integer", "1000", "Initial backoff before retrying retryable HTTP responses"
+   "retry.max.ms", "integer", "30000", "Maximum backoff applied between retries"
+   "retry.max_retries", "integer", "5", "Attempts made before returning the batch to the action queue"
+   "retry.jitter.percent", "integer", "20", "Jitter applied to retry delays (``0``–``100``)"
+   "headers", "string (JSON object)", "—", "Additional HTTP headers expressed as a JSON object"
+   "bearer_token", "string", "—", "Convenience token that expands to ``Authorization: Bearer <token>``"
+   "resource", "string (JSON)", "—", "Full resource attributes as JSON object. Merged with automatic attributes (service.name, telemetry.sdk.*). Supports string, integer, and boolean values (boolean exported as OTLP boolValue)."
+   "resource.service_instance_id", "string", "—", "Legacy: service.instance.id attribute (deprecated, use resource JSON)"
+   "resource.deployment.environment", "string", "—", "Legacy: deployment.environment attribute (deprecated, use resource JSON)"
+   "trace_id.property", "string", "trace_id", "Property name containing trace ID (32 hex characters = 128 bits)"
+   "span_id.property", "string", "span_id", "Property name containing span ID (16 hex characters = 64 bits)"
+   "trace_flags.property", "string", "trace_flags", "Property name containing trace flags (hex string, 0-255)"
+   "attributeMap", "string (JSON object)", "—", "Custom mapping of rsyslog properties to OTLP attribute names. JSON object with rsyslog property names as keys and OTLP attribute names as values. Supported properties: ``hostname``, ``appname``, ``procid``, ``msgid``, ``facility``."
+   "severity.map", "string (JSON object)", "—", "Custom mapping of syslog priorities to OTLP severity. JSON object with priority numbers (0-7) as keys and objects with ``number`` (OTLP severity number) and ``text`` (OTLP severity text) as values."
+   "tls.cacert", "string", "—", "Path to CA certificate bundle file (PEM format)"
+   "tls.cadir", "string", "—", "Path to directory containing CA certificates"
+   "tls.cert", "string", "—", "Path to client certificate file (PEM format) for mTLS"
+   "tls.key", "string", "—", "Path to client private key file (PEM format) for mTLS"
+   "tls.verify_hostname", "boolean", "on", "Enable/disable hostname verification in certificate"
+   "tls.verify_peer", "boolean", "on", "Enable/disable peer certificate verification"
+   "proxy", "string", "—", "Proxy server URL. Must include scheme: ``http://``, ``https://``, ``socks4://``, or ``socks5://``. Example: ``http://proxy.example.com:8080``. The proxy type is automatically detected from the URL scheme. If omitted, direct connections are used."
+   "proxy.user", "string", "—", "Proxy username for authentication. Required when proxy requires authentication. Used with ``proxy.password`` to enable basic or digest authentication. If ``proxy.user`` is provided without ``proxy.password``, an empty password is used."
+   "proxy.password", "string", "—", "Proxy password for authentication. Required when proxy requires authentication. Used together with ``proxy.user``. The authentication method (basic or digest) is automatically negotiated with the proxy server."
+
+Batch sizes are estimated from the body length plus per-record overhead so the
+module can limit payloads without rendering JSON for each candidate message.
+When a threshold is reached the batch is flushed immediately; otherwise it is
+sent when either the timeout elapses or rsyslog finishes the current queue
+transaction.
+
+Environment variables from the OpenTelemetry specification are consulted when a
+configuration omits explicit values. ``endpoint`` falls back to
+``OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`` and then ``OTEL_EXPORTER_OTLP_ENDPOINT``;
+``protocol`` and ``compression`` honour the matching ``*_PROTOCOL`` and
+``*_COMPRESSION`` variables; ``timeout.ms`` defaults to
+``OTEL_EXPORTER_OTLP_LOGS_TIMEOUT`` or ``OTEL_EXPORTER_OTLP_TIMEOUT``; and
+``headers`` consumes ``OTEL_EXPORTER_OTLP_LOGS_HEADERS`` or the generic
+``OTEL_EXPORTER_OTLP_HEADERS`` when no explicit headers are configured. Action
+parameters always take precedence, giving operators an easy override when
+reusing existing collector deployments.
+
+When the endpoint string includes an explicit path (for example,
+``https://otel:4318/v1/logs``), the module automatically splits the final path
+segment into the ``path`` parameter so that future HTTP transport code can join
+the pieces without duplicating ``/v1/logs``.
+
+Example
+-------
+
+The example below batches up to 200 records or 256 KiB every two seconds, uses
+gzip compression, and adds a custom tenant header alongside an Authorization
+bearer token read from the environment. Retry/backoff settings align with the
+default action queue behaviour: HTTP status codes ``429`` and ``5xx`` trigger
+``RS_RET_SUSPENDED`` so queued records are retried with jittered backoff, while
+other non-success responses discard the message and log an error.
+
+.. code-block:: none
+
+   module(load="omotlp")
+   action(
+     type="omotlp"
+     endpoint="https://otel-collector:4318"
+     path="/v1/logs"
+     protocol="http/json"
+     template="RSYSLOG_SyslogProtocol23Format"
+     batch.max_items="200"
+     batch.max_bytes="262144"
+     batch.timeout.ms="2000"
+     compression="gzip"
+     retry.max_retries="7"
+     retry.max.ms="45000"
+     headers='{ "X-OTel-Tenant": "blue" }'
+     bearer_token="${env:OTEL_TOKEN}"
+   )
+
+.. note::
+
+   When using an ``https://`` endpoint, TLS configuration is recommended for
+   proper certificate verification. If the system's default CA certificates are
+   sufficient, TLS parameters may be omitted. For production deployments or when
+   using custom CA certificates or mTLS, configure the appropriate ``tls.*``
+   parameters as shown in the :ref:`TLS Configuration Example <tls-config-example>`.
+   For environments requiring proxy support (corporate networks, firewalls), see
+   the :ref:`Proxy Configuration Example <proxy-config-example>`.
+
+Trace Correlation Example
+-------------------------
+
+The following example demonstrates how to extract trace context from JSON messages
+and populate OTLP trace correlation fields. The trace context is extracted from
+the message using ``mmjsonparse`` and then exported via ``omotlp`` with trace
+correlation enabled.
+
+.. code-block:: none
+
+   module(load="mmjsonparse")
+   module(load="omotlp")
+
+   # Parse JSON messages to extract trace properties
+   action(type="mmjsonparse" mode="find-json")
+
+   # Export with trace correlation
+   action(
+     type="omotlp"
+     endpoint="https://otel-collector:4318"
+     path="/v1/logs"
+     trace_id.property="trace_id"
+     span_id.property="span_id"
+     trace_flags.property="trace_flags"
+   )
+
+In this example, if a JSON message contains fields like ``trace_id``, ``span_id``,
+or ``trace_flags``, they will be extracted and included in the OTLP export. The
+property names can be customized using the ``trace_id.property``, ``span_id.property``,
+and ``trace_flags.property`` parameters.
+
+Resource Configuration Example
+-------------------------------
+
+The following example demonstrates how to configure full resource attributes using
+the ``resource`` parameter with a JSON object. This enables full OpenTelemetry
+resource semantic conventions compliance.
+
+.. code-block:: none
+
+   module(load="omotlp")
+   action(
+     type="omotlp"
+     endpoint="https://otel-collector:4318"
+     path="/v1/logs"
+     resource='{
+       "service.name": "my-application",
+       "service.instance.id": "${hostname}",
+       "service.version": "1.2.3",
+       "deployment.environment": "production",
+       "cloud.provider": "aws",
+       "cloud.region": "us-east-1",
+       "k8s.namespace.name": "default",
+       "k8s.pod.name": "${hostname}"
+     }'
+   )
+
+The resource attributes are merged with automatic attributes (``service.name``,
+``telemetry.sdk.*``) that are always added by the module. The resource JSON
+supports string, integer, and boolean values. Boolean values are exported as
+OTLP boolean attributes using the ``boolValue`` field.
+
+.. _tls-config-example:
+
+TLS Configuration Example
+---------------------------
+
+The following example demonstrates how to configure TLS/mTLS for secure HTTPS
+connections. This enables server certificate verification using a CA certificate
+bundle and optional mutual TLS authentication with client certificates.
+
+.. code-block:: none
+
+   module(load="omotlp")
+   action(
+     type="omotlp"
+     endpoint="https://otel-collector:4318"
+     path="/v1/logs"
+     tls.cacert="/etc/ssl/certs/ca-bundle.pem"
+     tls.cert="/etc/rsyslog/client.pem"
+     tls.key="/etc/rsyslog/client-key.pem"
+     tls.verify_hostname="on"
+     tls.verify_peer="on"
+   )
+
+The TLS parameters support:
+
+- **tls.cacert**: Path to a CA certificate bundle file (PEM format) for server
+  certificate verification
+- **tls.cadir**: Path to a directory containing CA certificates (alternative to
+  tls.cacert)
+- **tls.cert**: Path to a client certificate file (PEM format) for mutual TLS
+  authentication
+- **tls.key**: Path to a client private key file (PEM format) for mutual TLS
+  authentication
+- **tls.verify_hostname**: Enable/disable hostname verification in the server
+  certificate (default: ``on``)
+- **tls.verify_peer**: Enable/disable peer certificate verification (default: ``on``)
+
+File paths are validated at configuration time. Invalid or inaccessible
+certificate files will cause configuration to fail with an error message
+indicating the specific file and reason (e.g., "tls.cacert file '/path/to/ca.pem'
+cannot be accessed: No such file or directory"). If both ``tls.cacert`` and
+``tls.cadir`` are specified, both are used (libcurl behavior). Client certificate
+and key must be provided together for mTLS. The default behavior verifies both
+hostname and peer certificate for secure connections.
+
+When TLS verification fails at runtime (e.g., certificate mismatch, expired
+certificate, or hostname mismatch), the HTTP request fails and the batch is
+retried according to the configured retry policy. TLS verification errors are
+logged with details from libcurl (e.g., "SSL: certificate subject name does not
+match target host name"). For test environments or self-signed certificates,
+you may need to set ``tls.verify_hostname="off"`` if certificates don't have
+proper Subject Alternative Name (SAN) entries matching the endpoint hostname.
+
+Note that ``tls.verify_hostname`` requires ``tls.verify_peer`` to be enabled
+(``on``) for meaningful verification. If peer verification is disabled,
+hostname verification is effectively ignored.
+
+.. _proxy-config-example:
+
+Proxy Configuration Example
+---------------------------
+
+The following example demonstrates how to configure HTTP proxy support for
+corporate networks or environments that require traffic to pass through a proxy
+server. Proxy support enables omotlp to work through firewalls, network gateways,
+and corporate proxies.
+
+.. code-block:: none
+
+   module(load="omotlp")
+   action(
+     type="omotlp"
+     endpoint="https://otel-collector:4318"
+     path="/v1/logs"
+     proxy="http://proxy.example.com:8080"
+   )
+
+For proxies that require authentication, provide both username and password:
+
+.. code-block:: none
+
+   module(load="omotlp")
+   action(
+     type="omotlp"
+     endpoint="https://otel-collector:4318"
+     path="/v1/logs"
+     proxy="http://proxy.example.com:8080"
+     proxy.user="myuser"
+     proxy.password="mypassword"
+   )
+
+The proxy parameters support:
+
+- **proxy**: Full proxy server URL including scheme and port. Supported schemes:
+  
+  - ``http://`` - HTTP proxy (most common for corporate proxies)
+  - ``https://`` - HTTPS proxy (secure proxy connection)
+  - ``socks4://`` - SOCKS4 proxy
+  - ``socks5://`` - SOCKS5 proxy (supports authentication and UDP)
+
+  The proxy URL format is validated at configuration time. Invalid schemes or
+  malformed URLs will cause configuration to fail with an error message.
+
+- **proxy.user**: Username for proxy authentication. When provided, the module
+  automatically sends proxy authentication credentials with each request. The
+  authentication method (basic or digest) is automatically negotiated with the
+  proxy server based on the proxy's requirements.
+
+- **proxy.password**: Password for proxy authentication. Must be provided
+  together with ``proxy.user`` when the proxy requires authentication. If
+  ``proxy.user`` is specified without ``proxy.password``, an empty password is
+  used (which may work for some proxy configurations).
+
+Proxy authentication uses HTTP Basic authentication by default. If the proxy
+server requires Digest authentication, libcurl automatically upgrades to Digest
+when the proxy responds with a 407 (Proxy Authentication Required) status
+code. The authentication credentials are sent in the ``Proxy-Authorization``
+header for each HTTP request.
+
+When a proxy is configured, all HTTP requests to the OTLP collector endpoint
+are routed through the proxy server. The proxy acts as an intermediary,
+forwarding requests to the target collector and returning responses. This
+enables omotlp to work in environments where:
+
+- Direct connections to the collector are blocked by firewall rules
+- Network traffic must pass through a corporate proxy gateway
+- Network policies require all outbound HTTP/HTTPS traffic to use a proxy
+- The collector is only accessible through a proxy server
+
+Proxy configuration works with both HTTP and HTTPS endpoints. When using an
+HTTPS endpoint through an HTTP proxy, the proxy performs HTTP CONNECT tunneling
+to establish the secure connection. SOCKS proxies (SOCKS4 and SOCKS5) can also
+handle both HTTP and HTTPS traffic transparently.
+
+If proxy authentication fails (invalid credentials or unsupported authentication
+method), the HTTP request fails and the batch is retried according to the
+configured retry policy. Authentication errors are logged with details from
+libcurl (e.g., "Proxy authentication required" or "Invalid proxy credentials").
+
+Note that proxy configuration is independent of TLS configuration. You can use
+both proxy and TLS parameters together. For example, you might route HTTPS
+traffic through an HTTP proxy, or use an HTTPS proxy with TLS verification
+enabled for the collector endpoint.
+
+Legacy single-attribute parameters (``resource.service_instance_id`` and
+``resource.deployment.environment``) are still supported for backward compatibility
+but may be deprecated in future versions.
+
+Trace IDs must be exactly 32 hexadecimal
+characters (128 bits), span IDs must be exactly 16 hexadecimal characters (64 bits),
+and trace flags are parsed as hexadecimal values (0-255). Invalid values are logged
+but do not cause message processing to fail.
+
+OTLP Payload Structure
+----------------------
+
+The module generates OTLP/HTTP JSON payloads conforming to the OpenTelemetry
+log data model. Each batch wraps log records in the following hierarchy:
+
+**Resource attributes** (per-batch, automatically populated):
+
+.. csv-table::
+   :header: "Attribute", "Value"
+   :widths: auto
+
+   "``service.name``", "``rsyslog``"
+   "``telemetry.sdk.name``", "``rsyslog-omotlp``"
+   "``telemetry.sdk.language``", "``C``"
+   "``telemetry.sdk.version``", "rsyslog version string"
+   "``host.name``", "hostname (only if uniform across all records in batch)"
+
+**Scope metadata** (per-batch):
+
+.. csv-table::
+   :header: "Field", "Value"
+   :widths: auto
+
+   "``scope.name``", "``rsyslog.omotlp``"
+   "``scope.version``", "rsyslog version string"
+
+**Per-record attributes** (derived from syslog metadata):
+
+.. csv-table::
+   :header: "Attribute", "Source"
+   :widths: auto
+
+   "``log.syslog.appname``", "syslog APP-NAME field (customizable via ``attributeMap``)"
+   "``log.syslog.procid``", "syslog PROCID field (customizable via ``attributeMap``)"
+   "``log.syslog.msgid``", "syslog MSGID field (customizable via ``attributeMap``)"
+   "``log.syslog.facility``", "syslog facility code (integer, customizable via ``attributeMap``)"
+   "``log.syslog.hostname``", "syslog HOSTNAME field (customizable via ``attributeMap``)"
+
+**Per-record fields**:
+
+- ``body.stringValue``: rendered template output
+- ``timeUnixNano``: message timestamp in nanoseconds
+- ``observedTimeUnixNano``: reception timestamp in nanoseconds
+- ``severityNumber``: mapped OTLP severity (see table below)
+- ``severityText``: severity name string
+- ``traceId``: trace ID string (32 hex characters, if present in message properties)
+- ``spanId``: span ID string (16 hex characters, if present in message properties)
+- ``flags``: trace flags integer (0-255, if present in message properties)
+
+All of the attributes and fields above are emitted for every record; values are
+only omitted when the originating syslog message does not carry the associated
+property (for example, when ``APP-NAME`` is empty). Trace correlation fields
+(traceId, spanId, flags) are populated from message JSON variables when present
+and valid.
+
+Severity Mapping
+^^^^^^^^^^^^^^^^
+
+Syslog priority values are mapped to OTLP severity numbers following the
+OpenTelemetry semantic conventions. The default mapping can be overridden using
+the ``severity.map`` parameter.
+
+Default severity mapping:
+
+.. csv-table::
+   :header: "Syslog Priority", "OTLP SeverityNumber", "OTLP SeverityText"
+   :widths: auto
+
+   "0 (Emergency)", "24", "EMERGENCY"
+   "1 (Alert)", "23", "ALERT"
+   "2 (Critical)", "22", "CRITICAL"
+   "3 (Error)", "17", "ERROR"
+   "4 (Warning)", "13", "WARNING"
+   "5 (Notice)", "11", "NOTICE"
+   "6 (Info)", "9", "INFO"
+   "7 (Debug)", "5", "DEBUG"
+
+Custom Attribute and Severity Mapping Example
+----------------------------------------------
+
+The following example demonstrates how to customize attribute names and severity
+mapping to match collector expectations or custom severity schemes:
+
+.. code-block:: none
+
+   module(load="omotlp")
+   action(
+     type="omotlp"
+     endpoint="https://otel-collector:4318"
+     path="/v1/logs"
+     attributeMap='{
+       "hostname": "host.name",
+       "appname": "service.name",
+       "procid": "process.pid",
+       "msgid": "message.id",
+       "facility": "log.syslog.facility.code"
+     }'
+     severity.map='{
+       "0": { "number": 24, "text": "FATAL" },
+       "1": { "number": 23, "text": "ALERT" },
+       "2": { "number": 22, "text": "CRITICAL" },
+       "3": { "number": 17, "text": "ERROR" },
+       "4": { "number": 13, "text": "WARN" },
+       "5": { "number": 11, "text": "NOTICE" },
+       "6": { "number": 9, "text": "INFO" },
+       "7": { "number": 5, "text": "DEBUG" }
+     }'
+   )
+
+The ``attributeMap`` parameter allows you to remap standard syslog properties
+to different OTLP attribute names. This is useful when integrating with
+collectors that expect different attribute naming conventions.
+
+The ``severity.map`` parameter allows you to customize the mapping of syslog
+priorities (0-7) to OTLP severity numbers and text. All 8 priorities must be
+specified in the mapping, or defaults will be used for missing priorities.
+Custom severity numbers should follow OTLP severity conventions (0-24 range
+recommended).
+
+Statistic Counter
+=================
+
+This plugin maintains :doc:`statistics <../rsyslog_statistic_counter>` for each
+worker instance. The statistic origin is named "omotlp" with the instance URL
+appended (e.g., "omotlp-http://127.0.0.1:4318/v1/logs"). Statistics are visible
+via the :doc:`impstats <../modules/impstats>` module when enabled.
+
+The following counters are tracked per worker instance:
+
+- **batches.submitted** - Total number of batches submitted for transmission.
+  Each batch may contain multiple log records.
+
+- **batches.success** - Number of batches successfully sent (HTTP 2xx response).
+
+- **batches.retried** - Number of batches that triggered retry logic due to
+  retryable HTTP errors (5xx or 429 status codes).
+
+- **batches.dropped** - Number of batches dropped due to non-retryable errors
+  (HTTP 4xx status codes).
+
+- **http.status.4xx** - Total number of HTTP 4xx responses received from the
+  collector.
+
+- **http.status.5xx** - Total number of HTTP 5xx responses received from the
+  collector.
+
+- **records.sent** - Total number of log records successfully sent to the
+  collector (only incremented for successful batches).
+
+- **http.request.latency.ms** - Cumulative request latency in milliseconds
+  across all HTTP requests. This value represents the total time spent waiting
+  for HTTP responses and can be used to calculate average latency by dividing
+  by the number of requests.
+
+Counters are thread-safe and use atomic operations for updates. Each worker
+instance maintains its own statistics object, allowing operators to monitor
+performance per action instance when multiple omotlp actions are configured.

--- a/plugins/omotlp/AGENTS.md
+++ b/plugins/omotlp/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md – omotlp output module
+
+These instructions apply to files inside `plugins/omotlp/`.
+
+## Development notes
+- Keep the module pure C unless the optional gRPC shim is enabled.
+- Update `MODULE_METADATA.yaml` and the user documentation when adding new
+  configuration parameters or behavioral changes.
+- Refresh the concurrency note in `omotlp.c` if locking expectations change.
+- Run `devtools/format-code.sh` before committing.
+
+## Testing
+- Run `tests/omotlp-http-batch.sh` to exercise the HTTP batching, gzip, and
+  retry path.

--- a/plugins/omotlp/MODULE_METADATA.yaml
+++ b/plugins/omotlp/MODULE_METADATA.yaml
@@ -1,0 +1,6 @@
+support_status: core-supported
+maturity_level: fresh
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2024-04-09
+notes:
+  - "Phase 1 HTTP/JSON transport now batches with configurable thresholds, gzip, and retry/backoff; optional gRPC remains under development."

--- a/plugins/omotlp/Makefile.am
+++ b/plugins/omotlp/Makefile.am
@@ -1,0 +1,26 @@
+pkglib_LTLIBRARIES = omotlp.la
+
+omotlp_la_SOURCES = \
+       omotlp.c \
+       otlp_json.c \
+       omotlp_http.c
+
+noinst_HEADERS = \
+       otlp_json.h \
+       omotlp_http.h
+
+omotlp_la_CPPFLAGS = \
+       -I$(srcdir) \
+       -I$(top_srcdir) \
+       -I$(top_srcdir)/runtime \
+       -I$(top_srcdir)/grammar \
+       $(RSRT_CFLAGS) \
+       $(OMOTLP_HTTP_CFLAGS)
+
+omotlp_la_LDFLAGS = -module -avoid-version
+
+omotlp_la_LIBADD = $(OMOTLP_HTTP_LIBS) $(ZLIB_LIBS)
+
+EXTRA_DIST = \
+        AGENTS.md \
+        MODULE_METADATA.yaml

--- a/plugins/omotlp/omotlp.c
+++ b/plugins/omotlp/omotlp.c
@@ -1,0 +1,2855 @@
+/**
+ * @file omotlp.c
+ * @brief OpenTelemetry (OTLP) output module for rsyslog
+ *
+ * This module provides native OpenTelemetry log export capabilities using
+ * the OTLP/HTTP JSON protocol. It supports batching, compression, retry
+ * semantics, TLS/mTLS, and proxy configuration.
+ *
+ * Concurrency & Locking:
+ * - Shared configuration lives in the per-action instanceData structure and is
+ *   read-only after instantiation.
+ * - Each worker maintains its own HTTP client and batching buffer guarded by a
+ *   mutex so no cross-worker locks are required.
+ * - A per-worker flush thread wakes periodically to service batch timeouts and
+ *   returns control to the rsyslog action queue for retry/backoff decisions.
+ *
+ * Copyright 2025 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include "rsyslog.h"
+
+#include <ctype.h>
+#include <dirent.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <zlib.h>
+
+#include "conf.h"
+#include "datetime.h"
+#include "msg.h"
+#include "srUtils.h"
+#include "stringbuf.h"
+#include "syslogd-types.h"
+#include "template.h"
+#include "module-template.h"
+#include "errmsg.h"
+#include "statsobj.h"
+
+#include "otlp_json.h"
+#include "omotlp_http.h"
+
+MODULE_TYPE_OUTPUT;
+MODULE_TYPE_NOKEEP;
+MODULE_CNFNAME("omotlp")
+
+DEF_OMOD_STATIC_DATA;
+DEFobjCurrIf(datetime);
+DEFobjCurrIf(prop);
+DEFobjCurrIf(statsobj);
+
+typedef enum omotlp_compression_e {
+    OMOTLP_COMPRESSION_UNSET = 0,
+    OMOTLP_COMPRESSION_NONE,
+    OMOTLP_COMPRESSION_GZIP,
+} omotlp_compression_t;
+
+typedef struct header_list_s {
+    char **values;
+    size_t count;
+    size_t capacity;
+} header_list_t;
+
+typedef struct attribute_map_entry_s {
+    char *rsyslog_property; /* Source property name */
+    char *otlp_attribute; /* Target OTLP attribute name */
+} attribute_map_entry_t;
+
+typedef struct attribute_map_s {
+    attribute_map_entry_t *entries;
+    size_t count;
+    size_t capacity;
+} attribute_map_t;
+
+typedef struct severity_map_entry_s {
+    int syslog_priority; /* 0-7 */
+    uint32_t severity_number; /* OTLP severity number */
+    char *severity_text; /* OTLP severity text */
+} severity_map_entry_t;
+
+typedef struct severity_map_s {
+    severity_map_entry_t entries[8]; /* One per syslog priority */
+    int configured; /* 1 if custom mapping, 0 if default */
+} severity_map_t;
+
+enum {
+    OMOTLP_OMSR_IDX_MESSAGE = 0,
+    OMOTLP_OMSR_IDX_BODY = 1,
+};
+
+typedef struct _instanceData {
+    uchar *endpoint;
+    uchar *path;
+    uchar *protocol;
+    uchar *bodyTemplateName;
+    uchar *url;
+    long requestTimeoutMs;
+    size_t batchMaxItems;
+    size_t batchMaxBytes;
+    long batchTimeoutMs;
+    long retryInitialMs;
+    long retryMaxMs;
+    unsigned int retryMaxRetries;
+    unsigned int retryJitterPercent;
+    omotlp_compression_t compression_mode;
+    int compressionConfigured;
+    int headersConfigured;
+    int bearerConfigured;
+    int timeoutConfigured;
+    header_list_t headers;
+    uchar *resourceServiceInstanceId;
+    uchar *resourceDeploymentEnvironment;
+    /* Full resource configuration */
+    uchar *resourceJson; /* JSON string with resource attributes */
+    struct json_object *resourceJsonParsed; /* Parsed JSON object (cached) */
+    /* Trace correlation property names */
+    uchar *traceIdPropertyName;
+    uchar *spanIdPropertyName;
+    uchar *traceFlagsPropertyName;
+    /* Custom attribute mapping */
+    attribute_map_t attributeMap;
+    /* Custom severity mapping */
+    severity_map_t severityMap;
+    /* TLS configuration */
+    uchar *tlsCaCertFile;
+    uchar *tlsCaCertDir;
+    uchar *tlsClientCertFile;
+    uchar *tlsClientKeyFile;
+    int tlsVerifyHostname; /* 0 = disabled, 1 = enabled */
+    int tlsVerifyPeer; /* 0 = disabled, 1 = enabled */
+    /* Proxy configuration */
+    uchar *proxyUrl;
+    uchar *proxyUser;
+    uchar *proxyPassword;
+} instanceData;
+
+typedef struct omotlp_batch_entry_s {
+    omotlp_log_record_t record;
+    char *body;
+    char *hostname;
+    char *app_name;
+    char *proc_id;
+    char *msg_id;
+    char *trace_id; /* Allocated string for trace_id */
+    char *span_id; /* Allocated string for span_id */
+} omotlp_batch_entry_t;
+
+typedef struct omotlp_batch_state_s {
+    omotlp_batch_entry_t *entries;
+    size_t count;
+    size_t capacity;
+    size_t estimated_bytes;
+    long long first_enqueue_ms;
+} omotlp_batch_state_t;
+
+typedef struct wrkrInstanceData {
+    instanceData *pData;
+    omotlp_http_client_t *http_client;
+    omotlp_batch_state_t batch;
+    pthread_t flush_thread;
+    pthread_mutex_t batch_mutex;
+    int flush_thread_running;
+    int flush_thread_stop;
+
+    /* Statistics counters */
+    statsobj_t *stats;
+    STATSCOUNTER_DEF(ctrBatchesSubmitted, mutCtrBatchesSubmitted);
+    STATSCOUNTER_DEF(ctrBatchesSuccess, mutCtrBatchesSuccess);
+    STATSCOUNTER_DEF(ctrBatchesRetried, mutCtrBatchesRetried);
+    STATSCOUNTER_DEF(ctrBatchesDropped, mutCtrBatchesDropped);
+    STATSCOUNTER_DEF(ctrHttpStatus4xx, mutCtrHttpStatus4xx);
+    STATSCOUNTER_DEF(ctrHttpStatus5xx, mutCtrHttpStatus5xx);
+    STATSCOUNTER_DEF(ctrRecordsSent, mutCtrRecordsSent);
+    STATSCOUNTER_DEF(httpRequestLatencyMs, mutHttpRequestLatencyMs);
+} wrkrInstanceData_t;
+
+struct modConfData_s {
+    rsconf_t *pConf;
+};
+
+static modConfData_t *loadModConf = NULL;
+static modConfData_t *runModConf = NULL;
+
+static struct cnfparamdescr actpdescr[] = {{"endpoint", eCmdHdlrString, 0},
+                                           {"path", eCmdHdlrString, 0},
+                                           {"protocol", eCmdHdlrGetWord, 0},
+                                           {"template", eCmdHdlrGetWord, 0},
+                                           {"timeout.ms", eCmdHdlrGetWord, 0},
+                                           {"compression", eCmdHdlrGetWord, 0},
+                                           {"batch.max_items", eCmdHdlrGetWord, 0},
+                                           {"batch.max_bytes", eCmdHdlrGetWord, 0},
+                                           {"batch.timeout.ms", eCmdHdlrGetWord, 0},
+                                           {"retry.initial.ms", eCmdHdlrGetWord, 0},
+                                           {"retry.max.ms", eCmdHdlrGetWord, 0},
+                                           {"retry.max_retries", eCmdHdlrGetWord, 0},
+                                           {"retry.jitter.percent", eCmdHdlrGetWord, 0},
+                                           {"headers", eCmdHdlrString, 0},
+                                           {"bearer_token", eCmdHdlrString, 0},
+                                           {"resource.service_instance_id", eCmdHdlrString, 0},
+                                           {"resource.deployment.environment", eCmdHdlrString, 0},
+                                           {"resource", eCmdHdlrString, 0}, /* Full JSON resource configuration */
+                                           {"trace_id.property", eCmdHdlrString, 0},
+                                           {"span_id.property", eCmdHdlrString, 0},
+                                           {"trace_flags.property", eCmdHdlrString, 0},
+                                           {"attributeMap", eCmdHdlrString, 0},
+                                           {"severity.map", eCmdHdlrString, 0},
+                                           {"tls.cacert", eCmdHdlrString, 0},
+                                           {"tls.cadir", eCmdHdlrString, 0},
+                                           {"tls.cert", eCmdHdlrString, 0},
+                                           {"tls.key", eCmdHdlrString, 0},
+                                           {"tls.verify_hostname", eCmdHdlrGetWord, 0},
+                                           {"tls.verify_peer", eCmdHdlrGetWord, 0},
+                                           {"proxy", eCmdHdlrString, 0},
+                                           {"proxy.user", eCmdHdlrString, 0},
+                                           {"proxy.password", eCmdHdlrString, 0}};
+static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
+
+static rsRetVal parse_headers_env(instanceData *pData, const char *text);
+static rsRetVal parse_timeout_string(const char *text, long *out);
+static rsRetVal set_compression_mode(instanceData *pData, const char *value);
+
+static void lowercaseInPlace(uchar *value) {
+    char *cursor;
+
+    if (value == NULL) {
+        return;
+    }
+
+    for (cursor = (char *)value; *cursor != '\0'; ++cursor) {
+        *cursor = (char)tolower((unsigned char)*cursor);
+    }
+}
+
+static rsRetVal assignParamFromCStr(uchar **target, const char *value) {
+    uchar *tmp;
+    DEFiRet;
+
+    if (value == NULL) {
+        goto finalize_it;
+    }
+
+    tmp = (uchar *)strdup(value);
+    if (tmp == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    free(*target);
+    *target = tmp;
+
+finalize_it:
+    RETiRet;
+}
+
+static const char *firstPopulatedEnv(const char *const *names) {
+    size_t i;
+
+    if (names == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; names[i] != NULL; ++i) {
+        const char *value = getenv(names[i]);
+        if (value != NULL && value[0] != '\0') {
+            return value;
+        }
+    }
+
+    return NULL;
+}
+
+static rsRetVal applyEnvDefaults(instanceData *pData) {
+    const char *value;
+    static const char *const endpointEnvVars[] = {"OTEL_EXPORTER_OTLP_LOGS_ENDPOINT", "OTEL_EXPORTER_OTLP_ENDPOINT",
+                                                  NULL};
+    static const char *const protocolEnvVars[] = {"OTEL_EXPORTER_OTLP_LOGS_PROTOCOL", "OTEL_EXPORTER_OTLP_PROTOCOL",
+                                                  NULL};
+    static const char *const timeoutEnvVars[] = {"OTEL_EXPORTER_OTLP_LOGS_TIMEOUT", "OTEL_EXPORTER_OTLP_TIMEOUT", NULL};
+    static const char *const compressionEnvVars[] = {"OTEL_EXPORTER_OTLP_LOGS_COMPRESSION",
+                                                     "OTEL_EXPORTER_OTLP_COMPRESSION", NULL};
+    static const char *const headersEnvVars[] = {"OTEL_EXPORTER_OTLP_LOGS_HEADERS", "OTEL_EXPORTER_OTLP_HEADERS", NULL};
+
+    DEFiRet;
+
+    if (pData->endpoint == NULL) {
+        value = firstPopulatedEnv(endpointEnvVars);
+        if (value != NULL) {
+            CHKiRet(assignParamFromCStr(&pData->endpoint, value));
+        }
+    }
+
+    if (pData->protocol == NULL) {
+        value = firstPopulatedEnv(protocolEnvVars);
+        if (value != NULL) {
+            CHKiRet(assignParamFromCStr(&pData->protocol, value));
+        }
+    }
+
+    if (!pData->timeoutConfigured) {
+        value = firstPopulatedEnv(timeoutEnvVars);
+        if (value != NULL) {
+            long timeout_ms;
+            CHKiRet(parse_timeout_string(value, &timeout_ms));
+            pData->requestTimeoutMs = timeout_ms;
+        }
+    }
+
+    if (!pData->compressionConfigured && pData->compression_mode == OMOTLP_COMPRESSION_UNSET) {
+        value = firstPopulatedEnv(compressionEnvVars);
+        if (value != NULL) {
+            CHKiRet(set_compression_mode(pData, value));
+        }
+    }
+
+    if (!pData->headersConfigured) {
+        value = firstPopulatedEnv(headersEnvVars);
+        if (value != NULL) {
+            CHKiRet(parse_headers_env(pData, value));
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+/**
+ * @brief Split endpoint URL into base URL and path components
+ *
+ * If the endpoint contains a path component (e.g., "http://host:4318/v1/logs"),
+ * this function splits it into the base URL ("http://host:4318") and path
+ * ("/v1/logs"). This allows users to specify the full URL in the endpoint
+ * parameter while still supporting separate path configuration.
+ *
+ * @param[in,out] pData Instance data containing endpoint and path
+ * @return RS_RET_OK on success or if no split is needed
+ */
+static rsRetVal ensureEndpointPathSplit(instanceData *pData) {
+    char *endpoint;
+    char *schemeSeparator;
+    char *pathStart;
+    char *baseDup = NULL;
+    char *pathDup = NULL;
+    size_t baseLength;
+
+    DEFiRet;
+
+    if (pData->endpoint == NULL || pData->path != NULL) {
+        goto finalize_it;
+    }
+
+    endpoint = (char *)pData->endpoint;
+    schemeSeparator = strstr(endpoint, "://");
+    if (schemeSeparator != NULL) {
+        pathStart = strchr(schemeSeparator + 3, '/');
+    } else {
+        pathStart = strchr(endpoint, '/');
+    }
+
+    if (pathStart == NULL || *pathStart == '\0' || pathStart == endpoint) {
+        goto finalize_it;
+    }
+
+    baseLength = (size_t)(pathStart - endpoint);
+    baseDup = (char *)malloc(baseLength + 1);
+    if (baseDup == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    memcpy(baseDup, endpoint, baseLength);
+    baseDup[baseLength] = '\0';
+
+    pathDup = strdup(pathStart);
+    if (pathDup == NULL) {
+        free(baseDup);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    free(pData->endpoint);
+    pData->endpoint = (uchar *)baseDup;
+    pData->path = (uchar *)pathDup;
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal validateProtocol(instanceData *pData) {
+    DEFiRet;
+
+    if (pData->protocol == NULL) {
+        goto finalize_it;
+    }
+
+    if (!strcmp((char *)pData->protocol, "http/json")) {
+        goto finalize_it;
+    }
+
+    LogError(0, RS_RET_NOT_IMPLEMENTED, "omotlp: protocol '%s' is not supported by the scaffolding build",
+             pData->protocol);
+    ABORT_FINALIZE(RS_RET_NOT_IMPLEMENTED);
+
+finalize_it:
+    RETiRet;
+}
+
+/**
+ * @brief Build the effective URL from endpoint and path components
+ *
+ * Combines the endpoint base URL and path into a single effective URL,
+ * handling edge cases like duplicate slashes or missing slashes between
+ * components. The result is stored in pData->url.
+ *
+ * @param[in,out] pData Instance data with endpoint and path to combine
+ * @return RS_RET_OK on success, RS_RET_PARAM_ERROR if endpoint is NULL,
+ *         RS_RET_OUT_OF_MEMORY on allocation failure
+ */
+static rsRetVal buildEffectiveUrl(instanceData *pData) {
+    const char *endpoint = (const char *)pData->endpoint;
+    const char *path = (const char *)pData->path;
+    size_t endpoint_len;
+    size_t path_len;
+    size_t total;
+    int endpoint_has_slash;
+    int path_has_slash;
+    char *buffer = NULL;
+    size_t cursor = 0;
+
+    DEFiRet;
+
+    if (endpoint == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    endpoint_len = strlen(endpoint);
+    path_len = (path != NULL) ? strlen(path) : 0u;
+    endpoint_has_slash = (endpoint_len > 0 && endpoint[endpoint_len - 1] == '/');
+    path_has_slash = (path_len > 0 && path[0] == '/');
+
+    total = endpoint_len + path_len + 2u;
+    buffer = malloc(total);
+    if (buffer == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    memcpy(buffer, endpoint, endpoint_len);
+    cursor = endpoint_len;
+
+    if (path_len > 0) {
+        if (!endpoint_has_slash && !path_has_slash) {
+            buffer[cursor++] = '/';
+        } else if (endpoint_has_slash && path_has_slash) {
+            ++path;
+            --path_len;
+        }
+
+        memcpy(buffer + cursor, path, path_len);
+        cursor += path_len;
+    }
+
+    buffer[cursor] = '\0';
+
+    free(pData->url);
+    pData->url = (uchar *)buffer;
+
+finalize_it:
+    if (iRet != RS_RET_OK && buffer != NULL) {
+        free(buffer);
+    }
+    RETiRet;
+}
+
+typedef struct severity_mapping_s {
+    uint32_t number;
+    const char *text;
+} severity_mapping_t;
+
+static const severity_mapping_t severity_lookup[8] = {{24u, "EMERGENCY"}, {23u, "ALERT"},   {22u, "CRITICAL"},
+                                                      {17u, "ERROR"},     {13u, "WARNING"}, {11u, "NOTICE"},
+                                                      {9u, "INFO"},       {5u, "DEBUG"}};
+
+#define OMOTLP_DEFAULT_BATCH_MAX_ITEMS 512u
+#define OMOTLP_DEFAULT_BATCH_MAX_BYTES (512u * 1024u)
+#define OMOTLP_DEFAULT_BATCH_TIMEOUT_MS 5000L
+#define OMOTLP_DEFAULT_RETRY_INITIAL_MS 1000L
+#define OMOTLP_DEFAULT_RETRY_MAX_MS 30000L
+#define OMOTLP_DEFAULT_RETRY_MAX_RETRIES 5u
+#define OMOTLP_DEFAULT_RETRY_JITTER_PERCENT 20u
+
+#define OMOTLP_BATCH_BASE_OVERHEAD 256u
+#define OMOTLP_BATCH_RECORD_OVERHEAD 256u
+#define OMOTLP_IDLE_FLUSH_INTERVAL_MS 1000L
+
+static void header_list_init(header_list_t *list) {
+    if (list == NULL) {
+        return;
+    }
+
+    list->values = NULL;
+    list->count = 0u;
+    list->capacity = 0u;
+}
+
+static void header_list_clear(header_list_t *list) {
+    size_t i;
+
+    if (list == NULL) {
+        return;
+    }
+
+    for (i = 0; i < list->count; ++i) {
+        free(list->values[i]);
+        list->values[i] = NULL;
+    }
+
+    list->count = 0u;
+}
+
+static void header_list_destroy(header_list_t *list) {
+    if (list == NULL) {
+        return;
+    }
+
+    header_list_clear(list);
+    free(list->values);
+    list->values = NULL;
+    list->capacity = 0u;
+}
+
+static rsRetVal header_list_add(header_list_t *list, const char *header) {
+    char **tmp;
+    char *dup = NULL;
+    size_t new_capacity;
+
+    DEFiRet;
+
+    if (list == NULL || header == NULL || header[0] == '\0') {
+        goto finalize_it;
+    }
+
+    if (list->count == list->capacity) {
+        new_capacity = (list->capacity == 0u) ? 4u : list->capacity * 2u;
+        tmp = (char **)realloc(list->values, new_capacity * sizeof(char *));
+        if (tmp == NULL) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        list->values = tmp;
+        list->capacity = new_capacity;
+    }
+
+    dup = strdup(header);
+    if (dup == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    list->values[list->count++] = dup;
+    dup = NULL;
+
+finalize_it:
+    if (dup != NULL) {
+        free(dup);
+    }
+    RETiRet;
+}
+
+static rsRetVal header_list_add_kv(header_list_t *list, const char *key, const char *value) {
+    char *buffer = NULL;
+    size_t key_len;
+    size_t value_len;
+    DEFiRet;
+
+    if (key == NULL || key[0] == '\0') {
+        goto finalize_it;
+    }
+
+    key_len = strlen(key);
+    value_len = (value != NULL) ? strlen(value) : 0u;
+    buffer = (char *)malloc(key_len + 2u + value_len + 1u);
+    if (buffer == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    memcpy(buffer, key, key_len);
+    buffer[key_len] = ':';
+    buffer[key_len + 1u] = ' ';
+    if (value_len > 0u) {
+        memcpy(buffer + key_len + 2u, value, value_len);
+    }
+    buffer[key_len + 2u + value_len] = '\0';
+
+    CHKiRet(header_list_add(list, buffer));
+
+finalize_it:
+    if (buffer != NULL) {
+        free(buffer);
+    }
+    RETiRet;
+}
+
+static void attribute_map_init(attribute_map_t *map) {
+    if (map == NULL) {
+        return;
+    }
+    map->entries = NULL;
+    map->count = 0u;
+    map->capacity = 0u;
+}
+
+static void attribute_map_clear(attribute_map_t *map) {
+    size_t i;
+
+    if (map == NULL) {
+        return;
+    }
+
+    for (i = 0; i < map->count; ++i) {
+        free(map->entries[i].rsyslog_property);
+        free(map->entries[i].otlp_attribute);
+        map->entries[i].rsyslog_property = NULL;
+        map->entries[i].otlp_attribute = NULL;
+    }
+
+    map->count = 0u;
+}
+
+static void attribute_map_destroy(attribute_map_t *map) {
+    if (map == NULL) {
+        return;
+    }
+
+    attribute_map_clear(map);
+    free(map->entries);
+    map->entries = NULL;
+    map->capacity = 0u;
+}
+
+static rsRetVal attribute_map_add(attribute_map_t *map, const char *rsyslog_prop, const char *otlp_attr) {
+    attribute_map_entry_t *tmp;
+    size_t new_capacity;
+    char *prop_dup = NULL;
+    char *attr_dup = NULL;
+
+    DEFiRet;
+
+    if (map == NULL || rsyslog_prop == NULL || otlp_attr == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (map->count == map->capacity) {
+        new_capacity = (map->capacity == 0u) ? 4u : map->capacity * 2u;
+        tmp = (attribute_map_entry_t *)realloc(map->entries, new_capacity * sizeof(attribute_map_entry_t));
+        if (tmp == NULL) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        memset(tmp + map->count, 0, (new_capacity - map->count) * sizeof(attribute_map_entry_t));
+        map->entries = tmp;
+        map->capacity = new_capacity;
+    }
+
+    prop_dup = strdup(rsyslog_prop);
+    attr_dup = strdup(otlp_attr);
+
+    if (prop_dup == NULL || attr_dup == NULL) {
+        free(prop_dup);
+        free(attr_dup);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    map->entries[map->count].rsyslog_property = prop_dup;
+    map->entries[map->count].otlp_attribute = attr_dup;
+    ++map->count;
+
+finalize_it:
+    RETiRet;
+}
+
+
+static int hex_value(char c) {
+    if (c >= '0' && c <= '9') {
+        return c - '0';
+    }
+    if (c >= 'a' && c <= 'f') {
+        return 10 + (c - 'a');
+    }
+    if (c >= 'A' && c <= 'F') {
+        return 10 + (c - 'A');
+    }
+    return -1;
+}
+
+static void percent_decode(char *value) {
+    char *src;
+    char *dst;
+
+    if (value == NULL) {
+        return;
+    }
+
+    src = value;
+    dst = value;
+    while (*src != '\0') {
+        if (*src == '%' && isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2])) {
+            int hi = hex_value(src[1]);
+            int lo = hex_value(src[2]);
+            if (hi >= 0 && lo >= 0) {
+                *dst++ = (char)((hi << 4) | lo);
+                src += 3;
+                continue;
+            }
+        }
+
+        *dst++ = *src++;
+    }
+
+    *dst = '\0';
+}
+
+static char *trim_whitespace(char *value) {
+    char *start;
+    char *end;
+
+    if (value == NULL) {
+        return NULL;
+    }
+
+    start = value;
+    while (*start != '\0' && isspace((unsigned char)*start)) {
+        ++start;
+    }
+
+    end = start + strlen(start);
+    while (end > start && isspace((unsigned char)end[-1])) {
+        --end;
+    }
+
+    *end = '\0';
+    return start;
+}
+
+static rsRetVal parse_long_param(const char *name, es_str_t *value, long min, long *out) {
+    char *text = NULL;
+    char *end = NULL;
+    long parsed;
+
+    DEFiRet;
+
+    if (value == NULL || out == NULL) {
+        goto finalize_it;
+    }
+
+    text = (char *)es_str2cstr(value, NULL);
+    if (text == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    errno = 0;
+    parsed = strtol(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0') {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: invalid numeric value '%s' for parameter %s", text, name);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (parsed < min) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: value %ld for %s is below the minimum %ld", parsed, name, min);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    *out = parsed;
+
+finalize_it:
+    if (text != NULL) {
+        free(text);
+    }
+    RETiRet;
+}
+
+static rsRetVal parse_size_param(const char *name, es_str_t *value, size_t min, size_t *out) {
+    char *text = NULL;
+    char *end = NULL;
+    unsigned long long parsed;
+
+    DEFiRet;
+
+    if (value == NULL || out == NULL) {
+        goto finalize_it;
+    }
+
+    text = (char *)es_str2cstr(value, NULL);
+    if (text == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    errno = 0;
+    parsed = strtoull(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0') {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: invalid size value '%s' for parameter %s", text, name);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (parsed < (unsigned long long)min) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: value %s for %s is below the minimum %zu", text, name, min);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    *out = (size_t)parsed;
+
+finalize_it:
+    if (text != NULL) {
+        free(text);
+    }
+    RETiRet;
+}
+
+static rsRetVal parse_uint_param(const char *name, es_str_t *value, unsigned int min, unsigned int *out) {
+    char *text = NULL;
+    char *end = NULL;
+    unsigned long parsed;
+
+    DEFiRet;
+
+    if (value == NULL || out == NULL) {
+        goto finalize_it;
+    }
+
+    text = (char *)es_str2cstr(value, NULL);
+    if (text == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    errno = 0;
+    parsed = strtoul(text, &end, 10);
+    if (errno != 0 || end == text || *end != '\0') {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: invalid numeric value '%s' for parameter %s", text, name);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (parsed < (unsigned long)min) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: value %lu for %s is below the minimum %u", parsed, name, min);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    *out = (unsigned int)parsed;
+
+finalize_it:
+    if (text != NULL) {
+        free(text);
+    }
+    RETiRet;
+}
+
+static rsRetVal parse_headers_json(instanceData *pData, const char *text) {
+    struct json_object *root = NULL;
+    struct json_object_iterator iter;
+    struct json_object_iterator iter_end;
+
+    DEFiRet;
+
+    if (text == NULL || text[0] == '\0') {
+        goto finalize_it;
+    }
+
+    root = fjson_tokener_parse(text);
+    if (root == NULL) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: failed to parse headers JSON '%s'", text);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (!fjson_object_is_type(root, fjson_type_object)) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: headers parameter must be a JSON object");
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    iter = json_object_iter_begin(root);
+    iter_end = json_object_iter_end(root);
+    while (!json_object_iter_equal(&iter, &iter_end)) {
+        const char *key = json_object_iter_peek_name(&iter);
+        struct json_object *value_obj = json_object_iter_peek_value(&iter);
+        const char *value = NULL;
+
+        if (value_obj != NULL) {
+            if (!fjson_object_is_type(value_obj, fjson_type_string)) {
+                LogError(0, RS_RET_PARAM_ERROR, "omotlp: header '%s' value must be a string", key);
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            value = fjson_object_get_string(value_obj);
+        }
+
+        CHKiRet(header_list_add_kv(&pData->headers, key, value));
+        json_object_iter_next(&iter);
+    }
+
+finalize_it:
+    if (root != NULL) {
+        fjson_object_put(root);
+    }
+    RETiRet;
+}
+
+static rsRetVal parse_attribute_map(instanceData *pData, const char *json_text) {
+    struct json_object *root = NULL;
+    struct json_object_iterator iter;
+    struct json_object_iterator iter_end;
+
+    DEFiRet;
+
+    if (json_text == NULL || json_text[0] == '\0') {
+        goto finalize_it;
+    }
+
+    root = fjson_tokener_parse(json_text);
+    if (root == NULL) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: failed to parse attributeMap JSON: %s", json_text);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (!fjson_object_is_type(root, fjson_type_object)) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: attributeMap must be a JSON object");
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    iter = json_object_iter_begin(root);
+    iter_end = json_object_iter_end(root);
+
+    while (!json_object_iter_equal(&iter, &iter_end)) {
+        const char *rsyslog_prop = json_object_iter_peek_name(&iter);
+        struct json_object *value_obj = json_object_iter_peek_value(&iter);
+        const char *otlp_attr = NULL;
+
+        if (value_obj == NULL || !fjson_object_is_type(value_obj, fjson_type_string)) {
+            LogError(0, RS_RET_PARAM_ERROR, "omotlp: attributeMap value for '%s' must be a string", rsyslog_prop);
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        otlp_attr = fjson_object_get_string(value_obj);
+
+        /* Add to attribute map */
+        CHKiRet(attribute_map_add(&pData->attributeMap, rsyslog_prop, otlp_attr));
+
+        json_object_iter_next(&iter);
+    }
+
+finalize_it:
+    if (root != NULL) {
+        fjson_object_put(root);
+    }
+    RETiRet;
+}
+
+static rsRetVal parse_severity_map(instanceData *pData, const char *json_text) {
+    struct json_object *root = NULL;
+    struct json_object_iterator iter;
+    struct json_object_iterator iter_end;
+    int priority;
+    uint32_t severity_number;
+    const char *severity_text = NULL;
+    char *severity_text_dup = NULL;
+
+    DEFiRet;
+
+    if (json_text == NULL || json_text[0] == '\0') {
+        goto finalize_it;
+    }
+
+    root = fjson_tokener_parse(json_text);
+    if (root == NULL) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: failed to parse severity.map JSON: %s", json_text);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (!fjson_object_is_type(root, fjson_type_object)) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: severity.map must be a JSON object");
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    /* Initialize all entries */
+    for (priority = 0; priority < 8; ++priority) {
+        pData->severityMap.entries[priority].syslog_priority = priority;
+        pData->severityMap.entries[priority].severity_number = 0u;
+        pData->severityMap.entries[priority].severity_text = NULL;
+    }
+
+    iter = json_object_iter_begin(root);
+    iter_end = json_object_iter_end(root);
+
+    while (!json_object_iter_equal(&iter, &iter_end)) {
+        const char *key = json_object_iter_peek_name(&iter);
+        struct json_object *value_obj = json_object_iter_peek_value(&iter);
+        struct json_object *number_obj = NULL;
+        struct json_object *text_obj = NULL;
+
+        errno = 0;
+        priority = (int)strtol(key, NULL, 10);
+        if (errno != 0 || priority < 0 || priority > 7) {
+            LogError(0, RS_RET_PARAM_ERROR, "omotlp: severity.map key '%s' must be a number 0-7", key);
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        if (value_obj == NULL || !fjson_object_is_type(value_obj, fjson_type_object)) {
+            LogError(0, RS_RET_PARAM_ERROR, "omotlp: severity.map value for priority %d must be an object", priority);
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        /* Use fjson_object_object_get_ex for efficient key lookup */
+        fjson_object_object_get_ex(value_obj, "number", &number_obj);
+        fjson_object_object_get_ex(value_obj, "text", &text_obj);
+
+        if (number_obj == NULL || !fjson_object_is_type(number_obj, fjson_type_int)) {
+            LogError(0, RS_RET_PARAM_ERROR, "omotlp: severity.map[%d] must have 'number' field (integer)", priority);
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        if (text_obj == NULL || !fjson_object_is_type(text_obj, fjson_type_string)) {
+            LogError(0, RS_RET_PARAM_ERROR, "omotlp: severity.map[%d] must have 'text' field (string)", priority);
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        severity_number = (uint32_t)fjson_object_get_int64(number_obj);
+        severity_text = fjson_object_get_string(text_obj);
+
+        severity_text_dup = strdup(severity_text);
+        if (severity_text_dup == NULL) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+
+        pData->severityMap.entries[priority].severity_number = severity_number;
+        pData->severityMap.entries[priority].severity_text = severity_text_dup;
+        severity_text_dup = NULL; /* Ownership transferred */
+
+        json_object_iter_next(&iter);
+    }
+
+    pData->severityMap.configured = 1;
+
+finalize_it:
+    if (root != NULL) {
+        fjson_object_put(root);
+    }
+    if (severity_text_dup != NULL) {
+        free(severity_text_dup);
+    }
+    RETiRet;
+}
+
+static rsRetVal parse_headers_env(instanceData *pData, const char *text) {
+    char *dup = NULL;
+    char *cursor;
+
+    DEFiRet;
+
+    if (text == NULL || text[0] == '\0') {
+        goto finalize_it;
+    }
+
+    dup = strdup(text);
+    if (dup == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    cursor = dup;
+    while (cursor != NULL && *cursor != '\0') {
+        char *token = cursor;
+        char *next = strchr(cursor, ',');
+        char *key;
+        char *value;
+
+        if (next != NULL) {
+            *next = '\0';
+            cursor = next + 1;
+        } else {
+            cursor = NULL;
+        }
+
+        token = trim_whitespace(token);
+        if (token == NULL || token[0] == '\0') {
+            continue;
+        }
+
+        value = strchr(token, '=');
+        if (value == NULL) {
+            LogError(0, RS_RET_PARAM_ERROR, "omotlp: header entry '%s' is missing '='", token);
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        *value = '\0';
+        ++value;
+
+        key = trim_whitespace(token);
+        value = trim_whitespace(value);
+
+        percent_decode(key);
+        percent_decode(value);
+
+        CHKiRet(header_list_add_kv(&pData->headers, key, value));
+    }
+
+finalize_it:
+    if (dup != NULL) {
+        free(dup);
+    }
+    RETiRet;
+}
+
+static rsRetVal parse_timeout_string(const char *text, long *out) {
+    char *dup = NULL;
+    char *number;
+    char *end = NULL;
+    long multiplier = 1;
+    long parsed;
+    size_t len;
+
+    DEFiRet;
+
+    if (text == NULL || out == NULL) {
+        goto finalize_it;
+    }
+
+    dup = strdup(text);
+    if (dup == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    len = strlen(dup);
+    if (len >= 2 && dup[len - 2] == 'm' && dup[len - 1] == 's') {
+        dup[len - 2] = '\0';
+    } else if (len >= 1 && dup[len - 1] == 's') {
+        dup[len - 1] = '\0';
+        multiplier = 1000;
+    }
+
+    number = trim_whitespace(dup);
+    errno = 0;
+    parsed = strtol(number, &end, 10);
+    if (errno != 0 || end == number || *end != '\0') {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: invalid timeout value '%s'", text);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (parsed < 0) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: timeout must be non-negative, got %ld", parsed);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (multiplier != 1 && parsed > LONG_MAX / multiplier) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: timeout '%s' exceeds range", text);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    *out = parsed * multiplier;
+
+finalize_it:
+    if (dup != NULL) {
+        free(dup);
+    }
+    RETiRet;
+}
+
+static rsRetVal set_compression_mode(instanceData *pData, const char *value) {
+    char buffer[16];
+    size_t len;
+    size_t i;
+
+    DEFiRet;
+
+    if (pData == NULL || value == NULL || value[0] == '\0') {
+        goto finalize_it;
+    }
+
+    len = strlen(value);
+    if (len >= sizeof(buffer)) {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: unsupported compression value '%s'", value);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    for (i = 0; i < len; ++i) {
+        buffer[i] = (char)tolower((unsigned char)value[i]);
+    }
+    buffer[len] = '\0';
+
+    if (!strcmp(buffer, "gzip")) {
+        pData->compression_mode = OMOTLP_COMPRESSION_GZIP;
+    } else if (!strcmp(buffer, "none")) {
+        pData->compression_mode = OMOTLP_COMPRESSION_NONE;
+    } else {
+        LogError(0, RS_RET_PARAM_ERROR, "omotlp: compression '%s' is not supported", value);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal duplicate_optional_string(const char *source, char **dest) {
+    char *dup = NULL;
+
+    DEFiRet;
+
+    if (dest == NULL) {
+        goto finalize_it;
+    }
+
+    *dest = NULL;
+
+    if (source == NULL || source[0] == '\0') {
+        goto finalize_it;
+    }
+
+    dup = strdup(source);
+    if (dup == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    *dest = dup;
+    dup = NULL;
+
+finalize_it:
+    if (dup != NULL) {
+        free(dup);
+    }
+    RETiRet;
+}
+
+static void mapSeverity(int syslogSeverity, instanceData *pData, omotlp_log_record_t *record) {
+    if (syslogSeverity < 0 || syslogSeverity > 7) {
+        record->severity_number = 0u;
+        record->severity_text = NULL;
+        return;
+    }
+
+    if (pData != NULL && pData->severityMap.configured &&
+        pData->severityMap.entries[syslogSeverity].severity_text != NULL) {
+        /* Use custom mapping if it exists for this priority */
+        record->severity_number = pData->severityMap.entries[syslogSeverity].severity_number;
+        record->severity_text = pData->severityMap.entries[syslogSeverity].severity_text;
+    } else {
+        /* Use default mapping (either no custom map configured, or this priority not mapped) */
+        record->severity_number = severity_lookup[syslogSeverity].number;
+        record->severity_text = severity_lookup[syslogSeverity].text;
+    }
+}
+
+static uint64_t scaleFractionToNanos(int fraction, int precision) {
+    uint64_t value;
+
+    if (precision <= 0 || fraction <= 0) {
+        return 0u;
+    }
+
+    value = (uint64_t)fraction;
+    if (precision > 9) {
+        int diff = precision - 9;
+        while (diff-- > 0 && value > 0u) {
+            value /= 10u;
+        }
+    } else if (precision < 9) {
+        int diff = 9 - precision;
+        while (diff-- > 0) {
+            value *= 10u;
+        }
+    }
+
+    return value;
+}
+
+static uint64_t syslogTimeToUnixNanos(const struct syslogTime *timestamp) {
+    if (timestamp == NULL) {
+        return 0u;
+    }
+
+    return ((uint64_t)datetime.syslogTime2time_t(timestamp) * 1000000000ull) +
+           scaleFractionToNanos(timestamp->secfrac, timestamp->secfracPrecision);
+}
+
+static const char *cstrToConst(cstr_t *value) {
+    return value == NULL ? NULL : (const char *)rsCStrGetSzStrNoNULL(value);
+}
+
+static const char *extractAppName(const smsg_t *msg) {
+    const char *candidate;
+
+    if (msg == NULL) {
+        return NULL;
+    }
+
+    candidate = cstrToConst(msg->pCSAPPNAME);
+    if (candidate != NULL && candidate[0] != '\0') {
+        return candidate;
+    }
+
+    if (msg->iLenPROGNAME > 0 && msg->PROGNAME.ptr != NULL) {
+        return (const char *)msg->PROGNAME.ptr;
+    }
+
+    return NULL;
+}
+
+static const char *extractProcId(const smsg_t *msg) {
+    const char *candidate;
+
+    if (msg == NULL) {
+        return NULL;
+    }
+
+    candidate = cstrToConst(msg->pCSPROCID);
+    if (candidate != NULL && candidate[0] != '\0') {
+        return candidate;
+    }
+
+    return NULL;
+}
+
+static const char *extractMsgId(const smsg_t *msg) {
+    const char *candidate;
+
+    if (msg == NULL) {
+        return NULL;
+    }
+
+    candidate = cstrToConst(msg->pCSMSGID);
+    if (candidate != NULL && candidate[0] != '\0') {
+        return candidate;
+    }
+
+    return NULL;
+}
+
+/**
+ * Validates a hex string for trace_id (32 hex characters = 128 bits)
+ * Returns 1 if valid, 0 otherwise
+ */
+static int is_valid_trace_id(const char *value) {
+    size_t len;
+    size_t i;
+
+    if (value == NULL) {
+        return 0;
+    }
+
+    len = strlen(value);
+    if (len != 32) {
+        return 0;
+    }
+
+    for (i = 0; i < len; ++i) {
+        if (!isxdigit((unsigned char)value[i])) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/**
+ * Validates a hex string for span_id (16 hex characters = 64 bits)
+ * Returns 1 if valid, 0 otherwise
+ */
+static int is_valid_span_id(const char *value) {
+    size_t len;
+    size_t i;
+
+    if (value == NULL) {
+        return 0;
+    }
+
+    len = strlen(value);
+    if (len != 16) {
+        return 0;
+    }
+
+    for (i = 0; i < len; ++i) {
+        if (!isxdigit((unsigned char)value[i])) {
+            return 0;
+        }
+    }
+
+    return 1;
+}
+
+/**
+ * Parses trace_flags as hex string (1-2 hex characters, 0-255)
+ * Returns parsed value or 0 on error
+ */
+static uint8_t parse_trace_flags(const char *value) {
+    char *end = NULL;
+    unsigned long parsed;
+
+    if (value == NULL || value[0] == '\0') {
+        return 0;
+    }
+
+    errno = 0;
+    parsed = strtoul(value, &end, 16);
+    if (errno != 0 || end == value || *end != '\0') {
+        return 0;
+    }
+
+    if (parsed > 255) {
+        return 0;
+    }
+
+    return (uint8_t)parsed;
+}
+
+/**
+ * @brief Extract property value as string from message JSON variables
+ *
+ * Extracts a property value from the message's local JSON variables ($!).
+ * The property name is looked up in the message's JSON structure. If the
+ * property is a string, it is returned directly. If it's a non-string JSON
+ * object, it is converted to its JSON string representation.
+ *
+ * @param[in] msg Rsyslog message structure
+ * @param[in] prop_name Property name to extract (e.g., "trace_id")
+ * @return Allocated string containing the property value (caller must free),
+ *         or NULL if the property is not found or extraction fails
+ */
+static char *extract_property_string(smsg_t *msg, const char *prop_name) {
+    struct json_object *json = NULL;
+    msgPropDescr_t prop_descr;
+    uchar *cstr = NULL;
+    char *value = NULL;
+    char *var_name = NULL;
+    size_t name_len;
+
+    if (msg == NULL || prop_name == NULL || prop_name[0] == '\0') {
+        return NULL;
+    }
+
+    /* Prepend $! if not already present for local variable access */
+    name_len = strlen(prop_name);
+    if (name_len >= 2 && prop_name[0] == '$' && prop_name[1] == '!') {
+        var_name = (char *)prop_name;
+    } else {
+        /* Allocate space for $! prefix + property name + null terminator */
+        var_name = (char *)malloc(name_len + 3);
+        if (var_name == NULL) {
+            return NULL;
+        }
+        snprintf(var_name, name_len + 3, "$!%s", prop_name);
+    }
+
+    /* Construct property descriptor for local variable access */
+    if (msgPropDescrFill(&prop_descr, (uchar *)var_name, (int)strlen(var_name)) != RS_RET_OK) {
+        if (var_name != prop_name) {
+            free(var_name);
+        }
+        return NULL;
+    }
+
+    /* Access the JSON variable from localvars */
+    if (msgGetJSONPropJSONorString(msg, &prop_descr, &json, &cstr) != RS_RET_OK) {
+        msgPropDescrDestruct(&prop_descr);
+        if (var_name != prop_name) {
+            free(var_name);
+        }
+        return NULL;
+    }
+
+    if (cstr != NULL && cstr[0] != '\0') {
+        /* String value extracted (most common case for trace properties) */
+        value = strdup((const char *)cstr);
+    } else if (json != NULL) {
+        /* Non-string JSON object - convert to string representation */
+        const char *json_str = fjson_object_to_json_string(json);
+        if (json_str != NULL && json_str[0] != '\0') {
+            value = strdup(json_str);
+        }
+        fjson_object_put(json); /* Free the deep copy */
+    }
+
+    msgPropDescrDestruct(&prop_descr);
+    if (cstr != NULL) {
+        free(cstr);
+    }
+    if (var_name != prop_name) {
+        free(var_name);
+    }
+
+    return value;
+}
+
+/**
+ * @brief Populate OTLP log record from rsyslog message
+ *
+ * Extracts all relevant fields from the rsyslog message and populates the
+ * OTLP log record structure. This includes timestamps, severity mapping,
+ * hostname, application name, process ID, message ID, and trace correlation
+ * data (trace_id, span_id, trace_flags).
+ *
+ * The function allocates memory for trace correlation strings (trace_id,
+ * span_id) which must be freed by the caller.
+ *
+ * @param[in] msg Rsyslog message structure (may be NULL)
+ * @param[in] body Log message body text
+ * @param[in] pData Instance data containing configuration and property names
+ * @param[out] record OTLP log record to populate
+ * @return RS_RET_OK on success
+ */
+static rsRetVal populateLogRecord(smsg_t *msg, const char *body, instanceData *pData, omotlp_log_record_t *record) {
+    int severity;
+    char *trace_id_str = NULL;
+    char *span_id_str = NULL;
+    char *trace_flags_str = NULL;
+
+    DEFiRet;
+
+    memset(record, 0, sizeof(*record));
+
+    record->body = body;
+
+    if (msg != NULL) {
+        CHKiRet(MsgGetSeverity(msg, &severity));
+        mapSeverity(severity, pData, record);
+
+        record->hostname = (msg->pszHOSTNAME != NULL) ? (const char *)msg->pszHOSTNAME : NULL;
+        record->app_name = extractAppName(msg);
+        record->proc_id = extractProcId(msg);
+        record->msg_id = extractMsgId(msg);
+        record->facility = (uint16_t)msg->iFacility;
+        record->time_unix_nano = syslogTimeToUnixNanos(&msg->tTIMESTAMP);
+        record->observed_time_unix_nano = syslogTimeToUnixNanos(&msg->tRcvdAt);
+
+        /* Extract trace correlation data */
+        if (pData != NULL) {
+            trace_id_str = extract_property_string(msg, (const char *)pData->traceIdPropertyName);
+            if (trace_id_str != NULL) {
+                if (is_valid_trace_id(trace_id_str)) {
+                    record->trace_id = trace_id_str;
+                    trace_id_str = NULL; /* Ownership transferred */
+                } else {
+                    LogError(0, RS_RET_OK, "omotlp: invalid trace_id format (expected 32 hex chars): %s", trace_id_str);
+                    free(trace_id_str);
+                    trace_id_str = NULL;
+                }
+            }
+
+            span_id_str = extract_property_string(msg, (const char *)pData->spanIdPropertyName);
+            if (span_id_str != NULL) {
+                if (is_valid_span_id(span_id_str)) {
+                    record->span_id = span_id_str;
+                    span_id_str = NULL; /* Ownership transferred */
+                } else {
+                    LogError(0, RS_RET_OK, "omotlp: invalid span_id format (expected 16 hex chars): %s", span_id_str);
+                    free(span_id_str);
+                    span_id_str = NULL;
+                }
+            }
+
+            trace_flags_str = extract_property_string(msg, (const char *)pData->traceFlagsPropertyName);
+            if (trace_flags_str != NULL) {
+                record->trace_flags = parse_trace_flags(trace_flags_str);
+                free(trace_flags_str);
+                trace_flags_str = NULL;
+            }
+        }
+    } else {
+        record->severity_number = 0u;
+        record->severity_text = NULL;
+        record->hostname = NULL;
+        record->app_name = NULL;
+        record->proc_id = NULL;
+        record->msg_id = NULL;
+        record->facility = 0u;
+        record->time_unix_nano = 0u;
+        record->observed_time_unix_nano = 0u;
+    }
+
+    if (record->trace_id == NULL) {
+        record->trace_id = NULL;
+    }
+    if (record->span_id == NULL) {
+        record->span_id = NULL;
+    }
+    if (record->trace_flags == 0u && trace_flags_str == NULL) {
+        record->trace_flags = 0u;
+    }
+
+finalize_it:
+    if (trace_id_str != NULL) {
+        free(trace_id_str);
+    }
+    if (span_id_str != NULL) {
+        free(span_id_str);
+    }
+    if (trace_flags_str != NULL) {
+        free(trace_flags_str);
+    }
+    RETiRet;
+}
+
+static void omotlp_batch_entry_clear(omotlp_batch_entry_t *entry) {
+    if (entry == NULL) {
+        return;
+    }
+
+    free(entry->body);
+    free(entry->hostname);
+    free(entry->app_name);
+    free(entry->proc_id);
+    free(entry->msg_id);
+    free(entry->trace_id);
+    free(entry->span_id);
+
+    memset(entry, 0, sizeof(*entry));
+}
+
+static void omotlp_batch_clear(omotlp_batch_state_t *batch) {
+    size_t i;
+
+    if (batch == NULL) {
+        return;
+    }
+
+    for (i = 0; i < batch->count; ++i) {
+        omotlp_batch_entry_clear(&batch->entries[i]);
+    }
+
+    batch->count = 0u;
+    batch->estimated_bytes = 0u;
+    batch->first_enqueue_ms = 0;
+}
+
+static void omotlp_batch_destroy(omotlp_batch_state_t *batch) {
+    if (batch == NULL) {
+        return;
+    }
+
+    omotlp_batch_clear(batch);
+    free(batch->entries);
+    batch->entries = NULL;
+    batch->capacity = 0u;
+}
+
+static rsRetVal omotlp_batch_ensure_capacity(omotlp_batch_state_t *batch, size_t needed) {
+    omotlp_batch_entry_t *tmp;
+    size_t new_capacity;
+
+    DEFiRet;
+
+    if (batch == NULL) {
+        goto finalize_it;
+    }
+
+    if (needed <= batch->capacity) {
+        goto finalize_it;
+    }
+
+    new_capacity = batch->capacity == 0u ? 8u : batch->capacity;
+    while (new_capacity < needed) {
+        new_capacity *= 2u;
+    }
+
+    tmp = (omotlp_batch_entry_t *)realloc(batch->entries, new_capacity * sizeof(omotlp_batch_entry_t));
+    if (tmp == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    memset(tmp + batch->capacity, 0, (new_capacity - batch->capacity) * sizeof(omotlp_batch_entry_t));
+    batch->entries = tmp;
+    batch->capacity = new_capacity;
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal gzip_compress_buffer(const uint8_t *input, size_t input_len, uint8_t **out, size_t *out_len) {
+    z_stream stream;
+    uint8_t *buffer = NULL;
+    size_t bound;
+    int rc;
+
+    DEFiRet;
+
+    if (out == NULL || out_len == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    *out = NULL;
+    *out_len = 0u;
+
+    bound = (size_t)compressBound((uLong)input_len);
+    buffer = (uint8_t *)malloc(bound);
+    if (buffer == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    memset(&stream, 0, sizeof(stream));
+    rc = deflateInit2(&stream, Z_DEFAULT_COMPRESSION, Z_DEFLATED, 15 + 16, 8, Z_DEFAULT_STRATEGY);
+    if (rc != Z_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp: deflateInit2 failed: %d", rc);
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    stream.next_in = (Bytef *)input;
+    stream.avail_in = (uInt)input_len;
+    stream.next_out = buffer;
+    stream.avail_out = (uInt)bound;
+
+    rc = deflate(&stream, Z_FINISH);
+    if (rc != Z_STREAM_END) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp: gzip compression failed: %d", rc);
+        deflateEnd(&stream);
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    *out = buffer;
+    *out_len = stream.total_out;
+    buffer = NULL;
+
+    deflateEnd(&stream);
+
+finalize_it:
+    if (buffer != NULL) {
+        free(buffer);
+    }
+    RETiRet;
+}
+
+/**
+ * @brief Flush a batch of log records to the OTLP collector
+ *
+ * This function must be called with the batch mutex already held. It converts
+ * the batch entries to OTLP JSON format, optionally compresses the payload,
+ * sends it via HTTP POST, and updates statistics based on the response.
+ *
+ * HTTP status code handling:
+ * - 2xx: Success - batch is cleared, records.sent incremented
+ * - 4xx: Client error - batch is dropped (already delivered but rejected)
+ * - 5xx/408/429: Server error - batch is retained for retry
+ *
+ * @param[in] pWrkrData Worker instance data containing HTTP client and stats
+ * @param[in,out] batch Batch state to flush (cleared on success or 4xx)
+ * @return RS_RET_OK on success, RS_RET_SUSPENDED for retryable errors,
+ *         RS_RET_PARAM_ERROR for invalid parameters
+ */
+static rsRetVal omotlp_flush_batch_locked(wrkrInstanceData_t *pWrkrData, omotlp_batch_state_t *batch) {
+    omotlp_log_record_t *records = NULL;
+    char *payload = NULL;
+    uint8_t *compressed = NULL;
+    const uint8_t *to_send;
+    size_t send_len = 0u;
+    size_t payload_len = 0u;
+    size_t i;
+    long status_code = 0;
+    long latency_ms = 0;
+    size_t record_count = 0u;
+    omotlp_resource_attrs_t resource_attrs;
+
+    DEFiRet;
+
+    DBGPRINTF("omotlp: omotlp_flush_batch called, batch->count=%zu", batch ? batch->count : 0u);
+
+    if (pWrkrData == NULL || batch == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (batch->count == 0u) {
+        DBGPRINTF("omotlp: omotlp_flush_batch: batch is empty, skipping");
+        goto finalize_it;
+    }
+
+    record_count = batch->count;
+    DBGPRINTF("omotlp: omotlp_flush_batch: flushing %zu records", record_count);
+
+    STATSCOUNTER_INC(pWrkrData->ctrBatchesSubmitted, pWrkrData->mutCtrBatchesSubmitted);
+
+    records = (omotlp_log_record_t *)malloc(batch->count * sizeof(*records));
+    if (records == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    for (i = 0; i < batch->count; ++i) {
+        records[i] = batch->entries[i].record;
+    }
+
+    DBGPRINTF("omotlp: omotlp_flush_batch: building JSON export for %zu records", batch->count);
+    resource_attrs = (omotlp_resource_attrs_t){
+        .service_instance_id = pWrkrData->pData->resourceServiceInstanceId
+                                   ? (const char *)pWrkrData->pData->resourceServiceInstanceId
+                                   : NULL,
+        .deployment_environment = pWrkrData->pData->resourceDeploymentEnvironment
+                                      ? (const char *)pWrkrData->pData->resourceDeploymentEnvironment
+                                      : NULL,
+        .custom_attributes = pWrkrData->pData->resourceJsonParsed,
+    };
+
+    CHKiRet(
+        omotlp_json_build_export(records, batch->count, &resource_attrs, &pWrkrData->pData->attributeMap, &payload));
+
+    if (payload != NULL) {
+        payload_len = strlen(payload);
+        DBGPRINTF("omotlp: omotlp_flush_batch: JSON payload length=%zu", payload_len);
+    }
+
+    to_send = (const uint8_t *)payload;
+    send_len = payload_len;
+
+    if (pWrkrData->pData->compression_mode == OMOTLP_COMPRESSION_GZIP) {
+        DBGPRINTF("omotlp: omotlp_flush_batch: compressing payload");
+        CHKiRet(gzip_compress_buffer((const uint8_t *)payload, payload_len, &compressed, &send_len));
+        to_send = compressed;
+        DBGPRINTF("omotlp: omotlp_flush_batch: compressed size=%zu", send_len);
+    }
+
+    DBGPRINTF("omotlp: omotlp_flush_batch: calling omotlp_http_client_post, send_len=%zu", send_len);
+    iRet = omotlp_http_client_post(pWrkrData->http_client, to_send, send_len, &status_code, &latency_ms);
+
+    /* Update statistics based on HTTP response (status_code is set even on error) */
+    if (status_code > 0) {
+        if (status_code >= 200 && status_code < 300) {
+            STATSCOUNTER_INC(pWrkrData->ctrBatchesSuccess, pWrkrData->mutCtrBatchesSuccess);
+            STATSCOUNTER_ADD(pWrkrData->ctrRecordsSent, pWrkrData->mutCtrRecordsSent, record_count);
+            if (latency_ms > 0) {
+                STATSCOUNTER_ADD(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs, latency_ms);
+            }
+            DBGPRINTF("omotlp: omotlp_flush_batch: HTTP POST successful, clearing batch");
+            omotlp_batch_clear(batch);
+        } else if (status_code >= 400 && status_code < 500) {
+            STATSCOUNTER_INC(pWrkrData->ctrHttpStatus4xx, pWrkrData->mutCtrHttpStatus4xx);
+            if (status_code == 408 || status_code == 429) {
+                /* 408 (Request Timeout) and 429 (Too Many Requests) are retryable.
+                 * If the HTTP client exhausted retries and returned RS_RET_SUSPENDED,
+                 * we must retain the batch so rsyslog can retry it. Otherwise, the
+                 * batch data would be lost. */
+                if (iRet == RS_RET_SUSPENDED) {
+                    STATSCOUNTER_INC(pWrkrData->ctrBatchesRetried, pWrkrData->mutCtrBatchesRetried);
+                    if (latency_ms > 0) {
+                        STATSCOUNTER_ADD(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs,
+                                         latency_ms);
+                    }
+                    DBGPRINTF("omotlp: omotlp_flush_batch: HTTP %ld error, retaining batch for retry", status_code);
+                    /* Don't clear batch - it will be retried by rsyslog */
+                } else {
+                    STATSCOUNTER_INC(pWrkrData->ctrBatchesDropped, pWrkrData->mutCtrBatchesDropped);
+                    if (latency_ms > 0) {
+                        STATSCOUNTER_ADD(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs,
+                                         latency_ms);
+                    }
+                    DBGPRINTF("omotlp: omotlp_flush_batch: HTTP %ld error, clearing batch", status_code);
+                    omotlp_batch_clear(batch);
+                }
+            } else {
+                /* Non-retryable 4xx (400, 401, 403, 404, etc.) - clear batch */
+                STATSCOUNTER_INC(pWrkrData->ctrBatchesDropped, pWrkrData->mutCtrBatchesDropped);
+                if (latency_ms > 0) {
+                    STATSCOUNTER_ADD(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs, latency_ms);
+                }
+                DBGPRINTF("omotlp: omotlp_flush_batch: HTTP 4xx error, clearing batch");
+                omotlp_batch_clear(batch);
+                /* For non-retryable 4xx errors, clear the error so the caller can continue.
+                 * The batch has been dropped, but new records should still be accepted. */
+                if (iRet == RS_RET_DISCARDMSG) {
+                    iRet = RS_RET_OK;
+                }
+            }
+        } else if (status_code >= 500) {
+            STATSCOUNTER_INC(pWrkrData->ctrHttpStatus5xx, pWrkrData->mutCtrHttpStatus5xx);
+            STATSCOUNTER_INC(pWrkrData->ctrBatchesRetried, pWrkrData->mutCtrBatchesRetried);
+            if (latency_ms > 0) {
+                STATSCOUNTER_ADD(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs, latency_ms);
+            }
+            /* Don't clear batch on 5xx - it will be retried */
+        } else {
+            /* Other status codes (1xx, 3xx) - track latency if available */
+            if (latency_ms > 0) {
+                STATSCOUNTER_ADD(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs, latency_ms);
+            }
+        }
+    } else if (latency_ms > 0) {
+        /* Network error or other failure - still track latency if available */
+        STATSCOUNTER_ADD(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs, latency_ms);
+    }
+
+    if (iRet != RS_RET_OK) {
+        CHKiRet(iRet);
+    }
+
+finalize_it:
+    free(records);
+    free(payload);
+    free(compressed);
+    RETiRet;
+}
+
+static rsRetVal omotlp_flush_batch(wrkrInstanceData_t *pWrkrData) {
+    rsRetVal iRet;
+
+    if (pWrkrData == NULL) {
+        return RS_RET_PARAM_ERROR;
+    }
+
+    pthread_mutex_lock(&pWrkrData->batch_mutex);
+    iRet = omotlp_flush_batch_locked(pWrkrData, &pWrkrData->batch);
+    pthread_mutex_unlock(&pWrkrData->batch_mutex);
+
+    return iRet;
+}
+
+/**
+ * @brief Background thread for timeout-based batch flushing
+ *
+ * This thread runs in the background and periodically checks if any batches
+ * have exceeded their timeout threshold. It wakes every 100ms to check for
+ * batches that need to be flushed due to timeout. The thread performs a final
+ * flush of any remaining data before exiting when the stop flag is set.
+ *
+ * @param[in] arg Worker instance data pointer (cast from void*)
+ * @return NULL (pthread requirement)
+ */
+static void *omotlp_batch_flush_thread(void *arg) {
+    wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t *)arg;
+    struct timespec req;
+    req.tv_sec = 0;
+    req.tv_nsec = 100 * 1000 * 1000; /* 100 ms */
+
+    for (;;) {
+        nanosleep(&req, NULL);
+
+        pthread_mutex_lock(&pWrkrData->batch_mutex);
+        if (pWrkrData->flush_thread_stop) {
+            pthread_mutex_unlock(&pWrkrData->batch_mutex);
+            break;
+        }
+
+        if (pWrkrData->batch.count > 0u) {
+            long long timeout_ms =
+                pWrkrData->pData->batchTimeoutMs > 0 ? pWrkrData->pData->batchTimeoutMs : OMOTLP_IDLE_FLUSH_INTERVAL_MS;
+            if (timeout_ms > 0) {
+                long long now = currentTimeMills();
+                if (pWrkrData->batch.first_enqueue_ms != 0 && now - pWrkrData->batch.first_enqueue_ms >= timeout_ms) {
+                    /* Check stop flag before starting potentially long-running flush operation */
+                    if (!pWrkrData->flush_thread_stop) {
+                        (void)omotlp_flush_batch_locked(pWrkrData, &pWrkrData->batch);
+                    }
+                }
+            }
+        }
+
+        pthread_mutex_unlock(&pWrkrData->batch_mutex);
+    }
+
+    pthread_mutex_lock(&pWrkrData->batch_mutex);
+    /* Final flush before thread exit - flush any remaining data */
+    if (pWrkrData->batch.count > 0u) {
+        (void)omotlp_flush_batch_locked(pWrkrData, &pWrkrData->batch);
+    }
+    pthread_mutex_unlock(&pWrkrData->batch_mutex);
+
+    return NULL;
+}
+
+/**
+ * @brief Add a log record to the batch buffer
+ *
+ * Adds a log record to the worker's batch buffer. The function automatically
+ * flushes the batch if thresholds are reached (max_items, max_bytes) before
+ * adding the new record. The batch mutex is acquired internally and released
+ * on return.
+ *
+ * The function performs rollback of batch state if allocation fails after
+ * incrementing the count, ensuring consistency.
+ *
+ * @param[in] pWrkrData Worker instance data
+ * @param[in] record Log record to add to the batch
+ * @param[in] body Log message body (duplicated for batch entry)
+ * @return RS_RET_OK on success, RS_RET_PARAM_ERROR for invalid parameters,
+ *         RS_RET_OUT_OF_MEMORY on allocation failure
+ */
+static rsRetVal omotlp_batch_add_record(wrkrInstanceData_t *pWrkrData,
+                                        const omotlp_log_record_t *record,
+                                        const char *body) {
+    omotlp_batch_state_t *batch;
+    instanceData *cfg;
+    omotlp_batch_entry_t *entry = NULL;
+    const char *body_text;
+    size_t body_len;
+    size_t estimated_bytes;
+    int mutex_locked = 0;
+    int count_incremented = 0;
+    int estimated_bytes_updated = 0;
+
+    DEFiRet;
+
+    if (pWrkrData == NULL || record == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    batch = &pWrkrData->batch;
+    cfg = pWrkrData->pData;
+
+    pthread_mutex_lock(&pWrkrData->batch_mutex);
+    mutex_locked = 1;
+
+    if (cfg->batchMaxItems > 0u && batch->count >= cfg->batchMaxItems) {
+        CHKiRet(omotlp_flush_batch_locked(pWrkrData, batch));
+    }
+
+    body_text = (body != NULL) ? body : "";
+    body_len = strlen(body_text);
+    estimated_bytes = OMOTLP_BATCH_RECORD_OVERHEAD + body_len;
+
+    if (cfg->batchMaxBytes > 0u && batch->count > 0u && batch->estimated_bytes + estimated_bytes > cfg->batchMaxBytes) {
+        CHKiRet(omotlp_flush_batch_locked(pWrkrData, batch));
+    }
+
+    if (cfg->batchMaxBytes > 0u && estimated_bytes > cfg->batchMaxBytes) {
+        LogError(0, RS_RET_OK,
+                 "omotlp: single record estimated size %zu exceeds batch.max_bytes %zu; sending individually",
+                 estimated_bytes, cfg->batchMaxBytes);
+    }
+
+    CHKiRet(omotlp_batch_ensure_capacity(batch, batch->count + 1u));
+    entry = &batch->entries[batch->count];
+    memset(entry, 0, sizeof(*entry));
+
+    entry->body = strdup(body_text);
+    if (entry->body == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    CHKiRet(duplicate_optional_string(record->hostname, &entry->hostname));
+    CHKiRet(duplicate_optional_string(record->app_name, &entry->app_name));
+    CHKiRet(duplicate_optional_string(record->proc_id, &entry->proc_id));
+    CHKiRet(duplicate_optional_string(record->msg_id, &entry->msg_id));
+
+    entry->record = *record;
+    entry->record.body = entry->body;
+    entry->record.hostname = entry->hostname;
+    entry->record.app_name = entry->app_name;
+    entry->record.proc_id = entry->proc_id;
+    entry->record.msg_id = entry->msg_id;
+
+    /* Store trace correlation strings */
+    if (record->trace_id != NULL) {
+        CHKiRet(duplicate_optional_string(record->trace_id, &entry->trace_id));
+        entry->record.trace_id = entry->trace_id;
+    }
+    if (record->span_id != NULL) {
+        CHKiRet(duplicate_optional_string(record->span_id, &entry->span_id));
+        entry->record.span_id = entry->span_id;
+    }
+    entry->record.trace_flags = record->trace_flags;
+
+    ++batch->count;
+    count_incremented = 1;
+    if (batch->count == 1u) {
+        batch->estimated_bytes = OMOTLP_BATCH_BASE_OVERHEAD + estimated_bytes;
+        batch->first_enqueue_ms = currentTimeMills();
+        estimated_bytes_updated = 1;
+    } else {
+        batch->estimated_bytes += estimated_bytes;
+        estimated_bytes_updated = 1;
+    }
+
+    if (cfg->batchMaxItems > 0u && batch->count >= cfg->batchMaxItems) {
+        CHKiRet(omotlp_flush_batch_locked(pWrkrData, batch));
+    } else if (cfg->batchMaxBytes > 0u && batch->estimated_bytes >= cfg->batchMaxBytes) {
+        CHKiRet(omotlp_flush_batch_locked(pWrkrData, batch));
+    }
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        if (mutex_locked) {
+            /* Rollback batch count increment if we incremented it */
+            if (count_incremented && batch != NULL && batch->count > 0u) {
+                --batch->count;
+                /* Rollback estimated_bytes increment if we updated it */
+                if (estimated_bytes_updated) {
+                    if (batch->count == 0u) {
+                        /* Rolling back the first record: reset estimated_bytes */
+                        batch->estimated_bytes = 0u;
+                    } else {
+                        /* Rolling back a subsequent record: subtract the added bytes */
+                        batch->estimated_bytes -= estimated_bytes;
+                    }
+                }
+            }
+            /* Cleanup entry if it was allocated */
+            if (entry != NULL) {
+                omotlp_batch_entry_clear(entry);
+            }
+        } else {
+            /* Cleanup entry without mutex if mutex was never acquired */
+            if (entry != NULL) {
+                omotlp_batch_entry_clear(entry);
+            }
+        }
+    }
+    if (mutex_locked) {
+        pthread_mutex_unlock(&pWrkrData->batch_mutex);
+    }
+    RETiRet;
+}
+
+static rsRetVal omotlp_batch_flush_if_due(wrkrInstanceData_t *pWrkrData, long long now_ms) {
+    omotlp_batch_state_t *batch;
+    long long age;
+    int mutex_locked = 0;
+
+    DEFiRet;
+
+    if (pWrkrData == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    pthread_mutex_lock(&pWrkrData->batch_mutex);
+    mutex_locked = 1;
+    batch = &pWrkrData->batch;
+    if (pWrkrData->pData->batchTimeoutMs <= 0 || batch->count == 0u) {
+        goto finalize_it;
+    }
+
+    if (now_ms <= batch->first_enqueue_ms) {
+        goto finalize_it;
+    }
+
+    age = now_ms - batch->first_enqueue_ms;
+    if (age >= pWrkrData->pData->batchTimeoutMs) {
+        CHKiRet(omotlp_flush_batch_locked(pWrkrData, batch));
+    }
+
+finalize_it:
+    if (mutex_locked) {
+        pthread_mutex_unlock(&pWrkrData->batch_mutex);
+    }
+    RETiRet;
+}
+
+static inline void setInstParamDefaults(instanceData *pData) {
+    pData->endpoint = NULL;
+    pData->path = NULL;
+    pData->protocol = NULL;
+    pData->bodyTemplateName = NULL;
+    pData->url = NULL;
+    pData->requestTimeoutMs = 10000;
+    pData->batchMaxItems = OMOTLP_DEFAULT_BATCH_MAX_ITEMS;
+    pData->batchMaxBytes = OMOTLP_DEFAULT_BATCH_MAX_BYTES;
+    pData->batchTimeoutMs = OMOTLP_DEFAULT_BATCH_TIMEOUT_MS;
+    pData->retryInitialMs = OMOTLP_DEFAULT_RETRY_INITIAL_MS;
+    pData->retryMaxMs = OMOTLP_DEFAULT_RETRY_MAX_MS;
+    pData->retryMaxRetries = OMOTLP_DEFAULT_RETRY_MAX_RETRIES;
+    pData->retryJitterPercent = OMOTLP_DEFAULT_RETRY_JITTER_PERCENT;
+    pData->compression_mode = OMOTLP_COMPRESSION_UNSET;
+    pData->compressionConfigured = 0;
+    pData->headersConfigured = 0;
+    pData->bearerConfigured = 0;
+    pData->timeoutConfigured = 0;
+    header_list_init(&pData->headers);
+    pData->resourceServiceInstanceId = NULL;
+    pData->resourceDeploymentEnvironment = NULL;
+    pData->resourceJson = NULL;
+    pData->resourceJsonParsed = NULL;
+    /* TLS defaults */
+    pData->tlsCaCertFile = NULL;
+    pData->tlsCaCertDir = NULL;
+    pData->tlsClientCertFile = NULL;
+    pData->tlsClientKeyFile = NULL;
+    pData->tlsVerifyHostname = 1; /* Default: verify hostname */
+    pData->tlsVerifyPeer = 1; /* Default: verify peer certificate */
+    /* Proxy defaults */
+    pData->proxyUrl = NULL;
+    pData->proxyUser = NULL;
+    pData->proxyPassword = NULL;
+    /* Trace correlation defaults */
+    pData->traceIdPropertyName = NULL; /* Will default to "trace_id" */
+    pData->spanIdPropertyName = NULL; /* Will default to "span_id" */
+    pData->traceFlagsPropertyName = NULL; /* Will default to "trace_flags" */
+    /* Custom mappings */
+    attribute_map_init(&pData->attributeMap);
+    pData->severityMap.configured = 0;
+    for (int i = 0; i < 8; ++i) {
+        pData->severityMap.entries[i].severity_text = NULL;
+    }
+}
+
+BEGINbeginCnfLoad
+    CODESTARTbeginCnfLoad;
+    loadModConf = pModConf;
+    pModConf->pConf = pConf;
+ENDbeginCnfLoad
+
+BEGINendCnfLoad
+    CODESTARTendCnfLoad;
+ENDendCnfLoad
+
+BEGINcheckCnf
+    CODESTARTcheckCnf;
+ENDcheckCnf
+
+BEGINactivateCnf
+    CODESTARTactivateCnf;
+    runModConf = pModConf;
+ENDactivateCnf
+
+BEGINfreeCnf
+    CODESTARTfreeCnf;
+ENDfreeCnf
+
+BEGINcreateInstance
+    CODESTARTcreateInstance;
+    setInstParamDefaults(pData);
+ENDcreateInstance
+
+BEGINcreateWrkrInstance
+    omotlp_http_client_config_t http_cfg;
+    char stats_name[256];
+    CODESTARTcreateWrkrInstance;
+    pWrkrData->pData = pData;
+    pWrkrData->http_client = NULL;
+    pWrkrData->batch.entries = NULL;
+    pWrkrData->batch.count = 0u;
+    pWrkrData->batch.capacity = 0u;
+    pWrkrData->batch.estimated_bytes = 0u;
+    pWrkrData->batch.first_enqueue_ms = 0;
+    pWrkrData->flush_thread_running = 0;
+    pWrkrData->flush_thread_stop = 0;
+    pWrkrData->stats = NULL;
+    pthread_mutex_init(&pWrkrData->batch_mutex, NULL);
+
+    if (pData == NULL || pData->url == NULL) {
+        iRet = RS_RET_INTERNAL_ERROR;
+        goto finalize_it;
+    }
+
+    http_cfg.url = (const char *)pData->url;
+    http_cfg.timeout_ms = pData->requestTimeoutMs;
+    http_cfg.user_agent = "rsyslog-omotlp/" VERSION;
+    http_cfg.headers = (const char *const *)pData->headers.values;
+    http_cfg.header_count = pData->headers.count;
+    http_cfg.retry_initial_ms = pData->retryInitialMs;
+    http_cfg.retry_max_ms = pData->retryMaxMs;
+    http_cfg.retry_max_retries = pData->retryMaxRetries;
+    http_cfg.retry_jitter_percent = pData->retryJitterPercent;
+
+    /* TLS configuration */
+    http_cfg.tls_ca_cert_file = (const char *)pData->tlsCaCertFile;
+    http_cfg.tls_ca_cert_dir = (const char *)pData->tlsCaCertDir;
+    http_cfg.tls_client_cert_file = (const char *)pData->tlsClientCertFile;
+    http_cfg.tls_client_key_file = (const char *)pData->tlsClientKeyFile;
+    http_cfg.tls_verify_hostname = pData->tlsVerifyHostname;
+    http_cfg.tls_verify_peer = pData->tlsVerifyPeer;
+
+    /* Proxy configuration */
+    http_cfg.proxy_url = (const char *)pData->proxyUrl;
+    http_cfg.proxy_user = (const char *)pData->proxyUser;
+    http_cfg.proxy_password = (const char *)pData->proxyPassword;
+
+    iRet = omotlp_http_client_create(&http_cfg, &pWrkrData->http_client);
+    if (iRet != RS_RET_OK) {
+        goto finalize_it;
+    }
+
+    /* Initialize statistics */
+    snprintf(stats_name, sizeof(stats_name), "omotlp-%s", pData->url ? (char *)pData->url : "default");
+    stats_name[sizeof(stats_name) - 1] = '\0';
+    CHKiRet(statsobj.Construct(&pWrkrData->stats));
+    CHKiRet(statsobj.SetName(pWrkrData->stats, (uchar *)stats_name));
+    CHKiRet(statsobj.SetOrigin(pWrkrData->stats, (uchar *)"omotlp"));
+
+    STATSCOUNTER_INIT(pWrkrData->ctrBatchesSubmitted, pWrkrData->mutCtrBatchesSubmitted);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"batches.submitted", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrBatchesSubmitted)));
+
+    STATSCOUNTER_INIT(pWrkrData->ctrBatchesSuccess, pWrkrData->mutCtrBatchesSuccess);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"batches.success", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrBatchesSuccess)));
+
+    STATSCOUNTER_INIT(pWrkrData->ctrBatchesRetried, pWrkrData->mutCtrBatchesRetried);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"batches.retried", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrBatchesRetried)));
+
+    STATSCOUNTER_INIT(pWrkrData->ctrBatchesDropped, pWrkrData->mutCtrBatchesDropped);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"batches.dropped", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrBatchesDropped)));
+
+    STATSCOUNTER_INIT(pWrkrData->ctrHttpStatus4xx, pWrkrData->mutCtrHttpStatus4xx);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"http.status.4xx", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrHttpStatus4xx)));
+
+    STATSCOUNTER_INIT(pWrkrData->ctrHttpStatus5xx, pWrkrData->mutCtrHttpStatus5xx);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"http.status.5xx", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrHttpStatus5xx)));
+
+    STATSCOUNTER_INIT(pWrkrData->ctrRecordsSent, pWrkrData->mutCtrRecordsSent);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"records.sent", ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &(pWrkrData->ctrRecordsSent)));
+
+    STATSCOUNTER_INIT(pWrkrData->httpRequestLatencyMs, pWrkrData->mutHttpRequestLatencyMs);
+    CHKiRet(statsobj.AddCounter(pWrkrData->stats, (uchar *)"http.request.latency.ms", ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &(pWrkrData->httpRequestLatencyMs)));
+
+    CHKiRet(statsobj.ConstructFinalize(pWrkrData->stats));
+
+    if (pthread_create(&pWrkrData->flush_thread, NULL, omotlp_batch_flush_thread, pWrkrData) != 0) {
+        LogError(errno, RS_RET_SYS_ERR, "omotlp: failed to create flush thread");
+        iRet = RS_RET_SYS_ERR;
+        goto finalize_it;
+    }
+    pWrkrData->flush_thread_running = 1;
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        if (pWrkrData != NULL) {
+            if (pWrkrData->flush_thread_running) {
+                /* Acquire mutex before setting stop flag to synchronize with flush thread */
+                pthread_mutex_lock(&pWrkrData->batch_mutex);
+                pWrkrData->flush_thread_stop = 1;
+                pthread_mutex_unlock(&pWrkrData->batch_mutex);
+                pthread_join(pWrkrData->flush_thread, NULL);
+                pWrkrData->flush_thread_running = 0;
+            }
+            if (pWrkrData->stats != NULL) {
+                statsobj.Destruct(&pWrkrData->stats);
+            }
+            pthread_mutex_destroy(&pWrkrData->batch_mutex);
+        }
+        omotlp_http_client_destroy(&pWrkrData->http_client);
+        free(pWrkrData);
+        pWrkrData = NULL;
+    }
+ENDcreateWrkrInstance
+
+BEGINfreeInstance
+    CODESTARTfreeInstance;
+    if (pData != NULL) {
+        free(pData->endpoint);
+        free(pData->path);
+        free(pData->protocol);
+        free(pData->bodyTemplateName);
+        free(pData->url);
+        header_list_destroy(&pData->headers);
+        free(pData->resourceServiceInstanceId);
+        free(pData->resourceDeploymentEnvironment);
+        free(pData->resourceJson);
+        if (pData->resourceJsonParsed != NULL) {
+            fjson_object_put(pData->resourceJsonParsed);
+            pData->resourceJsonParsed = NULL;
+        }
+        free(pData->traceIdPropertyName);
+        free(pData->spanIdPropertyName);
+        free(pData->traceFlagsPropertyName);
+        attribute_map_destroy(&pData->attributeMap);
+        free(pData->tlsCaCertFile);
+        free(pData->tlsCaCertDir);
+        free(pData->tlsClientCertFile);
+        free(pData->tlsClientKeyFile);
+        free(pData->proxyUrl);
+        free(pData->proxyUser);
+        free(pData->proxyPassword);
+        for (int i = 0; i < 8; ++i) {
+            free(pData->severityMap.entries[i].severity_text);
+        }
+    }
+ENDfreeInstance
+
+BEGINfreeWrkrInstance
+    CODESTARTfreeWrkrInstance;
+    if (pWrkrData != NULL) {
+        if (pWrkrData->flush_thread_running) {
+            /* Acquire mutex before setting stop flag to synchronize with flush thread */
+            pthread_mutex_lock(&pWrkrData->batch_mutex);
+            pWrkrData->flush_thread_stop = 1;
+            pthread_mutex_unlock(&pWrkrData->batch_mutex);
+            pthread_join(pWrkrData->flush_thread, NULL);
+            pWrkrData->flush_thread_running = 0;
+        }
+        (void)omotlp_flush_batch(pWrkrData);
+        omotlp_batch_destroy(&pWrkrData->batch);
+        pthread_mutex_destroy(&pWrkrData->batch_mutex);
+        omotlp_http_client_destroy(&pWrkrData->http_client);
+        if (pWrkrData->stats != NULL) {
+            statsobj.Destruct(&pWrkrData->stats);
+        }
+    }
+ENDfreeWrkrInstance
+
+BEGINdbgPrintInstInfo
+    CODESTARTdbgPrintInstInfo;
+    dbgprintf("omotlp\n");
+    dbgprintf("\tendpoint='%s'\n", pData->endpoint ? (char *)pData->endpoint : "(default)");
+    dbgprintf("\tpath='%s'\n", pData->path ? (char *)pData->path : "(default)");
+    dbgprintf("\tprotocol='%s'\n", pData->protocol ? (char *)pData->protocol : "(default)");
+    dbgprintf("\ttemplate='%s'\n", pData->bodyTemplateName ? (char *)pData->bodyTemplateName : "RSYSLOG_FileFormat");
+    dbgprintf("\turl='%s'\n", pData->url ? (char *)pData->url : "(unresolved)");
+    dbgprintf("\ttimeout.ms=%ld\n", pData->requestTimeoutMs);
+    dbgprintf("\tbatch.max_items=%zu\n", pData->batchMaxItems);
+    dbgprintf("\tbatch.max_bytes=%zu\n", pData->batchMaxBytes);
+    dbgprintf("\tbatch.timeout.ms=%ld\n", pData->batchTimeoutMs);
+    dbgprintf("\tretry.initial.ms=%ld\n", pData->retryInitialMs);
+    dbgprintf("\tretry.max.ms=%ld\n", pData->retryMaxMs);
+    dbgprintf("\tretry.max_retries=%u\n", pData->retryMaxRetries);
+    dbgprintf("\tretry.jitter.percent=%u\n", pData->retryJitterPercent);
+    dbgprintf("\tcompression=%s\n", pData->compression_mode == OMOTLP_COMPRESSION_GZIP ? "gzip" : "none");
+ENDdbgPrintInstInfo
+
+BEGINtryResume
+    CODESTARTtryResume;
+ENDtryResume
+
+static rsRetVal assignParamFromEStr(uchar **target, es_str_t *value) {
+    uchar *tmp;
+    DEFiRet;
+
+    free(*target);
+    *target = NULL;
+    tmp = (uchar *)es_str2cstr(value, NULL);
+    if (tmp == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    *target = tmp;
+
+finalize_it:
+    RETiRet;
+}
+
+BEGINnewActInst
+    struct cnfparamvals *pvals;
+    int i;
+    uchar *tplToUse = NULL;
+    char *bearer_token = NULL;
+    char *bearer_auth = NULL;
+    char *resource_json_text = NULL;
+    struct json_object *resource_parsed = NULL;
+    char *attribute_map_json_text = NULL;
+    char *severity_map_json_text = NULL;
+    char *text = NULL;
+    CODESTARTnewActInst;
+
+    if ((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
+        LogError(0, RS_RET_MISSING_CNFPARAMS, "omotlp: error reading config parameters");
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+    }
+
+    CHKiRet(createInstance(&pData));
+
+    for (i = 0; i < actpblk.nParams; ++i) {
+        if (!pvals[i].bUsed) continue;
+
+        if (!strcmp(actpblk.descr[i].name, "endpoint")) {
+            CHKiRet(assignParamFromEStr(&pData->endpoint, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "path")) {
+            CHKiRet(assignParamFromEStr(&pData->path, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "protocol")) {
+            CHKiRet(assignParamFromEStr(&pData->protocol, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "template")) {
+            CHKiRet(assignParamFromEStr(&pData->bodyTemplateName, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "timeout.ms")) {
+            long timeout_ms = 0;
+            CHKiRet(parse_long_param("timeout.ms", pvals[i].val.d.estr, 0, &timeout_ms));
+            pData->requestTimeoutMs = timeout_ms;
+            pData->timeoutConfigured = 1;
+        } else if (!strcmp(actpblk.descr[i].name, "compression")) {
+            text = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (text == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            CHKiRet(set_compression_mode(pData, text));
+            pData->compressionConfigured = 1;
+            free(text);
+            text = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "batch.max_items")) {
+            size_t max_items = 0u;
+            CHKiRet(parse_size_param("batch.max_items", pvals[i].val.d.estr, 0u, &max_items));
+            pData->batchMaxItems = max_items;
+        } else if (!strcmp(actpblk.descr[i].name, "batch.max_bytes")) {
+            size_t max_bytes = 0u;
+            CHKiRet(parse_size_param("batch.max_bytes", pvals[i].val.d.estr, 0u, &max_bytes));
+            pData->batchMaxBytes = max_bytes;
+        } else if (!strcmp(actpblk.descr[i].name, "batch.timeout.ms")) {
+            long timeout_ms = 0;
+            CHKiRet(parse_long_param("batch.timeout.ms", pvals[i].val.d.estr, 0, &timeout_ms));
+            pData->batchTimeoutMs = timeout_ms;
+        } else if (!strcmp(actpblk.descr[i].name, "retry.initial.ms")) {
+            long backoff = 0;
+            CHKiRet(parse_long_param("retry.initial.ms", pvals[i].val.d.estr, 0, &backoff));
+            pData->retryInitialMs = backoff;
+        } else if (!strcmp(actpblk.descr[i].name, "retry.max.ms")) {
+            long max_backoff = 0;
+            CHKiRet(parse_long_param("retry.max.ms", pvals[i].val.d.estr, 0, &max_backoff));
+            pData->retryMaxMs = max_backoff;
+        } else if (!strcmp(actpblk.descr[i].name, "retry.max_retries")) {
+            unsigned int retries = 0u;
+            CHKiRet(parse_uint_param("retry.max_retries", pvals[i].val.d.estr, 0u, &retries));
+            pData->retryMaxRetries = retries;
+        } else if (!strcmp(actpblk.descr[i].name, "retry.jitter.percent")) {
+            unsigned int jitter = 0u;
+            CHKiRet(parse_uint_param("retry.jitter.percent", pvals[i].val.d.estr, 0u, &jitter));
+            if (jitter > 100u) {
+                LogError(0, RS_RET_PARAM_ERROR, "omotlp: retry.jitter.percent must be between 0 and 100");
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            pData->retryJitterPercent = jitter;
+        } else if (!strcmp(actpblk.descr[i].name, "headers")) {
+            text = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (text == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            CHKiRet(parse_headers_json(pData, text));
+            pData->headersConfigured = 1;
+            free(text);
+            text = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "bearer_token")) {
+            bearer_token = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (bearer_token == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            bearer_auth = (char *)malloc(strlen(bearer_token) + strlen("Bearer ") + 1u);
+            if (bearer_auth == NULL) {
+                free(bearer_token);
+                bearer_token = NULL;
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            snprintf(bearer_auth, strlen(bearer_token) + sizeof("Bearer "), "Bearer %s", bearer_token);
+            CHKiRet(header_list_add_kv(&pData->headers, "Authorization", bearer_auth));
+            pData->bearerConfigured = 1;
+            /* Free local allocations after successful header addition */
+            /* header_list_add_kv copies the string, so we can free immediately */
+            free(bearer_auth);
+            bearer_auth = NULL;
+            free(bearer_token);
+            bearer_token = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "resource.service_instance_id")) {
+            CHKiRet(assignParamFromEStr(&pData->resourceServiceInstanceId, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "resource.deployment.environment")) {
+            CHKiRet(assignParamFromEStr(&pData->resourceDeploymentEnvironment, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "resource")) {
+            resource_json_text = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+
+            if (resource_json_text == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+
+            /* Parse and validate JSON */
+            resource_parsed = fjson_tokener_parse(resource_json_text);
+            if (resource_parsed == NULL) {
+                LogError(0, RS_RET_PARAM_ERROR, "omotlp: resource parameter contains invalid JSON: %s",
+                         resource_json_text);
+                free(resource_json_text);
+                resource_json_text = NULL;
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+
+            if (!fjson_object_is_type(resource_parsed, fjson_type_object)) {
+                LogError(0, RS_RET_PARAM_ERROR, "omotlp: resource parameter must be a JSON object");
+                fjson_object_put(resource_parsed);
+                resource_parsed = NULL;
+                free(resource_json_text);
+                resource_json_text = NULL;
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+
+            /* Store both string and parsed object */
+            CHKiRet(assignParamFromCStr(&pData->resourceJson, resource_json_text));
+            pData->resourceJsonParsed = resource_parsed;
+            resource_parsed = NULL; /* Ownership transferred */
+            free(resource_json_text);
+            resource_json_text = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "trace_id.property")) {
+            CHKiRet(assignParamFromEStr(&pData->traceIdPropertyName, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "span_id.property")) {
+            CHKiRet(assignParamFromEStr(&pData->spanIdPropertyName, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "trace_flags.property")) {
+            CHKiRet(assignParamFromEStr(&pData->traceFlagsPropertyName, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "attributeMap")) {
+            attribute_map_json_text = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (attribute_map_json_text == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            CHKiRet(parse_attribute_map(pData, attribute_map_json_text));
+            free(attribute_map_json_text);
+            attribute_map_json_text = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "severity.map")) {
+            severity_map_json_text = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (severity_map_json_text == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            CHKiRet(parse_severity_map(pData, severity_map_json_text));
+            free(severity_map_json_text);
+            severity_map_json_text = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {
+            CHKiRet(assignParamFromEStr(&pData->tlsCaCertFile, pvals[i].val.d.estr));
+            /* Validate file exists and is readable */
+            FILE *fp = fopen((const char *)pData->tlsCaCertFile, "r");
+            if (fp == NULL) {
+                char errStr[1024];
+                rs_strerror_r(errno, errStr, sizeof(errStr));
+                LogError(0, RS_RET_NO_FILE_ACCESS, "omotlp: tls.cacert file '%s' cannot be accessed: %s",
+                         pData->tlsCaCertFile, errStr);
+                ABORT_FINALIZE(RS_RET_NO_FILE_ACCESS);
+            }
+            fclose(fp);
+        } else if (!strcmp(actpblk.descr[i].name, "tls.cadir")) {
+            CHKiRet(assignParamFromEStr(&pData->tlsCaCertDir, pvals[i].val.d.estr));
+            /* Validate directory exists */
+            DIR *dir = opendir((const char *)pData->tlsCaCertDir);
+            if (dir == NULL) {
+                char errStr[1024];
+                rs_strerror_r(errno, errStr, sizeof(errStr));
+                LogError(0, RS_RET_NO_FILE_ACCESS, "omotlp: tls.cadir directory '%s' cannot be accessed: %s",
+                         pData->tlsCaCertDir, errStr);
+                ABORT_FINALIZE(RS_RET_NO_FILE_ACCESS);
+            }
+            closedir(dir);
+        } else if (!strcmp(actpblk.descr[i].name, "tls.cert")) {
+            CHKiRet(assignParamFromEStr(&pData->tlsClientCertFile, pvals[i].val.d.estr));
+            /* Validate file exists and is readable */
+            FILE *fp = fopen((const char *)pData->tlsClientCertFile, "r");
+            if (fp == NULL) {
+                char errStr[1024];
+                rs_strerror_r(errno, errStr, sizeof(errStr));
+                LogError(0, RS_RET_NO_FILE_ACCESS, "omotlp: tls.cert file '%s' cannot be accessed: %s",
+                         pData->tlsClientCertFile, errStr);
+                ABORT_FINALIZE(RS_RET_NO_FILE_ACCESS);
+            }
+            fclose(fp);
+        } else if (!strcmp(actpblk.descr[i].name, "tls.key")) {
+            CHKiRet(assignParamFromEStr(&pData->tlsClientKeyFile, pvals[i].val.d.estr));
+            /* Validate file exists and is readable */
+            FILE *fp = fopen((const char *)pData->tlsClientKeyFile, "r");
+            if (fp == NULL) {
+                char errStr[1024];
+                rs_strerror_r(errno, errStr, sizeof(errStr));
+                LogError(0, RS_RET_NO_FILE_ACCESS, "omotlp: tls.key file '%s' cannot be accessed: %s",
+                         pData->tlsClientKeyFile, errStr);
+                ABORT_FINALIZE(RS_RET_NO_FILE_ACCESS);
+            }
+            fclose(fp);
+        } else if (!strcmp(actpblk.descr[i].name, "tls.verify_hostname")) {
+            text = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (text == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            lowercaseInPlace((uchar *)text);
+            if (!strcmp(text, "on") || !strcmp(text, "yes") || !strcmp(text, "1")) {
+                pData->tlsVerifyHostname = 1;
+            } else if (!strcmp(text, "off") || !strcmp(text, "no") || !strcmp(text, "0")) {
+                pData->tlsVerifyHostname = 0;
+            } else {
+                LogError(0, RS_RET_PARAM_ERROR, "omotlp: tls.verify_hostname must be 'on' or 'off'");
+                free(text);
+                text = NULL;
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            free(text);
+            text = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "tls.verify_peer")) {
+            text = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (text == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            lowercaseInPlace((uchar *)text);
+            if (!strcmp(text, "on") || !strcmp(text, "yes") || !strcmp(text, "1")) {
+                pData->tlsVerifyPeer = 1;
+            } else if (!strcmp(text, "off") || !strcmp(text, "no") || !strcmp(text, "0")) {
+                pData->tlsVerifyPeer = 0;
+            } else {
+                LogError(0, RS_RET_PARAM_ERROR, "omotlp: tls.verify_peer must be 'on' or 'off'");
+                free(text);
+                text = NULL;
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            free(text);
+            text = NULL;
+        } else if (!strcmp(actpblk.descr[i].name, "proxy")) {
+            CHKiRet(assignParamFromEStr(&pData->proxyUrl, pvals[i].val.d.estr));
+            /* Validate URL format */
+            if (pData->proxyUrl != NULL) {
+                if (strncmp((char *)pData->proxyUrl, "http://", 7) != 0 &&
+                    strncmp((char *)pData->proxyUrl, "https://", 8) != 0 &&
+                    strncmp((char *)pData->proxyUrl, "socks4://", 9) != 0 &&
+                    strncmp((char *)pData->proxyUrl, "socks5://", 9) != 0) {
+                    LogError(0, RS_RET_PARAM_ERROR,
+                             "omotlp: proxy URL must start with http://, https://, socks4://, or socks5://");
+                    ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+                }
+            }
+        } else if (!strcmp(actpblk.descr[i].name, "proxy.user")) {
+            CHKiRet(assignParamFromEStr(&pData->proxyUser, pvals[i].val.d.estr));
+        } else if (!strcmp(actpblk.descr[i].name, "proxy.password")) {
+            CHKiRet(assignParamFromEStr(&pData->proxyPassword, pvals[i].val.d.estr));
+        } else {
+            dbgprintf("omotlp: unhandled parameter '%s'\n", actpblk.descr[i].name);
+        }
+    }
+
+    CHKiRet(applyEnvDefaults(pData));
+    CHKiRet(ensureEndpointPathSplit(pData));
+
+    /* Set default trace property names if not configured */
+    if (pData->traceIdPropertyName == NULL) {
+        CHKmalloc(pData->traceIdPropertyName = (uchar *)strdup("trace_id"));
+    }
+    if (pData->spanIdPropertyName == NULL) {
+        CHKmalloc(pData->spanIdPropertyName = (uchar *)strdup("span_id"));
+    }
+    if (pData->traceFlagsPropertyName == NULL) {
+        CHKmalloc(pData->traceFlagsPropertyName = (uchar *)strdup("trace_flags"));
+    }
+
+    if (pData->compression_mode == OMOTLP_COMPRESSION_UNSET) {
+        pData->compression_mode = OMOTLP_COMPRESSION_NONE;
+    }
+
+    if (pData->compression_mode == OMOTLP_COMPRESSION_GZIP) {
+        CHKiRet(header_list_add(&pData->headers, "Content-Encoding: gzip"));
+    }
+
+    if (pData->protocol == NULL) CHKmalloc(pData->protocol = (uchar *)strdup("http/json"));
+    if (pData->endpoint == NULL) CHKmalloc(pData->endpoint = (uchar *)strdup("http://127.0.0.1:4318"));
+    if (pData->path == NULL) CHKmalloc(pData->path = (uchar *)strdup("/v1/logs"));
+    if (pData->bodyTemplateName == NULL) CHKmalloc(pData->bodyTemplateName = (uchar *)strdup("RSYSLOG_FileFormat"));
+
+    lowercaseInPlace(pData->protocol);
+    CHKiRet(validateProtocol(pData));
+    CHKiRet(buildEffectiveUrl(pData));
+
+    CODE_STD_STRING_REQUESTnewActInst(2);
+    CHKiRet(OMSRsetEntry(*ppOMSR, OMOTLP_OMSR_IDX_MESSAGE, NULL, OMSR_TPL_AS_MSG));
+
+    tplToUse = (uchar *)strdup((char *)pData->bodyTemplateName);
+    if (tplToUse == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    CHKiRet(OMSRsetEntry(*ppOMSR, OMOTLP_OMSR_IDX_BODY, tplToUse, OMSR_NO_RQD_TPL_OPTS));
+
+    CODE_STD_FINALIZERnewActInst;
+    /* Free text allocations if they were allocated but not freed (error path cleanup) */
+    if (text != NULL) {
+        free(text);
+        text = NULL;
+    }
+    /* Free bearer token allocations if they were allocated but not freed (error path cleanup) */
+    /* On success path, these are already freed in the loop after header_list_add_kv succeeds */
+    if (bearer_auth != NULL) {
+        free(bearer_auth);
+        bearer_auth = NULL;
+    }
+    if (bearer_token != NULL) {
+        free(bearer_token);
+        bearer_token = NULL;
+    }
+    /* Free JSON text and parsed object if they were allocated but not freed (error path cleanup) */
+    if (resource_json_text != NULL) {
+        free(resource_json_text);
+        resource_json_text = NULL;
+    }
+    if (resource_parsed != NULL) {
+        fjson_object_put(resource_parsed);
+        resource_parsed = NULL;
+    }
+    if (attribute_map_json_text != NULL) {
+        free(attribute_map_json_text);
+        attribute_map_json_text = NULL;
+    }
+    if (severity_map_json_text != NULL) {
+        free(severity_map_json_text);
+        severity_map_json_text = NULL;
+    }
+    cnfparamvalsDestruct(pvals, &actpblk);
+ENDnewActInst
+
+BEGINdoAction
+    char *body = NULL;
+    omotlp_log_record_t record = {0};
+    long long now_ms;
+    smsg_t **ppMsgParam = (smsg_t **)pMsgData;
+    smsg_t *msg = (ppMsgParam != NULL) ? ppMsgParam[OMOTLP_OMSR_IDX_MESSAGE] : NULL;
+    CODESTARTdoAction;
+
+    if (pWrkrData->pData == NULL) {
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    if (pWrkrData->http_client == NULL) {
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    if (ppString != NULL && ppString[OMOTLP_OMSR_IDX_BODY] != NULL) {
+        body = (char *)ppString[OMOTLP_OMSR_IDX_BODY];
+    }
+
+    if (body == NULL) {
+        body = (char *)"";
+    }
+
+    now_ms = currentTimeMills();
+    CHKiRet(omotlp_batch_flush_if_due(pWrkrData, now_ms));
+
+    CHKiRet(populateLogRecord(msg, body, pWrkrData->pData, &record));
+    CHKiRet(omotlp_batch_add_record(pWrkrData, &record, body));
+
+    pthread_mutex_lock(&pWrkrData->batch_mutex);
+    if (pWrkrData->batch.count == 0u) {
+        iRet = RS_RET_OK;
+    } else {
+        iRet = RS_RET_DEFER_COMMIT;
+    }
+    pthread_mutex_unlock(&pWrkrData->batch_mutex);
+
+finalize_it:
+    /* Free trace correlation strings if they were allocated by populateLogRecord */
+    if (record.trace_id != NULL) {
+        free((char *)record.trace_id);
+        record.trace_id = NULL;
+    }
+    if (record.span_id != NULL) {
+        free((char *)record.span_id);
+        record.span_id = NULL;
+    }
+ENDdoAction
+
+NO_LEGACY_CONF_parseSelectorAct /* clang-format off */
+BEGINmodExit
+    CODESTARTmodExit;
+    omotlp_http_global_cleanup();
+    objRelease(datetime, CORE_COMPONENT);
+    objRelease(prop, CORE_COMPONENT);
+    objRelease(statsobj, CORE_COMPONENT);
+ENDmodExit
+
+BEGINisCompatibleWithFeature
+    CODESTARTisCompatibleWithFeature;
+ENDisCompatibleWithFeature
+
+BEGINqueryEtryPt
+    CODESTARTqueryEtryPt;
+    CODEqueryEtryPt_STD_OMOD_QUERIES;
+    CODEqueryEtryPt_STD_OMOD8_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_QUERIES;
+ENDqueryEtryPt /* clang-format on */
+
+BEGINmodInit()
+    CODESTARTmodInit;
+    *ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+    CHKiRet(omotlp_http_global_init());
+    CHKiRet(objUse(datetime, CORE_COMPONENT));
+    CHKiRet(objUse(prop, CORE_COMPONENT));
+    CHKiRet(objUse(statsobj, CORE_COMPONENT));
+ENDmodInit

--- a/plugins/omotlp/omotlp_http.c
+++ b/plugins/omotlp/omotlp_http.c
@@ -1,0 +1,502 @@
+/**
+ * @file omotlp_http.c
+ * @brief HTTP client implementation for OTLP/HTTP JSON transport
+ *
+ * This file implements the HTTP client interface using libcurl. It provides
+ * HTTP POST functionality with retry semantics, TLS/mTLS support, and proxy
+ * configuration.
+ *
+ * Copyright 2025 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+
+#include "omotlp_http.h"
+
+#include <curl/curl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "srUtils.h"
+
+#include "errmsg.h"
+
+struct omotlp_http_client_s {
+    CURL *handle;
+    struct curl_slist *headers;
+    char *url;
+    long timeout_ms;
+    char error_buffer[CURL_ERROR_SIZE];
+    long retry_initial_ms;
+    long retry_max_ms;
+    unsigned int retry_max_retries;
+    unsigned int retry_jitter_percent;
+};
+
+static int g_http_global_initialized = 0;
+
+/**
+ * @brief libcurl write callback that discards response body
+ *
+ * This callback is used when we don't need to process the HTTP response body.
+ * It simply discards all received data and returns the number of bytes
+ * processed to satisfy libcurl's requirements.
+ */
+static size_t discard_response(void *ptr, size_t size, size_t nmemb, void *userdata) {
+    (void)ptr;
+    (void)userdata;
+    return size * nmemb;
+}
+
+/**
+ * @brief Configure common libcurl options for the HTTP client
+ *
+ * Sets up libcurl options including URL, timeout, headers, TLS configuration,
+ * and proxy settings. This function is called during client creation to
+ * configure the curl handle.
+ *
+ * @param[in,out] client HTTP client to configure
+ * @param[in] config Configuration parameters
+ * @return RS_RET_OK on success, RS_RET_INTERNAL_ERROR on curl configuration failure
+ */
+static rsRetVal set_common_options(omotlp_http_client_t *client, const omotlp_http_client_config_t *config) {
+    CURLcode rc;
+    DEFiRet;
+
+    if (client->url == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_URL, client->url);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set URL: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_POST, 1L);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to enable POST: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_WRITEFUNCTION, discard_response);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to install response sink: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_NOSIGNAL, 1L);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to disable signals: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    if (config->timeout_ms > 0) {
+        rc = curl_easy_setopt(client->handle, CURLOPT_TIMEOUT_MS, config->timeout_ms);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set timeout: %s", curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+    }
+
+    if (config->user_agent != NULL) {
+        rc = curl_easy_setopt(client->handle, CURLOPT_USERAGENT, config->user_agent);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set user-agent: %s", curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+    }
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_ERRORBUFFER, client->error_buffer);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to install error buffer: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_HTTPHEADER, client->headers);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to apply headers: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    /* TLS/SSL configuration */
+    if (config->tls_ca_cert_file != NULL && config->tls_ca_cert_file[0] != '\0') {
+        rc = curl_easy_setopt(client->handle, CURLOPT_CAINFO, config->tls_ca_cert_file);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set CA cert file: %s", curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+    }
+
+    if (config->tls_ca_cert_dir != NULL && config->tls_ca_cert_dir[0] != '\0') {
+        rc = curl_easy_setopt(client->handle, CURLOPT_CAPATH, config->tls_ca_cert_dir);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set CA cert directory: %s",
+                     curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+    }
+
+    if (config->tls_client_cert_file != NULL && config->tls_client_cert_file[0] != '\0') {
+        rc = curl_easy_setopt(client->handle, CURLOPT_SSLCERT, config->tls_client_cert_file);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set client cert: %s", curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+    }
+
+    if (config->tls_client_key_file != NULL && config->tls_client_key_file[0] != '\0') {
+        rc = curl_easy_setopt(client->handle, CURLOPT_SSLKEY, config->tls_client_key_file);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set client key: %s", curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+    }
+
+    /* Hostname verification */
+    rc = curl_easy_setopt(client->handle, CURLOPT_SSL_VERIFYHOST, config->tls_verify_hostname ? 2L : 0L);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set hostname verification: %s",
+                 curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    /* Peer certificate verification */
+    rc = curl_easy_setopt(client->handle, CURLOPT_SSL_VERIFYPEER, config->tls_verify_peer ? 1L : 0L);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set peer verification: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    /* Proxy configuration */
+    if (config->proxy_url != NULL && config->proxy_url[0] != '\0') {
+        rc = curl_easy_setopt(client->handle, CURLOPT_PROXY, config->proxy_url);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set proxy URL: %s", curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+
+        /* Proxy authentication */
+        if (config->proxy_user != NULL && config->proxy_user[0] != '\0') {
+            char *userpwd = NULL;
+            size_t user_len = strlen(config->proxy_user);
+            size_t pwd_len = (config->proxy_password != NULL) ? strlen(config->proxy_password) : 0;
+            size_t total = user_len + 1 + pwd_len + 1;
+
+            userpwd = (char *)malloc(total);
+            if (userpwd == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+
+            snprintf(userpwd, total, "%s:%s", config->proxy_user, config->proxy_password ? config->proxy_password : "");
+
+            rc = curl_easy_setopt(client->handle, CURLOPT_PROXYUSERPWD, userpwd);
+            if (rc != CURLE_OK) {
+                free(userpwd);
+                LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set proxy credentials: %s",
+                         curl_easy_strerror(rc));
+                ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+            }
+
+            free(userpwd);
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+rsRetVal omotlp_http_global_init(void) {
+    if (!g_http_global_initialized) {
+        CURLcode rc = curl_global_init(CURL_GLOBAL_DEFAULT);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: curl_global_init failed: %s", curl_easy_strerror(rc));
+            return RS_RET_INTERNAL_ERROR;
+        }
+        g_http_global_initialized = 1;
+    }
+
+    return RS_RET_OK;
+}
+
+void omotlp_http_global_cleanup(void) {
+    if (g_http_global_initialized) {
+        curl_global_cleanup();
+        g_http_global_initialized = 0;
+    }
+}
+
+rsRetVal omotlp_http_client_create(const omotlp_http_client_config_t *config, omotlp_http_client_t **out_client) {
+    omotlp_http_client_t *client = NULL;
+    DEFiRet;
+
+    if (config == NULL || out_client == NULL || config->url == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    client = calloc(1, sizeof(*client));
+    if (client == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    client->url = strdup(config->url);
+    if (client->url == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    client->timeout_ms = config->timeout_ms;
+
+    client->headers = curl_slist_append(client->headers, "Content-Type: application/json");
+    if (client->headers == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    client->headers = curl_slist_append(client->headers, "Accept: application/json");
+    if (client->headers == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    if (config->headers != NULL && config->header_count > 0) {
+        size_t i;
+        for (i = 0; i < config->header_count; ++i) {
+            client->headers = curl_slist_append(client->headers, config->headers[i]);
+            if (client->headers == NULL) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+        }
+    }
+
+    client->handle = curl_easy_init();
+    if (client->handle == NULL) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: curl_easy_init failed");
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    client->error_buffer[0] = '\0';
+    client->retry_initial_ms = config->retry_initial_ms;
+    client->retry_max_ms = config->retry_max_ms;
+    client->retry_max_retries = config->retry_max_retries;
+    client->retry_jitter_percent = config->retry_jitter_percent;
+    CHKiRet(set_common_options(client, config));
+
+    *out_client = client;
+    client = NULL;
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        omotlp_http_client_destroy(&client);
+    }
+
+    RETiRet;
+}
+
+void omotlp_http_client_destroy(omotlp_http_client_t **client_ptr) {
+    omotlp_http_client_t *client;
+
+    if (client_ptr == NULL || *client_ptr == NULL) {
+        return;
+    }
+
+    client = *client_ptr;
+    *client_ptr = NULL;
+
+    if (client->headers != NULL) {
+        curl_slist_free_all(client->headers);
+    }
+    if (client->handle != NULL) {
+        curl_easy_cleanup(client->handle);
+    }
+    free(client->url);
+    free(client);
+}
+
+/**
+ * @brief Apply jitter to a retry delay value
+ *
+ * Adds random jitter to a base delay value to prevent thundering herd
+ * problems when multiple clients retry simultaneously. The jitter is
+ * calculated as a percentage of the base delay and applied as a random
+ * offset in the range [-jitter, +jitter].
+ *
+ * @param[in] base_delay Base delay in milliseconds
+ * @param[in] jitter_percent Jitter percentage (0-100)
+ * @return Delay value with jitter applied (always >= 0)
+ */
+static long apply_jitter(long base_delay, unsigned int jitter_percent) {
+    long range;
+    long offset;
+
+    if (base_delay <= 0 || jitter_percent == 0) {
+        return base_delay;
+    }
+
+    range = (base_delay * (long)jitter_percent) / 100L;
+    if (range <= 0) {
+        return base_delay;
+    }
+
+    offset = (long)(labs(randomNumber()) % (range * 2L + 1L)) - range;
+    base_delay += offset;
+    if (base_delay < 0) {
+        base_delay = 0;
+    }
+
+    return base_delay;
+}
+
+static void sleep_with_backoff(long delay_ms) {
+    if (delay_ms <= 0) {
+        return;
+    }
+
+    srSleep((int)(delay_ms / 1000L), (int)((delay_ms % 1000L) * 1000L));
+}
+
+static int should_retry_status(long status) {
+    if (status == 0) {
+        return 1;
+    }
+
+    if (status == 408 || status == 429) {
+        return 1;
+    }
+
+    if (status >= 500) {
+        return 1;
+    }
+
+    return 0;
+}
+
+rsRetVal omotlp_http_client_post(omotlp_http_client_t *client,
+                                 const uint8_t *payload,
+                                 size_t payload_len,
+                                 long *out_status_code,
+                                 long *out_latency_ms) {
+    long status = 0;
+    CURLcode rc;
+    const uint8_t empty_payload[] = "";
+    const uint8_t *payload_bytes;
+    unsigned int retries = 0u;
+    long delay_ms;
+    long long start_ms = 0;
+    long long end_ms = 0;
+    DEFiRet;
+
+    DBGPRINTF("omotlp/http: omotlp_http_client_post called, payload_len=%zu, url=%s", payload_len,
+              client ? (client->url ? client->url : "(null)") : "(null client)");
+
+    if (client == NULL) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (out_status_code != NULL) {
+        *out_status_code = 0;
+    }
+    if (out_latency_ms != NULL) {
+        *out_latency_ms = 0;
+    }
+
+    payload_bytes = payload != NULL ? payload : empty_payload;
+
+    client->error_buffer[0] = '\0';
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_POSTFIELDS, (const char *)payload_bytes);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set payload: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    rc = curl_easy_setopt(client->handle, CURLOPT_POSTFIELDSIZE_LARGE, (curl_off_t)payload_len);
+    if (rc != CURLE_OK) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to set payload size: %s", curl_easy_strerror(rc));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    delay_ms = client->retry_initial_ms;
+
+    for (;;) {
+        client->error_buffer[0] = '\0';
+        status = 0;
+        start_ms = currentTimeMills();
+
+        DBGPRINTF("omotlp/http: calling curl_easy_perform, attempt %u", retries + 1);
+        rc = curl_easy_perform(client->handle);
+        end_ms = currentTimeMills();
+        DBGPRINTF("omotlp/http: curl_easy_perform returned: %d (%s)", rc, curl_easy_strerror(rc));
+        if (rc != CURLE_OK) {
+            const char *err = client->error_buffer[0] != '\0' ? client->error_buffer : curl_easy_strerror(rc);
+            LogError(0, RS_RET_SUSPENDED, "omotlp/http: HTTP POST failed: %s", err);
+
+            if (retries >= client->retry_max_retries) {
+                ABORT_FINALIZE(RS_RET_SUSPENDED);
+            }
+
+            if (delay_ms > 0) {
+                sleep_with_backoff(apply_jitter(delay_ms, client->retry_jitter_percent));
+                delay_ms *= 2;
+                if (client->retry_max_ms > 0 && delay_ms > client->retry_max_ms) {
+                    delay_ms = client->retry_max_ms;
+                }
+            }
+            ++retries;
+            continue;
+        }
+
+        rc = curl_easy_getinfo(client->handle, CURLINFO_RESPONSE_CODE, &status);
+        if (rc != CURLE_OK) {
+            LogError(0, RS_RET_INTERNAL_ERROR, "omotlp/http: failed to read response code: %s", curl_easy_strerror(rc));
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+
+        DBGPRINTF("omotlp/http: HTTP response status: %ld", status);
+        if (status >= 200 && status < 300) {
+            DBGPRINTF("omotlp/http: HTTP POST successful (status %ld)", status);
+            goto finalize_it;
+        }
+
+        if (should_retry_status(status)) {
+            LogError(0, RS_RET_SUSPENDED, "omotlp/http: collector returned status %ld; retrying batch", status);
+            if (retries >= client->retry_max_retries) {
+                ABORT_FINALIZE(RS_RET_SUSPENDED);
+            }
+
+            if (delay_ms > 0) {
+                sleep_with_backoff(apply_jitter(delay_ms, client->retry_jitter_percent));
+                delay_ms *= 2;
+                if (client->retry_max_ms > 0 && delay_ms > client->retry_max_ms) {
+                    delay_ms = client->retry_max_ms;
+                }
+            }
+            ++retries;
+            continue;
+        }
+
+        LogError(0, RS_RET_DISCARDMSG, "omotlp/http: collector rejected payload with status %ld", status);
+        ABORT_FINALIZE(RS_RET_DISCARDMSG);
+    }
+
+finalize_it:
+    if (out_status_code != NULL) {
+        *out_status_code = status;
+    }
+    if (out_latency_ms != NULL && start_ms > 0 && end_ms >= start_ms) {
+        *out_latency_ms = (long)(end_ms - start_ms);
+    }
+    DBGPRINTF("omotlp/http: omotlp_http_client_post completed, iRet=%d", iRet);
+    RETiRet;
+}

--- a/plugins/omotlp/omotlp_http.h
+++ b/plugins/omotlp/omotlp_http.h
@@ -1,0 +1,135 @@
+/**
+ * @file omotlp_http.h
+ * @brief HTTP client interface for OTLP/HTTP JSON transport
+ *
+ * This header defines the HTTP client API used by the omotlp module to
+ * communicate with OpenTelemetry collectors over HTTP/JSON. It provides
+ * functions for client lifecycle management and HTTP POST operations with
+ * retry semantics, TLS, and proxy support.
+ *
+ * Copyright 2025 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef OMOTLP_HTTP_H
+#define OMOTLP_HTTP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rsyslog.h"
+
+/**
+ * @brief HTTP client configuration structure
+ *
+ * Contains all configuration parameters needed to create and configure
+ * an HTTP client for OTLP/HTTP JSON transport.
+ */
+typedef struct omotlp_http_client_config_s {
+    const char *url; /**< Target URL for HTTP POST requests */
+    long timeout_ms; /**< Request timeout in milliseconds */
+    const char *user_agent; /**< User-Agent header value */
+    const char *const *headers; /**< Array of additional HTTP headers (key:value format) */
+    size_t header_count; /**< Number of headers in headers array */
+    long retry_initial_ms; /**< Initial retry delay in milliseconds */
+    long retry_max_ms; /**< Maximum retry delay in milliseconds */
+    unsigned int retry_max_retries; /**< Maximum number of retry attempts */
+    unsigned int retry_jitter_percent; /**< Jitter percentage for retry delays (0-100) */
+    /* TLS configuration */
+    const char *tls_ca_cert_file; /**< Path to CA certificate file */
+    const char *tls_ca_cert_dir; /**< Path to directory containing CA certificates */
+    const char *tls_client_cert_file; /**< Path to client certificate file */
+    const char *tls_client_key_file; /**< Path to client private key file */
+    int tls_verify_hostname; /**< Enable hostname verification (0=disabled, 1=enabled) */
+    int tls_verify_peer; /**< Enable peer certificate verification (0=disabled, 1=enabled) */
+    /* Proxy configuration */
+    const char *proxy_url; /**< Proxy URL (http://, https://, socks4://, or socks5://) */
+    const char *proxy_user; /**< Proxy username for authentication */
+    const char *proxy_password; /**< Proxy password for authentication */
+} omotlp_http_client_config_t;
+
+/** @brief Opaque HTTP client handle */
+typedef struct omotlp_http_client_s omotlp_http_client_t;
+
+/**
+ * @brief Initialize the HTTP client library
+ *
+ * This function must be called once before creating any HTTP clients.
+ * It initializes the underlying libcurl library. Multiple calls are
+ * safe and will only initialize once.
+ *
+ * @return RS_RET_OK on success, RS_RET_INTERNAL_ERROR on failure
+ */
+rsRetVal omotlp_http_global_init(void);
+
+/**
+ * @brief Cleanup the HTTP client library
+ *
+ * This function should be called during module shutdown to cleanup
+ * the underlying libcurl library. It is safe to call multiple times.
+ */
+void omotlp_http_global_cleanup(void);
+
+/**
+ * @brief Create a new HTTP client instance
+ *
+ * Creates and configures an HTTP client with the provided configuration.
+ * The client handle must be destroyed using omotlp_http_client_destroy()
+ * when no longer needed.
+ *
+ * @param[in] config Configuration parameters for the HTTP client
+ * @param[out] out_client On success, contains the created client handle
+ * @return RS_RET_OK on success, RS_RET_PARAM_ERROR if parameters are invalid,
+ *         RS_RET_OUT_OF_MEMORY on allocation failure, RS_RET_INTERNAL_ERROR
+ *         on configuration failure
+ */
+rsRetVal omotlp_http_client_create(const omotlp_http_client_config_t *config, omotlp_http_client_t **out_client);
+
+/**
+ * @brief Destroy an HTTP client instance
+ *
+ * Releases all resources associated with the HTTP client. The client handle
+ * is set to NULL after destruction. It is safe to call with a NULL pointer.
+ *
+ * @param[in,out] client_ptr Pointer to the client handle to destroy
+ */
+void omotlp_http_client_destroy(omotlp_http_client_t **client_ptr);
+
+/**
+ * @brief Send an HTTP POST request
+ *
+ * Sends the provided payload as an HTTP POST request to the configured URL.
+ * The function implements retry logic with exponential backoff and jitter
+ * for transient failures (5xx, 408, 429, network errors). On success or
+ * permanent failure (4xx), the function returns immediately.
+ *
+ * @param[in] client HTTP client handle
+ * @param[in] payload Payload data to send
+ * @param[in] payload_len Length of payload data in bytes
+ * @param[out] out_status_code HTTP status code (0 if no response received)
+ * @param[out] out_latency_ms Request latency in milliseconds
+ * @return RS_RET_OK on success (2xx response), RS_RET_SUSPENDED for retryable
+ *         errors (5xx, 408, 429, network errors), RS_RET_INTERNAL_ERROR for
+ *         configuration errors, RS_RET_PARAM_ERROR for invalid parameters
+ */
+rsRetVal omotlp_http_client_post(omotlp_http_client_t *client,
+                                 const uint8_t *payload,
+                                 size_t payload_len,
+                                 long *out_status_code,
+                                 long *out_latency_ms);
+
+#endif /* OMOTLP_HTTP_H */

--- a/plugins/omotlp/otlp_json.c
+++ b/plugins/omotlp/otlp_json.c
@@ -1,0 +1,501 @@
+/**
+ * @file otlp_json.c
+ * @brief OTLP JSON payload builder implementation
+ *
+ * This file implements the OTLP/HTTP JSON payload builder. It converts
+ * rsyslog log records into OpenTelemetry Protocol JSON format, handling
+ * resource attributes, scope information, log records, and attribute mapping.
+ *
+ * Copyright 2025 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+
+#include "otlp_json.h"
+
+#include <json.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "errmsg.h"
+
+/* Forward declaration of attribute_map_t structure */
+struct attribute_map_entry_s {
+    char *rsyslog_property;
+    char *otlp_attribute;
+};
+
+struct attribute_map_s {
+    struct attribute_map_entry_s *entries;
+    size_t count;
+    size_t capacity;
+};
+
+static const char *attribute_map_lookup(const attribute_map_t *map, const char *rsyslog_prop) {
+    size_t i;
+
+    if (map == NULL || rsyslog_prop == NULL) {
+        return NULL;
+    }
+
+    for (i = 0; i < map->count; ++i) {
+        if (strcmp(map->entries[i].rsyslog_property, rsyslog_prop) == 0) {
+            return map->entries[i].otlp_attribute;
+        }
+    }
+
+    return NULL;
+}
+
+static rsRetVal add_attribute_entry(struct json_object *attributes,
+                                    const char *key,
+                                    struct json_object *value_json,
+                                    const char *value_type_key) ATTR_NONNULL(1, 2, 3, 4);
+static rsRetVal add_string_attribute(struct json_object *attributes, const char *key, const char *value)
+    ATTR_NONNULL(1, 2);
+static rsRetVal add_int_attribute(struct json_object *attributes, const char *key, int64_t value) ATTR_NONNULL(1, 2);
+static rsRetVal add_double_attribute(struct json_object *attributes, const char *key, double value) ATTR_NONNULL(1, 2);
+static rsRetVal add_bool_attribute(struct json_object *attributes, const char *key, int value) ATTR_NONNULL(1, 2);
+static rsRetVal add_body(struct json_object *log_record, const char *body) ATTR_NONNULL(1);
+
+static rsRetVal add_attribute_entry(struct json_object *attributes,
+                                    const char *key,
+                                    struct json_object *value_json,
+                                    const char *value_type_key) {
+    struct json_object *entry = NULL;
+    struct json_object *value_wrapper = NULL;
+    struct json_object *key_json = NULL;
+
+    DEFiRet;
+
+    entry = fjson_object_new_object();
+    if (entry == NULL) {
+        fjson_object_put(value_json);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    value_wrapper = fjson_object_new_object();
+    if (value_wrapper == NULL) {
+        fjson_object_put(entry);
+        fjson_object_put(value_json);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    key_json = fjson_object_new_string(key);
+    if (key_json == NULL) {
+        fjson_object_put(value_wrapper);
+        fjson_object_put(entry);
+        fjson_object_put(value_json);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    fjson_object_object_add(value_wrapper, value_type_key, value_json);
+    fjson_object_object_add(entry, "key", key_json);
+    fjson_object_object_add(entry, "value", value_wrapper);
+
+    if (fjson_object_array_add(attributes, entry) != 0) {
+        fjson_object_put(entry);
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal add_string_attribute(struct json_object *attributes, const char *key, const char *value) {
+    struct json_object *string_json = NULL;
+
+    DEFiRet;
+
+    if (value == NULL || value[0] == '\0') {
+        goto finalize_it;
+    }
+
+    string_json = fjson_object_new_string(value);
+    if (string_json == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    CHKiRet(add_attribute_entry(attributes, key, string_json, "stringValue"));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal add_int_attribute(struct json_object *attributes, const char *key, int64_t value) {
+    struct json_object *int_json = NULL;
+
+    DEFiRet;
+
+    int_json = json_object_new_int64(value);
+    if (int_json == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    CHKiRet(add_attribute_entry(attributes, key, int_json, "intValue"));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal add_double_attribute(struct json_object *attributes, const char *key, double value) {
+    struct json_object *double_json = NULL;
+
+    DEFiRet;
+
+    double_json = json_object_new_double(value);
+    if (double_json == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    CHKiRet(add_attribute_entry(attributes, key, double_json, "doubleValue"));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal add_bool_attribute(struct json_object *attributes, const char *key, int value) {
+    struct json_object *bool_json = NULL;
+
+    DEFiRet;
+
+    bool_json = fjson_object_new_boolean(value);
+    if (bool_json == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    CHKiRet(add_attribute_entry(attributes, key, bool_json, "boolValue"));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal add_body(struct json_object *log_record, const char *body) {
+    struct json_object *body_wrapper = NULL;
+    struct json_object *string_json = NULL;
+
+    DEFiRet;
+
+    body_wrapper = fjson_object_new_object();
+    if (body_wrapper == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    string_json = fjson_object_new_string(body != NULL ? body : "");
+    if (string_json == NULL) {
+        fjson_object_put(body_wrapper);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    fjson_object_object_add(body_wrapper, "stringValue", string_json);
+    fjson_object_object_add(log_record, "body", body_wrapper);
+
+finalize_it:
+    RETiRet;
+}
+
+rsRetVal omotlp_json_build_export(const omotlp_log_record_t *records,
+                                  size_t record_count,
+                                  const omotlp_resource_attrs_t *resource_attrs,
+                                  const attribute_map_t *attribute_map,
+                                  char **out_payload) {
+    struct json_object *root = NULL;
+    struct json_object *resource_logs = NULL;
+    struct json_object *resource_entry = NULL;
+    struct json_object *resource = NULL;
+    struct json_object *resource_attributes = NULL;
+    struct json_object *scope_logs = NULL;
+    struct json_object *scope_entry = NULL;
+    struct json_object *scope = NULL;
+    struct json_object *log_records = NULL;
+    char *rendered = NULL;
+    size_t i;
+
+    DEFiRet;
+
+    if (out_payload == NULL || records == NULL || record_count == 0) {
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    *out_payload = NULL;
+
+    root = fjson_object_new_object();
+    if (root == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    resource_logs = fjson_object_new_array();
+    if (resource_logs == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    fjson_object_object_add(root, "resourceLogs", resource_logs);
+
+    resource_entry = fjson_object_new_object();
+    if (resource_entry == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    if (fjson_object_array_add(resource_logs, resource_entry) != 0) {
+        fjson_object_put(resource_entry);
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    resource = fjson_object_new_object();
+    if (resource == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    fjson_object_object_add(resource_entry, "resource", resource);
+
+    resource_attributes = fjson_object_new_array();
+    if (resource_attributes == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    fjson_object_object_add(resource, "attributes", resource_attributes);
+
+    CHKiRet(add_string_attribute(resource_attributes, "service.name", "rsyslog"));
+    CHKiRet(add_string_attribute(resource_attributes, "telemetry.sdk.name", "rsyslog-omotlp"));
+    CHKiRet(add_string_attribute(resource_attributes, "telemetry.sdk.language", "C"));
+    CHKiRet(add_string_attribute(resource_attributes, "telemetry.sdk.version", VERSION));
+
+    /* Add custom resource attributes from JSON configuration */
+    if (resource_attrs != NULL && resource_attrs->custom_attributes != NULL) {
+        struct json_object_iterator iter;
+        struct json_object_iterator iter_end;
+
+        iter = json_object_iter_begin(resource_attrs->custom_attributes);
+        iter_end = json_object_iter_end(resource_attrs->custom_attributes);
+
+        while (!json_object_iter_equal(&iter, &iter_end)) {
+            const char *key = json_object_iter_peek_name(&iter);
+            struct json_object *value_obj = json_object_iter_peek_value(&iter);
+            const char *string_value = NULL;
+            int64_t int_value = 0;
+            double double_value = 0.0;
+            int bool_value = 0;
+
+            if (value_obj != NULL) {
+                enum fjson_type value_type = fjson_object_get_type(value_obj);
+
+                switch (value_type) {
+                    case fjson_type_string:
+                        string_value = fjson_object_get_string(value_obj);
+                        CHKiRet(add_string_attribute(resource_attributes, key, string_value));
+                        break;
+
+                    case fjson_type_int:
+                        int_value = fjson_object_get_int64(value_obj);
+                        CHKiRet(add_int_attribute(resource_attributes, key, int_value));
+                        break;
+
+                    case fjson_type_double:
+                        double_value = fjson_object_get_double(value_obj);
+                        CHKiRet(add_double_attribute(resource_attributes, key, double_value));
+                        break;
+
+                    case fjson_type_boolean:
+                        bool_value = fjson_object_get_boolean(value_obj);
+                        CHKiRet(add_bool_attribute(resource_attributes, key, bool_value));
+                        break;
+
+                    case fjson_type_null:
+                    case fjson_type_object:
+                    case fjson_type_array:
+                        /* Skip arrays, objects, null - OTLP resource attributes are flat key-value pairs */
+                        break;
+
+                    default:
+                        /* Skip any other types */
+                        break;
+                }
+            }
+
+            json_object_iter_next(&iter);
+        }
+    }
+
+    /* Legacy single-attribute support (backward compatibility) */
+    if (resource_attrs != NULL) {
+        if (resource_attrs->service_instance_id != NULL && resource_attrs->service_instance_id[0] != '\0') {
+            CHKiRet(
+                add_string_attribute(resource_attributes, "service.instance.id", resource_attrs->service_instance_id));
+        }
+        if (resource_attrs->deployment_environment != NULL && resource_attrs->deployment_environment[0] != '\0') {
+            CHKiRet(add_string_attribute(resource_attributes, "deployment.environment",
+                                         resource_attrs->deployment_environment));
+        }
+    }
+
+    /* Set host.name at resource level only if all records share the same hostname.
+     * This ensures correct attribution when batching messages from a single source.
+     * If hostnames differ, hostname is only set per-record in attributes.
+     */
+    if (record_count > 0 && records[0].hostname != NULL && records[0].hostname[0] != '\0') {
+        size_t j;
+        int all_same_hostname = 1;
+        const char *first_hostname = records[0].hostname;
+
+        /* Validate all records have the same hostname */
+        for (j = 1; j < record_count; ++j) {
+            if (records[j].hostname == NULL || records[j].hostname[0] == '\0') {
+                all_same_hostname = 0;
+                break;
+            }
+            if (strcmp(records[j].hostname, first_hostname) != 0) {
+                all_same_hostname = 0;
+                break;
+            }
+        }
+
+        /* Only set resource-level host.name if all records share the same hostname */
+        if (all_same_hostname) {
+            CHKiRet(add_string_attribute(resource_attributes, "host.name", first_hostname));
+        }
+    }
+
+    scope_logs = fjson_object_new_array();
+    if (scope_logs == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    fjson_object_object_add(resource_entry, "scopeLogs", scope_logs);
+
+    scope_entry = fjson_object_new_object();
+    if (scope_entry == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    if (fjson_object_array_add(scope_logs, scope_entry) != 0) {
+        fjson_object_put(scope_entry);
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+
+    scope = fjson_object_new_object();
+    if (scope == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    fjson_object_object_add(scope_entry, "scope", scope);
+    fjson_object_object_add(scope, "name", fjson_object_new_string("rsyslog.omotlp"));
+    fjson_object_object_add(scope, "version", fjson_object_new_string(VERSION));
+
+    log_records = fjson_object_new_array();
+    if (log_records == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    fjson_object_object_add(scope_entry, "logRecords", log_records);
+
+    for (i = 0; i < record_count; ++i) {
+        const omotlp_log_record_t *record = &records[i];
+        struct json_object *log_record = NULL;
+        struct json_object *attributes = NULL;
+
+        log_record = fjson_object_new_object();
+        if (log_record == NULL) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        if (fjson_object_array_add(log_records, log_record) != 0) {
+            fjson_object_put(log_record);
+            ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+        }
+
+        fjson_object_object_add(log_record, "timeUnixNano", json_object_new_int64((long long)record->time_unix_nano));
+        if (record->observed_time_unix_nano != 0) {
+            fjson_object_object_add(log_record, "observedTimeUnixNano",
+                                    json_object_new_int64((long long)record->observed_time_unix_nano));
+        }
+        fjson_object_object_add(log_record, "severityNumber", json_object_new_int((int)record->severity_number));
+        if (record->severity_text != NULL) {
+            fjson_object_object_add(log_record, "severityText", fjson_object_new_string(record->severity_text));
+        }
+
+        CHKiRet(add_body(log_record, record->body));
+
+        if (record->trace_id != NULL) {
+            fjson_object_object_add(log_record, "traceId", fjson_object_new_string(record->trace_id));
+        }
+        if (record->span_id != NULL) {
+            fjson_object_object_add(log_record, "spanId", fjson_object_new_string(record->span_id));
+        }
+        if (record->trace_flags != 0) {
+            fjson_object_object_add(log_record, "flags", json_object_new_int((int)record->trace_flags));
+        }
+
+        attributes = fjson_object_new_array();
+        if (attributes == NULL) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        fjson_object_object_add(log_record, "attributes", attributes);
+
+        /* Default syslog attributes */
+        const char *hostname_attr = "log.syslog.hostname";
+        const char *appname_attr = "log.syslog.appname";
+        const char *procid_attr = "log.syslog.procid";
+        const char *msgid_attr = "log.syslog.msgid";
+        const char *facility_attr = "log.syslog.facility";
+
+        /* Apply custom attribute mapping if configured */
+        if (attribute_map != NULL) {
+            const char *mapped;
+
+            mapped = attribute_map_lookup(attribute_map, "hostname");
+            if (mapped != NULL) {
+                hostname_attr = mapped;
+            }
+
+            mapped = attribute_map_lookup(attribute_map, "appname");
+            if (mapped != NULL) {
+                appname_attr = mapped;
+            }
+
+            mapped = attribute_map_lookup(attribute_map, "procid");
+            if (mapped != NULL) {
+                procid_attr = mapped;
+            }
+
+            mapped = attribute_map_lookup(attribute_map, "msgid");
+            if (mapped != NULL) {
+                msgid_attr = mapped;
+            }
+
+            mapped = attribute_map_lookup(attribute_map, "facility");
+            if (mapped != NULL) {
+                facility_attr = mapped;
+            }
+        }
+
+        CHKiRet(add_string_attribute(attributes, appname_attr, record->app_name));
+        CHKiRet(add_string_attribute(attributes, procid_attr, record->proc_id));
+        CHKiRet(add_string_attribute(attributes, msgid_attr, record->msg_id));
+        CHKiRet(add_int_attribute(attributes, facility_attr, (int64_t)record->facility));
+        if (record->hostname != NULL && record->hostname[0] != '\0') {
+            CHKiRet(add_string_attribute(attributes, hostname_attr, record->hostname));
+        }
+    }
+
+    rendered = strdup(fjson_object_to_json_string(root));
+    if (rendered == NULL) {
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    *out_payload = rendered;
+
+finalize_it:
+    if (iRet != RS_RET_OK && rendered != NULL) {
+        free(rendered);
+    }
+    if (root != NULL) {
+        fjson_object_put(root);
+    }
+    RETiRet;
+}

--- a/plugins/omotlp/otlp_json.h
+++ b/plugins/omotlp/otlp_json.h
@@ -1,0 +1,101 @@
+/**
+ * @file otlp_json.h
+ * @brief OTLP JSON payload builder interface
+ *
+ * This header defines the API for building OpenTelemetry Protocol (OTLP)
+ * JSON payloads from rsyslog log records. It handles the conversion of
+ * rsyslog message properties to OTLP log record format, including resource
+ * attributes, scope information, and log record attributes.
+ *
+ * Copyright 2025 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef OMOTLP_OTLP_JSON_H
+#define OMOTLP_OTLP_JSON_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rsyslog.h"
+#include <json.h>
+
+/**
+ * @brief OTLP log record structure
+ *
+ * Contains all fields for a single OpenTelemetry log record. String fields
+ * are pointers to external memory and are not freed by this module.
+ */
+typedef struct omotlp_log_record_s {
+    uint64_t time_unix_nano; /**< Log timestamp in Unix nanoseconds */
+    uint64_t observed_time_unix_nano; /**< Observation timestamp in Unix nanoseconds */
+    uint32_t severity_number; /**< OTLP severity number (0-24) */
+    const char *severity_text; /**< OTLP severity text (e.g., "INFO", "ERROR") */
+    const char *body; /**< Log message body */
+    const char *hostname; /**< Hostname from syslog message */
+    const char *app_name; /**< Application name (tag) from syslog */
+    const char *proc_id; /**< Process ID from syslog */
+    const char *msg_id; /**< Message ID from syslog */
+    const char *trace_id; /**< OpenTelemetry trace ID (32 hex chars) */
+    const char *span_id; /**< OpenTelemetry span ID (16 hex chars) */
+    uint8_t trace_flags; /**< OpenTelemetry trace flags */
+    uint16_t facility; /**< Syslog facility number */
+} omotlp_log_record_t;
+
+/**
+ * @brief OTLP resource attributes structure
+ *
+ * Contains resource-level attributes that are applied to all log records
+ * in a batch. Custom attributes are provided as a parsed JSON object.
+ */
+typedef struct omotlp_resource_attrs_s {
+    const char *service_instance_id; /**< Service instance identifier */
+    const char *deployment_environment; /**< Deployment environment name */
+    struct json_object *custom_attributes; /**< Parsed JSON object with custom resource attributes */
+} omotlp_resource_attrs_t;
+
+/* Forward declaration for attribute_map_t */
+typedef struct attribute_map_s attribute_map_t;
+
+/**
+ * @brief Build OTLP/HTTP JSON export payload
+ *
+ * Converts an array of log records into an OTLP/HTTP JSON payload according
+ * to the OpenTelemetry Protocol specification. The payload includes resource
+ * logs, resource attributes, scope logs, and log records with their attributes.
+ *
+ * The function handles:
+ * - Resource attribute mapping (service.name, service.instance.id, etc.)
+ * - Custom attribute mapping via attribute_map
+ * - Syslog property to OTLP attribute conversion
+ * - Trace correlation data (trace_id, span_id, trace_flags)
+ *
+ * @param[in] records Array of log records to export
+ * @param[in] record_count Number of records in the array
+ * @param[in] resource_attrs Resource-level attributes to include
+ * @param[in] attribute_map Optional mapping from rsyslog properties to OTLP attributes
+ * @param[out] out_payload On success, contains the JSON payload string (caller must free)
+ * @return RS_RET_OK on success, RS_RET_PARAM_ERROR for invalid parameters,
+ *         RS_RET_OUT_OF_MEMORY on allocation failure
+ */
+rsRetVal omotlp_json_build_export(const omotlp_log_record_t *records,
+                                  size_t record_count,
+                                  const omotlp_resource_attrs_t *resource_attrs,
+                                  const attribute_map_t *attribute_map,
+                                  char **out_payload);
+
+#endif /* OMOTLP_OTLP_JSON_H */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1043,18 +1043,29 @@ TESTS +=  \
 	omhttp-batch-dynrestpath.sh
 if HAVE_VALGRIND
 TESTS +=  \
-	omhttp-auth-vg.sh \
-	omhttp-basic-vg.sh \
-	omhttp-basic-ignorecodes-vg.sh \
-	omhttp-batch-jsonarray-compress-vg.sh \
-	omhttp-batch-jsonarray-retry-vg.sh \
-	omhttp-batch-jsonarray-vg.sh \
-	omhttp-batch-kafkarest-retry-vg.sh \
-	omhttp-batch-lokirest-retry-vg.sh \
-	omhttp-retry-vg.sh \
-	omhttp-retry-timeout-vg.sh \
-	omhttp-batch-lokirest-vg.sh
+        omhttp-auth-vg.sh \
+        omhttp-basic-vg.sh \
+        omhttp-basic-ignorecodes-vg.sh \
+        omhttp-batch-jsonarray-compress-vg.sh \
+        omhttp-batch-jsonarray-retry-vg.sh \
+        omhttp-batch-jsonarray-vg.sh \
+        omhttp-batch-kafkarest-retry-vg.sh \
+        omhttp-batch-lokirest-retry-vg.sh \
+        omhttp-retry-vg.sh \
+        omhttp-retry-timeout-vg.sh \
+        omhttp-batch-lokirest-vg.sh
 endif
+endif
+
+if ENABLE_OMOTLP
+TESTS += \
+        omotlp-http-batch.sh \
+        omotlp-basic.sh \
+        omotlp-batch.sh \
+        omotlp-compression.sh \
+        omotlp-proxy.sh \
+        omotlp-tls.sh \
+        omotlp-trace-correlation.sh
 endif
 
 if ENABLE_OMKAFKA

--- a/tests/omotlp-attribute-mapping.sh
+++ b/tests/omotlp-attribute-mapping.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-attribute-mapping.sh -- test custom attribute mapping for omotlp module
+##
+## Tests that custom attribute mappings (attributeMap) correctly remap
+## rsyslog properties to custom OTLP attribute names.
+
+. ${srcdir:=.}/diag.sh init
+
+# Check if omotlp module is available
+require_plugin omotlp
+
+export NUMMESSAGES=10
+export EXTRA_EXIT=otel
+export SEQ_CHECK_OPTIONS=-d
+
+# Download and prepare OTEL Collector
+download_otel_collector
+prepare_otel_collector
+start_otel_collector
+
+# Read the port from the port file
+if [ ! -f ${RSYSLOG_DYNNAME}.otel_port.file ]; then
+	echo "ERROR: OTEL Collector port file not found: ${RSYSLOG_DYNNAME}.otel_port.file"
+	error_exit 1
+fi
+otel_port=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+if [ -z "$otel_port" ]; then
+	echo "ERROR: OTEL Collector port is empty"
+	error_exit 1
+fi
+echo "Using OTEL Collector port: $otel_port"
+
+# Create input file with syslog messages containing various syslog fields
+cat > ${RSYSLOG_DYNNAME}.input << 'INPUTFILE'
+<14>1 2024-01-01T12:00:00.000Z testhost1 testapp1 12345 msgid001 - test message 00000001
+<14>1 2024-01-01T12:00:00.000Z testhost2 testapp2 67890 msgid002 - test message 00000002
+<14>1 2024-01-01T12:00:00.000Z testhost3 testapp3 11111 msgid003 - test message 00000003
+<14>1 2024-01-01T12:00:00.000Z testhost4 testapp4 22222 msgid004 - test message 00000004
+<14>1 2024-01-01T12:00:00.000Z testhost5 testapp5 33333 msgid005 - test message 00000005
+<14>1 2024-01-01T12:00:00.000Z testhost6 testapp6 44444 msgid006 - test message 00000006
+<14>1 2024-01-01T12:00:00.000Z testhost7 testapp7 55555 msgid007 - test message 00000007
+<14>1 2024-01-01T12:00:00.000Z testhost8 testapp8 66666 msgid008 - test message 00000008
+<14>1 2024-01-01T12:00:00.000Z testhost9 testapp9 77777 msgid009 - test message 00000009
+<14>1 2024-01-01T12:00:00.000Z testhost10 testapp10 88888 msgid010 - test message 00000010
+INPUTFILE
+
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="%msg%")
+
+module(load="../plugins/omotlp/.libs/omotlp")
+
+# Export with custom attribute mapping
+action(
+	name="omotlp-http"
+	type="omotlp"
+	template="otlpBody"
+	endpoint="http://127.0.0.1:'$otel_port'"
+	path="/v1/logs"
+	attributeMap="{ \"hostname\": \"host.name\", \"appname\": \"service.name\", \"procid\": \"process.pid\", \"msgid\": \"message.id\", \"facility\": \"log.syslog.facility.code\" }"
+	batch.max_items="100"
+	batch.timeout.ms="1000"
+)
+'
+
+startup
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+shutdown_when_empty
+wait_shutdown
+
+# Stop OTEL Collector to ensure file exporter flushes data
+stop_otel_collector
+
+# Give OTEL Collector a moment to flush the output file after shutdown
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+# Extract data from OTEL Collector output
+otel_collector_get_data
+
+python3 - "$RSYSLOG_DYNNAME.otel-output.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    # OTEL Collector file exporter writes newline-delimited JSON (one JSON object per line)
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if "resourceLogs" in payload:
+                for resource_log in payload["resourceLogs"]:
+                    if "scopeLogs" in resource_log:
+                        for scope_log in resource_log["scopeLogs"]:
+                            if "logRecords" in scope_log:
+                                records.extend(scope_log["logRecords"])
+except Exception as exc:
+    sys.stderr.write(f"omotlp-attribute-mapping: failed to parse OTLP output: {exc}\n")
+    sys.exit(1)
+
+if not records:
+    sys.stderr.write("omotlp-attribute-mapping: OTLP output did not contain any logRecords\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-attribute-mapping: found {len(records)} log records in OTLP output\n")
+
+# Filter records to only test messages (contain "test message" in body)
+test_records = []
+for record in records:
+    body = record.get("body", {})
+    body_str = body.get("stringValue", "") if isinstance(body, dict) else str(body)
+    if "test message" in body_str:
+        test_records.append(record)
+
+if len(test_records) < 10:
+    sys.stderr.write(f"omotlp-attribute-mapping: expected at least 10 test records, found {len(test_records)}\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-attribute-mapping: filtered to {len(test_records)} test records\n")
+
+# Expected test data (from input file)
+expected_test_data = [
+    {"hostname": "testhost1", "appname": "testapp1", "procid": "12345", "msgid": "msgid001", "facility": 1},
+    {"hostname": "testhost2", "appname": "testapp2", "procid": "67890", "msgid": "msgid002", "facility": 1},
+    {"hostname": "testhost3", "appname": "testapp3", "procid": "11111", "msgid": "msgid003", "facility": 1},
+    {"hostname": "testhost4", "appname": "testapp4", "procid": "22222", "msgid": "msgid004", "facility": 1},
+    {"hostname": "testhost5", "appname": "testapp5", "procid": "33333", "msgid": "msgid005", "facility": 1},
+    {"hostname": "testhost6", "appname": "testapp6", "procid": "44444", "msgid": "msgid006", "facility": 1},
+    {"hostname": "testhost7", "appname": "testapp7", "procid": "55555", "msgid": "msgid007", "facility": 1},
+    {"hostname": "testhost8", "appname": "testapp8", "procid": "66666", "msgid": "msgid008", "facility": 1},
+    {"hostname": "testhost9", "appname": "testapp9", "procid": "77777", "msgid": "msgid009", "facility": 1},
+    {"hostname": "testhost10", "appname": "testapp10", "procid": "88888", "msgid": "msgid010", "facility": 1},
+]
+
+# Expected custom attribute names (from attributeMap configuration)
+expected_attr_names = {
+    "host.name",      # mapped from "hostname"
+    "service.name",   # mapped from "appname"
+    "process.pid",    # mapped from "procid"
+    "message.id",     # mapped from "msgid"
+    "log.syslog.facility.code"  # mapped from "facility"
+}
+
+# Verify attribute mappings for each test record
+errors = []
+for idx, record in enumerate(test_records[:10]):  # Only check first 10 test records
+    if "attributes" not in record:
+        errors.append(f"record {idx}: missing attributes array")
+        continue
+    
+    attrs = record["attributes"]
+    attr_dict = {}
+    
+    # Parse attributes into a dictionary
+    for attr_entry in attrs:
+        key = attr_entry.get("key")
+        value_obj = attr_entry.get("value", {})
+        
+        # Extract value based on type
+        if "stringValue" in value_obj:
+            attr_dict[key] = ("string", value_obj["stringValue"])
+        elif "intValue" in value_obj:
+            attr_dict[key] = ("int", value_obj["intValue"])
+        else:
+            attr_dict[key] = ("unknown", value_obj)
+    
+    # Get expected values for this record
+    if idx >= len(expected_test_data):
+        continue
+    expected = expected_test_data[idx]
+    
+    # Check that custom attribute names are present (when values exist)
+    for expected_attr in expected_attr_names:
+        # Only require attribute if the source field has a value
+        source_field = None
+        if expected_attr == "host.name" and expected["hostname"]:
+            source_field = "hostname"
+        elif expected_attr == "service.name" and expected["appname"]:
+            source_field = "appname"
+        elif expected_attr == "process.pid" and expected["procid"]:
+            source_field = "procid"
+        elif expected_attr == "message.id" and expected["msgid"]:
+            source_field = "msgid"
+        elif expected_attr == "log.syslog.facility.code":
+            source_field = "facility"
+        
+        if source_field and expected_attr not in attr_dict:
+            errors.append(f"record {idx}: missing custom attribute '{expected_attr}' (source: {source_field})")
+    
+    # Check that default attribute names are NOT present for mapped properties
+    # These should have been replaced by custom mappings
+    mapped_defaults = {
+        "log.syslog.hostname": "host.name",
+        "log.syslog.appname": "service.name",
+        "log.syslog.procid": "process.pid",
+        "log.syslog.msgid": "message.id",
+        "log.syslog.facility": "log.syslog.facility.code"
+    }
+    for default_attr, custom_attr in mapped_defaults.items():
+        if default_attr in attr_dict:
+            errors.append(f"record {idx}: found default attribute '{default_attr}' but should use custom mapping '{custom_attr}'")
+    
+    # Verify specific mappings with expected values
+    if "host.name" in attr_dict:
+        _, hostname = attr_dict["host.name"]
+        if hostname != expected["hostname"]:
+            errors.append(f"record {idx}: host.name mismatch: expected '{expected['hostname']}', got '{hostname}'")
+    
+    if "service.name" in attr_dict:
+        _, appname = attr_dict["service.name"]
+        if appname != expected["appname"]:
+            errors.append(f"record {idx}: service.name mismatch: expected '{expected['appname']}', got '{appname}'")
+    
+    if "process.pid" in attr_dict:
+        _, procid = attr_dict["process.pid"]
+        if procid != expected["procid"]:
+            errors.append(f"record {idx}: process.pid mismatch: expected '{expected['procid']}', got '{procid}'")
+    
+    if "message.id" in attr_dict:
+        _, msgid = attr_dict["message.id"]
+        if msgid != expected["msgid"]:
+            errors.append(f"record {idx}: message.id mismatch: expected '{expected['msgid']}', got '{msgid}'")
+    
+    if "log.syslog.facility.code" in attr_dict:
+        _, facility = attr_dict["log.syslog.facility.code"]
+        # Convert to int for comparison (JSON may return different numeric types)
+        facility_int = int(facility) if facility is not None else None
+        expected_facility = int(expected["facility"])
+        if facility_int != expected_facility:
+            errors.append(f"record {idx}: log.syslog.facility.code mismatch: expected {expected_facility}, got {facility_int}")
+    
+    sys.stdout.write(f"omotlp-attribute-mapping: record {idx}: verified {len(attr_dict)} attributes\n")
+
+if errors:
+    sys.stderr.write("omotlp-attribute-mapping: attribute mapping verification errors:\n")
+    for error in errors:
+        sys.stderr.write(f"  - {error}\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-attribute-mapping: successfully verified custom attribute mappings for {len(test_records[:10])} test records\n")
+PY
+
+exit_test
+

--- a/tests/omotlp-basic.sh
+++ b/tests/omotlp-basic.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-basic.sh -- basic functionality test for omotlp module
+##
+## Starts OTEL Collector, sends messages via omotlp, and verifies
+## messages are received and stored correctly in OTLP JSON format.
+
+. ${srcdir:=.}/diag.sh init
+
+# Check if omotlp module is available
+# NOTE: The module must be enabled during configure with --enable-omotlp
+# If the module fails to load with error -1001 (RS_RET_MISSING_INTERFACE),
+# the module was not built correctly and needs to be rebuilt with --enable-omotlp
+require_plugin omotlp
+
+export NUMMESSAGES=1000
+export EXTRA_EXIT=otel
+export SEQ_CHECK_OPTIONS=-d
+
+# Download and prepare OTEL Collector
+download_otel_collector
+prepare_otel_collector
+start_otel_collector
+
+# Read the port from the port file
+if [ ! -f ${RSYSLOG_DYNNAME}.otel_port.file ]; then
+	echo "ERROR: OTEL Collector port file not found: ${RSYSLOG_DYNNAME}.otel_port.file"
+	error_exit 1
+fi
+otel_port=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+if [ -z "$otel_port" ]; then
+	echo "ERROR: OTEL Collector port is empty"
+	error_exit 1
+fi
+echo "Using OTEL Collector port: $otel_port"
+
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="msgnum:%msg:F,58:2%")
+
+module(load="../plugins/omotlp/.libs/omotlp")
+
+if $msg contains "msgnum:" then
+	action(
+		name="omotlp-http"
+		type="omotlp"
+		template="otlpBody"
+		endpoint="http://127.0.0.1:'$otel_port'"
+		path="/v1/logs"
+		batch.max_items="100"
+		batch.timeout.ms="1000"
+	)
+'
+
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+# Stop OTEL Collector to ensure file exporter flushes data
+# The file exporter may buffer data until collector shuts down
+stop_otel_collector
+
+# Give OTEL Collector a moment to flush the output file after shutdown
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+# Extract data from OTEL Collector output
+otel_collector_get_data
+
+python3 - "$RSYSLOG_DYNNAME.otel-output.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    # OTEL Collector file exporter writes newline-delimited JSON (one JSON object per line)
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if "resourceLogs" in payload:
+                for resource_log in payload["resourceLogs"]:
+                    if "scopeLogs" in resource_log:
+                        for scope_log in resource_log["scopeLogs"]:
+                            if "logRecords" in scope_log:
+                                records.extend(scope_log["logRecords"])
+except Exception as exc:
+    sys.stderr.write(f"omotlp-basic: failed to parse OTLP output: {exc}\n")
+    sys.exit(1)
+
+if not records:
+    sys.stderr.write("omotlp-basic: OTLP output did not contain any logRecords\n")
+    sys.exit(1)
+
+def has_hostname(attrs):
+    for entry in attrs:
+        if entry.get("key") == "log.syslog.hostname":
+            val = entry.get("value", {}).get("stringValue", "")
+            if val:
+                return True
+    return False
+
+for idx, record in enumerate(records):
+    if record.get("severityNumber", 0) == 0:
+        sys.stderr.write(f"omotlp-basic: record {idx} missing severityNumber\n")
+        sys.exit(1)
+    if not has_hostname(record.get("attributes", [])):
+        sys.stderr.write(f"omotlp-basic: record {idx} missing log.syslog.hostname attribute\n")
+        sys.exit(1)
+PY
+
+seq_check
+exit_test

--- a/tests/omotlp-batch.sh
+++ b/tests/omotlp-batch.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-batch.sh -- batching test for omotlp module
+##
+## Tests that omotlp correctly batches multiple log records into
+## single ExportLogsServiceRequest payloads.
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=10000
+export EXTRA_EXIT=otel
+
+# Download and prepare OTEL Collector
+download_otel_collector
+prepare_otel_collector
+start_otel_collector
+
+# Read the port from the port file
+if [ ! -f ${RSYSLOG_DYNNAME}.otel_port.file ]; then
+	echo "ERROR: OTEL Collector port file not found: ${RSYSLOG_DYNNAME}.otel_port.file"
+	error_exit 1
+fi
+otel_port=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+if [ -z "$otel_port" ]; then
+	echo "ERROR: OTEL Collector port is empty"
+	error_exit 1
+fi
+echo "Using OTEL Collector port: $otel_port"
+
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="msgnum:%msg:F,58:2%")
+
+module(load="../plugins/omotlp/.libs/omotlp")
+
+if $msg contains "msgnum:" then
+	action(
+		name="omotlp-http"
+		type="omotlp"
+		template="otlpBody"
+		endpoint="http://127.0.0.1:'$otel_port'"
+		path="/v1/logs"
+		batch.max_items="3"
+		batch.timeout.ms="60000"
+	)
+'
+
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+# Stop OTEL Collector to ensure file exporter flushes data
+# The file exporter may buffer data until collector shuts down
+stop_otel_collector
+
+# Give OTEL Collector a moment to flush the output file after shutdown
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+# Extract data from OTEL Collector output
+otel_collector_get_data
+
+seq_check
+exit_test

--- a/tests/omotlp-compression.sh
+++ b/tests/omotlp-compression.sh
@@ -1,0 +1,193 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-compression.sh -- compression and resource config test for omotlp module
+##
+## Tests that omotlp correctly sends gzip-compressed payloads
+## and that OTEL Collector can decode them. Also tests resource parameter
+## configuration with string, integer, double, and boolean attributes.
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=2000
+export EXTRA_EXIT=otel
+
+# Download and prepare OTEL Collector
+download_otel_collector
+prepare_otel_collector
+start_otel_collector
+
+# Read the port from the port file
+if [ ! -f ${RSYSLOG_DYNNAME}.otel_port.file ]; then
+	echo "ERROR: OTEL Collector port file not found: ${RSYSLOG_DYNNAME}.otel_port.file"
+	error_exit 1
+fi
+otel_port=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+if [ -z "$otel_port" ]; then
+	echo "ERROR: OTEL Collector port is empty"
+	error_exit 1
+fi
+echo "Using OTEL Collector port: $otel_port"
+
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="msgnum:%msg:F,58:2%")
+
+module(load="../plugins/omotlp/.libs/omotlp")
+
+if $msg contains "msgnum:" then
+	action(
+		name="omotlp-http"
+		type="omotlp"
+		template="otlpBody"
+		endpoint="http://127.0.0.1:'$otel_port'"
+		path="/v1/logs"
+		batch.max_items="10"
+		batch.timeout.ms="1000"
+		compression="gzip"
+		resource="{ \"service.name\": \"test-service\", \"service.instance.id\": \"test-instance-123\", \"service.version\": \"1.2.3\", \"deployment.environment\": \"test\", \"custom.string.attr\": \"test-value\", \"custom.int.attr\": 42, \"custom.double.attr\": 3.14159, \"custom.bool.attr\": true }"
+	)
+'
+
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+# Stop OTEL Collector to ensure file exporter flushes data
+# The file exporter may buffer data until collector shuts down
+stop_otel_collector
+
+# Give OTEL Collector a moment to flush the output file after shutdown
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+# Extract data from OTEL Collector output
+otel_collector_get_data
+
+# Verify resource attributes
+python3 - "$RSYSLOG_DYNNAME.otel-output.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    # OTEL Collector file exporter writes newline-delimited JSON (one JSON object per line)
+    payloads = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if "resourceLogs" in payload:
+                payloads.append(payload)
+except Exception as exc:
+    sys.stderr.write(f"omotlp-compression: failed to parse OTLP output: {exc}\n")
+    sys.exit(1)
+
+if not payloads:
+    sys.stderr.write("omotlp-compression: OTLP output did not contain any resourceLogs\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-compression: found {len(payloads)} payload(s)\n")
+
+# Extract resource attributes from the first payload
+resource_attrs = {}
+found_resource = False
+
+for payload in payloads:
+    if "resourceLogs" in payload:
+        for resource_log in payload["resourceLogs"]:
+            if "resource" in resource_log and "attributes" in resource_log["resource"]:
+                found_resource = True
+                attrs = resource_log["resource"]["attributes"]
+                sys.stdout.write(f"omotlp-compression: found {len(attrs)} resource attributes\n")
+                
+                # Parse attributes into a dictionary
+                for attr_entry in attrs:
+                    key = attr_entry.get("key")
+                    value_obj = attr_entry.get("value", {})
+                    
+                    # Extract value based on type
+                    if "stringValue" in value_obj:
+                        resource_attrs[key] = ("string", value_obj["stringValue"])
+                    elif "intValue" in value_obj:
+                        resource_attrs[key] = ("int", value_obj["intValue"])
+                    elif "doubleValue" in value_obj:
+                        resource_attrs[key] = ("double", value_obj["doubleValue"])
+                    elif "boolValue" in value_obj:
+                        resource_attrs[key] = ("bool", value_obj["boolValue"])
+                    else:
+                        resource_attrs[key] = ("unknown", value_obj)
+                
+                # Only check the first resourceLogs entry
+                break
+        if found_resource:
+            break
+
+if not found_resource:
+    sys.stderr.write("omotlp-compression: no resource attributes found in OTLP output\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-compression: extracted {len(resource_attrs)} resource attributes\n")
+
+# Expected attributes (automatic + custom)
+expected_attrs = {
+    # Automatic attributes (always present)
+    "service.name": ("string", "test-service"),  # Overridden by custom config
+    "telemetry.sdk.name": ("string", "rsyslog-omotlp"),
+    "telemetry.sdk.language": ("string", "C"),
+    
+    # Custom attributes from resource parameter
+    "service.instance.id": ("string", "test-instance-123"),
+    "service.version": ("string", "1.2.3"),
+    "deployment.environment": ("string", "test"),
+    "custom.string.attr": ("string", "test-value"),
+    "custom.int.attr": ("int", 42),
+    "custom.double.attr": ("double", 3.14159),
+    "custom.bool.attr": ("bool", True),
+}
+
+# Verify expected attributes
+errors = []
+for key, (expected_type, expected_value) in expected_attrs.items():
+    if key not in resource_attrs:
+        errors.append(f"missing attribute: {key}")
+        continue
+    
+    actual_type, actual_value = resource_attrs[key]
+    
+    if actual_type != expected_type:
+        errors.append(f"attribute {key}: type mismatch (expected {expected_type}, got {actual_type})")
+        continue
+    
+    if actual_value != expected_value:
+        errors.append(f"attribute {key}: value mismatch (expected {expected_value}, got {actual_value})")
+        continue
+    
+    sys.stdout.write(f"omotlp-compression: verified {key} = {actual_value} ({actual_type})\n")
+
+# Check for telemetry.sdk.version (automatic, but version may vary)
+if "telemetry.sdk.version" not in resource_attrs:
+    errors.append("missing automatic attribute: telemetry.sdk.version")
+else:
+    sdk_type, sdk_version = resource_attrs["telemetry.sdk.version"]
+    if sdk_type != "string" or not sdk_version:
+        errors.append(f"telemetry.sdk.version has invalid value: {sdk_version}")
+    else:
+        sys.stdout.write(f"omotlp-compression: verified telemetry.sdk.version = {sdk_version}\n")
+
+if errors:
+    sys.stderr.write("omotlp-compression: resource attribute verification errors:\n")
+    for error in errors:
+        sys.stderr.write(f"  - {error}\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-compression: successfully verified all resource attributes\n")
+PY
+
+seq_check
+exit_test

--- a/tests/omotlp-http-batch.sh
+++ b/tests/omotlp-http-batch.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-http-batch.sh -- smoke-test OTLP batching and retries
+##
+## Starts the omhttp test server, emits four messages through omotlp with
+## batching and gzip enabled, and verifies the collector captured two payloads
+## with the expected retry behaviour and record order.
+
+. ${srcdir:=.}/diag.sh init
+
+# Check if omotlp module is available
+require_plugin omotlp
+
+omhttp_start_server 0 --decompress --fail-every 2 --fail-with 503
+
+generate_conf
+add_conf '
+module(load="../plugins/omotlp/.libs/omotlp")
+template(name="otlpBody" type="string" string="%msg%")
+
+# Process all messages through omotlp
+action(
+  name="omotlp-http"
+  type="omotlp"
+  template="otlpBody"
+  endpoint="http://127.0.0.1:'$omhttp_server_lstnport'"
+  path="/v1/logs"
+  batch.max_items="2"
+  batch.timeout.ms="1000"
+  compression="gzip"
+  retry.initial.ms="10"
+  retry.max.ms="100"
+  retry.max_retries="3"
+  headers='{ "X-Test-Header": "omotlp" }'
+)
+'
+
+startup
+injectmsg_literal 'msg 1
+msg 2
+msg 3
+msg 4'
+
+# Wait for batches to flush (batch.timeout.ms="1000" + retry time)
+# With batch.max_items="2", we expect 2 batches:
+# - Batch 1 (msg 1-2): should succeed immediately
+# - Batch 2 (msg 3-4): will fail with 503, then retry up to 3 times
+# Worst case retry time: 3 retries with exponential backoff up to 100ms = ~700ms
+# Add buffer for batch timeout (1000ms) + retries + network delays
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 3000
+else
+	sleep 3
+fi
+
+shutdown_when_empty
+wait_shutdown
+
+# Give a bit more time for any final retries to complete
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+attempt=0
+ret=1
+while [ $attempt -lt 30 ]; do
+python3 - "$omhttp_server_lstnport" <<'PY'
+import json
+import sys
+import urllib.request
+
+port = int(sys.argv[1])
+try:
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/v1/logs") as resp:
+        payloads = json.load(resp)
+except Exception as e:
+    sys.stderr.write(f"failed to fetch payloads: {e}\n")
+    sys.exit(1)
+
+if len(payloads) != 2:
+    sys.stderr.write(f"expected 2 payloads, got {len(payloads)}\n")
+    if len(payloads) > 0:
+        sys.stderr.write(f"first payload preview: {str(payloads[0])[:200]}...\n")
+    sys.exit(1)
+
+records = []
+batch_sizes = []
+for payload in payloads:
+    try:
+        document = json.loads(payload)
+        logs = document["resourceLogs"][0]["scopeLogs"][0]["logRecords"]
+        batch_sizes.append(len(logs))
+        for entry in logs:
+            body = entry.get("body", {}).get("stringValue")
+            if body:
+                records.append(body)
+    except (KeyError, json.JSONDecodeError) as e:
+        sys.stderr.write(f"failed to parse payload: {e}\n")
+        sys.stderr.write(f"payload: {payload[:200]}...\n")
+        sys.exit(1)
+
+expected = [f"msg {i}" for i in range(1, 5)]
+if batch_sizes != [2, 2]:
+    sys.stderr.write(f"unexpected batch sizes {batch_sizes}, expected [2, 2]\n")
+    sys.exit(1)
+
+if records != expected:
+    sys.stderr.write(f"unexpected bodies {records}, expected {expected}\n")
+    sys.exit(1)
+PY
+    ret=$?
+    if [ $ret -eq 0 ]; then
+        break
+    fi
+    attempt=$((attempt + 1))
+    if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+        $TESTTOOL_DIR/msleep 200
+    else
+        sleep 0.2
+    fi
+done
+
+omhttp_stop_server
+
+exit_test $ret

--- a/tests/omotlp-proxy.sh
+++ b/tests/omotlp-proxy.sh
@@ -1,0 +1,286 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-proxy.sh -- proxy support test for omotlp module
+##
+## Tests that omotlp correctly uses HTTP proxy to forward requests to
+## OTEL Collector, with and without proxy authentication.
+
+. ${srcdir:=.}/diag.sh init
+
+# Check if omotlp module is available
+require_plugin omotlp
+
+export NUMMESSAGES=100
+export EXTRA_EXIT="otel proxy"
+export SEQ_CHECK_OPTIONS=-d
+
+# Check for Python 3 (required for proxy server)
+if ! command -v python3 &> /dev/null; then
+	echo "ERROR: python3 not found - required for proxy server"
+	error_exit 77
+fi
+
+# Download and prepare OTEL Collector
+download_otel_collector
+prepare_otel_collector
+start_otel_collector
+
+# Read the OTEL Collector port
+if [ ! -f ${RSYSLOG_DYNNAME}.otel_port.file ]; then
+	echo "ERROR: OTEL Collector port file not found"
+	error_exit 1
+fi
+otel_port=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+if [ -z "$otel_port" ]; then
+	echo "ERROR: OTEL Collector port is empty"
+	error_exit 1
+fi
+echo "Using OTEL Collector port: $otel_port"
+
+# Start proxy server (no authentication)
+proxy_server_py="$srcdir/omotlp_proxy_server.py"
+if [ ! -f "$proxy_server_py" ]; then
+	echo "ERROR: Proxy server script not found: $proxy_server_py"
+	error_exit 1
+fi
+
+proxy_port_file="${RSYSLOG_DYNNAME}.proxy_port.file"
+proxy_data_file="${RSYSLOG_DYNNAME}.proxy_data.json"
+
+# Get a free port for the proxy server
+PROXY_PORT=$(get_free_port)
+export PROXY_PORT
+
+echo "Starting proxy server on port: $PROXY_PORT..."
+python3 "$proxy_server_py" \
+	--port "$PROXY_PORT" \
+	--port-file "$proxy_port_file" \
+	--target-host 127.0.0.1 \
+	--target-port "$otel_port" \
+	--data-file "$proxy_data_file" \
+	> "${RSYSLOG_DYNNAME}.proxy.log" 2>&1 &
+proxy_pid=$!
+
+# Wait for proxy to start and verify port file
+wait_file_exists "$proxy_port_file" 10
+if [ ! -f "$proxy_port_file" ]; then
+	echo "ERROR: Proxy server did not create port file"
+	kill $proxy_pid 2>/dev/null
+	error_exit 1
+fi
+
+proxy_port=$(cat "$proxy_port_file")
+if [ -z "$proxy_port" ]; then
+	echo "ERROR: Proxy port is empty"
+	kill $proxy_pid 2>/dev/null
+	error_exit 1
+fi
+
+# Verify the port matches what we requested
+if [ "$proxy_port" != "$PROXY_PORT" ]; then
+	echo "WARNING: Proxy port mismatch (requested: $PROXY_PORT, got: $proxy_port)"
+fi
+
+echo "Proxy server started on port: $proxy_port (pid: $proxy_pid)"
+
+# Function to stop proxy server
+stop_proxy() {
+	if [ -n "$proxy_pid" ] && kill -0 "$proxy_pid" 2>/dev/null; then
+		echo "Stopping proxy server (pid: $proxy_pid)"
+		kill "$proxy_pid" 2>/dev/null
+		wait "$proxy_pid" 2>/dev/null || true
+	fi
+}
+
+# Ensure proxy is stopped on exit
+trap 'stop_proxy' EXIT
+
+# Test 1: Proxy without authentication
+echo "=== Test 1: Proxy without authentication ==="
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="msgnum:%msg:F,58:2%")
+
+module(load="../plugins/omotlp/.libs/omotlp")
+
+if $msg contains "msgnum:" then
+	action(
+		name="omotlp-proxy"
+		type="omotlp"
+		template="otlpBody"
+		endpoint="http://127.0.0.1:'$otel_port'"
+		path="/v1/logs"
+		proxy="http://127.0.0.1:'$proxy_port'"
+		batch.max_items="50"
+		batch.timeout.ms="1000"
+	)
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+# Stop OTEL Collector to flush data
+stop_otel_collector
+
+# Give time for data to flush
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+# Verify proxy was used
+if [ -f "$proxy_data_file" ]; then
+	proxy_requests=$(python3 -c "import json; f=open('$proxy_data_file'); data=json.load(f); print(len(data)); f.close()" 2>/dev/null || echo "0")
+	if [ "$proxy_requests" -eq "0" ]; then
+		echo "ERROR: Proxy server did not receive any requests"
+		cat "${RSYSLOG_DYNNAME}.proxy.log"
+		error_exit 1
+	fi
+	echo "Proxy server received $proxy_requests requests"
+else
+	echo "WARNING: Proxy data file not found, but continuing..."
+fi
+
+# Extract and verify OTEL Collector output
+otel_collector_get_data
+
+# Use the output file path set by prepare_otel_collector
+if [ -z "$OTEL_OUTPUT_FILE" ]; then
+	# Fallback: construct path like other tests
+	test_dir="${srcdir:-$(pwd)}"
+	if [[ "$test_dir" != /* ]]; then
+		test_dir="$(cd "$test_dir" && pwd)"
+	fi
+	otel_output_file="$test_dir/${RSYSLOG_DYNNAME}.otel-output.json"
+else
+	otel_output_file="$OTEL_OUTPUT_FILE"
+fi
+
+python3 - "$otel_output_file" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if "resourceLogs" in payload:
+                for resource_log in payload["resourceLogs"]:
+                    if "scopeLogs" in resource_log:
+                        for scope_log in resource_log["scopeLogs"]:
+                            if "logRecords" in scope_log:
+                                records.extend(scope_log["logRecords"])
+except Exception as exc:
+    sys.stderr.write(f"omotlp-proxy: failed to parse OTLP output: {exc}\n")
+    sys.exit(1)
+
+if not records:
+    sys.stderr.write("omotlp-proxy: OTLP output did not contain any logRecords\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-proxy: successfully received {len(records)} log records via proxy\n")
+PY
+
+seq_check
+
+# Test 2: Proxy with authentication
+echo "=== Test 2: Proxy with authentication ==="
+
+# Stop current proxy and start new one with auth
+stop_proxy
+sleep 1
+
+proxy_port_file2="${RSYSLOG_DYNNAME}.proxy2_port.file"
+proxy_data_file2="${RSYSLOG_DYNNAME}.proxy2_data.json"
+
+# Get a free port for the authenticated proxy server
+PROXY_PORT2=$(get_free_port)
+export PROXY_PORT2
+
+echo "Starting authenticated proxy server on port: $PROXY_PORT2..."
+python3 "$proxy_server_py" \
+	--port "$PROXY_PORT2" \
+	--port-file "$proxy_port_file2" \
+	--target-host 127.0.0.1 \
+	--target-port "$otel_port" \
+	--require-auth \
+	--user "testuser" \
+	--password "testpass" \
+	--data-file "$proxy_data_file2" \
+	> "${RSYSLOG_DYNNAME}.proxy2.log" 2>&1 &
+proxy_pid2=$!
+
+wait_file_exists "$proxy_port_file2" 10
+proxy_port2=$(cat "$proxy_port_file2")
+
+# Verify the port matches what we requested
+if [ "$proxy_port2" != "$PROXY_PORT2" ]; then
+	echo "WARNING: Authenticated proxy port mismatch (requested: $PROXY_PORT2, got: $proxy_port2)"
+fi
+
+echo "Authenticated proxy server started on port: $proxy_port2 (pid: $proxy_pid2)"
+
+# Update trap to stop both proxies
+stop_proxy2() {
+	stop_proxy
+	if [ -n "$proxy_pid2" ] && kill -0 "$proxy_pid2" 2>/dev/null; then
+		echo "Stopping authenticated proxy server (pid: $proxy_pid2)"
+		kill "$proxy_pid2" 2>/dev/null
+		wait "$proxy_pid2" 2>/dev/null || true
+	fi
+}
+trap 'stop_proxy2' EXIT
+
+# Restart OTEL Collector for second test
+prepare_otel_collector
+start_otel_collector
+otel_port2=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="msgnum:%msg:F,58:2%")
+
+module(load="../plugins/omotlp/.libs/omotlp")
+
+if $msg contains "msgnum:" then
+	action(
+		name="omotlp-proxy-auth"
+		type="omotlp"
+		template="otlpBody"
+		endpoint="http://127.0.0.1:'$otel_port2'"
+		path="/v1/logs"
+		proxy="http://127.0.0.1:'$proxy_port2'"
+		proxy.user="testuser"
+		proxy.password="testpass"
+		batch.max_items="50"
+		batch.timeout.ms="1000"
+	)
+'
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+stop_otel_collector
+stop_proxy2
+
+# Verify authenticated proxy was used
+if [ -f "$proxy_data_file2" ]; then
+	proxy_requests2=$(python3 -c "import json; f=open('$proxy_data_file2'); data=json.load(f); print(len(data)); f.close()" 2>/dev/null || echo "0")
+	if [ "$proxy_requests2" -eq "0" ]; then
+		echo "ERROR: Authenticated proxy server did not receive any requests"
+		cat "${RSYSLOG_DYNNAME}.proxy2.log"
+		error_exit 1
+	fi
+	echo "Authenticated proxy server received $proxy_requests2 requests"
+fi
+
+exit_test
+

--- a/tests/omotlp-tls.sh
+++ b/tests/omotlp-tls.sh
@@ -1,0 +1,187 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-tls.sh -- TLS/mTLS support test for omotlp module
+##
+## Tests that omotlp correctly establishes HTTPS connections with TLS
+## certificate verification, and optionally with mutual TLS (mTLS) using
+## client certificates.
+
+. ${srcdir:=.}/diag.sh init
+
+# Check if omotlp module is available
+require_plugin omotlp
+
+export NUMMESSAGES=500
+export EXTRA_EXIT=otel
+export SEQ_CHECK_OPTIONS=-d
+
+# Check for required certificates
+if [ ! -f "$srcdir/testsuites/x.509/ca.pem" ]; then
+	echo "ERROR: CA certificate not found: $srcdir/testsuites/x.509/ca.pem"
+	echo "Skipping TLS test - certificates not available"
+	error_exit 77
+fi
+
+if [ ! -f "$srcdir/testsuites/x.509/client-cert.pem" ]; then
+	echo "ERROR: Client certificate not found: $srcdir/testsuites/x.509/client-cert.pem"
+	echo "Skipping TLS test - certificates not available"
+	error_exit 77
+fi
+
+if [ ! -f "$srcdir/testsuites/x.509/client-key.pem" ]; then
+	echo "ERROR: Client key not found: $srcdir/testsuites/x.509/client-key.pem"
+	echo "Skipping TLS test - certificates not available"
+	error_exit 77
+fi
+
+# We need a server certificate for OTEL Collector
+# For this test, we'll use the client cert as server cert (self-signed test scenario)
+# In a real deployment, you'd have separate server certificates
+server_cert="$srcdir/testsuites/x.509/client-cert.pem"
+server_key="$srcdir/testsuites/x.509/client-key.pem"
+ca_cert="$srcdir/testsuites/x.509/ca.pem"
+client_cert="$srcdir/testsuites/x.509/client-cert.pem"
+client_key="$srcdir/testsuites/x.509/client-key.pem"
+
+# Download and prepare OTEL Collector (extracts binary and sets up work directory)
+download_otel_collector
+prepare_otel_collector
+
+# Override config with TLS-enabled version
+dep_work_dir=$(readlink -f .dep_wrk 2>/dev/null || echo "$(pwd)/.dep_wrk")
+otelcol_work_dir="$dep_work_dir/otelcol-${RSYSLOG_DYNNAME}"
+
+# Copy certificates to OTEL Collector work directory
+cp "$server_cert" "$otelcol_work_dir/server-cert.pem"
+cp "$server_key" "$otelcol_work_dir/server-key.pem"
+cp "$ca_cert" "$otelcol_work_dir/ca.pem"
+
+# Get absolute path for output file
+test_dir="${srcdir:-$(pwd)}"
+if [[ "$test_dir" != /* ]]; then
+	test_dir="$(cd "$test_dir" && pwd)"
+fi
+otel_output_file="$test_dir/${RSYSLOG_DYNNAME}.otel-output.json"
+otel_output_file_abs=$(cd "$(dirname "$otel_output_file")" && pwd)/$(basename "$otel_output_file")
+
+# Override config with TLS-enabled version
+cat > "$otelcol_work_dir/config.yaml" <<EOF
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:${OTEL_COLLECTOR_PORT}
+        tls:
+          cert_file: server-cert.pem
+          key_file: server-key.pem
+          # For mTLS, require client certificates
+          client_ca_file: ca.pem
+
+exporters:
+  file:
+    path: ${otel_output_file_abs}
+    format: json
+    flush_interval: 1s
+
+service:
+  telemetry:
+    metrics:
+      address: 0.0.0.0:${OTEL_METRICS_PORT}
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [file]
+EOF
+
+echo "OTEL Collector TLS config created:"
+cat "$otelcol_work_dir/config.yaml"
+
+start_otel_collector
+
+# Read the port from the port file
+if [ ! -f ${RSYSLOG_DYNNAME}.otel_port.file ]; then
+	echo "ERROR: OTEL Collector port file not found: ${RSYSLOG_DYNNAME}.otel_port.file"
+	error_exit 1
+fi
+otel_port=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+if [ -z "$otel_port" ]; then
+	echo "ERROR: OTEL Collector port is empty"
+	error_exit 1
+fi
+echo "Using OTEL Collector port: $otel_port (HTTPS)"
+
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="msgnum:%msg:F,58:2%")
+
+module(load="../plugins/omotlp/.libs/omotlp")
+
+if $msg contains "msgnum:" then
+	action(
+		name="omotlp-https"
+		type="omotlp"
+		template="otlpBody"
+		endpoint="https://127.0.0.1:'$otel_port'"
+		path="/v1/logs"
+		batch.max_items="50"
+		batch.timeout.ms="1000"
+		tls.cacert="'$ca_cert'"
+		tls.cert="'$client_cert'"
+		tls.key="'$client_key'"
+		tls.verify_hostname="off"
+		tls.verify_peer="on"
+	)
+'
+
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+# Stop OTEL Collector to ensure file exporter flushes data
+stop_otel_collector
+
+# Give OTEL Collector a moment to flush the output file after shutdown
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+# Extract data from OTEL Collector output
+otel_collector_get_data
+
+# Verify messages were received
+python3 - "$RSYSLOG_DYNNAME.otel-output.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if "resourceLogs" in payload:
+                for resource_log in payload["resourceLogs"]:
+                    if "scopeLogs" in resource_log:
+                        for scope_log in resource_log["scopeLogs"]:
+                            if "logRecords" in scope_log:
+                                records.extend(scope_log["logRecords"])
+except Exception as exc:
+    sys.stderr.write(f"omotlp-tls: failed to parse OTLP output: {exc}\n")
+    sys.exit(1)
+
+if not records:
+    sys.stderr.write("omotlp-tls: OTLP output did not contain any logRecords\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-tls: successfully received {len(records)} log records via HTTPS/TLS\n")
+PY
+
+seq_check
+exit_test
+

--- a/tests/omotlp-trace-correlation.sh
+++ b/tests/omotlp-trace-correlation.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+## omotlp-trace-correlation.sh -- test trace correlation support for omotlp module
+##
+## Tests that trace_id, span_id, and trace_flags are extracted from message
+## properties and included in the OTLP export. Uses mmjsonparse to extract
+## trace properties from JSON messages.
+
+. ${srcdir:=.}/diag.sh init
+
+# Check if omotlp module is available
+require_plugin omotlp
+require_plugin mmjsonparse
+
+export NUMMESSAGES=10
+export EXTRA_EXIT=otel
+export SEQ_CHECK_OPTIONS=-d
+
+# Download and prepare OTEL Collector
+download_otel_collector
+prepare_otel_collector
+start_otel_collector
+
+# Read the port from the port file
+if [ ! -f ${RSYSLOG_DYNNAME}.otel_port.file ]; then
+	echo "ERROR: OTEL Collector port file not found: ${RSYSLOG_DYNNAME}.otel_port.file"
+	error_exit 1
+fi
+otel_port=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+if [ -z "$otel_port" ]; then
+	echo "ERROR: OTEL Collector port is empty"
+	error_exit 1
+fi
+echo "Using OTEL Collector port: $otel_port"
+
+# Create input file with syslog messages containing JSON with trace context
+cat > ${RSYSLOG_DYNNAME}.input << 'INPUTFILE'
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000001"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000002"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000003"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000004"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000005"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000006"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000007"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000008"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000009"}
+<14>1 2024-01-01T12:00:00.000Z testhost testapp 12345 - [test@123] {"trace_id":"4bf92f3577b34da6a3ce929d0e0e4736","span_id":"00f067aa0ba902b7","trace_flags":"01","message":"test message 00000010"}
+INPUTFILE
+
+generate_conf
+add_conf '
+template(name="otlpBody" type="string" string="%msg%")
+
+module(load="../plugins/mmjsonparse/.libs/mmjsonparse")
+module(load="../plugins/omotlp/.libs/omotlp")
+
+# Parse JSON to extract trace properties
+action(type="mmjsonparse" mode="find-json")
+
+# Export with trace correlation
+action(
+	name="omotlp-http"
+	type="omotlp"
+	template="otlpBody"
+	endpoint="http://127.0.0.1:'$otel_port'"
+	path="/v1/logs"
+	trace_id.property="trace_id"
+	span_id.property="span_id"
+	trace_flags.property="trace_flags"
+	batch.max_items="100"
+	batch.timeout.ms="1000"
+)
+'
+
+startup
+injectmsg_file ${RSYSLOG_DYNNAME}.input
+shutdown_when_empty
+wait_shutdown
+
+# Stop OTEL Collector to ensure file exporter flushes data
+stop_otel_collector
+
+# Give OTEL Collector a moment to flush the output file after shutdown
+if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
+	$TESTTOOL_DIR/msleep 1000
+else
+	sleep 1
+fi
+
+# Extract data from OTEL Collector output
+otel_collector_get_data
+
+python3 - "$RSYSLOG_DYNNAME.otel-output.json" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+try:
+    # OTEL Collector file exporter writes newline-delimited JSON (one JSON object per line)
+    records = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            payload = json.loads(line)
+            if "resourceLogs" in payload:
+                for resource_log in payload["resourceLogs"]:
+                    if "scopeLogs" in resource_log:
+                        for scope_log in resource_log["scopeLogs"]:
+                            if "logRecords" in scope_log:
+                                records.extend(scope_log["logRecords"])
+except Exception as exc:
+    sys.stderr.write(f"omotlp-trace-correlation: failed to parse OTLP output: {exc}\n")
+    sys.exit(1)
+
+if not records:
+    sys.stderr.write("omotlp-trace-correlation: OTLP output did not contain any logRecords\n")
+    sys.exit(1)
+
+sys.stdout.write(f"omotlp-trace-correlation: found {len(records)} log records in OTLP output\n")
+
+# Expected trace values
+expected_trace_id = "4bf92f3577b34da6a3ce929d0e0e4736"
+expected_span_id = "00f067aa0ba902b7"
+expected_trace_flags = 1
+
+sys.stdout.write(f"omotlp-trace-correlation: expected traceId='{expected_trace_id}', spanId='{expected_span_id}', flags={expected_trace_flags}\n")
+
+# Verify trace correlation fields
+for idx, record in enumerate(records):
+    trace_id = record.get("traceId")
+    span_id = record.get("spanId")
+    trace_flags = record.get("flags")
+    
+    sys.stdout.write(f"omotlp-trace-correlation: record {idx}: traceId={trace_id}, spanId={span_id}, flags={trace_flags}\n")
+    
+    if trace_id is None:
+        sys.stderr.write(f"omotlp-trace-correlation: record {idx} missing traceId\n")
+        sys.exit(1)
+    if trace_id != expected_trace_id:
+        sys.stderr.write(f"omotlp-trace-correlation: record {idx} traceId mismatch: expected '{expected_trace_id}', got '{trace_id}'\n")
+        sys.exit(1)
+    
+    if span_id is None:
+        sys.stderr.write(f"omotlp-trace-correlation: record {idx} missing spanId\n")
+        sys.exit(1)
+    if span_id != expected_span_id:
+        sys.stderr.write(f"omotlp-trace-correlation: record {idx} spanId mismatch: expected '{expected_span_id}', got '{span_id}'\n")
+        sys.exit(1)
+    
+    if trace_flags is None:
+        sys.stderr.write(f"omotlp-trace-correlation: record {idx} missing flags\n")
+        sys.exit(1)
+    if trace_flags != expected_trace_flags:
+        sys.stderr.write(f"omotlp-trace-correlation: record {idx} flags mismatch: expected {expected_trace_flags}, got {trace_flags}\n")
+        sys.exit(1)
+
+sys.stdout.write(f"omotlp-trace-correlation: verified {len(records)} records with trace correlation\n")
+PY
+
+exit_test
+

--- a/tests/omotlp_proxy_server.py
+++ b/tests/omotlp_proxy_server.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""
+Simple HTTP proxy server for omotlp proxy testing.
+
+This proxy server:
+- Forwards HTTP requests to a target server
+- Supports basic authentication
+- Logs proxy usage for verification
+- Writes received data to a file for inspection
+"""
+import argparse
+import base64
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+try:
+    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer  # Python 2
+    from SocketServer import ThreadingMixIn
+except ImportError:
+    from http.server import BaseHTTPRequestHandler, HTTPServer  # Python 3
+    from socketserver import ThreadingMixIn
+
+# Global state
+proxy_metadata = {
+    'requests': [],
+    'target_host': '127.0.0.1',
+    'target_port': 4318,
+    'require_auth': False,
+    'expected_user': '',
+    'expected_password': '',
+    'data_file': None
+}
+
+
+class ThreadingHTTPServer(ThreadingMixIn, HTTPServer):
+    """Threading HTTP server to handle concurrent requests."""
+    pass
+
+
+class ProxyHandler(BaseHTTPRequestHandler):
+    """HTTP proxy handler that forwards requests to target server."""
+
+    def validate_proxy_auth(self):
+        """Validate Proxy-Authorization header if required."""
+        if not proxy_metadata['require_auth']:
+            return True
+
+        if 'Proxy-Authorization' not in self.headers:
+            self.send_response(407)  # Proxy Authentication Required
+            self.send_header('Proxy-Authenticate', 'Basic realm="Proxy"')
+            self.end_headers()
+            self.wfile.write(b'Proxy authentication required')
+            return False
+
+        auth_header = self.headers['Proxy-Authorization']
+        if not auth_header.startswith('Basic '):
+            self.send_response(407)
+            self.send_header('Proxy-Authenticate', 'Basic realm="Proxy"')
+            self.end_headers()
+            self.wfile.write(b'Invalid proxy authentication method')
+            return False
+
+        try:
+            _, b64userpwd = auth_header.split(' ', 1)
+            userpwd = base64.b64decode(b64userpwd).decode('utf-8')
+            user, password = userpwd.split(':', 1)
+            expected_user = proxy_metadata['expected_user']
+            expected_password = proxy_metadata['expected_password']
+
+            if user != expected_user or password != expected_password:
+                self.send_response(407)
+                self.send_header('Proxy-Authenticate', 'Basic realm="Proxy"')
+                self.end_headers()
+                self.wfile.write(b'Invalid proxy credentials')
+                return False
+        except Exception as e:
+            self.send_response(407)
+            self.send_header('Proxy-Authenticate', 'Basic realm="Proxy"')
+            self.end_headers()
+            self.wfile.write(f'Proxy auth error: {e}'.encode('utf-8'))
+            return False
+
+        return True
+
+    def log_message(self, format, *args):
+        """Override to reduce noise in test output."""
+        # Only log errors
+        if 'error' in format.lower() or args[1].startswith('4') or args[1].startswith('5'):
+            super().log_message(format, *args)
+
+    def do_CONNECT(self):
+        """Handle CONNECT method for HTTPS tunneling."""
+        if not self.validate_proxy_auth():
+            return
+
+        # For HTTPS, we'd need to implement SSL tunneling
+        # For simplicity in tests, we'll just return an error
+        # Most tests will use HTTP, not HTTPS through proxy
+        self.send_response(501)
+        self.end_headers()
+        self.wfile.write(b'CONNECT method not fully implemented (use HTTP for testing)')
+
+    def do_POST(self):
+        """Handle POST requests by forwarding to target server."""
+        if not self.validate_proxy_auth():
+            return
+
+        # Record this request
+        content_length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(content_length) if content_length > 0 else b''
+
+        # When using HTTP proxy, libcurl sends the full URL in the path
+        # e.g., "http://127.0.0.1:50101/v1/logs" instead of just "/v1/logs"
+        # Parse the path to extract the actual target path
+        target_path = self.path
+        if self.path.startswith('http://') or self.path.startswith('https://'):
+            # Full URL provided - parse it
+            try:
+                parsed = urllib.parse.urlparse(self.path)
+                target_path = parsed.path
+                if parsed.query:
+                    target_path += '?' + parsed.query
+            except Exception:
+                # If parsing fails, use the path as-is
+                pass
+
+        request_info = {
+            'method': 'POST',
+            'path': self.path,
+            'target_path': target_path,
+            'headers': dict(self.headers),
+            'body': body.decode('utf-8', errors='replace'),
+            'client': self.client_address[0]
+        }
+        proxy_metadata['requests'].append(request_info)
+
+        # Forward request to target server
+        target_url = f"http://{proxy_metadata['target_host']}:{proxy_metadata['target_port']}{target_path}"
+
+        try:
+            # Create request with original headers (except Host and Connection)
+            # When forwarding through proxy, we need to set the Host header to the target
+            req_headers = {}
+            for header, value in self.headers.items():
+                header_lower = header.lower()
+                if header_lower not in ('host', 'connection', 'proxy-authorization'):
+                    req_headers[header] = value
+            
+            # Set Host header to target server
+            req_headers['Host'] = f"{proxy_metadata['target_host']}:{proxy_metadata['target_port']}"
+
+            req = urllib.request.Request(target_url, data=body, headers=req_headers, method='POST')
+
+            with urllib.request.urlopen(req, timeout=10) as response:
+                # Forward response
+                self.send_response(response.getcode())
+                for header, value in response.headers.items():
+                    if header.lower() not in ('connection', 'transfer-encoding'):
+                        self.send_header(header, value)
+                self.end_headers()
+
+                response_body = response.read()
+                self.wfile.write(response_body)
+
+        except urllib.error.HTTPError as e:
+            # Forward error response
+            self.send_response(e.code)
+            for header, value in e.headers.items():
+                if header.lower() not in ('connection', 'transfer-encoding'):
+                    self.send_header(header, value)
+            self.end_headers()
+            error_body = e.read()
+            self.wfile.write(error_body)
+
+        except Exception as e:
+            # Log the error for debugging
+            import traceback
+            error_msg = f'Proxy error: {e}\n{traceback.format_exc()}'
+            print(f"Proxy error: {error_msg}", file=sys.stderr)
+            self.send_response(502)  # Bad Gateway
+            self.end_headers()
+            self.wfile.write(f'Proxy error: {e}'.encode('utf-8'))
+
+    def do_GET(self):
+        """Handle GET requests (for health checks, data retrieval)."""
+        if self.path == '/proxy/requests':
+            # Return list of proxied requests
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            response = json.dumps(proxy_metadata['requests'], indent=2)
+            self.wfile.write(response.encode('utf-8'))
+        elif self.path == '/proxy/clear':
+            # Clear request log
+            proxy_metadata['requests'] = []
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b'OK')
+        else:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'Not found')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Simple HTTP proxy for omotlp testing')
+    parser.add_argument('-p', '--port', type=int, default=0, help='Listen port (0 = auto)')
+    parser.add_argument('--port-file', type=str, default='', help='File to write listen port')
+    parser.add_argument('--target-host', type=str, default='127.0.0.1', help='Target server host')
+    parser.add_argument('--target-port', type=int, default=4318, help='Target server port')
+    parser.add_argument('--require-auth', action='store_true', help='Require proxy authentication')
+    parser.add_argument('--user', type=str, default='', help='Expected proxy username')
+    parser.add_argument('--password', type=str, default='', help='Expected proxy password')
+    parser.add_argument('--data-file', type=str, default='', help='File to save request data')
+    args = parser.parse_args()
+
+    proxy_metadata['target_host'] = args.target_host
+    proxy_metadata['target_port'] = args.target_port
+    proxy_metadata['require_auth'] = args.require_auth
+    proxy_metadata['expected_user'] = args.user
+    proxy_metadata['expected_password'] = args.password
+    proxy_metadata['data_file'] = args.data_file
+
+    server = ThreadingHTTPServer(('127.0.0.1', args.port), ProxyHandler)
+    listen_port = server.server_address[1]
+    pid = os.getpid()
+
+    print(f'Starting proxy server on 127.0.0.1:{listen_port} (pid {pid})')
+    print(f'Forwarding to {args.target_host}:{args.target_port}')
+    if args.require_auth:
+        print(f'Proxy authentication required: {args.user}:***')
+
+    if args.port_file:
+        with open(args.port_file, 'w') as f:
+            f.write(str(listen_port))
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        print('\nShutting down proxy server...')
+        server.shutdown()
+        # Save request data if requested
+        if args.data_file and proxy_metadata['requests']:
+            with open(args.data_file, 'w') as f:
+                json.dump(proxy_metadata['requests'], f, indent=2)
+

--- a/tests/testsuites/otel-collector-config.yaml
+++ b/tests/testsuites/otel-collector-config.yaml
@@ -1,0 +1,20 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:0
+
+exporters:
+  file:
+    path: ${OTEL_OUTPUT_FILE}
+    format: json
+    flush_interval: 1s
+
+service:
+  telemetry:
+    metrics:
+      address: 0.0.0.0:${OTEL_METRICS_PORT}
+  pipelines:
+    logs:
+      receivers: [otlp]
+      exporters: [file]


### PR DESCRIPTION
## Why (non-technical)

OpenTelemetry adoption: provide a first-party, sidecar-free path to ship
rsyslog logs directly to OTLP collectors. This simplifies OTel pipelines
and aligns rsyslog with modern, container-friendly observability stacks.

## What’s included

* New output module `omotlp` adding OTLP/HTTP JSON transport with configurable
  batching by count/bytes/timeout, optional gzip, retry/backoff with jitter,
  TLS/mTLS, custom headers, and proxy support. 
* Build/CI wiring (`--enable-omotlp`), Autotools checks for `libcurl` and
  `libfastjson`, and module subdir integration. 
* User docs with parameter matrix, examples (basic, batching, TLS/proxy, trace
  correlation), and OTel env-var fallbacks. 
* Stats counters per instance: batches submitted/success/dropped/retried,
  HTTP 4xx/5xx tallies, records.sent, and cumulative request latency. 
* Tests covering batching, gzip, retry/5xx handling, and basic end-to-end with
  an OTEL Collector.

## Before / After (user-visible)

* **Before:** No native OpenTelemetry exporter in rsyslog.
* **After:** `action(type="omotlp")` streams records to an OTLP collector over
  HTTP/JSON with batching, compression, and robust retry semantics. 

## Configuration highlights

Key action parameters (defaults chosen to mirror OTLP guidance; all optional):

* `endpoint` (default `http://127.0.0.1:4318`) and `path` (default `/v1/logs`)
* `protocol` (`http/json`)
* Batching: `batch.max_items`, `batch.max_bytes`, `batch.timeout.ms`
* Compression: `compression=none|gzip`
* Retry: `retry.initial.ms`, `retry.max.ms`, `retry.max_retries`, `retry.jitter.percent`
* Headers, bearer token; TLS/mTLS and proxy options
  Environment fallbacks: `OTEL_EXPORTER_OTLP{_LOGS}_*` for endpoint, protocol,
  compression, timeout, and headers when not explicitly set. 

Example (docs):

```rsyslog
module(load="omotlp")
action(
  type="omotlp"
  endpoint="https://otel-collector:4318"
  path="/v1/logs"
  protocol="http/json"
  template="RSYSLOG_SyslogProtocol23Format"
  batch.max_items="200"
  batch.max_bytes="262144"
  batch.timeout.ms="2000"
  compression="gzip"
  retry.max_retries="7"
  retry.max.ms="45000"
  headers='{ "X-OTel-Tenant": "blue" }'
  bearer_token="${env:OTEL_TOKEN}"
)
```



## Attribute and severity mapping

* Optional `attributeMap` to remap rsyslog properties (e.g., `hostname` → `host.name`).
* Optional `severity.map` to customize syslog priority (0–7) → OTLP severity
  number/text (0–24 recommended), otherwise sane defaults apply. 

## Transport, batching, and retry semantics

* Workers own their HTTP client and batch buffer; no cross-worker locks.
  A lightweight flush thread handles timeout-based flushes and performs a final
  flush on exit.
* Flush triggers: threshold reached (items/bytes), timeout elapsed, or on
  completion of the current action queue transaction. 
* HTTP status handling:

  * 2xx: success; clear batch; update `records.sent` and latency. 
  * 4xx: drop batch and clear (payload was delivered but rejected). 
  * 5xx/408/429 or network errors: map to retry with exponential backoff and
    jitter; action queue sees `RS_RET_SUSPENDED`. 

## Stats (via `impstats`)

Per worker instance (origin `omotlp-<url>`):

* `batches.submitted`, `batches.success`, `batches.retried`, `batches.dropped`
* `http.status.4xx`, `http.status.5xx`
* `records.sent`
* `http.request.latency.ms` (cumulative) 

## Tests

* `tests/omotlp-http-batch.sh`: exercises batching + gzip; uses a test server
  to fail every 2nd request with 503 and verifies retry/order. 
* `tests/omotlp-basic.sh`: end-to-end against OTEL Collector; validates that
  each record has `severityNumber` and `log.syslog.hostname`. 
* Additional attribute/compression checks via helper scripts. 

## Build and CI

* Opt-in: `./configure --enable-omotlp` (default `no`); requires `libcurl` and
  `libfastjson`. Integrated into `Makefile.am` / `AC_CONFIG_FILES`. 
* GitHub Actions enable `--enable-omotlp` in selected jobs. 
* Module metadata and developer notes included. 

## Compatibility, limits, and roadmap

* Preview quality for OTLP/HTTP JSON. gRPC façade and HTTP/protobuf fast-path
  are planned; keep action queues enabled. 
* Attribute/severity customization optional; defaults aim to be sensible and
  spec-aligned. 

## Operational guidance

* Prefer HTTPS with proper CA verification; configure TLS/mTLS where required.
  Proxy settings supported for corporate networks. 
* Choose batching to balance latency vs. overhead; gzip reduces egress size at
  the cost of CPU. 
* Monitor `impstats` counters to spot 4xx/5xx spikes, drops, and latency
  regressions. 

## Risks and mitigations

* **Duplicate vs. loss trade-off:** 4xx are dropped (already delivered and
  rejected); 5xx/timeout/429 are retried—ensure collector SLOs and queue
  sizing are appropriate.
* **Timeout flush thread:** background timer flushes to prevent indefinite
  buffering; final flush on shutdown. Validate HUP/shutdown paths in follow-ups. 
* **Env var interplay:** action parameters override OTel env fallbacks; document
  clearly to avoid surprises when reusing collector env. 

## Developer checklist

* [x] Autotools: `--enable-omotlp`, `PKG_CHECK_MODULES(libcurl, libfastjson)` 
* [x] Runtime: per-worker client/batch, timeout flush thread, final flush
* [x] HTTP retry/backoff with jitter; 2xx/4xx/5xx mapping; metrics updates
* [x] Docs: parameters, examples, env fallbacks, trace correlation, TLS/proxy 
* [x] Tests: batching, gzip, retry, basic e2e with collector
