### PR TITLE
mmjsontransform: fix compiler warning

### DIFF
--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -156,7 +156,8 @@ static rsRetVal jsontransformFlattenInto(struct json_object *src,
 /**
  * @brief Record conflict details if not already set.
  */
-static rsRetVal jsontransformConflictSet(jsontransformConflict_t *conflict, const char *fmt, ...);
+static rsRetVal jsontransformConflictSet(jsontransformConflict_t *conflict, const char *fmt, ...)
+    __attribute__((format(printf, 2, 3)));
 /**
  * @brief Release any resources captured in the conflict descriptor.
  */


### PR DESCRIPTION
Required attribute was missing, now added. This should be sufficient to silence the warnings from all compilers and ensure proper parameter checking.
