### PR TITLE
mmanon: add random-consistent-unique mode and update documentation accordingly

### DIFF
--- a/doc/source/reference/parameters/mmanon-embeddedipv4-anonmode.rst
+++ b/doc/source/reference/parameters/mmanon-embeddedipv4-anonmode.rst
@@ -25,13 +25,19 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``random``, ``random-consistent``, and ``zero``.
+The available modes are ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 
 The modes ``random`` and ``random-consistent`` are very similar, in that they
 both anonymize IP addresses by randomizing the last bits (any number) of a given
 address. However, while ``random`` mode assigns a new random IP address for
 every address in a message, ``random-consistent`` will assign the same
 randomized address to every instance of the same original address.
+``random-consistent-unique`` builds on that behavior and guarantees that no
+two distinct original addresses share the same anonymized result. It may
+take longer to generate addresses because a replacement is retried until an
+unused randomized value is found; this effect grows as more unique IPs are
+processed.
 
 The default ``zero`` mode will do full anonymization of any number of bits and
 it will also normalize the address, so that no information about the original IP

--- a/doc/source/reference/parameters/mmanon-ipv4-mode.rst
+++ b/doc/source/reference/parameters/mmanon-ipv4-mode.rst
@@ -25,8 +25,8 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``simple``, ``random``, ``random-consistent``, and
-``zero``.
+The available modes are ``simple``, ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 In simple mode, only octets as a whole can be anonymized and the length of the
 message is never changed. This means that when the last three octets of the
 address 10.1.12.123 are anonymized, the result will be 10.x.xx.xxx.
@@ -42,6 +42,11 @@ they both anonymize IP addresses by randomizing the last bits (any number)
 of a given address. However, while ``random`` mode assigns a new random IP
 address for every address in a message, ``random-consistent`` will assign
 the same randomized address to every instance of the same original address.
+``random-consistent-unique`` builds on that behavior and guarantees that no
+two distinct original addresses share the same anonymized result. It may
+take longer to generate addresses because a replacement is retried until an
+unused randomized value is found; this effect grows as more unique IPs are
+processed.
 
 The default ``zero`` mode will do full anonymization of any number of bits.
 It will also normalize the address, so that no information about the original

--- a/doc/source/reference/parameters/mmanon-ipv6-anonmode.rst
+++ b/doc/source/reference/parameters/mmanon-ipv6-anonmode.rst
@@ -25,13 +25,19 @@ This parameter applies to :doc:`../../configuration/modules/mmanon`.
 
 Description
 -----------
-The available modes are ``random``, ``random-consistent``, and ``zero``.
+The available modes are ``random``, ``random-consistent``,
+``random-consistent-unique``, and ``zero``.
 
 The modes ``random`` and ``random-consistent`` are very similar, in that they
 both anonymize IP addresses by randomizing the last bits (any number) of a given
 address. However, while ``random`` mode assigns a new random IP address for
 every address in a message, ``random-consistent`` will assign the same
 randomized address to every instance of the same original address.
+``random-consistent-unique`` builds on that behavior and guarantees that no
+two distinct original addresses share the same anonymized result. It may
+take longer to generate addresses because a replacement is retried until an
+unused randomized value is found; this effect grows as more unique IPs are
+processed.
 
 The default ``zero`` mode will do full anonymization of any number of bits and it
 will also normalize the address, so that no information about the original IP


### PR DESCRIPTION
Add a mode that guarantees unique mappings in anonymization for
operators who need consistent-but-unique IP replacements. The
existing random-consistent behavior remains unchanged to avoid
unexpected perf shifts and to keep configs stable over upgrades.

Impact: New mode only; existing modes unchanged. Extra CPU/memory
overhead scales with number of unique anonymized IPs.

Before: random-consistent could map two different IPs to the same
anonymized IP.
After: random-consistent-unique retries until a never-before-used
replacement is selected for each original IP.

Technical details:
Introduce per-family flags and tables to track (a) original->anon
mappings and (b) the set of already-generated anonymized addrs.
On IPv4, a hashtable of generated u32 addrs prevents duplicates;
on IPv6 and embedded-IPv4, separate tables track originals and
generated outputs. Generation loops retry until an unused value
is found, under the existing mutexes. Teardown destroys the new
tables; docs for IPv4, IPv6, and embedded IPv4 are updated to
describe the new mode and its perf tradeoffs.

With the help of AI agent: codex

Fixes: https://github.com/rsyslog/rsyslog/issues/6353
