### PR TITLE
imjournal: fix potential segfault (SIGBUS)

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -698,6 +698,11 @@ static rsRetVal pollJournal(struct journalContext_s *journalContext, char *state
 
     err = sd_journal_wait(journalContext->j, POLL_TIMEOUT);
     if (err == SD_JOURNAL_INVALIDATE) {
+        const int processRet = sd_journal_process(journalContext->j);
+        if (processRet < 0) {
+            LogError(-processRet, RS_RET_ERR, "imjournal: sd_journal_process() failed during rotation handling");
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
         CHKiRet(handleRotation(journalContext, stateFile));
     }
 


### PR DESCRIPTION
This fixes a problem in imjournal that can result in SIGBUS or other problems. Note that I could not reproduce the issue myself, but it looks very plausible that this is indeed a useful fix.

closes: https://github.com/rsyslog/rsyslog/issues/6359

With the help of AI Agent: codex

@Cropi this may be of interest for you
