### PR TITLE
Remove macos-13 from CI and weekly jobs

### DIFF
--- a/.github/workflows/run_macos.yml
+++ b/.github/workflows/run_macos.yml
@@ -43,10 +43,6 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          # 1 x from macos-13 (x64 NONE)
-          - os: macos-13
-            arch: x64
-            sanitizer: none
           # 1 x from macos-14 (x64 NONE)
           - os: macos-14
             arch: x64

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -32,7 +32,7 @@ jobs:
       # We want a full picture weekly
       fail-fast: false
       matrix:
-        os: [macos-13, macos-14, macos-15]
+        os: [macos-14, macos-15]
         arch: [x64, arm64]
         sanitizer: [none, asan, tsan]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
### Summary (non-technical, complete)
This change removes references to macOS 13 from the CI workflows. The macOS 13 GitHub runners have been retired, and continuing to reference them would lead to workflow failures. This ensures our CI pipelines run only on currently supported macOS versions (14 and 15).

### References
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
- `.github/workflows/run_macos.yml`: Removed the specific `macos-13` matrix entry.
- `.github/workflows/run_macos_weekly.yml`: Removed `macos-13` from the `os` array in the matrix.
