### PR TITLE
doc: Fix RST documentation build errors

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -262,6 +262,7 @@ EXTRA_DIST += \
     doc/source/dataflow.png \
     doc/source/development/coding_practices.rst \
     doc/source/development/coding_practices/embedded_ipv4_tail_helper.rst \
+    doc/source/development/coding_practices/error_logging_with_errno.rst \
     doc/source/development/coding_practices/externalized_helper_contracts.rst \
     doc/source/development/config_data_model.rst \
     doc/source/development/debugging.rst \
@@ -919,6 +920,22 @@ EXTRA_DIST += \
     doc/source/reference/parameters/ommail-subject-template.rst \
     doc/source/reference/parameters/ommail-subject-text.rst \
     doc/source/reference/parameters/ommail-template.rst \
+    doc/source/reference/parameters/ommysql-db.rst \
+    doc/source/reference/parameters/ommysql-mysqlconfig-file.rst \
+    doc/source/reference/parameters/ommysql-mysqlconfig-section.rst \
+    doc/source/reference/parameters/ommysql-pwd.rst \
+    doc/source/reference/parameters/ommysql-server.rst \
+    doc/source/reference/parameters/ommysql-serverport.rst \
+    doc/source/reference/parameters/ommysql-socket.rst \
+    doc/source/reference/parameters/ommysql-template.rst \
+    doc/source/reference/parameters/ommysql-uid.rst \
+    doc/source/reference/parameters/ompgsql-conninfo.rst \
+    doc/source/reference/parameters/ompgsql-db.rst \
+    doc/source/reference/parameters/ompgsql-pass.rst \
+    doc/source/reference/parameters/ompgsql-port.rst \
+    doc/source/reference/parameters/ompgsql-server.rst \
+    doc/source/reference/parameters/ompgsql-template.rst \
+    doc/source/reference/parameters/ompgsql-user.rst \
     doc/source/reference/parameters/omprog-begintransactionmark.rst \
     doc/source/reference/parameters/omprog-binary.rst \
     doc/source/reference/parameters/omprog-closetimeout.rst \
@@ -934,6 +951,28 @@ EXTRA_DIST += \
     doc/source/reference/parameters/omprog-signalonclose.rst \
     doc/source/reference/parameters/omprog-template.rst \
     doc/source/reference/parameters/omprog-usetransactions.rst \
+    doc/source/reference/parameters/omrelp-conn-timeout.rst \
+    doc/source/reference/parameters/omrelp-keepalive.rst \
+    doc/source/reference/parameters/omrelp-keepalive-interval.rst \
+    doc/source/reference/parameters/omrelp-keepalive-probes.rst \
+    doc/source/reference/parameters/omrelp-keepalive-time.rst \
+    doc/source/reference/parameters/omrelp-localclientip.rst \
+    doc/source/reference/parameters/omrelp-port.rst \
+    doc/source/reference/parameters/omrelp-rebindinterval.rst \
+    doc/source/reference/parameters/omrelp-target.rst \
+    doc/source/reference/parameters/omrelp-template.rst \
+    doc/source/reference/parameters/omrelp-timeout.rst \
+    doc/source/reference/parameters/omrelp-tls.rst \
+    doc/source/reference/parameters/omrelp-tls-authmode.rst \
+    doc/source/reference/parameters/omrelp-tls-cacert.rst \
+    doc/source/reference/parameters/omrelp-tls-compression.rst \
+    doc/source/reference/parameters/omrelp-tls-mycert.rst \
+    doc/source/reference/parameters/omrelp-tls-myprivkey.rst \
+    doc/source/reference/parameters/omrelp-tls-permittedpeer.rst \
+    doc/source/reference/parameters/omrelp-tls-prioritystring.rst \
+    doc/source/reference/parameters/omrelp-tls-tlscfgcmd.rst \
+    doc/source/reference/parameters/omrelp-tls-tlslib.rst \
+    doc/source/reference/parameters/omrelp-windowsize.rst \
     doc/source/reference/parameters/omsendertrack-cmdfile.rst \
     doc/source/reference/parameters/omsendertrack-interval.rst \
     doc/source/reference/parameters/omsendertrack-senderid.rst \
@@ -949,6 +988,8 @@ EXTRA_DIST += \
     doc/source/reference/parameters/omsnmp-trapoid.rst \
     doc/source/reference/parameters/omsnmp-traptype.rst \
     doc/source/reference/parameters/omsnmp-version.rst \
+    doc/source/reference/parameters/omstdout-ensurelfending.rst \
+    doc/source/reference/parameters/omstdout-template.rst \
     doc/source/reference/parameters/omuxsock-abstract.rst \
     doc/source/reference/parameters/omuxsock-networknamespace.rst \
     doc/source/reference/parameters/omuxsock-socketname.rst \

--- a/doc/source/reference/parameters/ommysql-mysqlconfig-file.rst
+++ b/doc/source/reference/parameters/ommysql-mysqlconfig-file.rst
@@ -48,6 +48,7 @@ Legacy names (for reference)
 Historic names/directives for compatibility. Do not use in new configs.
 
 .. _ommysql.parameter.legacy.ommysqlconfigfile:
+
 - $OmMySQLConfigFile — maps to MySQLConfig.File (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/ommysql-mysqlconfig-section.rst
+++ b/doc/source/reference/parameters/ommysql-mysqlconfig-section.rst
@@ -54,6 +54,7 @@ Legacy names (for reference)
 Historic names/directives for compatibility. Do not use in new configs.
 
 .. _ommysql.parameter.legacy.ommysqlconfigsection:
+
 - $OmMySQLConfigSection — maps to MySQLConfig.Section (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/ommysql-serverport.rst
+++ b/doc/source/reference/parameters/ommysql-serverport.rst
@@ -44,6 +44,7 @@ Legacy names (for reference)
 Historic names/directives for compatibility. Do not use in new configs.
 
 .. _ommysql.parameter.legacy.actionommysqlserverport:
+
 - $ActionOmmysqlServerPort — maps to ServerPort (status: legacy)
 
 .. index::

--- a/doc/source/reference/parameters/omrelp-rebindinterval.rst
+++ b/doc/source/reference/parameters/omrelp-rebindinterval.rst
@@ -25,7 +25,7 @@ This parameter applies to :doc:`../../configuration/modules/omrelp`.
 
 Description
 -----------
-Permits to specify an interval at which the current connection is broken and re-established. This setting is primarily an aid to load balancers. After the configured number of messages has been transmitted, the current connection is terminated and a new one started. This usually is perceived as a ``new connection'' by load balancers, which in turn forward messages to another physical target system.
+Permits to specify an interval at which the current connection is broken and re-established. This setting is primarily an aid to load balancers. After the configured number of messages has been transmitted, the current connection is terminated and a new one started. This usually is perceived as a ``new connection`` by load balancers, which in turn forward messages to another physical target system.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/omstdout-ensurelfending.rst
+++ b/doc/source/reference/parameters/omstdout-ensurelfending.rst
@@ -43,6 +43,7 @@ Legacy names (for reference)
 Historic names/directives for compatibility. Do not use in new configs.
 
 .. _omstdout.parameter.legacy.actionomstdoutensurelfending:
+
 - ``$ActionOMStdoutEnsureLFEnding`` — maps to ensureLFEnding (status: legacy)
 
 .. index::


### PR DESCRIPTION

Fixes docutils warnings that were causing the documentation build to fail:

1. ommysql-mysqlconfig-file.rst: Added missing blank line after explicit markup directive
2. ommysql-mysqlconfig-section.rst: Added missing blank line after explicit markup directive  
3. ommysql-serverport.rst: Added missing blank line after explicit markup directive
4. omrelp-rebindinterval.rst: Fixed inline literal syntax (changed ``new connection'' to ``new connection``)
5. omstdout-ensurelfending.rst: Added missing blank line after explicit markup directive

All fixes follow reStructuredText syntax requirements where explicit markup
directives must be followed by a blank line, and inline literals require
matching double backticks on both sides.

The documentation now builds without warnings when using SPHINXOPTS="-W -q --keep-going".