### PR TITLE
CI: fix doc CI run

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -6,8 +6,6 @@ name: documentation build
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
   push:
     branches: [main, master]
   workflow_dispatch:
@@ -29,9 +27,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 8
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Check for doc changes
         id: doc_changes


### PR DESCRIPTION
pulling main branch was too shallow, resulting in incomplete doc updates from main, thus in (invalid) CI failure for non-rebased branches.

