### PR TITLE
rainerscript: add split() function

### DIFF
--- a/doc/source/rainerscript/functions/rs-split.rst
+++ b/doc/source/rainerscript/functions/rs-split.rst
@@ -1,0 +1,50 @@
+split()
+=======
+
+Purpose
+-------
+
+Splits a string into a JSON array using a specified separator.
+
+Syntax
+------
+
+.. code-block:: none
+
+   split(string, separator)
+
+Parameters
+----------
+
+string
+   The input string to be split.
+
+separator
+   The delimiter string used to split the input. Can be a single character
+   or a multi-character string.
+
+Return Value
+------------
+
+Returns a JSON array containing the split substrings.
+
+Examples
+--------
+
+.. code-block:: none
+
+   # Single-character separator
+   set $!tags = "error,warning,info";
+   set $!tag_array = split($!tags, ",");
+   # Result: ["error", "warning", "info"]
+
+   # Multi-character separator
+   set $!data = "item1::item2::item3";
+   set $!items = split($!data, "::");
+   # Result: ["item1", "item2", "item3"]
+
+See Also
+--------
+
+- :doc:`field() <rs-field>` - Extract a single field from delimited data
+- :doc:`parse_json() <rs-parse_json>` - Parse a JSON string

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -249,7 +249,8 @@ enum cnffuncid {
     CNFFUNC_PREVIOUS_ACTION_SUSPENDED,
     CNFFUNC_SCRIPT_ERROR,
     CNFFUNC_HTTP_REQUEST,
-    CNFFUNC_IS_TIME
+    CNFFUNC_IS_TIME,
+    CNFFUNC_SPLIT
 };
 
 typedef struct cnffunc cnffunc_t;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -459,6 +459,7 @@ TESTS +=  \
 	rscript_exists-not4.sh \
 	rscript-config_enable-on.sh \
 	rscript_get_property.sh \
+	rscript_split.sh \
 	config_output-o-option.sh \
 	rs-cnum.sh \
 	rs-substring.sh \
@@ -622,7 +623,8 @@ TESTS +=  \
 	threadingmq.sh \
 	threadingmqaq.sh \
 	func-substring-invld-startpos-vg.sh \
-	rscript_trim-vg.sh
+	rscript_trim-vg.sh \
+	rscript_split-vg.sh
 if ENABLE_LIBGCRYPT
 TESTS +=  \
 	queue-encryption-disk_keyfile-vg.sh
@@ -2319,6 +2321,8 @@ EXTRA_DIST= \
 	rscript_unflatten_object-vg.sh \
 	rscript_get_property.sh \
 	rscript_get_property-vg.sh \
+	rscript_split.sh \
+	rscript_split-vg.sh \
 	rs-cnum.sh \
 	rs-int2hex.sh \
 	rs-substring.sh \
@@ -3206,6 +3210,7 @@ EXTRA_DIST= \
 	rscript_hash64-vg.sh \
 	rscript_replace.sh \
 	rscript_replace_complex.sh \
+	rscript_split.sh \
 	testsuites/complex_replace_input \
 	rscript_unaffected_reset.sh \
 	rscript_wrap2.sh \

--- a/tests/rscript_split-vg.sh
+++ b/tests/rscript_split-vg.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Added 2025-12-19 by 20syldev, released under ASL 2.0
+export USE_VALGRIND="YES"
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%$!result%\n")
+
+if $msg contains "msgnum:" then {
+    set $!input = "slambert@zenetys.com, bdolez@zenetys.com, contact@sylvain.pro";
+    set $!result = split($!input, ", ");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup_vg
+tcpflood -m1
+shutdown_when_empty
+wait_shutdown_vg
+check_exit_vg
+
+export EXPECTED='[ "slambert@zenetys.com", "bdolez@zenetys.com", "contact@sylvain.pro" ]'
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test

--- a/tests/rscript_split.sh
+++ b/tests/rscript_split.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Added 2025-12-19 by 20syldev, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%$!result%\n")
+
+if $msg contains "msgnum:" then {
+    set $!input = "abc@example.com, def@example.com, ghi@example.com";
+    set $!result = split($!input, ", ");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+tcpflood -m1
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='[ "abc@example.com", "def@example.com", "ghi@example.com" ]'
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test


### PR DESCRIPTION
### Summary
Users need to parse delimited strings (CSV, tags, paths) into arrays for iteration or JSON output without external processing.

### Notes
- Tests included: `rscript_split.sh` and `rscript_split-vg.sh`
- Documentation added: `doc/source/rainerscript/functions/rs-split.rst`

Impact: New RainerScript function available to all users.
- **Before:** No native way to split strings into arrays in RainerScript. 
- **After:** `split(string, separator)` returns a JSON array of substrings.