### PR TITLE
docs: formalize defensive coding and assertion patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -240,6 +240,16 @@ When fixing compiler warnings like `stringop-overread`, explain in the commit me
 
 -----
 
+## Defensive Coding and Assertions
+
+Use `assert()` to signal "impossible" states to Static Analyzers and AI agents. Whenever feasible and low-complexity, follow with a defensive `if` check to prevent production crashes. See [Defensive Coding Practice](doc/source/development/coding_practices/defensive_coding.rst) for full details.
+
+- **Mandatory**: `assert()` for invariants (allows SA/AI to reason about code).
+- **Recommended**: Defensive `if` check (optional if fallback logic is excessively complex).
+- **Prohibited**: `__builtin_unreachable()` (causes Undefined Behavior).
+
+-----
+
 ## Editor & Formatting Configuration
 
 The repository includes:

--- a/Makefile.am
+++ b/Makefile.am
@@ -264,6 +264,7 @@ EXTRA_DIST += \
     doc/source/development/coding_practices/embedded_ipv4_tail_helper.rst \
     doc/source/development/coding_practices/error_logging_with_errno.rst \
     doc/source/development/coding_practices/externalized_helper_contracts.rst \
+    doc/source/development/coding_practices/defensive_coding.rst \
     doc/source/development/config_data_model.rst \
     doc/source/development/debugging.rst \
     doc/source/development/dev_action_threads.rst \

--- a/doc/source/development/coding_practices.rst
+++ b/doc/source/development/coding_practices.rst
@@ -122,6 +122,7 @@ toctree so navigation remains discoverable from the development guide.
    coding_practices/externalized_helper_contracts
    coding_practices/embedded_ipv4_tail_helper
    coding_practices/error_logging_with_errno
+   coding_practices/defensive_coding
 
 AI agent integration
 --------------------

--- a/doc/source/development/coding_practices/defensive_coding.rst
+++ b/doc/source/development/coding_practices/defensive_coding.rst
@@ -1,0 +1,34 @@
+.. _defensive-coding-and-assertions:
+
+Defensive Coding and Assertions
+===============================
+
+**Classification**: Pattern
+
+**Context**: Handling "impossible" states or logic paths that should theoretically never be reached.
+
+**Why it matters**:
+Rsyslog prioritizes production stability. We use Static Analysis (SA) and CI to detect bugs. ``assert()`` tells analyzers/AI that a state is invalid. Defensive checks protect production from crashes if the "impossible" happens.
+
+**Steps**:
+
+1.  **Mandatory Assertion**: Always use ``assert()`` to define the invariant. This informs SA tools and AI assistants that this state is invalid.
+2.  **Optional Defensive Fallback**: Follow the assert with an ``if`` check to handle the failure gracefully. This is recommended but optional if the fallback handler would be excessively complex or introduce more risk than it solves.
+3.  **No UB**: Never use ``__builtin_unreachable()``.
+4.  **Order**: Place the ``assert()`` before the defensive check.
+
+**Example**:
+
+.. code-block:: c
+
+   /* 1. Inform SA/AI */
+   assert(pPtr != NULL);
+
+   /* 2. Defensive check (optional if complex) */
+   if (pPtr == NULL) {
+       LogMsg(0, NO_ERRCODE, LOG_ERR, "logic error: pPtr is NULL");
+       return;
+   }
+
+   /* 3. Logic */
+   do_something(pPtr);


### PR DESCRIPTION
Standardizing how we handle "impossible" states to help automated tools detect bugs while keeping production code simple and stable. This modernization step aids maintainability and AI-assisted reviews.

BEFORE: No formalized guidance for "impossible" path handling.
AFTER: Mandatory assertions with optional defensive fallbacks.

Introduced a formalized hybrid pattern for defensive programming. The new guidance mandates the use of assert() for all invariants to allow Static Analyzers and AI agents to reason about code state correctly. It also recommends an optional defensive if fallback to prevent production crashes, except where recovery logic would be excessively complex. Updated the top-level AGENTS.md with a brief instruction and added a detailed practice document to the coding_practices catalog. Prohibited use of __builtin_unreachable() to prevent undefined behavior in release builds.

AI-Agent: Antigravity
