### PR TITLE
doc: add RAG Knowledge Base extraction and build integration

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -125,6 +125,19 @@ jobs:
           cd doc-builder/doc
           make html SPHINXOPTS="-j8 -W -q --keep-going"
 
+      - name: Build RAG Knowledge Base
+        if: >-
+          ${{ github.event_name != 'pull_request' ||
+          steps.doc_changes.outputs.any_changed == 'true' }}
+        run: |
+          cd doc-builder/doc
+          python3 build_rag_db.py
+          # Verify the RAG database was created and has content
+          test -f build/rag/rsyslog_rag_db.json
+          chunk_count=$(python3 -c "import json; print(len(json.load(open('build/rag/rsyslog_rag_db.json'))))")
+          echo "Generated $chunk_count RAG chunks"
+          test "$chunk_count" -gt 10000
+
       - name: Upload build artifact
         if: >-
           ${{ github.event_name != 'pull_request' ||
@@ -133,6 +146,16 @@ jobs:
         with:
           name: docs-html
           path: doc-builder/doc/build/html
+
+      - name: Upload RAG artifact
+        if: >-
+          ${{ github.event_name != 'pull_request' ||
+          steps.doc_changes.outputs.any_changed == 'true' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: rag-knowledge-base
+          path: doc-builder/doc/build/rag/rsyslog_rag_db.json
+
 
 
   publish_pr_preview:

--- a/Makefile.am
+++ b/Makefile.am
@@ -30,6 +30,7 @@ EXTRA_DIST += \
     doc/Makefile \
     doc/README.md \
     doc/STRATEGY.md \
+    doc/build_rag_db.py \
     doc/ai/README.md \
     doc/ai/authoring_guidelines.md \
     doc/ai/chunking_and_embeddings.md \

--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -36,6 +36,7 @@ This guide applies to everything under `doc/`.
 
 ## Build & validation
 - Run `./doc/tools/build-doc-linux.sh --clean --format html` after changes to catch Sphinx errors early.
+- For RAG Knowledge Base updates, use `make -j16 json-formatter`. This builds the doctrees and runs the extraction script to generate `doc/build/rag/rsyslog_rag_db.json`.
 - For quick linting, use `make -C doc html` (uses the repo’s virtualenv if present).
 - Verify Mermaid diagrams render correctly; invalid syntax halts the build.
 - Documentation-only commits generally do **not** require the full C test suite.
@@ -59,5 +60,7 @@ This guide applies to everything under `doc/`.
 | Authoring guide | `doc/ai/authoring_guidelines.md` |
 | Concept/tutorial templates | `doc/ai/templates/` |
 | Build scripts | `doc/tools/` |
+| RAG Knowledge Base script | `doc/build_rag_db.py` |
+| RAG Knowledge Base (Output) | `doc/build/rag/rsyslog_rag_db.json` |
 | Strategy and style | `doc/STRATEGY.md` |
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -11,7 +11,7 @@ define add_parallel_jobs
         $(eval SPHINXOPTS += $(if $(filter -j%,$(SPHINXOPTS)),,$(filter -j%,$(MAKEFLAGS))))
 endef
 
-.PHONY: help clean html html-with-sitemap singlehtml json alljson
+.PHONY: help clean html html-with-sitemap singlehtml json alljson rag-db json-formatter
 
 help:
 	@$(call add_parallel_jobs)
@@ -50,3 +50,8 @@ alljson: json
 %:
 	@$(call add_parallel_jobs)
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+rag-db: html
+	@python3 build_rag_db.py
+
+json-formatter: rag-db

--- a/doc/README.md
+++ b/doc/README.md
@@ -104,11 +104,13 @@ From the repository root:
   - `make -C doc singlehtml`
 - List available builders/targets:
   - `make -C doc help`
+- Generate RAG Knowledge Base (JSON):
+  - `make -C doc json-formatter` (Alias for `rag-db`; builds HTML first; output in `build/rag/`)
 
 Tips:
 - Pass extra Sphinx options via `SPHINXOPTS`, e.g. warnings-as-errors:
   - `make -C doc html SPHINXOPTS="-W -q --keep-going"`
-- Use parallel jobs: `make -C doc -j4 html` (the Makefile forwards `-j` to Sphinx).
+- Use parallel jobs: `make -C doc -j4 html` (the Makefile forwards `-j` to Sphinx)
 
 ### Quickstart using helper scripts
 

--- a/doc/ai/README.md
+++ b/doc/ai/README.md
@@ -4,18 +4,33 @@
 
 **Audience:** Contributors and AI assistants generating/maintaining docs.
 
-## What’s here
-- `structure_and_paths.md`
-- `authoring_guidelines.md`
-- `mermaid_rules.md`
-- `terminology.md`
-- `chunking_and_embeddings.md`
-- `crosslinking_and_nav.md`
-- `drift_monitoring.md`
-- `templates/` — RST templates for concept and tutorial pages
+## What's here
+
+| File | Purpose |
+|------|---------|
+| `structure_and_paths.md` | Directory layout and naming conventions |
+| `authoring_guidelines.md` | Required blocks, tone, section order |
+| `mermaid_rules.md` | Diagram syntax rules |
+| `terminology.md` | Canonical rsyslog vocabulary |
+| `chunking_and_embeddings.md` | RAG extraction schema and chunk structure |
+| `crosslinking_and_nav.md` | Navigation and cross-reference patterns |
+| `drift_monitoring.md` | Detecting doc/code drift |
+| `module_map.yaml` | Module paths and locking hints |
+| `templates/` | RST templates for concept and tutorial pages |
+
+## RAG Knowledge Base
+
+The documentation build generates a machine-readable RAG dataset at
+`build/rag/rsyslog_rag_db.json`. This is produced by `../build_rag_db.py`
+and contains ~12,000 structured chunks for AI retrieval pipelines.
+
+**Regenerate with:** `make -C doc json-formatter`
+
+See [chunking_and_embeddings.md](chunking_and_embeddings.md) for schema details.
 
 ## Current canonical terms
+
 - **Log pipeline** (internally also called *message pipeline*).
 - Use `getting_started/beginner_tutorials/` (no `learning_path/`).
 
-_Last reviewed:_ YYYY-MM-DD_
+_Last reviewed: 2025-12-23_

--- a/doc/ai/chunking_and_embeddings.md
+++ b/doc/ai/chunking_and_embeddings.md
@@ -1,6 +1,57 @@
 # Chunking & Embeddings
 
+Guidelines for documentation structure and the automated RAG extraction process.
+
+## Authoring Guidelines
+
 - Target 400–900 words per page.
 - One diagram and one code block typical.
 - Use lists; avoid giant paragraphs.
 - Maintain logical independence per file.
+
+## RAG Knowledge Base
+
+The automated extraction is performed by [build_rag_db.py](../build_rag_db.py),
+which processes Sphinx doctrees and generates `build/rag/rsyslog_rag_db.json`.
+
+### Chunk Types
+
+| Type | Description |
+|------|-------------|
+| `section_header` | Document section titles with hierarchy context |
+| `text_block` | Prose content (~2000 chars, merged thematically) |
+| `code` | Configuration examples and code blocks |
+
+### Metadata Schema
+
+Each chunk contains:
+
+- **chunk_id**: Stable MD5 hash for deduplication
+- **parent_id**: Links to parent section for context retrieval
+- **attributes**:
+  - `module`: rsyslog module name (e.g., imfile, omhttp) or "core"
+  - `scope`: Parameter scope (input, action, module, general)
+  - `item`: Specific parameter or section name
+- **vector_text**: Optimized for embedding search
+- **llm_text**: Full context with syntax templates for LLM consumption
+
+### Syntax Templates
+
+For parameter documentation, the extractor generates hints like:
+```
+input(type="imfile" file="...")
+action(type="omhttp" server="...")
+module(load="impstats" interval="...")
+```
+
+### Regeneration
+
+```bash
+# Full build with RAG extraction
+make -C doc json-formatter
+
+# Or use the alias
+make -C doc rag-db
+```
+
+The CI workflow automatically builds and uploads the RAG artifact on every PR.

--- a/doc/build_rag_db.py
+++ b/doc/build_rag_db.py
@@ -1,0 +1,297 @@
+
+import os
+import pickle
+import json
+import hashlib
+import re
+import traceback
+from docutils import nodes
+
+# Configuration
+BUILD_DIR = "build/doctrees"
+OUTPUT_FILE = "build/rag/rsyslog_rag_db.json"
+MAX_CHUNK_CHARS = 2000
+MIN_CHUNK_CHARS = 15
+
+# Module prefixes for detecting module documentation pages
+MODULE_PREFIXES = ('im', 'om', 'mm', 'pm', 'fm')
+
+# Scope detection keywords
+SCOPE_MAP = {
+    "input parameter": "input",
+    "module parameter": "module",
+    "action parameter": "action",
+    "parser parameter": "parser",
+    "template parameter": "template",
+}
+
+# Generic headers that should not generate syntax templates
+GENERIC_HEADERS = {
+    "input parameters", "module parameters", "action parameters",
+    "parameters", "configuration", "description", "notes", "examples",
+    "usage", "see also", "caveats", "input usage", "statistic counters"
+}
+
+# Node type constants for cleaner isinstance checks
+TEXT_NODES = (nodes.paragraph, nodes.Text, nodes.title)
+CONTAINER_NODES = (
+    nodes.bullet_list, nodes.enumerated_list, nodes.list_item,
+    nodes.definition_list, nodes.definition, nodes.field_list, nodes.field,
+    nodes.field_body, nodes.note, nodes.table, nodes.tgroup, nodes.tbody,
+    nodes.row, nodes.entry, nodes.block_quote
+)
+
+def get_node_text(node):
+    """Recursively extract raw text from a node, ignoring tags."""
+    return node.astext().replace('\n', ' ').strip()
+
+def generate_id(content, breadcrumbs):
+    """Generate a stable unique ID for a chunk (not for security)."""
+    seed = f"{breadcrumbs}|{content}".encode('utf-8')
+    return hashlib.md5(seed, usedforsecurity=False).hexdigest()  # noqa: S324
+
+def extract_module_from_filename(filename):
+    """Extract rsyslog module name from filename."""
+    base = os.path.basename(filename).split('.')[0]
+    match = re.match(r'^([iofpm]m[a-z0-9]+)', base)
+    if match:
+        return match.group(1)
+    return base
+
+def is_module_page(filename):
+    """Heuristic to determine if this file documents an rsyslog module."""
+    base = os.path.basename(filename)
+    return base.startswith(MODULE_PREFIXES)
+
+def parse_attributes(context_stack, filename):
+    """Extract module, scope, and item from the context stack."""
+    module = extract_module_from_filename(filename)
+    attributes = {
+        "module": module if is_module_page(filename) else "core",
+        "scope": "general",
+        "item": "none"
+    }
+    for part in context_stack:
+        if "Rsyslog Module" in part:
+            found_mod = part.replace("Rsyslog Module ", "").strip()
+            if found_mod:
+                attributes["module"] = found_mod.split(' ')[0].rstrip(':')
+                break
+    stack_str = " ".join(context_stack).lower()
+    for keyword, scope in SCOPE_MAP.items():
+        if keyword in stack_str:
+            attributes["scope"] = scope
+            break
+    if context_stack:
+        attributes["item"] = context_stack[-1]
+    return attributes
+
+def get_syntax_template(attrs):
+    """Generate a syntax hint based on scope and module."""
+    module = attrs["module"]
+    item = attrs["item"]
+    scope = attrs["scope"]
+    if not item or item.lower() in GENERIC_HEADERS or item == "none":
+        return ""
+    # Extract the actual parameter name from the reference or title
+    # e.g., "param-imfile-file" -> "file", or "Input Parameters" -> ""
+    match = re.search(r'(?:param-[a-z0-9]+-)?([a-z0-9\._]+)$', item, re.IGNORECASE)
+    clean_item = match.group(1) if match else item.split()[-1]
+    
+    if scope == "input":
+        return f'input(type="{module}" {clean_item}="...")'
+    elif scope == "action":
+        return f'action(type="{module}" {clean_item}="...")'
+    elif scope == "module":
+        return f'module(load="{module}" {clean_item}="...")'
+    return ""
+
+class ExtractorState:
+    def __init__(self, filename):
+        self.filename = filename
+        self.chunks = []
+        self.context_stack = []
+        self.buffer = []
+        self.buf_char_count = 0
+        self.current_parent_id = None
+
+    def flush_buffer(self):
+        if not self.buffer:
+            return
+        
+        text = "\n".join(self.buffer).strip()
+        if len(text) < MIN_CHUNK_CHARS:
+            return
+            
+        attrs = parse_attributes(self.context_stack, self.filename)
+        breadcrumbs = " > ".join(self.context_stack)
+        chunk_id = generate_id(text, breadcrumbs)
+        
+        # Determine if we can identify a specific item name from patterns
+        if attrs["scope"] in ["input", "module", "action"]:
+            match = re.search(r'param-[a-z0-9]+-([a-z0-9\._]+)', text, re.IGNORECASE)
+            if match:
+                attrs["item"] = match.group(1)
+            elif attrs["item"].lower() in ["input parameters", "module parameters", "action parameters"]:
+                words = text.split()
+                if words and re.match(r'^[a-z0-9\._]+$', words[0], re.IGNORECASE):
+                    attrs["item"] = words[0]
+
+        syntax = get_syntax_template(attrs)
+        syntax_line = f"Syntax: {syntax}\n" if syntax else ""
+        
+        vector_text = f"rsyslog {attrs['module']} {attrs['scope']} {attrs['item']} {text}"
+        llm_text = f"Module: {attrs['module']}\nScope: {attrs['scope']}\n"
+        if attrs['item'] != "none":
+            llm_text += f"Item: {attrs['item']}\n"
+        llm_text += syntax_line
+        llm_text += f"Content: {text}"
+
+        self.chunks.append({
+            "chunk_id": chunk_id,
+            "parent_id": self.current_parent_id,
+            "type": "text_block",
+            "attributes": attrs,
+            "vector_text": vector_text,
+            "llm_text": llm_text,
+            "source": self.filename
+        })
+        self.buffer = []
+        self.buf_char_count = 0
+
+    def add_to_buffer(self, text):
+        if not text: return
+        self.buffer.append(text)
+        self.buf_char_count += len(text)
+        if self.buf_char_count >= MAX_CHUNK_CHARS:
+            self.flush_buffer()
+
+    def process_node(self, node):
+        """Recursive node processor."""
+        
+        if isinstance(node, nodes.section):
+            self.flush_buffer()
+            title_node = next((n for n in node.children if isinstance(n, nodes.title)), None)
+            old_parent_id = self.current_parent_id
+            
+            if title_node:
+                title_text = get_node_text(title_node)
+                self.context_stack.append(title_text)
+                
+                attrs = parse_attributes(self.context_stack, self.filename)
+                breadcrumbs = " > ".join(self.context_stack[:-1])
+                content = f"Section: {title_text} (Part of {self.context_stack[0]})"
+                
+                chunk_id = generate_id(content, breadcrumbs + " > " + title_text)
+                self.chunks.append({
+                    "chunk_id": chunk_id,
+                    "parent_id": old_parent_id,
+                    "type": "section_header",
+                    "attributes": attrs,
+                    "vector_text": f"rsyslog {attrs['module']} {attrs['scope']} {title_text}",
+                    "llm_text": (f"Module: {attrs['module']}\nScope: {attrs['scope']}\nSection: {title_text}\n"
+                                f"Content: Documentation for {title_text} in {self.context_stack[0]}."),
+                    "source": self.filename
+                })
+                self.current_parent_id = chunk_id
+
+            # Recurse into section children
+            for child in node.children:
+                if isinstance(child, nodes.title): continue
+                self.process_node(child)
+            
+            self.flush_buffer()
+            if title_node:
+                self.context_stack.pop()
+            self.current_parent_id = old_parent_id
+
+        elif isinstance(node, nodes.literal_block):
+            self.flush_buffer()
+            code_text = node.astext()
+            attrs = parse_attributes(self.context_stack, self.filename)
+            chunk_id = generate_id(code_text, " > ".join(self.context_stack) + " [code]")
+            self.chunks.append({
+                "chunk_id": chunk_id,
+                "parent_id": self.current_parent_id,
+                "type": "code",
+                "attributes": attrs,
+                "vector_text": f"rsyslog {attrs['module']} {attrs['scope']} code example {self.context_stack[-1] if self.context_stack else ''}",
+                "llm_text": f"Module: {attrs['module']}\nScope: {attrs['scope']}\nCode Example:\n{code_text}",
+                "source": self.filename
+            })
+
+        elif isinstance(node, TEXT_NODES):
+            # Direct text nodes contribute to buffer
+            self.add_to_buffer(get_node_text(node))
+
+        elif isinstance(node, CONTAINER_NODES):
+            # Container nodes: recurse into children
+            for child in node.children:
+                self.process_node(child)
+        
+        elif isinstance(node, nodes.document):
+            for child in node.children:
+                self.process_node(child)
+        
+        else:
+            # Fallback for unknown nodes: if they have children, try to recurse
+            if hasattr(node, 'children'):
+                for child in node.children:
+                    self.process_node(child)
+
+def process_doctree(filepath, filename):
+    # Doctree files are generated by Sphinx during the same build; not untrusted data
+    with open(filepath, 'rb') as f:
+        try:
+            doctree = pickle.load(f)  # noqa: S301
+        except (pickle.UnpicklingError, EOFError, AttributeError) as e:
+            print(f"Warning: Failed to process doctree {filepath}: {e}")
+            return []
+    
+    state = ExtractorState(filename)
+    
+    # Context Injection
+    title = "Untitled"
+    for node in doctree.traverse(nodes.title):
+        title = get_node_text(node)
+        break
+        
+    if is_module_page(filename):
+        module_name = extract_module_from_filename(filename)
+        state.context_stack = [f"Rsyslog Module {module_name}"]
+    else:
+        state.context_stack = [title]
+
+    state.process_node(doctree)
+    state.flush_buffer()
+    return state.chunks
+
+def main():
+    all_rag_data = []
+    print(f"Scanning {BUILD_DIR}...")
+    
+    if not os.path.exists(BUILD_DIR):
+        print(f"Error: Directory {BUILD_DIR} not found. Did you run 'make html'?")
+        return
+
+    for root, _, files in os.walk(BUILD_DIR):
+        for file in files:
+            if file.endswith(".doctree"):
+                try:
+                    file_chunks = process_doctree(os.path.join(root, file), file)
+                    all_rag_data.extend(file_chunks)
+                except Exception:
+                    print(f"Failed to process {file}:")
+                    traceback.print_exc()
+
+    print(f"Generated {len(all_rag_data)} chunks.")
+    
+    output_dir = os.path.dirname(OUTPUT_FILE)
+    os.makedirs(output_dir, exist_ok=True)
+
+    with open(OUTPUT_FILE, 'w', encoding='utf-8') as f:
+        json.dump(all_rag_data, f, indent=2)
+    print(f"Saved to {OUTPUT_FILE}")
+
+if __name__ == "__main__":
+    main()

--- a/doc/source/about/ai_first.rst
+++ b/doc/source/about/ai_first.rst
@@ -193,6 +193,10 @@ verified by any contributor:
 - Inline provenance notes in AI-assisted files.
 - Issue and PR templates guiding contributors to supply needed info.
 - Metadata template applied to parameter documentation pages.
+- RAG Knowledge Base (``build/rag/rsyslog_rag_db.json``): A machine-readable
+  dataset of ~12,000 structured chunks extracted from all documentation pages,
+  enabling AI-powered search and context injection for the rsyslog Assistant.
+  Regenerated automatically by CI; build locally with ``make json-formatter``.
 
 .. _ai-first-roles:
 .. index:: Roles; Human-in-Control


### PR DESCRIPTION
This commit adds a context-aware RAG dataset generator and integrates it into the build system to support advanced AI-driven documentation workflows. It ensures a consistent knowledge base for RAG pipelines.

Impact: Adds doc/build_rag_db.py; output in build/rag/ (cleaned).

Before:
- No automated way to generate RAG-ready JSON from Sphinx doctrees.
- Nested code blocks in lists and notes were skipped during extraction.

After:
- Recursive walker captures all nested code and prose thematic blocks.
- Thematic merging creates context-rich chunks (~2000 chars).
- Metadata (module, scope, item) and syntax templates injected.
- Makefile target 'json-formatter' (and 'rag-db') automated the build.
- Project docs (README.md, AGENTS.md) updated with instructions.

AI-Agent: Antigravity
