### PR TITLE
doc: fix version (accidentally not updated)

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -228,9 +228,9 @@ rst_epilog = """
 # real values will be generated dynamically from info in the repo. If the
 # user builds the docs from "bare" sources not yet processed
 ###############################################################################
-version = '8.2510'
-release = '8.2510.0'
-#release = version + ' daily stable'
+version = '8.2512'
+#release = '8.2512.0'
+release = version + ' daily stable'
 
 # For this to be true, it means that we are not attempting to build from
 # a release tarball, as otherwise the values above would have been replaced


### PR DESCRIPTION
The version was not updated after last scheduled stable release. Now done.

