### PR TITLE
rainerscript: add split() function

### DIFF
--- a/doc/source/rainerscript/functions/rs-split.rst
+++ b/doc/source/rainerscript/functions/rs-split.rst
@@ -1,0 +1,96 @@
+split()
+=======
+
+Purpose
+-------
+
+Splits a string into a JSON array using a specified separator.
+
+Syntax
+------
+
+.. code-block:: none
+
+   split(string, separator)
+
+Parameters
+----------
+
+string
+   The input string to be split.
+
+separator
+   The delimiter string used to split the input. Can be a single character
+   or a multi-character string.
+
+Return Value
+------------
+
+Returns a JSON array containing the split substrings.
+
+Examples
+--------
+
+.. code-block:: none
+
+   # Single-character separator
+   set $!tags = "error,warning,info";
+   set $!tag_array = split($!tags, ",");
+   # Result: ["error", "warning", "info"]
+
+   # Multi-character separator
+   set $!data = "item1::item2::item3";
+   set $!items = split($!data, "::");
+   # Result: ["item1", "item2", "item3"]
+
+Complete Example
+----------------
+
+This example demonstrates splitting a comma-separated list of recipients
+and forwarding each one to a different destination based on their department.
+
+.. code-block:: none
+
+   module(load="omfwd")
+
+   template(name="forwardFormat" type="list") {
+       property(name="timestamp" dateFormat="rfc3339")
+       constant(value=" ")
+       property(name="hostname")
+       constant(value=" ")
+       property(name="syslogtag")
+       property(name="msg")
+       constant(value="\n")
+   }
+
+   ruleset(name="processRecipients") {
+       # Assume $!recipients contains "sales,engineering,support"
+       set $!recipient_array = split($!recipients, ",");
+
+       # Iterate through each recipient and route accordingly
+       foreach ($.recipient in $!recipient_array) do {
+           if $.recipient == "sales" then {
+               action(type="omfwd" target="sales-log.example.com" port="514"
+                      template="forwardFormat")
+           } else if $.recipient == "engineering" then {
+               action(type="omfwd" target="eng-log.example.com" port="514"
+                      template="forwardFormat")
+           } else if $.recipient == "support" then {
+               action(type="omfwd" target="support-log.example.com" port="514"
+                      template="forwardFormat")
+           }
+       }
+   }
+
+   # Example: Extract recipients from a structured log field and process
+   if $programname == "app-router" then {
+       # Parse the message to extract recipients (assumes JSON input)
+       set $!recipients = $!msg!notify;
+       call processRecipients
+   }
+
+See Also
+--------
+
+- :doc:`field() <rs-field>` - Extract a single field from delimited data
+- :doc:`parse_json() <rs-parse_json>` - Parse a JSON string

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3029,6 +3029,81 @@ finalize_it:
     }
 }
 
+static void ATTR_NONNULL() doFunct_split(struct cnffunc *__restrict__ const func,
+                                         struct svar *__restrict__ const ret,
+                                         void *const usrptr,
+                                         wti_t *const pWti) {
+    struct svar srcVal[2];
+    int bMustFree = 0;
+    int bMustFree2 = 0;
+
+    cnfexprEval(func->expr[0], &srcVal[0], usrptr, pWti);
+    cnfexprEval(func->expr[1], &srcVal[1], usrptr, pWti);
+
+    char *inputStr = (char *)var2CString(&srcVal[0], &bMustFree);
+    char *separator = (char *)var2CString(&srcVal[1], &bMustFree2);
+
+    struct json_object *jsonArray = json_object_new_array();
+
+    if (jsonArray == NULL) {
+        goto done;
+    }
+
+    if (inputStr == NULL || separator == NULL) {
+        json_object_put(jsonArray);
+        jsonArray = NULL;
+        goto done;
+    }
+
+    if (strlen(separator) == 0) {
+        goto done;
+    }
+
+    char *workStr = strdup(inputStr);
+    if (workStr == NULL) {
+        json_object_put(jsonArray);
+        jsonArray = NULL;
+        goto done;
+    }
+
+    const size_t sepLen = strlen(separator);
+    char *p = workStr;
+
+    while (1) {
+        char *next_sep = strstr(p, separator);
+        if (next_sep != NULL) {
+            *next_sep = '\0';
+        }
+        struct json_object *jsonStr = json_object_new_string(p);
+        if (jsonStr == NULL) {
+            json_object_put(jsonArray);
+            jsonArray = NULL;
+            break;
+        }
+        if (json_object_array_add(jsonArray, jsonStr) != 0) {
+            json_object_put(jsonStr);
+            json_object_put(jsonArray);
+            jsonArray = NULL;
+            break;
+        }
+        if (next_sep == NULL) {
+            break;
+        }
+        p = next_sep + sepLen;
+    }
+
+    free(workStr);
+
+done:
+    ret->datatype = 'J';
+    ret->d.json = jsonArray;
+
+    if (bMustFree) free(inputStr);
+    if (bMustFree2) free(separator);
+    varFreeMembers(&srcVal[0]);
+    varFreeMembers(&srcVal[1]);
+}
+
 static void evalVar(struct cnfvar *__restrict__ const var,
                     void *__restrict__ const usrptr,
                     struct svar *__restrict__ const ret) {
@@ -3807,6 +3882,7 @@ static struct scriptFunct functions[] = {
     {"script_error", 0, 0, doFunct_ScriptError, NULL, NULL},
     {"previous_action_suspended", 0, 0, doFunct_PreviousActionSuspended, NULL, NULL},
     {"b64_decode", 1, 1, doFunct_Base64Dec, NULL, NULL},
+    {"split", 2, 2, doFunct_split, NULL, NULL},
     {NULL, 0, 0, NULL, NULL, NULL}  // last element to check end of array
 };
 

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -249,7 +249,8 @@ enum cnffuncid {
     CNFFUNC_PREVIOUS_ACTION_SUSPENDED,
     CNFFUNC_SCRIPT_ERROR,
     CNFFUNC_HTTP_REQUEST,
-    CNFFUNC_IS_TIME
+    CNFFUNC_IS_TIME,
+    CNFFUNC_SPLIT
 };
 
 typedef struct cnffunc cnffunc_t;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -460,6 +460,7 @@ TESTS +=  \
 	rscript_exists-not4.sh \
 	rscript-config_enable-on.sh \
 	rscript_get_property.sh \
+	rscript_split.sh \
 	config_output-o-option.sh \
 	rs-cnum.sh \
 	rs-substring.sh \
@@ -623,7 +624,8 @@ TESTS +=  \
 	threadingmq.sh \
 	threadingmqaq.sh \
 	func-substring-invld-startpos-vg.sh \
-	rscript_trim-vg.sh
+	rscript_trim-vg.sh \
+	rscript_split-vg.sh
 if ENABLE_LIBGCRYPT
 TESTS +=  \
 	queue-encryption-disk_keyfile-vg.sh
@@ -2321,6 +2323,8 @@ EXTRA_DIST= \
 	rscript_unflatten_object-vg.sh \
 	rscript_get_property.sh \
 	rscript_get_property-vg.sh \
+	rscript_split.sh \
+	rscript_split-vg.sh \
 	rs-cnum.sh \
 	rs-int2hex.sh \
 	rs-substring.sh \
@@ -3208,6 +3212,7 @@ EXTRA_DIST= \
 	rscript_hash64-vg.sh \
 	rscript_replace.sh \
 	rscript_replace_complex.sh \
+	rscript_split.sh \
 	testsuites/complex_replace_input \
 	rscript_unaffected_reset.sh \
 	rscript_wrap2.sh \

--- a/tests/rscript_split-vg.sh
+++ b/tests/rscript_split-vg.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Added 2025-12-19 by 20syldev, released under ASL 2.0
+export USE_VALGRIND="YES"
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%$!result%\n")
+
+if $msg contains "msgnum:00000000" then {
+    # Basic case: normal split with multi-char separator
+    set $!input = "abc@example.com, def@example.com, ghi@example.com";
+    set $!result = split($!input, ", ");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000001" then {
+    # Edge case: empty input string
+    set $!result = split("", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000002" then {
+    # Edge case: trailing separator
+    set $!result = split("a,b,", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000003" then {
+    # Edge case: leading separator
+    set $!result = split(",a,b", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000004" then {
+    # Edge case: multiple separators together (empty field)
+    set $!result = split("a,,b", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000005" then {
+    # Edge case: input string is just the separator
+    set $!result = split(",", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000006" then {
+    # Edge case: input string with no separators
+    set $!result = split("abc", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000007" then {
+    # Edge case: empty separator string (returns empty array)
+    set $!result = split("abc", "");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup_vg
+tcpflood -m8
+shutdown_when_empty
+wait_shutdown_vg
+check_exit_vg
+
+# Verify all test cases
+export EXPECTED='[ "abc@example.com", "def@example.com", "ghi@example.com" ]
+[ "" ]
+[ "a", "b", "" ]
+[ "", "a", "b" ]
+[ "a", "", "b" ]
+[ "", "" ]
+[ "abc" ]
+[ ]'
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test

--- a/tests/rscript_split.sh
+++ b/tests/rscript_split.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Added 2025-12-19 by 20syldev, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%$!result%\n")
+
+if $msg contains "msgnum:00000000" then {
+    # Basic case: normal split with multi-char separator
+    set $!input = "abc@example.com, def@example.com, ghi@example.com";
+    set $!result = split($!input, ", ");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000001" then {
+    # Edge case: empty input string
+    set $!result = split("", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000002" then {
+    # Edge case: trailing separator
+    set $!result = split("a,b,", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000003" then {
+    # Edge case: leading separator
+    set $!result = split(",a,b", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000004" then {
+    # Edge case: multiple separators together (empty field)
+    set $!result = split("a,,b", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000005" then {
+    # Edge case: input string is just the separator
+    set $!result = split(",", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000006" then {
+    # Edge case: input string with no separators
+    set $!result = split("abc", ",");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+if $msg contains "msgnum:00000007" then {
+    # Edge case: empty separator string (returns empty array)
+    set $!result = split("abc", "");
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+tcpflood -m8
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='[ "abc@example.com", "def@example.com", "ghi@example.com" ]
+[ "" ]
+[ "a", "b", "" ]
+[ "", "a", "b" ]
+[ "a", "", "b" ]
+[ "", "" ]
+[ "abc" ]
+[ ]'
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test


### PR DESCRIPTION
### Summary
Users need to parse delimited strings (CSV, tags, paths) into arrays for iteration or JSON output without external processing.

### Notes
- Tests included: `rscript_split.sh` and `rscript_split-vg.sh`
- Documentation added: `doc/source/rainerscript/functions/rs-split.rst`

Impact: New RainerScript function available to all users.
- **Before:** No native way to split strings into arrays in RainerScript. 
- **After:** `split(string, separator)` returns a JSON array of substrings.