### PR TITLE
rainerscript: add append_json() function

### DIFF
--- a/doc/source/rainerscript/functions/rs-append_json.rst
+++ b/doc/source/rainerscript/functions/rs-append_json.rst
@@ -1,0 +1,73 @@
+append_json()
+=============
+
+Purpose
+-------
+
+Appends an element to a JSON array or adds a key-value pair to a JSON object,
+returning a new object (the original is not modified).
+
+Syntax
+------
+
+.. code-block:: none
+
+   append_json(array, element)
+   append_json(object, key, value)
+
+Parameters
+----------
+
+For arrays (2 parameters):
+
+array
+   The input JSON array to append to.
+
+element
+   The element to add at the end of the array. Can be a string, number,
+   or JSON value.
+
+For objects (3 parameters):
+
+object
+   The input JSON object to add a key-value pair to.
+
+key
+   The key name (string) for the new property.
+
+value
+   The value to associate with the key. Can be a string, number,
+   or JSON value.
+
+Return Value
+------------
+
+Returns a new JSON array or object with the element/property added.
+The original input is not modified. Returns null if the input is invalid.
+
+Examples
+--------
+
+.. code-block:: none
+
+   # Append to an array
+   set $.ret = parse_json('["error", "warning"]', "$!tags");
+   set $!tags = append_json($!tags, "info");
+   # Result: ["error", "warning", "info"]
+
+   # Add a property to an object (assign to a new variable)
+   set $.ret = parse_json('{"name": "test"}', "$!data");
+   set $!result = append_json($!data, "status", "active");
+   # Result in $!result: {"name": "test", "status": "active"}
+
+   # Chain multiple appends on arrays
+   set $.ret = parse_json('[]', "$!arr");
+   set $!arr = append_json($!arr, "first");
+   set $!arr = append_json($!arr, "second");
+   # Result: ["first", "second"]
+
+See Also
+--------
+
+- :doc:`split() <rs-split>` - Split a string into a JSON array
+- :doc:`parse_json() <rs-parse_json>` - Parse a JSON string

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3252,6 +3252,102 @@ finalize_it:
     ret->d.n = result;
 }
 
+static void ATTR_NONNULL() doFunct_append_json(struct cnffunc *__restrict__ const func,
+                                               struct svar *__restrict__ const ret,
+                                               void *const usrptr,
+                                               wti_t *const pWti) {
+    struct svar srcVal[3];
+    struct json_object *result = NULL;
+    struct json_object *input = NULL;
+    enum json_type type;
+    char *key = NULL;
+    int bMustFree = 0;
+    int bMustFree2 = 0;
+    int nParamsEvaluated = 0;
+
+    memset(srcVal, 0, sizeof(srcVal));
+
+    cnfexprEval(func->expr[0], &srcVal[0], usrptr, pWti);
+
+    if (srcVal[0].datatype != 'J' || srcVal[0].d.json == NULL) {
+        goto finalize_it;
+    }
+
+    input = srcVal[0].d.json;
+    type = json_object_get_type(input);
+
+    if (type == json_type_array) {
+        cnfexprEval(func->expr[1], &srcVal[1], usrptr, pWti);
+        nParamsEvaluated = 1;
+
+        result = jsonDeepCopy(input);
+        if (result == NULL) {
+            goto finalize_it;
+        }
+
+        struct json_object *newElem = NULL;
+        if (srcVal[1].datatype == 'J') {
+            newElem = jsonDeepCopy(srcVal[1].d.json);
+        } else if (srcVal[1].datatype == 'S') {
+            char *str = (char *)var2CString(&srcVal[1], &bMustFree2);
+            if (str != NULL) {
+                newElem = json_object_new_string(str);
+            }
+            if (bMustFree2) free(str);
+        } else if (srcVal[1].datatype == 'N') {
+            newElem = json_object_new_int64(srcVal[1].d.n);
+        }
+        if (newElem != NULL) {
+            if (json_object_array_add(result, newElem) != 0) {
+                json_object_put(newElem);
+                json_object_put(result);
+                result = NULL;
+            }
+        }
+
+    } else if (type == json_type_object && func->nParams >= 3) {
+        cnfexprEval(func->expr[1], &srcVal[1], usrptr, pWti);
+        cnfexprEval(func->expr[2], &srcVal[2], usrptr, pWti);
+        nParamsEvaluated = 2;
+
+        key = (char *)var2CString(&srcVal[1], &bMustFree);
+        if (key == NULL) {
+            goto finalize_it;
+        }
+
+        result = jsonDeepCopy(input);
+        if (result == NULL) {
+            goto finalize_it;
+        }
+
+        struct json_object *newVal = NULL;
+        if (srcVal[2].datatype == 'J') {
+            newVal = jsonDeepCopy(srcVal[2].d.json);
+        } else if (srcVal[2].datatype == 'S') {
+            char *str = (char *)var2CString(&srcVal[2], &bMustFree2);
+            if (str != NULL) {
+                newVal = json_object_new_string(str);
+            }
+            if (bMustFree2) free(str);
+        } else if (srcVal[2].datatype == 'N') {
+            newVal = json_object_new_int64(srcVal[2].d.n);
+        }
+        if (newVal != NULL) {
+            json_object_object_add(result, key, newVal);
+        }
+    }
+
+finalize_it:
+    ret->datatype = 'J';
+    ret->d.json = result;
+
+    if (bMustFree) free(key);
+    varFreeMembers(&srcVal[0]);
+
+    if (nParamsEvaluated >= 1) varFreeMembers(&srcVal[1]);
+    if (nParamsEvaluated >= 2) varFreeMembers(&srcVal[2]);
+}
+
 static void evalVar(struct cnfvar *__restrict__ const var,
                     void *__restrict__ const usrptr,
                     struct svar *__restrict__ const ret) {
@@ -4032,6 +4128,7 @@ static struct scriptFunct functions[] = {
     {"b64_decode", 1, 1, doFunct_Base64Dec, NULL, NULL},
     {"split", 2, 2, doFunct_split, NULL, NULL},
     {"is_in_subnet", 2, 2, doFunct_is_in_subnet, NULL, NULL},
+    {"append_json", 2, 3, doFunct_append_json, NULL, NULL},
     {NULL, 0, 0, NULL, NULL, NULL}  // last element to check end of array
 };
 

--- a/grammar/rainerscript.h
+++ b/grammar/rainerscript.h
@@ -250,7 +250,8 @@ enum cnffuncid {
     CNFFUNC_SCRIPT_ERROR,
     CNFFUNC_HTTP_REQUEST,
     CNFFUNC_IS_TIME,
-    CNFFUNC_SPLIT
+    CNFFUNC_SPLIT,
+    CNFFUNC_APPEND_JSON
 };
 
 typedef struct cnffunc cnffunc_t;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -462,6 +462,7 @@ TESTS +=  \
 	rscript-config_enable-on.sh \
 	rscript_get_property.sh \
 	rscript_split.sh \
+	rscript_append_json.sh \
 	config_output-o-option.sh \
 	rs-cnum.sh \
 	rs-substring.sh \
@@ -627,7 +628,8 @@ TESTS +=  \
 	threadingmqaq.sh \
 	func-substring-invld-startpos-vg.sh \
 	rscript_trim-vg.sh \
-	rscript_split-vg.sh
+	rscript_split-vg.sh \
+	rscript_append_json-vg.sh
 if ENABLE_LIBGCRYPT
 TESTS +=  \
 	queue-encryption-disk_keyfile-vg.sh
@@ -2347,6 +2349,8 @@ EXTRA_DIST= \
 	rscript_get_property-vg.sh \
 	rscript_split.sh \
 	rscript_split-vg.sh \
+	rscript_append_json.sh \
+	rscript_append_json-vg.sh \
 	rs-cnum.sh \
 	rs-int2hex.sh \
 	rs-substring.sh \
@@ -3242,6 +3246,7 @@ EXTRA_DIST= \
 	rscript_replace.sh \
 	rscript_replace_complex.sh \
 	rscript_split.sh \
+	rscript_append_json.sh \
 	testsuites/complex_replace_input \
 	rscript_unaffected_reset.sh \
 	rscript_wrap2.sh \

--- a/tests/rscript_append_json-vg.sh
+++ b/tests/rscript_append_json-vg.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Added 2025-12-26 by 20syldev, released under ASL 2.0
+export USE_VALGRIND="YES"
+source ${srcdir:-.}/rscript_append_json.sh

--- a/tests/rscript_append_json.sh
+++ b/tests/rscript_append_json.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Added 2025-12-26 by 20syldev, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%$!arr%|%$!obj_new%|%$!chain%\n")
+
+if $msg contains "msgnum:" then {
+    # Test 1: Append string to array
+    set $.ret = parse_json('\''["a", "b"]'\'', "\$!arr");
+    set $!arr = append_json($!arr, "c");
+
+    # Test 2: Append key-value to object (use new variable to test)
+    set $.ret = parse_json('\''{"name": "test"}'\'', "\$!obj");
+    set $!obj_new = append_json($!obj, "status", "active");
+
+    # Test 3: Chain multiple appends
+    set $.ret = parse_json('\''[]'\'', "\$!chain");
+    set $!chain = append_json($!chain, "first");
+    set $!chain = append_json($!chain, "second");
+
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+'
+startup
+tcpflood -m1
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='[ "a", "b", "c" ]|{ "name": "test", "status": "active" }|[ "first", "second" ]'
+cmp_exact $RSYSLOG_OUT_LOG
+exit_test


### PR DESCRIPTION
### Summary
Users need to dynamically build JSON arrays and objects by adding elements without external processing or complex workarounds.

### Notes
- Tests included: `rscript_append_json.sh` and `rscript_append_json-vg.sh`
- Documentation added: `doc/source/rainerscript/functions/rs-append_json.rst`

Impact: New RainerScript function available to all users.
- **Before:** No native way to append elements to JSON arrays/objects in RainerScript.
- **After:** `append_json(array, element)` or `append_json(object, key, value)` returns a new JSON structure with the element/property added.