### PR TITLE
docs: add module template and tighten RST AI authoring rules

### DIFF
--- a/ai/rsyslog_code_doc_builder/base_prompt.txt
+++ b/ai/rsyslog_code_doc_builder/base_prompt.txt
@@ -32,6 +32,11 @@ principles:
   can discover it quickly.
 - When introducing new metadata keys, refresh both the schema description and any
   templates/examples in the tree.
+- For RST pages under `doc/source`, include anchors, `.. meta::`, and summary
+  slices per `doc/ai/authoring_guidelines.md`. Add them when editing legacy
+  pages that lack the blocks.
+- Use the module template at `doc/ai/templates/template-module.rst` when
+  creating or normalizing module docs.
 
 ## 4. Validate and cross-link
 - Ensure every instruction you add references the exact filenames or scripts
@@ -46,3 +51,5 @@ principles:
   (sentence-case headings, wrapped paragraphs, consistent indentation).
 - Prefer American English spellings.
 - Call out when no tests are required and why (documentation-only changes).
+- Keep sections compact for human scanning and RAG chunking; follow the size
+  guidance in `doc/ai/chunking_and_embeddings.md`.

--- a/doc/AGENTS.md
+++ b/doc/AGENTS.md
@@ -32,7 +32,16 @@ This guide applies to everything under `doc/`.
   top-level `AGENTS.md`, and `coding_practices.rst` sits in the development
   toctree. When you move or rename that page, update the links here and in the
   base prompts so automated seeding does not break.
-- Every new page must include anchors, meta, and summary blocks per `authoring_guidelines.md`.
+- Every new or materially edited page must include anchors, meta, and summary
+  blocks per `authoring_guidelines.md`. If an existing page lacks them, add
+  the blocks as part of the update.
+- Module docs should include an explicit module metadata header (module name,
+  author/maintainer, introduced/version when known) and an `.. index::`
+  directive. Use `doc/ai/templates/template-module.rst` as the reference
+  structure when updating module pages.
+- Keep sections short for human scanning and RAG chunking: prefer 1–3 short
+  paragraphs per section and split long pages into subpages when they exceed
+  the size guidance in `doc/ai/chunking_and_embeddings.md`.
 
 ## Build & validation
 - Run `./doc/tools/build-doc-linux.sh --clean --format html` after changes to catch Sphinx errors early.
@@ -63,4 +72,3 @@ This guide applies to everything under `doc/`.
 | RAG Knowledge Base script | `doc/build_rag_db.py` |
 | RAG Knowledge Base (Output) | `doc/build/rag/rsyslog_rag_db.json` |
 | Strategy and style | `doc/STRATEGY.md` |
-

--- a/doc/ai/README.md
+++ b/doc/ai/README.md
@@ -16,7 +16,7 @@
 | `crosslinking_and_nav.md` | Navigation and cross-reference patterns |
 | `drift_monitoring.md` | Detecting doc/code drift |
 | `module_map.yaml` | Module paths and locking hints |
-| `templates/` | RST templates for concept and tutorial pages |
+| `templates/` | RST templates for concept, tutorial, and module pages |
 
 ## RAG Knowledge Base
 

--- a/doc/ai/authoring_guidelines.md
+++ b/doc/ai/authoring_guidelines.md
@@ -17,7 +17,27 @@ Short one-paragraph summary (≤200 chars).
 .. summary-end
 ```
 
+### Applies to all `doc/source` pages
+- Use these blocks on every new or materially edited RST page.
+- If an existing page lacks the blocks, add them while editing.
+- Module docs may add the blocks immediately after the module title and
+  before the module metadata table/field list.
+
+### Module documentation header
+Module pages should include:
+- `.. index:: ! <module>`
+- Module metadata (module name, author/maintainer, introduced/version)
+- A short summary slice per the required header blocks
+
+Use `doc/ai/templates/template-module.rst` when creating or normalizing
+module documentation.
+
 ## Tone
 - Concepts: neutral, precise.
 - Tutorials: friendly, runnable.
 - Avoid buzzwords; explain plainly.
+
+## Size & chunking (human + AI)
+- Keep sections to 150–350 words; split longer sections with subheads.
+- Prefer 1–3 short paragraphs per section and use lists for dense material.
+- Keep pages to ~400–800 words unless a multi-page cluster is more appropriate.

--- a/doc/ai/chunking_and_embeddings.md
+++ b/doc/ai/chunking_and_embeddings.md
@@ -4,10 +4,12 @@ Guidelines for documentation structure and the automated RAG extraction process.
 
 ## Authoring Guidelines
 
-- Target 400–900 words per page.
+- Target 400–800 words per page.
 - One diagram and one code block typical.
 - Use lists; avoid giant paragraphs.
 - Maintain logical independence per file.
+- Keep sections to 150–350 words; split earlier if a section becomes hard to
+  scan or exceeds the ~2,000-character chunk cap.
 
 ## RAG Knowledge Base
 
@@ -19,7 +21,7 @@ which processes Sphinx doctrees and generates `build/rag/rsyslog_rag_db.json`.
 | Type | Description |
 |------|-------------|
 | `section_header` | Document section titles with hierarchy context |
-| `text_block` | Prose content (~2000 chars, merged thematically) |
+| `text_block` | Prose content (~600–2,000 chars, merged thematically) |
 | `code` | Configuration examples and code blocks |
 
 ### Metadata Schema

--- a/doc/ai/templates/template-module.rst
+++ b/doc/ai/templates/template-module.rst
@@ -1,0 +1,59 @@
+.. _module-template:
+
+================================
+Module Page Template (im/om/mm)
+================================
+
+.. index:: ! module-name
+
+.. meta::
+   :description: <≤160 chars>
+   :keywords: rsyslog, module-name, input/output/processor, key-topic
+
+.. summary-start
+
+Short one-paragraph summary (≤200 chars) describing what the module does.
+
+.. summary-end
+
+===========================  ==========================================================
+**Module Name:**             **module-name**
+**Author/Maintainer:**       Name <email> (or project/organization)
+**Introduced:**              Version or release note (if known)
+===========================  ==========================================================
+
+Purpose
+=======
+
+State the module's primary responsibility and where it fits in the pipeline.
+
+Main Features
+=============
+
+- Feature one (short clause).
+- Feature two.
+- Compatibility or runtime constraints if critical.
+
+Configuration Parameters
+========================
+
+Use the parameter includes from `doc/source/reference/parameters/` when
+available.
+
+Example
+=======
+
+.. code-block:: rsyslog
+
+   module(load="module-name")
+   # input/action example goes here
+
+Notes
+=====
+
+Mention caveats, performance considerations, or dependencies.
+
+See also
+========
+
+- :doc:`../configuration/index`


### PR DESCRIPTION
This raises the quality bar for documentation so AI agents ingest and
navigate rsyslog docs more reliably. The guidance also improves human
scannability with consistent headers and compact sections.

Before: module pages and edited RST pages could lack anchors/meta/summary
blocks and there was no standard module template.
After: new/edited pages must include anchors/meta/summary; a module
template is provided and size guidance is clearer.

Impact: docs-only; improves contributor workflow and RAG consistency.

Technical:
- Extend ai/rsyslog_code_doc_builder base prompt with requirements to add
  anchors, `.. meta::`, and summary slices on `doc/source` RST pages, and
  to use `doc/ai/templates/template-module.rst` for module docs.
- Update `doc/AGENTS.md` to require blocks on new/material edits, add
  module metadata/index guidance, and stress compact sections with a
  pointer to chunking rules.
- Expand `doc/ai/authoring_guidelines.md` with a module documentation
  header (index directive, metadata table) and concrete size targets:
  sections 150–350 words; pages ~400–800 words.
- Tighten `doc/ai/chunking_and_embeddings.md`: page target 400–800 words;
  `text_block` chunk size ~600–2,000 chars and explicit section limits.
- Add `doc/ai/templates/template-module.rst` with a canonical module page
  skeleton (index, meta, summary, metadata table, sections, example).
- Refresh `doc/ai/README.md` to list module template availability.

With the help of AI Agents: codex