### PR TITLE
omelasticsearch fix: potential NULL dereference

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -316,7 +316,11 @@ BEGINfreeInstance
                 if (loadModConf->tail == inst) {
                     loadModConf->tail = prev;
                 }
-                prev->next = inst->next;
+                if (prev != NULL) {
+                    prev->next = inst->next;
+                } else {
+                    loadModConf->root = inst->next;
+                }
                 /* no need to correct inst back to prev - we exit now! */
                 break;
             } else {


### PR DESCRIPTION
Under some exotic cases, omelasticsearch could dereference a NULL pointer during shutdown cleanup. This would lead to undefined behaviour and most likely an abort. This is fixed in this patch.

closes https://github.com/rsyslog/rsyslog/issues/4016

With the Help of AI Agent: ChatGPT Codex
