### PR TITLE
msg, docs: document jsonMerge overwrite; drop TODO

### DIFF
--- a/doc/source/rainerscript/variable_property_types.rst
+++ b/doc/source/rainerscript/variable_property_types.rst
@@ -40,39 +40,11 @@ Check the following usage examples to understand how these statements behave:
 sets the value of a local-variable or json property, but if the addressed
 variable already contains a value its behaviour differs as follows:
 
-**merges** the value if both existing and new value are objects, 
-but merges the new value to *root* rather than with value of the given key. Eg. 
+**merges** the value if both existing and new value are objects,
+but merges the new value to *root* rather than with value of the given key.
+If a key exists in both the existing object and the new object, the value from
+the new object overwrites the existing one.
 
-::
-
-   set $.x!one = "val_1";
-   # results in $. = { "x": { "one": "val_1" } }
-   set $.y!two = "val_2";
-   # results in $. = { "x": { "one": "val_1" }, "y": { "two": "val_2" } }
-
-   set $.z!var = $.x;
-   # results in $. = { "x": { "one": "val_1" }, "y": { "two": "val_2" }, "z": { "var": { "one": "val_1" } } }
-
-   set $.z!var = $.y;
-   # results in $. = { "x": { "one": "val_1" }, "y": { "two": "val_2" }, "z": { "var": { "one": "val_1" } }, "two": "val_2" }
-   # note that the key *two* is at root level and not  under *$.z!var*.
-
-**ignores** the new value if old value was an object, but new value is a not an object (Eg. string, number etc). Eg:
-
-::
-
-   set $.x!one = "val_1";
-   set $.x = "quux";
-   # results in $. = { "x": { "one": "val_1" } }
-   # note that "quux" was ignored
-
-**resets** variable, if old value was not an object.
-
-::
-
-   set $.x!val = "val_1";
-   set $.x!val = "quux";
-   # results in $. = { "x": { "val": "quux" } }
 
 **unset**
 ---------

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -4666,7 +4666,6 @@ finalize_it:
 }
 
 static rsRetVal jsonMerge(struct json_object *existing, struct json_object *json) {
-    /* TODO: check & handle duplicate names */
     DEFiRet;
 
     struct json_object_iterator it = json_object_iter_begin(json);


### PR DESCRIPTION
Housekeeping to clean up lingering TODOs and align docs with actual behavior. This clarifies what users can expect and reduces confusion when merging JSON objects in rainerscript contexts.

Before: TODO in msg.c suggested duplicate-key handling might be TBD and docs did not state the overwrite rule.
After: TODO removed and docs explicitly say duplicates are overwritten by the incoming object's values.

Technically, jsonMerge has been overwriting existing keys when duplicates are encountered, consistent with common JSON merge practices and the json-c add semantics. This change only removes the stale TODO in runtime/msg.c and updates
doc/source/rainerscript/variable_property_types.rst with an example and wording that call out the overwrite behavior. No code paths, queues, HUP behavior, OMODTX, or ABI/API are affected.
