### PR TITLE
ossl: fix ctx double-free and config string leaks

### DIFF
--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -305,6 +305,10 @@ static rsRetVal net_ossl_osslCtxInit(net_ossl_t *pThis, const SSL_METHOD *method
     }
 
     /* Create main CTX Object based on method parameter */
+    if (pThis->ctx != NULL) {
+        SSL_CTX_free(pThis->ctx);
+        pThis->ctx = NULL;
+    }
     pThis->ctx = SSL_CTX_new(method);
 
     if (bHaveExtraCAFiles == 1) {
@@ -1221,6 +1225,7 @@ BEGINobjDestruct(net_ossl) /* be sure to specify the object type also in END and
     }
     if (pThis->ctx != NULL && !pThis->ctx_is_copy) {
         SSL_CTX_free(pThis->ctx);
+        pThis->ctx = NULL;
     }
     free((void *)pThis->pszCAFile);
     free((void *)pThis->pszCRLFile);

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1404,9 +1404,10 @@ static rsRetVal SetTlsCAFile(nsd_t *pNsd, const uchar *const caFile) {
     nsd_ossl_t *const pThis = (nsd_ossl_t *)pNsd;
 
     ISOBJ_TYPE_assert((pThis), nsd_ossl);
-    if (caFile == NULL) {
-        pThis->pNetOssl->pszCAFile = NULL;
-    } else {
+    free((void *)pThis->pNetOssl->pszCAFile);
+    pThis->pNetOssl->pszCAFile = NULL;
+
+    if (caFile != NULL) {
         CHKmalloc(pThis->pNetOssl->pszCAFile = (const uchar *)strdup((const char *)caFile));
     }
 
@@ -1419,9 +1420,10 @@ static rsRetVal SetTlsCRLFile(nsd_t *pNsd, const uchar *const crlFile) {
     nsd_ossl_t *const pThis = (nsd_ossl_t *)pNsd;
 
     ISOBJ_TYPE_assert((pThis), nsd_ossl);
-    if (crlFile == NULL) {
-        pThis->pNetOssl->pszCRLFile = NULL;
-    } else {
+    free((void *)pThis->pNetOssl->pszCRLFile);
+    pThis->pNetOssl->pszCRLFile = NULL;
+
+    if (crlFile != NULL) {
         CHKmalloc(pThis->pNetOssl->pszCRLFile = (const uchar *)strdup((const char *)crlFile));
     }
 
@@ -1435,9 +1437,10 @@ static rsRetVal SetTlsKeyFile(nsd_t *pNsd, const uchar *const pszFile) {
     nsd_ossl_t *const pThis = (nsd_ossl_t *)pNsd;
 
     ISOBJ_TYPE_assert((pThis), nsd_ossl);
-    if (pszFile == NULL) {
-        pThis->pNetOssl->pszKeyFile = NULL;
-    } else {
+    free((void *)pThis->pNetOssl->pszKeyFile);
+    pThis->pNetOssl->pszKeyFile = NULL;
+
+    if (pszFile != NULL) {
         CHKmalloc(pThis->pNetOssl->pszKeyFile = (const uchar *)strdup((const char *)pszFile));
     }
 
@@ -1450,9 +1453,10 @@ static rsRetVal SetTlsCertFile(nsd_t *pNsd, const uchar *const pszFile) {
     nsd_ossl_t *const pThis = (nsd_ossl_t *)pNsd;
 
     ISOBJ_TYPE_assert((pThis), nsd_ossl);
-    if (pszFile == NULL) {
-        pThis->pNetOssl->pszCertFile = NULL;
-    } else {
+    free((void *)pThis->pNetOssl->pszCertFile);
+    pThis->pNetOssl->pszCertFile = NULL;
+
+    if (pszFile != NULL) {
         CHKmalloc(pThis->pNetOssl->pszCertFile = (const uchar *)strdup((const char *)pszFile));
     }
 


### PR DESCRIPTION
This improves stability of the OpenSSL stream driver and prevents occasional aborts seen in the field with rulesets and per-host TLS configuration. It also reduces memory growth during reconfiguration.

Impact: Fixes a crash (double-free) and plugs several leaks; no config or API changes.

Before: Re-inits could reuse a stale SSL_CTX and leak TLS file paths.
        In some cases OpenSSL key material was freed twice and rsyslog
        aborted.
After:  We free any existing SSL_CTX before creating a new one and null
        the pointer on teardown. TLS setters free prior strings before
        assigning new values, preventing leaks on retries/reloads.

Technical details:
- net_ossl_osslCtxInit(): free existing pThis->ctx, then SSL_CTX_new().
- net_osslDestruct(): explicitly set ctx = NULL after SSL_CTX_free().
- nsd_ossl setters (CA/CRL/Key/Cert): free existing string, set to NULL, then strdup() the new value when provided.
- No changes to action queues or OMODTX; behavior is limited to driver init/reinit and resource ownership.

closes: https://github.com/rsyslog/rsyslog/issues/6358

With the help of AI-Agents: Jules
