### PR TITLE
omhiredis: Allow to define a name to instance and use it in logs

### DIFF
--- a/tests/omhiredis-dynakey.sh
+++ b/tests/omhiredis-dynakey.sh
@@ -17,6 +17,7 @@ template(name="dynakey" type="string" string="%$!dynaKey%")
 local4.* {
         set $!dynaKey = "myDynaKey";
         action(type="omhiredis"
+                name="omhiredis-dynakey"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="set"
@@ -44,12 +45,12 @@ wait_shutdown
 redis_command "GET myDynaKey" >> $RSYSLOG_OUT_LOG
 
 # The first get is before inserting, the second is after
-export EXPECTED="/usr/bin/redis-cli
-
-/usr/bin/redis-cli
+export EXPECTED="
  msgnum:00000001:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-dynakey]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-name-blank.sh
+++ b/tests/omhiredis-name-blank.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# added 2025-12-04 by Théo Bertin, released under ASL 2.0
+## Uncomment for debugging
+# export RS_REDIR=-d
+
+. ${srcdir:=.}/diag.sh init
+
+start_redis
+
+generate_conf
+add_conf '
+global(localhostname="server")
+module(load="../contrib/omhiredis/.libs/omhiredis")
+template(name="outfmt" type="string" string="%msg%")
+
+local4.* {
+        action(type="omhiredis"
+                server="127.0.0.1"
+                serverport="'$REDIS_RANDOM_PORT'"
+                mode="queue"
+                key="myKey"
+                template="outfmt")
+
+        stop
+}
+'
+
+startup
+
+injectmsg 1 1
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "omhiredis[action-1-../contrib/omhiredis/.libs/omhiredis]:" ${RSYSLOG_DYNNAME}.started
+check_not_present "omhiredis:" ${RSYSLOG_DYNNAME}.started
+stop_redis
+
+# Removes generated configuration file, log and pid files
+cleanup_redis
+
+exit_test

--- a/tests/omhiredis-publish.sh
+++ b/tests/omhiredis-publish.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-publish"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="publish"
@@ -36,8 +37,7 @@ shutdown_when_empty
 wait_shutdown
 
 # The SUBSCRIBE command gets the result of the subscribing and the 3 subsequent messages published by omhiredis
-export EXPECTED="/usr/bin/redis-cli
-subscribe
+export EXPECTED="subscribe
 myChannel
 1
 message
@@ -51,6 +51,8 @@ myChannel
  msgnum:00000003:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-publish]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-queue-rpush.sh
+++ b/tests/omhiredis-queue-rpush.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-queue-rpush"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="queue"
@@ -39,9 +40,7 @@ redis_command "LLEN myKey" > $RSYSLOG_OUT_LOG
 redis_command "LPOP myKey 6" >> $RSYSLOG_OUT_LOG
 
 # Messages should be retrieved in order (as they were inserted using RPUSH)
-export EXPECTED="/usr/bin/redis-cli
-5
-/usr/bin/redis-cli
+export EXPECTED="5
  msgnum:00000001:
  msgnum:00000002:
  msgnum:00000003:
@@ -49,6 +48,8 @@ export EXPECTED="/usr/bin/redis-cli
  msgnum:00000005:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-queue-rpush]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-queue.sh
+++ b/tests/omhiredis-queue.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-queue"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="queue"
@@ -38,9 +39,7 @@ redis_command "LLEN myKey" > $RSYSLOG_OUT_LOG
 redis_command "LPOP myKey 11" >> $RSYSLOG_OUT_LOG
 
 # Messages should be retrieved in reverse order (as they were inserted using LPUSH)
-export EXPECTED="/usr/bin/redis-cli
-10
-/usr/bin/redis-cli
+export EXPECTED="10
  msgnum:00000010:
  msgnum:00000009:
  msgnum:00000008:
@@ -53,6 +52,8 @@ export EXPECTED="/usr/bin/redis-cli
  msgnum:00000001:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-queue]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-ack.sh
+++ b/tests/omhiredis-stream-ack.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-ack"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -51,16 +52,12 @@ redis_command "XINFO GROUPS inStream" >> $RSYSLOG_OUT_LOG
 # 4. show group infos -> pending shows 1 pending entry
 # 4.2. start Rsyslog and send message -> omhiredis acknowledges index 1-0 on group 'group' for stream 'inStream'
 # 5. show group infos again -> pending now shows 0 pending entries
-export EXPECTED="/usr/bin/redis-cli
-OK
-/usr/bin/redis-cli
+export EXPECTED="OK
 1-0
-/usr/bin/redis-cli
 inStream
 1-0
 key
 value
-/usr/bin/redis-cli
 name
 group
 consumers
@@ -73,7 +70,6 @@ entries-read
 1
 lag
 0
-/usr/bin/redis-cli
 name
 group
 consumers
@@ -88,6 +84,9 @@ lag
 0"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-ack]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-capped.sh
+++ b/tests/omhiredis-stream-capped.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-capped"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -44,6 +45,9 @@ if [ ! "${count}" -le 500 ]; then
     echo "error: stream has too much entries -> $count"
     error_exit 1
 fi
+
+content_check "omhiredis: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-capped]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-del.sh
+++ b/tests/omhiredis-stream-del.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-del"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -48,19 +49,18 @@ redis_command "XLEN inStream" >> $RSYSLOG_OUT_LOG
 # 4. show stream length -> should be 1
 # 4.2. start Rsyslog and send message -> omhiredis deletes index 1-0 on stream 'inStream'
 # 5.  show stream length again -> should be 0
-export EXPECTED="/usr/bin/redis-cli
-1-0
-/usr/bin/redis-cli
+export EXPECTED="1-0
 inStream
 1-0
 key
 value
-/usr/bin/redis-cli
 1
-/usr/bin/redis-cli
 0"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis: no stream.outField set, using 'msg' as default " ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-del]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-dynack.sh
+++ b/tests/omhiredis-stream-dynack.sh
@@ -22,6 +22,7 @@ local4.* {
         set $.redis!group = "myGroup";
         set $.redis!index = "2-0";
         action(type="omhiredis"
+                name="omhiredis-stream-dynack"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -61,16 +62,12 @@ redis_command "XINFO GROUPS inputStream" >> $RSYSLOG_OUT_LOG
 # 4. show group infos -> pending shows 1 pending entry
 # 4.2. start Rsyslog and send message -> omhiredis acknowledges index 2-0 on group 'myGroup' for stream 'inputStream'
 # 5. show group infos again -> pending now shows 0 pending entries
-export EXPECTED="/usr/bin/redis-cli
-OK
-/usr/bin/redis-cli
+export EXPECTED="OK
 2-0
-/usr/bin/redis-cli
 inputStream
 2-0
 key
 value
-/usr/bin/redis-cli
 name
 myGroup
 consumers
@@ -83,7 +80,6 @@ entries-read
 1
 lag
 0
-/usr/bin/redis-cli
 name
 myGroup
 consumers
@@ -98,6 +94,9 @@ lag
 0"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream-dynack]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream-outfield.sh
+++ b/tests/omhiredis-stream-outfield.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream-outfield"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -48,6 +49,8 @@ content_count_check " msgnum:00000002:" 1 $RSYSLOG_OUT_LOG
 content_count_check "custom_field" 2 $RSYSLOG_OUT_LOG
 content_count_check "msg" 2 $RSYSLOG_OUT_LOG
 content_count_check "msgnum" 2 $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-stream-outfield]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-stream.sh
+++ b/tests/omhiredis-stream.sh
@@ -15,6 +15,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-stream"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 mode="stream"
@@ -54,6 +55,9 @@ content_count_check " msgnum:00000002:" 1 $RSYSLOG_OUT_LOG
 # 2 for the name of the field where the message was inserted, 2 for the 'msgnum' part
 content_count_check "msg" 4 $RSYSLOG_OUT_LOG
 content_count_check "msgnum" 2 $RSYSLOG_OUT_LOG
+
+content_check "omhiredis: no stream.outField set, using 'msg' as default" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-stream]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-withpass.sh
+++ b/tests/omhiredis-withpass.sh
@@ -19,6 +19,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-withpass"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 serverpassword="'${REDIS_PASSWORD}'"
@@ -32,7 +33,7 @@ action(type="omfile" file="'$RSYSLOG_DYNNAME.othermsg'" template="outfmt")
 '
 
 # Client MUST authentiate here!
-redis_command "AUTH ${REDIS_PASSWORD} \n GET outKey" > $RSYSLOG_OUT_LOG
+redis_command "AUTH ${REDIS_PASSWORD} \n TYPE outKey" > $RSYSLOG_OUT_LOG
 
 startup
 
@@ -46,14 +47,14 @@ wait_shutdown
 redis_command "AUTH ${REDIS_PASSWORD} \n GET outKey" >> $RSYSLOG_OUT_LOG
 
 # the "OK" replies are for authentication of the redis cli client
-export EXPECTED="/usr/bin/redis-cli
-OK
-
-/usr/bin/redis-cli
+export EXPECTED="OK
+none
 OK
  msgnum:00000001:"
 
 cmp_exact $RSYSLOG_OUT_LOG
+
+content_check "omhiredis[omhiredis-withpass]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
 
 stop_redis
 

--- a/tests/omhiredis-wrongpass.sh
+++ b/tests/omhiredis-wrongpass.sh
@@ -19,6 +19,7 @@ template(name="outfmt" type="string" string="%msg%")
 
 local4.* {
         action(type="omhiredis"
+                name="omhiredis-wrongpass"
                 server="127.0.0.1"
                 serverport="'$REDIS_RANDOM_PORT'"
                 serverpassword="ThatsNotMyPassword"
@@ -27,8 +28,6 @@ local4.* {
                 template="outfmt")
         stop
 }
-
-action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 
 startup
@@ -39,7 +38,9 @@ injectmsg 1 1
 shutdown_when_empty
 wait_shutdown
 
-content_check "error while authenticating: WRONGPASS invalid username-password pair or user is disabled." $RSYSLOG_OUT_LOG
+content_check "omhiredis[omhiredis-wrongpass]: trying connect to '127.0.0.1'" ${RSYSLOG_DYNNAME}.started
+content_check "omhiredis[omhiredis-wrongpass]: error while authenticating: WRONGPASS invalid username-password pair or user is disabled." ${RSYSLOG_DYNNAME}.started
+
 
 stop_redis
 


### PR DESCRIPTION
<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
This change introduces the ability to define a `name` to an `omhiredis` action in the rainerscript configuration.
This name will be used in all logs generated by the instance and written by rsyslog.
This also adds the possibility to name the (future) omhiredis-specific stats.

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
There are no issues linked to this change.

### Notes (optional)

Although `omhiredis` doesn't support module-specific stats, the addition of this parameter will also allow to add a name to each specific instance stats in the future, allowing to easily get and read each instance's statistics.

