### PR TITLE
core, runtime, omfwd: plumb action name into modules and logs

### DIFF
--- a/action.c
+++ b/action.c
@@ -18,7 +18,7 @@
  *
  * File begun on 2007-08-06 by Rainer Gerhards (extracted from syslogd.c).
  *
- * Copyright 2007-2022 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2026 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -2257,6 +2257,9 @@ rsRetVal addAction(action_t **ppAction,
     pAction->pModData = pModData;
 
     CHKiRet(actionConstructFinalize(pAction, lst));
+    if (pAction->pMod->mod.om.setActionInfo != NULL) {
+        CHKiRet(pAction->pMod->mod.om.setActionInfo(pAction->pModData, pAction));
+    }
 
     *ppAction = pAction; /* finally store the action pointer */
 
@@ -2270,6 +2273,19 @@ finalize_it:
     }
 
     RETiRet;
+}
+
+const uchar *actionGetName(const action_t *const pAction) {
+    static const uchar fallbackName[] = "[action]";
+
+    if (pAction == NULL) {
+        assert(pAction != NULL); /* should not happen, but we are robust */
+        return fallbackName;
+    }
+    if (pAction->pszName == NULL) {
+        return fallbackName;
+    }
+    return pAction->pszName;
 }
 
 

--- a/action.h
+++ b/action.h
@@ -4,7 +4,7 @@
  * File begun on 2007-08-06 by RGerhards (extracted from syslogd.c, which
  * was under BSD license at the time of rsyslog fork)
  *
- * Copyright 2007-2018 Adiscon GmbH.
+ * Copyright 2007-2026 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -189,5 +189,8 @@ void actionRemoveWorker(action_t *const pAction, void *const actWrkrData);
 
 /** Release parameter memory allocated by prepareDoActionParams(). */
 void releaseDoActionParams(action_t *const pAction, wti_t *const pWti, int action_destruct);
+
+/** Return the action name; never returns NULL. */
+const uchar *actionGetName(const action_t *const pAction);
 
 #endif /* #ifndef ACTION_H_INCLUDED */

--- a/runtime/module-template.h
+++ b/runtime/module-template.h
@@ -4,7 +4,7 @@
  *
  * File begun on 2007-07-25 by RGerhards
  *
- * Copyright 2007-2025 Adiscon GmbH.
+ * Copyright 2007-2026 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -270,6 +270,23 @@
 
 #define ENDdoAction \
     RETiRet;        \
+    }
+
+/* setActionInfo()
+ * Optional callback to provide the action object after creation.
+ */
+#define BEGINsetActionInfo                                                         \
+    static rsRetVal setActionInfo(void *const pModData, action_t *const pAction) { \
+        DEFiRet;                                                                   \
+        instanceData *pData;
+
+#define CODESTARTsetActionInfo        \
+    pData = (instanceData *)pModData; \
+    (void)pAction;                    \
+    (void)pData;
+
+#define ENDsetActionInfo \
+    RETiRet;             \
     }
 
 /* below is a variant of doAction where the passed-in data is not the common
@@ -600,6 +617,11 @@
 #define CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES \
     if (!strcmp((char *)name, "isCompatibleWithFeature")) {     \
         *pEtryPoint = isCompatibleWithFeature;                  \
+    }
+
+#define CODEqueryEtryPt_SetActionInfo_IF_OMOD_QUERIES \
+    if (!strcmp((char *)name, "setActionInfo")) {     \
+        *pEtryPoint = setActionInfo;                  \
     }
 
 /**

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -11,7 +11,7 @@
  *
  * File begun on 2007-07-22 by RGerhards
  *
- * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2026 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -622,6 +622,13 @@ static rsRetVal doModInit(pModInit_t modInit, uchar *name, void *pModHdlr, modIn
 
             localRet = (*pNew->modQueryEtryPt)((uchar *)"SetShutdownImmdtPtr", &pNew->mod.om.SetShutdownImmdtPtr);
             if (localRet != RS_RET_OK && localRet != RS_RET_MODULE_ENTRY_POINT_NOT_FOUND) ABORT_FINALIZE(localRet);
+
+            localRet = (*pNew->modQueryEtryPt)((uchar *)"setActionInfo", &pNew->mod.om.setActionInfo);
+            if (localRet == RS_RET_MODULE_ENTRY_POINT_NOT_FOUND) {
+                pNew->mod.om.setActionInfo = NULL;
+            } else if (localRet != RS_RET_OK) {
+                ABORT_FINALIZE(localRet);
+            }
 
             pNew->mod.om.supportsTX = 1;
             localRet = (*pNew->modQueryEtryPt)((uchar *)"beginTransaction", &pNew->mod.om.beginTransaction);

--- a/runtime/modules.h
+++ b/runtime/modules.h
@@ -12,7 +12,7 @@
  *
  * File begun on 2007-07-22 by RGerhards
  *
- * Copyright 2007-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2007-2026 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -37,6 +37,8 @@
 
 #include "objomsr.h"
 #include "rainerscript.h"
+
+typedef struct action_s action_t;
 
 
 /* the following define defines the current version of the module interface.
@@ -142,6 +144,7 @@ struct modInfo_s {
             rsRetVal (*SetShutdownImmdtPtr)(void *pData, void *pPtr);
             rsRetVal (*createWrkrInstance)(void *ppWrkrData, void *pData);
             rsRetVal (*freeWrkrInstance)(void *pWrkrData);
+            rsRetVal (*setActionInfo)(void *pData, action_t *pAction);
             sbool supportsTX; /* set if the module supports transactions */
         } om;
         struct { /* data for library modules */

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -4,7 +4,7 @@
  * NOTE: read comments in module-template.h to understand how this file
  *	 works!
  *
- * Copyright 2007-2024 Adiscon GmbH.
+ * Copyright 2007-2026 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -50,6 +50,7 @@
 #include "omfwd.h"
 #include "template.h"
 #include "msg.h"
+#include "action.h"
 #include "tcpclt.h"
 #include "cfsysline.h"
 #include "module-template.h"
@@ -84,6 +85,7 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(netstrms) DEFobjCurrIf(netstrm
 
 typedef struct _instanceData {
     uchar *tplName; /* name of assigned template */
+    action_t *pAction;
     uchar *pszStrmDrvr;
     uchar *pszStrmDrvrAuthMode;
     uchar *pszStrmDrvrPermitExpiredCerts;
@@ -488,6 +490,12 @@ BEGINisCompatibleWithFeature
     CODESTARTisCompatibleWithFeature;
     if (eFeat == sFEATURERepeatedMsgReduction) iRet = RS_RET_OK;
 ENDisCompatibleWithFeature
+
+
+BEGINsetActionInfo
+    CODESTARTsetActionInfo;
+    pData->pAction = pAction;
+ENDsetActionInfo
 
 
 BEGINfreeInstance
@@ -1322,7 +1330,8 @@ BEGINcommitTransaction
                 iRet = RS_RET_OK;
                 continue;
             } else if (iRet != RS_RET_OK) {
-                LogError(0, RS_RET_ERR, "omfwd: error during rate limit : %d.\n", iRet);
+                LogError(0, RS_RET_ERR, "omfwd: action '%s' error during rate limit: %d.\n",
+                         actionGetName(pWrkrData->pData->pAction), iRet);
             }
         }
 
@@ -1460,6 +1469,7 @@ finalize_it:
 
 static void setInstParamDefaults(instanceData *pData) {
     pData->tplName = NULL;
+    pData->pAction = NULL;
     pData->protocol = FORW_UDP;
     pData->networkNamespace = NULL;
     pData->originalNamespace = -1;
@@ -2038,6 +2048,7 @@ BEGINqueryEtryPt
     CODESTARTqueryEtryPt;
     CODEqueryEtryPt_STD_OMODTX_QUERIES;
     CODEqueryEtryPt_STD_OMOD8_QUERIES;
+    CODEqueryEtryPt_SetActionInfo_IF_OMOD_QUERIES;
     CODEqueryEtryPt_STD_CONF2_QUERIES;
     CODEqueryEtryPt_STD_CONF2_setModCnf_QUERIES;
     CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES;


### PR DESCRIPTION
Non-technical: actions need to obtain their name for better reporting. This wires a safe way for OMs to learn their owning action and use its human-readable name in diagnostics.

Impact: omfwd log messages now include the action name in some errors. Also, a generic internal API has been added to enable actions to obtain their assigned name. The omfwd change is primarily a template of how this can be done (but also useful in itself).

Before: output modules had no supported way to access the action name. omfwd rate-limit errors did not identify the action instance. After: core calls an optional OM callback with the action pointer and omfwd includes the action name in its error logs.

Technical details:
- Introduce optional OM entry point `setActionInfo(void *pData, action_t*)` and query it during module init; absent modules get NULL (no change).
- Call `setActionInfo()` from `addAction()` after finalize, passing the module's instance data and the new `action_t`.
- Provide `actionGetName(const action_t*)` that never returns NULL and falls back to "[action]".
- Extend `module-template.h` with BEGIN/CODESTART/END macros for the new callback and a query hook macro.
- omfwd implements `setActionInfo` to cache the action pointer and uses `actionGetName()` inside commitTransaction() logging.
- No OMODTX, batching, or HUP behavior changes; pointer lifetime is tied to the action instance managed by config.

With the help of AI Agents: ChatGPT Codex
