### PR TITLE
tests: imptcp very-large: raise MaxMessageSize to 100k

### DIFF
--- a/tests/imptcp_veryLargeOctateCountedMessages.sh
+++ b/tests/imptcp_veryLargeOctateCountedMessages.sh
@@ -6,7 +6,8 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=20000
 generate_conf
-add_conf '$MaxMessageSize 10k
+add_conf '$MaxMessageSize 100k
+# Intentionally allow 100k payloads to exercise large octet-counted frames.
 template(name="outfmt" type="string" string="%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n")
 
 module(load="../plugins/imptcp/.libs/imptcp" threads="32" processOnPoller="off")


### PR DESCRIPTION
Reduce CI flakiness by aligning the test limit with the intended payload size. This is a maintenance step to keep tests reliable and actionable.

Impact: test configuration only; runtime behavior unchanged.

Before/After: previously 100k payloads with a 10k limit; now limit is 100k.

The very-large octet-counted imptcp test sent ~100k-byte frames while $MaxMessageSize was set to 10k. That mismatch could trigger implicit truncation or splitting and lead to sporadic failures unrelated to imptcp correctness. This change sets $MaxMessageSize to 100k and adds an inline comment documenting the intent. The poller-disabled code path is still used, message count and threading remain unchanged, and no production code is touched. Test semantics otherwise stay the same.

With the help of AI-Agents: Codex
