### PR TITLE
tcpsrv: restore default stack size assignment

### DIFF
--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1202,7 +1202,7 @@ static rsRetVal ATTR_NONNULL() startWrkrPool(tcpsrv_t *const pThis) {
     /* Spawn workers. */
     pThis->currWrkrs = 0;
     for (unsigned i = 0; i < queue->numWrkr; ++i) {
-        if (pthread_create(&queue->wrkr_tids[i], NULL, wrkr, pThis) != 0) {
+        if (pthread_create(&queue->wrkr_tids[i], &default_thread_attr, wrkr, pThis) != 0) {
             iRet = RS_RET_ERR;
             break;
         }


### PR DESCRIPTION
Worker threads need to be assigned the "rsyslog default stack size". This is especially an issue with musl lib, which has a very small stack size. As such, rsyslog can segfault without specifying our expected stack size.

closes https://github.com/rsyslog/rsyslog/issues/6357
