### PR TITLE
tests: fix tcpflood segfault on connection failure

### DIFF
--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -560,7 +560,15 @@ int openConnections(void) {
 #elif defined(ENABLE_GNUTLS)
     sessArray = calloc(numConnections, sizeof(gnutls_session_t));
 #endif
-    sockArray = calloc(numConnections, sizeof(int));
+    sockArray = malloc(numConnections * sizeof(int));
+    if (sockArray == NULL) {
+        fprintf(stderr, "tcpflood: could not allocate sockArray, OOM.\n");
+        return 1;
+    }
+    /* use for loop based init for portability - no time critical code */
+    for (i = 0; i < numConnections; ++i) {
+        sockArray[i] = -1;
+    }
 
 #if defined(ENABLE_OPENSSL)
     // Use setupDTLS on DTLS


### PR DESCRIPTION
When tcpflood fails to establish a connection (e.g. due to TLS handshake failure), the socket array entry for that connection remains at its initialized value. Previously, `calloc` was used, initializing entries to 0. Since 0 is a valid file descriptor, tcpflood attempted to use this "valid" socket in subsequent operations (like `relpCltSendSyslog`), leading to a segmentation fault because the associated client/session state was not fully established or was invalid.

This commit changes the initialization of `sockArray` to use `malloc` and explicitly sets all entries to -1. This ensures that failed connections are correctly identified as invalid, triggering the appropriate reconnection or error handling logic instead of crashing.

Co-authored-by: Jules Agent <jules@example.com>

see also https://github.com/rsyslog/rsyslog/issues/6266
