### PR TITLE
runtime/nsd_ossl.c: fix authmode authorization bypass

### DIFF
--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -80,9 +80,12 @@ static rsRetVal doRetry(nsd_ossl_t *pNsd) {
     switch (pNsd->rtryCall) {
         case osslRtry_handshake:
             dbgprintf("doRetry: start osslHandshakeCheck, nsd: %p\n", pNsd);
+            /* Reset retry flag before calling handshake check.
+             * If it needs more retries, it will set it again.
+             */
+            pNsd->rtryCall = osslRtry_None;
             /* Do the handshake again*/
             CHKiRet(osslHandshakeCheck(pNsdOSSL));
-            pNsd->rtryCall = osslRtry_None; /* we are done */
             break;
         case osslRtry_recv:
         case osslRtry_None:


### PR DESCRIPTION
In the `ossl` driver, `doRetry` unconditionally cleared the `rtryCall` state after calling `osslHandshakeCheck`, even if the handshake was still incomplete (e.g., returning `WANT_READ` and re-setting the retry flag). This caused subsequent receive operations to assume the handshake was finished, potentially bypassing the authorization check (`osslChkPeerAuth`).

This change ensures `rtryCall` is reset *before* attempting the handshake, so that if `osslHandshakeCheck` sets it again, the state is preserved. This logic aligns with the intent of the retry mechanism and prevents the bypass.

closes https://github.com/rsyslog/rsyslog/issues/6350
