### PR TITLE
runtime/ratelimit: annotate ratelimit nonnull contracts

### DIFF
--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -208,11 +208,15 @@ finalize_it:
  * If *ppRepMsg != NULL on return, the caller must enqueue that
  * message before the original message.
  */
-rsRetVal ratelimitMsg(ratelimit_t *__restrict__ const ratelimit, smsg_t *pMsg, smsg_t **ppRepMsg) {
+rsRetVal ATTR_NONNULL(1, 2, 3)
+    ratelimitMsg(ratelimit_t *__restrict__ const ratelimit, smsg_t *pMsg, smsg_t **ppRepMsg) {
     DEFiRet;
     rsRetVal localRet;
     int severity = 0;
 
+    assert(ratelimit != NULL);
+    assert(pMsg != NULL);
+    assert(ppRepMsg != NULL);
     *ppRepMsg = NULL;
 
     if (runConf->globals.bReduceRepeatMsgs || ratelimit->severity > 0) {
@@ -257,11 +261,13 @@ int ratelimitChecked(ratelimit_t *ratelimit) {
  * settings.
  * if pMultiSub == NULL, a single-message enqueue happens (under reconsideration)
  */
-rsRetVal ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg) {
+rsRetVal ATTR_NONNULL(1, 3) ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg) {
     rsRetVal localRet;
     smsg_t *repMsg;
     DEFiRet;
 
+    assert(ratelimit != NULL);
+    assert(pMsg != NULL);
     localRet = ratelimitMsg(ratelimit, pMsg, &repMsg);
     if (pMultiSub == NULL) {
         if (repMsg != NULL) CHKiRet(submitMsg2(repMsg));

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -45,8 +45,8 @@ void ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned int interval, unsign
 void ratelimitSetNoTimeCache(ratelimit_t *ratelimit);
 void ratelimitSetSeverity(ratelimit_t *ratelimit, intTiny severity);
 rsRetVal ratelimitMsgCount(ratelimit_t *ratelimit, time_t tt, const char *const appname);
-rsRetVal ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep);
-rsRetVal ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg);
+rsRetVal ATTR_NONNULL(1, 2, 3) ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep);
+rsRetVal ATTR_NONNULL(1, 3) ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg);
 void ratelimitDestruct(ratelimit_t *pThis);
 int ratelimitChecked(ratelimit_t *ratelimit);
 rsRetVal ratelimitModInit(void);

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1812,6 +1812,7 @@ void processImInternal(void) {
     smsg_t *pMsg;
     smsg_t *repMsg;
 
+    assert(internalMsg_ratelimiter != NULL);
     while (iminternalRemoveMsg(&pMsg) == RS_RET_OK) {
         rsRetVal localRet = ratelimitMsg(internalMsg_ratelimiter, pMsg, &repMsg);
         if (repMsg != NULL) {


### PR DESCRIPTION
Improve code clarity and static analysis around ratelimit helpers. This clarifies the expected non-null contract for callers. Before: ratelimit helpers assumed non-null without annotation. After: helpers assert and declare non-null parameters.

Impact: static analysis may warn on null callers.

Add ATTR_NONNULL annotations to ratelimitMsg and ratelimitAddMsg in headers and definitions to make the contract explicit. Add debug asserts so unexpected nulls fail fast in debug builds. This keeps runtime behavior unchanged in release builds while making ownership and expectations clearer to readers and tools.

With the help of AI-Agents: Codex CLI
