### PR TITLE
imfile: fix incorrect fstat usage with inode instead of fd

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -784,7 +784,7 @@ static void detect_updates(fs_edge_t *const edge) {
                    e.g. file has been closed, so we will never have old inode (but
                         why was it closed then? --> check)
              */
-            r = fstat(act->ino, &fileInfo);
+            r = fstat(act->fd, &fileInfo);
             if (r == -1) {
                 time_t ttNow;
                 time(&ttNow);


### PR DESCRIPTION
Correct a bug that could cause file status checks to fail or behave unpredictably when handling rotated or deleted files.

Impact: Prevents potential errors or undefined behavior during file cleanup/rotation checks.
Before/After: fstat was called with an inode number; now it is correctly called with the file descriptor.

The `detect_updates` logic in imfile uses `fstat` to check the status of a file descriptor when it suspects the file might have been closed or replaced. Previously, the code incorrectly passed `act->ino` (the inode number) to `fstat`, which expects a file descriptor. This commit changes it to pass `act->fd`, ensuring the system call receives the correct argument type and value.

With the help of AI-Agents: Gemini-CLI
