### PR TITLE
imhttp: add address input parameter for explicit IPv4/IPv6 binding

### DIFF
--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -95,6 +95,7 @@ struct modConfData_s {
     instanceConf_t *root, *tail;
     struct option ports;
     struct option docroot;
+    struct option address;
     struct option *options;
     int nOptions;
     char *pszHealthCheckPath;


### PR DESCRIPTION
Improve usability and container readiness by allowing imhttp to bind to a specific IP address instead of always listening on 0.0.0.0.

Impact: Users can now explicitly bind imhttp to IPv4 or IPv6 addresses, including IPv6-only setups commonly used in Kubernetes.

Before/After:
- Before: imhttp always listened on 0.0.0.0, ignoring address intent
- After: imhttp respects the address parameter and binds accordingly

Technical details:
- Register and parse a new `address` input parameter in imhttp.
- Combine `address` and `ports` into the CivetWeb `listening_ports` configuration during activation.
- Automatically format IPv6 addresses using bracket notation as required by CivetWeb.
- Eliminates the need to use raw `liboptions` for dual-stack or IPv6-only configurations.