### PR TITLE
doc: add sparseArray lookup IPv4 subnet matching example

### DIFF
--- a/doc/source/configuration/lookup_tables.rst
+++ b/doc/source/configuration/lookup_tables.rst
@@ -252,6 +252,48 @@ key     return
 100     baz
 ======  ==============
 
+**IPv4 Subnet Matching with sparseArray**:
+
+A common use case for ``sparseArray`` is matching IPv4 subnets. To do this,
+you must convert the IPv4 address to its integer representation using the
+``ipv42num()`` function. The table index should be the integer value of the
+*start* of each subnet or range.
+
+Since ``sparseArray`` matches the largest index less than or equal to the key,
+a defined index starts a range that continues until the next defined index.
+
+Example mapping:
+* ``10.0.0.0/24`` (Start: ``167772160``) -> "Office"
+* ``10.0.1.0/24`` (Start: ``167772416``) -> "Guest"
+* ``10.0.2.0/24`` (Start: ``167772672``) -> "Lab"
+
+Table file:
+
+::
+
+    { "version" : 1,
+      "nomatch" : "unknown",
+      "type" : "sparseArray",
+      "table" : [
+        {"index" : 167772160, "value" : "Office" },
+        {"index" : 167772416, "value" : "Guest" },
+        {"index" : 167772672, "value" : "Lab" }]}
+
+Configuration:
+
+::
+
+   lookup_table(name="net_map" file="/path/to/net_map.json")
+   # ...
+   set $.ip_num = ipv42num($fromhost-ip);
+   set $.network = lookup("net_map", $.ip_num);
+
+Note: Any IP between ``10.0.0.0`` and ``10.0.0.255`` will match "Office".
+Any IP between ``10.0.1.0`` and ``10.0.1.255`` will match "Guest".
+Any IP greater than or equal to ``10.0.2.0`` will match "Lab" (unless another
+entry follows). Be sure to define the start of "gaps" if you want them to
+return a different value or fallback to a default.
+
 **regex table**:
 
 ::

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -487,6 +487,7 @@ TESTS +=  \
 	include-obj-text-from-file.sh \
 	include-obj-text-from-file-noexist.sh \
 	multiple_lookup_tables.sh \
+	lookup_sparse_array_ipv4.sh \
 	parsertest-parse1.sh \
 	parsertest-parse1-udp.sh \
 	parsertest-parse2.sh \
@@ -3284,7 +3285,9 @@ EXTRA_DIST= \
 	testsuites/xlate_array_more_misuse.lkp_tbl \
 	sparse_array_lookup_table.sh \
 	sparse_array_lookup_table-vg.sh \
+	lookup_sparse_array_ipv4.sh \
 	testsuites/xlate_sparse_array.lkp_tbl \
+	testsuites/lookup_sparse_array_ipv4.lkp_tbl \
 	testsuites/xlate_sparse_array_more.lkp_tbl \
 	lookup_table_bad_configs.sh \
 	lookup_table_bad_configs-vg.sh \

--- a/tests/lookup_sparse_array_ipv4.sh
+++ b/tests/lookup_sparse_array_ipv4.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Verification test for issue #4906: sparseArray lookup with ipv42num
+# This checks if the proposed documentation example strategy actually works.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+lookup_table(name="ip_lookup" file="'$RSYSLOG_DYNNAME'.lookup_sparse_array_ipv4.lkp_tbl")
+
+template(name="outfmt" type="string" string="%msg%: %$.lkp%\n")
+
+# Assuming msg contains the IP address
+set $.ip_num = ipv42num($msg);
+set $.lkp = lookup("ip_lookup", $.ip_num);
+
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+cp -f $srcdir/testsuites/lookup_sparse_array_ipv4.lkp_tbl $RSYSLOG_DYNNAME.lookup_sparse_array_ipv4.lkp_tbl
+startup
+
+inject_ip() {
+    injectmsg_literal "<13>1 2025-01-01T00:00:00Z localhost mytag - - - $1"
+}
+
+# 10.0.0.0 -> NetA
+inject_ip "10.0.0.0"
+# 10.0.0.5 -> NetA (inside range)
+inject_ip "10.0.0.5"
+# 10.0.0.255 -> NetA (end of range)
+inject_ip "10.0.0.255"
+
+# 10.0.1.0 -> Gap (explicitly defined)
+inject_ip "10.0.1.0"
+# 10.0.1.5 -> Gap (inside gap)
+inject_ip "10.0.1.5"
+
+# 10.0.2.0 -> NetB
+inject_ip "10.0.2.0"
+# 10.0.2.100 -> NetB
+inject_ip "10.0.2.100"
+
+# 9.0.0.0 -> Should be nomatch (less than first entry)
+inject_ip "9.0.0.0"
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "10.0.0.0: NetA"
+content_check "10.0.0.5: NetA"
+content_check "10.0.0.255: NetA"
+content_check "10.0.1.0: Gap"
+content_check "10.0.1.5: Gap"
+content_check "10.0.2.0: NetB"
+content_check "10.0.2.100: NetB"
+# For nomatch, lookup returns "nomatch" string if defined, or empty string?
+# The table file doesn't define "nomatch". Default is empty string?
+# Let's check documentation or code. 
+# doc says: nomatch <string literal, default: "">
+# So it should be empty.
+content_check "9.0.0.0: "
+
+exit_test

--- a/tests/testsuites/lookup_sparse_array_ipv4.lkp_tbl
+++ b/tests/testsuites/lookup_sparse_array_ipv4.lkp_tbl
@@ -1,0 +1,7 @@
+{
+  "type" : "sparseArray",
+  "table":[
+      {"index": 167772160, "value":"NetA" },
+      {"index": 167772416, "value":"Gap" },
+      {"index": 167772672, "value":"NetB" }]
+}


### PR DESCRIPTION
Documenting how to use sparseArray with ipv42num() for efficient IPv4 subnet matching.

Added a regression test to verify this functionality.

see also: https://github.com/rsyslog/rsyslog/issues/4906
