### PR TITLE
tcpsrv: fix race condition in session table slot allocation

### DIFF
--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -170,6 +170,7 @@ struct tcpsrv_s {
         unsigned int ratelimitInterval;
         unsigned int ratelimitBurst;
         tcps_sess_t **pSessions; /**< array of all of our sessions */
+        pthread_mutex_t mutSessions; /**< mutex protecting pSessions array access */
         unsigned int starvationMaxReads;
         void *pUsr; /**< a user-settable pointer (provides extensibility for "derived classes")*/
         /* callbacks */

--- a/tests/tsan.supp
+++ b/tests/tsan.supp
@@ -12,7 +12,7 @@ fun:doSIGTTIN
 #fun:
 
 # actual bugs that should be fixed ASAP after TSAN is in place:
-fun:TCPSessTblFindFreeSpot
+# fun:TCPSessTblFindFreeSpot - FIXED: protected with mutSessions mutex
 fun:processWorksetItem
 
 fun:doLogMsg


### PR DESCRIPTION
Fix race condition in TCPSessTblFindFreeSpot() where multiple worker threads could select the same free slot in the TCP session table, causing sessions to be lost or overwritten.

The race occurred because:
- TCPSessTblFindFreeSpot() searched for free slots without synchronization
- Multiple threads could find the same slot between the search and assignment operations
- The gap between finding a slot (line 674) and assigning it (line 765) allowed concurrent threads to select the same index

Solution:
- Add pthread_mutex_t mutSessions to tcpsrv structure to protect session table access
- Initialize mutex in TCPSessTblInit() and destroy in deinit_tcp_listener()
- Protect all session table operations:
  * Finding and reserving a slot (with temporary marker)
  * Assigning the actual session pointer
  * Removing sessions on close
  * Error path cleanup

The fix uses a temporary marker value to reserve slots during construction, ensuring no two threads can select the same slot even if construction takes time. Mutex is held only during table modifications, not during expensive operations.

Only active in non-EPOLL builds (EPOLL mode doesn't use the session table). Fixed compile errors for EPOLL builds by conditionally compiling unused code.

Resolves TSAN race condition warnings like detected on macOS ARM64 CI: https://github.com/rsyslog/rsyslog/actions/runs/20708776690/job/59444439825?pr=6415

Addresses race condition listed in tests/tsan.supp line 15.

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

