### PR TITLE
runtime: fix race condition in worker thread startup

### DIFF
--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -9,7 +9,7 @@
  * (and in the web doc set on https://www.rsyslog.com/doc/). Be sure to read it
  * if you are getting aquainted to the object.
  *
- * Copyright 2008-2025 Adiscon GmbH.
+ * Copyright 2008-2026 Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -119,6 +119,17 @@ rsRetVal ATTR_NONNULL() wtiSetState(wti_t *pThis, const int newVal) {
         ATOMIC_OR_INT_TO_INT(&pThis->bIsRunning, &pThis->mutIsRunning, newVal);
     }
     return RS_RET_OK;
+}
+
+/* Compare and Set state (atomic).
+ */
+rsRetVal ATTR_NONNULL() wtiCASState(wti_t *pThis, const int oldVal, const int newVal) {
+    ISOBJ_TYPE_assert(pThis, wti);
+    if (ATOMIC_CAS(&pThis->bIsRunning, oldVal, newVal, &pThis->mutIsRunning)) {
+        return RS_RET_OK;
+    } else {
+        return RS_RET_FALSE;
+    }
 }
 
 

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -105,6 +105,7 @@ rsRetVal wtiCancelThrd(wti_t *const pThis, const uchar *const cancelobj);
 void ATTR_NONNULL() wtiJoinThrd(wti_t *const pThis);
 rsRetVal wtiSetAlwaysRunning(wti_t *const pThis);
 rsRetVal wtiSetState(wti_t *const pThis, int bNew);
+rsRetVal wtiCASState(wti_t *const pThis, const int oldVal, const int newVal);
 rsRetVal wtiWakeupThrd(wti_t *const pThis);
 int wtiGetState(wti_t *const pThis);
 wti_t *wtiGetDummy(void);

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -8,7 +8,7 @@
  * (and in the web doc set on https://www.rsyslog.com/doc/). Be sure to read it
  * if you are getting aquainted to the object.
  *
- * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2026 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -454,7 +454,7 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
     wtpJoinTerminatedWrkr(pThis);
     /* find free spot in thread table. */
     for (i = 0; i < pThis->iNumWorkerThreads; ++i) {
-        if (wtiGetState(pThis->pWrkr[i]) == WRKTHRD_STOPPED) {
+        if (wtiCASState(pThis->pWrkr[i], WRKTHRD_STOPPED, WRKTHRD_INITIALIZING) == RS_RET_OK) {
             break;
         }
     }
@@ -466,7 +466,6 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
     }
 
     pWti = pThis->pWrkr[i];
-    wtiSetState(pWti, WRKTHRD_INITIALIZING);
     iState = pthread_create(&(pWti->thrdID), &pThis->attrThrd, wtpWorker, (void *)pWti);
     ATOMIC_INC(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd); /* we got one more! */
 


### PR DESCRIPTION
Fixed a critical race condition in `wtpStartWrkr` where the same worker thread instance (`wti_t`) could be started twice if multiple threads called `wtpStartWrkr` concurrently. This occurred because the check for `WRKTHRD_STOPPED` and the subsequent transition to `WRKTHRD_INITIALIZING` were not atomic.

The fix introduces a new `wtiCASState` function that uses atomic Compare-And-Swap to safely reserve a worker slot. This ensures that only one thread can successfully transition a worker from `STOPPED` to `INITIALIZING`, preventing duplicate reuse.

This resolves crashes and memory corruption seen in threaded outputs (e.g., ommysql) where thread-local data was incorrectly shared between two active threads.

With the help of AI Agents: Google Jules
