### PR TITLE
Fix mmsnareparse test data files missing in make dist

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2124,6 +2124,9 @@ EXTRA_DIST= \
     mmexternal-SegFault-empty-jroot-vg.sh \
     testsuites/mmexternal-SegFault-mm-python.py \
     testsuites/mmsnareparse/sample-custom-pattern.data \
+    testsuites/mmsnareparse/sample-windows2022-security.data \
+    testsuites/mmsnareparse/sample-windows2025-security.data \
+    testsuites/mmsnareparse/sample-events.data \
     mmsnareparse-basic.sh \
     mmsnareparse-comprehensive.sh \
     mmsnareparse-comprehensive-vg.sh \


### PR DESCRIPTION
Fixes issue #6360: mmsnareparse tests fail on Launchpad builds because required test data files are not included in the distribution tarball.

**Problem:**
The mmsnareparse tests (`mmsnareparse-comprehensive.sh`, `mmsnareparse-syslog.sh`, `mmsnareparse-kerberos.sh`) fail during Launchpad builds with errors like:
- `cat: ./testsuites/mmsnareparse/sample-windows2022-security.data: No such file or directory`
- `cat: ./testsuites/mmsnareparse/sample-windows2025-security.data: No such file or directory`
- `./testsuites/mmsnareparse/sample-events.data: No such file or directory`

**Root Cause:**
Only `sample-custom-pattern.data` was listed in `EXTRA_DIST` in `tests/Makefile.am`. The other three test data files were missing, so they weren't packaged when `make dist` ran.

**Solution:**
Added the three missing test data files to `EXTRA_DIST` in `tests/Makefile.am`:
- `testsuites/mmsnareparse/sample-windows2022-security.data`
- `testsuites/mmsnareparse/sample-windows2025-security.data`
- `testsuites/mmsnareparse/sample-events.data`

**Changes:**
- Modified `tests/Makefile.am` to include all mmsnareparse test data files in the distribution

Fixes: https://github.com/rsyslog/rsyslog/issues/6360