### PR TITLE
contrib/imczmq,omczmq: add CZMQ 4.2+ version guards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,4 @@ tools/rscryutil.1
 *.gcda
 *.gcno
 coverage*
+_codeql_detected_source_root

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -205,7 +205,7 @@ static rsRetVal addListener(instanceConf_t *iconf) {
 
     switch (iconf->sockType) {
         case ZMQ_SUB:
-#if defined(ZMQ_DISH)
+#if defined(ZMQ_DISH) && (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2))
         case ZMQ_DISH:
 #endif
             iconf->serverish = false;
@@ -243,7 +243,7 @@ static rsRetVal addListener(instanceConf_t *iconf) {
             if (iconf->sockType == ZMQ_SUB) {
                 zsock_set_subscribe(pData->sock, topic);
             }
-#if defined(ZMQ_DISH)
+#if defined(ZMQ_DISH) && (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2))
             else if (iconf->sockType == ZMQ_DISH) {
                 int rc = zsock_join(pData->sock, topic);
                 if (rc != 0) {
@@ -594,7 +594,7 @@ BEGINnewInpInst
             else if (!strcmp("SUB", stringType)) {
                 inst->sockType = ZMQ_SUB;
             }
-#if defined(ZMQ_DISH)
+#if defined(ZMQ_DISH) && (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2))
             else if (!strcmp("DISH", stringType)) {
                 inst->sockType = ZMQ_DISH;
             }

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -176,7 +176,7 @@ static rsRetVal initCZMQ(instanceData *pData) {
 
     switch (pData->sockType) {
         case ZMQ_PUB:
-#if defined(ZMQ_RADIO)
+#if defined(ZMQ_RADIO) && (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2))
         case ZMQ_RADIO:
 #endif
             pData->serverish = true;
@@ -231,7 +231,7 @@ static rsRetVal outputCZMQ(uchar **ppString, instanceData *pData) {
 
     /* if we are using a PUB (or RADIO) socket and we have a topic list then we
      * need some special care and attention */
-#if defined(ZMQ_RADIO)
+#if defined(ZMQ_RADIO) && (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2))
     DBGPRINTF("omczmq: ZMQ_RADIO is defined...\n");
     if ((pData->sockType == ZMQ_PUB || pData->sockType == ZMQ_RADIO) && pData->topics) {
 #else
@@ -264,7 +264,7 @@ static rsRetVal outputCZMQ(uchar **ppString, instanceData *pData) {
                     ABORT_FINALIZE(RS_RET_SUSPENDED);
                 }
             }
-#if defined(ZMQ_RADIO)
+#if defined(ZMQ_RADIO) && (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2))
             else if (pData->sockType == ZMQ_RADIO) {
                 DBGPRINTF("omczmq: sending on RADIO socket...\n");
                 zframe_t *frame = zframe_from((char *)ppString[0]);
@@ -521,7 +521,7 @@ BEGINnewActInst
                     pData->sockType = ZMQ_PUB;
                     DBGPRINTF("omczmq: sockType set to ZMQ_PUB\n");
                 }
-#if defined(ZMQ_RADIO)
+#if defined(ZMQ_RADIO) && (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2))
                 else if (!strcmp("RADIO", stringType)) {
                     pData->sockType = ZMQ_RADIO;
                     DBGPRINTF("omczmq: sockType set to ZMQ_RADIO\n");


### PR DESCRIPTION
### Summary (non-technical, complete)
CZMQ 4.2.0 removed zframe_set_group() and zsock_join() APIs used for experimental RADIO/DISH socket patterns, breaking builds on Fedora 41/42 and other distributions with modern CZMQ. This fix enables modules to build on current systems while maintaining backward compatibility.

Impact: RADIO/DISH socket types unavailable on CZMQ >= 4.2.0; all standard socket types (PUB/SUB, PUSH/PULL, DEALER/ROUTER, CLIENT/SERVER, SCATTER/GATHER) continue to work normally.

### References
Closes: https://github.com/rsyslog/rsyslog/issues/5996

### Notes
Technical changes: Add CZMQ version guards to conditionally compile RADIO/DISH support only when CZMQ < 4.2.0. Modified 7 preprocessor conditionals across omczmq.c and imczmq.c, wrapping all ZMQ_RADIO and ZMQ_DISH references with version check: (CZMQ_VERSION_MAJOR < 4 || (CZMQ_VERSION_MAJOR == 4 && CZMQ_VERSION_MINOR < 2)). This follows existing patterns for heartbeat feature version gating in the same modules.

Before: Build fails on CZMQ >= 4.2.0 with implicit function declaration errors for zframe_set_group() and zsock_join().
After: Clean build on all CZMQ versions; RADIO/DISH gracefully unavailable on 4.2+, standard sockets fully functional.

Also adds CodeQL artifact to .gitignore for cleaner builds.