### PR TITLE
tests: fix imjournal race condition from parallel execution

### DIFF
--- a/tests/imjournal-basic.sh
+++ b/tests/imjournal-basic.sh
@@ -14,7 +14,13 @@ module(load="../plugins/imjournal/.libs/imjournal" IgnorePreviousMessages="on"
 	RateLimit.Burst="1000000")
 
 template(name="outfmt" type="string" string="%msg%\n")
-action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+
+# Filter to only process messages from this test instance to avoid interference
+# from other parallel journal tests writing to the same system journal
+if $msg contains "'"$RSYSLOG_DYNNAME"'" then {
+	action(type="omfile" template="outfmt" file="'"$RSYSLOG_OUT_LOG"'")
+	stop
+}
 '
 TESTMSG="TestBenCH-RSYSLog imjournal This is a test message - $(date +%s) - $RSYSLOG_DYNNAME"
 

--- a/tests/imjournal-statefile.sh
+++ b/tests/imjournal-statefile.sh
@@ -17,7 +17,13 @@ module(load="../plugins/imjournal/.libs/imjournal" StateFile="imjournal.state"
        )
 
 template(name="outfmt" type="string" string="%msg%\n")
-action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+
+# Filter to only process messages from this test instance to avoid interference
+# from other parallel journal tests writing to the same system journal
+if $msg contains "'"$RSYSLOG_DYNNAME"'" then {
+	action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+	stop
+}
 '
 TESTMSG="TestBenCH-RSYSLog imjournal This is a test message - $(date +%s) - $RSYSLOG_DYNNAME"
 ./journal_print "$TESTMSG"


### PR DESCRIPTION
### Summary (non-technical, complete)
Fixes intermittent CI failures where journal tests timeout waiting for messages that never arrive, caused by concurrent tests interfering through the shared systemd journal.

### References
Investigation based on: https://github.com/alorbach/rsyslog/actions/runs/20849490421/job/59900882324

### Technical Details

**Root Cause**: CI runs `make -j8 check`, causing multiple imjournal tests to read/write the shared systemd journal simultaneously without isolation. Test A receives Test B's messages and times out waiting for its own specific message string.

**Example of the problem**:
```
Test A writes: "TestBenCH-RSYSLog ... - rstb_815925_5a8e3094CTLA"
Test B writes: "TestBenCH-RSYSLog ... 2 - rstb_623004_69593149MNVg"
Test A's rsyslog sees Test B's message, searches for exact string, timeout after 300s
```

**Solution**: Add per-test filtering using each test's unique `$RSYSLOG_DYNNAME`:

```rainerscript
if $msg contains "'$RSYSLOG_DYNNAME'" then {
    action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
    stop
}
```

**Changed files**:
- `tests/imjournal-basic.sh` - Added message filtering
- `tests/imjournal-statefile.sh` - Added message filtering

### Notes
Minimal change preserving all test behavior. Only filters journal messages to prevent cross-test contamination in parallel CI runs.
