### PR TITLE
omfile: fix pszSizeLimitCmd leak; own copy from outchannel

### DIFF
--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -17,7 +17,7 @@
  * pipes. These have been moved to ompipe, to reduced the entanglement
  * between the two different functionalities. -- rgerhards
  *
- * Copyright 2007-2024 Adiscon GmbH.
+ * Copyright 2007-2026 Adiscon GmbH.
  *
  * This file is part of rsyslog.
  *
@@ -485,10 +485,7 @@ static rsRetVal cflineParseOutchannel(
     /* OK, we finally got a correct template. So let's use it... */
     pData->fname = ustrdup(pOch->pszFileTemplate);
     pData->iSizeLimit = pOch->uSizeLimit;
-    /* WARNING: It is dangerous "just" to pass the pointer. As we
-     * never rebuild the output channel description, this is acceptable here.
-     */
-    pData->pszSizeLimitCmd = pOch->cmdOnSizeLimit;
+    if (pOch->cmdOnSizeLimit != NULL) pData->pszSizeLimitCmd = ustrdup(pOch->cmdOnSizeLimit);
 
     iRet = cflineParseTemplateName(&p, pOMSR, iEntry, iTplOpts, getDfltTpl());
 
@@ -1167,6 +1164,7 @@ BEGINfreeInstance
     CODESTARTfreeInstance;
     free(pData->tplName);
     free(pData->fname);
+    free(pData->pszSizeLimitCmd);
     if (pData->iCloseTimeout > 0) janitorDelEtry(pData->janitorID);
     if (pData->bDynamicName) {
         dynaFileFreeCache(pData);


### PR DESCRIPTION
Small shutdown-only memleak reduction. This keeps valgrind clean and improves general hygiene without changing runtime behavior.

Impact: None at runtime; reduces shutdown leak noise only.

Before: pszSizeLimitCmd could alias external storage and was not freed. After: when present, it is strdup'ed on parse and freed in freeInstance, making ownership consistent across parse paths.

Technical details: cflineParseOutchannel now strdup's pOch->cmdOnSizeLimit (guarded for NULL) instead of aliasing it. The free path releases pszSizeLimitCmd alongside other fields (tplName, fname). This aligns ownership with the alternate parse path that produced a heap cstr, and prevents the leak observed on shutdown. No API/ABI or user-visible changes; queues, OMODTX, and HUP behavior are unchanged. No tests/docs touched.

Fixes: https://github.com/rsyslog/rsyslog/issues/6443

With the help of AI Agents: Google Jules
