### PR TITLE
Implement is_in_subnet RainerScript function

### DIFF
--- a/doc/source/rainerscript/functions/rs-is_in_subnet.rst
+++ b/doc/source/rainerscript/functions/rs-is_in_subnet.rst
@@ -1,0 +1,32 @@
+**************
+is_in_subnet()
+**************
+
+Purpose
+=======
+
+is_in_subnet(ip, cidr)
+
+Checks if the provided IP address matches the specified CIDR subnet.
+Returns 1 if the IP is in the subnet, 0 otherwise.
+
+Parameters
+==========
+
+* **ip** - The IP address to check (IPv4 or IPv6 string).
+* **cidr** - The subnet in CIDR notation (e.g., "192.168.1.0/24" or "2001:db8::/32").
+
+Return Value
+============
+
+* **1** - If the IP address is valid and belongs to the subnet.
+* **0** - If the IP address is valid but does not belong to the subnet, or if inputs are invalid.
+
+Example
+=======
+
+.. code-block:: none
+
+   if is_in_subnet($fromhost-ip, "192.168.0.0/16") then {
+      action(type="omfile" file="/var/log/local_net.log")
+   }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -447,6 +447,7 @@ TESTS +=  \
 	rscript_format_time.sh \
 	rscript_parse_time.sh \
 	rscript_is_time.sh \
+	rscript_is_in_subnet.sh \
 	rscript_script_error.sh \
 	rscript_parse_json.sh \
 	rscript_parse_json_issue.sh \
@@ -2307,6 +2308,7 @@ EXTRA_DIST= \
 	rscript_parse_time.sh \
 	rscript_parse_time_get-ts.py \
 	rscript_is_time.sh \
+	rscript_is_in_subnet.sh \
 	rscript_script_error.sh \
 	rscript_parse_json.sh \
 	rscript_parse_json_issue.sh \

--- a/tests/rscript_is_in_subnet.sh
+++ b/tests/rscript_is_in_subnet.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+# Basic IPv4 tests
+set $!res!v4_1 = is_in_subnet("192.168.1.5", "192.168.1.0/24");
+set $!res!v4_2 = is_in_subnet("192.168.2.5", "192.168.1.0/24");
+set $!res!v4_3 = is_in_subnet("192.168.1.1", "192.168.1.1/32");
+set $!res!v4_4 = is_in_subnet("192.168.1.1", "0.0.0.0/0");
+
+# Basic IPv6 tests
+set $!res!v6_1 = is_in_subnet("2001:db8::1", "2001:db8::/32");
+set $!res!v6_2 = is_in_subnet("2001:db9::1", "2001:db8::/32");
+set $!res!v6_3 = is_in_subnet("::1", "::1/128");
+set $!res!v6_4 = is_in_subnet("::1", "::/0");
+
+# Mixed / Invalid tests
+set $!res!inv_1 = is_in_subnet("192.168.1.1", "2001:db8::/32");
+set $!res!inv_2 = is_in_subnet("invalid", "192.168.1.0/24");
+set $!res!inv_3 = is_in_subnet("192.168.1.1", "invalid");
+set $!res!inv_4 = is_in_subnet("192.168.1.1", "192.168.1.0/33"); # Invalid mask
+
+template(name="outfmt" type="string" string="%!res%\n")
+local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+startup
+tcpflood -m1 -y
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='{ "v4_1": 1, "v4_2": 0, "v4_3": 1, "v4_4": 1, "v6_1": 1, "v6_2": 0, "v6_3": 1, "v6_4": 1, "inv_1": 0, "inv_2": 0, "inv_3": 0, "inv_4": 0 }'
+cmp_exact
+exit_test


### PR DESCRIPTION
This function allows checking if an IP address belongs to a specific subnet in RainerScript. Usage: is_in_subnet(ip, cidr) -> boolean

Also adds relevant tests and documentation.

With the help of AI Agents: Google Jules

closes https://github.com/rsyslog/rsyslog/issues/1391