### PR TITLE
omhiredis: remove unneded param name from param table

### DIFF
--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -154,7 +154,6 @@ static struct cnfparamdescr actpdescr[] = {
     {"client_key", eCmdHdlrGetWord, 0},
     {"sni", eCmdHdlrGetWord, 0},
 #endif
-    {"name", eCmdHdlrGetWord, 0},
 };
 
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};


### PR DESCRIPTION
This was introduced in commit e981d7dbdbb286a60dbfc993e6ea9a71e37b30ba. I merged it as it really was just a nit and now do a quick fox to save everyone time.

see also https://github.com/rsyslog/rsyslog/pull/6406
