### PR TITLE
Harden disk queue recovery after invalid .qi seeka

### DIFF
--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -2322,6 +2322,19 @@ static rsRetVal strmGetCurrOffset(strm_t *pThis, int64 *pOffs) {
     RETiRet;
 }
 
+static rsRetVal strmSync(strm_t *pStrmDest, const strm_t *pStrmSrc) {
+    DEFiRet;
+
+    ISOBJ_TYPE_assert(pStrmDest, strm);
+    ISOBJ_TYPE_assert(pStrmSrc, strm);
+
+    pStrmDest->iCurrFNum = pStrmSrc->iCurrFNum;
+    pStrmDest->iCurrOffs = pStrmSrc->iCurrOffs;
+    pStrmDest->strtOffs = pStrmSrc->strtOffs;
+
+    RETiRet;
+}
+
 
 /* queryInterface function
  * rgerhards, 2008-02-29
@@ -2356,6 +2369,7 @@ BEGINobjQueryInterface(strm)
     pIf->Serialize = strmSerialize;
     pIf->GetCurrOffset = strmGetCurrOffset;
     pIf->Dup = strmDup;
+    pIf->Sync = strmSync;
     pIf->SetCompressionWorkers = SetCompressionWorkers;
     pIf->SetWCntr = strmSetWCntr;
     pIf->CheckFileChange = CheckFileChange;

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -200,6 +200,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*GetCurrOffset)(strm_t *pThis, int64 *pOffs);
     rsRetVal (*SetWCntr)(strm_t *pThis, number_t *pWCnt);
     rsRetVal (*Dup)(strm_t *pThis, strm_t **ppNew);
+    rsRetVal (*Sync)(strm_t *pStrmDest, const strm_t *pStrmSrc);
     rsRetVal (*SetCompressionWorkers)(strm_t *const pThis, int num_wrkrs);
     INTERFACEpropSetMeth(strm, bDeleteOnClose, int);
     INTERFACEpropSetMeth(strm, iMaxFileSize, int64);
@@ -227,7 +228,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
     INTERFACEpropSetMeth(strm, cryprov, cryprov_if_t *);
     INTERFACEpropSetMeth(strm, cryprovData, void *);
 ENDinterface(strm)
-#define strmCURR_IF_VERSION 14 /* increment whenever you change the interface structure! */
+#define strmCURR_IF_VERSION 15 /* increment whenever you change the interface structure! */
     /* V10, 2013-09-10: added new parameter bEscapeLF, changed mode to uint8_t (rgerhards) */
     /* V11, 2015-12-03: added new parameter bReopenOnTruncate */
     /* V12, 2015-12-11: added new parameter trimLineOverBytes, changed mode to uint32_t */


### PR DESCRIPTION
### Summary (non-technical, complete)
Hardens disk queue recovery after dirty shutdowns by resetting read/delete pointers and size accounting when an invalid `.qi` file is detected, and by repositioning the read stream so cleanup continues reliably for the daqueue dirty-shutdown scenario.

### References
Refs: https://github.com/alorbach/rsyslog/actions/runs/21024971278

### Notes (optional)
- Tests could not run because `libestr` was missing during configure (`make -j$(nproc) check TESTS=""` and `./tests/daqueue-dirty-shutdown.sh`).
- `devtools/format-code.sh` was not run to avoid reformatting the entire tree.

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.
