### PR TITLE
CI: do not compile on pure doc change

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -38,6 +38,7 @@ on:
       - 'tests/*.sh'
       - 'diag.sh'
       - '**/Makefile.am'
+      - '!doc/Makefile.am'
       - 'configure.ac'
       - '.github/workflows/*.yml'
 


### PR DESCRIPTION
The doc Makefile.am did trigger the general rule for running full builds, which is not necessary as it only contains doc-related stuff.
