### PR TITLE
testbench: robustly stop elasticsearch using kill -9 on timeout

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -3100,7 +3100,7 @@ stop_elasticsearch() {
 		i=0
 		while kill -0 $es_pid 2> /dev/null; do
 			$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
-			if test $i -gt $TB_TIMEOUT_STARTSTOP; then
+                        if test $i -ge $TB_TIMEOUT_STARTSTOP; then
 				printf 'Elasticsearch (pid %d) still running - Performing hard shutdown (-9)\n' $es_pid
 				kill -9 $es_pid
 				break


### PR DESCRIPTION
The previous implementation of stop_elasticsearch in diag.sh used wait_pid_termination which aborts the test script execution if the process does not terminate within the timeout, leaving the Elasticsearch process running. This caused subsequent tests to fail or hang when they tried to reuse the stuck instance.

This change replaces wait_pid_termination with a loop that waits for the process to exit and, if it does not exit within TB_TIMEOUT_STARTSTOP, forcefully terminates it with kill -9. This ensures that a stuck Elasticsearch instance is properly cleaned up, preventing it from interfering with future test runs.
