### PR TITLE
imfile: add inode generation check for file rotation detection

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,7 @@ AC_CHECK_HEADERS([malloc.h],[],[],[
      #endif
   ]
 ])
-AC_CHECK_HEADERS([fcntl.h locale.h netdb.h netinet/in.h paths.h stddef.h stdlib.h string.h sys/file.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h sys/stat.h unistd.h utmp.h utmpx.h sys/epoll.h sys/prctl.h sys/select.h getopt.h linux/close_range.h])
+AC_CHECK_HEADERS([fcntl.h locale.h netdb.h netinet/in.h paths.h stddef.h stdlib.h string.h sys/file.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h sys/stat.h unistd.h utmp.h utmpx.h sys/epoll.h sys/prctl.h sys/select.h getopt.h linux/close_range.h linux/fs.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST


### PR DESCRIPTION
This commit adds a check for inode generation number in the imfile module. This addresses an issue where file rotation is not detected when a new file reuses the same inode number as the old one (which can happen on some filesystems or scenarios).

The check is implemented by using `FS_IOC_GETVERSION` ioctl on Linux. It is guarded by `HAVE_FS_IOC_GETVERSION` and `HAVE_LINUX_FS_H`.

To minimize performance impact, the check is only performed if `st_ctime` has changed while the inode number remains the same.

This also updates the state file format to include `inode_gen` to detect inode reuse across rsyslog restarts.

Fixes #6292
