### PR TITLE
Fix OOM handling in JSON property extraction and formatting

### DIFF
--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -684,6 +684,14 @@ conflict:
     }
 
 finalize_it:
+    if (child != NULL) {
+        json_object_put(child);
+        child = NULL;
+    }
+    if (valueContext != NULL) {
+        free(valueContext);
+        valueContext = NULL;
+    }
     if (dest != NULL) json_object_put(dest);
     RETiRet;
 }


### PR DESCRIPTION
- Fixed potential NULL pointer dereferences in `getJSONPropVal` when `strdup` fails.
- Fixed unchecked `es_str2cstr` return values in `jsonEncode` and `jsonField`.
- Added error propagation in `MsgGetProp` to handle OOM errors from JSON helpers.
- Note on GH#5225: The reported double-free is likely a libfaketime/ASAN conflict.
