### PR TITLE
action: add batchesprocessed pstats counter

### DIFF
--- a/action.h
+++ b/action.h
@@ -111,6 +111,7 @@ struct action_s {
     /* for statistics subsystem */
     statsobj_t *statsobj;
     STATSCOUNTER_DEF(ctrProcessed, mutCtrProcessed)
+    STATSCOUNTER_DEF(ctrBatchesProcessed, mutCtrBatchesProcessed)
     STATSCOUNTER_DEF(ctrFail, mutCtrFail)
     STATSCOUNTER_DEF(ctrSuspend, mutCtrSuspend)
     STATSCOUNTER_DEF(ctrSuspendDuration, mutCtrSuspendDuration)

--- a/doc/source/configuration/rsyslog_statistic_counter.rst
+++ b/doc/source/configuration/rsyslog_statistic_counter.rst
@@ -1,6 +1,17 @@
 rsyslog statistic counter
 =========================
 
+.. meta::
+   :description: Overview of rsyslog statistic counters emitted via impstats.
+   :keywords: rsyslog, impstats, statistics, counters, monitoring
+
+.. summary-start
+
+This page describes core and plugin statistic counters emitted via impstats so
+operators can interpret rsyslog performance data.
+
+.. summary-end
+
 Rsyslog supports statistic counters via the :doc:`impstats <modules/impstats>` module.
 It is important to know that impstats and friends only provides an infrastructure
 where core components and plugins can register statistics counter. This FAQ entry
@@ -52,6 +63,8 @@ Actions
 
 -  **processed** - total number of messages processed by this action. This includes those messages that failed actual execution (so it is a total count of messages ever seen, but not necessarily successfully processed)
 
+-  **batchesprocessed** - total number of batches processed by this action. For direct actions (no action queue), each message counts as a batch of size 1.
+
 -  **failed** - total number of messages that failed during processing. These are actually lost if they have not been processed by some other action. Most importantly in a failover chain the messages are flagged as "failed" in the failing actions even though they are forwarded to the failover action (the failover action’s "processed" count should equal to failing actions "fail" count in this scenario)a
 
 -  **suspended** - (7.5.8+) – total number of times this action suspended itself. Note that this counts the number of times the action transitioned from active to suspended state. The counter is no indication of how long the action was suspended or how often it was retried. This is intentional, as the counter as it currently is permits to tell how often the action ran into a failure condition.
@@ -80,4 +93,3 @@ Plugins
 :doc:`omelasticsearch <modules/omelasticsearch>`
 
 :doc:`omkafka <modules/omkafka>`
-

--- a/tests/stats-cee-vg.sh
+++ b/tests/stats-cee-vg.sh
@@ -32,5 +32,5 @@ shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
 check_exit_vg
-custom_content_check '@cee: { "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check '@cee: { "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "batchesprocessed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/stats-cee.sh
+++ b/tests/stats-cee.sh
@@ -24,5 +24,5 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown
-custom_content_check '@cee: { "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check '@cee: { "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "batchesprocessed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/stats-json-es.sh
+++ b/tests/stats-json-es.sh
@@ -24,6 +24,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown
-custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "batchesprocessed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing '@cee' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/stats-json-prometheus.sh
+++ b/tests/stats-json-prometheus.sh
@@ -24,6 +24,8 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown
-custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended!duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check 'an_action_that_is_never_called_processed_total 0' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check 'an_action_that_is_never_called_batchesprocessed_total 0' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check 'an_action_that_is_never_called_failed_total 0' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing '@cee' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/stats-json-vg.sh
+++ b/tests/stats-json-vg.sh
@@ -32,6 +32,6 @@ shutdown_when_empty
 echo wait on shutdown
 wait_shutdown_vg
 check_exit_vg
-custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "batchesprocessed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing '@cee' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test

--- a/tests/stats-json.sh
+++ b/tests/stats-json.sh
@@ -23,6 +23,6 @@ echo doing shutdown
 shutdown_when_empty
 echo wait on shutdown
 wait_shutdown
-custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
+custom_content_check '{ "name": "an_action_that_is_never_called", "origin": "core.action", "processed": 0, "batchesprocessed": 0, "failed": 0, "suspended": 0, "suspended.duration": 0, "resumed": 0 }' "${RSYSLOG_DYNNAME}.out.stats.log"
 custom_assert_content_missing '@cee' "${RSYSLOG_DYNNAME}.out.stats.log"
 exit_test


### PR DESCRIPTION
Why:
Track batch usage in pstats so operators can infer average batch size.

Impact:
Action statistics now include batchesprocessed and docs note it.

Before/After:
Before: action pstats only reported message totals. After: action pstats reports processed and batchesprocessed.

Technical Overview:
- Add a batchesprocessed stats counter to action state.
- Register the counter with the core.action stats object.
- Increment it for direct actions and per processed batch.
- Document the counter in rsyslog_statistic_counter.rst.

With the help of AI-Agents: ChatGPT

closes https://github.com/rsyslog/rsyslog/issues/503

