### PR TITLE
agent/skills: standardize test registration and mock check

### DIFF
--- a/.agent/skills/rsyslog_commit/SKILL.md
+++ b/.agent/skills/rsyslog_commit/SKILL.md
@@ -16,8 +16,10 @@ This skill standardizes the final step of the development workflow: committing a
 ## Detailed Instructions
 
 ### 1. Pre-Commit Checklist
-- **Code Style**: Run `bash devtools/format-code.sh`. This is mandatory.
+- **Code Style**: Run `bash devtools/format-code.sh` IF any `.c` or `.h` files were modified. This is mandatory for C source changes.
 - **Validation**: Ensure `make -j$(nproc) check TESTS=""` passes and relevant tests are run.
+  - **Multi-Pass AI Audit**: Run the `/audit` workflow for a rigorous, persona-based review (Memory, Concurrency, Standards) using the project's canned prompts.
+  - **Mock Smoke Check**: If you added or renamed test files, run `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)` as a final distribution check.
   - **Note**: If you already successfully built and tested your changes immediately *before* formatting, you do NOT need to re-run the build/test cycle. Formatting is a normalization step and does not affect functionality.
 
 ### 2. Commit Message Structure

--- a/.agent/skills/rsyslog_module/SKILL.md
+++ b/.agent/skills/rsyslog_module/SKILL.md
@@ -41,6 +41,7 @@ Every module must implement and register standard entry points:
 
 ### 4. Build Configuration
 - Update `plugins/Makefile.am` and `configure.ac` when adding new modules.
+- **Test Registration**: Follow the "Define at Top, Distribute Unconditionally, Register Conditionally" pattern in `tests/Makefile.am`. See the `rsyslog_test` skill for details. This is critical for `make distcheck` validity.
 - Use `MODULE_TYPE(eMOD_OUT)` and other macros from `runtime/module-template.h`.
 
 ## Related Skills

--- a/.agent/skills/rsyslog_test/SKILL.md
+++ b/.agent/skills/rsyslog_test/SKILL.md
@@ -20,35 +20,68 @@ This skill provides guidelines and tools for running tests efficiently. It empha
 - **Rule**: Run individual shell scripts directly from the `tests/` directory.
 - **Benefit**: Immediate feedback and visible stdout/stderr.
 
-### 2. Using diag.sh Helpers
+### 2. Test Registration (tests/Makefile.am)
+New tests MUST be registered using the "Define at Top, Distribute Unconditionally, Register Conditionally" pattern. This ensures `make distcheck` validity.
+
+1.  **Define Variable**: Group your tests into a descriptive variable at the **top** of `tests/Makefile.am` (before the `if ENABLE_TESTBENCH` block).
+    ```makefile
+    TESTS_MYMODULE = \
+        test1.sh \
+        test2.sh
+    ```
+2.  **Unconditional Distribution**: Add it to `EXTRA_DIST` immediately after definition. **NEVER** add test scripts to `EXTRA_DIST` inside a conditional block.
+    ```makefile
+    EXTRA_DIST += $(TESTS_MYMODULE)
+    ```
+3.  **Conditional Registration**: Append the variable to the global `TESTS` list inside the appropriate `if ENABLE_...` block.
+    ```makefile
+    if ENABLE_MYMODULE_TESTS
+    TESTS += $(TESTS_MYMODULE)
+    endif
+    ```
+4.  **Serialization**: If tests must run in order, add `.log` dependencies:
+    ```makefile
+    test2.log: test1.log
+    ```
+
+### 3. Using diag.sh Helpers
 All tests source `tests/diag.sh`. You should use its standardized helpers:
 - `cmp_exact`: Verify file content matches.
 - `require_plugin`: Skip test if a module is not built.
 - `command_deny`: Ensure a specific command fails.
 
-### 3. Valgrind Testing
+### 4. Valgrind Testing
 For memory leak and race condition detection:
 - Use scripts ending in `-vg.sh`.
 - These are wrappers that set `USE_VALGRIND=1` and source the base test.
 
-### 4. Debugging Failed Tests
+### 5. Debugging Failed Tests
 If a test fails, you can inspect logs by:
 - Enabling debug: Uncomment `RSYSLOG_DEBUG` exports in `tests/diag.sh`.
 - Disabling cleanup: Comment out `exit_test` at the end of the script.
 - Output files: Look for `rstb_*.out.log` and `log`.
 
-### 5. Integration Test Policy
+### 6. Integration Test Policy
 Certain modules (Kafka, Elasticsearch, Journald) have heavy integration tests requiring external services.
 - **Policy**: Skip these in restricted environments (like AI sandboxes) unless build-only validation is insufficient.
 - Check module-specific `AGENTS.md` or `MODULE_METADATA.yaml`.
 
-### 6. Memory Lifecycle Validation (Mental Audit)
+### 7. Memory Lifecycle Validation (Mental Audit)
 Before committing C changes, agents SHOULD perform a self-audit of memory ownership and lifecycle.
-- **Rule**: Use the [Memory Lifecycle Prompt](../../ai/rsyslog_memory_auditor/base_prompt.txt) to review your diff.
-- **Critical Patterns**: 
+- **Rule**: Run the `/audit` workflow. It orchestrates multiple specialized passes (Memory Guardian, Concurrency Architect) using the [Canned Prompts](../../../ai/).
+- **Critical Patterns**:
   - **NULL Checks**: `es_str2cstr()` can return `NULL`. Every call MUST be followed by a `NULL` check.
   - **Macro Usage**: Prefer `CHKmalloc()` for allocations as it automatically handles the `NULL` check and jumps to `finalize_it`.
-- **Focus**: Pay special attention to `RS_RET` error paths and `strdup` calls in configuration parsing.
+- **Focus**: Pay special attention to `RS_RET` error paths, `es_str2cstr()` checks, and `strdup` calls.
+
+### 8. Mock Smoke Check (Fast Distcheck)
+Whenever you add or rename test scripts, you MUST run a fast distribution check to ensure all files are correctly registered and invocable in a VPATH build. This avoids breaking CI for distribution-related issues.
+
+**Command**:
+```bash
+make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
+```
+- **Pattern**: This uses the `MOCK-OK` mode in `tests/diag.sh` to exit tests with success immediately, skipping the overhead of actual execution while still verifying shell script invocability and distribution completeness.
 
 ## Related Skills
 - `rsyslog_build`: Required before running tests.

--- a/.agent/workflows/audit.md
+++ b/.agent/workflows/audit.md
@@ -1,0 +1,35 @@
+---
+description: Perform a comprehensive, multi-pass AI-driven review of current code changes.
+---
+
+// turbo-all
+
+1.  **Gather Changes**: Run `git diff` to identify all uncommitted changes.
+2.  **Specialized Persona Audits**:
+    -   **Pass 1: The Memory Guardian (Ownership & Leaks)**:
+        - Persona: Senior C Security Auditor.
+        - Canned Prompt: `ai/rsyslog_memory_auditor/base_prompt.txt`
+        - Focus: `RS_RET` paths, `es_str2cstr()` NULL checks, `strdup/free` balance, `CHKmalloc` usage.
+    -   **Pass 2: The Concurrency Architect (Races & Lock Logic)**:
+        - Persona: Systems Architect.
+        - Canned Prompt: `ai/rsyslog_bug_finder/base_prompt.txt`
+        - Focus: Data races, lock balance, structured path analysis, counterexamples for non-OK findings.
+    -   **Pass 3: The Project Standards Guard (Build & Distribution)**:
+        - Persona: rsyslog Maintainer.
+        - Focus: 
+            - `tests/Makefile.am`: "Define at Top, Distribute Unconditionally, Register Conditionally" pattern.
+            - `EXTRA_DIST` completeness.
+            - RainerScript syntax correctness (rsyslog Assistant mode from `ai/support_gpt/base_prompt-gpt4.txt`).
+    -   **Pass 4: The Structural & Formatting Auditor**:
+        - Persona: Documentation & Quality Engineer.
+        - Focus: 
+            - Check for duplicate section numbering (e.g., two "### 6.").
+            - Check for redundant or duplicate guidance lines (e.g., identical `- Focus:` bullets).
+            - Verify all file links and internal cross-references are valid.
+3.  **Adversarial Pass (Simulation)**:
+    - Persona: Adversarial Tester.
+    - Final Pass: Assume a different set of constraints (e.g., "Review this as if you are a strict static analysis tool like Clang Tidy or Coverity") to find any lingering edge cases.
+4.  **Consolidated Report**:
+    - **CRITICAL**: Functional bugs, leaks, or failing distribution rules (VPATH failures).
+    - **ADVISORY**: Pattern improvements, macro suggestions (`CHKmalloc`), or style nits.
+    - **CLEAN**: Verification of correctly implemented rsyslog patterns.


### PR DESCRIPTION
Why: To provide agents with clear, foolproof guidance on how to register tests in the refactored Makefile.am and ensure distribution integrity.

Impact: Improves CI reliability and agent consistency when adding tests.

Before/After: Undocumented test registration / Standardized "Define at Top, Distribute Unconditionally, Register Conditionally" pattern.

Technical Overview:
The rsyslog_test skill now enforces declaring test variables at the top of Makefile.am and adding them to EXTRA_DIST unconditionally, while keeping execution (TESTS +=) conditional. This prevents missing-file errors in VPATH builds. Additionally, the "Mock Smoke Check" pattern (make distcheck TEST_RUN_TYPE=MOCK-OK) is integrated as a mandatory pre-commit validation step for test changes. The rsyslog_module and rsyslog_commit skills are updated with cross-references to these standards.

With the help of AI-Agents: Antigravity
