### PR TITLE
omfile: pass size-limit file to rotate cmd

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -892,6 +892,7 @@ EXTRA_DIST = \
     source/reference/parameters/omfile-iobuffersize.rst \
     source/reference/parameters/omfile-rotation-sizelimit.rst \
     source/reference/parameters/omfile-rotation-sizelimitcommand.rst \
+    source/reference/parameters/omfile-rotation-sizelimitcommandpassfilename.rst \
     source/reference/parameters/omfile-sig-provider.rst \
     source/reference/parameters/omfile-sync.rst \
     source/reference/parameters/omfile-template.rst \

--- a/doc/source/configuration/modules/omfile.rst
+++ b/doc/source/configuration/modules/omfile.rst
@@ -76,6 +76,7 @@ learn about different configuration languages in use by rsyslog.
    ../../reference/parameters/omfile-iobuffersize
    ../../reference/parameters/omfile-rotation-sizelimit
    ../../reference/parameters/omfile-rotation-sizelimitcommand
+   ../../reference/parameters/omfile-rotation-sizelimitcommandpassfilename
    ../../reference/parameters/omfile-sig-provider
    ../../reference/parameters/omfile-sync
    ../../reference/parameters/omfile-template
@@ -237,6 +238,18 @@ selects whether a static or dynamic file (name) shall be written to.
      - .. include:: ../../reference/parameters/omfile-ziplevel.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omfile-rotation-sizelimit`
+     - .. include:: ../../reference/parameters/omfile-rotation-sizelimit.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omfile-rotation-sizelimitcommand`
+     - .. include:: ../../reference/parameters/omfile-rotation-sizelimitcommand.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omfile-rotation-sizelimitcommandpassfilename`
+     - .. include:: ../../reference/parameters/omfile-rotation-sizelimitcommandpassfilename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omfile-veryrobustzip`
      - .. include:: ../../reference/parameters/omfile-veryrobustzip.rst
         :start-after: .. summary-start
@@ -283,14 +296,6 @@ selects whether a static or dynamic file (name) shall be written to.
         :end-before: .. summary-end
    * - :ref:`param-omfile-cry-provider`
      - .. include:: ../../reference/parameters/omfile-cry-provider.rst
-        :start-after: .. summary-start
-        :end-before: .. summary-end
-   * - :ref:`param-omfile-rotation-sizelimit`
-     - .. include:: ../../reference/parameters/omfile-rotation-sizelimit.rst
-        :start-after: .. summary-start
-        :end-before: .. summary-end
-   * - :ref:`param-omfile-rotation-sizelimitcommand`
-     - .. include:: ../../reference/parameters/omfile-rotation-sizelimitcommand.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
 .. _omfile-statistic-counter:
@@ -395,5 +400,3 @@ The following command writes all syslog messages into a file.
 
    action(type="omfile" dirCreateMode="0700" FileCreateMode="0644"
           File="/var/log/messages")
-
-

--- a/doc/source/reference/parameters/omfile-rotation-sizelimitcommand.rst
+++ b/doc/source/reference/parameters/omfile-rotation-sizelimitcommand.rst
@@ -29,6 +29,10 @@ Description
 This sets the command executed when a file hits the configured size limit.
 Use together with :ref:`param-omfile-rotation-sizelimit`.
 
+By default, the current file name is passed as the last argument. Disable
+this behavior with :ref:`param-omfile-rotation-sizelimitcommandpassfilename`
+if your script expects no additional arguments.
+
 Action usage
 ------------
 

--- a/doc/source/reference/parameters/omfile-rotation-sizelimitcommandpassfilename.rst
+++ b/doc/source/reference/parameters/omfile-rotation-sizelimitcommandpassfilename.rst
@@ -1,0 +1,48 @@
+.. _param-omfile-rotation-sizelimitcommandpassfilename:
+.. _omfile.parameter.module.rotation-sizelimitcommandpassfilename:
+
+rotation.sizeLimitCommandPassFileName
+=====================================
+
+.. index::
+   single: omfile; rotation.sizeLimitCommandPassFileName
+   single: rotation.sizeLimitCommandPassFileName
+
+.. summary-start
+
+Controls whether the current file name is passed as an argument to
+`rotation.sizeLimitCommand`.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omfile`.
+
+:Name: rotation.sizeLimitCommandPassFileName
+:Scope: action
+:Type: boolean
+:Default: action=on
+:Required?: no
+:Introduced: 8.x (2026-01-28)
+
+Description
+-----------
+
+When enabled, the file name that exceeded `rotation.sizeLimit` is appended as
+the last argument to `rotation.sizeLimitCommand`. Any arguments specified as
+part of `rotation.sizeLimitCommand` are retained and passed first.
+
+Set to ``off`` to preserve scripts that expect no additional arguments.
+
+Action usage
+------------
+
+.. _param-omfile-action-rotation-sizelimitcommandpassfilename:
+.. _omfile.parameter.action.rotation-sizelimitcommandpassfilename:
+.. code-block:: rsyslog
+
+   action(type="omfile" rotation.sizeLimitCommandPassFileName="on")
+
+See also
+--------
+
+See also :doc:`../../configuration/modules/omfile`.

--- a/doc/source/tutorials/log_rotation_fix_size.rst
+++ b/doc/source/tutorials/log_rotation_fix_size.rst
@@ -36,12 +36,16 @@ rotates it once the size limit is exceeded.
         file="/var/log/log_rotation.log"
         rotation.sizeLimit="52428800"        # 50 MiB per file
         rotation.sizeLimitCommand="/home/me/log_rotation_script"
+        rotation.sizeLimitCommandPassFileName="on"
         template="RSYSLOG_TraditionalFileFormat"
     )
 
 When the configured limit is reached, rsyslog executes the command
-specified in ``rotation.sizeLimitCommand``. In our case it runs
-``/home/me/log_rotation_script`` which contains a single command:
+specified in ``rotation.sizeLimitCommand``. By default, the current file
+name is appended as the last argument; set
+``rotation.sizeLimitCommandPassFileName="off"`` if your script expects no
+additional arguments. In our case it runs ``/home/me/log_rotation_script``
+which contains a single command:
 
 ::
 
@@ -69,4 +73,3 @@ With this approach two files for logging are used, each with a maximum
 size of 50 MB. So we can say we have successfully configured a log
 rotation which satisfies our requirement. We keep the logs at a
 fixed-size level of 100 MB.
-

--- a/runtime/srUtils.h
+++ b/runtime/srUtils.h
@@ -85,7 +85,7 @@ int makeFileParentDirs(const uchar *const szFile,
                        const uid_t uid,
                        const gid_t gid,
                        const int bFailOnChown);
-int execProg(uchar *program, int bWait, uchar *arg);
+int execProg(uchar *program, int bWait, uchar *arg1, uchar *arg2);
 void skipWhiteSpace(uchar **pp);
 rsRetVal genFileName(
     uchar **ppName, uchar *pDirName, size_t lenDirName, uchar *pFName, size_t lenFName, int64_t lNum, int lNumDigits);

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -174,7 +174,7 @@ static rsRetVal resolveFileSizeLimit(strm_t *pThis, uchar *pszCurrFName) {
      * handled, we should also revisit how this command is run (and
      * with which parameters).   rgerhards, 2007-07-20
      */
-    execProg(pCmd, 1, pParams);
+    execProg(pCmd, 1, pParams, pThis->bSizeLimitCmdPassFileName ? pszCurrFName : NULL);
 
     free(pCmd);
 
@@ -1143,6 +1143,7 @@ BEGINobjConstruct(strm) /* be sure to specify the object type also in END macro!
     pThis->tOpenMode = 0600;
     pThis->compressionDriver = STRM_COMPRESS_ZIP;
     pThis->pszSizeLimitCmd = NULL;
+    pThis->bSizeLimitCmdPassFileName = 1;
     pThis->prevLineSegment = NULL;
     pThis->prevMsgSegment = NULL;
     pThis->strtOffs = 0;
@@ -2002,7 +2003,8 @@ DEFpropSetMeth(strm, iMaxFileSize, int64) DEFpropSetMeth(strm, iFileNumDigits, i
                 DEFpropSetMeth(strm, bSync, int) DEFpropSetMeth(strm, bReopenOnTruncate, int)
                     DEFpropSetMeth(strm, sIOBufSize, size_t) DEFpropSetMeth(strm, iSizeLimit, off_t)
                         DEFpropSetMeth(strm, iFlushInterval, int) DEFpropSetMeth(strm, pszSizeLimitCmd, uchar *)
-                            DEFpropSetMeth(strm, cryprov, cryprov_if_t *) DEFpropSetMeth(strm, cryprovData, void *)
+                            DEFpropSetMeth(strm, bSizeLimitCmdPassFileName, int)
+                                DEFpropSetMeth(strm, cryprov, cryprov_if_t *) DEFpropSetMeth(strm, cryprovData, void *)
 
     /* sets timeout in seconds */
     void ATTR_NONNULL() strmSetReadTimeout(strm_t *const __restrict__ pThis, const int val) {
@@ -2390,6 +2392,7 @@ BEGINobjQueryInterface(strm)
     pIf->SetiSizeLimit = strmSetiSizeLimit;
     pIf->SetiFlushInterval = strmSetiFlushInterval;
     pIf->SetpszSizeLimitCmd = strmSetpszSizeLimitCmd;
+    pIf->SetbSizeLimitCmdPassFileName = strmSetbSizeLimitCmdPassFileName;
     pIf->Setcryprov = strmSetcryprov;
     pIf->SetcryprovData = strmSetcryprovData;
 finalize_it:

--- a/runtime/stream.h
+++ b/runtime/stream.h
@@ -41,7 +41,7 @@
  * deflateInit2(zstrmptr, 6, Z_DEFLATED, 31, 9, Z_DEFAULT_STRATEGY);
  * --------------------------------------------------------------------------
  *
- * Copyright 2008-2018 Rainer Gerhards and Adiscon GmbH.
+ * Copyright 2008-2026 Rainer Gerhards and Adiscon GmbH.
  *
  * This file is part of the rsyslog runtime library.
  *
@@ -167,6 +167,7 @@ struct strm_s {
         /* support for omfile size-limiting commands, special counters, NOT persisted! */
         off_t iSizeLimit; /* file size limit, 0 = no limit */
         uchar *pszSizeLimitCmd; /* command to carry out when size limit is reached */
+        sbool bSizeLimitCmdPassFileName; /* pass current file name as arg to size limit command? */
         sbool bIsTTY; /* is this a tty file? */
         cstr_t *prevLineSegment; /* for ReadLine, previous, unprocessed part of file */
         cstr_t *prevMsgSegment; /* for ReadMultiLine, previous, yet unprocessed part of msg */
@@ -217,6 +218,7 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
     INTERFACEpropSetMeth(strm, iSizeLimit, off_t);
     INTERFACEpropSetMeth(strm, iFlushInterval, int);
     INTERFACEpropSetMeth(strm, pszSizeLimitCmd, uchar *);
+    INTERFACEpropSetMeth(strm, bSizeLimitCmdPassFileName, int);
     /* v6 added */
     rsRetVal (*ReadLine)(strm_t *pThis, cstr_t **ppCStr, uint8_t mode, sbool bEscapeLF, const uchar *,
                          uint32_t trimLineOverBytes, int64 *const strtOffs);
@@ -228,12 +230,14 @@ BEGINinterface(strm) /* name must also be changed in ENDinterface macro! */
     INTERFACEpropSetMeth(strm, cryprov, cryprov_if_t *);
     INTERFACEpropSetMeth(strm, cryprovData, void *);
 ENDinterface(strm)
-#define strmCURR_IF_VERSION 15 /* increment whenever you change the interface structure! */
+#define strmCURR_IF_VERSION 16 /* increment whenever you change the interface structure! */
     /* V10, 2013-09-10: added new parameter bEscapeLF, changed mode to uint8_t (rgerhards) */
     /* V11, 2015-12-03: added new parameter bReopenOnTruncate */
     /* V12, 2015-12-11: added new parameter trimLineOverBytes, changed mode to uint32_t */
     /* V13, 2017-09-06: added new parameter strtoffs to ReadLine() */
     /* V14, 2019-11-13: added new parameter bEscapeLFString (rgerhards) */
+    /* V15, ?? - description missing */
+    /* V16, 2026-01-28: added new parameter bSizeLimitCmdPassFileName (rgerhards) */
 
 #define strmGetCurrFileNum(pStrm) ((pStrm)->iCurrFNum)
 

--- a/tests/omfile-sizelimitcmd-many.sh
+++ b/tests/omfile-sizelimitcmd-many.sh
@@ -2,7 +2,8 @@
 # addd 2023-01-11 by RGerhards, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50000
-echo "ls -l $RSYSLOG_DYNNAME.channel.*
+echo "echo \"\$1 \$2\" > $RSYSLOG_DYNNAME.rotate.args
+ls -l $RSYSLOG_DYNNAME.channel.*
 mv -f $RSYSLOG_DYNNAME.channel.log.prev.9 $RSYSLOG_DYNNAME.channel.log.prev.10 2>/dev/null
 mv -f $RSYSLOG_DYNNAME.channel.log.prev.8 $RSYSLOG_DYNNAME.channel.log.prev.9 2>/dev/null
 mv -f $RSYSLOG_DYNNAME.channel.log.prev.7 $RSYSLOG_DYNNAME.channel.log.prev.8 2>/dev/null
@@ -23,7 +24,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 if $msg contains "msgnum:" then {
 	action(type="omfile" file="'$RSYSLOG_DYNNAME.channel.log'" template="outfmt"
 		rotation.sizeLimit="50k"
-		rotation.sizeLimitCommand="./'$RSYSLOG_DYNNAME.rotate.sh'")
+		rotation.sizeLimitCommand="./'$RSYSLOG_DYNNAME.rotate.sh' arg1")
 }
 '
 startup
@@ -32,5 +33,6 @@ shutdown_when_empty
 wait_shutdown
 ls -l $RSYSLOG_DYNNAME.channel.*
 cat $RSYSLOG_DYNNAME.channel.* > $RSYSLOG_OUT_LOG
+content_check "arg1 ./$RSYSLOG_DYNNAME.channel.log" $RSYSLOG_DYNNAME.rotate.args
 seq_check
 exit_test

--- a/tools/omshell.c
+++ b/tools/omshell.c
@@ -105,7 +105,7 @@ ENDtryResume
 BEGINdoAction
     CODESTARTdoAction;
     dbgprintf("\n");
-    if (execProg((uchar *)pWrkrData->pData->progName, 1, ppString[0]) == 0)
+    if (execProg((uchar *)pWrkrData->pData->progName, 1, (uchar *)ppString[0], NULL) == 0)
         LogError(0, NO_ERRCODE, "Executing program '%s' failed", (char *)pWrkrData->pData->progName);
 ENDdoAction
 


### PR DESCRIPTION
Why: rotation scripts need the target file name to act without external logrotate and to retain existing args.

Impact: new action param rotation.sizeLimitCommandPassFileName (default on) appends the file name; legacy outchannel stays unchanged.

Before: sizeLimitCommand could pass at most one arg and never the current file name.
After: optional file name is appended as the last argument when enabled.

Technical Overview:
- Add rotation.sizeLimitCommandPassFileName and plumb to streams.
- Default to on for action config; disable for legacy outchannel.
- Expand execProg to accept argv lists and update callers.
- Update docs/tutorial and register new doc in doc/Makefile.am.
- Extend size-limit test to validate arg order and file name.

closes: https://github.com/rsyslog/rsyslog/issues/6435

With the help of AI-Agents: Codex
