### PR TITLE
configure: fix xxhash library check missing error action

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -440,7 +440,7 @@ if test "$enable_fmhash_xxhash" = "yes"; then
 			HASH_XXHASH_LIBS="-lxxhash"
 			AC_SUBST(HASH_XXHASH_LIBS)],
 			[AC_MSG_ERROR([Unable to add XXHASH support for hash64.])])
-	])
+	], [AC_MSG_ERROR([libxxhash not found, but xxhash support was requested])])
 fi
 
 


### PR DESCRIPTION
Why:
When --enable-fmhash-xxhash is specified but libxxhash is not found, configure should fail with a clear error message instead of silently continuing and reporting success.

Impact:
Configure now correctly fails when xxhash is requested but not available, preventing silent build failures later.

Before:
AC_CHECK_LIB for xxhash had no action-if-not-found parameter, causing configure to report 'fmhash with xxhash enabled: yes' even when the library was missing.

After:
AC_CHECK_LIB now includes action-if-not-found that reports a clear error message when libxxhash is not found.

Technical Overview:
The AC_CHECK_LIB macro on line 436 was missing its fourth parameter (action-if-not-found). This caused the check to pass even when the library was not available. Added an AC_MSG_ERROR call as the action-if-not-found parameter to match the pattern used for the header check and other library checks in the file. This ensures early detection of missing dependencies during configuration rather than cryptic failures during build or runtime.

closes https://github.com/rsyslog/rsyslog/issues/2816

With the help of AI-Agents: GitHub Copilot
