### PR TITLE
queue: fix slow drain of disk-assisted queues

### DIFF
--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -515,7 +515,8 @@ static rsRetVal qqueueAdviseMaxWorkers(qqueue_t *pThis) {
     ISOBJ_TYPE_assert(pThis, qqueue);
 
     if (!pThis->bEnqOnly) {
-        if (pThis->bIsDA && getLogicalQueueSize(pThis) >= pThis->iHighWtrMrk) {
+        if (pThis->bIsDA && (getLogicalQueueSize(pThis) >= pThis->iHighWtrMrk ||
+                             (pThis->pqDA != NULL && getLogicalQueueSize(pThis->pqDA) > 0))) {
             DBGOPRINT((obj_t *)pThis, "(re)activating DA worker\n");
             wtpAdviseMaxWorkers(pThis->pWtpDA, 1, DENY_WORKER_START_DURING_SHUTDOWN);
             /* disk queues have always one worker */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -218,6 +218,7 @@ TESTS_DEFAULT = \
 	daqueue-persist.sh \
 	daqueue-invld-qi.sh \
 	daqueue-dirty-shutdown.sh \
+	daqueue-drain-without-traffic.sh \
 	diskq-rfc5424.sh \
 	diskqueue.sh \
 	diskqueue-fsync.sh \

--- a/tests/daqueue-drain-without-traffic.sh
+++ b/tests/daqueue-drain-without-traffic.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Test for issue #2646: disk-assisted queue draining without new traffic
+# This test verifies that a DA queue with persisted data will drain
+# automatically on restart, even when there is no new incoming traffic.
+# Before the fix, the DA worker only activated when the memory queue
+# reached the high watermark, causing slow drains that took days.
+# After the fix, the DA worker activates whenever the disk queue has data.
+#
+# Test scenario:
+# 1. Start rsyslog with a DA queue configured
+# 2. Inject messages with a slow consumer to fill disk queue
+# 3. Shutdown to persist queue to disk
+# 4. Restart rsyslog WITHOUT injecting new messages
+# 5. Verify that disk queue drains automatically
+#
+# added 2026-01-29 by rgerhards via GitHub Copilot
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=5000
+
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+
+# Configure main queue as disk-assisted with high watermark
+# The key is that we want the disk queue to have data, but the
+# memory queue to be empty on restart (below high watermark)
+main_queue(
+	queue.type="linkedList"
+	queue.filename="mainq"
+	queue.maxDiskSpace="50m"
+	queue.size="1000"
+	queue.highWatermark="800"
+	queue.lowWatermark="200"
+	queue.timeoutShutdown="1"
+	queue.saveOnShutdown="on"
+)
+
+module(load="../plugins/imdiag/.libs/imdiag")
+module(load="../plugins/omtesting/.libs/omtesting")
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+
+if $msg contains "msgnum:" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+
+$IncludeConfig '${RSYSLOG_DYNNAME}'work-delay.conf
+'
+
+# Phase 1: Fill the disk queue with a slow consumer
+echo "*.*     :omtesting:sleep 0 1000" > ${RSYSLOG_DYNNAME}work-delay.conf
+
+startup
+injectmsg 0 $NUMMESSAGES
+shutdown_immediate
+wait_shutdown
+check_mainq_spool
+
+# Verify we have queue files on disk
+ls -l ${RSYSLOG_DYNNAME}.spool/mainq.0000* > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+	echo "ERROR: no queue files found after phase 1 shutdown"
+	error_exit 1
+fi
+
+echo "Phase 1 complete: $NUMMESSAGES messages persisted to disk"
+
+# Phase 2: Restart WITHOUT injecting new messages
+# Remove the delay so messages can drain quickly
+echo "#" > ${RSYSLOG_DYNNAME}work-delay.conf
+
+# The critical test: restart and verify DA worker activates
+# even though no new messages are being injected
+echo "Phase 2: Restarting rsyslog WITHOUT new traffic..."
+startup
+
+# Wait for queue to drain - the DA worker should activate automatically
+# because the disk queue has data (the fix for issue #2646)
+shutdown_when_empty
+wait_shutdown
+
+# Verify all messages were processed
+seq_check 0 $((NUMMESSAGES - 1))
+
+# Verify queue files are cleaned up
+ls ${RSYSLOG_DYNNAME}.spool/mainq.0000* > /dev/null 2>&1
+if [ $? -eq 0 ]; then
+	echo "WARNING: queue files still exist after drain (this may be OK)"
+fi
+
+echo "SUCCESS: DA queue drained without new traffic"
+exit_test


### PR DESCRIPTION
Why:
Disk-assisted queues were taking days to drain after recovery because the DA worker only activated when the in-memory queue reached the high watermark, creating a catch-22 when starting with an empty memory queue but full disk queue.

Impact:
This fix enables proper recovery from backlogs and prevents data loss from queues that cannot drain. Existing behavior for normal operations is preserved.

Before:
DA worker only started when: memQueueSize >= highWatermark

After:
DA worker starts when: memQueueSize >= highWatermark OR diskQueueSize > 0

Technical Overview:
Modified qqueueAdviseMaxWorkers() in runtime/queue.c to check both the memory queue size against the high watermark (original condition) and whether the disk queue (pqDA) has pending messages. This ensures the DA worker activates whenever there is data on disk to process, not just when new incoming traffic fills the memory queue. The NULL check for pqDA prevents dereferencing before the DA queue is initialized. This change maintains the original high-watermark behavior while adding the recovery path.

closes https://github.com/rsyslog/rsyslog/issues/2646

With the help of AI-Agents: GitHub Copilot
