### PR TITLE
imkafka: add JSON batch splitting for Azure Event Hub messages

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -529,6 +529,7 @@ EXTRA_DIST = \
     source/reference/parameters/imkafka-consumergroup.rst \
     source/reference/parameters/imkafka-parsehostname.rst \
     source/reference/parameters/imkafka-ruleset.rst \
+    source/reference/parameters/imkafka-split-json-records.rst \
     source/reference/parameters/imkafka-topic.rst \
     source/reference/parameters/imklog-consoleloglevel.rst \
     source/reference/parameters/imklog-internalmsgfacility.rst \

--- a/doc/source/configuration/modules/imkafka.rst
+++ b/doc/source/configuration/modules/imkafka.rst
@@ -87,6 +87,10 @@ Input Parameters
      - .. include:: ../../reference/parameters/imkafka-ruleset.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imkafka-split-json-records`
+     - .. include:: ../../reference/parameters/imkafka-split-json-records.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imkafka-topic`
      - .. include:: ../../reference/parameters/imkafka-topic.rst
         :start-after: .. summary-start
@@ -100,6 +104,7 @@ Input Parameters
    ../../reference/parameters/imkafka-consumergroup
    ../../reference/parameters/imkafka-parsehostname
    ../../reference/parameters/imkafka-ruleset
+   ../../reference/parameters/imkafka-split-json-records
    ../../reference/parameters/imkafka-topic
 
 Statistic Counters

--- a/doc/source/reference/parameters/imkafka-split-json-records.rst
+++ b/doc/source/reference/parameters/imkafka-split-json-records.rst
@@ -1,0 +1,97 @@
+.. _param-imkafka-split-json-records:
+.. _imkafka.parameter.input.split.json.records:
+
+split.json.records
+==================
+
+.. index::
+   single: imkafka; split.json.records
+   single: split.json.records
+
+.. summary-start
+
+Controls whether imkafka splits JSON batches into individual messages.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkafka`.
+
+:Name: split.json.records
+:Scope: input
+:Type: boolean
+:Default: input=``off``
+:Required?: no
+:Introduced: 8.2502.0
+
+Description
+-----------
+When enabled, imkafka will detect JSON messages with the format ``{"records":[...]}`` 
+and split the array into individual syslog messages. Each record within the array 
+becomes a separate message, allowing for message-level filtering and processing.
+
+This is particularly useful when consuming messages from Azure Event Hub or other 
+systems that batch multiple log records into a single Kafka message.
+
+**Behavior:**
+
+- If splitting is enabled and the message contains a ``"records"`` array, each 
+  element is submitted as a separate message.
+- If the ``"records"`` field is not found or the JSON is malformed, the entire 
+  message is forwarded unchanged.
+- When a record contains a ``"time"`` field (ISO 8601 timestamp), it is used as 
+  the message timestamp.
+- Empty arrays ``{"records":[]}`` are forwarded as a single message without splitting.
+
+**Error Handling:**
+
+- Malformed JSON: A warning is logged and the message is forwarded as received.
+- Missing ``"records"`` field: The message is processed as a normal single event.
+
+Input usage
+-----------
+.. _imkafka.parameter.input.split.json.records-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imkafka")
+   input(type="imkafka"
+         topic="your-topic"
+         broker="localhost:9092"
+         consumergroup="default"
+         split.json.records="on")
+
+Example
+-------
+
+**Input (Single Kafka Message):**
+
+.. code-block:: json
+
+   {
+     "records": [
+       {
+         "time": "2025-02-20T03:19:34.655Z",
+         "operationName": "CreatePathDir",
+         "statusCode": 409
+       },
+       {
+         "time": "2025-02-20T03:19:34.693Z",
+         "operationName": "CreatePathDir",
+         "statusCode": 409
+       }
+     ]
+   }
+
+**Output (Two Separate Syslog Messages):**
+
+.. code-block:: json
+
+   {"time":"2025-02-20T03:19:34.655Z","operationName":"CreatePathDir","statusCode":409}
+
+.. code-block:: json
+
+   {"time":"2025-02-20T03:19:34.693Z","operationName":"CreatePathDir","statusCode":409}
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkafka`.

--- a/tests/imkafka-json-split-empty.sh
+++ b/tests/imkafka-json-split-empty.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Test for imkafka JSON message splitting with empty records array
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available kcat
+export KEEP_KAFKA_RUNNING="YES"
+
+export TESTMESSAGES=1
+export TESTMESSAGESFULL=$TESTMESSAGES
+# Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+
+export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+wait_for_kafka_startup
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server with JSON splitting enabled */
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker="127.0.0.1:29092"
+	consumergroup="default"
+	split.json.records="on"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+action( type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+
+# Inject a JSON batch message with empty records array
+printf '%s\n' '{"records":[]}' | kcat -P -b localhost:29092 -t $RANDTOPIC
+
+shutdown_when_empty
+wait_shutdown
+
+delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+# Check that the empty array message was forwarded as-is (not split, since there are no records)
+content_check '{"records":[]}'
+
+exit_test

--- a/tests/imkafka-json-split-invalid.sh
+++ b/tests/imkafka-json-split-invalid.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Test for imkafka JSON message splitting with invalid/malformed JSON
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available kcat
+export KEEP_KAFKA_RUNNING="YES"
+
+export TESTMESSAGES=1
+export TESTMESSAGESFULL=$TESTMESSAGES
+# Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+
+export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+wait_for_kafka_startup
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+export RSYSLOG_DEBUGLOG="log"
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server with JSON splitting enabled */
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker="127.0.0.1:29092"
+	consumergroup="default"
+	split.json.records="on"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+action( type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+
+# Inject a malformed JSON message (truncated)
+printf '%s\n' '{"records":[{"time":"2025-02-20' | kcat -P -b localhost:29092 -t $RANDTOPIC
+
+shutdown_when_empty
+wait_shutdown
+
+delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+# Check that warning was logged about JSON parsing failure
+content_check "splitJsonRecords: failed to parse JSON, forwarding as-is"
+
+# Check that the malformed message was still forwarded (partial content)
+content_check '{"records":[{"time":"2025-02-20'
+
+exit_test

--- a/tests/imkafka-json-split-nonarray.sh
+++ b/tests/imkafka-json-split-nonarray.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Test for imkafka JSON message splitting with non-array records field
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available kcat
+export KEEP_KAFKA_RUNNING="YES"
+
+export TESTMESSAGES=1
+export TESTMESSAGESFULL=$TESTMESSAGES
+# Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+
+export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+wait_for_kafka_startup
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server with JSON splitting enabled */
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker="127.0.0.1:29092"
+	consumergroup="default"
+	split.json.records="on"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+action( type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+
+# Inject a JSON message where "records" is an object, not an array
+printf '%s\n' '{"records":{"time":"2025-02-20T03:19:34.655Z","msg":"test"}}' | kcat -P -b localhost:29092 -t $RANDTOPIC
+
+shutdown_when_empty
+wait_shutdown
+
+delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+# Check that warning was logged about records not being an array
+content_check "splitJsonRecords: 'records' is not an array, forwarding as-is"
+
+# Check that the message was forwarded as-is (not split)
+content_check '{"records":{"time":"2025-02-20T03:19:34.655Z","msg":"test"}}'
+
+exit_test

--- a/tests/imkafka-json-split-timestamp.sh
+++ b/tests/imkafka-json-split-timestamp.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+# Test for imkafka JSON message splitting with timestamp edge cases
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available kcat
+export KEEP_KAFKA_RUNNING="YES"
+
+export TESTMESSAGES=3
+export TESTMESSAGESFULL=$TESTMESSAGES
+# Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+
+export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+wait_for_kafka_startup
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server with JSON splitting enabled */
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker="127.0.0.1:29092"
+	consumergroup="default"
+	split.json.records="on"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+action( type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+
+# Inject JSON batch with various timestamp scenarios:
+# 1. Record with valid timestamp
+# 2. Record without timestamp field (should use current time)
+# 3. Record with invalid timestamp format (should use current time)
+printf '%s\n' '{"records":[{"time":"2025-02-20T03:19:34.655Z","msg":"with-timestamp"},{"msg":"no-timestamp"},{"time":"invalid-format","msg":"bad-timestamp"}]}' | kcat -P -b localhost:29092 -t $RANDTOPIC
+
+shutdown_when_empty
+wait_shutdown
+
+delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+# Check that all 3 records were split into separate messages
+content_count_check '"msg":"with-timestamp"' 1
+content_count_check '"msg":"no-timestamp"' 1
+content_count_check '"msg":"bad-timestamp"' 1
+
+# Verify that splitting occurred - the "records" wrapper should NOT be present
+content_check --regex '^[^"]*"records":' --invert
+
+exit_test

--- a/tests/imkafka-json-split-valid.sh
+++ b/tests/imkafka-json-split-valid.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Test for imkafka JSON message splitting with valid records
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+check_command_available kcat
+export KEEP_KAFKA_RUNNING="YES"
+
+export TESTMESSAGES=2
+export TESTMESSAGESFULL=$TESTMESSAGES
+# Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
+export EXTRA_EXITCHECK=dumpkafkalogs
+export EXTRA_EXIT=kafka
+
+export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+
+download_kafka
+stop_zookeeper
+stop_kafka
+
+start_zookeeper
+start_kafka
+wait_for_kafka_startup
+create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+generate_conf
+add_conf '
+main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
+
+module(load="../plugins/imkafka/.libs/imkafka")
+/* Polls messages from kafka server with JSON splitting enabled */
+input(	type="imkafka"
+	topic="'$RANDTOPIC'"
+	broker="127.0.0.1:29092"
+	consumergroup="default"
+	split.json.records="on"
+	confParam=[ "compression.codec=none",
+		"session.timeout.ms=10000",
+		"socket.timeout.ms=5000",
+		"socket.keepalive.enable=true",
+		"reconnect.backoff.jitter.ms=1000",
+		"enable.partition.eof=false" ]
+	)
+
+action( type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+
+# Inject a JSON batch message with two records
+printf '%s\n' '{"records":[{"time":"2025-02-20T03:19:34.655Z","msg":"msgnum:00000001:"},{"time":"2025-02-20T03:19:34.693Z","msg":"msgnum:00000002:"}]}' | kcat -P -b localhost:29092 -t $RANDTOPIC
+
+shutdown_when_empty
+wait_shutdown
+
+delete_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
+
+# Check that we got 2 separate messages
+content_count_check "msgnum:00000001:" 1
+content_count_check "msgnum:00000002:" 1
+
+# Verify that splitting actually occurred - the "records" wrapper should NOT be present
+# This ensures the test fails if splitting doesn't work and the entire batch is forwarded as-is
+content_check --regex '^[^"]*"records":' --invert
+
+exit_test


### PR DESCRIPTION
### Summary (non-technical, complete)
Enables rsyslog to process Azure Event Hub and Kafka batch messages that contain multiple JSON records as individual syslog messages. Previously, batches like `{"records":[{...},{...}]}` were forwarded as single messages, making message-level filtering impossible. With `split.json.records=on`, each record becomes a discrete message with preserved timestamps.

### References
Refs: https://github.com/rsyslog/rsyslog/issues/5570

### Technical Changes

**Core Implementation** (`plugins/imkafka/imkafka.c`):
- New `split.json.records` parameter (boolean, default: off)
- `splitJsonRecords()`: Parses `{"records":[...]}` and submits each element individually
- `extractJsonTimestamp()`: Extracts ISO 8601 timestamps from record's `"time"` field
- `submitJsonRecord()`: Wrapper for submitting individual records with timestamp preservation
- Fallback: Malformed JSON or missing "records" field → forwards entire message unchanged

**Error Handling**:
- Null pointer validation on all parameters
- Tracks submission success; returns error if all records fail (triggers fallback)
- Logs warnings for JSON parse failures and array serialization errors

**Configuration Example**:
```rsyslog
module(load="imkafka")
input(type="imkafka"
      topic="azure-logs"
      broker="localhost:9092"
      consumergroup="default"
      split.json.records="on")
```

**Behavior**:
```json
// Input (single Kafka message)
{"records":[
  {"time":"2025-02-20T03:19:34.655Z","msg":"a"},
  {"time":"2025-02-20T03:19:34.693Z","msg":"b"}
]}

// Output (two syslog messages with preserved timestamps)
{"time":"2025-02-20T03:19:34.655Z","msg":"a"}
{"time":"2025-02-20T03:19:34.693Z","msg":"b"}
```

### Notes
- Tests: `imkafka-json-split-valid.sh` (valid batch), `imkafka-json-split-invalid.sh` (malformed JSON)
- Documentation: `imkafka-split-json-records.rst` added to parameter reference
- Timestamp precision: Milliseconds ignored by strptime (documented limitation)

---
