### PR TITLE
tests: suppress libfaketime in tsan runtime

### DIFF
--- a/tests/tsan-rt.supp
+++ b/tests/tsan-rt.supp
@@ -7,4 +7,5 @@ race:^imptcp_destruct_epd$
 race:doLogMsg
 race:setlocale
 race:doSIGTTIN
+race:libfaketime
 race:libmysqlclient


### PR DESCRIPTION
Why: avoid TSAN noise from LD_PRELOADed libfaketime Impact: TSAN runs ignore known-good libfaketime races Before/After: before TSAN reported libfaketime races; after suppressed in runtime suppression list
Technical Overview:
- add a libfaketime race suppression to tsan-rt.supp
- align with other external-library suppressions in that file
- keep scope at runtime-suppression level for TSAN runs
- avoid touching non-TSAN test behavior Closes https://github.com/rsyslog/rsyslog/issues/5225

With the help of AI-Agents: Codex
