### PR TITLE
runtime: include IPv6 scope id in DNS cache keys

### DIFF
--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -101,6 +101,13 @@ static unsigned int hash_from_key_fn(void *k) {
         hashval = (unsigned)(hashval * (unsigned long long)33) + *rkey++;
     }
 
+    if (((struct sockaddr *)k)->sa_family == AF_INET6) {
+        const uint32_t scope_id = ((struct sockaddr_in6 *)k)->sin6_scope_id;
+        for (size_t i = 0; i < sizeof(scope_id); ++i) {
+            hashval = (unsigned)(hashval * (unsigned long long)33) + ((scope_id >> (i * 8)) & 0xff);
+        }
+    }
+
     return hashval;
 }
 
@@ -118,7 +125,8 @@ static int key_equals_fn(void *key1, void *key2) {
             break;
         case AF_INET6:
             RetVal = !memcmp(&((struct sockaddr_in6 *)key1)->sin6_addr, &((struct sockaddr_in6 *)key2)->sin6_addr,
-                             sizeof(struct in6_addr));
+                             sizeof(struct in6_addr)) &&
+                     ((struct sockaddr_in6 *)key1)->sin6_scope_id == ((struct sockaddr_in6 *)key2)->sin6_scope_id;
             break;
         default:
             // No action needed for other cases


### PR DESCRIPTION
Why:
Link-local IPv6 sources can share an address but differ by scope, which can collide in the DNS cache and mix hostnames (https://github.com/rsyslog/rsyslog/issues/5645).

Impact:
Reduces misrouting risk for IPv6 link-local senders.

Before/After:
Before: DNS cache treated link-local IPv6 addresses as identical. After: DNS cache differentiates IPv6 scope IDs.

Technical Overview:
- Mix sin6_scope_id into the AF_INET6 cache hash key.
- Compare sin6_scope_id in the AF_INET6 cache key matcher.
- Keep IPv4 behavior unchanged.

closes https://github.com/rsyslog/rsyslog/issues/5645

With the help of AI-Agents: ChatGPT
