### PR TITLE
Fix build failure with OpenSSL 3.4.3+ due to deprecated ENGINE API

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1243,6 +1243,26 @@ if test "x$enable_openssl" = "xyes"; then
 	AC_DEFINE([ENABLE_OPENSSL], [1], [Indicator that openssl is present])
 	AC_DEFINE([ENABLE_OSSL], [1], [Indicator that ossl driver is present])
 	save_libs=$LIBS
+
+	# Check if OpenSSL has ENGINE support (it is deprecated in 3.0 and may be missing)
+	save_CFLAGS="$CFLAGS"
+	save_LIBS="$LIBS"
+	CFLAGS="$CFLAGS $OPENSSL_CFLAGS"
+	LIBS="$LIBS $OPENSSL_LIBS"
+	AC_CHECK_HEADER([openssl/engine.h],
+	  [
+	     AC_CHECK_DECL([ENGINE_load_builtin_engines],
+	        [],
+	        [AC_DEFINE([OPENSSL_NO_ENGINE], [1], [Define if OpenSSL ENGINE support is missing])],
+	        [[#include <openssl/engine.h>]]
+	     )
+	  ],
+	  [
+	     AC_DEFINE([OPENSSL_NO_ENGINE], [1], [Define if OpenSSL ENGINE support is missing])
+	  ]
+	)
+	CFLAGS="$save_CFLAGS"
+	LIBS="$save_LIBS"
 fi
 if test "x$enable_wolfssl" = "xyes" && test "x$enable_openssl" = "xyes"; then
 	AC_MSG_ERROR([wolfSSL and OpenSSL cannot be enabled together; select only one])


### PR DESCRIPTION
Detect if `ENGINE_load_builtin_engines` is declared in `openssl/engine.h` via `configure.ac`. If not (which happens in newer OpenSSL versions where ENGINE is deprecated/hidden/removed), define `OPENSSL_NO_ENGINE`. This macro triggers existing guards in `runtime/net_ossl.c` and other files to disable ENGINE support, allowing the build to succeed.

closes: https://github.com/rsyslog/rsyslog/issues/6310

With the help of AI agents: Google Jules
