### PR TITLE
tests: cover localHostname for internal messages

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -70,6 +70,7 @@ TESTS_ELASTICSEARCH_VALGRIND = \
 	es-basic-ha-vg.sh
 
 TESTS_DEFAULT = \
+	preservefqdn-localhostname-internal.sh \
 	immark.sh \
 	immark-inputname.sh \
 	immark-ruleset.sh \

--- a/tests/preservefqdn-localhostname-internal.sh
+++ b/tests/preservefqdn-localhostname-internal.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Verify localHostname is applied to internal rsyslogd messages (hostname property).
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+# Make sure local hostname is a FQDN and preserved.
+global(preserveFQDN="on" localHostname="host.example.com")
+
+template(name="outfmt" type="string" string="%hostname%\n")
+
+if ($syslogtag contains "rsyslogd") then {
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	stop
+}'
+
+startup
+./msleep 100
+shutdown_when_empty
+wait_shutdown
+
+line_count=$(wc -l < "$RSYSLOG_OUT_LOG")
+if [ "$line_count" -eq 0 ]; then
+	printf 'expected hostname output, got empty log\n'
+	error_exit 1
+fi
+content_count_check "host.example.com" "$line_count"
+
+exit_test


### PR DESCRIPTION
Why: prevent regressions around preserveFQDN/localHostname by asserting internal rsyslogd messages honor the configured FQDN.

Impact: adds one test; no runtime behavior changes.

Before/After: before no explicit coverage; after internal hostname is asserted as the configured FQDN.

Technical Overview:
- Add a testbench script that sets preserveFQDN and localHostname.
- Capture internal rsyslogd messages via syslogtag and write %hostname%.
- Validate every emitted hostname equals host.example.com.
- Register the test in TESTS_DEFAULT.

Closes https://github.com/rsyslog/rsyslog/issues/195

With the help of AI-Agents: Codex
