### PR TITLE
Modernize imuxsock tests: Replace backtick expansion with shell expan…

### DIFF
--- a/tests/imuxsock_ccmiddle_root.sh
+++ b/tests/imuxsock_ccmiddle_root.sh
@@ -18,7 +18,7 @@ add_conf '
 $ModLoad ../plugins/imuxsock/.libs/imuxsock
 
 $template outfmt,"%msg:%\n"
-local1.*    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+local1.*    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_ccmiddle_syssock.sh
+++ b/tests/imuxsock_ccmiddle_syssock.sh
@@ -23,7 +23,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock"
        SysSock.name="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-local1.*    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+local1.*    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_hostname.sh
+++ b/tests/imuxsock_hostname.sh
@@ -19,7 +19,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
 input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%hostname:%\n")
-local1.*    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+local1.*    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 # the message itself is irrelevant. The only important thing is

--- a/tests/imuxsock_impstats.sh
+++ b/tests/imuxsock_impstats.sh
@@ -19,7 +19,7 @@ input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket" RateLimit.Int
 
 if $msg contains "msgnum:" then {
 	:msg, contains, "msgnum:" action(type="omfile" template="outfmt"
-			         file=`echo $RSYSLOG_OUT_LOG`)
+			         file="'$RSYSLOG_OUT_LOG'")
 }
 '
 startup

--- a/tests/imuxsock_logger.sh
+++ b/tests/imuxsock_logger.sh
@@ -9,7 +9,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
 input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 logger -d -u $RSYSLOG_DYNNAME-testbench_socket test

--- a/tests/imuxsock_logger_err.sh
+++ b/tests/imuxsock_logger_err.sh
@@ -10,7 +10,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
 input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_logger_parserchain.sh
+++ b/tests/imuxsock_logger_parserchain.sh
@@ -12,7 +12,7 @@ input(	type="imuxsock" socket="'$RSYSLOG_DYNNAME'-testbench_socket"
 	parseHostname="on")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 logger -d --rfc3164 -u $RSYSLOG_DYNNAME-testbench_socket test

--- a/tests/imuxsock_logger_ratelimit.sh
+++ b/tests/imuxsock_logger_ratelimit.sh
@@ -29,7 +29,7 @@ for use_special_parser in on off; do
   template(name="outfmt" type="string" string="%msg:%\n")
 
   ruleset(name="testruleset") {
-    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
   }
   '
   startup

--- a/tests/imuxsock_logger_root.sh
+++ b/tests/imuxsock_logger_root.sh
@@ -12,7 +12,7 @@ add_conf '
 $ModLoad ../plugins/imuxsock/.libs/imuxsock
 
 $template outfmt,"%msg:%\n"
-*.=notice      action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+*.=notice      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_logger_ruleset.sh
+++ b/tests/imuxsock_logger_ruleset.sh
@@ -13,7 +13,7 @@ input(	type="imuxsock" socket="'$RSYSLOG_DYNNAME'-testbench_socket"
 template(name="outfmt" type="string" string="%msg:%\n")
 
 ruleset(name="testruleset") {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/imuxsock_logger_ruleset_ratelimit.sh
+++ b/tests/imuxsock_logger_ruleset_ratelimit.sh
@@ -14,7 +14,7 @@ input(	type="imuxsock" socket="'$RSYSLOG_DYNNAME'-testbench_socket"
 template(name="outfmt" type="string" string="%msg:%\n")
 
 ruleset(name="testruleset") {
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/imuxsock_traillf.sh
+++ b/tests/imuxsock_traillf.sh
@@ -14,7 +14,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
 input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-local1.*	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+local1.*	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 ./syslog_caller -fsyslog_inject-l -m1 -C "uxsock:$RSYSLOG_DYNNAME-testbench_socket"

--- a/tests/imuxsock_traillf_root.sh
+++ b/tests/imuxsock_traillf_root.sh
@@ -18,7 +18,7 @@ add_conf '
 $ModLoad ../plugins/imuxsock/.libs/imuxsock
 
 $template outfmt,"%msg:%\n"
-local1.*	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+local1.*	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 # send a message with trailing LF

--- a/tests/imuxsock_traillf_syssock.sh
+++ b/tests/imuxsock_traillf_syssock.sh
@@ -17,7 +17,7 @@ module(load="../plugins/imuxsock/.libs/imuxsock"
        SysSock.name="'$RSYSLOG_DYNNAME'-testbench_socket")
 
 template(name="outfmt" type="string" string="%msg:%\n")
-local1.*	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+local1.*	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 ./syslog_caller -fsyslog_inject-l -m1 -C "uxsock:$RSYSLOG_DYNNAME-testbench_socket"


### PR DESCRIPTION
…sion

Replaced legacy internal backtick expansion (e.g., file=`echo $RSYSLOG_OUT_LOG`) with standard shell expansion (e.g., file="'$RSYSLOG_OUT_LOG'") in imuxsock test scripts. This avoids unnecessary runtime shell forking and aligns with project best practices.

Affected files:
- tests/imuxsock_ccmiddle_root.sh
- tests/imuxsock_ccmiddle_syssock.sh
- tests/imuxsock_hostname.sh
- tests/imuxsock_impstats.sh
- tests/imuxsock_logger.sh
- tests/imuxsock_logger_err.sh
- tests/imuxsock_logger_parserchain.sh
- tests/imuxsock_logger_ratelimit.sh
- tests/imuxsock_logger_root.sh
- tests/imuxsock_logger_ruleset.sh
- tests/imuxsock_logger_ruleset_ratelimit.sh
- tests/imuxsock_traillf.sh
- tests/imuxsock_traillf_root.sh
- tests/imuxsock_traillf_syssock.sh
