### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix buffer overflow risk in datetime for…

### DIFF
--- a/runtime/datetime.c
+++ b/runtime/datetime.c
@@ -1268,13 +1268,14 @@ static int formatUnixTimeFromTime_t(time_t unixtime,
         }
 
         // MMM dd HH:mm:ss
-        sprintf(pBuf, "%s %2d %.2d:%.2d:%.2d", monthNames[lt.tm_mon], lt.tm_mday, lt.tm_hour, lt.tm_min, lt.tm_sec);
+        snprintf(pBuf, pBufMax, "%s %2d %.2d:%.2d:%.2d", monthNames[lt.tm_mon], lt.tm_mday, lt.tm_hour, lt.tm_min,
+                 lt.tm_sec);
     } else if (strcmp(format, "date-rfc3339") == 0) {
         assert(pBufMax >= 26);
 
         // YYYY-MM-DDTHH:mm:ss+00:00
-        sprintf(pBuf, "%d-%.2d-%.2dT%.2d:%.2d:%.2dZ", lt.tm_year + 1900, lt.tm_mon + 1, lt.tm_mday, lt.tm_hour,
-                lt.tm_min, lt.tm_sec);
+        snprintf(pBuf, pBufMax, "%d-%.2d-%.2dT%.2d:%.2d:%.2dZ", lt.tm_year + 1900, lt.tm_mon + 1, lt.tm_mday,
+                 lt.tm_hour, lt.tm_min, lt.tm_sec);
     }
 
     return strlen(pBuf);


### PR DESCRIPTION
…matting

Replaced unsafe `sprintf` calls with `snprintf` in `formatUnixTimeFromTime_t` in `runtime/datetime.c`. This prevents potential buffer overflows if the destination buffer is too small, respecting the `pBufMax` parameter.

Verified by running `tests/rscript_format_time.sh`, `tests/timestamp-3164.sh`, and `tests/timestamp-3339.sh`.

With the help of AI Agent: Google Jules
