### PR TITLE
Fix infinite loop in re_extract when regex matches empty string

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -1665,7 +1665,14 @@ static void doFunc_re_extract(struct cnffunc *func, struct svar *ret, void *usrp
             } else {
                 DBGPRINTF("re_extract: regex found at offset %d, new offset %d, tries %d\n", iOffs,
                           (int)(iOffs + pmatch[0].rm_eo), iTry);
-                iOffs += pmatch[0].rm_eo;
+                if (pmatch[0].rm_eo == 0) {
+                    if (str[iOffs] == '\0') {
+                        break;
+                    }
+                    iOffs++;
+                } else {
+                    iOffs += pmatch[0].rm_eo;
+                }
                 ++iTry;
             }
         } else {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -327,6 +327,7 @@ TESTS_DEFAULT = \
 	rscript_wrap3.sh \
 	rscript_re_extract_i.sh \
 	rscript_re_extract.sh \
+	rscript_re_extract_loop.sh \
 	rscript_re_match_i.sh \
 	rscript_re_match.sh \
 	rscript_re_match-dbl_quotes.sh \

--- a/tests/rscript_re_extract_loop.sh
+++ b/tests/rscript_re_extract_loop.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Test re_extract behavior with empty matches to prevent infinite loops/stuck behavior
+echo ===============================================================================
+echo \[rscript_re_extract_loop.sh\]: test re_extract empty match loop
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="*Result: %$.res%*\n")
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")'
+
+# Regex: a?
+# Input: " a" (space then a)
+# Match 0: "" (at start, before space)
+# Match 1: "a" (after space)
+# We want Match 1.
+add_conf "
+set \$.res = re_extract(\$msg, 'a?', 1, 0, 'fail');"
+
+add_conf '
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+export RSYSLOG_DEBUG="debug nostdout"
+export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debug"
+
+startup
+# Send proper syslog message so $msg is populated
+# Double quoting for eval in diag.sh
+tcpflood -m 1 -M '"<166>Jan 1 00:00:00 localhost tag: a"'
+echo doing shutdown
+shutdown_when_empty
+echo wait on shutdown
+wait_shutdown
+content_check "*Result: a*"
+exit_test


### PR DESCRIPTION
When `re_extract` executes a regex that matches an empty string (length 0), `regexec` returns `rm_eo = 0`. The loop logic `iOffs += pmatch[0].rm_eo` results in `iOffs` not advancing, causing the next iteration to find the same empty match at the same position. This leads to finding the same match repeatedly (up to `matchnbr`), which is incorrect behavior (subsequent matches should be distinct).

This commit fixes the issue by detecting zero-length matches and forcing an advance of `iOffs` by 1, while ensuring we do not overrun the string buffer.

Fixes issue #230 (potential infinite loop scenario).


Co-authored-by: Jules Agent
