### PR TITLE
ci: gate checks after compile

### DIFF
--- a/.github/workflows/ci_compile.yml
+++ b/.github/workflows/ci_compile.yml
@@ -37,7 +37,8 @@ jobs:
     timeout-minutes: 30
     strategy:
       # When set to true, cancel all in-progress jobs if any matrix job fails.
-      fail-fast: false
+      # A single compile failure is sufficient; stop the remaining matrix to save CI time.
+      fail-fast: true
       matrix:
         # note: we compile only with the oldest and newest supported compilers to
         # save resources. Other important ones are used during the rest of

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -25,25 +25,22 @@
 name: check
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.head_branch }}
   cancel-in-progress: true
 
 on:
-  pull_request:
-    paths:
-      - '**/*.c'
-      - '**/*.h'
-      - 'grammar/lexer.l'
-      - 'grammar/grammar.y'
-      - 'tests/*.sh'
-      - 'diag.sh'
-      - '**/Makefile.am'
-      - '!doc/Makefile.am'
-      - 'configure.ac'
-      - '.github/workflows/*.yml'
+  workflow_run:
+    # Run only after compile check completes so we avoid expensive CI if compile fails.
+    workflows: ["compile check"]
+    types: [completed]
 
 jobs:
   CI:
+    # Only proceed for successful compile runs on pull requests from this repo.
+    if: >-
+      ${{ github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.pull_requests[0].head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     timeout-minutes: 50
     strategy:
@@ -60,8 +57,31 @@ jobs:
     steps:
       - name: git checkout project
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: code_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          base_sha: ${{ github.event.workflow_run.pull_requests[0].base.sha }}
+          sha: ${{ github.event.workflow_run.head_sha }}
+          files: |
+            **/*.c
+            **/*.h
+            grammar/lexer.l
+            grammar/grammar.y
+            tests/*.sh
+            diag.sh
+            **/Makefile.am
+            configure.ac
+            .github/workflows/*.yml
+          files_ignore: |
+            doc/Makefile.am
 
       - name: run container CI pipeline
+        if: steps.code_changes.outputs.any_changed == 'true'
         run: |
           chmod -R go+rw .
           CODECOV_repo_slug="$(git config --get remote.origin.url | sed -E 's#.*[:/]([^/]+/[^/.]+)(\\.git)?$#\1#')"
@@ -225,6 +245,10 @@ jobs:
               ;;
           esac
           devtools/devcontainer.sh --rm devtools/run-ci.sh
+
+      - name: Skip CI, no relevant changes
+        if: steps.code_changes.outputs.any_changed != 'true'
+        run: echo "No relevant changes detected; skipping container CI."
 
       - name: show error logs (if we errored)
         if: ${{ failure() || cancelled() }}


### PR DESCRIPTION
Reduce CI runtime and improve green IT/cost efficiency by stopping redundant work on failures.

Impact: compile matrix cancels on first failure; checks wait on compile.
Before/After: checks ran in parallel; now they run after a successful compile.

Technical Overview:
- Enable fail-fast in compile matrix to cancel remaining jobs.
- Trigger run_checks via workflow_run on compile completion.
- Guard run_checks to PRs with successful compile outcomes.
- Recompute change filters in run_checks with changed-files.
- Skip container CI when no relevant changes are detected.
- No local tests run (workflow changes only).

With the help of AI-Agents: Codex
