### PR TITLE
rosi-collector: Add Syslog Health (impstats) dashboard and client sidecar

### DIFF
--- a/deploy/docker-compose/rosi-collector/clients/RSYSLOG-SETUP.md
+++ b/deploy/docker-compose/rosi-collector/clients/RSYSLOG-SETUP.md
@@ -57,7 +57,8 @@ The script will:
 3. Prompt you to enter port (default: 10514)
 4. Ask for confirmation to overwrite if configuration exists
 5. Install and configure everything automatically
-6. Restart rsyslog and show logs for verification
+6. Install the rsyslog impstats sidecar (default enabled)
+7. Restart rsyslog and show logs for verification
 
 ### Script Features
 
@@ -65,8 +66,29 @@ The script will:
 - **Overwrite protection**: Detects existing configs and asks before overwriting
 - **Configuration testing**: Validates configuration syntax before applying
 - **Automatic setup**: Creates spool directory and installs configuration
+- **Impstats sidecar**: Installs the rsyslog exporter service by default
+- **Exporter IP selection**: Prompts for the exporter bind address
+- **Python venv check**: Offers to install `pythonX.Y-venv` if missing
+- **Firewall rules**: Adds UFW or iptables-persistent rules on Ubuntu/Debian
 - **Log verification**: Shows recent logs and checks for errors
 - **Error handling**: Comprehensive error checking and reporting
+
+### Sidecar Installer (Optional)
+
+The client installer also sets up the rsyslog impstats exporter sidecar
+by default. To skip sidecar installation:
+
+```bash
+sudo ./install-rsyslog-client.sh --no-sidecar
+```
+
+### Add Client Targets (One Command)
+
+On the ROSI Collector server, add both node and impstats targets at once:
+
+```bash
+prometheus-target add-client CLIENT_IP host=CLIENT_HOSTNAME role=ROLE network=NETWORK
+```
 
 ### Example Output
 
@@ -76,6 +98,17 @@ The script provides color-coded output and interactive prompts:
 [INFO]==========================================
 [INFO]rsyslog Client Configuration Installer
 [INFO]==========================================
+
+[PROMPT]Install rsyslog impstats sidecar? [Y/n]
+y
+[WARN]python3 venv/ensurepip module is missing.
+[PROMPT]Run 'apt update && apt install python3.12-venv'? [Y/n]
+
+[INFO]Detected IP addresses on this system:
+  [1] 127.0.0.1
+  [2] 10.0.3.1
+[PROMPT]Select IP address to bind exporter [1-2] or enter custom IP:
+2
 
 [PROMPT]Enter central server IP address:
 10.135.0.10

--- a/deploy/docker-compose/rosi-collector/clients/install-rsyslog-client.sh
+++ b/deploy/docker-compose/rosi-collector/clients/install-rsyslog-client.sh
@@ -19,6 +19,43 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $1" >&2; }
 log_error() { echo -e "${RED}[ERROR]${NC} $1" >&2; }
 log_prompt() { echo -e "${BLUE}[PROMPT]${NC} $1" >&2; }
 
+INSTALL_SIDECAR_SET="false"
+LISTEN_ADDR_SET="false"
+LISTEN_PORT_SET="false"
+IMPSTATS_UDP_ADDR_SET="false"
+IMPSTATS_UDP_PORT_SET="false"
+
+if [ -n "${INSTALL_SIDECAR+x}" ]; then INSTALL_SIDECAR_SET="true"; fi
+if [ -n "${LISTEN_ADDR+x}" ]; then LISTEN_ADDR_SET="true"; fi
+if [ -n "${LISTEN_PORT+x}" ]; then LISTEN_PORT_SET="true"; fi
+if [ -n "${IMPSTATS_UDP_ADDR+x}" ]; then IMPSTATS_UDP_ADDR_SET="true"; fi
+if [ -n "${IMPSTATS_UDP_PORT+x}" ]; then IMPSTATS_UDP_PORT_SET="true"; fi
+
+INSTALL_SIDECAR="${INSTALL_SIDECAR:-true}"
+LISTEN_ADDR="${LISTEN_ADDR:-127.0.0.1}"
+LISTEN_PORT="${LISTEN_PORT:-9898}"
+IMPSTATS_UDP_ADDR="${IMPSTATS_UDP_ADDR:-127.0.0.1}"
+IMPSTATS_UDP_PORT="${IMPSTATS_UDP_PORT:-19090}"
+SIDECAR_PREFIX="${SIDECAR_PREFIX:-/opt/rsyslog-exporter}"
+
+to_lower() {
+    echo "$1" | tr 'A-Z' 'a-z'
+}
+
+is_true() {
+    case "$(to_lower "$1")" in
+        1|true|yes|y|on) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+is_false() {
+    case "$(to_lower "$1")" in
+        0|false|no|n|off) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
 need_root() {
     [ "${EUID:-$(id -u)}" -eq 0 ] || {
         log_error "This script must be run as root"
@@ -56,6 +93,167 @@ check_required_commands() {
     fi
 }
 
+check_sidecar_requirements() {
+    local missing=()
+    
+    for cmd in python3 tar; do
+        if ! command -v "$cmd" >/dev/null 2>&1; then
+            missing+=("$cmd")
+        fi
+    done
+    
+    if [ ${#missing[@]} -gt 0 ]; then
+        log_error "Missing required commands for sidecar install: ${missing[*]}"
+        log_error "Please install the required packages and try again"
+        exit 1
+    fi
+
+    if ! python3 -m venv -h >/dev/null 2>&1 || ! python3 -m ensurepip --version >/dev/null 2>&1; then
+        if [ -f /etc/os-release ]; then
+            . /etc/os-release
+        fi
+        if command -v apt-get >/dev/null 2>&1 && [[ "${ID:-}" =~ ^(ubuntu|debian)$ ]]; then
+            local py_ver
+            local venv_pkg
+            py_ver=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "")
+            if [ -n "$py_ver" ]; then
+                venv_pkg="python${py_ver}-venv"
+            else
+                venv_pkg="python3-venv"
+            fi
+            if [ -t 0 ]; then
+                log_warn "python3 venv/ensurepip module is missing."
+                log_prompt "Run 'apt update && apt install ${venv_pkg}'? [Y/n]"
+                read -r confirm < /dev/tty
+                if [[ "$confirm" =~ ^[Nn]$ ]]; then
+                    log_error "python3 venv module is required for sidecar install"
+                    exit 1
+                fi
+                apt update
+                if ! apt install -y "${venv_pkg}"; then
+                    if [ "${venv_pkg}" != "python3-venv" ]; then
+                        log_warn "Failed to install ${venv_pkg}, trying python3-venv..."
+                        apt install -y python3-venv
+                    fi
+                fi
+            else
+                log_error "python3 venv module is missing. Install python3-venv and retry."
+                exit 1
+            fi
+        else
+            log_error "python3 venv module is missing. Install python3-venv and retry."
+            exit 1
+        fi
+    fi
+}
+
+configure_impstats_firewall() {
+    local central_ip="$1"
+    local central_ips_v4=()
+    local central_ips_v6=()
+    local configured=false
+
+    if [ "$LISTEN_ADDR" = "127.0.0.1" ]; then
+        log_info "Impstats exporter is bound to 127.0.0.1; skipping firewall configuration"
+        return 0
+    fi
+
+    if [ -f /etc/os-release ]; then
+        . /etc/os-release
+    fi
+
+    if [[ "${ID:-}" =~ ^(ubuntu|debian)$ ]]; then
+        if validate_ip "$central_ip"; then
+            central_ips_v4=("$central_ip")
+        elif command -v getent >/dev/null 2>&1; then
+            while IFS= read -r ip; do
+                [ -n "$ip" ] && central_ips_v4+=("$ip")
+            done < <(getent ahostsv4 "$central_ip" 2>/dev/null | awk '{print $1}' | sort -u)
+            while IFS= read -r ip; do
+                [ -n "$ip" ] && central_ips_v6+=("$ip")
+            done < <(getent ahostsv6 "$central_ip" 2>/dev/null | awk '{print $1}' | sort -u)
+        fi
+
+        if [ ${#central_ips_v4[@]} -eq 0 ] && [ ${#central_ips_v6[@]} -eq 0 ]; then
+            log_warn "Central server name did not resolve; skipping firewall rule for impstats exporter"
+        fi
+
+        if [ -f "/etc/iptables/rules.v4" ] && command -v iptables >/dev/null 2>&1 && [ ${#central_ips_v4[@]} -gt 0 ]; then
+            log_info "Configuring iptables-persistent rule for impstats exporter..."
+            local backup_file="/etc/iptables/rules.v4.backup.$(date +%Y%m%d_%H%M%S)"
+            cp /etc/iptables/rules.v4 "$backup_file" 2>/dev/null || true
+            for src_ip in "${central_ips_v4[@]}"; do
+                local rule_desc="$src_ip -> $LISTEN_ADDR:$LISTEN_PORT"
+                if iptables -C INPUT -d "$LISTEN_ADDR" -s "$src_ip" -p tcp --dport "$LISTEN_PORT" -j ACCEPT 2>/dev/null; then
+                    log_info "iptables rule for $rule_desc already exists"
+                    continue
+                fi
+                if iptables -I INPUT 1 -d "$LISTEN_ADDR" -s "$src_ip" -p tcp --dport "$LISTEN_PORT" -j ACCEPT 2>/dev/null; then
+                    configured=true
+                else
+                    log_warn "Failed to add iptables rule for $rule_desc"
+                fi
+            done
+            if [ "$configured" = true ] && command -v iptables-save >/dev/null 2>&1; then
+                iptables-save > /etc/iptables/rules.v4 2>/dev/null || {
+                    log_warn "Failed to save iptables rules to /etc/iptables/rules.v4"
+                    log_warn "Backup available at: $backup_file"
+                }
+            fi
+        fi
+
+        if [[ "$LISTEN_ADDR" == *:* ]] && [ -f "/etc/iptables/rules.v6" ] && command -v ip6tables >/dev/null 2>&1 && [ ${#central_ips_v6[@]} -gt 0 ]; then
+            log_info "Configuring iptables-persistent IPv6 rule for impstats exporter..."
+            local backup_file_v6="/etc/iptables/rules.v6.backup.$(date +%Y%m%d_%H%M%S)"
+            cp /etc/iptables/rules.v6 "$backup_file_v6" 2>/dev/null || true
+            for src_ip in "${central_ips_v6[@]}"; do
+                local rule_desc="$src_ip -> $LISTEN_ADDR:$LISTEN_PORT"
+                if ip6tables -C INPUT -d "$LISTEN_ADDR" -s "$src_ip" -p tcp --dport "$LISTEN_PORT" -j ACCEPT 2>/dev/null; then
+                    log_info "ip6tables rule for $rule_desc already exists"
+                    continue
+                fi
+                if ip6tables -I INPUT 1 -d "$LISTEN_ADDR" -s "$src_ip" -p tcp --dport "$LISTEN_PORT" -j ACCEPT 2>/dev/null; then
+                    configured=true
+                else
+                    log_warn "Failed to add ip6tables rule for $rule_desc"
+                fi
+            done
+            if [ "$configured" = true ] && command -v ip6tables-save >/dev/null 2>&1; then
+                ip6tables-save > /etc/iptables/rules.v6 2>/dev/null || {
+                    log_warn "Failed to save ip6tables rules to /etc/iptables/rules.v6"
+                    log_warn "Backup available at: $backup_file_v6"
+                }
+            fi
+        fi
+
+        if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -q "Status: active"; then
+            log_info "Configuring UFW rule for impstats exporter on ${LISTEN_ADDR}:${LISTEN_PORT}..."
+            if [ ${#central_ips_v4[@]} -gt 0 ] || [ ${#central_ips_v6[@]} -gt 0 ]; then
+                for src_ip in "${central_ips_v4[@]}"; do
+                    if ufw allow from "$src_ip" to "$LISTEN_ADDR" port "$LISTEN_PORT" proto tcp comment "rsyslog impstats exporter" 2>/dev/null; then
+                        configured=true
+                    else
+                        log_warn "Failed to add UFW rule (may already exist)"
+                    fi
+                done
+                for src_ip in "${central_ips_v6[@]}"; do
+                    if ufw allow from "$src_ip" to "$LISTEN_ADDR" port "$LISTEN_PORT" proto tcp comment "rsyslog impstats exporter" 2>/dev/null; then
+                        configured=true
+                    else
+                        log_warn "Failed to add UFW rule (may already exist)"
+                    fi
+                done
+            else
+                log_warn "Central server name did not resolve; skipping UFW rule"
+            fi
+        fi
+    fi
+
+    if [ "$configured" = false ]; then
+        log_warn "No firewall rule configured for impstats exporter"
+    fi
+}
+
 validate_ip() {
     local ip="$1"
     if [[ $ip =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]]; then
@@ -79,6 +277,26 @@ validate_port() {
     return 1
 }
 
+validate_sidecar_params() {
+    if ! validate_ip "$LISTEN_ADDR"; then
+        log_error "Invalid sidecar listen address: $LISTEN_ADDR"
+        return 1
+    fi
+    if ! validate_ip "$IMPSTATS_UDP_ADDR"; then
+        log_error "Invalid impstats UDP address: $IMPSTATS_UDP_ADDR"
+        return 1
+    fi
+    if ! validate_port "$LISTEN_PORT"; then
+        log_error "Invalid sidecar listen port: $LISTEN_PORT"
+        return 1
+    fi
+    if ! validate_port "$IMPSTATS_UDP_PORT"; then
+        log_error "Invalid impstats UDP port: $IMPSTATS_UDP_PORT"
+        return 1
+    fi
+    return 0
+}
+
 validate_domain() {
     local domain="$1"
     if [[ $domain =~ ^([a-zA-Z0-9]([a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$ ]]; then
@@ -93,6 +311,186 @@ validate_ip_or_domain() {
         return 0
     fi
     return 1
+}
+
+detect_local_ips() {
+    local ips=()
+    local ip
+    
+    while IFS= read -r ip; do
+        [ -n "$ip" ] && validate_ip "$ip" && ips+=("$ip")
+    done < <(ip addr show 2>/dev/null | grep -E "inet (10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[01])\.)" | awk '{print $2}' | cut -d/ -f1 || true)
+    
+    printf '%s\n' "${ips[@]}"
+}
+
+detect_all_ips() {
+    local ips=()
+    local ip
+    
+    while IFS= read -r ip; do
+        [ -n "$ip" ] && validate_ip "$ip" && ips+=("$ip")
+    done < <(ip addr show 2>/dev/null | grep "inet " | awk '{print $2}' | cut -d/ -f1 || true)
+    
+    printf '%s\n' "${ips[@]}"
+}
+
+select_listen_ip() {
+    local detected_ips
+    local all_ips
+    local selected_ip
+    local user_input
+    
+    detected_ips=($(detect_local_ips))
+    all_ips=($(detect_all_ips))
+    
+    if [ ${#detected_ips[@]} -eq 0 ]; then
+        log_warn "No local network IPs detected (10.x.x.x, 192.168.x.x, 172.16-31.x.x)"
+        if [ ${#all_ips[@]} -gt 0 ]; then
+            log_info "Detected IP addresses on this system:"
+            for i in "${!all_ips[@]}"; do
+                echo "  [$((i+1))] ${all_ips[$i]}" >&2
+            done
+            echo "" >&2
+        fi
+        log_prompt "Select IP address to bind exporter [1-${#all_ips[@]}] or enter custom IP:"
+        read -r user_input < /dev/tty
+        if [[ "$user_input" =~ ^[0-9]+$ ]] && [ "$user_input" -ge 1 ] && [ "$user_input" -le ${#all_ips[@]} ]; then
+            echo "${all_ips[$((user_input-1))]}"
+            return
+        fi
+        while ! validate_ip "$user_input"; do
+            log_error "Invalid IP address format: $user_input"
+            log_prompt "Please enter a valid IP address (e.g., 10.135.0.10 or 127.0.0.1):"
+            read -r user_input < /dev/tty
+            if [[ "$user_input" =~ ^[0-9]+$ ]] && [ "$user_input" -ge 1 ] && [ "$user_input" -le ${#all_ips[@]} ]; then
+                echo "${all_ips[$((user_input-1))]}"
+                return
+            fi
+        done
+        echo "$user_input"
+        return
+    fi
+    
+    log_info "Detected IP addresses on this system:"
+    local display_count=0
+    for i in "${!all_ips[@]}"; do
+        display_count=$((display_count + 1))
+        local ip_type=""
+        if [[ " ${detected_ips[*]} " =~ " ${all_ips[$i]} " ]]; then
+            ip_type=" (local)"
+        else
+            ip_type=" (external)"
+        fi
+        echo "  [$display_count] ${all_ips[$i]}$ip_type" >&2
+    done
+    echo "" >&2
+    
+    if [ ${#all_ips[@]} -eq 1 ]; then
+        log_info "Using detected IP: ${all_ips[0]}"
+        log_prompt "Press Enter to use ${all_ips[0]} or type a different IP address:"
+        read -r user_input < /dev/tty
+        if [ -z "$user_input" ]; then
+            echo "${all_ips[0]}"
+            return
+        elif validate_ip "$user_input"; then
+            echo "$user_input"
+            return
+        else
+            log_warn "Invalid IP address, using detected IP: ${all_ips[0]}"
+            echo "${all_ips[0]}"
+            return
+        fi
+    fi
+    
+    log_prompt "Select IP address to bind exporter [1-${#all_ips[@]}] or enter custom IP:"
+    echo -n "" >&2
+    read -r user_input < /dev/tty
+    
+    if [ -z "$user_input" ]; then
+        selected_ip="${all_ips[0]}"
+    elif [[ "$user_input" =~ ^[0-9]+$ ]] && [ "$user_input" -ge 1 ] && [ "$user_input" -le ${#all_ips[@]} ]; then
+        selected_ip="${all_ips[$((user_input-1))]}"
+    elif validate_ip "$user_input"; then
+        selected_ip="$user_input"
+        log_info "Using custom IP: $selected_ip"
+    else
+        log_warn "Invalid selection, using first detected IP: ${all_ips[0]}"
+        selected_ip="${all_ips[0]}"
+    fi
+    
+    echo "$selected_ip"
+}
+
+show_usage() {
+    cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --no-sidecar                 Skip impstats sidecar install (default: enabled)
+  --sidecar                    Force impstats sidecar install
+  --sidecar-prefix <path>      Sidecar install prefix (default: /opt/rsyslog-exporter)
+  --sidecar-listen-addr <ip>   Sidecar HTTP listen address (default: 127.0.0.1)
+  --sidecar-listen-port <port> Sidecar HTTP listen port (default: 9898)
+  --impstats-udp-addr <ip>     UDP bind addr for impstats (default: 127.0.0.1)
+  --impstats-udp-port <port>   UDP port for impstats (default: 19090)
+  -h, --help                   Show this help
+EOF
+}
+
+parse_args() {
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --no-sidecar)
+                INSTALL_SIDECAR="false"
+                INSTALL_SIDECAR_SET="true"
+                shift
+                ;;
+            --sidecar)
+                INSTALL_SIDECAR="true"
+                INSTALL_SIDECAR_SET="true"
+                shift
+                ;;
+            --sidecar-prefix)
+                [ $# -ge 2 ] || { log_error "--sidecar-prefix requires an argument"; exit 2; }
+                SIDECAR_PREFIX="$2"
+                shift 2
+                ;;
+            --sidecar-listen-addr)
+                [ $# -ge 2 ] || { log_error "--sidecar-listen-addr requires an argument"; exit 2; }
+                LISTEN_ADDR="$2"
+                LISTEN_ADDR_SET="true"
+                shift 2
+                ;;
+            --sidecar-listen-port)
+                [ $# -ge 2 ] || { log_error "--sidecar-listen-port requires an argument"; exit 2; }
+                LISTEN_PORT="$2"
+                LISTEN_PORT_SET="true"
+                shift 2
+                ;;
+            --impstats-udp-addr)
+                [ $# -ge 2 ] || { log_error "--impstats-udp-addr requires an argument"; exit 2; }
+                IMPSTATS_UDP_ADDR="$2"
+                IMPSTATS_UDP_ADDR_SET="true"
+                shift 2
+                ;;
+            --impstats-udp-port)
+                [ $# -ge 2 ] || { log_error "--impstats-udp-port requires an argument"; exit 2; }
+                IMPSTATS_UDP_PORT="$2"
+                IMPSTATS_UDP_PORT_SET="true"
+                shift 2
+                ;;
+            -h|--help)
+                show_usage
+                exit 0
+                ;;
+            *)
+                log_error "Unknown argument: $1"
+                show_usage >&2
+                exit 2
+                ;;
+        esac
+    done
 }
 
 prompt_target_ip() {
@@ -142,6 +540,90 @@ prompt_target_port() {
     done
     
     echo "$user_input"
+}
+
+prompt_sidecar_install() {
+    if [ "$INSTALL_SIDECAR_SET" = "true" ]; then
+        return 0
+    fi
+    if [ ! -t 0 ]; then
+        return 0
+    fi
+    log_prompt "Install rsyslog impstats sidecar? [Y/n]"
+    read -r confirm < /dev/tty
+    if [[ "$confirm" =~ ^[Nn]$ ]]; then
+        INSTALL_SIDECAR="false"
+    else
+        INSTALL_SIDECAR="true"
+    fi
+}
+
+prompt_sidecar_listen_addr() {
+    if [ "$LISTEN_ADDR_SET" = "true" ] || [ ! -t 0 ]; then
+        return 0
+    fi
+    LISTEN_ADDR="$(select_listen_ip)"
+    LISTEN_ADDR_SET="true"
+}
+
+prompt_sidecar_listen_port() {
+    local user_input
+    if [ "$LISTEN_PORT_SET" = "true" ] || [ ! -t 0 ]; then
+        return 0
+    fi
+    log_prompt "Enter sidecar listen port [default: $LISTEN_PORT]:"
+    read -r user_input < /dev/tty
+    if [ -z "$user_input" ]; then
+        return 0
+    fi
+    while ! validate_port "$user_input"; do
+        log_error "Invalid port number: $user_input"
+        log_prompt "Please enter a valid port (1-65535) or press Enter for default ($LISTEN_PORT):"
+        read -r user_input < /dev/tty
+        [ -z "$user_input" ] && return 0
+    done
+    LISTEN_PORT="$user_input"
+    LISTEN_PORT_SET="true"
+}
+
+prompt_impstats_udp_addr() {
+    local user_input
+    if [ "$IMPSTATS_UDP_ADDR_SET" = "true" ] || [ ! -t 0 ]; then
+        return 0
+    fi
+    log_prompt "Enter impstats UDP target address [default: $IMPSTATS_UDP_ADDR]:"
+    read -r user_input < /dev/tty
+    if [ -z "$user_input" ]; then
+        return 0
+    fi
+    while ! validate_ip "$user_input"; do
+        log_error "Invalid IP address: $user_input"
+        log_prompt "Please enter a valid IP address (e.g., 127.0.0.1):"
+        read -r user_input < /dev/tty
+        [ -z "$user_input" ] && return 0
+    done
+    IMPSTATS_UDP_ADDR="$user_input"
+    IMPSTATS_UDP_ADDR_SET="true"
+}
+
+prompt_impstats_udp_port() {
+    local user_input
+    if [ "$IMPSTATS_UDP_PORT_SET" = "true" ] || [ ! -t 0 ]; then
+        return 0
+    fi
+    log_prompt "Enter impstats UDP port [default: $IMPSTATS_UDP_PORT]:"
+    read -r user_input < /dev/tty
+    if [ -z "$user_input" ]; then
+        return 0
+    fi
+    while ! validate_port "$user_input"; do
+        log_error "Invalid port number: $user_input"
+        log_prompt "Please enter a valid port (1-65535) or press Enter for default ($IMPSTATS_UDP_PORT):"
+        read -r user_input < /dev/tty
+        [ -z "$user_input" ] && return 0
+    done
+    IMPSTATS_UDP_PORT="$user_input"
+    IMPSTATS_UDP_PORT_SET="true"
 }
 
 check_existing_config() {
@@ -254,6 +736,173 @@ download_config_template() {
     log_error "Please verify the central server domain is correct and accessible"
     log_error "You can also manually download the file and place it in the same directory as this script"
     rm -rf "$temp_dir" 2>/dev/null || true
+    return 1
+}
+
+download_sidecar_bundle() {
+    local central_domain="$1"
+    local temp_dir
+    local bundle_url
+    local bundle_file
+    local protocol="https"
+    
+    temp_dir=$(mktemp -d)
+    bundle_file="${temp_dir}/rsyslog-exporter.tar.gz"
+    
+    if validate_ip "$central_domain"; then
+        protocol="http"
+        log_warn "IP address detected, using HTTP instead of HTTPS for sidecar download"
+    fi
+    
+    bundle_url="${protocol}://${central_domain}/downloads/rsyslog-exporter.tar.gz"
+    log_info "Downloading rsyslog exporter bundle from: $bundle_url"
+    
+    if command -v curl >/dev/null 2>&1; then
+        if curl -sSL --connect-timeout 10 --max-time 60 -o "$bundle_file" "$bundle_url" 2>&1; then
+            if [ -s "$bundle_file" ]; then
+                echo "$bundle_file"
+                return 0
+            fi
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if wget -q --timeout=60 -O "$bundle_file" "$bundle_url" 2>&1; then
+            if [ -s "$bundle_file" ]; then
+                echo "$bundle_file"
+                return 0
+            fi
+        fi
+    fi
+    
+    log_error "Failed to download rsyslog exporter bundle from $bundle_url"
+    rm -rf "$temp_dir" 2>/dev/null || true
+    return 1
+}
+
+install_impstats_config() {
+    local config_file="/etc/rsyslog.d/10-impstats.conf"
+    local tmpfile
+    
+    if [ -f "$config_file" ] && [ -t 0 ]; then
+        log_warn "Existing impstats config found: $config_file"
+        log_prompt "Overwrite existing impstats config? [y/N]"
+        read -r confirm < /dev/tty
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            log_info "Keeping existing impstats config"
+            return 0
+        fi
+    fi
+    
+    tmpfile=$(mktemp)
+    cat > "$tmpfile" <<EOF
+# rsyslog impstats -> UDP -> rsyslog_exporter sidecar
+#
+# This configuration emits impstats in JSON format and forwards ONLY the JSON
+# payload (no syslog header) via UDP to the local sidecar listener.
+
+# Send only the message payload (JSON) plus newline.
+# The sidecar expects one JSON object per line.
+template(name="impstatsJsonOnly" type="string" string="%msg%\\n")
+
+ruleset(name="impstats_to_exporter") {
+  action(
+    type="omfwd"
+    target="${IMPSTATS_UDP_ADDR}"
+    port="${IMPSTATS_UDP_PORT}"
+    protocol="udp"
+    template="impstatsJsonOnly"
+  )
+
+  # Stop further processing of impstats messages.
+  stop
+}
+
+# Emit impstats every 30 seconds and route them to the forwarding ruleset.
+# Note: when using a ruleset, syslog stream processing must be enabled, so do
+# not set logSyslog/log.syslog to "off".
+# bracketing="on" groups each interval's burst cleanly.
+module(load="impstats"
+       interval="30"
+       format="json"
+       ruleset="impstats_to_exporter"
+       bracketing="on"
+       resetCounters="off")
+EOF
+    
+    install -m 0644 "$tmpfile" "$config_file"
+    rm -f "$tmpfile"
+    log_info "Installed impstats config: $config_file"
+}
+
+install_sidecar_service() {
+    local central_domain="$1"
+    local script_dir
+    local local_installer
+    local bundle_file=""
+    local bundle_dir=""
+    local installer=""
+    local overwrite_flag=""
+    
+    script_dir=$(get_script_dir)
+    local_installer="${script_dir}/../../../../sidecar/install-service.sh"
+    
+    if [ -x "$local_installer" ]; then
+        installer="$local_installer"
+    else
+        bundle_file=$(download_sidecar_bundle "$central_domain") || return 1
+        bundle_dir=$(dirname "$bundle_file")
+        tar -xzf "$bundle_file" -C "$bundle_dir" || {
+            log_error "Failed to extract rsyslog exporter bundle"
+            return 1
+        }
+        installer="${bundle_dir}/sidecar/install-service.sh"
+    fi
+    
+    if [ ! -x "$installer" ]; then
+        log_error "Sidecar installer not found: $installer"
+        return 1
+    fi
+    
+    if [ -f /etc/systemd/system/rsyslog-exporter.service ]; then
+        if [ -t 0 ]; then
+            log_warn "rsyslog exporter service already exists"
+            log_prompt "Overwrite existing rsyslog-exporter service? [y/N]"
+            read -r confirm < /dev/tty
+            if [[ "$confirm" =~ ^[Yy]$ ]]; then
+                overwrite_flag="--overwrite"
+            else
+                log_info "Skipping sidecar install"
+                return 0
+            fi
+        else
+            overwrite_flag="--overwrite"
+        fi
+    fi
+    
+    log_info "Installing rsyslog exporter sidecar service..."
+    "$installer" \
+        --prefix "$SIDECAR_PREFIX" \
+        --listen-addr "$LISTEN_ADDR" \
+        --listen-port "$LISTEN_PORT" \
+        --impstats-mode udp \
+        --impstats-format json \
+        --impstats-udp-addr "$IMPSTATS_UDP_ADDR" \
+        --impstats-udp-port "$IMPSTATS_UDP_PORT" \
+        ${overwrite_flag} || return 1
+
+    if [ -n "$bundle_dir" ]; then
+        rm -rf "$bundle_dir" 2>/dev/null || true
+    fi
+    
+    return 0
+}
+
+verify_sidecar_service() {
+    if systemctl is-active --quiet rsyslog-exporter 2>/dev/null; then
+        log_info "rsyslog exporter sidecar is active"
+        return 0
+    fi
+    log_warn "rsyslog exporter sidecar is not active"
+    log_warn "Check logs: journalctl -u rsyslog-exporter -n 50"
     return 1
 }
 
@@ -429,6 +1078,14 @@ print_summary() {
     log_info "Config file: /etc/rsyslog.d/99-forward-to-central.conf"
     log_info "Target server: $target_ip:$target_port"
     log_info "Spool directory: /var/spool/rsyslog"
+    if is_true "$INSTALL_SIDECAR"; then
+        log_info "Impstats UDP target: ${IMPSTATS_UDP_ADDR}:${IMPSTATS_UDP_PORT}"
+        log_info "Impstats exporter: http://${LISTEN_ADDR}:${LISTEN_PORT}/metrics"
+        if [ "$LISTEN_ADDR" = "127.0.0.1" ]; then
+            log_warn "Exporter is bound to 127.0.0.1 (local-only). Prometheus on the collector will not reach it."
+        fi
+        log_info "Node exporter port: 9100"
+    fi
     echo ""
     log_info "Useful commands:"
     log_info "  Status:    sudo systemctl status rsyslog"
@@ -441,6 +1098,10 @@ print_summary() {
     log_info "1. Verify logs are being forwarded:"
     log_info "   logger 'test message from $(hostname)'"
     log_info "2. Check central server logs to confirm receipt"
+    if is_true "$INSTALL_SIDECAR"; then
+        log_info "3. Add this host to Prometheus impstats targets:"
+        log_info "   prometheus-target --job impstats add ${LISTEN_ADDR}:${LISTEN_PORT} host=$(hostname -f) role=rsyslog"
+    fi
     echo ""
 }
 
@@ -448,6 +1109,12 @@ main() {
     local target_ip
     local target_port
     local central_domain
+    
+    parse_args "$@"
+    if ! is_true "$INSTALL_SIDECAR" && ! is_false "$INSTALL_SIDECAR"; then
+        log_error "INSTALL_SIDECAR must be true or false"
+        exit 1
+    fi
     
     log_info "=========================================="
     log_info "rsyslog Client Configuration Installer"
@@ -477,10 +1144,27 @@ main() {
     target_port=$(prompt_target_port)
     echo ""
     
+    prompt_sidecar_install
+    if is_true "$INSTALL_SIDECAR"; then
+        check_sidecar_requirements
+        prompt_sidecar_listen_addr
+        prompt_sidecar_listen_port
+        prompt_impstats_udp_addr
+        prompt_impstats_udp_port
+        validate_sidecar_params || exit 1
+    fi
+    
     log_info "Installation configuration:"
     log_info "  Central Server Domain: $central_domain"
     log_info "  Target IP/Domain: $target_ip"
     log_info "  Target Port: $target_port"
+    if is_true "$INSTALL_SIDECAR"; then
+        log_info "  Sidecar: enabled"
+        log_info "  Sidecar listen: ${LISTEN_ADDR}:${LISTEN_PORT}"
+        log_info "  Impstats UDP: ${IMPSTATS_UDP_ADDR}:${IMPSTATS_UDP_PORT}"
+    else
+        log_info "  Sidecar: disabled"
+    fi
     echo ""
     
     log_prompt "Proceed with installation? [y/N]"
@@ -493,6 +1177,17 @@ main() {
     echo ""
     install_rsyslog_config "$target_ip" "$target_port" "$central_domain"
     create_spool_directory
+    
+    if is_true "$INSTALL_SIDECAR"; then
+        if ! install_sidecar_service "$central_domain"; then
+            log_error "Sidecar installation failed"
+            exit 1
+        fi
+        if [ ! -f /etc/rsyslog.d/10-impstats.conf ]; then
+            install_impstats_config
+        fi
+        configure_impstats_firewall "$target_ip"
+    fi
     
     if ! test_rsyslog_config; then
         log_error "Configuration test failed, aborting installation"
@@ -511,6 +1206,10 @@ main() {
     if ! verify_installation "$target_ip" "$target_port"; then
         log_error "Installation verification failed"
         exit 1
+    fi
+    
+    if is_true "$INSTALL_SIDECAR"; then
+        verify_sidecar_service || true
     fi
     
     print_summary "$target_ip" "$target_port"

--- a/deploy/docker-compose/rosi-collector/docker-compose.yml
+++ b/deploy/docker-compose/rosi-collector/docker-compose.yml
@@ -99,7 +99,7 @@ services:
       GF_SMTP_FROM_NAME: "Rsyslog Central Alerts"
       GF_SMTP_SKIP_VERIFY: ${SMTP_SKIP_VERIFY:-false}
       # Set default home dashboard to Syslog Explorer
-      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/syslog-explorer-logs.json
+      GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH: /etc/grafana/provisioning/dashboards/generated/syslog-explorer.json
     ports:
       - "127.0.0.1:3000:3000"
     volumes:
@@ -202,8 +202,9 @@ services:
         condition: service_healthy
     networks:
       - rosi-collector-net
+    # Healthcheck: container runs rsyslog in foreground (-n), so no PID file exists; check process instead.
     healthcheck:
-      test: ["CMD-SHELL", "test -f /var/run/rsyslogd.pid && kill -0 $(cat /var/run/rsyslogd.pid)"]
+      test: ["CMD-SHELL", "pidof rsyslogd >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3
@@ -252,8 +253,9 @@ services:
         condition: service_healthy
     networks:
       - rosi-collector-net
+    # Healthcheck: container runs rsyslog in foreground (-n), so no PID file exists; check process instead.
     healthcheck:
-      test: ["CMD-SHELL", "test -f /var/run/rsyslogd.pid && kill -0 $(cat /var/run/rsyslogd.pid)"]
+      test: ["CMD-SHELL", "pidof rsyslogd >/dev/null || exit 1"]
       interval: 30s
       timeout: 5s
       retries: 3

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/alerting/default.yml
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/alerting/default.yml
@@ -429,3 +429,289 @@ groups:
           alertname: Log volume anomaly
           severity: info
           component: rsyslog
+
+  # rsyslog impstats alerts. Disabled by default; enable in Grafana UI (Alerting → Alert rules → toggle) after tuning thresholds.
+  - name: rsyslog-impstats
+    interval: 1m
+    orgId: 1
+    folder: Alerts
+    rules:
+      - uid: impstats-queue-depth-high
+        title: Rsyslog queue depth high
+        isPaused: true
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: '(rsyslog_core_queue_size{job="rsyslog-impstats"} / rsyslog_core_queue_maxqsize{job="rsyslog-impstats"}) unless rsyslog_core_queue_maxqsize{job="rsyslog-impstats"} == 0'
+              refId: A
+              queryType: range
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              settings:
+                mode: dropNN
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params:
+                      - 0.8
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              expression: B
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Alerting
+        for: 5m
+        annotations:
+          description: 'Queue {{ $labels.rsyslog_resource }} on {{ $labels.host }} is above 80% of max (ratio: {{ printf "%.2f" $values.B.Value }})'
+          summary: 'Rsyslog queue depth high on {{ $labels.host }}'
+        labels:
+          alertname: Rsyslog queue depth high
+          severity: warning
+          component: rsyslog-impstats
+
+      - uid: impstats-discarded-messages
+        title: Rsyslog queue discarding messages
+        isPaused: true
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: 'sum by (host, rsyslog_resource) (rate(rsyslog_core_queue_discarded_full_total{job="rsyslog-impstats"}[5m]) + rate(rsyslog_core_queue_discarded_nf_total{job="rsyslog-impstats"}[5m]))'
+              refId: A
+              queryType: range
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              settings:
+                mode: dropNN
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              expression: B
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          description: 'Queue {{ $labels.rsyslog_resource }} on {{ $labels.host }} is discarding messages (rate: {{ printf "%.2f" $values.B.Value }}/s)'
+          summary: 'Rsyslog discarding messages on {{ $labels.host }}'
+        labels:
+          alertname: Rsyslog queue discarding messages
+          severity: warning
+          component: rsyslog-impstats
+
+      - uid: impstats-action-failures
+        title: Rsyslog action failures
+        isPaused: true
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: 'sum by (host, rsyslog_resource) (rate(rsyslog_core_action_failed_total{job="rsyslog-impstats"}[5m]))'
+              refId: A
+              queryType: range
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              settings:
+                mode: dropNN
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              expression: B
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          description: 'Action {{ $labels.rsyslog_resource }} on {{ $labels.host }} is failing (rate: {{ printf "%.2f" $values.B.Value }}/s)'
+          summary: 'Rsyslog action failures on {{ $labels.host }}'
+        labels:
+          alertname: Rsyslog action failures
+          severity: warning
+          component: rsyslog-impstats
+
+      - uid: impstats-action-suspended
+        title: Rsyslog action suspended
+        isPaused: true
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              expr: 'rsyslog_core_action_suspended{job="rsyslog-impstats"} == 1'
+              refId: A
+              queryType: range
+              intervalMs: 1000
+              maxDataPoints: 43200
+          - refId: B
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              expression: A
+              reducer: last
+              settings:
+                mode: dropNN
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: __expr__
+            model:
+              datasource:
+                name: Expression
+                type: __expr__
+                uid: __expr__
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params: []
+                  reducer:
+                    params: []
+                    type: avg
+                  type: query
+              expression: B
+              refId: C
+              type: threshold
+        noDataState: OK
+        execErrState: Alerting
+        for: 2m
+        annotations:
+          description: 'Action {{ $labels.rsyslog_resource }} on {{ $labels.host }} is suspended'
+          summary: 'Rsyslog action suspended on {{ $labels.host }}'
+        labels:
+          alertname: Rsyslog action suspended
+          severity: warning
+          component: rsyslog-impstats

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/dashboards.yml
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/dashboards.yml
@@ -9,4 +9,4 @@ providers:
     editable: true
     allowUiUpdates: true
     options:
-      path: /etc/grafana/provisioning/dashboards
+      path: /etc/grafana/provisioning/dashboards/generated

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/_shared.json
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/_shared.json
@@ -1,0 +1,64 @@
+{
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "doc",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Syslog Explorer",
+      "tooltip": "View All Syslogs",
+      "type": "link",
+      "url": "/d/logs-explore-like-v4"
+    },
+    {
+      "asDropdown": false,
+      "icon": "chart-line",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Analysis",
+      "tooltip": "Log analysis and patterns",
+      "type": "link",
+      "url": "/d/syslog-deep-dive"
+    },
+    {
+      "asDropdown": false,
+      "icon": "chart-line",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Health",
+      "tooltip": "rsyslog health (impstats)",
+      "type": "link",
+      "url": "/d/syslog-health-impstats"
+    },
+    {
+      "asDropdown": false,
+      "icon": "exclamation-triangle",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Alerting",
+      "tooltip": "View alerts overview",
+      "type": "link",
+      "url": "/d/alerting-overview"
+    },
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": true,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Host Metrics",
+      "tooltip": "CPU, memory, disk, network metrics",
+      "type": "link",
+      "url": "/d/node-overview"
+    }
+  ]
+}

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/alerts-overview.json
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/alerts-overview.json
@@ -6,56 +6,6 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": null,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "doc",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Syslog Explorer",
-      "tooltip": "View syslog logs",
-      "type": "link",
-      "url": "/d/logs-explore-like-v4"
-    },
-    {
-      "asDropdown": false,
-      "icon": "search-plus",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Analysis",
-      "tooltip": "Log analysis and patterns",
-      "type": "link",
-      "url": "/d/syslog-deep-dive"
-    },
-    {
-      "asDropdown": false,
-      "icon": "bell",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Alerting",
-      "tooltip": "View alerts overview",
-      "type": "link",
-      "url": "/d/alerting-overview"
-    },
-    {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Host Metrics",
-      "tooltip": "CPU, memory, disk, network metrics",
-      "type": "link",
-      "url": "/d/node-overview"
-    }
-  ],
   "panels": [
     {
       "datasource": {

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/host-metrics-overview.json
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/host-metrics-overview.json
@@ -6,56 +6,6 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": null,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "doc",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Syslog Explorer",
-      "tooltip": "View syslog logs",
-      "type": "link",
-      "url": "/d/logs-explore-like-v4"
-    },
-    {
-      "asDropdown": false,
-      "icon": "search-plus",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Analysis",
-      "tooltip": "Log analysis and patterns",
-      "type": "link",
-      "url": "/d/syslog-deep-dive"
-    },
-    {
-      "asDropdown": false,
-      "icon": "bell",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Alerting",
-      "tooltip": "View alerts overview",
-      "type": "link",
-      "url": "/d/alerting-overview"
-    },
-    {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Host Metrics",
-      "tooltip": "CPU, memory, disk, network metrics",
-      "type": "link",
-      "url": "/d/node-overview"
-    }
-  ],
   "panels": [
     {
       "datasource": {

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/syslog-analysis.json
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/syslog-analysis.json
@@ -7,56 +7,6 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
   "id": null,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "doc",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Syslog Explorer",
-      "tooltip": "View syslog logs",
-      "type": "link",
-      "url": "/d/logs-explore-like-v4"
-    },
-    {
-      "asDropdown": false,
-      "icon": "search-plus",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Analysis",
-      "tooltip": "Log analysis and patterns",
-      "type": "link",
-      "url": "/d/syslog-deep-dive"
-    },
-    {
-      "asDropdown": false,
-      "icon": "bell",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Alerting",
-      "tooltip": "View alerts overview",
-      "type": "link",
-      "url": "/d/alerting-overview"
-    },
-    {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Host Metrics",
-      "tooltip": "CPU, memory, disk, network metrics",
-      "type": "link",
-      "url": "/d/node-overview"
-    }
-  ],
   "panels": [
     {
       "datasource": {"type": "loki", "uid": "loki"},

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/syslog-explorer.json
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/syslog-explorer.json
@@ -20,68 +20,6 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": null,
-  "links": [
-    {
-      "asDropdown": false,
-      "icon": "doc",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Syslog Explorer",
-      "tooltip": "View syslog logs",
-      "type": "link",
-      "url": "/d/logs-explore-like-v4"
-    },
-    {
-      "asDropdown": false,
-      "icon": "search-plus",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Analysis",
-      "tooltip": "Log analysis and patterns",
-      "type": "link",
-      "url": "/d/syslog-deep-dive"
-    },
-    {
-      "asDropdown": false,
-      "icon": "bell",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Alerting",
-      "tooltip": "View alerts overview",
-      "type": "link",
-      "url": "/d/alerting-overview"
-    },
-    {
-      "asDropdown": false,
-      "icon": "dashboard",
-      "includeVars": false,
-      "keepTime": true,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Host Metrics",
-      "tooltip": "CPU, memory, disk, network metrics",
-      "type": "link",
-      "url": "/d/node-overview"
-    },
-    {
-      "asDropdown": false,
-      "icon": "refresh",
-      "includeVars": false,
-      "keepTime": false,
-      "tags": [],
-      "targetBlank": false,
-      "title": "Reset Filters",
-      "tooltip": "Reset all filters to default values",
-      "type": "link",
-      "url": "/d/${__dashboard.uid}?var-job=All&var-host=All&var-severity=All&var-facility=All&var-search="
-    }
-  ],
   "refresh": "30s",
   "panels": [
     {
@@ -1258,6 +1196,16 @@
               {
                 "id": "custom.width",
                 "value": 150
+              },
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open Analysis for host",
+                    "url": "/d/syslog-deep-dive?var-host=${__value.text}&var-job=${job}",
+                    "targetBlank": false
+                  }
+                ]
               }
             ]
           },
@@ -1435,13 +1383,9 @@
       {
         "allValue": ".+",
         "current": {
-          "selected": true,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "selected": false,
+          "text": "syslog",
+          "value": "syslog"
         },
         "datasource": {
           "type": "loki",
@@ -1593,4 +1537,3 @@
   "version": 1,
   "weekStart": ""
 }
-

--- a/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/syslog-health-impstats.json
+++ b/deploy/docker-compose/rosi-collector/grafana/provisioning/dashboards/templates/syslog-health-impstats.json
@@ -1,0 +1,1270 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "Syslog health overview for rsyslog impstats in ROSI Collector. Data from the impstats sidecar exporter (Prometheus job rsyslog-impstats). See ROSI_IMPSTATS_PLAN.md for metric groups and alert thresholds.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "title": "Overview",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(up{job=\"rsyslog-impstats\", host=~\"$host\"})",
+          "legendFormat": "up",
+          "refId": "A"
+        }
+      ],
+      "title": "Exporter Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1e-06
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rate(rsyslog_core_action_failed_total{host=~\"$host\"}[5m]))",
+          "legendFormat": "failures/s",
+          "refId": "A"
+        }
+      ],
+      "title": "Action Failures Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 1
+              },
+              {
+                "color": "red",
+                "value": 2
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum(rsyslog_core_action_suspended{host=~\"$host\"})",
+          "legendFormat": "suspended",
+          "refId": "A"
+        }
+      ],
+      "title": "Suspended Actions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(rsyslog_core_queue_full{host=~\"$host\"})",
+          "legendFormat": "full",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Full",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(rsyslog_impstats_openfiles{host=~\"$host\"})",
+          "legendFormat": "openfiles",
+          "refId": "A"
+        }
+      ],
+      "title": "Open Files (max)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "megabytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "max(rsyslog_impstats_maxrss{job=\"rsyslog-impstats\", host=~\"$host\"}) / 1024",
+          "legendFormat": "maxrss",
+          "refId": "A"
+        }
+      ],
+      "title": "Max RSS (MB)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 101,
+      "title": "Queues",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rsyslog_core_queue_size{host=~\"$host\"}",
+          "legendFormat": "{{host}} size {{rsyslog_resource}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rsyslog_core_queue_maxqsize{host=~\"$host\"}",
+          "legendFormat": "{{host}} max {{rsyslog_resource}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Size vs Max",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 80
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(100 * rsyslog_core_queue_size{host=~\"$host\"} / rsyslog_core_queue_maxqsize{host=~\"$host\"}) unless rsyslog_core_queue_maxqsize{host=~\"$host\"} == 0",
+          "legendFormat": "{{host}} - {{rsyslog_resource}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Queue Utilization",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(rsyslog_core_queue_discarded_full_total{host=~\"$host\"}[5m])",
+          "legendFormat": "{{host}} discarded_full {{rsyslog_resource}}",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "rate(rsyslog_core_queue_discarded_nf_total{host=~\"$host\"}[5m])",
+          "legendFormat": "{{host}} discarded_nf {{rsyslog_resource}}",
+          "refId": "B"
+        }
+      ],
+      "title": "Queue Drops Rate",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 102,
+      "title": "Input",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (host, rsyslog_component) (rate({__name__=~\"rsyslog_.*_submitted_total\", host=~\"$host\"}[5m]))",
+          "legendFormat": "{{host}} - {{rsyslog_component}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingest Rate by Input",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 103,
+      "title": "Actions",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "id": 8,
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (host, rsyslog_resource) (rate(rsyslog_core_action_processed_total{host=~\"$host\"}[5m]))",
+              "legendFormat": "{{host}} - {{rsyslog_resource}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Action Processed Rate",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 32
+          },
+          "id": 13,
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "sum by (host, rsyslog_resource) (rate(rsyslog_core_action_failed_total{host=~\"$host\"}[5m]))",
+              "legendFormat": "{{host}} - {{rsyslog_resource}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Action Failures by Action",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 40
+          },
+          "id": 14,
+          "options": {
+            "legend": {
+              "calcs": [
+                "last",
+                "max"
+              ],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (host) (rsyslog_core_action_suspended_duration{host=~\"$host\"})",
+              "legendFormat": "{{host}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Suspended Duration (max)",
+          "type": "timeseries"
+        }
+      ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 104,
+      "title": "Output & resource usage",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (host, rsyslog_resource) (rate(rsyslog_omfwd_bytes_sent_total{host=~\"$host\"}[5m]))",
+          "legendFormat": "{{host}} - {{rsyslog_resource}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Output Bytes (omfwd)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 15,
+      "options": {
+        "legend": {
+          "calcs": [
+            "last",
+            "max"
+          ],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "(sum by (host) (rate(rsyslog_impstats_utime_total{job=\"rsyslog-impstats\", host=~\"$host\"}[5m])) + sum by (host) (rate(rsyslog_impstats_stime_total{job=\"rsyslog-impstats\", host=~\"$host\"}[5m]))) / 10000",
+          "legendFormat": "{{host}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU usage (impstats)",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "tags": [
+    "syslog",
+    "rsyslog",
+    "impstats",
+    "rosi"
+  ],
+  "templating": {
+    "list": [
+      {
+        "allValue": ".*",
+        "current": {},
+        "datasource": {
+          "type": "prometheus",
+          "uid": "prometheus"
+        },
+        "definition": "label_values(up{job=\"rsyslog-impstats\"}, host)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Host",
+        "multi": true,
+        "name": "host",
+        "options": [],
+        "query": {
+          "query": "label_values(up{job=\"rsyslog-impstats\"}, host)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Syslog Health",
+  "uid": "syslog-health-impstats",
+  "version": 2,
+  "weekStart": ""
+}

--- a/deploy/docker-compose/rosi-collector/prometheus-targets/impstats.yml
+++ b/deploy/docker-compose/rosi-collector/prometheus-targets/impstats.yml
@@ -1,0 +1,17 @@
+# prometheus-targets/impstats.yml
+# rsyslog impstats exporter targets for Prometheus
+#
+# This file is auto-reloaded by Prometheus (no restart needed for changes).
+# Prometheus picks up changes within ~5 minutes.
+#
+# To add targets on the server, use:
+#   /usr/local/bin/prometheus-target --job impstats add <ip:port> host=<name> [labels...]
+#
+# Example entries (replace with actual targets):
+#
+#- targets:
+#    - 127.0.0.1:9898
+#  labels:
+#    host: rosi-collector
+#    role: rsyslog
+#    network: internal

--- a/deploy/docker-compose/rosi-collector/prometheus.yml
+++ b/deploy/docker-compose/rosi-collector/prometheus.yml
@@ -5,7 +5,15 @@ scrape_configs:
   - job_name: 'node'
     file_sd_configs:
       - files:
-          - /etc/prometheus/targets/*.yml
+          - /etc/prometheus/targets/nodes.yml
+        refresh_interval: 5m
+    metrics_path: /metrics
+    scrape_interval: 15s
+
+  - job_name: 'rsyslog-impstats'
+    file_sd_configs:
+      - files:
+          - /etc/prometheus/targets/impstats.yml
         refresh_interval: 5m
     metrics_path: /metrics
     scrape_interval: 15s

--- a/deploy/docker-compose/rosi-collector/scripts/monitor.sh
+++ b/deploy/docker-compose/rosi-collector/scripts/monitor.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # monitor.sh
 # Comprehensive monitoring and debugging script for ROSI Collector Docker stack (Loki/Grafana/Prometheus)
-# Part of RSyslog Open System for Information (ROSI)
+# Part of Rsyslog Operations Stack Initiative (ROSI)
 #
 # Usage examples:
 #   ./monitor.sh status          # Show container status

--- a/deploy/docker-compose/rosi-collector/scripts/render-dashboards.py
+++ b/deploy/docker-compose/rosi-collector/scripts/render-dashboards.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright 2025-2026 Rainer Gerhards and Adiscon GmbH.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Render Grafana dashboards from templates with shared navigation/links."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+def _load_json(path: Path) -> dict:
+    if not path.exists():
+        print(f"Error: missing file {path}", file=sys.stderr)
+        sys.exit(1)
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as e:
+        print(f"Error: invalid JSON in {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"Error: cannot read {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _write_json(path: Path, data: dict) -> None:
+    try:
+        path.write_text(
+            json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+        )
+    except (TypeError, ValueError) as e:
+        print(f"Error: cannot serialize JSON for {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+    except OSError as e:
+        print(f"Error: cannot write {path}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def _merge_links(shared_links: list[dict], template_links: list[dict]) -> list[dict]:
+    seen = {(link.get("title"), link.get("url")) for link in shared_links}
+    extras = [
+        link
+        for link in template_links
+        if (link.get("title"), link.get("url")) not in seen
+    ]
+    return [*shared_links, *extras]
+
+
+def _is_nav_panel(panel: dict, nav_title: str) -> bool:
+    return panel.get("type") == "text" and panel.get("title") == nav_title
+
+
+def _shift_panels_y(panels: list[dict], delta_y: int) -> None:
+    """Shift gridPos.y by delta_y for all panels and nested panels (e.g. inside rows)."""
+    for panel in panels:
+        if "gridPos" in panel and isinstance(panel["gridPos"], dict):
+            y = panel["gridPos"].get("y", 0)
+            panel["gridPos"]["y"] = y + delta_y
+        nested = panel.get("panels")
+        if isinstance(nested, list):
+            _shift_panels_y(nested, delta_y)
+
+
+def main() -> None:
+    base_dir = Path(__file__).resolve().parents[1] / "grafana" / "provisioning" / "dashboards"
+    templates_dir = base_dir / "templates"
+    output_dir = base_dir / "generated"
+    shared_path = templates_dir / "_shared.json"
+
+    shared = _load_json(shared_path)
+    shared_links = shared.get("links", [])
+    nav_title = "Dashboards"
+
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as e:
+        print(f"Error: cannot create output directory {output_dir}: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    for template_path in templates_dir.glob("*.json"):
+        if template_path.name == "_shared.json":
+            continue
+
+        dashboard = _load_json(template_path)
+        dashboard["links"] = _merge_links(shared_links, dashboard.get("links", []))
+
+        panels = [panel for panel in dashboard.get("panels", []) if not _is_nav_panel(panel, nav_title)]
+        min_y = min((panel.get("gridPos", {}).get("y", 0) for panel in panels), default=0)
+        if min_y > 0:
+            _shift_panels_y(panels, -min_y)
+
+        dashboard["panels"] = panels
+
+        output_path = output_dir / template_path.name
+        _write_json(output_path, dashboard)
+
+
+if __name__ == "__main__":
+    main()

--- a/doc/source/deployments/index.rst
+++ b/doc/source/deployments/index.rst
@@ -19,7 +19,7 @@ Available Deployments
 ROSI Collector
 ^^^^^^^^^^^^^^
 
-**RSyslog Open System for Information** is a complete log collection and
+**Rsyslog Operations Stack Initiative** is a complete log collection and
 monitoring stack including:
 
 - Centralized log aggregation with rsyslog

--- a/doc/source/deployments/rosi_collector/architecture.rst
+++ b/doc/source/deployments/rosi_collector/architecture.rst
@@ -107,9 +107,9 @@ Log Data Flow
 Metrics Data Flow
 ^^^^^^^^^^^^^^^^^
 
-1. **Client hosts** run node_exporter exposing system metrics on port 9100
-2. **Prometheus** scrapes metrics from targets listed in ``nodes.yml``
-3. **Grafana** queries Prometheus to display metrics in dashboards
+1. **Client hosts** run node_exporter exposing system metrics on port 9100; optionally an impstats sidecar on port 9898 for rsyslog internal metrics (Syslog Health dashboard)
+2. **Prometheus** scrapes metrics from targets listed in ``nodes.yml`` and ``impstats.yml``
+3. **Grafana** queries Prometheus to display metrics in dashboards (Host Metrics Overview and Syslog Health)
 
 Network Ports
 -------------

--- a/doc/source/deployments/rosi_collector/client_setup.rst
+++ b/doc/source/deployments/rosi_collector/client_setup.rst
@@ -25,7 +25,8 @@ Client configuration involves:
 
 1. **rsyslog** - Forward logs to the collector (TCP port 10514)
 2. **node_exporter** - Expose metrics for Prometheus (port 9100)
-3. **Collector registration** - Add client to Prometheus targets
+3. **impstats sidecar** (optional) - Expose rsyslog internal metrics (port 9898) for the Syslog Health dashboard
+4. **Collector registration** - Add client to Prometheus targets (node and/or impstats)
 
 Quick Setup (Automated)
 -----------------------
@@ -305,24 +306,42 @@ Register Client on Collector
 ----------------------------
 
 After configuring the client, add it to Prometheus targets on your
-ROSI Collector server using the ``prometheus-target`` CLI tool:
+ROSI Collector server using the ``prometheus-target`` CLI tool.
+
+**Node exporter only** (port 9100):
 
 .. code-block:: bash
 
    # SSH to your ROSI Collector, then:
-   prometheus-target add CLIENT_IP:9100 host=CLIENT_HOSTNAME role=ROLE [network=NETWORK]
+   prometheus-target add CLIENT_IP:9100 host=CLIENT_HOSTNAME [role=ROLE] [network=NETWORK]
+
+**Node exporter and impstats sidecar** (ports 9100 and 9898) in one step:
+
+.. code-block:: bash
+
+   prometheus-target add-client CLIENT_IP host=CLIENT_HOSTNAME [role=ROLE] [network=NETWORK]
+
+**Impstats only** (when the client runs the impstats sidecar on port 9898):
+
+.. code-block:: bash
+
+   prometheus-target --job impstats add CLIENT_IP:9898 host=CLIENT_HOSTNAME [role=ROLE] [network=NETWORK]
 
 Example:
 
 .. code-block:: bash
 
    prometheus-target add 10.0.0.50:9100 host=webserver-01 role=web network=production
+   # Or both node and impstats:
+   prometheus-target add-client 10.0.0.50 host=webserver-01 role=web network=internal
 
 Available commands:
 
 .. code-block:: bash
 
    prometheus-target add <IP:PORT> host=<name> [role=<value>] [network=<value>]
+   prometheus-target --job impstats add <IP:9898> host=<name> role=rsyslog [network=<value>]
+   prometheus-target add-client <IP> host=<name> [role=<value>] [network=<value>]
    prometheus-target list
    prometheus-target remove <IP:PORT>      # Remove by IP:port
    prometheus-target remove <hostname>     # Remove by hostname
@@ -366,9 +385,9 @@ Verification
 
 **Test Metrics Collection**
 
-1. Go to Grafana → Node Overview dashboard
+1. Go to Grafana → Host Metrics Overview dashboard
 2. Select your client from the host dropdown
-3. Verify CPU, memory, and disk metrics appear
+3. Verify CPU, memory, and disk metrics appear (Syslog Health shows impstats when the client runs the sidecar)
 
 **Check Connection Status**
 

--- a/doc/source/deployments/rosi_collector/grafana_dashboards.rst
+++ b/doc/source/deployments/rosi_collector/grafana_dashboards.rst
@@ -7,6 +7,8 @@ Grafana Dashboards
    pair: ROSI Collector; dashboards
    single: Grafana
    single: Syslog Explorer
+   single: Syslog Health
+   single: impstats
    single: LogQL
 
 ROSI Collector includes pre-built Grafana dashboards for exploring logs
@@ -18,19 +20,22 @@ Dashboard Overview
 
 ROSI Collector provisions five dashboards:
 
-+------------------------+------------------------------------------------+
-| Dashboard              | Purpose                                        |
-+========================+================================================+
-| Syslog Explorer        | Search and browse logs from all hosts          |
-+------------------------+------------------------------------------------+
-| Syslog Deep Dive       | Detailed analysis of log patterns              |
-+------------------------+------------------------------------------------+
-| Node Overview          | System metrics (CPU, memory, disk, network)    |
-+------------------------+------------------------------------------------+
-| Client Health          | rsyslog client status and statistics           |
-+------------------------+------------------------------------------------+
-| Alerting Overview      | Active alerts and notification status          |
-+------------------------+------------------------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 28 72
+
+   * - Dashboard
+     - Purpose
+   * - Syslog Explorer
+     - Search and browse logs from all hosts
+   * - Syslog Analysis
+     - Distribution analysis (severity, hosts, etc.)
+   * - Syslog Health
+     - rsyslog impstats (queues, actions, CPU)
+   * - Host Metrics Overview
+     - System metrics (CPU, memory, disk) per host
+   * - Alerting Overview
+     - Active alerts and notification status
 
 Syslog Explorer
 ---------------
@@ -71,14 +76,14 @@ Click "Explore" in the left sidebar and use LogQL queries:
    # Count errors by host
    sum by (host) (count_over_time({job="syslog"} | json | severity = "err" [5m]))
 
-Syslog Deep Dive
-----------------
+Syslog Analysis
+---------------
 
 .. figure:: /_static/dashboard-deepdive.png
-   :alt: Syslog Deep Dive Dashboard
+   :alt: Syslog Analysis Dashboard
    :align: center
    
-   Syslog Deep Dive dashboard for log analysis
+   Syslog Analysis dashboard for log distribution
 
 This dashboard provides analytical views of log data:
 
@@ -93,16 +98,34 @@ Use this dashboard to:
 - Track error rates over time
 - Find the most common error messages
 
-Node Overview
--------------
+Syslog Health (impstats)
+------------------------
+
+The **Syslog Health** dashboard shows rsyslog internal metrics when client
+hosts run the **impstats sidecar** (installed by default with the client
+setup script). Add impstats targets on the collector:
+
+.. code-block:: bash
+
+   prometheus-target --job impstats add CLIENT_IP:9898 host=HOSTNAME role=rsyslog network=internal
+   # Or add both node_exporter and impstats in one step:
+   prometheus-target add-client CLIENT_IP host=HOSTNAME role=rsyslog network=internal
+
+The dashboard is grouped into: **Overview** (exporter count, failures, queues),
+**Queues** (size, utilization, drops), **Input** (ingest rate), **Actions**
+(processed/failed/suspended), and **Output & resource usage** (egress bytes
+and CPU). Use the Host dropdown to filter by client.
+
+Host Metrics Overview
+---------------------
 
 .. figure:: /_static/dashboard-node.png
-   :alt: Node Overview Dashboard
+   :alt: Host Metrics Overview Dashboard
    :align: center
    
-   Node Overview showing system metrics
+   Host Metrics Overview showing system metrics
 
-The Node Overview shows system metrics from node_exporter:
+The Host Metrics Overview shows system metrics from node_exporter:
 
 - **CPU usage** - Per-core and total utilization
 - **Memory** - Used, available, and cached
@@ -111,7 +134,8 @@ The Node Overview shows system metrics from node_exporter:
 - **Disk space** - Usage by filesystem
 
 Select a host from the dropdown to view its metrics. Time range applies
-to all panels.
+to all panels. (When clients run the impstats sidecar, see **Syslog Health**
+for rsyslog-specific metrics.)
 
 **Key metrics to watch**:
 

--- a/doc/source/deployments/rosi_collector/index.rst
+++ b/doc/source/deployments/rosi_collector/index.rst
@@ -10,7 +10,7 @@ ROSI Collector
    single: Loki
    single: Grafana
 
-**RSyslog Open System for Information** (ROSI) Collector is a production-ready
+**Rsyslog Operations Stack Initiative** (ROSI) Collector is a production-ready
 centralized log collection and monitoring stack. It combines rsyslog's powerful
 log processing with modern observability tools to provide a complete logging
 solution.
@@ -55,8 +55,8 @@ Key Features
 ------------
 
 **Pre-built Dashboards**
-   Five Grafana dashboards included: Syslog Explorer, Syslog Deep Dive,
-   Node Overview, Client Health, and Alerting Overview.
+   Five Grafana dashboards: Syslog Explorer, Syslog Analysis, Syslog Health
+   (impstats), Host Metrics Overview, and Alerting Overview.
 
 **Automatic TLS**
    Traefik obtains Let's Encrypt certificates automatically. No manual

--- a/doc/source/deployments/rosi_collector/rosi-architecture.svg
+++ b/doc/source/deployments/rosi_collector/rosi-architecture.svg
@@ -5,38 +5,40 @@
   
   <!-- Title -->
   <text x="475" y="35" text-anchor="middle" font-size="24" font-weight="bold" fill="#2c3e50">ROSI Collector Architecture</text>
-  <text x="475" y="55" text-anchor="middle" font-size="12" fill="#7f8c8d">RSyslog Open System for Information</text>
+  <text x="475" y="55" text-anchor="middle" font-size="12" fill="#7f8c8d">Rsyslog Operations Stack Initiative</text>
   
   <!-- Client Hosts Section -->
   <rect x="30" y="80" width="240" height="520" rx="10" fill="#e8f4f8" stroke="#3498db" stroke-width="2"/>
   <text x="150" y="105" text-anchor="middle" font-size="16" font-weight="bold" fill="#2980b9">Client Hosts</text>
   
-  <!-- Client 1 -->
-  <rect x="50" y="130" width="200" height="110" rx="8" fill="#fff" stroke="#bdc3c7" stroke-width="1"/>
+  <!-- Client 1 (with optional impstats) -->
+  <rect x="50" y="130" width="200" height="130" rx="8" fill="#fff" stroke="#bdc3c7" stroke-width="1"/>
   <text x="150" y="152" text-anchor="middle" font-size="13" font-weight="bold" fill="#34495e">Client Host 1</text>
   <rect x="70" y="165" width="160" height="25" rx="4" fill="#27ae60" opacity="0.9"/>
   <text x="150" y="182" text-anchor="middle" font-size="11" fill="#fff">rsyslog</text>
   <rect x="70" y="195" width="160" height="18" rx="4" fill="#9b59b6" opacity="0.9"/>
   <text x="150" y="208" text-anchor="middle" font-size="9" fill="#fff">node_exporter :9100</text>
+  <rect x="70" y="218" width="160" height="18" rx="4" fill="#16a085" opacity="0.85" stroke="#16a085" stroke-width="1" stroke-dasharray="3,2"/>
+  <text x="150" y="231" text-anchor="middle" font-size="8" fill="#fff">impstats :9898 (optional)</text>
   
   <!-- Client 2 -->
-  <rect x="50" y="260" width="200" height="110" rx="8" fill="#fff" stroke="#bdc3c7" stroke-width="1"/>
-  <text x="150" y="282" text-anchor="middle" font-size="13" font-weight="bold" fill="#34495e">Client Host 2</text>
-  <rect x="70" y="295" width="160" height="25" rx="4" fill="#27ae60" opacity="0.9"/>
-  <text x="150" y="312" text-anchor="middle" font-size="11" fill="#fff">rsyslog</text>
-  <rect x="70" y="325" width="160" height="18" rx="4" fill="#9b59b6" opacity="0.9"/>
-  <text x="150" y="338" text-anchor="middle" font-size="9" fill="#fff">node_exporter :9100</text>
+  <rect x="50" y="280" width="200" height="110" rx="8" fill="#fff" stroke="#bdc3c7" stroke-width="1"/>
+  <text x="150" y="302" text-anchor="middle" font-size="13" font-weight="bold" fill="#34495e">Client Host 2</text>
+  <rect x="70" y="315" width="160" height="25" rx="4" fill="#27ae60" opacity="0.9"/>
+  <text x="150" y="332" text-anchor="middle" font-size="11" fill="#fff">rsyslog</text>
+  <rect x="70" y="345" width="160" height="18" rx="4" fill="#9b59b6" opacity="0.9"/>
+  <text x="150" y="358" text-anchor="middle" font-size="9" fill="#fff">node_exporter :9100</text>
   
   <!-- Client N (ellipsis) -->
-  <text x="150" y="400" text-anchor="middle" font-size="20" fill="#7f8c8d">...</text>
+  <text x="150" y="420" text-anchor="middle" font-size="20" fill="#7f8c8d">...</text>
   
   <!-- Client N -->
-  <rect x="50" y="420" width="200" height="110" rx="8" fill="#fff" stroke="#bdc3c7" stroke-width="1"/>
-  <text x="150" y="442" text-anchor="middle" font-size="13" font-weight="bold" fill="#34495e">Client Host N</text>
-  <rect x="70" y="455" width="160" height="25" rx="4" fill="#27ae60" opacity="0.9"/>
-  <text x="150" y="472" text-anchor="middle" font-size="11" fill="#fff">rsyslog</text>
-  <rect x="70" y="485" width="160" height="18" rx="4" fill="#9b59b6" opacity="0.9"/>
-  <text x="150" y="498" text-anchor="middle" font-size="9" fill="#fff">node_exporter :9100</text>
+  <rect x="50" y="440" width="200" height="110" rx="8" fill="#fff" stroke="#bdc3c7" stroke-width="1"/>
+  <text x="150" y="462" text-anchor="middle" font-size="13" font-weight="bold" fill="#34495e">Client Host N</text>
+  <rect x="70" y="475" width="160" height="25" rx="4" fill="#27ae60" opacity="0.9"/>
+  <text x="150" y="492" text-anchor="middle" font-size="11" fill="#fff">rsyslog</text>
+  <rect x="70" y="505" width="160" height="18" rx="4" fill="#9b59b6" opacity="0.9"/>
+  <text x="150" y="518" text-anchor="middle" font-size="9" fill="#fff">node_exporter :9100</text>
   
   <!-- ROSI Collector Server Section -->
   <rect x="320" y="80" width="600" height="520" rx="10" fill="#fef9e7" stroke="#f39c12" stroke-width="2"/>
@@ -141,25 +143,35 @@
   <text x="305" y="255" text-anchor="middle" font-size="8" fill="#16a085">TLS :6514</text>
   <text x="305" y="278" text-anchor="middle" font-size="7" fill="#16a085">(optional)</text>
   
-  <!-- Metrics Flow Arrow (Prometheus to Clients) -->
-  <path d="M 360 345 L 290 345 L 290 230 L 255 230" stroke="#9b59b6" stroke-width="2" fill="none" marker-end="url(#arrowhead-purple)"/>
-  <text x="290" y="285" text-anchor="middle" font-size="8" fill="#9b59b6" transform="rotate(-90, 290, 285)">scrape :9100</text>
+  <!-- Metrics Flow Arrow (Prometheus to Clients :9100) -->
+  <path d="M 360 345 L 290 345 L 290 358 L 255 358" stroke="#9b59b6" stroke-width="2" fill="none" marker-end="url(#arrowhead-purple)"/>
+  <text x="272" y="352" text-anchor="middle" font-size="8" fill="#9b59b6">scrape :9100</text>
+  <!-- Metrics Flow Arrow (Prometheus to Client impstats :9898, optional) -->
+  <path d="M 360 338 L 290 338 L 290 224 L 255 224" stroke="#16a085" stroke-width="1.5" fill="none" marker-end="url(#arrowhead)" stroke-dasharray="5,3"/>
+  <text x="272" y="218" text-anchor="middle" font-size="7" fill="#16a085">scrape :9898 (optional)</text>
   
-  <!-- Legend -->
-  <rect x="30" y="610" width="890" height="35" rx="5" fill="#ecf0f1"/>
-  <circle cx="55" cy="627" r="6" fill="#27ae60"/>
-  <text x="70" y="632" font-size="9" fill="#34495e">Log Flow</text>
-  <circle cx="140" cy="627" r="6" fill="#9b59b6"/>
-  <text x="155" y="632" font-size="9" fill="#34495e">Metrics</text>
-  <circle cx="215" cy="627" r="6" fill="#3498db"/>
-  <text x="230" y="632" font-size="9" fill="#34495e">HTTPS Proxy</text>
-  <rect x="310" y="621" width="12" height="12" rx="2" fill="#f39c12"/>
-  <text x="330" y="632" font-size="9" fill="#34495e">Visualization</text>
-  <rect x="415" y="621" width="12" height="12" rx="2" fill="#e74c3c"/>
-  <text x="435" y="632" font-size="9" fill="#34495e">Storage</text>
-  <rect x="500" y="621" width="12" height="12" rx="2" fill="#16a085"/>
-  <text x="520" y="632" font-size="9" fill="#34495e">Downloads</text>
-  <rect x="600" y="621" width="30" height="12" rx="2" fill="none" stroke="#16a085" stroke-dasharray="3,2"/>
-  <text x="640" y="632" font-size="9" fill="#34495e">Optional (TLS)</text>
-  <text x="780" y="632" font-size="9" fill="#7f8c8d">Let's Encrypt TLS</text>
+  <!-- Legend (two rows, centered, with generous spacing) -->
+  <rect x="30" y="602" width="890" height="44" rx="5" fill="#ecf0f1"/>
+  <!-- Row 1: 5 items, ~170px per slot, centered (total 850, start 50) -->
+  <circle cx="68" cy="618" r="6" fill="#27ae60"/>
+  <text x="85" y="624" font-size="9" fill="#34495e">Log Flow</text>
+  <circle cx="238" cy="618" r="6" fill="#9b59b6"/>
+  <text x="255" y="624" font-size="9" fill="#34495e">Metrics (:9100)</text>
+  <line x1="398" y1="618" x2="418" y2="618" stroke="#16a085" stroke-width="2" stroke-dasharray="3,2"/>
+  <text x="435" y="624" font-size="9" fill="#34495e">impstats :9898 (opt)</text>
+  <circle cx="558" cy="618" r="6" fill="#3498db"/>
+  <text x="575" y="624" font-size="9" fill="#34495e">HTTPS Proxy</text>
+  <rect x="718" y="612" width="12" height="12" rx="2" fill="#f39c12"/>
+  <text x="735" y="624" font-size="9" fill="#34495e">Visualization</text>
+  <!-- Row 2: 4 items, ~190px per slot, centered (total 760, start 95) -->
+  <rect x="110" y="634" width="12" height="12" rx="2" fill="#e74c3c"/>
+  <text x="127" y="642" font-size="9" fill="#34495e">Storage</text>
+  <rect x="300" y="634" width="12" height="12" rx="2" fill="#16a085"/>
+  <text x="317" y="642" font-size="9" fill="#34495e">Downloads</text>
+  <line x1="490" y1="640" x2="510" y2="640" stroke="#16a085" stroke-width="2" stroke-dasharray="3,2"/>
+  <text x="527" y="642" font-size="9" fill="#34495e">Optional (TLS)</text>
+  <rect x="680" y="634" width="14" height="14" rx="2" fill="none" stroke="#2ecc71" stroke-width="1.5"/>
+  <rect x="683" y="638" width="8" height="6" rx="1" fill="#2ecc71"/>
+  <path d="M 683 638 L 683 634 Q 683 632 685 632 L 689 632 Q 691 632 691 634 L 691 638" fill="none" stroke="#2ecc71" stroke-width="1.2" stroke-linecap="round"/>
+  <text x="702" y="642" font-size="9" fill="#7f8c8d">Let's Encrypt TLS</text>
 </svg>

--- a/doc/source/getting_started/next_steps.rst
+++ b/doc/source/getting_started/next_steps.rst
@@ -8,7 +8,7 @@ Production Deployments
 ----------------------
 
 For a complete log collection stack with dashboards and alerting, see
-ROSI Collector (RSyslog Open System for Information):
+ROSI Collector (Rsyslog Operations Stack Initiative):
 
 :doc:`../deployments/rosi_collector/index`
 


### PR DESCRIPTION
### Summary

This PR adds a **Syslog Health** Grafana dashboard and optional **impstats sidecar** for ROSI Collector clients so operators can see rsyslog queue depth, action failures, and resource usage per host via Prometheus, without parsing logs.

### What’s included

- **Syslog Health dashboard** – Overview (exporter count, failures, queues), Queues (size, utilization, drops), Input (ingest rate), Actions (processed/failed/suspended, collapsed by default), Output & resource usage (omfwd bytes and CPU). Host variable to filter by client.
- **Grafana** – Dashboards moved to **templates/** with `scripts/render-dashboards.py` building **generated/**; default home dashboard path updated; new **rsyslog-impstats** alert group (queue depth high, discards, action failures, action suspended), all rules **disabled by default** (`isPaused: true`).
- **Prometheus** – Second scrape job for impstats; **impstats.yml**; **prometheus-target** supports `--job impstats` and **add-client** (adds node :9100 and impstats :9898 in one command).
- **Client installer** – Optional impstats sidecar (default on): bind-IP prompt, Python venv check, UFW/iptables rules for port 9898; `--no-sidecar` to skip.
- **init.sh** – Optional firewall rule so the collector host’s impstats exporter (9898) is reachable; `ENABLE_IMPSTATS_FIREWALL=false` to disable.
- **Docs** – README, AGENTS.md, clients/README, RSYSLOG-SETUP.md; RST (architecture, client_setup, grafana_dashboards, index) and **rosi-architecture.svg** updated (impstats on Client 1, scrape :9898, add-client, dashboard names).
- **Dashboard renames** – Syslog Deep Dive → Syslog Analysis, Node Overview → Host Metrics Overview.
- **Misc** – rsyslog container healthcheck uses `pidof rsyslogd` (no PID file in `-n` mode). Note that `omfwd` is built-in (no `module(load="omfwd")`).

