### PR TITLE
omhttp: reuse reply buffer safely

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -920,6 +920,7 @@ EXTRA_DIST = \
     source/reference/parameters/omhttp-batch-maxbytes.rst \
     source/reference/parameters/omhttp-batch-maxsize.rst \
     source/reference/parameters/omhttp-batch.rst \
+    source/reference/parameters/omhttp-replymaxbytes.rst \
     source/reference/parameters/omhttp-checkpath.rst \
     source/reference/parameters/omhttp-compress-level.rst \
     source/reference/parameters/omhttp-compress.rst \

--- a/doc/source/configuration/modules/omhttp.rst
+++ b/doc/source/configuration/modules/omhttp.rst
@@ -136,6 +136,10 @@ Input Parameters
      - .. include:: ../../reference/parameters/omhttp-batch-maxbytes.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omhttp-replymaxbytes`
+     - .. include:: ../../reference/parameters/omhttp-replymaxbytes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omhttp-template`
      - .. include:: ../../reference/parameters/omhttp-template.rst
         :start-after: .. summary-start
@@ -230,6 +234,7 @@ Input Parameters
    ../../reference/parameters/omhttp-batch-format
    ../../reference/parameters/omhttp-batch-maxsize
    ../../reference/parameters/omhttp-batch-maxbytes
+   ../../reference/parameters/omhttp-replymaxbytes
    ../../reference/parameters/omhttp-template
    ../../reference/parameters/omhttp-retry
    ../../reference/parameters/omhttp-retry-ruleset

--- a/doc/source/reference/parameters/omhttp-replymaxbytes.rst
+++ b/doc/source/reference/parameters/omhttp-replymaxbytes.rst
@@ -1,0 +1,51 @@
+.. meta::
+   :description: Configure the maximum HTTP response size stored by omhttp.
+   :keywords: rsyslog, omhttp, replymaxbytes, http, response size
+
+.. _param-omhttp-replymaxbytes:
+.. _omhttp.parameter.input.replymaxbytes:
+
+replymaxbytes
+=============
+
+.. index::
+   single: omhttp; replymaxbytes
+   single: replymaxbytes
+
+.. summary-start
+
+Limits how much HTTP response data omhttp stores per request.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omhttp`.
+
+:Name: replymaxbytes
+:Scope: input
+:Type: Size
+:Default: input=1048576 (1MB)
+:Required?: no
+:Introduced: Not specified
+
+Description
+-----------
+``replymaxbytes`` caps the number of bytes retained from an HTTP response.
+Set this to bound memory usage when servers return large response bodies.
+Use ``0`` to disable the limit.
+
+Input usage
+-----------
+.. _omhttp.parameter.input.replymaxbytes-usage:
+
+.. code-block:: rsyslog
+
+   module(load="omhttp")
+
+   action(
+       type="omhttp"
+       replyMaxBytes="512k"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/omhttp`.


### PR DESCRIPTION
Why: reduce response handling overhead and avoid leaks

Impact: adds replymaxbytes cap; adjusts curl sizing logic

Before/After: reply buffers reallocated per chunk -> reused with limits

Technical Overview:

- Track reply length as size_t and reuse the buffer

- Enforce replymaxbytes and overflow guards during curl callbacks

- Keep replies NUL-terminated for logging/metadata

- Use CURLOPT_POSTFIELDSIZE_LARGE for large payloads

- Add defaults and config parsing for replymaxbytes

With the help of AI-Agents: Codex
