### PR TITLE
tests: harden imjournal basic flake handling

### DIFF
--- a/tests/journal_print.c
+++ b/tests/journal_print.c
@@ -31,6 +31,7 @@
 #include <config.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <syslog.h>
 #include <unistd.h>
 #include <systemd/sd-journal.h>
@@ -57,9 +58,18 @@ int main(int argc, char *argv[]) {
     }
 
     /* Now we can try inserting something */
-    if (fprintf(log, "%s", argv[1]) <= 0) {
+    if (fprintf(log, "%s\n", argv[1]) <= 0) {
         fprintf(stderr, "Failed to write to journal log: %m\n");
-        close(fd);
+        fclose(log);
+        exit(3);
+    }
+    if (fflush(log) != 0) {
+        fprintf(stderr, "Failed to flush journal log: %m\n");
+        fclose(log);
+        exit(3);
+    }
+    if (fclose(log) != 0) {
+        fprintf(stderr, "Failed to close journal log: %m\n");
         exit(3);
     }
 


### PR DESCRIPTION
Why:
Improve reliability of the imjournal basic test under CI timing variance and journal churn, reducing non-actionable failures.

Impact: imjournal basic tests become more resilient and may skip when host journal load is excessive.

Before/After: test could fail due to startup/noise races; now it waits for readiness, retries under noise, and reports cleaner errors.

Technical Overview:
- Added a readiness probe phase in imjournal-basic before the real assertion message to avoid IgnorePreviousMessages startup races.
- Added short retry logic for high recent journal volume and skip only after retries are exhausted.
- Added tunables for noise window, threshold, retries, and sleep.
- Updated journal_print to write newline-terminated records and explicitly fflush/fclose so writes are durably handed to journald.
- Updated content_check_with_count to treat missing output file as not-yet-done until the test hard deadline, then fail.
- Improved failure diagnostics for missing output file to avoid secondary shell errors that obscure the primary failure.

With the help of AI-Agents: Codex
