### PR TITLE
curl modules: pass long literal to CURLOPT_POST

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -1870,7 +1870,7 @@ static void ATTR_NONNULL() curlCheckConnSetup(wrkrInstanceData_t *const pWrkrDat
 static void ATTR_NONNULL(1) curlPostSetup(wrkrInstanceData_t *const pWrkrData) {
     PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
     curlSetupCommon(pWrkrData, pWrkrData->curlPostHandle);
-    curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_POST, 1);
+    curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_POST, 1L);
     CURLcode cRet;
     /* Enable TCP keep-alive for this transfer */
     cRet = curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_TCP_KEEPALIVE, 1L);

--- a/plugins/omclickhouse/omclickhouse.c
+++ b/plugins/omclickhouse/omclickhouse.c
@@ -647,7 +647,7 @@ static void ATTR_NONNULL() curlCheckConnSetup(wrkrInstanceData_t *const pWrkrDat
 
 static void ATTR_NONNULL(1) curlPostSetup(wrkrInstanceData_t *const pWrkrData) {
     curlSetupCommon(pWrkrData, pWrkrData->curlPostHandle);
-    curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_POST, 1);
+    curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_POST, 1L);
     if (pWrkrData->pData->timeout) {
         curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_TIMEOUT_MS, pWrkrData->pData->timeout);
     }

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -2106,7 +2106,7 @@ static void ATTR_NONNULL() curlCheckConnSetup(wrkrInstanceData_t *const pWrkrDat
 static void ATTR_NONNULL(1) curlPostSetup(wrkrInstanceData_t *const pWrkrData) {
     PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
     curlSetupCommon(pWrkrData, pWrkrData->curlPostHandle);
-    curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_POST, 1);
+    curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_POST, 1L);
     curl_easy_setopt(pWrkrData->curlPostHandle, CURLOPT_TIMEOUT_MS, pWrkrData->pData->indexTimeout);
 }
 


### PR DESCRIPTION
Why:
Debian builds against newer curl headers fail with -Werror because CURLOPT_POST requires a long argument and int literals trigger attribute warnings.

Impact:
Fixes compile failures in omhttp, omelasticsearch, and omclickhouse with strict warning settings.

Before/After:
Before: build failed on CURLOPT_POST type mismatch. After: build succeeds with explicit long literals.

Technical Overview:
Switch CURLOPT_POST values from 1 to 1L in three modules: contrib/omhttp, plugins/omelasticsearch, and plugins/omclickhouse. No runtime behavior changes are intended; only argument typing is corrected to satisfy curl's type-checked setopt wrappers. The change aligns with Debian hardening and -Werror builds and matches curl API expectations.

Closes https://github.com/rsyslog/rsyslog/issues/6516

With the help of AI-Agents: Codex
