### PR TITLE
omhttp: add VictoriaLogs jsonline CI test

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1257,6 +1257,80 @@ jobs:
         if: steps.code_changes.outputs.any_changed != 'true'
         run: echo "No relevant changes detected; skipping elasticsearch CI."
 
+  victorialogs_CI:
+    needs: compile
+    if: ${{ needs.compile.result == 'success' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    name: victorialogs-tests
+    env:
+      DOCKER_RUN_EXTRA_OPTS: --network host
+    services:
+      victorialogs:
+        image: victoriametrics/victoria-logs:latest
+        ports:
+          - 29428:9428
+    steps:
+      - name: checkout project
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for code changes
+        id: code_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          files: |
+            tests/omhttp-victorialogs-jsonline.sh
+            tests/Makefile.am
+            contrib/omhttp/**
+            .github/workflows/run_checks.yml
+          files_ignore: |
+            doc/Makefile.am
+
+      - name: run victoria logs omhttp jsonl test
+        if: steps.code_changes.outputs.any_changed == 'true'
+        env:
+          RSYSLOG_DEV_CONTAINER: rsyslog/rsyslog_dev_base_ubuntu:22.04
+          RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE: >-
+            --enable-testbench --enable-omstdout --enable-imdiag --enable-omhttp
+            --disable-default-tests --disable-imtcp-tests --disable-imfile
+            --disable-imfile-tests --disable-fmhttp
+          CI_MAKE_OPT: -j20
+          CI_MAKE_CHECK_OPT: -j1 TESTS=omhttp-victorialogs-jsonline.sh
+          CI_CHECK_CMD: check
+          ABORT_ALL_ON_TEST_FAIL: 'NO'
+          USE_AUTO_DEBUG: 'off'
+          VERBOSE: '1'
+        run: |
+          for i in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:29428/metrics >/dev/null; then
+              echo "VictoriaLogs is ready"
+              break
+            fi
+            sleep 1
+            if [ "$i" -eq 60 ]; then
+              echo "VictoriaLogs service did not become ready in time"
+              exit 1
+            fi
+          done
+          chmod -R go+rw .
+          devtools/devcontainer.sh --rm devtools/run-ci.sh
+
+      - name: show error logs (if we errored)
+        if: ${{ (failure() || cancelled()) && steps.code_changes.outputs.any_changed == 'true' }}
+        run: |
+          devtools/gather-check-logs.sh
+          cat failed-tests.log
+
+      - name: Skip VictoriaLogs CI, no relevant changes
+        if: steps.code_changes.outputs.any_changed != 'true'
+        run: echo "No relevant changes detected; skipping VictoriaLogs CI."
+
   clang_analyzer_CI:
     needs: compile
     if: ${{ needs.compile.result == 'success' }}

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -847,6 +847,9 @@ TESTS_OMHTTP_VALGRIND = \
         omhttp-retry-timeout-vg.sh \
         omhttp-batch-lokirest-vg.sh
 
+TESTS_OMHTTP_VICTORIALOGS = \
+	omhttp-victorialogs-jsonline.sh
+
 TESTS_OMOTEL = \
         omotel-http-batch.sh \
         omotel-basic.sh \
@@ -1693,6 +1696,7 @@ EXTRA_DIST += $(TESTS_OMPROG)
 EXTRA_DIST += $(TESTS_OMPROG_VALGRIND)
 EXTRA_DIST += $(TESTS_OMHTTP)
 EXTRA_DIST += $(TESTS_OMHTTP_VALGRIND)
+EXTRA_DIST += $(TESTS_OMHTTP_VICTORIALOGS)
 EXTRA_DIST += $(TESTS_OMOTEL)
 EXTRA_DIST += $(TESTS_KAFKA)
 EXTRA_DIST += $(TESTS_KAFKA_VALGRIND)

--- a/tests/omhttp-victorialogs-jsonline.sh
+++ b/tests/omhttp-victorialogs-jsonline.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=200
+
+VL_HOST="${VICTORIALOGS_HOST:-127.0.0.1}"
+VL_PORT="${VICTORIALOGS_PORT:-29428}"
+VL_BASE_URL="http://${VL_HOST}:${VL_PORT}"
+COOKIE="vlogs-ci-$(date +%s)-$$"
+VL_QUERY_OUT="${RSYSLOG_OUT_LOG}.victorialogs.query.out"
+
+# Keep stream fields stable and low-cardinality.
+VL_RESTPATH='insert/jsonline?_stream_fields=stream,host,app&_time_field=ts&_msg_field=msg'
+
+for i in $(seq 1 40); do
+	if curl -fsS "${VL_BASE_URL}/metrics" >/dev/null; then
+		break
+	fi
+	sleep 0.5
+	if [ "$i" -eq 40 ]; then
+		echo "FAIL: VictoriaLogs is not reachable at ${VL_BASE_URL}"
+		error_exit 1
+	fi
+done
+
+generate_conf
+add_conf '
+module(load="../contrib/omhttp/.libs/omhttp")
+
+template(name="tpl_victorialogs_jsonl" type="list" option.jsonf="on") {
+	constant(outname="stream" value="rsyslog-ci" format="jsonf")
+	property(outname="host" name="hostname" format="jsonf")
+	property(outname="app" name="programname" format="jsonf")
+	property(outname="ts" name="timegenerated" dateFormat="rfc3339" format="jsonf")
+	constant(outname="testid" value="'$COOKIE'" format="jsonf")
+	property(outname="msg" name="msg" format="jsonf")
+}
+
+if $msg contains "msgnum:" then
+	action(
+		name="omhttp_victorialogs_jsonline"
+		type="omhttp"
+		errorfile="'$RSYSLOG_DYNNAME/omhttp.victorialogs.error.log'"
+		server="'$VL_HOST'"
+		serverport="'$VL_PORT'"
+		restpath="'$VL_RESTPATH'"
+		httpcontenttype="application/stream+json"
+		template="tpl_victorialogs_jsonl"
+		batch="on"
+		batch.format="newline"
+		batch.maxsize="1000"
+		batch.maxbytes="1048576"
+		compress="on"
+		usehttps="off"
+	)
+'
+
+startup
+injectmsg 0 $NUMMESSAGES
+shutdown_when_empty
+wait_shutdown
+
+for i in $(seq 1 45); do
+	curl -fsS --get "${VL_BASE_URL}/select/logsql/query" \
+		--data-urlencode "query=msgnum" \
+		--data-urlencode "limit=10000" > "${VL_QUERY_OUT}"
+
+	line_count=$(grep -c "\"testid\":\"${COOKIE}\"" "${VL_QUERY_OUT}" || true)
+	if [ "${line_count}" -ge "${NUMMESSAGES}" ]; then
+		break
+	fi
+	sleep 1
+	if [ "$i" -eq 45 ]; then
+		echo "FAIL: timed out waiting for ${NUMMESSAGES} records in VictoriaLogs, got ${line_count}"
+		error_exit 1
+	fi
+done
+
+$PYTHON - <<'PY' "${VL_QUERY_OUT}" "${NUMMESSAGES}" "${COOKIE}"
+import json
+import re
+import sys
+
+path = sys.argv[1]
+expected = int(sys.argv[2])
+cookie = sys.argv[3]
+pat = re.compile(r"msgnum:(\d+):")
+seen = set()
+count = 0
+
+with open(path, "r", encoding="utf-8") as fh:
+    for line in fh:
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        if rec.get("testid") != cookie:
+            continue
+        count += 1
+        msg = rec.get("_msg", "")
+        m = pat.search(msg)
+        if m:
+            seen.add(int(m.group(1)))
+
+if count < expected:
+    raise SystemExit(f"expected at least {expected} records, got {count}")
+
+if len(seen) != expected:
+    raise SystemExit(f"expected {expected} unique msgnum values, got {len(seen)}")
+
+if min(seen) != 0 or max(seen) != expected - 1:
+    raise SystemExit(f"unexpected msgnum range: min={min(seen)} max={max(seen)} expected=0..{expected-1}")
+PY
+
+exit_test


### PR DESCRIPTION
Why
VictoriaLogs jsonline is a target deployment path for omhttp users and we need a direct integration signal in PR CI.

Impact
Adds a real-container omhttp->VictoriaLogs validation path and a scoped CI job for relevant PRs.

Before/After
Before: no CI test validated omhttp against VictoriaLogs jsonline. After: PRs touching omhttp or this test run a minimal live integration check.

Technical Overview
Add tests/omhttp-victorialogs-jsonline.sh to send batched newline JSONL payloads with omhttp to /insert/jsonline and verify indexed results via /select/logsql/query.

Use jsonf list templating and a per-run marker to isolate records during query validation. Keep transport on plain HTTP for CI simplicity.

Register the test in tests/Makefile.am under TESTS_OMHTTP so it is part of testbench distribution and invocable as a single .log target.

Add a new run_checks.yml job named victorialogs_CI that starts a VictoriaLogs service container, runs only
omhttp-victorialogs-jsonline.log, and gates execution with changed-files filters for the test, omhttp components, and the workflow itself.

With the help of AI-Agents: Codex (GPT-5)
