### PR TITLE
omkafka: poll callbacks while action is idle

### DIFF
--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -217,6 +217,8 @@ static uint64 getClockTopicAccess(void) {
 static int closeTimeout = 1000;
 static pthread_mutex_t closeTimeoutMut = PTHREAD_MUTEX_INITIALIZER;
 
+#define OMKAFKA_POLL_THREAD_SLEEP_USEC 100000
+
 /* stats callback window metrics */
 static uint64 rtt_avg_usec;
 static uint64 throttle_avg_msec;
@@ -285,6 +287,10 @@ typedef struct _instanceData {
     int bIsSuspended; /* when broker fail, we need to suspend the action */
     pthread_rwlock_t rkLock;
     pthread_mutex_t mut_doAction; /* make sure one wrkr instance max in parallel */
+    pthread_t pollThread;
+    int pollThreadRunning;
+    int stopPollThread;
+    DEF_ATOMIC_HELPER_MUT(mutStopPollThread);
     rd_kafka_t *rk;
     int closeTimeout;
     SLIST_HEAD(failedmsg_listhead, s_failedmsg_entry) failedmsg_head;
@@ -299,6 +305,58 @@ typedef struct _instanceData {
 typedef struct wrkrInstanceData {
     instanceData *pData;
 } wrkrInstanceData_t;
+
+static void *pollCallbackThread(void *arg) {
+    instanceData *const pData = (instanceData *)arg;
+
+    while (!ATOMIC_FETCH_32BIT(&pData->stopPollThread, &pData->mutStopPollThread)) {
+        if (pthread_mutex_trylock(&pData->mut_doAction) == 0) {
+            pthread_rwlock_rdlock(&pData->rkLock);
+            if (pData->bIsOpen && pData->rk != NULL) {
+                const int callbacksCalled = rd_kafka_poll(pData->rk, 0); /* call callbacks */
+                DBGPRINTF("omkafka: callback-poller outqueue length: %d, callbacks called %d\n",
+                          rd_kafka_outq_len(pData->rk), callbacksCalled);
+            }
+            pthread_rwlock_unlock(&pData->rkLock);
+            pthread_mutex_unlock(&pData->mut_doAction);
+        }
+        srSleep(0, OMKAFKA_POLL_THREAD_SLEEP_USEC);
+    }
+
+    return NULL;
+}
+
+static rsRetVal startPollCallbackThread(instanceData *const pData) {
+    DEFiRet;
+
+    if (pData->pollThreadRunning) {
+        FINALIZE;
+    }
+
+    ATOMIC_STORE_0_TO_INT(&pData->stopPollThread, &pData->mutStopPollThread);
+    const int r = pthread_create(&pData->pollThread, NULL, pollCallbackThread, pData);
+    if (r != 0) {
+        LogError(r, RS_RET_ERR, "omkafka: unable to create librdkafka callback poller thread");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    pData->pollThreadRunning = 1;
+
+finalize_it:
+    RETiRet;
+}
+
+static void stopPollCallbackThread(instanceData *const pData) {
+    if (!pData->pollThreadRunning) {
+        return;
+    }
+
+    ATOMIC_STORE_1_TO_INT(&pData->stopPollThread, &pData->mutStopPollThread);
+    const int r = pthread_join(pData->pollThread, NULL);
+    if (r != 0) {
+        LogError(r, RS_RET_ERR, "omkafka: unable to join librdkafka callback poller thread");
+    }
+    pData->pollThreadRunning = 0;
+}
 
 #define INST_STATSCOUNTER_INC(inst, ctr, mut) \
     do {                                      \
@@ -1469,6 +1527,11 @@ static rsRetVal openKafka(instanceData *const __restrict__ pData) {
     }
 
     pData->bIsOpen = 1;
+    /* callback poll thread is best-effort and must not prevent action open */
+    if (startPollCallbackThread(pData) != RS_RET_OK) {
+        LogMsg(0, RS_RET_ERR, LOG_WARNING,
+               "omkafka: proceeding without callback poll thread; callbacks are only drained on active writes");
+    }
 finalize_it:
     if (iRet == RS_RET_OK) {
         pData->bReportErrs = 1;
@@ -1749,6 +1812,9 @@ BEGINcreateInstance
     CHKiRet(pthread_rwlock_init(&pData->rkLock, NULL));
     CHKiRet(pthread_mutex_init(&pData->mutDynCache, NULL));
     INIT_ATOMIC_HELPER_MUT(pData->mutCurrPartition);
+    INIT_ATOMIC_HELPER_MUT(pData->mutStopPollThread);
+    pData->pollThreadRunning = 0;
+    ATOMIC_STORE_0_TO_INT(&pData->stopPollThread, &pData->mutStopPollThread);
 finalize_it:
 ENDcreateInstance
 
@@ -1768,6 +1834,7 @@ BEGINfreeInstance
     /* Helpers for Failed Msg List */
     failedmsg_entry *fmsgEntry1;
     failedmsg_entry *fmsgEntry2;
+    stopPollCallbackThread(pData);
     if (pData->fdErrFile != -1) close(pData->fdErrFile);
     if (pData->fdStatsFile != -1) close(pData->fdStatsFile);
     /* Closing Kafka first! */
@@ -1827,6 +1894,7 @@ BEGINfreeInstance
     pthread_mutex_destroy(&pData->mutErrFile);
     pthread_mutex_destroy(&pData->mutStatsFile);
     pthread_mutex_destroy(&pData->mutDynCache);
+    DESTROY_ATOMIC_HELPER_MUT(pData->mutStopPollThread);
 ENDfreeInstance
 
 BEGINfreeWrkrInstance


### PR DESCRIPTION
Why
When statistics.interval.ms is enabled, librdkafka queues stats events until rd_kafka_poll() is called. Idle omkafka actions can go long periods without polling, so callbacks pile up and consume memory.

Impact
Stats callbacks are drained continuously even when no new messages arrive, preventing callback queue buildup.

Before/After
Before: callbacks were mostly drained only during message processing. After: a lightweight poll thread drains callbacks during idle periods.

Technical Overview
Add a dedicated callback poller thread per omkafka instance. The thread uses mut_doAction and rkLock so callback execution stays serialized with doAction and handle recreation.
The thread wakes every 100ms and calls rd_kafka_poll(..., 0) only when the kafka handle is open.
Start the thread once openKafka succeeds and stop it during freeInstance. Thread lifecycle state is tracked in instanceData.

closes https://github.com/rsyslog/rsyslog/issues/3395

With the help of AI-Agents: GPT-5.2-Codex
