### PR TITLE
imjournal: fix stats counter type for uint64 fields

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -1143,9 +1143,9 @@ BEGINactivateCnf
     STATSCOUNTER_INIT(statsCounter.ctrRecoveryAttempts, statsCounter.mutCtrRecoveryAttempts);
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("recovery_attempts"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &(statsCounter.ctrRecoveryAttempts)));
-    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("ratelimit_discarded_in_interval"), ctrType_Int,
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("ratelimit_discarded_in_interval"), ctrType_IntCtr,
                                 CTR_FLAG_NONE, &(statsCounter.ratelimitDiscardedInInterval)));
-    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("disk_usage_bytes"), ctrType_Int, CTR_FLAG_NONE,
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("disk_usage_bytes"), ctrType_IntCtr, CTR_FLAG_NONE,
                                 &(statsCounter.diskUsageBytes)));
     CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));
     /* end stats counter */


### PR DESCRIPTION
The `ratelimit_discarded_in_interval` and `disk_usage_bytes` counters are declared as uint64 but were registered as `ctrType_Int`, which reads through an int pointer (4 bytes, signed). This truncates values above 4 GB and misinterprets values between 2-4 GB as negative.

Fix by using `ctrType_IntCtr` which matches the actual uint64 storage.