### PR TITLE
doc: describe impstats push mode for VictoriaMetrics

### DIFF
--- a/doc/source/reference/parameters/impstats-format.rst
+++ b/doc/source/reference/parameters/impstats-format.rst
@@ -44,6 +44,7 @@ Options:
 * ``cee``
 * ``legacy``
 * ``prometheus``
+* ``zabbix``
 
 .. note::
 


### PR DESCRIPTION
## Summary
- add a dedicated functional section for impstats push mode (VictoriaMetrics / Prometheus Remote Write)
- explain runtime behavior (parallel local output, retry on next interval, no cross-interval buffering)
- document build/runtime constraints and add a concrete VictoriaMetrics example
- add note that project-provided packages are built with push support and link to rsyslog.com package library locations
- include push parameter docs in impstats module toctree for discoverability
- align format docs by listing `zabbix` in `impstats format` options
- fix impstats example typo (`module(loadf=...)` -> `module(load=...)`)

## Validation
- focused sphinx build for touched pages completed successfully:
  - `doc/source/configuration/modules/impstats.rst`
  - `doc/source/reference/parameters/impstats-format.rst`
