### PR TITLE
doc: expand impstats push docs and FAQ coverage

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -339,6 +339,7 @@ EXTRA_DIST = \
     source/faq/etl_tool.rst \
     source/faq/faq_overall.rst \
     source/faq/imtcp-tls-gibberish.rst \
+    source/faq/impstats-push-mode.rst \
     source/faq/imudp-packet-loss.rst \
     source/faq/index.rst \
     source/faq/vespa-ai-integration.rst \

--- a/doc/source/configuration/modules/impstats.rst
+++ b/doc/source/configuration/modules/impstats.rst
@@ -81,6 +81,29 @@ Build and runtime notes:
 - Optional batch controls (``push.batch.maxBytes`` and ``push.batch.maxSeries``)
   split large Remote Write payloads.
 
+Naming and labels:
+
+- Metric names are generated as ``<origin>_<name>_<counter>_total``.
+  If ``name`` is empty, it is omitted.
+- Name components are sanitized to Prometheus-safe characters (for example,
+  ``-`` and ``.`` become ``_``).
+- ``push.labels`` provides static labels.
+- Dynamic labels are optional:
+  ``push.label.instance``, ``push.label.job``, ``push.label.origin``,
+  and ``push.label.name``.
+- If the same label key already exists in ``push.labels``, impstats does not
+  override it with a dynamic label.
+
+Current limitations:
+
+- Push is synchronous inside the impstats interval worker.
+- Failed pushes are retried only on the next interval.
+- No cross-interval buffering is performed for failed pushes.
+- No built-in HTTP authentication parameters are currently available for push.
+
+For troubleshooting-oriented questions, see
+:doc:`../../faq/impstats-push-mode`.
+
 
 
 

--- a/doc/source/faq/impstats-push-mode.rst
+++ b/doc/source/faq/impstats-push-mode.rst
@@ -1,0 +1,143 @@
+.. _faq-impstats-push-mode:
+
+.. meta::
+   :description: FAQ and troubleshooting guide for impstats push mode and Prometheus Remote Write backends such as VictoriaMetrics.
+   :keywords: rsyslog, impstats, push mode, Remote Write, VictoriaMetrics, Prometheus, troubleshooting
+
+.. summary-start
+
+Common setup and troubleshooting answers for impstats push mode
+(Prometheus Remote Write / VictoriaMetrics).
+
+.. summary-end
+
+FAQ: impstats Push Mode (Remote Write)
+======================================
+
+Q: Do I need ``format="prometheus"`` to use push mode?
+------------------------------------------------------
+
+No. Push mode is independent from local emission format. Set ``push.url`` to
+enable push, and keep local ``format``/``log.file``/``log.syslog`` according
+to your local processing needs.
+
+
+Q: What exactly enables push mode?
+----------------------------------
+
+Push is enabled when ``push.url`` is configured.
+
+
+Q: How do I verify my build supports push mode?
+------------------------------------------------
+
+Push mode is compiled only when rsyslog is built with
+``--enable-impstats-push`` (and required libraries). In project-provided
+packages, push support is included.
+
+
+Q: What happens when the remote endpoint is down?
+-------------------------------------------------
+
+impstats logs the push error and retries on the next impstats interval.
+It does not buffer failed push payloads across intervals.
+
+
+Q: Is push asynchronous?
+------------------------
+
+No. Push is synchronous in the impstats worker thread. ``push.timeout.ms``
+controls how long an HTTP request may block before timing out.
+
+
+Q: How are HTTP error responses handled?
+----------------------------------------
+
+Non-2xx responses fail the push for that interval. ``5xx`` responses are treated
+as retryable (next interval retry). ``4xx`` responses are treated as permanent
+configuration/request errors and should be fixed at configuration or endpoint
+level.
+
+
+Q: How are metric names generated?
+----------------------------------
+
+Metric names are constructed as ``<origin>_<name>_<counter>_total``.
+If ``name`` is empty, it is omitted. Non-Prometheus-safe characters are
+sanitized (for example ``-`` and ``.`` become ``_``).
+
+
+Q: Which labels are attached by default?
+----------------------------------------
+
+Static labels from ``push.labels`` are always included.
+
+By default:
+
+- ``push.label.instance`` is ``on``
+- ``push.label.job`` is ``rsyslog``
+- ``push.label.origin`` is ``off``
+- ``push.label.name`` is ``off``
+
+If a label key is already present in ``push.labels``, impstats does not
+override it with dynamic labels.
+
+
+Q: How do batch limits behave?
+------------------------------
+
+``push.batch.maxSeries`` limits the number of time series per request.
+
+``push.batch.maxBytes`` is an approximate size target; impstats estimates
+series-per-batch from encoded payload size and splits accordingly. It is
+best-effort, not a strict byte cap.
+
+
+Q: Do TLS parameters work with ``http://`` URLs?
+------------------------------------------------
+
+No. ``push.tls.*`` options only apply to ``https://`` endpoints. If TLS
+options are set with a non-HTTPS URL, impstats warns that those TLS options
+are ignored.
+
+
+Q: Do ``push.tls.certfile`` and ``push.tls.keyfile`` need to be set together?
+------------------------------------------------------------------------------
+
+Yes. They are a pair for mTLS client authentication. If only one is set,
+configuration validation fails and push mode is disabled.
+
+
+Q: Are there authentication parameters for HTTP Basic or Bearer token?
+----------------------------------------------------------------------
+
+Not currently. Push mode does not currently expose built-in auth parameters
+for headers or credentials.
+
+
+Q: Does ``resetCounters`` affect pushed values?
+-----------------------------------------------
+
+Push is executed before local formatted stats emission for each interval.
+That means pushed values are collected from current counters first, and then
+local emission/reset behavior is applied for the configured output path.
+
+
+Q: How should I verify push mode quickly?
+-----------------------------------------
+
+1. Configure impstats with ``push.url`` and a short ``interval``.
+2. Set ``global(debug.whitelist="on" debug.files=["impstats.c","impstats_push.c"])``
+   in test environments if you need detailed diagnostics.
+3. Check rsyslog logs for push success/failure messages and endpoint HTTP
+   status codes.
+4. Query your Remote Write backend for expected metric names and labels.
+
+
+See also
+--------
+
+- :doc:`../configuration/modules/impstats`
+- :doc:`../reference/parameters/impstats-push-url`
+- :doc:`../reference/parameters/impstats-push-labels`
+- :doc:`../reference/parameters/impstats-push-timeout-ms`

--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -11,6 +11,7 @@ FAQ
    imudp-packet-loss
    common-config-mistakes
    imtcp-tls-gibberish
+   impstats-push-mode
    etl_tool
    vespa-ai-integration
    does-rsyslog-run-under-windows

--- a/plugins/impstats/README_PUSH.md
+++ b/plugins/impstats/README_PUSH.md
@@ -1,155 +1,31 @@
-# impstats Push Support
+# impstats Push Notes (Developer Scope)
 
-## Overview
-This feature adds native push support to the impstats module, allowing rsyslog to send internal statistics directly to VictoriaMetrics (or any Prometheus Remote Write compatible endpoint) without requiring external collectors.
+This file is intentionally limited to contributor notes.
+User-facing documentation for impstats push mode lives in:
 
-**Implementation**: Uses native counter iteration API (`statsobj->GetAllCounters()`) to access raw counter values directly, eliminating text serialization and parsing overhead.
+- `doc/source/configuration/modules/impstats.rst`
+- `doc/source/faq/impstats-push-mode.rst`
+- `doc/source/reference/parameters/impstats-push-*.rst`
 
-## Architecture
-- **Direct push from impstats**: Metrics are pushed directly from the impstats module using the Prometheus Remote Write protocol
-- **Native counter access**: Direct access to statsobj counters via callback API (no text parsing)
-- **Efficient encoding**: Raw uint64 values → protobuf → Snappy compression → HTTP POST
-- **Conditional build**: Feature is optional via `--enable-impstats-push` flag
-- **Dependencies**: libcurl, libprotobuf-c, libsnappy
+## Implementation map
 
-## Build Requirements
+- `impstats.c`: module config parsing, activation, and integration hooks
+- `impstats_push.c`: Remote Write send path, metric/label shaping, HTTP/TLS
+- `prometheus_remote_write.c`: protobuf encoding + snappy compression
+- `remote.proto`: protobuf schema
+
+## Build gate
+
+Push support is compiled only with:
+
 ```bash
-# Install dependencies (Debian/Ubuntu)
-sudo apt-get install libcurl4-openssl-dev libprotobuf-c-dev libsnappy-dev protobuf-c-compiler
-
-# Configure and build
-./autogen.sh
 ./configure --enable-impstats --enable-impstats-push
-make
 ```
 
-## Configuration Example
-```
-module(load="impstats"
-    interval="10"
-    format="json"
-    
-    # Push configuration
-    push.url="http://localhost:8428/api/v1/write"
-    push.labels=["instance=rsyslog-test", "env=dev"]
-    push.timeout.ms="5000"
-)
-```
+## Contributor checklist
 
-## Configuration Parameters
-- **push.url**: VictoriaMetrics/Prometheus Remote Write endpoint URL (enables push when set)
-- **push.labels**: Array of static labels to attach to all metrics (format: "key=value")
-- **push.timeout.ms**: HTTP request timeout in milliseconds (default: 5000)
-- **push.label.instance**: Add `instance=<hostname>` label (default: on)
-- **push.label.job**: Add `job=<value>` label (default: "rsyslog"; set empty to disable)
-- **push.label.origin**: Add `origin=<statsobj origin>` label (default: off)
-- **push.label.name**: Add `name=<statsobj name>` label (default: off)
-- **push.tls.cafile**: CA bundle file for TLS verification
-- **push.tls.certfile**: Client certificate file for mTLS
-- **push.tls.keyfile**: Client private key file for mTLS
-- **push.tls.insecureSkipVerify**: Disable TLS verification (default: off)
-- **push.batch.maxBytes**: Approximate maximum protobuf size per request (default: 0, disabled)
-- **push.batch.maxSeries**: Maximum number of time series per request (default: 0, disabled)
+When changing push behavior:
 
-## Protocol Details
-- Uses Prometheus Remote Write protocol (protobuf + Snappy compression)
-- Required HTTP headers:
-  - `Content-Type: application/x-protobuf`
-  - `Content-Encoding: snappy`
-  - `X-Prometheus-Remote-Write-Version: 0.1.0`
-- Timestamps are milliseconds since Unix epoch
-- Labels are sorted lexicographically (required by spec)
-- `__name__` label contains the metric name
-
-## Metric Naming Convention
-
-Metric names are constructed from statsobj components:
-
-**Format**: `<origin>_<name>_<counter>_total`
-
-Where:
-- `origin`: Statsobj origin (e.g., "resource-usage", "core.queue", "imdiag")
-- `name`: Statsobj instance name (omitted if empty)
-- `counter`: Counter name (e.g., "utime", "enqueued", "submitted")
-
-**Sanitization**: All non-alphanumeric characters (hyphens, dots, etc.) are replaced with underscores to comply with Prometheus naming requirements.
-
-**Examples**:
-- `resource-usage` origin, `utime` counter → `resource_usage_utime_total`
-- `core.queue` origin, `main` name, `enqueued` counter → `core_queue_main_enqueued_total`
-- `imdiag` origin, `0` name, `submitted` counter → `imdiag_0_submitted_total`
-
-**Labels**: Supports static labels via `push.labels` and optional dynamic labels when enabled (`push.label.origin`, `push.label.name`, `push.label.instance`, `push.label.job`).
-
-## Implementation Files
-- **impstats_push.c/h**: Push orchestration (libcurl, native counter iteration)
-- **prometheus_remote_write.c/h**: Protobuf encoding and Snappy compression
-- **remote.proto**: Prometheus Remote Write protobuf schema
-- **impstats.c**: Integration hooks (#ifdef ENABLE_IMPSTATS_PUSH)
-- **Makefile.am**: Conditional compilation rules
-- **configure.ac**: Build system configuration
-- **runtime/statsobj.c/h**: Native counter iteration API (`GetAllCounters()`, interface v14)
-
-## Technical Details
-
-**Native Counter Access**:
-- Uses `statsobj->GetAllCounters(callback, ctx)` to iterate all counters
-- Callback receives: object name, origin, counter name, type, value, flags
-- Direct uint64 access (no string serialization)
-- Handles both atomic (`ctrType_IntCtr`) and non-atomic (`ctrType_Int`) counters safely
-
-**Thread Safety**:
-- Atomic counters (`ctrType_IntCtr`): Safe atomic read of uint64
-- Gauge counters (`ctrType_Int`): Best-effort read without application lock
-  - Values may be stale but acceptable for monitoring use cases
-  - Most are gauges (queue size, open files) protected by app-level mutexes
-
-**Performance**:
-- Eliminates text generation and parsing overhead
-- Direct memory-to-protobuf encoding
-- Minimal allocations (metric names built on-demand, freed immediately)
-
-## Testing
-```bash
-# Start VictoriaMetrics (Docker)
-docker run -it --rm -p 8428:8428 victoriametrics/victoria-metrics
-
-# Run rsyslog with test config
-rsyslogd -f test.conf -n
-
-# Query metrics
-curl http://localhost:8428/api/v1/query -d 'query=rsyslog_resource_usage_utime'
-```
-
-## Current Status
-✅ Build system (configure.ac, Makefile.am)
-✅ Protobuf schema (remote.proto)
-✅ Protobuf encoder (prometheus_remote_write.c/h)
-✅ HTTP client (impstats_push.c/h)
-✅ Native counter iteration API (statsobj v14)
-✅ Metric name sanitization
-✅ Integration into impstats.c
-✅ Basic and VictoriaMetrics integration tests
-✅ CI workflow (GitHub Actions)
-
-## Future Enhancements
-- Dynamic label injection (origin, object name as labels)
-- Configurable metric naming templates
-- Push batching/buffering for high-frequency stats
-- Support for Prometheus text exposition format output
-- Health endpoint (/metrics) alongside push
-⏳ Compilation testing
-⏳ Runtime testing with VictoriaMetrics
-
-## Known Limitations
-- Requires protoc-c at build time (not runtime)
-- Push happens synchronously in stats generation thread
-- No batching across multiple intervals
-- No authentication support yet (basic/bearer token)
-
-## Future Enhancements
-- [ ] Add HTTP Basic Auth / Bearer token support
-- [ ] Add TLS certificate verification options
-- [ ] Add retry logic with exponential backoff
-- [ ] Add push success/failure counters
-- [ ] Consider async push (separate thread)
+1. Update canonical docs in `doc/source/...` (not this file).
+2. Keep parameter docs and module/FAQ behavior descriptions consistent.
+3. Run relevant tests in `tests/` and update/add tests if behavior changes.


### PR DESCRIPTION
## Summary
- add dedicated `impstats` push-mode FAQ page with setup and troubleshooting answers
- expand module docs with push naming/label semantics, label precedence, and explicit current limitations
- link FAQ from module docs and add it to the FAQ index
- register new FAQ file in `doc/Makefile.am` for distribution
- refactor `plugins/impstats/README_PUSH.md` into a developer-scoped pointer to canonical docs
- make `doc/tools/build-doc-linux.sh` run `sphinx-build` in parallel by default (`-j <cpu-threads>`) with `--jobs` override

## Why
This consolidates canonical push behavior into published docs (better for operators and AI ingestion), removes stale duplicate guidance, and improves doc build turnaround in CI/dev environments.

## Validation
- focused sphinx checks for changed pages completed successfully
- strict/full doc build was executed in parallel mode and confirmed active (`jobs=<detected threads>`)
