### PR TITLE
doc: add optional Google Analytics via sphinxcontrib-googleanalytics

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,3 +4,4 @@ sphinx>=4.5.0
 furo
 sphinxcontrib.mermaid
 sphinx-sitemap
+sphinxcontrib-googleanalytics

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -388,6 +388,20 @@ if tags.has('with_sitemap'):
         sitemap_localtolinks = False
         sitemap_filename = "sitemap.xml"
 
+# Enable Google Analytics tracking when a tracking ID is provided via
+# the GOOGLE_ANALYTICS_ID environment variable.
+_ga_id = os.environ.get('GOOGLE_ANALYTICS_ID', '')
+if _ga_id:
+    try:
+        import sphinxcontrib.googleanalytics  # type: ignore  # noqa: F401
+    except ImportError:
+        # Optional extension - analytics skipped if not installed
+        pass
+    else:
+        extensions.append('sphinxcontrib.googleanalytics')
+        googleanalytics_id = _ga_id
+        googleanalytics_enabled = True
+
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'furo'


### PR DESCRIPTION
### Summary (non-technical, complete)

Adds optional Google Analytics tracking to the documentation build using the `sphinxcontrib-googleanalytics` extension. Opt-in only — enabled by setting the `GOOGLE_ANALYTICS_ID` environment variable at build time:

```bash
GOOGLE_ANALYTICS_ID="G-XXXXXXXXXX" make html
```

Without the variable, the extension is silently skipped and the build is unaffected.

### Changes

- **`doc/requirements.txt`** — Added `sphinxcontrib-googleanalytics` dependency.
- **`doc/source/conf.py`** — Conditional extension loading gated on `GOOGLE_ANALYTICS_ID` env var, with `try/except ImportError` guard. Follows the existing `sphinx_sitemap` pattern.

### References

### Notes
- No test changes needed — this is a build-time Sphinx configuration addition.
- No known security advisories for `sphinxcontrib-googleanalytics` v0.5.
