### PR TITLE
doc: add GA support with input validation and fallback

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -13,6 +13,7 @@
 
 import json
 import os
+import re
 import sys
 from urllib.parse import urljoin
 
@@ -391,6 +392,10 @@ if tags.has('with_sitemap'):
 # Enable Google Analytics tracking when a tracking ID is provided via
 # the GOOGLE_ANALYTICS_ID environment variable.
 _ga_id = os.environ.get('GOOGLE_ANALYTICS_ID', '')
+if _ga_id and not re.match(r'^(UA-\d+-\d+|G-[A-Za-z0-9]+)$', _ga_id):
+    print("Warning: Invalid GOOGLE_ANALYTICS_ID format: '%s'. "
+          "Disabling GA." % _ga_id, file=sys.stderr)
+    _ga_id = ''
 _ga_use_extension = False
 if _ga_id:
     try:


### PR DESCRIPTION
### Summary (non-technical, complete)

Adds Google Analytics support to the Sphinx documentation build. Uses `sphinxcontrib.googleanalytics` as the primary injection method; falls back to direct gtag script injection via `context['metatags']` when the extension is not installed (required for Furo theme compatibility). GA is opt-in via `GOOGLE_ANALYTICS_ID` env var.

Includes input validation to prevent XSS via malicious GA IDs, as flagged by Gemini code review.

### References

### Notes (optional)

**Changes:**

- **`doc/source/conf.py`** — Three additions:
  - `import re` for ID validation
  - GA ID format validation (`G-xxx` / `UA-xxx-x`) immediately after reading from env, rejecting anything else with a stderr warning
  - `_inject_ga` fallback in `setup()` that appends gtag snippet to `context['metatags']`, gated on `not _ga_use_extension`
- **`doc/requirements.txt`** — Added `sphinxcontrib-googleanalytics`

**GA ID validation example:**
```python
_ga_id = os.environ.get('GOOGLE_ANALYTICS_ID', '')
if _ga_id and not re.match(r'^(UA-\d+-\d+|G-[A-Za-z0-9]+)$', _ga_id):
    print("Warning: Invalid GOOGLE_ANALYTICS_ID format: '%s'. "
          "Disabling GA." % _ga_id, file=sys.stderr)
    _ga_id = ''
```

**Dual-path logic:**
- Extension available → `sphinxcontrib.googleanalytics` handles injection
- Extension unavailable → `setup()` registers `html-page-context` callback for direct gtag injection
- No `GOOGLE_ANALYTICS_ID` set → no GA code added
