### PR TITLE
runtime: add literal copy helper and use it in nsd_ptcp

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -739,8 +739,8 @@ static rsRetVal getPeerNames(prop_t **peerName, prop_t **peerIP, struct sockaddr
         error = getnameinfo(pAddr, SALEN(pAddr), (char *)szIP, sizeof(szIP), NULL, 0, NI_NUMERICHOST);
         if (error) {
             DBGPRINTF("Malformed from address %s\n", gai_strerror(error));
-            strcpy((char *)szHname, "???");
-            strcpy((char *)szIP, "???");
+            RS_COPY_LITERAL(szHname, "???");
+            RS_COPY_LITERAL(szIP, "???");
             ABORT_FINALIZE(RS_RET_INVALID_HNAME);
         }
 

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -360,8 +360,8 @@ static inline void setInstParamDefaults(instanceData *pData) {
     pData->trans_commit = 100;
     pData->trans_age = 60;
     pData->port = 5432;
-    strcpy(pData->user, "postgres");
-    strcpy(pData->pass, "postgres");
+    RS_COPY_LITERAL(pData->user, "postgres");
+    RS_COPY_LITERAL(pData->pass, "postgres");
 }
 
 BEGINnewActInst

--- a/runtime/dnscache.c
+++ b/runtime/dnscache.c
@@ -320,9 +320,7 @@ static rsRetVal ATTR_NONNULL() resolveAddr(struct sockaddr_storage *addr, dnscac
 
 finalize_it:
     if (iRet != RS_RET_OK) {
-        const char mockip[] = "?error.obtaining.ip?";
-        assert(sizeof(szIP) > sizeof(mockip));
-        strcpy(szIP, mockip);
+        RS_COPY_LITERAL(szIP, "?error.obtaining.ip?");
         error = 1; /* trigger hostname copies below! */
     }
 

--- a/runtime/net.c
+++ b/runtime/net.c
@@ -1122,13 +1122,13 @@ static rsRetVal getLocalHostname(rsconf_t *const pConf, uchar **ppName) {
     int empty_hostname = 1;
 
     if (gethostname(hnbuf, sizeof(hnbuf)) != 0) {
-        strcpy(hnbuf, EMPTY_HOSTNAME_REPLACEMENT);
+        RS_COPY_LITERAL(hnbuf, EMPTY_HOSTNAME_REPLACEMENT);
     } else {
         /* now guard against empty hostname
          * see https://github.com/rsyslog/rsyslog/issues/1040
          */
         if (hnbuf[0] == '\0') {
-            strcpy(hnbuf, EMPTY_HOSTNAME_REPLACEMENT);
+            RS_COPY_LITERAL(hnbuf, EMPTY_HOSTNAME_REPLACEMENT);
         } else {
             empty_hostname = 0;
             hnbuf[sizeof(hnbuf) - 1] = '\0'; /* be on the safe side... */

--- a/runtime/nsd_ptcp.c
+++ b/runtime/nsd_ptcp.c
@@ -463,10 +463,10 @@ static void get_socket_info(const int sockfd, char *const connInfo) {
     /* local system info */
     local_addr.sin_port = 0; /* just to keep clang static analyzer happy */
     if (getsockname(sockfd, (struct sockaddr *)&local_addr, &local_addr_len) == -1) {
-        strcpy(local_ip_str, "?");
+        RS_COPY_LITERAL(local_ip_str, "?");
     } else {
         if (inet_ntop(AF_INET, &local_addr.sin_addr, local_ip_str, INET_ADDRSTRLEN) == NULL) {
-            strcpy(local_ip_str, "?");
+            RS_COPY_LITERAL(local_ip_str, "?");
         }
         local_port = ntohs(local_addr.sin_port);
     }
@@ -474,22 +474,22 @@ static void get_socket_info(const int sockfd, char *const connInfo) {
     /* remote system info */
     remote_addr.sin_port = 0; /* just to keep clang static analyzer happy */
     if (getpeername(sockfd, (struct sockaddr *)&remote_addr, &remote_addr_len) == -1) {
-        strcpy(remote_ip_str, "?");
+        RS_COPY_LITERAL(remote_ip_str, "?");
     } else {
         if (inet_ntop(AF_INET, &remote_addr.sin_addr, remote_ip_str, INET_ADDRSTRLEN) == NULL) {
-            strcpy(remote_ip_str, "?");
+            RS_COPY_LITERAL(remote_ip_str, "?");
         }
         remote_port = ntohs(remote_addr.sin_port);
     }
 
     if (local_port == -1) {
-        strcpy(local_port_str, "?");
+        RS_COPY_LITERAL(local_port_str, "?");
     } else {
         snprintf(local_port_str, 7, "%d", local_port);
         local_port_str[7] = '\0'; /* be on safe side */
     }
     if (remote_port == -1) {
-        strcpy(remote_port_str, "?");
+        RS_COPY_LITERAL(remote_port_str, "?");
     } else {
         snprintf(remote_port_str, 7, "%d", remote_port);
         remote_port_str[7] = '\0'; /* be on safe side */

--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -238,7 +238,7 @@ static void sendwallmsg(const char *tty, uchar *pMsg) {
     int wrRet;
 
     /* compute the device name */
-    strcpy(p, _PATH_DEV);
+    RS_COPY_LITERAL(p, _PATH_DEV);
     size_t base_len = strlen(p);
     size_t avail = sizeof(p) - base_len - 1;
     size_t ttylen = strnlen(tty, avail);

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -125,7 +125,7 @@ int len;
 
     reply.svrreply.rtncode = msgno;
     /* AIXPORT :  srv was corrected to syslogd */
-    strcpy(reply.svrreply.objname, "syslogd");
+    RS_COPY_LITERAL(reply.svrreply.objname, "syslogd");
     snprintf(reply.svrreply.rtnmsg, SRCMIN(sizeof(reply.svrreply.rtnmsg) - 1, strlen(txt)), "%s", txt);
     srchdr = srcrrqs((char *)&srcpacket);
     srcsrpy(srchdr, (char *)&reply, len, cont);
@@ -576,7 +576,7 @@ static int forkRsyslog(void) {
     if (retval == -1)
         rs_strerror_r(errno, err, sizeof(err));
     else
-        strcpy(err, "OK");
+        RS_COPY_LITERAL(err, "OK");
     dbgprintf("rsyslogd: select() returns %d: %s\n", retval, err);
     if (retval == -1) {
         fprintf(stderr, "rsyslog startup failure, select() failed: %s\n", err);


### PR DESCRIPTION
Why:
Literal string copies into fixed-size local buffers can appear on hot paths and are not always good candidates for formatting APIs. Some modern AI assistants replace strcpy with snprintf by default; that can be safer in many cases, but it may also add overhead when the source is a constant literal and the destination is a known-sufficient fixed buffer.

Impact: No behavior change; compile-time size checks added for literals.

Before/After:
Before, constant fallback strings used strcpy directly at call sites. After, constant fallback strings use a shared checked helper macro.

Technical Overview:
Add RS_STATIC_ASSERT in runtime/rsyslog.h with a C11 _Static_assert path and a pre-C11 typedef fallback for older platforms. Add RS_COPY_LITERAL(dst, lit), implemented as size-checked memcpy of the literal including its trailing NUL byte.
Use RS_COPY_LITERAL in runtime/nsd_ptcp.c for '?' fallback assignments in get_socket_info().
This keeps the constant-copy operation lean on hot code paths while making the fixed-buffer precondition explicit in shared code. The helper centralizes intent so human and AI contributors are less likely to apply high-overhead snprintf substitutions where formatting is not required.
Even snprintf is not "set and forget": callers must still handle return edge cases (ret < 0, truncation via ret >= size, and related pitfalls).

With the help of AI-Agents: Codex

replaces https://github.com/rsyslog/rsyslog/pull/6560 with a far better solution