### PR TITLE
doc: add GitHub Actions workflow to deploy docs with GA to Pages

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1218,5 +1218,6 @@ EXTRA_DIST = \
     tools/buildenv/tools/help \
     tools/buildenv/tools/version-info \
     tools/fix-mermaid-offline.py \
+    tools/inside_docker_doc_html.sh \
     tools/release_build.sh \
     utils/release_build.sh

--- a/doc/tools/inside_docker_doc_html.sh
+++ b/doc/tools/inside_docker_doc_html.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Build rsyslog documentation inside the rsyslog/rsyslog_dev_doc_base_ubuntu container.
+# Expects GOOGLE_ANALYTICS_ID in env when GA tracking is desired.
+# Run with: docker run -e GOOGLE_ANALYTICS_ID -v "$(pwd)":/rsyslog --entrypoint /rsyslog/doc/tools/inside_docker_doc_html.sh rsyslog/rsyslog_dev_doc_base_ubuntu:22.04
+
+set -e
+
+cd /rsyslog/doc
+
+export HOME=/tmp
+pip install -q --user -r requirements.txt
+
+# Patch conf.py: upstream has version commented out but uses it in "if version == '8'"
+# Also set release_type default (upstream bug: not set when .git not at expected path)
+sed -i '/^#version = /a version = '\''8'\''  # Patched for docker build\
+release_type = '\''stable'\''  # Patched: default when .git not found' source/conf.py
+
+rm -rf build/html
+nice sphinx-build -j8 -t with_sitemap -b html -D html_theme=furo \
+  -W -q --keep-going source build/html
+
+python3 tools/fix-mermaid-offline.py build/html


### PR DESCRIPTION
### Why
Enable automated deployment of rsyslog documentation to GitHub Pages with Google Analytics, using the same build setup as production.

### Summary
- **New workflow** `doc_deploy_main.yml`: runs on push to `main` or manual trigger, uses `rsyslog/rsyslog_dev_doc_base_ubuntu:22.04` container
- **New script** `doc/tools/inside_docker_doc_html.sh`: entrypoint for the doc build inside Docker (requirements, conf.py patch, Sphinx with Furo/sitemap, Mermaid fix)
- **Deploy path**: docs published under `https://<site>/doc/` (works with custom domain, e.g. docs.rsyslog.com/doc/)

### Manual step
Add `GOOGLE_ANALYTICS_ID` as a repository secret (Settings → Secrets and variables → Actions) with value `G-3J00Q9TLQL` before using this workflow.

### Checklist
- [ ] GOOGLE_ANALYTICS_ID secret configured
- [ ] Workflow run tested on a test branch if desired