### PR TITLE
tools: fix linking issue with libyaml

### DIFF
--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -48,7 +48,7 @@ rsyslogd_CPPFLAGS += -DSD_EXPORT_SYMBOLS
 # note: it looks like librsyslog.la must be explicitely given on LDDADD,
 # otherwise dependencies are not properly calculated (resulting in a
 # potentially incomplete build, a problem we had several times...)
-rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la ../compat/compat.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS) $(HASH_XXHASH_LIBS) $(LIBRESOLV_LIBS)
+rsyslogd_LDADD = ../grammar/libgrammar.la ../runtime/librsyslog.la ../compat/compat.la $(ZLIB_LIBS) $(PTHREADS_LIBS) $(RSRT_LIBS) $(SOL_LIBS) $(LIBUUID_LIBS) $(HASH_XXHASH_LIBS) $(LIBRESOLV_LIBS) $(LIBYAML_LIBS)
 
 # Note: do NOT indent the if chain - it will not work!
 if OS_LINUX


### PR DESCRIPTION
When building rsyslogd with libyaml support, the library was not being explicitly linked. This implementation adds $(LIBYAML_LIBS) to rsyslogd_LDADD to resolve undefined references during linking, particularly in static or cross-compilation scenarios.

Fixes https://github.com/rsyslog/rsyslog/issues/6563

With the help of AI-Agents: Antigravity
