### PR TITLE
doc: add GitHub Actions workflow to deploy docs with GA to Pages

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -322,30 +322,3 @@ jobs:
               });
             }
 
-  cleanup_pr_preview:
-    name: Cleanup PR preview (on close)
-    runs-on: ubuntu-latest
-    if: >-
-      ${{ github.event_name=='pull_request'&&github.event.action=='closed'}}
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout gh-pages
-        uses: actions/checkout@v4
-        with:
-          ref: gh-pages
-          fetch-depth: 0
-
-      - name: Remove pr folder and push
-        run: |
-          set -e
-          dir="pr-${{ github.event.pull_request.number }}"
-          if [ -d "$dir" ]; then
-            git config user.name "github-actions"
-            git config user.email "github-actions@github.com"
-            git rm -r "$dir"
-            git commit -m "chore(docs): remove PR preview $dir"
-            git push
-          else
-            echo "No preview folder $dir to remove"
-          fi

--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -1,0 +1,88 @@
+name: Deploy documentation to GitHub Pages
+
+# Builds docs with Google Analytics and deploys to https://<site>/doc/
+# Uses rsyslog/rsyslog_dev_doc_base_ubuntu:22.04 Docker container for the Sphinx build.
+# Add GOOGLE_ANALYTICS_ID as a repository secret before use.
+
+on:
+  push:
+    # pr/publish-doc: for testing before merge; remove before final merge
+    branches: [main, master, pr/publish-doc]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: doc-deploy-main
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build documentation in Docker container
+        env:
+          GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
+        run: |
+          chmod +x doc/tools/inside_docker_doc_html.sh
+          docker run --rm \
+            -u "$(id -u):$(id -g)" \
+            -e GOOGLE_ANALYTICS_ID \
+            -e PYTHONUNBUFFERED=1 \
+            -v "$(pwd)":/rsyslog \
+            --entrypoint /rsyslog/doc/tools/inside_docker_doc_html.sh \
+            rsyslog/rsyslog_dev_doc_base_ubuntu:22.04
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: docs-html
+          path: doc/build/html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Download built docs artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: docs-html
+          path: preview-site
+
+      - name: Prepare Pages artifact with /doc/ subdirectory
+        run: |
+          set -e
+          mkdir -p pages-deployment/doc
+          rsync -a --delete preview-site/ pages-deployment/doc/
+          cp doc/tools/pages-root-index.html pages-deployment/index.html
+          # robots.txt: allow only /doc/, sitemap URL from github.repository
+          REPO="${{ github.repository }}"
+          BASE="https://${REPO%/*}.github.io/${REPO#*/}"
+          {
+            sed '/^# Sitemap/d' doc/tools/pages-robots.txt
+            echo "Sitemap: ${BASE}/doc/sitemap.xml"
+          } > pages-deployment/robots.txt
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload to Pages (artifact)
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages-deployment
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1218,5 +1218,8 @@ EXTRA_DIST = \
     tools/buildenv/tools/help \
     tools/buildenv/tools/version-info \
     tools/fix-mermaid-offline.py \
+    tools/inside_docker_doc_html.sh \
+    tools/pages-root-index.html \
+    tools/pages-robots.txt \
     tools/release_build.sh \
     utils/release_build.sh

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,6 +2,8 @@
 # Align with conf.py needs_sphinx requirement
 sphinx>=4.5.0
 furo
+sphinx_rtd_theme
+rst2pdf
 sphinxcontrib.mermaid
 sphinx-sitemap
 sphinxcontrib-googleanalytics

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -233,10 +233,21 @@ version = '8.2604'
 #release = '8.2604.0'
 release = version + ' daily stable'
 
+# Allow override from environment (e.g. Docker/CI builds without .git)
+_env_version = os.environ.get('RSYSLOG_DOC_VERSION')
+_env_release_type = os.environ.get('RSYSLOG_DOC_RELEASE_TYPE')
+if _env_version and _env_release_type:
+    version = _env_version
+    release_type = _env_release_type
+    release = f"{version} daily {release_type}"
+    rst_prolog = rst_prolog.format(
+        doc_build=release,
+        doc_commit='N/A',
+        doc_branch='N/A')
 # For this to be true, it means that we are not attempting to build from
 # a release tarball, as otherwise the values above would have been replaced
 # with official stable release values.
-if version == '8':
+elif version == '8':
 
     # Confirm that a .git folder is available. If not, skip all
     # following steps intended to generate daily stable build values for

--- a/doc/tools/inside_docker_doc_html.sh
+++ b/doc/tools/inside_docker_doc_html.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Build rsyslog documentation inside the rsyslog/rsyslog_dev_doc_base_ubuntu container.
+# Expects GOOGLE_ANALYTICS_ID in env when GA tracking is desired.
+# Run with: docker run -e GOOGLE_ANALYTICS_ID -v "$(pwd)":/rsyslog --entrypoint /rsyslog/doc/tools/inside_docker_doc_html.sh rsyslog/rsyslog_dev_doc_base_ubuntu:22.04
+
+set -euo pipefail
+
+cd /rsyslog/doc
+
+# Use pre-built venv from image (prepared in Dockerfile; needed when running as -u uid:gid)
+VENV=/opt/rsyslog-doc-venv
+
+# Use env vars for version/release_type (conf.py reads RSYSLOG_DOC_* when .git not in container)
+export RSYSLOG_DOC_VERSION="${RSYSLOG_DOC_VERSION:-8}"
+export RSYSLOG_DOC_RELEASE_TYPE="${RSYSLOG_DOC_RELEASE_TYPE:-stable}"
+
+rm -rf build/html
+nice "$VENV/bin/sphinx-build" -j"$(nproc)" -t with_sitemap -b html -D html_theme=furo \
+  -W --keep-going source build/html
+
+"$VENV/bin/python3" tools/fix-mermaid-offline.py build/html

--- a/doc/tools/pages-robots.txt
+++ b/doc/tools/pages-robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /doc/
+Disallow: /
+
+# Sitemap URL is injected by the doc_deploy_main workflow from github.repository

--- a/doc/tools/pages-root-index.html
+++ b/doc/tools/pages-root-index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>rsyslog documentation</title>
+  <meta http-equiv="refresh" content="0; url=doc/">
+  <link rel="canonical" href="doc/">
+</head>
+<body>
+  <p>Redirecting to <a href="doc/">rsyslog documentation</a>…</p>
+</body>
+</html>

--- a/packaging/docker/dev_env/ubuntu/doc_base/22.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/doc_base/22.04/Dockerfile
@@ -17,6 +17,7 @@ RUN	apt-get install -y \
 	wget \
 	python3-docutils  \
 	python3-pip \
+	python3-venv \
 	python3-pysnmp4
 RUN	apt-get install -y \
 	texlive-base \
@@ -29,6 +30,11 @@ RUN	apt-get install -y \
 	texlive-luatex \
 	texlive-xetex \
 	latexmk
+# Pre-built venv for doc build (used when running as -u uid:gid; repo mounts at /rsyslog)
+COPY doc/requirements.txt /tmp/doc-requirements.txt
+RUN python3 -m venv /opt/rsyslog-doc-venv \
+	&& /opt/rsyslog-doc-venv/bin/pip install --no-cache-dir -r /tmp/doc-requirements.txt \
+	&& rm /tmp/doc-requirements.txt
 RUN	pip install sphinx sphinx_rtd_theme rst2pdf furo sphinxcontrib-mermaid
 VOLUME	/rsyslog
 RUN	groupadd rsyslog \

--- a/packaging/docker/dev_env/ubuntu/doc_base/22.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/doc_base/22.04/build.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -e
+# Build from repo root so COPY doc/requirements.txt works for pre-built venv
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../../../.." && pwd)"
 # Use --no-cache to rebuild image
-docker build $1 -t rsyslog/rsyslog_dev_doc_base_ubuntu:22.04 .
+docker build $1 -f "$SCRIPT_DIR/Dockerfile" -t rsyslog/rsyslog_dev_doc_base_ubuntu:22.04 "$REPO_ROOT"
 printf "\n\n================== BUILD DONE\n"


### PR DESCRIPTION
Enable automated deployment of rsyslog documentation to GitHub Pages with Google Analytics, using the same build setup as production.

## Summary

- **New workflow** `doc_deploy_main.yml`: runs on push to `main`/`master`/`pr/publish-doc` or manual trigger; builds in `rsyslog/rsyslog_dev_doc_base_ubuntu:22.04`; deploys to Pages under `/doc/`
- **Root landing**: `index.html` redirects `/` → `/doc/`; `robots.txt` restricts crawlers to `/doc/` and adds Sitemap
- **New script** `doc/tools/inside_docker_doc_html.sh`: uses pre-built venv, env vars for version/release_type, Sphinx + Furo + sitemap, Mermaid fix
- **conf.py**: `RSYSLOG_DOC_VERSION` and `RSYSLOG_DOC_RELEASE_TYPE` env var support (Gemini feedback)
- **Docker image**: add `python3-venv`, pre-build `/opt/rsyslog-doc-venv` from `doc/requirements.txt`; `build.sh` runs from repo root
- **Removed**: `cleanup_pr_preview` job from `doc_build.yml`


