### PR TITLE
doc: fix release_string_detail NameError, narrow deploy to main only

### DIFF
--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -6,8 +6,7 @@ name: Deploy documentation to GitHub Pages
 
 on:
   push:
-    # pr/publish-doc: for testing before merge; remove before final merge
-    branches: [main, master, pr/publish-doc]
+    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -240,6 +240,8 @@ if _env_version and _env_release_type:
     version = _env_version
     release_type = _env_release_type
     release = f"{version} daily {release_type}"
+    if release_type == 'dev':
+        release_string_detail = 'simple'
     rst_prolog = rst_prolog.format(
         doc_build=release,
         doc_commit='N/A',


### PR DESCRIPTION
## Summary

- **conf.py**: Set `release_string_detail = 'simple'` when `release_type == 'dev'` in the env override path to avoid NameError when `RSYSLOG_DOC_RELEASE_TYPE=dev` is used (html_title and epub blocks expect this variable).
- **doc_deploy_main.yml**: Change workflow branches from `[main, master, pr/publish-doc]` to `[main]` so deploy runs only on push to main.