### PR TITLE
ci: enable core dumps in ASAN builds

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -501,7 +501,8 @@ jobs:
             echo "Configuring AddressSanitizer options"
             export ASAN_OPTIONS=":halt_on_error=1:\
               check_initialization_order=1:strict_init_order=1:\
-              detect_stack_use_after_return=1:print_stacktrace=1"
+              detect_stack_use_after_return=1:print_stacktrace=1:\
+              disable_coredump=0"
           elif [ "${{ matrix.sanitizer }}" = "tsan" ]; then
             echo "Configuring ThreadSanitizer options"
             export TSAN_OPTIONS=":halt_on_error=1:\
@@ -1609,7 +1610,7 @@ jobs:
               else
                 export CFLAGS="-g -O1 -fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope"
                 export LDFLAGS="-fsanitize=address"
-                export ASAN_OPTIONS="abort_on_error=1:symbolize=1:detect_leaks=0"
+                export ASAN_OPTIONS="abort_on_error=1:symbolize=1:detect_leaks=0:disable_coredump=0"
                 ./configure --enable-silent-rules --enable-testbench \
                   --enable-imdiag --disable-imdocker \
                   --enable-imfile --disable-imfile-tests \


### PR DESCRIPTION
AddressSanitizer by default sets disable_coredump=1, which prevents core file generation even when abort() is called. This commit adds disable_coredump=0 to ASAN_OPTIONS in both macOS and ARM64 workflows to ensure core dumps are generated on crashes.

This allows diag.sh to find and analyze core files for better debugging of test failures in ASAN-enabled CI jobs.

Affected workflows:
- macOS CI (ASAN builds)
- ARM64 CI (native ASAN builds)
