### PR TITLE
queue: harden disk queue corruption recovery

### DIFF
--- a/doc/source/rainerscript/queue_parameters.rst
+++ b/doc/source/rainerscript/queue_parameters.rst
@@ -318,6 +318,38 @@ be turned on without a good reason. Note that the penalty also depends on
 *queue.checkpointInterval* frequency.
 
 
+queue.onCorruption
+------------------
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "word", "safe", "no", "none"
+
+Controls how rsyslog handles disk queue corruption detected during startup.
+This applies to queue files and checkpoint state (``.qi``).
+
+Supported values are:
+
+* ``safe``: detect corruption, move queue files to a timestamped
+  ``.bad`` directory, and start with a fresh disk queue.
+* ``inMemory``: switch to a non-persistent in-memory queue for the current
+  process lifetime.
+* ``ignore``: skip the corruption verification logic and keep legacy startup
+  behavior.
+
+If rsyslog cannot safely quarantine corrupted files in ``safe`` mode (for
+example because the recovery directory cannot be created or files cannot be
+moved), it logs alert-level errors and switches to pure in-memory emergency
+mode for safety.
+
+The startup verification checks queue structure consistency (file sequence and
+pointer continuity). It does **not** parse and validate each payload record
+inside queue segment files.
+
+
 queue.samplingInterval
 ----------------------
 

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -66,6 +66,13 @@ typedef enum {
     QUEUETYPE_DIRECT = 3 /* no queuing happens, consumer is directly called */
 } queueType_t;
 
+/* queue recovery modes */
+typedef enum {
+    QUEUE_ON_CORRUPTION_SAFE_MODE = 0,
+    QUEUE_ON_CORRUPTION_IN_MEMORY = 1,
+    QUEUE_ON_CORRUPTION_IGNORE = 2
+} queueOnCorruption_t;
+
 /* list member definition for linked list types of queues: */
 typedef struct qLinkedList_S {
     struct qLinkedList_S *pNext;
@@ -110,6 +117,7 @@ struct queue_s {
         int iLightDlyMrk; /* if the queue is above this mark, LIGHT_DELAYable message are put on hold */
         int iDiscardSeverity; /* messages of this severity above are discarded on too-full queue */
         sbool bNeedDelQIF; /* does the QIF file need to be deleted when queue becomes empty? */
+        queueOnCorruption_t onCorruption; /* what to do on queue corruption */
         int toQShutdown; /* timeout for regular queue shutdown in ms */
         int toActShutdown; /* timeout for long-running action shutdown in ms */
         int toWrkShutdown; /* timeout for idle workers in ms, -1 means indefinite (0 is immediate) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -224,6 +224,7 @@ TESTS_DEFAULT = \
 	diskqueue-fsync.sh \
 	diskqueue-full.sh \
 	diskqueue-fail.sh \
+	diskqueue-oncorruption-missing-segment.sh \
 	diskqueue-non-unique-prefix.sh \
 	rulesetmultiqueue.sh \
 	rulesetmultiqueue-v6.sh \

--- a/tests/diskqueue-oncorruption-missing-segment.sh
+++ b/tests/diskqueue-oncorruption-missing-segment.sh
@@ -1,0 +1,151 @@
+#!/bin/bash
+# Validate queue.onCorruption behavior when a middle disk-queue segment
+# is missing at startup.
+# added 2026-02-07 by AI-assisted development, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=15000
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+RSYSLOGD_LOG="${RSYSLOG_DYNNAME}.rsyslogd.log"
+STARTED_LOG="${RSYSLOG_DYNNAME}.started"
+export RS_REDIR=">>$RSYSLOGD_LOG 2>&1"
+
+prepare_conf() {
+	local mode="$1"
+	generate_conf
+	add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'"$SPOOL_DIR"'")
+
+main_queue(
+	queue.type="disk"
+	queue.filename="mainq"
+	queue.maxFileSize="16k"
+	queue.saveOnShutdown="on"
+	queue.timeoutShutdown="1"
+	queue.onCorruption="'"$mode"'"
+)
+
+	template(name="outfmt" type="string" string="%msg:F,58:2%\\n")
+	template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`)
+
+:omtesting:sleep 0 20000
+if ($msg contains "msgnum:") then {
+	action(type="omfile" template="outfmt" dynaFile="dynfile")
+}
+'
+}
+
+create_missing_middle_segment() {
+	local missing_file
+	local mid_idx
+	local seg_files=()
+
+	startup
+	injectmsg 0 "$NUMMESSAGES"
+	shutdown_immediate
+	wait_shutdown
+
+	mapfile -t seg_files < <(find "$SPOOL_DIR" -maxdepth 1 -type f -name 'mainq.*' -printf '%f\n' \
+		| awk '/^mainq\.[0-9]+$/' | sort -t. -k2,2n)
+
+	if [ "${#seg_files[@]}" -lt 3 ]; then
+		printf 'FAIL: expected at least 3 queue segment files, found %d\n' "${#seg_files[@]}"
+		ls -l "$SPOOL_DIR"
+		error_exit 1
+	fi
+
+	mid_idx=$(( ${#seg_files[@]} / 2 ))
+	missing_file="$SPOOL_DIR/${seg_files[$mid_idx]}"
+	printf 'Removing queue segment to simulate corruption: %s\n' "$missing_file"
+	rm -f -- "$missing_file"
+	check_file_not_exists "$missing_file"
+}
+
+wait_shutdown_or_kill() {
+	local timeout_sec="${1:-${TB_TEST_TIMEOUT:-90}}"
+	local instance="${2:-}"
+	local pid_file="$RSYSLOG_PIDBASE${instance}.pid.save"
+	local pid
+	local deadline
+	local timed_out=0
+
+	pid="$(cat "$pid_file" 2>/dev/null || true)"
+	if [ -z "$pid" ]; then
+		return 0
+	fi
+
+	deadline=$(( $(date +%s) + timeout_sec ))
+	while kill -0 "$pid" 2>/dev/null; do
+		if [ "$(date +%s)" -gt "$deadline" ]; then
+			printf 'FAIL: shutdown timeout in ignore mode (pid %s), forcing kill -9\n' "$pid"
+			kill -9 "$pid" 2>/dev/null || true
+			timed_out=1
+			break
+		fi
+		$TESTTOOL_DIR/msleep 200
+	done
+
+	if [ "$timed_out" -eq 1 ]; then
+		error_exit 1
+	fi
+}
+
+run_mode_check() {
+	local mode="$1"
+	local bad_before
+	local bad_after
+
+	printf '\n===== queue.onCorruption=%s =====\n' "$mode"
+	rm -rf "$SPOOL_DIR" "$RSYSLOG_OUT_LOG" "$RSYSLOGD_LOG"
+
+	prepare_conf "$mode"
+	create_missing_middle_segment
+
+	bad_before=$(find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 -type d -name 'mainq.bad.*' | wc -l)
+	: > "$RSYSLOGD_LOG"
+	: > "$STARTED_LOG"
+	rm -f "${RSYSLOG_DYNNAME}.started" "${RSYSLOG_DYNNAME}.imdiag.port" "${RSYSLOG_DYNNAME}:.pid"
+	: > "$STARTED_LOG"
+
+	startup
+	$TESTTOOL_DIR/msleep 500
+	shutdown_immediate
+	if [ "$mode" = "ignore" ]; then
+		wait_shutdown_or_kill
+	else
+		wait_shutdown
+	fi
+
+	case "$mode" in
+	safe)
+		content_check "queue corruption: missing file in sequence:" "$RSYSLOGD_LOG"
+		check_not_present "pure in-memory emergency mode" "$STARTED_LOG"
+		bad_after=$(find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 -type d -name 'mainq.bad.*' | wc -l)
+		if [ "$bad_after" -le "$bad_before" ]; then
+			printf 'FAIL: expected a new mainq.bad.* directory in safe mode\n'
+			ls -l "$SPOOL_DIR"
+			error_exit 1
+		fi
+		;;
+	inMemory)
+		content_check "Queue corruption detected. Entering emergency in-memory mode" "$STARTED_LOG"
+		content_check "pure in-memory emergency mode" "$STARTED_LOG"
+		;;
+	ignore)
+		check_not_present "Queue corruption detected" "$STARTED_LOG"
+		check_not_present "queue corruption:" "$STARTED_LOG"
+		;;
+	*)
+		printf 'FAIL: unknown mode %s\n' "$mode"
+		error_exit 1
+		;;
+	esac
+}
+
+run_mode_check safe
+run_mode_check inMemory
+run_mode_check ignore
+
+exit_test


### PR DESCRIPTION
Why:
Queue recovery must fail safe and remain compatible with existing startup flows, including disk queue tests that rely on deferred spool setup.

Impact:
Disk queue startup validates corruption more safely, and imjournal CI is more resilient to transient readiness timing under journal churn.

Before/After:
Before, some startup paths could incorrectly switch to emergency mode when spool scanning could not run, and imjournal readiness could fail flakily. After, startup keeps legacy behavior when scan is unavailable and imjournal retries readiness before failing.

Technical Overview:
Expose queue.oncorruption as a user parameter and document it. Set explicit default mode to safe for queue defaults/construct paths. Harden disk queue scan parsing with bounds, overflow, and alloc checks. If spool directory/prefix is unset, return original load status unchanged. If spool scan cannot run (ENOENT/ENOTDIR), skip corruption scan. On recovery-path failures, switch to emergency in-memory mode with alerts. Retry imjournal readiness probes with bounded attempts and timeout. If readiness is still not observed, skip test as environment-limited.

Closes https://github.com/rsyslog/rsyslog/issues/5771

With the help of AI-Agents: codex
