### PR TITLE
ci: restrict doc deployment to official repository

### DIFF
--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -22,6 +22,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository == 'rsyslog/rsyslog'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
This prevents documentation deployment workflows from running on forks, saving GitHub Actions minutes and reducing noise for contributors. The workflow will now only execute when the repository is 'rsyslog/rsyslog'.
