### PR TITLE
CI: increase permitted macOS runner timeout

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -362,7 +362,7 @@ jobs:
             arch: arm64
             sanitizer: tsan
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 10
+    timeout-minutes: 15
     name: macOS CI (${{ matrix.os }}, ${{ matrix.arch }}, ${{ matrix.sanitizer }})
     env:
       USE_AUTO_DEBUG: true


### PR DESCRIPTION
Practice shows that the timeout is no longer sufficient and needs to be bumped.
