### PR TITLE
doc: add ROSI beginner and audience guides

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -297,6 +297,8 @@ EXTRA_DIST = \
     source/containers/user_images.rst \
     source/dataflow.png \
     source/deployments/index.rst \
+    source/deployments/rosi_for_decision_makers.rst \
+    source/deployments/rosi_for_platform_teams.rst \
     source/deployments/rosi_collector/architecture.rst \
     source/deployments/rosi_collector/client_setup.rst \
     source/deployments/rosi_collector/grafana_dashboards.rst \
@@ -357,6 +359,7 @@ EXTRA_DIST = \
     source/getting_started/index.rst \
     source/getting_started/installation.rst \
     source/getting_started/next_steps.rst \
+    source/getting_started/rosi_for_beginners.rst \
     source/getting_started/understanding_default_config.rst \
     source/gssapi.png \
     source/historical/high_performance.rst \

--- a/doc/source/deployments/index.rst
+++ b/doc/source/deployments/index.rst
@@ -30,6 +30,14 @@ monitoring stack including:
 
 :doc:`Get started with ROSI Collector <rosi_collector/index>`
 
+For the beginner-level ROSI rationale (freedom of choice and avoiding
+vendor lock-in), see :doc:`../getting_started/rosi_for_beginners`.
+
+For audience-specific ROSI follow-up guidance:
+
+- :doc:`rosi_for_platform_teams` for architecture and adoption patterns
+- :doc:`rosi_for_decision_makers` for strategic operations framing
+
 Deployment Comparison
 ---------------------
 
@@ -77,3 +85,5 @@ When to Use Each Option
    :caption: Deployment Guides
 
    rosi_collector/index
+   rosi_for_platform_teams
+   rosi_for_decision_makers

--- a/doc/source/deployments/rosi_for_decision_makers.rst
+++ b/doc/source/deployments/rosi_for_decision_makers.rst
@@ -1,0 +1,89 @@
+.. _rosi-for-decision-makers:
+
+ROSI for Decision-Makers
+========================
+
+.. meta::
+   :description: Strategic ROSI overview for decision-makers focused on operational sustainability, lock-in risk, and phased adoption.
+   :keywords: rsyslog, ROSI, operations strategy, vendor lock-in, sustainability, observability
+
+.. summary-start
+
+ROSI provides a concrete, deployable observability baseline while preserving
+freedom of choice. It is designed to reduce lock-in risk and support
+sustainable operations as requirements change.
+
+.. summary-end
+
+This page is for engineering managers, architects, and technical leaders who
+need to balance delivery speed with long-term platform flexibility.
+
+What ROSI Delivers Now
+----------------------
+
+ROSI is not a roadmap-only idea. The current ROSI Collector stack is deployable
+today and provides:
+
+- Centralized collection with rsyslog
+- Log storage and search in a production-ready baseline
+- Dashboards and metrics for operational visibility
+- Turnkey setup that reduces early integration effort
+- Container-based deployment model for practical operations today
+
+See :doc:`rosi_collector/index` for implementation details.
+
+Why This Matters Strategically
+------------------------------
+
+Most observability programs fail in one of two ways:
+
+- They remain fragmented and expensive to operate
+- They become tightly coupled to a single vendor and hard to evolve
+
+ROSI addresses both by combining a practical default with an explicit
+freedom-of-choice architecture stance.
+
+It also adds an efficiency posture that is increasingly important for both
+FinOps and Green IT programs.
+
+Decision Criteria ROSI Supports
+-------------------------------
+
+ROSI is a fit when you need to optimize for:
+
+- **Time to value**: a concrete stack that can be deployed quickly
+- **Operational sustainability**: simpler initial rollout without closing future options
+- **Risk control**: lower long-term lock-in risk through replaceable components
+- **Growth**: a path from small deployments to broader platform standardization
+- **Efficiency**: better compute economics through efficient ingestion and routing
+
+In many environments, placing rsyslog at the edge helps control central ingest
+volume and therefore backend cost.
+
+Risk Posture and Messaging
+--------------------------
+
+ROSI emphasizes architectural properties instead of vendor positioning:
+
+- Open interfaces and standards-oriented integration
+- Replaceable stack components
+- Incremental migration rather than forced rewrites
+
+This keeps decisions grounded in sustainable operations and freedom of choice.
+
+Scale Profile
+-------------
+
+ROSI is often an excellent fit for small to medium installations where
+efficiency is highly valued. It can also scale down effectively for homelab
+use, making it suitable for both evaluation and lightweight production use.
+
+Future evolution toward Kubernetes can build on the current container-based
+foundation without invalidating early adoption.
+
+Recommended Next Reading
+------------------------
+
+- :doc:`rosi_for_platform_teams` for architecture and adoption patterns
+- :doc:`../getting_started/rosi_for_beginners` for onboarding context
+- :doc:`rosi_collector/index` for concrete deployment details

--- a/doc/source/deployments/rosi_for_platform_teams.rst
+++ b/doc/source/deployments/rosi_for_platform_teams.rst
@@ -1,0 +1,102 @@
+.. _rosi-for-platform-teams:
+
+ROSI for Platform Teams
+=======================
+
+.. meta::
+   :description: ROSI guidance for platform engineers focused on architecture, adoption, and migration without lock-in.
+   :keywords: rsyslog, ROSI, platform engineering, architecture, migration, vendor lock-in
+
+.. summary-start
+
+ROSI gives platform teams a practical way to standardize log collection while
+keeping backend and integration choices open. It is designed for incremental
+adoption, not all-at-once migration.
+
+.. summary-end
+
+This guide is for teams operating shared logging infrastructure across multiple
+services, clusters, or business units.
+
+Design Intent
+-------------
+
+ROSI is built to solve a common platform problem: teams need a deployable
+default stack now, but they also need an architecture that can evolve later.
+
+For platform teams, this means:
+
+- A clear baseline with :doc:`rosi_collector/index`
+- rsyslog-centered collection and routing as a stable control point
+- Freedom to adapt downstream storage and analytics over time
+
+It also means optimizing for efficiency, not just feature count:
+
+- Lower operational overhead for small and medium environments
+- Better resource usage through early routing/filtering at ingestion
+- Practical operation in constrained environments, including homelabs
+
+Architecture Stance
+-------------------
+
+ROSI intentionally separates concerns:
+
+- **Collection and transport**: handled by rsyslog
+- **Storage and query**: chosen per operational need
+- **Visualization and alerting**: chosen per team workflow
+
+This reduces coupling and keeps migration scope manageable.
+
+Incremental Adoption Pattern
+----------------------------
+
+A practical rollout path:
+
+1. Start with ROSI Collector for immediate operational value.
+2. Standardize client forwarding and labeling conventions.
+3. Introduce additional destinations where needed (parallel or staged).
+4. Migrate dashboards and alerting workflows in controlled phases.
+
+The key principle is incremental change with stable ingestion.
+
+Container-First, Kubernetes-Next
+--------------------------------
+
+The current ROSI stack is container-based and intentionally straightforward to
+operate. Kubernetes is a next target, but not a prerequisite for value today.
+
+This container-first approach aligns with efficiency goals for teams that want
+predictable operations without immediate orchestration complexity.
+
+Integration Paths
+-----------------
+
+rsyslog already supports multiple output paths that help avoid hard coupling:
+
+- :doc:`../configuration/modules/omhttp` for HTTP targets
+- :doc:`../configuration/modules/omelasticsearch` for Elasticsearch and OpenSearch
+- :doc:`../configuration/modules/omkafka` for Kafka-based pipelines
+- :doc:`../configuration/modules/omfwd` for syslog forwarding
+
+This enables practical designs such as dual-write transitions, phased
+cutovers, and domain-specific routing.
+
+Using rsyslog on the edge can reduce central processing cost by shaping data
+before it reaches backends, which supports both FinOps and Green IT targets.
+
+Governance Recommendations
+--------------------------
+
+To keep freedom of choice real in daily operations:
+
+- Treat destination-specific logic as replaceable policy
+- Keep ingestion contracts stable (fields, labels, transport expectations)
+- Document migration playbooks before they are urgently needed
+- Prefer reversible rollout steps over one-way platform changes
+
+See Also
+--------
+
+- :doc:`rosi_collector/index` for concrete deployment details
+- :doc:`rosi_for_decision_makers` for sustainability and risk framing
+- :doc:`../getting_started/rosi_for_beginners` for newcomer context

--- a/doc/source/getting_started/index.rst
+++ b/doc/source/getting_started/index.rst
@@ -19,6 +19,7 @@ It includes:
    :maxdepth: 1
 
    beginner_tutorials/index
+   rosi_for_beginners
    ai-assistants
    installation
    basic_configuration

--- a/doc/source/getting_started/next_steps.rst
+++ b/doc/source/getting_started/next_steps.rst
@@ -12,6 +12,11 @@ ROSI Collector (Rsyslog Operations Stack Initiative):
 
 :doc:`../deployments/rosi_collector/index`
 
+For the beginner-level ROSI concepts (open approach, freedom of choice, and
+vendor lock-in guardrails), see:
+
+:doc:`rosi_for_beginners`
+
 ROSI Collector provides:
 
 - Centralized log aggregation from multiple hosts

--- a/doc/source/getting_started/rosi_for_beginners.rst
+++ b/doc/source/getting_started/rosi_for_beginners.rst
@@ -1,0 +1,149 @@
+.. _getting-started-rosi:
+
+ROSI for Beginners
+==================
+
+.. meta::
+   :description: Beginner introduction to ROSI as an open, rsyslog-backed operations stack that reduces lock-in and complexity.
+   :keywords: rsyslog, ROSI, vendor lock-in, observability, beginner, deployment
+
+.. summary-start
+
+ROSI (Rsyslog Operations Stack Initiative) gives beginners a concrete, deployable
+stack while keeping freedom of choice. It is built to reduce vendor lock-in and
+complexity, and to let teams evolve components over time.
+
+.. summary-end
+
+ROSI (Rsyslog Operations Stack Initiative) is the rsyslog approach to practical,
+modern observability: start with a concrete stack you can deploy now, but do not
+get trapped in one vendor or one fixed architecture.
+
+Why ROSI Exists
+---------------
+
+Many teams run into the same pain points:
+
+- Logging stacks that are hard to deploy and operate
+- rsyslog configurations that feel too complex for a first production rollout
+- Tool choices that later create vendor lock-in
+
+ROSI addresses these with a beginner-friendly default that is:
+
+- **Easy to use**: a turnkey collector stack that works out of the box
+- **Concrete**: not a future promise, but a deployable stack available now
+- **Open and growing**: designed to expand over time as new stack profiles are added
+
+ROSI at a Glance
+----------------
+
+.. raw:: html
+
+   <pre class="mermaid mermaid-rosi-glance">
+   flowchart LR
+     P1["Complex setup"] --> R1["Turnkey ROSI stack"]
+     P2["Vendor lock-in risk"] --> R2["Freedom of choice"]
+     P3["High ingest and ops cost"] --> R3["Efficient rsyslog at ingestion"]
+
+     R1 --> O1["Faster time to value"]
+     R2 --> O2["Replaceable architecture"]
+     R3 --> O3["Lower cost and energy use"]
+
+     classDef pain fill:#fde2e2,stroke:#c0392b,color:#1f1f1f;
+     classDef rosi fill:#e8f4fd,stroke:#2e86c1,color:#1f1f1f;
+     classDef outcome fill:#e8f8f0,stroke:#1d8348,color:#1f1f1f;
+
+     class P1,P2,P3 pain;
+     class R1,R2,R3 rosi;
+     class O1,O2,O3 outcome;
+   </pre>
+   <script src="../_static/vendor/mermaid/mermaid.min.js"></script>
+   <script>
+   window.addEventListener("load", function () {
+     if (typeof mermaid === "undefined") return;
+     mermaid.initialize({ startOnLoad: false });
+     mermaid.run({ nodes: document.querySelectorAll(".mermaid-rosi-glance") });
+   });
+   </script>
+
+Efficiency First (FinOps and Green IT)
+--------------------------------------
+
+ROSI also follows an efficiency-first mindset:
+
+- Use resource-efficient components (including rsyslog at ingestion)
+- Keep baseline operations practical for smaller and medium installations
+- Support "right-sized" observability, including homelab-scale deployments
+
+This helps align day-to-day operations with both **FinOps** goals (cost control)
+and **Green IT** goals (lower compute footprint).
+
+Freedom of Choice and Vendor Lock-In
+------------------------------------
+
+ROSI is intentionally built as a guard against vendor lock-in. The core idea is
+simple: your logging pipeline should stay under your control.
+
+In practice, that means:
+
+- rsyslog remains a strong routing and processing layer at the center
+- external components are selected for operational value, not lock-in
+- you can adapt outputs and destinations as your requirements evolve
+
+Today, rsyslog already supports multiple output targets and integration patterns,
+including modules such as:
+
+- :doc:`../configuration/modules/omhttp` for HTTP-based endpoints
+- :doc:`../configuration/modules/omelasticsearch` for Elasticsearch and OpenSearch
+- :doc:`../configuration/modules/omkafka` for Kafka
+- :doc:`../configuration/modules/omfwd` for syslog forwarding
+
+Common destination examples include Loki, Elasticsearch, OpenSearch, Kafka,
+Splunk (HEC-style HTTP), and cloud endpoints exposed over HTTP or syslog.
+
+As ROSI grows, additional pre-packaged stack profiles can be added without
+changing this core principle: keep architectures replaceable.
+
+This is the foundation for sustainable operations: freedom of choice instead of
+forced rewrites.
+
+Where rsyslog at the edge is used, teams can often reduce downstream ingest
+volume and processing cost by routing, filtering, and shaping data before it
+reaches central backends.
+
+What ROSI Is and Is Not
+-----------------------
+
+ROSI **is**:
+
+- A practical, rsyslog-backed observability approach
+- A concrete starter stack (ROSI Collector) for centralized logs and metrics
+- A path that can grow with your infrastructure over time
+- Container-based today, with Kubernetes-oriented evolution as a next target
+
+ROSI **is not**:
+
+- A closed product tied to a single vendor
+- A claim that one backend is always right for every team
+- A replacement for detailed implementation guides
+
+Current Starter Stack
+---------------------
+
+The current ROSI starter deployment is :doc:`../deployments/rosi_collector/index`.
+It combines rsyslog with Loki, Grafana, Prometheus, and Traefik to deliver a
+production-ready baseline quickly.
+
+This baseline solves immediate operational pain while preserving future options.
+
+What to Read Next
+-----------------
+
+- :doc:`../deployments/rosi_collector/index` for deployment and operations
+- :doc:`../deployments/index` for deployment choices
+- :doc:`next_steps` for the broader beginner path
+
+For deeper follow-up:
+
+- :doc:`../deployments/rosi_for_platform_teams` for platform architecture and adoption
+- :doc:`../deployments/rosi_for_decision_makers` for sustainability and risk framing


### PR DESCRIPTION
Why:
ROSI needed clearer documentation of its practical value for beginners and its strategic value for platform teams and decision-makers.

The new content explains ROSI as a concrete, deployable stack that reduces vendor lock-in risk while keeping freedom of choice and operational simplicity.

Impact: Added ROSI concept and follow-up guides, with navigation updates.

Before/After: ROSI messaging was fragmented across deployment docs; now it is coherent from beginner onboarding through architecture and strategy guidance.

Technical Overview:
Added a new beginner-facing ROSI page in getting_started with explicit positioning around lock-in guardrails, freedom of choice, and practical adoption.
Added two audience-specific follow-up pages under deployments for platform engineering and decision-maker perspectives.
Integrated the new pages into the table-of-contents hierarchy and added cross-links between beginner and deployments sections. Updated doc/Makefile.am EXTRA_DIST entries for all newly added rst files. Extended ROSI messaging with efficiency, FinOps, and Green IT framing, including edge rsyslog cost-control context and container-first, Kubernetes-next positioning.

Closes: https://github.com/rsyslog/rsyslog/issues/6057

With the help of AI-Agents: codex
