### PR TITLE
doc: bump footer copyright year to 2026

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -187,7 +187,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'rsyslog'
-copyright = u'2008-2022, Rainer Gerhards and Others'
+copyright = u'2008-2026, Rainer Gerhards and Others'
 author = u'Rainer Gerhards and Others'
 
 

--- a/doc/source/includes/footer.inc.rst
+++ b/doc/source/includes/footer.inc.rst
@@ -6,6 +6,6 @@ GitHub Issues: |GitHubSourceProject|_
 
 **Contributing:** Source & docs: |GitHubSourceProject|_
 
-© 2008–2025 `Rainer Gerhards <https://rainer.gerhards.net/>`_
+© 2008–2026 `Rainer Gerhards <https://rainer.gerhards.net/>`_
 and others. Licensed under the `Apache License 2.0 
 <https://www.apache.org/licenses/LICENSE-2.0>`_.


### PR DESCRIPTION
## Summary
- update docs footer copyright year to 2026
- keep `doc/source/conf.py` copyright range aligned

## Validation
- built docs with `./doc/tools/build-doc-linux.sh --format html`
- verified generated pages show `© 2008–2026`

