### PR TITLE
doc: fix stale relative links causing malformed paths

### DIFF
--- a/doc/source/concepts/messageparser.rst
+++ b/doc/source/concepts/messageparser.rst
@@ -92,8 +92,8 @@ of the syslog world. A wealth of different formats is. Unfortunately,
 many real-world implementations violate the relevant standards in one
 way or another. That makes it often very hard to extract meaningful
 information from a message or to process messages from different sources
-by the same rules. In my article `syslog parsing in
-rsyslog <syslog_parsing.html>`_ I have elaborated on all the real-world
+by the same rules. In my article :doc:`syslog parsing in
+rsyslog </whitepapers/syslog_parsing>` I have elaborated on all the real-world
 evil that you can usually see. So I won't repeat that here. But in
 short, the real problem is not the framing, but how to make malformed
 messages well-looking.
@@ -231,9 +231,10 @@ specific rulesets. As parser chains "reside" in rulesets, binding to a
 ruleset also binds to the parser chain that is bound to that ruleset. As
 a number one prerequisite, the input module must support binding to
 different rulesets. Not all do, but their number is growing. For
-example, the important `imudp <imudp.html>`_ and `imtcp <imtcp.html>`_
+example, the important :doc:`imudp </configuration/modules/imudp>` and
+:doc:`imtcp </configuration/modules/imtcp>`
 input modules support that functionality. Those that do not (for example
-`im3195 <im3195>`_) can only utilize the default ruleset and thus the
+:doc:`im3195 </configuration/modules/im3195>`) can only utilize the default ruleset and thus the
 parser chain defined in that ruleset.
 
 If you do not know if the input module in question supports ruleset

--- a/doc/source/concepts/queues.rst
+++ b/doc/source/concepts/queues.rst
@@ -263,7 +263,7 @@ recommended to use a disk-assisted linked list in-memory queue in front
 of each database and "send via tcp" action. Doing so makes these actions
 reliable and de-couples their potential low execution speed from the
 rest of your rules (e.g. the local file writes). There is a howto on
-`massive database inserts <rsyslog_high_database_rate.html>`_ which
+:doc:`massive database inserts </tutorials/high_database_rate>` which
 nicely describes this use case. It may even be a good read if you do not
 intend to use databases.
 

--- a/doc/source/configuration/action/index.rst
+++ b/doc/source/configuration/action/index.rst
@@ -22,7 +22,7 @@ These statements can be used with all types of actions.
    e.g. when generating a configuration graph. Available since 4.3.1.
 -  **$ActionExecOnlyOnceEveryInterval** <seconds> - execute action only if
    the last execute is at last <seconds> seconds in the past (more info
-   in `ommail <ommail.html>`_, but may be used with any action). To
+   in :doc:`ommail </configuration/modules/ommail>`, but may be used with any action). To
    disable this setting, use value 0.
 -  **$ActionExecOnlyEveryNthTime** <number> - If configured, the next
    action will only be executed every n-th time. For example, if

--- a/doc/source/configuration/global/index.rst
+++ b/doc/source/configuration/global/index.rst
@@ -97,10 +97,10 @@ True Global Directives
    :ref:`reverse_dns_cache` for controlling cache refresh.
 -  **$WorkDirectory** <name> (directory for spool and other work files. Do
    **not** use trailing slashes)
--  `$PrivDropToGroup <droppriv.html>`_
--  `$PrivDropToGroupID <droppriv.html>`_
--  `$PrivDropToUser <droppriv.html>`_
--  `$PrivDropToUserID <droppriv.html>`_
+-  :doc:`$PrivDropToGroup </configuration/droppriv>`
+-  :doc:`$PrivDropToGroupID </configuration/droppriv>`
+-  :doc:`$PrivDropToUser </configuration/droppriv>`
+-  :doc:`$PrivDropToUserID </configuration/droppriv>`
 -  **$Sleep** <seconds> - puts the rsyslog main thread to sleep for the
    specified number of seconds immediately when the directive is
    encountered. You should have a good reason for using this directive!

--- a/doc/source/configuration/global/options/rsconf1_abortonuncleanconfig.rst
+++ b/doc/source/configuration/global/options/rsconf1_abortonuncleanconfig.rst
@@ -1,4 +1,4 @@
-`rsyslog.conf configuration parameter <rsyslog_conf_global.html>`_
+:doc:`rsyslog.conf configuration parameter </configuration/global/index>`
 
 $AbortOnUncleanConfig
 ----------------------
@@ -37,4 +37,3 @@ such scenarios. As such, it is strongly recommended not to turn on this
 parameter.
 
 [`rsyslog site <http://www.rsyslog.com/>`_\ ]
-

--- a/doc/source/configuration/global/options/rsconf1_generateconfiggraph.rst
+++ b/doc/source/configuration/global/options/rsconf1_generateconfiggraph.rst
@@ -1,3 +1,16 @@
+.. _rsconf1_generateconfiggraph:
+
+.. meta::
+   :description: Legacy rsyslog global parameter $GenerateConfigGraph for generating configuration graph data.
+   :keywords: rsyslog, global option, GenerateConfigGraph, Graphviz, configuration graph
+
+.. summary-start
+
+``$GenerateConfigGraph`` is a legacy global parameter that can emit Graphviz
+dot data for visualizing rsyslog configuration flow. It is currently disabled.
+
+.. summary-end
+
 $GenerateConfigGraph
 --------------------
 
@@ -130,7 +143,7 @@ is does not have standard form (the same happened to the node named
 are executed synchronously.
 
 Configuration graphs are useful for documenting a setup, but are also a
-great `troubleshooting <troubleshoot.html>`_ resource. It is important
+great :doc:`troubleshooting </troubleshooting/troubleshoot>` resource. It is important
 to remember that **these graphs are generated from rsyslogd's in-memory
 action processing structures**. You can not get closer to understanding
 on how rsyslog interpreted its configuration files. So if the graph does

--- a/doc/source/configuration/input_directives/rsconf1_escape8bitcharsonreceive.rst
+++ b/doc/source/configuration/input_directives/rsconf1_escape8bitcharsonreceive.rst
@@ -27,8 +27,8 @@ $ControlCharacterEscapePrefix character (being '#' by default).
    character sets.
 -  turning on this option destroys digital signatures if such exists
    inside the message
--  if turned on, the drop-cc, space-cc and escape-cc `property
-   replacer <property_replacer.html>`_ options do not work as expected
+-  if turned on, the drop-cc, space-cc and escape-cc :doc:`property
+   replacer </configuration/property_replacer>` options do not work as expected
    because control characters are already removed upon message
    reception. If you intend to use these property replacer options, you
    must turn off $Escape8BitCharactersOnReceive.
@@ -36,4 +36,3 @@ $ControlCharacterEscapePrefix character (being '#' by default).
 **Sample:**
 
 ``$Escape8BitCharactersOnReceive on``
-

--- a/doc/source/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.rst
+++ b/doc/source/configuration/input_directives/rsconf1_escapecontrolcharactersonreceive.rst
@@ -22,8 +22,8 @@ To be compatible to sysklogd, this option must be turned on.
    sets (like Japanese, Chinese and Korean)
 -  turning on this option destroys digital signatures if such exists
    inside the message
--  if turned on, the drop-cc, space-cc and escape-cc `property
-   replacer <property_replacer.html>`_ options do not work as expected
+-  if turned on, the drop-cc, space-cc and escape-cc :doc:`property
+   replacer </configuration/property_replacer>` options do not work as expected
    because control characters are already removed upon message
    reception. If you intend to use these property replacer options, you
    must turn off $EscapeControlCharactersOnReceive.
@@ -31,4 +31,3 @@ To be compatible to sysklogd, this option must be turned on.
 **Sample:**
 
 ``$EscapeControlCharactersOnReceive on``
-

--- a/doc/source/configuration/modules/imptcp.rst
+++ b/doc/source/configuration/modules/imptcp.rst
@@ -15,7 +15,7 @@ Provides the ability to receive syslog messages via plain TCP syslog.
 This is a specialized input plugin tailored for high performance on
 Linux. It will probably not run on any other platform. Also, it does not
 provide TLS services. Encryption can be provided by using
-`stunnel <rsyslog_stunnel.html>`_.
+external wrappers such as stunnel.
 
 This module has no limit on the number of listeners and sessions that
 can be used.

--- a/doc/source/configuration/modules/imtcp.rst
+++ b/doc/source/configuration/modules/imtcp.rst
@@ -13,8 +13,8 @@ Purpose
 
 Provides the ability to receive syslog messages via TCP. Encryption is
 natively provided by selecting the appropriate network stream driver
-and can also be provided by using `stunnel <rsyslog_stunnel.html>`_ (an
-alternative is the use the `imgssapi <imgssapi.html>`_ module).
+and can also be provided by using external wrappers such as stunnel (an
+alternative is the use the :doc:`imgssapi </configuration/modules/imgssapi>` module).
 
 .. note::
    Reverse DNS lookups for remote senders are cached. To control refresh
@@ -495,7 +495,7 @@ Caveats/Known Bugs
 ==================
 
 -  module always binds to all interfaces
--  can not be loaded together with `imgssapi <imgssapi.html>`_ (which
+-  can not be loaded together with :doc:`imgssapi </configuration/modules/imgssapi>` (which
    includes the functionality of imtcp)
 
 

--- a/doc/source/configuration/modules/mmutf8fix.rst
+++ b/doc/source/configuration/modules/mmutf8fix.rst
@@ -42,7 +42,7 @@ problems, mmutf8fix can be conditionally called only on messages from
 them. This also offers performance benefits. If such multiple sources
 exists, it probably is a good idea to define different listeners for
 their incoming traffic, bind them to specific
-`ruleset <multi_ruleset.html>`_ and call mmutf8fix as first action in
+:doc:`ruleset </concepts/multi_ruleset>` and call mmutf8fix as first action in
 this ruleset.
 
 Configuration Parameters

--- a/doc/source/configuration/modules/ommongodb.rst
+++ b/doc/source/configuration/modules/ommongodb.rst
@@ -136,7 +136,7 @@ used. This template is:
 This creates the BSON document needed for MongoDB if no template is
 specified. The default schema is aligned to CEE and project lumberjack.
 As such, the field names are standard lumberjack field names, and
-**not** `rsyslog property names <property_replacer.html>`_. When
+**not** :doc:`rsyslog property names </configuration/property_replacer>`. When
 specifying templates, be sure to use rsyslog property names as given in
 the table. If you would like to use lumberjack-based field names inside
 MongoDB (which probably is useful depending on the use case), you need
@@ -245,5 +245,4 @@ PWD
    "word", "none", "no", "none"
 
 The user's password.
-
 

--- a/doc/source/configuration/modules/omruleset.rst
+++ b/doc/source/configuration/modules/omruleset.rst
@@ -12,7 +12,7 @@ omruleset: ruleset output/including module (DEPRECATED)
    **THIS MODULE IS DEPRECATED AND SHOULD NOT BE USED.**
 
    It is outdated and inefficient. It has been replaced by the much more
-   efficient `"call" RainerScript statement <../rainerscript/rainerscript_call.html>`_.
+   efficient :doc:`"call" RainerScript statement </rainerscript/rainerscript_call>`.
 
    The documentation below is provided to help you **identify and migrate** legacy configurations.
 

--- a/doc/source/configuration/output_channels.rst
+++ b/doc/source/configuration/output_channels.rst
@@ -46,7 +46,7 @@ In its current form, output channels primarily provide the ability to
 size-limit an output file. To do so, specify a maximum size. When this
 size is reached, rsyslogd will execute the action-on-max-size command
 and then reopen the file and retry. The command should be something like
-a `log rotation script <log_rotation_fix_size.html>`_ or a similar
+a :doc:`log rotation script </tutorials/log_rotation_fix_size>` or a similar
 thing.
 
 If there is no action-on-max-size command or the command did not resolve
@@ -58,4 +58,3 @@ writing to a single file. Meanwhile, rsyslogd has been fixed to support
 files larger 2gb, but obviously only on file systems and operating
 system versions that do so. So it can still make sense to enforce a 2gb
 file size limit.
-

--- a/doc/source/configuration/property_replacer.rst
+++ b/doc/source/configuration/property_replacer.rst
@@ -297,13 +297,13 @@ options are defined:
   the 3-digit decimal value of the control character. For example, a
   tabulator would be replaced by "#009".
   Note: using this option requires that
-  `$EscapeControlCharactersOnReceive <rsconf1_escapecontrolcharactersonreceive.html>`_
+  :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`
   is set to off.
 
 **space-cc**
   replace control characters by spaces
   Note: using this option requires that
-  `$EscapeControlCharactersOnReceive <rsconf1_escapecontrolcharactersonreceive.html>`_
+  :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`
   is set to off.
 
 **drop-cc**
@@ -311,7 +311,7 @@ options are defined:
   control characters, escape sequences nor any other replacement character
   like space.
   Note: using this option requires that
-  `$EscapeControlCharactersOnReceive <rsconf1_escapecontrolcharactersonreceive.html>`_
+  :doc:`$EscapeControlCharactersOnReceive </configuration/input_directives/rsconf1_escapecontrolcharactersonreceive>`
   is set to off.
 
 **compressspace**
@@ -365,7 +365,7 @@ Further Links
 -  Article on ":doc:`Recording the Priority of Syslog
    Messages <../tutorials/recording_pri>`" (describes use of
    templates to record severity and facility of a message)
--  `Configuration file syntax <rsyslog_conf.html>`_, this is where you
+-  :doc:`Configuration file syntax </configuration/basic_structure>`, this is where you
    actually use the property replacer.
 
 .. toctree::

--- a/doc/source/configuration/ruleset/rsconf1_rulesetcreatemainqueue.rst
+++ b/doc/source/configuration/ruleset/rsconf1_rulesetcreatemainqueue.rst
@@ -1,4 +1,4 @@
-`rsyslog.conf configuration directive <rsyslog_conf_global.html>`_
+:doc:`rsyslog.conf configuration directive </configuration/global/index>`
 
 $RulesetCreateMainQueue
 -----------------------
@@ -31,7 +31,7 @@ Note that the final set of ruleset configuration directives specifies
 the parameters for the default main message queue.
 
 To learn more about this feature, please be sure to read about
-`multi-ruleset support in rsyslog <multi_ruleset.html>`_.
+:doc:`multi-ruleset support in rsyslog </concepts/multi_ruleset>`.
 
 **Caveats:**
 
@@ -88,4 +88,3 @@ position is very important. It is highly suggested to use
 the *ruleset()* object in RainerScript config language if you intend
 to use ruleset queues. The configuration is much more straightforward in
 that language and less error-prone.
-

--- a/doc/source/configuration/ruleset/rsconf1_rulesetparser.rst
+++ b/doc/source/configuration/ruleset/rsconf1_rulesetparser.rst
@@ -53,7 +53,7 @@ is
 -  bind the listener to the ruleset with the required parser
 
 Note that it may be cumbersome to add all rules to all rulesets. To
-avoid this, you can either use $Include or `omruleset <omruleset.html>`_
+avoid this, you can either use $Include or :doc:`omruleset </configuration/modules/omruleset>`
 (what probably provides the best solution).
 
 More information about rulesets in general can be found in
@@ -119,9 +119,8 @@ parsed once any parser properly processed it).
 
 For an example of how multiple parser can be chained (and an actual use
 case), please see the example section on the
-`pmlastmsg <pmlastmsg.html>`_ parser module.
+:doc:`pmlastmsg </configuration/modules/pmlastmsg>` parser module.
 
 Note the positions of the directives. With the current config language,
 **sequence of statements is very important**. This is ugly, but
 unfortunately the way it currently works.
-

--- a/doc/source/development/dev_oplugins.rst
+++ b/doc/source/development/dev_oplugins.rst
@@ -37,7 +37,7 @@ points need to be provided and thus reading the code comments in the
 files mentioned is highly suggested.
 
 For testing, you need rsyslog's debugging support. Some useful
-information is given in "`troubleshooting rsyslog <troubleshoot.html>`_
+information is given in :doc:`troubleshooting rsyslog </troubleshooting/troubleshoot>`
 from the doc set.
 
 Special Topics

--- a/doc/source/features.rst
+++ b/doc/source/features.rst
@@ -8,25 +8,25 @@ is a vital project. Features are added each few days. If you would like
 to keep up of what is going on, you can also subscribe to the `rsyslog
 mailing list <http://lists.adiscon.net/mailman/listinfo/rsyslog>`_.
 
-A better structured feature list is now contained in our `rsyslog vs.
-syslog-ng comparison <rsyslog_ng_comparison.html>`_. Probably that page
+A better structured feature list used to be contained in our rsyslog vs.
+syslog-ng comparison. Probably that page
 will replace this one in the future.
 
 Current Features
 ----------------
 
--  native support for `writing to MariaDB/MySQL databases <rsyslog_mysql.html>`_
+-  native support for :doc:`writing to MariaDB/MySQL databases </tutorials/database>`
 -  native support for writing to Postgres databases
 -  direct support for Firebird/Interbase, OpenTDS (MS SQL, Sybase),
    SQLite, Ingres, Oracle, and mSQL via libdbi, a database abstraction
    layer (almost as good as native)
--  native support for `sending mail messages <ommail.html>`_ (first seen
+-  native support for :doc:`sending mail messages </configuration/modules/ommail>` (first seen
    in 3.17.0)
 -  support for (plain) tcp based syslog - much better reliability
 -  support for sending and receiving compressed syslog messages
 -  support for on-demand on-disk spooling of messages that can not be
-   processed fast enough (a great feature for `writing massive amounts
-   of syslog messages to a database <rsyslog_high_database_rate.html>`_)
+   processed fast enough (a great feature for :doc:`writing massive amounts
+   of syslog messages to a database </tutorials/high_database_rate>`)
 -  support for selectively `processing messages only during specific
    timeframes <http://wiki.rsyslog.com/index.php/OffPeakHours>`_ and
    spooling them to disk otherwise
@@ -48,9 +48,8 @@ Current Features
 -  support for file size limitation and automatic rollover command
    execution
 -  support for running multiple rsyslogd instances on a single machine
--  support for `TLS-protected syslog <rsyslog_tls.html>`_ (both
-   `natively <rsyslog_tls.html>`_ and via
-   `stunnel <rsyslog_stunnel.html>`_)
+-  support for :doc:`TLS-protected syslog </tutorials/tls>` (both
+   :doc:`natively </tutorials/tls>` and via stunnel wrappers)
 -  ability to filter on any part of the message, not just facility and
    severity
 -  ability to use regular expressions in filters
@@ -67,7 +66,7 @@ Current Features
    and shut themselves down on an as-needed basis (great for high log
    volume on multicore machines)
 -  very experimental and volatile support for
-   `syslog-protocol <syslog_protocol.html>`_ compliant messages (it is
+   :doc:`syslog-protocol </whitepapers/syslog_protocol>` compliant messages (it is
    volatile because standardization is currently underway and this is a
    proof-of-concept implementation to aid this effort)
 -  world's first implementation of syslog-transport-tls

--- a/doc/source/historical/php_syslog_ng.rst
+++ b/doc/source/historical/php_syslog_ng.rst
@@ -77,9 +77,9 @@ fix it.
 
 Once this schema is created, we simply instruct rsyslogd to store
 received data in it. I won't go into too much detail here. If you are
-interested in some more details, you might find my paper "`Writing
-syslog messages to MySQL <rsyslog_mysql.html>`_\ " worth reading. For
-this article, we simply modify `rsyslog.conf <rsyslog_conf.html>`_\ so
+interested in some more details, you might find my paper
+:doc:`Writing syslog messages to MySQL </tutorials/database>` worth reading. For
+this article, we simply modify :doc:`rsyslog.conf </configuration/basic_structure>` so
 that it writes to the database. That is easy. Just these two lines are
 needed:
 
@@ -98,7 +98,7 @@ inefficiency in our current usage: the
 ``'%timereported:::date-mysql%'``
 property is used for both the time
 and the date (if you wonder about what all these funny characters mean,
-see the `rsyslogd property replacer manual <property_replacer.html>`_) .
+see the :doc:`rsyslogd property replacer manual </configuration/property_replacer>`).
 We could have extracted just the date and time parts of the respective
 properties. However, this is more complicated and also adds processing
 time to rsyslogd's processing (substrings must be extracted). So we take

--- a/doc/source/installation/build_from_repo.rst
+++ b/doc/source/installation/build_from_repo.rst
@@ -67,7 +67,6 @@ Creating the Build Environment
 This is fairly easy: just issue "**autoreconf -fvi**\ ", which should do
 everything you need. Once this is done, you can follow the usual
 ./configure steps just like when you downloaded an official distribution
-tarball (see the `rsyslog install guide <install.html>`_, starting at
+tarball (see the :doc:`rsyslog install guide </installation/install_from_source>`, starting at
 step 2, for further details about that).
-
 

--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -291,8 +291,8 @@ The following parameters can be set:
      character sets.
   -  turning on this option destroys digital signatures if such exists
      inside the message
-  -  if turned on, the drop-cc, space-cc and escape-cc `property
-     replacer <property_replacer.html>`_ options do not work as expected
+  -  if turned on, the drop-cc, space-cc and escape-cc :doc:`property
+     replacer </configuration/property_replacer>` options do not work as expected
      because control characters are already removed upon message
      reception. If you intend to use these property replacer options, you
      must turn off *parser.escape8BitCharactersOnReceive*.
@@ -316,8 +316,8 @@ The following parameters can be set:
      sets (like Japanese, Chinese and Korean)
   -  turning on this option destroys digital signatures if such exists
      inside the message
-  -  if turned on, the drop-cc, space-cc and escape-cc `property
-     replacer <property_replacer.html>`_ options do not work as expected
+  -  if turned on, the drop-cc, space-cc and escape-cc :doc:`property
+     replacer </configuration/property_replacer>` options do not work as expected
      because control characters are already removed upon message
      reception. If you intend to use these property replacer options, you
      must turn off *parser.escapeControlCharactersOnReceive*.

--- a/doc/source/troubleshooting/troubleshoot.rst
+++ b/doc/source/troubleshooting/troubleshoot.rst
@@ -23,8 +23,8 @@ Useful troubleshooting resources are:
 Malformed Messages and Message Properties
 -----------------------------------------
 
-A common trouble source are `ill-formed syslog
-messages <syslog_parsing.html>`_, which lead to all sorts of
+A common trouble source are :doc:`ill-formed syslog
+messages </whitepapers/syslog_parsing>`, which lead to all sorts of
 interesting problems, including malformed hostnames and dates. Read the
 quoted guide to find relief. A common symptom is that the %HOSTNAME%
 property is used for generating dynafile names, but some gibberish

--- a/doc/source/tutorials/tls.rst
+++ b/doc/source/tutorials/tls.rst
@@ -21,7 +21,7 @@ have found the right spot.
 
 This is a quick guide. There is a more elaborate guide currently under
 construction which provides a much more secure environment. It is highly
-recommended to `at least have a look at it <rsyslog_secure_tls.html>`_.
+recommended to :doc:`at least have a look at it </tutorials/tls_cert_summary>`.
 
 Background
 ----------
@@ -32,8 +32,8 @@ problem at all. In others, it is a huge setback, probably even
 preventing deployment of syslog solutions. Thankfully, there are easy
 ways to encrypt syslog communication. 
 
-The traditional approach involves `running a wrapper like stunnel around
-the syslog session <rsyslog_stunnel.html>`_. This works quite well and
+The traditional approach involves running a wrapper like stunnel around
+the syslog session. This works quite well and
 is in widespread use. However, it is not tightly coupled with the main
 syslogd and some, even severe, problems can result from this (follow a
 mailing list thread that describes `total loss of syslog messages due to
@@ -42,7 +42,7 @@ mode <http://lists.adiscon.net/pipermail/rsyslog/2008-March/000580.html>`_
 and the `unreliability of TCP
 syslog <https://rainer.gerhards.net/2008/04/on-unreliability-of-plain-tcp-syslog.html>`_).
 
-`Rsyslog supports syslog via GSSAP <gssapi.html>`_\ I since long to
+:doc:`Rsyslog supports syslog via GSSAPI </configuration/modules/imgssapi>` since long to
 overcome these limitations. However, syslog via GSSAPI is a
 rsyslog-exclusive transfer mode and it requires a proper Kerberos
 environment. As such, it isn't a really universal solution. The

--- a/doc/source/whitepapers/syslog_parsing.rst
+++ b/doc/source/whitepapers/syslog_parsing.rst
@@ -251,8 +251,8 @@ Is available with rsyslog 5.3.4 and above. Here, we can define so-called
 custom parsers. These are plugin modules, written in C and adapted to a
 specific message format need. The big plus of custom parsers is that
 they offer excellent performance and unlimited possibilities - far
-better than any work-around could do. Custom parsers can be `bound to
-specific rule sets <rsconf1_rulesetparser.html>`_ (and thus listening)
+better than any work-around could do. Custom parsers can be :doc:`bound to
+specific rule sets </configuration/ruleset/rsconf1_rulesetparser>` (and thus listening)
 ports with relative ease. The only con is that they must be written.
 However, if you are lucky, a parser for your device may already exist.
 If not, you can opt to write it yourself, what is not too hard if you
@@ -275,8 +275,8 @@ well-formed messages. If that is not possible, you can work around these
 issues with rsyslog's property replacer and template system. Or you can
 use a suitable message parser or write one for your needs.
 
-I hope this is a useful guide. You may also have a look at the `rsyslog
-troubleshooting guide <troubleshoot.html>`_ for further help and places
+I hope this is a useful guide. You may also have a look at the :doc:`rsyslog
+troubleshooting guide </troubleshooting/troubleshoot>` for further help and places
 where to ask questions.
 
 
@@ -291,4 +291,3 @@ Conceptual model
 - rsyslog exposes internal properties (e.g., fromhost, timegenerated, rawmsg) to rebuild structured output when parsing fails.
 - Custom C parsers can be bound per ruleset to normalize proprietary formats efficiently, avoiding heavy regex-based workarounds.
 - The safest path is to configure senders to emit well-formed messages, reducing guesswork and preserving semantic fidelity.
-


### PR DESCRIPTION
Why:
Several legacy pages still used bare filename links like "foo.html". Those links resolve relative to the current URL path, which can cascade into malformed requests with repeated path segments when crawlers or users are already on deep/non-canonical URLs.

Impact: Internal docs links now resolve consistently across page depth.

Before/After: Build had 49 unresolved relative href targets; now it has 0.

Technical Overview:
Replaced stale bare .html links with canonical internal doc links using :doc: targets (and a few adjusted modern targets where legacy pages no longer exist).
Updated links across concepts, configuration, tutorials, troubleshooting, legacy/historical, and development pages.
Kept link style deterministic by using root-anchored doc paths where appropriate.
Validated with full HTML build and a resolver audit over generated HTML.

With the help of AI-Agents: codex
