### PR TITLE
tests: Makes all imfile-logrotate* tests pass with logrotate 3.8+

### DIFF
--- a/tests/imfile-logrotate-async.sh
+++ b/tests/imfile-logrotate-async.sh
@@ -13,6 +13,7 @@ export RETRIES=50
 # Write logrotate config file
 echo '"./'$RSYSLOG_DYNNAME'.input*.log"
 {
+    su '"$(id -un)"' '"$(id -gn)"'
     #daily
     rotate 60
     missingok

--- a/tests/imfile-logrotate-copytruncate.sh
+++ b/tests/imfile-logrotate-copytruncate.sh
@@ -43,6 +43,7 @@ if $msg contains "msgnum:" then
 # Write logrotate config file
 echo '"./'$RSYSLOG_DYNNAME'.input.*.log"
 {
+	su '"$(id -un)"' '"$(id -gn)"'
 	rotate 7
 	create
 	daily

--- a/tests/imfile-logrotate-multiple.sh
+++ b/tests/imfile-logrotate-multiple.sh
@@ -34,6 +34,7 @@ if $msg contains "msgnum:" then
 # Write logrotate config file
 echo '"./'$RSYSLOG_DYNNAME'.input"
 {
+	su '"$(id -un)"' '"$(id -gn)"'
 	create
 	daily
 	missingok

--- a/tests/imfile-logrotate-nocopytruncate.sh
+++ b/tests/imfile-logrotate-nocopytruncate.sh
@@ -42,6 +42,7 @@ if $msg contains "msgnum:" then
 # Write logrotate config file
 echo '"./'$RSYSLOG_DYNNAME'.input.*.log"
 {
+	su '"$(id -un)"' '"$(id -gn)"'
 	rotate 7
 	create
 	daily

--- a/tests/imfile-logrotate.sh
+++ b/tests/imfile-logrotate.sh
@@ -42,6 +42,7 @@ if $msg contains "msgnum:" then
 # Write logrotate config file
 echo '"./'$RSYSLOG_DYNNAME'.input.*.log"
 {
+	su '"$(id -un)"' '"$(id -gn)"'
 	rotate 7
 	create
 	daily


### PR DESCRIPTION
## Problem

- logrotate 3.8+ refuses to rotate files in world/group-writable parent
  directories unless a `su` directive is present
- `su root root` triggers "Operation not permitted" in non-root CI
  (e.g. uid 1000), since switching to root is not allowed

## Solution

Add dynamic `su $(id -un) $(id -gn)` to all five imfile-logrotate test
configs. This satisfies logrotate’s security check without requiring root.

## Tests Updated

- imfile-logrotate.sh
- imfile-logrotate-async.sh
- imfile-logrotate-copytruncate.sh
- imfile-logrotate-multiple.sh
- imfile-logrotate-nocopytruncate.sh

## Testing

- Tests pass locally under root and non-root
- CI succeeds with logrotate 3.8+ in non-root environments