### PR TITLE
ratelimit: wire ratelimit.name into remaining modules

### DIFF
--- a/ai/rsyslog_memory_auditor/audit_leaks.txt
+++ b/ai/rsyslog_memory_auditor/audit_leaks.txt
@@ -1,0 +1,17 @@
+You are a senior C security and performance auditor. Analyze the following rsyslog module code specifically for memory leaks on error paths.
+
+**Audit Focus: Error Path Leaks & Ownership**
+
+1. **Error Path Leaks**: 
+   - Trace every `RS_RET` return path. 
+   - Ensure that any memory allocated via `malloc`, `calloc`, or `strdup` (common in `setInstParam`) is freed before an error return.
+   - Check if `pData` or `WID` sub-elements are leaked during partial initialization failure.
+
+2. **Ownership Ambiguity**:
+   - Determine if memory passed to a function is "owned" (caller must free) or "transferred" (callee must free).
+   - In rsyslog, `pData` is typically freed in `freeInstance`, and `WID` in `freeWrkrInstance`. Ensure no double-frees occur during HUP or teardown.
+
+**Output**:
+- List any identified leaks (e.g., "Line 45: ptr is not freed on RS_RET_PARAM_ERROR").
+- Provide a summary of "Clean" vs "At Risk" allocations.
+- Suggest specific `free()` placements for identified leaks.

--- a/ai/rsyslog_memory_auditor/audit_lifecycle.txt
+++ b/ai/rsyslog_memory_auditor/audit_lifecycle.txt
@@ -1,0 +1,15 @@
+You are a senior C security and performance auditor. Analyze the following rsyslog module code specifically for global and instance lifecycle symmetry.
+
+**Audit Focus: Lifecycle Symmetry**
+
+1. **Module Lifecycle**:
+   - Verify `modInit` and `modExit` balance global resource allocations (mutexes, global hashes, etc.).
+   - Ensure `createInstance` results in a fully initialized `pData` that `freeInstance` can safely clean up (even if only partially initialized).
+
+2. **Worker Symmetry**:
+   - Check that `createWrkrInstance` and `freeWrkrInstance` are balanced.
+   - Look for thread-local storage or resources that might not be cleaned up if a thread terminates unexpectedly.
+
+**Output**:
+- List any identified symmetry issues (e.g., "Mutex initialized in modInit but not destroyed in modExit").
+- Verify if `freeInstance` handles NULL pointers safely.

--- a/ai/rsyslog_memory_auditor/audit_null_checks.txt
+++ b/ai/rsyslog_memory_auditor/audit_null_checks.txt
@@ -1,0 +1,18 @@
+You are a senior C security and performance auditor. Analyze the following rsyslog module code specifically for NULL check compliance and macro usage.
+
+**Audit Focus: NULL Checks & Memory Macros**
+
+1. **Memory Macros**:
+   - Prefer `CHKmalloc()` for allocations. It handles the `NULL` check and jumps to `finalize_it` (or the local error label) automatically.
+   - If `malloc` or `strdup` is used directly, verify there is an immediate `NULL` check.
+
+2. **Function-Specific Checks**:
+   - `es_str2cstr()` can fail and return `NULL`. Every call MUST be followed by a `NULL` check (or wrapped in `CHKmalloc` logic if applicable).
+
+3. **String Handling**:
+   - Look for `strdup()` calls. Are they matched by a `free()`?
+   - Check for buffer overflows in `snprintf` or `strcpy` (though `format-code.sh` helps, logic errors remain).
+
+**Output**:
+- List any identified risks (e.g., "Line 123: es_str2cstr return is not checked").
+- Suggest macro replacements (like `CHKmalloc`) where appropriate.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -520,6 +520,7 @@ EXTRA_DIST = \
     source/reference/parameters/imgssapi-inputgssserverpermitplaintcp.rst \
     source/reference/parameters/imgssapi-inputgssserverrun.rst \
     source/reference/parameters/imgssapi-inputgssserverservicename.rst \
+    source/reference/parameters/imhttp-ratelimit-name.rst \
     source/reference/parameters/imjournal-defaultfacility.rst \
     source/reference/parameters/imjournal-defaultseverity.rst \
     source/reference/parameters/imjournal-defaulttag.rst \
@@ -531,6 +532,7 @@ EXTRA_DIST = \
     source/reference/parameters/imjournal-persiststateinterval.rst \
     source/reference/parameters/imjournal-ratelimit-burst.rst \
     source/reference/parameters/imjournal-ratelimit-interval.rst \
+    source/reference/parameters/imjournal-ratelimit-name.rst \
     source/reference/parameters/imjournal-remote.rst \
     source/reference/parameters/imjournal-statefile.rst \
     source/reference/parameters/imjournal-usepid.rst \
@@ -551,6 +553,7 @@ EXTRA_DIST = \
     source/reference/parameters/imklog-permitnonkernelfacility.rst \
     source/reference/parameters/imklog-ratelimitburst.rst \
     source/reference/parameters/imklog-ratelimitinterval.rst \
+    source/reference/parameters/imklog-ratelimit-name.rst \
     source/reference/parameters/immark-interval.rst \
     source/reference/parameters/immark-markmessagetext.rst \
     source/reference/parameters/immark-ruleset.rst \
@@ -708,6 +711,7 @@ EXTRA_DIST = \
     source/reference/parameters/imuxsock-parsetrusted.rst \
     source/reference/parameters/imuxsock-ratelimit-burst.rst \
     source/reference/parameters/imuxsock-ratelimit-interval.rst \
+    source/reference/parameters/imuxsock-ratelimit-name.rst \
     source/reference/parameters/imuxsock-ratelimit-severity.rst \
     source/reference/parameters/imuxsock-ruleset.rst \
     source/reference/parameters/imuxsock-socket.rst \
@@ -720,6 +724,7 @@ EXTRA_DIST = \
     source/reference/parameters/imuxsock-syssock-parsetrusted.rst \
     source/reference/parameters/imuxsock-syssock-ratelimit-burst.rst \
     source/reference/parameters/imuxsock-syssock-ratelimit-interval.rst \
+    source/reference/parameters/imuxsock-syssock-ratelimit-name.rst \
     source/reference/parameters/imuxsock-syssock-ratelimit-severity.rst \
     source/reference/parameters/imuxsock-syssock-unlink.rst \
     source/reference/parameters/imuxsock-syssock-use.rst \
@@ -877,6 +882,7 @@ EXTRA_DIST = \
     source/reference/parameters/omelasticsearch-pwd.rst \
     source/reference/parameters/omelasticsearch-ratelimit-burst.rst \
     source/reference/parameters/omelasticsearch-ratelimit-interval.rst \
+    source/reference/parameters/omelasticsearch-ratelimit-name.rst \
     source/reference/parameters/omelasticsearch-rebindinterval.rst \
     source/reference/parameters/omelasticsearch-retryfailures.rst \
     source/reference/parameters/omelasticsearch-retryruleset.rst \
@@ -894,6 +900,7 @@ EXTRA_DIST = \
     source/reference/parameters/omelasticsearch-uid.rst \
     source/reference/parameters/omelasticsearch-usehttps.rst \
     source/reference/parameters/omelasticsearch-writeoperation.rst \
+    source/reference/parameters/omfwd-ratelimit-name.rst \
     source/reference/parameters/omfile-addlf.rst \
     source/reference/parameters/omfile-asyncwriting.rst \
     source/reference/parameters/omfile-closetimeout.rst \
@@ -958,6 +965,7 @@ EXTRA_DIST = \
     source/reference/parameters/omhttp-pwd.rst \
     source/reference/parameters/omhttp-ratelimit-burst.rst \
     source/reference/parameters/omhttp-ratelimit-interval.rst \
+    source/reference/parameters/omhttp-ratelimit-name.rst \
     source/reference/parameters/omhttp-reloadonhup.rst \
     source/reference/parameters/omhttp-restpath.rst \
     source/reference/parameters/omhttp-restpathtimeout.rst \

--- a/doc/source/configuration/modules/imhttp.rst
+++ b/doc/source/configuration/modules/imhttp.rst
@@ -264,6 +264,13 @@ RateLimit.Burst
 Specifies the rate-limiting burst in number of messages.
 
 
+RateLimit.Name
+^^^^^^^^^^^^^^
+
+.. include:: ../../reference/parameters/imhttp-ratelimit-name.rst
+   :start-after: .. summary-start
+   :end-before: .. summary-end
+
 
 flowControl
 ^^^^^^^^^^^

--- a/doc/source/configuration/modules/imjournal.rst
+++ b/doc/source/configuration/modules/imjournal.rst
@@ -77,6 +77,10 @@ Module Parameters
      - .. include:: ../../reference/parameters/imjournal-ratelimit-burst.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imjournal-ratelimit-name`
+     - .. include:: ../../reference/parameters/imjournal-ratelimit-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imjournal-ignorepreviousmessages`
      - .. include:: ../../reference/parameters/imjournal-ignorepreviousmessages.rst
         :start-after: .. summary-start
@@ -143,6 +147,7 @@ Parameters specific to the input module.
    ../../reference/parameters/imjournal-statefile
    ../../reference/parameters/imjournal-ratelimit-interval
    ../../reference/parameters/imjournal-ratelimit-burst
+   ../../reference/parameters/imjournal-ratelimit-name
    ../../reference/parameters/imjournal-ignorepreviousmessages
    ../../reference/parameters/imjournal-defaultseverity
    ../../reference/parameters/imjournal-defaultfacility

--- a/doc/source/configuration/modules/imklog.rst
+++ b/doc/source/configuration/modules/imklog.rst
@@ -64,6 +64,10 @@ Module Parameters
      - .. include:: ../../reference/parameters/imklog-ratelimitburst.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imklog-ratelimit-name`
+     - .. include:: ../../reference/parameters/imklog-ratelimit-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
 Caveats/Known Bugs
@@ -136,5 +140,6 @@ Unsupported |FmtObsoleteName| directives
    ../../reference/parameters/imklog-logpath
    ../../reference/parameters/imklog-ratelimitinterval
    ../../reference/parameters/imklog-ratelimitburst
+   ../../reference/parameters/imklog-ratelimit-name
 
 

--- a/doc/source/configuration/modules/imuxsock.rst
+++ b/doc/source/configuration/modules/imuxsock.rst
@@ -90,6 +90,10 @@ Module Parameters
      - .. include:: ../../reference/parameters/imuxsock-syssock-ratelimit-severity.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imuxsock-syssock-ratelimit-name`
+     - .. include:: ../../reference/parameters/imuxsock-syssock-ratelimit-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imuxsock-syssock-usesystimestamp`
      - .. include:: ../../reference/parameters/imuxsock-syssock-usesystimestamp.rst
         :start-after: .. summary-start
@@ -150,6 +154,10 @@ Input Parameters
         :end-before: .. summary-end
    * - :ref:`param-imuxsock-ratelimit-severity`
      - .. include:: ../../reference/parameters/imuxsock-ratelimit-severity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imuxsock-ratelimit-name`
+     - .. include:: ../../reference/parameters/imuxsock-ratelimit-name.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-imuxsock-usepidfromsystem`
@@ -539,6 +547,7 @@ system log socket.
    ../../reference/parameters/imuxsock-syssock-ratelimit-interval
    ../../reference/parameters/imuxsock-syssock-ratelimit-burst
    ../../reference/parameters/imuxsock-syssock-ratelimit-severity
+   ../../reference/parameters/imuxsock-syssock-ratelimit-name
    ../../reference/parameters/imuxsock-syssock-usesystimestamp
    ../../reference/parameters/imuxsock-syssock-annotate
    ../../reference/parameters/imuxsock-syssock-parsetrusted
@@ -552,6 +561,7 @@ system log socket.
    ../../reference/parameters/imuxsock-ratelimit-interval
    ../../reference/parameters/imuxsock-ratelimit-burst
    ../../reference/parameters/imuxsock-ratelimit-severity
+   ../../reference/parameters/imuxsock-ratelimit-name
    ../../reference/parameters/imuxsock-usepidfromsystem
    ../../reference/parameters/imuxsock-usesystimestamp
    ../../reference/parameters/imuxsock-createpath

--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -201,6 +201,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/omelasticsearch-ratelimit-burst.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-ratelimit-name`
+     - .. include:: ../../reference/parameters/omelasticsearch-ratelimit-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omelasticsearch-rebindinterval`
      - .. include:: ../../reference/parameters/omelasticsearch-rebindinterval.rst
         :start-after: .. summary-start
@@ -246,6 +250,7 @@ Action Parameters
    ../../reference/parameters/omelasticsearch-retryruleset
    ../../reference/parameters/omelasticsearch-ratelimit-interval
    ../../reference/parameters/omelasticsearch-ratelimit-burst
+   ../../reference/parameters/omelasticsearch-ratelimit-name
    ../../reference/parameters/omelasticsearch-rebindinterval
 
 .. _omelasticsearch-statistic-counter:

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -577,6 +577,14 @@ RateLimit.Burst
 Specifies the rate-limiting burst in number of messages.
 
 
+RateLimit.Name
+^^^^^^^^^^^^^^
+
+.. include:: ../../reference/parameters/omfwd-ratelimit-name.rst
+   :start-after: .. summary-start
+   :end-before: .. summary-end
+
+
 StreamDriver
 ^^^^^^^^^^^^
 

--- a/doc/source/configuration/modules/omhttp.rst
+++ b/doc/source/configuration/modules/omhttp.rst
@@ -164,6 +164,10 @@ Input Parameters
      - .. include:: ../../reference/parameters/omhttp-ratelimit-burst.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omhttp-ratelimit-name`
+     - .. include:: ../../reference/parameters/omhttp-ratelimit-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omhttp-errorfile`
      - .. include:: ../../reference/parameters/omhttp-errorfile.rst
         :start-after: .. summary-start
@@ -241,6 +245,7 @@ Input Parameters
    ../../reference/parameters/omhttp-retry-addmetadata
    ../../reference/parameters/omhttp-ratelimit-interval
    ../../reference/parameters/omhttp-ratelimit-burst
+   ../../reference/parameters/omhttp-ratelimit-name
    ../../reference/parameters/omhttp-errorfile
    ../../reference/parameters/omhttp-compress
    ../../reference/parameters/omhttp-compress-level

--- a/doc/source/reference/parameters/imhttp-ratelimit-name.rst
+++ b/doc/source/reference/parameters/imhttp-ratelimit-name.rst
@@ -1,0 +1,26 @@
+.. index:: ! imhttp; RateLimit.Name
+
+.. _param-imhttp-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. This allows multiple listeners to share the same rate
+limiting configuration (and state). The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, local per-listener limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/doc/source/reference/parameters/imjournal-ratelimit-name.rst
+++ b/doc/source/reference/parameters/imjournal-ratelimit-name.rst
@@ -1,0 +1,25 @@
+.. index:: ! imjournal; RateLimit.Name
+
+.. _param-imjournal-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, inline rate limit parameters cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/doc/source/reference/parameters/imklog-ratelimit-name.rst
+++ b/doc/source/reference/parameters/imklog-ratelimit-name.rst
@@ -1,0 +1,25 @@
+.. index:: ! imklog; RateLimit.Name
+
+.. _param-imklog-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimitinterval`` and
+``ratelimitburst``. If ``ratelimit.name`` is specified, inline rate limit parameters cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/doc/source/reference/parameters/imuxsock-ratelimit-name.rst
+++ b/doc/source/reference/parameters/imuxsock-ratelimit-name.rst
@@ -1,0 +1,26 @@
+.. index:: ! imuxsock; RateLimit.Name
+
+.. _param-imuxsock-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use for this socket. This allows multiple sockets to share
+the same rate limiting configuration (and state). The name refers to a :doc:`global rate limit
+object <../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, local per-socket limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/doc/source/reference/parameters/imuxsock-syssock-ratelimit-name.rst
+++ b/doc/source/reference/parameters/imuxsock-syssock-ratelimit-name.rst
@@ -1,0 +1,26 @@
+.. index:: ! imuxsock; SysSock.RateLimit.Name
+
+.. _param-imuxsock-syssock-ratelimit-name:
+
+SysSock.RateLimit.Name
+======================
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use for the system log socket. The name refers to a
+:doc:`global rate limit object <../../rainerscript/configuration_objects/ratelimit>` defined in
+the configuration.
+
+**Note:** This parameter is mutually exclusive with ``syssock.ratelimit.interval`` and
+``syssock.ratelimit.burst``. If ``syssock.ratelimit.name`` is specified, local limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/doc/source/reference/parameters/omelasticsearch-ratelimit-name.rst
+++ b/doc/source/reference/parameters/omelasticsearch-ratelimit-name.rst
@@ -1,0 +1,26 @@
+.. index:: ! omelasticsearch; RateLimit.Name
+
+.. _param-omelasticsearch-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. This allows multiple actions to share the same rate
+limiting configuration (and state). The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, local per-action limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/doc/source/reference/parameters/omfwd-ratelimit-name.rst
+++ b/doc/source/reference/parameters/omfwd-ratelimit-name.rst
@@ -1,0 +1,26 @@
+.. index:: ! omfwd; RateLimit.Name
+
+.. _param-omfwd-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. This allows multiple actions to share the same rate
+limiting configuration (and state). The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, local per-action limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/doc/source/reference/parameters/omhttp-ratelimit-name.rst
+++ b/doc/source/reference/parameters/omhttp-ratelimit-name.rst
@@ -1,0 +1,26 @@
+.. index:: ! omhttp; RateLimit.Name
+
+.. _param-omhttp-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. This allows multiple actions to share the same rate
+limiting configuration (and state). The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, local per-action limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/plugins/imklog/imklog.h
+++ b/plugins/imklog/imklog.h
@@ -43,6 +43,7 @@ struct modConfData_s {
     ratelimit_t *ratelimiter;
     int ratelimitInterval;
     int ratelimitBurst;
+    uchar *pszRatelimitName;
     ruleset_t *pBindRuleset; /* ruleset to bind (use system default if unspecified) */
     uchar *pszBindRuleset;
 };

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -238,6 +238,13 @@ TESTS_DEFAULT = \
 	sndrcv_udp_nonstdpt_v6.sh \
 	imudp_thread_hang.sh \
 	imudp_ratelimit_name.sh \
+	omfwd_ratelimit_name.sh \
+	omelasticsearch_ratelimit_name.sh \
+	omhttp_ratelimit_name.sh \
+	imhttp_ratelimit_name.sh \
+	imjournal_ratelimit_name.sh \
+	imklog_ratelimit_name.sh \
+	imuxsock_ratelimit_name.sh \
 	asynwr_simple.sh \
 	asynwr_simple_2.sh \
 	asynwr_timeout.sh \
@@ -597,7 +604,11 @@ TESTS_IMTCP_VALGRIND = \
 TESTS_RATELIMIT = \
 	ratelimit_exclusivity.sh \
 	ratelimit_name.sh \
-	ratelimit_duplicate.sh
+	ratelimit_duplicate.sh \
+	omfwd_ratelimit_name.sh \
+	omelasticsearch_ratelimit_name.sh \
+	imklog_ratelimit_name.sh \
+	imuxsock_ratelimit_name.sh
 
 TESTS_IMTCP_IMPSTATS = \
 	imtcp-impstats.sh
@@ -756,7 +767,8 @@ TESTS_OMHTTP_FLAKY_VALGRIND = \
 
 TESTS_IMJOURNAL = \
 	imjournal-basic.sh \
-	imjournal-statefile.sh
+	imjournal-statefile.sh \
+	imjournal_ratelimit_name.sh
 
 TESTS_IMJOURNAL_VALGRIND = \
 	imjournal-basic-vg.sh \
@@ -833,7 +845,8 @@ TESTS_OMHTTP = \
 	omhttp-httpheaderkey.sh \
 	omhttp-multiplehttpheaders.sh \
 	omhttp-dynrestpath.sh \
-	omhttp-batch-dynrestpath.sh
+	omhttp-batch-dynrestpath.sh \
+	omhttp_ratelimit_name.sh
 
 TESTS_OMHTTP_VALGRIND = \
         omhttp-auth-vg.sh \
@@ -916,7 +929,8 @@ TESTS_IMHTTP = \
 	imhttp-post-payload-compress.sh \
 	imhttp-getrequest-file.sh \
 	imhttp-healthcheck.sh \
-	imhttp-metrics.sh
+	imhttp-metrics.sh \
+	imhttp_ratelimit_name.sh
 
 TESTS_IMHTTP_VALGRIND = \
 	imhttp-post-payload-vg.sh \

--- a/tests/imhttp_ratelimit_name.sh
+++ b/tests/imhttp_ratelimit_name.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test named rate limits for imhttp (config-validation)
+# Verifies that imhttp accepts ratelimit.name without error.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+ratelimit(name="imhttp_test_limit" interval="2" burst="5")
+
+module(load="../contrib/imhttp/.libs/imhttp"
+       ports="0"
+       listenportfilename="'$RSYSLOG_DYNNAME'.imhttp.port")
+input(type="imhttp" endpoint="/test" ratelimit.name="imhttp_test_limit" ruleset="imhttp")
+
+template(name="outfmt" type="string" string="%msg%\n")
+ruleset(name="imhttp") {
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/imjournal_ratelimit_name.sh
+++ b/tests/imjournal_ratelimit_name.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Test named rate limits for imjournal (config-validation)
+# Verifies that imjournal accepts ratelimit.name without error.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+ratelimit(name="imjournal_test_limit" interval="2" burst="5")
+
+module(load="../plugins/imjournal/.libs/imjournal"
+       ratelimit.name="imjournal_test_limit"
+       StateFile="'$RSYSLOG_DYNNAME'.imjournal.state"
+       IgnorePreviousMessages="on")
+
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/imklog_ratelimit_name.sh
+++ b/tests/imklog_ratelimit_name.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Test named rate limits for imklog (config-validation)
+# Verifies that imklog accepts ratelimit.name without error.
+. ${srcdir:=.}/diag.sh init
+if [ "$EUID" -ne 0 ]; then
+    exit 77 # Not root, skip this test
+fi
+generate_conf
+add_conf '
+ratelimit(name="imklog_test_limit" interval="2" burst="5")
+
+module(load="../plugins/imklog/.libs/imklog"
+       ratelimit.name="imklog_test_limit")
+
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/imuxsock_ratelimit_name.sh
+++ b/tests/imuxsock_ratelimit_name.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# Test named rate limits for imuxsock
+# Verifies that imuxsock accepts ratelimit.name and
+# syssock.ratelimit.name without error.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+ratelimit(name="imuxsock_test_limit" interval="2" burst="5")
+ratelimit(name="imuxsock_syssock_limit" interval="3" burst="10")
+
+module(load="../plugins/imuxsock/.libs/imuxsock"
+       SysSock.Use="off")
+input(type="imuxsock" Socket="'$RSYSLOG_DYNNAME'-imuxsock.sock"
+      ratelimit.name="imuxsock_test_limit")
+
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/omelasticsearch_ratelimit_name.sh
+++ b/tests/omelasticsearch_ratelimit_name.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Test named rate limits for omelasticsearch (config-validation)
+# Verifies that omelasticsearch accepts ratelimit.name without error.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+ratelimit(name="omelasticsearch_test_limit" interval="2" burst="5")
+
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omelasticsearch" server="localhost" serverport="19200"
+       ratelimit.name="omelasticsearch_test_limit"
+       retryfailures="on" template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/omfwd_ratelimit_name.sh
+++ b/tests/omfwd_ratelimit_name.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Test named rate limits for omfwd (config-validation)
+# Verifies that omfwd accepts ratelimit.name without error.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+ratelimit(name="omfwd_test_limit" interval="2" burst="5")
+
+module(load="../plugins/imudp/.libs/imudp")
+input(type="imudp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr.port")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "msgnum:" then
+    action(type="omfwd" target="127.0.0.1" port="514" protocol="udp"
+           ratelimit.name="omfwd_test_limit" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/omhttp_ratelimit_name.sh
+++ b/tests/omhttp_ratelimit_name.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# Test named rate limits for omhttp (config-validation)
+# Verifies that omhttp accepts ratelimit.name without error.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+ratelimit(name="omhttp_test_limit" interval="2" burst="5")
+
+module(load="../contrib/omhttp/.libs/omhttp")
+
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omhttp" server="localhost" serverport="19280"
+       ratelimit.name="omhttp_test_limit"
+       retryfailures="on" template="outfmt")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test


### PR DESCRIPTION
Why: Commit 3ee31a8d0 added shared named ratelimit support (ratelimit.name + ratelimitNewFromConfig) but only wired it into imtcp, imptcp, and imudp. Seven modules with existing ratelimit.interval/ratelimit.burst support were left without the ability to reference shared ratelimit() objects.

Impact: Adds ratelimit.name parameter to omfwd,
omelasticsearch, omhttp, imhttp, imjournal, imklog, and imuxsock. Existing configurations remain unchanged.

Before: These seven modules could only use inline
ratelimit.interval/ratelimit.burst parameters.
After: All modules can now reference shared ratelimit() configuration objects via ratelimit.name.

Technical Overview:
For each module, the same pattern from the imudp reference implementation is applied:
- Add uchar *pszRatelimitName to config struct
- Add ratelimit.name to cnfparamdescr
- Change interval/burst defaults to -1 (sentinel)
- Parse ratelimit.name in config handler
- Add mutual-exclusivity check (name vs interval/burst)
- Branch ratelimiter creation on pszRatelimitName: if set, call ratelimitNewFromConfig(); else legacy path
- Free pszRatelimitName in destructor

imuxsock is the most complex: it supports both per-socket ratelimit.name and syssock.ratelimit.name, with the per-source hashtable ratelimiter path also updated.

imklog uses legacy parameter names (ratelimitinterval, ratelimitburst) but the new parameter uses the dotted form (ratelimit.name) for consistency.

Each module receives a parameter doc page, module doc update, and a config-validation test.

With the help of AI-Agents: GitHub Copilot
