### PR TITLE
omusrmsg: add ratelimit support

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1088,6 +1088,7 @@ EXTRA_DIST = \
     source/reference/parameters/omudpspoof-sourcetemplate.rst \
     source/reference/parameters/omudpspoof-target.rst \
     source/reference/parameters/omudpspoof-template.rst \
+    source/reference/parameters/omusrmsg-ratelimit-name.rst \
     source/reference/parameters/omuxsock-abstract.rst \
     source/reference/parameters/omuxsock-networknamespace.rst \
     source/reference/parameters/omuxsock-socketname.rst \

--- a/doc/source/configuration/modules/omusrmsg.rst
+++ b/doc/source/configuration/modules/omusrmsg.rst
@@ -53,6 +53,44 @@ Template to user for the message. Default is WallFmt when parameter users is
 "*" and StdUsrMsgFmt otherwise.
 
 
+RateLimit.Interval
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "0", "no", "none"
+
+The rate-limiting interval in seconds. A value of 0 turns off rate-limiting.
+Set it together with ``ratelimit.burst`` to control how many messages can be
+forwarded per interval.
+
+
+RateLimit.Burst
+^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "default", "mandatory", "|FmtObsoleteName| directive"
+   :widths: auto
+   :class: parameter-table
+
+   "integer", "200", "no", "none"
+
+Maximum number of messages that can be emitted within the
+``ratelimit.interval``. This setting is only relevant if
+``ratelimit.interval`` is not 0.
+
+
+RateLimit.Name
+^^^^^^^^^^^^^^
+
+.. include:: ../../reference/parameters/omusrmsg-ratelimit-name.rst
+   :start-after: .. summary-start
+   :end-before: .. summary-end
+
+
 Examples
 ========
 

--- a/doc/source/reference/parameters/omusrmsg-ratelimit-name.rst
+++ b/doc/source/reference/parameters/omusrmsg-ratelimit-name.rst
@@ -1,0 +1,26 @@
+.. index:: ! omusrmsg; RateLimit.Name
+
+.. _param-omusrmsg-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. This allows multiple actions to share the same rate
+limiting configuration (and state). The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, local per-action limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2602.0
+
+.. summary-end

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -133,6 +133,7 @@ TESTS_DEFAULT = \
 	omfile-subtree-jsonf.sh \
 	omusrmsg-errmsg-no-params.sh \
 	omusrmsg-noabort.sh \
+	omusrmsg_ratelimit_name.sh \
 	omfile-module-params.sh \
 	omfile-read-only-errmsg.sh \
 	omfile-null-filename.sh \

--- a/tests/omusrmsg_ratelimit_name.sh
+++ b/tests/omusrmsg_ratelimit_name.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Test for omusrmsg ratelimit.name support (config-validation test).
+# added 2025-07-10 by RGerhards, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+ratelimit(name="omusrmsg_test_limit" interval="2" burst="5")
+
+:msg, contains, "msgnum:" {
+    action(type="omusrmsg" users="nouser"
+           ratelimit.name="omusrmsg_test_limit")
+}
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -88,6 +88,7 @@
 #include "omusrmsg.h"
 #include "module-template.h"
 #include "errmsg.h"
+#include "ratelimit.h"
 
 
 /* portability: */
@@ -118,11 +119,21 @@ typedef struct _instanceData {
     int bIsWall; /* 1- is wall, 0 - individual users */
     char uname[MAXUNAMES][UNAMESZ + 1];
     uchar *tplName;
+    int ratelimitInterval;
+    int ratelimitBurst;
+    uchar *pszRatelimitName;
+    ratelimit_t *ratelimiter;
 } instanceData;
 
 typedef struct wrkrInstanceData {
     instanceData *pData;
 } wrkrInstanceData_t;
+
+struct modConfData_s {
+    rsconf_t *pConf;
+};
+static modConfData_t *loadModConf = NULL;
+static modConfData_t *runModConf = NULL;
 
 typedef struct configSettings_s {
     EMPTY_STRUCT
@@ -133,12 +144,44 @@ static configSettings_t __attribute__((unused)) cs;
 /* tables for interfacing with the v6 config system */
 /* action (instance) parameters */
 static struct cnfparamdescr actpdescr[] = {{"users", eCmdHdlrString, CNFPARAM_REQUIRED},
-                                           {"template", eCmdHdlrGetWord, 0}};
+                                           {"template", eCmdHdlrGetWord, 0},
+                                           {"ratelimit.interval", eCmdHdlrInt, 0},
+                                           {"ratelimit.burst", eCmdHdlrInt, 0},
+                                           {"ratelimit.name", eCmdHdlrString, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 BEGINinitConfVars /* (re)set config variables to default values */
     CODESTARTinitConfVars;
 ENDinitConfVars
+
+
+BEGINbeginCnfLoad
+    CODESTARTbeginCnfLoad;
+    loadModConf = pModConf;
+    pModConf->pConf = pConf;
+ENDbeginCnfLoad
+
+
+BEGINendCnfLoad
+    CODESTARTendCnfLoad;
+    loadModConf = NULL;
+ENDendCnfLoad
+
+
+BEGINcheckCnf
+    CODESTARTcheckCnf;
+ENDcheckCnf
+
+
+BEGINactivateCnf
+    CODESTARTactivateCnf;
+    runModConf = pModConf;
+ENDactivateCnf
+
+
+BEGINfreeCnf
+    CODESTARTfreeCnf;
+ENDfreeCnf
 
 
 BEGINcreateInstance
@@ -160,6 +203,11 @@ ENDisCompatibleWithFeature
 BEGINfreeInstance
     CODESTARTfreeInstance;
     free(pData->tplName);
+    free(pData->pszRatelimitName);
+    if (pData->ratelimiter != NULL) {
+        ratelimitDestruct(pData->ratelimiter);
+        pData->ratelimiter = NULL;
+    }
 ENDfreeInstance
 
 
@@ -404,7 +452,10 @@ ENDtryResume
 BEGINdoAction
     CODESTARTdoAction;
     dbgprintf("\n");
-    iRet = wallmsg(ppString[0], pWrkrData->pData);
+    if (pWrkrData->pData->ratelimiter == NULL ||
+        ratelimitMsgCount(pWrkrData->pData->ratelimiter, 0, "omusrmsg") != RS_RET_DISCARDMSG) {
+        iRet = wallmsg(ppString[0], pWrkrData->pData);
+    }
 ENDdoAction
 
 
@@ -470,6 +521,10 @@ populateUsers(instanceData *pData, es_str_t *usrs)
 static inline void setInstParamDefaults(instanceData *pData) {
     pData->bIsWall = 0;
     pData->tplName = NULL;
+    pData->ratelimiter = NULL;
+    pData->ratelimitInterval = -1;
+    pData->ratelimitBurst = -1;
+    pData->pszRatelimitName = NULL;
 }
 
 BEGINnewActInst
@@ -494,6 +549,12 @@ BEGINnewActInst
             }
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
             pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+        } else if (!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
+            pData->ratelimitInterval = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "ratelimit.burst")) {
+            pData->ratelimitBurst = (int)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "ratelimit.name")) {
+            pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
         } else {
             dbgprintf(
                 "omusrmsg: program error, non-handled "
@@ -502,12 +563,36 @@ BEGINnewActInst
         }
     }
 
+    if (pData->pszRatelimitName != NULL) {
+        if (pData->ratelimitInterval != -1 || pData->ratelimitBurst != -1) {
+            LogError(0, RS_RET_INVALID_PARAMS,
+                     "omusrmsg: ratelimit.name is mutually exclusive with "
+                     "ratelimit.interval and ratelimit.burst - using ratelimit.name");
+        }
+        pData->ratelimitInterval = 0;
+        pData->ratelimitBurst = 0;
+    } else {
+        if (pData->ratelimitInterval == -1) pData->ratelimitInterval = 0;
+        if (pData->ratelimitBurst == -1) pData->ratelimitBurst = 200;
+    }
+
     if (pData->tplName == NULL) {
         CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar *)strdup(pData->bIsWall ? " WallFmt" : " StdUsrMsgFmt"),
                              OMSR_NO_RQD_TPL_OPTS));
     } else {
         CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar *)strdup((char *)pData->tplName), OMSR_NO_RQD_TPL_OPTS));
     }
+
+    if (pData->pszRatelimitName != NULL) {
+        CHKiRet(ratelimitNewFromConfig(&pData->ratelimiter, loadModConf->pConf, (char *)pData->pszRatelimitName,
+                                       "omusrmsg", NULL));
+        ratelimitSetNoTimeCache(pData->ratelimiter);
+    } else if (pData->ratelimitInterval > 0) {
+        CHKiRet(ratelimitNew(&pData->ratelimiter, "omusrmsg", NULL));
+        ratelimitSetLinuxLike(pData->ratelimiter, (unsigned)pData->ratelimitInterval, (unsigned)pData->ratelimitBurst);
+        ratelimitSetNoTimeCache(pData->ratelimiter);
+    }
+
     CODE_STD_FINALIZERnewActInst;
     cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst
@@ -568,6 +653,7 @@ BEGINqueryEtryPt
     CODESTARTqueryEtryPt;
     CODEqueryEtryPt_STD_OMOD_QUERIES;
     CODEqueryEtryPt_STD_OMOD8_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_QUERIES;
     CODEqueryEtryPt_STD_CONF2_OMOD_QUERIES;
 ENDqueryEtryPt
 


### PR DESCRIPTION
Add ratelimit.interval, ratelimit.burst, and ratelimit.name parameters to omusrmsg. This prevents DoS scenarios where emergency message floods can overwhelm user terminals.

The implementation follows the established output module pattern:
- Sentinel-based (-1) defaults for mutual-exclusivity detection
- ratelimit.name references a shared ratelimit() configuration object
- Per-action ratelimiters via ratelimitNew()/ratelimitSetLinuxLike()
- ratelimitMsgCount() gate in doAction

Also adds module-level config (modConfData_s) with beginCnfLoad, endCnfLoad, checkCnf, activateCnf, freeCnf entry points, needed to stash rsconf_t* for ratelimitNewFromConfig().

Includes documentation updates and a config-validation test.

Closes: https://github.com/rsyslog/rsyslog/issues/4547
