### PR TITLE
imrelp: add ratelimit support (interval, burst, name)

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -625,6 +625,7 @@ EXTRA_DIST = \
     source/reference/parameters/imrelp-name.rst \
     source/reference/parameters/imrelp-oversizemode.rst \
     source/reference/parameters/imrelp-port.rst \
+    source/reference/parameters/imrelp-ratelimit-name.rst \
     source/reference/parameters/imrelp-ruleset-input.rst \
     source/reference/parameters/imrelp-ruleset.rst \
     source/reference/parameters/imrelp-tls-authmode.rst \

--- a/doc/source/configuration/modules/imrelp.rst
+++ b/doc/source/configuration/modules/imrelp.rst
@@ -160,6 +160,18 @@ Input Parameters
      - .. include:: ../../reference/parameters/imrelp-flowcontrol.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - RateLimit.Interval
+     - The rate-limiting interval in seconds. A value of 0 (the default) turns
+       off rate-limiting. Set it together with ``ratelimit.burst`` to control
+       how many messages can be forwarded per interval.
+   * - RateLimit.Burst
+     - Maximum number of messages that can be emitted within the
+       ``ratelimit.interval``. Default is 10000. Only relevant when
+       ``ratelimit.interval`` is not 0.
+   * - :ref:`param-imrelp-ratelimit-name`
+     - .. include:: ../../reference/parameters/imrelp-ratelimit-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
 
 
 About Chained Certificates
@@ -265,4 +277,5 @@ actual deployments. For details, see parameter descriptions.
    ../../reference/parameters/imrelp-keepalive-time
    ../../reference/parameters/imrelp-oversizemode
    ../../reference/parameters/imrelp-flowcontrol
+   ../../reference/parameters/imrelp-ratelimit-name
 

--- a/doc/source/reference/parameters/imrelp-ratelimit-name.rst
+++ b/doc/source/reference/parameters/imrelp-ratelimit-name.rst
@@ -1,0 +1,29 @@
+.. index:: ! imrelp; RateLimit.Name
+
+.. _param-imrelp-ratelimit-name:
+
+RateLimit.Name
+==============
+
+.. summary-start
+
+**Default:** none
+
+**Type:** string
+
+**Description:**
+
+Sets the name of the rate limit to use. All listeners (even across different modules) that
+reference the same name share the same rate limiting configuration and per-source tracking
+state. Each listener still maintains its own basic message counters so that independent input
+streams are rate-limited individually.
+The name refers to a :doc:`global rate limit object
+<../../rainerscript/configuration_objects/ratelimit>` defined in the configuration.
+
+**Note:** This parameter is mutually exclusive with ``ratelimit.interval`` and
+``ratelimit.burst``. If ``ratelimit.name`` is specified, local per-listener limits cannot be
+defined and any attempt to do so will result in an error (and the named rate limit will be used).
+
+.. versionadded:: 8.2604.0
+
+.. summary-end

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1409,6 +1409,7 @@ TESTS_RELP = \
 	 imrelp-oversizeMode-accept.sh \
 	 imrelp-invld-tlslib.sh \
 	 imrelp-bigmessage.sh \
+	 imrelp_ratelimit_name.sh \
 	 omrelp-invld-tlslib.sh \
 	 sndrcv_relp_dflt_pt.sh \
 	 glbl-oversizeMsg-log.sh \

--- a/tests/imrelp_ratelimit_name.sh
+++ b/tests/imrelp_ratelimit_name.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Test named rate limits for imrelp
+# added 2025-07-15 by Copilot, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+skip_ARM "ratelimit timing flaky on ARM"
+export SENDMESSAGES=20
+export NUMMESSAGES=5 # used by wait_file_lines (QUEUE_EMPTY_CHECK_FUNC); matches burst
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+
+generate_conf
+add_conf '
+ratelimit(name="imrelp_test_limit" interval="2" burst="5")
+
+module(load="../plugins/imrelp/.libs/imrelp")
+input(type="imrelp" port="'$TCPFLOOD_PORT'" ratelimit.name="imrelp_test_limit")
+
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "msgnum:" then
+    action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+startup
+
+tcpflood -Trelp-plain -p$TCPFLOOD_PORT -m $SENDMESSAGES
+
+shutdown_when_empty
+wait_shutdown
+
+content_count=$(grep -c "msgnum:" $RSYSLOG_OUT_LOG)
+echo "content_count: $content_count"
+
+if [ $content_count -eq $SENDMESSAGES ]; then
+    echo "FAIL: No rate limiting occurred (received all $content_count messages)"
+    error_exit 1
+fi
+
+if [ $content_count -eq 0 ]; then
+    echo "FAIL: All messages lost or dropped (received 0)"
+    error_exit 1
+fi
+
+echo "SUCCESS: Rate limiting occurred (received $content_count/$SENDMESSAGES)"
+exit_test


### PR DESCRIPTION
Wire `ratelimit.interval`, `ratelimit.burst`, and `ratelimit.name` into **imrelp**, following the established pattern from imtcp/imptcp/imudp.

When `ratelimit.name` is set, the listener uses a shared named rate limiter (with per-source support). Local interval/burst and named rate limiters are mutually exclusive.

### Changes
- **plugins/imrelp/imrelp.c**: Added ratelimit fields to instance config, ratelimiter creation in `addListner`, rate-limiting gate in `onSyslogRcv`, param parsing with mutual-exclusivity check, cleanup in `freeCnf`
- **doc/source/reference/parameters/imrelp-ratelimit-name.rst**: New parameter reference page
- **doc/source/configuration/modules/imrelp.rst**: Added ratelimit params to input parameters table and toctree
- **doc/Makefile.am**: Registered new rst file
- **tests/imrelp_ratelimit_name.sh**: Integration test verifying named rate limiting
- **tests/Makefile.am**: Registered test

Closes #6597