### PR TITLE
imjournal docs: FileCreateMode was introduced in v8.2306.0

### DIFF
--- a/doc/source/reference/parameters/imjournal-filecreatemode.rst
+++ b/doc/source/reference/parameters/imjournal-filecreatemode.rst
@@ -25,7 +25,7 @@ This parameter applies to :doc:`../../configuration/modules/imjournal`.
 :Type: integer
 :Default: module=0644
 :Required?: no
-:Introduced: at least 8.x, possibly earlier
+:Introduced: 8.2306.0
 
 Description
 -----------


### PR DESCRIPTION
### Summary (non-technical, complete)

This documents somewhat more precisely when the FileCreateMode parameter for imjournal was introduced. The documented behaviour produces parse errors in rsyslog versions shipped with Debian 12, Ubuntu 22.04 and RHEL 8, so adding precision may be worthwhile. This might clear this up.

### References

See commit: https://github.com/rsyslog/rsyslog/commit/4abe60f526b824cd4318be14ca9f30c9a7894bd8. Diff between subsequent tags: https://github.com/rsyslog/rsyslog/compare/v8.2304.0...v8.2306.0