### PR TITLE
docs: remove -c5 from troubleshooting example

### DIFF
--- a/doc/source/troubleshooting/troubleshoot.rst
+++ b/doc/source/troubleshooting/troubleshoot.rst
@@ -265,7 +265,7 @@ can also be controlled via some environment options. Please see
 
 In general, it is advisable to run rsyslogd in the foreground to obtain
 the log. To do so, make sure you know which options are usually used
-when you start rsyslogd as a background daemon. Let's assume "-c5" is
+when you start rsyslogd as a background daemon. Let's assume "-iNONE" is
 the only option used. Then, do the following:
 
 -  make sure rsyslogd as a daemon is stopped (verify with ps -ef\|grep
@@ -276,7 +276,7 @@ the only option used. Then, do the following:
    where "your options" is what you usually use. /sbin/rsyslogd is the
    full path to the rsyslogd binary (location different depending on
    distro). In our case, the command would be
-   ```/sbin/rsyslogd -c5 -dn > logfile```
+   ```/sbin/rsyslogd -iNONE -dn > logfile```
 -  press ctrl-C when you have sufficient data (e.g. a device logged a
    record)
    **NOTE: rsyslogd will NOT stop automatically - you need to ctrl-c out


### PR DESCRIPTION
The -c flag has been removed. The deprecation warning in the manpages was removed in 2014, with v8.6.0.

Commit: https://github.com/rsyslog/rsyslog/commit/79b7c05331a0fd97be2790ad40519de5473cabac

Diff between tagged versions: https://github.com/rsyslog/rsyslog/compare/v8.5.0...v8.6.0