### PR TITLE
docs: clarify PrioritizeSAN fallback behavior and auth mode prerequisite

### DIFF
--- a/doc/source/concepts/ns_gtls.rst
+++ b/doc/source/concepts/ns_gtls.rst
@@ -87,5 +87,13 @@ PrioritizeSAN
    allowed.
 
 -  **on** - if you turn this option on, it will perform stricter name checking
-   as per newer RFC 6125, where, if any SAN is found, contents of CN are 
-   completely ignored and name validity is decided based on SAN only. 
+   as per newer RFC 6125, where, if any SAN is found, contents of CN are
+   completely ignored and name validity is decided based on SAN only.
+
+.. note::
+
+   When set to "on" and the certificate contains *no* SAN entries at all,
+   validation falls back to checking the CN — certificates are not rejected
+   simply for lacking SANs. Also, this setting only affects name-checking
+   auth modes (``x509/name``). It has no effect when using ``x509/certvalid``,
+   which does not perform name matching.

--- a/doc/source/concepts/ns_mbedtls.rst
+++ b/doc/source/concepts/ns_mbedtls.rst
@@ -86,3 +86,11 @@ PrioritizeSAN
 -  **on** - if you turn this option on, it will perform stricter name checking
    as per newer RFC 6125, where, if any SAN is found, contents of CN are
    completely ignored and name validity is decided based on SAN only.
+
+.. note::
+
+   When set to "on" and the certificate contains *no* SAN entries at all,
+   validation falls back to checking the CN — certificates are not rejected
+   simply for lacking SANs. Also, this setting only affects name-checking
+   auth modes (``x509/name``). It has no effect when using ``x509/certvalid``,
+   which does not perform name matching.

--- a/doc/source/concepts/ns_ossl.rst
+++ b/doc/source/concepts/ns_ossl.rst
@@ -83,5 +83,13 @@ PrioritizeSAN
    allowed.
 
 -  **on** - if you turn this option on, it will perform stricter name checking
-   as per newer RFC 6125, where, if any SAN is found, contents of CN are 
-   completely ignored and name validity is decided based on SAN only. 
+   as per newer RFC 6125, where, if any SAN is found, contents of CN are
+   completely ignored and name validity is decided based on SAN only.
+
+.. note::
+
+   When set to "on" and the certificate contains *no* SAN entries at all,
+   validation falls back to checking the CN — certificates are not rejected
+   simply for lacking SANs. Also, this setting only affects name-checking
+   auth modes (``x509/name``). It has no effect when using ``x509/certvalid``,
+   which does not perform name matching.

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -706,6 +706,14 @@ StreamDriver.PrioritizeSAN
 
 Whether to use stricter SAN/CN matching. (driver-specific)
 
+When set to "on", if any SAN is found in the peer certificate, only the SAN is
+used for name validation and the CN is ignored (per RFC 6125). If the
+certificate contains *no* SAN entries at all, validation falls back to checking
+the CN — certificates are not rejected simply for lacking SANs.
+
+This setting only affects name-checking auth modes (``x509/name``). It has no
+effect when using ``x509/certvalid``, which does not perform name matching.
+
 
 StreamDriver.TlsVerifyDepth
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/reference/parameters/imtcp-streamdriver-prioritizesan.rst
+++ b/doc/source/reference/parameters/imtcp-streamdriver-prioritizesan.rst
@@ -28,6 +28,14 @@ Description
 -----------
 Whether to use stricter SAN/CN matching. (driver-specific)
 
+When set to "on", if any SAN is found in the peer certificate, only the SAN is
+used for name validation and the CN is ignored (per RFC 6125). If the
+certificate contains *no* SAN entries at all, validation falls back to checking
+the CN — certificates are not rejected simply for lacking SANs.
+
+This setting only affects name-checking auth modes (``x509/name``). It has no
+effect when using ``x509/certvalid``, which does not perform name matching.
+
 The same-named input parameter can override this module setting.
 
 


### PR DESCRIPTION
Clarify across all TLS driver docs (GnuTLS, OpenSSL, MbedTLS), omfwd, and imtcp parameter reference that  `PrioritizeSAN="on"` does **not** reject certificates lacking SANs - validation falls back to CN.

The existing documentation is technically correct but too terse, it never explicitly states the CN fallback behavior (per RFC 6125) or the auth mode prerequisite.