### PR TITLE
github: assign maintainers to CODEOWNERS coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,15 @@
-.github/workflows/*.yml @rgerhards
-.github/workflows/*.yaml @rgerhards
+# Security-sensitive repository metadata
+/.gitmodules @rgerhards @alorbach
+/.gitattributes @rgerhards @alorbach
+
+# CI workflows
+/.github/workflows/* @rgerhards @alorbach
+
+# Build and release tooling
+/autogen.sh @rgerhards @alorbach
+/configure.ac @rgerhards @alorbach
+/Makefile.am @rgerhards @alorbach
+/devtools/ @rgerhards @alorbach
+
+# Default ownership for the core source tree and all other repository paths
+* @rgerhards @alorbach


### PR DESCRIPTION
## Summary
Extend CODEOWNERS coverage for security-sensitive repository areas so
GitHub can deterministically require maintainer review.

## Why
The existing file only covered workflow globs and only assigned one
owner. This change explicitly covers repository metadata, CI workflows,
build and release tooling, and the default source tree.

## Testing
Not run. This is a repository policy change only.
