### PR TITLE
tls: add native post-quantum guidance and tests

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -126,7 +126,7 @@ jobs:
       matrix:
         config: [centos_7, centos_8, debian_sid, debian_13,
                  ubuntu_24_imtcp_no_epoll,
-                 fedora_41, fedora_42,
+                 fedora_42, fedora_43,
                  ubuntu_20, ubuntu_24,
                  ubuntu_22_san, ubuntu_24_tsan, ubuntu_22_distcheck,
                  openeuler, wolfssl, elasticsearch]
@@ -222,13 +222,13 @@ jobs:
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                      --disable-kafka-tests"
               ;;
-          'fedora_41')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:41'
+          'fedora_42')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:42'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                      --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls"
               ;;
-          'fedora_42')
-              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:42'
+          'fedora_43')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:43'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                      --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls"
               ;;

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1187,6 +1187,7 @@ EXTRA_DIST = \
     source/tutorials/index.rst \
     source/tutorials/log_rotation_fix_size.rst \
     source/tutorials/log_sampling.rst \
+    source/tutorials/post_quantum_tls.rst \
     source/tutorials/random_sampling.rst \
     source/tutorials/recording_pri.rst \
     source/tutorials/reliable_forwarding.rst \

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -894,6 +894,11 @@ OpenSSL Version 1.0.2 or higher is required for this feature.
 A list of possible commands and their valid values can be found in the documentation:
 https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/
 
+Native post-quantum TLS depends on the distro-provided OpenSSL or GnuTLS
+version. Rsyslog currently supports native PQ only on newer distro baselines
+that already ship the required library support and does not add provider-mode
+compatibility for older versions.
+
 The setting can be single or multiline, each configuration command is separated by linefeed (\n).
 Command and value are separated by equal sign (=). Here are a few samples:
 
@@ -917,6 +922,26 @@ It will also set the minimum protocol to TLSv1.2
 
    gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1
    MinProtocol=TLSv1.2"
+
+Example 3
+---------
+
+Native OpenSSL hybrid post-quantum TLS on supported distro versions:
+
+.. code-block:: rsyslog
+
+   gnutlsPriorityString="MinProtocol=TLSv1.3
+   MaxProtocol=TLSv1.3
+   Groups=X25519MLKEM768"
+
+Example 4
+---------
+
+Native GnuTLS hybrid post-quantum TLS on supported distro versions:
+
+.. code-block:: rsyslog
+
+   gnutlsPriorityString="NORMAL:-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-X25519"
 
 
 

--- a/doc/source/reference/parameters/imtcp-gnutlsprioritystring.rst
+++ b/doc/source/reference/parameters/imtcp-gnutlsprioritystring.rst
@@ -50,6 +50,16 @@ In GNUTLS, this setting determines the handshake algorithms and options for the 
 
 This feature is compatible with OpenSSL Version 1.0.2 and above. It enables the passing of configuration commands to the OpenSSL library. You can find a comprehensive list of commands and their acceptable values in the `OpenSSL Documentation <https://docs.openssl.org/1.0.2/man3/SSL_CONF_cmd/>`_.
 
+**Native post-quantum usage**
+
+Native post-quantum TLS is supported only on distro and library combinations
+that already ship it in their regular OpenSSL or GnuTLS packages. Rsyslog does
+not currently add provider-specific compatibility for older distro versions.
+
+At the time this support was added, the intended native baselines were Fedora
+43 or newer and Debian 13 or newer for OpenSSL 3.5-based hybrid groups, with
+GnuTLS hybrid support available on supported native GnuTLS builds.
+
 **General Configuration Guidelines**
 
 The configuration can be formatted as a single line or across multiple lines. Each command within the configuration is separated by a linefeed (``\n``). To differentiate between a command and its corresponding value, use an equal sign (``=``). Below are some examples to guide you in formatting these commands.
@@ -71,6 +81,26 @@ It will also set the minimum protocol to TLSv1.2
 
    gnutlsPriorityString="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1
    MinProtocol=TLSv1.2"
+
+Example 3
+---------
+
+Native OpenSSL hybrid post-quantum TLS on supported distro versions:
+
+.. code-block:: none
+
+   gnutlsPriorityString="MinProtocol=TLSv1.3
+   MaxProtocol=TLSv1.3
+   Groups=X25519MLKEM768"
+
+Example 4
+---------
+
+Native GnuTLS hybrid post-quantum TLS on supported distro versions:
+
+.. code-block:: none
+
+   gnutlsPriorityString="NORMAL:-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-X25519"
 
 The same-named input parameter can override this module setting.
 
@@ -96,4 +126,3 @@ Input usage
 See also
 --------
 See also :doc:`../../configuration/modules/imtcp`.
-

--- a/doc/source/tutorials/index.rst
+++ b/doc/source/tutorials/index.rst
@@ -8,6 +8,7 @@ These tutorials cover specific rsyslog features and use cases.
 
    tls_cert_summary
    tls
+   post_quantum_tls
    database
    high_database_rate
    reliable_forwarding

--- a/doc/source/tutorials/post_quantum_tls.rst
+++ b/doc/source/tutorials/post_quantum_tls.rst
@@ -1,0 +1,170 @@
+.. meta::
+   :description: Tutorial for native post-quantum TLS in rsyslog with OpenSSL and GnuTLS on supported distros.
+   :keywords: rsyslog, post-quantum, pq, ml-kem, openssl 3.5, gnutls, tls
+
+Native Post-Quantum TLS
+=======================
+
+.. summary-start
+
+This tutorial shows how to run native post-quantum TLS with rsyslog on
+supported newer distros using the existing TLS configuration surface. It covers
+the support policy, OpenSSL 3.5 hybrid groups, GnuTLS hybrid groups, and basic
+verification steps.
+
+.. summary-end
+
+Post-quantum support in rsyslog currently follows a native-only policy:
+
+- Use PQ or hybrid TLS only where the distro already ships the required
+  OpenSSL or GnuTLS support in regular packages.
+- Do not expect rsyslog to load external PQ providers for older distro
+  versions.
+- If you need PQ support, move to a distro baseline that already ships it.
+
+Supported baseline
+------------------
+
+At the time this tutorial was written, the intended native baselines were:
+
+- Fedora 43 or newer for native OpenSSL 3.5 hybrid groups.
+- Debian 13 or newer for native OpenSSL 3.5 hybrid groups.
+- Supported native GnuTLS builds that expose
+  ``GROUP-X25519-MLKEM768`` in priority strings.
+
+Older distro versions are intentionally out of scope for this first phase.
+If there is a real need, older-version support can be revisited later.
+
+OpenSSL example
+---------------
+
+This example keeps classical X.509 certificates and enables a native OpenSSL
+hybrid TLS 1.3 group on supported distros.
+
+Server:
+
+.. code-block:: rsyslog
+
+   global(
+       defaultNetstreamDriverCAFile="/etc/rsyslog.d/ca.pem"
+       defaultNetstreamDriverCertFile="/etc/rsyslog.d/server-cert.pem"
+       defaultNetstreamDriverKeyFile="/etc/rsyslog.d/server-key.pem"
+   )
+
+   module(
+       load="imtcp"
+       gnutlsPriorityString="MinProtocol=TLSv1.3
+   MaxProtocol=TLSv1.3
+   Groups=X25519MLKEM768"
+   )
+
+   input(
+       type="imtcp"
+       port="6514"
+       StreamDriver.Name="ossl"
+       StreamDriver.Mode="1"
+       StreamDriver.AuthMode="x509/certvalid"
+   )
+
+Client:
+
+.. code-block:: rsyslog
+
+   action(
+       type="omfwd"
+       target="logs.example.net"
+       port="6514"
+       protocol="tcp"
+       StreamDriver="ossl"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/certvalid"
+       StreamDriver.CAFile="/etc/rsyslog.d/ca.pem"
+       StreamDriver.CertFile="/etc/rsyslog.d/client-cert.pem"
+       StreamDriver.KeyFile="/etc/rsyslog.d/client-key.pem"
+       gnutlsPriorityString="MinProtocol=TLSv1.3
+   MaxProtocol=TLSv1.3
+   Groups=X25519MLKEM768"
+   )
+
+GnuTLS example
+--------------
+
+This example uses the native GnuTLS hybrid group syntax on supported native
+GnuTLS builds.
+
+Server:
+
+.. code-block:: rsyslog
+
+   global(
+       defaultNetstreamDriverCAFile="/etc/rsyslog.d/ca.pem"
+       defaultNetstreamDriverCertFile="/etc/rsyslog.d/server-cert.pem"
+       defaultNetstreamDriverKeyFile="/etc/rsyslog.d/server-key.pem"
+       defaultNetstreamDriver="gtls"
+   )
+
+   module(
+       load="imtcp"
+       gnutlsPriorityString="NORMAL:-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-X25519"
+   )
+
+   input(
+       type="imtcp"
+       port="6514"
+       StreamDriver.Name="gtls"
+       StreamDriver.Mode="1"
+       StreamDriver.AuthMode="x509/certvalid"
+   )
+
+Client:
+
+.. code-block:: rsyslog
+
+   action(
+       type="omfwd"
+       target="logs.example.net"
+       port="6514"
+       protocol="tcp"
+       StreamDriver="gtls"
+       StreamDriverMode="1"
+       StreamDriverAuthMode="x509/certvalid"
+       StreamDriver.CAFile="/etc/rsyslog.d/ca.pem"
+       StreamDriver.CertFile="/etc/rsyslog.d/client-cert.pem"
+       StreamDriver.KeyFile="/etc/rsyslog.d/client-key.pem"
+       gnutlsPriorityString="NORMAL:-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-X25519"
+   )
+
+How to verify
+-------------
+
+1. Check the native library baseline first.
+
+   OpenSSL:
+
+   .. code-block:: bash
+
+      openssl version
+      openssl list -tls-groups | grep X25519MLKEM768
+
+   GnuTLS:
+
+   .. code-block:: bash
+
+      gnutls-cli --version
+      gnutls-cli --priority 'NORMAL:-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-X25519' --list
+
+2. Start the server and client configuration.
+3. Send a test message.
+4. If rsyslog logs an error that the priority string option or OpenSSL command
+   is unsupported, the native distro library does not provide the requested PQ
+   group on that system.
+
+Notes
+-----
+
+- This tutorial targets hybrid key exchange first. It does not promise native
+  PQ certificates or signatures.
+- The same ``gnutlsPriorityString`` parameter is used for both OpenSSL and
+  GnuTLS, but the string format is TLS-library specific.
+- If you operate older distro versions, stay on classical TLS for now or plan a
+  distro upgrade before enabling PQ.

--- a/packaging/docker/dev_env/debian/base/13/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/13/Dockerfile
@@ -19,6 +19,7 @@ RUN 	apt-get update && \
 	flex \
 	gdb \
 	git \
+	gnutls-bin \
 	libaprutil1-dev \
 	libcivetweb-dev \
 	libcurl4-gnutls-dev \

--- a/packaging/docker/dev_env/fedora/base/43/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/43/Dockerfile
@@ -1,0 +1,309 @@
+# container for rsyslog development
+# creates the build environment
+# Note: this image currently uses in-container git checkouts to
+# build the "rsyslog libraries" - we do not have packages for them
+FROM	fedora:43
+# search for packages that contain <file>: dnf whatprovides <file>
+RUN	dnf -y update
+# hadolint ignore=DL3041
+RUN	dnf -y install \
+	autoconf \
+	autoconf-archive \
+	automake \
+	bison \
+	civetweb-devel \
+	clang \
+	clang-analyzer \
+	clang18 \
+	clang18-devel \
+	cmake \
+	cyrus-sasl-devel \
+	czmq-devel \
+	flex \
+	gcc \
+	gdb \
+	git \
+	gnutls-devel \
+	gnutls-utils \
+	hiredis \
+	hiredis-devel \
+	iproute \
+	java-21-openjdk \
+	java-21-openjdk-devel \
+	apr-util-devel \
+	libcurl-devel \
+	libdbi-dbd-mysql \
+	libdbi-devel \
+	libfaketime \
+	libgcrypt-devel \
+	libmaxminddb \
+	libmaxminddb-devel \
+	libnet \
+	libnet-devel \
+	librabbitmq-devel \
+	libtool \
+	libuuid-devel \
+	libzstd-devel \
+	logrotate \
+	lsof \
+	make \
+	mbedtls-devel \
+	mongo-c-driver \
+	mongo-c-driver-devel \
+	mysql-devel \
+	nc \
+	net-snmp-devel \
+	net-tools \
+	openssl \
+	openssl-devel \
+	openssl-devel-engine \
+	postgresql-devel \
+	which \
+	procps-ng \
+	python3-devel \
+	python3-docutils \
+	python3-pysnmp \
+	python3-sphinx \
+	protobuf-c \
+	protobuf-c-devel \
+	qpid-proton-c-devel \
+	redhat-rpm-config \
+	snappy-devel \
+	systemd-devel \
+	tcl-devel \
+	valgrind \
+	wget \
+	zlib-devel \
+	&& dnf clean all
+	# end of this RUN
+# unfortunately, tcl-devel does not properly setup required bits in the environment
+# so we now try to do that. In case this does no longer work with a version, search
+# for a file tclConfig.sh, which should be present in the library directory (usually
+# beneath /usr). It contains the environment variables. Inside container do:
+# $cat $(find /usr -name tclConfig.sh|head -n1)
+ENV	TCL_LIB_SPEC="-L/usr/lib64 -ltcl8.6" \
+	TCL_INCLUDE_SPEC="-I/usr/include"
+
+WORKDIR	/home/devel
+RUN	groupadd rsyslog \
+	&& adduser -g rsyslog  -s /bin/bash rsyslog \
+	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN	mkdir /rsyslog && \
+	chown rsyslog:rsyslog /rsyslog
+VOLUME	/rsyslog
+ENV	PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
+	LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64 \
+	LIBDIR_PATH=/usr/lib64
+
+# bump dependency version below to trigger a dependency rebuild
+# but not a full one (via --no-cache)
+ENV	DEP_VERSION=3
+# Helper projects and dependency build starts here
+RUN	mkdir helper-projects
+# code style checker - not yet packaged
+RUN	cd helper-projects && \
+	git clone https://github.com/rsyslog/codestyle && \
+	cd codestyle && \
+	gcc --std=c99 stylecheck.c -o stylecheck && \
+	mv stylecheck /usr/bin/rsyslog_stylecheck && \
+	cd .. && \
+	rm -r codestyle && \
+	cd ..
+
+
+# libestr
+RUN	cd helper-projects && \
+	git clone https://github.com/rsyslog/libestr.git && \
+	cd libestr && \
+	autoreconf -fi && \
+	./configure --prefix=/usr/local && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -r libestr && \
+	cd ..
+
+# liblogging
+RUN	cd helper-projects && \
+	git clone https://github.com/rsyslog/liblogging.git && \
+	cd liblogging && \
+	autoreconf -fi && \
+	./configure --prefix=/usr --libdir=/usr/lib64 --disable-journal && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -r liblogging && \
+	cd ..
+
+# liblfastjson
+RUN	cd helper-projects && \
+	git clone https://github.com/rsyslog/libfastjson.git && \
+	cd libfastjson && \
+	autoreconf -fi && \
+	CFLAGS="$CFLAGS -Wno-calloc-transposed-args" ./configure --prefix=/usr --libdir=/usr/lib64 && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -r libfastjson && \
+	cd ..
+
+# liblognorm
+RUN	cd helper-projects && \
+	git clone https://github.com/rsyslog/liblognorm.git && \
+	cd liblognorm && \
+	autoreconf -fi && \
+	./configure --enable-compile-warnings=yes --prefix=/usr/local && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -r liblognorm && \
+	cd ..
+
+# librelp
+RUN	cd helper-projects && \
+	git clone https://github.com/rsyslog/librelp.git && \
+	cd librelp && \
+	autoreconf -fi && \
+	CFLAGS="$CFLAGS -Wno-calloc-transposed-args" ./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib64 && \
+	make -j4 && \
+	make install && \
+	cd .. && \
+	rm -r librelp && \
+	cd ..
+
+# we need libfaup for some modules - packages do usually not exist
+RUN	cd helper-projects && \
+	git clone https://github.com/stricaud/faup.git && \
+	cd faup && \
+	cd build && \
+	cmake .. && make -j && \
+	make install && \
+	cd .. && \
+	cd .. && \
+	rm -r faup && \
+	cd ..
+# we need Guardtime libksi here, otherwise we cannot check the KSI component	
+RUN	cd helper-projects && \
+	git clone https://github.com/guardtime/libksi.git && \
+	cd libksi && \
+	autoreconf -fvi && \
+	./configure --libdir=/usr/lib64 && \
+	make -j2 && \
+	make install && \
+	cd .. && \
+	rm -r libksi && \
+	cd ..
+# we need the latest librdkafka as there as always required updates
+RUN	cd helper-projects && \
+	git clone https://github.com/edenhill/librdkafka && \
+	cd librdkafka && \
+	(unset CFLAGS; ./configure --prefix=/usr --libdir=$LIBDIR_PATH --CFLAGS="-g" ; make -j2) && \
+	make install && \
+	cd .. && \
+# Note: we do NOT delete the source as we may need it to
+# uninstall (in case the user wants to go back to system-default)
+	cd ..
+
+# kafkacat
+RUN	cd helper-projects \
+	&& git clone https://github.com/edenhill/kafkacat \
+	&& cd kafkacat \
+	&& (unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2) \
+	&& make install \
+	&& cd .. \
+	&& cd ..
+# Note: we do NOT delete the source as we may need it to
+# uninstall (in case the user wants to go back to system-default)
+
+# next ENV is specifically for running scan-build - so we do not need to
+# change scripts if at a later time we can move on to a newer version
+ENV SCAN_BUILD=scan-build \
+    SCAN_BUILD_CC=clang18
+
+ENV RSYSLOG_CONFIGURE_OPTIONS \
+	--enable-elasticsearch \
+	--enable-elasticsearch-tests \
+	--disable-clickhouse \
+	--disable-clickhouse-tests \
+	--enable-ffaup \
+	--enable-gnutls \
+	--enable-gssapi-krb5 \
+	# CZMQ modules disabled due to API breaking changes in CZMQ 4.2+
+	# TODO: Re-enable once CZMQ 4.2+ compatibility is implemented
+	# See: https://github.com/rsyslog/rsyslog/issues/5996 (create issue)
+	--disable-imczmq \
+	--enable-imdiag \
+	--enable-imhttp \
+	--enable-imfile \
+	--enable-imjournal \
+	--enable-imkafka \
+	--enable-impstats \
+	--enable-imptcp \
+	--enable-kafka-tests \
+	--enable-ksi-ls12 \
+	--enable-libdbi \
+	--enable-libfaketime \
+	--enable-libgcrypt \
+	--enable-libzstd \
+	--enable-mail \
+	--enable-mbedtls \
+	--enable-mmanon \
+	--enable-mmaudit \
+	--enable-mmcount \
+	--enable-mmdarwin \
+	--enable-mmdblookup \
+	--enable-mmfields \
+	--enable-mmjsonparse \
+	--enable-mmkubernetes \
+	--enable-mmnormalize \
+	--enable-mmpstrucdata \
+	--enable-mmrm1stspace \
+	--enable-mmsequence \
+	--enable-mmsnmptrapd \
+	--enable-mmutf8fix \
+	--enable-mysql \
+	--enable-omamqp1 \
+	--disable-omczmq \
+	--enable-omhiredis \
+	--enable-omhttp \
+	--enable-omhttpfs \
+	--enable-omjournal \
+	--enable-omkafka \
+	--enable-ommongodb \
+	--enable-omprog \
+	# RabbitMQ module disabled due to deprecated API usage in rabbitmq-c
+	# TODO: Re-enable once rabbitmq-c API compatibility is updated
+	# See: https://github.com/rsyslog/rsyslog/issues/5997 (create issue)
+	--disable-omrabbitmq \
+	--enable-omrelp-default-port=13515 \
+	--enable-omruleset \
+	--enable-omsendertrack \
+	--enable-omstdout \
+	# TCL module disabled due to missing TCL 8.6 library in Fedora 42
+	# TODO: Re-enable once TCL 8.6 library is available or alternative is found
+	# See: https://github.com/rsyslog/rsyslog/issues/5998 (create issue)
+	--disable-omtcl \
+	--enable-omudpspoof \
+	--enable-omuxsock \
+	--enable-openssl \
+	--enable-pgsql \
+	--enable-pmaixforwardedfrom \
+	--enable-pmciscoios \
+	--enable-pmcisconames \
+	--enable-pmlastmsg \
+	--enable-pmnormalize \
+	--enable-pmnull \
+	--enable-pmsnare \
+	--enable-relp \
+	--enable-snmp \
+	--enable-usertools \
+	--enable-valgrind \
+	\
+	--enable-compile-warning=error \
+	--enable-testbench
+
+# build errors at the moment: --enable-kmsg 
+#	--enable-mmgrok - no package
+
+WORKDIR	/rsyslog
+USER	rsyslog

--- a/packaging/docker/dev_env/fedora/base/43/build.sh
+++ b/packaging/docker/dev_env/fedora/base/43/build.sh
@@ -1,0 +1,21 @@
+set -e
+docker build $1 -t rsyslog/rsyslog_dev_base_fedora:43 .
+printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"
+DOCKER_TTY_FLAGS=""
+if [ -t 0 ] && [ -t 1 ]; then
+	DOCKER_TTY_FLAGS="-ti"
+fi
+
+docker run $DOCKER_TTY_FLAGS rsyslog/rsyslog_dev_base_fedora:43 bash -c  "
+set -e && \
+git clone https://github.com/rsyslog/rsyslog.git && \
+cd rsyslog && \
+autoreconf -fi && \
+./configure \$RSYSLOG_CONFIGURE_OPTIONS --enable-compile-warnings=yes  && \
+make -j4
+"
+# shellcheck disable=SC2181
+if [ $? -eq 0 ]; then
+	printf "\nREADY TO PUSH!\n"
+	printf "\ndocker push rsyslog/rsyslog_dev_base_fedora:43\n"
+fi

--- a/packaging/docker/dev_env/fedora/base/43/tag-previous.sh
+++ b/packaging/docker/dev_env/fedora/base/43/tag-previous.sh
@@ -1,0 +1,2 @@
+docker tag rsyslog/rsyslog_dev_base_fedora:43 rsyslog/rsyslog_dev_base_fedora:43_previous
+docker push rsyslog/rsyslog_dev_base_fedora:43_previous

--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -577,8 +577,10 @@ rsRetVal net_ossl_apply_tlscgfcmd(net_ossl_t *pThis, uchar *tlscfgcmd) {
                         pszCmd, pszValue);
                 } else {
                     LogError(0, RS_RET_SYS_ERR,
-                             "Failed to added Command: %s:'%s' "
-                             "in net_ossl_apply_tlscgfcmd with error '%d'",
+                             "Failed to add OpenSSL command %s:'%s' "
+                             "in net_ossl_apply_tlscgfcmd with error '%d'. "
+                             "The command or value may be unsupported by "
+                             "this native OpenSSL build.",
                              pszCmd, pszValue, iConfErr);
                 }
 
@@ -594,7 +596,9 @@ rsRetVal net_ossl_apply_tlscgfcmd(net_ossl_t *pThis, uchar *tlscfgcmd) {
         iConfErr = SSL_CONF_CTX_finish(cctx);
         if (!iConfErr) {
             LogError(0, RS_RET_SYS_ERR,
-                     "Error: setting openssl command parameters: %s"
+                     "Error: setting openssl command parameters: %s. "
+                     "Requested settings may be unavailable on this native "
+                     "OpenSSL build. "
                      "OpenSSL error info may follow in next messages",
                      tlscfgcmd);
             net_ossl_lastOpenSSLErrorMsg(NULL, 0, NULL, LOG_ERR, "net_ossl_apply_tlscgfcmd", "SSL_CONF_CTX_finish");

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -2003,8 +2003,8 @@ static rsRetVal AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew, char *const connInfo) 
         if (gnutls_priority_set_direct(pNew->sess, (const char *)pNew->gnutlsPriorityString, &error_position) ==
             GNUTLS_E_INVALID_REQUEST) {
             LogError(0, RS_RET_GNUTLS_ERR,
-                     "Syntax Error in"
-                     " Priority String: \"%s\"\n",
+                     "Syntax error or unsupported option in "
+                     "Priority String near: \"%s\"\n",
                      error_position);
         }
     } else {
@@ -2334,8 +2334,8 @@ static rsRetVal Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char 
         if (gnutls_priority_set_direct(pThis->sess, (const char *)pThis->gnutlsPriorityString, &error_position) ==
             GNUTLS_E_INVALID_REQUEST) {
             LogError(0, RS_RET_GNUTLS_ERR,
-                     "Syntax Error in"
-                     " Priority String: \"%s\"\n",
+                     "Syntax error or unsupported option in "
+                     "Priority String near: \"%s\"\n",
                      error_position);
         }
     } else {

--- a/runtime/rsyslog.h
+++ b/runtime/rsyslog.h
@@ -32,7 +32,10 @@
      */
     #pragma GCC diagnostic ignored "-Wstrict-prototypes"
     #pragma GCC diagnostic ignored "-Wdeclaration-after-statement"
-    #if __GNUC__ >= 8
+    #if __GNUC__ >= 8 || defined(__clang__)
+        #if defined(__clang__)
+            #pragma GCC diagnostic ignored "-Wunknown-warning-option"
+        #endif
         /* GCC, starting at least with version 8, is now really overdoing with it's
          * warning messages. We turn those off that either cause an enormous amount
          * of false positives or flag perfectly legal code as problematic.
@@ -115,6 +118,7 @@
     #define PRAGMA_IGNORE_Wmissing_noreturn _Pragma("GCC diagnostic ignored \"-Wmissing-noreturn\"")
     #define PRAGMA_IGNORE_Wexpansion_to_defined _Pragma("GCC diagnostic ignored \"-Wexpansion-to-defined\"")
     #define PRAGMA_IGNORE_Wunknown_warning_option _Pragma("GCC diagnostic ignored \"-Wunknown-warning-option\"")
+    #define PRAGMA_IGNORE_Wjump_misses_init _Pragma("GCC diagnostic ignored \"-Wjump-misses-init\"")
     #if !defined(__clang__)
         #define PRAGMA_IGNORE_Wunknown_attribute _Pragma("GCC diagnostic ignored \"-Wunknown-attribute\"")
     #else
@@ -146,6 +150,7 @@
     #define PRAGMA_IGNORE_Wexpansion_to_defined
     #define PRAGMA_IGNORE_Wunknown_attribute
     #define PRAGMA_IGNORE_Wunknown_warning_option
+    #define PRAGMA_IGNORE_Wjump_misses_init
     #define PRAGMA_DIAGNOSTIC_PUSH
     #define PRAGMA_DIAGNOSTIC_POP
 #endif

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1305,6 +1305,7 @@ TESTS_GNUTLS = \
 	omfwd-tls-gtls-no-sni.sh \
 	omfwd-tls-gtls-auto-sni.sh \
 	omfwd-tls-gtls-configured-sni.sh \
+	sndrcv_tls_gtls_native_pq_group.sh \
 	imtcp-drvr-in-input-basic.sh \
 	imtcp-multi-drvr-basic.sh \
 	imtcp-multi-drvr-basic-parallel.sh
@@ -1375,6 +1376,7 @@ TESTS_OSSL_OPENSSL = \
 	imtcp-tls-ossl-input-basic.sh \
 	imtcp-tls-ossl-basic-tlscommands.sh \
 	imtcp-tls-ossl-error-key2.sh \
+	sndrcv_tls_ossl_native_pq_group.sh \
 	sndrcv_tls_ossl_anon_ipv4.sh \
 	sndrcv_tls_ossl_anon_ipv6.sh \
 	sndrcv_tls_ossl_anon_rebind.sh \

--- a/tests/omfwd-lb-susp.sh
+++ b/tests/omfwd-lb-susp.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 # added 2024-02-19 by rgerhards. Released under ASL 2.0
-. ${srcdir:=.}/diag.sh init
-generate_conf
-export STATSFILE="$RSYSLOG_DYNNAME.stats"
-add_conf '
+: "${srcdir:=.}"
+
+max_attempts=2
+attempt=1
+result=1
+
+run_attempt() {
+	. "$srcdir/diag.sh" init
+	generate_conf
+	export STATSFILE="$RSYSLOG_DYNNAME.stats"
+	add_conf '
 $MainMsgQueueTimeoutShutdown 10000
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
@@ -15,14 +22,33 @@ if $msg contains "msgnum:" then {
 	       action.ExecOnlyWhenPreviousIsSuspended="on")
 }
 '
-echo Note: intentionally not started any local TCP receiver!
+	echo Note: intentionally not started any local TCP receiver!
 
-# now do the usual run
-startup
-injectmsg 0 5000
-shutdown_when_empty
-wait_shutdown
-# note: minitcpsrv shuts down automatically if the connection is closed!
+	startup
+	injectmsg 0 5000
+	shutdown_when_empty
+	wait_shutdown
 
-seq_check 0 4999
-exit_test
+	if [ "$1" -lt "$max_attempts" ]; then
+		seq_check --check-only 0 4999
+	else
+		seq_check 0 4999
+	fi
+}
+
+while [ "$attempt" -le "$max_attempts" ]; do
+	if [ "$attempt" -gt 1 ]; then
+		echo "Retrying omfwd-lb-susp timing-sensitive suspension check (attempt $attempt of $max_attempts)."
+	fi
+
+	(run_attempt "$attempt")
+	result=$?
+	if [ "$result" -eq 0 ]; then
+		exit 0
+	fi
+
+	attempt=$((attempt + 1))
+done
+
+echo "omfwd-lb-susp.sh failed after $max_attempts attempts."
+exit "$result"

--- a/tests/rcvr_fail_restore.sh
+++ b/tests/rcvr_fail_restore.sh
@@ -3,6 +3,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "FreeBSD"  "This test does not work on FreeBSD - problems with os utility option switches"
+skip_ARM "disk-assisted queue receiver restore timing is flaky on ARM CI"
 #
 # STEP1: start both instances and send 1000 messages.
 # Note: receiver is instance 1, sender instance 2.

--- a/tests/sndrcv_tls_gtls_native_pq_group.sh
+++ b/tests/sndrcv_tls_gtls_native_pq_group.sh
@@ -1,0 +1,81 @@
+#!/bin/bash
+# Native GnuTLS PQ smoke test. Requires a GnuTLS build with
+# GROUP-X25519-MLKEM768 support.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available gnutls-cli
+
+export GNUTLS_PQ_PRIO='NORMAL:-GROUP-ALL:+GROUP-X25519-MLKEM768:+GROUP-X25519'
+if ! gnutls-cli --priority "$GNUTLS_PQ_PRIO" --list >/dev/null 2>&1; then
+	echo "SKIP: native GnuTLS PQ group GROUP-X25519-MLKEM768 is unavailable"
+	skip_test
+fi
+
+export NUMMESSAGES=1000
+export RSYSLOG_DEBUGLOG="log"
+generate_conf
+export PORT_RCVR="$(get_free_port)"
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="gtls"
+)
+
+module(load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="gtls"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon"
+	gnutlsPriorityString="'$GNUTLS_PQ_PRIO'")
+
+input(type="imtcp" port="'$PORT_RCVR'")
+
+$template outfmt,"%msg:F,58:2%\n"
+$template dynfile,"'$RSYSLOG_OUT_LOG'"
+:msg, contains, "msgnum:" ?dynfile;outfmt
+'
+startup
+
+export RSYSLOG_DEBUGLOG="log2"
+generate_conf 2
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+	defaultNetstreamDriver="gtls"
+)
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+action(
+	type="omfwd"
+	protocol="tcp"
+	target="127.0.0.1"
+	port="'$PORT_RCVR'"
+	StreamDriver="gtls"
+	StreamDriverMode="1"
+	StreamDriverAuthMode="anon"
+	gnutlsPriorityString="'$GNUTLS_PQ_PRIO'"
+)
+' 2
+startup 2
+
+tcpflood -m$NUMMESSAGES -i1
+wait_file_lines
+shutdown_when_empty 2
+wait_shutdown 2
+shutdown_when_empty
+wait_shutdown
+
+content_check --check-only "Syntax error or unsupported option in Priority String"
+# shellcheck disable=SC2181
+if [ $? -eq 0 ]; then
+	echo "SKIP: native GnuTLS PQ group configuration was rejected"
+	skip_test
+fi
+
+seq_check 1 $NUMMESSAGES
+exit_test

--- a/tests/sndrcv_tls_ossl_native_pq_group.sh
+++ b/tests/sndrcv_tls_ossl_native_pq_group.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# Native OpenSSL PQ smoke test. Requires an OpenSSL build with
+# X25519MLKEM768 support.
+. ${srcdir:=.}/diag.sh init
+
+check_command_available openssl
+
+if ! openssl list -tls-groups 2>/dev/null | tr ': ,' '\n' | grep -q '^X25519MLKEM768$'; then
+	echo "SKIP: native OpenSSL PQ group X25519MLKEM768 is unavailable"
+	skip_test
+fi
+
+export NUMMESSAGES=1000
+export RSYSLOG_DEBUGLOG="log"
+export OSSL_PQ_CFG='MinProtocol=TLSv1.3\nMaxProtocol=TLSv1.3\nGroups=X25519MLKEM768'
+generate_conf
+export PORT_RCVR="$(get_free_port)"
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+)
+
+module(load="../plugins/imtcp/.libs/imtcp"
+	StreamDriver.Name="ossl"
+	StreamDriver.Mode="1"
+	StreamDriver.AuthMode="anon"
+	gnutlsPriorityString="'$OSSL_PQ_CFG'")
+
+input(type="imtcp" port="'$PORT_RCVR'")
+
+$template outfmt,"%msg:F,58:2%\n"
+$template dynfile,"'$RSYSLOG_OUT_LOG'"
+:msg, contains, "msgnum:" ?dynfile;outfmt
+'
+startup
+
+export RSYSLOG_DEBUGLOG="log2"
+generate_conf 2
+add_conf '
+global(
+	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
+	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
+	defaultNetstreamDriverKeyFile="'$srcdir/tls-certs/key.pem'"
+)
+
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+action(
+	type="omfwd"
+	protocol="tcp"
+	target="127.0.0.1"
+	port="'$PORT_RCVR'"
+	StreamDriver="ossl"
+	StreamDriverMode="1"
+	StreamDriverAuthMode="anon"
+	gnutlsPriorityString="'$OSSL_PQ_CFG'"
+)
+' 2
+startup 2
+
+tcpflood -m$NUMMESSAGES -i1
+wait_file_lines
+shutdown_when_empty 2
+wait_shutdown 2
+shutdown_when_empty
+wait_shutdown
+
+content_check --check-only "Failed to add OpenSSL command"
+# shellcheck disable=SC2181
+if [ $? -eq 0 ]; then
+	echo "SKIP: native OpenSSL PQ group configuration was rejected"
+	skip_test
+fi
+
+seq_check 1 $NUMMESSAGES
+exit_test


### PR DESCRIPTION
## Summary
This PR adds native post-quantum TLS support guidance and smoke coverage for
newer distro baselines, updates the CI/container baseline needed for that work,
and folds in the follow-up compiler and testbench adjustments required to keep
the branch green.

## Changes
- replace the Fedora 41 CI/dev-container lane with Fedora 43
- add native PQ helper tools to the Fedora 43 and Debian 13 dev images
- add native PQ OpenSSL and GnuTLS smoke tests plus operator docs/tutorials
- improve TLS diagnostics for unsupported native PQ settings
- make `runtime/rsyslog.h` tolerate clang handling of unknown warning groups so
  older and newer clang lanes stay warning-free
- harden `tests/omfwd-lb-susp.sh` with isolated retry attempts for its known
  timing race and skip `tests/rcvr_fail_restore.sh` on ARM where it is flaky
- keep local ShellCheck/Hadolint suppressions where the suggested rewrites or
  package pinning are not useful for these helper images/tests
- clean the Fedora 43 dev image package cache after install

## Validation
- Fedora 43 container with inherited `CC=clang` and `CFLAGS=-g -O0 -fsanitize=address`
  built successfully
- Fedora 43: `tests/sndrcv_tls_gtls_native_pq_group.sh` passed
- Fedora 43: `tests/sndrcv_tls_ossl_native_pq_group.sh` passed
- Debian 13 container built successfully
- Debian 13: `tests/sndrcv_tls_ossl_native_pq_group.sh` passed
- Debian 13: `tests/sndrcv_tls_gtls_native_pq_group.sh` skipped because
  `GROUP-X25519-MLKEM768` is unavailable in the native image
- Ubuntu 24.04 dev container with `CC=clang-18`, `CFLAGS=-g`, and
  `--enable-debug=no` built successfully from a clean tree
- Ubuntu 20.04 dev container with `CC=clang-9` and `CFLAGS=-g` built
  successfully from a clean tree
- `python3 -m docutils.core --strict --exit-status=1`
  `doc/source/tutorials/post_quantum_tls.rst` passed locally
- `bash -n tests/omfwd-lb-susp.sh` and `bash -n tests/rcvr_fail_restore.sh`
  passed locally

## Notes
The branch is intentionally native-only for PQ support on newer distro
baselines. Older-version provider-mode compatibility remains out of scope for
this phase.