### PR TITLE
Upgrade RPM CI from Rocky Linux 8 / EPEL-8 to Rocky Linux 9 / EPEL-9.

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -349,7 +349,7 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 45
     container:
-      image: quay.io/rockylinux/rockylinux:8
+      image: quay.io/rockylinux/rockylinux:9
       options: --privileged
     steps:
       - name: Install git (before checkout so it can clone)
@@ -401,13 +401,13 @@ jobs:
           {
             echo '[adiscon]'
             echo 'name=adiscon'
-            echo "baseurl=https://rpms.adiscon.com/v8-stable/epel-8/\$basearch"
+            echo "baseurl=https://rpms.adiscon.com/v8-stable/epel-9/\$basearch"
             echo 'enabled=1'
             echo 'gpgcheck=1'
             echo 'gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-Adiscon'
           } > /etc/yum.repos.d/adiscon.repo
           dnf install -y dnf-plugins-core
-          dnf config-manager --set-enabled powertools
+          dnf config-manager --set-enabled crb
           dnf install -y libestr-devel libfastjson4-devel zlib-devel libuuid-devel libgcrypt-devel libcurl-devel file protobuf-c-compiler protobuf-c-devel snappy-devel python3-docutils dos2unix
           echo "== Copy mock configs =="
           cp -v packaging/rpm/etc-mock/*.cfg /etc/mock/ || true
@@ -429,7 +429,7 @@ jobs:
         if: steps.code_changes.outputs.any_changed == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: rpms-epel-8-x86_64
+          name: rpms-epel-9-x86_64
           path: build-result/
           if-no-files-found: error
 

--- a/devtools/run-rpm-build.sh
+++ b/devtools/run-rpm-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # CI helper: build RPMs from current source via mock.
 # Run from repo root. Expects mock configs in /etc/mock/, epel-release and mock installed.
-# Env: MOCK_CONFIG (default: epel-8-x86_64)
+# Env: MOCK_CONFIG (default: epel-9-x86_64)
 #
 # Steps: autoreconf, configure, make dist; patch spec for local tarball; mock --buildsrpm; mock build.
 
@@ -10,7 +10,7 @@ set -e
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
 cd "$REPO_ROOT"
 
-MOCK_CONFIG="${MOCK_CONFIG:-epel-8-x86_64}"
+MOCK_CONFIG="${MOCK_CONFIG:-epel-9-x86_64}"
 RPM_SPEC="${RPM_SPEC:-rsyslog-v8-stable}"
 RPM_DIR="$REPO_ROOT/packaging/rpm"
 RPM_SOURCES="$RPM_DIR/rpmbuild/SOURCES"


### PR DESCRIPTION
## Why
Align CI with current Rocky Linux and EPEL versions for ongoing support and security.

## Changes
- **GitHub workflow** (`.github/workflows/run_checks.yml`): Use Rocky Linux 9 container image, EPEL-9 repo baseurl, enable `crb` instead of `powertools`, and set artifact name to `rpms-epel-9-x86_64`.
- **RPM build helper** (`devtools/run-rpm-build.sh`): Default `MOCK_CONFIG` to `epel-9-x86_64` so local and CI builds match the new environment.

## Impact
RPM build job and mock defaults now target EL9; artifact names change from `rpms-epel-8-x86_64` to `rpms-epel-9-x86_64`.