### PR TITLE
doc: Fix Mermaid diagrams and unify doc build output

### DIFF
--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -36,7 +36,9 @@ jobs:
         with:
           files: |
             doc/**/*.rst
+            doc/source/conf.py
             doc/tools/check-html-links.py
+            doc/tools/fix-mermaid-offline.py
 
       # we build from tarball to ensure no missing files!
       - name: setup make dist build env
@@ -150,7 +152,7 @@ jobs:
           steps.doc_changes.outputs.any_changed == 'true' }}
         run: |
           python3 doc/tools/check-html-links.py \
-            doc-builder/doc/build/html \
+            doc-builder/doc/build \
             --check-root-absolute \
             --check-anchors
 
@@ -174,7 +176,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs-html
-          path: doc-builder/doc/build/html
+          path: doc-builder/doc/build
 
       - name: Upload RAG artifact
         if: >-

--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: docs-html
-          path: doc/build/html
+          path: doc/build
 
   deploy:
     needs: build

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -11,14 +11,14 @@ BUILDDIR      = build
 
 # However, to be safe and clean in Automake:
 html-local:
-	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	@echo "Applying Mermaid offline fix..."
-	@python3 ./tools/fix-mermaid-offline.py "$(BUILDDIR)/html"
+	@python3 ./tools/fix-mermaid-offline.py "$(BUILDDIR)"
 
 html-with-sitemap:
-	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" -t with_sitemap $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -b html "$(SOURCEDIR)" "$(BUILDDIR)" -t with_sitemap $(SPHINXOPTS) $(O)
 	@echo "Applying Mermaid offline fix..."
-	@python3 ./tools/fix-mermaid-offline.py "$(BUILDDIR)/html"
+	@python3 ./tools/fix-mermaid-offline.py "$(BUILDDIR)"
 
 singlehtml:
 	@$(SPHINXBUILD) -M singlehtml "$(SOURCEDIR)" "$(BUILDDIR)" -t minimal_build $(SPHINXOPTS) -D rst_epilog='' $(O)

--- a/doc/README.md
+++ b/doc/README.md
@@ -193,7 +193,7 @@ If you prefer the manual route instead of the helper script above:
     -   `make -C doc epub`
     -   Fallback: `sphinx-build -b epub source build`
 3.  Review generated contents:
-    -   Makefile builds: open `rsyslog/doc/build/html/index.html`.
+    -   Makefile builds: open `rsyslog/doc/build/index.html`.
     -   Direct Sphinx builds: open `rsyslog/doc/build/index.html`.
     -   Use any EPUB reader to view `rsyslog/doc/build/rsyslog.epub`.
 

--- a/doc/build_rag_db.py
+++ b/doc/build_rag_db.py
@@ -8,7 +8,7 @@ import traceback
 from docutils import nodes
 
 # Configuration
-BUILD_DIR = "build/doctrees"
+BUILD_DIR = "build/.doctrees"
 OUTPUT_FILE = "build/rag/rsyslog_rag_db.json"
 MAX_CHUNK_CHARS = 2000
 MIN_CHUNK_CHARS = 15

--- a/doc/source/_static/vendor/README.md
+++ b/doc/source/_static/vendor/README.md
@@ -30,7 +30,7 @@ The documentation is automatically fixed for offline viewing during the build
 process. If you need to run the fix manually:
 
 ```bash
-python3 tools/fix-mermaid-offline.py doc/build/html
+python3 tools/fix-mermaid-offline.py doc/build
 ```
 
 This script removes the `type="module"` attribute from Mermaid script tags

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -45,9 +45,15 @@ edit_on_github_branch = 'main'
 
 # Configure local copies of the JavaScript assets that power the Mermaid
 # diagrams so that the generated HTML does not fetch files from a CDN.
-# Use non-module builds to avoid CORS issues with file:// URLs
+#
+# Design choice: UMD (mermaid.min.js) over ESM for file:// support.
+# ES modules are blocked by CORS when opening HTML via file:// (browser security).
+# Using UMD + monkey-patch to strip type="module" allows offline viewing.
+# Trade-off: ELK layout is not available in offline mode (fix-mermaid-offline.py
+# removes the ELK script tag). For HTTP-served docs, ELK would work with ESM;
+# we prioritize file:// compatibility so built docs work without a local server.
 MERMAID_JS_PATH = 'vendor/mermaid/mermaid.min.js'
-MERMAID_ELK_JS_PATH = 'vendor/mermaid/mermaid-layout-elk.esm.min.mjs'  # Keep ES module for ELK
+MERMAID_ELK_JS_PATH = 'vendor/mermaid/mermaid-layout-elk.esm.min.mjs'  # Stripped by fix script for file://
 D3_JS_PATH = 'vendor/d3/d3.min.js'
 
 mermaid_use_local = MERMAID_JS_PATH
@@ -117,9 +123,11 @@ window.addEventListener("load", () => {{
     mermaid_init_js = """
 window.addEventListener("load", () => {
     if (typeof mermaid !== 'undefined') {
-        // Note: ELK layout is not available in non-module builds
-        // Basic Mermaid functionality will work without ELK
-        mermaid.initialize({startOnLoad:false});
+        // Force Dagre renderer; ELK is not available in non-module builds (CORS with file://)
+        mermaid.initialize({
+            startOnLoad: false,
+            flowchart: { defaultRenderer: 'dagre' }
+        });
     }
 });
 """.strip()
@@ -127,49 +135,28 @@ window.addEventListener("load", () => {
     _original_install_js = _sphinx_mermaid.install_js
 
     def _vendored_install_js(app, *args, **kwargs):
-        """Force sphinxcontrib-mermaid to load the vendored JavaScript."""
+        """Force sphinxcontrib-mermaid to load the vendored UMD JavaScript (file:// compatible)."""
 
-        if hasattr(app.config, 'mermaid_use_local'):
-            app.config.mermaid_use_local = MERMAID_JS_PATH
-            app.config.mermaid_elk_use_local = MERMAID_ELK_JS_PATH
-            app.config.d3_use_local = D3_JS_PATH
-            app.config.mermaid_init_js = mermaid_init_js
-            return _original_install_js(app, *args, **kwargs)
+        app.config.mermaid_use_local = MERMAID_JS_PATH
+        app.config.mermaid_elk_use_local = MERMAID_ELK_JS_PATH
+        app.config.d3_use_local = D3_JS_PATH
+        app.config.mermaid_init_js = mermaid_init_js
 
         original_add_js_file = app.add_js_file
-        original_init_js = getattr(app.config, 'mermaid_init_js', '')
 
-        def _rewrite_js_file(filename, **file_kwargs):
-            if filename:
-                if 'mermaid-layout-elk' in filename:
-                    filename = MERMAID_ELK_JS_PATH
-                    file_kwargs.setdefault('type', 'module')
-                elif 'mermaid' in filename and not filename.endswith('.mjs'):
-                    filename = MERMAID_JS_PATH
-                    # Explicitly remove module type for main mermaid script
-                    file_kwargs.pop('type', None)
-                    file_kwargs.pop('async', None)
-                elif 'd3' in filename and filename.endswith('.js'):
-                    filename = D3_JS_PATH
-            return original_add_js_file(filename, **file_kwargs)
-
-        # Also monkey-patch the app.add_js_file method to intercept Mermaid scripts
         def _intercept_add_js_file(filename, **file_kwargs):
-            # Only target our specific vendored Mermaid files
+            # Remove type=module from UMD mermaid script so it works with file:// URLs
             if filename and any(vendor_path in filename for vendor_path in [MERMAID_JS_PATH, MERMAID_ELK_JS_PATH]):
                 if 'mermaid' in filename and not filename.endswith('.mjs'):
-                    # Remove module type for Mermaid scripts
                     file_kwargs.pop('type', None)
                     file_kwargs.pop('async', None)
             return original_add_js_file(filename, **file_kwargs)
 
         try:
             app.add_js_file = _intercept_add_js_file  # type: ignore[assignment]
-            app.config.mermaid_init_js = mermaid_init_js
             return _original_install_js(app, *args, **kwargs)
         finally:
             app.add_js_file = original_add_js_file  # type: ignore[assignment]
-            app.config.mermaid_init_js = original_init_js
 
     _sphinx_mermaid.install_js = _vendored_install_js
 

--- a/doc/tools/build-doc-linux.sh
+++ b/doc/tools/build-doc-linux.sh
@@ -148,4 +148,9 @@ fi
 echo "Building docs: format=${FORMAT} output=${OUTPUT_DIR} jobs=${JOBS}"
 sphinx-build -j "${JOBS}" ${SPHINXOPTS} -b "${FORMAT}" "${DOC_DIR}/source" "${OUTPUT_DIR}"
 
+if [[ "${FORMAT}" == "html" ]]; then
+  echo "Running fix-mermaid-offline.py for file:// and GitHub Pages compatibility..."
+  python3 "${SCRIPT_DIR}/fix-mermaid-offline.py" "${OUTPUT_DIR}"
+fi
+
 echo "Done. Open ${OUTPUT_DIR}/index.html for HTML builds."

--- a/doc/tools/fix-mermaid-offline.py
+++ b/doc/tools/fix-mermaid-offline.py
@@ -1,13 +1,29 @@
 #!/usr/bin/env python3
 """
 Fix Mermaid offline viewing by converting ES modules to non-module builds.
-This script modifies generated HTML files to work with file:// URLs.
+This script modifies generated HTML files to work with file:// URLs and
+HTTP-served docs (e.g. GitHub Pages PR previews).
 """
 
 import os
 import re
 import sys
 from pathlib import Path
+
+# Path to Mermaid UMD in Sphinx _static (relative to HTML root)
+MERMAID_STATIC_PATH = "_static/vendor/mermaid/mermaid.min.js"
+
+
+def _static_relpath(html_path: Path, html_file: Path) -> str:
+    """Return relative path from html_file to _static (e.g. '../' for development/foo.html)."""
+    try:
+        rel = html_file.relative_to(html_path)
+    except ValueError:
+        return ""
+    depth = len(rel.parts) - 1  # -1 because the file itself is the last part
+    if depth <= 0:
+        return ""
+    return "../" * depth
 
 
 def fix_mermaid_offline(html_dir):
@@ -27,20 +43,6 @@ def fix_mermaid_offline(html_dir):
     
     print(f"Found {len(html_files)} HTML files to process...")
     
-    # Patterns to fix
-    fixes = [
-        # Remove type="module" from Mermaid scripts (but keep for ELK)
-        (
-            r'<script type="module" src="([^"]*mermaid[^"]*\.min\.js[^"]*)"',
-            r'<script src="\1"'
-        ),
-        # Add fallback script for offline viewing - only once per file
-        (
-            r'(<script src="[^"]*mermaid[^"]*\.min\.js[^"]*"></script>)',
-            r'\1\n    <script>console.info("Mermaid offline mode: Basic diagrams supported");</script>'
-        )
-    ]
-    
     fixed_count = 0
     
     for html_file in html_files:
@@ -49,10 +51,46 @@ def fix_mermaid_offline(html_dir):
                 content = f.read()
             
             original_content = content
+            relpath = _static_relpath(html_path, html_file)
+            mermaid_src = relpath + MERMAID_STATIC_PATH
             
-            # Apply fixes
-            for pattern, replacement in fixes:
-                content = re.sub(pattern, replacement, content)
+            # 1. Remove ELK layout script first (before step 2). If we did step 2 first,
+            #    its regex would also match mermaid-layout-elk.min.js, strip type="module",
+            #    and then this step would no longer see the tag to remove.
+            content = re.sub(
+                r'\s*<script type="module" src="[^"]*mermaid-layout-elk[^"]*"></script>\n?',
+                '',
+                content
+            )
+            
+            # 2. Remove type="module" from Mermaid UMD script (monkey-patched build)
+            content = re.sub(
+                r'<script type="module" src="([^"]*mermaid[^"]*\.min\.js[^"]*)"',
+                r'<script src="\1"',
+                content
+            )
+            
+            # 3. Replace inline ESM import with UMD script (unpatched sphinxcontrib-mermaid)
+            #    e.g. <script type="module">import mermaid from "vendor/mermaid/mermaid.min.js";
+            #    The import path "vendor/..." is wrong for HTTP; use correct _static path.
+            esm_import_pat = re.compile(
+                r'<script type="module">\s*import mermaid from ["\']vendor/mermaid/mermaid\.min\.js["\'];\s*\n',
+                re.IGNORECASE
+            )
+            if esm_import_pat.search(content):
+                content = esm_import_pat.sub(
+                    f'<script src="{mermaid_src}"></script>\n    <script>',
+                    content,
+                    count=1
+                )
+            
+            # 4. Add fallback script for offline viewing - only once per file
+            content = re.sub(
+                r'(<script src="[^"]*mermaid[^"]*\.min\.js[^"]*"></script>)(?!\s*\n\s*<script>console\.info)',
+                r'\1\n    <script>console.info("Mermaid offline mode: Basic diagrams supported");</script>',
+                content,
+                count=1
+            )
             
             # Only write if content changed
             if content != original_content:
@@ -72,7 +110,7 @@ def fix_mermaid_offline(html_dir):
 def main():
     if len(sys.argv) != 2:
         print("Usage: python3 doc/tools/fix-mermaid-offline.py <html_directory>")
-        print("Example: python3 doc/tools/fix-mermaid-offline.py doc/build/html")
+        print("Example: python3 doc/tools/fix-mermaid-offline.py doc/build")
         sys.exit(1)
     
     html_dir = sys.argv[1]

--- a/doc/tools/inside_docker_doc_html.sh
+++ b/doc/tools/inside_docker_doc_html.sh
@@ -14,8 +14,8 @@ VENV=/opt/rsyslog-doc-venv
 export RSYSLOG_DOC_VERSION="${RSYSLOG_DOC_VERSION:-8}"
 export RSYSLOG_DOC_RELEASE_TYPE="${RSYSLOG_DOC_RELEASE_TYPE:-stable}"
 
-rm -rf build/html
+rm -rf build
 nice "$VENV/bin/sphinx-build" -j"$(nproc)" -t with_sitemap -b html -D html_theme=furo \
-  -W --keep-going source build/html
+  -W --keep-going source build
 
-"$VENV/bin/python3" tools/fix-mermaid-offline.py build/html
+"$VENV/bin/python3" tools/fix-mermaid-offline.py build


### PR DESCRIPTION
### Problem
- Mermaid diagrams do not render on GitHub Pages PR previews or when opening built HTML via `file://` (CORS blocks ES modules; wrong import paths).
- Two build output paths existed: `build/html/` (Makefile, Docker, CI) vs `build/` (RPM spec, build-doc-linux.sh, release scripts), causing inconsistent fix application.

### Solution

**Mermaid fixes**
- `conf.py`: Simplify monkey-patch; force `flowchart: { defaultRenderer: 'dagre' }` to avoid ELK load attempts; improve UMD/file:// comments.
- `fix-mermaid-offline.py`: Remove ELK script first (fixes regex ordering bug); add handling for inline ESM import format with correct `_static` path per file depth; support both monkey-patched and unpatched sphinxcontrib-mermaid output.

**Build path unification**
- Switch Makefile and Docker from `-M html` to `-b html`; output to `build/` instead of `build/html/`.
- Update doc_build.yml, doc_deploy_main.yml, README, vendor README.
- `build_rag_db.py`: Use `build/.doctrees` (correct for `-b html`).

**CI**
- Add `conf.py` and `fix-mermaid-offline.py` to changed-files so doc CI rebuilds when Mermaid config changes.

### Trade-off
ELK layout is not available in offline mode; basic Mermaid diagrams work with Dagre.