### PR TITLE
ci: add focused repo policy review

### DIFF
--- a/.github/workflows/repo-policy-focus-review.yml
+++ b/.github/workflows/repo-policy-focus-review.yml
@@ -1,0 +1,134 @@
+# Copyright 2026 Rainer Gerhards and Others
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+---
+name: repo policy focus review
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/repo-policy-focus-review.yml"
+      - "docs/repo-policy-focus-review.md"
+      - "scripts/build_repo_policy_focus_input.py"
+      - "scripts/evaluate_repo_policy_focus.py"
+      - "scripts/score_repo_policy_focus.py"
+      - "tests/**"
+      - "doc/**"
+      - "plugins/**"
+      - "contrib/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  repo-policy-focus-review:
+    name: repo policy focus review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build focused review package
+        run: |
+          mkdir -p out
+          python3 scripts/build_repo_policy_focus_input.py \
+            --base "${{ github.event.pull_request.base.sha }}" \
+            --head "${{ github.event.pull_request.head.sha }}" \
+            --output out/review-package.json
+
+      - name: Read applicability
+        id: package
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          with open("out/review-package.json", "r", encoding="utf-8") as fh:
+              package = json.load(fh)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"applicable_count={package['applicable_count']}\n")
+          PY
+
+      - name: Run deterministic evaluator
+        if: ${{ steps.package.outputs.applicable_count != '0' }}
+        run: |
+          python3 scripts/evaluate_repo_policy_focus.py \
+            --input out/review-package.json \
+            --output out/model-output.json
+
+      - name: Stamp evaluation mode
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("out/review-package.json")
+          package = json.loads(path.read_text(encoding="utf-8"))
+          if package["applicable_count"] == 0:
+              package["evaluation_mode"] = "not_needed"
+          elif Path("out/model-output.json").exists():
+              package["evaluation_mode"] = "deterministic"
+          else:
+              package["evaluation_mode"] = "unavailable"
+          path.write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8")
+          PY
+
+      - name: Score focused review result
+        run: |
+          if [ -f out/model-output.json ]; then
+            python3 scripts/score_repo_policy_focus.py \
+              --review-input out/review-package.json \
+              --model-output out/model-output.json \
+              --summary-md out/summary.md \
+              --summary-json out/summary.json
+          else
+            python3 scripts/score_repo_policy_focus.py \
+              --review-input out/review-package.json \
+              --summary-md out/summary.md \
+              --summary-json out/summary.json
+          fi
+
+      - name: Publish workflow summary
+        run: cat out/summary.md >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Enforce focused policy checks
+        run: |
+          python3 - <<'PY'
+          import json
+          import sys
+          from pathlib import Path
+
+          summary = json.loads(Path("out/summary.json").read_text(encoding="utf-8"))
+          warnings = [check for check in summary["checks"] if check["status"] == "warn"]
+          failures = [check for check in summary["checks"] if check["status"] == "fail"]
+
+          if warnings:
+              print("Focused repo-policy warnings:")
+              for check in warnings:
+                  print(f"- {check['id']}: {check['reason']}")
+                  for issue in check["issues"]:
+                      location = issue["file"] or "(no file)"
+                      if issue["line"]:
+                          location = f"{location}:{issue['line']}"
+                      print(f"  * {location} - {issue['message']}")
+
+          if not failures:
+              print("Focused repo-policy checks passed.")
+              raise SystemExit(0)
+
+          print("Focused repo-policy checks failed:", file=sys.stderr)
+          for check in failures:
+              print(f"- {check['id']}: {check['reason']}", file=sys.stderr)
+              for issue in check["issues"]:
+                  location = issue["file"] or "(no file)"
+                  if issue["line"]:
+                      location = f"{location}:{issue['line']}"
+                  print(f"  * {location} - {issue['message']}", file=sys.stderr)
+          raise SystemExit(1)
+          PY

--- a/docs/repo-policy-focus-review.md
+++ b/docs/repo-policy-focus-review.md
@@ -1,0 +1,70 @@
+# Repo Policy Focus Review
+
+This workflow adds a small repository-policy review for pull
+requests. It does not try to rate the whole patch. Instead, it focuses on three
+high-value policy areas that are not covered well by the existing CI suite:
+
+- test registration under `tests/`
+- documentation distribution sync under `doc/source/`
+- new-module onboarding under `plugins/` and `contrib/`
+
+## Why this exists
+
+The repository already has strong generic CI for formatting, linting, CodeQL,
+docs, and the build/test matrix. What it lacked was rsyslog-specific policy
+feedback in areas where contributors often need repository knowledge instead of
+generic code review.
+
+This workflow uses deterministic fact collection and deterministic evaluation to
+turn those fact bundles into `pass`, `warn`, `fail`, or `not_applicable`
+results.
+
+## Focused checks
+
+### `tests-registration`
+
+Applied when a pull request adds or renames shell tests in `tests/`.
+
+The package builder collects facts such as:
+
+- new test script paths
+- whether `tests/Makefile.am` mentions those scripts
+- whether new `-vg.sh` wrappers appear to source the base scenario
+
+### `doc-dist-sync`
+
+Applied when a pull request changes `.rst` files under `doc/source/`.
+
+The package builder collects facts such as:
+
+- changed doc paths
+- missing `doc/Makefile.am` `EXTRA_DIST` entries for added or renamed docs
+- stale `EXTRA_DIST` entries left behind for deleted or renamed docs
+
+### `module-onboarding`
+
+Applied when a pull request appears to add a new module under `plugins/` or
+`contrib/`.
+
+The package builder collects facts such as:
+
+- new module directories relative to the base revision
+- whether `MODULE_METADATA.yaml` exists
+- whether a likely module doc touchpoint exists under `doc/source/`
+
+## Workflow behavior
+
+- always builds the focused review package
+- only runs the evaluator when at least one focused check is applicable
+- writes a workflow summary
+- fails the workflow when an applicable check returns `fail`
+
+The workflow follows the normal CI failure path so policy failures are visible
+in the standard checks UI and logs.
+
+## Files
+
+- workflow: `.github/workflows/repo-policy-focus-review.yml`
+- builder: `scripts/build_repo_policy_focus_input.py`
+- evaluator: `scripts/evaluate_repo_policy_focus.py`
+- scorer: `scripts/score_repo_policy_focus.py`

--- a/scripts/build_repo_policy_focus_input.py
+++ b/scripts/build_repo_policy_focus_input.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Build a focused repo-policy review package from a pull-request diff."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+TOP_LEVEL_AGENTS = ROOT_DIR / "AGENTS.md"
+DOC_AGENTS = ROOT_DIR / "doc" / "AGENTS.md"
+TESTS_AGENTS = ROOT_DIR / "tests" / "AGENTS.md"
+PLUGINS_AGENTS = ROOT_DIR / "plugins" / "AGENTS.md"
+CONTRIB_AGENTS = ROOT_DIR / "contrib" / "AGENTS.md"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", help="base ref or sha")
+    parser.add_argument("--head", help="head ref or sha")
+    parser.add_argument("--output", required=True, help="output JSON path")
+    return parser.parse_args()
+
+
+def resolve_ref(cli_value: str | None, env_names: tuple[str, ...], default: str | None) -> str:
+    if cli_value:
+        return cli_value
+    for env_name in env_names:
+        value = os.environ.get(env_name)
+        if value:
+            return value
+    if default is None:
+        raise SystemExit(f"missing required ref; checked {', '.join(env_names)}")
+    return default
+
+
+def run_git(args: list[str], check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=ROOT_DIR,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def file_exists_at_ref(ref: str, path: str) -> bool:
+    result = subprocess.run(
+        ["git", "cat-file", "-e", f"{ref}:{path}"],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def read_file_at_ref(ref: str, path: str) -> str:
+    return run_git(["show", f"{ref}:{path}"])
+
+
+def collect_name_status(base: str, head: str) -> list[dict[str, object]]:
+    entries = []
+    output = run_git(["diff", "--name-status", "--find-renames", base, head])
+    for line in output.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        status = parts[0]
+        entry: dict[str, object] = {"status": status}
+        if status.startswith("R") and len(parts) >= 3:
+            entry["old_path"] = parts[1]
+            entry["path"] = parts[2]
+        elif len(parts) >= 2:
+            entry["path"] = parts[1]
+        else:
+            continue
+        entries.append(entry)
+    return entries
+
+
+def limited_diff(base: str, head: str, paths: list[str]) -> str:
+    unique_paths = []
+    for path in paths:
+        if path and path not in unique_paths:
+            unique_paths.append(path)
+    if not unique_paths:
+        return ""
+    return run_git(["diff", "--unified=12", base, head, "--", *unique_paths])
+
+
+def build_tests_check(name_status: list[dict[str, object]], base: str, head: str) -> dict[str, object]:
+    # This rule is strict: new or renamed shell tests must stay wired into
+    # tests/Makefile.am, and lightweight -vg.sh wrappers should source the base
+    # scenario instead of cloning its logic.
+    added_tests: list[str] = []
+    renamed_tests: list[dict[str, str]] = []
+    for entry in name_status:
+        path = str(entry.get("path", ""))
+        if not path.startswith("tests/") or not path.endswith(".sh"):
+            continue
+        if Path(path).name in {"diag.sh"}:
+            continue
+        status = str(entry["status"])
+        if status.startswith("A"):
+            added_tests.append(path)
+        elif status.startswith("R"):
+            renamed_tests.append(
+                {"old_path": str(entry["old_path"]), "path": path}
+            )
+
+    tests_makefile = (ROOT_DIR / "tests" / "Makefile.am").read_text(encoding="utf-8")
+    tracked_tests = added_tests + [item["path"] for item in renamed_tests]
+    missing_entries = [
+        path for path in tracked_tests if Path(path).name not in tests_makefile
+    ]
+    stale_entries = [
+        str(item["old_path"])
+        for item in renamed_tests
+        if Path(str(item["old_path"])).name in tests_makefile
+    ]
+
+    vg_wrappers = []
+    for path in tracked_tests:
+        if not path.endswith("-vg.sh"):
+            continue
+        content = read_file_at_ref(head, path)
+        base_script = Path(path).name.replace("-vg.sh", ".sh")
+        sources_base = base_script in content and ". " in content
+        vg_wrappers.append(
+            {
+                "file": path,
+                "base_script": f"tests/{base_script}",
+                "sources_base": sources_base,
+                "snippet": content[:600],
+            }
+        )
+
+    applicable = bool(tracked_tests)
+    relevant_paths = ["tests/Makefile.am", *tracked_tests]
+    return {
+        "id": "tests-registration",
+        "title": "Test registration and wrapper policy",
+        "applicable": applicable,
+        "facts": {
+            "added_tests": added_tests,
+            "renamed_tests": renamed_tests,
+            "missing_makefile_entries": missing_entries,
+            "stale_makefile_entries": stale_entries,
+            "vg_wrappers": vg_wrappers,
+            "tests_makefile_touched": any(
+                str(entry.get("path", "")) == "tests/Makefile.am" for entry in name_status
+            ),
+            "relevant_diff": limited_diff(base, head, relevant_paths) if applicable else "",
+        },
+    }
+
+
+def build_doc_check(name_status: list[dict[str, object]], base: str, head: str) -> dict[str, object]:
+    # doc/Makefile.am is the distribution source of truth for rst files under
+    # doc/source/, so renamed or deleted docs can leave stale entries behind.
+    changed_docs = []
+    for entry in name_status:
+        path = str(entry.get("path", ""))
+        if path.startswith("doc/source/") and path.endswith(".rst"):
+            changed_docs.append(
+                {
+                    "status": str(entry["status"]),
+                    "path": path,
+                    "old_path": str(entry.get("old_path", "")),
+                }
+            )
+
+    doc_makefile = (ROOT_DIR / "doc" / "Makefile.am").read_text(encoding="utf-8")
+    missing_entries = []
+    stale_entries = []
+    relevant_paths = ["doc/Makefile.am"]
+    for item in changed_docs:
+        path = item["path"]
+        relative = path[len("doc/") :]
+        if item["status"].startswith(("A", "R")) and relative not in doc_makefile:
+            missing_entries.append(relative)
+        if item["status"].startswith("D") and relative in doc_makefile:
+            stale_entries.append(relative)
+        if item["status"].startswith("R"):
+            old_path = item["old_path"]
+            if old_path:
+                old_relative = old_path[len("doc/") :]
+                if old_relative in doc_makefile:
+                    stale_entries.append(old_relative)
+        relevant_paths.append(path)
+
+    applicable = bool(changed_docs)
+    return {
+        "id": "doc-dist-sync",
+        "title": "Documentation distribution sync",
+        "applicable": applicable,
+        "facts": {
+            "changed_docs": changed_docs,
+            "missing_extra_dist_entries": sorted(set(missing_entries)),
+            "stale_extra_dist_entries": sorted(set(stale_entries)),
+            "doc_makefile_touched": any(
+                str(entry.get("path", "")) == "doc/Makefile.am" for entry in name_status
+            ),
+            "relevant_diff": limited_diff(base, head, relevant_paths) if applicable else "",
+        },
+    }
+
+
+def list_tree(ref: str, path: str) -> list[str]:
+    output = run_git(["ls-tree", "-r", "--name-only", ref, "--", path], check=False)
+    return [line for line in output.splitlines() if line]
+
+
+def build_module_check(name_status: list[dict[str, object]], base: str, head: str) -> dict[str, object]:
+    # Treat a brand-new plugins/ or contrib/ subtree with code or build files as
+    # a module candidate, then check only for deterministic onboarding signals.
+    candidate_dirs: dict[str, dict[str, object]] = {}
+    for entry in name_status:
+        path = str(entry.get("path", ""))
+        parts = Path(path).parts
+        if len(parts) < 2:
+            continue
+        if parts[0] not in {"plugins", "contrib"}:
+            continue
+        if parts[0] == "plugins" and parts[1] == "external":
+            continue
+        module_dir = f"{parts[0]}/{parts[1]}"
+        candidate_dirs.setdefault(module_dir, {"tree": parts[0], "name": parts[1], "paths": []})
+        candidate_dirs[module_dir]["paths"].append(path)
+
+    new_modules = []
+    for module_dir, info in sorted(candidate_dirs.items()):
+        if file_exists_at_ref(base, module_dir):
+            continue
+        head_files = list_tree(head, module_dir)
+        if not head_files:
+            continue
+        if not any(
+            file.endswith(("Makefile.am", ".c", ".h", "MODULE_METADATA.yaml"))
+            for file in head_files
+        ):
+            continue
+        name = str(info["name"])
+        metadata_path = f"{module_dir}/MODULE_METADATA.yaml"
+        # The doc probe is heuristic on purpose: a likely module doc path is
+        # enough for a warning/pass decision, but missing metadata is a hard
+        # failure regardless of docs.
+        doc_candidates = [
+            f"doc/source/configuration/modules/{name}.rst",
+            f"doc/source/configuration/modules/im{name}.rst",
+            f"doc/source/configuration/modules/om{name}.rst",
+        ]
+        existing_docs = [path for path in doc_candidates if file_exists_at_ref(head, path)]
+        new_modules.append(
+            {
+                "dir": module_dir,
+                "tree": info["tree"],
+                "has_metadata": file_exists_at_ref(head, metadata_path),
+                "metadata_path": metadata_path,
+                "doc_candidates": doc_candidates,
+                "existing_docs": existing_docs,
+                "changed_paths": info["paths"],
+            }
+        )
+
+    applicable = bool(new_modules)
+    relevant_paths = [item["dir"] for item in new_modules]
+    return {
+        "id": "module-onboarding",
+        "title": "Module metadata and doc touchpoints",
+        "applicable": applicable,
+        "facts": {
+            "new_modules": new_modules,
+            "relevant_diff": limited_diff(base, head, relevant_paths) if applicable else "",
+        },
+    }
+
+
+def collect_repo_guidance(checks: list[dict[str, object]]) -> dict[str, str]:
+    guidance = {"AGENTS.md": TOP_LEVEL_AGENTS.read_text(encoding="utf-8")}
+    if checks[0]["applicable"]:
+        guidance["tests/AGENTS.md"] = TESTS_AGENTS.read_text(encoding="utf-8")
+    if checks[1]["applicable"]:
+        guidance["doc/AGENTS.md"] = DOC_AGENTS.read_text(encoding="utf-8")
+    if checks[2]["applicable"]:
+        guidance["plugins/AGENTS.md"] = PLUGINS_AGENTS.read_text(encoding="utf-8")
+        guidance["contrib/AGENTS.md"] = CONTRIB_AGENTS.read_text(encoding="utf-8")
+    return guidance
+
+
+def main() -> int:
+    args = parse_args()
+    base = resolve_ref(args.base, ("AI_REVIEW_BASE", "GITHUB_BASE_SHA"), "HEAD")
+    head = resolve_ref(args.head, ("AI_REVIEW_HEAD", "GITHUB_HEAD_SHA"), "HEAD")
+
+    name_status = collect_name_status(base, head)
+    changed_files = [str(entry.get("path", "")) for entry in name_status if entry.get("path")]
+    checks = [
+        build_tests_check(name_status, base, head),
+        build_doc_check(name_status, base, head),
+        build_module_check(name_status, base, head),
+    ]
+    applicable_count = sum(1 for check in checks if check["applicable"])
+
+    package = {
+        "base": base,
+        "head": head,
+        "changed_files": changed_files,
+        "applicable_count": applicable_count,
+        "checks": checks,
+        "repo_guidance": collect_repo_guidance(checks),
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(package, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/evaluate_repo_policy_focus.py
+++ b/scripts/evaluate_repo_policy_focus.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Deterministically evaluate focused repo-policy checks."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", required=True, help="focused review package JSON")
+    parser.add_argument("--output", required=True, help="evaluation output JSON")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def build_issue(file_path: str, message: str, line: int = 0) -> dict[str, object]:
+    return {"file": file_path, "line": line, "message": message}
+
+
+def evaluate_tests_registration(check: dict[str, object]) -> dict[str, object]:
+    # Registration issues are deterministic and should block immediately because
+    # they break the test inventory rather than merely lowering confidence.
+    facts = check["facts"]
+    added_tests = facts["added_tests"]
+    renamed_tests = facts["renamed_tests"]
+    missing_entries = facts["missing_makefile_entries"]
+    stale_entries = facts.get("stale_makefile_entries", [])
+    vg_wrappers = facts["vg_wrappers"]
+    issues: list[dict[str, object]] = []
+
+    for path in missing_entries:
+        issues.append(
+            build_issue(
+                "tests/Makefile.am",
+                f"Missing entry for '{path}'.",
+            )
+        )
+    for path in stale_entries:
+        issues.append(
+            build_issue(
+                "tests/Makefile.am",
+                f"Stale entry remains for renamed test '{path}'.",
+            )
+        )
+    for wrapper in vg_wrappers:
+        if not wrapper["sources_base"]:
+            issues.append(
+                build_issue(
+                    wrapper["file"],
+                    f"Wrapper should source '{wrapper['base_script']}' instead of duplicating logic.",
+                )
+            )
+
+    if issues:
+        return {
+            "id": check["id"],
+            "status": "fail",
+            "confidence": "high",
+            "reason": "Test registration or wrapper policy needs follow-up.",
+            "issues": issues,
+        }
+
+    tracked = added_tests + [item["path"] for item in renamed_tests]
+    if tracked:
+        return {
+            "id": check["id"],
+            "status": "pass",
+            "confidence": "high",
+            "reason": "New or renamed tests are registered and wrappers follow the expected pattern.",
+            "issues": [],
+        }
+
+    return {
+        "id": check["id"],
+        "status": "not_applicable",
+        "confidence": "low",
+        "reason": "Check not applicable.",
+        "issues": [],
+    }
+
+
+def evaluate_doc_dist_sync(check: dict[str, object]) -> dict[str, object]:
+    # EXTRA_DIST drift is a packaging bug, so this rule stays fully blocking.
+    facts = check["facts"]
+    missing_entries = facts["missing_extra_dist_entries"]
+    stale_entries = facts["stale_extra_dist_entries"]
+    issues = [
+        build_issue("doc/Makefile.am", f"Missing EXTRA_DIST entry for '{path}'.")
+        for path in missing_entries
+    ]
+    issues.extend(
+        build_issue("doc/Makefile.am", f"Stale EXTRA_DIST entry remains for '{path}'.")
+        for path in stale_entries
+    )
+
+    if issues:
+        return {
+            "id": check["id"],
+            "status": "fail",
+            "confidence": "high",
+            "reason": "Documentation distribution metadata is out of sync with the doc tree.",
+            "issues": issues,
+        }
+
+    if facts["changed_docs"]:
+        return {
+            "id": check["id"],
+            "status": "pass",
+            "confidence": "high",
+            "reason": "Documentation distribution metadata matches the changed doc files.",
+            "issues": [],
+        }
+
+    return {
+        "id": check["id"],
+        "status": "not_applicable",
+        "confidence": "low",
+        "reason": "Check not applicable.",
+        "issues": [],
+    }
+
+
+def evaluate_module_onboarding(check: dict[str, object]) -> dict[str, object]:
+    # Missing metadata is a hard policy failure; missing docs stay advisory
+    # until rsyslog has a stricter deterministic doc coverage rule.
+    facts = check["facts"]
+    issues: list[dict[str, object]] = []
+    warnings: list[dict[str, object]] = []
+
+    for module in facts["new_modules"]:
+        if not module["has_metadata"]:
+            issues.append(
+                build_issue(
+                    module["dir"],
+                    f"New module is missing '{module['metadata_path']}'.",
+                )
+            )
+        if not module["existing_docs"]:
+            warnings.append(
+                build_issue(
+                    module["dir"],
+                    "No likely module documentation file was detected under doc/source/configuration/modules/.",
+                )
+            )
+
+    if issues:
+        return {
+            "id": check["id"],
+            "status": "fail",
+            "confidence": "high",
+            "reason": "New module onboarding is missing required metadata.",
+            "issues": issues + warnings,
+        }
+
+    if warnings:
+        return {
+            "id": check["id"],
+            "status": "warn",
+            "confidence": "medium",
+            "reason": "New module metadata exists, but documentation touchpoints were not detected.",
+            "issues": warnings,
+        }
+
+    if facts["new_modules"]:
+        return {
+            "id": check["id"],
+            "status": "pass",
+            "confidence": "high",
+            "reason": "New modules include metadata and a likely documentation touchpoint.",
+            "issues": [],
+        }
+
+    return {
+        "id": check["id"],
+        "status": "not_applicable",
+        "confidence": "low",
+        "reason": "Check not applicable.",
+        "issues": [],
+    }
+
+
+def evaluate_check(check: dict[str, object]) -> dict[str, object]:
+    # The workflow is intentionally closed over a small fixed rule set so each
+    # check can carry its own deterministic semantics.
+    if not check["applicable"]:
+        return {
+            "id": check["id"],
+            "status": "not_applicable",
+            "confidence": "low",
+            "reason": "Check not applicable.",
+            "issues": [],
+        }
+    if check["id"] == "tests-registration":
+        return evaluate_tests_registration(check)
+    if check["id"] == "doc-dist-sync":
+        return evaluate_doc_dist_sync(check)
+    if check["id"] == "module-onboarding":
+        return evaluate_module_onboarding(check)
+    return {
+        "id": check["id"],
+        "status": "warn",
+        "confidence": "low",
+        "reason": "No deterministic evaluator was implemented for this check.",
+        "issues": [],
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    review_input = load_json(Path(args.input))
+    if not isinstance(review_input, dict):
+        raise SystemExit("review input must be a JSON object")
+
+    checks = [evaluate_check(check) for check in review_input["checks"]]
+    if review_input["applicable_count"] == 0:
+        summary = "Focused repo-policy evaluation was not needed for this patch."
+    else:
+        fail_count = sum(1 for check in checks if check["status"] == "fail")
+        warn_count = sum(1 for check in checks if check["status"] == "warn")
+        if fail_count:
+            summary = "Focused repo-policy evaluation found required follow-up."
+        elif warn_count:
+            summary = "Focused repo-policy evaluation found advisory follow-up."
+        else:
+            summary = "Focused repo-policy evaluation found no issues in the applicable checks."
+
+    output = {"summary": summary, "checks": checks}
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/score_repo_policy_focus.py
+++ b/scripts/score_repo_policy_focus.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Normalize focused repo-policy review output into markdown and JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+
+VALID_STATUS = {"pass", "warn", "fail", "not_applicable"}
+VALID_CONFIDENCE = {"high", "medium", "low"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--review-input", required=True, help="focused review package JSON")
+    parser.add_argument("--model-output", help="model output JSON")
+    parser.add_argument("--summary-md", required=True, help="markdown summary output path")
+    parser.add_argument("--summary-json", required=True, help="JSON summary output path")
+    return parser.parse_args()
+
+
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def normalize_issue(item: object) -> dict[str, object]:
+    if not isinstance(item, dict):
+        return {"file": "", "line": 0, "message": "Invalid issue entry."}
+    line = item.get("line")
+    if not isinstance(line, int):
+        line = 0
+    return {
+        "file": str(item.get("file", "")).strip(),
+        "line": line,
+        "message": str(item.get("message", "")).strip(),
+    }
+
+
+def normalize_check(raw_check: object, expected_id: str, applicable: bool) -> dict[str, object]:
+    if not isinstance(raw_check, dict):
+        raw_check = {}
+    status = str(raw_check.get("status", "not_applicable"))
+    if status not in VALID_STATUS:
+        status = "not_applicable"
+    confidence = str(raw_check.get("confidence", "low"))
+    if confidence not in VALID_CONFIDENCE:
+        confidence = "low"
+    issues_payload = raw_check.get("issues", [])
+    if not isinstance(issues_payload, list):
+        issues_payload = []
+    reason = str(raw_check.get("reason", "")).strip()
+    issues = [normalize_issue(item) for item in issues_payload]
+    if not applicable:
+        status = "not_applicable"
+        reason = "Check not applicable."
+        issues = []
+    return {
+        "id": expected_id,
+        "status": status,
+        "confidence": confidence,
+        "reason": reason,
+        "issues": issues,
+    }
+
+
+def normalize_model_output(review_input: dict[str, object], payload: object) -> dict[str, object]:
+    if not isinstance(payload, dict):
+        payload = {}
+    summary = str(payload.get("summary", "No evaluator summary was provided.")).strip()
+    checks_payload = payload.get("checks", [])
+    if not isinstance(checks_payload, list):
+        checks_payload = []
+    checks_by_id = {
+        str(item.get("id")): item for item in checks_payload if isinstance(item, dict)
+    }
+    normalized_checks = []
+    for check in review_input["checks"]:
+        check_id = str(check["id"])
+        normalized_checks.append(
+            normalize_check(
+                checks_by_id.get(check_id, {}),
+                check_id,
+                bool(check["applicable"]),
+            )
+        )
+    return {"summary": summary, "checks": normalized_checks}
+
+
+def build_unavailable_summary(review_input: dict[str, object]) -> dict[str, object]:
+    return {
+        "status": "skipped",
+        "evaluation_mode": str(review_input.get("evaluation_mode", "unavailable")),
+        "applicable_count": review_input.get("applicable_count", 0),
+        "changed_files": review_input.get("changed_files", []),
+        "summary": "Focused repo-policy evaluation was not run.",
+        "checks": [
+            {
+                "id": str(check["id"]),
+                "status": "not_applicable" if not check["applicable"] else "warn",
+                "confidence": "low",
+                "reason": "Evaluator unavailable." if check["applicable"] else "Check not applicable.",
+                "issues": [],
+            }
+            for check in review_input["checks"]
+        ],
+    }
+
+
+def build_scored_summary(review_input: dict[str, object], model_output: dict[str, object]) -> dict[str, object]:
+    failing = [check for check in model_output["checks"] if check["status"] == "fail"]
+    warnings = [check for check in model_output["checks"] if check["status"] == "warn"]
+    status = "reviewed"
+    summary = model_output["summary"] or "Focused repo-policy review completed."
+    if review_input.get("applicable_count", 0) == 0:
+        status = "skipped"
+        summary = "No focused repo-policy checks were applicable to this patch."
+    elif not summary or summary in {"Patch review", "short overall assessment"}:
+        summary = "Focused repo-policy review completed, but the evaluator summary was too generic."
+    return {
+        "status": status,
+        "evaluation_mode": str(review_input.get("evaluation_mode", "unknown")),
+        "applicable_count": review_input.get("applicable_count", 0),
+        "changed_files": review_input.get("changed_files", []),
+        "summary": summary,
+        "checks": model_output["checks"],
+        "totals": {
+            "fail": len(failing),
+            "warn": len(warnings),
+            "pass": len([check for check in model_output["checks"] if check["status"] == "pass"]),
+        },
+    }
+
+
+def render_markdown(summary: dict[str, object]) -> str:
+    lines = [
+        "# Repo Policy Focus Review",
+        "",
+        f"- Status: {summary['status']}",
+        f"- Evaluator: {summary.get('evaluation_mode', 'unknown')}",
+        f"- Applicable checks: {summary['applicable_count']}",
+        f"- Changed files: {len(summary['changed_files'])}",
+        "",
+        summary["summary"],
+        "",
+        "## Checks",
+        "",
+        "| Check | Status | Confidence | Reason |",
+        "| --- | --- | --- | --- |",
+    ]
+    for check in summary["checks"]:
+        reason = check["reason"] or "-"
+        lines.append(
+            f"| `{check['id']}` | {check['status']} | {check['confidence']} | {reason} |"
+        )
+    lines.extend(["", "## Issues", ""])
+
+    any_issues = False
+    for check in summary["checks"]:
+        if not check["issues"]:
+            continue
+        any_issues = True
+        lines.append(f"### `{check['id']}`")
+        lines.append("")
+        for issue in check["issues"]:
+            location = issue["file"] or "(no file)"
+            if issue["line"]:
+                location = f"{location}:{issue['line']}"
+            lines.append(f"- {location} - {issue['message']}")
+        lines.append("")
+    if not any_issues:
+        lines.append("- None.")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    review_input = load_json(Path(args.review_input))
+    if not isinstance(review_input, dict):
+        raise SystemExit("review input must be a JSON object")
+
+    if not args.model_output:
+        summary = build_unavailable_summary(review_input)
+    else:
+        normalized_output = normalize_model_output(review_input, load_json(Path(args.model_output)))
+        summary = build_scored_summary(review_input, normalized_output)
+
+    summary_md = Path(args.summary_md)
+    summary_json = Path(args.summary_json)
+    summary_md.parent.mkdir(parents=True, exist_ok=True)
+    summary_json.parent.mkdir(parents=True, exist_ok=True)
+    summary_md.write_text(render_markdown(summary), encoding="utf-8")
+    summary_json.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Why: rsyslog CI already covers generic quality well, but it lacked repository-specific policy checks in a few recurring areas.

Impact: pull requests now get a focused deterministic policy check for test registration, doc distribution sync, and new-module onboarding.

Before/After: before these repository rules depended on reviewer memory; after CI checks them directly and reports all findings in one run.

Technical Overview:
Add a dedicated workflow that only triggers for policy-relevant changes and builds a focused review package from the pull-request diff.

Evaluate the focused checks deterministically for tests, docs, and new modules, then normalize the results into a workflow summary.

Fail the workflow only for deterministic policy violations, while still printing advisory warnings so contributors can address all follow-up in one iteration.

With the help of AI-Agents: Codex
