### PR TITLE
ci: extend focused repo policy checks

### DIFF
--- a/.github/workflows/repo-policy-focus-review.yml
+++ b/.github/workflows/repo-policy-focus-review.yml
@@ -10,6 +10,8 @@ on:
   pull_request:
     paths:
       - ".github/workflows/repo-policy-focus-review.yml"
+      - "Makefile.am"
+      - "configure.ac"
       - "docs/repo-policy-focus-review.md"
       - "scripts/build_repo_policy_focus_input.py"
       - "scripts/evaluate_repo_policy_focus.py"

--- a/docs/repo-policy-focus-review.md
+++ b/docs/repo-policy-focus-review.md
@@ -1,12 +1,14 @@
 # Repo Policy Focus Review
 
 This workflow adds a small repository-policy review for pull
-requests. It does not try to rate the whole patch. Instead, it focuses on three
+requests. It does not try to rate the whole patch. Instead, it focuses on five
 high-value policy areas that are not covered well by the existing CI suite:
 
 - test registration under `tests/`
 - documentation distribution sync under `doc/source/`
 - new-module onboarding under `plugins/` and `contrib/`
+- new-module build wiring in the top-level build manifests
+- parameter reference doc coverage for newly introduced module parameters
 
 ## Why this exists
 
@@ -51,6 +53,27 @@ The package builder collects facts such as:
 - new module directories relative to the base revision
 - whether `MODULE_METADATA.yaml` exists
 - whether a likely module doc touchpoint exists under `doc/source/`
+
+### `module-build-wiring`
+
+Applied when a pull request appears to add a new module under `plugins/` or
+`contrib/`.
+
+The package builder collects facts such as:
+
+- whether the new module directory is listed in the top-level `Makefile.am`
+- whether `configure.ac` contains the expected `AC_CONFIG_FILES` entry
+
+### `parameter-doc-sync`
+
+Applied when changed module source files introduce new configuration parameter
+names in `cnfparamdescr` tables.
+
+The package builder collects facts such as:
+
+- newly introduced parameter names relative to the base revision
+- expected parameter doc paths under `doc/source/reference/parameters/`
+- whether those doc files exist in the head revision
 
 ## Workflow behavior
 

--- a/scripts/build_repo_policy_focus_input.py
+++ b/scripts/build_repo_policy_focus_input.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 
@@ -16,6 +17,7 @@ DOC_AGENTS = ROOT_DIR / "doc" / "AGENTS.md"
 TESTS_AGENTS = ROOT_DIR / "tests" / "AGENTS.md"
 PLUGINS_AGENTS = ROOT_DIR / "plugins" / "AGENTS.md"
 CONTRIB_AGENTS = ROOT_DIR / "contrib" / "AGENTS.md"
+PARAMETER_RE = re.compile(r'\{\s*"([^"]+)"\s*,\s*eCmdHdlr')
 
 
 def parse_args() -> argparse.Namespace:
@@ -91,6 +93,25 @@ def limited_diff(base: str, head: str, paths: list[str]) -> str:
     if not unique_paths:
         return ""
     return run_git(["diff", "--unified=12", base, head, "--", *unique_paths])
+
+
+def manifest_contains_subdir(manifest: str, module_dir: str) -> bool:
+    pattern = re.compile(rf"(?<![A-Za-z0-9_./-]){re.escape(module_dir)}(?![A-Za-z0-9_./-])")
+    return bool(pattern.search(manifest))
+
+
+def configure_lists_makefile(configure_text: str, module_dir: str) -> bool:
+    needle = f"{module_dir}/Makefile"
+    pattern = re.compile(rf"(?<![A-Za-z0-9_./-]){re.escape(needle)}(?![A-Za-z0-9_./-])")
+    return bool(pattern.search(configure_text))
+
+
+def slugify_parameter_name(name: str) -> str:
+    return re.sub(r"[^a-z0-9_-]+", "-", name.lower().replace(".", "-")).strip("-")
+
+
+def extract_parameter_names(content: str) -> set[str]:
+    return {match.group(1) for match in PARAMETER_RE.finditer(content)}
 
 
 def build_tests_check(name_status: list[dict[str, object]], base: str, head: str) -> dict[str, object]:
@@ -281,13 +302,106 @@ def build_module_check(name_status: list[dict[str, object]], base: str, head: st
     }
 
 
+def build_module_build_wiring_check(module_check: dict[str, object], base: str, head: str) -> dict[str, object]:
+    # New modules must be wired into the top-level automake/autoconf files or
+    # they will never participate in normal builds and dist checks.
+    new_modules = module_check["facts"]["new_modules"]
+    applicable = bool(new_modules)
+    top_makefile = read_file_at_ref(head, "Makefile.am") if applicable else ""
+    configure_ac = read_file_at_ref(head, "configure.ac") if applicable else ""
+    wiring = []
+    for module in new_modules:
+        module_dir = str(module["dir"])
+        wiring.append(
+            {
+                "dir": module_dir,
+                "makefile_listed": manifest_contains_subdir(top_makefile, module_dir),
+                "configure_listed": configure_lists_makefile(configure_ac, module_dir),
+            }
+        )
+
+    relevant_paths = ["Makefile.am", "configure.ac", *[item["dir"] for item in new_modules]]
+    return {
+        "id": "module-build-wiring",
+        "title": "Module build wiring",
+        "applicable": applicable,
+        "facts": {
+            "new_modules": wiring,
+            "relevant_diff": limited_diff(base, head, relevant_paths) if applicable else "",
+        },
+    }
+
+
+def build_parameter_doc_check(
+    name_status: list[dict[str, object]], base: str, head: str
+) -> dict[str, object]:
+    # New module parameters should come with matching parameter reference docs.
+    changed_sources = []
+    parameter_docs = []
+    for entry in name_status:
+        path = str(entry.get("path", ""))
+        base_path = str(entry.get("old_path", path))
+        parts = Path(path).parts
+        if len(parts) < 3:
+            continue
+        if parts[0] not in {"plugins", "contrib"}:
+            continue
+        if not path.endswith((".c", ".h")):
+            continue
+        if not file_exists_at_ref(head, path):
+            continue
+
+        head_params = extract_parameter_names(read_file_at_ref(head, path))
+        base_params = set()
+        if file_exists_at_ref(base, base_path):
+            base_params = extract_parameter_names(read_file_at_ref(base, base_path))
+        new_params = sorted(head_params - base_params)
+        if not new_params:
+            continue
+
+        changed_sources.append(path)
+        module_name = parts[1]
+        for param in new_params:
+            doc_path = (
+                f"doc/source/reference/parameters/{module_name}-{slugify_parameter_name(param)}.rst"
+            )
+            parameter_docs.append(
+                {
+                    "module": module_name,
+                    "source_file": path,
+                    "parameter": param,
+                    "doc_path": doc_path,
+                    "has_doc": file_exists_at_ref(head, doc_path),
+                }
+            )
+
+    applicable = bool(parameter_docs)
+    relevant_paths = changed_sources + [
+        item["doc_path"] for item in parameter_docs if item["has_doc"]
+    ]
+    return {
+        "id": "parameter-doc-sync",
+        "title": "Parameter documentation sync",
+        "applicable": applicable,
+        "facts": {
+            "new_parameters": parameter_docs,
+            "relevant_diff": limited_diff(base, head, relevant_paths) if applicable else "",
+        },
+    }
+
+
 def collect_repo_guidance(checks: list[dict[str, object]]) -> dict[str, str]:
     guidance = {"AGENTS.md": TOP_LEVEL_AGENTS.read_text(encoding="utf-8")}
-    if checks[0]["applicable"]:
+    is_applicable = {str(check["id"]): bool(check["applicable"]) for check in checks}
+    if is_applicable.get("tests-registration"):
         guidance["tests/AGENTS.md"] = TESTS_AGENTS.read_text(encoding="utf-8")
-    if checks[1]["applicable"]:
+    if is_applicable.get("doc-dist-sync") or is_applicable.get("parameter-doc-sync"):
         guidance["doc/AGENTS.md"] = DOC_AGENTS.read_text(encoding="utf-8")
-    if checks[2]["applicable"]:
+    if (
+        is_applicable.get("module-onboarding")
+        or is_applicable.get("module-build-wiring")
+        or is_applicable.get("parameter-doc-sync")
+    ):
         guidance["plugins/AGENTS.md"] = PLUGINS_AGENTS.read_text(encoding="utf-8")
         guidance["contrib/AGENTS.md"] = CONTRIB_AGENTS.read_text(encoding="utf-8")
     return guidance
@@ -300,10 +414,13 @@ def main() -> int:
 
     name_status = collect_name_status(base, head)
     changed_files = [str(entry.get("path", "")) for entry in name_status if entry.get("path")]
+    module_check = build_module_check(name_status, base, head)
     checks = [
         build_tests_check(name_status, base, head),
         build_doc_check(name_status, base, head),
-        build_module_check(name_status, base, head),
+        module_check,
+        build_module_build_wiring_check(module_check, base, head),
+        build_parameter_doc_check(name_status, base, head),
     ]
     applicable_count = sum(1 for check in checks if check["applicable"])
 

--- a/scripts/evaluate_repo_policy_focus.py
+++ b/scripts/evaluate_repo_policy_focus.py
@@ -185,6 +185,95 @@ def evaluate_module_onboarding(check: dict[str, object]) -> dict[str, object]:
     }
 
 
+def evaluate_module_build_wiring(check: dict[str, object]) -> dict[str, object]:
+    # Build wiring is deterministic: new modules should appear in the top-level
+    # automake and autoconf manifests before they can be built in CI or distcheck.
+    facts = check["facts"]
+    issues: list[dict[str, object]] = []
+    for module in facts["new_modules"]:
+        if not module["makefile_listed"]:
+            issues.append(
+                build_issue(
+                    "Makefile.am",
+                    f"Missing SUBDIRS entry for '{module['dir']}'.",
+                )
+            )
+        if not module["configure_listed"]:
+            issues.append(
+                build_issue(
+                    "configure.ac",
+                    f"Missing AC_CONFIG_FILES entry for '{module['dir']}/Makefile'.",
+                )
+            )
+
+    if issues:
+        return {
+            "id": check["id"],
+            "status": "fail",
+            "confidence": "high",
+            "reason": "New module build wiring is incomplete.",
+            "issues": issues,
+        }
+
+    if facts["new_modules"]:
+        return {
+            "id": check["id"],
+            "status": "pass",
+            "confidence": "high",
+            "reason": "New modules are wired into the top-level build manifests.",
+            "issues": [],
+        }
+
+    return {
+        "id": check["id"],
+        "status": "not_applicable",
+        "confidence": "low",
+        "reason": "Check not applicable.",
+        "issues": [],
+    }
+
+
+def evaluate_parameter_doc_sync(check: dict[str, object]) -> dict[str, object]:
+    # This stays advisory for now because parameter extraction is deterministic,
+    # but doc coverage still relies on a filename convention rather than parsing
+    # the module reference pages end to end.
+    facts = check["facts"]
+    issues = [
+        build_issue(
+            item["source_file"],
+            f"New parameter '{item['parameter']}' is missing '{item['doc_path']}'.",
+        )
+        for item in facts["new_parameters"]
+        if not item["has_doc"]
+    ]
+
+    if issues:
+        return {
+            "id": check["id"],
+            "status": "warn",
+            "confidence": "medium",
+            "reason": "New parameters were detected without matching parameter reference docs.",
+            "issues": issues,
+        }
+
+    if facts["new_parameters"]:
+        return {
+            "id": check["id"],
+            "status": "pass",
+            "confidence": "high",
+            "reason": "New parameters have matching parameter reference docs.",
+            "issues": [],
+        }
+
+    return {
+        "id": check["id"],
+        "status": "not_applicable",
+        "confidence": "low",
+        "reason": "Check not applicable.",
+        "issues": [],
+    }
+
+
 def evaluate_check(check: dict[str, object]) -> dict[str, object]:
     # The workflow is intentionally closed over a small fixed rule set so each
     # check can carry its own deterministic semantics.
@@ -202,6 +291,10 @@ def evaluate_check(check: dict[str, object]) -> dict[str, object]:
         return evaluate_doc_dist_sync(check)
     if check["id"] == "module-onboarding":
         return evaluate_module_onboarding(check)
+    if check["id"] == "module-build-wiring":
+        return evaluate_module_build_wiring(check)
+    if check["id"] == "parameter-doc-sync":
+        return evaluate_parameter_doc_sync(check)
     return {
         "id": check["id"],
         "status": "warn",


### PR DESCRIPTION
Why: the first deterministic policy workflow covers the highest-value rules, but it still leaves new-module build wiring and parameter reference doc coverage to human review.

Impact: the focused policy review now also checks top-level build wiring for new modules and warns when new module parameters lack matching reference docs.

Before/After: before the workflow only checked tests, doc distribution, and basic module onboarding; after it also covers module build manifests and parameter doc sync.

Technical Overview:
Extend the review package builder with deterministic facts for new module build wiring against the top-level `Makefile.am` and `configure.ac`.

Add a `parameter-doc-sync` rule that compares newly introduced `cnfparamdescr` names against the expected files under `doc/source/reference/parameters/`.

Teach the deterministic evaluator about the two new checks and update the workflow trigger and documentation to match the expanded rule set.

With the help of AI-Agents: Codex
