### PR TITLE
ci: enable imfile tests in ARM CI

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1675,7 +1675,7 @@ jobs:
               autoreconf -fvi
               if [ "$ARCH" = "armhf" ]; then
                 ./configure --enable-silent-rules --enable-testbench \
-                  --enable-imdiag --disable-imdocker --disable-imfile \
+                  --enable-imdiag --disable-imdocker --enable-imfile \
                   --disable-default-tests --disable-impstats \
                   --disable-impstats-push \
                   --disable-imptcp \
@@ -1706,7 +1706,7 @@ jobs:
                 export ASAN_OPTIONS="abort_on_error=1:symbolize=1:detect_leaks=0:disable_coredump=0"
                 ./configure --enable-silent-rules --enable-testbench \
                   --enable-imdiag --disable-imdocker \
-                  --enable-imfile --disable-imfile-tests \
+                  --enable-imfile \
                   --enable-impstats --enable-imptcp \
                   --enable-mmanon --enable-mmaudit \
                   --enable-mmfields --enable-mmjsonparse \

--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -275,9 +275,9 @@ rsRetVal rsCStrAppendStrWithLen(cstr_t *const pThis, const uchar *const psz, con
     rsCHECKVALIDOBJECT(pThis, OIDrsCStr);
     assert(psz != NULL);
 
-    /* does the string fit? */
-    if (pThis->iStrLen + iStrLen >= pThis->iBufSize) {
-        CHKiRet(rsCStrExtendBuf(pThis, iStrLen)); /* need more memory! */
+    /* Keep one spare byte for cstrFinalize(), which appends the trailing NUL. */
+    if (pThis->iStrLen + iStrLen + 1 > pThis->iBufSize) {
+        CHKiRet(rsCStrExtendBuf(pThis, iStrLen + 1)); /* need more memory! */
     }
 
     /* ok, now we always have sufficient continues memory to do a memcpy() */

--- a/tests/imfile-rename-while-stopped.sh
+++ b/tests/imfile-rename-while-stopped.sh
@@ -49,6 +49,7 @@ if $msg contains "msgnum:" then
 ls -li $RSYSLOG_DYNNAME.input*
 
 startup
+wait_file_lines "$RSYSLOG_OUT_LOG" "$TESTMESSAGES"
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown	# we need to wait until rsyslogd is finished!
 
@@ -62,6 +63,7 @@ echo ls ${RSYSLOG_DYNNAME}.spool:
 ls -l ${RSYSLOG_DYNNAME}.spool
 
 startup
+wait_file_lines "$RSYSLOG_OUT_LOG" "$((TESTMESSAGES + TESTMESSAGES))"
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown	# we need to wait until rsyslogd is finished!
 


### PR DESCRIPTION
## Summary
Enable `imfile` test coverage in ARM CI for both `armhf` and `arm64`.

`imfile` is a standard rsyslog component, so ARM CI should exercise it as
part of the regular testbench. This also helps keep an eye on
`imfile-symlink-ext-tmp-dir-tree.sh`, which is worth watching on slower or
more constrained platforms.

See also https://github.com/rsyslog/rsyslog/issues/6576

## Testing
Not run locally. Workflow-only change.
