### PR TITLE
imfile: fix FD leak when symlink and target both enter pending_destroy

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -1117,14 +1117,19 @@ static void act_obj_destroy(act_obj_t *const act, const int is_deleted) {
     DBGPRINTF("act_obj_destroy: act %p '%s' (source '%s'), wd %d, pStrm %p, is_deleted %d, in_move %d\n", act,
               act->name, act->source_name ? act->source_name : "---", act->wd, act->pStrm, is_deleted, act->in_move);
     if (act->is_symlink && is_deleted) {
-        act_obj_t *target_act;
-        for (target_act = act->edge->active; target_act != NULL; target_act = target_act->next) {
-            if (target_act->source_name && !strcmp(target_act->source_name, act->name)) {
-                DBGPRINTF("act_obj_destroy: detect_updates for parent of target %s of %s symlink\n", target_act->name,
-                          act->name);
-                detect_updates(target_act->edge->parent->root->edges);
-                break;
-            }
+        /* When a symlink is deleted we must trigger detect_updates on the parent
+         * directory edge so that the target's parent directory FD is released.
+         * The symlink's target is always added to the same edge (act->edge), so
+         * act->edge->parent->root->edges is equivalent to
+         * target_act->edge->parent->root->edges used in the old code.
+         * We cannot search act->edge->active for the target because it may
+         * already have been moved to pending_destroy in the same detect_updates
+         * pass, causing the active list search to find nothing and skip the
+         * necessary cleanup.
+         */
+        if (act->edge->parent != NULL && act->edge->parent->root != NULL && act->edge->parent->root->edges != NULL) {
+            DBGPRINTF("act_obj_destroy: detect_updates for parent edges of symlink '%s'\n", act->name);
+            detect_updates(act->edge->parent->root->edges);
         }
     }
     if (act->pStrm != NULL) {


### PR DESCRIPTION
When act_obj_destroy() was called for a deleted symlink, it searched act->edge->active for the target to call detect_updates() on the parent directory edge. However, after commit 262b22d, detect_updates() may move both the symlink AND its target to pending_destroy in the same pass (when both have expired deletion delays). In that case, the target is no longer in act->edge->active, so the search fails, detect_updates(links_edge) is never called, and the target's parent directory FD is never released.

Fix: instead of searching act->edge->active for the target, directly call detect_updates(act->edge->parent->root->edges). This is always correct because the target is always added to the same edge as the symlink by process_symlink(), making act->edge->parent->root->edges equivalent to target_act->edge->parent->root->edges.

Fixes: imfile-symlink-ext-tmp-dir-tree test failure (issue #6576)

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

