### PR TITLE
core: Fix typos in comments

### DIFF
--- a/runtime/module-template.h
+++ b/runtime/module-template.h
@@ -1072,7 +1072,7 @@
  * only, but may be made available to other types of plugins in the future.
  * A plugin does not need to define this entry point. If if does, it gets
  * called when a HUP at the action level is to be done. A plugin should register
- * this function so that it can close files, connection or other ressources
+ * this function so that it can close files, connection or other resources
  * on HUP - if it can be assume the user wanted to do this as a part of HUP
  * processing. Note that the name "HUP" has historical reasons, it stems back
  * to the infamous SIGHUP which was sent to restart a syslogd. We still retain

--- a/runtime/modules.c
+++ b/runtime/modules.c
@@ -156,7 +156,7 @@ static void modUsrDel(modInfo_t *pThis, const char *pszUsr) {
         } else {
             pPrev->pNext = pUsr->pNext;
         }
-        /* free ressources */
+        /* free resources */
         free(pUsr->pszFile);
         free(pUsr);
         pUsr = NULL; /* just to make sure... */

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -484,8 +484,8 @@ static int getLogicalQueueSize(qqueue_t *pThis) {
 
 /* This function drains the queue in cases where this needs to be done. The most probable
  * reason is a HUP which needs to discard data (because the queue is configured to be lossy).
- * During a shutdown, this is typically not needed, as the OS frees up ressources and does
- * this much quicker than when we clean up ourselvs. -- rgerhards, 2008-10-21
+ * During a shutdown, this is typically not needed, as the OS frees up resources and does
+ * this much quicker than when we clean up ourselves. -- rgerhards, 2008-10-21
  * This function returns void, as it makes no sense to communicate an error back, even if
  * it happens.
  * This functions works "around" the regular deque mechanism, because it is only used to
@@ -663,7 +663,7 @@ static rsRetVal ATTR_NONNULL() InitDA(qqueue_t *const pThis, const int bLockMute
     /* check if we already have a DA worker pool. If not, initiate one. Please note that the
      * pool is created on first need but never again destructed (until the queue is). This
      * is intentional. We assume that when we need it once, we may also need it on another
-     * occasion. Ressources used are quite minimal when no worker is running.
+     * occasion. Resources used are quite minimal when no worker is running.
      * rgerhards, 2008-01-24
      * NOTE: this is the DA worker *pool*, not the DA queue!
      */
@@ -1270,7 +1270,7 @@ finalize_it:
  * with all on-disk structures kept as-is as much as possible. However,
  * we do not really stop or destruct the in-memory disk queue object.
  * Practice has shown that this may cause races during destruction which
- * themselfs can lead to segfault. So we prefer to was some ressources by
+ * themselves can lead to segfault. So we prefer to was some resources by
  * keeping the queue active.
  * Instead, the queue is switched to direct mode, so that at least
  * some processing can happen. Of course, this may still have lots of

--- a/runtime/tcpclt.c
+++ b/runtime/tcpclt.c
@@ -472,6 +472,6 @@ BEGINmodInit()
     CODESTARTmodInit;
     *ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
 
-    /* Initialize all classes that are in our module - this includes ourselfs */
+    /* Initialize all classes that are in our module - this includes ourselves */
     CHKiRet(tcpcltClassInit(pModInfo)); /* must be done after tcps_sess, as we use it */
 ENDmodInit

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -440,8 +440,8 @@ finalize_it:
 /* This should be called before a normal (non forced) close
  * of a TCP session. This function checks if there is any unprocessed
  * message left in the TCP stream. Such a message is probably a
- * fragement. If evrything goes well, we must be right at the
- * beginnig of a new frame without any data received from it. If
+ * fragment. If everything goes well, we must be right at the
+ * beginning of a new frame without any data received from it. If
  * not, there is some kind of a framing error. I think I remember that
  * some legacy syslog/TCP implementations have non-LF terminated
  * messages at the end of the stream. For now, we allow this behaviour.
@@ -770,7 +770,7 @@ finalize_it:
  * RS_RET_OK, which means the session should be kept open
  * or anything else, which means it must be closed.
  * rgerhards, 2008-03-01
- * As a performance optimization, we pick up the timestamp here. Acutally,
+ * As a performance optimization, we pick up the timestamp here. Actually,
  * this *is* the *correct* reception step for all the data we received, because
  * we have just received a bunch of data! -- rgerhards, 2009-06-16
  */
@@ -796,7 +796,7 @@ static rsRetVal DataRcvd(tcps_sess_t *pThis, char *pData, const size_t iLen) {
     multiSub.nElem = 0;
 
     /* We now copy the message to the session buffer. */
-    pEnd = pData + iLen; /* this is one off, which is intensional */
+    pEnd = pData + iLen; /* this is one off, which is intentional */
 
     while (pData < pEnd) {
         CHKiRet(processDataRcvd(pThis, &pData, pEnd - pData, &stTime, ttGenTime, &multiSub, &nMsgs));

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -547,7 +547,7 @@ static int ATTR_NONNULL() TCPSessGetNxtSess(tcpsrv_t *pThis, const int iCurr) {
 #endif
 
 
-/* De-Initialize TCP listner sockets.
+/* De-Initialize TCP listener sockets.
  * This function deinitializes everything, including freeing the
  * session table. No TCP listen receive operations are permitted
  * unless the subsystem is reinitialized.
@@ -1713,7 +1713,7 @@ static rsRetVal ATTR_NONNULL() Run(tcpsrv_t *const pThis) {
     ISOBJ_TYPE_assert(pThis, tcpsrv);
 
     if (pThis->iLstnCurr == 0) {
-        dbgprintf("tcpsrv: no listeneres at all (probably init error), terminating\n");
+        dbgprintf("tcpsrv: no listeners at all (probably init error), terminating\n");
         FINALIZE;
     }
 
@@ -2214,7 +2214,7 @@ static rsRetVal ATTR_NONNULL(1) SetDrvrTlsRevocationCheck(tcpsrv_t *pThis, int e
 }
 
 
-/* End of methods to shuffle autentication settings to the driver.;
+/* End of methods to shuffle authentication settings to the driver.;
 
  * -------------------------------------------------------------------------- */
 
@@ -2417,7 +2417,7 @@ ENDqueryEtryPt
 BEGINmodInit()
     CODESTARTmodInit;
     *ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
-    /* Initialize all classes that are in our module - this includes ourselfs */
+    /* Initialize all classes that are in our module - this includes ourselves */
     CHKiRet(tcps_sessClassInit(pModInfo));
     CHKiRet(tcpsrvClassInit(pModInfo)); /* must be done after tcps_sess, as we use it */
 ENDmodInit

--- a/runtime/tcpsrv.h
+++ b/runtime/tcpsrv.h
@@ -265,7 +265,7 @@ BEGINinterface(tcpsrv) /* name must also be changed in ENDinterface macro! */
     rsRetVal (*SetOnMsgReceive)(tcpsrv_t *pThis,
                                 rsRetVal (*OnMsgReceive)(tcps_sess_t *, uchar *, int)); /* 2009-05-24 */
     rsRetVal (*SetRuleset)(tcpsrv_t *pThis, ruleset_t *); /* 2009-06-12 */
-    /* added v7 (accidently named v8!) */
+    /* added v7 (accidentally named v8!) */
     rsRetVal (*SetLstnMax)(tcpsrv_t *pThis, int iMaxLstn); /* 2009-08-17 */
     rsRetVal (*SetNotificationOnRemoteClose)(tcpsrv_t *pThis, int bNewVal); /* 2009-10-01 */
     rsRetVal (*SetNotificationOnRemoteOpen)(tcpsrv_t *pThis, int bNewVal); /* 2022-08-23 */

--- a/runtime/typedefs.h
+++ b/runtime/typedefs.h
@@ -267,7 +267,7 @@ typedef enum cslCmdHdlrType {
     eCmdHdlrString,
     eCmdHdlrArray,
     eCmdHdlrQueueType,
-    eCmdHdlrGoneAway /* statment existed, but is no longer supported */
+    eCmdHdlrGoneAway /* statement existed, but is no longer supported */
 } ecslCmdHdrlType;
 
 

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -7,7 +7,7 @@
  *
  * There is some in-depth documentation available in doc/dev_queue.html
  * (and in the web doc set on https://www.rsyslog.com/doc/). Be sure to read it
- * if you are getting aquainted to the object.
+ * if you are getting acquainted to the object.
  *
  * Copyright 2008-2026 Adiscon GmbH.
  *
@@ -410,7 +410,7 @@ PRAGMA_IGNORE_Wempty_body rsRetVal wtiWorker(wti_t *__restrict__ const pThis) {
      * this is not true: it actually is unlocked when the actual processing
      * is done, as part of pWtp->pfDoWork() processing. Note that this
      * function is required to re-lock it when done. We cannot do the
-     * lock/unlock here ourselfs, as pfDoWork() needs to access queue
+     * lock/unlock here ourselves, as pfDoWork() needs to access queue
      * structures itself.
      * The same goes for pfRateLimiter(). While we could unlock/lock when
      * we call it, in practice the function is often called without any

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -6,7 +6,7 @@
  *
  * There is some in-depth documentation available in doc/dev_queue.html
  * (and in the web doc set on https://www.rsyslog.com/doc/). Be sure to read it
- * if you are getting aquainted to the object.
+ * if you are getting acquainted to the object.
  *
  * Copyright 2008-2026 Rainer Gerhards and Adiscon GmbH.
  *

--- a/runtime/zlibw.c
+++ b/runtime/zlibw.c
@@ -163,7 +163,7 @@ finalize_it:
     }
     RETiRet;
 }
-/* destruction of caller's zlib ressources - a dummy for us */
+/* destruction of caller's zlib resources - a dummy for us */
 static rsRetVal zlib_Destruct(ATTR_UNUSED strm_t *pThis) {
     return RS_RET_OK;
 }


### PR DESCRIPTION
This improves code readability and maintainability by correcting
typos in comments. While non-functional, clear comments reduce
confusion for contributors and support long-term project quality.

Before: comments contained minor typos and inconsistencies.
After: comments use corrected spelling and clearer wording.

Impact: none (no functional or behavioral changes).

The patch updates comment text only, without modifying logic,
interfaces, or runtime behavior. No changes to queue semantics,
transactions, or module interactions are introduced.

This aligns with ongoing maintenance efforts to keep the codebase
clean and easier to understand for contributors and reviewers.

AI-Agent: Copilot 2026-03

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
This improves code readability and maintainability by correcting
typos in comments. While non-functional, clear comments reduce
confusion for contributors and support long-term project quality.


### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/6023





