### PR TITLE
ci: fix yamllint changed-file handling

### DIFF
--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -48,13 +48,15 @@ jobs:
 
       - name: Run yamllint
         if: steps.changed.outputs.any_changed == 'true'
+        env:
+          CHANGED_YAML_FILES: ${{ steps.changed.outputs.all_changed_files }}
         run: |
-          mapfile -t files <<'EOF'
-          ${{ steps.changed.outputs.all_changed_files }}
-          EOF
-          yamllint \
-            -d '{extends: relaxed, rules: {line-length: {max: 120}}}' \
-            "${files[@]}"
+          while IFS= read -r file; do
+            [ -n "$file" ] || continue
+            yamllint \
+              -d '{extends: relaxed, rules: {line-length: {max: 120}}}' \
+              "$file"
+          done <<< "$CHANGED_YAML_FILES"
 
       - name: Skip yamllint, no YAML changes
         if: steps.changed.outputs.any_changed != 'true'


### PR DESCRIPTION
## Summary
Fix the `yamllint` workflow so changed YAML paths are passed to the shell as
data instead of being reconstructed inside the `run` script.

## Why
The current workflow can hand `yamllint` a malformed filename when multiline
`changed-files` output is interpolated into a heredoc.

## Impact
Changed YAML files continue to be linted, but the workflow no longer trips over
its own filename handling.

## Before/After
Before, the job could invoke `yamllint` with a bogus path ending in `\`.
After, it reads the changed-file list from an environment variable and lints
one file at a time.

## Verification
- Parsed `.github/workflows/yaml_lint.yml` with `yaml.safe_load`
- Ran the new loop against the two YAML files from PR 6615
