### PR TITLE
doc: add ROSI Windows Agent guidance

### DIFF
--- a/doc/source/deployments/rosi_collector/architecture.rst
+++ b/doc/source/deployments/rosi_collector/architecture.rst
@@ -3,6 +3,16 @@
 Architecture
 ============
 
+.. meta::
+   :description: Architecture overview of ROSI Collector, including rsyslog, Loki, Grafana, Prometheus, Traefik, and Windows client integration.
+   :keywords: rsyslog, ROSI Collector, architecture, Loki, Grafana, Prometheus, Windows Agent
+
+.. summary-start
+
+ROSI Collector combines rsyslog, Loki, Grafana, Prometheus, and Traefik, with Windows systems feeding the stack through rsyslog Windows Agent.
+
+.. summary-end
+
 .. index::
    pair: ROSI Collector; architecture
    single: Loki
@@ -12,6 +22,9 @@ Architecture
 ROSI Collector combines several components into a cohesive logging and
 monitoring stack. This page describes each component, how they interact,
 and the data flows through the system.
+Most examples in this guide use Linux clients, but the broader ROSI stack also
+includes official Windows-side components such as
+`rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`__.
 
 .. figure:: rosi-architecture.svg
    :alt: ROSI Collector Architecture Diagram
@@ -103,6 +116,11 @@ Log Data Flow
 3. **rsyslog omhttp** sends logs directly to Loki with labels
 4. **Loki** stores labeled log entries in compressed format
 5. **Grafana** queries Loki to display logs in dashboards and Explore
+
+For Windows systems, the client-side collector is typically
+`rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`__. It is an
+official ROSI Windows-side component and forwards Windows Event Log data,
+file-based logs, and relay traffic into the same collector-side pipeline.
 
 Metrics Data Flow
 ^^^^^^^^^^^^^^^^^

--- a/doc/source/deployments/rosi_collector/client_setup.rst
+++ b/doc/source/deployments/rosi_collector/client_setup.rst
@@ -3,6 +3,16 @@
 Client Setup
 ============
 
+.. meta::
+   :description: Configure Linux and Windows clients to send logs to ROSI Collector, with Linux metrics collection and Windows forwarding guidance.
+   :keywords: rsyslog, ROSI Collector, client setup, Windows Agent, node_exporter, log forwarding
+
+.. summary-start
+
+Configure ROSI Collector clients for log forwarding, with Linux-specific metrics steps and Windows guidance via rsyslog Windows Agent.
+
+.. summary-end
+
 .. index::
    pair: ROSI Collector; client configuration
    single: rsyslog forwarding
@@ -52,6 +62,44 @@ Download and run the setup scripts from your ROSI Collector:
 
 Replace ``YOUR_COLLECTOR_DOMAIN`` with your ROSI Collector's base domain
 (the same value as ``TRAEFIK_DOMAIN`` in your ``.env`` file).
+
+Windows Clients
+---------------
+
+For Windows systems, use `rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`__
+as the official ROSI Windows-side collector/forwarder. The official rsyslog
+FAQ notes that rsyslog itself, including the Linux rsyslog collector/forwarder
+used elsewhere in this guide, does not run natively on Windows and points
+Windows users to the agent:
+`Does rsyslog run under Windows? <https://www.rsyslog.com/doc/faq/does-rsyslog-run-under-windows.html>`__.
+
+The agent is a commercial, closed-source Windows collector from the same team
+behind rsyslog. It is optimized to work with rsyslog-based backends, and its
+commercial support helps fund ongoing rsyslog development on Linux:
+`Windows Agent support <https://www.rsyslog.com/windows-agent/support-contract-windows-agent/>`__.
+
+From a ROSI Collector perspective, it fills the same client-side role as the
+Linux rsyslog forwarder: collect logs at the edge, buffer and process them
+efficiently, and forward them to the central collector. The product manual
+describes support for Windows Event Log collection, text log files, syslog
+relay, filtering, and forwarding over UDP, TCP, TLS, and RELP:
+`rsyslog Windows Agent manual <https://www.rsyslog.com/download/files/windows-agent-manual/index.rsyslog.html>`__.
+
+Within the broader ROSI stack, this fits the same general pattern as other
+supported components: use the part that best matches the source platform and
+operational need. That can include Adiscon-side components such as WinSyslog
+or EventReporter in some deployments, just as other ROSI profiles may combine
+rsyslog with Grafana, Elasticsearch, or Splunk where appropriate.
+
+The agent is built on `Adiscon <https://www.adiscon.com/>`__'s mature Windows
+log collection technology, which is designed for robust, resource-efficient
+event collection and is tuned to integrate well with rsyslog environments.
+For more background, see the `Windows Event Log format and technology background <https://www.rsyslog.com/windows-agent/event-log-format-windows-agent/>`__
+and `feature overview <https://www.rsyslog.com/download/files/windows-agent-manual/rsyslogwaspecific/features.html>`__.
+
+This Windows section covers log forwarding only. The ``node_exporter``,
+``impstats`` sidecar, and port ``9100`` metrics steps later in this page are
+Linux-oriented and do not apply to Windows hosts using rsyslog Windows Agent.
 
 Manual Setup: rsyslog
 ---------------------

--- a/doc/source/deployments/rosi_collector/index.rst
+++ b/doc/source/deployments/rosi_collector/index.rst
@@ -3,6 +3,16 @@
 ROSI Collector
 ==============
 
+.. meta::
+   :description: ROSI Collector is the current container-based ROSI deployment profile for centralized logging, dashboards, metrics, and alerting.
+   :keywords: rsyslog, ROSI Collector, centralized logging, Grafana, Loki, Prometheus, Windows Agent
+
+.. summary-start
+
+ROSI Collector is the current container-based ROSI deployment profile, combining rsyslog, Loki, Grafana, Prometheus, and Traefik for centralized logging and monitoring.
+
+.. summary-end
+
 .. index::
    single: ROSI
    single: ROSI Collector
@@ -35,6 +45,13 @@ ROSI Collector is a Docker Compose stack that deploys:
 
 Together, these components provide centralized log management for any number
 of client hosts, with powerful search, visualization, and alerting capabilities.
+
+ROSI Collector is the current container-based ROSI deployment profile described
+in this guide. The broader ROSI stack also supports Windows clients via
+official components such as
+`rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`__. Other
+Adiscon components can also be integrated to meet specific operational
+requirements.
 
 .. note::
    The installation scripts have been tested on **Ubuntu 24.04 LTS**.
@@ -134,6 +151,11 @@ Data flows:
 
 1. **Logs**: Client rsyslog → Collector rsyslog → Loki → Grafana
 2. **Metrics**: Prometheus scrapes node_exporter on clients → Grafana
+
+For Windows senders, use
+`rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`__ as an
+official ROSI Windows-side component. The collector-side flow stays the same
+once events reach the ROSI Collector.
 
 All external access goes through Traefik, which handles TLS termination.
 


### PR DESCRIPTION
## Summary
Add ROSI Collector documentation for `rsyslog Windows Agent` so the ROSI
client story no longer reads as Linux-only.

## What Changed
- add Windows-agent context to the ROSI Collector overview
- explain Windows-side data flow in the ROSI Collector architecture page
- add a `Windows Clients` section to the client setup guide with official links
- note explicitly that rsyslog itself does not run natively on Windows

## Why
ROSI documentation already describes the collector-side stack well, but it had
no concrete Windows client guidance. This change documents how
`rsyslog Windows Agent` fits into ROSI while keeping `ROSI Collector` scoped as
its current container-based deployment profile.

## Validation
- `./doc/tools/build-doc-linux.sh --clean --format html`

## Notes
The requested milestone `2026-04` does not exist in `rsyslog/rsyslog`, so this
PR is created without a milestone.
