### PR TITLE
doc: improve ROSI navigation and scope notes

### DIFF
--- a/doc/source/deployments/index.rst
+++ b/doc/source/deployments/index.rst
@@ -30,6 +30,24 @@ monitoring stack including:
 
 :doc:`Get started with ROSI Collector <rosi_collector/index>`
 
+ROSI Collector is the primary packaged ROSI deployment profile today. The
+broader ROSI direction is larger than this single stack and includes
+alternative destinations, mixed-component architectures, and Windows-side
+collection options. Many of those wider integration paths have existed in
+practice for years through rsyslog's open integration model. ROSI formalizes
+that long-standing approach, provides clearer guidance around it, and adds
+progressively more turnkey artifacts. Today, those artifacts are still uneven
+in maturity, with ROSI Collector as the clearest packaged starting point.
+
+Examples within that broader ROSI space include destinations such as
+Elasticsearch, OpenSearch, Splunk, VictoriaLogs, Kafka, and HTTP-based or cloud
+endpoints, as well as Windows-side components such as
+`rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`_,
+`WinSyslog <https://www.winsyslog.com/>`_, `EventReporter <https://www.eventreporter.com/>`_,
+and `MonitorWare Agent <https://www.monitorware.com/>`_. Some of these come
+from `Adiscon <https://www.adiscon.com/>`_, while others are third-party
+components that ROSI can integrate with.
+
 For the beginner-level ROSI rationale (freedom of choice and avoiding
 vendor lock-in), see :doc:`../getting_started/rosi_for_beginners`.
 
@@ -78,7 +96,8 @@ When to Use Each Option
 **Custom Stack**
    Build your own stack when you have specific requirements that aren't
    met by the provided deployments, or when integrating with enterprise
-   systems like Elasticsearch, Splunk, or cloud logging services.
+   systems like Elasticsearch, Splunk, VictoriaLogs, Kafka, or cloud logging
+   services.
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/deployments/rosi_collector/index.rst
+++ b/doc/source/deployments/rosi_collector/index.rst
@@ -50,8 +50,14 @@ ROSI Collector is the current container-based ROSI deployment profile described
 in this guide. The broader ROSI stack also supports Windows clients via
 official components such as
 `rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`__. Other
-Adiscon components can also be integrated to meet specific operational
-requirements.
+components such as `WinSyslog <https://www.winsyslog.com/>`_,
+`EventReporter <https://www.eventreporter.com/>`_, and
+`MonitorWare Agent <https://www.monitorware.com/>`_ can also be integrated to
+meet specific operational requirements. ROSI Collector is the primary packaged
+artifact today, while the broader ROSI idea extends beyond this single
+deployment profile. That broader model has long been possible through
+rsyslog-based integrations and parallel destinations; ROSI adds clearer
+guidance and progressively more turnkey artifacts around those practices.
 
 .. note::
    The installation scripts have been tested on **Ubuntu 24.04 LTS**.

--- a/doc/source/deployments/rosi_for_decision_makers.rst
+++ b/doc/source/deployments/rosi_for_decision_makers.rst
@@ -32,6 +32,26 @@ today and provides:
 
 See :doc:`rosi_collector/index` for implementation details.
 
+Current State and Broader Direction
+-----------------------------------
+
+ROSI Collector is the main visible and ready-to-run ROSI artifact today. It is
+the clearest starting point for teams that want immediate operational value.
+
+The broader ROSI direction is larger than that single deployment profile. It
+includes replaceable backend choices, mixed-component topologies, and
+Windows-side collection paths. Many of these implementation patterns have
+existed around rsyslog for a long time already. ROSI formalizes that operating
+model, provides clearer guidance, and adds progressively more turnkey artifacts.
+Those artifacts are not yet all equally mature, which is why ROSI Collector is
+the clearest starting point today.
+
+That broader space can include destinations such as Elasticsearch, OpenSearch,
+Splunk, VictoriaLogs, Kafka, and HTTP-based services, plus Windows-side
+components such as `rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`_,
+`WinSyslog <https://www.winsyslog.com/>`_, `EventReporter <https://www.eventreporter.com/>`_,
+and `MonitorWare Agent <https://www.monitorware.com/>`_.
+
 Why This Matters Strategically
 ------------------------------
 

--- a/doc/source/deployments/rosi_for_platform_teams.rst
+++ b/doc/source/deployments/rosi_for_platform_teams.rst
@@ -30,6 +30,21 @@ For platform teams, this means:
 - rsyslog-centered collection and routing as a stable control point
 - Freedom to adapt downstream storage and analytics over time
 
+Where ROSI Is Today
+-------------------
+
+The main packaged ROSI artifact today is :doc:`rosi_collector/index`. That is
+the recommended operational baseline because it is the most complete and
+ready-to-run profile.
+
+At the same time, ROSI is intentionally broader than ROSI Collector alone.
+Platform teams can already combine rsyslog-centered ingestion with additional
+destinations and side components. That is not new in itself: many teams have
+been doing this with rsyslog for years. What ROSI adds is a clearer
+formalization of those patterns, stronger guidance, and a growing set of
+artifacts that reduce setup effort. Those artifacts are not yet all equally
+turnkey, which is why ROSI Collector remains the main packaged baseline today.
+
 It also means optimizing for efficiency, not just feature count:
 
 - Lower operational overhead for small and medium environments
@@ -80,6 +95,20 @@ rsyslog already supports multiple output paths that help avoid hard coupling:
 
 This enables practical designs such as dual-write transitions, phased
 cutovers, and domain-specific routing.
+
+In ROSI terms, this means the current collector profile can coexist with
+additional destinations such as Splunk, VictoriaLogs, or other HTTP-accessible
+backends when platform requirements call for that.
+
+The broader ROSI picture can also include Windows-side components such as
+`rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`_,
+`WinSyslog <https://www.winsyslog.com/>`_, `EventReporter <https://www.eventreporter.com/>`_,
+and `MonitorWare Agent <https://www.monitorware.com/>`_ where those products
+fit existing operational models.
+
+ROSI therefore helps in three ways at once: it preserves architectural freedom,
+it gives clearer guidance on how to use that freedom well, and it gradually
+adds more ready-made artifacts around proven rsyslog-based patterns.
 
 Using rsyslog on the edge can reduce central processing cost by shaping data
 before it reaches backends, which supports both FinOps and Green IT targets.

--- a/doc/source/getting_started/rosi_for_beginners.rst
+++ b/doc/source/getting_started/rosi_for_beginners.rst
@@ -19,6 +19,14 @@ ROSI (Rsyslog Operations Stack Initiative) is the rsyslog approach to practical,
 modern observability: start with a concrete stack you can deploy now, but do not
 get trapped in one vendor or one fixed architecture.
 
+Today, the main ready-to-run ROSI artifact is :doc:`../deployments/rosi_collector/index`.
+That is the easiest way to get started, but ROSI itself is broader than that
+single profile. The larger ROSI picture includes additional backend choices,
+mixed-component deployments, and Windows-side collection options. Many of these
+architectures have been built with rsyslog for a long time already; what ROSI
+adds is a clearer formalization of that approach, better guidance, and a
+growing set of artifacts that make adoption easier.
+
 Why ROSI Exists
 ---------------
 
@@ -99,7 +107,22 @@ including modules such as:
 - :doc:`../configuration/modules/omfwd` for syslog forwarding
 
 Common destination examples include Loki, Elasticsearch, OpenSearch, Kafka,
-Splunk (HEC-style HTTP), and cloud endpoints exposed over HTTP or syslog.
+Splunk (HEC-style HTTP), VictoriaLogs, and cloud endpoints exposed over HTTP or
+syslog.
+
+ROSI can also include Windows-side collection components where they fit the
+operational need, such as `rsyslog Windows Agent <https://www.rsyslog.com/windows-agent/>`_,
+`WinSyslog <https://www.winsyslog.com/>`_, `EventReporter <https://www.eventreporter.com/>`_,
+and `MonitorWare Agent <https://www.monitorware.com/>`_. These complement the
+rsyslog-centered ingestion and routing model rather than replacing it.
+Some of these components come from `Adiscon <https://www.adiscon.com/>`_, while
+others are third-party tools that fit the same freedom-of-choice model.
+
+In other words, ROSI does not invent freedom-of-choice logging around rsyslog.
+Users have long connected rsyslog to destinations such as Elasticsearch,
+Splunk, Kafka, syslog receivers, and HTTP-based services, sometimes in
+parallel. ROSI formalizes that long-standing practice and provides clearer
+guidance and more reusable artifacts around it.
 
 As ROSI grows, additional pre-packaged stack profiles can be added without
 changing this core principle: keep architectures replaceable.
@@ -118,6 +141,12 @@ ROSI **is**:
 
 - A practical, rsyslog-backed observability approach
 - A concrete starter stack (ROSI Collector) for centralized logs and metrics
+- A formalization of long-standing rsyslog practices around replaceable
+  architectures and parallel destinations
+- A guidance layer that makes proven rsyslog-based patterns easier to choose
+  and operate well
+- A broader ecosystem direction that can incorporate additional backends and
+  Windows-side components, with more turnkey artifacts being added over time
 - A path that can grow with your infrastructure over time
 - Container-based today, with Kubernetes-oriented evolution as a next target
 


### PR DESCRIPTION
## Summary
Improve ROSI docs navigation and clarify the Windows integration scope.

## What changed
- link the ROSI Collector index to the guided walkthrough
- add the walkthrough to See Also on the same page
- clarify that Windows Agent integration covers log ingestion, while metrics remain Linux-oriented
- add the walkthrough link to the ROSI beginner page

## Validation
- ./doc/tools/build-doc-linux.sh --clean --format html
