### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix buffer overflow risk in omazureeventhubs

### DIFF
--- a/plugins/omazureeventhubs/omazureeventhubs.c
+++ b/plugins/omazureeventhubs/omazureeventhubs.c
@@ -534,7 +534,7 @@ static rsRetVal writeProton(wrkrInstanceData_t *__restrict__ const pWrkrData,
     char szMsgID[64];
     pthread_mutex_lock(&pWrkrData->msgLock);
     lockHeld = 1;
-    sprintf(szMsgID, "%d", pWrkrData->iMsgSeq);
+    snprintf(szMsgID, sizeof(szMsgID), "%d", pWrkrData->iMsgSeq);
 
     const char *pszParamStr = (const char *)actParam(pParam, 1 /*pData->iNumTpls*/, iMsg, 0).param;
     size_t tzParamStrLen = actParam(pParam, 1 /*pData->iNumTpls*/, iMsg, 0).lenStr;


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** `sprintf` was used to write an integer to a 64-byte buffer `szMsgID` in `omazureeventhubs.c`. While `iMsgSeq` values are technically bounded by the integer size and should not overflow the 64-byte limit under normal operation, using `sprintf` without bounds checking is generally an unsafe practice and a potential vector for future regressions if the variable type or buffer size changes. 

🎯 **Impact:** Potential buffer overflow leading to a crash or arbitrary code execution (though difficult to exploit in this specific context due to integer bounds).

🔧 **Fix:** Replaced `sprintf` with `snprintf(szMsgID, sizeof(szMsgID), ...)` to enforce strict bounds checking.

✅ **Verification:** Verified by compiling the codebase (`./autogen.sh && make -j4`) and passing the tests (`make check`).

---
*PR created automatically by Jules for task [2790835950936173432](https://jules.google.com/task/2790835950936173432) started by @rgerhards*