### PR TITLE
doc: link ROSI references to overview page

### DIFF
--- a/doc/source/deployments/index.rst
+++ b/doc/source/deployments/index.rst
@@ -30,6 +30,7 @@ monitoring stack including:
 
 :doc:`Get started with ROSI Collector <rosi_collector/index>`
 
+<<<<<<< HEAD
 ROSI Collector is the primary packaged ROSI deployment profile today. The
 broader ROSI direction is larger than this single stack and includes
 alternative destinations, mixed-component architectures, and Windows-side
@@ -48,8 +49,8 @@ and `MonitorWare Agent <https://www.monitorware.com/>`_. Some of these come
 from `Adiscon <https://www.adiscon.com/>`_, while others are third-party
 components that ROSI can integrate with.
 
-For the beginner-level ROSI rationale (freedom of choice and avoiding
-vendor lock-in), see :doc:`../getting_started/rosi_for_beginners`.
+For the beginner-level ROSI rationale (freedom of choice and avoiding vendor
+lock-in), see :doc:`../getting_started/rosi_for_beginners`.
 
 For audience-specific ROSI follow-up guidance:
 

--- a/doc/source/getting_started/next_steps.rst
+++ b/doc/source/getting_started/next_steps.rst
@@ -8,7 +8,7 @@ Production Deployments
 ----------------------
 
 For a complete log collection stack with dashboards and alerting, see
-ROSI Collector (:doc:`Rsyslog Operations Stack Initiative <../deployments/rosi_for_decision_makers>`):
+ROSI Collector (:doc:`Rsyslog Operations Stack Initiative <rosi_for_beginners>`):
 
 :doc:`../deployments/rosi_collector/index`
 


### PR DESCRIPTION
## Summary
Add direct links from high-level ROSI references to the ROSI overview page.

## What changed
- link a ROSI reference in deployments/index.rst to the ROSI overview page
- link the ROSI spelling-out in getting_started/next_steps.rst to the same page

## Validation
- ./doc/tools/build-doc-linux.sh --clean --format html
