### PR TITLE
packaging/docker: trim container image rough edges

### DIFF
--- a/packaging/docker/rsyslog/Makefile
+++ b/packaging/docker/rsyslog/Makefile
@@ -16,6 +16,12 @@ ORG_NAME = rsyslog
 # This can be overridden via command line: 'make VERSION=my-custom-tag <target>'
 VERSION ?= 2025-10
 
+# Default OCI metadata values for local builds.
+BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+VCS_REF ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
+OCI_BUILD_ARGS = --build-arg BUILD_DATE="$(BUILD_DATE)" \
+                 --build-arg VCS_REF="$(VCS_REF)"
+
 # Variable to control cache busting. Set to 'yes' to force a rebuild from scratch for all targets.
 # Example: make all REBUILD=yes
 REBUILD ?= no
@@ -84,19 +90,21 @@ etl: build_etl_image
 build_minimal_image: ./minimal/Dockerfile ./minimal/rsyslog.conf
 	@echo "--- Building minimal image: $(MINIMAL_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
-	              -t $(MINIMAL_IMAGE_TAG) \
-	              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
-	              -f ./minimal/Dockerfile ./minimal
+		              -t $(MINIMAL_IMAGE_TAG) \
+		              $(OCI_BUILD_ARGS) \
+		              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
+		              -f ./minimal/Dockerfile ./minimal
 
 # Build the standard rsyslog container.
 # Depends on 'build_minimal_image'. Assumes ./standard/Dockerfile exists.
 build_standard_image: build_minimal_image ./standard/Dockerfile # Add ./standard/rsyslog.conf if it exists
 	@echo "--- Building standard image: $(STANDARD_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
-	              -t $(STANDARD_IMAGE_TAG) \
-	              --build-arg BASE_IMAGE_TAG=$(MINIMAL_IMAGE_TAG) \
-	              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
-	              -f ./standard/Dockerfile ./standard
+		              -t $(STANDARD_IMAGE_TAG) \
+		              --build-arg BASE_IMAGE_TAG=$(MINIMAL_IMAGE_TAG) \
+		              $(OCI_BUILD_ARGS) \
+		              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
+		              -f ./standard/Dockerfile ./standard
 
 # Build the collector rsyslog container.
 # Depends on 'build_standard_image'.
@@ -106,10 +114,11 @@ build_collector_image: build_standard_image \
                        ./collector/80-file-output.conf
 	@echo "--- Building collector image: $(COLLECTOR_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
-	              -t $(COLLECTOR_IMAGE_TAG) \
-	              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
-	              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
-	              -f ./collector/Dockerfile ./collector
+		              -t $(COLLECTOR_IMAGE_TAG) \
+		              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
+		              $(OCI_BUILD_ARGS) \
+		              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
+		              -f ./collector/Dockerfile ./collector
 
 # Build the dockerlogs rsyslog container.
 # Depends on 'build_standard_image'. Dockerfile path assumed ./dockerlogs/
@@ -118,10 +127,11 @@ build_dockerlogs_image: build_standard_image \
                         ./dockerlogs/30-docker.conf
 	@echo "--- Building dockerlogs image: $(DOCKERLOGS_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
-	              -t $(DOCKERLOGS_IMAGE_TAG) \
-	              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
-	              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
-	              -f ./dockerlogs/Dockerfile ./dockerlogs
+		              -t $(DOCKERLOGS_IMAGE_TAG) \
+		              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
+		              $(OCI_BUILD_ARGS) \
+		              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
+		              -f ./dockerlogs/Dockerfile ./dockerlogs
 
 # Build the etl rsyslog container.
 # Depends on 'build_standard_image'.
@@ -131,10 +141,11 @@ build_etl_image: build_standard_image \
                   ./etl/70-vespa_ai.conf
 	@echo "--- Building ETL image: $(ETL_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
-	              -t $(ETL_IMAGE_TAG) \
-	              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
-	              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
-	              -f ./etl/Dockerfile ./etl
+		              -t $(ETL_IMAGE_TAG) \
+		              --build-arg BASE_IMAGE_TAG=$(STANDARD_IMAGE_TAG) \
+		              $(OCI_BUILD_ARGS) \
+		              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
+		              -f ./etl/Dockerfile ./etl
 
 # Generic build target, alias for 'all'.
 build: all

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -9,6 +9,8 @@ ARG BASE_IMAGE_TAG="rsyslog/rsyslog:latest"
 ARG UBUNTU_VERSION="24.04"
 # Version passed from Makefile for image metadata
 ARG RSYSLOG_IMG_VERSION="unset"
+ARG BUILD_DATE="unknown"
+ARG VCS_REF="unknown"
 
 # Use the rsyslog/rsyslog (standard) image as the base.
 # This ensures common modules, core rsyslog setup, and imhttp are inherited.
@@ -18,12 +20,23 @@ FROM ${BASE_IMAGE_TAG}
 ARG UBUNTU_VERSION
 ARG RSYSLOG_IMG_VERSION
 ARG BASE_IMAGE_TAG
+ARG BUILD_DATE
+ARG VCS_REF
 
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Rsyslog collector container, based on the standard image, optimized for log collection. Ubuntu ${UBUNTU_VERSION}."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"
 # Explicitly label the base image used for traceability.
 LABEL com.adiscon.rsyslog.base.image="${BASE_IMAGE_TAG}"
+LABEL org.opencontainers.image.title="rsyslog/rsyslog-collector"
+LABEL org.opencontainers.image.description="Central rsyslog collector image with network inputs, RELP, and optional TLS support."
+LABEL org.opencontainers.image.url="https://www.rsyslog.com/"
+LABEL org.opencontainers.image.documentation="https://www.rsyslog.com/doc/containers/collector.html"
+LABEL org.opencontainers.image.source="https://github.com/rsyslog/rsyslog"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.version="${RSYSLOG_IMG_VERSION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
 
 # Set DEBIAN_FRONTEND to noninteractive to prevent interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/packaging/docker/rsyslog/dockerlogs/Dockerfile
+++ b/packaging/docker/rsyslog/dockerlogs/Dockerfile
@@ -8,6 +8,8 @@
 ARG BASE_IMAGE_TAG="rsyslog/rsyslog:latest"
 ARG UBUNTU_VERSION="24.04" # Inherited from base, but good to keep for consistency/labels
 ARG RSYSLOG_IMG_VERSION="unset" # Version passed from Makefile for image metadata
+ARG BUILD_DATE="unknown"
+ARG VCS_REF="unknown"
 
 # Use the rsyslog/rsyslog (standard) image as the base.
 # This ensures common modules and core rsyslog setup is inherited.
@@ -17,12 +19,23 @@ FROM ${BASE_IMAGE_TAG}
 ARG UBUNTU_VERSION
 ARG RSYSLOG_IMG_VERSION
 ARG BASE_IMAGE_TAG
+ARG BUILD_DATE
+ARG VCS_REF
 
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Rsyslog container specialized for Docker log collection using imdocker, based on the rsyslog/rsyslog (standard) image."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"
 # Explicitly label the base image used for traceability.
 LABEL com.adiscon.rsyslog.base.image="${BASE_IMAGE_TAG}"
+LABEL org.opencontainers.image.title="rsyslog/rsyslog-dockerlogs"
+LABEL org.opencontainers.image.description="Rsyslog image specialized for Docker daemon log collection and forwarding."
+LABEL org.opencontainers.image.url="https://www.rsyslog.com/"
+LABEL org.opencontainers.image.documentation="https://www.rsyslog.com/doc/containers/dockerlogs.html"
+LABEL org.opencontainers.image.source="https://github.com/rsyslog/rsyslog"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.version="${RSYSLOG_IMG_VERSION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
 
 # Set DEBIAN_FRONTEND to noninteractive to prevent interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive

--- a/packaging/docker/rsyslog/etl/Dockerfile
+++ b/packaging/docker/rsyslog/etl/Dockerfile
@@ -9,6 +9,8 @@ ARG BASE_IMAGE_TAG="rsyslog/rsyslog:latest"
 ARG UBUNTU_VERSION="24.04"
 # Version passed from Makefile for image metadata
 ARG RSYSLOG_IMG_VERSION="unset"
+ARG BUILD_DATE="unknown"
+ARG VCS_REF="unknown"
 
 # Use the rsyslog/rsyslog (standard) image as the base.
 # This ensures common modules, core rsyslog setup, and imhttp are inherited.
@@ -18,12 +20,23 @@ FROM ${BASE_IMAGE_TAG}
 ARG UBUNTU_VERSION
 ARG RSYSLOG_IMG_VERSION
 ARG BASE_IMAGE_TAG
+ARG BUILD_DATE
+ARG VCS_REF
 
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Rsyslog collector container, based on the standard image, optimized for ETL. Ubuntu ${UBUNTU_VERSION}."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"
 # Explicitly label the base image used for traceability.
 LABEL com.adiscon.rsyslog.base.image="${BASE_IMAGE_TAG}"
+LABEL org.opencontainers.image.title="rsyslog/rsyslog-etl"
+LABEL org.opencontainers.image.description="Experimental rsyslog ETL image for receiving syslog and forwarding events to Vespa over HTTP."
+LABEL org.opencontainers.image.url="https://www.rsyslog.com/"
+LABEL org.opencontainers.image.documentation="https://www.rsyslog.com/doc/containers/etl.html"
+LABEL org.opencontainers.image.source="https://github.com/rsyslog/rsyslog"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.version="${RSYSLOG_IMG_VERSION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
 
 # Set DEBIAN_FRONTEND to noninteractive to prevent interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive
@@ -53,8 +66,6 @@ ENV ENABLE_UDP=on
 ENV ENABLE_TCP=on
 ENV ENABLE_RELP=on
 ENV ENABLE_VESPA=on
-ENV WRITE_ALL_FILE=on
-ENV WRITE_JSON_FILE=on
 
 # Define the container role for the entrypoint script
 ENV RSYSLOG_ROLE=collector

--- a/packaging/docker/rsyslog/minimal/Dockerfile
+++ b/packaging/docker/rsyslog/minimal/Dockerfile
@@ -5,16 +5,29 @@
 # Build arguments passed from the Makefile
 ARG UBUNTU_VERSION="24.04"
 ARG RSYSLOG_IMG_VERSION="unset" # New ARG to pick up version from Makefile
+ARG BUILD_DATE="unknown"
+ARG VCS_REF="unknown"
 
 FROM ubuntu:${UBUNTU_VERSION}
 
 # Re-declare ARGs after FROM to make them available to subsequent instructions like LABEL
 ARG UBUNTU_VERSION
 ARG RSYSLOG_IMG_VERSION
+ARG BUILD_DATE
+ARG VCS_REF
 
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Minimal rsyslog container based on Ubuntu ${UBUNTU_VERSION} with Adiscon PPA for latest rsyslog. Optimized for size."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"
+LABEL org.opencontainers.image.title="rsyslog/rsyslog-minimal"
+LABEL org.opencontainers.image.description="Minimal rsyslog container based on Ubuntu ${UBUNTU_VERSION} with the Adiscon rsyslog packages."
+LABEL org.opencontainers.image.url="https://www.rsyslog.com/"
+LABEL org.opencontainers.image.documentation="https://www.rsyslog.com/doc/containers/minimal.html"
+LABEL org.opencontainers.image.source="https://github.com/rsyslog/rsyslog"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.version="${RSYSLOG_IMG_VERSION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
 
 # Set DEBIAN_FRONTEND to noninteractive to prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
@@ -32,7 +45,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         software-properties-common \
         ca-certificates \
-        vim-tiny \
     && add-apt-repository -y ppa:adiscon/daily-stable \
     && apt-get update && \
     apt-get install -y --no-install-recommends rsyslog rsyslog-omstdout \

--- a/packaging/docker/rsyslog/standard/Dockerfile
+++ b/packaging/docker/rsyslog/standard/Dockerfile
@@ -7,6 +7,8 @@
 ARG BASE_IMAGE_TAG="rsyslog/rsyslog-minimal:latest" # Or a specific version
 ARG UBUNTU_VERSION="24.04" # Inherited from base, but good to keep for consistency/labels
 ARG RSYSLOG_IMG_VERSION="unset" # Version passed from Makefile for image metadata
+ARG BUILD_DATE="unknown"
+ARG VCS_REF="unknown"
 
 # Use the rsyslog/rsyslog-minimal image as the base.
 # This ensures all the core rsyslog setup (PPA, basic install, permissions) is inherited.
@@ -16,12 +18,23 @@ FROM ${BASE_IMAGE_TAG}
 ARG UBUNTU_VERSION
 ARG RSYSLOG_IMG_VERSION
 ARG BASE_IMAGE_TAG
+ARG BUILD_DATE
+ARG VCS_REF
 
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Standard rsyslog container based on Ubuntu ${UBUNTU_VERSION} with Adiscon PPA. Includes common modules like imhttp and omhttp for general use."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"
 # Explicitly label the base image used for traceability.
 LABEL com.adiscon.rsyslog.base.image="${BASE_IMAGE_TAG}"
+LABEL org.opencontainers.image.title="rsyslog/rsyslog"
+LABEL org.opencontainers.image.description="General-purpose rsyslog container with common HTTP-capable modules."
+LABEL org.opencontainers.image.url="https://www.rsyslog.com/"
+LABEL org.opencontainers.image.documentation="https://www.rsyslog.com/doc/containers/standard.html"
+LABEL org.opencontainers.image.source="https://github.com/rsyslog/rsyslog"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+LABEL org.opencontainers.image.version="${RSYSLOG_IMG_VERSION}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.revision="${VCS_REF}"
 
 # Set DEBIAN_FRONTEND to noninteractive to prevent interactive prompts during package installation.
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Summary
- remove `vim-tiny` from the minimal container image
- drop ETL file-output env vars that are not consumed by the shipped ETL config
- add OCI metadata labels across the rsyslog container family
- pass build date and VCS revision through the Docker Makefile so the new labels are populated

## Why
These are small cleanup changes that improve image quality immediately and reduce rough edges before release automation work starts.

## Validation
- `make -C packaging/docker/rsyslog all VERSION=local-test-cleanup`
