### PR TITLE
ci: add container image build workflow

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -1,0 +1,60 @@
+---
+name: container image build
+
+on:
+  pull_request:
+    # Run on every PR so this workflow can be used in branch protection.
+    # The actual container build is gated below and becomes a no-op when the
+    # PR does not touch files related to the rsyslog container family.
+  push:
+    branches: [main, master]
+    paths:
+      - 'packaging/docker/rsyslog/**'
+      - '.github/workflows/container_build.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build_containers:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for container image changes
+        id: container_changes
+        uses: tj-actions/changed-files@v46
+        with:
+          files: |
+            packaging/docker/rsyslog/**
+            .github/workflows/container_build.yml
+
+      - name: Build rsyslog container family
+        # Keep the workflow green for unrelated PRs while still exercising the
+        # full image family whenever container packaging inputs change.
+        if: >-
+          ${{ github.event_name == 'workflow_dispatch' ||
+          steps.container_changes.outputs.any_changed == 'true' }}
+        run: |
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          make -C packaging/docker/rsyslog all VERSION="ci-${short_sha}"
+
+      - name: Skip container build, no relevant changes
+        # This step is intentionally successful so the workflow can participate
+        # in branch protection without forcing container rebuilds on unrelated
+        # changes.
+        if: >-
+          ${{ github.event_name != 'workflow_dispatch' &&
+          steps.container_changes.outputs.any_changed != 'true' }}
+        run: echo "No rsyslog container image changes detected; skipping build."


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow for the rsyslog container image family
- build the full layered image set through `packaging/docker/rsyslog/Makefile`
- keep PR checks green on unrelated changes by skipping the build when the container subtree was not touched
- add comments explaining the branch-protection and skip behavior

## Why
This adds the first dedicated CI step for the container family without coupling it to release publishing yet.

## Validation
- `make -C packaging/docker/rsyslog all VERSION=ci-local-build`
