### PR TITLE
doc/container: mark ETL image experimental

### DIFF
--- a/doc/source/containers/etl.rst
+++ b/doc/source/containers/etl.rst
@@ -31,6 +31,12 @@ This image is a concrete example of rsyslog being used as an ETL transport and
 delivery component. It is optimized for Vespa-oriented pipelines, not presented
 here as a generic all-destinations ETL appliance.
 
+.. warning::
+
+   ``rsyslog/rsyslog-etl`` is currently experimental. Treat it as a
+   specialized example image for Vespa-oriented ETL pipelines rather
+   than a broadly supported general-purpose container role.
+
 .. note::
 
    - **UDP (514/udp)** and **TCP (514/tcp)** are enabled by default.

--- a/doc/source/containers/user_images.rst
+++ b/doc/source/containers/user_images.rst
@@ -31,8 +31,8 @@ Available variants include:
   centralized log collection, including RELP and optional TLS reception.
 * :doc:`rsyslog/rsyslog-dockerlogs <dockerlogs>` – includes ``imdocker``
   to process logs from the Docker daemon.
-* :doc:`rsyslog/rsyslog-etl <etl>` – receives syslog and forwards events
-  to a Vespa HTTP endpoint using ``omhttp``.
+* :doc:`rsyslog/rsyslog-etl <etl>` – experimental image that receives
+  syslog and forwards events to a Vespa HTTP endpoint using ``omhttp``.
 * ``rsyslog/rsyslog-debug`` – planned variant with troubleshooting tools.
 
 .. toctree::

--- a/packaging/docker/rsyslog/etl/README.md
+++ b/packaging/docker/rsyslog/etl/README.md
@@ -1,4 +1,7 @@
-## rsyslog official container for syslog ETL functionality
+## rsyslog experimental container for syslog ETL functionality
+
+This image is currently experimental and specialized for Vespa-oriented
+ETL pipelines.
 
 ## Env vars
 


### PR DESCRIPTION
## Summary
- mark `rsyslog/rsyslog-etl` as experimental in the container docs
- label the ETL variant as experimental in the user-image overview
- align the packaging-local ETL README with the same support-level wording

## Validation
- reviewed the ETL container page, user-images overview, and packaging README for wording consistency
