### PR TITLE
packaging/docker: clarify host is not a published image

### DIFF
--- a/packaging/docker/rsyslog/README.md
+++ b/packaging/docker/rsyslog/README.md
@@ -9,6 +9,10 @@ container image family:
 - `rsyslog/rsyslog-dockerlogs`
 - `rsyslog/rsyslog-etl`
 
+These are the only published image variants in this subtree.
+The `host/` subdirectory contains auxiliary host-side forwarding
+material and is not a built or published container image target.
+
 Docker Hub descriptions for these repos can be maintained from this
 subtree with `sync_dockerhub_metadata.py` and `dockerhub_metadata.json`.
 The script reads credentials from `DOCKERHUB_USERNAME` /

--- a/packaging/docker/rsyslog/host/README.md
+++ b/packaging/docker/rsyslog/host/README.md
@@ -1,5 +1,10 @@
-## rsyslog container for forwarding host logs
+## Host-side forwarding example material
 
-This configuration is meant for a container that ships logs from the local host to a remote collector using rsyslog.
+This directory is not a built or published Docker image variant.
 
-See the [main README](../../README.md) for an overview of all images and build instructions.
+It contains auxiliary rsyslog configuration material for forwarding host
+logs to a remote collector. It is not part of the supported container
+image family built by `packaging/docker/rsyslog/Makefile`.
+
+See the [main README](../README.md) for the actual published image
+variants and build instructions.


### PR DESCRIPTION
## Summary
This clarifies that `packaging/docker/rsyslog/host/` is auxiliary host-side
material and not a built or published container image variant.

## Why
A recent CI review treated `host/` as a missing image target because its README
read like an image-specific artifact. The current tree benefits from a sharper
boundary between the five published images and unsupported helper material.

## What changed
- state in `packaging/docker/rsyslog/README.md` that only the five Makefile
  image variants are published from this subtree
- update `packaging/docker/rsyslog/host/README.md` to say explicitly that it is
  not a built or published Docker image target
- describe `host/` as host-side forwarding configuration material and point
  readers back to the main container README for the supported image list

## Testing
Documentation-only clarification; no code or workflow behavior changed.
