### PR TITLE
packaging/docker: harden base image user defaults

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -66,8 +66,18 @@ jobs:
           tag="ci-${{ steps.build_containers.outputs.short_sha }}"
 
           docker run --rm \
+            --entrypoint id \
+            "rsyslog/rsyslog-minimal:${tag}" \
+            -u | grep -Fx 101
+
+          docker run --rm \
             "rsyslog/rsyslog-minimal:${tag}" \
             rsyslogd -N1 -f /etc/rsyslog.conf
+
+          docker run --rm \
+            --entrypoint id \
+            "rsyslog/rsyslog:${tag}" \
+            -u | grep -Fx 101
 
           docker run --rm \
             "rsyslog/rsyslog:${tag}" \

--- a/doc/source/containers/collector.rst
+++ b/doc/source/containers/collector.rst
@@ -31,6 +31,10 @@ other backends or reshape the pipeline.
 This image is the recommended starting point for building a log
 collector or relay service.
 
+The packaged collector still runs as root by default. Its shipped
+configuration binds privileged listener ports such as ``514`` and
+``6514`` and writes files under ``/var/log``.
+
 .. note::
 
    - **UDP (514/udp)** and **TCP (514/tcp)** are enabled by default.  

--- a/doc/source/containers/dockerlogs.rst
+++ b/doc/source/containers/dockerlogs.rst
@@ -23,6 +23,10 @@ Docker daemon and forward them to a central rsyslog instance. The packaged
 configuration uses ``omfwd`` over TCP with an in-memory queue and infinite
 retry so temporary collector outages do not immediately drop events.
 
+The packaged dockerlogs image still runs as root by default. Typical
+deployments rely on Docker daemon or socket access, which is commonly
+root-scoped.
+
 Environment Variables
 ---------------------
 

--- a/doc/source/containers/minimal.rst
+++ b/doc/source/containers/minimal.rst
@@ -13,6 +13,16 @@ configuration that writes logs to standard output. It serves as the
 foundation for the other rsyslog images and is suitable when you want to
 add your own modules or configuration.
 
+Runtime Notes
+-------------
+
+The packaged default configuration uses ``/var/spool/rsyslog`` as the
+work directory and writes to standard output via ``omstdout``.
+
+The image runs as ``syslog:adm`` by default. That fits simple container
+deployments that use unprivileged ports and do not depend on privileged
+inputs such as host log sockets or other root-only resources.
+
 Environment Variables
 ---------------------
 

--- a/doc/source/containers/standard.rst
+++ b/doc/source/containers/standard.rst
@@ -12,6 +12,13 @@ The general-purpose image builds on ``rsyslog-minimal`` and adds commonly
 used modules such as ``imhttp`` and ``omhttp``. Use it when you need a
 ready-to-run rsyslog with HTTP ingestion or forwarding capabilities.
 
+Runtime Notes
+-------------
+
+Like :doc:`minimal`, this image runs as ``syslog:adm`` by default. That
+fits the packaged general-purpose role because the shipped configuration
+does not bind privileged ports.
+
 Environment Variables
 ---------------------
 

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -23,6 +23,11 @@ ARG BASE_IMAGE_TAG
 ARG BUILD_DATE
 ARG VCS_REF
 
+# The standard base image defaults to syslog:adm; collector installs extra
+# packages and still needs root at runtime for low default listener ports and
+# file output under /var/log.
+USER root
+
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Rsyslog collector container, based on the standard image, optimized for log collection. Ubuntu ${UBUNTU_VERSION}."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"

--- a/packaging/docker/rsyslog/dockerlogs/Dockerfile
+++ b/packaging/docker/rsyslog/dockerlogs/Dockerfile
@@ -22,6 +22,11 @@ ARG BASE_IMAGE_TAG
 ARG BUILD_DATE
 ARG VCS_REF
 
+# The standard base image defaults to syslog:adm; switch back to root for
+# package installation in this derived image. Common dockerlogs deployments
+# also rely on Docker daemon or socket access that is root-scoped.
+USER root
+
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Rsyslog container specialized for Docker log collection using imdocker, based on the rsyslog/rsyslog (standard) image."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"

--- a/packaging/docker/rsyslog/etl/Dockerfile
+++ b/packaging/docker/rsyslog/etl/Dockerfile
@@ -23,6 +23,11 @@ ARG BASE_IMAGE_TAG
 ARG BUILD_DATE
 ARG VCS_REF
 
+# The standard base image defaults to syslog:adm; switch back to root for
+# package installation in this derived image. ETL also stays root at runtime
+# because the packaged role binds privileged listener ports.
+USER root
+
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Rsyslog collector container, based on the standard image, optimized for ETL. Ubuntu ${UBUNTU_VERSION}."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"

--- a/packaging/docker/rsyslog/minimal/Dockerfile
+++ b/packaging/docker/rsyslog/minimal/Dockerfile
@@ -40,7 +40,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 #    - Install rsyslog with --no-install-recommends for minimal footprint.
 #    - Purge build-time-only dependencies (software-properties-common) and auto-remove any unused packages.
 #    - Clean apt caches and remove temporary files to minimize layer size.
-#    - Create essential runtime directories (/run for PID, /var/log for logs, /etc/rsyslog.d for config snippets).
+#    - Create the writable runtime paths used by the shipped config.
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         software-properties-common \
@@ -52,9 +52,11 @@ RUN apt-get update && \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /etc/rsyslog.d/50-default.conf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && mkdir -p /etc/rsyslog.d /run /var/log /var/lib/rsyslog && \
-    chown root:syslog /var/log /var/lib/rsyslog && \
-    chmod g+w /var/log /var/lib/rsyslog
+    && mkdir -p /etc/rsyslog.d /var/log /var/spool/rsyslog \
+    && chown root:syslog /var/log \
+    && chmod 0775 /var/log \
+    && chown syslog:adm /var/spool/rsyslog \
+    && chmod 0700 /var/spool/rsyslog
 
 # Copy custom rsyslog configuration file into the container.
 # This file defines how rsyslog behaves (e.g., inputs, outputs, rules).
@@ -62,12 +64,16 @@ RUN apt-get update && \
 COPY rsyslog.conf /etc/rsyslog.conf
 COPY 01-main-queue.conf /etc/rsyslog.d/
 COPY start.sh /usr/local/bin/start.sh
-RUN chmod +x /usr/local/bin/start.sh
+RUN chmod 0755 /usr/local/bin/start.sh
 # Set the entrypoint (this will run the script when the container starts)
 ENTRYPOINT ["/usr/local/bin/start.sh"]
 
 # Define the container role for the entrypoint script
 ENV RSYSLOG_ROLE=minimal
+
+# The minimal image is safe to run as the packaged syslog user for
+# unprivileged container workloads.
+USER syslog:adm
 
 # Set the default command to run rsyslog in the foreground.
 # -n: Prevents rsyslog from forking (essential for Docker containers).

--- a/packaging/docker/rsyslog/minimal/README.md
+++ b/packaging/docker/rsyslog/minimal/README.md
@@ -11,3 +11,10 @@ b) want to run rsyslog with a custom config by you
 We also have a series of other official minimal containers for more
 advanced use cases, e.g. gathering docker logs or acting as a central
 hub.
+
+The packaged default configuration uses ``/var/spool/rsyslog`` as the
+work directory and writes to standard output via ``omstdout``.
+
+This image now runs as ``syslog:adm`` by default. That fits simple
+container deployments that use unprivileged ports and do not depend on
+host log sockets or other root-only resources.

--- a/packaging/docker/rsyslog/standard/Dockerfile
+++ b/packaging/docker/rsyslog/standard/Dockerfile
@@ -21,6 +21,10 @@ ARG BASE_IMAGE_TAG
 ARG BUILD_DATE
 ARG VCS_REF
 
+# The base image defaults to syslog:adm; switch back to root for package
+# installation in this derived image.
+USER root
+
 LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
 LABEL description="Standard rsyslog container based on Ubuntu ${UBUNTU_VERSION} with Adiscon PPA. Includes common modules like imhttp and omhttp for general use."
 LABEL com.adiscon.rsyslog.image.version="${RSYSLOG_IMG_VERSION}"
@@ -54,6 +58,10 @@ RUN apt-get update && \
 
 # Define the container role for the entrypoint script
 ENV RSYSLOG_ROLE=standard
+
+# The standard image remains non-root-capable by default because its
+# packaged behavior stays on unprivileged resources.
+USER syslog:adm
 
 # Inherit CMD from base image (rsyslogd -n -f /etc/rsyslog.conf), no need to set explicitly
 # unless specific default arguments for the standard role are needed.

--- a/packaging/docker/rsyslog/standard/README.md
+++ b/packaging/docker/rsyslog/standard/README.md
@@ -2,4 +2,8 @@
 
 This image builds on the minimal variant and includes commonly used rsyslog modules for a balanced default setup.
 
+Like the minimal image, it runs as ``syslog:adm`` by default. That is
+appropriate for the packaged HTTP-capable base role, which does not bind
+privileged ports in its shipped configuration.
+
 See the [main README](../../README.md) for build instructions and details on the image variants.


### PR DESCRIPTION
## Summary
This hardens the container family bottom-up by moving the base images to
non-root defaults where the current runtime contract allows it, while keeping
collector-side roles root for compatibility.

## Why
The container family needed a meaningful least-privilege improvement without
breaking the collector role or the existing ROSI and third-party tutorial story
around privileged listener ports.

## What changed
- set `rsyslog/rsyslog-minimal` to run as `syslog:adm` by default
- set `rsyslog/rsyslog` back to root for package installation, then return it
  to `syslog:adm` for runtime
- keep `rsyslog-collector`, `rsyslog-dockerlogs`, and `rsyslog-etl` explicitly
  on root by default
- make the minimal image's shipped writable paths explicit
- document the split runtime contract in the container docs and image READMEs
- extend container CI so it proves the default UID for `minimal` and `standard`

## Compatibility notes
- `collector` stays root because its shipped config still binds privileged
  listener ports and ROSI Collector plus external tutorials assume that role
  contract today
- `dockerlogs` stays root because common deployments rely on Docker daemon or
  socket access
- `etl` stays root because it still binds privileged ports and remains
  experimental

## Verification
Local validation:
- `make -C packaging/docker/rsyslog all VERSION=ci-nonroot REBUILD=yes`
- `docker run --rm --entrypoint id rsyslog/rsyslog-minimal:ci-nonroot -u` -> `101`
- `docker run --rm --entrypoint id rsyslog/rsyslog:ci-nonroot -u` -> `101`
- `docker run --rm --entrypoint id rsyslog/rsyslog-collector:ci-nonroot -u` -> `0`
- `docker run --rm --entrypoint id rsyslog/rsyslog-dockerlogs:ci-nonroot -u` -> `0`
- `docker run --rm --entrypoint id rsyslog/rsyslog-etl:ci-nonroot -u` -> `0`
- `docker run --rm rsyslog/rsyslog-minimal:ci-nonroot rsyslogd -N1 -f /etc/rsyslog.conf`
- `docker run --rm rsyslog/rsyslog:ci-nonroot rsyslogd -N1 -f /etc/rsyslog.conf`
- `docker run --rm -e ENABLE_RELP=on rsyslog/rsyslog-collector:ci-nonroot rsyslogd -N1 -f /etc/rsyslog.conf`
- `docker run --rm -e REMOTE_SERVER_NAME=collector -e REMOTE_SERVER_PORT=514 rsyslog/rsyslog-dockerlogs:ci-nonroot rsyslogd -N1 -f /etc/rsyslog.conf`
- `docker run --rm -e VESPA_NAMESPACE=default -e VESPA_DOCTYPE=logs -e VESPA_SERVER=vespa -e VESPA_PORT=8080 rsyslog/rsyslog-etl:ci-nonroot rsyslogd -N1 -f /etc/rsyslog.conf`
