### PR TITLE
doc: imptcp: remove outdated 16-thread limit note

### DIFF
--- a/doc/source/reference/parameters/imptcp-threads.rst
+++ b/doc/source/reference/parameters/imptcp-threads.rst
@@ -30,8 +30,8 @@ threads are utilized to pull data off the network. On a busy system,
 additional helper threads (but not more than there are CPUs/Cores)
 can help improving performance. The default value is two, which means
 there is a default thread count of three (the main input thread plus
-two helpers). No more than 16 threads can be set (if tried to,
-rsyslog always resorts to 16).
+two helpers). The maximum number of worker threads is bound only by
+system resources (CPU, memory).
 
 Module usage
 ------------


### PR DESCRIPTION

### Summary 
This PR clarifies thread configuration to better reflect current behavior and
modern system capabilities. This improves documentation accuracy and
avoids misleading limits during performance tuning.

Impact: Users may configure higher thread counts based on docs.

BEFORE: Docs stated a hard cap of 16 threads with fallback to 16.
AFTER: Docs state threads are limited by system resources only.

The imptcp parameter documentation previously described a fixed
maximum of 16 worker threads and implied automatic capping. This
change removes that statement and replaces it with guidance that
thread count is constrained by available CPU and memory resources.

This aligns documentation with expected modern behavior and avoids
artificial tuning constraints. No functional code changes are made;
only documentation text is updated. Module usage and defaults remain
unchanged.

### References
Refs: https://github.com/rsyslog/rsyslog-doc/issues/1069



