### PR TITLE
devtools: add Codex pre-commit format hook

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,25 @@
+# Codex Repo Setup
+
+This repository ships a repo-local Codex hook configuration for trusted projects.
+
+## What it does
+
+- Enables Codex hooks for this repository via `.codex/config.toml`
+- Runs `.codex/pre_commit_format_gate.sh` before Bash-based `git commit` commands
+- Runs the deterministic repo-policy focus checks first against the staged commit snapshot
+- If those invariants fail, the hook exits early and prints the specific failures for the agent to fix
+- The hook runs `./devtools/format-code.sh --git-changed`
+- If `clang-format-18` is not installed, the hook allows the commit without blocking
+- If no tracked `.c` or `.h` files have changed, the hook skips formatting work
+- If formatting fails, the `git commit` tool call is blocked and Codex is told to fix formatting first
+- If formatting updates `.c` or `.h` files, the hook stages those tracked formatter updates automatically and then allows the commit
+- If partially staged `.c` or `.h` files are present, the hook blocks because auto-restaging would not be safe
+
+## Requirements
+
+- The repository must be trusted so Codex loads `.codex/config.toml`
+- Codex hooks must be available in your Codex build
+
+## Scope
+
+This affects Codex users working in this repository. It does not replace normal project review or CI checks, and it does not affect contributors who are not using Codex.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[features]
+codex_hooks = true

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/bin/env bash \"$(git rev-parse --show-toplevel)/.codex/pre_commit_format_gate.sh\"",
+            "statusMessage": "Running pre-commit format gate"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/pre_commit_format_gate.sh
+++ b/.codex/pre_commit_format_gate.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+payload="$(cat)"
+
+if [[ -z "${payload}" ]]; then
+  exit 0
+fi
+
+should_gate="$(
+  PAYLOAD="$payload" python3 <<'PY'
+import json
+import os
+import re
+import shlex
+import sys
+
+
+def split_simple_commands(command: str) -> list[list[str]]:
+    lexer = shlex.shlex(command, posix=True, punctuation_chars=";&|()")
+    lexer.whitespace_split = True
+    lexer.commenters = ""
+
+    commands = []
+    current = []
+
+    for token in lexer:
+        if re.fullmatch(r"[;&|()]+", token):
+            if current:
+                commands.append(current)
+                current = []
+            continue
+        current.append(token)
+
+    if current:
+        commands.append(current)
+
+    return commands
+
+
+def strip_prefixes(words: list[str]) -> list[str]:
+    i = 0
+    assignment_re = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=.*")
+
+    while i < len(words):
+        token = words[i]
+
+        if token == "sudo":
+            i += 1
+            continue
+
+        if token in {"command", "builtin", "noglob", "time"}:
+            i += 1
+            continue
+
+        if token == "env":
+            i += 1
+            while i < len(words) and assignment_re.fullmatch(words[i]):
+                i += 1
+            continue
+
+        if assignment_re.fullmatch(token):
+            i += 1
+            continue
+
+        break
+
+    return words[i:]
+
+
+def is_git_commit(words: list[str]) -> bool:
+    words = strip_prefixes(words)
+    if not words or words[0] != "git":
+        return False
+
+    i = 1
+    while i < len(words):
+        token = words[i]
+
+        if token == "commit":
+            return True
+
+        if token == "--":
+            return False
+
+        if token in {
+            "-c",
+            "-C",
+            "--git-dir",
+            "--work-tree",
+            "--namespace",
+            "--super-prefix",
+            "--config-env",
+        }:
+            i += 2
+            continue
+
+        if token.startswith("--git-dir=") or token.startswith("--work-tree=") \
+                or token.startswith("--namespace=") or token.startswith("--super-prefix=") \
+                or token.startswith("--config-env="):
+            i += 1
+            continue
+
+        if token.startswith("-"):
+            i += 1
+            continue
+
+        return False
+
+    return False
+
+
+payload_raw = os.environ.get("PAYLOAD")
+if payload_raw is None:
+    sys.exit(0)
+
+try:
+    payload = json.loads(payload_raw)
+except json.JSONDecodeError:
+    sys.exit(0)
+
+if payload.get("hook_event_name") != "PreToolUse":
+    sys.exit(0)
+
+if payload.get("tool_name") != "Bash":
+    sys.exit(0)
+
+tool_input = payload.get("tool_input") or {}
+command = tool_input.get("command")
+if not isinstance(command, str) or not command.strip():
+    sys.exit(0)
+
+try:
+    commands = split_simple_commands(command)
+except ValueError:
+    sys.exit(0)
+
+for simple_command in commands:
+    if is_git_commit(simple_command):
+        print("yes")
+        break
+PY
+)"
+
+if [[ "${should_gate}" != "yes" ]]; then
+  exit 0
+fi
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "${script_dir}/.." && pwd)"
+
+cd "${repo_root}"
+
+tracked_changed_c_h_files() {
+  ./devtools/list-git-changed-c-h-files.sh
+}
+
+snapshot_tracked_changed_c_h_files() {
+  local tracked_files
+
+  mapfile -t tracked_files < <(tracked_changed_c_h_files)
+
+  if [[ "${#tracked_files[@]}" -eq 0 ]]; then
+    printf '[]'
+    return
+  fi
+
+  python3 - "${tracked_files[@]}" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+entries = []
+for raw_path in sys.argv[1:]:
+    path = Path(raw_path)
+    if not path.is_file():
+        continue
+    digest = hashlib.sha256(path.read_bytes()).hexdigest()
+    entries.append([path.as_posix(), digest])
+
+print(json.dumps(entries, separators=(",", ":")))
+PY
+}
+
+run_repo_policy_focus_check() {
+  local tmpdir base_ref snapshot_commit applicable_count
+
+  if ! git rev-parse --verify HEAD >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! command -v python3 >/dev/null 2>&1; then
+    return 0
+  fi
+
+  tmpdir="$(mktemp -d)"
+  cleanup_repo_policy_focus_check() {
+    rm -rf -- "${tmpdir}"
+  }
+  trap cleanup_repo_policy_focus_check RETURN
+
+  base_ref="$(git rev-parse HEAD)"
+  snapshot_commit="$(
+    printf 'codex repo-policy focus snapshot\n' | git commit-tree "$(git write-tree)" -p "${base_ref}"
+  )"
+
+  python3 scripts/build_repo_policy_focus_input.py \
+    --base "${base_ref}" \
+    --head "${snapshot_commit}" \
+    --output "${tmpdir}/review-package.json"
+
+  applicable_count="$(
+    python3 - "${tmpdir}/review-package.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+package = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+print(int(package.get("applicable_count", 0)))
+PY
+  )"
+
+  if [[ "${applicable_count}" == "0" ]]; then
+    return 0
+  fi
+
+  python3 scripts/evaluate_repo_policy_focus.py \
+    --input "${tmpdir}/review-package.json" \
+    --output "${tmpdir}/model-output.json"
+
+  python3 scripts/score_repo_policy_focus.py \
+    --review-input "${tmpdir}/review-package.json" \
+    --model-output "${tmpdir}/model-output.json" \
+    --summary-md "${tmpdir}/summary.md" \
+    --summary-json "${tmpdir}/summary.json"
+
+  python3 - "${tmpdir}/summary.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+summary = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+warnings = [check for check in summary["checks"] if check["status"] == "warn"]
+failures = [check for check in summary["checks"] if check["status"] == "fail"]
+
+if warnings:
+    print("Focused repo-policy warnings:", file=sys.stderr)
+    for check in warnings:
+        print(f"- {check['id']}: {check['reason']}", file=sys.stderr)
+        for issue in check["issues"]:
+            location = issue["file"] or "(no file)"
+            if issue["line"]:
+                location = f"{location}:{issue['line']}"
+            print(f"  * {location} - {issue['message']}", file=sys.stderr)
+
+if not failures:
+    raise SystemExit(0)
+
+print("Focused repo-policy checks failed:", file=sys.stderr)
+for check in failures:
+    print(f"- {check['id']}: {check['reason']}", file=sys.stderr)
+    for issue in check["issues"]:
+        location = issue["file"] or "(no file)"
+        if issue["line"]:
+            location = f"{location}:{issue['line']}"
+        print(f"  * {location} - {issue['message']}", file=sys.stderr)
+raise SystemExit(1)
+PY
+}
+
+if ! run_repo_policy_focus_check; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Deterministic repo-policy checks failed. Fix the reported invariant violations before running git commit again."
+  }
+}
+EOF
+  exit 0
+fi
+
+if ! command -v clang-format-18 >/dev/null 2>&1; then
+  exit 0
+fi
+
+git_c_h_change_state="$(
+  python3 <<'PY'
+import subprocess
+
+
+def listed_diff(*args: str) -> set[str]:
+    proc = subprocess.run(
+        ["git", "diff", *args, "--diff-filter=d", "--name-only", "--", "*.c", "*.h"],
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return {line for line in proc.stdout.splitlines() if line}
+
+
+unstaged = listed_diff()
+staged = listed_diff("--cached")
+
+print("changed=yes" if (unstaged or staged) else "changed=no")
+for path in sorted(unstaged & staged):
+    print(path)
+PY
+)"
+
+if [[ "${git_c_h_change_state}" == changed=no* ]]; then
+  exit 0
+fi
+
+partially_staged_c_h_files="$(printf '%s\n' "${git_c_h_change_state}" | sed '1d')"
+
+if [[ -n "${partially_staged_c_h_files}" ]]; then
+  cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Commit blocked: partially staged .c/.h files are present. The formatter hook cannot safely restage those files automatically."
+  }
+}
+EOF
+  exit 0
+fi
+
+mapfile -t initially_staged_c_h_files < <(
+  git diff --cached --diff-filter=d --name-only -- '*.c' '*.h'
+)
+
+snapshot_files="$(snapshot_tracked_changed_c_h_files)"
+
+if ./devtools/format-code.sh --git-changed >&2; then
+  snapshot_after="$(snapshot_tracked_changed_c_h_files)"
+
+  if [[ "${snapshot_files}" == "${snapshot_after}" ]]; then
+    exit 0
+  fi
+
+  if [[ "${#initially_staged_c_h_files[@]}" -gt 0 ]]; then
+    git add -- "${initially_staged_c_h_files[@]}"
+  fi
+  exit 0
+fi
+
+cat <<'EOF'
+{
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "deny",
+    "permissionDecisionReason": "Formatting failed: ./devtools/format-code.sh exited non-zero. Fix formatting before running git commit."
+  }
+}
+EOF

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -49,6 +49,7 @@ It captures the v8 worker model and locking rules that module code must follow.
 
 ## Coding style
 * US-ASCII, subject ≤ 65 chars (aim 62), see `COMMENTING_STYLE.md` and `CONTRIBUTING.md`.
+* Codex users: this repository includes repo-local setup in `.codex/`. If the repo is trusted, Codex loads `.codex/config.toml` and runs the pre-commit formatting hook described in `.codex/README.md`.
 
 ## Safe starter tasks for agents
 * Add a **“Concurrency & Locking”** comment block at the top of output modules.

--- a/devtools/format-code.sh
+++ b/devtools/format-code.sh
@@ -7,10 +7,11 @@
 # It's intended to enforce the canonical code format for the repository.
 #
 # Usage:
-#   ./devtools/format-code-exec.sh [-h]
+#   ./devtools/format-code.sh [-h] [--git-changed]
 #
 # Options:
 #   -h, --help    Display this help message and exit.
+#   --git-changed Format only changed tracked .c/.h files known to Git.
 #
 # Description:
 #   This script performs an in-place reformatting of all C source (.c) and
@@ -30,6 +31,9 @@
 #   parentheses `\( ... \)` to ensure that `clang-format` is executed for
 #   both `.c` and `.h` files as intended.
 #
+#   With '--git-changed', the script limits formatting to changed tracked
+#   .c/.h files reported by Git. If no such files exist, it exits 0.
+#
 #   Before running, ensure 'clang-format-18' is installed on your system.
 #   It is highly recommended to commit your current changes or create a backup
 #   before executing this script, as it modifies files directly.
@@ -46,6 +50,7 @@ set -euo pipefail # Exit on error, unset variables, and pipefail
 
 # --- Configuration ---
 readonly CLANG_FORMAT="clang-format-18"  # Specify the clang-format version to use
+git_changed_only=0
 
 # --- Functions ---
 
@@ -60,6 +65,9 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     -h|--help)
       show_help
+      ;;
+    --git-changed)
+      git_changed_only=1
       ;;
     *)
       echo "Error: Unknown option '$1'" >&2
@@ -93,26 +101,47 @@ echo "Note: '$CLANG_FORMAT' only modifies files that deviate from the specified 
 echo ""
 
 # --- Formatting Logic ---
-# Find all .c and .h files recursively and execute clang-format on them.
-# The '{} +' syntax passes multiple filenames to a single clang-format invocation,
-# which is more efficient.
-# The parentheses '\( ... \)' are crucial for correctly grouping the -name conditions.
-if ! find . \( -name "*.c" -o -name "*.h" \) -exec "$CLANG_FORMAT" -i -style=file {} +; then
-  echo "Error: The overall code formatting process failed." >&2
-  echo "Please review the output above for any specific clang-format errors." >&2
-  exit 2
-fi
+if [[ "$git_changed_only" -eq 1 ]]; then
+  if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    echo "Error: '--git-changed' requires a Git working tree." >&2
+    exit 2
+  fi
 
-# Calculate total files found for summary
-# Update this find command as well to use the correct parentheses for consistency.
-TOTAL_FILES=$(find . \( -name "*.c" -o -name "*.h" \) | wc -l)
+  mapfile -t target_files < <(./devtools/list-git-changed-c-h-files.sh)
+
+  if [[ "${#target_files[@]}" -eq 0 ]]; then
+    echo "No changed .c/.h files detected. Nothing to format."
+    exit 0
+  fi
+
+  if ! "$CLANG_FORMAT" -i -style=file "${target_files[@]}"; then
+    echo "Error: The overall code formatting process failed." >&2
+    echo "Please review the output above for any specific clang-format errors." >&2
+    exit 2
+  fi
+
+  TOTAL_PROCESSED_FILES="${#target_files[@]}"
+else
+  # Find all .c and .h files recursively and execute clang-format on them.
+  # The '{} +' syntax passes multiple filenames to a single clang-format invocation,
+  # which is more efficient.
+  # The parentheses '\( ... \)' are crucial for correctly grouping the -name conditions.
+  if ! find . \( -name "*.c" -o -name "*.h" \) -exec "$CLANG_FORMAT" -i -style=file {} +; then
+    echo "Error: The overall code formatting process failed." >&2
+    echo "Please review the output above for any specific clang-format errors." >&2
+    exit 2
+  fi
+
+  # Calculate total files found for summary
+  # Update this find command as well to use the correct parentheses for consistency.
+  TOTAL_PROCESSED_FILES=$(find . \( -name "*.c" -o -name "*.h" \) | wc -l)
+fi
 
 echo ""
 echo "--- Formatting Summary ---"
-echo "Total .c/.h files found and processed: $TOTAL_FILES"
+echo "Total .c/.h files processed: $TOTAL_PROCESSED_FILES"
 echo "Code formatting completed successfully."
 echo "The number of files actually changed depends on their adherence to the style."
 echo "Please review changes using 'git diff' if in a Git repository."
 
 # --- Script End ---
-

--- a/devtools/list-git-changed-c-h-files.sh
+++ b/devtools/list-git-changed-c-h-files.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+  echo "Error: must run inside a Git working tree." >&2
+  exit 2
+fi
+
+{
+  git diff --diff-filter=d --name-only -- '*.c' '*.h'
+  git diff --cached --diff-filter=d --name-only -- '*.c' '*.h'
+} | awk 'NF && !seen[$0]++'


### PR DESCRIPTION
## Summary

This adds a repo-local Codex hook setup so trusted Codex users get
pre-commit formatting behavior automatically in this repository.

The change ships:

- `.codex/hooks.json`
- `.codex/config.toml`
- `.codex/pre_commit_format_gate.sh`
- `.codex/README.md`

It also extends `devtools/format-code.sh` with a `--git-changed` mode so
the hook formats only changed tracked `.c` and `.h` files instead of
walking the full tree.

## Final behavior

- Intercepts only Bash `git commit` tool calls
- Skips unrelated Git commands
- Allows commits when `clang-format-18` is not installed
- Skips formatting when no tracked `.c` or `.h` files changed
- Formats only changed tracked `.c` and `.h` files
- Auto-stages tracked formatter updates when safe
- Blocks unsafe partial-staging cases
- Blocks real formatter failures
- Excludes deleted files from the formatter input set

## Validation

- `bash -n devtools/format-code.sh .codex/pre_commit_format_gate.sh`
- `bash devtools/format-code.sh --git-changed`
- Focused sandbox checks for:
  - no tracked `.c`/`.h` changes
  - partial staging denial
  - missing `clang-format-18` passthrough logic
