### PR TITLE
doc(yaml_config): add version requirement note (8.2604.0+)

### DIFF
--- a/doc/source/configuration/yaml_config.rst
+++ b/doc/source/configuration/yaml_config.rst
@@ -41,9 +41,16 @@ therefore valid to mix formats:  a YAML main config may include ``.conf``
 RainerScript fragments and vice versa.
 
 .. note::
-   YAML configuration support requires rsyslog to have been compiled with
-   libyaml (``yaml-0.1``).  If libyaml is absent at build time the daemon
-   will print an error and refuse to load a ``.yaml`` / ``.yml`` file.
+   YAML configuration support requires **rsyslog 8.2604.0 or later**.
+   Older distribution packages do not include this feature.  Up-to-date
+   packages for many platforms are available via `www.rsyslog.com
+   <https://www.rsyslog.com>`_.  The easiest option is often a
+   containerized build: the rsyslog team publishes ready-to-use images
+   documented in :doc:`../containers/index`.
+
+   In addition, rsyslog must have been compiled with libyaml
+   (``yaml-0.1``).  If libyaml is absent at build time the daemon will
+   print an error and refuse to load a ``.yaml`` / ``.yml`` file.
    Install the ``libyaml-dev`` (Debian/Ubuntu) or ``libyaml-devel``
    (RHEL/Fedora) package before compiling.
 


### PR DESCRIPTION
## Why

The YAML configuration feature was introduced in rsyslog 8.2604.0. Users on older distribution packages would find no mention of this requirement and have no guidance on how to get a supported version.

## Changes

Expands the existing libyaml prerequisite note in `yaml_config.rst` to also:
- State the minimum rsyslog version (**8.2604.0**)
- Point to [www.rsyslog.com](https://www.rsyslog.com) for up-to-date packages
- Reference the rsyslog container images (`containers/index`) as the easiest upgrade path

The libyaml compile-time requirement is retained as a second paragraph in the same note block.

## Checks
- Doc build: ✅ clean
- `doc-dist-sync`: ✅ pass (existing file, no EXTRA_DIST change needed)
- `doc-xref-sync`: ✅ pass (cross-reference to `../containers/index` resolves correctly)