### PR TITLE
doc: remove stray merge marker in deployments index

### DIFF
--- a/doc/source/deployments/index.rst
+++ b/doc/source/deployments/index.rst
@@ -30,7 +30,6 @@ monitoring stack including:
 
 :doc:`Get started with ROSI Collector <rosi_collector/index>`
 
-<<<<<<< HEAD
 ROSI Collector is the primary packaged ROSI deployment profile today. The
 broader ROSI direction is larger than this single stack and includes
 alternative destinations, mixed-component architectures, and Windows-side


### PR DESCRIPTION
## Summary
Remove a stray merge-conflict marker from the production deployments index.

## Why
The page currently shows a raw `<<<<<<< HEAD` line. That is visible doc breakage on a high-level landing page and should be fixed independently of the broader doc update still in progress.

## Scope
- delete the stray merge marker in `doc/source/deployments/index.rst`
- keep the surrounding ROSI text unchanged because it reads as intended content, not leftover conflict text

## Validation
- inspected the surrounding paragraph for out-of-place merge residue
- confirmed the resulting diff is a one-line deletion
