### PR TITLE
doc: clarify YAML positioning and workflow guidance

### DIFF
--- a/doc/source/configuration/basic_structure.rst
+++ b/doc/source/configuration/basic_structure.rst
@@ -94,14 +94,20 @@ To specify a different configuration file, use:
 Supported Configuration Formats
 -------------------------------
 
-Rsyslog historically supported three configuration syntaxes:
+Rsyslog currently supports four configuration syntaxes:
 
-1. **RainerScript (modern style)** – **recommended and actively maintained**  
+1. **RainerScript (modern style)** - **fully supported and actively maintained**
 
    This is the current, fully supported configuration format. It is
-   clean, structured, and best suited for new and complex configurations.
+   clean, structured, and a strong fit when you author rsyslog logic directly.
 
-2. **sysklogd style (legacy)** – **deprecated for new configs**  
+2. **YAML** - **fully supported for YAML-centric workflows**
+
+   Use this when rsyslog is part of a broader YAML-based deployment or
+   automation environment. YAML and RainerScript express the same underlying
+   rsyslog concepts and share the same core semantics.
+
+3. **sysklogd style (legacy)** - **deprecated for new configs**
 
    This format is widely known and still functional, but **hard to grasp for
    new users**. It remains an option for experienced admins who know it
@@ -112,20 +118,21 @@ Rsyslog historically supported three configuration syntaxes:
       mail.info    /var/log/mail.log
       mail.err     @server.example.net
 
-3. **Legacy rsyslog style (dollar-prefix)** – **deprecated**  
+4. **Legacy rsyslog style (dollar-prefix)** - **deprecated**
 
    This format, with directives starting with `$` (e.g.,
    `$ActionFileDefaultTemplate`), is fully supported for backward
    compatibility but **not recommended for any new configuration**.
 
-Why Prefer RainerScript?
-~~~~~~~~~~~~~~~~~~~~~~~~
+Why Use RainerScript Directly?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 RainerScript is easier to read and maintain, avoids side effects with
 include files, and supports modern features such as structured filters,
 templates, and complex control flow.
 
-**For new configurations, always use RainerScript.**  
+For direct rsyslog authoring, RainerScript remains the clearest default.
+If your environment is already YAML-centric, YAML is also a first-class fit.
 Legacy formats exist only for compatibility with older setups and
 distributions.
 
@@ -222,4 +229,3 @@ Example:
        Ruleset2 --> Action3[omelasticsearch]
 
 For details, see :doc:`../concepts/multi_ruleset`.
-

--- a/doc/source/configuration/conf_formats.rst
+++ b/doc/source/configuration/conf_formats.rst
@@ -9,7 +9,9 @@ Configuration Formats
 
 .. summary-start
 
-rsyslog supports four configuration formats. For new configs use RainerScript (advanced); YAML is a good alternative if you are more comfortable with YAML syntax.
+rsyslog supports four configuration formats. For modern configurations, choose
+RainerScript or YAML based on workflow fit: RainerScript for direct rsyslog
+authoring, YAML for YAML-centric environments and automation.
 
 .. summary-end
 
@@ -21,13 +23,15 @@ different configuration formats:
    and writing to a log file.
 
 -  |FmtAdvancedName| - previously known as the ``RainerScript`` format. The
-   recommended format for all non-trivial use cases. First available in rsyslog v6,
-   it handles advanced filtering, forwarding, queueing, and custom actions.
+   recommended format when you author rsyslog logic directly. First available
+   in rsyslog v6, it handles advanced filtering, forwarding, queueing, and
+   custom actions.
 
--  |FmtYamlName| - an alternative syntax for users more comfortable with
-   YAML than with RainerScript. Every YAML key maps directly to the equivalent
-   RainerScript parameter, so both formats share the same feature set.
-   See :doc:`yaml_config` for full reference.
+-  |FmtYamlName| - an additional syntax for YAML-centric environments such as
+   Kubernetes, Ansible, GitOps workflows, generated config, or other tooling
+   that already speaks YAML. Every YAML key maps directly to the equivalent
+   RainerScript parameter, so both formats share the same feature set and core
+   rsyslog model. See :doc:`yaml_config` for full reference.
 
 -  |FmtObsoleteName| - previously known as the ``legacy`` format. This format is
    **obsolete** and must not be used in new configurations.
@@ -35,20 +39,22 @@ different configuration formats:
 Which Format Should I Use?
 --------------------------
 
-For New Configurations
-~~~~~~~~~~~~~~~~~~~~~~
+For Modern Configurations
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the |FmtAdvancedName| format for all new configurations due to its
-flexibility, precision, and control. It handles complex use cases such as
-advanced filtering, forwarding, and actions with specific parameters.
+Choose between |FmtAdvancedName| and |FmtYamlName| based on environment fit,
+not ideology:
 
-If You Prefer YAML
-~~~~~~~~~~~~~~~~~~
+- Use |FmtAdvancedName| when your team already works effectively with
+  RainerScript, when you author rsyslog logic directly, or when that is the
+  clearer fit for your workflow.
+- Use |FmtYamlName| when rsyslog is part of a broader YAML-centric deployment
+  or automation workflow and you want to avoid conversion layers or embedded
+  RainerScript text.
 
-If you are already familiar with YAML and find it more readable than
-RainerScript, use the :doc:`YAML format <yaml_config>`.  The two formats
-are functionally equivalent — you can also mix them: a YAML main config
-may include RainerScript ``.conf`` fragments and vice versa.
+The two formats are functionally equivalent for the base configuration model.
+You can also mix them: a YAML main config may include RainerScript ``.conf``
+fragments and vice versa.
 
 Existing Configurations in Basic Format
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -74,7 +80,8 @@ Example - Basic Format
 Advanced Use Cases
 ~~~~~~~~~~~~~~~~~~
 
-For anything beyond basic logging, use the |FmtAdvancedName| format:
+For direct authoring beyond basic logging, |FmtAdvancedName| remains an
+excellent fit:
 
 - Fine control via advanced parameters
 - Easy-to-follow block structure
@@ -98,5 +105,6 @@ Conclusion
 ----------
 
 Use |FmtAdvancedName| for new configurations, or the :doc:`YAML format
-<yaml_config>` if you prefer YAML syntax.  The |FmtBasicName| format is
-acceptable for simple, existing configurations.  Never use |FmtObsoleteName|.
+<yaml_config>` when rsyslog lives inside a YAML-centric workflow. The
+|FmtBasicName| format is acceptable for simple, existing configurations.
+Never use |FmtObsoleteName|.

--- a/doc/source/configuration/yaml_config.rst
+++ b/doc/source/configuration/yaml_config.rst
@@ -9,20 +9,53 @@ YAML Configuration Format
 
 .. summary-start
 
-rsyslog supports YAML as an alternative configuration syntax for users comfortable with YAML. Every YAML key maps directly to the equivalent RainerScript parameter.
+rsyslog supports YAML as an additional configuration format for YAML-centric
+environments. YAML and RainerScript express the same core rsyslog model and
+share the same semantics.
 
 .. summary-end
 
-rsyslog supports configuration via YAML files as an alternative to
-RainerScript.  It is one of the :doc:`supported configuration formats
-<conf_formats>` and is a good choice if you are more comfortable with
-YAML syntax than with RainerScript.
+rsyslog supports configuration via YAML files as an additional format alongside
+RainerScript. It is one of the :doc:`supported configuration formats
+<conf_formats>` and is a good fit when rsyslog is part of a broader
+YAML-centric operational workflow.
 
-The two formats are equivalent: every YAML configuration key maps
+Typical examples include Kubernetes deployments, Ansible-managed systems,
+GitOps-style repositories, generated configuration, and AI-assisted
+infrastructure workflows. In those environments YAML support reduces
+integration friction because rsyslog can stay in the same format family as the
+surrounding tooling instead of relying on conversion steps or embedded
+RainerScript text.
+
+This is about workflow fit, not about replacing RainerScript. The two formats
+express the same core rsyslog concepts, including inputs, actions, rulesets,
+filters and routing, templates, and queues. Every YAML configuration key maps
 directly to a RainerScript parameter of the same name, so all per-module
-documentation remains applicable unchanged.  You can also mix formats:
-a YAML main config may include RainerScript ``.conf`` fragments and vice
-versa.
+documentation remains applicable unchanged. You can also mix formats: a YAML
+main config may include RainerScript ``.conf`` fragments and vice versa.
+
+Continuity with RainerScript
+----------------------------
+
+Existing RainerScript configurations remain fully valid and fully supported.
+You do not need to migrate them in order to use current rsyslog features.
+
+Existing RainerScript knowledge also transfers directly. YAML changes the
+surface syntax, but it does not introduce a separate rsyslog model or separate
+runtime semantics.
+
+When to Use YAML or RainerScript
+--------------------------------
+
+Choose the format that fits your environment and workflow:
+
+- Use YAML when rsyslog is part of a broader YAML-centric deployment or
+  automation workflow.
+- Use RainerScript when you already work effectively with it, when your team
+  authors rsyslog logic directly, or when it is simply the clearer fit for your
+  operational model.
+- Mix formats when that is practical. YAML and RainerScript can include each
+  other and share the same object names and parameter semantics.
 
 Activation
 ----------
@@ -222,11 +255,11 @@ logic is expressed in one of three ways:
    `Structured Filter Shortcut`_ below.
 2. **YAML-native statements** (``statements:`` key) — for conditional
    routing, ``if/then/else``, ``call``, ``call_indirect``, ``foreach``,
-   ``stop``, ``unset``, variable assignment — without writing any
-   RainerScript syntax.  See `YAML-Native Statements`_ below.
-   **Recommended for most configs.**
-3. **Inline RainerScript** (``script:`` key) — escape hatch for complex
-   metaprogramming or advanced RainerScript not covered by ``statements:``.
+   ``stop``, ``unset``, variable assignment — without writing raw
+   RainerScript blocks. See `YAML-Native Statements`_ below.
+   **Recommended for most YAML configs.**
+3. **Inline RainerScript** (``script:`` key) — intentional escape hatch for
+   advanced logic that is better expressed directly in RainerScript.
    See `Scripting`_ below.
 
 ``filter:`` + ``actions:`` example:
@@ -433,10 +466,10 @@ YAML-Native Statements
 ----------------------
 
 The ``statements:`` key is the recommended way to express conditional routing
-and control flow without writing raw RainerScript.  Each item in the sequence
-is a YAML mapping that represents one statement.  Only the *filter expression*
-inside ``if:`` remains as a RainerScript expression string — all structural
-elements and action parameters are expressed as YAML.
+and control flow for most YAML configs. Each item in the sequence is a YAML
+mapping that represents one statement. Only the *filter expression* inside
+``if:`` remains as a RainerScript expression string. All structural elements
+and action parameters are expressed as YAML.
 
 ``statements:`` is mutually exclusive with ``script:``, ``filter:``, and
 ``actions:``.
@@ -537,10 +570,15 @@ statement items using the same syntax as ``statements:``.  Example:
 Scripting
 ---------
 
+Use ``script:`` when a ruleset is better expressed directly in RainerScript,
+or when you need advanced logic that you intentionally want to keep in
+RainerScript form. For normal YAML configs, prefer ``statements:`` so the
+structure stays visible to YAML tooling, review, and generation workflows.
+
 RainerScript filter expressions and statement types (``if/then/else``,
 ``set``, ``unset``, ``foreach``, ``stop``, ``call``, legacy PRI-filters,
 property-filters, ``action()``) are all available inside a ``script:``
-block.  The value is an ordinary YAML scalar (use a
+block. The value is an ordinary YAML scalar (use a
 `YAML block scalar <https://yaml.org/spec/1.2.2/#81-block-scalar-styles>`_
 for multi-line content):
 
@@ -564,7 +602,7 @@ for multi-line content):
 
 The script content is passed verbatim to the RainerScript lexer/parser,
 so anything that is valid RainerScript in a ``ruleset() {}`` body is valid
-here.  Inline actions defined in the ``script:`` block do **not** need to
+here. Inline actions defined in the ``script:`` block do **not** need to
 be listed separately under an ``inputs:`` or ``actions:`` section.
 
 .. tip::
@@ -573,10 +611,11 @@ be listed separately under an ``inputs:`` or ``actions:`` section.
    `Structured Filter Shortcut`_.
    For conditional routing, variable assignments, ``call``, ``foreach``,
    ``stop``, and ``reload_lookup_table`` use the ``statements:`` block
-   described in `YAML-Native Statements`_.  **Recommended for most configs.**
-   Reserve ``script:`` only for advanced RainerScript that cannot be
-   expressed through ``statements:``, such as complex nested legacy
-   priority/property filters or inline ``call_direct`` patterns.
+   described in `YAML-Native Statements`_. **Recommended for most YAML
+   configs.**
+   Reserve ``script:`` for advanced logic that is better expressed directly in
+   RainerScript, such as complex nested legacy priority/property filters or
+   inline ``call_direct`` patterns.
 
 Complete Example
 ----------------
@@ -656,6 +695,10 @@ intermediate representation that the RainerScript lex/bison grammar produces —
 and hands them to the shared ``cnfDoObj()`` dispatcher.  There is no independent
 YAML runtime; the shared back-end handles all validation, module initialisation,
 and execution.
+
+That shared back-end is why RainerScript experience transfers directly.
+Whether you write YAML or RainerScript, you are still configuring the same
+rsyslog objects and execution model.
 
 This approach deliberately minimises the change surface: the YAML-specific code
 is confined to one file with no runtime presence after configuration loading.


### PR DESCRIPTION
## Summary
Clarify how rsyslog YAML configuration fits operationally without changing any technical facts.

## Why
The YAML docs were technically solid, but the positioning still read too much like
"rsyslog now has another syntax". That left the workflow guidance underspecified
for operators deciding when YAML fits, how it relates to RainerScript, and
whether any migration pressure exists.

## What changed
- position YAML as an additional format for YAML-centric environments such as Kubernetes, Ansible, GitOps, generated config, and AI-assisted infra workflows
- state clearly that this is about workflow fit, not replacing RainerScript
- add continuity guidance that existing RainerScript configs remain valid and existing knowledge transfers directly
- add balanced "when to use what" guidance in the YAML and configuration-format docs
- strengthen the recommendation to use `statements:` for most YAML configs and describe `script:` as the intentional escape hatch for advanced logic better expressed in RainerScript
- make the shared rsyslog model more explicit across the touched pages

## Validation
Built docs locally with:
`make -C doc html SPHINXOPTS='-q -W --keep-going'`
