### PR TITLE
build: stop shipping .gitignore files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,7 +4,6 @@ pkglib_LTLIBRARIES =
 pkgconfigdir = $(libdir)/pkgconfig
 
 EXTRA_DIST = \
-    .gitignore \
 	README.md \
 	platform/README \
 	platform/freebsd/rsyslogd \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -47,7 +47,6 @@ help:
 .PHONY: html-local html-with-sitemap singlehtml json alljson rag-db json-formatter clean-local help
 
 EXTRA_DIST = \
-    .gitignore \
     AGENTS.md \
     BUILDS_README.md \
     CONTRIBUTING.md \


### PR DESCRIPTION
## Summary
Stop shipping `.gitignore` files in release tarballs.

## Why
The source distribution should not impose repository ignore rules on downstream packaging trees. Including `.gitignore` in the tarball can cause files such as `debian/patches` to be ignored after unpacking.

## Root Cause
Both the top-level [`Makefile.am`](/home/rger/proj/rsyslog5/Makefile.am) and [`doc/Makefile.am`](/home/rger/proj/rsyslog5/doc/Makefile.am) listed `.gitignore` in `EXTRA_DIST`, so Automake copied them into the source tarball.

## What Changed
Remove `.gitignore` from the top-level and documentation `EXTRA_DIST` lists while keeping the existing `dist-hook` behavior unchanged.

## Validation
- `./autogen.sh --enable-debug --enable-testbench`
- `make -j$(nproc) check TESTS=""`
- `make dist`
- Verified the generated tarball contains `.tarball-version` and no `.gitignore` entries

closes: https://github.com/rsyslog/rsyslog/issues/6575
