### PR TITLE
mmjsontransform: reload transformation mode from policy

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,9 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2604.0 (aka 2026.04) 2026-04-??
+- 2026-03-30: mmjsontransform: add YAML policy preprocessing
+  mmjsontransform can now load a YAML policy file to rename or drop JSON
+  keys before flatten/unflatten processing. Policy files are documented
+  and reloaded on HUP when they change.
 - 2026-03-30: distribution tarballs no longer ship .gitignore files
   Source tarballs should not impose repository ignore rules on downstream
   packaging trees. This was a problem e.g. in Debian packaging.

--- a/doc/source/configuration/modules/mmjsontransform.rst
+++ b/doc/source/configuration/modules/mmjsontransform.rst
@@ -43,8 +43,8 @@ Notable Features
   and nested containers.
 - :ref:`mmjsontransform-conflict-handling` — detailed conflict reporting to
   locate incompatible payloads quickly.
-- :ref:`mmjsontransform-policy` — optional YAML policy-based key renaming and
-  field dropping before flatten/unflatten processing.
+- :ref:`mmjsontransform-policy` — optional YAML policy-based mode selection,
+  key renaming, and field dropping before processing.
 
 Configuration Parameters
 ========================
@@ -86,8 +86,9 @@ Transformation modes
 ====================
 
 ``mmjsontransform`` supports two modes controlled by the :ref:`mode
-<param-mmjsontransform-mode>` parameter. Both modes rewrite the entire input
-object before assigning it to the configured output property.
+<param-mmjsontransform-mode>` parameter or, when configured, by the reloadable
+:ref:`policy <param-mmjsontransform-policy>` file. Both modes rewrite the
+entire input object before assigning it to the configured output property.
 
 .. _mmjsontransform-mode-unflatten:
 

--- a/doc/source/reference/parameters/mmjsontransform-policy.rst
+++ b/doc/source/reference/parameters/mmjsontransform-policy.rst
@@ -11,7 +11,8 @@ policy
 
 .. summary-start
 
-Loads a YAML policy file that can rename or drop keys before transformation.
+Loads a YAML policy file that can select the transformation mode and
+rename or drop keys before processing.
 
 .. summary-end
 
@@ -32,14 +33,24 @@ re-checks it on ``HUP``. If the file's mtime changed, the module reloads it;
 when reload fails, the previous in-memory policy is kept. The current
 implementation supports these sections:
 
+``mode``
+   Selects ``unflatten`` or ``flatten`` from the policy file. When present,
+   this overrides the action parameter on startup and after a successful
+   ``HUP`` reload.
+
 ``map.rename``
    Mapping of source keys to destination keys. Both keys are dotted JSON paths.
 
 ``map.drop``
    Sequence of dotted JSON paths that should be removed before transformation.
 
-The policy is applied before the regular ``mode`` processing. This makes it
-possible to drop noisy fields and normalize names in one action invocation.
+The policy is applied before the selected transformation mode runs. This makes
+it possible to drop noisy fields, normalize names, and switch between
+``flatten`` and ``unflatten`` from one reloadable file.
+
+``input`` and ``output`` remain action parameters because they define which
+message properties are read and written; the policy file only controls the
+transformation behavior.
 
 If rsyslog is compiled without libyaml support, setting ``policy`` produces a
 configuration error.
@@ -54,6 +65,20 @@ Input usage
    action(type="mmjsontransform"
           policy="/etc/rsyslog/mmjsontransform-policy.yaml"
           input="$!raw" output="$!normalized")
+
+Example policy file
+-------------------
+
+.. code-block:: yaml
+
+   version: 1
+   mode: unflatten
+   map:
+     rename:
+       "usr": "user.name"
+       "ctx.old": "ctx.new"
+     drop:
+       - "debug"
 
 See also
 --------

--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -77,6 +77,8 @@ typedef struct _instanceData {
     msgPropDescr_t *outputProp;
     mmjsontransformMode_t mode;
     char *policyPath;
+    sbool hasPolicyMode;
+    mmjsontransformMode_t policyMode;
     char **dropKeys;
     size_t nDropKeys;
     struct json_object *dropKeySet;
@@ -185,6 +187,7 @@ static void jsontransformConflictCleanup(jsontransformConflict_t *conflict);
  * @brief Allocate a dotted path string combining prefix and segment.
  */
 static rsRetVal jsontransformBuildPath(char **out, const char *prefix, const char *segment);
+static rsRetVal jsontransformParseModeValue(const char *mode, mmjsontransformMode_t *outMode);
 static const char *jsontransformTargetInContext(const char *target, const char *contextPath);
 static rsRetVal jsontransformApplyPolicyRules(struct json_object *src,
                                               struct json_object **out,
@@ -246,6 +249,8 @@ BEGINcreateInstance
     pData->outputProp = NULL;
     pData->mode = MMJSONTRANSFORM_MODE_UNFLATTEN;
     pData->policyPath = NULL;
+    pData->hasPolicyMode = 0;
+    pData->policyMode = MMJSONTRANSFORM_MODE_UNFLATTEN;
     pData->dropKeys = NULL;
     pData->nDropKeys = 0;
     pData->dropKeySet = NULL;
@@ -417,11 +422,7 @@ BEGINnewActInst
             if (mode == NULL) {
                 ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
             }
-            if (strcasecmp(mode, "unflatten") == 0 || mode[0] == '\0') {
-                pData->mode = MMJSONTRANSFORM_MODE_UNFLATTEN;
-            } else if (strcasecmp(mode, "flatten") == 0) {
-                pData->mode = MMJSONTRANSFORM_MODE_FLATTEN;
-            } else {
+            if (jsontransformParseModeValue(mode, &pData->mode) != RS_RET_OK) {
                 parser_errmsg("mmjsontransform: mode '%s' is invalid; use 'unflatten' or 'flatten'", mode);
                 free(mode);
                 ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
@@ -465,6 +466,7 @@ BEGINdoAction_NoStrings
     struct json_object *policyAdjusted = NULL;
     struct json_object *rewritten = NULL;
     jsontransformConflict_t conflict = {0, NULL};
+    mmjsontransformMode_t effectiveMode;
     rsRetVal localRet;
     CODESTARTdoAction;
 
@@ -490,16 +492,20 @@ BEGINdoAction_NoStrings
     }
 
     activeInput = input;
+    effectiveMode = pData->mode;
 
     if (pData->policyPath != NULL) {
         pthread_mutex_lock(&pData->policyLock);
         localRet = jsontransformApplyPolicyRules(activeInput, &policyAdjusted, pData, &conflict, NULL);
+        if (localRet == RS_RET_OK && pData->hasPolicyMode) {
+            effectiveMode = pData->policyMode;
+        }
         pthread_mutex_unlock(&pData->policyLock);
         CHKiRet(localRet);
         activeInput = policyAdjusted;
     }
 
-    if (pData->mode == MMJSONTRANSFORM_MODE_UNFLATTEN) {
+    if (effectiveMode == MMJSONTRANSFORM_MODE_UNFLATTEN) {
         CHKiRet(jsontransformRewriteObject(activeInput, &rewritten, &conflict, NULL));
     } else {
         CHKiRet(jsontransformFlattenObject(activeInput, &rewritten, &conflict));
@@ -527,6 +533,9 @@ ENDdoAction
 static void jsontransformFreePolicy(instanceData *pData) {
     size_t i;
 
+    pData->hasPolicyMode = 0;
+    pData->policyMode = MMJSONTRANSFORM_MODE_UNFLATTEN;
+
     for (i = 0; i < pData->nDropKeys; ++i) {
         free(pData->dropKeys[i]);
     }
@@ -547,6 +556,20 @@ static void jsontransformFreePolicy(instanceData *pData) {
     pData->renameMap = NULL;
 }
 
+static rsRetVal jsontransformParseModeValue(const char *mode, mmjsontransformMode_t *outMode) {
+    if (mode == NULL || mode[0] == '\0' || strcasecmp(mode, "unflatten") == 0) {
+        *outMode = MMJSONTRANSFORM_MODE_UNFLATTEN;
+        return RS_RET_OK;
+    }
+
+    if (strcasecmp(mode, "flatten") == 0) {
+        *outMode = MMJSONTRANSFORM_MODE_FLATTEN;
+        return RS_RET_OK;
+    }
+
+    return RS_RET_INVALID_PARAMS;
+}
+
 static rsRetVal jsontransformLoadPolicy(instanceData *pData, const char *policyPath) {
 #ifndef HAVE_LIBYAML
     LogError(0, RS_RET_CONF_PARAM_INVLD,
@@ -557,10 +580,13 @@ static rsRetVal jsontransformLoadPolicy(instanceData *pData, const char *policyP
     yaml_parser_t parser;
     yaml_event_t event;
     sbool parserInitialized = 0;
+    sbool eventInitialized = 0;
     char *currentKey = NULL;
     sbool inMap = 0;
     sbool inMapRename = 0;
     sbool inMapDrop = 0;
+    sbool newHasPolicyMode = 0;
+    mmjsontransformMode_t newPolicyMode = MMJSONTRANSFORM_MODE_UNFLATTEN;
     sbool renameExpectValue = 0;
     char *renameFrom = NULL;
     char **newDropKeys = NULL;
@@ -586,15 +612,22 @@ static rsRetVal jsontransformLoadPolicy(instanceData *pData, const char *policyP
     yaml_parser_set_input_file(&parser, fh);
 
     while (yaml_parser_parse(&parser, &event)) {
+        eventInitialized = 1;
         if (event.type == YAML_MAPPING_START_EVENT) {
             if (currentKey != NULL && !strcmp(currentKey, "map")) {
                 inMap = 1;
+                free(currentKey);
+                currentKey = NULL;
             } else if (inMap && currentKey != NULL && !strcmp(currentKey, "rename")) {
                 inMapRename = 1;
+                free(currentKey);
+                currentKey = NULL;
             }
         } else if (event.type == YAML_SEQUENCE_START_EVENT) {
             if (inMap && currentKey != NULL && !strcmp(currentKey, "drop")) {
                 inMapDrop = 1;
+                free(currentKey);
+                currentKey = NULL;
             }
         } else if (event.type == YAML_MAPPING_END_EVENT) {
             if (inMapRename) {
@@ -635,6 +668,19 @@ static rsRetVal jsontransformLoadPolicy(instanceData *pData, const char *policyP
                 newDropKeys = tmp;
                 CHKmalloc(newDropKeys[idx] = strdup(scalar));
                 nNewDropKeys++;
+            } else if (currentKey != NULL && !strcmp(currentKey, "mode")) {
+                if (jsontransformParseModeValue(scalar, &newPolicyMode) != RS_RET_OK) {
+                    yaml_event_delete(&event);
+                    eventInitialized = 0;
+                    LogError(0, RS_RET_CONF_PARAM_INVLD,
+                             "mmjsontransform: policy file '%s' has invalid mode '%s'; "
+                             "use 'unflatten' or 'flatten'",
+                             policyPath, scalar);
+                    ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+                }
+                newHasPolicyMode = 1;
+                free(currentKey);
+                currentKey = NULL;
             } else {
                 free(currentKey);
                 currentKey = strdup(scalar);
@@ -644,9 +690,11 @@ static rsRetVal jsontransformLoadPolicy(instanceData *pData, const char *policyP
 
         if (event.type == YAML_STREAM_END_EVENT) {
             yaml_event_delete(&event);
+            eventInitialized = 0;
             break;
         }
         yaml_event_delete(&event);
+        eventInitialized = 0;
     }
 
     if (renameExpectValue) {
@@ -682,6 +730,8 @@ static rsRetVal jsontransformLoadPolicy(instanceData *pData, const char *policyP
     }
 
     jsontransformFreePolicy(pData);
+    pData->hasPolicyMode = newHasPolicyMode;
+    pData->policyMode = newPolicyMode;
     pData->dropKeys = newDropKeys;
     pData->nDropKeys = nNewDropKeys;
     pData->dropKeySet = newDropKeySet;
@@ -696,6 +746,7 @@ static rsRetVal jsontransformLoadPolicy(instanceData *pData, const char *policyP
     newRenameMap = NULL;
 
 finalize_it:
+    if (eventInitialized) yaml_event_delete(&event);
     free(renameFrom);
     free(currentKey);
     if (parserInitialized) yaml_parser_delete(&parser);

--- a/tests/mmjsontransform-policy-basic.sh
+++ b/tests/mmjsontransform-policy-basic.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-# Validate mmjsontransform YAML policy rename/drop preprocessing and HUP reload.
+# Validate mmjsontransform YAML policy rename/drop preprocessing, mode, and HUP reload.
 . ${srcdir:=.}/diag.sh init
 
 policy_file="$RSYSLOG_DYNNAME.policy.yaml"
 cat > "$policy_file" <<'YAML'
 version: 1
+mode: flatten
 map:
   rename:
     "usr": "user.name"
@@ -35,6 +36,7 @@ tcpflood -m1 -M '"<166>Mar 10 01:00:00 host app: { \"usr\": \"alice\", \"debug\"
 sleep 2
 cat > "$policy_file" <<'YAML'
 version: 1
+mode: unflatten
 map:
   rename:
     "usr": "actor.name"
@@ -43,6 +45,18 @@ YAML
 
 issue_HUP
 tcpflood -m1 -M '"<166>Mar 10 01:00:00 host app: { \"usr\": \"bob\", \"debug\": true, \"ctx\": { \"old\": 2 } }"'
+
+sleep 2
+cat > "$policy_file" <<'YAML'
+version: 1
+mode: sideways
+map:
+  rename:
+    "usr": "broken.name"
+YAML
+
+issue_HUP
+tcpflood -m1 -M '"<166>Mar 10 01:00:00 host app: { \"usr\": \"carol\", \"debug\": true, \"ctx\": { \"old\": 3 } }"'
 
 shutdown_when_empty
 wait_shutdown
@@ -59,20 +73,26 @@ import sys
 with open(sys.argv[1], "r", encoding="utf-8") as fh:
     lines = [line.strip() for line in fh if line.strip()]
 
-if len(lines) != 2:
-    print("expected 2 JSON lines, got", len(lines))
+if len(lines) != 3:
+    print("expected 3 JSON lines, got", len(lines))
     sys.exit(1)
 
 first = json.loads(lines[0])
 second = json.loads(lines[1])
+third = json.loads(lines[2])
 
 expected_first = {
-    "user": {"name": "alice"},
-    "ctx": {"new": 1},
+    "user.name": "alice",
+    "ctx.new": 1,
 }
 expected_second = {
     "actor": {"name": "bob"},
     "ctx": {"after": 2},
+    "debug": True,
+}
+expected_third = {
+    "actor": {"name": "carol"},
+    "ctx": {"after": 3},
     "debug": True,
 }
 
@@ -82,8 +102,16 @@ if first != expected_first:
 if second != expected_second:
     print("unexpected second output:", second)
     sys.exit(1)
+if third != expected_third:
+    print("unexpected third output:", third)
+    sys.exit(1)
 PY
 if [ $? -ne 0 ]; then
+    error_exit 1
+fi
+
+if ! grep -q "failed to reload policy file" "$RSYSLOG_DYNNAME.started"; then
+    echo "FAIL: expected reload failure to be logged for invalid policy mode"
     error_exit 1
 fi
 


### PR DESCRIPTION
## Why

The YAML policy file should cover the full transformation behavior that
`mmjsontransform` exposes, so operators can update policy-driven JSON
normalization in one place and reload it on HUP.

## What Changed

- added support for a top-level `mode` key in the YAML policy file
- kept the action parameter `mode` as the fallback default when the
  policy omits it
- reload policy-owned mode together with `map.rename` and `map.drop` on
  HUP
- retain the previous in-memory policy when a HUP reload fails
- updated the policy docs and module docs to describe the expanded
  schema and precedence
- added a ChangeLog entry for the user-visible policy enhancement

## Behavior

Before this change, policy files could only rename or drop keys and the
transform mode stayed fixed until restart.

After this change, policy files can also select `flatten` or
`unflatten`, and a successful HUP reload updates the effective mode and
preprocessing rules together.

`input` and `output` remain action parameters because they control which
message properties are read and written rather than the transformation
behavior itself.

## Validation

- `./devtools/format-code.sh --git-changed`
- `make -j$(nproc)`
- `./tests/mmjsontransform-policy-basic.sh`