### PR TITLE
[General]: Add tzdata to minimal and standard docker images

### DIFF
--- a/packaging/docker/rsyslog/minimal/Dockerfile
+++ b/packaging/docker/rsyslog/minimal/Dockerfile
@@ -47,7 +47,7 @@ RUN apt-get update && \
         ca-certificates \
     && add-apt-repository -y ppa:adiscon/daily-stable \
     && apt-get update && \
-    apt-get install -y --no-install-recommends rsyslog rsyslog-omstdout \
+    apt-get install -y --no-install-recommends tzdata rsyslog rsyslog-omstdout \
     && apt-get purge -y --auto-remove software-properties-common \
     && apt-get autoremove -y \
     && apt-get clean \

--- a/packaging/docker/rsyslog/standard/Dockerfile
+++ b/packaging/docker/rsyslog/standard/Dockerfile
@@ -44,11 +44,12 @@ LABEL org.opencontainers.image.revision="${VCS_REF}"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install common rsyslog modules suitable for a standard image.
+# - tzadata: For timezone data, needed for log timestamps. 
 # - rsyslog-imhttp: For the built-in HTTP server (health, metrics, potential future ingestion).
 # - rsyslog-omhttp: For forwarding logs via HTTP.
 # apt-get update is run to ensure the package lists are fresh before installing.
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends rsyslog-imhttp rsyslog-omhttp && \
+    apt-get install -y --no-install-recommends tzdata rsyslog-imhttp rsyslog-omhttp && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 


### PR DESCRIPTION
### Summary 
Ensures Docker images include timezone data for correct timestamp
handling in containerized environments. This improves reliability
and avoids subtle issues with missing timezone info in logs.

Impact: Containers now have timezone data available; image size
increases slightly.

Before: minimal and standard images installed rsyslog packages
without tzdata, which could lead to missing timezone information
at runtime.
After: tzdata is installed alongside rsyslog packages in both
images, ensuring consistent timezone support.

### References
Refs: https://github.com/rsyslog/rsyslog/issues/6623

