### PR TITLE
[build]: require OpenSSL if imdtls or omdtls is used

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,11 @@
 --------------------------------------------------------------------------------------
 Scheduled Release 8.2604.0 (aka 2026.04) 2026-04-??
+- 2026-03-31: build: require --enable-openssl if imdtls or omdtls is used
+  The DTLS modules (imdtls and omdtls) depend on the OpenSSL network
+  stream driver. Previously, the build would succeed in a broken
+  state (missing lmnsd_ossl.la) if OpenSSL support was not also
+  explicitly enabled.
+  closes: https://github.com/rsyslog/rsyslog/issues/5339
 - 2026-03-30: mmjsontransform: add YAML policy preprocessing
   mmjsontransform can now load a YAML policy file to rename or drop JSON
   keys before flatten/unflatten processing. Policy files are documented

--- a/configure.ac
+++ b/configure.ac
@@ -3021,9 +3021,9 @@ fi
 AM_CONDITIONAL(ENABLE_OMDTLS, test x$enable_omdtls = xyes)
 # END OMDTLS INPUT
 
-if test "x$enable_wolfssl" = "xyes"; then
-	if test "x$enable_imdtls" = "xyes" -o "x$enable_omdtls" = "xyes"; then
-		AC_MSG_ERROR([DTLS modules (imdtls/omdtls) require OpenSSL; they cannot be built with wolfSSL enabled])
+if test "x$enable_imdtls" = "xyes" -o "x$enable_omdtls" = "xyes"; then
+	if test "x$enable_openssl" != "xyes"; then
+		AC_MSG_ERROR([DTLS modules (imdtls/omdtls) require OpenSSL support to be enabled (--enable-openssl)])
 	fi
 fi
 


### PR DESCRIPTION
This PR addresses #5339 by enforcing that OpenSSL support must be explicitly enabled when building with DTLS modules.

The DTLS modules (imdtls and omdtls) have a runtime dependency on the OpenSSL network stream driver (lmnsd_ossl.la). Previously, the build would succeed in a broken state if OpenSSL support was not also explicitly enabled, leading to runtime failures or test crashes.

**Changes:**
- Updated configure.ac to check for --enable-openssl when imdtls or omdtls is selected.
- Updated ChangeLog.

closes: https://github.com/rsyslog/rsyslog/issues/5339