### PR TITLE
doc: expand YAML statements with complex nested examples

### DIFF
--- a/doc/source/configuration/yaml_config.rst
+++ b/doc/source/configuration/yaml_config.rst
@@ -560,18 +560,47 @@ and action parameters are expressed as YAML.
 +----------------------+-------------------------------------------------------------+
 
 ``foreach`` iterates over a JSON array.  The ``do:`` value is a sequence of
-statement items using the same syntax as ``statements:``.  Example:
+statement items using the same syntax as ``statements:``.
+
+**Complex routing and iteration example**
+
+This example demonstrates how to combine variable assignment, a ``foreach`` loop,
+and a nested ``if/then/else`` statement to achieve complex routing without writing
+raw RainerScript blocks.
 
 .. code-block:: yaml
 
-   statements:
-     - foreach:
-         var: "$.item"
-         in: "$!items"
-         do:
-           - type: omfile
-             file: /var/log/items.log
-             template: outfmt
+   rulesets:
+     - name: process_items
+       statements:
+         # Set a local variable based on message content
+         - set:
+             var: "$.is_audit"
+             expr: 're_match($msg, "AUDIT")'
+
+         # Parse the JSON message content into $! variables
+         - type: mmjsonparse
+
+         # Iterate over a JSON array in the message
+         - foreach:
+             var: "$.item"
+             in: "$!items"
+             do:
+               - if: '$.is_audit == 1'
+                 then:
+                   - type: omfile
+                     file: /var/log/audit_items.log
+                     template: outfmt
+                 else:
+                   - if: '$.item!type == "error"'
+                     then:
+                       - type: omfile
+                         file: /var/log/error_items.log
+                         template: outfmt
+                     else:
+                       - type: omfile
+                         file: /var/log/standard_items.log
+                         template: outfmt
 
 .. _yaml_scripting:
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -593,7 +593,6 @@ TESTS_LIBYAML = \
 	yaml-statements-stop.sh \
 	yaml-statements-call.sh \
 	yaml-statements-unset.sh \
-	yaml-statements-foreach.sh \
 	yaml-template-list.sh \
 	yaml-template-subtree.sh \
 	yaml-statements-reload-lookup.sh
@@ -604,6 +603,10 @@ TESTS_RATELIMIT_WATCH = \
 	ratelimit_policy_watch_invalid.sh \
 	ratelimit_policy_watch_multi.sh \
 	yaml-ratelimit-policywatch.sh
+
+TESTS_LIBYAML_IMPTCP_MMJSONPARSE = \
+	yaml-statements-foreach.sh \
+	yaml-statements-complex.sh
 
 TESTS_IMTCP = \
 	fromhost-port.sh \
@@ -1779,6 +1782,7 @@ EXTRA_DIST += $(TESTS_DEFAULT_VALGRIND)
 EXTRA_DIST += $(TESTS_LIBGCRYPT_VALGRIND)
 EXTRA_DIST += $(TESTS_LIBYAML)
 EXTRA_DIST += $(TESTS_RATELIMIT_WATCH)
+EXTRA_DIST += $(TESTS_LIBYAML_IMPTCP_MMJSONPARSE)
 EXTRA_DIST += $(TESTS_LIBYAML_IMTCP)
 EXTRA_DIST += $(TESTS_LIBYAML_IMHTTP)
 EXTRA_DIST += $(TESTS_LIBYAML_OMSTDOUT)
@@ -2177,6 +2181,11 @@ TESTS += $(TESTS_LIBYAML)
 if ENABLE_INOTIFY
 TESTS += $(TESTS_RATELIMIT_WATCH)
 endif # ENABLE_INOTIFY
+if ENABLE_IMPTCP
+if ENABLE_MMJSONPARSE
+TESTS += $(TESTS_LIBYAML_IMPTCP_MMJSONPARSE)
+endif # ENABLE_MMJSONPARSE
+endif # ENABLE_IMPTCP
 if ENABLE_IMTCP_TESTS
 TESTS += $(TESTS_LIBYAML_IMTCP)
 endif # ENABLE_IMTCP_TESTS
@@ -3084,6 +3093,7 @@ EXTRA_DIST += \
 	testsuites/tokenized_input \
 	testsuites/complex_replace_input \
 	testsuites/wrap3_input\
+	testsuites/yaml_complex_input \
 	testsuites/json_array_input \
 	testsuites/json_object_input \
 	testsuites/json_nonarray_input \

--- a/tests/testsuites/yaml_complex_input
+++ b/tests/testsuites/yaml_complex_input
@@ -1,0 +1,2 @@
+<167>Mar  6 16:57:54 host tag @cee:{"items": [{"type": "info", "val": "audit1"}, {"type": "error", "val": "audit2"}], "txt": "this is an AUDIT message"}
+<167>Mar  6 16:57:54 host tag @cee:{"items": [{"type": "info", "val": "std1"}, {"type": "error", "val": "err1"}], "txt": "this is a NORMAL message"}

--- a/tests/yaml-statements-complex.sh
+++ b/tests/yaml-statements-complex.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Tests the YAML-native statements complex routing and iteration example
+# from the YAML configuration documentation.
+#
+# Added 2026, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+out_audit="${RSYSLOG_OUT_LOG}.audit"
+out_error="${RSYSLOG_OUT_LOG}.error"
+out_standard="${RSYSLOG_OUT_LOG}.standard"
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" <<YAMLEOF
+modules:
+  - load: "../plugins/imptcp/.libs/imptcp"
+  - load: "../plugins/mmjsonparse/.libs/mmjsonparse"
+
+templates:
+  - name: outfmt
+    type: string
+    string: "val: %\$.item!val%\n"
+
+rulesets:
+  - name: process_items
+    statements:
+      - set:
+          var: "\$.is_audit"
+          expr: 're_match(\$msg, "AUDIT")'
+      - type: mmjsonparse
+      - foreach:
+          var: "\$.item"
+          in: "\$!items"
+          do:
+            - if: '\$.is_audit == 1'
+              then:
+                - type: omfile
+                  file: "${out_audit}"
+                  template: outfmt
+              else:
+                - if: '\$.item!type == "error"'
+                  then:
+                    - type: omfile
+                      file: "${out_error}"
+                      template: outfmt
+                  else:
+                    - type: omfile
+                      file: "${out_standard}"
+                      template: outfmt
+YAMLEOF
+
+add_conf '
+input(type="imptcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="process_items")
+'
+startup
+tcpflood -p"$(cat "${RSYSLOG_DYNNAME}.tcpflood_port")" -m 1 -I "$srcdir/testsuites/yaml_complex_input"
+shutdown_when_empty
+wait_shutdown
+
+# The AUDIT message has "audit1" and "audit2" which both go to the audit log
+custom_content_check "val: audit1" "${out_audit}"
+custom_content_check "val: audit2" "${out_audit}"
+
+# The NORMAL message has "err1" (type error) and "std1" (type info)
+custom_content_check "val: err1" "${out_error}"
+
+custom_content_check "val: std1" "${out_standard}"
+
+exit_test


### PR DESCRIPTION
This adds a comprehensive example to the YAML-Native Statements section, demonstrating how to combine variable assignment (set), array iteration (foreach), and nested conditional branching (if/then/else) directly in YAML, reducing the need for raw RainerScript blocks.
