### PR TITLE
omfwd: fall back to standard resolver APIs on musl

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -426,6 +426,56 @@ static const char *resolverErrorString(const int err) {
     }
 }
 
+#if defined(__RES) && (__RES >= 19991006)
+    #define HAVE_RESOLV_RES_N_API 1
+#endif
+
+static rsRetVal initResolverState(res_state *const pres) {
+    DEFiRet;
+
+#ifdef HAVE_RESOLV_RES_N_API
+    CHKmalloc(*pres = (res_state)calloc(1, sizeof(struct __res_state)));
+    if (res_ninit(*pres) != 0) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+#else
+    if (res_init() != 0) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+    *pres = &_res;
+#endif
+
+finalize_it:
+    RETiRet;
+}
+
+static int queryResolverState(res_state const res,
+                              const char *const srvName,
+                              unsigned char *const answer,
+                              const size_t answerSize) {
+#ifdef HAVE_RESOLV_RES_N_API
+    return res_nquery(res, srvName, ns_c_in, ns_t_srv, answer, answerSize);
+#else
+    (void)res;
+    return res_query(srvName, ns_c_in, ns_t_srv, answer, answerSize);
+#endif
+}
+
+static void closeResolverState(res_state const res) {
+    if (res == NULL) {
+        return;
+    }
+#ifdef HAVE_RESOLV_RES_N_API
+    res_nclose(res);
+    free(res);
+#else
+    /* Old resolver APIs use global state; musl's implementation is stateless. */
+    (void)res;
+#endif
+}
+
 static rsRetVal applyResolverOverrides(res_state res) {
     const char *const dnsServerEnv = getenv("RSYSLOG_DNS_SERVER");
     const char *const dnsPortEnv = getenv("RSYSLOG_DNS_PORT");
@@ -506,15 +556,10 @@ static rsRetVal resolveSrvTargets(instanceData *const pData) {
         ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     }
 
-    CHKmalloc(res = (res_state)calloc(1, sizeof(struct __res_state)));
-    if (res_ninit(res) != 0) {
-        LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
-        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
-    }
-
+    CHKiRet(initResolverState(&res));
     CHKiRet(applyResolverOverrides(res));
 
-    const int ansLen = res_nquery(res, srvName, ns_c_in, ns_t_srv, answer, sizeof(answer));
+    const int ansLen = queryResolverState(res, srvName, answer, sizeof(answer));
     if (ansLen < 0) {
         LogError(0, RS_RET_PARAM_ERROR, "omfwd: failed to resolve SRV records for '%s': %s", srvName,
                  resolverErrorString(res->res_h_errno));
@@ -642,10 +687,7 @@ static rsRetVal resolveSrvTargets(instanceData *const pData) {
 finalize_it:
     free(records);
     free(ordered);
-    if (res != NULL) {
-        res_nclose(res);
-        free(res);
-    }
+    closeResolverState(res);
     RETiRet;
 #endif
 }


### PR DESCRIPTION
## Summary
This fixes the musl build failure in `omfwd` SRV discovery by using the
traditional resolver API when libc does not provide the glibc-specific
`res_n*` entry points.

## Root Cause
`omfwd` unconditionally called `res_ninit`, `res_nquery`, and `res_nclose`.
That works on glibc, but musl intentionally exposes the older stateless
resolver API instead.

## What Changed
Resolver setup, query, and cleanup are now wrapped behind small helpers.
When `__RES` indicates support for `res_n*`, rsyslog keeps the existing
per-query resolver-state path. Otherwise it falls back to `res_init()` and
`res_query()` while leaving SRV response parsing and target ordering
unchanged.

## Validation
- `make -j$(nproc) check TESTS=""`
- `./tests/omfwd-srv-discovery-errors.sh`
- `./tests/omfwd-srv-discovery-udp.sh`

Closes https://github.com/rsyslog/rsyslog/issues/6655
