### PR TITLE
[Modernization] Replace Internal Backticks with Shell Expansion

### DIFF
--- a/tests/mmanon_recognize_ipembedded.sh
+++ b/tests/mmanon_recognize_ipembedded.sh
@@ -12,7 +12,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.enable="off" ipv6.enable="off" embeddedipv4.bits="128" embeddedipv4.anonmode="zero")
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }'
 
 startup

--- a/tests/mmanon_recognize_ipv4.sh
+++ b/tests/mmanon_recognize_ipv4.sh
@@ -16,7 +16,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 
 ruleset(name="testing") {
 	action(type="mmanon" mode="zero" ipv4.bits="32")
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }'
 
 startup

--- a/tests/mmanon_simple_8_ipv4.sh
+++ b/tests/mmanon_simple_8_ipv4.sh
@@ -12,7 +12,7 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 
 ruleset(name="testing") {
 	action(type="mmanon" ipv4.bits="8" ipv4.mode="simple")
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }'
 
 startup

--- a/tests/mmdb.sh
+++ b/tests/mmdb.sh
@@ -16,11 +16,11 @@ module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
 
-ruleset(name="testing") {
-	action(type="mmnormalize" rulebase=`echo $srcdir/mmdb.rb`)
-	action(type="mmdblookup" mmdbfile=`echo $srcdir/test.mmdb` key="$!ip" fields="city" )
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
-}'
+	ruleset(name="testing") {
+		action(type="mmnormalize" rulebase="'$srcdir/mmdb.rb'")
+		action(type="mmdblookup" mmdbfile="'$srcdir/test.mmdb'" key="$!ip" fields="city" )
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}'
 startup
 tcpflood -m 1 -j "202.106.0.20\ "
 shutdown_when_empty

--- a/tests/mmnormalize_processing_test1.sh
+++ b/tests/mmnormalize_processing_test1.sh
@@ -22,12 +22,12 @@ template(name="t_analytics_msg_normalized_vc" type="string" string="%timereporte
 template(name="t_analytics" type="string" string="[][][%$!v_fromhost-ip%][%timestamp:::date-unixtimestamp%][] %$!v_analytics_msg%\n")
 
 ruleset(name="ruleset1") {
-	action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_processing_tests.rulebase` useRawMsg="on")
+	action(type="mmnormalize" rulebase="'$srcdir/testsuites/mmnormalize_processing_tests.rulebase'" useRawMsg="on")
 	if ($!v_file == "") then {
 		set $!v_file=$!v_tag;
 	}
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_record")
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_path")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_record")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_path")
 
 	set $!v_forward="PCI";
 
@@ -50,7 +50,7 @@ ruleset(name="ruleset1") {
 				set $!v_analytics_msg=exec_template("t_analytics_msg_normalized");
 			}
 		}
-		action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_analytics")
+		action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_analytics")
 	}	
 }
 '

--- a/tests/mmnormalize_processing_test2.sh
+++ b/tests/mmnormalize_processing_test2.sh
@@ -22,12 +22,12 @@ template(name="t_analytics_msg_normalized_vc" type="string" string="%timereporte
 template(name="t_analytics" type="string" string="[][][%$!v_fromhost-ip%][%timestamp:::date-unixtimestamp%][] %$!v_analytics_msg%\n")
 
 ruleset(name="ruleset1") {
-	action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_processing_tests.rulebase` useRawMsg="on")
+	action(type="mmnormalize" rulebase="'$srcdir/testsuites/mmnormalize_processing_tests.rulebase'" useRawMsg="on")
 	if ($!v_file == "") then {
 		set $!v_file=$!v_tag;
 	}
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_record")
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_path")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_record")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_path")
 
 	set $!v_forward="PCI";
 
@@ -50,7 +50,7 @@ ruleset(name="ruleset1") {
 				set $!v_analytics_msg=exec_template("t_analytics_msg_normalized");
 			}
 		}
-		action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_analytics")
+		action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_analytics")
 	}	
 }
 '

--- a/tests/mmnormalize_processing_test3.sh
+++ b/tests/mmnormalize_processing_test3.sh
@@ -22,12 +22,12 @@ template(name="t_analytics_msg_normalized_vc" type="string" string="%timereporte
 template(name="t_analytics" type="string" string="[][][%$!v_fromhost-ip%][%timestamp:::date-unixtimestamp%][] %$!v_analytics_msg%\n")
 
 ruleset(name="ruleset1") {
-	action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_processing_tests.rulebase` useRawMsg="on")
+	action(type="mmnormalize" rulebase="'$srcdir/testsuites/mmnormalize_processing_tests.rulebase'" useRawMsg="on")
 	if ($!v_file == "") then {
 		set $!v_file=$!v_tag;
 	}
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_record")
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_path")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_record")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_path")
 
 	set $!v_forward="PCI";
 
@@ -50,7 +50,7 @@ ruleset(name="ruleset1") {
 				set $!v_analytics_msg=exec_template("t_analytics_msg_normalized");
 			}
 		}
-		action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_analytics")
+		action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_analytics")
 	}	
 }
 '

--- a/tests/mmnormalize_processing_test4.sh
+++ b/tests/mmnormalize_processing_test4.sh
@@ -15,12 +15,12 @@ template(name="t_file_record" type="string" string="%timestamp:::date-rfc3339% %
 template(name="t_file_path" type="string" string="/sb/logs/incoming/%$year%/%$month%/%$day%/svc_%$!v_svc%/ret_%$!v_ret%/os_%$!v_os%/%fromhost-ip%/r_relay1/%$!v_file:::lowercase%.gz\n")
 
 ruleset(name="ruleset1") {
-	action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_processing_tests.rulebase` useRawMsg="on")
+	action(type="mmnormalize" rulebase="'$srcdir/testsuites/mmnormalize_processing_tests.rulebase'" useRawMsg="on")
 	if ($!v_file == "") then {
 		set $!v_file=$!v_tag;
 	}
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_record")
-	action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="t_file_path")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_record")
+	action(type="omfile" File="'$RSYSLOG_OUT_LOG'" template="t_file_path")
 
 }
 '

--- a/tests/mmnormalize_regex.sh
+++ b/tests/mmnormalize_regex.sh
@@ -15,8 +15,8 @@ module(load="../plugins/mmnormalize/.libs/mmnormalize" allowRegex="on")
 module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
-action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")
+action(type="mmnormalize" rulebase="'$srcdir/testsuites/mmnormalize_regex.rulebase'")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="hosts_and_ports")
 '
 startup
 tcpflood -m 1 -I $srcdir/testsuites/regex_input

--- a/tests/mmnormalize_regex_defaulted.sh
+++ b/tests/mmnormalize_regex_defaulted.sh
@@ -15,8 +15,8 @@ module(load="../plugins/mmnormalize/.libs/mmnormalize")
 module(load="../plugins/imptcp/.libs/imptcp")
 input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
-action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_regex.rulebase`)
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="hosts_and_ports")
+action(type="mmnormalize" rulebase="'$srcdir/testsuites/mmnormalize_regex.rulebase'")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="hosts_and_ports")
 '
 startup
 tcpflood -m 1 -I $srcdir/testsuites/regex_input

--- a/tests/mmnormalize_rule_from_array.sh
+++ b/tests/mmnormalize_rule_from_array.sh
@@ -12,7 +12,7 @@ template(name="outfmt" type="string" string="%hostname% %syslogtag%\n")
 
 ruleset(name="norm") {
 	action(type="mmnormalize" rule=["rule=: no longer listening on %ip:ipv4%#%port:number%", "rule=: is sending messages on %ip:ipv4%", "rule=: apfelkuchen"])
-	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 }
 '
 startup

--- a/tests/mmnormalize_variable.sh
+++ b/tests/mmnormalize_variable.sh
@@ -18,8 +18,8 @@ template(name="time_fragment" type="list") {
 
 set $.time_frag = exec_template("time_fragment");
 
-action(type="mmnormalize" rulebase=`echo $srcdir/testsuites/mmnormalize_variable.rulebase` variable="$.time_frag")
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+action(type="mmnormalize" rulebase="'$srcdir/testsuites/mmnormalize_variable.rulebase'" variable="$.time_frag")
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
 tcpflood -m 1 -I $srcdir/testsuites/date_time_msg


### PR DESCRIPTION
### Summary

Modernize the  manon / mmnormalize test suite to remove legacy backtick-based
expansion and align with current shell best practices. This
reduces overhead and improves maintainability, especially in
CI and containerized environments.

Impact: test behavior may change in edge quoting cases.

BEFORE: tests used `echo $VAR` via backticks, spawning shells.
AFTER: tests use direct '$VAR' expansion without subshells.

The update replaces command substitution patterns used to
populate file paths and parameters with direct variable
expansion. This avoids per-expansion process forks and keeps
evaluation within the shell, improving performance and
readability.

Care is taken to preserve quoting semantics where variables
are passed to rsyslog configs. No rsyslog runtime behavior is
changed; only test execution mechanics are affected.

AI-Agent: Copilot 2026-04

Refs: https://github.com/rsyslog/rsyslog/issues/6523

