### PR TITLE
runtime: harden stringbuf contains matching

### DIFF
--- a/runtime/stringbuf.c
+++ b/runtime/stringbuf.c
@@ -698,12 +698,13 @@ int ATTR_NONNULL(1, 2) rsCStrLocateInSzStr(cstr_t *const pThis, uchar *const sz)
     assert(sz != NULL);
 
     if (pThis->iStrLen == 0) return 0;
+    if (pThis->iStrLen > len_sz) return -1;
 
     /* compute the largest index where a match could occur - after all,
      * the to-be-located string must be able to be present in the
      * searched string (it needs its size ;)).
      */
-    iMax = (pThis->iStrLen >= len_sz) ? 0 : len_sz - pThis->iStrLen;
+    iMax = len_sz - pThis->iStrLen;
 
     bFound = 0;
     i = 0;

--- a/runtime/stringbuf.h
+++ b/runtime/stringbuf.h
@@ -31,6 +31,16 @@
 
 /**
  * The dynamic string buffer object.
+ *
+ * Contract notes:
+ * - The buffer stores counted bytes and may keep `pBuf == NULL` for empty
+ *   strings.
+ * - Constructors and mutating helpers do not guarantee a trailing NUL.
+ *   Callers must invoke `cstrFinalize()` before using any API that exposes the
+ *   buffer as a classic C string.
+ * - `cstrFinalize()` writes the trailing NUL but is not a hard state change in
+ *   release builds; appending after finalize remains invalid API usage even if
+ *   some call paths appear to tolerate it.
  */
 typedef struct cstr_s {
 #ifndef NDEBUG
@@ -44,7 +54,10 @@ typedef struct cstr_s {
 
 
 /**
- * Construct a rsCStr object.
+ * Construct an empty counted string.
+ *
+ * The resulting object is not finalized. Call `cstrFinalize()` before passing
+ * it to any consumer that expects a NUL-terminated string view.
  */
 rsRetVal cstrConstruct(cstr_t **ppThis);
 #define rsCStrConstruct(x) cstrConstruct((x))
@@ -66,8 +79,11 @@ void rsCStrDestruct(cstr_t **ppThis);
  */
 rsRetVal cstrAppendChar(cstr_t *pThis, const uchar c);
 
-/* Finalize the string object. This must be called after all data is added to it
- * but before that data is used.
+/* Finalize the string object.
+ *
+ * This writes the trailing NUL expected by `cstrGetSzStrNoNULL()`, regex
+ * matching, and other C-string consumers. Call it after the last mutation and
+ * before any read that depends on classic NUL-terminated semantics.
  * rgerhards, 2009-06-16
  */
 #ifdef NDEBUG
@@ -99,6 +115,8 @@ void cstrTrimTrailingWhiteSpace(cstr_t *pThis);
  * use rsCStrAppenStrWithLen() if you know the length.
  *
  * \param psz pointer to string to be appended. Must not be NULL.
+ *
+ * The object remains non-finalized after this call.
  */
 rsRetVal rsCStrAppendStr(cstr_t *pThis, const uchar *psz);
 
@@ -107,6 +125,8 @@ rsRetVal rsCStrAppendStr(cstr_t *pThis, const uchar *psz);
  *
  * \param psz pointer to string to be appended. Must not be NULL.
  * \param iStrLen the length of the string pointed to by psz
+ *
+ * The object remains non-finalized after this call.
  */
 rsRetVal rsCStrAppendStrWithLen(cstr_t *pThis, const uchar *psz, size_t iStrLen);
 
@@ -114,6 +134,8 @@ rsRetVal rsCStrAppendStrWithLen(cstr_t *pThis, const uchar *psz, size_t iStrLen)
  * Append a printf-style formated string to the buffer.
  *
  * \param fmt pointer to the format string (see man 3 printf for details). Must not be NULL.
+ *
+ * The object remains non-finalized after this call.
  */
 rsRetVal rsCStrAppendStrf(cstr_t *pThis, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
 
@@ -125,8 +147,19 @@ rsRetVal rsCStrAppendInt(cstr_t *pThis, long i);
 
 
 rsRetVal strExit(void);
+/* Return a borrowed NUL-terminated view of the internal buffer.
+ *
+ * The object must already be finalized. The returned pointer is owned by the
+ * cstr object and remains valid only until the next mutation or destruction.
+ * Empty strings are returned as `""`, never as NULL.
+ */
 uchar *cstrGetSzStrNoNULL(cstr_t *pThis);
 #define rsCStrGetSzStrNoNULL(x) cstrGetSzStrNoNULL(x)
+/* Replace the current contents from a classic NUL-terminated string.
+ *
+ * Passing `NULL` resets the object to an empty string and may leave
+ * `pBuf == NULL`. The setter does not finalize the object.
+ */
 rsRetVal rsCStrSetSzStr(cstr_t *pThis, uchar *pszNew);
 int rsCStrCStrCmp(cstr_t *pCS1, cstr_t *pCS2);
 int rsCStrSzStrCmp(cstr_t *pCS1, uchar *psz, size_t iLenSz);
@@ -138,7 +171,12 @@ int rsCStrSzStrEndsWithCStr(cstr_t *pCS1, uchar *psz, size_t iLenSz);
 rsRetVal rsCStrSzStrMatchRegex(cstr_t *pCS1, uchar *psz, int iType, void *cache);
 void rsCStrRegexDestruct(void *rc);
 
-/* new calling interface */
+/* Convert to an owned C string and destroy the counted-string object.
+ *
+ * Ownership of the returned buffer transfers to the caller, which must
+ * `free()` it unless `bRetNULL == 1` and the string was empty. `*ppThis` is
+ * always cleared on return.
+ */
 rsRetVal cstrConvSzStrAndDestruct(cstr_t **pThis, uchar **ppSz, int bRetNULL);
 rsRetVal cstrAppendCStr(cstr_t *pThis, cstr_t *pstrAppend);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -104,6 +104,7 @@ TESTS_DEFAULT = \
 	hostname-with-slash-dflt-slash-valid.sh \
 	empty-app-name.sh \
 	endswith-basic.sh \
+	contains-longer-needle.sh \
 	stop-localvar.sh \
 	stop-msgvar.sh \
 	glbl-ruleset-queue-defaults.sh \
@@ -575,6 +576,7 @@ TESTS_LIBYAML = \
 	yaml-script-msgvar.sh \
 	yaml-imfile-basic.sh \
 	yaml-propfilt-basic.sh \
+	yaml-propfilt-contains-longer-needle.sh \
 	yaml-statements-basic.sh \
 	yaml-statements-stop.sh \
 	yaml-statements-call.sh \
@@ -1916,11 +1918,14 @@ liboverride_getaddrinfo_la_CFLAGS =
 liboverride_getaddrinfo_la_LDFLAGS = -avoid-version -shared
 
 # TODO: reenable TESTRUNS = rt_init rscript
-check_PROGRAMS = runtime_unit_linkedlist
-TESTS = runtime_unit_linkedlist
+check_PROGRAMS = runtime_unit_linkedlist runtime_unit_stringbuf
+TESTS = runtime_unit_linkedlist runtime_unit_stringbuf
 
 runtime_unit_linkedlist_SOURCES = \
 	unit/linkedlist_test.c
+
+runtime_unit_stringbuf_SOURCES = \
+	unit/stringbuf_test.c
 
 runtime_unit_linkedlist_CPPFLAGS = \
 	-DSD_EXPORT_SYMBOLS \
@@ -1937,10 +1942,15 @@ runtime_unit_linkedlist_CPPFLAGS = \
 	-I$(top_srcdir)/runtime \
 	-I$(top_srcdir)/tools
 
+runtime_unit_stringbuf_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS)
+
 runtime_unit_linkedlist_LDADD = $(RSRT_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
+runtime_unit_stringbuf_LDADD = $(LIBESTR_LIBS) $(LIBFASTJSON_LIBS) $(LIBSYSTEMD_LIBS) $(PTHREADS_LIBS) $(SOL_LIBS)
 
 if ENABLE_LIBLOGGING_STDLOG
 runtime_unit_linkedlist_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
+runtime_unit_stringbuf_CPPFLAGS += $(LIBLOGGING_STDLOG_CFLAGS)
 endif
 
 if ENABLE_TESTBENCH

--- a/tests/contains-longer-needle.sh
+++ b/tests/contains-longer-needle.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+UNEXPECTED_LOG="${RSYSLOG_DYNNAME}.unexpected.log"
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+if $msg contains "this-needle-is-clearly-longer-than-the-message-under-test" then {
+        action(type="omfile" template="outfmt" file="'$UNEXPECTED_LOG'")
+}
+if $syslogtag == "app" then {
+        action(type="omfile" template="outfmt" file="'${RSYSLOG_OUT_LOG}'")
+}
+'
+startup
+injectmsg_literal '<165>1 2003-03-01T01:00:00.000Z host app - - - short'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED="short"
+cmp_exact
+if test -e "$UNEXPECTED_LOG"; then
+        test ! -s "$UNEXPECTED_LOG"
+fi
+exit_test

--- a/tests/unit/stringbuf_test.c
+++ b/tests/unit/stringbuf_test.c
@@ -1,0 +1,168 @@
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdarg.h>
+
+#include "rsyslog.h"
+#include "obj.h"
+#include "srUtils.h"
+#include "stringbuf.h"
+
+#define CHECK(cond)                                                                  \
+    do {                                                                             \
+        if (!(cond)) {                                                               \
+            fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
+            return 1;                                                                \
+        }                                                                            \
+    } while (0)
+
+void LogError(const int iErrno __attribute__((unused)),
+              const int iErrCode __attribute__((unused)),
+              const char *fmt __attribute__((unused)),
+              ...) {}
+
+rsRetVal objGetObjInterface(obj_if_t *pIf) {
+    memset(pIf, 0, sizeof(*pIf));
+    return RS_RET_OK;
+}
+
+rsRetVal srUtilItoA(char *pBuf, int iLenBuf, number_t iToConv) {
+    int r = snprintf(pBuf, iLenBuf, "%lld", (long long)iToConv);
+
+    /* Keep the stub strict: truncation and rare encoding errors are both failures. */
+    return (r < 0 || r >= iLenBuf) ? RS_RET_INVALID_VALUE : RS_RET_OK;
+}
+
+/*
+ * Pull the implementation into this test translation unit so Automake does not
+ * need to manage dependency files for sources outside tests/ during distcheck.
+ */
+#include "../../runtime/stringbuf.c"
+
+static int test_empty_finalize_and_getsz(void) {
+    cstr_t *str = NULL;
+
+    CHECK(rsCStrConstruct(&str) == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(rsCStrLen(str) == 0);
+    CHECK(strcmp((char *)rsCStrGetSzStrNoNULL(str), "") == 0);
+    rsCStrDestruct(&str);
+    CHECK(str == NULL);
+
+    return 0;
+}
+
+static int test_destructive_convert_semantics(void) {
+    cstr_t *str = NULL;
+    uchar *buf = NULL;
+
+    CHECK(rsCStrConstruct(&str) == RS_RET_OK);
+    CHECK(rsCStrAppendStr(str, (uchar *)"ab") == RS_RET_OK);
+    CHECK(cstrAppendChar(str, 'c') == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(cstrConvSzStrAndDestruct(&str, &buf, 0) == RS_RET_OK);
+    CHECK(str == NULL);
+    CHECK(strcmp((char *)buf, "abc") == 0);
+    free(buf);
+
+    CHECK(rsCStrConstruct(&str) == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(cstrConvSzStrAndDestruct(&str, &buf, 0) == RS_RET_OK);
+    CHECK(str == NULL);
+    CHECK(strcmp((char *)buf, "") == 0);
+    free(buf);
+
+    CHECK(rsCStrConstruct(&str) == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(cstrConvSzStrAndDestruct(&str, &buf, 1) == RS_RET_OK);
+    CHECK(str == NULL);
+    CHECK(buf == NULL);
+
+    return 0;
+}
+
+static int test_setszstr_requires_finalize(void) {
+    cstr_t *str = NULL;
+
+    CHECK(rsCStrConstruct(&str) == RS_RET_OK);
+    CHECK(rsCStrSetSzStr(str, (uchar *)"new-value") == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(rsCStrLen(str) == strlen("new-value"));
+    CHECK(strcmp((char *)rsCStrGetSzStrNoNULL(str), "new-value") == 0);
+
+    CHECK(rsCStrSetSzStr(str, NULL) == RS_RET_OK);
+    cstrFinalize(str);
+    CHECK(rsCStrLen(str) == 0);
+    CHECK(strcmp((char *)rsCStrGetSzStrNoNULL(str), "") == 0);
+
+    rsCStrDestruct(&str);
+    return 0;
+}
+
+static int test_locate_in_szstr_basic_cases(void) {
+    cstr_t *needle = NULL;
+
+    CHECK(rsCStrConstructFromszStr(&needle, (uchar *)"needle") == RS_RET_OK);
+    CHECK(rsCStrLocateInSzStr(needle, (uchar *)"hayneedlehay") == 3);
+    CHECK(rsCStrLocateInSzStr(needle, (uchar *)"haystack") == -1);
+    rsCStrDestruct(&needle);
+
+    CHECK(rsCStrConstruct(&needle) == RS_RET_OK);
+    CHECK(rsCStrLocateInSzStr(needle, (uchar *)"anything") == 0);
+    rsCStrDestruct(&needle);
+
+    return 0;
+}
+
+static int test_locate_in_szstr_needle_longer_than_haystack(void) {
+    cstr_t *needle = NULL;
+
+    CHECK(rsCStrConstructFromszStr(&needle, (uchar *)"much-longer-needle") == RS_RET_OK);
+    CHECK(rsCStrLocateInSzStr(needle, (uchar *)"short") == -1);
+    rsCStrDestruct(&needle);
+
+    return 0;
+}
+
+static int test_prefix_suffix_helpers(void) {
+    cstr_t *pattern = NULL;
+
+    CHECK(rsCStrConstructFromszStr(&pattern, (uchar *)"prefix") == RS_RET_OK);
+    CHECK(rsCStrSzStrStartsWithCStr(pattern, (uchar *)"prefix-value", strlen("prefix-value")) == 0);
+    CHECK(rsCStrSzStrStartsWithCStr(pattern, (uchar *)"value-prefix", strlen("value-prefix")) != 0);
+    rsCStrDestruct(&pattern);
+
+    CHECK(rsCStrConstructFromszStr(&pattern, (uchar *)".log") == RS_RET_OK);
+    CHECK(rsCStrSzStrEndsWithCStr(pattern, (uchar *)"app.log", strlen("app.log")) == 0);
+    CHECK(rsCStrSzStrEndsWithCStr(pattern, (uchar *)"app.txt", strlen("app.txt")) != 0);
+    rsCStrDestruct(&pattern);
+
+    return 0;
+}
+
+int main(void) {
+    struct {
+        const char *name;
+        int (*fn)(void);
+    } tests[] = {
+        {"empty_finalize_and_getsz", test_empty_finalize_and_getsz},
+        {"destructive_convert_semantics", test_destructive_convert_semantics},
+        {"setszstr_requires_finalize", test_setszstr_requires_finalize},
+        {"locate_in_szstr_basic_cases", test_locate_in_szstr_basic_cases},
+        {"locate_in_szstr_needle_longer_than_haystack", test_locate_in_szstr_needle_longer_than_haystack},
+        {"prefix_suffix_helpers", test_prefix_suffix_helpers},
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
+        if (tests[i].fn() != 0) {
+            fprintf(stderr, "FAILED: %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("stringbuf tests passed (%zu cases)\n", sizeof(tests) / sizeof(tests[0]));
+    return 0;
+}

--- a/tests/yaml-propfilt-contains-longer-needle.sh
+++ b/tests/yaml-propfilt-contains-longer-needle.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Exercise the YAML property-filter path with a contains-pattern that is longer
+# than the incoming message to ensure the backend returns "no match" cleanly.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+
+templates:
+  - name: outfmt
+    type: string
+    string: "%msg%\n"
+
+rulesets:
+  - name: main
+    script: |
+      if $msg contains "this-needle-is-clearly-longer-than-the-message-under-test" then {
+        action(type="omfile" template="outfmt" file="${UNEXPECTED_LOG}")
+      }
+      action(type="omfile" template="outfmt" file="${RSYSLOG_OUT_LOG}")
+YAMLEOF
+sed -i "s|\${RSYSLOG_OUT_LOG}|${RSYSLOG_OUT_LOG}|g" "${RSYSLOG_DYNNAME}.yaml"
+sed -i "s|\${UNEXPECTED_LOG}|${RSYSLOG_DYNNAME}.unexpected.log|g" "${RSYSLOG_DYNNAME}.yaml"
+
+add_conf '
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="main")
+'
+startup
+tcpflood -m1 -M "\"<165>1 2003-03-01T01:00:00.000Z host app - - - short\""
+shutdown_when_empty
+wait_shutdown
+if test -e "${RSYSLOG_DYNNAME}.unexpected.log"; then
+        test ! -s "${RSYSLOG_DYNNAME}.unexpected.log"
+fi
+export EXPECTED="short"
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary
- fix `rsCStrLocateInSzStr()` so a longer needle returns no match before any out-of-bounds scan window is computed
- document the non-obvious `stringbuf` API contracts around finalize-before-read, empty buffers, and destructive conversion ownership
- add focused unit and integration regression coverage for the contains/property-filter path

## Validation
- `make -j$(nproc) check TESTS=""`
- `make check TESTS='runtime_unit_linkedlist'`
- `make check TESTS='runtime_unit_stringbuf'`
- `make check TESTS='runtime_unit_linkedlist runtime_unit_stringbuf'`
- `./tests/contains-longer-needle.sh`
- `./tests/yaml-propfilt-contains-longer-needle.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
