### PR TITLE
runtime: harden TCP framing size handling

### DIFF
--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -38,6 +38,7 @@
 #include <sys/types.h>
 #include <signal.h>
 #include <assert.h>
+#include <limits.h>
 #include <sys/wait.h>
 #include <ctype.h>
 #include <inttypes.h>
@@ -582,6 +583,8 @@ char *rs_strerror_r(int errnum, char *buf, size_t buflen) {
 int decodeSyslogName(uchar *name, syslogName_t *codetab) {
     register syslogName_t *c;
     register uchar *p;
+    char *end = NULL;
+    long val;
     uchar buf[80];
 
     assert(name != NULL);
@@ -590,9 +593,15 @@ int decodeSyslogName(uchar *name, syslogName_t *codetab) {
     DBGPRINTF("symbolic name: %s", name);
     if (isdigit((int)*name)) {
         DBGPRINTF("\n");
-        return (atoi((char *)name));
+        errno = 0;
+        val = strtol((char *)name, &end, 10);
+        if (errno != 0 || end == (char *)name || *end != '\0' || val < INT_MIN || val > INT_MAX) {
+            return -1;
+        }
+        return (int)val;
     }
     strncpy((char *)buf, (char *)name, 79);
+    buf[sizeof(buf) - 1] = '\0';
     for (p = buf; *p; p++) {
         if (isupper((int)*p)) *p = tolower((int)*p);
     }

--- a/runtime/tcpclt.c
+++ b/runtime/tcpclt.c
@@ -29,6 +29,7 @@
 #include <unistd.h>
 #include <errno.h>
 #include <assert.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <sys/types.h>
@@ -120,6 +121,7 @@ static rsRetVal TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int 
     TCPFRAMINGMODE framingToUse;
     int bIsCompressed;
     size_t len;
+    size_t frameSize;
     char *msg;
     char *buf = NULL; /* if this is non-NULL, it MUST be freed before return! */
 
@@ -154,6 +156,12 @@ static rsRetVal TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int 
     /* Build frame based on selected framing */
     if (framingToUse == TCP_FRAMING_OCTET_STUFFING) {
         if ((*(msg + len - 1) != pThis->tcp_framingDelimiter)) {
+            if (len > SIZE_MAX - 2) {
+                LogError(0, RS_RET_OUT_OF_MEMORY,
+                         "Error: TCP frame too large to append framing delimiter safely. Message is lost.");
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+
             /* in the malloc below, we need to add 2 to the length. The
              * reason is that we a) add one character and b) len does
              * not take care of the '\0' byte. Up until today, it was just
@@ -201,15 +209,29 @@ static rsRetVal TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int 
 		 * consensus to do the octet count on the SYSLOG-MSG part only. I am
 		 * now changing the code to reflect this. Hopefully, it will not change
 		 * once again (there can no compatibility layer programmed for this).
-		 * To be on the save side, I just comment the code out. I mark these
+         * To be on the save side, I just comment the code out. I mark these
 		 * comments with "IETF20061218".
 		 * rgerhards, 2006-12-19
 		 */
+        if (len > (size_t)INT_MAX) {
+            LogError(0, RS_RET_OUT_OF_MEMORY,
+                     "Error: TCP frame too large for octet-counted framing header. Message is lost.");
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
         iLenBuf = snprintf(szLenBuf, sizeof(szLenBuf), "%d ", (int)len);
         /* IETF20061218 iLenBuf =
           snprintf(szLenBuf, sizeof(szLenBuf), "%d ", len + iLenBuf);*/
+        if (iLenBuf < 0) {
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        if (len > SIZE_MAX - (size_t)iLenBuf) {
+            LogError(0, RS_RET_OUT_OF_MEMORY,
+                     "Error: TCP frame too large to prepend octet-counted header safely. Message is lost.");
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        frameSize = len + (size_t)iLenBuf;
 
-        if ((buf = malloc(len + iLenBuf)) == NULL) {
+        if ((buf = malloc(frameSize)) == NULL) {
             /* we are out of memory. This is an extreme situation. We do not
              * call any alarm handlers because they most likely run out of mem,
              * too. We are brave enough to call debug output, though. Other than
@@ -229,7 +251,7 @@ static rsRetVal TCPSendBldFrame(tcpclt_t *pThis, char **pmsg, size_t *plen, int 
 
         memcpy(buf, szLenBuf, iLenBuf); /* header */
         memcpy(buf + iLenBuf, msg, len); /* message */
-        len += iLenBuf; /* new message size */
+        len = frameSize; /* new message size */
         msg = buf; /* set message buffer */
     }
 

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -28,6 +28,7 @@
  * limitations under the License.
  */
 #include "config.h"
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 #include <assert.h>
@@ -89,6 +90,8 @@ DEFobjCurrIf(parser)
 
 /* Standard-Constructor */
 BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END macro! */
+    size_t bufSize;
+
     pThis->iMsg = 0; /* just make sure... */
     pThis->iMaxLine = glbl.GetMaxLine(runConf);
     pThis->inputState = eAtStrtFram; /* indicate frame header expected */
@@ -105,7 +108,8 @@ BEGINobjConstruct(tcps_sess) /* be sure to specify the object type also in END m
     memset(pThis->tlsProbeBuf, 0, sizeof(pThis->tlsProbeBuf));
     wtiInitIParam(&pThis->perSourceKeyParam);
     /* now allocate the message reception buffer */
-    CHKmalloc(pThis->pMsg = (uchar *)malloc(pThis->iMaxLine + 1));
+    bufSize = (size_t)pThis->iMaxLine + 1;
+    CHKmalloc(pThis->pMsg = (uchar *)malloc(bufSize));
 finalize_it:
 ENDobjConstruct(tcps_sess)
 
@@ -117,9 +121,18 @@ static rsRetVal tcps_sessConstructFinalize(tcps_sess_t *pThis) {
     ISOBJ_TYPE_assert(pThis, tcps_sess);
 #ifdef FEATURE_REGEXP
     if (pThis->pLstnInfo->bHasStartRegex) {
+        size_t regexBufSize;
+
+        if (pThis->iMaxLine > (INT_MAX - 1) / 2) {
+            LogError(0, RS_RET_ERR,
+                     "imtcp: framing.delimiter.regex requires maxMessageSize <= %d to avoid session buffer overflow",
+                     (INT_MAX - 1) / 2);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        regexBufSize = ((size_t)pThis->iMaxLine * 2) + 1;
         /* in this case, we need a second buffer and a larger primary one */
-        CHKmalloc(pThis->pMsg = (uchar *)realloc(pThis->pMsg, (2 * pThis->iMaxLine) + 1));
-        CHKmalloc(pThis->pMsg_save = (uchar *)malloc((2 * pThis->iMaxLine) + 1));
+        CHKmalloc(pThis->pMsg = (uchar *)realloc(pThis->pMsg, regexBufSize));
+        CHKmalloc(pThis->pMsg_save = (uchar *)malloc(regexBufSize));
     }
 #endif
     if (pThis->pSrv->OnSessConstructFinalize != NULL) {

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -48,6 +48,7 @@
 #include <unistd.h>
 #include <stdarg.h>
 #include <ctype.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <pthread.h>
@@ -392,6 +393,12 @@ static rsRetVal ATTR_NONNULL() addNewLstnPort(tcpsrv_t *const pThis, tcpLstnPara
 
 #ifdef FEATURE_REGEXP
     if (cnf_params->pszStartRegex != NULL) {
+        if (glbl.GetMaxLine(runConf) > (INT_MAX - 1) / 2) {
+            LogError(0, RS_RET_ERR,
+                     "imtcp: framing.delimiter.regex requires maxMessageSize <= %d to avoid session buffer overflow",
+                     (INT_MAX - 1) / 2);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
         const int errcode = regexp.regcomp(&pEntry->start_preg, (char *)cnf_params->pszStartRegex, REG_EXTENDED);
         if (errcode != 0) {
             char errbuff[512];

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -110,6 +110,7 @@ TESTS_DEFAULT = \
 	glbl-internalmsg_severity-info-shown.sh \
 	glbl-internalmsg_severity-debug-shown.sh \
 	glbl-internalmsg_severity-debug-not_shown.sh \
+	glbl-internalmsg_severity-invalid-long.sh \
 	glbl-umask.sh \
 	glbl-unloadmodules.sh \
 	glbl-invld-param.sh \
@@ -600,6 +601,7 @@ TESTS_IMTCP = \
 	imtcp-discard-truncated-msg.sh \
 	imtcp-basic.sh \
 	imtcp_framing_regex.sh \
+	imtcp_framing_regex_maxmsg_overflow.sh \
 	imtcp-multiline.sh \
 	imtcp-basic-hup.sh \
 	imtcp-impstats-single-thread.sh \

--- a/tests/glbl-internalmsg_severity-invalid-long.sh
+++ b/tests/glbl-internalmsg_severity-invalid-long.sh
@@ -27,7 +27,7 @@ action(type=\"omfile\" file=\"${RSYSLOG_OUT_LOG}\")
 }
 
 long_symbolic="$(printf 'A%.0s' $(seq 1 160))"
-run_bad_severity_check 1 "${long_symbolic}" "${RSYSLOG_DYNNAME}.long.error.log"
+run_bad_severity_check "" "${long_symbolic}" "${RSYSLOG_DYNNAME}.long.error.log"
 run_bad_severity_check 2 "999999999999999999999999" "${RSYSLOG_DYNNAME}.overflow.error.log"
 
 exit_test

--- a/tests/glbl-internalmsg_severity-invalid-long.sh
+++ b/tests/glbl-internalmsg_severity-invalid-long.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Regression test for long and overflowing severity names reaching decodeSyslogName().
+. ${srcdir:=.}/diag.sh init
+
+run_bad_severity_check() {
+    instance="$1"
+    severity_value="$2"
+    log_file="$3"
+
+    generate_conf "$instance"
+    add_conf "
+global(internalmsg.severity=\"$severity_value\")
+action(type=\"omfile\" file=\"${RSYSLOG_OUT_LOG}\")
+    " "$instance"
+
+    ../tools/rsyslogd -C -N1 \
+        -M"${RSYSLOG_MODDIR}" \
+        -f"${TESTCONF_NM}${instance}.conf" \
+        > "${log_file}" 2>&1
+    rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "FAIL: rsyslogd should reject invalid internalmsg.severity=${severity_value}"
+        error_exit 1
+    fi
+
+    content_check 'invalid internalmsg.severity value' "${log_file}"
+}
+
+long_symbolic="$(printf 'A%.0s' $(seq 1 160))"
+run_bad_severity_check 1 "${long_symbolic}" "${RSYSLOG_DYNNAME}.long.error.log"
+run_bad_severity_check 2 "999999999999999999999999" "${RSYSLOG_DYNNAME}.overflow.error.log"
+
+exit_test

--- a/tests/imtcp_framing_regex_maxmsg_overflow.sh
+++ b/tests/imtcp_framing_regex_maxmsg_overflow.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Regression test for regex framing with an oversized maxMessageSize.
+# This must fail cleanly when the first TCP session is constructed rather than
+# overflowing the regex framing buffer arithmetic.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(maxMessageSize="2147483647")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp"
+      port="0"
+      framing.delimiter.regex="^<[0-9]{2}>")
+'
+
+startup
+content_check 'framing.delimiter.regex requires maxMessageSize <=' "${RSYSLOG_DYNNAME}.started"
+shutdown_immediate
+wait_shutdown
+exit_test


### PR DESCRIPTION
Why
Prevent malformed or oversized runtime inputs from reaching unsafe
allocation and framing paths in core TCP runtime components.

Defects fixed
- `runtime/tcps_sess.c`: prevent integer overflow when sizing the base
  per-session receive buffer from `maxMessageSize`.
- `runtime/tcps_sess.c`: prevent integer overflow when regex framing
  doubles the session buffers.
- `runtime/tcpsrv.c`: reject regex framing configurations early when
  `maxMessageSize` would overflow session buffer sizing.
- `runtime/tcpclt.c`: prevent integer overflow in outbound
  octet-stuffing and octet-counted framing buffer construction.
- `runtime/srutils.c`: harden facility/severity decoding by forcing NUL
  termination of the symbolic lookup buffer and using checked numeric
  parsing.

What changed
- Added explicit size guards before allocation and copy in the main TCP
  framing paths.
- Switched the base TCP session buffer allocation to `size_t`
  arithmetic.
- Added fail-closed validation for `framing.delimiter.regex` with
  oversized `maxMessageSize`.
- Replaced unchecked `atoi` parsing in `decodeSyslogName()` with
  validated `strtol()` handling.
- Added focused shell regression tests for the regex framing overflow
  case and invalid long internal severity values.

Validation
- `make -j$(nproc) check TESTS=""`
- `./tests/imtcp_framing_regex.sh`
- `./tests/imtcp_framing_regex_maxmsg_overflow.sh`
- `./tests/glbl-internalmsg_severity-invalid-long.sh`
- `./tests/tcp_forwarding_dflt_tpl.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`

Notes
This work was done in a separate worktree on branch
`codex/runtime-security-review`, based directly on `main`.
