### PR TITLE
Fix for File is not always closed

### DIFF
--- a/tests/omhttp_server.py
+++ b/tests/omhttp_server.py
@@ -151,7 +151,6 @@ if __name__ == '__main__':
     print('starting omhttp test server at {interface}:{port} with pid {pid}'
           .format(interface=args.interface, port=lstn_port, pid=pid))
     if args.port_file != '':
-        f = open(args.port_file, "w")
-        f.write(str(lstn_port))
-        f.close()
+        with open(args.port_file, "w") as f:
+            f.write(str(lstn_port))
     server.serve_forever()


### PR DESCRIPTION
Use a context manager (`with open(...) as f:`) so the file is always closed, even if `write` raises.

Best fix in this snippet:
- In `tests/omhttp_server.py`, replace the `open/write/close` block under `if args.port_file != '':` with a `with open(..., "w") as f:` block.
- No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._