### PR TITLE
Fix for Unused import

### DIFF
--- a/plugins/external/skeletons/python/plugin-with-feedback.py
+++ b/plugins/external/skeletons/python/plugin-with-feedback.py
@@ -26,7 +26,6 @@ limitations under the License.
 """
 
 import sys
-import os
 import logging
 
 


### PR DESCRIPTION
Remove the unused `os` import from `plugins/external/skeletons/python/plugin-with-feedback.py`.

Best fix (without changing functionality):
- Edit the import section at the top of the file.
- Delete only `import os` (line 29 in the provided snippet).
- Keep `import sys` and `import logging`, which are both used.

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._