### PR TITLE
Fix for Unused import

### DIFF
--- a/tests/snmptrapreceiverv2.py
+++ b/tests/snmptrapreceiverv2.py
@@ -1,6 +1,5 @@
 # call this via "python[3] script name"
 import sys
-import importlib.util
 import asyncio
 import os
 


### PR DESCRIPTION
To fix this, remove the unused `import importlib.util` statement from `tests/snmptrapreceiverv2.py`.

Best single fix without changing behavior:
- Edit the import section at the top of `tests/snmptrapreceiverv2.py`.
- Delete only `import importlib.util` (line 3 in the snippet).
- Keep all other imports unchanged.

No new methods, definitions, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._