### PR TITLE
Fix for Unused import

### DIFF
--- a/doc/tools/fix-mermaid-offline.py
+++ b/doc/tools/fix-mermaid-offline.py
@@ -5,7 +5,6 @@ This script modifies generated HTML files to work with file:// URLs and
 HTTP-served docs (e.g. GitHub Pages PR previews).
 """
 
-import os
 import re
 import sys
 from pathlib import Path


### PR DESCRIPTION
To fix this, remove the unused `import os` statement from `doc/tools/fix-mermaid-offline.py`.

Best single fix without changing functionality:
- In `doc/tools/fix-mermaid-offline.py`, in the import section at the top of the file, delete line 8 (`import os`).
- Keep all other imports unchanged (`re`, `sys`, `Path`) since they are used or likely used.
- No additional methods, definitions, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._