### PR TITLE
[codex] impstats: clean up minor report nits

### DIFF
--- a/plugins/impstats/statslog-graph.py
+++ b/plugins/impstats/statslog-graph.py
@@ -203,20 +203,6 @@ else:
 
             # Increment counter
             nLineCount += 1
-
-    #       if nLineCount > 25:
-    #           break
-
-    #   if nMaxDataCount > 0:
-    #       # Check if we need to reduce the data amount
-    #       nTotalDataCount = len( aData[aFields[0]] )
-    #       nDataStepCount = nTotalDataCount / (nMaxDataCount)
-    #       if nTotalDataCount > nMaxDataCount:
-    #           for iDataNum in reversed(range(0, nTotalDataCount)):
-    #               # Remove all entries who
-    #               if iDataNum % nDataStepCount == 0:
-    #                   aMajorXData.append( aData[aFields[0]][iDataNum] )
-            
     # Import Style
 #   from pygal.style import LightSolarizedStyle
 #   from pygal.style import DefaultStyle

--- a/plugins/impstats/svg.jquery.js
+++ b/plugins/impstats/svg.jquery.js
@@ -1046,8 +1046,7 @@ jQuery.Callbacks = function( flags ) {
 			var i,
 				length,
 				elem,
-				type,
-				actual;
+				type;
 			for ( i = 0, length = args.length; i < length; i++ ) {
 				elem = args[ i ];
 				type = jQuery.type( elem );
@@ -1317,7 +1316,6 @@ jQuery.extend({
 			length = args.length,
 			pValues = new Array( length ),
 			count = length,
-			pCount = length,
 			deferred = length <= 1 && firstParam && jQuery.isFunction( firstParam.promise ) ?
 				firstParam :
 				jQuery.Deferred(),
@@ -2668,7 +2666,7 @@ jQuery.event = {
 
 		var elemData, eventHandle, events,
 			t, tns, type, namespaces, handleObj,
-			handleObjIn, quick, handlers, special;
+			handleObjIn, handlers, special;
 
 		// Don't attach events to noData or text/comment nodes (allow plain objects tho)
 		if ( elem.nodeType === 3 || elem.nodeType === 8 || !types || !handler || !(elemData = jQuery._data( elem )) ) {
@@ -3022,7 +3020,7 @@ jQuery.event = {
 			run_all = !event.exclusive && !event.namespace,
 			special = jQuery.event.special[ event.type ] || {},
 			handlerQueue = [],
-			i, j, cur, jqcur, ret, selMatch, matched, matches, handleObj, sel, related;
+			i, j, cur, jqcur, ret, selMatch, matched, matches, handleObj, sel;
 
 		// Use the fix-ed jQuery.Event rather than the (read-only) native event
 		args[0] = event;
@@ -8394,7 +8392,7 @@ jQuery.fn.extend({
 			clearQueue = type;
 			type = undefined;
 		}
-		if ( clearQueue && type !== false ) {
+		if ( clearQueue ) {
 			this.queue( type || "fx", [] );
 		}
 
@@ -8488,10 +8486,10 @@ jQuery.each({
 jQuery.extend({
 	speed: function( speed, easing, fn ) {
 		var opt = speed && typeof speed === "object" ? jQuery.extend( {}, speed ) : {
-			complete: fn || !fn && easing ||
+			complete: fn || easing ||
 				jQuery.isFunction( speed ) && speed,
 			duration: speed,
-			easing: fn && easing || easing && !jQuery.isFunction( easing ) && easing
+			easing: fn ? easing : ( easing && !jQuery.isFunction( easing ) && easing )
 		};
 
 		opt.duration = jQuery.fx.off ? 0 : typeof opt.duration === "number" ? opt.duration :

--- a/sidecar/rsyslog_exporter.py
+++ b/sidecar/rsyslog_exporter.py
@@ -809,7 +809,8 @@ def create_app():
                     detected_workers = int(val)
                     break
                 except ValueError:
-                    pass
+                    # Ignore malformed values and keep probing other sources.
+                    continue
         if detected_workers == 1:
             # parse from GUNICORN_CMD_ARGS like "--workers 4" or "-w 4"
             cmd_args = os.getenv("GUNICORN_CMD_ARGS", "")


### PR DESCRIPTION
This PR cleans up a set of minor static-analysis and readability nits in the impstats-sidecar code.

What changed:
- removed stale commented-out code from `plugins/impstats/statslog-graph.py`
- simplified a redundant conditional in vendored jQuery without changing behavior
- removed a few unused locals from the vendored jQuery copy
- made the worker-detection fallback in `sidecar/rsyslog_exporter.py` explicit
- replaced a comment-only `except ValueError: pass` with the same fallback plus a comment

Why:
- the report findings pointed at code that was either dead scaffolding or overly compact control flow
- the intent is to keep the code easier to read while preserving existing behavior

Impact:
- no functional behavior change
- validation still passes after the cleanup

Checks:
- `node --check plugins/impstats/svg.jquery.js`
- `python3 -m py_compile sidecar/rsyslog_exporter.py`
- `make -j$(nproc) check TESTS=""`
