### PR TITLE
runtime: cleanup zero-size alloc handling and TODO items

### DIFF
--- a/runtime/libcry_common.c
+++ b/runtime/libcry_common.c
@@ -56,6 +56,10 @@ int cryGetKeyFromFile(const char *const fn, char **const key, unsigned *const ke
         errno = EMSGSIZE;
         goto done;
     }
+    if (sb.st_size == 0) {
+        errno = EINVAL;
+        goto done;
+    }
     if ((*key = malloc(sb.st_size)) == NULL) goto done;
     if (read(fd, *key, sb.st_size) != sb.st_size) goto done;
     *keylen = sb.st_size;

--- a/runtime/libossl.c
+++ b/runtime/libossl.c
@@ -77,6 +77,10 @@ int osslGetKeyFromFile(const char* const fn, char** const key, unsigned* const k
         errno = EMSGSIZE;
         goto done;
     }
+    if (sb.st_size == 0) {
+        errno = EINVAL;
+        goto done;
+    }
     if ((*key = malloc(sb.st_size)) == NULL) goto done;
     if (read(fd, *key, sb.st_size) != sb.st_size) goto done;
     *keylen = sb.st_size;

--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -1051,6 +1051,11 @@ static rsRetVal ATTR_NONNULL()
         ABORT_FINALIZE(RS_RET_FILE_NOT_FOUND);
     }
 
+    if (sb.st_size == 0) {
+        LogError(0, RS_RET_JSON_PARSE_ERR, "lookup table file '%s' is empty", filename);
+        ABORT_FINALIZE(RS_RET_JSON_PARSE_ERR);
+    }
+
     CHKmalloc(iobuf = malloc(sb.st_size));
 
     tokener = json_tokener_new();

--- a/runtime/nsd_ossl.c
+++ b/runtime/nsd_ossl.c
@@ -1070,9 +1070,9 @@ static rsRetVal AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew, char *const connInfo) 
     /* Store nsd_ossl_t* reference in SSL obj
      * Index allocation: 0=pTcp, 1=permitExpiredCerts, 2=imdtls instance, 3=revocationCheck
      */
-    SSL_set_ex_data(pNew->pNetOssl->ssl, 0, pThis->pTcp);
-    SSL_set_ex_data(pNew->pNetOssl->ssl, 1, &pThis->permitExpiredCerts);
-    SSL_set_ex_data(pNew->pNetOssl->ssl, 3, &pThis->DrvrTlsRevocationCheck);
+    SSL_set_ex_data(pNew->pNetOssl->ssl, 0, pNew->pTcp);
+    SSL_set_ex_data(pNew->pNetOssl->ssl, 1, &pNew->permitExpiredCerts);
+    SSL_set_ex_data(pNew->pNetOssl->ssl, 3, &pNew->DrvrTlsRevocationCheck);
 
     /* We now do the handshake */
     CHKiRet(osslHandshakeCheck(pNew));

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -737,7 +737,6 @@ static rsRetVal ATTR_NONNULL(1) processDataRcvd(tcps_sess_t *pThis,
                          cnf_params->pszInputName, peerName, peerIP, peerPort, c);
             }
             if (pThis->iOctetsRemain < 1) {
-                /* TODO: handle the case where the octet count is 0! */
                 LogError(0, NO_ERRCODE,
                          "imtcp %s: Framing Error in received TCP message from "
                          "peer: (hostname) %s, (ip) %s, (port) %s: invalid octet count %d.",

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -1008,6 +1008,7 @@ static rsRetVal ATTR_NONNULL(1)
     while (state == RS_READING || state == RS_STARVATION) {
         switch (state) {
             case RS_READING:
+                /* maxReads==0 is intentional and documented: it disables starvation protection. */
                 while (state == RS_READING && (maxReads == 0 || read_calls < maxReads)) {
                     iRet = pThis->pRcvData(pSess, buf, sizeof(buf), &iRcvd, &oserr, &pioDescr->ioDirection);
 


### PR DESCRIPTION
## Summary

This cleanup hardens a few obvious runtime edge cases and removes stale or
misleading review noise in the TCP/TLS path.

## What changed

- reject empty key files before zero-size allocations in the libgcry and
  OpenSSL runtime helpers
- reject empty lookup-table files before allocation and JSON parsing
- fix accepted OpenSSL sessions to store per-session callback context in SSL
  ex-data instead of listener-owned pointers
- remove a stale TODO in the imtcp octet-count parser
- note in tcpsrv that `maxReads == 0` is intentional, documented behavior

## Why

The zero-size allocation cases were low-severity robustness bugs, but they were
still real edge cases in runtime-facing file handling.

The OpenSSL ex-data fix keeps verification callback context aligned with the
accepted session object instead of the listener object, which is the correct
ownership model and reduces future review ambiguity.

## Validation

- `bash devtools/format-code.sh`

I did not run the build or test suite in this pass.
