### PR TITLE
ratelimit: keep TCP batch processing on drops

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -972,7 +972,8 @@ static rsRetVal doSubmitMsg(ptcpsess_t *pThis, struct syslogTime *stTime, time_t
         DBGPRINTF("imptcp: message discarded by ratelimit helper\n");
         iRet = RS_RET_OK;
     } else {
-        DBGPRINTF("imptcp: ratelimit helper returned error %d, continuing\n", localRet);
+        DBGPRINTF("imptcp: ratelimit helper returned error %d, dropping message and continuing\n", localRet);
+        msgDestruct(&pMsg);
         iRet = RS_RET_OK;
     }
 

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -945,6 +945,7 @@ finalize_it:
 static rsRetVal doSubmitMsg(ptcpsess_t *pThis, struct syslogTime *stTime, time_t ttGenTime, multi_submit_t *pMultiSub) {
     smsg_t *pMsg;
     ptcpsrv_t *pSrv;
+    rsRetVal localRet;
     DEFiRet;
 
     if (pThis->iMsg == 0) {
@@ -964,9 +965,16 @@ static rsRetVal doSubmitMsg(ptcpsess_t *pThis, struct syslogTime *stTime, time_t
     MsgSetRcvFrom(pMsg, pThis->peerName);
     CHKiRet(MsgSetRcvFromIP(pMsg, pThis->peerIP));
     MsgSetRuleset(pMsg, pSrv->pRuleset);
-    STATSCOUNTER_INC(pThis->pLstn->ctrSubmit, pThis->pLstn->mutCtrSubmit);
-
-    ratelimitAddMsg(pSrv->ratelimiter, pMultiSub, pMsg);
+    localRet = ratelimitAddMsg(pSrv->ratelimiter, pMultiSub, pMsg);
+    if (localRet == RS_RET_OK) {
+        STATSCOUNTER_INC(pThis->pLstn->ctrSubmit, pThis->pLstn->mutCtrSubmit);
+    } else if (localRet == RS_RET_DISCARDMSG) {
+        DBGPRINTF("imptcp: message discarded by ratelimit helper\n");
+        iRet = RS_RET_OK;
+    } else {
+        DBGPRINTF("imptcp: ratelimit helper returned error %d, continuing\n", localRet);
+        iRet = RS_RET_OK;
+    }
 
 finalize_it:
     /* reset status variables */

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -448,7 +448,8 @@ static rsRetVal defaultDoSubmitMessage(tcps_sess_t *pThis,
         DBGPRINTF("tcps_sess: message discarded by ratelimit helper\n");
         iRet = RS_RET_OK;
     } else {
-        DBGPRINTF("tcps_sess: ratelimit helper returned error %d, continuing\n", localRet);
+        DBGPRINTF("tcps_sess: ratelimit helper returned error %d, dropping message and continuing\n", localRet);
+        msgDestruct(&pMsg);
         iRet = RS_RET_OK;
     }
 

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -330,6 +330,7 @@ static rsRetVal defaultDoSubmitMessage(tcps_sess_t *pThis,
                                        time_t ttGenTime,
                                        multi_submit_t *pMultiSub) {
     smsg_t *pMsg;
+    rsRetVal localRet;
     DEFiRet;
 
     ISOBJ_TYPE_assert(pThis, tcps_sess);
@@ -357,7 +358,6 @@ static rsRetVal defaultDoSubmitMessage(tcps_sess_t *pThis,
     CHKiRet(MsgSetRcvFromPort(pMsg, pThis->fromHostPort));
     MsgSetRuleset(pMsg, cnf_params->pRuleset);
 
-    STATSCOUNTER_INC(pThis->pLstnInfo->ctrSubmit, pThis->pLstnInfo->mutCtrSubmit);
     if (pThis->pLstnInfo->ratelimiter->pShared != NULL && pThis->pLstnInfo->ratelimiter->pShared->per_source_enabled) {
         const char *per_source_key = NULL;
         size_t per_source_key_len = 0;
@@ -436,10 +436,20 @@ static rsRetVal defaultDoSubmitMessage(tcps_sess_t *pThis,
                     break;
             }
         }
-        ratelimitAddMsgPerSource(pThis->pLstnInfo->ratelimiter, pMultiSub, pMsg, per_source_key, per_source_key_len,
-                                 ttGenTime);
+        localRet = ratelimitAddMsgPerSource(pThis->pLstnInfo->ratelimiter, pMultiSub, pMsg, per_source_key,
+                                            per_source_key_len, ttGenTime);
     } else {
-        ratelimitAddMsg(pThis->pLstnInfo->ratelimiter, pMultiSub, pMsg);
+        localRet = ratelimitAddMsg(pThis->pLstnInfo->ratelimiter, pMultiSub, pMsg);
+    }
+
+    if (localRet == RS_RET_OK) {
+        STATSCOUNTER_INC(pThis->pLstnInfo->ctrSubmit, pThis->pLstnInfo->mutCtrSubmit);
+    } else if (localRet == RS_RET_DISCARDMSG) {
+        DBGPRINTF("tcps_sess: message discarded by ratelimit helper\n");
+        iRet = RS_RET_OK;
+    } else {
+        DBGPRINTF("tcps_sess: ratelimit helper returned error %d, continuing\n", localRet);
+        iRet = RS_RET_OK;
     }
 
 finalize_it:


### PR DESCRIPTION
## Summary
- keep `imptcp` and generic TCP submit paths running when the ratelimit helper drops a message
- only increment submit counters when the helper actually accepts the message
- emit `DBGPRINTF` diagnostics for helper drops and unexpected helper errors instead of aborting batch handling

## Why
Rate limiting is a normal control path. A dropped message should not make the
caller unwind the current TCP batch, and even unexpected helper failures are
less harmful if the input path keeps moving while leaving diagnostics behind.

## Validation
- `./tests/imtcp-persource-ratelimit.sh`
- `./tests/ratelimit_exclusivity.sh`
- `make -C plugins/imptcp imptcp_la-imptcp.lo`
- `bash devtools/format-code.sh --git-changed`

## Notes
- `./tests/ratelimit_name.sh` is not usable in this local configure because
  `imptcp` is not built as a loadable module in this tree.
