### PR TITLE
Alpine compile check CI and musl resolver support

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        config: [clang9, clang18-noatomics, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc14-gnu23-debug]
+        config: [alpine, clang9, clang18-noatomics, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc14-gnu23-debug]
     steps:
       - name: git checkout project
         uses: actions/checkout@v4
@@ -60,6 +60,8 @@ jobs:
             tests/*.sh
             diag.sh
             **/Makefile.am
+            packaging/docker/dev_env/alpine/**
+            packaging/docker/dev_env/common/**
 
       - name: run compile check (container)
         if: steps.code_changes.outputs.any_changed == 'true'
@@ -68,6 +70,10 @@ jobs:
           export RSYSLOG_CONTAINER_UID="" # use default
           export CFLAGS='-g'
           case "${{ matrix.config }}" in
+          'alpine')
+              export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_full:alpine_latest'
+              export CC='gcc'
+              ;;
           'clang9')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:20.04'
               export CC='clang-9'

--- a/configure.ac
+++ b/configure.ac
@@ -265,6 +265,10 @@ AC_SUBST([LIBRESOLV_LIBS])
 AS_IF([test "x$ac_cv_search_ns_initparse" != "xno"],
       [AC_DEFINE([HAVE_RESOLV_NS_INITPARSE], [1],
                  [Define if resolver provides ns_initparse])])
+AC_CHECK_FUNCS([res_ninit res_nquery res_nclose])
+AS_IF([test "x$ac_cv_func_res_ninit" = "xyes" -a "x$ac_cv_func_res_nquery" = "xyes" -a "x$ac_cv_func_res_nclose" = "xyes"],
+      [AC_DEFINE([HAVE_RESOLV_RES_N_API], [1],
+                 [Define if resolver provides res_n* APIs])])
 AM_CONDITIONAL([HAVE_SRV_DISCOVERY], [test "x$ac_cv_search_ns_initparse" != "xno"])
 
 # the check below is probably ugly. If someone knows how to do it in a better way, please

--- a/configure.ac
+++ b/configure.ac
@@ -257,18 +257,16 @@ AC_SEARCH_LIBS([getifaddrs], [socket], [AC_DEFINE(HAVE_GETIFADDRS, [1], [set def
 
 AC_CHECK_HEADERS([arpa/nameser.h resolv.h])
 AC_SEARCH_LIBS([ns_initparse], [resolv])
-AC_SEARCH_LIBS([res_init], [resolv])
 AC_SEARCH_LIBS([res_query], [resolv])
 LIBRESOLV_LIBS=
-for libresolv_lib in "$ac_cv_search_ns_initparse" "$ac_cv_search_res_init" "$ac_cv_search_res_query"; do
-        AS_CASE([$libresolv_lib],
-                ["none required"], [],
-                ["no"], [],
-                [""], [],
-                [*], [
-                        AS_CASE([" $LIBRESOLV_LIBS "], [*" $libresolv_lib "*], [], [LIBRESOLV_LIBS="$LIBRESOLV_LIBS $libresolv_lib"])
-                ])
-done
+AS_CASE([$ac_cv_search_ns_initparse],
+        ["none required"], [],
+        ["no"], [],
+        [*], [LIBRESOLV_LIBS="$ac_cv_search_ns_initparse"])
+AS_CASE([$ac_cv_search_res_query],
+        ["none required"], [],
+        ["no"], [],
+        [*], [AS_CASE([" $LIBRESOLV_LIBS "], [*" $ac_cv_search_res_query "*], [], [LIBRESOLV_LIBS="$LIBRESOLV_LIBS $ac_cv_search_res_query"])])
 LIBRESOLV_LIBS=${LIBRESOLV_LIBS# }
 AC_SUBST([LIBRESOLV_LIBS])
 AS_IF([test "x$ac_cv_search_ns_initparse" != "xno"],

--- a/configure.ac
+++ b/configure.ac
@@ -257,10 +257,19 @@ AC_SEARCH_LIBS([getifaddrs], [socket], [AC_DEFINE(HAVE_GETIFADDRS, [1], [set def
 
 AC_CHECK_HEADERS([arpa/nameser.h resolv.h])
 AC_SEARCH_LIBS([ns_initparse], [resolv])
-LIBRESOLV_LIBS=$ac_cv_search_ns_initparse
-AS_CASE([$LIBRESOLV_LIBS],
-        ["none required"], [LIBRESOLV_LIBS=""],
-        ["no"], [LIBRESOLV_LIBS=""])
+AC_SEARCH_LIBS([res_init], [resolv])
+AC_SEARCH_LIBS([res_query], [resolv])
+LIBRESOLV_LIBS=
+for libresolv_lib in "$ac_cv_search_ns_initparse" "$ac_cv_search_res_init" "$ac_cv_search_res_query"; do
+        AS_CASE([$libresolv_lib],
+                ["none required"], [],
+                ["no"], [],
+                [""], [],
+                [*], [
+                        AS_CASE([" $LIBRESOLV_LIBS "], [*" $libresolv_lib "*], [], [LIBRESOLV_LIBS="$LIBRESOLV_LIBS $libresolv_lib"])
+                ])
+done
+LIBRESOLV_LIBS=${LIBRESOLV_LIBS# }
 AC_SUBST([LIBRESOLV_LIBS])
 AS_IF([test "x$ac_cv_search_ns_initparse" != "xno"],
       [AC_DEFINE([HAVE_RESOLV_NS_INITPARSE], [1],

--- a/packaging/docker/dev_env/alpine/Dockerfile
+++ b/packaging/docker/dev_env/alpine/Dockerfile
@@ -1,28 +1,75 @@
 # container for rsyslog development
 # creates the build environment
-FROM	alpine:latest
+FROM	alpine:3.23
 LABEL   maintainer="rgerhards@adiscon.com"
-COPY	rsyslog@lists.adiscon.com-5a55e598.rsa.pub /etc/apk/keys/rsyslog@lists.adiscon.com-5a55e598.rsa.pub
-RUN	echo "http://alpine.rsyslog.com/3.7/stable" >> /etc/apk/repositories \
-	&& apk --no-cache update
-RUN	apk add --no-cache \
-		git build-base automake libtool autoconf py-docutils gnutls gnutls-dev \
-		zlib-dev curl-dev mysql-dev libdbi-dev libuuid util-linux-dev \
-		libgcrypt-dev flex bison bsd-compat-headers linux-headers valgrind librdkafka-dev \
+RUN	apk --no-cache update && \
+	apk add --no-cache \
+		autoconf \
 		autoconf-archive \
+		automake \
+		bison \
+		build-base \
+		bash \
+		bsd-compat-headers \
+		curl-dev \
+		flex \
+		git \
+		gnutls-dev \
+		libdbi-dev \
 		libestr-dev \
 		libfastjson-dev \
+		libgcrypt-dev \
 		liblognorm-dev \
 		librelp-dev \
-		liblogging-dev
-WORKDIR /home/ci
+		libtool \
+		libuuid \
+		linux-headers \
+		librdkafka-dev \
+		mariadb-dev \
+		pkgconf \
+		python3 \
+		py3-docutils \
+		protobuf-c-compiler \
+		protobuf-c-dev \
+		snappy-dev \
+		util-linux-dev \
+		valgrind \
+		yaml-dev \
+		zlib-dev
+COPY	rsyslog@lists.adiscon.com-5a55e598.rsa.pub /etc/apk/keys/rsyslog@lists.adiscon.com-5a55e598.rsa.pub
+WORKDIR /rsyslog
 ADD common/setup-projects.sh /home/ci
 ADD setup-system.sh setup-system.sh
 ENV SUDO=
 ENV PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
     LD_LIBRARY_PATH=/usr/local/lib \
     CFLAGS="-Os -fomit-frame-pointer"
-ENV RSYSLOG_CONFIGURE_OPTIONS -enable-testbench --enable-imdiag --enable-imfile --enable-impstats --enable-imptcp --enable-mmanon --enable-mmaudit --enable-mmfields --enable-mmjsonparse --enable-mmpstrucdata --enable-mmsequence --enable-mmutf8fix --enable-mail --enable-omprog --enable-omruleset --enable-omstdout --enable-omuxsock --enable-pmaixforwardedfrom --enable-pmciscoios --enable-pmcisconames --enable-pmlastmsg --enable-pmsnare --enable-libgcrypt --enable-mmnormalize --disable-omudpspoof --enable-relp --disable-snmp --disable-mmsnmptrapd --enable-gnutls --enable-mysql --enable-mysql-tests --enable-usertools=no --enable-libdbi --enable-omhttpfs --enable-elasticsearch --enable-valgrind --enable-ommongodb=no --enable-imkafka --enable-omkafka --enable-pmnull
+ENV RSYSLOG_CONFIGURE_OPTIONS="\
+--enable-testbench \
+--enable-imdiag \
+--enable-imfile \
+--enable-impstats \
+--enable-imptcp \
+--enable-mmjsonparse \
+--enable-mmutf8fix \
+--enable-omstdout \
+--enable-omuxsock \
+--enable-gnutls \
+--enable-libgcrypt \
+--enable-libdbi \
+--enable-mysql \
+--enable-relp \
+--enable-mmnormalize \
+--enable-imkafka \
+--enable-omkafka \
+--enable-valgrind \
+--enable-usertools=no \
+--disable-omudpspoof \
+--disable-snmp \
+--disable-mmsnmptrapd \
+--disable-elasticsearch-tests \
+--disable-ommongodb \
+--enable-pmnull"
 
 # the second step shall later go into a different container
 # for now, let's get things going first... - we currently do not even need it!

--- a/packaging/docker/dev_env/alpine/build.sh
+++ b/packaging/docker/dev_env/alpine/build.sh
@@ -2,3 +2,5 @@ rm -rf common
 cp -r ../common common
 docker build $1 --rm -t rsyslog/rsyslog_dev_full:alpine_latest .
 rm -rf common
+printf "\n\n================== BUILD DONE, NOW PUSHING:\n"
+printf "\ndocker push rsyslog/rsyslog_dev_full:alpine_latest\n"

--- a/packaging/docker/dev_env/alpine/setup-system.sh
+++ b/packaging/docker/dev_env/alpine/setup-system.sh
@@ -1,11 +1,34 @@
-# note: repository key is added in Dockerfile!
-echo "http://build.rsyslog.com/alpine/3.7/unstable" >> /etc/apk/repositories
 apk --no-cache update
 apk add --no-cache \
-	git build-base automake libtool autoconf py-docutils gnutls gnutls-dev \
-	zlib-dev curl-dev mysql-dev libdbi-dev libuuid util-linux-dev \
-	libgcrypt-dev flex bison bsd-compat-headers linux-headers valgrind librdkafka-dev \
-	autoconf-archive
-
-# interactive dev only:
-apk add man man-pages gcc-doc
+	autoconf \
+	autoconf-archive \
+	automake \
+	bison \
+	build-base \
+	bash \
+	bsd-compat-headers \
+	curl-dev \
+	flex \
+	git \
+	gnutls-dev \
+	libdbi-dev \
+	libestr-dev \
+	libfastjson-dev \
+	libgcrypt-dev \
+	liblognorm-dev \
+	librelp-dev \
+	libtool \
+	libuuid \
+	linux-headers \
+	librdkafka-dev \
+	mariadb-dev \
+	pkgconf \
+	python3 \
+	py3-docutils \
+	protobuf-c-compiler \
+	protobuf-c-dev \
+	snappy-dev \
+	util-linux-dev \
+	valgrind \
+	yaml-dev \
+	zlib-dev

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -428,10 +428,6 @@ static const char *resolverErrorString(const int err) {
     }
 }
 
-#if defined(__RES) && (__RES >= 19991006)
-    #define HAVE_RESOLV_RES_N_API 1
-#endif
-
 static rsRetVal initResolverState(res_state *const pres) {
     DEFiRet;
 

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -428,6 +428,56 @@ static const char *resolverErrorString(const int err) {
     }
 }
 
+#if defined(__RES) && (__RES >= 19991006)
+    #define HAVE_RESOLV_RES_N_API 1
+#endif
+
+static rsRetVal initResolverState(res_state *const pres) {
+    DEFiRet;
+
+#ifdef HAVE_RESOLV_RES_N_API
+    CHKmalloc(*pres = (res_state)calloc(1, sizeof(struct __res_state)));
+    if (res_ninit(*pres) != 0) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+#else
+    if (res_init() != 0) {
+        LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
+        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
+    }
+    *pres = &_res;
+#endif
+
+finalize_it:
+    RETiRet;
+}
+
+static int queryResolverState(res_state const res,
+                              const char *const srvName,
+                              unsigned char *const answer,
+                              const size_t answerSize) {
+#ifdef HAVE_RESOLV_RES_N_API
+    return res_nquery(res, srvName, ns_c_in, ns_t_srv, answer, answerSize);
+#else
+    (void)res;
+    return res_query(srvName, ns_c_in, ns_t_srv, answer, answerSize);
+#endif
+}
+
+static void closeResolverState(res_state const res) {
+    if (res == NULL) {
+        return;
+    }
+#ifdef HAVE_RESOLV_RES_N_API
+    res_nclose(res);
+    free(res);
+#else
+    /* Old resolver APIs use global state; musl's implementation is stateless. */
+    (void)res;
+#endif
+}
+
 static rsRetVal applyResolverOverrides(res_state res) {
     const char *const dnsServerEnv = getenv("RSYSLOG_DNS_SERVER");
     const char *const dnsPortEnv = getenv("RSYSLOG_DNS_PORT");
@@ -508,15 +558,11 @@ static rsRetVal resolveSrvTargets(instanceData *const pData) {
         ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     }
 
-    CHKmalloc(res = (res_state)calloc(1, sizeof(struct __res_state)));
-    if (res_ninit(res) != 0) {
-        LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: failed to init resolver state: %s", strerror(errno));
-        ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
-    }
+    CHKiRet(initResolverState(&res));
 
     CHKiRet(applyResolverOverrides(res));
 
-    const int ansLen = res_nquery(res, srvName, ns_c_in, ns_t_srv, answer, sizeof(answer));
+    const int ansLen = queryResolverState(res, srvName, answer, sizeof(answer));
     if (ansLen < 0) {
         LogError(0, RS_RET_PARAM_ERROR, "omfwd: failed to resolve SRV records for '%s': %s", srvName,
                  resolverErrorString(res->res_h_errno));
@@ -644,10 +690,7 @@ static rsRetVal resolveSrvTargets(instanceData *const pData) {
 finalize_it:
     free(records);
     free(ordered);
-    if (res != NULL) {
-        res_nclose(res);
-        free(res);
-    }
+    closeResolverState(res);
     RETiRet;
 #endif
 }


### PR DESCRIPTION
## Summary

Add an Alpine compile-check CI path and refresh the Alpine dev container so
it can build current rsyslog sources. The PR also fixes `omfwd` resolver
handling on musl by falling back to the traditional resolver APIs when
`res_n*` is unavailable.

## Details

- Add an Alpine matrix entry to `.github/workflows/run_checks.yml`.
- Update `packaging/docker/dev_env/alpine/` for the current build image and
  package set.
- Fix `tools/omfwd.c` so SRV discovery builds on musl without disabling
  the feature.
- Add a push hint to the Alpine container build script.

## Validation

- `PATH="$PWD/.codex-bin:$PATH" CC=gcc CFLAGS='-g' RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_full:alpine_latest' devtools/devcontainer.sh --rm devtools/run-configure.sh`
- `PATH="$PWD/.codex-bin:$PATH" CC=gcc CFLAGS='-g' RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_full:alpine_latest' devtools/devcontainer.sh --rm make -j20`

closes https://github.com/rsyslog/rsyslog/issues/6655