### PR TITLE
omrelp: use stable data in librelp callbacks

### DIFF
--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -183,11 +183,17 @@ static uchar *getRelpPt(instanceData *pData) {
 }
 
 static void onErr(void *pUsr, char *objinfo, char *errmesg, __attribute__((unused)) relpRetVal errcode) {
-    wrkrInstanceData_t *pWrkrData = (wrkrInstanceData_t *)pUsr;
+    instanceData *pData = (instanceData *)pUsr;
+    if (pData == NULL) {
+        LogError(0, RS_RET_RELP_ERR,
+                 "omrelp: error '%s', object '%s' - action may not work as intended",
+                 errmesg, objinfo);
+        return;
+    }
     LogError(0, RS_RET_RELP_AUTH_FAIL,
              "omrelp[%s:%s]: error '%s', object "
              " '%s' - action may not work as intended",
-             pWrkrData->pData->target, pWrkrData->pData->port, errmesg, objinfo);
+             pData->target, getRelpPt(pData), errmesg, objinfo);
 }
 
 static void onGenericErr(char *objinfo, char *errmesg, __attribute__((unused)) relpRetVal errcode) {
@@ -198,11 +204,17 @@ static void onGenericErr(char *objinfo, char *errmesg, __attribute__((unused)) r
 }
 
 static void onAuthErr(void *pUsr, char *authinfo, char *errmesg, __attribute__((unused)) relpRetVal errcode) {
-    instanceData *pData = ((wrkrInstanceData_t *)pUsr)->pData;
+    instanceData *pData = (instanceData *)pUsr;
+    if (pData == NULL) {
+        LogError(0, RS_RET_RELP_AUTH_FAIL,
+                 "omrelp: authentication error '%s', peer is '%s' - DISABLING action",
+                 errmesg, authinfo);
+        return;
+    }
     LogError(0, RS_RET_RELP_AUTH_FAIL,
              "omrelp[%s:%s]: authentication error '%s', peer "
              "is '%s' - DISABLING action",
-             pData->target, pData->port, errmesg, authinfo);
+             pData->target, getRelpPt(pData), errmesg, authinfo);
     pData->bHadAuthFail = 1;
 }
 
@@ -304,7 +316,7 @@ BEGINcreateWrkrInstance
     CODESTARTcreateWrkrInstance;
     pWrkrData->pRelpClt = NULL;
     iRet = doCreateRelpClient(pWrkrData->pData, &pWrkrData->pRelpClt);
-    if (relpCltSetUsrPtr(pWrkrData->pRelpClt, pWrkrData) != RELP_RET_OK)
+    if (relpCltSetUsrPtr(pWrkrData->pRelpClt, pWrkrData->pData) != RELP_RET_OK)
         LogError(0, RS_RET_NO_ERRCODE, "omrelp: error when creating relp client");
     pWrkrData->bInitialConnect = 1;
     pWrkrData->nSent = 0;
@@ -613,7 +625,7 @@ static rsRetVal doRebind(wrkrInstanceData_t *pWrkrData) {
     CHKiRet(relpEngineCltDestruct(pRelpEngine, &pWrkrData->pRelpClt));
     pWrkrData->bIsConnected = 0;
     CHKiRet(doCreateRelpClient(pWrkrData->pData, &pWrkrData->pRelpClt));
-    if (relpCltSetUsrPtr(pWrkrData->pRelpClt, pWrkrData) != RELP_RET_OK)
+    if (relpCltSetUsrPtr(pWrkrData->pRelpClt, pWrkrData->pData) != RELP_RET_OK)
         LogError(0, RS_RET_NO_ERRCODE, "omrelp: error when creating relp client");
     pWrkrData->bInitialConnect = 1;
     pWrkrData->nSent = 0;

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -185,12 +185,11 @@ static uchar *getRelpPt(instanceData *pData) {
 static void onErr(void *pUsr, char *objinfo, char *errmesg, __attribute__((unused)) relpRetVal errcode) {
     instanceData *pData = (instanceData *)pUsr;
     if (pData == NULL) {
-        LogError(0, RS_RET_RELP_ERR,
-                 "omrelp: error '%s', object '%s' - action may not work as intended",
-                 errmesg, objinfo);
+        LogError(0, RS_RET_RELP_ERR, "omrelp: error '%s', object '%s' - action may not work as intended", errmesg,
+                 objinfo);
         return;
     }
-    LogError(0, RS_RET_RELP_AUTH_FAIL,
+    LogError(0, RS_RET_RELP_ERR,
              "omrelp[%s:%s]: error '%s', object "
              " '%s' - action may not work as intended",
              pData->target, getRelpPt(pData), errmesg, objinfo);
@@ -206,8 +205,7 @@ static void onGenericErr(char *objinfo, char *errmesg, __attribute__((unused)) r
 static void onAuthErr(void *pUsr, char *authinfo, char *errmesg, __attribute__((unused)) relpRetVal errcode) {
     instanceData *pData = (instanceData *)pUsr;
     if (pData == NULL) {
-        LogError(0, RS_RET_RELP_AUTH_FAIL,
-                 "omrelp: authentication error '%s', peer is '%s' - DISABLING action",
+        LogError(0, RS_RET_RELP_AUTH_FAIL, "omrelp: authentication error '%s', peer is '%s' - DISABLING action",
                  errmesg, authinfo);
         return;
     }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1480,6 +1480,7 @@ TESTS_RELP = \
 	sndrcv_relp.sh \
 	 sndrcv_relp_rebind.sh \
 	 omrelp_errmsg_no_connect.sh \
+	 omrelp-shutdown-partial-session.sh \
 	 imrelp-basic.sh \
 	 imrelp-basic-oldstyle.sh \
 	 imrelp-basic-hup.sh \
@@ -3085,6 +3086,7 @@ EXTRA_DIST += \
 	testsuites/omprog-defaults-bin.sh \
 	testsuites/omprog-output-capture-bin.sh \
 	testsuites/omprog-output-capture-mt-bin.py \
+	holdtcpopen.py \
 	testsuites/omprog-feedback-bin.sh \
 	testsuites/omprog-feedback-mt-bin.sh \
 	testsuites/omprog-feedback-timeout-bin.sh \

--- a/tests/holdtcpopen.py
+++ b/tests/holdtcpopen.py
@@ -1,11 +1,19 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import socket
 import sys
 import time
 
 
-def main() -> None:
+def write_text(path, content):
+    fh = open(path, "w")
+    try:
+        fh.write(content)
+    finally:
+        fh.close()
+
+
+def main():
     if len(sys.argv) != 4:
         raise SystemExit("usage: holdtcpopen.py <portfile> <acceptfile> <hold-seconds>")
 
@@ -18,12 +26,10 @@ def main() -> None:
     listener.bind(("127.0.0.1", 0))
     listener.listen(1)
 
-    with open(portfile, "w", encoding="ascii") as fh:
-        fh.write(str(listener.getsockname()[1]))
+    write_text(portfile, str(listener.getsockname()[1]))
 
     conn, _ = listener.accept()
-    with open(acceptfile, "w", encoding="ascii") as fh:
-        fh.write("accepted\n")
+    write_text(acceptfile, "accepted\n")
 
     conn.settimeout(0.2)
     deadline = time.time() + hold_seconds

--- a/tests/holdtcpopen.py
+++ b/tests/holdtcpopen.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import socket
+import sys
+import time
+
+
+def main() -> None:
+    if len(sys.argv) != 4:
+        raise SystemExit("usage: holdtcpopen.py <portfile> <acceptfile> <hold-seconds>")
+
+    portfile = sys.argv[1]
+    acceptfile = sys.argv[2]
+    hold_seconds = float(sys.argv[3])
+
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+
+    with open(portfile, "w", encoding="ascii") as fh:
+        fh.write(str(listener.getsockname()[1]))
+
+    conn, _ = listener.accept()
+    with open(acceptfile, "w", encoding="ascii") as fh:
+        fh.write("accepted\n")
+
+    conn.settimeout(0.2)
+    deadline = time.time() + hold_seconds
+    while time.time() < deadline:
+        try:
+            data = conn.recv(4096)
+            if not data:
+                break
+        except socket.timeout:
+            pass
+
+    conn.close()
+    listener.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/omrelp-shutdown-partial-session.sh
+++ b/tests/omrelp-shutdown-partial-session.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# added 2026-04-14 to guard issue #6547, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_plugin omrelp
+
+export ASAN_OPTIONS="detect_leaks=0${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
+LISTENER_PORT_FILE="${RSYSLOG_DYNNAME}.holdtcpopen.port"
+LISTENER_ACCEPT_FILE="${RSYSLOG_DYNNAME}.holdtcpopen.accepted"
+
+$PYTHON ${srcdir}/holdtcpopen.py "${LISTENER_PORT_FILE}" "${LISTENER_ACCEPT_FILE}" 15 &
+HOLDTCP_PID=$!
+trap 'kill ${HOLDTCP_PID} 2>/dev/null || true' EXIT
+
+wait_file_exists "${LISTENER_PORT_FILE}"
+RELP_PORT=$(cat "${LISTENER_PORT_FILE}")
+
+generate_conf
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp")
+main_queue(queue.type="Direct")
+action(type="omrelp" target="127.0.0.1" port="'${RELP_PORT}'")
+'
+
+startup
+injectmsg_literal "issue-6547"
+wait_file_exists "${LISTENER_ACCEPT_FILE}"
+shutdown_immediate
+wait_shutdown
+
+wait ${HOLDTCP_PID} || true
+trap - EXIT
+exit_test


### PR DESCRIPTION
## Summary
- pass omrelp's shared instanceData to librelp callbacks instead of worker-local state
- make callback logging tolerate a missing librelp user pointer
- add a shutdown regression that keeps a plain TCP listener open long enough to reproduce the partial-session teardown path

## Why
The underlying bug is in librelp, but distros may need a temporary rsyslog-side mitigation before the library fix lands everywhere. omrelp previously gave librelp a wrkrInstanceData_t pointer, so teardown-time onErr callbacks depended on worker-lifetime state while freeWrkrInstance() was already running. rsyslog already keeps the shared action instance alive through worker cleanup, so switching callback context to instanceData makes those callbacks safe even with an unpatched librelp.

This was rebuilt and validated against an unpatched librelp checkout using the new regression.

Closes https://github.com/rsyslog/rsyslog/issues/6547
See also https://github.com/rsyslog/librelp/pull/289
