### PR TITLE
[codex] omfile: harden dynafile cache validation

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -138,6 +138,7 @@ TESTS_DEFAULT = \
 	omusrmsg-noabort.sh \
 	omusrmsg_ratelimit_name.sh \
 	omfile-module-params.sh \
+	omfile-dynafilecachesize-invalid.sh \
 	omfile-read-only-errmsg.sh \
 	omfile-null-filename.sh \
 	omfile-whitespace-filename.sh \
@@ -567,6 +568,7 @@ TESTS_LIBYAML = \
 	ratelimit_hup.sh \
 	yaml-basic.sh \
 	yaml-basic-yamlonly.sh \
+	yaml-omfile-dynafilecachesize-invalid.sh \
 	yaml-include.sh \
 	yaml-ruleset-script.sh \
 	yaml-error.sh \

--- a/tests/omfile-dynafilecachesize-invalid.sh
+++ b/tests/omfile-dynafilecachesize-invalid.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Ensure action-level dynaFileCacheSize values below 1 are normalized instead
+# of crashing startup or dynafile writes.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+template(name="dynfile" type="string" string="'$RSYSLOG_DYNNAME'.out.log")
+template(name="outfmt" type="string" string="%msg:F,58:2%\n")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+:msg, contains, "msg:" action(type="omfile" dynafile="dynfile" template="outfmt" dynaFileCacheSize="0")
+'
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag msg:normalized-cache-size\""
+shutdown_when_empty
+wait_shutdown
+
+grep "DynaFileCacheSize must be greater 0 (0 given), changed to 1." "${RSYSLOG_DYNNAME}.started" > /dev/null || {
+    echo "FAIL: expected normalization message not found in startup log"
+    cat "${RSYSLOG_DYNNAME}.started"
+    error_exit 1
+}
+
+printf 'normalized-cache-size\n' > "${RSYSLOG_DYNNAME}.expected"
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected" "${RSYSLOG_DYNNAME}.out.log" || {
+    echo "FAIL: dynafile write did not succeed after normalization"
+    cat "${RSYSLOG_DYNNAME}.out.log"
+    error_exit 1
+}
+
+exit_test

--- a/tests/yaml-omfile-dynafilecachesize-invalid.sh
+++ b/tests/yaml-omfile-dynafilecachesize-invalid.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Ensure YAML omfile actions normalize invalid dynaFileCacheSize values during
+# startup while still allowing dynafile writes.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+
+templates:
+  - name: dynfile
+    type: string
+    string: "${RSYSLOG_DYNNAME}.out.log"
+  - name: outfmt
+    type: string
+    string: "%msg:F,58:2%\n"
+
+rulesets:
+  - name: main
+    filter: ':msg, contains, "msg:"'
+    actions:
+      - type: omfile
+        dynafile: dynfile
+        template: outfmt
+        dynaFileCacheSize: 0
+YAMLEOF
+sed -i "s|\${RSYSLOG_DYNNAME}|${RSYSLOG_DYNNAME}|g" "${RSYSLOG_DYNNAME}.yaml"
+
+add_conf '
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="main")
+'
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag msg:yaml-normalized-cache-size\""
+shutdown_when_empty
+wait_shutdown
+
+grep "DynaFileCacheSize must be greater 0 (0 given), changed to 1." "${RSYSLOG_DYNNAME}.started" > /dev/null || {
+    echo "FAIL: expected normalization message not found in YAML startup log"
+    cat "${RSYSLOG_DYNNAME}.started"
+    error_exit 1
+}
+
+printf 'yaml-normalized-cache-size\n' > "${RSYSLOG_DYNNAME}.expected"
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected" "${RSYSLOG_DYNNAME}.out.log" || {
+    echo "FAIL: YAML dynafile write did not succeed after normalization"
+    cat "${RSYSLOG_DYNNAME}.out.log"
+    error_exit 1
+}
+
+exit_test

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -78,6 +78,7 @@ MODULE_CNFNAME("omfile")
 
 /* forward definitions */
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __attribute__((unused)) * pVal);
+static rsRetVal normalizeDynaFileCacheSize(int *const pNewVal);
 
 /* internal structures
  */
@@ -418,22 +419,29 @@ finalize_it:
  */
 static rsRetVal setDynaFileCacheSize(void __attribute__((unused)) * pVal, int iNewVal) {
     DEFiRet;
+    iRet = normalizeDynaFileCacheSize(&iNewVal);
 
-    if (iNewVal < 1) {
+    cs.iDynaFileCacheSize = iNewVal;
+    DBGPRINTF("DynaFileCacheSize changed to %d.\n", iNewVal);
+    RETiRet;
+}
+
+static rsRetVal normalizeDynaFileCacheSize(int *const pNewVal) {
+    DEFiRet;
+    assert(pNewVal != NULL);
+
+    if (*pNewVal < 1) {
         errno = 0;
-        parser_errmsg("DynaFileCacheSize must be greater 0 (%d given), changed to 1.", iNewVal);
+        parser_errmsg("DynaFileCacheSize must be greater 0 (%d given), changed to 1.", *pNewVal);
         iRet = RS_RET_VAL_OUT_OF_RANGE;
-        iNewVal = 1;
-    } else if (iNewVal > 25000) {
+        *pNewVal = 1;
+    } else if (*pNewVal > 25000) {
         errno = 0;
         parser_warnmsg(
             "DynaFileCacheSize is larger than 25,000 (%d given) - this looks very "
             "large. Is it intended?",
-            iNewVal);
+            *pNewVal);
     }
-
-    cs.iDynaFileCacheSize = iNewVal;
-    DBGPRINTF("DynaFileCacheSize changed to %d.\n", iNewVal);
 
     RETiRet;
 }
@@ -760,6 +768,12 @@ static rsRetVal ATTR_NONNULL()
 
     assert(pData != NULL);
     assert(newFileName != NULL);
+
+    if (pData->iDynaFileCacheSize < 1 || pData->dynCache == NULL) {
+        parser_errmsg("omfile: invalid dynafile cache state for '%s' (size %d) - discarding message", pData->fname,
+                      pData->iDynaFileCacheSize);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
 
     pCache = pData->dynCache;
 
@@ -1439,6 +1453,7 @@ BEGINnewActInst
     struct cnfparamvals *pvals;
     uchar *tplToUse;
     int i;
+    rsRetVal localRet;
     CODESTARTnewActInst;
     DBGPRINTF("newActInst (omfile)\n");
 
@@ -1462,6 +1477,10 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "dynafilecachesize")) {
             pData->iDynaFileCacheSize = (int)pvals[i].val.d.n;
+            localRet = normalizeDynaFileCacheSize(&pData->iDynaFileCacheSize);
+            if (localRet != RS_RET_OK && localRet != RS_RET_VAL_OUT_OF_RANGE) {
+                ABORT_FINALIZE(localRet);
+            }
         } else if (!strcmp(actpblk.descr[i].name, "ziplevel")) {
             pData->iZipLevel = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "flushinterval")) {
@@ -1544,7 +1563,7 @@ BEGINnewActInst
 
     int allWhiteSpace = 1;
     for (const char *p = (const char *)pData->fname; *p; ++p) {
-        if (!isspace(*p)) {
+        if (!isspace((unsigned char)*p)) {
             allWhiteSpace = 0;
             break;
         }

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -770,8 +770,8 @@ static rsRetVal ATTR_NONNULL()
     assert(newFileName != NULL);
 
     if (pData->iDynaFileCacheSize < 1 || pData->dynCache == NULL) {
-        parser_errmsg("omfile: invalid dynafile cache state for '%s' (size %d) - discarding message", pData->fname,
-                      pData->iDynaFileCacheSize);
+        parser_errmsg("omfile: invalid dynafile cache state for '%s' (size %d) - discarding message",
+                      (char *)pData->fname, pData->iDynaFileCacheSize);
         ABORT_FINALIZE(RS_RET_ERR);
     }
 
@@ -1453,7 +1453,6 @@ BEGINnewActInst
     struct cnfparamvals *pvals;
     uchar *tplToUse;
     int i;
-    rsRetVal localRet;
     CODESTARTnewActInst;
     DBGPRINTF("newActInst (omfile)\n");
 
@@ -1477,7 +1476,7 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "dynafilecachesize")) {
             pData->iDynaFileCacheSize = (int)pvals[i].val.d.n;
-            localRet = normalizeDynaFileCacheSize(&pData->iDynaFileCacheSize);
+            const rsRetVal localRet = normalizeDynaFileCacheSize(&pData->iDynaFileCacheSize);
             if (localRet != RS_RET_OK && localRet != RS_RET_VAL_OUT_OF_RANGE) {
                 ABORT_FINALIZE(localRet);
             }


### PR DESCRIPTION
## What changed
- normalize action-level `dynaFileCacheSize` the same way as the legacy setter
- add a defensive `prepareDynFile()` guard against invalid zero-sized cache state
- cast filename bytes to `unsigned char` before `isspace()` in the whitespace-only check
- add RainerScript and YAML regressions for invalid omfile dynafile cache sizes

## Why
A zero dynafile cache size could survive new-style omfile action parsing and
reach runtime unchanged, where the first dynamic-file open could index an empty
cache and crash rsyslog. The filename whitespace validation also invoked ctype
logic on signed chars, which is undefined for non-ASCII bytes.

## Impact
Invalid omfile action cache sizes are normalized to `1` instead of reaching the
crash path, and both configuration frontends now have regression coverage for
that behavior.

## Root cause
The legacy `$DynaFileCacheSize` handler already enforced a lower bound, but the
new-style action parser stored `dynaFileCacheSize` directly without reusing that
validation. `prepareDynFile()` then assumed the cache had at least one slot.
Separately, the whitespace-only filename check passed raw `char` values to
`isspace()`.

## Validation
- `make -j$(nproc) check TESTS=""`
- `./tests/omfile-dynafilecachesize-invalid.sh`
- `./tests/yaml-omfile-dynafilecachesize-invalid.sh`
- `./tests/dynfile_invld_sync.sh`
- `./tests/omfile-whitespace-filename.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
