### PR TITLE
[codex] runtime: harden queue config and worker handling

### DIFF
--- a/action.c
+++ b/action.c
@@ -2428,8 +2428,8 @@ rsRetVal actionClassInit(void) {
     CHKiRet(regCfSysLineHdlr((uchar *)"actionqueuesyncqueuefiles", 0, eCmdHdlrBinary, NULL, &cs.bActionQSyncQeueFiles,
                              NULL));
     CHKiRet(regCfSysLineHdlr((uchar *)"actionqueuetype", 0, eCmdHdlrGetWord, setActionQueType, NULL, NULL));
-    CHKiRet(
-        regCfSysLineHdlr((uchar *)"actionqueueworkerthreads", 0, eCmdHdlrInt, NULL, &cs.iActionQueueNumWorkers, NULL));
+    CHKiRet(regCfSysLineHdlr((uchar *)"actionqueueworkerthreads", 0, eCmdHdlrPositiveInt, NULL,
+                             &cs.iActionQueueNumWorkers, NULL));
     CHKiRet(
         regCfSysLineHdlr((uchar *)"actionqueuetimeoutshutdown", 0, eCmdHdlrInt, NULL, &cs.iActionQtoQShutdown, NULL));
     CHKiRet(regCfSysLineHdlr((uchar *)"actionqueuetimeoutactioncompletion", 0, eCmdHdlrInt, NULL,

--- a/runtime/cfsysline.c
+++ b/runtime/cfsysline.c
@@ -276,6 +276,48 @@ finalize_it:
 }
 
 
+static rsRetVal doGetNonNegInt(uchar **pp, rsRetVal (*pSetHdlr)(void *, uid_t), void *pVal) {
+    int val;
+    DEFiRet;
+
+    CHKiRet(doGetInt(pp, NULL, &val));
+    if (val < 0) {
+        LogError(0, RS_RET_INVALID_VALUE, "value %d must not be less than zero.", val);
+        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+    }
+
+    if (pSetHdlr == NULL) {
+        *((int *)pVal) = val;
+    } else {
+        CHKiRet(pSetHdlr(pVal, val));
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+
+static rsRetVal doGetPositiveInt(uchar **pp, rsRetVal (*pSetHdlr)(void *, uid_t), void *pVal) {
+    int val;
+    DEFiRet;
+
+    CHKiRet(doGetInt(pp, NULL, &val));
+    if (val < 1) {
+        LogError(0, RS_RET_INVALID_VALUE, "value %d must be greater than zero.", val);
+        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+    }
+
+    if (pSetHdlr == NULL) {
+        *((int *)pVal) = val;
+    } else {
+        CHKiRet(pSetHdlr(pVal, val));
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+
 /* Parse and interpret a $FileCreateMode and $umask line. This function
  * pulls the creation mode and, if successful, stores it
  * into the global variable so that the rest of rsyslogd
@@ -745,6 +787,12 @@ static rsRetVal cslchCallHdlr(cslCmdHdlr_t *pThis, uchar **ppConfLine) {
         case eCmdHdlrInt:
             CHKiRet(doGetInt(ppConfLine, pThis->cslCmdHdlr, pThis->pData));
             break;
+        case eCmdHdlrNonNegInt:
+            CHKiRet(doGetNonNegInt(ppConfLine, pThis->cslCmdHdlr, pThis->pData));
+            break;
+        case eCmdHdlrPositiveInt:
+            CHKiRet(doGetPositiveInt(ppConfLine, pThis->cslCmdHdlr, pThis->pData));
+            break;
         case eCmdHdlrSize:
             CHKiRet(doGetSize(ppConfLine, pThis->cslCmdHdlr, pThis->pData));
             break;
@@ -765,8 +813,6 @@ static rsRetVal cslchCallHdlr(cslCmdHdlr_t *pThis, uchar **ppConfLine) {
             break;
         /* some non-legacy handler (used in v6+ solely) */
         case eCmdHdlrInvalid:
-        case eCmdHdlrNonNegInt:
-        case eCmdHdlrPositiveInt:
         case eCmdHdlrString:
         case eCmdHdlrArray:
         case eCmdHdlrQueueType:

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -274,7 +274,7 @@ static struct cnfparamdescr cnfpdescr[] = {{"queue.filename", eCmdHdlrGetWord, 0
                                            {"queue.checkpointinterval", eCmdHdlrInt, 0},
                                            {"queue.syncqueuefiles", eCmdHdlrBinary, 0},
                                            {"queue.type", eCmdHdlrQueueType, 0},
-                                           {"queue.workerthreads", eCmdHdlrInt, 0},
+                                           {"queue.workerthreads", eCmdHdlrPositiveInt, 0},
                                            {"queue.timeoutshutdown", eCmdHdlrInt, 0},
                                            {"queue.timeoutactioncompletion", eCmdHdlrInt, 0},
                                            {"queue.timeoutenqueue", eCmdHdlrInt, 0},
@@ -322,6 +322,7 @@ void qqueueDoneLoadCnf(void) {
         free((void *)del->dirname);
         free((void *)del);
     }
+    queue_filename_root = NULL;
 }
 
 
@@ -379,6 +380,7 @@ static rsRetVal tdlPop(qqueue_t *pQueue) {
 static rsRetVal tdlAdd(qqueue_t *pQueue, qDeqID deqID, int nElemDeq) {
     toDeleteLst_t *pNew;
     toDeleteLst_t *pPrev;
+    toDeleteLst_t *pCur;
     DEFiRet;
 
     ISOBJ_TYPE_assert(pQueue, qqueue);
@@ -389,16 +391,31 @@ static rsRetVal tdlAdd(qqueue_t *pQueue, qDeqID deqID, int nElemDeq) {
     pNew->nElemDeq = nElemDeq;
 
     /* now find right spot */
-    for (pPrev = pQueue->toDeleteLst; pPrev != NULL && deqID > pPrev->deqID; pPrev = pPrev->pNext) {
+    pPrev = NULL;
+    for (pCur = pQueue->toDeleteLst; pCur != NULL && deqID > pCur->deqID; pCur = pCur->pNext) {
+        pPrev = pCur;
         /*JUST SEARCH*/;
     }
 
     if (pPrev == NULL) {
-        pNew->pNext = pQueue->toDeleteLst;
+        pNew->pNext = pCur;
         pQueue->toDeleteLst = pNew;
     } else {
-        pNew->pNext = pPrev->pNext;
+        pNew->pNext = pCur;
         pPrev->pNext = pNew;
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+
+static rsRetVal validateQueueSpoolDir(qqueue_t *pThis) {
+    DEFiRet;
+
+    if (pThis->pszSpoolDir != NULL && pThis->lenSpoolDir == 0) {
+        parser_errmsg("queue.spooldirectory must not be empty");
+        ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
     }
 
 finalize_it:
@@ -1977,7 +1994,7 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis,
 
     assert(ppThis != NULL);
     assert(pConsumer != NULL);
-    assert(iWorkerThreads >= 0);
+    assert(iWorkerThreads > 0);
 
     CHKmalloc(pThis = (qqueue_t *)calloc(1, sizeof(qqueue_t)));
 
@@ -1998,7 +2015,6 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis,
     pThis->takeFlowCtlFromMsg = 0;
     pThis->iMaxQueueSize = iMaxQueueSize;
     pThis->pConsumer = pConsumer;
-    pThis->iNumWorkerThreads = iWorkerThreads;
     pThis->iDeqtWinToHr = 25; /* disable time-windowed dequeuing by default */
     pThis->iDeqBatchSize = 8; /* conservative default, should still provide good performance */
     pThis->iMinDeqBatchSize = 0; /* conservative default, should still provide good performance */
@@ -2011,6 +2027,7 @@ rsRetVal qqueueConstruct(qqueue_t **ppThis,
 
     INIT_ATOMIC_HELPER_MUT(pThis->mutQueueSize);
     INIT_ATOMIC_HELPER_MUT(pThis->mutLogDeq);
+    CHKiRet(qqueueSetiNumWorkerThreads(pThis, iWorkerThreads));
 
 finalize_it:
     OBJCONSTRUCT_CHECK_SUCCESS_AND_CLEANUP
@@ -3794,6 +3811,7 @@ finalize_it:
     if (iRet != RS_RET_OK) {
         if (newetry != NULL) {
             free((void *)newetry->filename);
+            free((void *)newetry->dirname);
             free((void *)newetry);
         }
     }
@@ -3972,7 +3990,8 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst) {
             free(pThis->pszSpoolDir);
             pThis->pszSpoolDir = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
             pThis->lenSpoolDir = es_strlen(pvals[i].val.d.estr);
-            if (pThis->pszSpoolDir[pThis->lenSpoolDir - 1] == '/') {
+            CHKiRet(validateQueueSpoolDir(pThis));
+            if (pThis->lenSpoolDir > 0 && pThis->pszSpoolDir[pThis->lenSpoolDir - 1] == '/') {
                 pThis->pszSpoolDir[pThis->lenSpoolDir - 1] = '\0';
                 --pThis->lenSpoolDir;
                 parser_errmsg(
@@ -4029,7 +4048,7 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst) {
                 n_params_set--;
             }
         } else if (!strcmp(pblk.descr[i].name, "queue.workerthreads")) {
-            pThis->iNumWorkerThreads = pvals[i].val.d.n;
+            CHKiRet(qqueueSetiNumWorkerThreads(pThis, pvals[i].val.d.n));
         } else if (!strcmp(pblk.descr[i].name, "queue.timeoutshutdown")) {
             pThis->toQShutdown = pvals[i].val.d.n;
         } else if (!strcmp(pblk.descr[i].name, "queue.timeoutactioncompletion")) {
@@ -4106,7 +4125,7 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst) {
     }
 
     if (pThis->cryprovName != NULL) {
-        initCryprov(pThis, lst);
+        CHKiRet(initCryprov(pThis, lst));
     }
 
     cnfparamvalsDestruct(pvals, &pblk);
@@ -4149,7 +4168,6 @@ DEFpropSetMeth(qqueue, iLowWtrMrk, int);
 DEFpropSetMeth(qqueue, iDiscardMrk, int);
 DEFpropSetMeth(qqueue, iDiscardSeverity, int);
 DEFpropSetMeth(qqueue, iLightDlyMrk, int);
-DEFpropSetMeth(qqueue, iNumWorkerThreads, int);
 DEFpropSetMeth(qqueue, iMinMsgsPerWrkr, int);
 DEFpropSetMeth(qqueue, bSaveOnShutdown, int);
 DEFpropSetMeth(qqueue, pAction, action_t *);
@@ -4158,6 +4176,16 @@ DEFpropSetMeth(qqueue, iDeqBatchSize, int);
 DEFpropSetMeth(qqueue, iMinDeqBatchSize, int);
 DEFpropSetMeth(qqueue, sizeOnDiskMax, int64);
 DEFpropSetMeth(qqueue, iSmpInterval, int);
+
+rsRetVal qqueueSetiNumWorkerThreads(qqueue_t *pThis, int pVal) {
+    if (pVal <= 0) {
+        LogError(0, RS_RET_CONF_PARAM_INVLD, "queue.workerthreads must be greater than 0, but is %d", pVal);
+        return RS_RET_CONF_PARAM_INVLD;
+    }
+
+    pThis->iNumWorkerThreads = pVal;
+    return RS_RET_OK;
+}
 
 /* This function can be used as a generic way to set properties. Only the subset
  * of properties required to read persisted property bags is supported. This

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -1380,7 +1380,7 @@ static rsRetVal initLegacyConf(void) {
     CHKiRet(regCfSysLineHdlr((uchar *)"mainmsgqueuesyncqueuefiles", 0, eCmdHdlrBinary, NULL,
                              &loadConf->globals.mainQ.bMainMsgQSyncQeueFiles, NULL));
     CHKiRet(regCfSysLineHdlr((uchar *)"mainmsgqueuetype", 0, eCmdHdlrGetWord, setMainMsgQueType, NULL, NULL));
-    CHKiRet(regCfSysLineHdlr((uchar *)"mainmsgqueueworkerthreads", 0, eCmdHdlrInt, NULL,
+    CHKiRet(regCfSysLineHdlr((uchar *)"mainmsgqueueworkerthreads", 0, eCmdHdlrPositiveInt, NULL,
                              &loadConf->globals.mainQ.iMainMsgQueueNumWorkers, NULL));
     CHKiRet(regCfSysLineHdlr((uchar *)"mainmsgqueuetimeoutshutdown", 0, eCmdHdlrInt, NULL,
                              &loadConf->globals.mainQ.iMainMsgQtoQShutdown, NULL));

--- a/runtime/stream.c
+++ b/runtime/stream.c
@@ -554,8 +554,13 @@ static rsRetVal strmNextFile(strm_t *pThis) {
 
     assert(pThis != NULL);
     assert(pThis->sType == STREAMTYPE_FILE_CIRCULAR);
-    assert(pThis->iMaxFiles != 0);
     assert(pThis->fd != -1);
+
+    if (pThis->iMaxFiles <= 0) {
+        LogError(0, RS_RET_CONF_PARAM_INVLD, "stream: circular file mode requires iMaxFiles > 0, but is %d",
+                 pThis->iMaxFiles);
+        ABORT_FINALIZE(RS_RET_CONF_PARAM_INVLD);
+    }
 
     CHKiRet(strmCloseFile(pThis));
 
@@ -1825,6 +1830,7 @@ finalize_it:
 rsRetVal strmMultiFileSeek(strm_t *pThis, unsigned int FNum, off64_t offs, off64_t *bytesDel) {
     struct stat statBuf;
     int skipped_files;
+    off64_t deletedBytes;
     DEFiRet;
     ISOBJ_TYPE_assert(pThis, strm);
 
@@ -1840,6 +1846,8 @@ rsRetVal strmMultiFileSeek(strm_t *pThis, unsigned int FNum, off64_t offs, off64
         CHKiRet(genFileName(&pThis->pszCurrFName, pThis->pszDir, pThis->lenDir, pThis->pszFName, pThis->lenFName,
                             pThis->iCurrFNum, pThis->iFileNumDigits));
         dbgprintf("rger: processing file %s\n", pThis->pszCurrFName);
+        memset(&statBuf, 0, sizeof(statBuf));
+        deletedBytes = 0;
         if (stat((char *)pThis->pszCurrFName, &statBuf) != 0) {
             LogError(errno, RS_RET_IO_ERROR,
                      "unexpected error doing a stat() "
@@ -1849,12 +1857,14 @@ rsRetVal strmMultiFileSeek(strm_t *pThis, unsigned int FNum, off64_t offs, off64
              * situation. As such, we just keep running and try to delete
              * as many files as possible.
              */
+        } else {
+            deletedBytes = statBuf.st_size;
+            *bytesDel += deletedBytes;
         }
-        *bytesDel += statBuf.st_size;
         DBGPRINTF(
             "strmMultiFileSeek: detected new filenum, was %u, new %u, "
             "deleting '%s' (%lld bytes)\n",
-            pThis->iCurrFNum, FNum, pThis->pszCurrFName, (long long)statBuf.st_size);
+            pThis->iCurrFNum, FNum, pThis->pszCurrFName, (long long)deletedBytes);
         unlink((char *)pThis->pszCurrFName);
         if (pThis->cryprov != NULL) pThis->cryprov->DeleteStateFiles(pThis->pszCurrFName);
         free(pThis->pszCurrFName);

--- a/runtime/wti.c
+++ b/runtime/wti.c
@@ -36,6 +36,7 @@
 #include <signal.h>
 #include <pthread.h>
 #include <errno.h>
+#include <stdint.h>
 
 #include "rsyslog.h"
 #include "stringbuf.h"
@@ -89,6 +90,7 @@ void ATTR_NONNULL() wtiJoinThrd(wti_t *const pThis) {
         DBGPRINTF("%s: joining terminated worker\n", wtiGetDbgHdr(pThis));
         if ((r = pthread_join(pThis->thrdID, NULL)) != 0) {
             LogMsg(r, RS_RET_INTERNAL_ERROR, LOG_WARNING, "rsyslog bug? wti cannot join terminated wrkr");
+            return;
         }
         DBGPRINTF("%s: worker fully terminated\n", wtiGetDbgHdr(pThis));
         wtiSetState(pThis, WRKTHRD_STOPPED);
@@ -232,17 +234,28 @@ finalize_it:
 rsRetVal wtiNewIParam(wti_t *const pWti, action_t *const pAction, actWrkrIParams_t **piparams) {
     actWrkrInfo_t *const wrkrInfo = &(pWti->actWrkrInfo[pAction->iActionNbr]);
     actWrkrIParams_t *iparams;
-    int newMax;
+    size_t allocCount;
+    size_t newMax;
+    size_t startOffset;
+    size_t zeroCount;
     DEFiRet;
 
     if (wrkrInfo->p.tx.currIParam == wrkrInfo->p.tx.maxIParams) {
         /* we need to extend */
-        newMax = (wrkrInfo->p.tx.maxIParams == 0) ? CONF_IPARAMS_BUFSIZE : 2 * wrkrInfo->p.tx.maxIParams;
-        CHKmalloc(iparams = realloc(wrkrInfo->p.tx.iparams, sizeof(actWrkrIParams_t) * pAction->iNumTpls * newMax));
-        memset(iparams + (wrkrInfo->p.tx.currIParam * pAction->iNumTpls), 0,
-               sizeof(actWrkrIParams_t) * pAction->iNumTpls * (newMax - wrkrInfo->p.tx.maxIParams));
+        newMax = (wrkrInfo->p.tx.maxIParams == 0) ? CONF_IPARAMS_BUFSIZE : 2u * (size_t)wrkrInfo->p.tx.maxIParams;
+        if ((size_t)pAction->iNumTpls > SIZE_MAX / newMax) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        allocCount = (size_t)pAction->iNumTpls * newMax;
+        if (allocCount > SIZE_MAX / sizeof(actWrkrIParams_t)) {
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+        CHKmalloc(iparams = realloc(wrkrInfo->p.tx.iparams, sizeof(actWrkrIParams_t) * allocCount));
+        startOffset = (size_t)wrkrInfo->p.tx.currIParam * (size_t)pAction->iNumTpls;
+        zeroCount = ((size_t)newMax - (size_t)wrkrInfo->p.tx.maxIParams) * (size_t)pAction->iNumTpls;
+        memset(iparams + startOffset, 0, sizeof(actWrkrIParams_t) * zeroCount);
         wrkrInfo->p.tx.iparams = iparams;
-        wrkrInfo->p.tx.maxIParams = newMax;
+        wrkrInfo->p.tx.maxIParams = (int)newMax;
     }
     *piparams = wrkrInfo->p.tx.iparams + wrkrInfo->p.tx.currIParam * pAction->iNumTpls;
     ++wrkrInfo->p.tx.currIParam;

--- a/runtime/wtp.c
+++ b/runtime/wtp.c
@@ -499,6 +499,11 @@ static rsRetVal ATTR_NONNULL() wtpStartWrkr(wtp_t *const pThis, const int permit
 
     pWti = pThis->pWrkr[i];
     iState = pthread_create(&(pWti->thrdID), &pThis->attrThrd, wtpWorker, (void *)pWti);
+    if (iState != 0) {
+        wtiSetState(pWti, WRKTHRD_STOPPED);
+        LogError(iState, RS_RET_ERR, "%s: pthread_create failed while starting a worker", wtpGetDbgHdr(pThis));
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
     ATOMIC_INC(&pThis->iCurNumWrkThrd, &pThis->mutCurNumWrkThrd); /* we got one more! */
 
     // TESTBENCH bughunt - remove when done! 2018-11-05 rgerhards

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -229,6 +229,8 @@ TESTS_DEFAULT = \
 	diskqueue-fsync.sh \
 	diskqueue-full.sh \
 	diskqueue-fail.sh \
+	queue-invalid-spooldirectory-empty.sh \
+	queue-invalid-workerthreads-zero.sh \
 	diskqueue-oncorruption-missing-segment.sh \
 	diskqueue-non-unique-prefix.sh \
 	rulesetmultiqueue.sh \

--- a/tests/queue-invalid-spooldirectory-empty.sh
+++ b/tests/queue-invalid-spooldirectory-empty.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Verify that an empty queue.spooldirectory is rejected during config validation.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'"
+       queue.type="disk" queue.filename="qf1" queue.spooldirectory="")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 1 ]; then
+    echo "FAIL: expected config validation failure for empty queue.spooldirectory"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+grep -F "queue.spooldirectory must not be empty" "${RSYSLOG_DYNNAME}.log" >/dev/null || {
+    echo "FAIL: expected empty queue.spooldirectory error message"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+}
+
+exit_test

--- a/tests/queue-invalid-workerthreads-zero.sh
+++ b/tests/queue-invalid-workerthreads-zero.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Verify that worker-thread counts of zero are rejected in both object and
+# legacy queue configuration paths.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'"
+       queue.type="linkedList" queue.workerthreads="0")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M../runtime/.libs:../.libs >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 1 ]; then
+    echo "FAIL: expected config validation failure for object queue.workerthreads=0"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+grep -F "parameter 'queue.workerthreads' cannot be less than one" "${RSYSLOG_DYNNAME}.log" >/dev/null || {
+    echo "FAIL: expected object queue.workerthreads validation error"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+}
+
+generate_conf 2
+add_conf '
+$MainMsgQueueWorkerThreads 0
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+' 2
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}2.conf" -M../runtime/.libs:../.libs >"${RSYSLOG_DYNNAME}.legacy.log" 2>&1
+if [ $? -ne 1 ]; then
+    echo "FAIL: expected config validation failure for legacy mainmsgqueueworkerthreads=0"
+    cat "${RSYSLOG_DYNNAME}.legacy.log"
+    error_exit 1
+fi
+
+grep -F "must be greater than zero" "${RSYSLOG_DYNNAME}.legacy.log" >/dev/null || {
+    echo "FAIL: expected legacy mainmsgqueueworkerthreads validation error"
+    cat "${RSYSLOG_DYNNAME}.legacy.log"
+    error_exit 1
+}
+
+exit_test


### PR DESCRIPTION
## Summary
This batch addresses the first set of validated queue-subsystem security audit findings.

The changes harden queue configuration parsing, worker lifecycle handling, and disk queue recovery/accounting paths. They also add focused regression coverage for the newly enforced invalid-configuration cases.

## What changed
- require positive integer handling for queue worker thread settings in both object config and legacy sysline plumbing
- reject empty `queue.spooldirectory` values before trailing-slash normalization
- propagate queue cryprov initialization failures instead of continuing
- keep the queue to-delete list sorted correctly and clear duplicate-filename registry state after teardown
- avoid counting uninitialized `stat()` data during multifile queue seek and reject invalid `iMaxFiles` values
- handle `pthread_create()` and `pthread_join()` failures without leaving worker state inconsistent
- add overflow guards for transactional worker parameter growth
- add regression tests for empty spool directories and zero worker-thread configurations

## Why
The audit found a mix of reachable validation bugs and recovery-path issues that could allow invalid queue settings, inconsistent worker state, or incorrect disk queue accounting.

## Validation
- `./autogen.sh --enable-debug --enable-testbench`
- `make -j$(nproc) check TESTS=""`
- `srcdir=. ./validation-run.sh`
- `srcdir=. ./queue-invalid-spooldirectory-empty.sh`
- `srcdir=. ./queue-invalid-workerthreads-zero.sh`
- `srcdir=. ./diskqueue.sh`
- `srcdir=. ./queue-persist.sh`
- `srcdir=. ./daqueue-dirty-shutdown-recovery.sh`
- `srcdir=. ./diskqueue-oncorruption-missing-segment.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`

## Notes
This is intended as the first remediation batch for the queue audit. Remaining findings still need a disposition pass to separate duplicates/noise from the next set of actionable fixes.