### PR TITLE
[codex] imjournal: harden state file handling

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -57,6 +57,16 @@
 #include "unicode-helper.h"
 #include "ratelimit.h"
 
+#ifndef O_CLOEXEC
+    #define O_CLOEXEC 0
+#endif
+#ifndef O_NOCTTY
+    #define O_NOCTTY 0
+#endif
+#ifndef O_NOFOLLOW
+    #define O_NOFOLLOW 0
+#endif
+
 
 MODULE_TYPE_INPUT;
 MODULE_TYPE_NOKEEP;
@@ -183,6 +193,97 @@ static modConfData_t *runModConf = NULL; /* modConf ptr to use for run process *
 
 static rsRetVal persistJournalState(struct journalContext_s *journalContext, char *stateFile);
 static rsRetVal loadJournalState(struct journalContext_s *journalContext, char *stateFile);
+
+/**
+ * Create a unique temporary state file next to the final cursor file.
+ *
+ * The temp file must live in the target directory so that the later rename()
+ * stays atomic on the same filesystem. Callers receive ownership of *tmpPath
+ * and must free it. On success, *fd is an open descriptor positioned at the
+ * beginning of an empty file created with the configured mode and protected
+ * against symlink traversal.
+ */
+static rsRetVal openStateFileTemp(const char *stateFile, char **tmpPath, int *fd) {
+    struct timespec ts;
+    char *candidate = NULL;
+    int localFd = -1;
+    int attempt;
+    DEFiRet;
+
+    if (clock_gettime(CLOCK_REALTIME, &ts) != 0) {
+        ts.tv_sec = time(NULL);
+        ts.tv_nsec = 0;
+    }
+
+    for (attempt = 0; attempt < 100; ++attempt) {
+        free(candidate);
+        candidate = NULL;
+        if (asprintf(&candidate, "%s.tmp.%ld.%ld.%d", stateFile, (long)getpid(), (long)ts.tv_nsec, attempt) == -1) {
+            LogError(0, RS_RET_OUT_OF_MEMORY, "imjournal: asprintf failed\n");
+            ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+        }
+
+        localFd = open(candidate, O_WRONLY | O_CREAT | O_EXCL | O_CLOEXEC | O_NOCTTY | O_NOFOLLOW, cs.fCreateMode);
+        if (localFd >= 0) {
+            *tmpPath = candidate;
+            *fd = localFd;
+            candidate = NULL;
+            FINALIZE;
+        }
+
+        if (errno != EEXIST) {
+            LogError(errno, RS_RET_FILE_OPEN_ERROR, "imjournal: open() failed for path: '%s'", candidate);
+            ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
+        }
+    }
+
+    LogError(0, RS_RET_FILE_OPEN_ERROR, "imjournal: could not create a unique temp state file for '%s'", stateFile);
+    ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
+
+finalize_it:
+    free(candidate);
+    RETiRet;
+}
+
+/**
+ * Fsync the directory that contains the persisted cursor file.
+ *
+ * After the caller has fsync'd the file contents and renamed the temporary
+ * file into place, syncing the parent directory is required to make the name
+ * update durable across power loss. The path may be absolute or relative.
+ */
+static rsRetVal fsyncStateFileParentDir(const char *stateFile) {
+    DIR *dir = NULL;
+    char *dirPath = NULL;
+    const char *slash;
+    DEFiRet;
+
+    slash = strrchr(stateFile, '/');
+    if (slash == NULL) {
+        CHKmalloc(dirPath = strdup("."));
+    } else if (slash == stateFile) {
+        CHKmalloc(dirPath = strdup("/"));
+    } else {
+        const size_t len = (size_t)(slash - stateFile);
+        CHKmalloc(dirPath = strndup(stateFile, len));
+    }
+
+    if ((dir = opendir(dirPath)) == NULL) {
+        LogError(errno, RS_RET_IO_ERROR, "imjournal: failed to open '%s' directory", dirPath);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (fsync(dirfd(dir)) != 0) {
+        LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", dirPath);
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+
+finalize_it:
+    if (dir != NULL) {
+        closedir(dir);
+    }
+    free(dirPath);
+    RETiRet;
+}
 
 static rsRetVal openJournal(struct journalContext_s *journalContext) {
     int r;
@@ -319,8 +420,8 @@ static rsRetVal readJSONfromJournalMsg(struct journalContext_s *journalContext, 
         if (equal_sign == NULL) {
             LogError(0, RS_RET_ERR,
                      "SD_JOURNAL_FOREACH_DATA()"
-                     "returned a malformed field (has no '='): '%s'",
-                     (char *)get);
+                     " returned a malformed field without '=' (length %zu)",
+                     l);
             continue; /* skip the entry */
         }
 
@@ -521,8 +622,8 @@ static rsRetVal readjournal(struct journalContext_s *journalContext, ruleset_t *
         } else {
             DBGPRINTF(
                 "The value of the 'FACILITY' field has an "
-                "unexpected length: %zu value: '%s'\n",
-                length, (const char *)get);
+                "unexpected length: %zu\n",
+                length);
         }
     }
 
@@ -598,7 +699,7 @@ finalize_it:
  */
 static rsRetVal persistJournalState(struct journalContext_s *journalContext, char *stateFile) {
     DEFiRet;
-    char tmp_sf[MAXFNAME];
+    char *tmp_sf = NULL;
     int fd = -1;
     size_t len;
     ssize_t wr_ret;
@@ -611,31 +712,7 @@ static rsRetVal persistJournalState(struct journalContext_s *journalContext, cha
         ABORT_FINALIZE(RS_RET_OK);
     }
 
-    /* we create a temporary name by adding a ".tmp"
-     * suffix to the end of our state file's name
-     *
-     * we use snprintf() to safely honor the boundaries
-     * of the temporary state file name buffer by using
-     * a precision specifier, which will limit the number
-     * of bytes taken from stateFile to what will fit
-     *
-     * TODO: figure out a better way to avoid the PATH_MAX
-     * problem. The truncated stateFile with .tmp at the
-     * end is not optimal
-     */
-#define IM_SF_TMP_SUFFIX ".tmp"
-    snprintf(tmp_sf, sizeof(tmp_sf), "%.*s%s",
-             /* this calculates the max size for state file name, note that
-              * sizeof() NOT -1 is intentional - it reserves spaces for the
-              * NUL terminator.
-              */
-             (int)(sizeof(tmp_sf) - sizeof(IM_SF_TMP_SUFFIX)), stateFile, IM_SF_TMP_SUFFIX);
-
-    fd = open((char *)tmp_sf, O_WRONLY | O_CREAT | O_CLOEXEC, cs.fCreateMode);
-    if (fd == -1) {
-        LogError(errno, RS_RET_FILE_OPEN_ERROR, "imjournal: open() failed for path: '%s'", tmp_sf);
-        ABORT_FINALIZE(RS_RET_FILE_OPEN_ERROR);
-    }
+    CHKiRet(openStateFileTemp(stateFile, &tmp_sf, &fd));
 
     len = strlen(journalContext->cursor);
     wr_ret = write(fd, journalContext->cursor, len);
@@ -643,9 +720,23 @@ static rsRetVal persistJournalState(struct journalContext_s *journalContext, cha
         LogError(errno, RS_RET_IO_ERROR,
                  "imjournal: failed to save cursor to: '%s',"
                  "write returned %zd, expected %zu",
-                 cs.stateFile, wr_ret, len);
+                 stateFile, wr_ret, len);
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
+
+    if (cs.bFsync) {
+        if (fsync(fd) != 0) {
+            LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", tmp_sf);
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+    }
+
+    if (close(fd) == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "imjournal: close() failed for path: '%s'", tmp_sf);
+        fd = -1;
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    fd = -1;
 
     /* change the name of the file to the configured one */
     if (rename(tmp_sf, stateFile) < 0) {
@@ -654,23 +745,7 @@ static rsRetVal persistJournalState(struct journalContext_s *journalContext, cha
     }
 
     if (cs.bFsync) {
-        if (fsync(fd) != 0) {
-            LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", stateFile);
-            ABORT_FINALIZE(RS_RET_IO_ERROR);
-        }
-        /* In order to guarantee physical write we need to force parent sync as well */
-        DIR *wd;
-        if (!(wd = opendir((char *)glbl.GetWorkDir(runModConf->pConf)))) {
-            LogError(errno, RS_RET_IO_ERROR, "imjournal: failed to open '%s' directory",
-                     glbl.GetWorkDir(runModConf->pConf));
-            ABORT_FINALIZE(RS_RET_IO_ERROR);
-        }
-        if (fsync(dirfd(wd)) != 0) {
-            LogError(errno, RS_RET_IO_ERROR, "imjournal: fsync on '%s' failed", glbl.GetWorkDir(runModConf->pConf));
-            ABORT_FINALIZE(RS_RET_IO_ERROR);
-        }
-
-        closedir(wd);
+        CHKiRet(fsyncStateFileParentDir(stateFile));
     }
 
     DBGPRINTF("Persisted journal to '%s'\n", stateFile);
@@ -682,6 +757,10 @@ finalize_it:
             iRet = RS_RET_IO_ERROR;
         }
     }
+    if (iRet != RS_RET_OK && tmp_sf != NULL) {
+        unlink(tmp_sf);
+    }
+    free(tmp_sf);
     RETiRet;
 }
 
@@ -764,14 +843,16 @@ finalize_it:
  */
 static rsRetVal loadJournalState(struct journalContext_s *journalContext, char *stateFile) {
     DEFiRet;
+    struct stat st;
     int r;
+    int fd = -1;
     FILE *r_sf;
 
     DBGPRINTF("Loading journal position, at head? %d, reloaded? %d\n", journalContext->atHead,
               journalContext->reloaded);
 
-    /* if state file not exists (on very first run), skip */
-    if (access(stateFile, F_OK | R_OK) == -1 && errno == ENOENT) {
+    fd = open(stateFile, O_RDONLY | O_CLOEXEC | O_NOCTTY | O_NOFOLLOW);
+    if (fd == -1 && errno == ENOENT) {
         if (cs.bIgnorePrevious) {
             /* Seek to the very end of the journal and ignore all older messages. */
             skipOldMessages(journalContext);
@@ -782,8 +863,27 @@ static rsRetVal loadJournalState(struct journalContext_s *journalContext, char *
                stateFile);
         FINALIZE;
     }
+    if (fd == -1) {
+        LogError(errno, RS_RET_FOPEN_FAILURE, "imjournal: open on state file `%s' failed\n", stateFile);
+        if (cs.bIgnorePrevious) {
+            /* Seek to the very end of the journal and ignore all older messages. */
+            skipOldMessages(journalContext);
+        }
+        FINALIZE;
+    }
+    if (fstat(fd, &st) != 0) {
+        LogError(errno, RS_RET_IO_ERROR, "imjournal: fstat on state file `%s' failed\n", stateFile);
+        iRet = RS_RET_IO_ERROR;
+        FINALIZE;
+    }
+    if (!S_ISREG(st.st_mode)) {
+        LogError(0, RS_RET_IO_ERROR, "imjournal: state file `%s' is not a regular file\n", stateFile);
+        iRet = RS_RET_IO_ERROR;
+        FINALIZE;
+    }
 
-    if ((r_sf = fopen(stateFile, "rb")) != NULL) {
+    if ((r_sf = fdopen(fd, "rb")) != NULL) {
+        fd = -1;
         char readCursor[128 + 1];
         if (fscanf(r_sf, "%128s\n", readCursor) != EOF) {
             if (sd_journal_seek_cursor(journalContext->j, readCursor) != 0) {
@@ -841,7 +941,7 @@ static rsRetVal loadJournalState(struct journalContext_s *journalContext, char *
             }
         }
     } else {
-        LogError(0, RS_RET_FOPEN_FAILURE, "imjournal: open on state file `%s' failed\n", stateFile);
+        LogError(errno, RS_RET_FOPEN_FAILURE, "imjournal: fdopen on state file `%s' failed\n", stateFile);
         if (cs.bIgnorePrevious) {
             /* Seek to the very end of the journal and ignore all older messages. */
             skipOldMessages(journalContext);
@@ -849,6 +949,9 @@ static rsRetVal loadJournalState(struct journalContext_s *journalContext, char *
     }
 
 finalize_it:
+    if (fd != -1) {
+        close(fd);
+    }
     RETiRet;
 }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -809,6 +809,7 @@ TESTS_OMHTTP_FLAKY_VALGRIND = \
 TESTS_IMJOURNAL = \
 	imjournal-basic.sh \
 	imjournal-statefile.sh \
+	imjournal-statefile-symlink.sh \
 	imjournal_ratelimit_name.sh
 
 TESTS_IMJOURNAL_VALGRIND = \

--- a/tests/imjournal-statefile-symlink.sh
+++ b/tests/imjournal-statefile-symlink.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Ensure imjournal does not follow or reuse attacker-controlled temp state files.
+. ${srcdir:=.}/diag.sh init
+. $srcdir/diag.sh require-journalctl
+generate_conf
+
+VICTIM="$RSYSLOG_DYNNAME.spool/victim.txt"
+STATEFILE_BASE="$RSYSLOG_DYNNAME.spool/imjournal.state"
+
+printf '%s\n' "do-not-touch" > "$VICTIM"
+ln -s victim.txt "$STATEFILE_BASE.tmp"
+
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(load="../plugins/imjournal/.libs/imjournal" StateFile="imjournal.state"
+	RateLimit.interval="0")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "'"$RSYSLOG_DYNNAME"'" then {
+	action(type="omfile" template="outfmt" file=`echo $RSYSLOG_OUT_LOG`)
+	stop
+}
+'
+
+TESTMSG="TestBenCH-RSYSLog imjournal symlink statefile test - $(date +%s) - $RSYSLOG_DYNNAME"
+./journal_print "$TESTMSG"
+if [ $? -ne 0 ]; then
+	echo "SKIP: failed to put test into journal."
+	error_exit 77
+fi
+
+sleep 1
+
+journalctl -an 200 > /dev/null 2>&1
+if [ $? -ne 0 ]; then
+	echo "SKIP: cannot read journal."
+	error_exit 77
+fi
+
+journalctl -an 200 | grep -qF "$TESTMSG"
+if [ $? -ne 0 ]; then
+	echo "SKIP: cannot find '$TESTMSG' in journal."
+	error_exit 77
+fi
+
+startup
+content_check_with_count "$TESTMSG" 1 300
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='do-not-touch'
+cmp_exact "$VICTIM"
+
+if [ ! -f "$STATEFILE_BASE" ]; then
+	echo "FAIL: expected state file '$STATEFILE_BASE' was not created"
+	error_exit 1
+fi
+
+if [ -L "$STATEFILE_BASE" ]; then
+	echo "FAIL: state file '$STATEFILE_BASE' must not be a symlink"
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary
- harden `imjournal` state-file persistence against predictable temp-file reuse and symlink tricks
- stop treating malformed journald buffers as NUL-terminated strings in log paths
- add a regression test covering the symlinked temp-state-file case

## Why
`imjournal` reads untrusted local journal data and persists cursor state on disk.
Those paths should fail safely under hostile local filesystem conditions and
malformed journal field contents.

## Root cause
The module wrote cursor state through a fixed `.tmp` path and loaded state files
without rejecting symlinks or other non-regular files. It also logged some raw
journald buffers with `%s` even though the API only guarantees pointer-plus-
length buffers.

## Impact
This reduces local file-clobbering risk around the state file and removes unsafe
buffer logging in malformed-field paths.

## Validation
- `make -j$(nproc) check TESTS=""`
- `make -C plugins/imjournal`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
- Direct live `imjournal` journal-ingestion tests were not run here because this
  build disables `ENABLE_JOURNAL_TESTS`.
