### PR TITLE
ci: temporarily disable focal package build

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -358,7 +358,8 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - suite: focal
+          # Temporarily disabled: Ubuntu 20.04 (focal) is EOL and the package
+          # build no longer works reliably there.
           - suite: jammy
           - suite: noble
     steps:


### PR DESCRIPTION
This recently has frequent failures. We assume this is due to EOL of focal (20.04). Disabling, will reconsider,  probably at latest when we add 26.04 support.
