### PR TITLE
gssapi: harden framing and fix imgssapi settings

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -537,17 +537,43 @@ solaris) GSSLIB=gss ;;
 *)       GSSLIB=gssapi_krb5 ;;
 esac
 
+gssapi_found=no
+GSS_CFLAGS=""
+GSS_LIBS=""
 if test $enable_gssapi_krb5 = yes; then
-	AC_CHECK_LIB($GSSLIB, gss_acquire_cred, [
-		AC_CHECK_HEADER(gssapi/gssapi.h, [
-			AC_DEFINE(USE_GSSAPI,,
-				  Define if you want to use GSSAPI)
-			GSS_LIBS="-l$GSSLIB"
-			AC_SUBST(GSS_LIBS)
-		])
-	])
+	AC_CHECK_HEADER(gssapi/gssapi.h, [
+		if test "x$PKG_CONFIG" != "xno" && $PKG_CONFIG --exists krb5-gssapi; then
+			GSS_CFLAGS=`$PKG_CONFIG --cflags krb5-gssapi`
+			GSS_LIBS=`$PKG_CONFIG --libs krb5-gssapi`
+			gssapi_found=yes
+		else
+			save_LIBS="$LIBS"
+			LIBS="-l$GSSLIB $LIBS"
+			AC_LINK_IFELSE(
+				[AC_LANG_PROGRAM(
+					[[#include <gssapi/gssapi.h>]],
+					[[OM_uint32 maj = 0, min = 0; gss_cred_id_t cred = GSS_C_NO_CREDENTIAL;
+					  return gss_acquire_cred(&min, GSS_C_NO_NAME, 0, GSS_C_NULL_OID_SET,
+						GSS_C_ACCEPT, &cred, 0, 0) == maj;]]
+				)],
+				[
+					GSS_LIBS="-l$GSSLIB"
+					gssapi_found=yes
+				]
+			)
+			LIBS="$save_LIBS"
+		fi
+	], [])
+	if test "x$gssapi_found" = "xyes"; then
+		AC_DEFINE(USE_GSSAPI,,
+			  Define if you want to use GSSAPI)
+	else
+		AC_MSG_ERROR([--enable-gssapi-krb5 requested, but usable GSSAPI headers/libraries were not found])
+	fi
 fi
-AM_CONDITIONAL(ENABLE_GSSAPI, test x$enable_gssapi_krb5 = xyes)
+AC_SUBST(GSS_CFLAGS)
+AC_SUBST(GSS_LIBS)
+AM_CONDITIONAL(ENABLE_GSSAPI, test x$gssapi_found = xyes)
 
 
 # shall the testbench try to run test that require root permissions?

--- a/doc/source/reference/parameters/imgssapi-inputgssservermaxsessions.rst
+++ b/doc/source/reference/parameters/imgssapi-inputgssservermaxsessions.rst
@@ -27,12 +27,6 @@ Description
 -----------
 Sets the maximum number of concurrent sessions supported by the listener.
 
-.. note::
-
-   Due to a long-standing bug, the configured limit is not forwarded to the
-   underlying TCP listener. Regardless of the value set here, the listener
-   currently enforces the built-in default of 200 sessions.
-
 Input usage
 -----------
 .. _imgssapi.parameter.input.inputgssservermaxsessions-usage:

--- a/doc/source/reference/parameters/imgssapi-inputgssserverpermitplaintcp.rst
+++ b/doc/source/reference/parameters/imgssapi-inputgssserverpermitplaintcp.rst
@@ -28,6 +28,13 @@ Description
 Permits the server to receive plain TCP syslog (without GSS protection) on the
 same port that the GSS listener uses.
 
+.. warning::
+
+   This creates an intentional security downgrade path. Use it only on trusted
+   networks. Plain TCP fallback is limited to connections that are identified as
+   regular octet-counted syslog before GSS token processing begins; malformed
+   GSS tokens are no longer reinterpreted as plain TCP traffic.
+
 Input usage
 -----------
 .. _imgssapi.parameter.input.inputgssserverpermitplaintcp-usage:

--- a/plugins/imgssapi/MODULE_METADATA.yaml
+++ b/plugins/imgssapi/MODULE_METADATA.yaml
@@ -1,0 +1,11 @@
+support_status: contributor-supported
+maturity_level: mature
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2026-04-16
+build_dependencies:
+  - MIT Kerberos or compatible GSSAPI development headers (`--enable-gssapi-krb5`)
+documentation:
+  - doc/source/configuration/modules/imgssapi.rst
+notes:
+  - Legacy-format-only input module with contributor-maintained GSSAPI support.
+  - Negative-path coverage exists for listen port file and max session handling; full Kerberos integration tests are still absent.

--- a/plugins/imgssapi/Makefile.am
+++ b/plugins/imgssapi/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = imgssapi.la
 
 imgssapi_la_SOURCES = imgssapi.c
-imgssapi_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+imgssapi_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(GSS_CFLAGS)
 imgssapi_la_LDFLAGS = -module -avoid-version
 imgssapi_la_LIBADD = $(GSS_LIBS)

--- a/plugins/imgssapi/imgssapi.c
+++ b/plugins/imgssapi/imgssapi.c
@@ -38,6 +38,7 @@
 #include <ctype.h>
 #include <netinet/in.h>
 #include <netdb.h>
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #if HAVE_FCNTL_H
@@ -52,6 +53,7 @@
 #include "net.h"
 #include "srUtils.h"
 #include "gss-misc.h"
+#include "gss-token-util.h"
 #include "tcpsrv.h"
 #include "tcps_sess.h"
 #include "errmsg.h"
@@ -184,16 +186,60 @@ static int isPermittedHost(struct sockaddr *addr, char *fromHostFQDN, void *pUsr
 }
 
 
+static rsRetVal getAllowedMethodsForSess(tcps_sess_t *pSess, gsssrv_t *pGSrv, char *pAllowedMethods) {
+    DEFiRet;
+    int fdSess;
+    struct sockaddr_storage peerAddr;
+    socklen_t peerAddrLen;
+    uchar *pszPeer = NULL;
+    int lenPeer = 0;
+    char allowedMethods = 0;
+
+    assert(pSess != NULL);
+    assert(pGSrv != NULL);
+    assert(pAllowedMethods != NULL);
+
+    peerAddrLen = sizeof(peerAddr);
+    CHKiRet(netstrm.GetSock(pSess->pStrm, &fdSess));
+    if (getpeername(fdSess, (struct sockaddr *)&peerAddr, &peerAddrLen) != 0) {
+        LogError(errno, RS_RET_ERR, "imgssapi: could not determine peer address during session accept");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    prop.GetString(pSess->fromHost, &pszPeer, &lenPeer);
+    if ((pGSrv->allowedMethods & ALLOWEDMETHOD_TCP) &&
+        net.isAllowedSender2((uchar *)"TCP", (struct sockaddr *)&peerAddr, (char *)pszPeer, 1))
+        allowedMethods |= ALLOWEDMETHOD_TCP;
+    if ((pGSrv->allowedMethods & ALLOWEDMETHOD_GSS) &&
+        net.isAllowedSender2((uchar *)"GSS", (struct sockaddr *)&peerAddr, (char *)pszPeer, 1))
+        allowedMethods |= ALLOWEDMETHOD_GSS;
+
+    *pAllowedMethods = allowedMethods;
+
+finalize_it:
+    RETiRet;
+}
+
+
 static rsRetVal onSessAccept(tcpsrv_t *pThis, tcps_sess_t *pSess, ATTR_UNUSED char *connInfo) {
     DEFiRet;
+    char allowedMethods;
     gsssrv_t *pGSrv;
+    gss_sess_t *pGSess;
 
     pGSrv = (gsssrv_t *)pThis->pUsr;
+    pGSess = (gss_sess_t *)pSess->pUsr;
+    assert(pGSess != NULL);
 
-    if (pGSrv->allowedMethods & ALLOWEDMETHOD_GSS) {
+    CHKiRet(getAllowedMethodsForSess(pSess, pGSrv, &allowedMethods));
+    if (allowedMethods == 0) ABORT_FINALIZE(RS_RET_HOST_NOT_PERMITTED);
+    pGSess->allowedMethods = allowedMethods;
+
+    if (allowedMethods & ALLOWEDMETHOD_GSS) {
         iRet = OnSessAcceptGSS(pThis, pSess);
     }
 
+finalize_it:
     RETiRet;
 }
 
@@ -334,10 +380,15 @@ static rsRetVal actGSSListener(uchar *port) {
     CHKiRet(tcpsrv.SetCBOnRegularClose(pOurTcpsrv, onRegularClose));
     CHKiRet(tcpsrv.SetCBOnErrClose(pOurTcpsrv, onErrClose));
     CHKiRet(tcpsrv.SetInputName(pOurTcpsrv, cnf_params, UCHAR_CONSTANT("imgssapi")));
+    CHKiRet(tcpsrv.SetNumWrkr(pOurTcpsrv, 1));
     CHKiRet(tcpsrv.SetKeepAlive(pOurTcpsrv, bKeepAlive));
+    CHKiRet(tcpsrv.SetSessMax(pOurTcpsrv, iTCPSessMax));
     CHKiRet(tcpsrv.SetOrigin(pOurTcpsrv, UCHAR_CONSTANT("imgssapi")));
     cnf_params->pszPort = port;
     cnf_params->bSuppOctetFram = 1;
+    if (pszLstnPortFileName != NULL) {
+        CHKmalloc(cnf_params->pszLstnPortFileName = ustrdup(pszLstnPortFileName));
+    }
     tcpsrv.configureTCPListen(pOurTcpsrv, cnf_params);
     CHKiRet(tcpsrv.ConstructFinalize(pOurTcpsrv));
     cnf_params = NULL;
@@ -385,16 +436,16 @@ static int TCPSessGSSInit(void) {
 /* returns 0 if all went OK, -1 if it failed
  * tries to guess if the connection uses gssapi.
  */
-static rsRetVal OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess) {
+static rsRetVal OnSessAcceptGSS(ATTR_UNUSED tcpsrv_t *pThis, tcps_sess_t *pSess) {
     DEFiRet;
-    gss_buffer_desc send_tok, recv_tok;
+    gss_buffer_desc send_tok = GSS_C_EMPTY_BUFFER;
+    gss_buffer_desc recv_tok = GSS_C_EMPTY_BUFFER;
     gss_name_t client;
     OM_uint32 maj_stat, min_stat, acc_sec_min_stat;
     gss_ctx_id_t *context;
     OM_uint32 *sess_flags;
     int fdSess;
     char allowedMethods;
-    gsssrv_t *pGSrv;
     gss_sess_t *pGSess;
     uchar *pszPeer = NULL;
     int lenPeer = 0;
@@ -402,9 +453,8 @@ static rsRetVal OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess) {
 
     assert(pSess != NULL);
 
-    pGSrv = (gsssrv_t *)pThis->pUsr;
     pGSess = (gss_sess_t *)pSess->pUsr;
-    allowedMethods = pGSrv->allowedMethods;
+    allowedMethods = pGSess->allowedMethods;
     if (allowedMethods & ALLOWEDMETHOD_GSS) {
         int ret = 0;
         const size_t bufsize = glbl.GetMaxLine(runConf);
@@ -416,7 +466,7 @@ static rsRetVal OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess) {
 
         CHKiRet(netstrm.GetSock(pSess->pStrm, &fdSess));  // TODO: method access!
         if (allowedMethods & ALLOWEDMETHOD_TCP) {
-            int len;
+            size_t hinted_len = 0;
             struct timeval tv;
 #ifdef USE_UNLIMITED_SELECT
             fd_set *pFds = malloc(glbl.GetFdSetSize());
@@ -485,8 +535,8 @@ static rsRetVal OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess) {
             }
 
             /* TODO: how does this work together with IPv6? Does it? */
-            len = ntohl((buf[0] << 24) | (buf[1] << 16) | (buf[2] << 8) | buf[3]);
-            if ((ret - 4) < len || len == 0) {
+            if (gssTokenDecodeLength((unsigned char *)buf, SIZE_MAX, &hinted_len) != RS_RET_OK ||
+                (size_t)(ret - 4) < hinted_len || hinted_len == 0) {
                 dbgprintf("GSS-API Reverting to plain TCP from %s\n", (char *)pszPeer);
                 pGSess->allowedMethods = ALLOWEDMETHOD_TCP;
                 ABORT_FINALIZE(RS_RET_OK);  // TODO: define good error codes
@@ -499,7 +549,7 @@ static rsRetVal OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess) {
         *context = GSS_C_NO_CONTEXT;
         sess_flags = &pGSess->gss_flags;
         do {
-            if (gssutil.recv_token(fdSess, &recv_tok) <= 0) {
+            if (gssutil.recv_token(fdSess, &recv_tok, GSS_TOKEN_MAX_HANDSHAKE_BYTES) <= 0) {
                 LogError(0, NO_ERRCODE,
                          "TCP session %p from %s will be "
                          "closed, error ignored\n",
@@ -516,20 +566,6 @@ static rsRetVal OnSessAcceptGSS(tcpsrv_t *pThis, tcps_sess_t *pSess) {
             if (maj_stat != GSS_S_COMPLETE && maj_stat != GSS_S_CONTINUE_NEEDED) {
                 gss_release_buffer(&min_stat, &send_tok);
                 if (*context != GSS_C_NO_CONTEXT) gss_delete_sec_context(&min_stat, context, GSS_C_NO_BUFFER);
-                if ((allowedMethods & ALLOWEDMETHOD_TCP) && (GSS_ROUTINE_ERROR(maj_stat) == GSS_S_DEFECTIVE_TOKEN)) {
-                    dbgprintf("GSS-API Reverting to plain TCP from %s\n", (char *)pszPeer);
-                    dbgprintf("tcp session socket with new data: #%d\n", fdSess);
-                    if (tcps_sess.DataRcvd(pSess, buf, ret) != RS_RET_OK) {
-                        LogError(0, NO_ERRCODE,
-                                 "Tearing down TCP "
-                                 "Session %p from %s - see previous messages "
-                                 "for reason(s)\n",
-                                 pSess, (char *)pszPeer);
-                        ABORT_FINALIZE(RS_RET_ERR);  // TODO: define good error codes
-                    }
-                    pGSess->allowedMethods = ALLOWEDMETHOD_TCP;
-                    ABORT_FINALIZE(RS_RET_OK);  // TODO: define good error codes
-                }
                 gssutil.display_status((char *)"accepting context", maj_stat, acc_sec_min_stat);
                 ABORT_FINALIZE(RS_RET_ERR);  // TODO: define good error codes
             }
@@ -571,7 +607,8 @@ finalize_it:
  */
 rsRetVal TCPSessGSSRecv(tcps_sess_t *pSess, void *buf, size_t buf_len, ssize_t *piLenRcvd) {
     DEFiRet;
-    gss_buffer_desc xmit_buf, msg_buf;
+    gss_buffer_desc xmit_buf = GSS_C_EMPTY_BUFFER;
+    gss_buffer_desc msg_buf = GSS_C_EMPTY_BUFFER;
     gss_ctx_id_t *context;
     OM_uint32 maj_stat, min_stat;
     int fdSess;
@@ -583,7 +620,7 @@ rsRetVal TCPSessGSSRecv(tcps_sess_t *pSess, void *buf, size_t buf_len, ssize_t *
     pGSess = (gss_sess_t *)pSess->pUsr;
 
     netstrm.GetSock(pSess->pStrm, &fdSess);  // TODO: method access, CHKiRet!
-    if (gssutil.recv_token(fdSess, &xmit_buf) <= 0) ABORT_FINALIZE(RS_RET_GSS_ERR);
+    if (gssutil.recv_token(fdSess, &xmit_buf, gssTokenGetMessageLimit(buf_len)) <= 0) ABORT_FINALIZE(RS_RET_GSS_ERR);
 
     context = &pGSess->gss_context;
     maj_stat = gss_unwrap(&min_stat, *context, &xmit_buf, &msg_buf, &conf_state, (gss_qop_t *)NULL);
@@ -600,7 +637,14 @@ rsRetVal TCPSessGSSRecv(tcps_sess_t *pSess, void *buf, size_t buf_len, ssize_t *
         xmit_buf.value = 0;
     }
 
-    *piLenRcvd = msg_buf.length < buf_len ? msg_buf.length : buf_len;
+    if (msg_buf.length > buf_len) {
+        LogError(0, NO_ERRCODE, "GSS-API message length %zu exceeds configured max message size %zu; closing session",
+                 (size_t)msg_buf.length, buf_len);
+        gss_release_buffer(&min_stat, &msg_buf);
+        ABORT_FINALIZE(RS_RET_GSS_ERR);
+    }
+
+    *piLenRcvd = msg_buf.length;
     memcpy(buf, msg_buf.value, *piLenRcvd);
     gss_release_buffer(&min_stat, &msg_buf);
 

--- a/plugins/omgssapi/Makefile.am
+++ b/plugins/omgssapi/Makefile.am
@@ -1,6 +1,6 @@
 pkglib_LTLIBRARIES = omgssapi.la
 
 omgssapi_la_SOURCES = omgssapi.c
-omgssapi_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+omgssapi_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(GSS_CFLAGS)
 omgssapi_la_LDFLAGS = -module -avoid-version
 omgssapi_la_LIBADD = $(GSS_LIBS)

--- a/plugins/omgssapi/omgssapi.c
+++ b/plugins/omgssapi/omgssapi.c
@@ -51,6 +51,7 @@
     #include "cfsysline.h"
     #include "module-template.h"
     #include "gss-misc.h"
+    #include "gss-token-util.h"
     #include "tcpclt.h"
     #include "glbl.h"
     #include "errmsg.h"
@@ -253,7 +254,7 @@ static rsRetVal TCPSendGSSInit(void *pvData) {
 
         if (maj_stat == GSS_S_CONTINUE_NEEDED) {
             dbgprintf("GSS-API Continue needed...\n");
-            if (gssutil.recv_token(s, &in_tok) <= 0) {
+            if (gssutil.recv_token(s, &in_tok, GSS_TOKEN_MAX_HANDSHAKE_BYTES) <= 0) {
                 goto fail;
             }
             tok_ptr = &in_tok;

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -301,8 +301,8 @@ endif
 #
 if ENABLE_GSSAPI
 pkglib_LTLIBRARIES += lmgssutil.la
-lmgssutil_la_SOURCES = gss-misc.c gss-misc.h
-lmgssutil_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS)
+lmgssutil_la_SOURCES = gss-misc.c gss-misc.h gss-token-util.h
+lmgssutil_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(GSS_CFLAGS)
 lmgssutil_la_LDFLAGS = -module -avoid-version
 lmgssutil_la_LIBADD = $(GSS_LIBS)
 endif

--- a/runtime/gss-misc.c
+++ b/runtime/gss-misc.c
@@ -47,6 +47,7 @@
 #include "obj.h"
 #include "errmsg.h"
 #include "gss-misc.h"
+#include "gss-token-util.h"
 #include "debug.h"
 #include "glbl.h"
 #include "unlimited_select.h"
@@ -94,10 +95,11 @@ static void display_ctx_flags(OM_uint32 flags) {
 }
 
 
-static int read_all(int fd, char *buf, unsigned int nbyte) {
-    int ret;
+static ssize_t read_all(int fd, char *buf, size_t nbyte) {
+    ssize_t ret;
     char *ptr;
     struct timeval tv;
+    const time_t deadline = time(NULL) + GSS_TOKEN_IO_TIMEOUT_SECS;
 #ifdef USE_UNLIMITED_SELECT
     fd_set *pRfds = malloc(glbl.GetFdSetSize());
 
@@ -108,12 +110,18 @@ static int read_all(int fd, char *buf, unsigned int nbyte) {
 #endif
 
     for (ptr = buf; nbyte; ptr += ret, nbyte -= ret) {
+        const time_t now = time(NULL);
+        if (now == (time_t)-1 || now >= deadline) {
+            errno = ETIMEDOUT;
+            freeFdSet(pRfds);
+            return -1;
+        }
         FD_ZERO(pRfds);
         FD_SET(fd, pRfds);
         tv.tv_sec = 1;
         tv.tv_usec = 0;
 
-        if ((ret = select(FD_SETSIZE, pRfds, NULL, NULL, &tv)) <= 0 || !FD_ISSET(fd, pRfds)) {
+        if ((ret = select(fd + 1, pRfds, NULL, NULL, &tv)) <= 0 || !FD_ISSET(fd, pRfds)) {
             freeFdSet(pRfds);
             return ret;
         }
@@ -151,10 +159,14 @@ static int write_all(int fd, char *buf, unsigned int nbyte) {
 }
 
 
-static int recv_token(int s, gss_buffer_t tok) {
-    int ret;
+static int recv_token(int s, gss_buffer_t tok, size_t max_tok_len) {
+    ssize_t ret;
     unsigned char lenbuf[4] = "xxx";  // initialized to make clang static analyzer happy
-    unsigned int len;
+    size_t len = 0;
+
+    assert(tok != NULL);
+    tok->length = 0;
+    tok->value = NULL;
 
     ret = read_all(s, (char *)lenbuf, 4);
     if (ret < 0) {
@@ -167,8 +179,11 @@ static int recv_token(int s, gss_buffer_t tok) {
         return -1;
     }
 
-    len = ((lenbuf[0] << 24) | (lenbuf[1] << 16) | (lenbuf[2] << 8) | lenbuf[3]);
-    tok->length = ntohl(len);
+    if (gssTokenDecodeLength(lenbuf, max_tok_len, &len) != RS_RET_OK) {
+        LogError(0, NO_ERRCODE, "GSS-API rejecting token length %zu that exceeds limit %zu", len, max_tok_len);
+        return -1;
+    }
+    tok->length = len;
 
     tok->value = (char *)malloc(tok->length ? tok->length : 1);
     if (tok->length && tok->value == NULL) {
@@ -181,7 +196,7 @@ static int recv_token(int s, gss_buffer_t tok) {
         LogError(0, NO_ERRCODE, "GSS-API error reading token data");
         free(tok->value);
         return -1;
-    } else if (ret != (int)tok->length) {
+    } else if ((size_t)ret != tok->length) {
         LogError(0, NO_ERRCODE, "GSS-API error reading token data");
         free(tok->value);
         return -1;
@@ -196,9 +211,10 @@ static int send_token(int s, gss_buffer_t tok) {
     unsigned char lenbuf[4];
     unsigned int len;
 
-    if (tok->length > 0xffffffffUL)
-        abort(); /* TODO: we need to reconsider this, abort() is not really
-               a solution - degrade, but keep running */
+    if (tok->length > 0xffffffffUL) {
+        LogError(0, NO_ERRCODE, "GSS-API token length %lu exceeds wire format limit", (unsigned long)tok->length);
+        return -1;
+    }
     len = htonl(tok->length);
     lenbuf[0] = (len >> 24) & 0xff;
     lenbuf[1] = (len >> 16) & 0xff;

--- a/runtime/gss-misc.h
+++ b/runtime/gss-misc.h
@@ -22,17 +22,18 @@
 #ifndef GSS_MISC_H_INCLUDED
 #define GSS_MISC_H_INCLUDED 1
 
+#include <stddef.h>
 #include <gssapi/gssapi.h>
 #include "obj.h"
 
 /* interfaces */
 BEGINinterface(gssutil) /* name must also be changed in ENDinterface macro! */
-    int (*recv_token)(int s, gss_buffer_t tok);
+    int (*recv_token)(int s, gss_buffer_t tok, size_t max_tok_len);
     int (*send_token)(int s, gss_buffer_t tok);
     void (*display_status)(char *m, OM_uint32 maj_stat, OM_uint32 min_stat);
     void (*display_ctx_flags)(OM_uint32 flags);
 ENDinterface(gssutil)
-#define gssutilCURR_IF_VERSION 1 /* increment whenever you change the interface structure! */
+#define gssutilCURR_IF_VERSION 2 /* increment whenever you change the interface structure! */
 
 
 /* prototypes */

--- a/runtime/gss-token-util.h
+++ b/runtime/gss-token-util.h
@@ -1,0 +1,94 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/* gss-token-util.h
+ *
+ * Copyright 2026 Rainer Gerhards and Adiscon GmbH.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#ifndef GSS_TOKEN_UTIL_H_INCLUDED
+#define GSS_TOKEN_UTIL_H_INCLUDED 1
+
+/**
+ * @file gss-token-util.h
+ * @brief Shared helpers for bounded GSS token framing in rsyslog.
+ *
+ * This header centralizes small, header-only helpers that validate GSS wire
+ * framing and derive conservative token-size limits. It exists so the common
+ * GSS runtime helper and both GSS modules use the same length-decoding and
+ * size-bound logic instead of open-coding slightly different checks.
+ *
+ * Current users include:
+ * - `runtime/gss-misc.c` for framed token receive time/size enforcement
+ * - `plugins/imgssapi/imgssapi.c` for server-side handshake/message limits
+ * - `plugins/omgssapi/omgssapi.c` for client-side handshake limits
+ */
+
+#include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "rsyslog.h"
+
+#define GSS_TOKEN_MAX_HANDSHAKE_BYTES (1024U * 1024U)
+#define GSS_TOKEN_MAX_WRAP_OVERHEAD_BYTES (64U * 1024U)
+#define GSS_TOKEN_IO_TIMEOUT_SECS 10U
+
+/**
+ * @brief Decode a 4-byte GSS wire length field and validate it against a limit.
+ *
+ * GSS token framing in rsyslog uses a fixed 4-byte network-order length prefix.
+ * Callers use this helper before allocating buffers or attempting to read token
+ * bodies from the peer.
+ *
+ * @param[in]  lenbuf     Four bytes containing the network-order token length.
+ * @param[in]  max_len    Maximum token size the caller is willing to accept.
+ * @param[out] token_len  Decoded token length on success.
+ *
+ * @retval RS_RET_OK              Length decoded and within @p max_len.
+ * @retval RS_RET_INVALID_PARAMS  @p token_len is NULL.
+ * @retval RS_RET_INVALID_VALUE   Decoded length exceeds @p max_len.
+ */
+static inline rsRetVal gssTokenDecodeLength(const unsigned char lenbuf[4], size_t max_len, size_t *const token_len) {
+    const uint32_t wire_len =
+        ((uint32_t)lenbuf[0] << 24) | ((uint32_t)lenbuf[1] << 16) | ((uint32_t)lenbuf[2] << 8) | (uint32_t)lenbuf[3];
+
+    if (token_len == NULL) {
+        return RS_RET_INVALID_PARAMS;
+    }
+
+    *token_len = (size_t)wire_len;
+    if ((size_t)wire_len > max_len) {
+        return RS_RET_INVALID_VALUE;
+    }
+
+    return RS_RET_OK;
+}
+
+/**
+ * @brief Derive a safe wrapped-token size limit from a plaintext message limit.
+ *
+ * Wrapped GSS messages carry protocol overhead beyond the unwrapped syslog
+ * payload. Receivers use this helper to cap the framed token size while still
+ * accepting valid wrapped messages for a given plaintext maximum.
+ *
+ * @param[in] max_plaintext_len  Maximum accepted plaintext message length.
+ *
+ * @return The wrapped-token limit derived from @p max_plaintext_len. If adding
+ *         the configured overhead would overflow `size_t`, `SIZE_MAX` is
+ *         returned instead.
+ */
+static inline size_t gssTokenGetMessageLimit(size_t max_plaintext_len) {
+    if (max_plaintext_len > SIZE_MAX - GSS_TOKEN_MAX_WRAP_OVERHEAD_BYTES) {
+        return SIZE_MAX;
+    }
+
+    return max_plaintext_len + GSS_TOKEN_MAX_WRAP_OVERHEAD_BYTES;
+}
+
+#endif

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -704,6 +704,7 @@ finalize_it:
 static ATTR_NONNULL() rsRetVal SessAccept(tcpsrv_t *const pThis,
                                           tcpLstnPortList_t *const pLstnInfo,
                                           tcps_sess_t **ppSess,
+                                          int *const piSessIdx,
                                           netstrm_t *pStrm,
                                           char *const connInfo) {
     DEFiRet;
@@ -721,6 +722,7 @@ static ATTR_NONNULL() rsRetVal SessAccept(tcpsrv_t *const pThis,
 
     ISOBJ_TYPE_assert(pThis, tcpsrv);
     assert(pLstnInfo != NULL);
+    assert(piSessIdx != NULL);
 
     CHKiRet(netstrm.AcceptConnReq(pStrm, &pNewStrm, connInfo));
 
@@ -815,9 +817,8 @@ static ATTR_NONNULL() rsRetVal SessAccept(tcpsrv_t *const pThis,
     }
 
     *ppSess = pSess;
-#if !defined(ENABLE_IMTCP_EPOLL)
     pThis->pSessions[iSess] = pSess;
-#endif
+    *piSessIdx = iSess;
     pSess = NULL; /* this is now also handed over */
 
     if (pThis->bEmitMsgOnOpen) {
@@ -884,12 +885,11 @@ static ATTR_NONNULL() rsRetVal closeSess(tcpsrv_t *const pThis, tcpsrv_io_descr_
     pThis->pOnRegularClose(pSess);
 
     tcps_sess.Destruct(&pSess);
+    pThis->pSessions[pioDescr->id] = NULL;
 #if defined(ENABLE_IMTCP_EPOLL)
     /* in epoll mode, pioDescr is dynamically allocated */
     DESTROY_ATOMIC_HELPER_MUT(pioDescr->mut_isInError);
     free(pioDescr);
-#else
-    pThis->pSessions[pioDescr->id] = NULL;
 #endif
     RETiRet;
 }
@@ -1103,12 +1103,13 @@ static rsRetVal ATTR_NONNULL(1) doSingleAccept(tcpsrv_io_descr_t *const pioDescr
     tcps_sess_t *pNewSess = NULL;
     tcpsrv_io_descr_t *pDescrNew = NULL;
     const int idx = pioDescr->id;
+    int iSess = -1;
     tcpsrv_t *const pThis = pioDescr->pSrv;
     char connInfo[TCPSRV_CONNINFO_SIZE] = "\0";
     DEFiRet;
 
     DBGPRINTF("New connect on NSD %p.\n", pThis->ppLstn[idx]);
-    iRet = SessAccept(pThis, pThis->ppLstnPort[idx], &pNewSess, pThis->ppLstn[idx], connInfo);
+    iRet = SessAccept(pThis, pThis->ppLstnPort[idx], &pNewSess, &iSess, pThis->ppLstn[idx], connInfo);
     if (iRet == RS_RET_NO_MORE_DATA) {
         goto no_more_data;
     }
@@ -1118,7 +1119,7 @@ static rsRetVal ATTR_NONNULL(1) doSingleAccept(tcpsrv_io_descr_t *const pioDescr
         /* pDescrNew is only dyn allocated in epoll mode! */
         CHKmalloc(pDescrNew = (tcpsrv_io_descr_t *)calloc(1, sizeof(tcpsrv_io_descr_t)));
         pDescrNew->pSrv = pThis;
-        pDescrNew->id = idx;
+        pDescrNew->id = iSess;
         pDescrNew->isInError = 0;
         INIT_ATOMIC_HELPER_MUT(pDescrNew->mut_isInError);
         pDescrNew->ptrType = NSD_PTR_TYPE_SESS;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,13 @@ EXTRA_DIST = \
 TESTS_JSON_OMITIFZERO = json-omitifzero.sh json-omitifzero-subtree.sh json-whitespace.sh
 EXTRA_DIST += $(TESTS_JSON_OMITIFZERO)
 
+TESTS_GSSAPI = \
+	imgssapi-listen-port-file.sh \
+	imgssapi-maxsessions.sh
+TESTS_GSSAPI_LIBYAML = \
+	imgssapi-yaml-include-listen-port-file.sh
+EXTRA_DIST += $(TESTS_GSSAPI) $(TESTS_GSSAPI_LIBYAML) unit/gss_token_util_test.c
+
 TESTS_IMPTCP_TABESCAPE = \
 	tabescape_dflt.sh \
 	tabescape_dflt-udp.sh \
@@ -1948,6 +1955,18 @@ runtime_unit_linkedlist_SOURCES = \
 runtime_unit_stringbuf_SOURCES = \
 	unit/stringbuf_test.c
 
+if ENABLE_GSSAPI
+check_PROGRAMS += runtime_unit_gss_token_util
+TESTS += runtime_unit_gss_token_util
+
+runtime_unit_gss_token_util_SOURCES = \
+	unit/gss_token_util_test.c
+
+runtime_unit_gss_token_util_CPPFLAGS = \
+	$(runtime_unit_linkedlist_CPPFLAGS)
+runtime_unit_gss_token_util_LDADD = $(PTHREADS_LIBS) $(SOL_LIBS)
+endif
+
 runtime_unit_linkedlist_CPPFLAGS = \
 	-DSD_EXPORT_SYMBOLS \
 	-D_PATH_MODDIR=\"$(pkglibdir)/\" \
@@ -1990,6 +2009,13 @@ check_PROGRAMS += journal_print
 endif
 endif # if ENABLE_JOURNAL_TESTS
 TESTS += $(TESTRUNS)
+
+if ENABLE_GSSAPI
+TESTS += $(TESTS_GSSAPI)
+if HAVE_LIBYAML
+TESTS += $(TESTS_GSSAPI_LIBYAML)
+endif # HAVE_LIBYAML
+endif
 
 
 

--- a/tests/imgssapi-listen-port-file.sh
+++ b/tests/imgssapi-listen-port-file.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Verify that imgssapi forwards listenPortFileName to tcpsrv and can accept
+# plain TCP when explicitly permitted.
+. ${srcdir:=.}/diag.sh init
+require_plugin imgssapi
+
+count_imgssapi_msgs() {
+	if [ -f "$RSYSLOG_DYNNAME.msgs.log" ]; then
+		grep -c 'msgnum:' "$RSYSLOG_DYNNAME.msgs.log"
+	else
+		echo 0
+	fi
+}
+
+wait_imgssapi_msgs() {
+	wait_file_lines --count-function count_imgssapi_msgs "$RSYSLOG_DYNNAME.msgs.log" 10
+}
+
+export QUEUE_EMPTY_CHECK_FUNC=wait_imgssapi_msgs
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../plugins/imgssapi/.libs/imgssapi")
+$InputGSSServerPermitPlainTCP on
+$InputGSSListenPortFileName '$RSYSLOG_DYNNAME'.gss_port
+$InputGSSServerRun 0
+action(type="omfile" file="'$RSYSLOG_DYNNAME'.msgs.log" template="outfmt")
+'
+startup
+
+assign_file_content GSS_PORT "$RSYSLOG_DYNNAME.gss_port"
+if [ -z "$GSS_PORT" ] || [ "$GSS_PORT" = "0" ]; then
+	echo "FAIL: expected dynamic GSS port file to contain a bound port, got '$GSS_PORT'"
+	exit 1
+fi
+
+export TCPFLOOD_PORT="$GSS_PORT"
+tcpflood -m10 -i1
+shutdown_when_empty
+wait_shutdown
+
+content_count_check "msgnum:" 10 "$RSYSLOG_DYNNAME.msgs.log"
+exit_test

--- a/tests/imgssapi-maxsessions.sh
+++ b/tests/imgssapi-maxsessions.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Verify that imgssapi forwards its configured max session count to tcpsrv.
+. ${srcdir:=.}/diag.sh init
+require_plugin imgssapi
+skip_platform "FreeBSD" "This test currently does not work on FreeBSD"
+
+export NUMMESSAGES=500
+MAXSESSIONS=10
+CONNECTIONS=20
+EXPECTED_DROPS=$((CONNECTIONS - MAXSESSIONS))
+MIN_EXPECTED_DROPS=$((EXPECTED_DROPS - 2))
+EXPECTED_STR='too many tcp sessions - dropping incoming request'
+
+wait_too_many_sessions()
+{
+	local count
+	count=$(grep "$EXPECTED_STR" "$RSYSLOG_OUT_LOG" | wc -l)
+	test "$count" -ge "$MIN_EXPECTED_DROPS" && test "$count" -le "$EXPECTED_DROPS"
+}
+
+export QUEUE_EMPTY_CHECK_FUNC=wait_too_many_sessions
+
+generate_conf
+add_conf '
+$MaxMessageSize 10k
+module(load="../plugins/imgssapi/.libs/imgssapi")
+$InputGSSServerPermitPlainTCP on
+$InputGSSListenPortFileName '$RSYSLOG_DYNNAME'.gss_port
+$InputGSSServerMaxSessions '$MAXSESSIONS'
+$InputGSSServerRun 0
+action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
+'
+startup
+
+assign_file_content GSS_PORT "$RSYSLOG_DYNNAME.gss_port"
+export TCPFLOOD_PORT="$GSS_PORT"
+tcpflood -c"$CONNECTIONS" -m"$NUMMESSAGES" -r -d100 -P129 -A
+
+shutdown_when_empty
+wait_shutdown
+
+count=$(grep "$EXPECTED_STR" "$RSYSLOG_OUT_LOG" | wc -l)
+if [ "$count" -lt "$MIN_EXPECTED_DROPS" ] || [ "$count" -gt "$EXPECTED_DROPS" ]; then
+	echo "FAIL: expected between $MIN_EXPECTED_DROPS and $EXPECTED_DROPS dropped sessions, got $count"
+	exit 1
+fi
+exit_test

--- a/tests/imgssapi-yaml-include-listen-port-file.sh
+++ b/tests/imgssapi-yaml-include-listen-port-file.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Verify that a YAML top-level config can include legacy imgssapi directives
+# and still exercise the listenPortFileName forwarding path.
+. ${srcdir:=.}/diag.sh init
+require_plugin imgssapi
+
+count_imgssapi_msgs() {
+	if [ -f "$RSYSLOG_DYNNAME.msgs.log" ]; then
+		grep -c 'msgnum:' "$RSYSLOG_DYNNAME.msgs.log"
+	else
+		echo 0
+	fi
+}
+
+wait_imgssapi_msgs() {
+	wait_file_lines --count-function count_imgssapi_msgs "$RSYSLOG_DYNNAME.msgs.log" 10
+}
+
+export QUEUE_EMPTY_CHECK_FUNC=wait_imgssapi_msgs
+
+generate_conf --yaml-only
+
+cat > "${RSYSLOG_DYNNAME}_imgssapi.conf" << EOF
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../plugins/imgssapi/.libs/imgssapi")
+\$InputGSSServerPermitPlainTCP on
+\$InputGSSListenPortFileName ${RSYSLOG_DYNNAME}.gss_port
+\$InputGSSServerRun 0
+action(type="omfile" file="${RSYSLOG_DYNNAME}.msgs.log" template="outfmt")
+EOF
+
+add_yaml_conf 'include:'
+add_yaml_conf '  - path: "'${RSYSLOG_DYNNAME}'_imgssapi.conf"'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_imdiag_input
+
+startup
+
+assign_file_content GSS_PORT "$RSYSLOG_DYNNAME.gss_port"
+if [ -z "$GSS_PORT" ] || [ "$GSS_PORT" = "0" ]; then
+	echo "FAIL: expected dynamic GSS port file to contain a bound port, got '$GSS_PORT'"
+	exit 1
+fi
+
+export TCPFLOOD_PORT="$GSS_PORT"
+tcpflood -m10 -i1
+shutdown_when_empty
+wait_shutdown
+
+content_count_check "msgnum:" 10 "$RSYSLOG_DYNNAME.msgs.log"
+exit_test

--- a/tests/unit/gss_token_util_test.c
+++ b/tests/unit/gss_token_util_test.c
@@ -1,0 +1,78 @@
+#include "config.h"
+
+#include <limits.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#include "rsyslog.h"
+#include "gss-token-util.h"
+
+#define CHECK(cond)                                                                  \
+    do {                                                                             \
+        if (!(cond)) {                                                               \
+            fprintf(stderr, "%s:%d: check failed: %s\n", __FILE__, __LINE__, #cond); \
+            return 1;                                                                \
+        }                                                                            \
+    } while (0)
+
+static int test_decode_length_accepts_small_frame(void) {
+    static const unsigned char lenbuf[4] = {0x00, 0x00, 0x01, 0x00};
+    size_t token_len = 0;
+
+    CHECK(gssTokenDecodeLength(lenbuf, 512, &token_len) == RS_RET_OK);
+    CHECK(token_len == 256);
+
+    return 0;
+}
+
+static int test_decode_length_rejects_oversize_frame(void) {
+    static const unsigned char lenbuf[4] = {0x00, 0x10, 0x00, 0x00};
+    size_t token_len = 0;
+
+    CHECK(gssTokenDecodeLength(lenbuf, 4096, &token_len) == RS_RET_INVALID_VALUE);
+    CHECK(token_len == 0x00100000U);
+
+    return 0;
+}
+
+static int test_decode_length_rejects_null_output_pointer(void) {
+    static const unsigned char lenbuf[4] = {0x00, 0x00, 0x00, 0x01};
+
+    CHECK(gssTokenDecodeLength(lenbuf, 1, NULL) == RS_RET_INVALID_PARAMS);
+    return 0;
+}
+
+static int test_message_limit_adds_wrap_overhead(void) {
+    CHECK(gssTokenGetMessageLimit(4096) == 4096 + GSS_TOKEN_MAX_WRAP_OVERHEAD_BYTES);
+    return 0;
+}
+
+static int test_message_limit_saturates_on_overflow(void) {
+    CHECK(gssTokenGetMessageLimit(SIZE_MAX) == SIZE_MAX);
+    CHECK(gssTokenGetMessageLimit(SIZE_MAX - 1) == SIZE_MAX);
+    return 0;
+}
+
+int main(void) {
+    struct {
+        const char *name;
+        int (*fn)(void);
+    } tests[] = {
+        {"decode_length_accepts_small_frame", test_decode_length_accepts_small_frame},
+        {"decode_length_rejects_oversize_frame", test_decode_length_rejects_oversize_frame},
+        {"decode_length_rejects_null_output_pointer", test_decode_length_rejects_null_output_pointer},
+        {"message_limit_adds_wrap_overhead", test_message_limit_adds_wrap_overhead},
+        {"message_limit_saturates_on_overflow", test_message_limit_saturates_on_overflow},
+    };
+    size_t i;
+
+    for (i = 0; i < sizeof(tests) / sizeof(tests[0]); ++i) {
+        if (tests[i].fn() != 0) {
+            fprintf(stderr, "FAILED: %s\n", tests[i].name);
+            return 1;
+        }
+    }
+
+    printf("gss token util tests passed (%zu cases)\n", sizeof(tests) / sizeof(tests[0]));
+    return 0;
+}


### PR DESCRIPTION
The GSSAPI helper and imgssapi paths benefit from more defensive framing, clearer shared limits, and better coverage for longstanding listener configuration behavior.

Impact
GSS token processing is more robust, and imgssapi now honors its existing max-sessions and dynamic port file settings as documented.

Before/After
Before, token framing checks were less consistent across the GSS helper and modules, and imgssapi silently ignored some listener settings. After, framing logic is centralized and bounded, and the documented listener settings take effect.

Technical Overview
Add shared helpers for decoding framed GSS token lengths and deriving bounded message limits for wrapped payloads.

Update gss-misc to apply token-size limits, use a whole-token timeout, use the correct select() nfds value, and return an error instead of aborting on oversized outbound tokens.

Update imgssapi and omgssapi to use the bounded recv_token() interface. Keep the imgssapi listener and receive-path cleanup, including the size_t token-length check and the tcpsrv wiring for existing settings.

Add focused tests for listener port-file and session-limit handling, plus YAML include coverage for the legacy imgssapi configuration path and a unit test for the shared token helpers.

With the help of AI-Agents: Codex

