### PR TITLE
hardening: stabilize imgssapi maxsessions CI check

### DIFF
--- a/tests/imgssapi-maxsessions.sh
+++ b/tests/imgssapi-maxsessions.sh
@@ -23,17 +23,16 @@ count_dropped_sessions()
 
 wait_for_drop_logs()
 {
-	local tries=${1:-15}
-	local count
-	local i=1
+	wait_tries=${1:-15}
+	wait_i=1
 
-	while [ "$i" -le "$tries" ]; do
+	while [ "$wait_i" -le "$wait_tries" ]; do
 		count=$(count_dropped_sessions)
 		if [ "$count" -ge "$MIN_EXPECTED_DROPS" ] && [ "$count" -le "$EXPECTED_DROPS" ]; then
 			return 0
 		fi
 		$TESTTOOL_DIR/msleep 1000
-		i=$((i + 1))
+		wait_i=$((wait_i + 1))
 	done
 
 	return 1

--- a/tests/imgssapi-maxsessions.sh
+++ b/tests/imgssapi-maxsessions.sh
@@ -25,13 +25,15 @@ wait_for_drop_logs()
 {
 	local tries=${1:-15}
 	local count
+	local i=1
 
-	for ((i = 1; i <= tries; ++i)); do
+	while [ "$i" -le "$tries" ]; do
 		count=$(count_dropped_sessions)
 		if [ "$count" -ge "$MIN_EXPECTED_DROPS" ] && [ "$count" -le "$EXPECTED_DROPS" ]; then
 			return 0
 		fi
 		$TESTTOOL_DIR/msleep 1000
+		i=$((i + 1))
 	done
 
 	return 1

--- a/tests/imgssapi-maxsessions.sh
+++ b/tests/imgssapi-maxsessions.sh
@@ -10,15 +10,32 @@ CONNECTIONS=20
 EXPECTED_DROPS=$((CONNECTIONS - MAXSESSIONS))
 MIN_EXPECTED_DROPS=$((EXPECTED_DROPS - 2))
 EXPECTED_STR='too many tcp sessions - dropping incoming request'
+STARTED_LOG="${RSYSLOG_DYNNAME}.started"
 
-wait_too_many_sessions()
+count_dropped_sessions()
 {
-	local count
-	count=$(grep "$EXPECTED_STR" "$RSYSLOG_OUT_LOG" | wc -l)
-	test "$count" -ge "$MIN_EXPECTED_DROPS" && test "$count" -le "$EXPECTED_DROPS"
+	if [ -f "$STARTED_LOG" ]; then
+		grep -F -c -- "$EXPECTED_STR" "$STARTED_LOG" || true
+	else
+		printf '0\n'
+	fi
 }
 
-export QUEUE_EMPTY_CHECK_FUNC=wait_too_many_sessions
+wait_for_drop_logs()
+{
+	local tries=${1:-15}
+	local count
+
+	for ((i = 1; i <= tries; ++i)); do
+		count=$(count_dropped_sessions)
+		if [ "$count" -ge "$MIN_EXPECTED_DROPS" ] && [ "$count" -le "$EXPECTED_DROPS" ]; then
+			return 0
+		fi
+		$TESTTOOL_DIR/msleep 1000
+	done
+
+	return 1
+}
 
 generate_conf
 add_conf '
@@ -36,12 +53,18 @@ assign_file_content GSS_PORT "$RSYSLOG_DYNNAME.gss_port"
 export TCPFLOOD_PORT="$GSS_PORT"
 tcpflood -c"$CONNECTIONS" -m"$NUMMESSAGES" -r -d100 -P129 -A
 
+# Wait briefly for rsyslog's own session-drop diagnostics to land, but do not
+# hold shutdown open on an exact drop count. That makes the test hang on slow
+# coverage runners even when the main queue is already empty.
+wait_for_drop_logs 15 || true
 shutdown_when_empty
 wait_shutdown
 
-count=$(grep "$EXPECTED_STR" "$RSYSLOG_OUT_LOG" | wc -l)
+count=$(count_dropped_sessions)
 if [ "$count" -lt "$MIN_EXPECTED_DROPS" ] || [ "$count" -gt "$EXPECTED_DROPS" ]; then
 	echo "FAIL: expected between $MIN_EXPECTED_DROPS and $EXPECTED_DROPS dropped sessions, got $count"
+	echo "STARTED_LOG contents:"
+	cat "$STARTED_LOG"
 	exit 1
 fi
 exit_test


### PR DESCRIPTION
Why
`codecov base CI` intermittently hangs in `imgssapi-maxsessions.sh` and
forces unrelated PRs through repeated reruns.

What changed
- count the expected session-drop diagnostics from `${RSYSLOG_DYNNAME}.started`
  instead of the main output log
- remove the `QUEUE_EMPTY_CHECK_FUNC` shutdown dependency from the test
- add a short bounded settle wait before shutdown
- keep the final acceptable drop-count range assertion and dump the started log
  on failure

Validation
- `make -j$(nproc) check TESTS=""`
- `./tests/imgssapi-maxsessions.sh`
- `for i in 1 2 3 4 5; do ./tests/imgssapi-maxsessions.sh; done`

Notes
This is a side patch to stabilize the flaky CI lane, not a functional change
to `imgssapi` itself.
