### PR TITLE
doc: clarify severity-aware shared ratelimit use

### DIFF
--- a/doc/source/configuration/modules/imjournal.rst
+++ b/doc/source/configuration/modules/imjournal.rst
@@ -38,6 +38,11 @@ activated and permits the processing of 20,000 messages within 10
 minutes, which should be sufficient for most use cases. If insufficient,
 use the parameters described below to adjust the permitted volume.
 
+If you need severity-aware throttling similar to ``imuxsock``, use a shared
+``ratelimit()`` object together with ``RateLimit.Name``. ``imjournal`` derives
+the severity from the journal ``PRIORITY`` field and falls back to
+``DefaultSeverity`` when the field is missing or invalid.
+
 
 Notable Features
 ================

--- a/doc/source/rainerscript/configuration_objects/ratelimit.rst
+++ b/doc/source/rainerscript/configuration_objects/ratelimit.rst
@@ -51,6 +51,26 @@ burst
 
 The maximum number of messages allowed within the ``interval``.
 
+.. _ratelimit_severity:
+
+severity
+^^^^^^^^
+
+.. csv-table::
+   :header: "type", "required", "default"
+   :widths: 20, 10, 20
+
+   "severity", "no", "0"
+
+Only messages with a syslog severity numerically greater than or equal to this
+threshold are subject to rate limiting. Lower numeric severities remain
+unlimited.
+
+This is useful when a shared policy should throttle verbose traffic such as
+``info`` or ``debug`` while leaving more urgent messages untouched. Modules that
+derive severity from input metadata, such as ``imjournal``, can use the same
+shared policy without a module-specific severity knob.
+
 .. _ratelimit_policywatch:
 
 policyWatch
@@ -170,6 +190,12 @@ Example
    # Define a strict rate limit for public facing ports
    ratelimit(name="strict" interval="1" burst="50")
 
+   # Rate-limit only lower-priority journal traffic
+   ratelimit(name="journal_lowprio"
+             interval="600"
+             burst="20000"
+             severity="info")
+
    # Define a watched YAML policy for automatic reload
    ratelimit(name="watched"
              policy="/etc/rsyslog/ratelimit.yaml"
@@ -190,6 +216,9 @@ Example
 
    # Apply per-source limits to a TCP listener
    input(type="imtcp" port="10516" rateLimit.Name="per_source")
+
+   # Apply a severity-aware shared policy to the journal reader
+   module(load="imjournal" rateLimit.Name="journal_lowprio")
 
 Per-source key examples
 -----------------------


### PR DESCRIPTION
## Summary

Clarify that issue #4432 was fixed through the shared `ratelimit()` design rather than by adding an `imjournal`-specific severity parameter.

## What Changed

- document the `severity` parameter on the shared `ratelimit()` object
- add an example showing `imjournal` with `RateLimit.Name`
- clarify in the `imjournal` module docs that severity comes from journal `PRIORITY` and falls back to `DefaultSeverity`

## Why

The implementation is already on `main`, but the user-facing docs did not make the supported configuration path obvious.

## Validation

- `./doc/tools/build-doc-linux.sh --clean --format html`

Ref https://github.com/rsyslog/rsyslog/issues/4432