### PR TITLE
hardening: imczmq config checks and CI deps

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -935,6 +935,7 @@ jobs:
             libcap-ng0 \
             libcurl4-gnutls-dev \
             libdbi-dev \
+            libevent-dev \
             libgcrypt20-dev \
             libglib2.0-dev \
             libgnutls28-dev \

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -90,6 +90,7 @@ struct listener_t {
 static zlist_t *listenerList;
 static modConfData_t *runModConf = NULL;
 static prop_t *s_namep = NULL;
+enum { IMCZMQ_MAX_TOPIC_LEN = 255 };
 
 static struct cnfparamdescr inppdescr[] = {
     {"endpoints", eCmdHdlrGetWord, 1},
@@ -111,6 +112,34 @@ static void setDefaults(instanceConf_t *iconf) {
     iconf->pBindRuleset = NULL;
     iconf->next = NULL;
 };
+
+static rsRetVal validateTopics(const char *topics) {
+    DEFiRet;
+    const char *cursor;
+
+    if (topics == NULL) {
+        FINALIZE;
+    }
+
+    for (cursor = topics; *cursor != '\0';) {
+        const char *delimiter = strchr(cursor, ',');
+        const size_t topic_len = (delimiter == NULL) ? strlen(cursor) : (size_t)(delimiter - cursor);
+
+        if (topic_len > IMCZMQ_MAX_TOPIC_LEN) {
+            LogError(0, RS_RET_PARAM_ERROR, "imczmq: configured topic exceeds maximum supported length of %u bytes",
+                     (unsigned)IMCZMQ_MAX_TOPIC_LEN);
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+
+        if (delimiter == NULL) {
+            break;
+        }
+        cursor = delimiter + 1;
+    }
+
+finalize_it:
+    RETiRet;
+}
 
 /**
  * @brief Allocate a new listener configuration block.
@@ -228,20 +257,22 @@ static rsRetVal addListener(instanceConf_t *iconf) {
     }
 
     if (iconf->topics) {
+        const char *topic_cursor = iconf->topics;
         // A zero-length topic means subscribe to everything
-        if (!*iconf->topics && iconf->sockType == ZMQ_SUB) {
+        if (!*topic_cursor && iconf->sockType == ZMQ_SUB) {
             DBGPRINTF("imczmq: subscribing to all topics\n");
             zsock_set_subscribe(pData->sock, "");
         }
 
-        char topic[256];
-        while (*iconf->topics) {
-            char *delimiter = strchr(iconf->topics, ',');
+        char topic[IMCZMQ_MAX_TOPIC_LEN + 1];
+        while (*topic_cursor) {
+            const char *delimiter = strchr(topic_cursor, ',');
+            const size_t topic_len = (delimiter == NULL) ? strlen(topic_cursor) : (size_t)(delimiter - topic_cursor);
             if (!delimiter) {
-                delimiter = iconf->topics + strlen(iconf->topics);
+                delimiter = topic_cursor + topic_len;
             }
-            memcpy(topic, iconf->topics, delimiter - iconf->topics);
-            topic[delimiter - iconf->topics] = 0;
+            memcpy(topic, topic_cursor, topic_len);
+            topic[topic_len] = 0;
             DBGPRINTF("imczmq: subscribing to %s\n", topic);
             if (iconf->sockType == ZMQ_SUB) {
                 zsock_set_subscribe(pData->sock, topic);
@@ -259,7 +290,7 @@ static rsRetVal addListener(instanceConf_t *iconf) {
             if (*delimiter == 0) {
                 break;
             }
-            iconf->topics = delimiter + 1;
+            topic_cursor = delimiter + 1;
         }
     }
 
@@ -541,6 +572,7 @@ BEGINfreeCnf
     for (inst = pModConf->root; inst != NULL;) {
         free(inst->pszBindRuleset);
         free(inst->sockEndpoints);
+        free(inst->topics);
         inst_r = inst;
         inst = inst->next;
         free(inst_r);
@@ -575,11 +607,12 @@ BEGINnewInpInst
         }
 
         if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "endpoints")) {
-            inst->sockEndpoints = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->sockEndpoints = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "topics")) {
-            inst->topics = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->topics = es_str2cstr(pvals[i].val.d.estr, NULL));
+            CHKiRet(validateTopics(inst->topics));
         } else if (!strcmp(inppblk.descr[i].name, "socktype")) {
             char *stringType = es_str2cstr(pvals[i].val.d.estr, NULL);
             if (NULL == stringType) {
@@ -612,6 +645,11 @@ BEGINnewInpInst
                 inst->sockType = ZMQ_SERVER;
             }
 #endif
+            else {
+                LogError(0, RS_RET_CONFIG_ERROR, "imczmq: invalid socktype '%s'", stringType);
+                free(stringType);
+                ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
+            }
             free(stringType);
 
         } else {

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -646,6 +646,7 @@ BEGINnewInpInst
             }
 #endif
             else {
+                /* Config parsing should never accept unknown socktypes; fail closed if it does. */
                 LogError(0, RS_RET_CONFIG_ERROR, "imczmq: invalid socktype '%s'", stringType);
                 free(stringType);
                 ABORT_FINALIZE(RS_RET_CONFIG_ERROR);

--- a/contrib/imdocker/imdocker.c
+++ b/contrib/imdocker/imdocker.c
@@ -1734,13 +1734,20 @@ BEGINrunInput
     docker_cont_log_instances_t *pInstances = NULL;
     pthread_t thrd_id; /* the worker's thread ID */
     pthread_attr_t thrd_attr;
+    CURLcode curlRet;
+    int curl_initialized = 0;
     int get_containers_thread_initialized = 0;
     time_t now;
     CODESTARTrunInput;
     datetime.GetTime(&now);
 
     CHKiRet(ratelimitNew(&ratelimiter, "imdocker", NULL));
-    curl_global_init(CURL_GLOBAL_ALL);
+    curlRet = curl_global_init(CURL_GLOBAL_ALL);
+    if (curlRet != CURLE_OK) {
+        LogError(0, RS_RET_OBJ_CREATION_FAILED, "imdocker: curl_global_init failed: %s", curl_easy_strerror(curlRet));
+        ABORT_FINALIZE(RS_RET_OBJ_CREATION_FAILED);
+    }
+    curl_initialized = 1;
     localRet = dockerContLogReqsNew(&pInstances);
     if (localRet != RS_RET_OK) {
         return localRet;
@@ -1771,8 +1778,12 @@ finalize_it:
     if (pInstances) {
         dockerContLogReqsDestruct(pInstances);
     }
+    if (curl_initialized) {
+        curl_global_cleanup();
+    }
     if (ratelimiter) {
         ratelimitDestruct(ratelimiter);
+        ratelimiter = NULL;
     }
 ENDrunInput
 

--- a/contrib/imdocker/imdocker.c
+++ b/contrib/imdocker/imdocker.c
@@ -198,6 +198,10 @@ static void dockerContainerInfoDestruct(docker_container_info_t *pThis);
 /* utility functions */
 static CURLcode docker_get(imdocker_req_t *req, const char *url);
 static char *dupDockerContainerName(const char *pname);
+static rsRetVal allocContainerLogsUrl(
+    char **out, const uchar *apiAddr, const uchar *apiVersion, const char *containerId, const uchar *options);
+static rsRetVal allocContainersListUrl(
+    char **out, const uchar *apiAddr, const uchar *apiVersion, const uchar *options, const uchar *sinceId);
 static rsRetVal SubmitMsg(docker_cont_logs_inst_t *pInst, docker_cont_logs_buf_t *pBufData, const uchar *pszTag);
 /* support multi-line */
 static rsRetVal SubmitMsg2(docker_cont_logs_inst_t *pInst, docker_cont_logs_buf_t *pBufData, const uchar *pszTag);
@@ -344,6 +348,78 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal allocContainerLogsUrl(
+    char **out, const uchar *apiAddr, const uchar *apiVersion, const char *containerId, const uchar *options) {
+    DEFiRet;
+    int needed;
+
+    assert(out != NULL);
+    assert(apiAddr != NULL);
+    assert(apiVersion != NULL);
+    assert(containerId != NULL);
+    assert(options != NULL);
+
+    *out = NULL;
+    needed = snprintf(NULL, 0, "%s/%s/containers/%s/logs?%s", apiAddr, apiVersion, containerId, options);
+    if (needed < 0) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    CHKmalloc(*out = malloc((size_t)needed + 1));
+    if (snprintf(*out, (size_t)needed + 1, "%s/%s/containers/%s/logs?%s", apiAddr, apiVersion, containerId, options) !=
+        needed) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        free(*out);
+        *out = NULL;
+    }
+    RETiRet;
+}
+
+static rsRetVal allocContainersListUrl(
+    char **out, const uchar *apiAddr, const uchar *apiVersion, const uchar *options, const uchar *sinceId) {
+    DEFiRet;
+    int needed;
+
+    assert(out != NULL);
+    assert(apiAddr != NULL);
+    assert(apiVersion != NULL);
+    assert(options != NULL);
+
+    *out = NULL;
+    if (sinceId != NULL) {
+        needed = snprintf(NULL, 0, "%s/%s/containers/json?%s&filters={\"since\":[\"%s\"]}", apiAddr, apiVersion,
+                          options, sinceId);
+        if (needed < 0) {
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        CHKmalloc(*out = malloc((size_t)needed + 1));
+        if (snprintf(*out, (size_t)needed + 1, "%s/%s/containers/json?%s&filters={\"since\":[\"%s\"]}", apiAddr,
+                     apiVersion, options, sinceId) != needed) {
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+    } else {
+        needed = snprintf(NULL, 0, "%s/%s/containers/json?%s", apiAddr, apiVersion, options);
+        if (needed < 0) {
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        CHKmalloc(*out = malloc((size_t)needed + 1));
+        if (snprintf(*out, (size_t)needed + 1, "%s/%s/containers/json?%s", apiAddr, apiVersion, options) != needed) {
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+    }
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        free(*out);
+        *out = NULL;
+    }
+    RETiRet;
+}
+
 rsRetVal imdockerReqNew(imdocker_req_t **ppThis) {
     DEFiRet;
 
@@ -458,6 +534,10 @@ static rsRetVal parseLabels(docker_cont_logs_inst_t *inst, const uchar *json) {
     DBGPRINTF("%s() - parsing json=%s\n", __FUNCTION__, json);
 
     struct fjson_object *json_obj = fjson_tokener_parse((const char *)json);
+    if (json_obj == NULL || !fjson_object_is_type(json_obj, fjson_type_object)) {
+        LogMsg(0, RS_RET_OK_WARN, LOG_WARNING, "imdocker: ignoring malformed container labels payload");
+        FINALIZE;
+    }
     struct fjson_object_iterator it = fjson_object_iter_begin(json_obj);
     struct fjson_object_iterator itEnd = fjson_object_iter_end(json_obj);
     while (!fjson_object_iter_equal(&it, &itEnd)) {
@@ -467,7 +547,7 @@ static rsRetVal parseLabels(docker_cont_logs_inst_t *inst, const uchar *json) {
         }
 
         if (strcmp(fjson_object_iter_peek_name(&it), DOCKER_CONTAINER_LABEL_KEY_STARTREGEX) == 0) {
-            inst->start_regex = (uchar *)strdup(fjson_object_get_string(fjson_object_iter_peek_value(&it)));
+            CHKmalloc(inst->start_regex = (uchar *)strdup(fjson_object_get_string(fjson_object_iter_peek_value(&it))));
             // compile the regex for future use.
             int err =
                 regcomp(&inst->start_preg, fjson_object_get_string(fjson_object_iter_peek_value(&it)), REG_EXTENDED);
@@ -497,25 +577,26 @@ static rsRetVal dockerContLogsInstNew(docker_cont_logs_inst_t **ppThis,
     docker_cont_logs_inst_t *pThis = NULL;
     CHKmalloc(pThis = calloc(1, sizeof(docker_cont_logs_inst_t)));
 
-    pThis->id = strdup((char *)id);
+    CHKmalloc(pThis->id = strdup((char *)id));
     strncpy((char *)pThis->short_id, id, sizeof(pThis->short_id) - 1);
     CHKiRet(dockerContLogsReqNew(&pThis->logsReq, submitMsg));
     /* make a copy */
     if (container_info) {
         CHKiRet(dockerContainerInfoNew(&pThis->container_info));
         if (container_info->image) {
-            pThis->container_info->image = (uchar *)strdup((char *)container_info->image);
+            CHKmalloc(pThis->container_info->image = (uchar *)strdup((char *)container_info->image));
         }
         if (container_info->image_id) {
-            pThis->container_info->image_id = (uchar *)strdup((char *)container_info->image_id);
+            CHKmalloc(pThis->container_info->image_id = (uchar *)strdup((char *)container_info->image_id));
         }
         if (container_info->name) {
             const char *pname = (const char *)container_info->name;
             /* removes un-needed characters */
-            pThis->container_info->name = (uchar *)dupDockerContainerName(pname);
+            CHKmalloc(pThis->container_info->name = (uchar *)dupDockerContainerName(pname));
         }
         if (container_info->json_str_labels) {
-            pThis->container_info->json_str_labels = (uchar *)strdup((char *)container_info->json_str_labels);
+            CHKmalloc(pThis->container_info->json_str_labels =
+                          (uchar *)strdup((char *)container_info->json_str_labels));
         }
         pThis->container_info->created = container_info->created;
     }
@@ -523,7 +604,7 @@ static rsRetVal dockerContLogsInstNew(docker_cont_logs_inst_t **ppThis,
     pThis->prevSegEnd = 0;
     /* initialize based on labels found */
     if (pThis->container_info && pThis->container_info->json_str_labels) {
-        parseLabels(pThis, pThis->container_info->json_str_labels);
+        CHKiRet(parseLabels(pThis, pThis->container_info->json_str_labels));
     }
 
     *ppThis = pThis;
@@ -597,7 +678,8 @@ static rsRetVal dockerContLogsInstSetUrlById(sbool isInit,
                                              docker_cont_logs_inst_t *pThis,
                                              CURLM *curlm,
                                              const char *containerId) {
-    char url[256];
+    DEFiRet;
+    char *url = NULL;
     const uchar *container_log_options = runModConf->getContainerLogOptionsWithoutTail;
 
     if (isInit || !runModConf->retrieveNewLogsFromStart) {
@@ -609,11 +691,14 @@ static rsRetVal dockerContLogsInstSetUrlById(sbool isInit,
         pApiAddr = runModConf->dockerApiAddr;
     }
 
-    snprintf(url, sizeof(url), "%s/%s/containers/%s/logs?%s", pApiAddr, runModConf->apiVersionStr, containerId,
-             container_log_options);
+    CHKiRet(allocContainerLogsUrl(&url, pApiAddr, runModConf->apiVersionStr, containerId, container_log_options));
     DBGPRINTF("%s() - url: %s\n", __FUNCTION__, url);
 
-    return dockerContLogsInstSetUrl(pThis, curlm, url);
+    CHKiRet(dockerContLogsInstSetUrl(pThis, curlm, url));
+
+finalize_it:
+    free(url);
+    RETiRet;
 }
 
 /* special destructor for hashtable object. */
@@ -715,20 +800,19 @@ static rsRetVal dockerContLogReqsPrint(docker_cont_log_instances_t *pThis) {
 /* NOTE: not thread safe */
 static rsRetVal dockerContLogReqsAdd(docker_cont_log_instances_t *pThis, docker_cont_logs_inst_t *pContLogsReqInst) {
     DEFiRet;
+    uchar *keyName = NULL;
+
     if (!pContLogsReqInst) {
         return RS_RET_ERR;
     }
 
-    uchar *keyName = (uchar *)strdup((char *)pContLogsReqInst->id);
-
-    if (keyName) {
-        docker_cont_logs_inst_t *pFind;
-        if (RS_RET_NOT_FOUND == dockerContLogReqsGet(pThis, &pFind, (void *)keyName)) {
-            if (!hashtable_insert(pThis->ht_container_log_insts, keyName, pContLogsReqInst)) {
-                ABORT_FINALIZE(RS_RET_ERR);
-            }
-            keyName = NULL;
+    CHKmalloc(keyName = (uchar *)strdup((char *)pContLogsReqInst->id));
+    docker_cont_logs_inst_t *pFind;
+    if (RS_RET_NOT_FOUND == dockerContLogReqsGet(pThis, &pFind, (void *)keyName)) {
+        if (!hashtable_insert(pThis->ht_container_log_insts, keyName, pContLogsReqInst)) {
+            ABORT_FINALIZE(RS_RET_ERR);
         }
+        keyName = NULL;
     }
 finalize_it:
     free(keyName);
@@ -835,7 +919,7 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "trimlineoverbytes")) {
             loadModConf->trimLineOverBytes = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "listcontainersoptions")) {
-            loadModConf->listContainersOptions = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->listContainersOptions = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "getcontainerlogoptions")) {
             CHKmalloc(loadModConf->getContainerLogOptions = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             /* also initialize the non-tail version */
@@ -869,11 +953,11 @@ BEGINsetModCnf
             free(buf);
             buf = NULL;
         } else if (!strcmp(modpblk.descr[i].name, "dockerapiunixsockaddr")) {
-            loadModConf->dockerApiUnixSockAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->dockerApiUnixSockAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "dockerapiaddr")) {
-            loadModConf->dockerApiAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->dockerApiAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "apiversionstr")) {
-            loadModConf->apiVersionStr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->apiVersionStr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "retrievenewlogsfromstart")) {
             loadModConf->retrieveNewLogsFromStart = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "defaultseverity")) {
@@ -909,19 +993,20 @@ ENDcheckCnf
 BEGINactivateCnf
     CODESTARTactivateCnf;
     if (!loadModConf->dockerApiUnixSockAddr) {
-        loadModConf->dockerApiUnixSockAddr = (uchar *)strdup(DFLT_dockerAPIUnixSockAddr);
+        CHKmalloc(loadModConf->dockerApiUnixSockAddr = (uchar *)strdup(DFLT_dockerAPIUnixSockAddr));
     }
     if (!loadModConf->apiVersionStr) {
-        loadModConf->apiVersionStr = (uchar *)strdup(DFLT_apiVersionStr);
+        CHKmalloc(loadModConf->apiVersionStr = (uchar *)strdup(DFLT_apiVersionStr));
     }
     if (!loadModConf->listContainersOptions) {
-        loadModConf->listContainersOptions = (uchar *)strdup(DFLT_listContainersOptions);
+        CHKmalloc(loadModConf->listContainersOptions = (uchar *)strdup(DFLT_listContainersOptions));
     }
     if (!loadModConf->getContainerLogOptions) {
-        loadModConf->getContainerLogOptions = (uchar *)strdup(DFLT_getContainerLogOptions);
+        CHKmalloc(loadModConf->getContainerLogOptions = (uchar *)strdup(DFLT_getContainerLogOptions));
     }
     if (!loadModConf->getContainerLogOptionsWithoutTail) {
-        loadModConf->getContainerLogOptionsWithoutTail = (uchar *)strdup(DFLT_getContainerLogOptionsWithoutTail);
+        CHKmalloc(loadModConf->getContainerLogOptionsWithoutTail =
+                      (uchar *)strdup(DFLT_getContainerLogOptionsWithoutTail));
     }
     runModConf = loadModConf;
 
@@ -1449,6 +1534,7 @@ static rsRetVal process_json(sbool isInit, const char *json, docker_cont_log_ins
                 docker_cont_logs_inst_t *pInst = NULL;
                 iRet = dockerContLogReqsGet(pInstances, &pInst, containerId);
                 if (iRet == RS_RET_NOT_FOUND) {
+                    uchar *new_last_container_id = NULL;
 #ifdef USE_MULTI_LINE
                     if (dockerContLogsInstNew(&pInst, containerId, &containerInfo, SubmitMsg2)
 #else
@@ -1456,16 +1542,32 @@ static rsRetVal process_json(sbool isInit, const char *json, docker_cont_log_ins
 #endif
                         == RS_RET_OK) {
                         if (pInstances->last_container_created < containerInfo.created) {
+                            CHKmalloc(new_last_container_id = (uchar *)strdup(containerId));
                             pInstances->last_container_created = containerInfo.created;
-                            if (pInstances->last_container_id) {
-                                free(pInstances->last_container_id);
-                            }
-                            pInstances->last_container_id = (uchar *)strdup(containerId);
+                            free(pInstances->last_container_id);
+                            pInstances->last_container_id = new_last_container_id;
+                            new_last_container_id = NULL;
                             DBGPRINTF("last_container_id updated: ('%s', %u)\n", pInstances->last_container_id,
                                       (unsigned)pInstances->last_container_created);
                         }
-                        CHKiRet(dockerContLogsInstSetUrlById(isInit, pInst, pInstances->curlm, containerId));
-                        CHKiRet(dockerContLogReqsAdd(pInstances, pInst));
+                        iRet = dockerContLogsInstSetUrlById(isInit, pInst, pInstances->curlm, containerId);
+                        if (iRet != RS_RET_OK) {
+                            dockerContLogsInstDestruct(pInst);
+                            pInst = NULL;
+                            free(new_last_container_id);
+                            new_last_container_id = NULL;
+                            ABORT_FINALIZE(iRet);
+                        }
+
+                        iRet = dockerContLogReqsAdd(pInstances, pInst);
+                        if (iRet != RS_RET_OK) {
+                            dockerContLogsInstDestruct(pInst);
+                            pInst = NULL;
+                            free(new_last_container_id);
+                            new_last_container_id = NULL;
+                            ABORT_FINALIZE(iRet);
+                        }
+                        pInst = NULL;
                     }
                 }
             }
@@ -1506,7 +1608,7 @@ finalize_it:
 static rsRetVal getContainerIdsAndAppend(sbool isInit, docker_cont_log_instances_t *pInstances) {
     DEFiRet;
 
-    char url[256];
+    char *url = NULL;
     const uchar *pApiAddr = (uchar *)"http:";
 
     if (runModConf->dockerApiAddr) {
@@ -1518,11 +1620,11 @@ static rsRetVal getContainerIdsAndAppend(sbool isInit, docker_cont_log_instances
      * and i'm almost certain Travis CI will complain its not used.
      */
     if (pInstances->last_container_id) {
-        snprintf(url, sizeof(url), "%s/%s/containers/json?%s&filters={\"since\":[\"%s\"]}", pApiAddr,
-                 runModConf->apiVersionStr, runModConf->listContainersOptions, pInstances->last_container_id);
+        CHKiRet(allocContainersListUrl(&url, pApiAddr, runModConf->apiVersionStr, runModConf->listContainersOptions,
+                                       pInstances->last_container_id));
     } else {
-        snprintf(url, sizeof(url), "%s/%s/containers/json?%s", pApiAddr, runModConf->apiVersionStr,
-                 runModConf->listContainersOptions);
+        CHKiRet(
+            allocContainersListUrl(&url, pApiAddr, runModConf->apiVersionStr, runModConf->listContainersOptions, NULL));
     }
     DBGPRINTF("listcontainers url: %s\n", url);
 
@@ -1532,6 +1634,7 @@ static rsRetVal getContainerIdsAndAppend(sbool isInit, docker_cont_log_instances
     }
 
 finalize_it:
+    free(url);
     RETiRet;
 }
 
@@ -1614,7 +1717,12 @@ static void *getContainersTask(void *pdata) {
     docker_cont_log_instances_t *pInstances = (docker_cont_log_instances_t *)pdata;
 
     while (glbl.GetGlobalInputTermState() == 0) {
-        srSleep(runModConf->iPollInterval, 10);
+        for (int i = 0; i < runModConf->iPollInterval * 10 && glbl.GetGlobalInputTermState() == 0; ++i) {
+            srSleep(0, 100000);
+        }
+        if (glbl.GetGlobalInputTermState() != 0) {
+            break;
+        }
         getContainerIdsAndAppend(false, pInstances);
     }
     return pdata;
@@ -1657,7 +1765,6 @@ BEGINrunInput
 
 finalize_it:
     if (get_containers_thread_initialized) {
-        pthread_kill(thrd_id, SIGTTIN);
         pthread_join(thrd_id, NULL);
         pthread_attr_destroy(&thrd_attr);
     }

--- a/contrib/imhiredis/imhiredis.c
+++ b/contrib/imhiredis/imhiredis.c
@@ -67,7 +67,7 @@ MODULE_CNFNAME("imhiredis")
 DEF_IMOD_STATIC_DATA;
 #define BATCH_SIZE 10
 #define WAIT_TIME_MS 500
-#define STREAM_INDEX_STR_MAXLEN 44  // "18446744073709551615-18446744073709551615"
+#define STREAM_INDEX_STR_BUFSZ 44 /* max stream index text plus NUL */
 #define IMHIREDIS_MODE_QUEUE 1
 #define IMHIREDIS_MODE_SUBSCRIBE 2
 #define IMHIREDIS_MODE_STREAM 3
@@ -251,6 +251,8 @@ rsRetVal ackStreamIndex(instanceConf_t *inst, uchar *stream, uchar *group, uchar
 static rsRetVal enqueueRedisStreamReply(instanceConf_t *const inst, redisReply *reply);
 static rsRetVal handleRedisXREADReply(instanceConf_t *const inst, const redisReply *reply);
 static rsRetVal handleRedisXAUTOCLAIMReply(instanceConf_t *const inst, const redisReply *reply, char **autoclaimIndex);
+static rsRetVal copyStreamIndexText(
+    char *dst, size_t dstSize, const char *src, size_t srcLen, rsRetVal err, const char *context);
 rsRetVal redisStreamRead(instanceConf_t *inst);
 rsRetVal redisSubscribe(instanceConf_t *inst);
 void workerLoop(struct imhiredisWrkrInfo_s *me);
@@ -278,7 +280,7 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
     inst->useLPop = 0;
     inst->streamConsumerGroup = NULL;
     inst->streamConsumerName = NULL;
-    CHKmalloc(inst->streamReadFrom = calloc(1, STREAM_INDEX_STR_MAXLEN));
+    CHKmalloc(inst->streamReadFrom = calloc(1, STREAM_INDEX_STR_BUFSZ));
     inst->streamAutoclaimIdleTime = 0;
     inst->streamConsumerACK = 1;
     inst->pszBindRuleset = NULL;
@@ -483,31 +485,31 @@ BEGINnewInpInst
         if (!pvals[i].bUsed) continue;
 
         if (!strcmp(inppblk.descr[i].name, "server")) {
-            inst->redisNodesList->server = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->redisNodesList->server = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "socketPath")) {
-            inst->redisNodesList->socketPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->redisNodesList->socketPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "port")) {
             inst->redisNodesList->port = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "password")) {
-            inst->password = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->password = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "stream.consumerGroup")) {
-            inst->streamConsumerGroup = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->streamConsumerGroup = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "stream.consumerName")) {
-            inst->streamConsumerName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->streamConsumerName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "stream.consumerACK")) {
             inst->streamConsumerACK = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "stream.readFrom")) {
-            // inst->streamReadFrom is already allocated, only copy contents
-            memcpy(inst->streamReadFrom, es_getBufAddr(pvals[i].val.d.estr), es_strlen(pvals[i].val.d.estr));
-            inst->streamReadFrom[es_strlen(pvals[i].val.d.estr)] = '\0';
+            CHKiRet(copyStreamIndexText(
+                (char *)inst->streamReadFrom, STREAM_INDEX_STR_BUFSZ, (const char *)es_getBufAddr(pvals[i].val.d.estr),
+                es_strlen(pvals[i].val.d.estr), RS_RET_PARAM_ERROR, "configured stream.readFrom value"));
         } else if (!strcmp(inppblk.descr[i].name, "stream.autoclaimIdleTime")) {
             inst->streamAutoclaimIdleTime = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "uselpop")) {
             inst->useLPop = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "mode")) {
-            inst->modeDescription = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->modeDescription = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcmp((const char *)inst->modeDescription, "queue")) {
                 inst->mode = IMHIREDIS_MODE_QUEUE;
             } else if (!strcmp((const char *)inst->modeDescription, "subscribe")) {
@@ -551,20 +553,20 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "batchsize")) {
             inst->batchsize = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "key")) {
-            inst->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #ifdef HIREDIS_SSL
         } else if (!strcmp(inppblk.descr[i].name, "use_tls")) {
             inst->use_tls = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ca_cert_bundle")) {
-            inst->ca_cert_bundle = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->ca_cert_bundle = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ca_cert_dir")) {
-            inst->ca_cert_dir = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->ca_cert_dir = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "client_cert")) {
-            inst->client_cert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->client_cert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "client_key")) {
-            inst->client_key = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->client_key = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "sni")) {
-            inst->sni = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->sni = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #endif
         } else {
             dbgprintf(
@@ -664,7 +666,13 @@ BEGINactivateCnf
     CODESTARTactivateCnf;
     for (instanceConf_t *inst = pModConf->root; inst != NULL; inst = inst->next) {
         iRet = checkInstance(inst);
-        if (inst->mode == IMHIREDIS_MODE_SUBSCRIBE) inst->evtBase = event_base_new();
+        if (inst->mode == IMHIREDIS_MODE_SUBSCRIBE) {
+            if ((inst->evtBase = event_base_new()) == NULL) {
+                LogError(0, RS_RET_OUT_OF_MEMORY, "imhiredis: could not create libevent base");
+                iRet = RS_RET_OUT_OF_MEMORY;
+                break;
+            }
+        }
     }
 ENDactivateCnf
 
@@ -997,6 +1005,27 @@ static struct json_object *_redisParseDoubleReply(const redisReply *reply) {
 
 static struct json_object *_redisParseStringReply(const redisReply *reply) {
     return json_object_new_string_len(reply->str, reply->len);
+}
+
+static rsRetVal copyStreamIndexText(
+    char *dst, size_t dstSize, const char *src, size_t srcLen, rsRetVal err, const char *context) {
+    DEFiRet;
+
+    assert(dst != NULL);
+    assert(src != NULL);
+    assert(context != NULL);
+
+    if (srcLen >= dstSize) {
+        LogError(0, err, "imhiredis: %s exceeds maximum supported stream index length of %zu bytes", context,
+                 dstSize - 1);
+        ABORT_FINALIZE(err);
+    }
+
+    memcpy(dst, src, srcLen);
+    dst[srcLen] = '\0';
+
+finalize_it:
+    RETiRet;
 }
 
 static struct json_object *_redisParseArrayReply(const redisReply *reply) {
@@ -1947,8 +1976,9 @@ static rsRetVal handleRedisXREADReply(instanceConf_t *const inst, const redisRep
                 CHKiRet(enqueueRedisStreamReply(inst, msgObj));
 
                 // Update current stream index
-                memcpy(inst->streamReadFrom, msgObj->element[0]->str, msgObj->element[0]->len);
-                inst->streamReadFrom[msgObj->element[0]->len] = '\0';
+                CHKiRet(copyStreamIndexText((char *)inst->streamReadFrom, STREAM_INDEX_STR_BUFSZ,
+                                            msgObj->element[0]->str, msgObj->element[0]->len, RS_RET_REDIS_ERROR,
+                                            "Redis XREAD stream index"));
                 DBGPRINTF("handleRedisXREADReply: current stream index is %s\n", inst->streamReadFrom);
             }
         }
@@ -2048,8 +2078,8 @@ static rsRetVal handleRedisXAUTOCLAIMReply(instanceConf_t *const inst, const red
 
         // Update current stream index with next index from XAUTOCLAIM
         // No message has to be claimed after that if value is "0-0"
-        memcpy(*autoclaimIndex, reply->element[0]->str, reply->element[0]->len);
-        (*autoclaimIndex)[reply->element[0]->len] = '\0';
+        CHKiRet(copyStreamIndexText(*autoclaimIndex, STREAM_INDEX_STR_BUFSZ, reply->element[0]->str,
+                                    reply->element[0]->len, RS_RET_REDIS_ERROR, "Redis XAUTOCLAIM stream index"));
         DBGPRINTF("handleRedisXAUTOCLAIMReply: next stream index is %s\n", (*autoclaimIndex));
     }
 
@@ -2080,15 +2110,18 @@ rsRetVal redisStreamRead(instanceConf_t *inst) {
     if (inst->streamAutoclaimIdleTime != 0) {
         DBGPRINTF("redisStreamRead: getting pending entries for stream '%s' from '%s', with idle time %d\n", inst->key,
                   inst->streamReadFrom, inst->streamAutoclaimIdleTime);
-        CHKmalloc(autoclaimIndex = calloc(1, STREAM_INDEX_STR_MAXLEN));
+        CHKmalloc(autoclaimIndex = calloc(1, STREAM_INDEX_STR_BUFSZ));
         // Cannot claim from '$', will have to claim from the beginning of the stream
         if (inst->streamReadFrom[0] == '$') {
             LogMsg(0, RS_RET_OK, LOG_WARNING,
                    "Cannot claim pending entries from '$', "
                    "will have to claim from the beginning of the stream");
-            memcpy(autoclaimIndex, "0-0", 4);
+            CHKiRet(copyStreamIndexText(autoclaimIndex, STREAM_INDEX_STR_BUFSZ, "0-0", strlen("0-0"),
+                                        RS_RET_REDIS_ERROR, "default XAUTOCLAIM stream index"));
         } else {
-            memcpy(autoclaimIndex, inst->streamReadFrom, STREAM_INDEX_STR_MAXLEN);
+            CHKiRet(copyStreamIndexText(autoclaimIndex, STREAM_INDEX_STR_BUFSZ, (const char *)inst->streamReadFrom,
+                                        strlen((const char *)inst->streamReadFrom), RS_RET_REDIS_ERROR,
+                                        "stored stream.readFrom value"));
         }
         mustClaimIdle = 1;
     } else {

--- a/contrib/imhiredis/imhiredis.c
+++ b/contrib/imhiredis/imhiredis.c
@@ -262,9 +262,8 @@ void insertNodeAfter(redisNode *root, redisNode *elem);
 void dbgPrintNode(redisNode *node);
 
 
-static rsRetVal
-copyStreamIndexText(char *dst, size_t dstSize, const char *src, size_t srcLen, rsRetVal err, const char *context)
-{
+static rsRetVal copyStreamIndexText(
+    char *dst, size_t dstSize, const char *src, size_t srcLen, rsRetVal err, const char *context) {
     DEFiRet;
 
     assert(dst != NULL);

--- a/contrib/imhiredis/imhiredis.c
+++ b/contrib/imhiredis/imhiredis.c
@@ -251,8 +251,6 @@ rsRetVal ackStreamIndex(instanceConf_t *inst, uchar *stream, uchar *group, uchar
 static rsRetVal enqueueRedisStreamReply(instanceConf_t *const inst, redisReply *reply);
 static rsRetVal handleRedisXREADReply(instanceConf_t *const inst, const redisReply *reply);
 static rsRetVal handleRedisXAUTOCLAIMReply(instanceConf_t *const inst, const redisReply *reply, char **autoclaimIndex);
-static rsRetVal copyStreamIndexText(
-    char *dst, size_t dstSize, const char *src, size_t srcLen, rsRetVal err, const char *context);
 rsRetVal redisStreamRead(instanceConf_t *inst);
 rsRetVal redisSubscribe(instanceConf_t *inst);
 void workerLoop(struct imhiredisWrkrInfo_s *me);
@@ -262,6 +260,29 @@ rsRetVal copyNode(redisNode *src, redisNode **dst);
 redisNode *freeNode(redisNode *node);
 void insertNodeAfter(redisNode *root, redisNode *elem);
 void dbgPrintNode(redisNode *node);
+
+
+static rsRetVal
+copyStreamIndexText(char *dst, size_t dstSize, const char *src, size_t srcLen, rsRetVal err, const char *context)
+{
+    DEFiRet;
+
+    assert(dst != NULL);
+    assert(src != NULL);
+    assert(context != NULL);
+
+    if (srcLen >= dstSize) {
+        LogError(0, err, "imhiredis: %s exceeds maximum supported stream index length of %zu bytes", context,
+                 dstSize - 1);
+        ABORT_FINALIZE(err);
+    }
+
+    memcpy(dst, src, srcLen);
+    dst[srcLen] = '\0';
+
+finalize_it:
+    RETiRet;
+}
 
 
 /* create input instance, set default parameters, and
@@ -1005,27 +1026,6 @@ static struct json_object *_redisParseDoubleReply(const redisReply *reply) {
 
 static struct json_object *_redisParseStringReply(const redisReply *reply) {
     return json_object_new_string_len(reply->str, reply->len);
-}
-
-static rsRetVal copyStreamIndexText(
-    char *dst, size_t dstSize, const char *src, size_t srcLen, rsRetVal err, const char *context) {
-    DEFiRet;
-
-    assert(dst != NULL);
-    assert(src != NULL);
-    assert(context != NULL);
-
-    if (srcLen >= dstSize) {
-        LogError(0, err, "imhiredis: %s exceeds maximum supported stream index length of %zu bytes", context,
-                 dstSize - 1);
-        ABORT_FINALIZE(err);
-    }
-
-    memcpy(dst, src, srcLen);
-    dst[srcLen] = '\0';
-
-finalize_it:
-    RETiRet;
 }
 
 static struct json_object *_redisParseArrayReply(const redisReply *reply) {

--- a/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
@@ -34,6 +34,7 @@ RUN 	apt-get update && \
 	libcap-ng0 \
 	libcurl4-gnutls-dev \
 	libdbi-dev \
+	libevent-dev \
 	libgcrypt20-dev \
 	libglib2.0-dev \
 	libgnutls28-dev \

--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -878,6 +878,8 @@ finalize_it:
 static rsRetVal ATTR_NONNULL()
     processKafkaParam(char *const param, const char **const name, const char **const paramval) {
     DEFiRet;
+    char *tmpName = NULL;
+    char *tmpVal = NULL;
     char *val = strstr(param, "=");
     if (val == NULL) {
         LogError(0, RS_RET_PARAM_ERROR, "missing equal sign in parameter '%s'", param);
@@ -885,9 +887,15 @@ static rsRetVal ATTR_NONNULL()
     }
     *val = '\0'; /* terminates name */
     ++val; /* now points to begin of value */
-    CHKmalloc(*name = strdup(param));
-    CHKmalloc(*paramval = strdup(val));
+    CHKmalloc(tmpName = strdup(param));
+    CHKmalloc(tmpVal = strdup(val));
+    *name = tmpName;
+    *paramval = tmpVal;
+    tmpName = NULL;
+    tmpVal = NULL;
 finalize_it:
+    free(tmpName);
+    free(tmpVal);
     RETiRet;
 }
 
@@ -916,22 +924,23 @@ BEGINnewInpInst
                 es_addStr(&es, pvals[i].val.d.ar->arr[j]);
                 bNeedComma = 1;
             }
-            inst->brokers = es_str2cstr(es, NULL);
+            CHKmalloc(inst->brokers = es_str2cstr(es, NULL));
             es_deleteStr(es);
         } else if (!strcmp(inppblk.descr[i].name, "confparam")) {
             inst->nConfParams = pvals[i].val.d.ar->nmemb;
             CHKmalloc(inst->confParams = malloc(sizeof(struct kafka_params) * inst->nConfParams));
             for (int j = 0; j < inst->nConfParams; j++) {
-                char *cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                char *cstr = NULL;
+                CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
                 CHKiRet(processKafkaParam(cstr, &inst->confParams[j].name, &inst->confParams[j].val));
                 free(cstr);
             }
         } else if (!strcmp(inppblk.descr[i].name, "topic")) {
-            inst->topic = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->topic = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "consumergroup")) {
-            inst->consumergroup = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->consumergroup = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "parsehostname")) {
             if (pvals[i].val.d.n) {
                 inst->nMsgParsingFlags = NEEDS_PARSING | PARSE_HOSTNAME;
@@ -979,7 +988,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "ruleset")) {
-            loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf("imkafka: program error, non-handled param '%s' in beginCnfLoad\n", modpblk.descr[i].name);
         }
@@ -1092,9 +1101,15 @@ static void shutdownKafkaWorkers(void) {
     kafkaWrkrInfo = NULL;
 
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        if (inst->rk == NULL) {
+            continue;
+        }
         DBGPRINTF("imkafka: stop consuming %s/%s/%s\n", inst->topic, inst->consumergroup, inst->brokers);
         rd_kafka_consumer_close(inst->rk); /* Close the consumer, committing final offsets, etc. */
         rd_kafka_destroy(inst->rk); /* Destroy handle object */
+        inst->rk = NULL;
+        inst->bIsConnected = 0;
+        inst->bIsSubscribed = 0;
         DBGPRINTF("imkafka: stopped consuming %s/%s/%s\n", inst->topic, inst->consumergroup, inst->brokers);
 #if RD_KAFKA_VERSION < 0x00090001
         /* Wait for kafka being destroyed in old API */
@@ -1110,23 +1125,24 @@ static void shutdownKafkaWorkers(void) {
 /* This function is called to gather input. */
 BEGINrunInput
     int i;
+    int workerSlots = 0;
     instanceConf_t *inst;
     CODESTARTrunInput;
     DBGPRINTF("imkafka: runInput loop started ...\n");
     activeKafkaworkers = 0;
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
         if (inst->rk != NULL) {
-            ++activeKafkaworkers;
+            ++workerSlots;
         }
     }
-    if (activeKafkaworkers == 0) {
+    if (workerSlots == 0) {
         LogError(
             0, RS_RET_ERR,
             "imkafka: no active inputs, input not run - other additional error messages should've given previously");
         ABORT_FINALIZE(RS_RET_ERR);
     }
-    DBGPRINTF("imkafka: Starting %d imkafka workerthreads\n", activeKafkaworkers);
-    kafkaWrkrInfo = calloc(activeKafkaworkers, sizeof(struct kafkaWrkrInfo_s));
+    DBGPRINTF("imkafka: Starting %d imkafka workerthreads\n", workerSlots);
+    kafkaWrkrInfo = calloc(workerSlots, sizeof(struct kafkaWrkrInfo_s));
     if (kafkaWrkrInfo == NULL) {
         LogError(errno, RS_RET_OUT_OF_MEMORY, "imkafka: worker-info array allocation failed.");
         ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
@@ -1134,11 +1150,21 @@ BEGINrunInput
     /* Start worker threads for each imkafka input source */
     i = 0;
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        if (inst->rk == NULL) {
+            continue;
+        }
         /* init worker info structure! */
         kafkaWrkrInfo[i].inst = inst; /* Set reference pointer */
-        pthread_create(&kafkaWrkrInfo[i].tid, &wrkrThrdAttr, imkafkawrkr, &(kafkaWrkrInfo[i]));
+        int r = pthread_create(&kafkaWrkrInfo[i].tid, &wrkrThrdAttr, imkafkawrkr, &(kafkaWrkrInfo[i]));
+        if (r != 0) {
+            activeKafkaworkers = i;
+            LogError(r, RS_RET_ERR, "imkafka: failed to start worker thread %d", i);
+            shutdownKafkaWorkers();
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
         i++;
     }
+    activeKafkaworkers = i;
     while (glbl.GetGlobalInputTermState() == 0) {
         /* Note: the additional 10000ns wait is vitally important. It guards rsyslog
          * against totally hogging the CPU if the users selects a polling interval

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -983,6 +983,7 @@ TESTS_IMDOCKER = \
 	imdocker-basic.sh \
 	imdocker-image-name.sh \
 	imdocker-long-logline.sh \
+	imdocker-long-options.sh \
 	imdocker-new-logs-from-start.sh \
 	imdocker-multi-line.sh
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1046,6 +1046,7 @@ TESTS_OMRABBITMQ_VALGRIND = \
 	omrabbitmq_data_1server-vg.sh
 
 TESTS_IMHIREDIS = \
+	imhiredis-stream-readfrom-too-long.sh \
 	imhiredis-queue.sh \
 	imhiredis-queue-lpop.sh \
 	imhiredis-redis-restart.sh \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -993,6 +993,9 @@ TESTS_IMDOCKER_VALGRIND = \
 	imdocker-new-logs-from-start-vg.sh \
 	imdocker-multi-line-vg.sh
 
+TESTS_IMCZMQ = \
+	imczmq-topic-too-long.sh
+
 TESTS_IMHTTP = \
 	imhttp-post-payload.sh \
 	imhttp-post-payload-basic-auth.sh \
@@ -1839,6 +1842,7 @@ EXTRA_DIST += omazuredce-env.sh
 EXTRA_DIST += testsuites/yaml-omazuredce-compression.yaml
 EXTRA_DIST += $(TESTS_IMDOCKER)
 EXTRA_DIST += $(TESTS_IMDOCKER_VALGRIND)
+EXTRA_DIST += $(TESTS_IMCZMQ)
 EXTRA_DIST += $(TESTS_IMHTTP)
 EXTRA_DIST += $(TESTS_IMHTTP_VALGRIND)
 EXTRA_DIST += $(TESTS_OMRABBITMQ)
@@ -2534,6 +2538,11 @@ endif # HAVE_VALGRIND
 endif # ENABLE_IMDOCKER_TESTS
 endif # ENABLE_IMDOCKER
 
+
+
+if ENABLE_IMCZMQ
+TESTS += $(TESTS_IMCZMQ)
+endif # ENABLE_IMCZMQ
 
 
 if ENABLE_IMHTTP

--- a/tests/imczmq-topic-too-long.sh
+++ b/tests/imczmq-topic-too-long.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Verify that imczmq rejects configured topics that exceed the supported limit.
+. ${srcdir:=.}/diag.sh init
+
+LONG_TOPIC=$(printf 'a%.0s' $(seq 1 256))
+modpath="../runtime/.libs:../contrib/imczmq/.libs:../.libs"
+
+generate_conf
+add_conf '
+module(load="../contrib/imczmq/.libs/imczmq")
+input(type="imczmq"
+      endpoints="inproc://imczmq-topic-too-long"
+      socktype="SUB"
+      topics="'$LONG_TOPIC'")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$modpath" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 1 ]; then
+	echo "FAIL: expected config validation failure for oversize imczmq topic"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+fi
+
+grep -F "configured topic exceeds maximum supported length" "${RSYSLOG_DYNNAME}.log" >/dev/null || {
+	echo "FAIL: expected imczmq oversize topic validation error"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+}
+
+exit_test

--- a/tests/imdocker-long-options.sh
+++ b/tests/imdocker-long-options.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# This is part of the rsyslog testbench, licensed under ASL 2.0
+# imdocker unit tests are enabled with --enable-imdocker-tests
+. ${srcdir:=.}/diag.sh init
+NUMMESSAGES=50
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+LONG_PREFIX=$(printf 'noop=1&%.0s' $(seq 1 80))
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+module(load="../contrib/imdocker/.libs/imdocker"
+        ListContainersOptions="all=true"
+        GetContainerLogOptions="'$LONG_PREFIX'timestamps=0&follow=1&stdout=1&stderr=0")
+if $!metadata!Names == "'$COOKIE'" then {
+  action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+docker run \
+   --name $COOKIE \
+   -e NUMMESSAGES=$NUMMESSAGES \
+   alpine \
+   /bin/sh -c 'for i in $(seq 0 $((NUMMESSAGES-1))); do echo "$i"; done' > /dev/null
+
+startup
+
+shutdown_when_empty
+wait_shutdown
+
+seq_check
+
+docker container rm $COOKIE
+exit_test

--- a/tests/imhiredis-stream-readfrom-too-long.sh
+++ b/tests/imhiredis-stream-readfrom-too-long.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Verify that imhiredis rejects stream.readFrom values that exceed the fixed index buffer.
+. ${srcdir:=.}/diag.sh init
+
+LONG_STREAM_INDEX=$(printf '1%.0s' $(seq 1 44))
+modpath="../runtime/.libs:../contrib/imhiredis/.libs:../.libs"
+
+generate_conf
+add_conf '
+module(load="../contrib/imhiredis/.libs/imhiredis")
+input(type="imhiredis"
+      key="mystream"
+      mode="stream"
+      stream.readFrom="'$LONG_STREAM_INDEX'")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$modpath" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 1 ]; then
+	echo "FAIL: expected config validation failure for oversize imhiredis stream.readFrom"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+fi
+
+grep -F "configured stream.readFrom value exceeds maximum supported stream index length" \
+	"${RSYSLOG_DYNNAME}.log" >/dev/null || {
+	echo "FAIL: expected imhiredis stream.readFrom validation error"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+}
+
+exit_test


### PR DESCRIPTION
## Summary
- harden `imczmq` config parsing so invalid topics and socktype values fail during config load
- add a direct `-N1` regression for oversize `imczmq` topics
- install `libevent-dev` in the Ubuntu 24.04 check paths so `imhiredis` coverage is available in CI

## Root Cause
`imczmq` accepted topic strings straight into a fixed subscription buffer path, mutated the owned `topics` pointer while iterating subscriptions, and did not free the stored topics string during config teardown. In parallel, the Ubuntu 24.04 check environment had `libczmq-dev` but not `libevent-dev`, which blocks `imhiredis` coverage in this service-input hardening tranche.

## Impact
Invalid `imczmq` configuration now fails closed before listener startup, and CI has the missing dependency needed to exercise the related service-input checks.

## Validation
- `bash devtools/format-code.sh`
- `./tests/imczmq-topic-too-long.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
