### PR TITLE
hardening: ignore generated omotel protobuf tree

### DIFF
--- a/plugins/omotel/.gitignore
+++ b/plugins/omotel/.gitignore
@@ -1,0 +1,1 @@
+/opentelemetry/


### PR DESCRIPTION
## Summary
- ignore the generated `plugins/omotel/opentelemetry/` protobuf output tree

## Root Cause
`omotel` generates protobuf C and header files into `$(builddir)/opentelemetry`, which maps into the source checkout for normal in-tree builds. That expected generated tree then shows up as untracked work.

## Impact
`git status` stays quiet after configured `omotel` builds without changing build behavior.

## Validation
- inspected `plugins/omotel/Makefile.am` generation rules
- reproduced the generated `plugins/omotel/opentelemetry/` tree locally
