### PR TITLE
queue: delete orphaned disk queue write files

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1122,7 +1122,7 @@ finalize_it:
 static void reinitVar(var_t *pVar) {
     rsCStrDestruct(&pVar->pcsName); /* no longer needed */
     if (pVar->varType == VARTYPE_STR) {
-        if (pVar->val.pStr != NULL) rsCStrDestruct(&pVar->val.pStr);
+        rsCStrDestruct(&pVar->val.pStr);
     }
     memset(&pVar->val, 0, sizeof(pVar->val));
     pVar->varType = VARTYPE_NONE;

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -1124,6 +1124,8 @@ static void reinitVar(var_t *pVar) {
     if (pVar->varType == VARTYPE_STR) {
         if (pVar->val.pStr != NULL) rsCStrDestruct(&pVar->val.pStr);
     }
+    memset(&pVar->val, 0, sizeof(pVar->val));
+    pVar->varType = VARTYPE_NONE;
 }
 /* deserialize the message again
  * we deserialize the properties in the same order that we serialized them. Except

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -650,6 +650,9 @@ finalize_it:
      * the deconstruct method of var might free unallocated memory
      */
     if (iRet != RS_RET_OK && iRet != RS_RET_NO_PROPLINE) {
+        if (pProp->varType == VARTYPE_STR && step < 4) {
+            pProp->val.pStr = NULL;
+        }
         if (step <= 2) {
             pProp->varType = VARTYPE_NONE;
         }
@@ -761,6 +764,18 @@ finalize_it:
 }
 
 
+static void
+varResetState(var_t *pVar)
+{
+    rsCStrDestruct(&pVar->pcsName); /* no longer needed */
+    if (pVar->varType == VARTYPE_STR) {
+        if (pVar->val.pStr != NULL) rsCStrDestruct(&pVar->val.pStr);
+    }
+    memset(&pVar->val, 0, sizeof(pVar->val));
+    pVar->varType = VARTYPE_NONE;
+}
+
+
 /* De-serialize the properties of an object. This includes processing
  * of the trailer. Header must already have been processed.
  * rgerhards, 2008-01-11
@@ -778,11 +793,7 @@ static rsRetVal objDeserializeProperties(obj_t *pObj, rsRetVal (*objSetProperty)
     iRet = objDeserializeProperty(pVar, pStrm);
     while (iRet == RS_RET_OK) {
         CHKiRet(objSetProperty(pObj, pVar));
-        /* re-init var object - TODO: method of var! */
-        rsCStrDestruct(&pVar->pcsName); /* no longer needed */
-        if (pVar->varType == VARTYPE_STR) {
-            if (pVar->val.pStr != NULL) rsCStrDestruct(&pVar->val.pStr);
-        }
+        varResetState(pVar);
         iRet = objDeserializeProperty(pVar, pStrm);
     }
 

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -767,7 +767,7 @@ finalize_it:
 static void varResetState(var_t *pVar) {
     rsCStrDestruct(&pVar->pcsName); /* no longer needed */
     if (pVar->varType == VARTYPE_STR) {
-        if (pVar->val.pStr != NULL) rsCStrDestruct(&pVar->val.pStr);
+        rsCStrDestruct(&pVar->val.pStr);
     }
     memset(&pVar->val, 0, sizeof(pVar->val));
     pVar->varType = VARTYPE_NONE;

--- a/runtime/obj.c
+++ b/runtime/obj.c
@@ -764,9 +764,7 @@ finalize_it:
 }
 
 
-static void
-varResetState(var_t *pVar)
-{
+static void varResetState(var_t *pVar) {
     rsCStrDestruct(&pVar->pcsName); /* no longer needed */
     if (pVar->varType == VARTYPE_STR) {
         if (pVar->val.pStr != NULL) rsCStrDestruct(&pVar->val.pStr);

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -1518,11 +1518,11 @@ static rsRetVal qDestructDisk(qqueue_t *pThis) {
 
     free(pThis->pszQIFNam);
     if (pThis->tVars.disk.pWrite != NULL) {
-        int64 currOffs;
-        strm.GetCurrOffset(pThis->tVars.disk.pWrite, &currOffs);
-        if (currOffs == 0) {
-            /* if no data is present, we can (and must!) delete this
-             * file. Else we can leave garbagge after termination.
+        if (getPhysicalQueueSize(pThis) == 0) {
+            /* Once the disk queue is logically empty, any remaining active write
+             * file only contains untracked tail data, typically late internal
+             * messages emitted during shutdown. Keep teardown from leaving that
+             * orphaned file behind.
              */
             strm.SetbDeleteOnClose(pThis->tVars.disk.pWrite, 1);
         }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -232,6 +232,7 @@ TESTS_DEFAULT = \
 	daqueue-invld-qi.sh \
 	daqueue-dirty-shutdown-recovery.sh \
 	diskq-rfc5424.sh \
+	diskqueue-truncated-segment-startup.sh \
 	diskqueue.sh \
 	diskqueue-fsync.sh \
 	diskqueue-full.sh \

--- a/tests/diskqueue-truncated-segment-startup.sh
+++ b/tests/diskqueue-truncated-segment-startup.sh
@@ -56,36 +56,51 @@ action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
 }
 
 list_spool_top() {
-	find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 -printf '%f %s bytes\n' | sort
+	for path in "$SPOOL_DIR"/*; do
+		[ -e "$path" ] || continue
+		base="${path##*/}"
+		if [ -f "$path" ]; then
+			size=$(wc -c < "$path")
+			printf '%s %s bytes\n' "$base" "$size"
+		elif [ -L "$path" ]; then
+			printf '%s symlink\n' "$base"
+		else
+			printf '%s/\n' "$base"
+		fi
+	done | sort
 }
 
 count_bad_dirs() {
-	find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 -type d -name 'mainq.bad.*' | wc -l
+	count=0
+	for path in "$SPOOL_DIR"/mainq.bad.*; do
+		[ -d "$path" ] || continue
+		count=$((count + 1))
+	done
+	printf '%s\n' "$count"
 }
 
 check_no_live_mainq_files() {
-	local live_files
-
-	live_files="$(find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 \
-		\( -type f -o -type l \) -name 'mainq*' -printf '%f\n')"
-	if [ -n "$live_files" ]; then
+	live_list="${RSYSLOG_DYNNAME}.live-mainq"
+	: > "$live_list"
+	for path in "$SPOOL_DIR"/mainq*; do
+		[ -e "$path" ] || continue
+		[ -f "$path" ] || [ -L "$path" ] || continue
+		printf '%s\n' "${path##*/}" >> "$live_list"
+	done
+	if [ -s "$live_list" ]; then
 		echo "FAIL: live mainq files remain after restart recovery"
-		printf '%s\n' "$live_files"
+		cat "$live_list"
 		ls -l "$SPOOL_DIR"
+		rm -f "$live_list"
 		error_exit 1
 	fi
+	rm -f "$live_list"
 }
 
 corrupt_middle_segment() {
-	local seg_files=()
-	local base
-	local num
-	local target
-	local orig_size
-	local mid_idx
-	local seek_offs
-	local corrupt_len
-
+	seg_list="${RSYSLOG_DYNNAME}.segments"
+	sorted_list="${seg_list}.sorted"
+	: > "$seg_list"
 	for path in "$SPOOL_DIR"/mainq.*; do
 		[ -f "$path" ] || continue
 		base="${path##*/}"
@@ -95,27 +110,27 @@ corrupt_middle_segment() {
 			continue
 			;;
 		esac
-		seg_files+=("$base")
+		printf '%s\n' "$base" >> "$seg_list"
 	done
 
-	if [ "${#seg_files[@]}" -gt 0 ]; then
-		IFS=$'\n' seg_files=($(printf '%s\n' "${seg_files[@]}" | sort -t. -k2,2n))
-		unset IFS
-	fi
-
-	if [ "${#seg_files[@]}" -lt 3 ]; then
-		printf 'FAIL: expected at least 3 queue segment files, found %d\n' "${#seg_files[@]}"
+	sort -t. -k2,2n "$seg_list" > "$sorted_list"
+	seg_count=$(wc -l < "$sorted_list")
+	if [ "$seg_count" -lt 3 ]; then
+		printf 'FAIL: expected at least 3 queue segment files, found %s\n' "$seg_count"
 		list_spool_top
+		rm -f "$seg_list" "$sorted_list"
 		error_exit 1
 	fi
 
-	mid_idx=$(( ${#seg_files[@]} / 2 ))
-	target="$SPOOL_DIR/${seg_files[$mid_idx]}"
-	orig_size=$(stat -c%s "$target")
+	mid_line=$(( (seg_count / 2) + 1 ))
+	target_base=$(sed -n "${mid_line}p" "$sorted_list")
+	target="$SPOOL_DIR/$target_base"
+	orig_size=$(wc -c < "$target")
 	seek_offs=$(( orig_size / 2 ))
 	corrupt_len=4096
 	if [ "$seek_offs" -le 0 ] || [ "$seek_offs" -ge "$orig_size" ]; then
 		printf 'FAIL: invalid corruption offset for %s (size=%s)\n' "$target" "$orig_size"
+		rm -f "$seg_list" "$sorted_list"
 		error_exit 1
 	fi
 	if [ $(( seek_offs + corrupt_len )) -gt "$orig_size" ]; then
@@ -123,7 +138,9 @@ corrupt_middle_segment() {
 	fi
 
 	printf 'Corrupting queue segment %s at offset %s for %s bytes\n' "$target" "$seek_offs" "$corrupt_len"
-	dd if=/dev/zero of="$target" bs=1 seek="$seek_offs" count="$corrupt_len" conv=notrunc status=none
+	dd if=/dev/zero of="$target" bs=1 seek="$seek_offs" count="$corrupt_len" conv=notrunc \
+		>/dev/null 2>&1
+	rm -f "$seg_list" "$sorted_list"
 }
 
 write_phase1_conf

--- a/tests/diskqueue-truncated-segment-startup.sh
+++ b/tests/diskqueue-truncated-segment-startup.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+# Validate queue.onCorruption handling when bytes inside a persisted disk-queue
+# segment are corrupted in the middle of the queue sequence. Restart should either
+# quarantine the corrupted queue into mainq.bad.* or finish draining it
+# without leaving live queue files behind.
+# added 2026-04-20 by Codex, released under ASL 2.0
+
+. ${srcdir:=.}/diag.sh init
+
+export NUMMESSAGES=15000
+SPOOL_DIR="${RSYSLOG_DYNNAME}.spool"
+RSYSLOGD_LOG="${RSYSLOG_DYNNAME}.rsyslogd.log"
+STARTED_LOG="${RSYSLOG_DYNNAME}.started"
+
+write_phase1_conf() {
+	generate_conf
+	add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'"$SPOOL_DIR"'")
+
+main_queue(
+	queue.type="disk"
+	queue.filename="mainq"
+	queue.maxFileSize="16k"
+	queue.saveOnShutdown="on"
+	queue.timeoutShutdown="1"
+)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\\n")
+template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`)
+
+:omtesting:sleep 0 20000
+if ($msg contains "msgnum:") then {
+	action(type="omfile" template="outfmt" dynaFile="dynfile")
+}
+'
+}
+
+write_phase2_conf() {
+	generate_conf
+	add_conf '
+module(load="../plugins/omtesting/.libs/omtesting")
+global(workDirectory="'"$SPOOL_DIR"'")
+
+main_queue(
+	queue.type="disk"
+	queue.filename="mainq"
+	queue.maxFileSize="16k"
+	queue.saveOnShutdown="on"
+	queue.onCorruption="safe"
+)
+
+template(name="outfmt" type="string" string="%msg:F,58:2%\\n")
+action(type="omfile" file="'"$RSYSLOG_OUT_LOG"'" template="outfmt")
+'
+}
+
+list_spool_top() {
+	find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 -printf '%f %s bytes\n' | sort
+}
+
+count_bad_dirs() {
+	find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 -type d -name 'mainq.bad.*' | wc -l
+}
+
+check_no_live_mainq_files() {
+	local live_files
+
+	live_files="$(find "$SPOOL_DIR" -maxdepth 1 -mindepth 1 \
+		\( -type f -o -type l \) -name 'mainq*' -printf '%f\n')"
+	if [ -n "$live_files" ]; then
+		echo "FAIL: live mainq files remain after restart recovery"
+		printf '%s\n' "$live_files"
+		ls -l "$SPOOL_DIR"
+		error_exit 1
+	fi
+}
+
+corrupt_middle_segment() {
+	local seg_files=()
+	local base
+	local num
+	local target
+	local orig_size
+	local mid_idx
+	local seek_offs
+	local corrupt_len
+
+	for path in "$SPOOL_DIR"/mainq.*; do
+		[ -f "$path" ] || continue
+		base="${path##*/}"
+		num="${base#mainq.}"
+		case "$num" in
+		''|*[!0-9]*)
+			continue
+			;;
+		esac
+		seg_files+=("$base")
+	done
+
+	if [ "${#seg_files[@]}" -gt 0 ]; then
+		IFS=$'\n' seg_files=($(printf '%s\n' "${seg_files[@]}" | sort -t. -k2,2n))
+		unset IFS
+	fi
+
+	if [ "${#seg_files[@]}" -lt 3 ]; then
+		printf 'FAIL: expected at least 3 queue segment files, found %d\n' "${#seg_files[@]}"
+		list_spool_top
+		error_exit 1
+	fi
+
+	mid_idx=$(( ${#seg_files[@]} / 2 ))
+	target="$SPOOL_DIR/${seg_files[$mid_idx]}"
+	orig_size=$(stat -c%s "$target")
+	seek_offs=$(( orig_size / 2 ))
+	corrupt_len=4096
+	if [ "$seek_offs" -le 0 ] || [ "$seek_offs" -ge "$orig_size" ]; then
+		printf 'FAIL: invalid corruption offset for %s (size=%s)\n' "$target" "$orig_size"
+		error_exit 1
+	fi
+	if [ $(( seek_offs + corrupt_len )) -gt "$orig_size" ]; then
+		corrupt_len=$(( orig_size - seek_offs ))
+	fi
+
+	printf 'Corrupting queue segment %s at offset %s for %s bytes\n' "$target" "$seek_offs" "$corrupt_len"
+	dd if=/dev/zero of="$target" bs=1 seek="$seek_offs" count="$corrupt_len" conv=notrunc status=none
+}
+
+write_phase1_conf
+startup
+injectmsg 0 "$NUMMESSAGES"
+shutdown_immediate
+wait_shutdown
+
+if [ ! -f "$SPOOL_DIR/mainq.qi" ]; then
+	echo "FAIL: mainq.qi missing after initial shutdown"
+	list_spool_top
+	error_exit 1
+fi
+
+echo "spool files after initial shutdown:"
+list_spool_top
+
+corrupt_middle_segment
+
+printf 'RSYSLOG RESTART\n\n'
+write_phase2_conf
+
+: > "$RSYSLOGD_LOG"
+: > "$STARTED_LOG"
+export RS_REDIR=">>\"$RSYSLOGD_LOG\" 2>&1"
+bad_before=$(count_bad_dirs)
+
+startup
+shutdown_when_empty
+wait_shutdown
+unset RS_REDIR
+
+echo "spool files after restart recovery:"
+list_spool_top
+
+bad_after=$(count_bad_dirs)
+if [ "$bad_after" -gt "$bad_before" ]; then
+	echo "truncated queue segment quarantined into mainq.bad.*"
+	check_no_live_mainq_files
+	exit_test
+fi
+
+if [ ! -s "$RSYSLOG_OUT_LOG" ]; then
+	echo "FAIL: truncated queue recovery produced no output and no quarantine directory"
+	list_spool_top
+	cat "$RSYSLOGD_LOG"
+	error_exit 1
+fi
+
+check_no_live_mainq_files
+exit_test


### PR DESCRIPTION
## Summary

This fixes disk queue teardown after corruption recovery when the queue has
already become logically empty.

## Root Cause

After restart recovery from a corrupted persisted disk queue, rsyslog can emit
late internal messages during shutdown. Those messages land in the active write
stream even though the queue is already logically empty and the `.qi` file has
been removed. The old destructor only deleted the write file when its offset was
zero, which left an orphaned `mainq.*` file behind.

## What Changed

- delete the active disk queue write file on close when the queue is logically
  empty
- add a reproducer that corrupts bytes inside a persisted disk queue segment and
  verifies restart recovery does not leave live queue files behind

## Impact

Disk queue recovery after corrupted persisted state no longer leaves orphaned
queue files behind at shutdown.

## Validation

- `./tests/diskqueue-truncated-segment-startup.sh`
- `./tests/diskqueue-oncorruption-missing-segment.sh`
- `./tests/daqueue-dirty-shutdown-recovery.sh`
- `./tests/daqueue-invld-qi.sh`

Closes https://github.com/rsyslog/rsyslog/issues/5085
