### PR TITLE
tests: re-enable imrelp tls cfgcmd test

### DIFF
--- a/tests/imrelp-tls-cfgcmd.sh
+++ b/tests/imrelp-tls-cfgcmd.sh
@@ -2,9 +2,6 @@
 # addd 2019-11-14 by alorbach, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 require_relpEngineSetTLSLibByName
-echo This test seems to have problems with a tcpflood segfault on some platforms, thus skipping
-echo see https://github.com/rsyslog/rsyslog/issues/6267
-skip_test
 export NUMMESSAGES=1000
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"


### PR DESCRIPTION
## Summary
Re-enable `tests/imrelp-tls-cfgcmd.sh` by removing the unconditional hard skip added while the tcpflood/librelp crash was under investigation.

## Why
The tcpflood null-session crash path was fixed separately, but this regression scenario remained disabled, so CI no longer exercises it.

## Validation
- `./tests/imrelp-tls-cfgcmd.sh` in the feature worktree
- In this local environment the test now gets past the removed hard skip and stops only on the existing prerequisite gate: `relpEngineSetTLSLibByName API not available. Test stopped`

See also:
- https://github.com/rsyslog/rsyslog/issues/6266
- https://github.com/rsyslog/rsyslog/issues/6267