### PR TITLE
fmhash: guard FNV/DJB with USE_HASH_XXHASH

### DIFF
--- a/contrib/fmhash/fmhash.c
+++ b/contrib/fmhash/fmhash.c
@@ -77,9 +77,9 @@ struct hash_context_s {
 
 #ifndef USE_HASH_XXHASH
     /*
-    * Fowler–Noll–Vo hash 32 bit
-    * http://www.isthe.com/chongo/src/fnv/hash_32.c
-    */
+     * Fowler–Noll–Vo hash 32 bit
+     * http://www.isthe.com/chongo/src/fnv/hash_32.c
+     */
     #if defined(__clang__)
         #pragma GCC diagnostic ignored "-Wunknown-attributes"
     #endif
@@ -108,9 +108,9 @@ static hash_t
 
 
     /*
-    * Modified Bernstein
-    * http://www.eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
-    */
+     * Modified Bernstein
+     * http://www.eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
+     */
     #if defined(__clang__)
         #pragma GCC diagnostic ignored "-Wunknown-attributes"
     #endif

--- a/contrib/fmhash/fmhash.c
+++ b/contrib/fmhash/fmhash.c
@@ -75,17 +75,18 @@ struct hash_context_s {
     hash_wrapper_3 hash_wrapper_2_3;
 };
 
-/*
- * Fowler–Noll–Vo hash 32 bit
- * http://www.isthe.com/chongo/src/fnv/hash_32.c
- */
-#if defined(__clang__)
-    #pragma GCC diagnostic ignored "-Wunknown-attributes"
-#endif
+#ifndef USE_HASH_XXHASH
+    /*
+    * Fowler–Noll–Vo hash 32 bit
+    * http://www.isthe.com/chongo/src/fnv/hash_32.c
+    */
+    #if defined(__clang__)
+        #pragma GCC diagnostic ignored "-Wunknown-attributes"
+    #endif
 static hash_t
-#if defined(__clang__)
+    #if defined(__clang__)
     __attribute__((no_sanitize("unsigned-integer-overflow")))
-#endif
+    #endif
     fnv_32(const void *input, size_t len, seed_t seed) {
     unsigned char *bp = (unsigned char *)input; /* start of buffer */
 
@@ -106,17 +107,17 @@ static hash_t
 }
 
 
-/*
- * Modified Bernstein
- * http://www.eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
- */
-#if defined(__clang__)
-    #pragma GCC diagnostic ignored "-Wunknown-attributes"
-#endif
+    /*
+    * Modified Bernstein
+    * http://www.eternallyconfuzzled.com/tuts/algorithms/jsw_tut_hashing.aspx
+    */
+    #if defined(__clang__)
+        #pragma GCC diagnostic ignored "-Wunknown-attributes"
+    #endif
 static hash_t
-#if defined(__clang__)
+    #if defined(__clang__)
     __attribute__((no_sanitize("unsigned-integer-overflow")))
-#endif
+    #endif
     djb_hash(const void *input, size_t len, seed_t seed) {
     const char *p = input;
     hash_t hash = 5381;
@@ -127,6 +128,7 @@ static hash_t
 
     return hash + seed;
 }
+#endif /* ifndef USE_HASH_XXHASH */
 
 /*Get 32 bit hash for input*/
 static hash_t hash32(const void *input, size_t len, seed_t seed) {


### PR DESCRIPTION
Adjust build-time selection of hash implementations to improve consistency across configurations and reduce maintenance overhead.

Impact: behavior may vary by build flag; no test updates included.

Before: FNV 32-bit hash implementation was always compiled in.
After: FNV code is excluded when USE_HASH_XXHASH is defined.

Wrap the FNV 32-bit implementation in a conditional so it is only compiled when xxhash is not selected. This aligns the source with the intended single-hash backend model and avoids compiling unused code paths. The public hash32() entry point remains, with behavior determined by the selected backend at compile time.

Same reasoning applies to DJB 64-bit hash function.

No changes to interfaces; selection is controlled via USE_HASH_XXHASH. This reduces code footprint and clarifies which implementation is active in a given build.

Refs: no issue

<!--
Thanks for your PR!

Commit Assistant (recommended for the commit message):
- Web (humans): https://www.rsyslog.com/tool_rsyslog-commit-assistant
- Base prompt (canonical): https://github.com/rsyslog/rsyslog/blob/main/ai/rsyslog_commit_assistant/base_prompt.txt

Important: put the substance into the **commit message** (not only here).
If needed, amend first (`git commit --amend`) and then open the PR.
-->

### Summary (non-technical, complete)
<!-- Why this change matters: modernization, maintainability, perf/security,
     Docker/CI readiness, or user value. This text should mirror the commit’s
     non-technical intro. -->

### References
<!-- Full GitHub URLs; use Fixes: only if conclusively fixed. -->
Refs: https://github.com/rsyslog/rsyslog/issues/<id>

### Notes (optional)
<!-- Mention tests/docs updates or planned follow-ups. If behavior changed,
     ensure the commit body has a one-line Impact and a one-line Before/After. -->

---

#### Quick check (optional)
- Commit message follows rules (ASCII; title ≤62, body ≤72; `<component>:`).
- Commit message includes non-technical “why”, Impact (if behavior/tests changed),
  and a one-line Before/After when behavior changed.
- Used the Commit Assistant or mirrored its structure.

---

#### Git workflow tips (optional, but helps reviews)
- Start by crafting the commit message locally (use the Assistant).
- If you already committed, improve it with:
  ```
  git commit --amend
  ```
- Squash related commits before PR where appropriate.
- Push your branch and then open the PR.
- If key info is only in the PR text, maintainers may ask you to move it
  into the commit message for a clean history.

