### PR TITLE
omelasticsearch error handling

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -901,11 +901,13 @@ static rsRetVal ATTR_NONNULL() checkConn(wrkrInstanceData_t *const pWrkrData) {
         free(healthUrl);
 
         if (res == CURLE_OK) {
-            DBGPRINTF(
-                "omelasticsearch: checkConn %s completed with success "
-                "on attempt %d\n",
-                serverUrl, i);
-            ABORT_FINALIZE(RS_RET_OK);
+            long httpStatus = 0;
+            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpStatus);
+            if (httpStatus >= 200 && httpStatus <= 299) {
+                DBGPRINTF("omelasticsearch: checkConn %s completed with success on attempt %d\n", serverUrl, i);
+                ABORT_FINALIZE(RS_RET_OK);
+            }
+            DBGPRINTF("omelasticsearch: checkConn %s HTTP status %ld on attempt %d\n", serverUrl, httpStatus, i);
         }
 
         DBGPRINTF("omelasticsearch: checkConn %s failed on attempt %d: %s\n", serverUrl, i, curl_easy_strerror(res));

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1979,6 +1979,14 @@ static rsRetVal ATTR_NONNULL(1, 2)
         ABORT_FINALIZE(RS_RET_SUSPENDED);
     }
 
+    if (pWrkrData->httpStatusCode >= 500 || pWrkrData->httpStatusCode == 429) {
+        STATSCOUNTER_INC(indexHTTPReqFail, mutIndexHTTPReqFail);
+        STATSCOUNTER_ADD(indexHTTPFail, mutIndexHTTPFail, nmsgs);
+        LogError(0, RS_RET_SUSPENDED, "omelasticsearch: server returned unexpected HTTP status code %ld",
+                 pWrkrData->httpStatusCode);
+        ABORT_FINALIZE(RS_RET_SUSPENDED);
+    }
+
     if (pWrkrData->pData->rebindInterval > -1) pWrkrData->nOperations++;
 
     if (pWrkrData->reply == NULL) {


### PR DESCRIPTION
Hello @rgerhards,

Please find here 2 patches for proper error handling on omelasticsearch :

- Suspend the action on 5xx or 429 HTTP responses (e.g. 503 from a reverse proxy) instead of failing JSON parsing and looping on retries.
- Make checkConn() verify the HTTP status code of the health check, so a non-2xx response from a reverse proxy no longer falsely resumes a suspended action and causes a suspend/resume loop.

Many thanks,
Julien T. / ZENETYS