### PR TITLE
[codex] imkubernetes: add Kubernetes-native log input

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -187,6 +187,10 @@ if ENABLE_IMDOCKER
 SUBDIRS += contrib/imdocker
 endif
 
+if ENABLE_IMKUBERNETES
+SUBDIRS += contrib/imkubernetes
+endif
+
 if ENABLE_IMPTCP
 SUBDIRS += plugins/imptcp
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -2273,6 +2273,21 @@ if test "x$enable_imdocker" = "xyes"; then
 fi
 AM_CONDITIONAL(ENABLE_IMDOCKER, test x$enable_imdocker = xyes)
 
+AC_ARG_ENABLE(imkubernetes,
+        [AS_HELP_STRING([--enable-imkubernetes],[input kubernetes log module enabled @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_imkubernetes="yes" ;;
+          no) enable_imkubernetes="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-imkubernetes) ;;
+         esac],
+        [enable_imkubernetes=no]
+)
+if test "x$enable_imkubernetes" = "xyes"; then
+	AC_CHECK_HEADERS([curl/curl.h glob.h])
+	PKG_CHECK_MODULES([CURL], [libcurl >= 7.40.0])
+fi
+AM_CONDITIONAL(ENABLE_IMKUBERNETES, test x$enable_imkubernetes = xyes)
+
 AC_ARG_ENABLE(imdocker-tests,
         [AS_HELP_STRING([--enable-imdocker-tests],[Enable imdocker tests @<:@default=no@:>@])],
         [case "${enableval}" in
@@ -3627,6 +3642,7 @@ AC_CONFIG_FILES([Makefile \
 		contrib/omtcl/Makefile \
 		contrib/imbatchreport/Makefile \
 		contrib/mmkubernetes/Makefile \
+		contrib/imkubernetes/Makefile \
 		contrib/impcap/Makefile \
 		contrib/imtuxedoulog/Makefile \
 		contrib/improg/Makefile \
@@ -3676,6 +3692,7 @@ echo "    imdiag enabled:                           $enable_imdiag"
 echo "    file input module enabled:                $enable_imfile"
 echo "    fifo input module enabled:                $enable_imfifo"
 echo "    docker log input module enabled:          $enable_imdocker"
+echo "    kubernetes log input module enabled:      $enable_imkubernetes"
 echo "    Solaris input module enabled:             $enable_imsolaris"
 echo "    periodic statistics module enabled:       $enable_impstats"
 echo "    imczmq input module enabled:              $enable_imczmq"

--- a/contrib/imkubernetes/MODULE_METADATA.yaml
+++ b/contrib/imkubernetes/MODULE_METADATA.yaml
@@ -1,0 +1,19 @@
+support_status: experimental
+maturity_level: experimental
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2026-04-20
+build_dependencies:
+  - libcurl development headers and library
+runtime_dependencies:
+  - Kubernetes node log files mounted from the host, typically under /var/log/pods or /var/log/containers
+  - Kubernetes API reachability and credentials when EnrichKubernetes is enabled
+ci_targets:
+  - imkubernetes-cri-basic.sh
+  - imkubernetes-dockerjson-basic.sh
+  - yaml-imkubernetes-dockerjson-basic.sh
+documentation:
+  - doc/source/configuration/modules/imkubernetes.rst
+notes:
+  - The module is experimental; user feedback from real Kubernetes deployments is actively requested.
+  - The module is a Kubernetes-first file tailer and does not depend on a local Docker daemon.
+  - File state, partial-record assembly, cache entries, and the CURL handle are owned by the single input thread.

--- a/contrib/imkubernetes/Makefile.am
+++ b/contrib/imkubernetes/Makefile.am
@@ -1,0 +1,6 @@
+pkglib_LTLIBRARIES = imkubernetes.la
+
+imkubernetes_la_SOURCES = imkubernetes.c
+imkubernetes_la_CPPFLAGS = $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(CURL_CFLAGS)
+imkubernetes_la_LDFLAGS = -module -avoid-version
+imkubernetes_la_LIBADD = $(CURL_LIBS)

--- a/contrib/imkubernetes/imkubernetes.c
+++ b/contrib/imkubernetes/imkubernetes.c
@@ -1,0 +1,1540 @@
+/* imkubernetes.c
+ * Kubernetes-native container log input module.
+ *
+ * This module tails Kubernetes pod/container log files from the host
+ * filesystem, parses CRI or Docker json-file records, and optionally enriches
+ * them with pod metadata from the Kubernetes API.
+ *
+ * Copyright (C) 2026 the rsyslog project.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *       -or-
+ *       see COPYING.ASL20 in the source distribution
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _GNU_SOURCE
+    #define _GNU_SOURCE
+#endif
+
+#include "config.h"
+#include "rsyslog.h"
+#include <assert.h>
+#include <ctype.h>
+#include <curl/curl.h>
+#include <errno.h>
+#include <glob.h>
+#include <json.h>
+#include <signal.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "cfsysline.h"
+#include "datetime.h"
+#include "debug.h"
+#include "errmsg.h"
+#include "glbl.h"
+#include "module-template.h"
+#include "msg.h"
+#include "parser.h"
+#include "prop.h"
+#include "ratelimit.h"
+#include "ruleset.h"
+#include "srUtils.h"
+#include "statsobj.h"
+#include "unicode-helper.h"
+
+MODULE_TYPE_INPUT;
+MODULE_TYPE_NOKEEP;
+MODULE_CNFNAME("imkubernetes")
+
+#define DFLT_LOG_FILE_GLOB "/var/log/pods/*/*/*.log"
+#define DFLT_KUBERNETES_URL "https://kubernetes.default.svc.cluster.local:443"
+#define DFLT_TOKEN_FILE "/var/run/secrets/kubernetes.io/serviceaccount/token"
+#define DFLT_CA_CERT_FILE "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+#define DFLT_pollingInterval 1
+#define DFLT_cacheEntryTtl 300
+#define DFLT_freshStartTail 0
+#define DFLT_bEscapeLF 1
+#define DFLT_enrichKubernetes 1
+#define DFLT_SEVERITY pri2sev(LOG_INFO)
+#define DFLT_FACILITY pri2fac(LOG_USER)
+
+enum { dst_invalid = -1, dst_stdout, dst_stderr };
+
+typedef struct partial_msg_s {
+    uchar *data;
+    size_t len;
+    size_t cap;
+    int stream_type;
+    struct syslogTime st;
+    time_t ttGenTime;
+    sbool hasTime;
+} partial_msg_t;
+
+typedef struct path_meta_s {
+    char *namespace_name;
+    char *pod_name;
+    char *pod_uid;
+    char *container_name;
+    char *container_id;
+    int restart_count;
+} path_meta_t;
+
+typedef struct file_state_s {
+    char *path;
+    ino_t inode;
+    off_t offset;
+    sbool seen;
+    path_meta_t meta;
+    partial_msg_t partial;
+    struct file_state_s *next;
+} file_state_t;
+
+typedef struct pod_cache_entry_s {
+    char *key;
+    time_t expires_at;
+    struct json_object *json;
+    struct pod_cache_entry_s *next;
+} pod_cache_entry_t;
+
+typedef struct curl_buf_s {
+    char *data;
+    size_t len;
+    size_t cap;
+} curl_buf_t;
+
+typedef struct parsed_record_s {
+    const uchar *msg;
+    uchar *owned_msg;
+    size_t len;
+    int stream_type;
+    struct syslogTime st;
+    time_t ttGenTime;
+    sbool hasTime;
+    sbool is_partial;
+    const char *format_name;
+    sbool parse_error;
+} parsed_record_t;
+
+struct modConfData_s {
+    rsconf_t *pConf;
+    uchar *logFileGlob;
+    int iPollInterval;
+    int cacheEntryTtl;
+    int iDfltSeverity;
+    int iDfltFacility;
+    sbool bEscapeLf;
+    sbool freshStartTail;
+    sbool enrichKubernetes;
+    uchar *kubernetesUrl;
+    uchar *token;
+    uchar *tokenFile;
+    uchar *caCertFile;
+    sbool allowUnsignedCerts;
+    sbool skipVerifyHost;
+    uchar *pszBindRuleset;
+    ruleset_t *pBindRuleset;
+};
+
+static modConfData_t *loadModConf = NULL;
+static modConfData_t *runModConf = NULL;
+static int bLegacyCnfModGlobalsPermitted;
+
+DEF_IMOD_STATIC_DATA;
+DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(parser) DEFobjCurrIf(ruleset) DEFobjCurrIf(statsobj)
+    DEFobjCurrIf(datetime)
+
+        static prop_t *pInputName = NULL;
+static ratelimit_t *ratelimiter = NULL;
+static statsobj_t *modStats = NULL;
+static file_state_t *g_fileStates = NULL;
+static pod_cache_entry_t *g_podCache = NULL;
+static CURL *g_apiCurl = NULL;
+static struct curl_slist *g_apiHdr = NULL;
+static char *gLineBuf = NULL;
+static size_t gLineBufCap = 0;
+
+STATSCOUNTER_DEF(ctrSubmitted, mutCtrSubmitted)
+STATSCOUNTER_DEF(ctrParseErrors, mutCtrParseErrors)
+STATSCOUNTER_DEF(ctrFilesDiscovered, mutCtrFilesDiscovered)
+STATSCOUNTER_DEF(ctrCriRecords, mutCtrCriRecords)
+STATSCOUNTER_DEF(ctrDockerJsonRecords, mutCtrDockerJsonRecords)
+STATSCOUNTER_DEF(ctrCacheHits, mutCtrCacheHits)
+STATSCOUNTER_DEF(ctrCacheMisses, mutCtrCacheMisses)
+STATSCOUNTER_DEF(ctrApiErrors, mutCtrApiErrors)
+STATSCOUNTER_DEF(ctrLostRatelimit, mutCtrLostRatelimit)
+
+static struct cnfparamdescr modpdescr[] = {
+    {"logfileglob", eCmdHdlrString, 0},
+    {"pollinginterval", eCmdHdlrPositiveInt, 0},
+    {"cacheentryttl", eCmdHdlrPositiveInt, 0},
+    {"freshstarttail", eCmdHdlrBinary, 0},
+    {"defaultseverity", eCmdHdlrSeverity, 0},
+    {"defaultfacility", eCmdHdlrFacility, 0},
+    {"escapelf", eCmdHdlrBinary, 0},
+    {"enrichkubernetes", eCmdHdlrBinary, 0},
+    {"kubernetesurl", eCmdHdlrString, 0},
+    {"token", eCmdHdlrString, 0},
+    {"tokenfile", eCmdHdlrString, 0},
+    {"tls.cacert", eCmdHdlrString, 0},
+    {"allowunsignedcerts", eCmdHdlrBinary, 0},
+    {"skipverifyhost", eCmdHdlrBinary, 0},
+    {"ruleset", eCmdHdlrString, 0},
+};
+static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
+static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
+
+static void freePathMeta(path_meta_t *meta) {
+    if (meta == NULL) {
+        return;
+    }
+    free(meta->namespace_name);
+    free(meta->pod_name);
+    free(meta->pod_uid);
+    free(meta->container_name);
+    free(meta->container_id);
+    memset(meta, 0, sizeof(*meta));
+    meta->restart_count = -1;
+}
+
+static void freePartialMsg(partial_msg_t *partial) {
+    if (partial == NULL) {
+        return;
+    }
+    free(partial->data);
+    memset(partial, 0, sizeof(*partial));
+    partial->stream_type = dst_invalid;
+}
+
+static void freeFileStates(void) {
+    file_state_t *curr = g_fileStates;
+    while (curr != NULL) {
+        file_state_t *next = curr->next;
+        free(curr->path);
+        freePathMeta(&curr->meta);
+        freePartialMsg(&curr->partial);
+        free(curr);
+        curr = next;
+    }
+    g_fileStates = NULL;
+}
+
+static void freePodCache(void) {
+    pod_cache_entry_t *curr = g_podCache;
+    while (curr != NULL) {
+        pod_cache_entry_t *next = curr->next;
+        free(curr->key);
+        if (curr->json != NULL) {
+            json_object_put(curr->json);
+        }
+        free(curr);
+        curr = next;
+    }
+    g_podCache = NULL;
+}
+
+static char *dupRange(const char *start, size_t len) {
+    char *out = NULL;
+    if (start == NULL) {
+        return NULL;
+    }
+    out = malloc(len + 1);
+    if (out == NULL) {
+        return NULL;
+    }
+    memcpy(out, start, len);
+    out[len] = '\0';
+    return out;
+}
+
+static rsRetVal partialAppend(partial_msg_t *partial, const uchar *msg, size_t len) {
+    DEFiRet;
+    size_t needed;
+    uchar *newbuf = NULL;
+
+    assert(partial != NULL);
+    if (msg == NULL || len == 0) {
+        FINALIZE;
+    }
+
+    needed = partial->len + len + 1;
+    if (needed > partial->cap) {
+        size_t newcap = partial->cap == 0 ? 256 : partial->cap;
+        while (newcap < needed) {
+            newcap *= 2;
+        }
+        CHKmalloc(newbuf = realloc(partial->data, newcap));
+        partial->data = newbuf;
+        partial->cap = newcap;
+    }
+
+    memcpy(partial->data + partial->len, msg, len);
+    partial->len += len;
+    partial->data[partial->len] = '\0';
+
+finalize_it:
+    RETiRet;
+}
+
+static void trimTrailingNewline(const char *line, size_t *len) {
+    while (*len > 0 && (line[*len - 1] == '\n' || line[*len - 1] == '\r')) {
+        --(*len);
+    }
+}
+
+static rsRetVal parseTimestamp3339(const char *ts, size_t len, struct syslogTime *st, time_t *ttGenTime, sbool *ok) {
+    DEFiRet;
+    uchar *mutableTs = NULL;
+    uchar *parsePtr = NULL;
+    int parseLen;
+
+    assert(st != NULL);
+    assert(ttGenTime != NULL);
+    assert(ok != NULL);
+    *ok = 0;
+    *ttGenTime = 0;
+
+    CHKmalloc(mutableTs = (uchar *)dupRange(ts, len));
+    parsePtr = mutableTs;
+    parseLen = (int)len;
+    if (datetime.ParseTIMESTAMP3339(st, &parsePtr, &parseLen) == RS_RET_OK) {
+        *ttGenTime = datetime.syslogTime2time_t(st);
+        *ok = 1;
+    }
+
+finalize_it:
+    free(mutableTs);
+    RETiRet;
+}
+
+static sbool parsePodsPath(const char *path, path_meta_t *meta) {
+    const char *filePart;
+    const char *containerStart;
+    const char *containerEnd;
+    const char *podStart;
+    const char *podEnd;
+    const char *podsDirStart;
+    const char *podsDirEnd;
+    const char *u1;
+    const char *u2;
+    char *restartStr = NULL;
+    char *restartEnd = NULL;
+
+    filePart = strrchr(path, '/');
+    if (filePart == NULL || filePart == path) {
+        return 0;
+    }
+    containerEnd = filePart;
+    containerStart = containerEnd;
+    while (containerStart > path && containerStart[-1] != '/') {
+        --containerStart;
+    }
+    if (containerStart == path) {
+        return 0;
+    }
+    podEnd = containerStart - 1;
+    podStart = podEnd;
+    while (podStart > path && podStart[-1] != '/') {
+        --podStart;
+    }
+    if (podStart == path) {
+        return 0;
+    }
+    podsDirEnd = podStart - 1;
+    podsDirStart = podsDirEnd;
+    while (podsDirStart > path && podsDirStart[-1] != '/') {
+        --podsDirStart;
+    }
+    if ((size_t)(podsDirEnd - podsDirStart) != sizeof("pods") - 1 ||
+        strncmp(podsDirStart, "pods", sizeof("pods") - 1)) {
+        return 0;
+    }
+    u1 = memchr(podStart, '_', (size_t)(podEnd - podStart));
+    if (u1 == NULL) {
+        return 0;
+    }
+    u2 = memchr(u1 + 1, '_', (size_t)(podEnd - (u1 + 1)));
+    if (u2 == NULL) {
+        return 0;
+    }
+
+    meta->namespace_name = dupRange(podStart, (size_t)(u1 - podStart));
+    meta->pod_name = dupRange(u1 + 1, (size_t)(u2 - (u1 + 1)));
+    meta->pod_uid = dupRange(u2 + 1, (size_t)(podEnd - (u2 + 1)));
+    meta->container_name = dupRange(containerStart, (size_t)(containerEnd - containerStart));
+    if (meta->namespace_name == NULL || meta->pod_name == NULL || meta->pod_uid == NULL ||
+        meta->container_name == NULL) {
+        freePathMeta(meta);
+        return 0;
+    }
+
+    restartStr = dupRange(filePart + 1, strlen(filePart + 1));
+    if (restartStr != NULL) {
+        char *dot = strrchr(restartStr, '.');
+        if (dot != NULL) {
+            *dot = '\0';
+        }
+        errno = 0;
+        meta->restart_count = (int)strtol(restartStr, &restartEnd, 10);
+        if (errno != 0 || restartEnd == restartStr || *restartEnd != '\0') {
+            free(restartStr);
+            freePathMeta(meta);
+            return 0;
+        }
+    }
+    free(restartStr);
+    return 1;
+}
+
+static sbool parseContainersPath(const char *path, path_meta_t *meta) {
+    const char *filePart = strrchr(path, '/');
+    char *base = NULL;
+    char *dot = NULL;
+    char *dash = NULL;
+    char *u1 = NULL;
+    char *u2 = NULL;
+
+    if (filePart == NULL) {
+        filePart = path;
+    } else {
+        ++filePart;
+    }
+    base = strdup(filePart);
+    if (base == NULL) {
+        return 0;
+    }
+    dot = strrchr(base, '.');
+    if (dot != NULL) {
+        *dot = '\0';
+    }
+    dash = strrchr(base, '-');
+    if (dash == NULL || dash == base || dash[1] == '\0') {
+        free(base);
+        return 0;
+    }
+    *dash = '\0';
+    u1 = strchr(base, '_');
+    if (u1 == NULL) {
+        free(base);
+        return 0;
+    }
+    u2 = strchr(u1 + 1, '_');
+    if (u2 == NULL) {
+        free(base);
+        return 0;
+    }
+
+    meta->pod_name = dupRange(base, (size_t)(u1 - base));
+    meta->namespace_name = dupRange(u1 + 1, (size_t)(u2 - (u1 + 1)));
+    meta->container_name = strdup(u2 + 1);
+    meta->container_id = strdup(dash + 1);
+    meta->restart_count = -1;
+    free(base);
+    if (meta->pod_name == NULL || meta->namespace_name == NULL || meta->container_name == NULL ||
+        meta->container_id == NULL) {
+        freePathMeta(meta);
+        return 0;
+    }
+    return 1;
+}
+
+static sbool populatePathMeta(const char *path, path_meta_t *meta) {
+    const char *containersSeg = strstr(path, "/containers/");
+    const char *podsSeg = strstr(path, "/pods/");
+
+    memset(meta, 0, sizeof(*meta));
+    meta->restart_count = -1;
+    if (containersSeg != NULL) {
+        if (parseContainersPath(path, meta)) {
+            return 1;
+        }
+        freePathMeta(meta);
+    }
+    if (podsSeg != NULL) {
+        if (parsePodsPath(path, meta)) {
+            return 1;
+        }
+        freePathMeta(meta);
+    }
+    if (parsePodsPath(path, meta)) {
+        return 1;
+    }
+    freePathMeta(meta);
+    if (parseContainersPath(path, meta)) {
+        return 1;
+    }
+    freePathMeta(meta);
+    return 0;
+}
+
+static file_state_t *findFileState(const char *path) {
+    file_state_t *curr;
+    for (curr = g_fileStates; curr != NULL; curr = curr->next) {
+        if (!strcmp(curr->path, path)) {
+            return curr;
+        }
+    }
+    return NULL;
+}
+
+static file_state_t *createFileState(const char *path) {
+    file_state_t *state = NULL;
+    state = calloc(1, sizeof(*state));
+    if (state == NULL) {
+        return NULL;
+    }
+    state->path = strdup(path);
+    if (state->path == NULL) {
+        free(state);
+        return NULL;
+    }
+    state->offset = 0;
+    state->inode = 0;
+    state->seen = 1;
+    state->partial.stream_type = dst_invalid;
+    if (!populatePathMeta(path, &state->meta)) {
+        LogError(0, RS_RET_ERR, "imkubernetes: could not parse kubernetes metadata from path '%s'", path);
+        STATSCOUNTER_INC(ctrParseErrors, mutCtrParseErrors);
+    }
+    state->next = g_fileStates;
+    g_fileStates = state;
+    STATSCOUNTER_INC(ctrFilesDiscovered, mutCtrFilesDiscovered);
+    return state;
+}
+
+static void markAllFileStatesUnseen(void) {
+    file_state_t *curr;
+    for (curr = g_fileStates; curr != NULL; curr = curr->next) {
+        curr->seen = 0;
+    }
+}
+
+static void sweepFileStates(void) {
+    file_state_t **cursor = &g_fileStates;
+    while (*cursor != NULL) {
+        file_state_t *curr = *cursor;
+        if (curr->seen) {
+            cursor = &curr->next;
+            continue;
+        }
+        *cursor = curr->next;
+        free(curr->path);
+        freePathMeta(&curr->meta);
+        freePartialMsg(&curr->partial);
+        free(curr);
+    }
+}
+
+static pod_cache_entry_t *findPodCacheEntry(const char *key, time_t now) {
+    pod_cache_entry_t **cursor = &g_podCache;
+    while (*cursor != NULL) {
+        pod_cache_entry_t *curr = *cursor;
+        if (curr->expires_at <= now) {
+            *cursor = curr->next;
+            free(curr->key);
+            if (curr->json != NULL) {
+                json_object_put(curr->json);
+            }
+            free(curr);
+            continue;
+        }
+        if (!strcmp(curr->key, key)) {
+            return curr;
+        }
+        cursor = &curr->next;
+    }
+    return NULL;
+}
+
+static rsRetVal setPodCacheEntry(const char *key, struct json_object *json, time_t now) {
+    DEFiRet;
+    pod_cache_entry_t *entry = NULL;
+
+    assert(key != NULL);
+    assert(json != NULL);
+
+    if ((entry = findPodCacheEntry(key, now)) != NULL) {
+        if (entry->json != NULL) {
+            json_object_put(entry->json);
+        }
+        entry->json = json;
+        entry->expires_at = now + runModConf->cacheEntryTtl;
+        entry = NULL;
+        FINALIZE;
+    }
+
+    CHKmalloc(entry = calloc(1, sizeof(*entry)));
+    CHKmalloc(entry->key = strdup(key));
+    entry->json = json;
+    entry->expires_at = now + runModConf->cacheEntryTtl;
+    entry->next = g_podCache;
+    g_podCache = entry;
+    entry = NULL;
+
+finalize_it:
+    if (entry != NULL) {
+        free(entry->key);
+        free(entry);
+    }
+    RETiRet;
+}
+
+static size_t apiCurlCB(void *data, size_t size, size_t nmemb, void *buffer) {
+    curl_buf_t *buf = (curl_buf_t *)buffer;
+    size_t realsize = size * nmemb;
+    size_t needed = buf->len + realsize + 1;
+    char *newbuf;
+
+    if (needed > buf->cap) {
+        size_t newcap = buf->cap == 0 ? 1024 : buf->cap;
+        while (newcap < needed) {
+            newcap *= 2;
+        }
+        newbuf = realloc(buf->data, newcap);
+        if (newbuf == NULL) {
+            return 0;
+        }
+        buf->data = newbuf;
+        buf->cap = newcap;
+    }
+
+    memcpy(buf->data + buf->len, data, realsize);
+    buf->len += realsize;
+    buf->data[buf->len] = '\0';
+    return realsize;
+}
+
+static char *readFileTrimmed(const char *path) {
+    FILE *fp = NULL;
+    char *line = NULL;
+    size_t cap = 0;
+    ssize_t len;
+
+    fp = fopen(path, "r");
+    if (fp == NULL) {
+        return NULL;
+    }
+    len = getline(&line, &cap, fp);
+    fclose(fp);
+    if (len < 0) {
+        free(line);
+        return NULL;
+    }
+    while (len > 0 && (line[len - 1] == '\n' || line[len - 1] == '\r')) {
+        line[--len] = '\0';
+    }
+    return line;
+}
+
+static void copyJsonField(struct json_object *dst, struct json_object *src, const char *field) {
+    struct json_object *value = NULL;
+    if (dst == NULL || src == NULL || !json_object_is_type(src, json_type_object)) {
+        return;
+    }
+    if (json_object_object_get_ex(src, field, &value)) {
+        json_object_object_add(dst, (char *)field, json_object_get(value));
+    }
+}
+
+static rsRetVal initApiClient(void) {
+    DEFiRet;
+    CURLcode ccode;
+    char *token = NULL;
+    char authHeader[4096];
+    int authLen;
+
+    if (!runModConf->enrichKubernetes) {
+        FINALIZE;
+    }
+
+    if ((ccode = curl_global_init(CURL_GLOBAL_ALL)) != CURLE_OK) {
+        LogError(0, RS_RET_ERR, "imkubernetes: curl_global_init failed: %s", curl_easy_strerror(ccode));
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    if (runModConf->token != NULL) {
+        token = strdup((char *)runModConf->token);
+    } else if (runModConf->tokenFile != NULL) {
+        token = readFileTrimmed((char *)runModConf->tokenFile);
+    }
+
+    g_apiCurl = curl_easy_init();
+    if (g_apiCurl == NULL) {
+        LogError(0, RS_RET_ERR, "imkubernetes: curl_easy_init failed");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    if (token != NULL && token[0] != '\0') {
+        authLen = snprintf(authHeader, sizeof(authHeader), "Authorization: Bearer %s", token);
+        if (authLen < 0 || (size_t)authLen >= sizeof(authHeader)) {
+            LogError(0, RS_RET_ERR, "imkubernetes: bearer token is too long for Authorization header");
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        authHeader[sizeof(authHeader) - 1] = '\0';
+        g_apiHdr = curl_slist_append(g_apiHdr, authHeader);
+    }
+
+    curl_easy_setopt(g_apiCurl, CURLOPT_HTTPHEADER, g_apiHdr);
+    curl_easy_setopt(g_apiCurl, CURLOPT_WRITEFUNCTION, apiCurlCB);
+    curl_easy_setopt(g_apiCurl, CURLOPT_FOLLOWLOCATION, 1L);
+    curl_easy_setopt(g_apiCurl, CURLOPT_NOPROGRESS, 1L);
+    curl_easy_setopt(g_apiCurl, CURLOPT_USERAGENT, "rsyslog/imkubernetes");
+    if (runModConf->caCertFile != NULL) {
+        curl_easy_setopt(g_apiCurl, CURLOPT_CAINFO, runModConf->caCertFile);
+    }
+    if (runModConf->allowUnsignedCerts) {
+        curl_easy_setopt(g_apiCurl, CURLOPT_SSL_VERIFYPEER, 0L);
+    }
+    if (runModConf->skipVerifyHost) {
+        curl_easy_setopt(g_apiCurl, CURLOPT_SSL_VERIFYHOST, 0L);
+    }
+
+finalize_it:
+    free(token);
+    RETiRet;
+}
+
+static void freeApiClient(void) {
+    if (g_apiCurl != NULL) {
+        curl_easy_cleanup(g_apiCurl);
+        g_apiCurl = NULL;
+    }
+    if (g_apiHdr != NULL) {
+        curl_slist_free_all(g_apiHdr);
+        g_apiHdr = NULL;
+    }
+    if (runModConf != NULL && runModConf->enrichKubernetes) {
+        curl_global_cleanup();
+    }
+}
+
+static rsRetVal queryPodMetadata(const path_meta_t *meta, struct json_object **result) {
+    DEFiRet;
+    char *url = NULL;
+    curl_buf_t buf = {0};
+    CURLcode ccode;
+    long respCode = 0;
+    struct json_object *reply = NULL;
+    struct json_object *metadata = NULL;
+    struct json_object *status = NULL;
+    struct json_object *ownerRefs = NULL;
+    struct json_object *ownerRef = NULL;
+    struct json_object *out = NULL;
+    struct json_object *value = NULL;
+
+    assert(result != NULL);
+    *result = NULL;
+
+    if (g_apiCurl == NULL || meta == NULL || meta->namespace_name == NULL || meta->pod_name == NULL) {
+        FINALIZE;
+    }
+
+    if (asprintf(&url, "%s/api/v1/namespaces/%s/pods/%s", (char *)runModConf->kubernetesUrl, meta->namespace_name,
+                 meta->pod_name) == -1) {
+        url = NULL;
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+
+    curl_easy_setopt(g_apiCurl, CURLOPT_URL, url);
+    curl_easy_setopt(g_apiCurl, CURLOPT_WRITEDATA, &buf);
+    ccode = curl_easy_perform(g_apiCurl);
+    if (ccode != CURLE_OK) {
+        LogError(0, RS_RET_ERR, "imkubernetes: kubernetes API request failed for '%s': %s", url,
+                 curl_easy_strerror(ccode));
+        STATSCOUNTER_INC(ctrApiErrors, mutCtrApiErrors);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    ccode = curl_easy_getinfo(g_apiCurl, CURLINFO_RESPONSE_CODE, &respCode);
+    if (ccode != CURLE_OK) {
+        LogError(0, RS_RET_ERR, "imkubernetes: curl_easy_getinfo failed for '%s': %s", url, curl_easy_strerror(ccode));
+        STATSCOUNTER_INC(ctrApiErrors, mutCtrApiErrors);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    if (respCode == 404) {
+        ABORT_FINALIZE(RS_RET_NOT_FOUND);
+    }
+    if (respCode != 200) {
+        LogError(0, RS_RET_ERR, "imkubernetes: kubernetes API returned %ld for '%s'", respCode, url);
+        STATSCOUNTER_INC(ctrApiErrors, mutCtrApiErrors);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    reply = json_tokener_parse(buf.data != NULL ? buf.data : "{}");
+    if (reply == NULL) {
+        STATSCOUNTER_INC(ctrApiErrors, mutCtrApiErrors);
+        ABORT_FINALIZE(RS_RET_JSON_PARSE_ERR);
+    }
+    if (!json_object_is_type(reply, json_type_object)) {
+        STATSCOUNTER_INC(ctrApiErrors, mutCtrApiErrors);
+        ABORT_FINALIZE(RS_RET_JSON_PARSE_ERR);
+    }
+
+    CHKmalloc(out = json_object_new_object());
+    if (json_object_object_get_ex(reply, "metadata", &metadata)) {
+        copyJsonField(out, metadata, "uid");
+        if (json_object_object_get_ex(metadata, "uid", &value)) {
+            json_object_object_del(out, "uid");
+            json_object_object_add(out, "pod_id", json_object_get(value));
+        }
+        copyJsonField(out, metadata, "creationTimestamp");
+        if (json_object_object_get_ex(metadata, "creationTimestamp", &value)) {
+            json_object_object_del(out, "creationTimestamp");
+            json_object_object_add(out, "creation_timestamp", json_object_get(value));
+        }
+        copyJsonField(out, metadata, "labels");
+        copyJsonField(out, metadata, "annotations");
+        if (json_object_object_get_ex(metadata, "ownerReferences", &ownerRefs) &&
+            json_object_is_type(ownerRefs, json_type_array) && json_object_array_length(ownerRefs) > 0) {
+            ownerRef = json_object_array_get_idx(ownerRefs, 0);
+            copyJsonField(out, ownerRef, "kind");
+            if (json_object_object_get_ex(ownerRef, "kind", &value)) {
+                json_object_object_del(out, "kind");
+                json_object_object_add(out, "owner_kind", json_object_get(value));
+            }
+            copyJsonField(out, ownerRef, "name");
+            if (json_object_object_get_ex(ownerRef, "name", &value)) {
+                json_object_object_del(out, "name");
+                json_object_object_add(out, "owner_name", json_object_get(value));
+            }
+        }
+    }
+    if (json_object_object_get_ex(reply, "status", &status)) {
+        copyJsonField(out, status, "podIP");
+        if (json_object_object_get_ex(status, "podIP", &value)) {
+            json_object_object_del(out, "podIP");
+            json_object_object_add(out, "pod_ip", json_object_get(value));
+        }
+        copyJsonField(out, status, "hostIP");
+        if (json_object_object_get_ex(status, "hostIP", &value)) {
+            json_object_object_del(out, "hostIP");
+            json_object_object_add(out, "host_ip", json_object_get(value));
+        }
+    }
+    if (json_object_object_get_ex(reply, "spec", &status)) {
+        if (json_object_object_get_ex(status, "nodeName", &value)) {
+            json_object_object_add(out, "host", json_object_get(value));
+        }
+    }
+    json_object_object_add(out, "master_url", json_object_new_string((char *)runModConf->kubernetesUrl));
+    *result = out;
+    out = NULL;
+
+finalize_it:
+    free(url);
+    free(buf.data);
+    if (reply != NULL) {
+        json_object_put(reply);
+    }
+    if (out != NULL) {
+        json_object_put(out);
+    }
+    RETiRet;
+}
+
+static struct json_object *getPodMetadataForState(const path_meta_t *meta) {
+    char *key = NULL;
+    time_t now;
+    struct json_object *cached = NULL;
+    struct json_object *fresh = NULL;
+    pod_cache_entry_t *entry = NULL;
+    rsRetVal iRet;
+
+    if (!runModConf->enrichKubernetes || meta == NULL || meta->namespace_name == NULL || meta->pod_name == NULL) {
+        return NULL;
+    }
+
+    datetime.GetTime(&now);
+    if (asprintf(&key, "%s/%s", meta->namespace_name, meta->pod_name) == -1) {
+        key = NULL;
+        return NULL;
+    }
+
+    entry = findPodCacheEntry(key, now);
+    if (entry != NULL) {
+        cached = entry->json;
+        STATSCOUNTER_INC(ctrCacheHits, mutCtrCacheHits);
+        free(key);
+        return cached;
+    }
+
+    STATSCOUNTER_INC(ctrCacheMisses, mutCtrCacheMisses);
+    iRet = queryPodMetadata(meta, &fresh);
+    if (iRet == RS_RET_OK && fresh != NULL) {
+        if (setPodCacheEntry(key, fresh, now) == RS_RET_OK) {
+            free(key);
+            return fresh;
+        }
+        json_object_put(fresh);
+    }
+    free(key);
+    return NULL;
+}
+
+static rsRetVal addRuntimeMetadata(smsg_t *pMsg, const file_state_t *state, const parsed_record_t *record) {
+    struct json_object *k8s = NULL;
+    struct json_object *docker = NULL;
+    struct json_object *podMd = NULL;
+    struct json_object *value = NULL;
+    DEFiRet;
+
+    assert(pMsg != NULL);
+    assert(state != NULL);
+    assert(record != NULL);
+
+    CHKmalloc(k8s = json_object_new_object());
+    if (state->meta.namespace_name != NULL) {
+        json_object_object_add(k8s, "namespace_name", json_object_new_string(state->meta.namespace_name));
+    }
+    if (state->meta.pod_name != NULL) {
+        json_object_object_add(k8s, "pod_name", json_object_new_string(state->meta.pod_name));
+    }
+    if (state->meta.pod_uid != NULL) {
+        json_object_object_add(k8s, "pod_uid", json_object_new_string(state->meta.pod_uid));
+    }
+    if (state->meta.container_name != NULL) {
+        json_object_object_add(k8s, "container_name", json_object_new_string(state->meta.container_name));
+    }
+    if (state->meta.restart_count >= 0) {
+        json_object_object_add(k8s, "restart_count", json_object_new_int(state->meta.restart_count));
+    }
+    json_object_object_add(k8s, "log_file", json_object_new_string(state->path));
+    json_object_object_add(k8s, "stream",
+                           json_object_new_string(record->stream_type == dst_stderr ? "stderr" : "stdout"));
+    json_object_object_add(k8s, "log_format", json_object_new_string(record->format_name));
+    if (record->parse_error) {
+        json_object_object_add(k8s, "parse_error", json_object_new_boolean(1));
+    }
+
+    podMd = getPodMetadataForState(&state->meta);
+    if (podMd != NULL) {
+        copyJsonField(k8s, podMd, "pod_id");
+        copyJsonField(k8s, podMd, "creation_timestamp");
+        copyJsonField(k8s, podMd, "labels");
+        copyJsonField(k8s, podMd, "annotations");
+        copyJsonField(k8s, podMd, "owner_kind");
+        copyJsonField(k8s, podMd, "owner_name");
+        copyJsonField(k8s, podMd, "pod_ip");
+        copyJsonField(k8s, podMd, "host_ip");
+        copyJsonField(k8s, podMd, "master_url");
+        if (json_object_object_get_ex(podMd, "host", &value)) {
+            json_object_object_add(k8s, "host", json_object_get(value));
+        }
+    }
+
+    CHKmalloc(docker = json_object_new_object());
+    if (state->meta.container_id != NULL) {
+        json_object_object_add(docker, "container_id", json_object_new_string(state->meta.container_id));
+    }
+
+    iRet = msgAddJSON(pMsg, (uchar *)"!kubernetes", k8s, 0, 0);
+    k8s = NULL;
+    CHKiRet(iRet);
+    iRet = msgAddJSON(pMsg, (uchar *)"!docker", docker, 0, 0);
+    docker = NULL;
+    CHKiRet(iRet);
+
+finalize_it:
+    if (k8s != NULL) {
+        json_object_put(k8s);
+    }
+    if (docker != NULL) {
+        json_object_put(docker);
+    }
+    RETiRet;
+}
+
+static rsRetVal enqMsg(const file_state_t *state, const parsed_record_t *record) {
+    smsg_t *pMsg = NULL;
+    DEFiRet;
+
+    if (record == NULL || record->msg == NULL) {
+        FINALIZE;
+    }
+
+    if (record->hasTime) {
+        CHKiRet(msgConstructWithTime(&pMsg, &record->st, record->ttGenTime));
+    } else {
+        CHKiRet(msgConstruct(&pMsg));
+    }
+
+    MsgSetFlowControlType(pMsg, eFLOWCTL_LIGHT_DELAY);
+    MsgSetInputName(pMsg, pInputName);
+    MsgSetRawMsg(pMsg, (const char *)record->msg, record->len);
+
+    if (runModConf->bEscapeLf) {
+        parser.SanitizeMsg(pMsg);
+    } else {
+        if (pMsg->iLenRawMsg > 0 && pMsg->pszRawMsg[pMsg->iLenRawMsg - 1] == '\0') {
+            pMsg->iLenRawMsg--;
+        }
+    }
+
+    MsgSetMSGoffs(pMsg, 0);
+    MsgSetRcvFrom(pMsg, glbl.GetLocalHostNameProp());
+    MsgSetRcvFromIP(pMsg, glbl.GetLocalHostIP());
+    MsgSetHOSTNAME(pMsg, glbl.GetLocalHostName(), ustrlen(glbl.GetLocalHostName()));
+    MsgSetTAG(pMsg, UCHAR_CONSTANT("kubernetes:"), sizeof("kubernetes:") - 1);
+    MsgSetRuleset(pMsg, runModConf->pBindRuleset);
+    pMsg->iFacility = runModConf->iDfltFacility;
+    pMsg->iSeverity = (record->stream_type == dst_stderr) ? LOG_ERR : runModConf->iDfltSeverity;
+
+    CHKiRet(addRuntimeMetadata(pMsg, state, record));
+    CHKiRet(ratelimitAddMsg(ratelimiter, NULL, pMsg));
+    STATSCOUNTER_INC(ctrSubmitted, mutCtrSubmitted);
+
+finalize_it:
+    if (iRet == RS_RET_DISCARDMSG) {
+        STATSCOUNTER_INC(ctrLostRatelimit, mutCtrLostRatelimit);
+    }
+    RETiRet;
+}
+
+static rsRetVal emitPartialIfComplete(file_state_t *state, const parsed_record_t *record) {
+    parsed_record_t finalRecord = {0};
+    DEFiRet;
+
+    if (!record->is_partial && state->partial.len == 0) {
+        CHKiRet(enqMsg(state, record));
+        FINALIZE;
+    }
+
+    if (record->is_partial && state->partial.len == 0) {
+        state->partial.stream_type = record->stream_type;
+        state->partial.hasTime = record->hasTime;
+        state->partial.ttGenTime = record->ttGenTime;
+        if (record->hasTime) {
+            memcpy(&state->partial.st, &record->st, sizeof(record->st));
+        }
+    }
+
+    if (state->partial.len > 0 && state->partial.stream_type != record->stream_type) {
+        freePartialMsg(&state->partial);
+        state->partial.stream_type = record->stream_type;
+        state->partial.hasTime = record->hasTime;
+        state->partial.ttGenTime = record->ttGenTime;
+        if (record->hasTime) {
+            memcpy(&state->partial.st, &record->st, sizeof(record->st));
+        }
+    }
+
+    if (record->is_partial) {
+        CHKiRet(partialAppend(&state->partial, record->msg, record->len));
+        FINALIZE;
+    }
+
+    if (state->partial.len > 0) {
+        CHKiRet(partialAppend(&state->partial, record->msg, record->len));
+        finalRecord.msg = state->partial.data;
+        finalRecord.len = state->partial.len;
+        finalRecord.stream_type = state->partial.stream_type;
+        finalRecord.hasTime = state->partial.hasTime;
+        finalRecord.ttGenTime = state->partial.ttGenTime;
+        finalRecord.format_name = record->format_name;
+        finalRecord.parse_error = record->parse_error;
+        if (finalRecord.hasTime) {
+            memcpy(&finalRecord.st, &state->partial.st, sizeof(finalRecord.st));
+        }
+        CHKiRet(enqMsg(state, &finalRecord));
+        freePartialMsg(&state->partial);
+        FINALIZE;
+    }
+
+    CHKiRet(enqMsg(state, record));
+
+finalize_it:
+    RETiRet;
+}
+
+static sbool parseCriLine(const char *line, size_t len, parsed_record_t *record) {
+    const char *sp1;
+    const char *sp2;
+    const char *sp3;
+
+    sp1 = memchr(line, ' ', len);
+    if (sp1 == NULL) {
+        return 0;
+    }
+    sp2 = memchr(sp1 + 1, ' ', len - (size_t)(sp1 + 1 - line));
+    if (sp2 == NULL) {
+        return 0;
+    }
+    sp3 = memchr(sp2 + 1, ' ', len - (size_t)(sp2 + 1 - line));
+    if (sp3 == NULL || sp3 <= sp2 + 1) {
+        return 0;
+    }
+    if ((size_t)(sp2 - (sp1 + 1)) != 6) {
+        return 0;
+    }
+    if (memcmp(sp1 + 1, "stdout", 6) && memcmp(sp1 + 1, "stderr", 6)) {
+        return 0;
+    }
+    record->stream_type = !memcmp(sp1 + 1, "stderr", 6) ? dst_stderr : dst_stdout;
+    record->is_partial = (*(sp2 + 1) == 'P');
+    record->msg = (const uchar *)(sp3 + 1);
+    record->len = len - (size_t)(sp3 + 1 - line);
+    record->format_name = "cri";
+    parseTimestamp3339(line, (size_t)(sp1 - line), &record->st, &record->ttGenTime, &record->hasTime);
+    return 1;
+}
+
+static sbool parseDockerJsonLine(const char *line, size_t len, parsed_record_t *record) {
+    struct json_object *json = NULL;
+    struct json_object *logObj = NULL;
+    struct json_object *streamObj = NULL;
+    struct json_object *timeObj = NULL;
+    const char *msg = NULL;
+    size_t msgLen = 0;
+
+    (void)len;
+    json = json_tokener_parse(line);
+    if (json == NULL) {
+        return 0;
+    }
+    if (!json_object_is_type(json, json_type_object)) {
+        json_object_put(json);
+        return 0;
+    }
+    if (!json_object_object_get_ex(json, "log", &logObj) || !json_object_is_type(logObj, json_type_string)) {
+        json_object_put(json);
+        return 0;
+    }
+
+    msg = json_object_get_string(logObj);
+    msgLen = strlen(msg);
+    if (msgLen > 0 && msg[msgLen - 1] == '\n') {
+        --msgLen;
+    }
+
+    record->owned_msg = (uchar *)dupRange(msg, msgLen);
+    if (record->owned_msg == NULL) {
+        json_object_put(json);
+        return 0;
+    }
+    record->msg = record->owned_msg;
+    record->len = msgLen;
+    record->stream_type = dst_stdout;
+    record->hasTime = 0;
+    record->is_partial = 0;
+    record->format_name = "docker_json";
+    if (json_object_object_get_ex(json, "stream", &streamObj) && json_object_is_type(streamObj, json_type_string)) {
+        const char *stream = json_object_get_string(streamObj);
+        if (stream != NULL && !strcmp(stream, "stderr")) {
+            record->stream_type = dst_stderr;
+        }
+    }
+    if (json_object_object_get_ex(json, "time", &timeObj) && json_object_is_type(timeObj, json_type_string)) {
+        const char *timeStr = json_object_get_string(timeObj);
+        if (timeStr != NULL) {
+            parseTimestamp3339(timeStr, strlen(timeStr), &record->st, &record->ttGenTime, &record->hasTime);
+        }
+    }
+
+    json_object_put(json);
+    return 1;
+}
+
+static rsRetVal processLine(file_state_t *state, const char *line, size_t len) {
+    parsed_record_t record = {0};
+    DEFiRet;
+
+    trimTrailingNewline(line, &len);
+    if (len == 0) {
+        FINALIZE;
+    }
+
+    if (parseCriLine(line, len, &record)) {
+        STATSCOUNTER_INC(ctrCriRecords, mutCtrCriRecords);
+        CHKiRet(emitPartialIfComplete(state, &record));
+        FINALIZE;
+    }
+
+    if (parseDockerJsonLine(line, len, &record)) {
+        STATSCOUNTER_INC(ctrDockerJsonRecords, mutCtrDockerJsonRecords);
+        CHKiRet(emitPartialIfComplete(state, &record));
+        FINALIZE;
+    }
+
+    record.msg = (const uchar *)line;
+    record.len = len;
+    record.stream_type = dst_stdout;
+    record.hasTime = 0;
+    record.is_partial = 0;
+    record.format_name = "raw";
+    record.parse_error = 1;
+    STATSCOUNTER_INC(ctrParseErrors, mutCtrParseErrors);
+    CHKiRet(emitPartialIfComplete(state, &record));
+
+finalize_it:
+    free(record.owned_msg);
+    RETiRet;
+}
+
+static rsRetVal processFileState(file_state_t *state) {
+    DEFiRet;
+    FILE *fp = NULL;
+    ssize_t readLen;
+    struct stat st;
+    off_t pos;
+
+    assert(state != NULL);
+
+    if (stat(state->path, &st) != 0) {
+        FINALIZE;
+    }
+
+    if (state->inode != 0 && (state->inode != st.st_ino || st.st_size < state->offset)) {
+        state->offset = 0;
+        freePartialMsg(&state->partial);
+    }
+    state->inode = st.st_ino;
+
+    if (state->offset == 0 && runModConf->freshStartTail && st.st_size > 0) {
+        state->offset = st.st_size;
+        FINALIZE;
+    }
+    if (st.st_size <= state->offset) {
+        FINALIZE;
+    }
+
+    fp = fopen(state->path, "r");
+    if (fp == NULL) {
+        ABORT_FINALIZE(RS_RET_NO_FILE_ACCESS);
+    }
+    if (fseeko(fp, state->offset, SEEK_SET) != 0) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    while ((readLen = getline(&gLineBuf, &gLineBufCap, fp)) >= 0) {
+        CHKiRet(processLine(state, gLineBuf, (size_t)readLen));
+    }
+    if (ferror(fp)) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    pos = ftello(fp);
+    if (pos == (off_t)-1) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    state->offset = pos;
+
+finalize_it:
+    if (fp != NULL) {
+        fclose(fp);
+    }
+    RETiRet;
+}
+
+static rsRetVal scanAndProcessFiles(void) {
+    DEFiRet;
+    glob_t matches;
+    int gret;
+    size_t i;
+
+    memset(&matches, 0, sizeof(matches));
+    markAllFileStatesUnseen();
+
+    gret = glob((char *)runModConf->logFileGlob, 0, NULL, &matches);
+    if (gret != 0 && gret != GLOB_NOMATCH) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    for (i = 0; i < matches.gl_pathc; ++i) {
+        file_state_t *state = findFileState(matches.gl_pathv[i]);
+        if (state == NULL) {
+            state = createFileState(matches.gl_pathv[i]);
+            if (state == NULL) {
+                continue;
+            }
+        }
+        state->seen = 1;
+        processFileState(state);
+    }
+
+    sweepFileStates();
+
+finalize_it:
+    globfree(&matches);
+    RETiRet;
+}
+
+static rsRetVal applyConfigParams(struct nvlst *lst, struct cnfparamblk *paramblk, const char *context) {
+    struct cnfparamvals *pvals = NULL;
+    int i;
+    DEFiRet;
+
+    pvals = nvlstGetParams(lst, paramblk, NULL);
+    if (pvals == NULL) {
+        LogError(0, RS_RET_MISSING_CNFPARAMS, "imkubernetes: error processing %s config parameters", context);
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+    }
+    if (Debug) {
+        dbgprintf("%s param blk for imkubernetes:\n", context);
+        cnfparamsPrint(paramblk, pvals);
+    }
+    for (i = 0; i < paramblk->nParams; ++i) {
+        if (!pvals[i].bUsed) {
+            continue;
+        } else if (!strcmp(paramblk->descr[i].name, "logfileglob")) {
+            free(loadModConf->logFileGlob);
+            CHKmalloc(loadModConf->logFileGlob = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(paramblk->descr[i].name, "pollinginterval")) {
+            loadModConf->iPollInterval = (int)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "cacheentryttl")) {
+            loadModConf->cacheEntryTtl = (int)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "freshstarttail")) {
+            loadModConf->freshStartTail = (sbool)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "defaultseverity")) {
+            loadModConf->iDfltSeverity = (int)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "defaultfacility")) {
+            loadModConf->iDfltFacility = (int)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "escapelf")) {
+            loadModConf->bEscapeLf = (sbool)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "enrichkubernetes")) {
+            loadModConf->enrichKubernetes = (sbool)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "kubernetesurl")) {
+            free(loadModConf->kubernetesUrl);
+            CHKmalloc(loadModConf->kubernetesUrl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(paramblk->descr[i].name, "token")) {
+            free(loadModConf->token);
+            CHKmalloc(loadModConf->token = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(paramblk->descr[i].name, "tokenfile")) {
+            free(loadModConf->tokenFile);
+            CHKmalloc(loadModConf->tokenFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(paramblk->descr[i].name, "tls.cacert")) {
+            free(loadModConf->caCertFile);
+            CHKmalloc(loadModConf->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(paramblk->descr[i].name, "allowunsignedcerts")) {
+            loadModConf->allowUnsignedCerts = (sbool)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "skipverifyhost")) {
+            loadModConf->skipVerifyHost = (sbool)pvals[i].val.d.n;
+        } else if (!strcmp(paramblk->descr[i].name, "ruleset")) {
+            free(loadModConf->pszBindRuleset);
+            CHKmalloc(loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        }
+    }
+
+finalize_it:
+    if (pvals != NULL) {
+        cnfparamvalsDestruct(pvals, paramblk);
+    }
+    RETiRet;
+}
+
+BEGINbeginCnfLoad
+    CODESTARTbeginCnfLoad;
+    loadModConf = pModConf;
+    pModConf->pConf = pConf;
+    pModConf->logFileGlob = NULL;
+    pModConf->iPollInterval = DFLT_pollingInterval;
+    pModConf->cacheEntryTtl = DFLT_cacheEntryTtl;
+    pModConf->iDfltSeverity = DFLT_SEVERITY;
+    pModConf->iDfltFacility = DFLT_FACILITY;
+    pModConf->bEscapeLf = DFLT_bEscapeLF;
+    pModConf->freshStartTail = DFLT_freshStartTail;
+    pModConf->enrichKubernetes = DFLT_enrichKubernetes;
+    pModConf->kubernetesUrl = NULL;
+    pModConf->token = NULL;
+    pModConf->tokenFile = NULL;
+    pModConf->caCertFile = NULL;
+    pModConf->allowUnsignedCerts = 0;
+    pModConf->skipVerifyHost = 0;
+    pModConf->pszBindRuleset = NULL;
+    pModConf->pBindRuleset = NULL;
+    bLegacyCnfModGlobalsPermitted = 1;
+ENDbeginCnfLoad
+
+BEGINsetModCnf
+    CODESTARTsetModCnf;
+    CHKiRet(applyConfigParams(lst, &modpblk, "module"));
+    bLegacyCnfModGlobalsPermitted = 0;
+finalize_it:
+ENDsetModCnf
+
+BEGINnewInpInst
+    CODESTARTnewInpInst;
+    CHKiRet(applyConfigParams(lst, &inppblk, "input"));
+finalize_it:
+    CODE_STD_FINALIZERnewInpInst
+ENDnewInpInst
+
+BEGINendCnfLoad
+    CODESTARTendCnfLoad;
+ENDendCnfLoad
+
+BEGINcheckCnf
+    ruleset_t *pRuleset = NULL;
+    rsRetVal localRet;
+    CODESTARTcheckCnf;
+    if (loadModConf->iPollInterval <= 0) {
+        LogError(0, RS_RET_CONFIG_ERROR, "imkubernetes: PollingInterval must be greater than zero");
+        iRet = RS_RET_CONFIG_ERROR;
+    }
+    loadModConf->pBindRuleset = NULL;
+    if (loadModConf->pszBindRuleset != NULL) {
+        localRet = ruleset.GetRuleset(loadModConf->pConf, &pRuleset, loadModConf->pszBindRuleset);
+        if (localRet == RS_RET_NOT_FOUND) {
+            LogError(0, NO_ERRCODE, "imkubernetes: ruleset '%s' not found - using default ruleset instead",
+                     loadModConf->pszBindRuleset);
+            FINALIZE;
+        }
+        CHKiRet(localRet);
+        loadModConf->pBindRuleset = pRuleset;
+    }
+finalize_it:
+ENDcheckCnf
+
+BEGINactivateCnf
+    CODESTARTactivateCnf;
+    if (loadModConf->logFileGlob == NULL) {
+        CHKmalloc(loadModConf->logFileGlob = (uchar *)strdup(DFLT_LOG_FILE_GLOB));
+    }
+    if (loadModConf->kubernetesUrl == NULL) {
+        CHKmalloc(loadModConf->kubernetesUrl = (uchar *)strdup(DFLT_KUBERNETES_URL));
+    }
+    if (loadModConf->tokenFile == NULL) {
+        CHKmalloc(loadModConf->tokenFile = (uchar *)strdup(DFLT_TOKEN_FILE));
+    }
+    if (loadModConf->caCertFile == NULL) {
+        CHKmalloc(loadModConf->caCertFile = (uchar *)strdup(DFLT_CA_CERT_FILE));
+    }
+    runModConf = loadModConf;
+
+    CHKiRet(statsobj.Construct(&modStats));
+    CHKiRet(statsobj.SetName(modStats, UCHAR_CONSTANT("imkubernetes")));
+    CHKiRet(statsobj.SetOrigin(modStats, UCHAR_CONSTANT("imkubernetes")));
+    STATSCOUNTER_INIT(ctrSubmitted, mutCtrSubmitted);
+    STATSCOUNTER_INIT(ctrParseErrors, mutCtrParseErrors);
+    STATSCOUNTER_INIT(ctrFilesDiscovered, mutCtrFilesDiscovered);
+    STATSCOUNTER_INIT(ctrCriRecords, mutCtrCriRecords);
+    STATSCOUNTER_INIT(ctrDockerJsonRecords, mutCtrDockerJsonRecords);
+    STATSCOUNTER_INIT(ctrCacheHits, mutCtrCacheHits);
+    STATSCOUNTER_INIT(ctrCacheMisses, mutCtrCacheMisses);
+    STATSCOUNTER_INIT(ctrApiErrors, mutCtrApiErrors);
+    STATSCOUNTER_INIT(ctrLostRatelimit, mutCtrLostRatelimit);
+    CHKiRet(
+        statsobj.AddCounter(modStats, UCHAR_CONSTANT("submitted"), ctrType_IntCtr, CTR_FLAG_RESETTABLE, &ctrSubmitted));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("parse.errors"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrParseErrors));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("files.discovered"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrFilesDiscovered));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("records.cri"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrCriRecords));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("records.dockerjson"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrDockerJsonRecords));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("kube.cache_hits"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrCacheHits));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("kube.cache_misses"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrCacheMisses));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("kube.api_errors"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrApiErrors));
+    CHKiRet(statsobj.AddCounter(modStats, UCHAR_CONSTANT("ratelimit.discarded"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &ctrLostRatelimit));
+    CHKiRet(statsobj.ConstructFinalize(modStats));
+finalize_it:
+ENDactivateCnf
+
+BEGINfreeCnf
+    CODESTARTfreeCnf;
+    free(loadModConf->logFileGlob);
+    free(loadModConf->kubernetesUrl);
+    free(loadModConf->token);
+    free(loadModConf->tokenFile);
+    free(loadModConf->caCertFile);
+    free(loadModConf->pszBindRuleset);
+    if (modStats != NULL) {
+        statsobj.Destruct(&modStats);
+        modStats = NULL;
+    }
+ENDfreeCnf
+
+BEGINrunInput
+    CODESTARTrunInput;
+    CHKiRet(ratelimitNew(&ratelimiter, "imkubernetes", NULL));
+    CHKiRet(initApiClient());
+    while (glbl.GetGlobalInputTermState() == 0) {
+        scanAndProcessFiles();
+        srSleep(runModConf->iPollInterval, 0);
+    }
+finalize_it:
+    freeApiClient();
+    freePodCache();
+    freeFileStates();
+    free(gLineBuf);
+    gLineBuf = NULL;
+    gLineBufCap = 0;
+    if (ratelimiter != NULL) {
+        ratelimitDestruct(ratelimiter);
+        ratelimiter = NULL;
+    }
+ENDrunInput
+
+BEGINwillRun
+    CODESTARTwillRun;
+ENDwillRun
+
+BEGINafterRun
+    CODESTARTafterRun;
+ENDafterRun
+
+BEGINmodExit
+    CODESTARTmodExit;
+    if (pInputName != NULL) {
+        prop.Destruct(&pInputName);
+    }
+    objRelease(parser, CORE_COMPONENT);
+    objRelease(glbl, CORE_COMPONENT);
+    objRelease(prop, CORE_COMPONENT);
+    objRelease(ruleset, CORE_COMPONENT);
+    objRelease(statsobj, CORE_COMPONENT);
+    objRelease(datetime, CORE_COMPONENT);
+ENDmodExit
+
+BEGINisCompatibleWithFeature
+    CODESTARTisCompatibleWithFeature;
+    if (eFeat == sFEATURENonCancelInputTermination) {
+        iRet = RS_RET_OK;
+    }
+ENDisCompatibleWithFeature
+
+BEGINqueryEtryPt
+    CODESTARTqueryEtryPt;
+    CODEqueryEtryPt_STD_IMOD_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_setModCnf_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_IMOD_QUERIES;
+    CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES;
+ENDqueryEtryPt
+
+BEGINmodInit()
+    CODESTARTmodInit;
+    *ipIFVersProvided = CURR_MOD_IF_VERSION;
+    CODEmodInit_QueryRegCFSLineHdlr
+
+        CHKiRet(objUse(glbl, CORE_COMPONENT));
+    CHKiRet(objUse(prop, CORE_COMPONENT));
+    CHKiRet(objUse(ruleset, CORE_COMPONENT));
+    CHKiRet(objUse(statsobj, CORE_COMPONENT));
+    CHKiRet(objUse(datetime, CORE_COMPONENT));
+    CHKiRet(objUse(parser, CORE_COMPONENT));
+
+    CHKiRet(prop.Construct(&pInputName));
+    CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("imkubernetes"), sizeof("imkubernetes") - 1));
+    CHKiRet(prop.ConstructFinalize(pInputName));
+ENDmodInit

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -193,6 +193,7 @@ EXTRA_DIST = \
     source/configuration/modules/imhttp.rst \
     source/configuration/modules/imjournal.rst \
     source/configuration/modules/imkafka.rst \
+    source/configuration/modules/imkubernetes.rst \
     source/configuration/modules/imklog.rst \
     source/configuration/modules/imkmsg.rst \
     source/configuration/modules/immark.rst \
@@ -517,6 +518,21 @@ EXTRA_DIST = \
     source/reference/parameters/imdocker-listcontainersoptions.rst \
     source/reference/parameters/imdocker-pollinginterval.rst \
     source/reference/parameters/imdocker-retrievenewlogsfromstart.rst \
+    source/reference/parameters/imkubernetes-allowunsignedcerts.rst \
+    source/reference/parameters/imkubernetes-cacheentryttl.rst \
+    source/reference/parameters/imkubernetes-defaultfacility.rst \
+    source/reference/parameters/imkubernetes-defaultseverity.rst \
+    source/reference/parameters/imkubernetes-enrichkubernetes.rst \
+    source/reference/parameters/imkubernetes-escapelf.rst \
+    source/reference/parameters/imkubernetes-freshstarttail.rst \
+    source/reference/parameters/imkubernetes-kubernetesurl.rst \
+    source/reference/parameters/imkubernetes-logfileglob.rst \
+    source/reference/parameters/imkubernetes-pollinginterval.rst \
+    source/reference/parameters/imkubernetes-ruleset.rst \
+    source/reference/parameters/imkubernetes-skipverifyhost.rst \
+    source/reference/parameters/imkubernetes-tls-cacert.rst \
+    source/reference/parameters/imkubernetes-token.rst \
+    source/reference/parameters/imkubernetes-tokenfile.rst \
     source/reference/parameters/imdtls-address.rst \
     source/reference/parameters/imdtls-listenportfilename.rst \
     source/reference/parameters/imdtls-name.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -51,6 +51,12 @@ contrib_mmkubernetes:
   notes:
     - WID is per-thread; shared caches in pData must be guarded.
 
+contrib_imkubernetes:
+  paths: ["contrib/imkubernetes/"]
+  requires_serialization: false
+  notes:
+    - The single input thread owns file tail state, partial-record buffers, cache entries, and the CURL client.
+
 mmsnareparse:
   paths: ["plugins/mmsnareparse/"]
   requires_serialization: false

--- a/doc/source/configuration/modules/imkubernetes.rst
+++ b/doc/source/configuration/modules/imkubernetes.rst
@@ -1,0 +1,277 @@
+.. _ref-imkubernetes:
+
+.. meta::
+   :description: rsyslog imkubernetes input module for Kubernetes pod and container logs.
+   :keywords: rsyslog, imkubernetes, Kubernetes, CRI, container logs, input module
+
+***************************************
+imkubernetes: Kubernetes input module
+***************************************
+
+===========================  ==========================================================================
+**Module Name:**             **imkubernetes**
+**Author:**                  `rsyslog project <https://github.com/rsyslog/rsyslog>`_
+**Available since:**         8.2604.0
+===========================  ==========================================================================
+
+.. summary-start
+
+``imkubernetes`` is an experimental Kubernetes-first input module that tails
+node-local pod log files, parses CRI or Docker ``json-file`` records,
+preserves stream and timestamp metadata, and can enrich each record with pod
+metadata from the Kubernetes API.
+
+.. summary-end
+
+Purpose
+========
+
+.. warning::
+
+   ``imkubernetes`` is experimental. Its configuration interface, metadata
+   shape, and operational behavior may change based on real-world Kubernetes
+   deployments. Please test it carefully before production use and share
+   feedback, bug reports, and missing use cases through the rsyslog GitHub
+   issue tracker or discussions.
+
+``imkubernetes`` is designed for node-agent deployments, typically as part of a
+DaemonSet. It reads the host's Kubernetes container log files directly instead
+of talking to a Docker daemon, which makes it fit current Kubernetes runtimes
+better than ``imdocker``.
+
+The module supports two common file layouts:
+
+* pod log files such as ``/var/log/pods/<namespace>_<pod>_<uid>/<container>/<restart>.log``
+* container symlink paths such as ``/var/log/containers/<pod>_<namespace>_<container>-<containerid>.log``
+
+For CRI logs, ``imkubernetes`` merges partial records before submission. For
+Docker ``json-file`` logs, it extracts the embedded timestamp, message payload,
+and stream.
+
+Message metadata
+================
+
+``imkubernetes`` stores parsed fields under ``$!kubernetes`` and, when present,
+container IDs under ``$!docker``.
+
+Common ``$!kubernetes`` properties include:
+
+* ``namespace_name``
+* ``pod_name``
+* ``pod_uid``
+* ``container_name``
+* ``restart_count`` for pod log paths
+* ``stream`` (``stdout`` or ``stderr``)
+* ``log_format`` (``cri`` or ``docker_json``)
+* ``log_file``
+
+When :ref:`EnrichKubernetes <param-imkubernetes-enrichkubernetes>` is enabled,
+the module also adds selected pod metadata from the Kubernetes API, including
+pod UID, labels, annotations, owner references, pod IP, and host IP.
+
+Configuration Parameters
+========================
+
+.. note::
+
+   Parameter names are case-insensitive. CamelCase is recommended for
+   readability.
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imkubernetes-allowunsignedcerts
+   ../../reference/parameters/imkubernetes-cacheentryttl
+   ../../reference/parameters/imkubernetes-defaultfacility
+   ../../reference/parameters/imkubernetes-defaultseverity
+   ../../reference/parameters/imkubernetes-enrichkubernetes
+   ../../reference/parameters/imkubernetes-escapelf
+   ../../reference/parameters/imkubernetes-freshstarttail
+   ../../reference/parameters/imkubernetes-kubernetesurl
+   ../../reference/parameters/imkubernetes-logfileglob
+   ../../reference/parameters/imkubernetes-pollinginterval
+   ../../reference/parameters/imkubernetes-ruleset
+   ../../reference/parameters/imkubernetes-skipverifyhost
+   ../../reference/parameters/imkubernetes-tls-cacert
+   ../../reference/parameters/imkubernetes-token
+   ../../reference/parameters/imkubernetes-tokenfile
+
+Module Parameters
+-----------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imkubernetes-logfileglob`
+     - .. include:: ../../reference/parameters/imkubernetes-logfileglob.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-pollinginterval`
+     - .. include:: ../../reference/parameters/imkubernetes-pollinginterval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imkubernetes-ruleset`
+     - .. include:: ../../reference/parameters/imkubernetes-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-cacheentryttl`
+     - .. include:: ../../reference/parameters/imkubernetes-cacheentryttl.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-freshstarttail`
+     - .. include:: ../../reference/parameters/imkubernetes-freshstarttail.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-defaultseverity`
+     - .. include:: ../../reference/parameters/imkubernetes-defaultseverity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-defaultfacility`
+     - .. include:: ../../reference/parameters/imkubernetes-defaultfacility.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-escapelf`
+     - .. include:: ../../reference/parameters/imkubernetes-escapelf.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-enrichkubernetes`
+     - .. include:: ../../reference/parameters/imkubernetes-enrichkubernetes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-kubernetesurl`
+     - .. include:: ../../reference/parameters/imkubernetes-kubernetesurl.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-token`
+     - .. include:: ../../reference/parameters/imkubernetes-token.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-tokenfile`
+     - .. include:: ../../reference/parameters/imkubernetes-tokenfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-tls-cacert`
+     - .. include:: ../../reference/parameters/imkubernetes-tls-cacert.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-allowunsignedcerts`
+     - .. include:: ../../reference/parameters/imkubernetes-allowunsignedcerts.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imkubernetes-skipverifyhost`
+     - .. include:: ../../reference/parameters/imkubernetes-skipverifyhost.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+Deployment notes
+================
+
+``imkubernetes`` is intended to run close to the node logs. Typical
+deployments:
+
+* mount ``/var/log/pods`` read-only and keep the default
+  :ref:`LogFileGlob <param-imkubernetes-logfileglob>`
+* mount ``/var/log/containers`` read-only and override
+  :ref:`LogFileGlob <param-imkubernetes-logfileglob>` if you prefer the
+  symlink view
+* mount the service-account token and CA certificate when enrichment is enabled
+
+If you only need file-derived metadata, set
+:ref:`EnrichKubernetes <param-imkubernetes-enrichkubernetes>` to ``off`` and
+the module will avoid Kubernetes API calls entirely.
+
+Statistic Counter
+=================
+
+This plugin maintains per-module :doc:`statistics
+<../rsyslog_statistic_counter>`. The statistic name is ``imkubernetes``.
+
+The following counters are maintained:
+
+* ``submitted`` - records submitted to the main queue
+* ``parse.errors`` - lines that could not be parsed as CRI or Docker JSON and
+  were submitted as raw payloads
+* ``files.discovered`` - log files discovered by glob scans
+* ``records.cri`` - CRI records parsed successfully
+* ``records.dockerjson`` - Docker ``json-file`` records parsed successfully
+* ``kube.cache_hits`` - pod metadata cache hits
+* ``kube.cache_misses`` - pod metadata cache misses
+* ``kube.api_errors`` - Kubernetes API request failures
+* ``ratelimit.discarded`` - records dropped by rate limiting
+
+Examples
+========
+
+Collect pod logs with in-cluster enrichment
+-------------------------------------------
+
+.. code-block:: rsyslog
+
+   module(
+     load="imkubernetes"
+     LogFileGlob="/var/log/pods/*/*/*.log"
+     PollingInterval="1"
+     KubernetesUrl="https://kubernetes.default.svc.cluster.local:443"
+     TokenFile="/var/run/secrets/kubernetes.io/serviceaccount/token"
+     tls.caCert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+   )
+
+   template(name="k8s-json" type="list" option.jsonf="on") {
+     property(outname="msg" name="msg" format="jsonf")
+     property(outname="namespace" name="$!kubernetes!namespace_name" format="jsonf")
+     property(outname="pod" name="$!kubernetes!pod_name" format="jsonf")
+     property(outname="container" name="$!kubernetes!container_name" format="jsonf")
+     property(outname="stream" name="$!kubernetes!stream" format="jsonf")
+     property(outname="pod_ip" name="$!kubernetes!pod_ip" format="jsonf")
+   }
+
+   action(type="omfile" file="/var/log/rsyslog-k8s.json" template="k8s-json")
+
+The same module-level settings can be provided through YAML configuration:
+
+.. code-block:: yaml
+
+   modules:
+     - load: imkubernetes
+
+   inputs:
+     - type: imkubernetes
+       logfileglob: "/var/log/pods/*/*/*.log"
+       pollinginterval: 1
+       kubernetesurl: "https://kubernetes.default.svc.cluster.local:443"
+       tokenfile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
+       tls.cacert: "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+       ruleset: main
+
+Collect container symlink logs without API enrichment
+-----------------------------------------------------
+
+.. code-block:: rsyslog
+
+   module(
+     load="imkubernetes"
+     LogFileGlob="/var/log/containers/*.log"
+     EnrichKubernetes="off"
+   )
+
+.. code-block:: yaml
+
+   modules:
+     - load: imkubernetes
+
+   inputs:
+     - type: imkubernetes
+       logfileglob: "/var/log/containers/*.log"
+       enrichkubernetes: off
+       ruleset: main
+
+See also
+========
+
+* :doc:`imdocker` for Docker-daemon based collection on non-Kubernetes hosts
+* :doc:`mmkubernetes` for post-ingest enrichment of ``imfile`` or
+  ``imjournal`` pipelines

--- a/doc/source/reference/parameters/imkubernetes-allowunsignedcerts.rst
+++ b/doc/source/reference/parameters/imkubernetes-allowunsignedcerts.rst
@@ -1,0 +1,40 @@
+.. _param-imkubernetes-allowunsignedcerts:
+.. _imkubernetes.parameter.module.allowunsignedcerts:
+
+AllowUnsignedCerts
+==================
+
+.. index::
+   single: imkubernetes; AllowUnsignedCerts
+   single: AllowUnsignedCerts
+
+.. summary-start
+
+Disable TLS peer verification for Kubernetes API requests; default ``off``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: AllowUnsignedCerts
+:Scope: module
+:Type: binary
+:Default: ``off``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+When enabled, ``imkubernetes`` skips certificate trust validation for
+Kubernetes API TLS connections. Use only in controlled test environments.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" AllowUnsignedCerts="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-cacheentryttl.rst
+++ b/doc/source/reference/parameters/imkubernetes-cacheentryttl.rst
@@ -1,0 +1,40 @@
+.. _param-imkubernetes-cacheentryttl:
+.. _imkubernetes.parameter.module.cacheentryttl:
+
+CacheEntryTtl
+=============
+
+.. index::
+   single: imkubernetes; CacheEntryTtl
+   single: CacheEntryTtl
+
+.. summary-start
+
+Seconds to keep pod metadata in the in-memory cache; default ``300``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: CacheEntryTtl
+:Scope: module
+:Type: integer
+:Default: ``300``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+When Kubernetes enrichment is enabled, successful pod lookups are cached for
+this many seconds before the entry expires and must be re-fetched.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" CacheEntryTtl="300")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-defaultfacility.rst
+++ b/doc/source/reference/parameters/imkubernetes-defaultfacility.rst
@@ -1,0 +1,40 @@
+.. _param-imkubernetes-defaultfacility:
+.. _imkubernetes.parameter.module.defaultfacility:
+
+DefaultFacility
+===============
+
+.. index::
+   single: imkubernetes; DefaultFacility
+   single: DefaultFacility
+
+.. summary-start
+
+Default syslog facility assigned to submitted records; default ``user``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: DefaultFacility
+:Scope: module
+:Type: facility
+:Default: ``user``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Sets the facility used for messages created by ``imkubernetes`` before they are
+placed on the main queue.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" DefaultFacility="local0")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-defaultseverity.rst
+++ b/doc/source/reference/parameters/imkubernetes-defaultseverity.rst
@@ -1,0 +1,42 @@
+.. _param-imkubernetes-defaultseverity:
+.. _imkubernetes.parameter.module.defaultseverity:
+
+DefaultSeverity
+===============
+
+.. index::
+   single: imkubernetes; DefaultSeverity
+   single: DefaultSeverity
+
+.. summary-start
+
+Default severity assigned to submitted records that are not mapped to
+``stderr``; default ``info``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: DefaultSeverity
+:Scope: module
+:Type: severity
+:Default: ``info``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+``imkubernetes`` uses ``err`` for parsed ``stderr`` records. For other records,
+including ``stdout`` and raw fallback lines, this setting controls the emitted
+syslog severity.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" DefaultSeverity="notice")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-enrichkubernetes.rst
+++ b/doc/source/reference/parameters/imkubernetes-enrichkubernetes.rst
@@ -1,0 +1,41 @@
+.. _param-imkubernetes-enrichkubernetes:
+.. _imkubernetes.parameter.module.enrichkubernetes:
+
+EnrichKubernetes
+================
+
+.. index::
+   single: imkubernetes; EnrichKubernetes
+   single: EnrichKubernetes
+
+.. summary-start
+
+Enable Kubernetes API lookups for pod metadata enrichment; default ``on``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: EnrichKubernetes
+:Scope: module
+:Type: binary
+:Default: ``on``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+When enabled, ``imkubernetes`` fetches pod metadata from the Kubernetes API and
+adds it under ``$!kubernetes``. Turn this off to operate purely from the file
+path and log record contents.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" EnrichKubernetes="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-escapelf.rst
+++ b/doc/source/reference/parameters/imkubernetes-escapelf.rst
@@ -1,0 +1,40 @@
+.. _param-imkubernetes-escapelf:
+.. _imkubernetes.parameter.module.escapelf:
+
+EscapeLF
+========
+
+.. index::
+   single: imkubernetes; EscapeLF
+   single: EscapeLF
+
+.. summary-start
+
+Escapes embedded line feeds in the submitted message payload; default ``on``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: EscapeLF
+:Scope: module
+:Type: binary
+:Default: ``on``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+When enabled, line-feed characters in the final message payload are escaped
+before submission so each rsyslog record remains single-line by default.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" EscapeLF="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-freshstarttail.rst
+++ b/doc/source/reference/parameters/imkubernetes-freshstarttail.rst
@@ -1,0 +1,42 @@
+.. _param-imkubernetes-freshstarttail:
+.. _imkubernetes.parameter.module.freshstarttail:
+
+FreshStartTail
+==============
+
+.. index::
+   single: imkubernetes; FreshStartTail
+   single: FreshStartTail
+
+.. summary-start
+
+Start newly discovered files at end-of-file instead of replaying existing
+content; default ``off``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: FreshStartTail
+:Scope: module
+:Type: binary
+:Default: ``off``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+When enabled, ``imkubernetes`` seeks to the current end of a file the first
+time it sees that file. Use this when you only want records appended after
+startup.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" FreshStartTail="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-kubernetesurl.rst
+++ b/doc/source/reference/parameters/imkubernetes-kubernetesurl.rst
@@ -1,0 +1,42 @@
+.. _param-imkubernetes-kubernetesurl:
+.. _imkubernetes.parameter.module.kubernetesurl:
+
+KubernetesUrl
+=============
+
+.. index::
+   single: imkubernetes; KubernetesUrl
+   single: KubernetesUrl
+
+.. summary-start
+
+Base URL of the Kubernetes API server; default
+``https://kubernetes.default.svc.cluster.local:443``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: KubernetesUrl
+:Scope: module
+:Type: word
+:Default: ``https://kubernetes.default.svc.cluster.local:443``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Sets the API endpoint used when enrichment is enabled. The module queries pod
+metadata using ``/api/v1/namespaces/<namespace>/pods/<pod>`` below this base
+URL.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" KubernetesUrl="https://localhost:8443")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-logfileglob.rst
+++ b/doc/source/reference/parameters/imkubernetes-logfileglob.rst
@@ -1,0 +1,42 @@
+.. _param-imkubernetes-logfileglob:
+.. _imkubernetes.parameter.module.logfileglob:
+
+LogFileGlob
+===========
+
+.. index::
+   single: imkubernetes; LogFileGlob
+   single: LogFileGlob
+
+.. summary-start
+
+Glob that selects Kubernetes log files to tail; default
+``/var/log/pods/*/*/*.log``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: LogFileGlob
+:Scope: module
+:Type: path
+:Default: ``/var/log/pods/*/*/*.log``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Use this to point ``imkubernetes`` at the node-local container log files you
+want to follow. Common values are ``/var/log/pods/*/*/*.log`` and
+``/var/log/containers/*.log``.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" LogFileGlob="/var/log/pods/*/*/*.log")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-pollinginterval.rst
+++ b/doc/source/reference/parameters/imkubernetes-pollinginterval.rst
@@ -1,0 +1,40 @@
+.. _param-imkubernetes-pollinginterval:
+.. _imkubernetes.parameter.module.pollinginterval:
+
+PollingInterval
+===============
+
+.. index::
+   single: imkubernetes; PollingInterval
+   single: PollingInterval
+
+.. summary-start
+
+Seconds between filesystem scans for matching log files; default ``1``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: PollingInterval
+:Scope: module
+:Type: integer
+:Default: ``1``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Controls how often ``imkubernetes`` refreshes the configured glob and tails
+newly discovered files.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" PollingInterval="1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-ruleset.rst
+++ b/doc/source/reference/parameters/imkubernetes-ruleset.rst
@@ -1,0 +1,46 @@
+.. _param-imkubernetes-ruleset:
+.. _imkubernetes.parameter.input.ruleset:
+
+Ruleset
+========
+
+.. index::
+   single: imkubernetes; Ruleset
+   single: Ruleset
+
+.. summary-start
+
+Ruleset that receives records submitted by ``imkubernetes``; default is the
+default ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: Ruleset
+:Scope: module, input
+:Type: string
+:Default: default ruleset
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Bind ``imkubernetes`` records to the named ruleset. This is especially useful
+with YAML configuration, where the input object can name the ruleset that owns
+the output actions.
+
+Input usage
+-----------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" Ruleset="kubernetes")
+
+.. code-block:: rsyslog
+
+   input(type="imkubernetes" Ruleset="kubernetes")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-skipverifyhost.rst
+++ b/doc/source/reference/parameters/imkubernetes-skipverifyhost.rst
@@ -1,0 +1,41 @@
+.. _param-imkubernetes-skipverifyhost:
+.. _imkubernetes.parameter.module.skipverifyhost:
+
+SkipVerifyHost
+==============
+
+.. index::
+   single: imkubernetes; SkipVerifyHost
+   single: SkipVerifyHost
+
+.. summary-start
+
+Disable TLS hostname verification for Kubernetes API requests; default ``off``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: SkipVerifyHost
+:Scope: module
+:Type: binary
+:Default: ``off``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+When enabled, ``imkubernetes`` does not verify that the Kubernetes API server
+certificate matches the requested host name. Use only for testing or temporary
+workarounds.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" SkipVerifyHost="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-tls-cacert.rst
+++ b/doc/source/reference/parameters/imkubernetes-tls-cacert.rst
@@ -1,0 +1,41 @@
+.. _param-imkubernetes-tls-cacert:
+.. _imkubernetes.parameter.module.tls-cacert:
+
+tls.caCert
+==========
+
+.. index::
+   single: imkubernetes; tls.caCert
+   single: tls.caCert
+
+.. summary-start
+
+CA certificate bundle used to verify the Kubernetes API TLS certificate;
+default ``/var/run/secrets/kubernetes.io/serviceaccount/ca.crt``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: tls.caCert
+:Scope: module
+:Type: path
+:Default: ``/var/run/secrets/kubernetes.io/serviceaccount/ca.crt``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Points libcurl at the CA certificate bundle that should be trusted for the
+Kubernetes API endpoint.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" tls.caCert="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-token.rst
+++ b/doc/source/reference/parameters/imkubernetes-token.rst
@@ -1,0 +1,40 @@
+.. _param-imkubernetes-token:
+.. _imkubernetes.parameter.module.token:
+
+Token
+=====
+
+.. index::
+   single: imkubernetes; Token
+   single: Token
+
+.. summary-start
+
+Literal bearer token used for Kubernetes API authentication.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: Token
+:Scope: module
+:Type: string
+:Default: none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+If set, this token is used directly in the ``Authorization: Bearer`` header.
+It takes precedence over :ref:`TokenFile <param-imkubernetes-tokenfile>`.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" Token="eyJhbGciOi...")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/doc/source/reference/parameters/imkubernetes-tokenfile.rst
+++ b/doc/source/reference/parameters/imkubernetes-tokenfile.rst
@@ -1,0 +1,42 @@
+.. _param-imkubernetes-tokenfile:
+.. _imkubernetes.parameter.module.tokenfile:
+
+TokenFile
+=========
+
+.. index::
+   single: imkubernetes; TokenFile
+   single: TokenFile
+
+.. summary-start
+
+Path to a file containing the Kubernetes API bearer token; default
+``/var/run/secrets/kubernetes.io/serviceaccount/token``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imkubernetes`.
+
+:Name: TokenFile
+:Scope: module
+:Type: path
+:Default: ``/var/run/secrets/kubernetes.io/serviceaccount/token``
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+If :ref:`Token <param-imkubernetes-token>` is not set, ``imkubernetes`` reads
+the first line from this file and uses it as the bearer token for Kubernetes
+API requests.
+
+Module usage
+------------
+
+.. code-block:: rsyslog
+
+   module(load="imkubernetes" TokenFile="/var/run/secrets/kubernetes.io/serviceaccount/token")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imkubernetes`.

--- a/packaging/docker/dev_env/alpine/Dockerfile
+++ b/packaging/docker/dev_env/alpine/Dockerfile
@@ -52,6 +52,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS="\
 --enable-imfile \
 --enable-impstats \
 --enable-imptcp \
+--enable-imkubernetes \
 --enable-mmjsonparse \
 --enable-mmutf8fix \
 --enable-omstdout \

--- a/packaging/docker/dev_env/centos/base/7/Dockerfile
+++ b/packaging/docker/dev_env/centos/base/7/Dockerfile
@@ -304,6 +304,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmdblookup \
 	--enable-mmfields \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/centos/base/8/Dockerfile
+++ b/packaging/docker/dev_env/centos/base/8/Dockerfile
@@ -304,6 +304,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmdblookup \
 	--enable-mmfields \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/debian/base/11/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/11/Dockerfile
@@ -94,7 +94,7 @@ RUN	mkdir /local_dep_cache && \
 	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.6.9.tar.gz -O /local_dep_cache/elasticsearch-5.6.9.tar.gz
 RUN	wget -nv https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.0.0.tar.gz -O /local_dep_cache/elasticsearch-6.0.0.tar.gz
 RUN	wget -nv https://www.rsyslog.com/files/download/rsyslog/elasticsearch-7.14.1-linux-x86_64.tar.gz -O /local_dep_cache/elasticsearch-7.14.1-linux-x86_64.tar.gz
-RUN	wget -nv https://dlcdn.apache.org/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
+RUN	wget -nv https://archive.apache.org/dist/zookeeper/zookeeper-3.9.3/apache-zookeeper-3.9.3-bin.tar.gz -O /local_dep_cache/apache-zookeeper-3.9.3-bin.tar.gz
 RUN	wget -nv https://www.apache.org/dyn/closer.cgi?path=/kafka/2.8.0/kafka_2.13-2.8.0.tgz -O /local_dep_cache/kafka_2.13-2.8.0.tgz
 # tell tests which are the newester versions, so they can be checked without the need
 # to adjust test sources.
@@ -253,6 +253,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmfields \
 	--enable-mmgrok \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/debian/base/13/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/13/Dockerfile
@@ -238,6 +238,7 @@ ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmfields \
 	--disable-mmgrok \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/fedora/base/43/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/43/Dockerfile
@@ -257,6 +257,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmdblookup \
 	--enable-mmfields \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/fedora/base/44/Dockerfile
+++ b/packaging/docker/dev_env/fedora/base/44/Dockerfile
@@ -257,6 +257,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmdblookup \
 	--enable-mmfields \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/openeuler/base/24.03-lts/Dockerfile
+++ b/packaging/docker/dev_env/openeuler/base/24.03-lts/Dockerfile
@@ -137,6 +137,7 @@ ENV     RSYSLOG_CONFIGURE_OPTIONS=" \
         --enable-mmdblookup \
         --enable-mmfields \
         --enable-mmjsonparse \
+        --enable-imkubernetes \
         --enable-mmkubernetes \
         --enable-mmnormalize \
         --enable-mmpstrucdata \

--- a/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
@@ -333,6 +333,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmfields \
 	--enable-mmgrok \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile.arm
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile.arm
@@ -164,6 +164,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-mmfields \
 	--enable-mmgrok \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
@@ -309,6 +309,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS=" \
 	--enable-mmgrok \
 	--enable-mmjsonparse \
 	--enable-mmleefparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmnormalize \
 	--enable-mmpstrucdata \

--- a/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
@@ -356,6 +356,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS=" \
 	--enable-mmdblookup \
 	--enable-mmfields \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmleefparse \
 	--enable-mmnormalize \

--- a/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
@@ -357,6 +357,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS=" \
 	--enable-mmdblookup \
 	--enable-mmfields \
 	--enable-mmjsonparse \
+	--enable-imkubernetes \
 	--enable-mmkubernetes \
 	--enable-mmleefparse \
 	--enable-mmnormalize \

--- a/packaging/ubuntu/noble/v8-stable/debian/rsyslog-kubernetes.install
+++ b/packaging/ubuntu/noble/v8-stable/debian/rsyslog-kubernetes.install
@@ -1,1 +1,2 @@
+usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/imkubernetes.so
 usr/lib/${DEB_HOST_MULTIARCH}/rsyslog/mmkubernetes.so

--- a/packaging/ubuntu/noble/v8-stable/debian/rules
+++ b/packaging/ubuntu/noble/v8-stable/debian/rules
@@ -63,6 +63,7 @@ override_dh_auto_configure: build-qpid-proton
 		--enable-mmsequence \
 		--enable-mmfields \
 		--enable-mmrm1stspace \
+		--enable-imkubernetes \
 		--enable-mmkubernetes \
 		--enable-mmleefparse \
 		--enable-imczmq \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2093,6 +2093,11 @@ TESTS_MMKUBERNETES_VALGRIND = \
 	mmkubernetes-basic-vg.sh \
 	mmkubernetes-cache-expire-vg.sh
 
+TESTS_IMKUBERNETES = \
+	imkubernetes-cri-basic.sh \
+	imkubernetes-dockerjson-basic.sh \
+	yaml-imkubernetes-dockerjson-basic.sh
+
 TESTS_IMTUXEDOULOG = \
 	imtuxedoulog_errmsg_no_params.sh \
 	imtuxedoulog_data.sh
@@ -2298,6 +2303,7 @@ EXTRA_DIST += $(TESTS_OMTCL)
 EXTRA_DIST += $(TESTS_MMTAGHOSTNAME)
 EXTRA_DIST += $(TESTS_MMKUBERNETES)
 EXTRA_DIST += $(TESTS_MMKUBERNETES_VALGRIND)
+EXTRA_DIST += $(TESTS_IMKUBERNETES)
 EXTRA_DIST += $(TESTS_IMTUXEDOULOG)
 EXTRA_DIST += $(TESTS_IMTUXEDOULOG_VALGRIND)
 EXTRA_DIST += $(TESTS_OMAMQP1)
@@ -3439,6 +3445,10 @@ endif
 endif
 endif
 endif
+endif
+
+if ENABLE_IMKUBERNETES
+TESTS += $(TESTS_IMKUBERNETES)
 endif
 
 

--- a/tests/imkubernetes-cri-basic.sh
+++ b/tests/imkubernetes-cri-basic.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+# Verify CRI parsing, CRI partial-message merge, and Kubernetes API enrichment.
+# The helper API server binds an OS-assigned port and writes it to a readiness
+# file; the parsed/enriched JSON output is the success oracle. The timeout is
+# only a fail-safe around the helper because readiness is file-based.
+. ${srcdir:=.}/diag.sh init
+require_plugin imkubernetes ../contrib/imkubernetes
+check_command_available timeout
+
+export NUMMESSAGES=2
+pwd=$( pwd )
+testsrv=imk8s-test-server
+k8s_srv_port=0
+k8s_srv_port_file=${RSYSLOG_DYNNAME}${testsrv}.port
+logdir="${RSYSLOG_DYNNAME}.spool/pods/namespace-name1_pod-name1_uid1/container-a"
+logfile="${logdir}/0.log"
+
+mkdir -p "$logdir"
+echo starting kubernetes test server
+MMK8S_INCLUDE_NODE_NAME=1 timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py \
+	0 \
+	${RSYSLOG_DYNNAME}${testsrv}.pid \
+	${RSYSLOG_DYNNAME}${testsrv}.started \
+	$k8s_srv_port_file \
+	> ${RSYSLOG_DYNNAME}.spool/imkubernetes_srv.log 2>&1 &
+BGPROCESS=$!
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+assign_file_content k8s_srv_port "$k8s_srv_port_file"
+
+generate_conf
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(load="../contrib/imkubernetes/.libs/imkubernetes"
+       LogFileGlob="'$pwd/$logdir'/*.log"
+       PollingInterval="1"
+       KubernetesUrl="http://localhost:'$k8s_srv_port'"
+       Token="dummy"
+       cacheEntryTtl="60")
+
+template(name="outfmt" type="list" option.jsonf="on") {
+    property(outname="msg" name="msg" format="jsonf")
+    property(outname="namespace" name="$!kubernetes!namespace_name" format="jsonf")
+    property(outname="pod" name="$!kubernetes!pod_name" format="jsonf")
+    property(outname="pod_uid" name="$!kubernetes!pod_uid" format="jsonf")
+    property(outname="container" name="$!kubernetes!container_name" format="jsonf")
+    property(outname="restart_count" name="$!kubernetes!restart_count" format="jsonf" dataType="number")
+    property(outname="stream" name="$!kubernetes!stream" format="jsonf")
+    property(outname="format" name="$!kubernetes!log_format" format="jsonf")
+    property(outname="pod_id" name="$!kubernetes!pod_id" format="jsonf")
+    property(outname="pod_ip" name="$!kubernetes!pod_ip" format="jsonf")
+    property(outname="host" name="$!kubernetes!host" format="jsonf")
+    property(outname="label_component" name="$!kubernetes!labels!component" format="jsonf")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+
+{
+	printf '%s\n' '2026-04-20T10:00:00.123456789Z stdout F hello from cri'
+	printf '%s \n' '2026-04-20T10:00:01.000000000Z stderr P partial one'
+	printf '%s\n' '2026-04-20T10:00:02.000000000Z stderr F partial two'
+} > "$logfile"
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 2
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+
+kill $BGPROCESS
+wait_pid_termination ${RSYSLOG_DYNNAME}${testsrv}.pid
+
+$PYTHON - "$RSYSLOG_OUT_LOG" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+records = [json.loads(line) for line in open(path)]
+records = [item for item in records if item.get("format") == "cri"]
+assert len(records) == 2, records
+by_msg = {item["msg"]: item for item in records}
+
+cri = by_msg["hello from cri"]
+assert cri["namespace"] == "namespace-name1"
+assert cri["pod"] == "pod-name1"
+assert cri["pod_uid"] == "uid1"
+assert cri["container"] == "container-a"
+assert cri["restart_count"] == 0
+assert cri["stream"] == "stdout"
+assert cri["format"] == "cri"
+assert cri["pod_id"] == "pod-name1-id"
+assert cri["pod_ip"] == "10.128.0.14"
+assert cri["host"] == "pod-name1-node"
+assert cri["label_component"] == "pod-name1-component"
+
+partial = by_msg["partial one partial two"]
+assert partial["stream"] == "stderr"
+assert partial["format"] == "cri"
+assert partial["pod_id"] == "pod-name1-id"
+PY
+
+exit_test

--- a/tests/imkubernetes-dockerjson-basic.sh
+++ b/tests/imkubernetes-dockerjson-basic.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Verify Docker json-file parsing from a Kubernetes /var/log/containers-style
+# path with API enrichment disabled. Parsed output metadata is the oracle.
+. ${srcdir:=.}/diag.sh init
+require_plugin imkubernetes ../contrib/imkubernetes
+
+pwd=$( pwd )
+logdir="${RSYSLOG_DYNNAME}.spool/containers"
+logfile="${logdir}/pod-name2_namespace-name2_container-b-deadbeef.log"
+
+generate_conf
+add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
+module(load="../contrib/imkubernetes/.libs/imkubernetes"
+       LogFileGlob="'$pwd/$logdir'/*.log"
+       PollingInterval="1"
+       EnrichKubernetes="off")
+
+template(name="outfmt" type="list" option.jsonf="on") {
+    property(outname="msg" name="msg" format="jsonf")
+    property(outname="namespace" name="$!kubernetes!namespace_name" format="jsonf")
+    property(outname="pod" name="$!kubernetes!pod_name" format="jsonf")
+    property(outname="container" name="$!kubernetes!container_name" format="jsonf")
+    property(outname="stream" name="$!kubernetes!stream" format="jsonf")
+    property(outname="format" name="$!kubernetes!log_format" format="jsonf")
+    property(outname="container_id" name="$!docker!container_id" format="jsonf")
+}
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+mkdir -p "$logdir"
+startup
+
+cat > "$logfile" <<'EOF'
+{"log":"docker stdout line\n","stream":"stdout","time":"2026-04-20T10:01:00.123456789Z"}
+{"log":"docker stderr line\n","stream":"stderr","time":"2026-04-20T10:01:01.123456789Z"}
+EOF
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 2
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+
+$PYTHON - "$RSYSLOG_OUT_LOG" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+records = [json.loads(line) for line in open(path)]
+records = [item for item in records if item.get("format") == "docker_json"]
+assert len(records) == 2, records
+by_msg = {item["msg"]: item for item in records}
+
+stdout = by_msg["docker stdout line"]
+assert stdout["namespace"] == "namespace-name2"
+assert stdout["pod"] == "pod-name2"
+assert stdout["container"] == "container-b"
+assert stdout["stream"] == "stdout"
+assert stdout["format"] == "docker_json"
+assert stdout["container_id"] == "deadbeef"
+
+stderr = by_msg["docker stderr line"]
+assert stderr["stream"] == "stderr"
+assert stderr["format"] == "docker_json"
+assert stderr["container_id"] == "deadbeef"
+PY
+
+exit_test

--- a/tests/mmkubernetes_test_server.py
+++ b/tests/mmkubernetes_test_server.py
@@ -72,7 +72,7 @@ pod_template = '''{{
       "annotation.with.empty.value":""
     }}
   }},
-  "status": {{
+{spec_block}  "status": {{
     "phase": "Running",
     "hostIP": "172.18.4.32",
     "podIP": "10.128.0.14",
@@ -97,6 +97,7 @@ err_template = '''{{
 }}'''
 
 is_busy = False
+include_node_name = os.environ.get("MMK8S_INCLUDE_NODE_NAME") == "1"
 
 
 class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
@@ -119,6 +120,14 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
                 hsh['pod_name'] = comps[6]
                 hsh['kind'] = 'pods'
                 hsh['objectname'] = hsh['pod_name']
+                if include_node_name:
+                    hsh['spec_block'] = (
+                        '  "spec": {{\n'
+                        '    "nodeName": "{pod_name}-node"\n'
+                        '  }},\n'
+                    ).format(**hsh)
+                else:
+                    hsh['spec_block'] = ''
                 resp_template = pod_template
                 status = 200
             else:

--- a/tests/yaml-imkubernetes-dockerjson-basic.sh
+++ b/tests/yaml-imkubernetes-dockerjson-basic.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Verify imkubernetes can be configured through the YAML frontend. The test
+# tails a Kubernetes /var/log/containers-style Docker json-file record with API
+# enrichment disabled; output metadata proves the YAML module parameters reached
+# imkubernetes and the parsed record flowed through the regular queue.
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+require_plugin imkubernetes ../contrib/imkubernetes
+
+pwd=$( pwd )
+logdir="${RSYSLOG_DYNNAME}.spool/containers"
+logfile="${logdir}/pod-name3_namespace-name3_container-c-feedface.log"
+
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../contrib/imkubernetes/.libs/imkubernetes"'
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imkubernetes'
+add_yaml_conf '    logfileglob: "'$pwd/$logdir'/*.log"'
+add_yaml_conf '    pollinginterval: 1'
+add_yaml_conf '    enrichkubernetes: off'
+add_yaml_conf '    ruleset: main'
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%msg%|%$!kubernetes!namespace_name%|%$!kubernetes!pod_name%|%$!kubernetes!container_name%|%$!kubernetes!stream%|%$!kubernetes!log_format%|%$!docker!container_id%\n"'
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf '      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")'
+
+mkdir -p "$logdir"
+startup
+
+cat > "$logfile" <<'EOF'
+{"log":"yaml docker line\n","stream":"stdout","time":"2026-04-20T10:02:00.123456789Z"}
+EOF
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+wait_queueempty
+shutdown_when_empty
+wait_shutdown
+
+content_check 'yaml docker line|namespace-name3|pod-name3|container-c|stdout|docker_json|feedface'
+exit_test


### PR DESCRIPTION
## What changed

This PR adds `imkubernetes`, a new experimental Kubernetes-first input module
for rsyslog. It tails node-local pod and container log files, parses CRI and
Docker `json-file` records, merges CRI partial messages, and can enrich records
with pod metadata from the Kubernetes API.

This module is intentionally marked experimental. The goal is to make it
available for early adopters, gather real Kubernetes deployment feedback, and
adjust the configuration interface, metadata shape, and operational behavior
before treating it as a mature production module.

The change also wires the module into autotools, packaging, docs, and the
rsyslog testbench.

## Why

rsyslog had Docker log collection via `imdocker` and Kubernetes metadata
lookup via `mmkubernetes`, but it did not have a native Kubernetes log input.
That left Kubernetes users without a direct path for collecting modern
node-local pod logs.

## Impact

Kubernetes deployments can experiment with direct pod and container log
collection using a module designed for current runtime layouts instead of
relying on a Docker API collector.

The module is loadable and is not used unless configured. The intended risk for
existing syslog deployments is therefore limited to build/package integration;
runtime behavior of existing configurations should be unaffected unless
`imkubernetes` is explicitly loaded. If the experimental module is loaded, a
fatal module failure can still fail the rsyslog process like other loaded input
modules.

Feedback is actively requested through GitHub issues or discussions, especially
for Kubernetes runtime layouts, metadata expectations, RBAC/API behavior, and
DaemonSet deployment patterns not covered by the current tests.

## Root cause

The codebase had a gap between Docker-oriented ingestion and Kubernetes
metadata enrichment: there was no input module centered on `/var/log/pods` or
`/var/log/containers` semantics.

## Validation

- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-imkubernetes --enable-mmkubernetes`
- `make -j$(nproc) check TESTS=""`
- `(cd tests && ./imkubernetes-cri-basic.sh)`
- `(cd tests && ./imkubernetes-dockerjson-basic.sh)`
- `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`
