### PR TITLE
omusrmsg: guard empty systemd session lists

### DIFF
--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -339,7 +339,7 @@ static rsRetVal wallmsg(uchar *pMsg, instanceData *pData) {
     if (sd_booted() > 0) {
         register int j;
         int sdRet;
-        char **sessions_list;
+        char **sessions_list = NULL;
         int sessions = sd_get_sessions(&sessions_list);
 
         for (j = 0; j < sessions; j++) {


### PR DESCRIPTION
## Summary

- initialize `sessions_list` to `NULL` before `sd_get_sessions()` in the systemd branch of `omusrmsg`
- keep the existing session iteration behavior unchanged while making zero-session cleanup safe

## Root Cause

`sd_get_sessions()` can return zero sessions without allocating a session list. The old code always freed `sessions_list`, which could still hold an indeterminate stack value and trigger `free(): invalid pointer`.

## Validation

- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `make -j$(nproc) check TESTS=""`
- `./tests/omusrmsg-noabort.sh`

Closes https://github.com/rsyslog/rsyslog/issues/6748
