### PR TITLE
packaging/docker: default rsyslog images to stable PPA

### DIFF
--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -102,7 +102,7 @@ The following sections describe previous efforts and image bases that are **no l
 * `/appliance` - This directory represents an early experiment at creating an all-in-one rsyslog logging appliance. This approach did not align with current containerization best practices and was discontinued. The images are outdated and should not be used.
 
 ### Legacy Base Images
-* Legacy Alpine and CentOS base images previously existed in a `/base` directory. These are no longer maintained. Development now focuses exclusively on Ubuntu-based images, which integrate best with our daily stable package builds.
+* Legacy Alpine and CentOS base images previously existed in a `/base` directory. These are no longer maintained. Development now focuses exclusively on Ubuntu-based images, which integrate with the Adiscon stable and daily-stable package feeds.
 
 ### CentOS Notes (Historical)
 * Older CentOS 7 definitions can be found under `/base/centos7`. Like the Alpine files, these are no longer maintained but remain for reference.

--- a/packaging/docker/rsyslog/Makefile
+++ b/packaging/docker/rsyslog/Makefile
@@ -20,9 +20,21 @@ DEFAULT_VERSION = dev-local
 #   make all VERSION=2026-03
 VERSION ?= $(DEFAULT_VERSION)
 
+# Package source channel for all container builds.
+# Local and CI builds default to the stable PPA; pass PPA_CHANNEL=daily-stable
+# to switch the image family to the daily package feed.
+PPA_CHANNEL ?= stable
+ifeq ($(PPA_CHANNEL),stable)
+RSYSLOG_APT_PPA = ppa:adiscon/v8-stable
+else ifeq ($(PPA_CHANNEL),daily-stable)
+RSYSLOG_APT_PPA = ppa:adiscon/daily-stable
+else
+RSYSLOG_APT_PPA =
+endif
+
 # Stable release targets derive the container tag from RSYSLOG_VERSION using
 # 8.yymm.0 -> 20yy-mm. Example: 8.2602.0 -> 2026-02.
-RELEASE_CHANNEL ?= stable
+RELEASE_CHANNEL ?= $(PPA_CHANNEL)
 RELEASE_VERSION = $(strip $(shell \
 	if [ "$(RELEASE_CHANNEL)" = "daily-stable" ]; then \
 		printf 'daily-stable\n'; \
@@ -35,6 +47,8 @@ BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VCS_REF ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
 OCI_BUILD_ARGS = --build-arg BUILD_DATE="$(BUILD_DATE)" \
                  --build-arg VCS_REF="$(VCS_REF)"
+PPA_BUILD_ARGS = --build-arg RSYSLOG_APT_PPA="$(RSYSLOG_APT_PPA)" \
+                 --build-arg RSYSLOG_PPA_CHANNEL="$(PPA_CHANNEL)"
 
 # Manual release publishing is downstream of PPA readiness. Operators must
 # provide the expected rsyslog release version explicitly before stable
@@ -80,7 +94,7 @@ ETL_IMAGE_TAG = $(strip $(ETL_IMAGE_NAME):$(VERSION))
         minimal standard collector dockerlogs etl \
         build_minimal_image build_standard_image build_collector_image build_dockerlogs_image build_etl_image \
         push_minimal push_standard push_collector push_dockerlogs push_etl \
-        rebuild_all check_publish_version check_release_inputs \
+        rebuild_all check_build_channel check_publish_version check_release_inputs \
         check_ppa_release_ready release_build release_push release_publish
 
 # Default target: Builds all functional images.
@@ -108,12 +122,23 @@ etl: build_etl_image
 
 # --- Core Build Logic ---
 
+check_build_channel:
+	@case "$(PPA_CHANNEL)" in \
+		stable|daily-stable) \
+			echo "Using container PPA channel $(PPA_CHANNEL) ($(RSYSLOG_APT_PPA))" ;; \
+		*) \
+			echo "ERROR: invalid PPA_CHANNEL=$(PPA_CHANNEL)." >&2; \
+			echo "Expected one of: stable, daily-stable" >&2; \
+			exit 1 ;; \
+	esac
+
 # Build the minimal rsyslog container.
-build_minimal_image: ./minimal/Dockerfile ./minimal/rsyslog.conf
+build_minimal_image: check_build_channel ./minimal/Dockerfile ./minimal/rsyslog.conf
 	@echo "--- Building minimal image: $(MINIMAL_IMAGE_TAG) ---"
 	docker build $(DOCKER_BUILD_FLAGS) \
 		              -t $(MINIMAL_IMAGE_TAG) \
 		              $(OCI_BUILD_ARGS) \
+		              $(PPA_BUILD_ARGS) \
 		              --build-arg RSYSLOG_IMG_VERSION=$(VERSION) \
 		              -f ./minimal/Dockerfile ./minimal
 
@@ -188,6 +213,13 @@ check_publish_version:
 	esac
 
 check_release_inputs:
+	@case "$(RELEASE_CHANNEL)" in \
+		stable|daily-stable) ;; \
+		*) \
+			echo "ERROR: invalid RELEASE_CHANNEL=$(RELEASE_CHANNEL)." >&2; \
+			echo "Expected one of: stable, daily-stable" >&2; \
+			exit 1 ;; \
+	esac
 	@if [ "$(RELEASE_CHANNEL)" = "stable" ] && [ -z "$(RSYSLOG_VERSION)" ]; then \
 		echo "ERROR: stable release targets require RSYSLOG_VERSION." >&2; \
 		echo "Example: make release_build RSYSLOG_VERSION=8.2602.0" >&2; \
@@ -244,16 +276,16 @@ check_ppa_release_ready: check_release_inputs
 
 release_build: check_ppa_release_ready
 	@echo "--- Manual release build for VERSION=$(RELEASE_VERSION) ---"
-	$(MAKE) all VERSION=$(RELEASE_VERSION)
+	$(MAKE) all VERSION=$(RELEASE_VERSION) PPA_CHANNEL=$(RELEASE_CHANNEL) REBUILD=$(REBUILD)
 
 release_push: check_ppa_release_ready
 	@echo "--- Manual release push for VERSION=$(RELEASE_VERSION) ---"
-	$(MAKE) all_push VERSION=$(RELEASE_VERSION)
+	$(MAKE) all_push VERSION=$(RELEASE_VERSION) PPA_CHANNEL=$(RELEASE_CHANNEL) REBUILD=$(REBUILD)
 
 release_publish: release_push
 	@if [ "$(PUSH_LATEST)" = "yes" ]; then \
 		echo "--- Updating latest tags for VERSION=$(RELEASE_VERSION) ---"; \
-		$(MAKE) push_latest VERSION=$(RELEASE_VERSION); \
+		$(MAKE) push_latest VERSION=$(RELEASE_VERSION) PPA_CHANNEL=$(RELEASE_CHANNEL) REBUILD=$(REBUILD); \
 	else \
 		echo "Skipping latest tag update. Set PUSH_LATEST=yes to publish latest."; \
 	fi
@@ -345,6 +377,9 @@ help:
 	@echo "                       Current default: $(VERSION)"
 	@echo "                       The default is intentionally non-release for local builds."
 	@echo "                       Publish/tag targets reject development-like values."
+	@echo "  PPA_CHANNEL        - Package source for image builds. Defaults to stable."
+	@echo "                       stable -> ppa:adiscon/v8-stable"
+	@echo "                       daily-stable -> ppa:adiscon/daily-stable"
 	@echo "  RSYSLOG_VERSION    - Expected rsyslog release version, for example 8.2602.0."
 	@echo "                       Required for RELEASE_CHANNEL=stable."
 	@echo "  RELEASE_CHANNEL    - Release source. Defaults to stable."
@@ -357,9 +392,10 @@ help:
 	@echo ""
 	@echo "Example Workflow:"
 	@echo "  1. Local smoke build: make all"
-	@echo "  2. Local release rehearsal: make VERSION=2026-03 all"
-	@echo "  3. Force a full rebuild of all images: make rebuild_all"
-	@echo "  4. Check PPA readiness: make check_ppa_release_ready RSYSLOG_VERSION=8.2602.0"
-	@echo "  5. Manual release push: make release_push RSYSLOG_VERSION=8.2602.0"
-	@echo "  6. Release push plus latest: make release_publish RSYSLOG_VERSION=8.2602.0 PUSH_LATEST=yes"
-	@echo "  7. Daily channel build: make release_build RELEASE_CHANNEL=daily-stable"
+	@echo "  2. Local daily build: make all PPA_CHANNEL=daily-stable"
+	@echo "  3. Local release rehearsal: make VERSION=2026-03 all"
+	@echo "  4. Force a full rebuild of all images: make rebuild_all"
+	@echo "  5. Check PPA readiness: make check_ppa_release_ready RSYSLOG_VERSION=8.2602.0"
+	@echo "  6. Manual release push: make release_push RSYSLOG_VERSION=8.2602.0"
+	@echo "  7. Release push plus latest: make release_publish RSYSLOG_VERSION=8.2602.0 PUSH_LATEST=yes"
+	@echo "  8. Daily channel build: make release_build RELEASE_CHANNEL=daily-stable"

--- a/packaging/docker/rsyslog/Makefile
+++ b/packaging/docker/rsyslog/Makefile
@@ -47,8 +47,7 @@ BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VCS_REF ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
 OCI_BUILD_ARGS = --build-arg BUILD_DATE="$(BUILD_DATE)" \
                  --build-arg VCS_REF="$(VCS_REF)"
-PPA_BUILD_ARGS = --build-arg RSYSLOG_APT_PPA="$(RSYSLOG_APT_PPA)" \
-                 --build-arg RSYSLOG_PPA_CHANNEL="$(PPA_CHANNEL)"
+PPA_BUILD_ARGS = --build-arg RSYSLOG_APT_PPA="$(RSYSLOG_APT_PPA)"
 
 # Manual release publishing is downstream of PPA readiness. Operators must
 # provide the expected rsyslog release version explicitly before stable

--- a/packaging/docker/rsyslog/README.md
+++ b/packaging/docker/rsyslog/README.md
@@ -21,7 +21,8 @@ to a dry run.
 
 ## Version and tag contract
 
-Local builds default to a non-release tag on purpose:
+Local builds default to a non-release tag on purpose and use the stable
+Adiscon PPA by default:
 
 ```bash
 make all
@@ -40,6 +41,13 @@ make all VERSION=2026-03
 The build system treats `VERSION` as the source of truth for image tags.
 Release automation must pass the intended stable version explicitly
 instead of relying on the Makefile default.
+
+To build against the daily package stream instead of stable, pass the
+channel explicitly:
+
+```bash
+make all PPA_CHANNEL=daily-stable
+```
 
 Stable container tags are expected to follow the rsyslog release train:
 
@@ -111,12 +119,16 @@ modify the host system's apt sources.
 
 ## Manual release flow
 
+For release-tagged builds and pushes, prefer the wrapper script in this
+directory. It uses the stable channel by default and exposes explicit
+long options for channel selection.
+
 1. Determine the container tag from the rsyslog release tag.
    Example: `8.2602.0` and `v.26-02.0` both map to `2026-02`.
 2. Verify PPA readiness:
 
 ```bash
-make check_ppa_release_ready RSYSLOG_VERSION=8.2602.0
+./release-images.sh check --rsyslog-version 8.2602.0
 ```
 
 This looks up the newest `8.2602.0-*` package published in the Adiscon
@@ -126,19 +138,19 @@ early. If subpackages are still missing, the actual image build fails.
 3. Build the release-tagged image family:
 
 ```bash
-make release_build RSYSLOG_VERSION=8.2602.0
+./release-images.sh build --rsyslog-version 8.2602.0
 ```
 
 4. Push the release-tagged images:
 
 ```bash
-make release_push RSYSLOG_VERSION=8.2602.0
+./release-images.sh push --rsyslog-version 8.2602.0
 ```
 
 5. Update `latest` only when that is intended:
 
 ```bash
-make release_publish RSYSLOG_VERSION=8.2602.0 PUSH_LATEST=yes
+./release-images.sh publish --rsyslog-version 8.2602.0 --latest
 ```
 
 If `PUSH_LATEST` is not set to `yes`, `release_publish` pushes only the
@@ -147,9 +159,18 @@ versioned images and leaves `latest` unchanged.
 For the daily channel:
 
 ```bash
-make check_ppa_release_ready RELEASE_CHANNEL=daily-stable
-make release_build RELEASE_CHANNEL=daily-stable
-make release_push RELEASE_CHANNEL=daily-stable
+./release-images.sh check --daily
+./release-images.sh build --daily
+./release-images.sh push --daily
+```
+
+The underlying Makefile targets remain available when needed:
+
+```bash
+make check_ppa_release_ready RSYSLOG_VERSION=8.2602.0
+make release_build RSYSLOG_VERSION=8.2602.0
+make release_push RSYSLOG_VERSION=8.2602.0
+make all PPA_CHANNEL=daily-stable VERSION=ci-example
 ```
 
 ## CI guidance

--- a/packaging/docker/rsyslog/minimal/Dockerfile
+++ b/packaging/docker/rsyslog/minimal/Dockerfile
@@ -5,6 +5,7 @@
 # Build arguments passed from the Makefile
 ARG UBUNTU_VERSION="24.04"
 ARG RSYSLOG_IMG_VERSION="unset" # New ARG to pick up version from Makefile
+ARG RSYSLOG_APT_PPA="ppa:adiscon/v8-stable"
 ARG BUILD_DATE="unknown"
 ARG VCS_REF="unknown"
 
@@ -13,6 +14,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 # Re-declare ARGs after FROM to make them available to subsequent instructions like LABEL
 ARG UBUNTU_VERSION
 ARG RSYSLOG_IMG_VERSION
+ARG RSYSLOG_APT_PPA
 ARG BUILD_DATE
 ARG VCS_REF
 
@@ -35,7 +37,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # 1. Combined RUN instruction for all apt operations:
 #    - Update apt cache.
 #    - Install software-properties-common (provides add-apt-repository) and ca-certificates.
-#    - Add the Adiscon PPA for rsyslog (using the correct v8-stable PPA).
+#    - Add the selected Adiscon PPA for rsyslog.
 #    - Update apt cache again after adding the PPA to fetch package lists from it.
 #    - Install rsyslog with --no-install-recommends for minimal footprint.
 #    - Purge build-time-only dependencies (software-properties-common) and auto-remove any unused packages.
@@ -45,7 +47,7 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         software-properties-common \
         ca-certificates \
-    && add-apt-repository -y ppa:adiscon/daily-stable \
+    && add-apt-repository -y "${RSYSLOG_APT_PPA}" \
     && apt-get update && \
     apt-get install -y --no-install-recommends tzdata rsyslog rsyslog-omstdout \
     && apt-get purge -y --auto-remove software-properties-common \

--- a/packaging/docker/rsyslog/release-images.sh
+++ b/packaging/docker/rsyslog/release-images.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+	cat <<'EOF'
+Usage:
+  ./release-images.sh <check|build|push|publish> [options]
+
+Release channel options:
+  --channel <stable|daily-stable>  Select the package source channel.
+  --daily                          Shortcut for --channel daily-stable.
+  --stable                         Shortcut for --channel stable.
+
+Stable release options:
+  --rsyslog-version <8.yymm.0>     Required for the stable channel.
+
+Additional options:
+  --latest                         With publish, also update :latest tags.
+  --rebuild                        Force docker builds to bypass cache.
+  --ubuntu-version <version>       Override the readiness-check Ubuntu base.
+  -h, --help                       Show this help text.
+
+Examples:
+  ./release-images.sh check --rsyslog-version 8.2604.0
+  ./release-images.sh build --rsyslog-version 8.2604.0
+  ./release-images.sh publish --rsyslog-version 8.2604.0 --latest
+  ./release-images.sh build --daily
+EOF
+}
+
+die() {
+	echo "ERROR: $*" >&2
+	exit 1
+}
+
+action=""
+channel="stable"
+rsyslog_version=""
+push_latest="no"
+rebuild="no"
+release_ubuntu_version=""
+
+while (($# > 0)); do
+	case "$1" in
+		check|build|push|publish)
+			[[ -z "$action" ]] || die "only one command may be provided"
+			action="$1"
+			shift
+			;;
+		--channel)
+			[[ $# -ge 2 ]] || die "--channel requires a value"
+			channel="$2"
+			shift 2
+			;;
+		--daily)
+			channel="daily-stable"
+			shift
+			;;
+		--stable)
+			channel="stable"
+			shift
+			;;
+		--rsyslog-version)
+			[[ $# -ge 2 ]] || die "--rsyslog-version requires a value"
+			rsyslog_version="$2"
+			shift 2
+			;;
+		--latest)
+			push_latest="yes"
+			shift
+			;;
+		--rebuild)
+			rebuild="yes"
+			shift
+			;;
+		--ubuntu-version)
+			[[ $# -ge 2 ]] || die "--ubuntu-version requires a value"
+			release_ubuntu_version="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			die "unknown argument: $1"
+			;;
+	esac
+done
+
+[[ -n "$action" ]] || die "missing command (expected one of: check, build, push, publish)"
+
+case "$channel" in
+	stable|daily-stable) ;;
+	*) die "invalid channel: $channel (expected stable or daily-stable)" ;;
+esac
+
+if [[ "$channel" == "stable" && -z "$rsyslog_version" ]]; then
+	die "--rsyslog-version is required for the stable channel"
+fi
+
+if [[ "$channel" == "daily-stable" && -n "$rsyslog_version" ]]; then
+	die "--rsyslog-version is only valid for the stable channel"
+fi
+
+if [[ "$action" != "publish" && "$push_latest" == "yes" ]]; then
+	die "--latest is only valid with the publish command"
+fi
+
+case "$action" in
+	check) make_target="check_ppa_release_ready" ;;
+	build) make_target="release_build" ;;
+	push) make_target="release_push" ;;
+	publish) make_target="release_publish" ;;
+	*) die "unsupported command: $action" ;;
+esac
+
+make_args=(
+	-C "$script_dir"
+	"$make_target"
+	"RELEASE_CHANNEL=$channel"
+	"PPA_CHANNEL=$channel"
+	"REBUILD=$rebuild"
+)
+
+if [[ -n "$rsyslog_version" ]]; then
+	make_args+=("RSYSLOG_VERSION=$rsyslog_version")
+fi
+
+if [[ -n "$release_ubuntu_version" ]]; then
+	make_args+=("RELEASE_UBUNTU_VERSION=$release_ubuntu_version")
+fi
+
+if [[ "$push_latest" == "yes" ]]; then
+	make_args+=("PUSH_LATEST=yes")
+fi
+
+exec make "${make_args[@]}"


### PR DESCRIPTION
## Summary
- default the user-facing container builds to `ppa:adiscon/v8-stable`
- make the selected package channel flow from the Makefile into the minimal image build
- add a small `release-images.sh` wrapper with stable as the default and `--daily` as the explicit daily override
- update the Docker docs to describe the stable-first workflow and the daily override path

## Validation
- `bash -n packaging/docker/rsyslog/release-images.sh`
- `./packaging/docker/rsyslog/release-images.sh check --rsyslog-version 8.2604.0`
- `./packaging/docker/rsyslog/release-images.sh check --daily`
- `make -C packaging/docker/rsyslog minimal VERSION=ci-stable-verify`
