### PR TITLE
[codex] add s390x run_checks job

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1652,6 +1652,11 @@ jobs:
             platform: linux/arm/v7
             qemu_platform: arm
             use_qemu: true
+          - arch: s390x
+            runs_on: ubuntu-24.04
+            platform: linux/s390x
+            qemu_platform: s390x
+            use_qemu: true
           - arch: arm64
             runs_on: ubuntu-24.04-arm
             platform: linux/arm64
@@ -1706,10 +1711,10 @@ jobs:
           context: .
           file: devtools/ci/Dockerfile.arm
           platforms: ${{ matrix.platform }}
-          tags: rsyslog-arm-dev:${{ matrix.arch }}
+          tags: rsyslog-cross-dev:${{ matrix.arch }}
           load: true
-          cache-from: type=gha,scope=arm-dev-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=arm-dev-${{ matrix.arch }}
+          cache-from: type=gha,scope=cross-dev-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=cross-dev-${{ matrix.arch }}
 
       - name: Run ${{ matrix.arch }} build and testbench
         if: steps.code_changes.outputs.any_changed == 'true'
@@ -1722,13 +1727,13 @@ jobs:
             --security-opt seccomp=unconfined \
             -v "${{ github.workspace }}:/rsyslog" \
             -w /rsyslog \
-            rsyslog-arm-dev:${{ matrix.arch }} bash -c '
+            rsyslog-cross-dev:${{ matrix.arch }} bash -c '
               set -e
               export CFLAGS="-g -O1 -fno-omit-frame-pointer"
               export CC=gcc
               export TEST_MAX_RUNTIME=1200
               autoreconf -fvi
-              if [ "$ARCH" = "armhf" ]; then
+              if [ "$ARCH" = "armhf" ] || [ "$ARCH" = "s390x" ]; then
                 ./configure --enable-silent-rules --enable-testbench \
                   --enable-imdiag --disable-imdocker --enable-imfile \
                   --disable-default-tests --disable-impstats \

--- a/runtime/conf.c
+++ b/runtime/conf.c
@@ -2,7 +2,7 @@
  *
  * This file is based on an excerpt from syslogd.c, which dates back
  * much later. I began the file on 2008-02-19 as part of the modularization
- * effort. Over time, a clean abstration will become even more important
+ * effort. Over time, a clean abstraction will become even more important
  * because the config file handler will by dynamically be loaded and be
  * kept in memory only as long as the config file is actually being
  * processed. Thereafter, it shall be unloaded. -- rgerhards


### PR DESCRIPTION
## Summary
Add an emulated `s390x` variant to `run_checks.yml` using the same
Docker QEMU pattern as the existing `armhf` job.

The workflow matrix now includes `linux/s390x`, enables the matching
QEMU platform, and reuses the reduced configure path that is already
used for `armhf`.

The cached image tag and cache scope names are also generalized from
`arm` to `cross` so the workflow naming matches the new
multi-architecture behavior.

A comment-only typo fix in `runtime/conf.c` is included so the
changed-files filter sees a core C file update and triggers the build
path during validation.

## Why
`armhf` already gives CI an emulated non-native architecture lane.
Adding `s390x` extends that coverage to another important Linux target
without requiring dedicated native runners.

## Impact
`run_checks` will now build the dev image and run the reduced testbench
configuration for `s390x` under QEMU.

## Validation
- `bash devtools/format-code.sh`
- `docker buildx build --platform linux/s390x -f devtools/ci/Dockerfile.arm -t rsyslog-cross-dev:s390x --load .`
