### PR TITLE
tests: stop orphaning omhttp helper servers

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -3435,7 +3435,13 @@ omhttp_stop_server() {
     if [ ! -d $omhttp_work_dir ]; then
         echo "omhttp server $omhttp_work_dir does not exist, no action needed"
     else
-        omhttp_server_pid=$(cat ${omhttp_work_dir}/omhttp_server.pid)
+        omhttp_server_pid=$(cat "${omhttp_work_dir}/omhttp_server.pid" 2>/dev/null)
+        case "$omhttp_server_pid" in
+            "" | *[!0-9]* | 0)
+                echo "omhttp server PID could not be read from ${omhttp_work_dir}/omhttp_server.pid, cannot stop server."
+                return 1
+                ;;
+        esac
         echo "Stopping omhttp server process group ${omhttp_server_pid}"
         kill -TERM -- -${omhttp_server_pid} > /dev/null 2>&1
         wait ${omhttp_server_pid} 2>/dev/null || :

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -3415,7 +3415,7 @@ omhttp_start_server() {
 
     server_args="-p $omhttp_server_port ${*:2} --port-file $RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
 
-    timeout 30m $PYTHON ${omhttp_server_py} ${server_args} >> ${omhttp_server_logfile} 2>&1 &
+    setsid timeout 30m $PYTHON ${omhttp_server_py} ${server_args} >> ${omhttp_server_logfile} 2>&1 &
     if [ ! $? -eq 0 ]; then
         echo "Failed to start omhttp test server."
         rm -rf $omhttp_work_dir
@@ -3426,7 +3426,7 @@ omhttp_start_server() {
     wait_file_exists "$RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
     omhttp_server_lstnport="$(cat $RSYSLOG_DYNNAME.omhttp_server_lstnport.file)"
     echo ${omhttp_server_pid} > ${omhttp_server_pidfile}
-    echo "Started omhttp test server with args ${server_args} with pid ${omhttp_server_pid}, port {$omhttp_server_lstnport}"
+    echo "Started omhttp test server with args ${server_args} with process group ${omhttp_server_pid}, port {$omhttp_server_lstnport}"
 }
 
 omhttp_stop_server() {
@@ -3435,8 +3435,21 @@ omhttp_stop_server() {
     if [ ! -d $omhttp_work_dir ]; then
         echo "omhttp server $omhttp_work_dir does not exist, no action needed"
     else
-        echo "Stopping omhttp server"
-        kill -9 $(cat ${omhttp_work_dir}/omhttp_server.pid) > /dev/null 2>&1
+        omhttp_server_pid=$(cat ${omhttp_work_dir}/omhttp_server.pid)
+        echo "Stopping omhttp server process group ${omhttp_server_pid}"
+        kill -TERM -- -${omhttp_server_pid} > /dev/null 2>&1
+        wait ${omhttp_server_pid} 2>/dev/null || :
+        i=0
+        while kill -0 -- -${omhttp_server_pid} > /dev/null 2>&1; do
+            $TESTTOOL_DIR/msleep 100
+            (( i++ ))
+            if test $i -gt $TB_TIMEOUT_STARTSTOP; then
+                echo "omhttp server process group ${omhttp_server_pid} still running - Performing hard shutdown (-9)"
+                kill -9 -- -${omhttp_server_pid} > /dev/null 2>&1
+                wait ${omhttp_server_pid} 2>/dev/null || :
+                break
+            fi
+        done
         rm -rf $omhttp_work_dir
     fi
 }


### PR DESCRIPTION
## Summary

Fix omhttp test helper teardown so it stops the Python HTTP server instead of only killing the `timeout` wrapper.

## Root Cause

`omhttp_start_server` started helpers as:

```sh
timeout 30m $PYTHON ./omhttp_server.py ... &
```

and stored `$!` in `omhttp_server.pid`. That PID belongs to the `timeout` wrapper. `omhttp_stop_server` then used `kill -9` on that PID, which can prevent `timeout` from forwarding termination to the Python child. The child server can survive, become orphaned, and keep listening after the test run.

## Change

- Start the timeout-wrapped helper under `setsid`, making the stored PID also the helper process group id.
- Stop the entire helper process group with `SIGTERM` first.
- Wait for normal shutdown, then escalate to `SIGKILL` only if the process group remains after the existing start/stop timeout window.
- Preserve the 30-minute runaway guard.

## Validation

- `bash -n tests/diag.sh`
- Focused direct lifecycle check in the isolated worktree:
  - sourced `tests/diag.sh`
  - ran `omhttp_start_server 0`
  - confirmed the process group contained both `timeout` and `python3 ./omhttp_server.py`
  - ran `omhttp_stop_server`
  - scanned `/proc` scoped to the worktree cwd/path
  - result: no scoped `timeout` or `python3 ./omhttp_server.py` helpers remained

Full `make check` was not run for this focused testbench cleanup change.
