### PR TITLE
queue: quarantine runtime disk corruption safely

### DIFF
--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -2,6 +2,12 @@
 # Per-module metadata (support status, maturity, contacts) lives in each module
 # directory as `MODULE_METADATA.yaml`; update both the metadata file and this map
 # when concurrency guidance changes.
+runtime_queue:
+  paths: ["runtime/queue.c", "runtime/queue.h"]
+  requires_serialization: true
+  notes:
+    - Disk-assisted mode is an in-memory parent plus a first-class disk child; disk queue semantics apply to the child.
+
 omfile:
   paths: ["plugins/omfile/"]
   requires_serialization: true

--- a/doc/source/development/dev_queue.rst
+++ b/doc/source/development/dev_queue.rst
@@ -53,6 +53,11 @@ is empty, it is shut down and processing of the primary queue continues
 as a regular in-memory queue (aka "DA mode is shut down"). The whole
 thing iterates once the high water mark is hit again.
 
+The DA queue is a first-class disk queue object. Disk queue semantics
+for ``.qi`` state, segment files, ``queue.onCorruption``, quarantine,
+and runtime corruption handling apply to the DA queue in the same way as
+they apply to a queue configured directly as ``queue.type="disk"``.
+
 There is one special case: if the primary queue is shut down and could
 not finish processing all messages within the configured timeout
 periods, the DA queue is instantiated to take up the remaining messages.
@@ -303,4 +308,3 @@ destruction - this is what enables us to persist the disk queue!
 
 After that point, left over queue resources (mutexes, dynamic memory,
 ...) are freed and the queue object is actually destructed.
-

--- a/runtime/AGENTS.md
+++ b/runtime/AGENTS.md
@@ -15,6 +15,10 @@ collection, and process orchestration).
 - `modules.c`, `module-template.h`: module loader contracts shared with
   `plugins/` and `contrib/`.
 - `queue.c`, `wti.c`, `wtp.c`: work queue implementation and worker threads.
+  Disk-assisted mode creates two queue objects: an in-memory parent and a
+  first-class disk child (`pqDA`). Disk queue semantics for `.qi` state,
+  segment files, `queue.onCorruption`, quarantine, and runtime corruption
+  handling apply to the DA child just as they apply to pure disk queues.
 - `tcpsrv.c`, `tcpclt.c`, `net*.c`: TCP/TLS listeners and clients.
 - `parser.c`, `prop.c`, `template.c`: core message parsing and property engine.
 - `statsobj.c`, `dynstats*.c`: statistics registry and dynamic counters.

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -230,6 +230,7 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(strm) DEFobjCurrIf(datetime) DEFobjCurrIf(statso
 
 #define OVERSIZE_QUEUE_WATERMARK 500000 /* when is a queue considered to be "overly large"? */
 #define MAX_DISK_QUEUE_FILES 10000000 /* maximum file number for disk queues */
+#define DISKQUEUE_CORRUPTION_RESYNC_MAX_BYTES (1024 * 1024)
 
 
 /* forward-definitions */
@@ -245,6 +246,7 @@ static rsRetVal qqueueMultiEnqObjDirect(qqueue_t *pThis, multi_submit_t *pMultiS
 static rsRetVal qAddDirect(qqueue_t *pThis, smsg_t *pMsg);
 static rsRetVal qDestructDirect(qqueue_t __attribute__((unused)) * pThis);
 static rsRetVal qConstructDirect(qqueue_t __attribute__((unused)) * pThis);
+static rsRetVal qConstructDisk(qqueue_t *pThis);
 static rsRetVal qDestructDisk(qqueue_t *pThis);
 rsRetVal qqueueSetSpoolDir(qqueue_t *pThis, uchar *pszSpoolDir, int lenSpoolDir);
 static rsRetVal handleReadSeekError(rsRetVal seekRet, qqueue_t *pThis, const char *streamName, sbool *pReadSeekFailed);
@@ -252,6 +254,7 @@ static void alignReadDeqToWrite(qqueue_t *pThis);
 static void recoverFromInvalidQi(qqueue_t *pThis, int wr_fd, int64_t wr_offs);
 static void qqueueDestroyDiskStreams(qqueue_t *pThis);
 static rsRetVal qqueueSwitchToInMemoryEmergency(qqueue_t *pThis);
+static rsRetVal qqueueResetDiskQueueAfterCorruption(qqueue_t *pThis);
 
 /* some constants for queuePersist () */
 #define QUEUE_CHECKPOINT 1
@@ -620,6 +623,7 @@ static rsRetVal StartDA(qqueue_t *pThis) {
     pThis->pqDA->iMinDeqBatchSize = pThis->iMinDeqBatchSize;
     pThis->pqDA->iMinMsgsPerWrkr = pThis->iMinMsgsPerWrkr;
     pThis->pqDA->iLowWtrMrk = pThis->iLowWtrMrk;
+    pThis->pqDA->onCorruption = pThis->onCorruption;
     if (pThis->useCryprov) {
         /* hand over cryprov to DA queue - in-mem queue does no longer need it
          * and DA queue will be kept active from now on until termination.
@@ -907,23 +911,48 @@ static void qqueueDestroyDiskStreams(qqueue_t *pThis) {
     if (pThis->tVars.disk.pReadDel != NULL) strm.Destruct(&pThis->tVars.disk.pReadDel);
 }
 
-static void qqueueResetRecoveredQueueSize(qqueue_t *pThis) {
+static void qqueueResetRecoveredQueueSize(qqueue_t *pThis, const sbool adjustOverallQueueSize) {
     if (pThis->iQueueSize > 0) {
 #ifdef ENABLE_IMDIAG
+        if (adjustOverallQueueSize) {
     #ifdef HAVE_ATOMIC_BUILTINS
-        ATOMIC_SUB(&iOverallQueueSize, pThis->iQueueSize, &NULL);
+            ATOMIC_SUB(&iOverallQueueSize, pThis->iQueueSize, &NULL);
     #else
-        iOverallQueueSize -= pThis->iQueueSize; /* racy, but we can't wait for a mutex! */
+            iOverallQueueSize -= pThis->iQueueSize; /* racy, but we can't wait for a mutex! */
     #endif
+        }
 #endif
         pThis->iQueueSize = 0;
     }
     pThis->nLogDeq = 0;
 }
 
+static void qqueueSubtractOverallQueueSize(const int nElem) {
+    if (nElem <= 0) {
+        return;
+    }
+#ifdef ENABLE_IMDIAG
+    #ifdef HAVE_ATOMIC_BUILTINS
+    ATOMIC_SUB(&iOverallQueueSize, nElem, &NULL);
+    #else
+    iOverallQueueSize -= nElem; /* racy, but we can't wait for a mutex! */
+    #endif
+#endif
+}
+
+static void qqueueAddLogDeq(qqueue_t *pThis, const int nElem) {
+#ifdef HAVE_ATOMIC_BUILTINS
+    ATOMIC_ADD(pThis->nLogDeq, nElem);
+#else
+    pthread_mutex_lock(&pThis->mutLogDeq);
+    pThis->nLogDeq += nElem;
+    pthread_mutex_unlock(&pThis->mutLogDeq);
+#endif
+}
+
 static rsRetVal qqueueSwitchToInMemoryEmergency(qqueue_t *pThis) {
     DEFiRet;
-    qqueueResetRecoveredQueueSize(pThis);
+    qqueueResetRecoveredQueueSize(pThis, 1);
     qqueueDestroyDiskStreams(pThis);
     free(pThis->pszFilePrefix);
     pThis->pszFilePrefix = NULL;
@@ -1190,7 +1219,7 @@ static rsRetVal qqueueVerifyAndRecover(qqueue_t *pThis, rsRetVal loadRet) {
                 FINALIZE;
             }
 
-            if (mkdir(badDir, 0700) != 0) {
+            if (mkdir(badDir, 0755) != 0) {
                 if (errno == EEXIST) {
                     struct stat badDirStat;
                     if (stat(badDir, &badDirStat) != 0 || !S_ISDIR(badDirStat.st_mode)) {
@@ -1263,7 +1292,7 @@ static rsRetVal qqueueVerifyAndRecover(qqueue_t *pThis, rsRetVal loadRet) {
                 }
             }
 
-            qqueueResetRecoveredQueueSize(pThis);
+            qqueueResetRecoveredQueueSize(pThis, 1);
             iRet = RS_RET_FILE_NOT_FOUND;
         }
     } else {
@@ -1277,6 +1306,181 @@ finalize_it:
     if (files) {
         for (i = 0; i < nFiles; i++) free(files[i].name);
         free(files);
+    }
+    RETiRet;
+}
+
+static rsRetVal makeDiskQueueBadDir(qqueue_t *pThis, char *badDir, const size_t badDirLen) {
+    char timebuf[96];
+    struct tm tm_buf;
+    time_t now = time(NULL);
+    DEFiRet;
+
+    if (now == (time_t)-1) {
+        struct timespec ts;
+        if (clock_gettime(CLOCK_REALTIME, &ts) == 0) {
+            snprintf(timebuf, sizeof(timebuf), "timeerr-%ld-%ld", (long)getpid(), (long)ts.tv_nsec);
+        } else {
+            snprintf(timebuf, sizeof(timebuf), "timeerr-%ld", (long)getpid());
+        }
+    } else {
+        localtime_r(&now, &tm_buf);
+        strftime(timebuf, sizeof(timebuf), "%Y%m%d%H%M%S", &tm_buf);
+    }
+
+    const int len = snprintf(badDir, badDirLen, "%s/%s.bad.%s.%ld", pThis->pszSpoolDir, pThis->pszFilePrefix, timebuf,
+                             (long)getpid());
+    if (len < 0 || len >= (int)badDirLen) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    if (mkdir(badDir, 0755) != 0) {
+        if (errno != EEXIST) {
+            LogError(errno, RS_RET_ERR, "queue corruption: failed to create quarantine directory %s", badDir);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        struct stat badDirStat;
+        if (stat(badDir, &badDirStat) != 0 || !S_ISDIR(badDirStat.st_mode)) {
+            LogError(errno, RS_RET_ERR, "queue corruption: quarantine path exists but is unusable %s", badDir);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal moveQueueFileToBadDir(qqueue_t *pThis, const char *badDir, const char *fileName) {
+    char oldPath[MAXFNAME];
+    char newPath[MAXFNAME];
+    DEFiRet;
+
+    const int oldLen = snprintf(oldPath, sizeof(oldPath), "%s/%s", pThis->pszSpoolDir, fileName);
+    const int newLen = snprintf(newPath, sizeof(newPath), "%s/%s", badDir, fileName);
+    if (oldLen < 0 || oldLen >= (int)sizeof(oldPath) || newLen < 0 || newLen >= (int)sizeof(newPath)) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    if (rename(oldPath, newPath) != 0 && errno != ENOENT) {
+        LogError(errno, RS_RET_ERR, "queue corruption: could not move queue file %s to quarantine directory %s",
+                 fileName, badDir);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal qqueueQuarantineCurrentDiskFiles(qqueue_t *pThis, char *badDir, const size_t badDirLen) {
+    DIR *d = NULL;
+    struct dirent *dir;
+    fileEntry_t *files = NULL;
+    int nFiles = 0;
+    int capFiles = 0;
+    int i;
+    DEFiRet;
+
+    CHKiRet(makeDiskQueueBadDir(pThis, badDir, badDirLen));
+    d = opendir((char *)pThis->pszSpoolDir);
+    if (d == NULL) {
+        LogError(errno, RS_RET_ERR, "queue corruption: unable to scan spool directory %s for quarantine",
+                 pThis->pszSpoolDir);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    errno = 0;
+    while ((dir = readdir(d)) != NULL) {
+        const size_t nameLen = strlen(dir->d_name);
+        const size_t prefixLen = pThis->lenFilePrefix;
+        if (nameLen <= prefixLen + 1 || strncmp(dir->d_name, (char *)pThis->pszFilePrefix, prefixLen) != 0 ||
+            dir->d_name[prefixLen] != '.') {
+            continue;
+        }
+        const char *suffix = dir->d_name + prefixLen + 1;
+        if (strcmp(suffix, "qi") == 0) {
+            continue;
+        }
+        char *endptr;
+        errno = 0;
+        const long parsedNum = strtol(suffix, &endptr, 10);
+        if (*endptr != '\0' || errno == ERANGE || parsedNum < 0 || parsedNum > INT_MAX) {
+            continue;
+        }
+        if (nFiles == capFiles) {
+            fileEntry_t *newFiles;
+            const int newCapFiles = capFiles ? capFiles * 2 : 16;
+            if ((size_t)newCapFiles > SIZE_MAX / sizeof(fileEntry_t)) {
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            CHKmalloc(newFiles = realloc(files, (size_t)newCapFiles * sizeof(fileEntry_t)));
+            files = newFiles;
+            capFiles = newCapFiles;
+        }
+        CHKmalloc(files[nFiles].name = strdup(dir->d_name));
+        files[nFiles].number = (int)parsedNum;
+        ++nFiles;
+    }
+    if (errno != 0) {
+        LogError(errno, RS_RET_ERR, "queue corruption: unable to fully scan spool directory %s for quarantine",
+                 pThis->pszSpoolDir);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    closedir(d);
+    d = NULL;
+
+    qqueueDestroyDiskStreams(pThis);
+
+    char qiName[MAXFNAME];
+    const int qiLen = snprintf(qiName, sizeof(qiName), "%s.qi", pThis->pszFilePrefix);
+    if (qiLen < 0 || qiLen >= (int)sizeof(qiName)) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    CHKiRet(moveQueueFileToBadDir(pThis, badDir, qiName));
+    for (i = 0; i < nFiles; ++i) {
+        CHKiRet(moveQueueFileToBadDir(pThis, badDir, files[i].name));
+    }
+
+finalize_it:
+    if (d != NULL) {
+        closedir(d);
+    }
+    if (files != NULL) {
+        for (i = 0; i < nFiles; ++i) free(files[i].name);
+        free(files);
+    }
+    RETiRet;
+}
+
+static rsRetVal qqueueResetDiskQueueAfterCorruption(qqueue_t *pThis) {
+    char badDir[MAXFNAME];
+    DEFiRet;
+
+    CHKiRet(qqueueQuarantineCurrentDiskFiles(pThis, badDir, sizeof(badDir)));
+    LogMsg(0, RS_RET_ERR, LOG_ALERT,
+           "%s: disk queue corruption could not be resynchronized; quarantined unread queue tail into %s",
+           obj.GetName((obj_t *)pThis), badDir);
+
+    qqueueResetRecoveredQueueSize(pThis, 0);
+    pThis->tVars.disk.sizeOnDisk = 0;
+    pThis->tVars.disk.deqFileNumIn = 0;
+    pThis->tVars.disk.deqFileNumOut = 0;
+    pThis->tVars.disk.deqOffs = 0;
+    pThis->tVars.disk.nForcePersist = 0;
+    pThis->tVars.disk.pendingCorruptRet = RS_RET_OK;
+    pThis->bNeedDelQIF = 0;
+    pThis->iUpdsSincePersist = 0;
+    CHKiRet(qConstructDisk(pThis));
+    LogMsg(0, RS_RET_OK, LOG_WARNING, "%s: disk queue active state reset after corruption quarantine",
+           obj.GetName((obj_t *)pThis));
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        LogError(0, iRet, "%s: disk queue corruption quarantine failed; switching to emergency in-memory mode",
+                 obj.GetName((obj_t *)pThis));
+        const rsRetVal localRet = qqueueSwitchToInMemoryEmergency(pThis);
+        if (localRet != RS_RET_OK) {
+            LogError(0, localRet, "%s: emergency in-memory mode switch failed after disk queue corruption",
+                     obj.GetName((obj_t *)pThis));
+        }
+        iRet = RS_RET_OK;
     }
     RETiRet;
 }
@@ -1436,6 +1640,8 @@ static rsRetVal qConstructDisk(qqueue_t *pThis) {
     int bRestarted = 0;
 
     assert(pThis != NULL);
+    pThis->tVars.disk.pendingCorruptRet = RS_RET_OK;
+    pThis->tVars.disk.runtimeCorruptionSkip = 0;
 
     /* and now check if there is some persistent information that needs to be read in */
     iRet = qqueueTryLoadPersistedInfo(pThis);
@@ -1595,6 +1801,83 @@ static rsRetVal qDeqDisk(qqueue_t *pThis, smsg_t **ppMsg) {
     RETiRet;
 }
 
+static rsRetVal qDeqDiskRecoverAfterCorruption(qqueue_t *pThis,
+                                               smsg_t **ppMsg,
+                                               const rsRetVal corruptRet,
+                                               int *const pSkippedMsgs) {
+    uchar c;
+    int64_t startOffs;
+    int startFile;
+    unsigned int scanned = 0;
+    DEFiRet;
+
+    assert(ppMsg != NULL);
+    assert(pSkippedMsgs != NULL);
+    *ppMsg = NULL;
+    *pSkippedMsgs = 0;
+
+    if (pThis->onCorruption != QUEUE_ON_CORRUPTION_SAFE_MODE || pThis->tVars.disk.pReadDeq == NULL) {
+        ABORT_FINALIZE(corruptRet);
+    }
+
+    if (pThis->tVars.disk.pWrite != NULL &&
+        strmGetCurrFileNum(pThis->tVars.disk.pReadDeq) == strmGetCurrFileNum(pThis->tVars.disk.pWrite) &&
+        pThis->tVars.disk.pReadDeq->iCurrOffs >= pThis->tVars.disk.pWrite->iCurrOffs) {
+        ABORT_FINALIZE(corruptRet);
+    }
+
+    startFile = strmGetCurrFileNum(pThis->tVars.disk.pReadDeq);
+    startOffs = pThis->tVars.disk.pReadDeq->iCurrOffs;
+    LogMsg(0, corruptRet, LOG_ALERT,
+           "%s: disk queue corruption detected while dequeuing at file %d offset %lld; attempting bounded resync",
+           obj.GetName((obj_t *)pThis), startFile, (long long)startOffs);
+
+    while (scanned < DISKQUEUE_CORRUPTION_RESYNC_MAX_BYTES) {
+        if (pThis->tVars.disk.pWrite != NULL &&
+            strmGetCurrFileNum(pThis->tVars.disk.pReadDeq) == strmGetCurrFileNum(pThis->tVars.disk.pWrite) &&
+            pThis->tVars.disk.pReadDeq->iCurrOffs >= pThis->tVars.disk.pWrite->iCurrOffs) {
+            break;
+        }
+
+        iRet = strm.ReadChar(pThis->tVars.disk.pReadDeq, &c);
+        if (iRet != RS_RET_OK) {
+            break;
+        }
+        ++scanned;
+        if (c != '<') {
+            continue;
+        }
+
+        CHKiRet(strm.UnreadChar(pThis->tVars.disk.pReadDeq, c));
+        iRet = objDeserializeWithMethods(ppMsg, (uchar *)"msg", sizeof("msg") - 1, pThis->tVars.disk.pReadDeq, NULL,
+                                         NULL, msgConstructFromVoid, NULL, msgDeserializeFromVoid);
+        if (iRet == RS_RET_OK) {
+            *pSkippedMsgs = 1;
+            LogMsg(0, RS_RET_OK, LOG_WARNING,
+                   "%s: disk queue corruption recovery resumed after skipping a damaged record; "
+                   "resynchronized at file %d offset %lld after scanning %u bytes",
+                   obj.GetName((obj_t *)pThis), strmGetCurrFileNum(pThis->tVars.disk.pReadDeq),
+                   (long long)pThis->tVars.disk.pReadDeq->iCurrOffs, scanned);
+            FINALIZE;
+        }
+        if (iRet == RS_RET_OUT_OF_MEMORY) {
+            ABORT_FINALIZE(iRet);
+        }
+        *ppMsg = NULL;
+    }
+
+    LogMsg(0, corruptRet, LOG_ALERT,
+           "%s: disk queue corruption recovery failed after bounded scan of %u bytes; quarantining unread tail",
+           obj.GetName((obj_t *)pThis), scanned);
+    const int skippedTail = getLogicalQueueSize(pThis);
+    CHKiRet(qqueueResetDiskQueueAfterCorruption(pThis));
+    *pSkippedMsgs = skippedTail;
+    iRet = RS_RET_NO_DATA;
+
+finalize_it:
+    RETiRet;
+}
+
 
 /* -------------------- direct (no queueing) -------------------- */
 static rsRetVal qConstructDirect(qqueue_t __attribute__((unused)) * pThis) {
@@ -1688,28 +1971,6 @@ static rsRetVal qqueueAdd(qqueue_t *pThis, smsg_t *pMsg) {
     }
 
 finalize_it:
-    RETiRet;
-}
-
-
-/* generic code to dequeue a queue entry
- */
-static rsRetVal qqueueDeq(qqueue_t *pThis, smsg_t **ppMsg) {
-    DEFiRet;
-
-    assert(pThis != NULL);
-
-    /* we do NOT abort if we encounter an error, because otherwise the queue
-     * will not be decremented, what will most probably result in an endless loop.
-     * If we decrement, however, we may lose a message. But that is better than
-     * losing the whole process because it loops... -- rgerhards, 2008-01-03
-     */
-    iRet = pThis->qDeq(pThis, ppMsg);
-    ATOMIC_INC(&pThis->nLogDeq, &pThis->mutLogDeq);
-
-    DBGOPRINT((obj_t *)pThis, "entry deleted, size now log %d, phys %d entries\n", getLogicalQueueSize(pThis),
-              getPhysicalQueueSize(pThis));
-
     RETiRet;
 }
 
@@ -2176,6 +2437,8 @@ static void alignReadDeqToWrite(qqueue_t *pThis) {
 }
 
 static void recoverFromInvalidQi(qqueue_t *pThis, const int wr_fd, const int64_t wr_offs) {
+    pThis->tVars.disk.runtimeCorruptionSkip = 0;
+
     if (pThis->tVars.disk.pReadDel == NULL || pThis->tVars.disk.pWrite == NULL || wr_fd < 0 || wr_offs < 0) {
         return;
     }
@@ -2250,7 +2513,11 @@ static rsRetVal ATTR_NONNULL(1) DoDeleteBatchFromQStore(qqueue_t *const pThis, c
          * size. -- rgerhards, 2008-01-30
          */
         if (bytesDel != 0) {
-            pThis->tVars.disk.sizeOnDisk -= bytesDel;
+            if (pThis->tVars.disk.sizeOnDisk >= bytesDel) {
+                pThis->tVars.disk.sizeOnDisk -= bytesDel;
+            } else {
+                pThis->tVars.disk.sizeOnDisk = 0;
+            }
             DBGOPRINT((obj_t *)pThis,
                       "doDeleteBatch: a %lld octet file has been deleted, now %lld "
                       "octets disk space used\n",
@@ -2325,7 +2592,7 @@ static rsRetVal DeleteBatchFromQStore(qqueue_t *pThis, batch_t *pBatch) {
 
     switch (phase) {
         case TDL_EMPTY:
-            DoDeleteBatchFromQStore(pThis, pBatch->nElem);
+            DoDeleteBatchFromQStore(pThis, pBatch->nElemDeq);
             break;
 
         case TDL_PROCESS_HEAD:
@@ -2337,13 +2604,13 @@ static rsRetVal DeleteBatchFromQStore(qqueue_t *pThis, batch_t *pBatch) {
             }
             assert(pThis->deqIDDel == nextID);
             /* old entries deleted, now delete current ones... */
-            DoDeleteBatchFromQStore(pThis, pBatch->nElem);
+            DoDeleteBatchFromQStore(pThis, pBatch->nElemDeq);
             break;
 
         case TDL_QUEUE:
             /* cannot delete, insert into to-delete list */
             DBGPRINTF("not at head of to-delete list, enqueue %d\n", (int)pBatch->deqID);
-            CHKiRet(tdlAdd(pThis, pBatch->deqID, pBatch->nElem));
+            CHKiRet(tdlAdd(pThis, pBatch->deqID, pBatch->nElemDeq));
             break;
 
         default:
@@ -2418,6 +2685,8 @@ static rsRetVal ATTR_NONNULL() DequeueConsumableElements(qqueue_t *const pThis,
     int nDeleted;
     int iQueueSize;
     int keep_running = 1;
+    int deferredDiskCorruption = 0;
+    rsRetVal pendingCorruptRet = RS_RET_OK;
     struct timespec timeout;
     smsg_t *pMsg;
     rsRetVal localRet;
@@ -2429,6 +2698,11 @@ static rsRetVal ATTR_NONNULL() DequeueConsumableElements(qqueue_t *const pThis,
     nDequeued = nDiscarded = 0;
     if (pThis->qType == QUEUETYPE_DISK) {
         pThis->tVars.disk.deqFileNumIn = strmGetCurrFileNum(pThis->tVars.disk.pReadDeq);
+        pThis->tVars.disk.runtimeCorruptionSkip = 0;
+        if (pThis->tVars.disk.pendingCorruptRet != RS_RET_OK) {
+            pendingCorruptRet = pThis->tVars.disk.pendingCorruptRet;
+            pThis->tVars.disk.pendingCorruptRet = RS_RET_OK;
+        }
     }
 
     /* work-around clang static analyzer false positive, we need a const value */
@@ -2450,30 +2724,161 @@ static rsRetVal ATTR_NONNULL() DequeueConsumableElements(qqueue_t *const pThis,
             wr_fd = strmGetCurrFileNum(pThis->tVars.disk.pWrite);
             wr_offs = pThis->tVars.disk.pWrite->iCurrOffs;
         }
-        if (rd_fd != -1 && rd_fd == wr_fd && rd_offs == wr_offs) {
-            DBGPRINTF(
-                "problem on disk queue '%s': "
-                //"queue size log %d, phys %d, but rd_fd=wr_rd=%d and offs=%lld\n",
-                "queue size log %d, phys %d, but rd_fd=wr_rd=%d and offs=%" PRId64 "\n",
-                obj.GetName((obj_t *)pThis), iQueueSize, pThis->iQueueSize, rd_fd, rd_offs);
-            *pSkippedMsgs = iQueueSize;
-#ifdef ENABLE_IMDIAG
-            iOverallQueueSize -= iQueueSize;
-#endif
-            pThis->iQueueSize -= iQueueSize;
-            recoverFromInvalidQi(pThis, wr_fd, wr_offs);
-            iQueueSize = 0;
-            break;
-        }
+        pMsg = NULL;
+        if (pendingCorruptRet != RS_RET_OK) {
+            localRet = pendingCorruptRet;
+            pendingCorruptRet = RS_RET_OK;
+        } else {
+            if (rd_fd != -1 && rd_fd == wr_fd && rd_offs == wr_offs) {
+                DBGPRINTF(
+                    "problem on disk queue '%s': "
+                    //"queue size log %d, phys %d, but rd_fd=wr_rd=%d and offs=%lld\n",
+                    "queue size log %d, phys %d, but rd_fd=wr_rd=%d and offs=%" PRId64 "\n",
+                    obj.GetName((obj_t *)pThis), iQueueSize, pThis->iQueueSize, rd_fd, rd_offs);
+                if (pThis->onCorruption == QUEUE_ON_CORRUPTION_SAFE_MODE && iQueueSize > 1) {
+                    LogMsg(0, RS_RET_ERR, LOG_ALERT,
+                           "%s: disk queue corruption reached the write pointer with %d logical records remaining; "
+                           "quarantining unread tail",
+                           obj.GetName((obj_t *)pThis), iQueueSize);
+                    pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                    *pSkippedMsgs += iQueueSize;
+                    qqueueSubtractOverallQueueSize(iQueueSize);
+                    pThis->iQueueSize -= iQueueSize;
+                    CHKiRet(qqueueResetDiskQueueAfterCorruption(pThis));
+                    pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                    nDiscarded = 0;
+                    iQueueSize = 0;
+                    break;
+                }
+                *pSkippedMsgs = iQueueSize;
+                qqueueSubtractOverallQueueSize(iQueueSize - nDiscarded);
+                pThis->iQueueSize -= iQueueSize;
+                recoverFromInvalidQi(pThis, wr_fd, wr_offs);
+                iQueueSize = 0;
+                break;
+            }
 
-        localRet = qqueueDeq(pThis, &pMsg);
-        if (localRet == RS_RET_FILE_NOT_FOUND) {
-            DBGPRINTF(
-                "fatal error on disk queue '%s': file '%s' "
-                "not found, queue size said to be %d",
-                obj.GetName((obj_t *)pThis), "...", iQueueSize);
+            localRet = pThis->qDeq(pThis, &pMsg);
+            if (localRet == RS_RET_FILE_NOT_FOUND) {
+                DBGPRINTF(
+                    "fatal error on disk queue '%s': file '%s' "
+                    "not found, queue size said to be %d",
+                    obj.GetName((obj_t *)pThis), "...", iQueueSize);
+                if (pThis->qType == QUEUETYPE_DISK) {
+                    if (pThis->onCorruption == QUEUE_ON_CORRUPTION_SAFE_MODE && iQueueSize > 1) {
+                        LogMsg(0, localRet, LOG_ALERT,
+                               "%s: disk queue corruption reached a missing file with %d logical records remaining; "
+                               "quarantining unread tail",
+                               obj.GetName((obj_t *)pThis), iQueueSize);
+                        pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                        *pSkippedMsgs += iQueueSize;
+                        qqueueSubtractOverallQueueSize(iQueueSize);
+                        pThis->iQueueSize -= iQueueSize;
+                        CHKiRet(qqueueResetDiskQueueAfterCorruption(pThis));
+                        pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                        nDiscarded = 0;
+                        iQueueSize = 0;
+                        break;
+                    }
+                    *pSkippedMsgs = iQueueSize;
+                    qqueueSubtractOverallQueueSize(iQueueSize - nDiscarded);
+                    pThis->iQueueSize -= iQueueSize;
+                    recoverFromInvalidQi(pThis, wr_fd, wr_offs);
+                    iQueueSize = 0;
+                    break;
+                }
+            }
+            if (localRet != RS_RET_OK && pThis->qType == QUEUETYPE_DISK && pThis->tVars.disk.pReadDeq != NULL &&
+                pThis->tVars.disk.pWrite != NULL &&
+                strmGetCurrFileNum(pThis->tVars.disk.pReadDeq) == strmGetCurrFileNum(pThis->tVars.disk.pWrite) &&
+                pThis->tVars.disk.pReadDeq->iCurrOffs >= pThis->tVars.disk.pWrite->iCurrOffs) {
+                if (pThis->onCorruption == QUEUE_ON_CORRUPTION_SAFE_MODE && iQueueSize > 1) {
+                    LogMsg(0, localRet, LOG_ALERT,
+                           "%s: disk queue corruption reached the write pointer with %d logical records remaining; "
+                           "quarantining unread tail",
+                           obj.GetName((obj_t *)pThis), iQueueSize);
+                    pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                    *pSkippedMsgs += iQueueSize;
+                    qqueueSubtractOverallQueueSize(iQueueSize);
+                    pThis->iQueueSize -= iQueueSize;
+                    CHKiRet(qqueueResetDiskQueueAfterCorruption(pThis));
+                    pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                    nDiscarded = 0;
+                    iQueueSize = 0;
+                    break;
+                }
+                *pSkippedMsgs = iQueueSize;
+                qqueueSubtractOverallQueueSize(iQueueSize - nDiscarded);
+                pThis->iQueueSize -= iQueueSize;
+                recoverFromInvalidQi(pThis, strmGetCurrFileNum(pThis->tVars.disk.pWrite),
+                                     pThis->tVars.disk.pWrite->iCurrOffs);
+                iQueueSize = 0;
+                break;
+            }
+        }
+        if (localRet != RS_RET_OK && pThis->qType == QUEUETYPE_DISK &&
+            pThis->onCorruption == QUEUE_ON_CORRUPTION_SAFE_MODE) {
+            int nSkippedCorrupt = 0;
+            if (nDequeued > 0) {
+                LogMsg(0, localRet, LOG_WARNING,
+                       "%s: disk queue corruption detected after %d valid records; deferring recovery until "
+                       "the current batch is committed",
+                       obj.GetName((obj_t *)pThis), nDequeued);
+                deferredDiskCorruption = 1;
+                pThis->tVars.disk.pendingCorruptRet = localRet;
+                iRet = RS_RET_OK;
+                break;
+            }
+            localRet = qDeqDiskRecoverAfterCorruption(pThis, &pMsg, localRet, &nSkippedCorrupt);
+            if (localRet != RS_RET_OK && pThis->tVars.disk.pReadDeq != NULL && pThis->tVars.disk.pWrite != NULL &&
+                strmGetCurrFileNum(pThis->tVars.disk.pReadDeq) == strmGetCurrFileNum(pThis->tVars.disk.pWrite) &&
+                pThis->tVars.disk.pReadDeq->iCurrOffs >= pThis->tVars.disk.pWrite->iCurrOffs) {
+                if (iQueueSize > 1) {
+                    LogMsg(0, localRet, LOG_ALERT,
+                           "%s: disk queue corruption reached the write pointer with %d logical records remaining; "
+                           "quarantining unread tail",
+                           obj.GetName((obj_t *)pThis), iQueueSize);
+                    pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                    *pSkippedMsgs += iQueueSize;
+                    qqueueSubtractOverallQueueSize(iQueueSize);
+                    pThis->iQueueSize -= iQueueSize;
+                    CHKiRet(qqueueResetDiskQueueAfterCorruption(pThis));
+                    pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                    nDiscarded = 0;
+                    iQueueSize = 0;
+                    break;
+                }
+                *pSkippedMsgs = iQueueSize;
+                qqueueSubtractOverallQueueSize(iQueueSize - nDiscarded);
+                pThis->iQueueSize -= iQueueSize;
+                recoverFromInvalidQi(pThis, strmGetCurrFileNum(pThis->tVars.disk.pWrite),
+                                     pThis->tVars.disk.pWrite->iCurrOffs);
+                iQueueSize = 0;
+                break;
+            }
+            if (localRet == RS_RET_NO_DATA) {
+                pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                *pSkippedMsgs += nSkippedCorrupt;
+                qqueueSubtractOverallQueueSize(nSkippedCorrupt);
+                iQueueSize = 0;
+                break;
+            }
+            if (nSkippedCorrupt > 0) {
+                pThis->tVars.disk.runtimeCorruptionSkip = 1;
+                nDiscarded += nSkippedCorrupt;
+                *pSkippedMsgs += nSkippedCorrupt;
+            }
+            if (localRet == RS_RET_OK) {
+                qqueueAddLogDeq(pThis, nSkippedCorrupt + 1);
+            }
+        } else if (localRet == RS_RET_OK) {
+            qqueueAddLogDeq(pThis, 1);
         }
         CHKiRet(localRet);
+        if (pThis->qType == QUEUETYPE_DISK) {
+            strm.GetCurrOffset(pThis->tVars.disk.pReadDeq, &pThis->tVars.disk.deqOffs);
+            pThis->tVars.disk.deqFileNumOut = strmGetCurrFileNum(pThis->tVars.disk.pReadDeq);
+        }
 
         /* check if we should discard this element */
         localRet = qqueueChkDiscardMsg(pThis, pThis->iQueueSize, pMsg);
@@ -2507,7 +2912,7 @@ static rsRetVal ATTR_NONNULL() DequeueConsumableElements(qqueue_t *const pThis,
         }
     }
 
-    if (pThis->qType == QUEUETYPE_DISK) {
+    if (pThis->qType == QUEUETYPE_DISK && !deferredDiskCorruption) {
         strm.GetCurrOffset(pThis->tVars.disk.pReadDeq, &pThis->tVars.disk.deqOffs);
         pThis->tVars.disk.deqFileNumOut = strmGetCurrFileNum(pThis->tVars.disk.pReadDeq);
     }
@@ -2552,8 +2957,13 @@ static rsRetVal DequeueConsumable(qqueue_t *pThis, wti_t *pWti, int *const pSkip
     /* dequeue element batch (still protected from mutex) */
     iRet = DequeueConsumableElements(pThis, pWti, &iQueueSize, pSkippedMsgs);
     if (*pSkippedMsgs > 0) {
-        LogError(0, RS_RET_ERR, "%s: lost %d messages from diskqueue (invalid .qi file)", obj.GetName((obj_t *)pThis),
-                 *pSkippedMsgs);
+        if (pThis->qType == QUEUETYPE_DISK && pThis->tVars.disk.runtimeCorruptionSkip) {
+            LogMsg(0, RS_RET_ERR, LOG_ERR, "%s: skipped %d messages from diskqueue during runtime corruption handling",
+                   obj.GetName((obj_t *)pThis), *pSkippedMsgs);
+        } else {
+            LogError(0, RS_RET_ERR, "%s: lost %d messages from diskqueue (invalid .qi file)",
+                     obj.GetName((obj_t *)pThis), *pSkippedMsgs);
+        }
     }
 
     /* awake some flow-controlled sources if we can do this right now */

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -204,6 +204,8 @@ struct queue_s {
                 strm_t *pReadDeq; /* current file for dequeueing */
                 strm_t *pReadDel; /* current file for deleting */
                 int nForcePersist; /* force persist of .qi file the next "n" times */
+                int pendingCorruptRet; /* deferred dequeue-time corruption result to recover on next batch */
+                sbool runtimeCorruptionSkip; /* skipped messages in current batch due to runtime corruption */
             } disk;
         } tVars;
         sbool useCryprov; /* quicker than checkig ptr (1 vs 8 bytes!) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -231,6 +231,7 @@ TESTS_DEFAULT = \
 	daqueue-persist.sh \
 	daqueue-invld-qi.sh \
 	daqueue-dirty-shutdown-recovery.sh \
+	daqueue-truncated-segment-startup.sh \
 	diskq-rfc5424.sh \
 	diskqueue-truncated-segment-startup.sh \
 	diskqueue.sh \

--- a/tests/daqueue-invld-qi.sh
+++ b/tests/daqueue-invld-qi.sh
@@ -12,10 +12,10 @@ input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port
 
 $ModLoad ../plugins/omtesting/.libs/omtesting
 
-# set spool locations and switch queue to disk-only mode
+# Configure a disk-assisted main queue.
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool
+$MainMsgQueueType LinkedList
 $MainMsgQueueFilename mainq
-$IncludeConfig '${RSYSLOG_DYNNAME}'work-queuemode.conf
 
 $template outfmt,"%msg:F,58:2%\n"
 template(name="dynfile" type="string" string=`echo $RSYSLOG_OUT_LOG`) # trick to use relative path names!
@@ -26,11 +26,9 @@ $IncludeConfig '${RSYSLOG_DYNNAME}'work-delay.conf
 #export RSYSLOG_DEBUG="debug nologfuncflow nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 
-# prepare config
-echo \$MainMsgQueueType LinkedList > ${RSYSLOG_DYNNAME}work-queuemode.conf
 echo "*.*     :omtesting:sleep 0 1000" > ${RSYSLOG_DYNNAME}work-delay.conf
 
-# inject 10000 msgs, so that DO hit the high watermark
+# Phase 1: inject enough messages to hit the high watermark and persist DA state.
 startup
 injectmsg 0 10000
 shutdown_immediate
@@ -41,8 +39,7 @@ mv tmp.qi ${RSYSLOG_DYNNAME}.spool/mainq.qi
 
 echo "Enter phase 2, rsyslogd restart"
 
-# restart engine and have rest processed
-#remove delay
+# Phase 2: remove the artificial delay and verify the mangled .qi recovers.
 echo "#" > ${RSYSLOG_DYNNAME}work-delay.conf
 startup
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/daqueue-truncated-segment-startup.sh
+++ b/tests/daqueue-truncated-segment-startup.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-# Validate queue.onCorruption handling when bytes inside a persisted disk-queue
-# segment are corrupted in the middle of the queue sequence. Restart must
-# process the valid prefix, quarantine the unread tail into mainq.bad.*,
-# and leave no stale live queue files behind. A fresh mainq.00000001/mainq.qi
-# pair is acceptable because resetting a pure disk queue constructs a new live
-# head.
-# added 2026-04-20 by Codex, released under ASL 2.0
+# Validate queue.onCorruption handling when bytes inside a persisted
+# disk-assisted queue segment are corrupted. The DA child is a first-class disk
+# queue, so it must process the valid prefix, quarantine the unread tail into
+# mainq.bad.*, and leave no stale live queue files behind. A fresh
+# mainq.00000001/mainq.qi pair is acceptable because resetting the DA disk
+# child constructs a new live head.
+# added 2026-04-25 by Codex, released under ASL 2.0
 
 export TEST_MAX_RUNTIME=${TEST_MAX_RUNTIME:-300}
 
@@ -29,7 +29,7 @@ module(load="../plugins/omtesting/.libs/omtesting")
 global(workDirectory="'"$SPOOL_DIR"'")
 
 main_queue(
-	queue.type="disk"
+	queue.type="LinkedList"
 	queue.filename="mainq"
 	queue.maxFileSize="16k"
 	queue.saveOnShutdown="on"
@@ -53,7 +53,7 @@ module(load="../plugins/omtesting/.libs/omtesting")
 global(workDirectory="'"$SPOOL_DIR"'")
 
 main_queue(
-	queue.type="disk"
+	queue.type="LinkedList"
 	queue.filename="mainq"
 	queue.maxFileSize="16k"
 	queue.saveOnShutdown="off"
@@ -84,16 +84,6 @@ count_bad_dirs() {
 	count=0
 	for path in "$SPOOL_DIR"/mainq.bad.*; do
 		[ -d "$path" ] || continue
-		count=$((count + 1))
-	done
-	printf '%s\n' "$count"
-}
-
-count_live_mainq_files() {
-	count=0
-	for path in "$SPOOL_DIR"/mainq*; do
-		[ -e "$path" ] || continue
-		[ -f "$path" ] || [ -L "$path" ] || continue
 		count=$((count + 1))
 	done
 	printf '%s\n' "$count"
@@ -201,7 +191,7 @@ prepare_corrupted_queue() {
 
 		seg_count=$(count_segment_files)
 		if [ -f "$SPOOL_DIR/mainq.qi" ] && [ "$seg_count" -ge 3 ]; then
-			printf 'Prepared persisted queue with %s messages and %s segment files\n' \
+			printf 'Prepared persisted DA queue with %s messages and %s segment files\n' \
 				"$NUMMESSAGES" "$seg_count"
 			return 0
 		fi
@@ -212,7 +202,7 @@ prepare_corrupted_queue() {
 		current_messages=$((current_messages + BASE_NUMMESSAGES / 2))
 	done
 
-	printf 'FAIL: unable to create a persisted queue with at least 3 segment files after %s attempts\n' \
+	printf 'FAIL: unable to create a persisted DA queue with at least 3 segment files after %s attempts\n' \
 		"$PREPARE_ATTEMPTS"
 	list_spool_top
 	error_exit 1
@@ -239,7 +229,7 @@ wait_for_recovery_outcome() {
 		$TESTTOOL_DIR/msleep 100
 	done
 
-	echo "FAIL: timed out waiting for truncated queue recovery outcome"
+	echo "FAIL: timed out waiting for truncated DA queue recovery outcome"
 	list_spool_top
 	[ -s "$RSYSLOGD_LOG" ] && cat "$RSYSLOGD_LOG"
 	error_exit 1
@@ -284,7 +274,7 @@ if grep -q "invalid \\.qi file" "$STARTED_LOG" "$RSYSLOGD_LOG"; then
 fi
 
 if [ ! -s "$RSYSLOG_OUT_LOG" ]; then
-	echo "FAIL: truncated queue recovery produced no output before quarantine"
+	echo "FAIL: truncated DA queue recovery produced no output before quarantine"
 	list_spool_top
 	cat "$RSYSLOGD_LOG"
 	error_exit 1
@@ -292,7 +282,7 @@ fi
 
 bad_after=$(count_bad_dirs)
 if [ "$bad_after" -le "$bad_before" ]; then
-	echo "FAIL: truncated queue segment was not quarantined into mainq.bad.*"
+	echo "FAIL: truncated DA queue segment was not quarantined into mainq.bad.*"
 	list_spool_top
 	error_exit 1
 fi

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -382,7 +382,7 @@ generate_conf() {
 		export RSYSLOG_OUT_LOG="${RSYSLOG_DYNNAME}.out.log"
 		export RSYSLOG2_OUT_LOG="${RSYSLOG_DYNNAME}_2.out.log"
 		export RSYSLOG_PIDBASE="${RSYSLOG_DYNNAME}:" # also used by instance 2!
-		mkdir $RSYSLOG_DYNNAME.spool
+		mkdir -p $RSYSLOG_DYNNAME.spool
 	fi
 	if [ "$yaml_only" = "1" ]; then
 		export RSYSLOG_YAML_ONLY=1


### PR DESCRIPTION
## What changed

This teaches the disk queue runtime path to handle in-file corruption in
`queue.onCorruption="safe"` without weakening the existing startup
checks.

When dequeue-time corruption is hit, rsyslog now:
- preserves already dequeued valid records in the current batch
- quarantines the unread tail into `mainq.bad.*` when bounded resync does
  not recover safely
- reconstructs a fresh active disk queue state
- emits explicit user-visible runtime corruption and quarantine messages

The targeted regression test now requires the strict contract that was
requested during analysis:
- valid output before the corrupted point must still be processed
- quarantine must happen
- zero live `mainq*` files may remain afterwards

## Root cause

Startup validation only checks queue topology and pointer consistency. It
cannot cheaply scan every record payload in every queue segment.

The failing s390x case corrupted bytes inside a queue segment, so startup
still accepted the queue. The old runtime path then surfaced that damage
through generic skipped-message handling, which could report it like an
`invalid .qi file` style loss and did not provide a dedicated runtime
corruption quarantine flow with a clear zero-live-segments end state.

This change closes that gap at runtime instead of weakening startup
behavior.

## User impact

Users now get explicit rsyslog messages when runtime disk queue
corruption is detected, when unread tail data is quarantined, and how
many messages were skipped during runtime corruption handling.

## Validation

Local s390x QEMU/container reruns:
- `./tests/diskqueue-truncated-segment-startup.sh` passed 3 consecutive
  times
- `./tests/diskqueue-oncorruption-missing-segment.sh` passed once to
  confirm the startup corruption path was not weakened

Artifact root:
- `/home/rger/proj/rsyslog-s390x-artifacts/other-bin-runtime-20260424T112114Z`
