### PR TITLE
imdocker: stabilize image-name test

### DIFF
--- a/tests/imdocker-image-name-vg.sh
+++ b/tests/imdocker-image-name-vg.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export USE_VALGRIND="YES"
-. ${srcdir:-.}/imdocker-image-name.sh
+. "${srcdir:-$(dirname "$0")}/imdocker-image-name.sh"

--- a/tests/imdocker-image-name.sh
+++ b/tests/imdocker-image-name.sh
@@ -2,13 +2,15 @@
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # imdocker unit tests are enabled with --enable-imdocker-tests
 . ${srcdir:=.}/diag.sh init
+export NUMMESSAGES=1
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
 
 generate_conf
 add_conf '
 template(name="outfmt" type="string" string="image=%$!metadata!Image%\n")
-module(load="../contrib/imdocker/.libs/imdocker")
+module(load="../contrib/imdocker/.libs/imdocker"
+        ListContainersOptions="all=true")
 if $!metadata!Names == "'$COOKIE'" then {
   action(type="omfile" template="outfmt"  file="'$RSYSLOG_OUT_LOG'")
 }


### PR DESCRIPTION
## Summary

This stabilizes the imdocker image-name test and its valgrind wrapper.

The test is meant to verify that imdocker emits the Docker image name metadata for a known container log line. Under the flake campaign it failed reproducibly in `make -j24 check`, `make -j40 check`, and `make -j1 check` with:

`wait_file_lines failed, expected got 0`

## Root Cause

`tests/imdocker-image-name.sh` selected `wait_file_lines` through `QUEUE_EMPTY_CHECK_FUNC` but never set `NUMMESSAGES`. The queue-empty helper therefore compared the output line count against an empty expected value and timed out even when the test logic should expect one output record.

The test also created a short-lived container before rsyslog startup but left imdocker on the default running-container inventory. That made the already-exited test container an unreliable input source. The test needs imdocker to include non-running containers so the pre-created fixture container is visible when rsyslog starts.

The `-vg` wrapper had a separate direct-execution problem: when invoked from the repository root it sourced `./imdocker-image-name.sh`, which depends on the current directory instead of the wrapper script location.

## What Changed

- Set `NUMMESSAGES=1` for the expected single output line.
- Configure imdocker to inspect all containers so the fixture container is visible after it exits.
- Make the valgrind wrapper source the base test relative to the wrapper path.

## Validation

- Reproduced the pre-fix direct failure for `./tests/imdocker-image-name.sh`.
- `make -j$(nproc) check TESTS=""` passed.
- `./tests/imdocker-image-name.sh` passed.
- `./tests/imdocker-image-name-vg.sh` passed with valgrind, `ERROR SUMMARY: 0 errors`.
