### PR TITLE
tests: stabilize uxsock receiver reset

### DIFF
--- a/tests/uxsock_multiple-vg.sh
+++ b/tests/uxsock_multiple-vg.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export USE_VALGRIND="YES"
-. ${srcdir:-.}/uxsock_multiple.sh
+. "${srcdir:-$(dirname "$0")}/uxsock_multiple.sh"

--- a/tests/uxsock_multiple.sh
+++ b/tests/uxsock_multiple.sh
@@ -6,27 +6,41 @@
 # Based on uxsock_simple.sh added 2010-08-06 by Rgerhards
 # Updated 2025-04-16 for abstract sockets
 . ${srcdir:=.}/diag.sh init
-check_command_available timeout
-
 uname
 if [ $(uname) != "Linux" ] ; then
     echo "This test requires Linux (AF_UNIX abstract addresses)"
     exit 77
 fi
 
-SOCKET_NAMES=(
-    "$RSYSLOG_DYNNAME-testbench-dgram-uxsock.0"
-    "$RSYSLOG_DYNNAME-testbench-dgram-uxsock.DGRAM"
-    "$RSYSLOG_DYNNAME-testbench-dgram-uxsock.STREAM"
-    "$RSYSLOG_DYNNAME-testbench-dgram-uxsock.SEQPACKET"
-)
+wait_receiver_ready() {
+    expected_generation=$1
+    ready_file=$2
+    count=1
+
+    while [ "$count" -le 100 ]; do
+        if [ -r "$ready_file" ] && [ "$(cat "$ready_file")" = "$expected_generation" ]; then
+            return
+        fi
+        $TESTTOOL_DIR/msleep 100
+        count=$((count + 1))
+    done
+    echo "uxsockrcvr did not report ready generation $expected_generation for $ready_file"
+    error_exit 1
+}
+
+SOCKET_NAMES="
+$RSYSLOG_DYNNAME-testbench-dgram-uxsock.0
+$RSYSLOG_DYNNAME-testbench-dgram-uxsock.DGRAM
+$RSYSLOG_DYNNAME-testbench-dgram-uxsock.STREAM
+$RSYSLOG_DYNNAME-testbench-dgram-uxsock.SEQPACKET
+"
 
 # create the pipe and start a background process that copies data from
 # it to the "regular" work file
 generate_conf
-for name in "${SOCKET_NAMES[@]}"; do
+for name in $SOCKET_NAMES; do
     ext=${name##*.}
-    if [ ${ext} == "0" ]; then
+    if [ ${ext} = "0" ]; then
         add_conf '
 
         $template outfmt,"%msg:F,58:2%\n"
@@ -56,18 +70,22 @@ done
 add_conf '
 }
 '
-BGPROCESS=()
-for name in "${SOCKET_NAMES[@]}"; do
+BGPROCESS=""
+RECEIVER_READY=""
+for name in $SOCKET_NAMES; do
     ext=${name##*.}
-    if [ "${ext}" == "0" ]; then
+    if [ "${ext}" = "0" ]; then
         type=""
     else
         type="-T${ext}"
     fi
-    timeout 30s ./uxsockrcvr -a -s$name ${type} -o ${RSYSLOG_OUT_LOG}.${ext} -t 60 &
-    PID=($!)
-    BGPROCESS+=($PID)
+    ready_file=${RSYSLOG_DYNNAME}.uxsockrcvr.${ext}.ready
+    ./uxsockrcvr -a -s$name ${type} -o ${RSYSLOG_OUT_LOG}.${ext} -r ${ready_file} -t 60 &
+    PID=$!
+    BGPROCESS="$BGPROCESS $PID"
+    RECEIVER_READY="$RECEIVER_READY $ready_file"
     echo background uxsockrcvr ${name} process id is $PID
+    wait_receiver_ready 1 "$ready_file"
 done
 
 # now do the usual run
@@ -77,17 +95,22 @@ startup
 injectmsg 0 10000
 wait_queueempty
 echo resetting uxsockrcvr...
-for pid in ${BGPROCESS[@]}; do
+for pid in $BGPROCESS; do
     kill -HUP $pid
 done
-injectmsg 10000 10000
+for ready_file in $RECEIVER_READY; do
+    wait_receiver_ready 2 "$ready_file"
+done
+injectmsg 10000 1
+wait_queueempty
+injectmsg 10001 9999
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown
 
 # wait for the cp process to finish, do pipe-specific cleanup
 echo shutting down uxsockrcvr...
 # TODO: we should do this more reliable in the long run! (message counter? timeout?)
-for pid in ${BGPROCESS[@]}; do
+for pid in $BGPROCESS; do
     kill $pid
     wait $pid
 done
@@ -95,7 +118,7 @@ echo background processes have terminated, continue test...
 
 # and continue the usual checks.
 BASE=${RSYSLOG_OUT_LOG}
-for name in "${SOCKET_NAMES[@]}"; do
+for name in $SOCKET_NAMES; do
     SEQ_CHECK_FILE=${BASE}.${name##*.}
     case ${name##*.} in
         STREAM|SEQPACKET)

--- a/tests/uxsock_simple.sh
+++ b/tests/uxsock_simple.sh
@@ -4,13 +4,27 @@
 # messages and sends them to the unix socket. Datagram sockets are being used.
 # added 2010-08-06 by Rgerhards
 . ${srcdir:=.}/diag.sh init
-check_command_available timeout
-
 uname
 if [ $(uname) = "FreeBSD" ] ; then
    echo "This test currently does not work on FreeBSD."
    exit 77
 fi
+
+wait_receiver_ready() {
+    expected_generation=$1
+    ready_file=$2
+    count=1
+
+    while [ "$count" -le 100 ]; do
+        if [ -r "$ready_file" ] && [ "$(cat "$ready_file")" = "$expected_generation" ]; then
+            return
+        fi
+        $TESTTOOL_DIR/msleep 100
+        count=$((count + 1))
+    done
+    echo "uxsockrcvr did not report ready generation $expected_generation for $ready_file"
+    error_exit 1
+}
 
 # create the pipe and start a background process that copies data from
 # it to the "regular" work file
@@ -23,9 +37,11 @@ $template outfmt,"%msg:F,58:2%\n"
 $OMUXSockSocket '$RSYSLOG_DYNNAME'-testbench-dgram-uxsock
 :msg, contains, "msgnum:" :omuxsock:;outfmt
 '
-timeout 30s ./uxsockrcvr -s$RSYSLOG_DYNNAME-testbench-dgram-uxsock -o $RSYSLOG_OUT_LOG -t 60 &
+RECEIVER_READY=$RSYSLOG_DYNNAME.uxsockrcvr.ready
+./uxsockrcvr -s$RSYSLOG_DYNNAME-testbench-dgram-uxsock -o $RSYSLOG_OUT_LOG -r $RECEIVER_READY -t 60 &
 BGPROCESS=$!
 echo background uxsockrcvr process id is $BGPROCESS
+wait_receiver_ready 1 "$RECEIVER_READY"
 
 # now do the usual run
 startup
@@ -34,6 +50,7 @@ injectmsg 0 10000
 wait_queueempty
 echo resetting uxsockrcvr...
 kill -HUP $BGPROCESS
+wait_receiver_ready 2 "$RECEIVER_READY"
 injectmsg 10000 10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown

--- a/tests/uxsockrcvr.c
+++ b/tests/uxsockrcvr.c
@@ -5,6 +5,7 @@
  * -s name of socket (required)
  * -o name of output file (stdout if not given)
  * -l add newline after each message received (default: do not add anything)
+ * -r file to write the receiver ready generation after bind/listen
  * -t timeout in seconds (default 60)
  *
  * Part of the testbench for rsyslog.
@@ -63,6 +64,8 @@ int sockBacklog = MAX_FDS - 1;
 struct pollfd fds[MAX_FDS];
 int nfds;
 volatile int need_reset;
+static const char *readyFile;
+static unsigned int readyGeneration;
 
 /* called to clean up on exit
  */
@@ -97,6 +100,7 @@ void usage(void) {
             "-l adds newline after each message received\n"
             "-s MUST be specified\n"
             "-a Use abstract socket name\n"
+            "-r file to write receiver ready generation after bind/listen\n"
             "-T {DGRAM|STREAM"
 #ifdef SOCK_SEQPACKET
             "|SEQPACKET"
@@ -104,6 +108,19 @@ void usage(void) {
             "} Set socket type (default DGRAM)\n"
             "if -o ist not specified, stdout is used\n");
     exit(1);
+}
+
+static void signal_ready(void) {
+    FILE *fp;
+
+    if (readyFile == NULL) return;
+
+    if ((fp = fopen(readyFile, "w")) == NULL) {
+        perror(readyFile);
+        exit(1);
+    }
+    fprintf(fp, "%u\n", ++readyGeneration);
+    fclose(fp);
 }
 
 static struct {
@@ -184,6 +201,7 @@ void initialize_socket(void) {
 
     fds[0].events = POLLIN;
     nfds = 1;
+    signal_ready();
 }
 
 int main(int argc, char *argv[]) {
@@ -201,7 +219,7 @@ int main(int argc, char *argv[]) {
         usage();
     }
 
-    while ((opt = getopt(argc, argv, "as:o:lt:T:")) != EOF) {
+    while ((opt = getopt(argc, argv, "as:o:lr:t:T:")) != EOF) {
         switch ((char)opt) {
             case 'a':
                 abstract = 1;
@@ -217,6 +235,9 @@ int main(int argc, char *argv[]) {
                     perror(optarg);
                     exit(1);
                 }
+                break;
+            case 'r':
+                readyFile = optarg;
                 break;
             case 't':
                 timeout = atoi(optarg);


### PR DESCRIPTION
## Summary

This stabilizes the uxsock reset tests by synchronizing the scripts with the helper receiver after startup and after `SIGHUP` resets, and by ensuring `SIGHUP` is sent to the actual receiver process.

PR 6756 CI showed isolated failures in `uxsock_simple.sh` and `uxsock_multiple.sh` on slower CI jobs. PR 6761 then exposed the same race in `uxsock_multiple-vg.sh` and `uxsock_multiple.sh` while validating the first fix, which confirmed the reset path was still not deterministic enough under slow CI.

## Root Cause

`uxsock_simple.sh` and `uxsock_multiple.sh` sent `SIGHUP` to `uxsockrcvr` and immediately injected the next message batch. The helper handles reset asynchronously in its poll loop, so on slower or loaded CI systems the next batch could be sent while the receiver was still closing and rebinding its socket.

The first version of this PR also left one hidden problem in place: the scripts launched the receiver as `timeout 30s ./uxsockrcvr ... &`. In that form `$!` is the `timeout` wrapper PID, not reliably the `uxsockrcvr` PID. The test then sent `SIGHUP` to the wrapper, so the receiver did not always reset and write ready generation 2. This was the direct cause of the PR 6761 CI failures that reported missing ready generation 2.

For connected `STREAM` and `SEQPACKET` sockets in `uxsock_multiple.sh`, listener readiness alone was not enough. `omuxsock` may still need a reconnect-triggering send after the receiver reset. If the full post-reset sequence was injected immediately, extra sequence values could be lost during the reconnect window.

## What Changed

- Added a `-r readyfile` option to `uxsockrcvr`.
- `uxsockrcvr` writes an incrementing ready generation after each bind/listen cycle.
- `uxsock_simple.sh` waits for receiver readiness before startup and after reset.
- `uxsock_multiple.sh` waits for all receiver generations and sends the expected connected-socket reconnect trigger separately before the remaining sequence.
- The uxsock scripts start `uxsockrcvr` directly and rely on its existing `-t 60` timeout, so `$!` is the real helper PID that receives `SIGHUP`.
- `uxsock_multiple-vg.sh` resolves its base script through `srcdir` or its own directory so direct and VPATH-style invocations both work.

## Validation

- `make -j$(nproc) check TESTS=""` passed.
- `./tests/uxsock_simple.sh` passed.
- `./tests/uxsock_multiple.sh` passed.
- `./tests/uxsock_multiple-vg.sh` passed with valgrind `ERROR SUMMARY: 0`.
- Earlier worker validation: 20 focused iterations of `uxsock_simple.sh` plus `uxsock_multiple.sh` passed, followed by 5 additional post-format/post-build iterations.
- AI review portability comments addressed: helper wait loops now avoid brace expansion/local variables, and uxsock_multiple.sh uses plain shell lists instead of Bash arrays.
- `git diff --check` passed.