### PR TITLE
testbench: wait for abstract uxsock receiver reset

### DIFF
--- a/tests/uxsock_simple_abstract.sh
+++ b/tests/uxsock_simple_abstract.sh
@@ -5,13 +5,27 @@
 # added 2010-08-06 by Rgerhards
 # Updated 2025-04-16 for abstract sockets
 . ${srcdir:=.}/diag.sh init
-check_command_available timeout
-
 uname
 if [ $(uname) != "Linux" ] ; then
     echo "This test requires Linux (AF_UNIX abstract addresses)"
     exit 77
 fi
+
+wait_receiver_ready() {
+    expected_generation=$1
+    ready_file=$2
+    count=1
+
+    while [ "$count" -le "$TB_TIMEOUT_STARTSTOP" ]; do
+        if [ -r "$ready_file" ] && [ "$(cat "$ready_file")" = "$expected_generation" ]; then
+            return
+        fi
+        $TESTTOOL_DIR/msleep 100
+        count=$((count + 1))
+    done
+    echo "uxsockrcvr did not report ready generation $expected_generation for $ready_file"
+    error_exit 1
+}
 
 SOCKET_NAME="$RSYSLOG_DYNNAME-testbench-dgram-uxsock-abstract"
 
@@ -34,9 +48,11 @@ module(
     abstract = "1"
 )
 '
-timeout 30s ./uxsockrcvr -a -s$SOCKET_NAME -o $RSYSLOG_OUT_LOG -t 60 &
+RECEIVER_READY=$RSYSLOG_DYNNAME.uxsockrcvr.ready
+./uxsockrcvr -a -s$SOCKET_NAME -o $RSYSLOG_OUT_LOG -r $RECEIVER_READY -t 60 &
 BGPROCESS=$!
 echo background uxsockrcvr process id is $BGPROCESS
+wait_receiver_ready 1 "$RECEIVER_READY"
 
 # now do the usual run
 RS_REDIR="> ${RSYSLOG_DYNNAME}.log 2>&1"
@@ -46,6 +62,7 @@ injectmsg 0 10000
 wait_queueempty
 echo resetting uxsockrcvr...
 kill -HUP $BGPROCESS
+wait_receiver_ready 2 "$RECEIVER_READY"
 injectmsg 10000 10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown


### PR DESCRIPTION
## What changed

`uxsock_simple_abstract.sh` now starts `uxsockrcvr` directly and waits for the
receiver readiness file both at initial startup and after the SIGHUP receiver
reset.

## Root cause

The abstract-socket variant still used a `timeout` wrapper around `uxsockrcvr`.
The test reset path killed the wrapper process and then immediately continued
with the next message batch. Under high scheduler pressure, the actual receiver
child could still be exiting or the replacement receiver had not rebound the
abstract socket yet. That made the sender race the receiver reset and could
drop part of the second batch, producing sequence gaps such as 19723/20000.

The plain uxsock test already used a receiver-ready generation file after
restart. The abstract-socket test lacked that synchronization.

## Validation

- Direct worker validation for `uxsock_simple_abstract.sh` passed.
- Parent `make clean && make check -j80` validation did not fail
  `uxsock_simple_abstract.sh`; unrelated full-suite flakes were recorded in the
  campaign artifacts and are not acceptance criteria for this branch.
- Later parent validations for other branches passed both
  `uxsock_simple_abstract.sh` and `uxsock_simple_abstract-vg.sh`.

## Campaign note

The unrelated failures observed during full-suite stress runs remain tracked by
the flake campaign and are intentionally not bundled into this PR.
