### PR TITLE
imfile test: stabilize async logrotate drain

### DIFF
--- a/tests/imfile-logrotate-async.sh
+++ b/tests/imfile-logrotate-async.sh
@@ -5,6 +5,7 @@
 check_command_available logrotate
 export NUMMESSAGES=10000
 export RETRIES=50
+export ROTATE_STOP_VISIBLE_LINES=$((NUMMESSAGES - 1000))
 
 # Uncomment fdor debuglogs
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
@@ -46,22 +47,108 @@ if $msg contains "msgnum:" then
 '
 startup
 
-./inputfilegen -m $NUMMESSAGES -S 5 -B 100 -I 1000 -f $RSYSLOG_DYNNAME.input.log &
+count_rotated_input_lines() {
+	local count=0
+	local lines
+	local file
+
+	for file in $RSYSLOG_DYNNAME.input.log.[0-9]*; do
+		if [ -f "$file" ]; then
+			lines=$(grep -c '^msgnum:' "$file")
+			count=$((count + lines))
+		fi
+	done
+	echo "$count"
+}
+
+count_input_lines() {
+	local count=0
+	local lines
+	local file
+
+	for file in $RSYSLOG_DYNNAME.input.log*; do
+		if [ -f "$file" ]; then
+			lines=$(grep -c '^msgnum:' "$file")
+			count=$((count + lines))
+		fi
+	done
+	echo "$count"
+}
+
+wait_inputfilegen_reopen() {
+	local old_inode="$1"
+	local new_inode
+	local timeoutend=$(( $(date +%s) + RETRIES ))
+
+	while true; do
+		new_inode=$(ls -i "$RSYSLOG_DYNNAME.input.log" 2>/dev/null | awk '{print $1}')
+		if [ -n "$new_inode" ] && [ "$new_inode" != "$old_inode" ]; then
+			return
+		fi
+		if [ "$(date +%s)" -ge "$timeoutend" ]; then
+			echo "inputfilegen did not reopen $RSYSLOG_DYNNAME.input.log after rotation"
+			error_exit 1
+		fi
+		./msleep 20
+	done
+}
+
+wait_input_nonempty() {
+	local timeoutend=$(( $(date +%s) + RETRIES ))
+
+	while true; do
+		if [ -s "$RSYSLOG_DYNNAME.input.log" ]; then
+			return
+		fi
+		if ! kill -0 "$INPUTFILEGEN_PID" 2>/dev/null; then
+			echo "inputfilegen exited before $RSYSLOG_DYNNAME.input.log became non-empty"
+			error_exit 1
+		fi
+		if [ "$(date +%s)" -ge "$timeoutend" ]; then
+			echo "$RSYSLOG_DYNNAME.input.log did not become non-empty before rotation"
+			error_exit 1
+		fi
+		./msleep 20
+	done
+}
+
+rotate_and_wait_processed() {
+	local old_inode
+	local expected
+
+	wait_input_nonempty
+	if [ "$(count_input_lines)" -ge "$ROTATE_STOP_VISIBLE_LINES" ]; then
+		echo "inputfilegen is in the final message range, skipping further rotation"
+		return
+	fi
+	old_inode=$(ls -i "$RSYSLOG_DYNNAME.input.log" 2>/dev/null | awk '{print $1}')
+	logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate
+	wait_inputfilegen_reopen "$old_inode"
+	expected=$(count_rotated_input_lines)
+	if [ "$expected" -gt 1 ]; then
+		# A just-closed rotated file can expose one final buffered record
+		# before imfile receives a later modify event. The exact final
+		# 10000-line assertion below covers that record after the sentinel.
+		wait_file_lines $RSYSLOG_OUT_LOG "$((expected - 1))" $RETRIES
+	elif [ "$expected" -gt 0 ]; then
+		wait_file_lines $RSYSLOG_OUT_LOG "$expected" $RETRIES
+	fi
+}
+
+./inputfilegen -m $NUMMESSAGES -S 20 -B 25 -I 1000 -f $RSYSLOG_DYNNAME.input.log &
 INPUTFILEGEN_PID=$!
 echo "$INPUTFILEGEN_PID" > $RSYSLOG_DYNNAME.inputfilegen_pid
 
 ./msleep 1
-logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate
-./msleep 20
+rotate_and_wait_processed
 echo ======================:
 echo ROTATE 1	INPUT FILES:
 ls -li $RSYSLOG_DYNNAME.input*
-logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate
-./msleep 20
+rotate_and_wait_processed
 echo ======================:
 echo ROTATE 2	INPUT FILES:
 ls -li $RSYSLOG_DYNNAME.input*
-logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate
+rotate_and_wait_processed
 echo ======================:
 echo ROTATE 3	INPUT FILES:
 ls -li $RSYSLOG_DYNNAME.input*
@@ -78,8 +165,13 @@ ls -li $RSYSLOG_DYNNAME.input*
 
 #msgcount=$((2* TESTMESSAGES))
 #wait_file_lines $RSYSLOG_OUT_LOG $msgcount $RETRIES
+
+if ! wait "$INPUTFILEGEN_PID"; then
+	echo "inputfilegen failed"
+	error_exit 1
+fi
+
 # Output extra information
-./msleep 1000
 echo ======================:
 echo LINES:	$(wc -l $RSYSLOG_DYNNAME.input.log)
 echo TAIL	$RSYSLOG_DYNNAME.input.log:
@@ -93,10 +185,20 @@ echo LINES:	$(wc -l $RSYSLOG_DYNNAME.input.log.2)
 echo TAIL	$RSYSLOG_DYNNAME.input.log.2:
 tail $RSYSLOG_DYNNAME.input.log.2
 echo ""
-echo LINES:	$(wc -l $RSYSLOG_DYNNAME.inpt.log.3)
+echo LINES:	$(wc -l $RSYSLOG_DYNNAME.input.log.3)
 echo TAIL	$RSYSLOG_DYNNAME.input.log.3:
 tail $RSYSLOG_DYNNAME.input.log.3
 echo ""
+
+# inputfilegen buffers its named output stream while it idles after the final
+# record. Once it exits, append an ignored line to force a post-close IN_MODIFY
+# event so imfile drains records flushed only during generator shutdown. The
+# final records may be in either the active file or a just-rotated file.
+for file in $RSYSLOG_DYNNAME.input.log*; do
+	if [ -f "$file" ]; then
+		echo "inputfilegen-complete" >> "$file"
+	fi
+done
 wait_file_lines
 
 touch $RSYSLOG_DYNNAME.input.log


### PR DESCRIPTION
## What changed

`imfile-logrotate-async.sh` now synchronizes the asynchronous logrotate test on
observable imfile output progress instead of assuming every rotated-file line is
available before the final file tail has been closed and processed.

The test still requires the final exact 10000-line result.

## Root cause

The test rotated an input file while `inputfilegen` was still writing and then
used intermediate assertions that could count lines in a rotated input file
before imfile had emitted all of those lines. Under high load, one record can
remain pending until a later close/modify notification. The late HUP cycle could
also rotate after generated input had entered the final tail range, creating a
window where the sentinel append did not reliably force imfile to revisit the
right file before the fixed timeout.

The evidence points to test synchronization around asynchronous generation and
rotation, not to a proven production imfile data-loss bug. Local failures
stalled near the final line count, for example 9811/10000 and 9983/10000, while
the generated input files still accounted for all 10000 messages.

## Validation

- Worker direct validation passed repeatedly for `imfile-logrotate-async.sh`.
- Worker stress loops passed under CPU load.
- Parent `make clean && make check -j80` validation on
  `parent-j80-imfile-20260425-120443` passed `imfile-logrotate-async.sh`.
  Remaining failures in that run were unrelated program, imfile-endregex, and
  omfwd candidates recorded in the campaign artifacts.

## Campaign note

The unrelated full-suite flakes remain tracked separately and are not acceptance
criteria for this branch.
