### PR TITLE
tests: synchronize prog lifecycle flakes

### DIFF
--- a/tests/improg_prog_confirm.sh
+++ b/tests/improg_prog_confirm.sh
@@ -13,6 +13,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+wait_content "program data" "$RSYSLOG_OUT_LOG"
 shutdown_when_empty
 wait_shutdown
 content_check "program data"

--- a/tests/improg_prog_confirm_killonclose.sh
+++ b/tests/improg_prog_confirm_killonclose.sh
@@ -13,6 +13,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+wait_content "program data" "$RSYSLOG_OUT_LOG"
 shutdown_when_empty
 wait_shutdown
 content_check "program data"

--- a/tests/improg_prog_killonclose.sh
+++ b/tests/improg_prog_killonclose.sh
@@ -13,6 +13,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+wait_content "program data" "$RSYSLOG_OUT_LOG"
 shutdown_when_empty
 wait_shutdown
 content_check "program data"

--- a/tests/improg_prog_simple.sh
+++ b/tests/improg_prog_simple.sh
@@ -13,6 +13,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+wait_content "program data" "$RSYSLOG_OUT_LOG"
 shutdown_when_empty
 wait_shutdown
 content_check "program data"

--- a/tests/improg_simple_multi.sh
+++ b/tests/improg_simple_multi.sh
@@ -14,6 +14,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+wait_file_lines "$RSYSLOG_OUT_LOG" 10
 shutdown_when_empty
 wait_shutdown
 NUM_ITEMS=10

--- a/tests/omprog-feedback-timeout.sh
+++ b/tests/omprog-feedback-timeout.sh
@@ -22,12 +22,15 @@ template(name="outfmt" type="string" string="%msg%\n")
         queue.type="Direct"  # the default; facilitates sync with the child process
         confirmMessages="on"
         confirmTimeout="2000"  # 2 seconds
+        action.resumeInterval="1"
+        action.resumeRetryCount="10"
         reportFailures="on"
     )
 }
 '
 startup
 injectmsg 0 10
+content_check_with_count "=> msgnum:00000004:" 2 90
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/testsuites/omprog-feedback-timeout-bin.sh
+++ b/tests/testsuites/omprog-feedback-timeout-bin.sh
@@ -2,8 +2,16 @@
 
 outfile=$RSYSLOG_OUT_LOG
 
-echo "Starting" >> $outfile
-echo "<= OK" >> $outfile
+interruptible_sleep() {
+    elapsed=0
+    trap 'exit 0' TERM INT PIPE
+    while [[ $elapsed -lt $1 ]]; do
+        ./msleep 100
+        elapsed=$((elapsed + 100))
+    done
+    trap - TERM INT PIPE
+}
+
 echo "OK"
 
 just_started=true
@@ -11,6 +19,10 @@ just_started=true
 read line
 while [[ -n "$line" ]]; do
     message=${line//$'\n'}
+    if [[ $just_started == true ]]; then
+        echo "Starting" >> $outfile
+        echo "<= OK" >> $outfile
+    fi
     echo "=> $message" >> $outfile
 
     if [[ $message == *02* ]]; then
@@ -23,7 +35,8 @@ while [[ -n "$line" ]]; do
         if [[ $just_started == false ]]; then
             # Force a restart due to 'confirmTimeout' (2 seconds) exceeded
             echo "<= (timeout)" >> $outfile
-            ./msleep 10000
+            interruptible_sleep 3500
+            exit 0
         else
             # When the message is retried (just after restart), confirm it correctly
             echo "<= OK" >> $outfile


### PR DESCRIPTION
## What changed

This stabilizes the program lifecycle tests that rely on external helper
processes:

- improg tests now wait for concrete helper output before calling
  `shutdown_when_empty`
- the multiline improg test uses the same output-before-shutdown synchronization
- `omprog-feedback-timeout.sh` now waits for the timeout retry to begin before
  shutdown
- the omprog timeout helper exits shortly after the intentional timeout instead
  of depending on killing a long-sleeping child
- the omprog timeout action uses explicit resume scheduling for this test path

## Root cause

Under high parallel load, queue-empty was not a sufficient synchronization point
for these tests. The main queue could be empty while an external helper had not
yet produced the output asserted later by the test. That allowed shutdown to
cancel or kill the helper before the expected transcript was complete.

`omprog-feedback-timeout.sh` had an additional timing problem. It intended to
prove that a message is retried after `confirmTimeout`, but the test still
depended on default action resume timing. Under full `-j80` load the action
could remain suspended long enough that the restarted helper never received the
retried `msgnum:00000004` within the test wait window.

## Validation

- Worker validation:
  - `./omprog-feedback-timeout.sh` direct repeated runs passed
  - 80-way parallel `omprog-feedback-timeout.sh` stress passed
  - owned direct program test set passed
- Coordinator validation:
  - `make clean && make check -j80` on
    `parent-j80-prog-20260425-125543` passed all owned program tests,
    including `omprog-feedback-timeout.sh`
  - the only remaining failure in that run was unrelated
    `imfile-logrotate-async.sh`, which is tracked separately in PR 6763

## Negative-control proof

A separate proof worktree temporarily changed the omprog timeout helper's retry
ACK transcript from `<= OK` to `<= BAD-ACK`. The test failed at the final
`cmp_exact` check with:

```text
< <= OK
---
> <= BAD-ACK
FAIL: Test ./tests/omprog-feedback-timeout.sh
```

The temporary mutation was fully undone before finishing, and the proof worktree
was left clean. This confirms the test still catches invalid retry behavior and
was not weakened into an always-pass test.

## Campaign note

Unrelated full-suite flakes found during validation are recorded in the flake
campaign memory but are not bundled into this PR.
