### PR TITLE
Fix RFC3339 formatting for high-precision fractional seconds

### DIFF
--- a/runtime/datetime.c
+++ b/runtime/datetime.c
@@ -831,6 +831,24 @@ static int formatTimestampToPgSQL(struct syslogTime *ts, char *pBuf) {
 }
 
 
+static int getNormalizedSecFracPower(const struct syslogTime *ts, int *secfrac) {
+    int precision;
+
+    assert(ts != NULL);
+    assert(secfrac != NULL);
+    assert(ts->secfracPrecision > 0);
+
+    precision = ts->secfracPrecision;
+    *secfrac = ts->secfrac;
+    while (precision > 6) {
+        *secfrac /= 10;
+        --precision;
+    }
+
+    return tenPowers[precision - 1];
+}
+
+
 /**
  * Format a syslogTimestamp to just the fractional seconds.
  * The caller must provide the timestamp as well as a character
@@ -851,8 +869,7 @@ static int formatTimestampSecFrac(struct syslogTime *ts, char *pBuf) {
 
     iBuf = 0;
     if (ts->secfracPrecision > 0) {
-        power = tenPowers[(ts->secfracPrecision - 1) % 6];
-        secfrac = ts->secfrac;
+        power = getNormalizedSecFracPower(ts, &secfrac);
         while (power > 0) {
             digit = secfrac / power;
             secfrac -= digit * power;
@@ -916,8 +933,7 @@ static int formatTimestamp3339(struct syslogTime *ts, char *pBuf) {
 
     if (ts->secfracPrecision > 0) {
         pBuf[iBuf++] = '.';
-        power = tenPowers[(ts->secfracPrecision - 1) % 6];
-        secfrac = ts->secfrac;
+        power = getNormalizedSecFracPower(ts, &secfrac);
         while (power > 0) {
             digit = secfrac / power;
             secfrac -= digit * power;

--- a/tests/timestamp-3339.sh
+++ b/tests/timestamp-3339.sh
@@ -18,6 +18,10 @@ injectmsg_literal "<34>1 2003-11-11T22:04:05.003Z mymachine.example.com su - ID4
 injectmsg_literal "<34>1 2003-11-11T22:04:05.003+02:00 mymachine.example.com su - ID47 - MSG"
 injectmsg_literal "<34>1 2003-11-11T22:04:05.003+01:30 mymachine.example.com su - ID47 - MSG"
 injectmsg_literal "<34>1 2003-11-11T22:04:05.123456+01:30 mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.0300000Z mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.03000000Z mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.000006930Z mymachine.example.com su - ID47 - MSG"
+injectmsg_literal "<34>1 2026-04-27T15:46:41.000022054Z mymachine.example.com su - ID47 - MSG"
 shutdown_when_empty
 wait_shutdown
 
@@ -28,6 +32,10 @@ export EXPECTED='2003-11-11T22:14:15.003Z
 2003-11-11T22:04:05.003Z
 2003-11-11T22:04:05.003+02:00
 2003-11-11T22:04:05.003+01:30
-2003-11-11T22:04:05.123456+01:30'
+2003-11-11T22:04:05.123456+01:30
+2026-04-27T15:46:41.030000Z
+2026-04-27T15:46:41.030000Z
+2026-04-27T15:46:41.000006Z
+2026-04-27T15:46:41.000022Z'
 cmp_exact
 exit_test


### PR DESCRIPTION
Summary:
- Fixes issue #6768 by normalizing parsed fractional seconds to the six-digit precision supported by rsyslog’s RFC3339 formatter.
- Removes the old modulo-based divisor selection that could emit corrupted fractional output for 7-9 digit secfrac values.
- Refactors the shared secfrac normalization/divisor logic into a helper used by both `formatTimestampSecFrac()` and `formatTimestamp3339()`.
- Adds regression coverage for the reported 7, 8, and 9 digit timestamp cases.
