### PR TITLE
Fix omrelp TLS auth failure CPU spin

### DIFF
--- a/action.c
+++ b/action.c
@@ -1678,6 +1678,9 @@ static rsRetVal ATTR_NONNULL() actionCommit(action_t *__restrict__ const pThis, 
     DBGPRINTF("actionCommit[%s]: unhappy, we still have %d uncommitted messages.\n", pThis->pszName, nMsgs);
     int bDone = 0;
     do {
+        if (*pWti->pbShutdownImmediate) {
+            ABORT_FINALIZE(RS_RET_FORCE_TERM);
+        }
         iRet = actionTryCommit(pThis, pWti, iparams, nMsgs);
         DBGPRINTF("actionCommit[%s]: in retry loop, iRet %d\n", pThis->pszName, iRet);
         if (iRet == RS_RET_FORCE_TERM) {
@@ -1760,6 +1763,14 @@ finalize_it:
     RETiRet;
 }
 
+static void markBatchCommittedFrom(batch_t *const pBatch, const int firstElem) {
+    for (int i = firstElem; i < batchNumMsgs(pBatch); ++i) {
+        if (batchIsValidElem(pBatch, i)) {
+            batchSetElemState(pBatch, i, BATCH_STATE_COMM);
+        }
+    }
+}
+
 /**
  * @brief Worker callback for action queues.
  *
@@ -1785,7 +1796,8 @@ static rsRetVal ATTR_NONNULL() processBatchMain(void *__restrict__ const pVoid,
 
     if (actionIsDisabled(pAction)) {
         actionDisableForWorker(pAction, pWti);
-        ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
+        markBatchCommittedFrom(pBatch, 0);
+        FINALIZE;
     }
 
     for (i = 0; i < batchNumMsgs(pBatch) && !*pWti->pbShutdownImmediate; ++i) {
@@ -1801,7 +1813,8 @@ static rsRetVal ATTR_NONNULL() processBatchMain(void *__restrict__ const pVoid,
                 DBGPRINTF("processBatchMain: i %d, COMM state set\n", i);
             } else if (localRet == RS_RET_DISABLE_ACTION) {
                 actionDisableForWorker(pAction, pWti);
-                ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
+                markBatchCommittedFrom(pBatch, i);
+                FINALIZE;
             }
         }
     }

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -216,6 +216,18 @@ static void onAuthErr(void *pUsr, char *authinfo, char *errmesg, __attribute__((
     pData->bHadAuthFail = 1;
 }
 
+static int relpRetIsAuthErr(const relpRetVal relpRet) {
+    switch (relpRet) {
+        case RELP_RET_AUTH_ERR_FP:
+        case RELP_RET_AUTH_ERR_NAME:
+        case RELP_RET_AUTH_NO_CERT:
+        case RELP_RET_AUTH_CERT_INVL:
+            return 1;
+        default:
+            return 0;
+    }
+}
+
 static rsRetVal doCreateRelpClient(instanceData *pData, relpClt_t **pRelpClt) {
     int i;
     DEFiRet;
@@ -592,6 +604,15 @@ static rsRetVal ATTR_NONNULL() doConnect(wrkrInstanceData_t *const pWrkrData) {
                  "Note: anonymous TLS is probably supported.");
         FINALIZE;
     } else {
+        if (relpRetIsAuthErr(iRet)) {
+            if (!pWrkrData->pData->bHadAuthFail) {
+                LogError(0, RS_RET_RELP_AUTH_FAIL,
+                         "omrelp[%s:%s]: TLS authentication failed, librelp error %d - DISABLING action",
+                         pWrkrData->pData->target, getRelpPt(pWrkrData->pData), iRet);
+                pWrkrData->pData->bHadAuthFail = 1;
+            }
+            ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
+        }
         if (pWrkrData->bIsSuspended == 0) {
             LogError(0, RS_RET_RELP_ERR,
                      "omrelp: could not connect to "

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1555,6 +1555,9 @@ TESTS_RELP = \
 	 glbl-oversizeMsg-truncate.sh \
 	 glbl-oversizeMsg-split.sh
 
+TESTS_RELP_OPENSSL = \
+	 omrelp-tls-ossl-authfail-no-cacert.sh
+
 TESTS_RELP_GNUTLS = \
          sndrcv_relp_tls.sh \
          sndrcv_relp_tls_certvalid.sh \
@@ -1920,6 +1923,7 @@ EXTRA_DIST += $(TESTS_GNUTLS_OPENSSL_INTEROP)
 EXTRA_DIST += $(TESTS_OMUXSOCK)
 EXTRA_DIST += $(TESTS_OMUXSOCK_VALGRIND)
 EXTRA_DIST += $(TESTS_RELP)
+EXTRA_DIST += $(TESTS_RELP_OPENSSL)
 EXTRA_DIST += $(TESTS_RELP_GNUTLS)
 EXTRA_DIST += $(TESTS_RELP_GNUTLS_CFG)
 EXTRA_DIST += $(TESTS_RELP_VALGRIND)
@@ -2829,6 +2833,9 @@ endif
 
 if ENABLE_RELP
 TESTS += $(TESTS_RELP)
+if ENABLE_OPENSSL
+TESTS += $(TESTS_RELP_OPENSSL)
+endif # ENABLE_OPENSSL
 if ENABLE_GNUTLS
 TESTS += $(TESTS_RELP_GNUTLS)
 if USE_RELPENGINESETTLSCFGCMD

--- a/tests/omrelp-tls-ossl-authfail-no-cacert.sh
+++ b/tests/omrelp-tls-ossl-authfail-no-cacert.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+# added 2026-04-30 to guard issue #6612, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_plugin imrelp
+require_plugin omrelp
+require_relpEngineSetTLSLibByName
+
+if [ ! -r /proc/$$/stat ]; then
+	echo "/proc CPU accounting not available. Test stopped"
+	exit 77
+fi
+
+clk_tck=$(getconf CLK_TCK 2>/dev/null)
+if ! [[ "$clk_tck" =~ ^[0-9]+$ ]] || [ "$clk_tck" -le 0 ]; then
+	echo "CLK_TCK unavailable. Test stopped"
+	exit 77
+fi
+
+read_proc_cpu_ticks() {
+	local stat fields
+	stat=$(cat "/proc/$1/stat" 2>/dev/null) || return 1
+	fields=${stat##*) }
+	set -- $fields
+	echo $((${12} + ${13}))
+}
+
+sample_cpu_delta_ticks() {
+	local pid="$1"
+	local interval_ms="$2"
+	local start_ticks end_ticks
+
+	start_ticks=$(read_proc_cpu_ticks "$pid") || return 1
+	$TESTTOOL_DIR/msleep "$interval_ms"
+	end_ticks=$(read_proc_cpu_ticks "$pid") || return 1
+	echo $((end_ticks - start_ticks))
+}
+
+export NUMMESSAGES=100
+export TB_TEST_MAX_RUNTIME=30
+export PORT_RCVR="$(get_free_port)"
+
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp" tls.tlslib="openssl")
+
+input(type="imrelp"
+	port="'$PORT_RCVR'"
+	tls="on"
+	tls.cacert="'$srcdir'/tls-certs/ca.pem"
+	tls.mycert="'$srcdir'/tls-certs/cert.pem"
+	tls.myprivkey="'$srcdir'/tls-certs/key.pem")
+
+*.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+
+generate_conf 2
+add_conf '
+module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="openssl")
+
+action(type="omrelp"
+	name="issue_6612_omrelp"
+	target="127.0.0.1"
+	port="'$PORT_RCVR'"
+	tls="on"
+	queue.type="LinkedList")
+action(type="omfile" file="'$RSYSLOG_DYNNAME.errmsgs'")
+' 2
+startup 2
+
+sender_pid=$(cat "${RSYSLOG_PIDBASE}2.pid")
+injectmsg2 1 $NUMMESSAGES
+
+$TESTTOOL_DIR/msleep 500
+if ! delta_ticks=$(sample_cpu_delta_ticks "$sender_pid" 1200); then
+	error_exit 1 "sender process exited before CPU sampling started"
+fi
+threshold_ticks=$((clk_tck / 2))
+if [ "$threshold_ticks" -lt 10 ]; then
+	threshold_ticks=10
+fi
+
+printf 'sender pid %s consumed %d CPU ticks while handling TLS auth failure, threshold %d\n' \
+	"$sender_pid" "$delta_ticks" "$threshold_ticks"
+
+content_check "DISABLING action" "$RSYSLOG_DYNNAME.errmsgs"
+
+shutdown_immediate 2
+$TESTTOOL_DIR/msleep 100
+if shutdown_delta_ticks=$(sample_cpu_delta_ticks "$sender_pid" 1200); then
+	printf 'sender pid %s consumed %d CPU ticks after shutdown started, threshold %d\n' \
+		"$sender_pid" "$shutdown_delta_ticks" "$threshold_ticks"
+else
+	shutdown_delta_ticks=0
+	printf 'sender pid %s exited before shutdown CPU sample completed\n' "$sender_pid"
+fi
+wait_shutdown 2 10
+shutdown_immediate
+wait_shutdown "" 10
+
+if [ "$delta_ticks" -gt "$threshold_ticks" ] || [ "$shutdown_delta_ticks" -gt "$threshold_ticks" ]; then
+	printf 'FAIL: omrelp consumed too much CPU after OpenSSL TLS auth failure without tls.caCert\n'
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary

Fixes issue #6612: `omrelp` with OpenSSL TLS could spin at 100% CPU after TLS authentication failed, especially with an action queue such as `queue.type="LinkedList"`.

The failure mode is not a crash. The action reaches an authentication failure, becomes disabled, and then the queued action worker can keep retrying the same already-dequeued messages against an action that can never recover.

## Changes

- Add `tests/omrelp-tls-ossl-authfail-no-cacert.sh`.
- Register the new test under RELP + OpenSSL coverage in `tests/Makefile.am`.
- Update `omrelp` to classify librelp TLS authentication return codes as permanent auth failures.
- Update action queue handling so `RS_RET_DISABLE_ACTION` commits the affected queued batch entries from the queue’s perspective instead of reprocessing them forever.
- Make the action commit retry loop honor immediate shutdown before starting another retry attempt.

## Why `action.c` is part of the fix

The `omrelp` side can correctly return `RS_RET_DISABLE_ACTION`, but the CPU spin happened in the action queue layer.

For queued actions, `processBatchMain()` receives a batch from the action queue. Before this change, if processing returned `RS_RET_DISABLE_ACTION`, the action was disabled but the dequeued batch entries were not marked committed. That allowed the queue to retry the same messages immediately, which just hit the same disabled action again. With no network wait or retry sleep left, this became a tight CPU loop.

The new queue behavior is limited to permanent action disable. Transient failures still use the normal `RS_RET_SUSPENDED` retry path.

## Test Coverage

The new regression test:

- starts an OpenSSL TLS `imrelp` receiver using existing `tests/tls-certs`
- starts an OpenSSL TLS `omrelp` sender with `queue.type="LinkedList"`
- intentionally omits client `tls.caCert`
- injects messages into the sender
- checks that the auth failure disables the action
- samples `/proc/<pid>/stat` CPU ticks after auth failure and after shutdown starts
- fails if the sender consumes CPU like a tight loop

## Validation

Passed:

- `./tests/omrelp-tls-ossl-authfail-no-cacert.sh`
- `./tests/sndrcv_relp_tls_chainedcert.sh`
- `./tests/omrelp_errmsg_no_connect.sh`
