### PR TITLE
github: make actionlint fail on findings

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,6 +4,9 @@ name: Workflow Lint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -13,3 +16,5 @@ jobs:
         uses: reviewdog/action-actionlint@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          filter_mode: file
+          fail_level: any


### PR DESCRIPTION
## Summary

- make the actionlint reviewdog check fail when any diff-scoped issue is reported
- keep `filter_mode: file` explicit so unrelated pre-existing workflow findings do not block unrelated PRs
- add explicit read-only workflow permissions

## Validation

- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color=false .github/workflows/actionlint.yml`
