### PR TITLE
github: refresh workflow lint targets

### DIFF
--- a/.github/workflows/ci_codestyle_check.yml
+++ b/.github/workflows/ci_codestyle_check.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Detect changed files
         id: code_changes
@@ -40,4 +40,3 @@ jobs:
             echo "can help apply formatting fixes if needed."
             exit 1
           fi
-

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -103,16 +103,16 @@ jobs:
           ./configure --enable-imfile --enable-mysql --enable-usertools --enable-pgsql --enable-libdbi --enable-snmp --enable-elasticsearch --enable-gnutls --enable-mail --enable-imdiag --enable-mmjsonparse --enable-mmaudit --enable-mmanon --enable-mmrm1stspace --enable-mmutf8fix --enable-mmcount --enable-mmdblookup --enable-mmfields --enable-mmpstrucdata --enable-imptcp --enable-impstats --enable-omprog --enable-omudpspoof --enable-omstdout --enable-omjournal --enable-pmlastmsg --enable-pmcisconames --enable-pmciscoios --enable-pmnull --enable-pmaixforwardedfrom --enable-pmsnare --enable-pmpanngfw --enable-omuxsock --enable-omkafka --enable-imkafka --enable-ommongodb --enable-omhiredis --enable-omhttpfs --enable-gssapi-krb5 --enable-mmkubernetes --enable-relp --enable-mmnormalize --enable-pmnormalize --enable-openssl --disable-mmgrok --enable-omtcl --enable-omhttp --enable-improg --enable-imtuxedoulog --enable-mmtaghostname --enable-imbatchreport --enable-imdocker --enable-mmdarwin --enable-pmdb2diag --enable-omrabbitmq --enable-libzstd
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yml
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/impstats_push_victoriametrics.yml
+++ b/.github/workflows/impstats_push_victoriametrics.yml
@@ -162,6 +162,6 @@ jobs:
           devtools/gather-check-logs.sh
           cat failed-tests.log || echo "No failed-tests.log found"
           echo "=== VictoriaMetrics logs ==="
-          docker logs $(docker ps -q \
-            -f ancestor=victoriametrics/victoria-metrics:v1.134.0) || \
+          docker logs "$(docker ps -q \
+            -f ancestor=victoriametrics/victoria-metrics:v1.134.0)" || \
             echo "Could not get VM logs"


### PR DESCRIPTION
## Summary

This PR clears the remaining active actionlint findings outside the package-build gating work:

- updates `actions/checkout@v3` to `@v4` in the code style workflow
- updates CodeQL `init`, `autobuild`, and `analyze` actions from `@v2` to `@v4`
- quotes the VictoriaMetrics `docker ps` substitution before passing it to `docker logs`

## Scope

The change is intentionally limited to actionlint-reported issues. It does not touch `run_checks.yml` or broader action major upgrades.

## Validation

- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/*.yml`
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/ci_codestyle_check.yml .github/workflows/codeql.yml .github/workflows/impstats_push_victoriametrics.yml`
- `git diff --check -- .github/workflows/ci_codestyle_check.yml .github/workflows/codeql.yml .github/workflows/impstats_push_victoriametrics.yml`

All passed with no output.
