### PR TITLE
github: narrow workflow token permissions

### DIFF
--- a/.github/workflows/ci.yml.template
+++ b/.github/workflows/ci.yml.template
@@ -31,6 +31,9 @@ on:
       - '**/*.md'
       - '**/*.txt'
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -22,10 +22,6 @@ on:
     types: [opened, synchronize, reopened]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  issues: write
-
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
@@ -42,6 +38,8 @@ jobs:
   debian_experimental_gate:
     name: debian experimental gate
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 75
     container:
       image: debian:trixie
@@ -128,6 +126,9 @@ jobs:
   debian_experimental_diagnostics:
     name: debian experimental diagnostics
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     timeout-minutes: 90
     needs: debian_experimental_gate
     if: always()

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -197,8 +197,8 @@ jobs:
       needs.build_docs.outputs.docs_changed=='true'&&
       github.event.pull_request.head.repo.full_name==github.repository}}
     permissions:
+      contents: read
       issues: write
-      pull-requests: write
     steps:
       - name: Comment on PR with artifact links
         uses: actions/github-script@v7

--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -10,11 +10,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-
 concurrency:
   group: doc-deploy-main
   cancel-in-progress: true
@@ -22,6 +17,8 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.repository == 'rsyslog/rsyslog'
     steps:
       - name: Checkout code
@@ -51,6 +48,11 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    if: github.repository == 'rsyslog/rsyslog'
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -21,12 +21,10 @@ name: weekly_run_macos
     - cron: '0 3 * * 1'
   workflow_dispatch:
 
-permissions:
-  contents: read
-  issues: write
-
 jobs:
   check_run:
+    permissions:
+      contents: read
     strategy:
       # Do not cancel other matrix jobs if one fails
       # We want a full picture weekly
@@ -139,6 +137,9 @@ jobs:
     name: Summarize and report failures
     needs: check_run
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     if: always()
     steps:
       - name: Download all result artifacts
@@ -168,7 +169,9 @@ jobs:
           echo "failures=$FAILURES" >> "$GITHUB_OUTPUT"
 
       - name: Create or update tracking issue
-        if: steps.summary.outputs.failures != '0'
+        if: >-
+          steps.summary.outputs.failures != '0' &&
+          github.repository == 'rsyslog/rsyslog'
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,6 +4,9 @@ name: Spellcheck
 'on':
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-latest

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -20,6 +20,9 @@ name: yamllint check
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

This PR narrows GitHub token permissions and adds explicit upstream-only guards where jobs mutate project state.

Changes include:

- moves Debian package issue-write permissions to the diagnostics job only
- keeps the Debian package gate read-only
- moves macOS weekly issue-write permissions to the reporting job only
- guards macOS issue creation to `rsyslog/rsyslog`
- limits Pages write/OIDC permissions to the docs deploy job
- keeps docs preview commenting on issue-comment permissions without PR-write
- adds explicit read-only permissions to spellcheck, yamllint, and the CI template

## Scope

This preserves fork-usable validation jobs. The write-scoped changes are limited to jobs or steps that update upstream issues or deploy upstream Pages.

## Validation

- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/debian_package_build.yml .github/workflows/run_macos_weekly.yml .github/workflows/doc_deploy_main.yml .github/workflows/doc_build.yml .github/workflows/spellcheck.yml .github/workflows/yaml_lint.yml`
- `git diff --check -- .github/workflows/debian_package_build.yml .github/workflows/run_macos_weekly.yml .github/workflows/doc_deploy_main.yml .github/workflows/doc_build.yml .github/workflows/spellcheck.yml .github/workflows/yaml_lint.yml .github/workflows/ci.yml.template`

Both passed with no output.

`ci.yml.template` still has pre-existing actionlint findings for `ubuntu-18.04` and `actions/checkout@v1`; those are intentionally left for a separate template cleanup.
