### PR TITLE
github: avoid shell expansion of PR base refs

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -144,9 +144,11 @@ jobs:
           fetch-depth: 0
 
       - name: fetch upstream (for changed-files diff)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream "${{ github.event.pull_request.base.ref }}"
+          git fetch upstream "$BASE_REF"
 
       - name: Check for code changes
         id: code_changes
@@ -369,9 +371,11 @@ jobs:
           fetch-depth: 0
 
       - name: fetch upstream (for changed-files diff)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream "${{ github.event.pull_request.base.ref }}"
+          git fetch upstream "$BASE_REF"
 
       - name: Check for package changes
         id: package_changes
@@ -448,10 +452,12 @@ jobs:
           fetch-depth: 0
 
       - name: fetch upstream (for changed-files diff)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream "${{ github.event.pull_request.base.ref }}"
+          git fetch upstream "$BASE_REF"
 
       - name: Check for code changes
         id: code_changes
@@ -1703,9 +1709,11 @@ jobs:
           fetch-depth: 0
 
       - name: fetch upstream (for changed-files diff)
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
         run: |
           git remote add upstream https://github.com/${{ github.repository }}.git
-          git fetch upstream "${{ github.event.pull_request.base.ref }}"
+          git fetch upstream "$BASE_REF"
 
       - name: Check for code changes
         id: code_changes


### PR DESCRIPTION
## Summary

This PR avoids direct shell interpolation of pull request base refs in `run_checks.yml`.

Changes:
- passes `github.event.pull_request.base.ref` through step-level `BASE_REF`
- uses `git fetch upstream "$BASE_REF"` in the four changed-files fetch steps

## Rationale

`zizmor` reported these as high-confidence template-injection patterns because pull request metadata was expanded directly inside shell `run:` blocks. Passing the value as environment data keeps the behavior unchanged while avoiding shell template expansion.

## Validation

- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/run_checks.yml`
- `git diff --check -- .github/workflows/run_checks.yml`
- `/home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json .github/workflows/run_checks.yml`

`actionlint` and `diff --check` passed. `zizmor` still exits non-zero for pre-existing findings, but the high-confidence `template-injection` findings from these four fetch steps are gone.
