### PR TITLE
github: drop Debian diagnostics artifacts

### DIFF
--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -112,23 +112,11 @@ jobs:
           "$GITHUB_WORKSPACE/$DEBIAN_CI_HELPER" build_package \
             /tmp/debian-src
 
-      - name: Upload gate build artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: debian-experimental-gate
-          path: |
-            /tmp/*.deb
-            /tmp/debian-src/debian/build
-          if-no-files-found: ignore
-          retention-days: 7
-
   debian_experimental_diagnostics:
     name: debian experimental diagnostics
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      issues: write
     timeout-minutes: 90
     needs: debian_experimental_gate
     if: always()
@@ -267,60 +255,3 @@ jobs:
             echo
             cat /tmp/debian-ci-findings.md
           } >> "$GITHUB_STEP_SUMMARY"
-          {
-            echo "has_findings=true"
-            echo "body<<EOF"
-            cat /tmp/debian-ci-findings.md
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Comment PR with diagnostics findings
-        if: >-
-          ${{ github.event_name == 'pull_request' &&
-          steps.findings.outputs.has_findings == 'true' }}
-        continue-on-error: true
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const marker = '<!-- debian-ci-findings-main -->';
-            const body = `${marker}\n\nDebian experimental diagnostics findings:\n\n${process.env.FINDINGS_BODY}`;
-            const { owner, repo } = context.repo;
-            const issue_number = context.issue.number;
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              owner,
-              repo,
-              issue_number,
-              per_page: 100,
-            });
-            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner,
-                repo,
-                comment_id: existing.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner,
-                repo,
-                issue_number,
-                body,
-              });
-            }
-        env:
-          FINDINGS_BODY: ${{ steps.findings.outputs.body }}
-
-      - name: Upload diagnostics artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: debian-experimental-diagnostics
-          path: |
-            /tmp/debian-build.log
-            /tmp/debian-ci-findings.md
-            /tmp/debian-ci-findings.d
-            /tmp/*.deb
-            /tmp/debian-src/debian/build
-          if-no-files-found: ignore
-          retention-days: 7


### PR DESCRIPTION
## Summary

This PR removes durable Debian package CI artifacts and PR diagnostics comments.

Changes:
- removes both Debian workflow `actions/upload-artifact` steps
- removes the diagnostics comment job and its `issues: write` permission
- keeps diagnostics rendering in the workflow job summary

## Rationale

The Debian package gate already reports failures through job status and logs. The diagnostics job also writes rendered findings to `GITHUB_STEP_SUMMARY`. Persisting package/build artifacts for seven days and mirroring diagnostics into PR comments is not useful for normal review and adds storage/noise.

## Validation

- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/debian_package_build.yml`
- `git diff --check -- .github/workflows/debian_package_build.yml`
- Python structural check that there are no durable artifact uploads, no `issues: write`, no PR comment API calls, and the workflow summary remains

All passed.