### PR TITLE
github: avoid persisted checkout credentials

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Lint GitHub Actions workflows
         uses: reviewdog/action-actionlint@v1
         with:

--- a/.github/workflows/ci_codestyle_check.yml
+++ b/.github/workflows/ci_codestyle_check.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Detect changed files
         id: code_changes

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,6 +40,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          persist-credentials: false
 
       - name: Install Packages (cpp)
         if: ${{ matrix.language == 'cpp' }}

--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Check for container image changes

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check for doc changes
         id: doc_changes

--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Build documentation in Docker container
         env:
@@ -59,6 +61,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Download built docs artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup make dist build env

--- a/.github/workflows/impstats_push_victoriametrics.yml
+++ b/.github/workflows/impstats_push_victoriametrics.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: checkout project
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: wait for VictoriaMetrics to be ready
         run: |

--- a/.github/workflows/repo-policy-focus-review.yml
+++ b/.github/workflows/repo-policy-focus-review.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Build focused review package

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: git checkout project
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: prepare for build
         run: |

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install codespell
         run: pip install codespell
       - name: Check spelling in docs

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 2
 
       - name: Identify changed YAML files


### PR DESCRIPTION
## Summary

This PR disables persisted Git credentials for checkout steps in read-only workflow jobs not already covered by active hardening PRs.

Changes:
- sets `persist-credentials: false` on checkout steps in twelve workflows
- preserves existing `fetch-depth` settings and workflow behavior
- leaves `run_checks.yml`, `debian_package_build.yml`, and the removed template file to their active PRs

## Rationale

These jobs only need a checked-out working tree. Leaving the GitHub token in local Git config is unnecessary and triggers zizmor `artipacked` findings.

## Validation

- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false <changed workflows>`
- `git diff --check -- .github/workflows`
- `/home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json <changed workflows>`

`actionlint` and `diff --check` passed. `zizmor` still exits non-zero for other known findings, but it reports no remaining `artipacked` findings in the changed workflows.
