### PR TITLE
github: set read-only token for small CI workflows

### DIFF
--- a/.github/workflows/ci_codestyle_check.yml
+++ b/.github/workflows/ci_codestyle_check.yml
@@ -3,6 +3,9 @@ name: "Code Style Check"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/impstats_push_victoriametrics.yml
+++ b/.github/workflows/impstats_push_victoriametrics.yml
@@ -25,6 +25,9 @@ name: impstats push to VictoriaMetrics
       - 'configure.ac'
       - '.github/workflows/impstats_push_victoriametrics.yml'
 
+permissions:
+  contents: read
+
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event.pull_request.number ||


### PR DESCRIPTION
## Summary
- add explicit `contents: read` permissions to the code style workflow
- add explicit `contents: read` permissions to the impstats VictoriaMetrics workflow
- remove the remaining `excessive-permissions` zizmor findings for these two read-only workflows

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color=false .github/workflows/ci_codestyle_check.yml .github/workflows/impstats_push_victoriametrics.yml`
- `/home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json --no-exit-codes --quiet .github/workflows/ci_codestyle_check.yml .github/workflows/impstats_push_victoriametrics.yml | jq '[.[] | select(.ident == "excessive-permissions")] | length'`
- `git diff --check -- .github/workflows/ci_codestyle_check.yml .github/workflows/impstats_push_victoriametrics.yml`
