### PR TITLE
github: enable Dependabot action updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "CI"
+      - "cleanup"
+    commit-message:
+      prefix: "ci"


### PR DESCRIPTION
## Summary
- add Dependabot configuration for GitHub Actions updates
- schedule weekly grouped action update PRs from the repository root
- label update PRs with `CI` and `cleanup` and cap concurrent update PRs

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml"); puts "YAML parsed successfully"'`
- `yamllint .github/dependabot.yml`