### PR TITLE
github: disable checkout credential persistence

### DIFF
--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -120,6 +120,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Skip Debian package gate, no relevant changes
         if: needs.debian_package_changes.outputs.any_changed != 'true'
@@ -214,6 +215,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Skip Debian package diagnostics, no relevant changes
         if: needs.debian_package_changes.outputs.any_changed != 'true'

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - name: git checkout project
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -142,6 +144,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: fetch upstream (for changed-files diff)
         env:
@@ -369,6 +372,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: fetch upstream (for changed-files diff)
         env:
@@ -450,6 +454,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: fetch upstream (for changed-files diff)
         env:
@@ -558,6 +563,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -770,6 +776,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -931,6 +938,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -1208,6 +1216,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -1406,6 +1415,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -1472,6 +1482,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -1538,6 +1549,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -1619,6 +1631,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
@@ -1707,6 +1720,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: fetch upstream (for changed-files diff)
         env:


### PR DESCRIPTION
## Summary
- set `persist-credentials: false` on remaining checkout steps in `run_checks.yml`
- set `persist-credentials: false` on the remaining Debian package workflow checkouts
- preserve existing `fetch-depth` and workflow behavior

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color=false .github/workflows/run_checks.yml .github/workflows/debian_package_build.yml`
- `git diff --check -- .github/workflows/run_checks.yml .github/workflows/debian_package_build.yml`
- `/home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json --no-exit-codes --quiet .github/workflows/run_checks.yml .github/workflows/debian_package_build.yml | jq '[.[] | select(.ident == "artipacked" and (.ignored | not))] | length'`
