### PR TITLE
github: pin docs and release workflow actions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           persist-credentials: false
 
@@ -105,16 +105,16 @@ jobs:
           ./configure --enable-imfile --enable-mysql --enable-usertools --enable-pgsql --enable-libdbi --enable-snmp --enable-elasticsearch --enable-gnutls --enable-mail --enable-imdiag --enable-mmjsonparse --enable-mmaudit --enable-mmanon --enable-mmrm1stspace --enable-mmutf8fix --enable-mmcount --enable-mmdblookup --enable-mmfields --enable-mmpstrucdata --enable-imptcp --enable-impstats --enable-omprog --enable-omudpspoof --enable-omstdout --enable-omjournal --enable-pmlastmsg --enable-pmcisconames --enable-pmciscoios --enable-pmnull --enable-pmaixforwardedfrom --enable-pmsnare --enable-pmpanngfw --enable-omuxsock --enable-omkafka --enable-imkafka --enable-ommongodb --enable-omhiredis --enable-omhttpfs --enable-gssapi-krb5 --enable-mmkubernetes --enable-relp --enable-mmnormalize --enable-pmnormalize --enable-openssl --disable-mmgrok --enable-omtcl --enable-omhttp --enable-improg --enable-imtuxedoulog --enable-mmtaghostname --enable-imbatchreport --enable-imdocker --enable-mmdarwin --enable-pmdb2diag --enable-omrabbitmq --enable-libzstd
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yml
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@e46ed2cbd01164d986452f91f178727624ae40d7 # v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -26,13 +26,13 @@ jobs:
       docs_changed: ${{steps.doc_changes.outputs.any_changed}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Check for doc changes
         id: doc_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             doc/**/*.rst
@@ -110,7 +110,7 @@ jobs:
         if: >-
           ${{ github.event_name != 'pull_request' ||
           steps.doc_changes.outputs.any_changed == 'true' }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: '3.x'
 
@@ -173,7 +173,7 @@ jobs:
         if: >-
           ${{ github.event_name != 'pull_request' ||
           steps.doc_changes.outputs.any_changed == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-html
           path: doc-builder/doc/build
@@ -182,7 +182,7 @@ jobs:
         if: >-
           ${{ github.event_name != 'pull_request' ||
           steps.doc_changes.outputs.any_changed == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rag-knowledge-base
           path: doc-builder/doc/build/rag/rsyslog_rag_db.json
@@ -203,7 +203,7 @@ jobs:
       issues: write
     steps:
       - name: Comment on PR with artifact links
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const repo = context.repo;

--- a/.github/workflows/doc_deploy_main.yml
+++ b/.github/workflows/doc_deploy_main.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.repository == 'rsyslog/rsyslog'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -42,7 +42,7 @@ jobs:
             rsyslog/rsyslog_dev_doc_base_ubuntu:22.04
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docs-html
           path: doc/build
@@ -60,12 +60,12 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Download built docs artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: docs-html
           path: preview-site
@@ -88,13 +88,13 @@ jobs:
           } > pages-deployment/robots.txt
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
 
       - name: Upload to Pages (artifact)
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: pages-deployment
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -60,7 +60,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           fetch-depth: 0
@@ -118,7 +118,7 @@ jobs:
           printf 'dist_tarball_sha256=%s\n' "$dist_tarball.sha256" >> "$GITHUB_OUTPUT"
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: draft-release-assets
           path: |
@@ -136,7 +136,7 @@ jobs:
 
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: draft-release-assets
           path: release-assets

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -52,7 +52,7 @@ jobs:
             libtool
 
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
@@ -126,7 +126,7 @@ jobs:
           exit 0
 
       - name: Upload result artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: res-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.sanitizer }}
           path: result.txt
@@ -145,7 +145,7 @@ jobs:
     if: always()
     steps:
       - name: Download all result artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: results
 
@@ -174,7 +174,7 @@ jobs:
         if: >-
           steps.summary.outputs.failures != '0' &&
           github.repository == 'rsyslog/rsyslog'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
@@ -207,7 +207,7 @@ jobs:
             }
 
       - name: Upload summary as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: weekly-macos-summary
           path: summary.md


### PR DESCRIPTION
## Summary
- pin action references in docs, docs deploy, draft release, weekly macOS, and CodeQL workflows to full commit SHAs
- keep original action tags as trailing comments for maintainability
- pin CodeQL sub-actions to the current `github/codeql-action` v4 commit

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color=false .github/workflows/doc_build.yml .github/workflows/doc_deploy_main.yml .github/workflows/draft_release.yml .github/workflows/run_macos_weekly.yml .github/workflows/codeql.yml`
- `git diff --check -- .github/workflows/doc_build.yml .github/workflows/doc_deploy_main.yml .github/workflows/draft_release.yml .github/workflows/run_macos_weekly.yml .github/workflows/codeql.yml`
- `/home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json --no-exit-codes --quiet <touched workflows> | jq '[.[] | select(.ident == "unpinned-uses" and (.ignored | not))] | length'`
