### PR TITLE
github: pin small workflow actions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -11,11 +11,11 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Lint GitHub Actions workflows
-        uses: reviewdog/action-actionlint@v1
+        uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           filter_mode: file

--- a/.github/workflows/ci_codestyle_check.yml
+++ b/.github/workflows/ci_codestyle_check.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Detect changed files
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             **/*.c

--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -28,14 +28,14 @@ jobs:
     timeout-minutes: 90
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           fetch-depth: 0
 
       - name: Check for container image changes
         id: container_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           files: |
             packaging/docker/rsyslog/**

--- a/.github/workflows/impstats_push_victoriametrics.yml
+++ b/.github/workflows/impstats_push_victoriametrics.yml
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 

--- a/.github/workflows/repo-policy-focus-review.yml
+++ b/.github/workflows/repo-policy-focus-review.yml
@@ -33,7 +33,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -11,7 +11,7 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
       - name: Install codespell

--- a/.github/workflows/yaml_lint.yml
+++ b/.github/workflows/yaml_lint.yml
@@ -32,14 +32,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
           fetch-depth: 2
 
       - name: Identify changed YAML files
         id: changed
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           json: "true"
           separator: "\n"


### PR DESCRIPTION
## Summary
- pin action references in small CI/lint/container workflows to full commit SHAs
- keep original action tags as trailing comments for maintainability
- avoid `run_checks.yml` and `debian_package_build.yml` to keep this batch isolated from active PRs

## Validation
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:latest -color=false .github/workflows/actionlint.yml .github/workflows/ci_codestyle_check.yml .github/workflows/yaml_lint.yml .github/workflows/spellcheck.yml .github/workflows/container_build.yml .github/workflows/impstats_push_victoriametrics.yml .github/workflows/repo-policy-focus-review.yml`
- `git diff --check -- .github/workflows/actionlint.yml .github/workflows/ci_codestyle_check.yml .github/workflows/yaml_lint.yml .github/workflows/spellcheck.yml .github/workflows/container_build.yml .github/workflows/impstats_push_victoriametrics.yml .github/workflows/repo-policy-focus-review.yml`
- `/home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json --no-exit-codes --quiet <touched workflows> | jq '[.[] | select(.ident == "unpinned-uses" and (.ignored | not))] | length'`
