### PR TITLE
codeql: add explicit Python fallbacks

### DIFF
--- a/doc/source/conf_helpers.py
+++ b/doc/source/conf_helpers.py
@@ -57,6 +57,7 @@ def get_current_branch():
                 detached_from_branch = branch.split('/')[-1].replace(')', '')
 
                 return detached_from_branch
+        return 'unknown'
 
     else:
         # The assumption is that we are on a branch at this point. Return that.

--- a/plugins/external/messagemod/anon_cc_nbrs/anon_cc_nbrs.py
+++ b/plugins/external/messagemod/anon_cc_nbrs/anon_cc_nbrs.py
@@ -62,6 +62,7 @@ def onReceive(msg):
             res = re.match(pat, match.group(0))
             if res:
                 return str(res.group(1))+patterns[pat]+str(res.group(res.lastindex))
+        return match.group(0)
 
     res_msg = rc.sub(lambda m: lookup(m), msg)
     if res_msg == msg:


### PR DESCRIPTION
## Summary

This PR addresses the pasted GitHub Code Quality `Explicit returns mixed with implicit returns` findings by:

- adding an explicit `unknown` fallback to `doc/source/conf_helpers.py::get_current_branch()` when detached-HEAD branch parsing does not find a marked branch
- adding an explicit original-match fallback to the `anon_cc_nbrs.py` replacement callback

Both changes make the existing fallback behavior deliberate and avoid implicit `None` returns.

## Validation

- `./doc/tools/build-doc-linux.sh --clean --format html`
- `python3 -m py_compile doc/source/conf_helpers.py`
- Function-level smoke tests for the branch fallback and anonymizer fallback
- `git diff --check`

## Notes

I did not run the external anonymizer script with Python 2 because this environment does not have a `python2` interpreter installed, and its Python 2 parser module is also unavailable in the installed Python 3 runtime.
