### PR TITLE
improg: stop on child stdout EOF

### DIFF
--- a/contrib/improg/improg.c
+++ b/contrib/improg/improg.c
@@ -401,7 +401,7 @@ static rsRetVal readChild(instanceConf_t *const pInst) {
             cstrAppendChar(pInst->ppCStr, c);
         }
     }
-    return (retval == 0) ? RS_RET_OK : RS_RET_IO_ERROR;
+    return (retval == 0) ? RS_RET_EOF : RS_RET_IO_ERROR;
 }
 
 /* create input instance, set default parameters, and
@@ -553,6 +553,7 @@ BEGINrunInput
     struct timeval tv;
     int retval;
     instanceConf_t *pInst;
+    rsRetVal readRet;
     CODESTARTrunInput;
     FD_ZERO(&rfds);
 
@@ -581,9 +582,16 @@ BEGINrunInput
         /* retval is the number of fd with data to read */
         while (retval > 0) {
             for (pInst = confRoot; pInst != NULL; pInst = pInst->next) {
-                if (FD_ISSET(pInst->fdPipeFromChild, &temp)) {
+                if (pInst->fdPipeFromChild != -1 && FD_ISSET(pInst->fdPipeFromChild, &temp)) {
                     DBGPRINTF("read child %s\n", pInst->pszBinary);
-                    readChild(pInst);
+                    readRet = readChild(pInst);
+                    if (readRet == RS_RET_EOF) {
+                        DBGPRINTF("improg: program '%s' closed stdout pipe\n", pInst->pszBinary);
+                        terminateChild(pInst);
+                    } else if (readRet != RS_RET_OK) {
+                        LogError(errno, readRet, "improg: error reading from child process");
+                        terminateChild(pInst);
+                    }
                     retval--;
                 }
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -840,6 +840,7 @@ TESTS_OMJOURNAL = \
 
 TESTS_IMPROG = \
 	improg_errmsg_no_params.sh \
+	improg_child_killed.sh \
 	improg_prog_simple.sh \
 	improg_prog_confirm.sh \
 	improg_prog_confirm_killonclose.sh \
@@ -3197,6 +3198,7 @@ EXTRA_DIST += \
 	testsuites/omprog-defaults-bin.sh \
 	testsuites/omprog-output-capture-bin.sh \
 	testsuites/omprog-output-capture-mt-bin.py \
+	testsuites/improg-child-kill-bin.sh \
 	holdtcpopen.py \
 	testsuites/omprog-feedback-bin.sh \
 	testsuites/omprog-feedback-mt-bin.sh \

--- a/tests/improg_child_killed.sh
+++ b/tests/improg_child_killed.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+if [ ! -r /proc/$$/stat ]; then
+	echo "This test requires Linux /proc process CPU counters"
+	skip_test
+fi
+
+get_proc_cpu_ticks() {
+	awk '{ print $14 + $15 }' "/proc/$1/stat"
+}
+
+generate_conf
+add_conf '
+module(load="../contrib/improg/.libs/improg")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+input(type="improg" tag="tag" ruleset="improg_ruleset"
+      binary="'${srcdir:=.}'/testsuites/improg-child-kill-bin.sh '$RSYSLOG_DYNNAME'.child.pid"
+      confirmmessages="off" signalonclose="off" killunresponsive="on"
+      closetimeout="1000"
+     )
+
+ruleset(name="improg_ruleset") {
+    action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+
+syslog.* {
+    action(type="omfile" template="outfmt" file="'$RSYSLOG2_OUT_LOG'")
+}
+'
+
+startup
+wait_content "program data" "$RSYSLOG_OUT_LOG"
+wait_file_lines "$RSYSLOG_DYNNAME.child.pid" 1 5
+
+child_pid=$(cat "$RSYSLOG_DYNNAME.child.pid")
+rsyslog_pid=$(getpid)
+kill -s KILL "$child_pid"
+
+ticks_before=$(get_proc_cpu_ticks "$rsyslog_pid")
+$TESTTOOL_DIR/msleep 1200
+ticks_after=$(get_proc_cpu_ticks "$rsyslog_pid")
+ticks_delta=$((ticks_after - ticks_before))
+echo "rsyslogd CPU ticks after improg child kill: $ticks_delta"
+if [ "$ticks_delta" -gt 25 ]; then
+	echo "improg appears to spin after child EOF"
+	error_exit 1
+fi
+
+old_timeout="$TB_TEST_TIMEOUT"
+TB_TEST_TIMEOUT=5
+wait_content "(pid $child_pid) terminated by signal 9" "$RSYSLOG2_OUT_LOG"
+TB_TEST_TIMEOUT="$old_timeout"
+
+shutdown_when_empty
+wait_shutdown
+
+exit_test

--- a/tests/testsuites/improg-child-kill-bin.sh
+++ b/tests/testsuites/improg-child-kill-bin.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+pidfile="$1"
+block_fifo="${pidfile}.fifo"
+
+rm -f "$block_fifo"
+mkfifo "$block_fifo" || exit 1
+
+echo "$$" > "$pidfile"
+echo "program data"
+
+read -r _ < "$block_fifo"


### PR DESCRIPTION
## Summary
- Treat EOF on the improg child stdout pipe as child termination.
- Close/reap the child on EOF or read errors so the fd is removed from the select loop.
- Add a regression test that kills the improg child and checks rsyslogd CPU ticks to catch the old spin.

## Issue validity
I reproduced the issue before applying the fix with the new regression test. The test failed on the old code with `rsyslogd CPU ticks after improg child kill: 120`, which matches the reported busy loop after the child exits. With the fix, the same test reports `0` CPU ticks in the sampling window.

Closes https://github.com/rsyslog/rsyslog/issues/6791

## Validation
- `./autogen.sh --enable-debug --enable-testbench --enable-improg`
- `make -j$(nproc) check TESTS=""`
- `./tests/improg_child_killed.sh` (failed before fix: 120 CPU ticks)
- `./tests/improg_child_killed.sh`
- `./tests/improg_prog_simple.sh`
- `./tests/improg_prog_confirm.sh`
- `./tests/improg_prog_killonclose.sh`
- `./tests/improg_prog_confirm_killonclose.sh`
- `./tests/improg_simple_multi.sh`
- `./tests/improg_errmsg_no_params.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
- `git diff --check`

With the help of AI-Agents: Codex
