### PR TITLE
github: pin main CI workflow actions

### DIFF
--- a/.github/workflows/debian_package_build.yml
+++ b/.github/workflows/debian_package_build.yml
@@ -48,7 +48,7 @@ jobs:
         }}
     steps:
       - name: Checkout rsyslog source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -64,7 +64,7 @@ jobs:
       - name: Check for Debian package relevant changes
         id: debian_package_changes
         if: github.event_name == 'pull_request'
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -117,7 +117,7 @@ jobs:
 
     steps:
       - name: Checkout rsyslog source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -212,7 +212,7 @@ jobs:
 
     steps:
       - name: Checkout rsyslog source
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -44,13 +44,13 @@ jobs:
         config: [alpine, clang9, clang18-noatomics, clang18-ndebug, gcc8-debug, gcc-11-ndebug, gcc14-gnu23-debug]
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           # Keep doc/Makefile.am in scope: compile must not ignore it to satisfy
           # branch protection requirements for this workflow.
@@ -141,7 +141,7 @@ jobs:
 
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -155,7 +155,7 @@ jobs:
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -369,7 +369,7 @@ jobs:
           - suite: noble
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -383,7 +383,7 @@ jobs:
 
       - name: Check for package changes
         id: package_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -451,7 +451,7 @@ jobs:
         run: dnf install -y git
 
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -466,7 +466,7 @@ jobs:
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -525,7 +525,7 @@ jobs:
 
       - name: Upload RPM artifacts
         if: steps.code_changes.outputs.any_changed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: rpms-epel-9-x86_64
           path: build-result/
@@ -560,14 +560,14 @@ jobs:
       ABORT_ALL_ON_TEST_FAIL: true
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -773,14 +773,14 @@ jobs:
     name: journal CI
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -900,7 +900,7 @@ jobs:
 
       - name: Upload coverage to Codecov (internal)
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
@@ -909,7 +909,7 @@ jobs:
 
       - name: Upload coverage to Codecov (fork PR)
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: coverage.info
           flags: journal
@@ -935,14 +935,14 @@ jobs:
     name: codecov base CI
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -1178,7 +1178,7 @@ jobs:
 
       - name: Upload coverage to Codecov (internal)
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
@@ -1187,7 +1187,7 @@ jobs:
 
       - name: Upload coverage to Codecov (fork PR)
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: coverage.info
           flags: main
@@ -1213,14 +1213,14 @@ jobs:
     name: codecov kafka CI
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -1272,7 +1272,7 @@ jobs:
 
       - name: cache configure results
         if: steps.code_changes.outputs.any_changed == 'true'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: config.cache
           key: >
@@ -1358,7 +1358,7 @@ jobs:
 
       - name: Upload coverage to Codecov (internal)
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' && github.event.pull_request.head.repo.full_name == github.repository }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.info
@@ -1367,7 +1367,7 @@ jobs:
 
       - name: Upload coverage to Codecov (fork PR)
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' && github.event.pull_request.head.repo.full_name != github.repository }}
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@b9fd7d16f6d7d1b5d2bec1a2887e65ceed900238 # v4
         with:
           files: coverage.info
           flags: kafka
@@ -1412,14 +1412,14 @@ jobs:
           --health-retries=30
     steps:
       - name: checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -1479,14 +1479,14 @@ jobs:
           - 29428:9428
     steps:
       - name: checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -1546,14 +1546,14 @@ jobs:
     name: clang static analyzer
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -1586,7 +1586,7 @@ jobs:
       - name: Upload clang static analyzer report
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' }}
         id: upload-report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: clang-static-analyzer-report
           path: scan-build-report
@@ -1628,14 +1628,14 @@ jobs:
     name: kafka distcheck CI
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -1717,7 +1717,7 @@ jobs:
     name: ${{ matrix.arch }} CI (${{ matrix.use_qemu && 'QEMU' || 'native, asan' }})${{ matrix.arch == 'arm64' && ', asan' || '' }}
     steps:
       - name: git checkout project
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
           persist-credentials: false
@@ -1731,7 +1731,7 @@ jobs:
 
       - name: Check for code changes
         id: code_changes
-        uses: tj-actions/changed-files@v46
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
         with:
           base_sha: ${{ github.event.pull_request.base.sha }}
           sha: ${{ github.event.pull_request.head.sha }}
@@ -1751,17 +1751,17 @@ jobs:
 
       - name: Set up QEMU for ${{ matrix.arch }} emulation
         if: steps.code_changes.outputs.any_changed == 'true' && matrix.use_qemu
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
         with:
           platforms: ${{ matrix.qemu_platform }}
 
       - name: Set up Docker Buildx
         if: steps.code_changes.outputs.any_changed == 'true'
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Build ${{ matrix.arch }} dev image (cached)
         if: steps.code_changes.outputs.any_changed == 'true'
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           file: devtools/ci/Dockerfile.arm
@@ -1857,7 +1857,7 @@ jobs:
 
       - name: Upload ${{ matrix.arch }} test logs
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ${{ matrix.arch }}-test-logs
           path: |


### PR DESCRIPTION
## Summary
- pin remaining actions in run_checks.yml and debian_package_build.yml to full commit SHAs
- keep original major-version tags as comments for review/update context
- leave the intentional VictoriaLogs latest image for the later zizmor policy step

## Validation
- actionlint .github/workflows/run_checks.yml .github/workflows/debian_package_build.yml
- git diff --check
- scoped zizmor: no remaining unpinned action refs in the changed files; remaining findings are VictoriaLogs latest and low-confidence template-injection notices