### PR TITLE
github: reduce zizmor workflow findings

### DIFF
--- a/.github/workflows/ci_codestyle_check.yml
+++ b/.github/workflows/ci_codestyle_check.yml
@@ -30,8 +30,10 @@ jobs:
             devtools/format-code.sh
 
       - name: Enforce code style
+        env:
+          ANY_CHANGED: ${{ steps.code_changes.outputs.any_changed }}
         run: |
-          if [ "${{ steps.code_changes.outputs.any_changed }}" != "true" ]; then
+          if [ "$ANY_CHANGED" != "true" ]; then
             echo "No code changes detected; skipping style check."
             exit 0
           fi

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1474,7 +1474,7 @@ jobs:
       DOCKER_RUN_EXTRA_OPTS: --network host
     services:
       victorialogs:
-        image: victoriametrics/victoria-logs:latest
+        image: victoriametrics/victoria-logs:latest # zizmor: ignore[unpinned-images] intentional: CI tracks latest VictoriaLogs compatibility
         ports:
           - 29428:9428
     steps:
@@ -1595,23 +1595,25 @@ jobs:
 
       - name: Show clang static analyzer report link
         if: ${{ always() && steps.code_changes.outputs.any_changed == 'true' }}
+        env:
+          ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
         run: |
-          artifact="${{ steps.upload-report.outputs.artifact-url }}"
           cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           Clang static analyzer HTML report (download):
-          $artifact
+          $ARTIFACT_URL
           EOF
           echo "Clang static analyzer HTML report (download):"
-          echo "$artifact"
+          echo "$ARTIFACT_URL"
 
       - name: Fail if analysis failed
         if: ${{ steps.code_changes.outputs.any_changed == 'true' && steps.run-clang.outputs.exitcode != '0' }}
+        env:
+          ARTIFACT_URL: ${{ steps.upload-report.outputs.artifact-url }}
         run: |
-          artifact="${{ steps.upload-report.outputs.artifact-url }}"
           echo "clang static analyzer detected issues:" >&2
           tail -n 200 clang-analyzer.log >&2 || true
           echo >&2
-          echo "Clang static analyzer HTML report (download): $artifact" >&2
+          echo "Clang static analyzer HTML report (download): $ARTIFACT_URL" >&2
           exit 1
 
       - name: Skip clang analyzer CI, no relevant changes


### PR DESCRIPTION
## Summary
- move selected workflow step outputs used by shell scripts into env variables
- document the intentional VictoriaLogs latest image with an inline zizmor ignore
- leave VictoriaLogs testing against latest to catch upstream compatibility changes
- defer the remaining container_build.yml low-confidence notice because touching it currently triggers a flaky PPA-backed container build

## Validation
- actionlint .github/workflows/ci_codestyle_check.yml .github/workflows/run_checks.yml
- /home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json .github/workflows
- git diff --check