### PR TITLE
imtcp test: capture mbedtls diagnostics directly

### DIFF
--- a/tests/imtcp-tls-mbedtls-error-ca.sh
+++ b/tests/imtcp-tls-mbedtls-error-ca.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
@@ -24,5 +26,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config"
+content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test

--- a/tests/imtcp-tls-mbedtls-error-cert.sh
+++ b/tests/imtcp-tls-mbedtls-error-cert.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+
 export NUMMESSAGES=10
 generate_conf
 add_conf '
@@ -21,5 +23,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config"
+content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test

--- a/tests/imtcp-tls-mbedtls-error-key.sh
+++ b/tests/imtcp-tls-mbedtls-error-key.sh
@@ -2,6 +2,8 @@
 # check error message on cert as key file
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+
 export NUMMESSAGES=10
 generate_conf
 add_conf '
@@ -22,5 +24,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config"
+content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test

--- a/tests/imtcp-tls-mbedtls-error-key2.sh
+++ b/tests/imtcp-tls-mbedtls-error-key2.sh
@@ -2,6 +2,8 @@
 # added 2018-11-07 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+
 export NUMMESSAGES=10
 generate_conf
 add_conf '
@@ -22,5 +24,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config"
+content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test

--- a/tests/imtcp-tls-mbedtls-x509fingerprint-invld.sh
+++ b/tests/imtcp-tls-mbedtls-x509fingerprint-invld.sh
@@ -3,6 +3,8 @@
 # check for INVALID fingerprint!
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+
 export NUMMESSAGES=10000
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="log"
@@ -28,5 +30,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 tcpflood --check-only -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_shutdown
-content_check --regex "peer fingerprint .* unknown"
+content_check --regex "peer fingerprint .* unknown" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test

--- a/tests/imtcp-tls-mbedtls-x509invalid.sh
+++ b/tests/imtcp-tls-mbedtls-x509invalid.sh
@@ -2,6 +2,8 @@
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released  under GPLv3
 . ${srcdir:=.}/diag.sh init
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+
 export NUMMESSAGES=10000
 generate_conf
 add_conf '
@@ -22,5 +24,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 tcpflood --check-only -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_shutdown
-content_check "X509 - Certificate verification failed"
+content_check "X509 - Certificate verification failed" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test

--- a/tests/imtcp-tls-mbedtls-x509name_invalid.sh
+++ b/tests/imtcp-tls-mbedtls-x509name_invalid.sh
@@ -2,6 +2,8 @@
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+
 export NUMMESSAGES=10000
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="log"
@@ -25,5 +27,5 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 startup
 tcpflood --check-only -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
 wait_shutdown
-content_check "peer name not authorized"
+content_check "peer name not authorized" "${RSYSLOG_DYNNAME}.rsyslog.log"
 exit_test


### PR DESCRIPTION
## Summary

This stabilizes the negative imtcp/mbedtls diagnostic tests by checking the
rsyslogd process log directly instead of the normal action output file.

Affected tests:

- `imtcp-tls-mbedtls-error-cert.sh`
- `imtcp-tls-mbedtls-error-ca.sh`
- `imtcp-tls-mbedtls-error-key.sh`
- `imtcp-tls-mbedtls-error-key2.sh`
- `imtcp-tls-mbedtls-x509invalid.sh`
- `imtcp-tls-mbedtls-x509fingerprint-invld.sh`
- `imtcp-tls-mbedtls-x509name_invalid.sh`

## Root Cause

These tests intentionally exercise failed TLS setup or rejected-peer paths.
In those paths rsyslogd emits the expected diagnostic on stderr, but no
normal message action output is guaranteed. Under slow or loaded CI, the
default `content_check` target, `$RSYSLOG_OUT_LOG`, can be missing even
though the expected diagnostic was produced.

The first PR CI run confirmed the same signature in
`imtcp-tls-mbedtls-error-key.sh`: the expected
`nsd mbedtls: error parsing crypto config` diagnostic appeared on rsyslogd
stderr, while the action output file was missing. The branch was expanded
to cover the remaining same-family negative mbedtls diagnostic tests.

## Change

Each test now sets `RS_REDIR` before `startup` to capture rsyslogd stdout
and stderr into a deterministic per-test process log, then passes that log
to `content_check` for the expected diagnostic. This changes only the test
assertion target and does not change rsyslog runtime behavior.

## Validation

- `make -j24 check TESTS=""`
- `make -j24 check TESTS="imtcp-tls-mbedtls-error-cert.sh imtcp-tls-mbedtls-error-ca.sh imtcp-tls-mbedtls-error-key.sh imtcp-tls-mbedtls-error-key2.sh imtcp-tls-mbedtls-x509invalid.sh imtcp-tls-mbedtls-x509fingerprint-invld.sh imtcp-tls-mbedtls-x509name_invalid.sh"`
- Direct runs of all seven affected tests
- Negative-control proof with an intentionally wrong diagnostic string; the test failed as expected while the real diagnostic remained in the process log