### PR TITLE
[codex] Add Ubuntu WSL development setup

### DIFF
--- a/devtools/README.md
+++ b/devtools/README.md
@@ -6,6 +6,15 @@ CI. The goal is to have a consistent way to do things.
 - run-static-analyzer.sh
   Run the currently approved rsyslog project clang static analyzer.
 
+- codex-setup.sh
+  Prepare an Ubuntu 24.04 WSL checkout for full rsyslog development. It
+  installs the packages and helper libraries used by the Ubuntu 24.04
+  development container and can optionally verify a build with the container's
+  RSYSLOG_CONFIGURE_OPTIONS.
+
+- codex-setup-wsl.ps1
+  Windows wrapper for running codex-setup.sh inside a WSL distro.
+
 ## Environment Variables
 
 - RSYSLOG\_HOME
@@ -17,3 +26,7 @@ CI. The goal is to have a consistent way to do things.
 
 Contains the full name of the container to be used for development
 task if no other is given.
+
+### codex-wsl-bootstrap-prompt.md
+
+Copy-paste prompt for asking Codex to set up rsyslog development on a new Windows machine.

--- a/devtools/codex-setup-wsl.ps1
+++ b/devtools/codex-setup-wsl.ps1
@@ -1,0 +1,57 @@
+param(
+    [string] $Distro = "Ubuntu-24.04",
+    [string] $RepoPath = "",
+    [string] $AptMirror = "",
+    [switch] $VerifyBuild,
+    [switch] $AllowWindowsMount
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+if ($RepoPath -eq "") {
+    $RepoPath = (wsl.exe -d $Distro -- bash -lc 'printf "%s" "$HOME/rsyslog"')
+    if ($LASTEXITCODE -ne 0 -or $RepoPath -eq "") {
+        throw "Unable to determine the WSL home directory for distro '$Distro'. Pass -RepoPath explicitly."
+    }
+}
+
+function Quote-Bash {
+    param([string] $Value)
+    return "'" + $Value.Replace("'", "'\''") + "'"
+}
+
+$setupArgs = @()
+if ($AptMirror -ne "") {
+    $setupArgs += "--apt-mirror"
+    $setupArgs += $AptMirror
+}
+if ($VerifyBuild) {
+    $setupArgs += "--verify-build"
+}
+if ($AllowWindowsMount) {
+    $setupArgs += "--allow-windows-mount"
+}
+
+$quotedArgs = @()
+foreach ($arg in $setupArgs) {
+    $quotedArgs += (Quote-Bash $arg)
+}
+
+$repo = Quote-Bash $RepoPath
+$argText = $quotedArgs -join " "
+$command = "cd $repo && sudo ./devtools/codex-setup.sh $argText"
+
+Write-Host "Running rsyslog Ubuntu 24.04 WSL setup in distro '$Distro'"
+Write-Host "Repository: $RepoPath"
+if ($AptMirror -ne "") {
+    Write-Host "Apt mirror override: $AptMirror"
+}
+if ($VerifyBuild) {
+    Write-Host "Build verification: enabled"
+}
+
+wsl.exe -d $Distro -- bash -lc $command
+if ($LASTEXITCODE -ne 0) {
+    throw "WSL setup failed with exit code $LASTEXITCODE"
+}

--- a/devtools/codex-setup.sh
+++ b/devtools/codex-setup.sh
@@ -1,47 +1,536 @@
 #!/usr/bin/env bash
-##
-## rsyslog base environment setup script
-##
-## Installs required build tools and libraries once,
-## then records completion in /tmp/rsyslog_base_env.flag
-##
-## Usage:
-##   ./setup-env.sh
-##
+set -euo pipefail
 
-FLAG="/tmp/rsyslog_base_env.flag"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DOCKERFILE="$REPO_ROOT/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile"
+if [ "$(id -u)" -eq 0 ] && [ -z "${SUDO_USER:-}" ]; then
+	BUILD_USER="$(stat -c %U "$REPO_ROOT")"
+else
+	BUILD_USER="${SUDO_USER:-${USER:-$(id -un)}}"
+fi
+BUILD_HOME="$(getent passwd "$BUILD_USER" | cut -d: -f6)"
+CACHE_DIR="${RSYSLOG_DEV_SETUP_CACHE:-$BUILD_HOME/.cache/rsyslog-dev-deps}"
+STAMP_DIR="/usr/local/share/rsyslog-dev-setup/stamps"
+ALLOW_WINDOWS_MOUNT=0
+VERIFY_BUILD=0
+APT_MIRROR=""
+ORIGINAL_ARGS=("$@")
 
-## If the flag exists, skip setup
-if [ -f "$FLAG" ]; then
-  echo "Base environment already set up (flag at $FLAG), skipping."
-  exit 0
+usage() {
+	cat <<'USAGE'
+Usage: devtools/codex-setup.sh [options]
+
+Prepare an Ubuntu 24.04 WSL environment for full rsyslog development.
+
+Options:
+  --apt-mirror URL        Rewrite Ubuntu apt sources to URL before updating.
+  --verify-build          Run autoreconf, configure, and make after setup.
+  --allow-windows-mount   Permit running from /mnt/*, not recommended.
+  -h, --help              Show this help text.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--apt-mirror)
+			APT_MIRROR="${2:-}"
+			if [ -z "$APT_MIRROR" ]; then
+				echo "error: --apt-mirror requires a URL" >&2
+				exit 2
+			fi
+			shift 2
+			;;
+		--verify-build)
+			VERIFY_BUILD=1
+			shift
+			;;
+		--allow-windows-mount)
+			ALLOW_WINDOWS_MOUNT=1
+			shift
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			echo "error: unknown option: $1" >&2
+			usage >&2
+			exit 2
+			;;
+	esac
+done
+
+if [ "$(id -u)" -ne 0 ]; then
+	exec sudo -E "$0" "${ORIGINAL_ARGS[@]}"
 fi
 
-## Perform package update and installation
-echo "Setting up rsyslog build environment..."
-apt-get update
-apt-get install -y \
-  autoconf \
-  autoconf-archive \
-  automake \
-  autotools-dev \
-  bison \
-  flex \
-  gcc \
-  libtool \
-  libtool-bin \
-  make \
-  libcurl4-gnutls-dev \
-  libgcrypt20-dev \
-  libgnutls28-dev \
-  libestr-dev \
-  libfastjson-dev \
-  liblognorm-dev \
-  libaprutil1-dev \
-  libcivetweb-dev \
-  python3-docutils \
-  valgrind
+log() {
+	printf '\n==> %s\n' "$*"
+}
 
-## Record that setup has completed
-touch "$FLAG"
-echo "Base environment setup complete. Flag created at $FLAG."
+run_as_build_user() {
+	if [ "$BUILD_USER" = "root" ]; then
+		"$@"
+	else
+		sudo -H -u "$BUILD_USER" "$@"
+	fi
+}
+
+require_ubuntu_2404() {
+	if [ ! -r /etc/os-release ]; then
+		echo "error: /etc/os-release is missing" >&2
+		exit 1
+	fi
+	. /etc/os-release
+	if [ "${ID:-}" != "ubuntu" ] || [ "${VERSION_ID:-}" != "24.04" ]; then
+		echo "error: this setup targets Ubuntu 24.04; found ${PRETTY_NAME:-unknown}" >&2
+		exit 1
+	fi
+}
+
+refuse_windows_mount_checkout() {
+	case "$REPO_ROOT" in
+		/mnt/*)
+			if [ "$ALLOW_WINDOWS_MOUNT" -ne 1 ]; then
+				cat >&2 <<'EOF'
+error: rsyslog checkout is under /mnt/*.
+
+Use a WSL-native checkout, for example /home/<user>/rsyslog, to avoid CRLF,
+filemode, symlink, and build performance problems. Re-run with
+--allow-windows-mount only if you intentionally accept those risks.
+EOF
+				exit 1
+			fi
+			;;
+	esac
+}
+
+configure_git_line_endings() {
+	log "Configuring WSL Git for LF checkouts"
+	run_as_build_user git config --global core.autocrlf false
+	run_as_build_user git config --global core.eol lf
+	run_as_build_user git config --global core.filemode true
+	run_as_build_user git -C "$REPO_ROOT" config core.filemode true
+}
+
+rewrite_apt_mirror() {
+	local mirror="$1"
+	local sources="/etc/apt/sources.list.d/ubuntu.sources"
+	local backup="/etc/apt/ubuntu.sources.codex-backup"
+	local legacy_backup="$sources.codex-backup"
+
+	if [ -z "$mirror" ]; then
+		return
+	fi
+
+	if [ ! -f "$sources" ]; then
+		echo "error: cannot apply --apt-mirror because $sources is missing" >&2
+		exit 1
+	fi
+
+	log "Rewriting Ubuntu apt sources to $mirror"
+	if [ ! -f "$backup" ]; then
+		cp "$sources" "$backup"
+	fi
+	if [ -f "$legacy_backup" ]; then
+		rm -f "$legacy_backup"
+	fi
+
+	python3 - "$sources" "$mirror" <<'PY'
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+mirror = sys.argv[2].rstrip("/") + "/"
+text = path.read_text()
+lines = []
+for line in text.splitlines():
+    if line.startswith("URIs: "):
+        lines.append("URIs: " + mirror)
+    else:
+        lines.append(line)
+path.write_text("\n".join(lines) + "\n")
+PY
+}
+
+apt_update() {
+	log "Updating apt package indexes"
+	if apt-get update; then
+		return
+	fi
+	cat >&2 <<'EOF'
+
+apt-get update failed. If the default Canonical mirror times out from WSL,
+re-run with a responding mirror, for example:
+
+  sudo ./devtools/codex-setup.sh --apt-mirror http://de.archive.ubuntu.com/ubuntu/
+EOF
+	exit 1
+}
+
+install_apt_packages() {
+	log "Installing Ubuntu 24.04 rsyslog development packages"
+	apt-get install -y \
+		autoconf \
+		autoconf-archive \
+		automake \
+		autotools-dev \
+		bison \
+		ca-certificates \
+		clang \
+		clang-tools \
+		cmake \
+		cmake-curses-gui \
+		curl \
+		default-jdk \
+		default-jre \
+		faketime \
+		flex \
+		g++ \
+		gcc \
+		gcc-14 \
+		gdb \
+		git \
+		gnupg \
+		libaprutil1-dev \
+		libbson-dev \
+		libcap-ng-dev \
+		libcap-ng0 \
+		libcivetweb-dev \
+		libczmq-dev \
+		libcurl4-gnutls-dev \
+		libdbd-mysql \
+		libdbi-dev \
+		libevent-dev \
+		libgcrypt20-dev \
+		libglib2.0-dev \
+		libgnutls28-dev \
+		libhiredis-dev \
+		libkrb5-dev \
+		liblz4-dev \
+		libmaxminddb-dev \
+		libmbedtls-dev \
+		libmongoc-dev \
+		libmysqlclient-dev \
+		libnet1-dev \
+		libpcap-dev \
+		libprotobuf-c-dev \
+		librabbitmq-dev \
+		libsasl2-2 \
+		libsasl2-dev \
+		libsodium-dev \
+		libsasl2-modules \
+		libsnappy-dev \
+		libsnmp-dev \
+		libssl-dev \
+		libsystemd-dev \
+		libtirpc-dev \
+		libtokyocabinet-dev \
+		libtool \
+		libtool-bin \
+		libwolfssl-dev \
+		libyaml-dev \
+		libzstd-dev \
+		logrotate \
+		lsof \
+		make \
+		mysql-server \
+		net-tools \
+		pkg-config \
+		postgresql-client \
+		libpq-dev \
+		protobuf-c-compiler \
+		python3-dev \
+		python3-docutils \
+		python3-pip \
+		python3-pysnmp4 \
+		python3-sphinx \
+		ruby-dev \
+		software-properties-common \
+		sudo \
+		swig \
+		tcl-dev \
+		uuid-dev \
+		valgrind \
+		vim \
+		wget \
+		zlib1g-dev \
+		zstd
+}
+
+install_obs_packages() {
+	local list_file="/etc/apt/sources.list.d/home-rgerhards.sources"
+	local keyring="/usr/share/keyrings/home-rgerhards.gpg"
+
+	log "Installing rsyslog helper packages from the rgerhards OBS repository"
+	if [ ! -f "$keyring" ]; then
+		wget -nv https://download.opensuse.org/repositories/home:rgerhards/xUbuntu_22.04/Release.key -O - \
+			| gpg --dearmor > "$keyring"
+	fi
+
+	cat > "$list_file" <<EOF
+Types: deb
+URIs: http://download.opensuse.org/repositories/home:/rgerhards/xUbuntu_22.04/
+Suites: /
+Signed-By: $keyring
+EOF
+
+	apt-get update
+	apt-get install -y \
+		libestr-dev \
+		liblogging-stdlog-dev \
+		liblognorm-dev
+}
+
+prepare_build_cache() {
+	mkdir -p "$CACHE_DIR" "$STAMP_DIR"
+	chown -R "$BUILD_USER:$BUILD_USER" "$CACHE_DIR"
+}
+
+stamp_exists() {
+	test -f "$STAMP_DIR/$1"
+}
+
+write_stamp() {
+	touch "$STAMP_DIR/$1"
+}
+
+clone_clean() {
+	local url="$1"
+	local dir="$2"
+	rm -rf "$dir"
+	run_as_build_user git clone --depth 1 "$url" "$dir"
+}
+
+multiarch_libdir() {
+	printf '/usr/lib/%s\n' "$(gcc -print-multiarch)"
+}
+
+build_codestyle() {
+	local stamp="codestyle"
+	local dir="$CACHE_DIR/codestyle"
+	if stamp_exists "$stamp"; then
+		log "codestyle already installed"
+		return
+	fi
+	log "Building rsyslog codestyle checker"
+	clone_clean https://github.com/rsyslog/codestyle "$dir"
+	run_as_build_user gcc --std=c99 "$dir/stylecheck.c" -o "$dir/stylecheck"
+	install -m 0755 "$dir/stylecheck" /usr/bin/rsyslog_stylecheck
+	write_stamp "$stamp"
+}
+
+build_libfastjson() {
+	local stamp="libfastjson"
+	local dir="$CACHE_DIR/libfastjson"
+	if stamp_exists "$stamp"; then
+		log "libfastjson already installed"
+		return
+	fi
+	local libdir
+	log "Building libfastjson"
+	clone_clean https://github.com/rsyslog/libfastjson.git "$dir"
+	cd "$dir"
+	libdir="$(multiarch_libdir)"
+	autoreconf -fi
+	./configure --prefix=/usr --libdir="$libdir" --includedir=/usr/include
+	make -j"$(nproc)"
+	make install
+	rm -f "$libdir/libfastjson.a"
+	write_stamp "$stamp"
+}
+
+build_faup() {
+	local stamp="faup"
+	local dir="$CACHE_DIR/faup"
+	if stamp_exists "$stamp"; then
+		log "faup already installed"
+		return
+	fi
+	log "Building faup"
+	clone_clean https://github.com/stricaud/faup.git "$dir"
+	cmake -S "$dir" -B "$dir/build"
+	make -C "$dir/build" -j"$(nproc)"
+	make -C "$dir/build" install
+	rm -f /usr/local/lib/libfaupl.a
+	write_stamp "$stamp"
+}
+
+build_libksi() {
+	local stamp="libksi"
+	local dir="$CACHE_DIR/libksi"
+	if stamp_exists "$stamp"; then
+		log "libksi already installed"
+		return
+	fi
+	log "Building Guardtime libksi"
+	clone_clean https://github.com/guardtime/libksi.git "$dir"
+	cd "$dir"
+	autoreconf -fvi
+	./configure --prefix=/usr
+	make -j"$(nproc)"
+	make install
+	rm -f /usr/lib/libksi.a
+	write_stamp "$stamp"
+}
+
+build_librelp() {
+	local stamp="librelp"
+	local dir="$CACHE_DIR/librelp"
+	if stamp_exists "$stamp"; then
+		log "librelp already installed"
+		return
+	fi
+	log "Building librelp"
+	clone_clean https://github.com/rsyslog/librelp.git "$dir"
+	cd "$dir"
+	autoreconf -fi
+	./configure --prefix=/usr --enable-compile-warnings=yes --libdir=/usr/lib --includedir=/usr/include
+	make -j"$(nproc)"
+	make install
+	rm -f /usr/lib/librelp.a
+	write_stamp "$stamp"
+}
+
+build_qpid_proton() {
+	local stamp="qpid-proton"
+	local dir="$CACHE_DIR/qpid-proton"
+	if stamp_exists "$stamp"; then
+		log "qpid-proton already installed"
+		return
+	fi
+	log "Building qpid-proton"
+	clone_clean https://github.com/apache/qpid-proton.git "$dir"
+	cmake -S "$dir" -B "$dir/build" -DCMAKE_INSTALL_PREFIX=/usr -DSYSINSTALL_BINDINGS=ON -DBUILD_TESTING=OFF
+	make -C "$dir/build" -j"$(nproc)"
+	make -C "$dir/build" install
+	rm -f /usr/lib/libqpid-proton-core.a /usr/lib/libqpid-proton-cpp.a \
+		/usr/lib/libqpid-proton-proactor.a /usr/lib/libqpid-proton.a
+	write_stamp "$stamp"
+}
+
+build_librdkafka() {
+	local stamp="librdkafka-v1.5.3"
+	local dir="$CACHE_DIR/librdkafka"
+	if stamp_exists "$stamp"; then
+		log "librdkafka v1.5.3 already installed"
+		return
+	fi
+	log "Building librdkafka v1.5.3"
+	clone_clean https://github.com/edenhill/librdkafka "$dir"
+	cd "$dir"
+	run_as_build_user git fetch --depth 1 origin tag v1.5.3
+	run_as_build_user git checkout v1.5.3
+	(
+		unset CFLAGS
+		./configure --prefix=/usr --libdir=/usr/lib --CFLAGS="-g"
+		make -j"$(nproc)"
+	)
+	make install
+	rm -f /usr/lib/librdkafka.a /usr/lib/librdkafka++.a
+	write_stamp "$stamp"
+}
+
+build_kafkacat() {
+	local stamp="kafkacat"
+	local dir="$CACHE_DIR/kafkacat"
+	if stamp_exists "$stamp"; then
+		log "kafkacat already installed"
+		return
+	fi
+	log "Building kafkacat"
+	clone_clean https://github.com/edenhill/kafkacat "$dir"
+	cd "$dir"
+	(
+		unset CFLAGS
+		./configure --prefix=/usr --CFLAGS="-g"
+		make -j"$(nproc)"
+	)
+	make install
+	write_stamp "$stamp"
+}
+
+install_python_packages() {
+	log "Installing Python helper packages"
+	python3 -m pip install pyasn1 pysnmp --break-system-packages --upgrade --no-cache-dir
+}
+
+prepare_service_dirs() {
+	log "Preparing service runtime directories"
+	mkdir -p /var/run/mysqld
+	chown mysql:mysql /var/run/mysqld
+	chmod o+rx /var/run/mysqld
+	mkdir -p /var/log/mysql
+	: > /var/log/mysql/error.log
+}
+
+extract_configure_options() {
+	awk '
+		/^ENV[[:space:]]+RSYSLOG_CONFIGURE_OPTIONS="/ {
+			in_opts=1
+			sub(/^ENV[[:space:]]+RSYSLOG_CONFIGURE_OPTIONS="/, "")
+		}
+		in_opts {
+			line=$0
+			sub(/[[:space:]]*\\$/, "", line)
+			sub(/[[:space:]]*"$/, "", line)
+			gsub(/^[[:space:]]+|[[:space:]]+$/, "", line)
+			if (line != "") {
+				printf "%s ", line
+			}
+			if ($0 ~ /"$/) {
+				exit
+			}
+		}
+	' "$DOCKERFILE"
+}
+
+verify_build() {
+	log "Verifying rsyslog build with Ubuntu 24.04 container configure options"
+	local configure_options
+	configure_options="$(extract_configure_options)"
+	printf 'Using RSYSLOG_CONFIGURE_OPTIONS:\n%s\n' "$configure_options"
+	run_as_build_user env \
+		PKG_CONFIG_PATH=/usr/local/lib/pkgconfig \
+		LD_LIBRARY_PATH=/usr/local/lib \
+		C_INCLUDE_PATH=/usr/include/tirpc/ \
+		MYSQLD_START_CMD="sudo mysqld_safe --pid-file=/var/run/mysqld/mysqld.pid" \
+		MYSQLD_STOP_CMD="sudo kill \$(sudo cat /var/run/mysqld/mysqld.pid)" \
+		ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-18/bin/llvm-symbolizer \
+		RSYSLOG_CONFIGURE_OPTIONS="$configure_options" \
+		bash -c '
+			set -euo pipefail
+			cd "$1"
+			autoreconf -fvi
+			./configure $RSYSLOG_CONFIGURE_OPTIONS
+			make -j"$(nproc)"
+		' _ "$REPO_ROOT"
+}
+
+main() {
+	require_ubuntu_2404
+	refuse_windows_mount_checkout
+	configure_git_line_endings
+	rewrite_apt_mirror "$APT_MIRROR"
+	apt_update
+	install_apt_packages
+	install_obs_packages
+	prepare_build_cache
+	build_codestyle
+	build_libfastjson
+	build_faup
+	build_libksi
+	build_librelp
+	build_qpid_proton
+	build_librdkafka
+	build_kafkacat
+	install_python_packages
+	prepare_service_dirs
+	if [ "$VERIFY_BUILD" -eq 1 ]; then
+		verify_build
+	fi
+	log "rsyslog Ubuntu 24.04 WSL development setup complete"
+}
+
+main "$@"

--- a/devtools/codex-wsl-bootstrap-prompt.md
+++ b/devtools/codex-wsl-bootstrap-prompt.md
@@ -1,0 +1,39 @@
+# Codex Prompt: Windows WSL Rsyslog Development Setup
+
+Copy this prompt into a new Codex session on a Windows machine:
+
+```text
+Set up this Windows machine for rsyslog development with Codex.
+
+Target:
+- Use Ubuntu 24.04 under WSL2.
+- Use a WSL-native checkout, not C:\git or any /mnt/c path.
+- Clone rsyslog into /home/<linux-user>/rsyslog.
+- Avoid CRLF problems: configure WSL Git with core.autocrlf=false,
+  core.eol=lf, and core.filemode=true.
+- Run the rsyslog setup tooling from the repo:
+  ./devtools/codex-setup.sh --verify-build
+
+If Ubuntu 24.04 WSL is not installed:
+- Install WSL2 and Ubuntu-24.04 first.
+- Start Ubuntu once so the Linux user is created.
+- Then continue inside that distro.
+
+If apt update times out on the default Ubuntu mirrors:
+- Retry setup with:
+  ./devtools/codex-setup.sh --apt-mirror http://de.archive.ubuntu.com/ubuntu/ --verify-build
+
+Success criteria:
+- rsyslog checkout lives under /home, not /mnt.
+- apt update succeeds.
+- setup script completes.
+- full rsyslog configure and make succeed with RSYSLOG_CONFIGURE_OPTIONS
+  from packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile.
+- Do not build from Windows-mounted paths.
+```
+
+If WSL and the checkout already exist, run this from Windows PowerShell:
+
+```powershell
+.\devtools\codex-setup-wsl.ps1 -Distro Ubuntu-24.04 -VerifyBuild
+```


### PR DESCRIPTION
## Summary

Adds WSL-focused Ubuntu 24.04 setup tooling for rsyslog development:

- expands `devtools/codex-setup.sh` into an idempotent setup script based on the Ubuntu 24.04 development container dependencies
- adds `devtools/codex-setup-wsl.ps1` as a Windows wrapper for running the setup inside WSL
- adds `devtools/codex-wsl-bootstrap-prompt.md`, a copy-paste prompt for bootstrapping new Windows machines with Codex
- documents the setup scripts and prompt file in `devtools/README.md`

The setup script configures LF-safe Git defaults inside WSL, refuses Windows-mounted checkouts by default, supports an apt mirror override for WSL mirror timeout cases, installs the package dependencies, builds source-only helper libraries, and can verify the rsyslog build with the Dockerfile `RSYSLOG_CONFIGURE_OPTIONS`.

## Validation

Ran successfully in Ubuntu-24.04 WSL using `/home/rger/rsyslog`:

- `apt-get update`
- `./devtools/codex-setup.sh`
- `./devtools/codex-setup.sh --verify-build`

The verify build extracted `RSYSLOG_CONFIGURE_OPTIONS` from `packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile`, then completed `autoreconf -fvi`, `./configure`, and `make -j$(nproc)`.

Addressed AI review feedback by replacing hardcoded `x86_64-linux-gnu` paths with `gcc -print-multiarch` and making the PowerShell wrapper derive the default repo path from the WSL distro home directory.