### PR TITLE
gitignore: ignore local Codex agent notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ plugins/impstats/remote.pb-c.h
 # Python cache artifacts
 __pycache__/
 *.py[cod]
+
+# Local machine-specific Codex notes
+AGENTS.local.md


### PR DESCRIPTION
## Summary
- Ignore `AGENTS.local.md` for machine-specific Codex notes.

## Testing
- Not run; ignore-only change.