### PR TITLE
github: scope and harden container CI

### DIFF
--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -3,9 +3,9 @@ name: container image build
 
 on:
   pull_request:
-    # Run on every PR so this workflow can be used in branch protection.
-    # The actual container build is gated below and becomes a no-op when the
-    # PR does not touch files related to the rsyslog container family.
+    paths:
+      - 'packaging/docker/rsyslog/**'
+      - '.github/workflows/container_build.yml'
   push:
     branches: [main, master]
     paths:
@@ -33,23 +33,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - name: Check for container image changes
-        id: container_changes
-        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c # v46
-        with:
-          files: |
-            packaging/docker/rsyslog/**
-            .github/workflows/container_build.yml
-
       - name: Build rsyslog container family
-        # Keep the workflow green for unrelated PRs while still exercising the
-        # full image family whenever container packaging inputs change.
         # CI intentionally uses a non-release `ci-<sha>` tag. Stable release
         # workflows must inject their own explicit release version instead.
         id: build_containers
-        if: >-
-          ${{ github.event_name == 'workflow_dispatch' ||
-          steps.container_changes.outputs.any_changed == 'true' }}
         run: |
           short_sha="$(git rev-parse --short=12 HEAD)"
           echo "short_sha=${short_sha}" >> "$GITHUB_OUTPUT"
@@ -60,11 +47,13 @@ jobs:
         # config contracts for each role without requiring external services.
         # These runs are short-lived and use representative environment values
         # for images whose entrypoint/config expects them.
-        if: >-
-          ${{ github.event_name == 'workflow_dispatch' ||
-          steps.container_changes.outputs.any_changed == 'true' }}
+        # This workflow is intentionally path-scoped because these tests
+        # validate the PPA-backed container image family, not arbitrary source
+        # changes from normal pull requests.
+        env:
+          IMAGE_TAG_SUFFIX: ${{ steps.build_containers.outputs.short_sha }}
         run: |
-          tag="ci-${{ steps.build_containers.outputs.short_sha }}"
+          tag="ci-${IMAGE_TAG_SUFFIX}"
 
           docker run --rm \
             --entrypoint id \
@@ -102,12 +91,3 @@ jobs:
             -e VESPA_PORT=8080 \
             "rsyslog/rsyslog-etl:${tag}" \
             rsyslogd -N1 -f /etc/rsyslog.conf
-
-      - name: Skip container build, no relevant changes
-        # This step is intentionally successful so the workflow can participate
-        # in branch protection without forcing container rebuilds on unrelated
-        # changes.
-        if: >-
-          ${{ github.event_name != 'workflow_dispatch' &&
-          steps.container_changes.outputs.any_changed != 'true' }}
-        run: echo "No rsyslog container image changes detected; skipping build."

--- a/packaging/docker/rsyslog/Makefile
+++ b/packaging/docker/rsyslog/Makefile
@@ -26,10 +26,13 @@ VERSION ?= $(DEFAULT_VERSION)
 PPA_CHANNEL ?= stable
 ifeq ($(PPA_CHANNEL),stable)
 RSYSLOG_APT_PPA = ppa:adiscon/v8-stable
+RSYSLOG_APT_ORIGIN = LP-PPA-adiscon-v8-stable
 else ifeq ($(PPA_CHANNEL),daily-stable)
 RSYSLOG_APT_PPA = ppa:adiscon/daily-stable
+RSYSLOG_APT_ORIGIN = LP-PPA-adiscon-daily-stable
 else
 RSYSLOG_APT_PPA =
+RSYSLOG_APT_ORIGIN =
 endif
 
 # Stable release targets derive the container tag from RSYSLOG_VERSION using
@@ -47,7 +50,8 @@ BUILD_DATE ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VCS_REF ?= $(shell git rev-parse --short=12 HEAD 2>/dev/null || echo unknown)
 OCI_BUILD_ARGS = --build-arg BUILD_DATE="$(BUILD_DATE)" \
                  --build-arg VCS_REF="$(VCS_REF)"
-PPA_BUILD_ARGS = --build-arg RSYSLOG_APT_PPA="$(RSYSLOG_APT_PPA)"
+PPA_BUILD_ARGS = --build-arg RSYSLOG_APT_PPA="$(RSYSLOG_APT_PPA)" \
+                 --build-arg RSYSLOG_APT_ORIGIN="$(RSYSLOG_APT_ORIGIN)"
 BUILDX_COMMON_ARGS = $(DOCKER_BUILD_FLAGS) \
                      --platform $(PLATFORMS) \
                      --push \

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -48,7 +48,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # Install additional rsyslog modules/packages specific to the collector's role.
 # Includes TLS support via OpenSSL (rsyslog-openssl) for secure log collection.
-RUN apt-get update && \
+RUN apt-get -o APT::Update::Error-Mode=any update && \
     apt-get install -y --no-install-recommends \
         rsyslog-elasticsearch \
         rsyslog-kafka \

--- a/packaging/docker/rsyslog/dockerlogs/Dockerfile
+++ b/packaging/docker/rsyslog/dockerlogs/Dockerfile
@@ -48,7 +48,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install the rsyslog-imdocker module.
 # This module is necessary to read logs directly from the Docker daemon's logging driver.
 # apt-get update is run to ensure the package lists are fresh before installing.
-RUN apt-get update && \
+RUN apt-get -o APT::Update::Error-Mode=any update && \
     apt-get install -y --no-install-recommends rsyslog-imdocker && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/packaging/docker/rsyslog/etl/Dockerfile
+++ b/packaging/docker/rsyslog/etl/Dockerfile
@@ -47,7 +47,7 @@ LABEL org.opencontainers.image.revision="${VCS_REF}"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install additional rsyslog modules/packages specific to the collector's role.
-RUN apt-get update && \
+RUN apt-get -o APT::Update::Error-Mode=any update && \
     apt-get install -y --no-install-recommends \
         rsyslog-elasticsearch \
         rsyslog-omhttp \

--- a/packaging/docker/rsyslog/minimal/Dockerfile
+++ b/packaging/docker/rsyslog/minimal/Dockerfile
@@ -6,6 +6,7 @@
 ARG UBUNTU_VERSION="24.04"
 ARG RSYSLOG_IMG_VERSION="unset" # New ARG to pick up version from Makefile
 ARG RSYSLOG_APT_PPA="ppa:adiscon/v8-stable"
+ARG RSYSLOG_APT_ORIGIN="LP-PPA-adiscon-v8-stable"
 ARG BUILD_DATE="unknown"
 ARG VCS_REF="unknown"
 
@@ -15,6 +16,7 @@ FROM ubuntu:${UBUNTU_VERSION}
 ARG UBUNTU_VERSION
 ARG RSYSLOG_IMG_VERSION
 ARG RSYSLOG_APT_PPA
+ARG RSYSLOG_APT_ORIGIN
 ARG BUILD_DATE
 ARG VCS_REF
 
@@ -48,7 +50,16 @@ RUN apt-get update && \
         software-properties-common \
         ca-certificates \
     && add-apt-repository -y "${RSYSLOG_APT_PPA}" \
-    && apt-get update && \
+    && printf '%s\n' \
+        'Package: rsyslog*' \
+        "Pin: release o=${RSYSLOG_APT_ORIGIN}" \
+        'Pin-Priority: 1001' \
+        '' \
+        'Package: rsyslog*' \
+        'Pin: release o=Ubuntu' \
+        'Pin-Priority: -1' \
+        > /etc/apt/preferences.d/rsyslog-adiscon \
+    && apt-get -o APT::Update::Error-Mode=any update && \
     apt-get install -y --no-install-recommends tzdata rsyslog rsyslog-omstdout \
     && apt-get purge -y --auto-remove software-properties-common \
     && apt-get autoremove -y \

--- a/packaging/docker/rsyslog/standard/Dockerfile
+++ b/packaging/docker/rsyslog/standard/Dockerfile
@@ -48,7 +48,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # - rsyslog-imhttp: For the built-in HTTP server (health, metrics, potential future ingestion).
 # - rsyslog-omhttp: For forwarding logs via HTTP.
 # apt-get update is run to ensure the package lists are fresh before installing.
-RUN apt-get update && \
+RUN apt-get -o APT::Update::Error-Mode=any update && \
     apt-get install -y --no-install-recommends tzdata rsyslog-imhttp rsyslog-omhttp && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
## Summary
- run container image CI only for container packaging/workflow changes or manual dispatch
- document at the smoke test why this validates PPA-backed container images, not arbitrary PRs
- keep the zizmor shell-template fix by passing the image tag suffix via env
- pin rsyslog packages in the image family to the selected Adiscon PPA origin and hard-fail PPA update errors

## Validation
- actionlint .github/workflows/container_build.yml
- /home/rger/proj/.codex-tools/zizmor-venv/bin/zizmor --format=json .github/workflows
- git diff --check

## CI note
The previous build_containers failure exposed a real issue: apt could continue after a PPA refresh warning and then consider Ubuntu archive rsyslog modules against a PPA-installed core package. This patch makes that fail before any mixed package set can be installed.