### PR TITLE
imtcp: wait for mbedtls diagnostics in tests

### DIFF
--- a/tests/imtcp-tls-mbedtls-error-ca.sh
+++ b/tests/imtcp-tls-mbedtls-error-ca.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
-export NUMMESSAGES=10
+export NUMMESSAGES=3
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca-fail.pem'"
@@ -25,6 +25,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 # Begin actual testcase
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
+content_check "nsd mbedtls: error parsing crypto config"
 exit_test

--- a/tests/imtcp-tls-mbedtls-error-cert.sh
+++ b/tests/imtcp-tls-mbedtls-error-cert.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
-export NUMMESSAGES=10
+export NUMMESSAGES=3
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -22,6 +22,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 # Begin actual testcase
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
+content_check "nsd mbedtls: error parsing crypto config"
 exit_test

--- a/tests/imtcp-tls-mbedtls-error-key.sh
+++ b/tests/imtcp-tls-mbedtls-error-key.sh
@@ -2,9 +2,9 @@
 # check error message on cert as key file
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
-export NUMMESSAGES=10
+export NUMMESSAGES=3
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -23,6 +23,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 # Begin actual testcase
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
+content_check "nsd mbedtls: error parsing crypto config"
 exit_test

--- a/tests/imtcp-tls-mbedtls-error-key2.sh
+++ b/tests/imtcp-tls-mbedtls-error-key2.sh
@@ -2,9 +2,9 @@
 # added 2018-11-07 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
-export NUMMESSAGES=10
+export NUMMESSAGES=3
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -23,6 +23,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 # Begin actual testcase
 startup
 tcpflood --check-only -p$TCPFLOOD_PORT -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
 wait_shutdown
-content_check "nsd mbedtls: error parsing crypto config" "${RSYSLOG_DYNNAME}.rsyslog.log"
+content_check "nsd mbedtls: error parsing crypto config"
 exit_test

--- a/tests/imtcp-tls-mbedtls-x509fingerprint-invld.sh
+++ b/tests/imtcp-tls-mbedtls-x509fingerprint-invld.sh
@@ -3,9 +3,9 @@
 # check for INVALID fingerprint!
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
-export NUMMESSAGES=10000
+export NUMMESSAGES=3
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
@@ -29,6 +29,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 tcpflood --check-only -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
 wait_shutdown
-content_check --regex "peer fingerprint .* unknown" "${RSYSLOG_DYNNAME}.rsyslog.log"
+content_check --regex "peer fingerprint .* unknown"
 exit_test

--- a/tests/imtcp-tls-mbedtls-x509invalid.sh
+++ b/tests/imtcp-tls-mbedtls-x509invalid.sh
@@ -2,9 +2,9 @@
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released  under GPLv3
 . ${srcdir:=.}/diag.sh init
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
-export NUMMESSAGES=10000
+export NUMMESSAGES=3
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 generate_conf
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'" # wrong CA
@@ -23,6 +23,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 # Begin actual testcase
 startup
 tcpflood --check-only -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
 wait_shutdown
-content_check "X509 - Certificate verification failed" "${RSYSLOG_DYNNAME}.rsyslog.log"
+content_check "X509 - Certificate verification failed"
 exit_test

--- a/tests/imtcp-tls-mbedtls-x509name_invalid.sh
+++ b/tests/imtcp-tls-mbedtls-x509name_invalid.sh
@@ -2,9 +2,9 @@
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
-export NUMMESSAGES=10000
+export NUMMESSAGES=3
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
@@ -26,6 +26,7 @@ action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 tcpflood --check-only -p'$TCPFLOOD_PORT' -m$NUMMESSAGES -Ttls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem
+shutdown_when_empty
 wait_shutdown
-content_check "peer name not authorized" "${RSYSLOG_DYNNAME}.rsyslog.log"
+content_check "peer name not authorized"
 exit_test


### PR DESCRIPTION
## Summary

This replaces the temporary PR 6798 process-output capture with the proper test synchronization. The affected mbedtls negative tests now wait until rsyslog internal diagnostics reach the configured omfile output before shutting rsyslogd down.

## Root cause

The diagnostics in these tests are emitted through `LogMsg`/`LogError`, enter the internal rsyslog message path, and are intended to reach working omfile actions in testbench mode. On slow or loaded systems the tests could terminate rsyslogd before that internal diagnostic line was written to `$RSYSLOG_OUT_LOG`. Capturing stderr with `RS_REDIR` avoided the symptom, but it no longer checked the user-visible omfile/internal-message path.

## Changes

- Remove the temporary `RS_REDIR` capture from seven mbedtls negative tests.
- Keep each test's existing tcpflood `NUMMESSAGES` value unchanged.
- Add a local `QUEUE_EMPTY_CHECK_FUNC` that waits for at least one line in `$RSYSLOG_OUT_LOG` via `wait_file_lines`.
- Use `shutdown_when_empty` before `wait_shutdown`.
- Restore `content_check` assertions to the default `$RSYSLOG_OUT_LOG`.

## Validation

- `make -j24 check TESTS=""`
- Direct runs of all seven affected mbedtls negative tests
- `make -j24 check TESTS="imtcp-tls-mbedtls-error-cert.sh imtcp-tls-mbedtls-error-ca.sh imtcp-tls-mbedtls-error-key.sh imtcp-tls-mbedtls-error-key2.sh imtcp-tls-mbedtls-x509invalid.sh imtcp-tls-mbedtls-x509fingerprint-invld.sh imtcp-tls-mbedtls-x509name_invalid.sh"` with `TOTAL: 7`, `PASS: 7`

Negative-control proof: temporarily changed one expected diagnostic string in `imtcp-tls-mbedtls-error-ca.sh`; the test failed while `$RSYSLOG_OUT_LOG` contained the real `nsd mbedtls: error parsing crypto config` diagnostic. The temporary break was reverted before commit.