### PR TITLE
ratelimit: preserve severity sentinel on s390x

### DIFF
--- a/runtime/ratelimit.c
+++ b/runtime/ratelimit.c
@@ -82,12 +82,12 @@ static inline void ratelimitSharedStoreUInt(unsigned int *value, pthread_mutex_t
 #endif
 }
 
-static inline intTiny ratelimitSharedLoadSeverity(const intTiny *value, pthread_mutex_t *mut) {
+static inline int ratelimitSharedLoadSeverity(const int *value, pthread_mutex_t *mut) {
 #ifdef HAVE_ATOMIC_BUILTINS
     (void)mut;
     return __atomic_load_n(value, __ATOMIC_RELAXED);
 #else
-    intTiny snapshot;
+    int snapshot;
     pthread_mutex_lock(mut);
     snapshot = *value;
     pthread_mutex_unlock(mut);
@@ -95,7 +95,7 @@ static inline intTiny ratelimitSharedLoadSeverity(const intTiny *value, pthread_
 #endif
 }
 
-static inline void ratelimitSharedStoreSeverity(intTiny *value, pthread_mutex_t *mut, intTiny newval) {
+static inline void ratelimitSharedStoreSeverity(int *value, pthread_mutex_t *mut, int newval) {
 #ifdef HAVE_ATOMIC_BUILTINS
     (void)mut;
     __atomic_store_n(value, newval, __ATOMIC_RELAXED);
@@ -424,7 +424,7 @@ static rsRetVal parsePolicyFile(const char *policy_file
                                 ,
                                 unsigned int *interval,
                                 unsigned int *burst,
-                                intTiny *severity
+                                int *severity
 #endif
 ) {
     DEFiRet;
@@ -477,10 +477,12 @@ static rsRetVal parsePolicyFile(const char *policy_file
                         long val = 0;
                         if (!strcmp(curr_key, "interval") || !strcmp(curr_key, "burst") ||
                             !strcmp(curr_key, "severity")) {
+                            const int is_severity = !strcmp(curr_key, "severity");
                             val = strtol((char *)token.data.scalar.value, &endptr, 10);
+                            const int out_of_range =
+                                is_severity ? (val < -1 || val > 127) : (val < 0 || (unsigned long)val > UINT_MAX);
                             if ((errno == ERANGE && (val == LONG_MAX || val == LONG_MIN)) || (errno != 0 && val == 0) ||
-                                endptr == (char *)token.data.scalar.value || *endptr != '\0' || val < 0 ||
-                                val > UINT_MAX) {
+                                endptr == (char *)token.data.scalar.value || *endptr != '\0' || out_of_range) {
                                 LogError(0, RS_RET_CONF_PARAM_INVLD, "ratelimit: invalid integer value for '%s': %s",
                                          curr_key, (char *)token.data.scalar.value);
                                 /* ignore invalid values, keep parsing */
@@ -495,7 +497,7 @@ static rsRetVal parsePolicyFile(const char *policy_file
                                                  "ratelimit: severity value %ld out of range (max 127) in %s", val,
                                                  policy_file);
                                     } else {
-                                        *severity = (intTiny)val;
+                                        *severity = (int)val;
                                     }
                                 }
                             }
@@ -965,7 +967,7 @@ static void ratelimitSwapPerSourcePolicy(ratelimit_shared_t *shared, ratelimit_p
 static rsRetVal ratelimitReloadPolicyFile(ratelimit_shared_t *shared, const char *trigger) {
     unsigned int interval;
     unsigned int burst;
-    intTiny severity;
+    int severity;
     DEFiRet;
 
     if (shared == NULL || shared->policy_file == NULL) {
@@ -1139,7 +1141,7 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
                             const char *name,
                             unsigned int interval,
                             unsigned int burst,
-                            intTiny severity,
+                            int severity,
                             const char *policy_file,
                             sbool policy_watch,
                             const char *policy_watch_debounce,
@@ -1522,7 +1524,7 @@ rsRetVal ATTR_NONNULL(1, 2, 3)
     rsRetVal localRet;
     int severity = 0;
     unsigned int interval;
-    intTiny threshold;
+    int threshold;
 
     assert(ratelimit != NULL);
     assert(pMsg != NULL);
@@ -1735,7 +1737,7 @@ void ratelimitSetNoTimeCache(ratelimit_t *ratelimit) {
 /* Severity level determines which messages are subject to
  * ratelimiting. Default (no value set) is all messages.
  */
-void ratelimitSetSeverity(ratelimit_t *ratelimit, intTiny severity) {
+void ratelimitSetSeverity(ratelimit_t *ratelimit, int severity) {
     ratelimitSharedStoreSeverity(&ratelimit->pShared->severity, &ratelimit->pShared->mut, severity);
 }
 

--- a/runtime/ratelimit.h
+++ b/runtime/ratelimit.h
@@ -35,7 +35,7 @@ typedef struct ratelimit_shared_s {
     char *name;
     unsigned int interval;
     unsigned int burst;
-    intTiny severity;
+    int severity;
     char *policy_file;
     sbool policy_watch;
     unsigned int policy_watch_debounce_ms;
@@ -102,7 +102,7 @@ rsRetVal ratelimitAddConfig(rsconf_t *conf,
                             const char *name,
                             unsigned int interval,
                             unsigned int burst,
-                            intTiny severity,
+                            int severity,
                             const char *policy_file,
                             sbool policy_watch,
                             const char *policy_watch_debounce,
@@ -116,7 +116,7 @@ void ratelimit_cfgsDestruct(ratelimit_cfgs_t *cfgs);
 void ratelimitSetThreadSafe(ratelimit_t *ratelimit);
 void ratelimitSetLinuxLike(ratelimit_t *ratelimit, unsigned int interval, unsigned int burst);
 void ratelimitSetNoTimeCache(ratelimit_t *ratelimit);
-void ratelimitSetSeverity(ratelimit_t *ratelimit, intTiny severity);
+void ratelimitSetSeverity(ratelimit_t *ratelimit, int severity);
 rsRetVal ratelimitMsgCount(ratelimit_t *ratelimit, time_t tt, const char *const appname);
 rsRetVal ATTR_NONNULL(1, 2, 3) ratelimitMsg(ratelimit_t *ratelimit, smsg_t *pMsg, smsg_t **ppRep);
 rsRetVal ATTR_NONNULL(1, 3) ratelimitAddMsg(ratelimit_t *ratelimit, multi_submit_t *pMultiSub, smsg_t *pMsg);

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -555,8 +555,8 @@ static rsRetVal initFunc_ratelimit(struct cnfobj *o) {
         ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
     }
 
-    CHKiRet(ratelimitAddConfig(loadConf, (char *)name, (unsigned)interval, (unsigned)burst, (intTiny)severity,
-                               (char *)policy, policy_watch, (char *)policy_watch_debounce, per_source_enabled,
+    CHKiRet(ratelimitAddConfig(loadConf, (char *)name, (unsigned)interval, (unsigned)burst, severity, (char *)policy,
+                               policy_watch, (char *)policy_watch_debounce, per_source_enabled,
                                (char *)per_source_policy, (char *)per_source_key_tpl, (unsigned)per_source_max_states,
                                (unsigned)per_source_topn));
 


### PR DESCRIPTION
## Summary

Fix named ratelimits on unsigned-char architectures, especially s390x.

Named ratelimits use `severity=-1` as the default sentinel for all messages. The shared named-ratelimit config stored severity in `intTiny`, which is `char`-sized. On s390x, plain `char` is unsigned, so `-1` became `255`; normal syslog severities `0..7` never matched the threshold and no rate limiting occurred.

This PR:

- stores shared ratelimit severity as `int` instead of `intTiny`
- keeps `ratelimitAddConfig()` and `ratelimitSetSeverity()` using `int`
- removes the `intTiny` cast from the `ratelimit()` config handoff
- allows policy-file `severity: -1` while keeping `interval` and `burst` nonnegative
- validates policy-file severity and interval/burst ranges separately, avoiding a lossy `(long)UINT_MAX` cast that broke Solaris x64

## Root Cause

The primary bug is signedness-sensitive storage of the `-1` severity sentinel. On s390x, storing the sentinel in `intTiny` converts it to `255`, so rate limiting configured with the default severity never applies to normal messages.

A follow-up CI issue during review exposed a second root cause in the first amendment: the policy parser used `(long)UINT_MAX` as the interval/burst maximum. On the Solaris buildbot ABI, that cast cannot represent `UINT_MAX`, so valid values like `interval: 1` and `burst: 1000` were rejected. The parser now checks severity and unsigned interval/burst ranges separately.

## Validation

Current-main s390x proof reproduced the issue before the fix:

- `imudp_ratelimit_name.sh`: received 20/20 messages
- `ratelimit_name.sh`: received 40/40 messages
- `imrelp_ratelimit_name.sh`: received 20/20 messages

Fixed branch validation:

- `bash devtools/format-code.sh`
- `git diff --check`
- `make -j$(nproc) check TESTS=""`
- `./tests/ratelimit_hup.sh`
- `./tests/imudp_ratelimit_name.sh`
- `./tests/ratelimit_name.sh`
- `./tests/imrelp_ratelimit_name.sh`
- s390x QEMU `make -j2 check TESTS=""`
- s390x QEMU `./tests/imudp_ratelimit_name.sh`
- s390x QEMU `./tests/ratelimit_name.sh`
- s390x QEMU `./tests/imrelp_ratelimit_name.sh`
- temporary native `ratelimit_hup.sh` variant with policy-file `severity: -1`

See also https://github.com/rsyslog/rsyslog/issues/6666