### PR TITLE
ci: broaden s390x PR check profile

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1792,7 +1792,52 @@ jobs:
               export CC=gcc
               export TEST_MAX_RUNTIME=1200
               autoreconf -fvi
-              if [ "$ARCH" = "armhf" ] || [ "$ARCH" = "s390x" ]; then
+              if [ "$ARCH" = "s390x" ]; then
+                apt-get update
+                apt-get install -y --no-install-recommends \
+                  curl liblognorm-dev libmaxminddb-dev libsnmp-dev \
+                  libssl-dev libsystemd-dev libyaml-dev libzstd-dev openssl
+                rm -rf /var/lib/apt/lists/*
+                useradd --create-home rsyslogci
+                chown -R rsyslogci:rsyslogci /rsyslog
+                su rsyslogci -c "./configure --enable-silent-rules \
+                  --enable-testbench --disable-extended-tests \
+                  --enable-imdiag --disable-imdocker \
+                  --enable-imfile --enable-imfile-tests \
+                  --enable-impstats --enable-imptcp \
+                  --enable-mmanon --enable-mmaudit \
+                  --enable-mmcount --enable-mmdblookup \
+                  --enable-mmfields --enable-mmjsonparse \
+                  --enable-mmnormalize --enable-mmpstrucdata \
+                  --enable-mmrm1stspace --enable-mmsequence \
+                  --enable-mmsnmptrapd --enable-mmutf8fix \
+                  --enable-mail \
+                  --disable-omhttp --enable-omjournal \
+                  --enable-omprog --enable-omruleset \
+                  --enable-omstdout --enable-omuxsock \
+                  --enable-pmaixforwardedfrom --enable-pmciscoios \
+                  --enable-pmcisconames --enable-pmlastmsg \
+                  --enable-pmnull --enable-pmsnare \
+                  --enable-gnutls --enable-openssl \
+                  --enable-relp --enable-snmp \
+                  --enable-usertools --enable-imdtls --enable-omdtls \
+                  --enable-imjournal \
+                  --enable-fmhash --enable-libzstd \
+                  --enable-klog --enable-kmsg \
+                  --enable-libsystemd=yes \
+                  --disable-libgcrypt --disable-liblogging-stdlog \
+                  --disable-fmhttp --disable-mysql \
+                  --disable-valgrind --without-valgrind-testbench \
+                  --disable-helgrind --disable-mmkubernetes \
+                  --disable-omkafka --disable-imkafka \
+                  --disable-ommongodb --disable-omrabbitmq \
+                  --disable-mmdarwin \
+                  --disable-root-tests \
+                  --disable-elasticsearch-tests \
+                  --disable-kafka-tests --disable-snmp-tests \
+                  --disable-journal-tests"
+                su rsyslogci -c "grep -q \"^#define HAVE_LIBYAML 1\" config.h"
+              elif [ "$ARCH" = "armhf" ]; then
                 ./configure --enable-silent-rules --enable-testbench \
                   --enable-imdiag --disable-imdocker --enable-imfile \
                   --disable-default-tests --disable-impstats \
@@ -1851,8 +1896,29 @@ jobs:
                   --disable-elasticsearch-tests \
                   --disable-kafka-tests --disable-snmp-tests
               fi
-              make -j8
-              make -j3 check
+              if [ "$ARCH" = "s390x" ]; then
+                S390X_TESTS="runtime_unit_linkedlist runtime_unit_stringbuf \
+                  yaml-basic.sh yaml-script-call.sh yaml-ratelimit-policywatch.sh \
+                  imudp_ratelimit_name.sh ratelimit_name.sh imrelp_ratelimit_name.sh \
+                  imtcp-basic.sh imtcp-starvation-1.sh \
+                  imtcp_framing_regex_maxmsg_overflow.sh imtcp-impstats.sh \
+                  imptcp_framing_regex.sh imptcp-connection-msg-received.sh \
+                  diskqueue-truncated-segment-startup.sh \
+                  diskqueue-oncorruption-missing-segment.sh \
+                  sndrcv_tls_anon_rebind.sh sndrcv_tls_certvalid_action_level.sh \
+                  sndrcv_tls_ossl_certvalid_action_level.sh \
+                  sndrcv_tls_ossl_anon_rebind.sh \
+                  sndrcv_relp.sh sndrcv_relp_tls_certvalid.sh \
+                  imdtls-basic.sh sndrcv_dtls_certvalid.sh \
+                  imfile-basic.sh imfile-logrotate.sh \
+                  mmjsonparse_simple.sh mmnormalize_variable.sh mmpstrucdata.sh \
+                  omprog-feedback.sh omprog-feedback-timeout.sh \
+                  uxsock_simple.sh"
+                su rsyslogci -c "make -j8 && timeout 40m make -j2 check TESTS=\"$S390X_TESTS\""
+              else
+                make -j8
+                make -j3 check
+              fi
             '
 
       - name: Collect test logs


### PR DESCRIPTION
## Summary

This PR makes the s390x QEMU PR lane use a dedicated Debian-overlap profile instead of sharing the reduced armhf configure set.

The new s390x profile keeps the PR lane core-focused and bounded:

- enables broader Debian-relevant module coverage, including imtcp, imptcp, imfile tests, imjournal build coverage, RELP, TLS/DTLS, parser/mm modules, omprog, omuxsock, omjournal, libzstd, and YAML support
- installs the s390x dependencies needed by that profile, including `libyaml-dev`, `curl`, and `openssl`
- verifies YAML support explicitly via `HAVE_LIBYAML`
- runs configure/build/check as a non-root user inside the container, closer to Debian buildd behavior and avoiding root-only permission artifacts
- disables extended, root, journal, and external-heavy test groups for PR runtime stability
- runs a curated `TESTS=` list instead of the whole default suite
- caps s390x `make -j2 check` at 40 minutes
- leaves armhf and arm64 behavior unchanged

## Rationale

The previous s390x lane was too small to catch architecture-sensitive failures that Debian-like builders expose, especially the named ratelimit class. A full Debian-like default test profile was tested in CI and proved too slow for PR feedback: the 40 minute check cap expired while the run was still in the TLS section.

This PR keeps the useful s390x/core coverage while selecting a smaller, solid test set for PR latency.

## Test selection

The curated s390x test list covers:

- runtime unit smoke tests
- YAML config and ratelimit policy watch coverage
- named ratelimit tests for UDP, TCP/imptcp, and RELP
- imtcp/imptcp startup, framing, starvation, and connection-message behavior
- diskqueue corruption recovery checks
- GnuTLS, OpenSSL, RELP TLS, and DTLS smoke checks
- imfile basics and logrotate
- mmjsonparse, mmnormalize, and mmpstrucdata
- omprog feedback and timeout behavior
- uxsock basic behavior

## Validation

Static validation in the dedicated worktree:

- workflow YAML parsed successfully
- embedded Docker shell block passed `bash -n`
- `git diff --check` passed
- all curated `TESTS=` entries exist in `tests/` or are built unit-test binaries

CI validation history:

- the first expanded run confirmed the broader s390x profile builds and catches the named-ratelimit class
- after PR #6806 merged, this branch was rebased onto the ratelimit fix
- the profile was then reduced to the curated `TESTS=` set so the PR lane can finish inside the target runtime budget