### PR TITLE
ci: allow Debian maintainer patch skips

### DIFF
--- a/.github/debian-ci-policy.yml
+++ b/.github/debian-ci-policy.yml
@@ -7,6 +7,14 @@
     {
       "patch": "imfile-preserve-symlink-cleanup-notifications-with-deferr.patch",
       "reason": "Debian latest still carries an imfile patch that is already effectively upstream and now applies in reverse."
+    },
+    {
+      "patch": "ratelimit-preserve-severity-sentinel-on-s390x.patch",
+      "reason": "Debian latest carries an s390x ratelimit severity-sentinel patch that is already effectively upstream and now applies in reverse."
+    },
+    {
+      "patch": "queue-quarantine-runtime-disk-corruption-safely.patch",
+      "reason": "Debian latest carries a queue disk-corruption quarantine patch that is already effectively upstream and now applies in reverse."
     }
   ],
   "supplemental_build_deps": [],


### PR DESCRIPTION
## Summary

Debian experimental currently fails before the package build because Debian latest carries maintainer patches that no longer apply to upstream.

The following Debian patches can be reverse-applied, which indicates the changes are already effectively present upstream:

- `ratelimit-preserve-severity-sentinel-on-s390x.patch`
- `queue-quarantine-runtime-disk-corruption-safely.patch`

This PR records both patches in the existing Debian CI policy so the gate excludes these known redundant maintainer patches while continuing to fail on unexpected Debian patch drift.

## Validation

- `python3 -m json.tool .github/debian-ci-policy.yml >/dev/null`
- `.github/scripts/debian_package_build.sh load_policy .github/debian-ci-policy.yml <tmpdir>`
- Confirmed both patch names and reasons are emitted by the policy loader
- `git diff --check`
- PR CI: Debian experimental gate passes after adding both policy skips