### PR TITLE
python: close script file handles

### DIFF
--- a/plugins/external/skeletons/python/plugin-with-feedback.py
+++ b/plugins/external/skeletons/python/plugin-with-feedback.py
@@ -115,7 +115,9 @@ def onExit():
     # For illustrative purposes, this plugin skeleton appends the received logs
     # to a file. When implementing your plugin, remove the following code.
     global outfile
-    outfile.close()
+    if outfile is not None:
+        outfile.close()
+        outfile = None
 
 
 """

--- a/plugins/external/solr/rsyslog_solr.py
+++ b/plugins/external/solr/rsyslog_solr.py
@@ -36,19 +36,21 @@ pollPeriod = 0.75 # the number of seconds between polling for new messages
 maxAtOnce = 5000  # max nbr of messages that are processed within one batch
 retryInterval = 5
 numberOfRetries = 10
-errorFile = open("/var/log/rsyslog_solr_oopsies.log", "a")
+errorFile = None
 
 # App logic global variables
 solrServer = "localhost"
 solrPort = 8983
 solrUpdatePath = "/solr/gettingstarted/update"
-solrConnection = "" # HTTP connection to solr
+solrConnection = None # HTTP connection to solr
 
 def onInit():
     """ Do everything that is needed to initialize processing (e.g.
         open files, create handles, connect to systems...)
     """
     global solrConnection
+    global errorFile
+    errorFile = open("/var/log/rsyslog_solr_oopsies.log", "a")
     solrConnection = httplib.HTTPConnection(solrServer, solrPort)
     
 
@@ -73,39 +75,48 @@ def onExit():
         close files, handles, disconnect from systems...). This is
         being called immediately before exiting.
     """
-    solrConnection.close()
-    errorFile.close()
+    global solrConnection
+    global errorFile
+    if solrConnection is not None:
+        solrConnection.close()
+        solrConnection = None
+    if errorFile is not None:
+        errorFile.close()
+        errorFile = None
 
-onInit()
-keepRunning = 1
-while keepRunning == 1:
-    while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
-        msgs = "["
-        msgsInBatch = 0
-        while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
-            line = sys.stdin.readline()
-            if line:
-                # append the JSON array used by Solr for updates
-                msgs += line
-                msgs += ","
-            else: # an empty line means stdin has been closed
-                keepRunning = 0
-            msgsInBatch = msgsInBatch + 1
-            if msgsInBatch >= maxAtOnce:
-                break
-        if len(msgs) > 0:
-            retries = 0
-            while (retries < numberOfRetries):
-                try:
-                    # close the JSON array used by Solr for updates
-                    onReceive(msgs[:-1] + "]")
+try:
+    onInit()
+    keepRunning = 1
+    while keepRunning == 1:
+        while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
+            msgs = "["
+            msgsInBatch = 0
+            while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
+                line = sys.stdin.readline()
+                if line:
+                    # append the JSON array used by Solr for updates
+                    msgs += line
+                    msgs += ","
+                else: # an empty line means stdin has been closed
+                    keepRunning = 0
                     break
-                except socket.error:
-                    # retry if connection failed; it will crash with flames on other exceptions, and you will lose data. But this is something you'd normally see when you first set things up
-                    time.sleep(retryInterval)
-                retries += 1
-            # if we failed, we write the failed batch to the error file
-            if (retries == numberOfRetries):
-                errorFile.write("%s\n" % msgs)
-            sys.stdout.flush() # very important, Python buffers far too much!
-onExit()
+                msgsInBatch = msgsInBatch + 1
+                if msgsInBatch >= maxAtOnce:
+                    break
+            if msgsInBatch > 0:
+                retries = 0
+                while (retries < numberOfRetries):
+                    try:
+                        # close the JSON array used by Solr for updates
+                        onReceive(msgs[:-1] + "]")
+                        break
+                    except socket.error:
+                        # retry if connection failed; it will crash with flames on other exceptions, and you will lose data. But this is something you'd normally see when you first set things up
+                        time.sleep(retryInterval)
+                    retries += 1
+                # if we failed, we write the failed batch to the error file
+                if (retries == numberOfRetries):
+                    errorFile.write("%s\n" % msgs)
+                sys.stdout.flush() # very important, Python buffers far too much!
+finally:
+    onExit()

--- a/plugins/external/spm/rsyslog_spm_custom_metrics.py
+++ b/plugins/external/spm/rsyslog_spm_custom_metrics.py
@@ -31,12 +31,12 @@ pollPeriod = 0.75  # the number of seconds between polling for new messages
 maxAtOnce = 5000  # max nbr of messages that are processed within one batch
 retryInterval = 5
 numberOfRetries = 10
-errorFile = open("/var/log/rsyslog_spm_oopsies.log", "a")
+errorFile = None
 
 # App logic global variables
 spmHost = "spm-receiver.sematext.com"
 spmPort = 80
-spmConnection = ""  # HTTP connection to SPM
+spmConnection = None  # HTTP connection to SPM
 spmToken = "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
 spmPath = "/receiver/custom/receive.json?token=" + spmToken
 
@@ -46,6 +46,8 @@ def onInit():
         open files, create handles, connect to systems...)
     """
     global spmConnection
+    global errorFile
+    errorFile = open("/var/log/rsyslog_spm_oopsies.log", "a")
     spmConnection = httplib.HTTPConnection(spmHost, spmPort)
 
 
@@ -72,42 +74,51 @@ def onExit():
         close files, handles, disconnect from systems...). This is
         being called immediately before exiting.
     """
-    spmConnection.close()
-    errorFile.close()
+    global spmConnection
+    global errorFile
+    if spmConnection is not None:
+        spmConnection.close()
+        spmConnection = None
+    if errorFile is not None:
+        errorFile.close()
+        errorFile = None
 
 
-onInit()
-keepRunning = 1
-while keepRunning == 1:
-    while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
-        msgs = "{ \"datapoints\" : ["
-        msgsInBatch = 0
-        while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
-            line = sys.stdin.readline()
-            if line:
-                # append the JSON array that we'll send later to SPM
-                msgs += line
-                msgs += ","
-            else:  # an empty line means stdin has been closed
-                keepRunning = 0
-            msgsInBatch = msgsInBatch + 1
-            if msgsInBatch >= maxAtOnce:
-                break
-        if len(msgs) > 0:
-            retries = 0
-            while (retries < numberOfRetries):
-                try:
-                    # close the JSON array
-                    onReceive(msgs[:-1] + "]}")
+try:
+    onInit()
+    keepRunning = 1
+    while keepRunning == 1:
+        while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
+            msgs = "{ \"datapoints\" : ["
+            msgsInBatch = 0
+            while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
+                line = sys.stdin.readline()
+                if line:
+                    # append the JSON array that we'll send later to SPM
+                    msgs += line
+                    msgs += ","
+                else:  # an empty line means stdin has been closed
+                    keepRunning = 0
                     break
-                except socket.error:
-                    # retry if connection failed;
-                    # it will crash with flames on other exceptions, and you will lose data.
-                    # But this is something you'd normally see when you first set things up
-                    time.sleep(retryInterval)
-                retries += 1
-            # if we failed, we write the failed batch to the error file
-            if (retries == numberOfRetries):
-                errorFile.write("%s\n" % msgs)
-            sys.stdout.flush()  # very important, Python buffers far too much!
-onExit()
+                msgsInBatch = msgsInBatch + 1
+                if msgsInBatch >= maxAtOnce:
+                    break
+            if msgsInBatch > 0:
+                retries = 0
+                while (retries < numberOfRetries):
+                    try:
+                        # close the JSON array
+                        onReceive(msgs[:-1] + "]}")
+                        break
+                    except socket.error:
+                        # retry if connection failed;
+                        # it will crash with flames on other exceptions, and you will lose data.
+                        # But this is something you'd normally see when you first set things up
+                        time.sleep(retryInterval)
+                    retries += 1
+                # if we failed, we write the failed batch to the error file
+                if (retries == numberOfRetries):
+                    errorFile.write("%s\n" % msgs)
+                sys.stdout.flush()  # very important, Python buffers far too much!
+finally:
+    onExit()

--- a/plugins/impstats/statslog-analyzer.py
+++ b/plugins/impstats/statslog-analyzer.py
@@ -41,8 +41,12 @@ LN_HOST = 1
 LN_LINENUM = 2
 LN_DATA = 3
 
-# Open Errorlog on init
-errorlog = open(szTmpDir + "statslog-analyzer.corrupted.log", 'w')
+szErrorLog = szTmpDir + "statslog-analyzer.corrupted.log"
+errorlog = None
+
+
+def writeErrorLog(message):
+    errorlog.write(message)
 
 # Process Arguments
 for arg in sys.argv: # [-4:]:
@@ -77,142 +81,144 @@ else:
     print " Start sorting impstats file ... "
     if bDebugOutput:
         print ": '" + szInput+ "'"
-    
+
+    # Open Errorlog on init
+    errorlog = open(szErrorLog, 'w')
+
     # Open inout file
-    inputfile = open(szInput, 'r')
-    for line in inputfile.readlines():
-#       if line.find("rsyslogd-pstats") != -1:
+    try:
+        with open(szInput, 'r') as inputfile:
+            for line in inputfile:
+        #       if line.find("rsyslogd-pstats") != -1:
 
-        # Init variables
-        aFields = []
-        aData = {}
-        aDataCsv = []
-        iLogRegExIndex = 0
-        bLogProcessed = False
+                # Init variables
+                aFields = []
+                aData = {}
+                aDataCsv = []
+                iLogRegExIndex = 0
+                bLogProcessed = False
 
-        # Loop through Regex parsers
-        for loglineregex in loglineregexes:
-            # Parse IMPStats Line!
-            result = loglineregex.split(line)
-            
-            # Found valid logline, save into file!
-            if len(result) >= loglineindexes[iLogRegExIndex]["LN_LOGDATA"]:
-                # Get/Set SyslogTag
-                if loglineindexes[iLogRegExIndex]["LN_SYSLOGTAG"] == -1:
-                    szLogSyslogTag = "rsyslogd-pstats" # Set to "rsyslogd-pstats" if no SyslogTag is available
-                else:
-                    szLogSyslogTag = result[ loglineindexes[iLogRegExIndex]["LN_SYSLOGTAG"] ]
+                # Loop through Regex parsers
+                for loglineregex in loglineregexes:
+                    # Parse IMPStats Line!
+                    result = loglineregex.split(line)
 
-                # Get/Set SyslogTag
-                if loglineindexes[iLogRegExIndex]["LN_HOST"] == -1:
-                    szLogHost = "localhost" # Set default to "localhost" if no host is available
-                else:
-                    szLogHost = result[ loglineindexes[iLogRegExIndex]["LN_HOST"] ]
-
-                if szLogSyslogTag == "rsyslogd-pstats":
-                    # Init StatsID!
-                    szStatsID = "Unknown"
-
-                    # If LogobjectID is -1, we have JSON Format in LN_LOGDATA
-                    if loglineindexes[iLogRegExIndex]["LN_LOGOBJECT"] == -1:
-                        # Remove unecessary characters and split into templ array
-                        aCleanedArray = re.sub("[{}\"]", "", result[loglineindexes[iLogRegExIndex]["LN_LOGDATA"]]).split(",")
-                        # Reset Logdata
-                        result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ] = ""
-                        # Loop Through temp array
-                        for szTempEntry in aCleanedArray:
-                            if szTempEntry.find("name:") != -1:
-                                szStatsID = szTempEntry[5:]
-                            else:
-                                # Correct and append to Logdata
-                                result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ] += re.sub("[:]", "=", szTempEntry) + " "
-                        #print szStatsID + " - " + result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ]
-                        #sys.exit(0)
-                    else:
-                        # Remove invalid characters from StatsID!
-    #                   szStatsID = re.sub("[^a-zA-Z0-9]", "_", result[ loglineindexes[iLogRegExIndex]["LN_LOGOBJECT"] ])
-                        szStatsID = result[ loglineindexes[iLogRegExIndex]["LN_LOGOBJECT"] ]
-
-                    # Convert Datetime!
-                    try:
-                        filedate = datetime.datetime.strptime(result[ loglineindexes[iLogRegExIndex]["LN_MONTH"] ] + " " + str(datetime.datetime.now().year) + " " + result[ loglineindexes[iLogRegExIndex]["LN_DAY"] ] + " " + result[ loglineindexes[iLogRegExIndex]["LN_TIME"] ] ,"%m %Y %d %H:%M:%S")
-                    except ValueError:
-                        filedate = datetime.datetime.strptime(result[ loglineindexes[iLogRegExIndex]["LN_MONTH"] ] + " " + str(datetime.datetime.now().year) + " " + result[ loglineindexes[iLogRegExIndex]["LN_DAY"] ] + " " + result[ loglineindexes[iLogRegExIndex]["LN_TIME"] ] ,"%b %Y %d %H:%M:%S")
-
-                    # Split logdata into Array
-                    aProperties = result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ].rstrip().split(" ")
-                    for szProperty in aProperties:
-                        aProperty = szProperty.split("=")
-                        aFields.append(aProperty[0])    # Append FieldID
-                        if len(aProperty) > 1:
-                            aDataCsv.append(aProperty[1])   # Append FieldData
-                            aData[aProperty[0]] = aProperty[1]
+                    # Found valid logline, save into file!
+                    if len(result) >= loglineindexes[iLogRegExIndex]["LN_LOGDATA"]:
+                        # Get/Set SyslogTag
+                        if loglineindexes[iLogRegExIndex]["LN_SYSLOGTAG"] == -1:
+                            szLogSyslogTag = "rsyslogd-pstats" # Set to "rsyslogd-pstats" if no SyslogTag is available
                         else:
-                            errorlog.write("Corrupted Logline at line " + str(nLogLineNum) + " failed to parse: " + result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ])
-                            break
-                
-                    # Open Statsdata per ID
-                    if szStatsID not in outputData:
-                        outputData[szStatsID] = []
-                    
-                    # Add data into array
-                    outputData[szStatsID].append( [ filedate.strftime("%Y/%b/%d %H:%M:%S"),
-                                    szLogHost,
-                                    nLogLineNum,
-                                    aData ] )
+                            szLogSyslogTag = result[ loglineindexes[iLogRegExIndex]["LN_SYSLOGTAG"] ]
 
-                    # --- Save into CSV File as well!
-                    # Remove invalid characters for filename!
-                    szFileName = szInput + "-" + re.sub("[^a-zA-Z0-9]", "_", szStatsID) + ".csv"
+                        # Get/Set SyslogTag
+                        if loglineindexes[iLogRegExIndex]["LN_HOST"] == -1:
+                            szLogHost = "localhost" # Set default to "localhost" if no host is available
+                        else:
+                            szLogHost = result[ loglineindexes[iLogRegExIndex]["LN_HOST"] ]
 
-                    # Open file for writing!
-                    if szFileName not in outputFiles:
-                        if bDebugOutput:
-                            print "Creating file : " + szFileName
-                        outputFiles[szFileName] = open(szFileName, 'w')
-                        nLogFileCount += 1
-                        
-                        # Output CSV Header
-                        outputFiles[szFileName].write("Date;")
-                        outputFiles[szFileName].write("Host;")
-                        outputFiles[szFileName].write("Object;")
-                        for szField in aFields:
-                            outputFiles[szFileName].write(szField + ";")
-                        outputFiles[szFileName].write("\n")
-                    # Output CSV Data
-                    outputFiles[szFileName].write(filedate.strftime("%Y/%b/%d %H:%M:%S") + ";")
-                    outputFiles[szFileName].write(szLogHost + ";")
-                    outputFiles[szFileName].write(szStatsID + ";")
-                    for szData in aDataCsv:
-                        outputFiles[szFileName].write(szData + ";")
-                    outputFiles[szFileName].write("\n")
-                    # ---
+                        if szLogSyslogTag == "rsyslogd-pstats":
+                            # Init StatsID!
+                            szStatsID = "Unknown"
 
-                    # Set Log as processed, abort Loop!
-                    bLogProcessed = True
-                    
+                            # If LogobjectID is -1, we have JSON Format in LN_LOGDATA
+                            if loglineindexes[iLogRegExIndex]["LN_LOGOBJECT"] == -1:
+                                # Remove unecessary characters and split into templ array
+                                aCleanedArray = re.sub("[{}\"]", "", result[loglineindexes[iLogRegExIndex]["LN_LOGDATA"]]).split(",")
+                                # Reset Logdata
+                                result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ] = ""
+                                # Loop Through temp array
+                                for szTempEntry in aCleanedArray:
+                                    if szTempEntry.find("name:") != -1:
+                                        szStatsID = szTempEntry[5:]
+                                    else:
+                                        # Correct and append to Logdata
+                                        result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ] += re.sub("[:]", "=", szTempEntry) + " "
+                                #print szStatsID + " - " + result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ]
+                                #sys.exit(0)
+                            else:
+                                # Remove invalid characters from StatsID!
+            #                   szStatsID = re.sub("[^a-zA-Z0-9]", "_", result[ loglineindexes[iLogRegExIndex]["LN_LOGOBJECT"] ])
+                                szStatsID = result[ loglineindexes[iLogRegExIndex]["LN_LOGOBJECT"] ]
 
-            # Increment Logreged Counter
-            iLogRegExIndex += 1
+                            # Convert Datetime!
+                            try:
+                                filedate = datetime.datetime.strptime(result[ loglineindexes[iLogRegExIndex]["LN_MONTH"] ] + " " + str(datetime.datetime.now().year) + " " + result[ loglineindexes[iLogRegExIndex]["LN_DAY"] ] + " " + result[ loglineindexes[iLogRegExIndex]["LN_TIME"] ] ,"%m %Y %d %H:%M:%S")
+                            except ValueError:
+                                filedate = datetime.datetime.strptime(result[ loglineindexes[iLogRegExIndex]["LN_MONTH"] ] + " " + str(datetime.datetime.now().year) + " " + result[ loglineindexes[iLogRegExIndex]["LN_DAY"] ] + " " + result[ loglineindexes[iLogRegExIndex]["LN_TIME"] ] ,"%b %Y %d %H:%M:%S")
 
-            # Abort Loop if processed
-            if bLogProcessed:
-                break
+                            # Split logdata into Array
+                            aProperties = result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ].rstrip().split(" ")
+                            for szProperty in aProperties:
+                                aProperty = szProperty.split("=")
+                                aFields.append(aProperty[0])    # Append FieldID
+                                if len(aProperty) > 1:
+                                    aDataCsv.append(aProperty[1])   # Append FieldData
+                                    aData[aProperty[0]] = aProperty[1]
+                                else:
+                                    writeErrorLog("Corrupted Logline at line " + str(nLogLineNum) + " failed to parse: " + result[ loglineindexes[iLogRegExIndex]["LN_LOGDATA"] ])
+                                    break
 
-        # Debug output if format not detected
-        if bLogProcessed == False and bDebugOutput:
-            print "Fail parsing logline: "
-            print result
+                            # Open Statsdata per ID
+                            if szStatsID not in outputData:
+                                outputData[szStatsID] = []
 
-        # Increment helper counter
-        nLogLineNum += 1
+                            # Add data into array
+                            outputData[szStatsID].append( [ filedate.strftime("%Y/%b/%d %H:%M:%S"),
+                                            szLogHost,
+                                            nLogLineNum,
+                                            aData ] )
 
-    # Close outfiles
-    for outFileName in outputFiles:
-        outputFiles[outFileName].close()
+                            # --- Save into CSV File as well!
+                            # Remove invalid characters for filename!
+                            szFileName = szInput + "-" + re.sub("[^a-zA-Z0-9]", "_", szStatsID) + ".csv"
 
-    # Close input file
-    inputfile.close()
+                            # Open file for writing!
+                            if szFileName not in outputFiles:
+                                if bDebugOutput:
+                                    print "Creating file : " + szFileName
+                                outputFiles[szFileName] = open(szFileName, 'w')
+                                nLogFileCount += 1
+
+                                # Output CSV Header
+                                outputFiles[szFileName].write("Date;")
+                                outputFiles[szFileName].write("Host;")
+                                outputFiles[szFileName].write("Object;")
+                                for szField in aFields:
+                                    outputFiles[szFileName].write(szField + ";")
+                                outputFiles[szFileName].write("\n")
+                            # Output CSV Data
+                            outputFiles[szFileName].write(filedate.strftime("%Y/%b/%d %H:%M:%S") + ";")
+                            outputFiles[szFileName].write(szLogHost + ";")
+                            outputFiles[szFileName].write(szStatsID + ";")
+                            for szData in aDataCsv:
+                                outputFiles[szFileName].write(szData + ";")
+                            outputFiles[szFileName].write("\n")
+                            # ---
+
+                            # Set Log as processed, abort Loop!
+                            bLogProcessed = True
+
+
+                    # Increment Logreged Counter
+                    iLogRegExIndex += 1
+
+                    # Abort Loop if processed
+                    if bLogProcessed:
+                        break
+
+                # Debug output if format not detected
+                if bLogProcessed == False and bDebugOutput:
+                    print "Fail parsing logline: "
+                    print result
+
+                # Increment helper counter
+                nLogLineNum += 1
+    finally:
+        for outFileName in outputFiles:
+            outputFiles[outFileName].close()
+        if errorlog is not None:
+            errorlog.close()
 
     # Data sorted, now analyze data!
     print " Sorting finished with '" + str(nLogLineNum) + "' loglines processed."
@@ -321,7 +327,7 @@ else:
 
         # Debug break
 #       sys.exit(0)
-    
+
 
     print " End analyzing logdata"
 

--- a/plugins/impstats/statslog-graph.py
+++ b/plugins/impstats/statslog-graph.py
@@ -39,6 +39,11 @@ aFields = []
 aData = {}
 aMajorXData = []
 aCounters = None
+errorlog = None
+
+
+def writeErrorLog(message):
+    errorlog.write(message)
 
 # Helper variables
 nDataRecordCound = 0
@@ -121,88 +126,93 @@ else:
         aCounters = szCounters.strip().split(";")
 
     # Open Errorlog on init
-    errorlog = open(szOutputFile + ".corrupted.log", 'w')
+    szErrorLog = szOutputFile + ".corrupted.log"
+    errorlog = open(szErrorLog, 'w')
 
     # Process inputfile
-    with open(szInput) as inputfile:
-        aLineDataPrev = [] # Helper variable for previous line!
-        for line in inputfile:
-            if nLineCount == 0:
-                aFields = line.strip().split(";")
-                # remove last item if empty
-                if len(aFields[len(aFields)-1]) == 0:
-                    aFields.pop()
+    try:
+        with open(szInput) as inputfile:
+            aLineDataPrev = [] # Helper variable for previous line!
+            for line in inputfile:
+                if nLineCount == 0:
+                    aFields = line.strip().split(";")
+                    # remove last item if empty
+                    if len(aFields[len(aFields)-1]) == 0:
+                        aFields.pop()
 
-                #print aFields
-                #sys.exit(0)
+                    #print aFields
+                    #sys.exit(0)
 
-                #Init data arrays
-                for field in aFields:
-                    aData[field] = []
-            else:
-                aLineData = line.strip().split(";")
-                # remove last item if empty
-                if len(aLineData[len(aLineData)-1]) == 0:
-                    aLineData.pop()
+                    #Init data arrays
+                    for field in aFields:
+                        aData[field] = []
+                else:
+                    aLineData = line.strip().split(";")
+                    # remove last item if empty
+                    if len(aLineData[len(aLineData)-1]) == 0:
+                        aLineData.pop()
 
-                # Loop Through line data
-                iFieldNum = 0
-                for field in aFields:
-                    if iFieldNum == 0:
-                        if bUseDateTime:
-                            aData[field].append( datetime.datetime.strptime(aLineData[iFieldNum],"%Y/%b/%d %H:%M:%S") )
-                        else:
-                            # Convert Time String into UNIX Timestamp
-                            myDateTime = datetime.datetime.strptime(aLineData[iFieldNum],"%Y/%b/%d %H:%M:%S")
-                            iTimeStamp = int(time.mktime(myDateTime.timetuple()))
+                    # Loop Through line data
+                    iFieldNum = 0
+                    for field in aFields:
+                        if iFieldNum == 0:
+                            if bUseDateTime:
+                                aData[field].append( datetime.datetime.strptime(aLineData[iFieldNum],"%Y/%b/%d %H:%M:%S") )
+                            else:
+                                # Convert Time String into UNIX Timestamp
+                                myDateTime = datetime.datetime.strptime(aLineData[iFieldNum],"%Y/%b/%d %H:%M:%S")
+                                iTimeStamp = int(time.mktime(myDateTime.timetuple()))
 
-                            # Init Start Seconds
-                            if iStartSeconds == 0:
-                                iStartSeconds = iTimeStamp
+                                # Init Start Seconds
+                                if iStartSeconds == 0:
+                                    iStartSeconds = iTimeStamp
 
-                            # Set data field
-                            aData[field].append( iTimeStamp - iStartSeconds )
-                    elif iFieldNum == 2 and szChartName == "":
-                        szChartName = aLineData[iFieldNum]
-                    elif iFieldNum > 2:
-                        # Check if we need to calculate Deltas!
-                        if bChartCalcDelta and len(aLineDataPrev) > 0 and field.find("size") == -1: # Do not calc delta für SIZE!
-                            try:
-                                iPreviousVal = int(aLineDataPrev[iFieldNum])
-                                iCurrentVal = int(aLineData[iFieldNum])
-                                if iCurrentVal != 0:    # Calc DELTA
-                                    iCurrentDelta = iCurrentVal - iPreviousVal
-                                    if bDeltaIgnoreNegativeValues:
-                                        if iCurrentDelta >= 0:
-                                            aData[field].append(iCurrentDelta)
+                                # Set data field
+                                aData[field].append( iTimeStamp - iStartSeconds )
+                        elif iFieldNum == 2 and szChartName == "":
+                            szChartName = aLineData[iFieldNum]
+                        elif iFieldNum > 2:
+                            # Check if we need to calculate Deltas!
+                            if bChartCalcDelta and len(aLineDataPrev) > 0 and field.find("size") == -1: # Do not calc delta für SIZE!
+                                try:
+                                    iPreviousVal = int(aLineDataPrev[iFieldNum])
+                                    iCurrentVal = int(aLineData[iFieldNum])
+                                    if iCurrentVal != 0:    # Calc DELTA
+                                        iCurrentDelta = iCurrentVal - iPreviousVal
+                                        if bDeltaIgnoreNegativeValues:
+                                            if iCurrentDelta >= 0:
+                                                aData[field].append(iCurrentDelta)
+                                            else:
+                                                aData[field].append(0)
                                         else:
-                                            aData[field].append(0)
-                                    else:
-                                        aData[field].append(iCurrentDelta)
-                                else:   # Don't Calc delta value!
-                                    aData[field].append( iCurrentVal )
-                            except ValueError:
-                                errorlog.write("Error, Field not an INTEGER: " + aLineData[iFieldNum])
+                                            aData[field].append(iCurrentDelta)
+                                    else:   # Don't Calc delta value!
+                                        aData[field].append( iCurrentVal )
+                                except ValueError:
+                                    writeErrorLog("Error, Field not an INTEGER: " + aLineData[iFieldNum])
+                            else:
+                                try:            # Try as INTEGER
+                                    aData[field].append( int(aLineData[iFieldNum]) )
+                                except ValueError:  # Not an INTEGER, skip value
+                                    writeErrorLog("Error, Field not an INTEGER: " + aLineData[iFieldNum])
                         else:
-                            try:            # Try as INTEGER
-                                aData[field].append( int(aLineData[iFieldNum]) )
-                            except ValueError:  # Not an INTEGER, skip value
-                                errorlog.write("Error, Field not an INTEGER: " + aLineData[iFieldNum])
-                    else:
-                        aData[field].append( aLineData[iFieldNum] )
+                            aData[field].append( aLineData[iFieldNum] )
 
-                    iFieldNum += 1
-                    # print aData[field[nLineCount]]
-                
+                        iFieldNum += 1
+                        # print aData[field[nLineCount]]
+
+                    # Increment counter
+                    nDataRecordCound += 1
+
+                    # in case deltas need to be calculated, Store current line into previous line
+                    if bChartCalcDelta:
+                        aLineDataPrev = aLineData
+
                 # Increment counter
-                nDataRecordCound += 1
-
-                # in case deltas need to be calculated, Store current line into previous line
-                if bChartCalcDelta:
-                    aLineDataPrev = aLineData
-
-            # Increment counter
-            nLineCount += 1
+                nLineCount += 1
+    finally:
+        if errorlog is not None:
+            errorlog.close()
     # Import Style
 #   from pygal.style import LightSolarizedStyle
 #   from pygal.style import DefaultStyle
@@ -233,7 +243,7 @@ else:
     chartCfg.no_data_text = "All values are 0"
     if bLogarithmicChart:
         chartCfg.logarithmic=True   # Makes chart Y-Axis data more readable
-    
+
     # remove first item if configured!
     if bDeltaIgnoreFirstValue:
         for iChartNum in range(3, len(aFields) ):

--- a/tests/CI/check_commit_text.py
+++ b/tests/CI/check_commit_text.py
@@ -5,13 +5,13 @@ import sys
 rc=0
 max_line_length=72 # github limit; actually lending towards smaller (50) is better
 len_hash = 9 # we use 8-char hash plus space
-f = open(sys.argv[1], "r")
-for line in f:
-   len_line = len(line) - len_hash
-   if len_line > max_line_length:
-       sys.stderr.write("This commit line is {} characters too long (maximum is {}, line len is {}):\n".format(
-           len_line - max_line_length, max_line_length, len_line))
-       sys.stderr.write(line)
-       rc = 1
+with open(sys.argv[1], "r") as f:
+   for line in f:
+      len_line = len(line) - len_hash
+      if len_line > max_line_length:
+          sys.stderr.write("This commit line is {} characters too long (maximum is {}, line len is {}):\n".format(
+              len_line - max_line_length, max_line_length, len_line))
+          sys.stderr.write(line)
+          rc = 1
 
 sys.exit(rc)

--- a/tests/snmptrapreceiver.py
+++ b/tests/snmptrapreceiver.py
@@ -27,7 +27,11 @@ if len(sys.argv) > 4:
 
 # Create output files
 outputFile = open(szOutputfile,"w+")
-logFile = open(szSnmpLogfile,"a+")
+try:
+    logFile = open(szSnmpLogfile,"a+")
+except:
+    outputFile.close()
+    raise
 
 # Assemble MIB viewer
 mibBuilder = builder.MibBuilder()
@@ -101,10 +105,26 @@ ntfrcv.NotificationReceiver(snmpEngine, cbReceiverSnmp)
 # this job would never finish
 snmpEngine.transportDispatcher.jobStarted(1)
 
+def cleanup_started_file():
+    try:
+        os.remove(szSnmpLogfile + ".started")
+    except OSError:
+        pass
+
+
+def close_output_files():
+    outputFile.close()
+    logFile.close()
+
+
 # Run I/O dispatcher which would receive queries and send confirmations
 try:
-    snmpEngine.transportDispatcher.runDispatcher()
-except:
-    os.remove(szOutputfile + ".started")  # Remove PID file on shutdown
-    snmpEngine.transportDispatcher.closeDispatcher()
-    raise
+    try:
+        snmpEngine.transportDispatcher.runDispatcher()
+    except KeyboardInterrupt:
+        print("Received keyboard interrupt, shutting down")
+    finally:
+        cleanup_started_file()
+        snmpEngine.transportDispatcher.closeDispatcher()
+finally:
+    close_output_files()

--- a/tests/snmptrapreceiverv2.py
+++ b/tests/snmptrapreceiverv2.py
@@ -67,7 +67,11 @@ if len(sys.argv) > 4:
 # Create output files
 print(f"Creating output files: {szOutputfile}, {szSnmpLogfile}", file=sys.stderr)
 outputFile = open(szOutputfile,"w+")
-logFile = open(szSnmpLogfile,"a+")
+try:
+    logFile = open(szSnmpLogfile,"a+")
+except:
+    outputFile.close()
+    raise
 print("Output files created successfully", file=sys.stderr)
 
 # Assemble MIB viewer
@@ -156,14 +160,18 @@ print("Registering notification receiver", file=sys.stderr)
 ntfrcv.NotificationReceiver(snmpEngine, cbReceiverSnmp)
 
 # Run I/O dispatcher which would receive queries and send confirmations
-print("Starting transport dispatcher", file=sys.stderr)
 try:
-    snmpEngine.transportDispatcher.runDispatcher()
-except KeyboardInterrupt:
-    print("Received keyboard interrupt, shutting down", file=sys.stderr)
-except Exception as e:
-    print(f"Exception in dispatcher: {e}", file=sys.stderr)
-    raise
+    try:
+        print("Starting transport dispatcher", file=sys.stderr)
+        snmpEngine.transportDispatcher.runDispatcher()
+    except KeyboardInterrupt:
+        print("Received keyboard interrupt, shutting down", file=sys.stderr)
+    except Exception as e:
+        print(f"Exception in dispatcher: {e}", file=sys.stderr)
+        raise
+    finally:
+        cleanup_started_file()
+        snmpEngine.transportDispatcher.closeDispatcher()
 finally:
-    cleanup_started_file()
-    snmpEngine.transportDispatcher.closeDispatcher()
+    outputFile.close()
+    logFile.close()


### PR DESCRIPTION
## Summary

This addresses CodeQL file-handle lifetime findings in Python helper scripts.

The changes add explicit cleanup for long-running plugin and SNMP receiver
handles, and convert short-lived file access in the impstats utilities and CI
commit checker to context-managed `open()` calls.

## Impact

Runtime behavior is intended to stay the same, except descriptors are closed
more reliably during normal shutdown and error paths.

## Validation

- `git diff --check`
- `python3 -m py_compile tests/CI/check_commit_text.py tests/snmptrapreceiverv2.py plugins/external/skeletons/python/plugin-with-feedback.py`
- `python3 -m py_compile tests/snmptrapreceiver.py plugins/external/solr/rsyslog_solr.py plugins/external/skeletons/python/plugin.py`
- `python3 tests/CI/check_commit_text.py <(git log -1 --pretty=format:'%h %s%n%b')`

The fresh worktree was not configured with a `Makefile`, so no full rsyslog
build was run for these script-only changes.
