### PR TITLE
impstats: avoid analyzer wildcard import

### DIFF
--- a/plugins/impstats/statslog-analyzer.py
+++ b/plugins/impstats/statslog-analyzer.py
@@ -13,10 +13,10 @@
 
 import sys
 import datetime
+import re
 
 # Include regex definitions
-#import statslog_regex
-from statslog_regex import *
+from statslog_regex import loglineindexes, loglineregexes
 
 # Set default variables
 szInput = "rsyslog-stats.log"


### PR DESCRIPTION
## Summary

Replaces a wildcard import in the impstats analyzer with explicit imports.

The script now imports `re` directly and imports only the regex tables it uses
from `statslog_regex`, avoiding namespace pollution while preserving behavior.

## Impact

No runtime behavior change is intended.

## Validation

- `git diff --check`

`python2` is not available in this environment, so Python 2 bytecode validation
for this legacy script was not run.
