### PR TITLE
scripts: restore repo policy helpers

### DIFF
--- a/scripts/build_repo_policy_focus_input.py
+++ b/scripts/build_repo_policy_focus_input.py
@@ -300,7 +300,7 @@ def build_doc_xref_check(name_status: list[dict[str, object]], base: str, head: 
     }
 
 
-
+def list_tree(ref: str, path: str) -> list[str]:
     output = run_git(["ls-tree", "-r", "--name-only", ref, "--", path], check=False)
     return [line for line in output.splitlines() if line]
 

--- a/scripts/evaluate_repo_policy_focus.py
+++ b/scripts/evaluate_repo_policy_focus.py
@@ -166,7 +166,7 @@ def evaluate_doc_xref_sync(check: dict[str, object]) -> dict[str, object]:
     }
 
 
-
+def evaluate_module_check(check: dict[str, object]) -> dict[str, object]:
     # Missing metadata is a hard policy failure; missing docs stay advisory
     # until rsyslog has a stricter deterministic doc coverage rule.
     facts = check["facts"]
@@ -332,7 +332,7 @@ def evaluate_check(check: dict[str, object]) -> dict[str, object]:
     if check["id"] == "doc-xref-sync":
         return evaluate_doc_xref_sync(check)
     if check["id"] == "module-onboarding":
-        return evaluate_module_onboarding(check)
+        return evaluate_module_check(check)
     if check["id"] == "module-build-wiring":
         return evaluate_module_build_wiring(check)
     if check["id"] == "parameter-doc-sync":

--- a/scripts/evaluate_repo_policy_focus.py
+++ b/scripts/evaluate_repo_policy_focus.py
@@ -166,7 +166,7 @@ def evaluate_doc_xref_sync(check: dict[str, object]) -> dict[str, object]:
     }
 
 
-def evaluate_module_check(check: dict[str, object]) -> dict[str, object]:
+def evaluate_module_onboarding(check: dict[str, object]) -> dict[str, object]:
     # Missing metadata is a hard policy failure; missing docs stay advisory
     # until rsyslog has a stricter deterministic doc coverage rule.
     facts = check["facts"]
@@ -332,7 +332,7 @@ def evaluate_check(check: dict[str, object]) -> dict[str, object]:
     if check["id"] == "doc-xref-sync":
         return evaluate_doc_xref_sync(check)
     if check["id"] == "module-onboarding":
-        return evaluate_module_check(check)
+        return evaluate_module_onboarding(check)
     if check["id"] == "module-build-wiring":
         return evaluate_module_build_wiring(check)
     if check["id"] == "parameter-doc-sync":


### PR DESCRIPTION
## Summary

Restores two repo-policy helper function boundaries so existing logic is
reachable again.

The focus-input builder now exposes the `list_tree()` helper used by module
onboarding checks, and the evaluator now routes module-onboarding checks to the
restored module metadata evaluator.

## Impact

Repo-policy evaluation can execute the intended module onboarding paths instead
of leaving them as unreachable code.

## Validation

- `python3 -m py_compile scripts/build_repo_policy_focus_input.py scripts/evaluate_repo_policy_focus.py`
- `git diff --check origin/main..HEAD`
- Focused smoke run with temporary JSON outputs outside the worktree
