### PR TITLE
java: simplify simple plugin file creation

### DIFF
--- a/plugins/external/skeletons/java/SimplePlugin.java
+++ b/plugins/external/skeletons/java/SimplePlugin.java
@@ -27,9 +27,6 @@ public class SimplePlugin {
     		BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
     		String s;
 		File outFile = new File("out.txt");
-      		if (! outFile.exists())  {
-         		outFile.createNewFile();
-      		}
 		BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(outFile, true)));
 
  		while ((s = in.readLine()) != null && s.length() != 0) 	{


### PR DESCRIPTION
## Summary

Removes redundant manual file creation from the Java external plugin skeleton.

Append-mode `FileOutputStream` already creates the output file when needed, so
the ignored `createNewFile()` return value is no longer present.

## Impact

No behavior change is intended. The skeleton still appends to `out.txt` and
still reports file creation/open failures through `IOException`.

## Validation

- `git diff --check origin/main..HEAD`
- `javac -d /tmp/rsyslog-javac-simpleplugin-maincheck plugins/external/skeletons/java/SimplePlugin.java`
