### PR TITLE
tests: clean up python helpers

### DIFF
--- a/tests/holdtcpopen.py
+++ b/tests/holdtcpopen.py
@@ -39,7 +39,9 @@ def main():
             if not data:
                 break
         except socket.timeout:
-            pass
+            # No data yet; keep holding until data closes the connection or the
+            # deadline expires.
+            continue
 
     conn.close()
     listener.close()

--- a/tests/testsuites/mmexternal-SegFault-mm-python.py
+++ b/tests/testsuites/mmexternal-SegFault-mm-python.py
@@ -46,7 +46,7 @@ def onReceive(msg):
        and so each message needs to be fully processed (rsyslog will wait for the
        reply before the next message is pushed to this module).
     """
-    data = json.loads(msg)
+    json.loads(msg)
     print(json.dumps({"$!": {"sometag": "somevalue"}}))
 
 def onExit():


### PR DESCRIPTION
## Summary

Cleans up two Python test helper CodeQL findings.

The TCP hold helper now documents and explicitly continues on expected socket
timeouts, and the mmexternal fixture keeps JSON validation without assigning the
unused parsed object.

## Impact

No behavior change is intended.

## Validation

- `python3 -m py_compile tests/holdtcpopen.py tests/testsuites/mmexternal-SegFault-mm-python.py`
- `git diff --check origin/main..HEAD`
