### PR TITLE
tests: validate diagtalker port

### DIFF
--- a/tests/historical/DiagTalker.java
+++ b/tests/historical/DiagTalker.java
@@ -1,4 +1,4 @@
-This tool has been replaced by ./tests/diagtalker.c in release 4.7.1
+/* This tool has been replaced by ./tests/diagtalker.c in release 4.7.1 */
 /* A yet very simple tool to talk to imdiag.
  *
  * Copyright 2009 Rainer Gerhards and Adiscon GmbH.
@@ -33,7 +33,12 @@ public class DiagTalker {
 	final String host = "127.0.0.1";
 	int port = 13500;
 	if(args.length > 1) {
-		port = Integer.parseInt(args[1]);
+		try {
+			port = Integer.parseInt(args[1]);
+		} catch (NumberFormatException e) {
+			System.err.println("Invalid port: " + args[1]);
+			System.exit(1);
+		}
 	}
 
         try {

--- a/tests/historical/DiagTalker.java
+++ b/tests/historical/DiagTalker.java
@@ -35,6 +35,10 @@ public class DiagTalker {
 	if(args.length > 1) {
 		try {
 			port = Integer.parseInt(args[1]);
+			if(port < 0 || port > 65535) {
+				System.err.println("Port out of range: " + args[1]);
+				System.exit(1);
+			}
 		} catch (NumberFormatException e) {
 			System.err.println("Invalid port: " + args[1]);
 			System.exit(1);
@@ -76,4 +80,3 @@ public class DiagTalker {
 	diagSocket.close();
     }
 }
-


### PR DESCRIPTION
## Summary

Adds controlled handling for invalid DiagTalker port arguments.

`DiagTalker.java` now catches invalid integer input, reports the bad port, and
exits before opening a socket. The historical replacement note is also made a
Java comment so the helper can compile for validation.

## Impact

Default port behavior is unchanged. Invalid custom ports now fail with a clear
error instead of an uncaught `NumberFormatException` stack trace.

## Validation

- `git diff --check origin/main..HEAD`
- `javac -d /tmp/rsyslog-javac-diagtalker-maincheck tests/historical/DiagTalker.java`
