### PR TITLE
doc: avoid unused python imports

### DIFF
--- a/doc/source/_ext/rsyslog_lexer.py
+++ b/doc/source/_ext/rsyslog_lexer.py
@@ -1,11 +1,8 @@
 # source/_ext/rsyslog_lexer.py
 
-import re
-
 from pygments.lexer import RegexLexer, bygroups
 from pygments.token import (
     Text, Comment, Operator, Keyword, Name, String, Number, Punctuation,
-    Error
 )
 
 __all__ = ['RainerScriptLexer']
@@ -125,8 +122,6 @@ class RainerScriptLexer(RegexLexer):
 
 # --- Sphinx Extension setup function ---
 def setup(app):
-    from sphinx.highlighting import PygmentsBridge
-    
     app.add_lexer('rainerscript', RainerScriptLexer)
     app.add_lexer('rsyslog', RainerScriptLexer) 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import importlib.util
+import importlib
 import json
 import os
 import re
@@ -367,9 +367,10 @@ suppress_warnings = ['epub.unknown_project_files']
 
 def has_optional_extension(name):
     try:
-        return importlib.util.find_spec(name) is not None
+        importlib.import_module(name)
     except ImportError:
         return False
+    return True
 
 
 # The base URL which points to the root of the HTML documentation.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -11,6 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import importlib.util
 import json
 import os
 import re
@@ -363,6 +364,14 @@ suppress_warnings = ['epub.unknown_project_files']
 
 # -- Options for HTML output ---------------------------------------------------
 
+
+def has_optional_extension(name):
+    try:
+        return importlib.util.find_spec(name) is not None
+    except ModuleNotFoundError:
+        return False
+
+
 # The base URL which points to the root of the HTML documentation.
 # It is used to indicate the location of document like canonical_url and sitemap.
 # DOC_BASE_URL env (e.g. https://docs.rsyslog.com) overrides when set (CI deploy).
@@ -375,9 +384,7 @@ ENABLE_JSON_LD = not DISABLE_JSON_LD
 
 # Enable sitemap generation only when explicitly requested
 if tags.has('with_sitemap'):
-    try:
-        import sphinx_sitemap  # type: ignore
-    except ImportError:
+    if not has_optional_extension('sphinx_sitemap'):
         # Optional extension - sitemap generation skipped if not installed
         pass
     else:
@@ -399,9 +406,7 @@ if _ga_id and not re.match(r'^(UA-\d+-\d+|G-[A-Za-z0-9]+)$', _ga_id):
     _ga_id = ''
 _ga_use_extension = False
 if _ga_id:
-    try:
-        import sphinxcontrib.googleanalytics  # type: ignore  # noqa: F401
-    except ImportError:
+    if not has_optional_extension('sphinxcontrib.googleanalytics'):
         # Extension not installed – fall back to metatags injection in setup().
         pass
     else:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -368,7 +368,7 @@ suppress_warnings = ['epub.unknown_project_files']
 def has_optional_extension(name):
     try:
         return importlib.util.find_spec(name) is not None
-    except ModuleNotFoundError:
+    except ImportError:
         return False
 
 


### PR DESCRIPTION
## Summary

Removes unused Python imports from documentation configuration and lexer code.

Optional Sphinx extension checks now use a small `importlib.util.find_spec()`
helper instead of importing modules only to test availability.

## Impact

No documentation behavior change is intended. Sitemap and Google Analytics
extensions are still enabled only when configured and available; the existing
GA metatag fallback remains in place when the extension is missing.

## Validation

- `python3 -m py_compile doc/source/conf.py doc/source/_ext/rsyslog_lexer.py`
- `git diff --check origin/main..HEAD`
