### PR TITLE
tests: stabilize imptcp maxsessions guard

### DIFF
--- a/tests/imptcp_maxsessions.sh
+++ b/tests/imptcp_maxsessions.sh
@@ -12,21 +12,77 @@ CONNECTIONS=20
 EXPECTED_DROPS=$((CONNECTIONS - MAXSESSIONS))
 
 EXPECTED_STR='too many tcp sessions - dropping incoming request'
-wait_too_many_sessions()
+STARTED_LOG="${RSYSLOG_DYNNAME}.started"
+HOLDER_PID=
+
+stop_holder()
 {
-  test "$(grep "$EXPECTED_STR" "$RSYSLOG_OUT_LOG" | wc -l)" = "$EXPECTED_DROPS"
+	if [ -n "$HOLDER_PID" ]; then
+		if kill -0 "$HOLDER_PID" 2>/dev/null; then
+			kill "$HOLDER_PID" 2>/dev/null || true
+		fi
+		wait "$HOLDER_PID" 2>/dev/null || true
+		HOLDER_PID=
+	fi
 }
 
-export QUEUE_EMPTY_CHECK_FUNC=wait_too_many_sessions
+test_error_exit_handler()
+{
+	stop_holder
+}
+
+count_dropped_sessions()
+{
+	if [ -f "$STARTED_LOG" ]; then
+		count=$(grep -F -c -- "$EXPECTED_STR" "$STARTED_LOG" || true)
+		case "$count" in
+			''|*[!0-9]*) printf '0\n' ;;
+			*) printf '%s\n' "$count" ;;
+		esac
+	else
+		printf '0\n'
+	fi
+}
+
+wait_for_exact_drops()
+{
+	wait_tries=${1:-20}
+	wait_i=1
+
+	while [ "$wait_i" -le "$wait_tries" ]; do
+		count=$(count_dropped_sessions)
+		if [ "$count" -eq "$EXPECTED_DROPS" ]; then
+			return 0
+		fi
+		if [ "$count" -gt "$EXPECTED_DROPS" ]; then
+			break
+		fi
+		$TESTTOOL_DIR/msleep 1000
+		wait_i=$((wait_i + 1))
+	done
+
+	return 1
+}
+
+start_holder()
+{
+	./tcpflood -p"$TCPFLOOD_PORT" -c"$MAXSESSIONS" -m"$MAXSESSIONS" -P129 -K0 &
+	HOLDER_PID=$!
+}
+
 generate_conf
 add_conf '
 $MaxMessageSize 10k
 
 module(load="../plugins/imptcp/.libs/imptcp" maxsessions="'$MAXSESSIONS'")
 input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
-action(type="omfile" file=`echo $RSYSLOG_OUT_LOG`)
 
-$template outfmt,"%msg:F,58:2%,%msg:F,58:3%,%msg:F,58:4%\n"
+$template outfmt,"%msg:F,58:2%\n"
+
+if $msg contains "msgnum:" then {
+	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+}
+
 $OMFileFlushInterval 2
 $OMFileIOBufferSize 256k
 '
@@ -34,14 +90,44 @@ startup
 
 echo "INFO: RSYSLOG_OUT_LOG: $RSYSLOG_OUT_LOG"
 
-echo "About to run tcpflood"
-tcpflood -c$CONNECTIONS -m$NUMMESSAGES -r -d100 -P129 -A
+echo "Opening $MAXSESSIONS held sessions"
+start_holder
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" "$MAXSESSIONS"
+
+echo "About to run tcpflood for $EXPECTED_DROPS extra sessions"
+tcpflood -c$EXPECTED_DROPS -m$EXPECTED_DROPS -i$MAXSESSIONS -P129 -A
 echo "-------> NOTE: CLOSED REMOTELY messages are expected and OK! <-------"
 echo "done run tcpflood"
+
+if ! wait_for_exact_drops 20; then
+	count=$(count_dropped_sessions)
+	echo "FAIL: expected exactly $EXPECTED_DROPS dropped sessions, got $count"
+	echo "STARTED_LOG contents:"
+	if [ -f "$STARTED_LOG" ]; then
+		cat "$STARTED_LOG"
+	else
+		echo "$STARTED_LOG does not exist"
+	fi
+	error_exit 1
+fi
+
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" "$MAXSESSIONS" 2
+stop_holder
 shutdown_when_empty
 wait_shutdown
 
-content_count_check "$EXPECTED_STR" $EXPECTED_DROPS
+count=$(count_dropped_sessions)
+if [ "$count" -ne "$EXPECTED_DROPS" ]; then
+	echo "FAIL: expected exactly $EXPECTED_DROPS dropped sessions, got $count"
+	echo "STARTED_LOG contents:"
+	if [ -f "$STARTED_LOG" ]; then
+		cat "$STARTED_LOG"
+	else
+		echo "$STARTED_LOG does not exist"
+	fi
+	exit 1
+fi
+seq_check 0 $((MAXSESSIONS - 1))
 echo "Got expected drops: $EXPECTED_DROPS, looks good!"
 
 exit_test

--- a/tests/tcpflood.c
+++ b/tests/tcpflood.c
@@ -43,6 +43,8 @@
  * -D	randomly drop and re-establish connections. Useful for stress-testing
  *      the TCP receiver.
  * -F	USASCII value for frame delimiter (in octet-stuffing mode), default LF
+ * -K   keep still-open plain TCP sockets open after sending. -K0 holds until
+ *      terminated, -K<N> holds for N seconds before closing connections.
  * -R	number of times the test shall be run (very useful for gathering performance
  *      data and other repetitive things). Default: 1
  * -S   number of seconds to sleep between different runs (-R) Default: 30
@@ -122,6 +124,7 @@
 #include <stdbool.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <limits.h>
 #ifdef ENABLE_RELP
     #include <librelp.h>
 #endif
@@ -234,6 +237,7 @@ static int bShowProgress = 1; /* show progress messages */
 static int bSilent = 0; /* completely silent operation */
 static int bRandConnDrop = 0; /* randomly drop connections? */
 static double dbRandConnDrop = 0.95; /* random drop probability */
+static int holdOpenSeconds = -1; /* keep plain TCP sockets open after sending? */
 static char *MsgToSend = NULL; /* if non-null, this is the actual message to send */
 static char *hostname = "172.20.245.8"; /* this is the "tratditional" default, as bad is it is... */
 static int bBinaryFile = 0; /* is -I file binary */
@@ -714,6 +718,48 @@ void closeConnections(void) {
         lenMsg = snprintf(msgBuf, sizeof(msgBuf), "\r%5.5d close connections\n", i);
         if (write(1, msgBuf, lenMsg)) {
         }
+    }
+}
+
+
+static void holdOpenConnections(void) {
+    int i;
+    int openSockets = 0;
+    unsigned int secondsRemaining;
+
+    if (holdOpenSeconds < 0) {
+        return;
+    }
+
+    for (i = 0; i < numConnections; ++i) {
+        if (sockArray[i] != -1) {
+            ++openSockets;
+        }
+    }
+    if (openSockets == 0) {
+        if (!bSilent) {
+            printf("no open TCP connections to hold\n");
+        }
+        return;
+    }
+
+    if (!bSilent) {
+        if (holdOpenSeconds == 0) {
+            printf("holding %d TCP connections until terminated\n", openSockets);
+        } else {
+            printf("holding %d TCP connections for %d seconds\n", openSockets, holdOpenSeconds);
+        }
+    }
+
+    if (holdOpenSeconds == 0) {
+        while (1) {
+            pause();
+        }
+    }
+
+    secondsRemaining = (unsigned int)holdOpenSeconds;
+    while (secondsRemaining > 0) {
+        secondsRemaining = sleep(secondsRemaining);
     }
 }
 
@@ -2061,7 +2107,7 @@ int main(int argc, char *argv[]) {
     setvbuf(stdout, buf, _IONBF, 48);
 
     while ((opt = getopt(argc, argv,
-                         "a:ABb:c:C:d:DeE:f:F:h:i:I:j:k:l:L:m:M:n:o:OP:p:rR:"
+                         "a:ABb:c:C:d:DeE:f:F:h:i:I:j:K:k:l:L:m:M:n:o:OP:p:rR:"
                          "sS:t:T:u:vW:w:x:XyYz:Z:H")) != -1) {
         switch (opt) {
             case 'b':
@@ -2098,6 +2144,19 @@ int main(int argc, char *argv[]) {
             case 'j':
                 jsonCookie = optarg;
                 break;
+            case 'K': {
+                char *endptr;
+                long parsed;
+
+                errno = 0;
+                parsed = strtol(optarg, &endptr, 10);
+                if (errno != 0 || *optarg == '\0' || *endptr != '\0' || parsed < 0 || parsed > INT_MAX) {
+                    fprintf(stderr, "-K requires a non-negative seconds value\n");
+                    exit(1);
+                }
+                holdOpenSeconds = (int)parsed;
+                break;
+            }
             case 'd':
                 extraDataLen = atoi(optarg);
                 if (extraDataLen > MAX_EXTRADATA_LEN) {
@@ -2298,6 +2357,21 @@ int main(int argc, char *argv[]) {
         exit(1);
     }
 
+    if (holdOpenSeconds >= 0) {
+        if (transport != TP_TCP) {
+            fprintf(stderr, "-K is only supported with plain TCP transport\n");
+            exit(1);
+        }
+        if (numRuns != 1) {
+            fprintf(stderr, "-K cannot be combined with multiple runs (-R must be 1)\n");
+            exit(1);
+        }
+        if (bRandConnDrop) {
+            fprintf(stderr, "-K cannot be combined with random connection drops (-D)\n");
+            exit(1);
+        }
+    }
+
     if (portFile != NULL && numConnections != 1) {
         fprintf(stderr, "-w requires exactly one connection\n");
         exit(1);
@@ -2434,6 +2508,7 @@ int main(int argc, char *argv[]) {
         }
     }
 
+    holdOpenConnections();
     closeConnections(); /* this is important so that we do not finish too early! */
 
 #ifdef ENABLE_RELP


### PR DESCRIPTION
Root cause:
The original test intended to prove that `imptcp` enforces `maxsessions=10` by opening 20 client sessions and expecting 10 refusal diagnostics. Kernel-level TCP `connect()` success is not the same as imptcp session acceptance: over-limit sockets may connect at the OS level, then be rejected when imptcp accepts them and checks the session table. The old test also used the exact diagnostic count as `QUEUE_EMPTY_CHECK_FUNC`, so a timing miss could hold shutdown until the global testbench abort timeout.

Fix:
Keep the original threshold semantics, but make the accepted session state deterministic with project testbench plumbing. `tcpflood` now has short option `-K seconds`; after normal `openConnections()` and message sending it keeps still-open plain TCP sockets open before the normal close path. `-K0` holds until the test terminates the holder process.

The test now starts a background tcpflood holder for 10 accepted sessions, waits until those 10 messages are written, then runs a second tcpflood probe for 10 extra connections and requires exactly 10 `too many tcp sessions` diagnostics. The exact diagnostic count is no longer used as the queue-empty shutdown predicate.

Additional checks retained/added:
- `MAXSESSIONS=10`, `CONNECTIONS=20`, and `EXPECTED_DROPS=10` remain explicit.
- The output file is checked for exactly the 10 accepted holder messages.
- `seq_check 0 9` verifies the accepted messages are the intended holder sessions.
- Error cleanup kills and waits for the tcpflood holder.
- `tcpflood -K` is restricted to plain TCP, one run, and no random connection dropping; invalid combinations fail before sockets are opened.

Proof that the test still fails for invalid behavior:
- Temporarily setting test config to `maxsessions="20"` failed with `expected exactly 10 dropped sessions, got 0`.
- Temporarily injecting an off-by-one guard in `plugins/imptcp/imptcp.c` by changing `>=` to `>` failed with `expected exactly 10 dropped sessions, got 9`.
- Both temporary negative-control edits were reverted before commit.

Local validation before PR update:
- Worker: `make -C tests -j$(nproc) tcpflood`
- Worker: `./tests/imptcp_maxsessions.sh`, 3 iterations before negative controls
- Worker: `./tests/imptcp_maxsessions.sh`, 2 iterations after negative controls
- Worker: `make check TESTS='imptcp_maxsessions.sh'`
- Worker: `git diff --check`
- Worker: `-K` invalid-combo smoke checks rejected UDP, `-R2`, and `-D`
- Coordinator: signed commit and `git diff --check HEAD~1..HEAD`