### PR TITLE
tests: stabilize omfwd target-fail sequence check

### DIFF
--- a/tests/chkseq.c
+++ b/tests/chkseq.c
@@ -163,6 +163,14 @@ int main(int argc, char *argv[]) {
             }
         }
         if (!scanfOK) {
+            if (feof(fp) && lostok > 0) {
+                while (i <= end && lostok > 0) {
+                    --lostok;
+                    printf("message %d missing (ok due to -m [now %d])\n", i, lostok);
+                    i += increment;
+                }
+                if (i > end) break;
+            }
             printf("scanf error in index i=%d\n", i);
             exit(1);
         }

--- a/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
+++ b/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
@@ -7,6 +7,8 @@
 skip_platform "SunOS" "This test is currently not supported on solaris due to too-different timing"
 generate_conf
 export NUMMESSAGES=2000
+export OMFWD_TARGETFAIL_MAX_LOSS=250
+export OMFWD_TARGETFAIL_MIN_RECEIVED=$((NUMMESSAGES - OMFWD_TARGETFAIL_MAX_LOSS))
 
 # starting minitcpsrvr receivers so that we can obtain their port
 # numbers
@@ -35,11 +37,14 @@ echo Note: intentionally not started any local TCP receiver!
 startup
 
 injectmsg
+wait_file_lines "$RSYSLOG_OUT_LOG" "$OMFWD_TARGETFAIL_MIN_RECEIVED"
 shutdown_when_empty
 wait_shutdown
 # note: minitcpsrv shuts down automatically if the connection is closed!
 
 export SEQ_CHECK_OPTIONS=-d
-#permit 250 messages to be lost in this extreme test (-m 250)
-seq_check 0 $((NUMMESSAGES-1)) -m250
+# Permit bounded message loss in this extreme test. The pre-shutdown
+# wait above keeps the assertion meaningful while the -m check also
+# accepts bounded loss at the end of the stream.
+seq_check 0 $((NUMMESSAGES-1)) -m"$OMFWD_TARGETFAIL_MAX_LOSS"
 exit_test


### PR DESCRIPTION
Root cause:
The target-fail fixture intentionally drops and reopens the only TCP receiver and permits bounded loss. Under load, the test could begin shutdown once the main queue was empty while omfwd was still draining. It then checked output that could contain bounded tail loss. `chkseq -m` handled interior gaps followed by later sequence numbers, but EOF inside the allowed missing range produced `scanf error`, matching the campaign failures.

Fix:
Keep NUMMESSAGES=2000 and the max allowed loss at 250. Wait for at least 1750 received lines before shutdown so the test still requires substantial delivery. Teach `chkseq -m` to accept EOF tail loss only while the missing count is still inside the configured loss budget; loss above 250 and malformed records still fail.

Proof that the test still fails for invalid behavior:
Old `chkseq` failed `seq 0 1780 | chkseq -s0 -e1999 -d -m250` with `scanf error`. The updated `chkseq` accepts that bounded tail loss, but rejects 251 missing tail messages and malformed input.

Local validation before PR:
- Worker: `make -j$(nproc) check TESTS=""`
- Worker: affected test, 10/10 direct passes
- Worker: affected Automake target, 5/5 passes
- Worker: `make clean && make -j80 check TESTS="omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh"`
- Coordinator: affected test, 10/10 direct passes from `tests/` cwd
- Coordinator: `make check TESTS="omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh"`