### PR TITLE
python: fix external plugin comment typos

### DIFF
--- a/plugins/external/messagemod/anon_cc_nbrs/anon_cc_nbrs.py
+++ b/plugins/external/messagemod/anon_cc_nbrs/anon_cc_nbrs.py
@@ -45,7 +45,7 @@ def onInit():
 
 def onReceive(msg):
     """This is the entry point where actual work needs to be done. It receives
-       the messge from rsyslog and now needs to examine it, do any processing
+       the message from rsyslog and now needs to examine it, do any processing
        necessary. The to-be-modified properties (one or many) need to be pushed
        back to stdout, in JSON format, with no interim line breaks and a line
        break at the end of the JSON. If no field is to be modified, empty
@@ -82,8 +82,8 @@ def onExit():
 -------------------------------------------------------
 This is plumbing that DOES NOT need to be CHANGED
 -------------------------------------------------------
-Implementor's note: Python seems to very agressively
-buffer stdouot. The end result was that rsyslog does not
+Implementor's note: Python seems to very aggressively
+buffer stdout. The end result was that rsyslog does not
 receive the script's messages in a timely manner (sometimes
 even never, probably due to races). To prevent this, we
 flush stdout after we have done processing. This is especially

--- a/plugins/external/skeletons/python/mm-python.py
+++ b/plugins/external/skeletons/python/mm-python.py
@@ -37,7 +37,7 @@ def onInit():
 
 def onReceive(msg):
     """This is the entry point where actual work needs to be done. It receives
-       the messge from rsyslog and now needs to examine it, do any processing
+       the message from rsyslog and now needs to examine it, do any processing
        necessary. The to-be-modified properties (one or many) need to be pushed
        back to stdout, in JSON format, with no interim line breaks and a line
        break at the end of the JSON. If no field is to be modified, empty
@@ -60,8 +60,8 @@ def onExit():
 -------------------------------------------------------
 This is plumbing that DOES NOT need to be CHANGED
 -------------------------------------------------------
-Implementor's note: Python seems to very agressively
-buffer stdouot. The end result was that rsyslog does not
+Implementor's note: Python seems to very aggressively
+buffer stdout. The end result was that rsyslog does not
 receive the script's messages in a timely manner (sometimes
 even never, probably due to races). To prevent this, we
 flush stdout after we have done processing. This is especially

--- a/plugins/external/skeletons/python/plugin.py
+++ b/plugins/external/skeletons/python/plugin.py
@@ -70,7 +70,7 @@ def onExit():
 -------------------------------------------------------
 This is plumbing that DOES NOT need to be CHANGED
 -------------------------------------------------------
-Implementor's note: Python seems to very agressively
+Implementor's note: Python seems to very aggressively
 buffer stdout. The end result was that rsyslog does not
 receive the script's messages in a timely manner (sometimes
 even never, probably due to races). To prevent this, we

--- a/tests/testsuites/mmexternal-SegFault-mm-python.py
+++ b/tests/testsuites/mmexternal-SegFault-mm-python.py
@@ -37,7 +37,7 @@ def onInit():
 
 def onReceive(msg):
     """This is the entry point where actual work needs to be done. It receives
-       the messge from rsyslog and now needs to examine it, do any processing
+       the message from rsyslog and now needs to examine it, do any processing
        necessary. The to-be-modified properties (one or many) need to be pushed
        back to stdout, in JSON format, with no interim line breaks and a line
        break at the end of the JSON. If no field is to be modified, empty
@@ -61,8 +61,8 @@ def onExit():
 -------------------------------------------------------
 This is plumbing that DOES NOT need to be CHANGED
 -------------------------------------------------------
-Implementor's note: Python seems to very agressively
-buffer stdouot. The end result was that rsyslog does not
+Implementor's note: Python seems to very aggressively
+buffer stdout. The end result was that rsyslog does not
 receive the script's messages in a timely manner (sometimes
 even never, probably due to races). To prevent this, we
 flush stdout after we have done processing. This is especially


### PR DESCRIPTION
Why:
The external plugin examples and related test helper carried repeated comment typos that surfaced in automated quality review.

Impact:
No runtime behavior changes; this is comment-only cleanup.

Before/After:
Before, the comments used misspellings such as messge, agressively, and stdouot. After, the comments use the intended words.

Technical Overview:
- Correct message wording in message-modification plugin comments.
- Correct aggressively/stdout wording in the stdout buffering note.
- Apply the same comment fixes to the skeleton, example, and test helper copies that still carried the old text.

Validation:
- rg -n "messge|agressively|stdouot" selected files
- python3 -m tokenize selected files
- git diff --check

With the help of AI-Agents: Codex