### PR TITLE
tests: remove dead mmexternal json parse

### DIFF
--- a/tests/testsuites/mmexternal-SegFault-mm-python.py
+++ b/tests/testsuites/mmexternal-SegFault-mm-python.py
@@ -46,7 +46,6 @@ def onReceive(msg):
        and so each message needs to be fully processed (rsyslog will wait for the
        reply before the next message is pushed to this module).
     """
-    json.loads(msg)
     print(json.dumps({"$!": {"sometag": "somevalue"}}))
 
 def onExit():


### PR DESCRIPTION
Why:
The mmexternal SegFault helper parsed each input message as JSON but never used the parsed value.

Impact:
The test helper keeps emitting the same JSON update without a dead parse step.

Before/After:
Before, onReceive called json.loads(msg) only for its validation side effect. After, onReceive directly emits the fixed response used by the test.

Technical Overview:
- Remove the unused json.loads(msg) call from the SegFault helper.
- Keep the json import because json.dumps() is still used for the response.
- Do not add json.JSONDecodeError handling because this compatibility test has no invalid-JSON assertion and older Python runtimes do not expose that exception name consistently.

Validation:
- rg -n "json\\.loads\\(msg\\)|json\\.loads" tests/testsuites/mmexternal-SegFault-mm-python.py
- python3 -m py_compile tests/testsuites/mmexternal-SegFault-mm-python.py
- printf sample JSON through the helper with python3
- git diff --check

With the help of AI-Agents: Codex