### PR TITLE
python: make file cleanup lexical

### DIFF
--- a/plugins/external/skeletons/python/plugin-with-feedback.py
+++ b/plugins/external/skeletons/python/plugin-with-feedback.py
@@ -72,11 +72,6 @@ def onInit():
     # emitted you must set 'level' to logging.DEBUG above.)
     logging.debug("onInit called")
 
-    # For illustrative purposes, this plugin skeleton appends the received logs
-    # to a file. When implementing your plugin, remove the following code.
-    global outfile
-    outfile = open("/tmp/logfile", "w")
-
 
 def onMessage(msg):
     """Process one log message received from rsyslog (e.g. send it to a
@@ -112,12 +107,8 @@ def onExit():
     """
     logging.debug("onExit called")
 
-    # For illustrative purposes, this plugin skeleton appends the received logs
-    # to a file. When implementing your plugin, remove the following code.
     global outfile
-    if outfile is not None:
-        outfile.close()
-        outfile = None
+    outfile = None
 
 
 """
@@ -141,26 +132,29 @@ print("OK", flush=True)
 
 endedWithError = False
 try:
-    line = sys.stdin.readline()
-    while line:
-        line = line.rstrip('\n')
-        try:
-            onMessage(line)
-            status = "OK"
-        except RecoverableError as e:
-            # Any line written to stdout that is not a status code will be
-            # treated as a recoverable error by 'omprog', and cause the action
-            # to be temporarily suspended. In this skeleton, we simply return
-            # a one-line representation of the Python exception. (If debugging
-            # is enabled in rsyslog, this line will appear in the debug logs.)
-            status = repr(e)
-            # We also log the complete exception to stderr (or to the logging
-            # handler(s) configured in doInit, if any).
-            logging.exception(e)
-
-        # Send the status code (or the one-line error message) to rsyslog:
-        print(status, flush=True)
+    # For illustrative purposes, this plugin skeleton appends the received logs
+    # to a file. When implementing your plugin, remove the following code.
+    with open("/tmp/logfile", "w") as outfile:
         line = sys.stdin.readline()
+        while line:
+            line = line.rstrip('\n')
+            try:
+                onMessage(line)
+                status = "OK"
+            except RecoverableError as e:
+                # Any line written to stdout that is not a status code will be
+                # treated as a recoverable error by 'omprog', and cause the action
+                # to be temporarily suspended. In this skeleton, we simply return
+                # a one-line representation of the Python exception. (If debugging
+                # is enabled in rsyslog, this line will appear in the debug logs.)
+                status = repr(e)
+                # We also log the complete exception to stderr (or to the logging
+                # handler(s) configured in doInit, if any).
+                logging.exception(e)
+
+            # Send the status code (or the one-line error message) to rsyslog:
+            print(status, flush=True)
+            line = sys.stdin.readline()
 
 except Exception:
     # If a non-recoverable error occurs, log it and terminate. The 'omprog'

--- a/plugins/external/skeletons/python/plugin.py
+++ b/plugins/external/skeletons/python/plugin.py
@@ -34,8 +34,7 @@ def onInit():
     """ Do everything that is needed to initialize processing (e.g.
         open files, create handles, connect to systems...)
     """
-    global outfile
-    outfile = open("/tmp/logfile", "a+")
+    # most often, nothing to do here
 
 
 def onReceive(msgs):
@@ -57,13 +56,7 @@ def onExit():
         being called immediately before exiting.
     """
     global outfile
-    if outfile is not None:
-        try:
-            outfile.close()
-        except Exception as e:
-            # Ignore close errors during shutdown, but report for diagnostics.
-            sys.stderr.write("onExit: failed to close outfile: %s\n" % e)
-        outfile = None
+    outfile = None
 
 
 """
@@ -79,24 +72,25 @@ important once we get to the point where the plugin does
 two-way conversations with rsyslog. Do NOT change this!
 See also: https://github.com/rsyslog/rsyslog/issues/22
 """
-try:
-    onInit()
-    keepRunning = 1
-    while keepRunning == 1:
-        while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
-            msgs = []
-            msgsInBatch = 0
-            while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
-                line = sys.stdin.readline()
-                if line:
-                    msgs.append(line)
-                else: # an empty line means stdin has been closed
-                    keepRunning = 0
-                msgsInBatch = msgsInBatch + 1
-                if msgsInBatch >= maxAtOnce:
-                    break
-            if len(msgs) > 0:
-                onReceive(msgs)
-                sys.stdout.flush() # very important, Python buffers far too much!
-finally:
-    onExit()
+with open("/tmp/logfile", "a+") as outfile:
+    try:
+        onInit()
+        keepRunning = 1
+        while keepRunning == 1:
+            while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
+                msgs = []
+                msgsInBatch = 0
+                while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
+                    line = sys.stdin.readline()
+                    if line:
+                        msgs.append(line)
+                    else: # an empty line means stdin has been closed
+                        keepRunning = 0
+                    msgsInBatch = msgsInBatch + 1
+                    if msgsInBatch >= maxAtOnce:
+                        break
+                if len(msgs) > 0:
+                    onReceive(msgs)
+                    sys.stdout.flush() # very important, Python buffers far too much!
+    finally:
+        onExit()

--- a/plugins/external/solr/rsyslog_solr.py
+++ b/plugins/external/solr/rsyslog_solr.py
@@ -49,8 +49,6 @@ def onInit():
         open files, create handles, connect to systems...)
     """
     global solrConnection
-    global errorFile
-    errorFile = open("/var/log/rsyslog_solr_oopsies.log", "a")
     solrConnection = httplib.HTTPConnection(solrServer, solrPort)
     
 
@@ -76,47 +74,47 @@ def onExit():
         being called immediately before exiting.
     """
     global solrConnection
-    global errorFile
     if solrConnection is not None:
         solrConnection.close()
         solrConnection = None
-    if errorFile is not None:
-        errorFile.close()
-        errorFile = None
 
 try:
-    onInit()
-    keepRunning = 1
-    while keepRunning == 1:
-        while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
-            msgs = "["
-            msgsInBatch = 0
-            while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
-                line = sys.stdin.readline()
-                if line:
-                    # append the JSON array used by Solr for updates
-                    msgs += line
-                    msgs += ","
-                else: # an empty line means stdin has been closed
-                    keepRunning = 0
-                    break
-                msgsInBatch = msgsInBatch + 1
-                if msgsInBatch >= maxAtOnce:
-                    break
-            if msgsInBatch > 0:
-                retries = 0
-                while (retries < numberOfRetries):
-                    try:
-                        # close the JSON array used by Solr for updates
-                        onReceive(msgs[:-1] + "]")
-                        break
-                    except socket.error:
-                        # retry if connection failed; it will crash with flames on other exceptions, and you will lose data. But this is something you'd normally see when you first set things up
-                        time.sleep(retryInterval)
-                    retries += 1
-                # if we failed, we write the failed batch to the error file
-                if (retries == numberOfRetries):
-                    errorFile.write("%s\n" % msgs)
-                sys.stdout.flush() # very important, Python buffers far too much!
+    with open("/var/log/rsyslog_solr_oopsies.log", "a") as errorFile:
+        try:
+            onInit()
+            keepRunning = 1
+            while keepRunning == 1:
+                while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
+                    msgs = "["
+                    msgsInBatch = 0
+                    while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
+                        line = sys.stdin.readline()
+                        if line:
+                            # append the JSON array used by Solr for updates
+                            msgs += line
+                            msgs += ","
+                        else: # an empty line means stdin has been closed
+                            keepRunning = 0
+                            break
+                        msgsInBatch = msgsInBatch + 1
+                        if msgsInBatch >= maxAtOnce:
+                            break
+                    if msgsInBatch > 0:
+                        retries = 0
+                        while (retries < numberOfRetries):
+                            try:
+                                # close the JSON array used by Solr for updates
+                                onReceive(msgs[:-1] + "]")
+                                break
+                            except socket.error:
+                                # retry if connection failed; it will crash with flames on other exceptions, and you will lose data. But this is something you'd normally see when you first set things up
+                                time.sleep(retryInterval)
+                            retries += 1
+                        # if we failed, we write the failed batch to the error file
+                        if (retries == numberOfRetries):
+                            errorFile.write("%s\n" % msgs)
+                        sys.stdout.flush() # very important, Python buffers far too much!
+        finally:
+            onExit()
 finally:
-    onExit()
+    errorFile = None

--- a/plugins/external/spm/rsyslog_spm_custom_metrics.py
+++ b/plugins/external/spm/rsyslog_spm_custom_metrics.py
@@ -46,8 +46,6 @@ def onInit():
         open files, create handles, connect to systems...)
     """
     global spmConnection
-    global errorFile
-    errorFile = open("/var/log/rsyslog_spm_oopsies.log", "a")
     spmConnection = httplib.HTTPConnection(spmHost, spmPort)
 
 
@@ -75,50 +73,50 @@ def onExit():
         being called immediately before exiting.
     """
     global spmConnection
-    global errorFile
     if spmConnection is not None:
         spmConnection.close()
         spmConnection = None
-    if errorFile is not None:
-        errorFile.close()
-        errorFile = None
 
 
 try:
-    onInit()
-    keepRunning = 1
-    while keepRunning == 1:
-        while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
-            msgs = "{ \"datapoints\" : ["
-            msgsInBatch = 0
-            while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
-                line = sys.stdin.readline()
-                if line:
-                    # append the JSON array that we'll send later to SPM
-                    msgs += line
-                    msgs += ","
-                else:  # an empty line means stdin has been closed
-                    keepRunning = 0
-                    break
-                msgsInBatch = msgsInBatch + 1
-                if msgsInBatch >= maxAtOnce:
-                    break
-            if msgsInBatch > 0:
-                retries = 0
-                while (retries < numberOfRetries):
-                    try:
-                        # close the JSON array
-                        onReceive(msgs[:-1] + "]}")
-                        break
-                    except socket.error:
-                        # retry if connection failed;
-                        # it will crash with flames on other exceptions, and you will lose data.
-                        # But this is something you'd normally see when you first set things up
-                        time.sleep(retryInterval)
-                    retries += 1
-                # if we failed, we write the failed batch to the error file
-                if (retries == numberOfRetries):
-                    errorFile.write("%s\n" % msgs)
-                sys.stdout.flush()  # very important, Python buffers far too much!
+    with open("/var/log/rsyslog_spm_oopsies.log", "a") as errorFile:
+        try:
+            onInit()
+            keepRunning = 1
+            while keepRunning == 1:
+                while keepRunning and sys.stdin in select.select([sys.stdin], [], [], pollPeriod)[0]:
+                    msgs = "{ \"datapoints\" : ["
+                    msgsInBatch = 0
+                    while keepRunning and sys.stdin in select.select([sys.stdin], [], [], 0)[0]:
+                        line = sys.stdin.readline()
+                        if line:
+                            # append the JSON array that we'll send later to SPM
+                            msgs += line
+                            msgs += ","
+                        else:  # an empty line means stdin has been closed
+                            keepRunning = 0
+                            break
+                        msgsInBatch = msgsInBatch + 1
+                        if msgsInBatch >= maxAtOnce:
+                            break
+                    if msgsInBatch > 0:
+                        retries = 0
+                        while (retries < numberOfRetries):
+                            try:
+                                # close the JSON array
+                                onReceive(msgs[:-1] + "]}")
+                                break
+                            except socket.error:
+                                # retry if connection failed;
+                                # it will crash with flames on other exceptions, and you will lose data.
+                                # But this is something you'd normally see when you first set things up
+                                time.sleep(retryInterval)
+                            retries += 1
+                        # if we failed, we write the failed batch to the error file
+                        if (retries == numberOfRetries):
+                            errorFile.write("%s\n" % msgs)
+                        sys.stdout.flush()  # very important, Python buffers far too much!
+        finally:
+            onExit()
 finally:
-    onExit()
+    errorFile = None

--- a/plugins/impstats/statslog-analyzer.py
+++ b/plugins/impstats/statslog-analyzer.py
@@ -177,16 +177,23 @@ else:
                             if szFileName not in outputFiles:
                                 if bDebugOutput:
                                     print "Creating file : " + szFileName
-                                outputFiles[szFileName] = open(szFileName, 'w')
-                                nLogFileCount += 1
+                                outputFile = open(szFileName, 'w')
+                                try:
+                                    outputFiles[szFileName] = outputFile
+                                    nLogFileCount += 1
 
-                                # Output CSV Header
-                                outputFiles[szFileName].write("Date;")
-                                outputFiles[szFileName].write("Host;")
-                                outputFiles[szFileName].write("Object;")
-                                for szField in aFields:
-                                    outputFiles[szFileName].write(szField + ";")
-                                outputFiles[szFileName].write("\n")
+                                    # Output CSV Header
+                                    outputFile.write("Date;")
+                                    outputFile.write("Host;")
+                                    outputFile.write("Object;")
+                                    for szField in aFields:
+                                        outputFile.write(szField + ";")
+                                    outputFile.write("\n")
+                                except Exception:
+                                    if outputFiles.get(szFileName) is outputFile:
+                                        del outputFiles[szFileName]
+                                    outputFile.close()
+                                    raise
                             # Output CSV Data
                             outputFiles[szFileName].write(filedate.strftime("%Y/%b/%d %H:%M:%S") + ";")
                             outputFiles[szFileName].write(szLogHost + ";")
@@ -215,8 +222,8 @@ else:
                 # Increment helper counter
                 nLogLineNum += 1
     finally:
-        for outFileName in outputFiles:
-            outputFiles[outFileName].close()
+        for outputFile in outputFiles.values():
+            outputFile.close()
         if errorlog is not None:
             errorlog.close()
 

--- a/tests/snmptrapreceiver.py
+++ b/tests/snmptrapreceiver.py
@@ -26,107 +26,94 @@ if len(sys.argv) > 4:
     szSnmpLogfile = sys.argv[4]
 
 # Create output files
-outputFile = open(szOutputfile,"w+")
-try:
-    logFile = open(szSnmpLogfile,"a+")
-except:
-    outputFile.close()
-    raise
+with open(szOutputfile,"w+") as outputFile:
+    with open(szSnmpLogfile,"a+") as logFile:
+        # Assemble MIB viewer
+        mibBuilder = builder.MibBuilder()
+        compiler.addMibCompiler(mibBuilder, sources=['file:///usr/share/snmp/mibs', 'file:///var/lib/snmp/mibs', '/usr/local/share/snmp/mibs/'])
+        mibViewController = view.MibViewController(mibBuilder)
+        # Pre-load MIB modules we expect to work with
+        try:
+            mibBuilder.loadModules('SNMPv2-MIB', 'SNMP-COMMUNITY-MIB', 'SYSLOG-MSG-MIB')
+        except Exception:
+            print("Failed loading MIBs")
 
-# Assemble MIB viewer
-mibBuilder = builder.MibBuilder()
-compiler.addMibCompiler(mibBuilder, sources=['file:///usr/share/snmp/mibs', 'file:///var/lib/snmp/mibs', '/usr/local/share/snmp/mibs/'])
-mibViewController = view.MibViewController(mibBuilder)
-# Pre-load MIB modules we expect to work with
-try:
-    mibBuilder.loadModules('SNMPv2-MIB', 'SNMP-COMMUNITY-MIB', 'SYSLOG-MSG-MIB')
-except Exception:
-    print("Failed loading MIBs")
+        # Create SNMP engine with autogenernated engineID and pre-bound to socket transport dispatcher
+        snmpEngine = engine.SnmpEngine()
 
-# Create SNMP engine with autogenernated engineID and pre-bound to socket transport dispatcher
-snmpEngine = engine.SnmpEngine()
+        # Transport setup
+        # UDP over IPv4, add listening interface/port
+        config.addTransport(
+            snmpEngine,
+            udp.domainName + (1,),
+            udp.UdpTransport().openServerMode((snmpip, snmpport))
+        )
 
-# Transport setup
-# UDP over IPv4, add listening interface/port
-config.addTransport(
-    snmpEngine,
-    udp.domainName + (1,),
-    udp.UdpTransport().openServerMode((snmpip, snmpport))
-)
+        # SNMPv1/2c setup
+        # SecurityName <-> CommunityName mapping
+        config.addV1System(snmpEngine, 'my-area', 'public')
 
-# SNMPv1/2c setup
-# SecurityName <-> CommunityName mapping
-config.addV1System(snmpEngine, 'my-area', 'public')
-
-print("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
-logFile.write("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
-logFile.flush()
-
-# Add PID file creation after startup message
-import os
-with open(szSnmpLogfile + ".started", "w") as f:
-    f.write(str(os.getpid()))
-
-# Callback function for receiving notifications
-# noinspection PyUnusedLocal,PyUnusedLocal,PyUnusedLocal
-def cbReceiverSnmp(snmpEngine, stateReference, contextEngineId, contextName, varBinds, cbCtx):
-    transportDomain, transportAddress = snmpEngine.msgAndPduDsp.getTransportInfo(stateReference)
-    if (bDebug):
-        szDebug = str("Notification From: %s, Domain: %s, SNMP Engine: %s, Context: %s" %
-            (transportAddress, transportDomain, contextEngineId.prettyPrint(), contextName.prettyPrint()))
-        print(szDebug)
-        logFile.write(szDebug)
+        print("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
+        logFile.write("Started SNMP Trap Receiver: %s, %s, Output: %s" % (snmpport, snmpip, szOutputfile))
         logFile.flush()
 
-    # Create output String
-    szOut = "Trap Source{}, Trap OID {}".format(transportAddress, transportDomain)
+        # Add PID file creation after startup message
+        import os
+        with open(szSnmpLogfile + ".started", "w") as f:
+            f.write(str(os.getpid()))
 
-    varBinds = [rfc1902.ObjectType(rfc1902.ObjectIdentity(x[0]), x[1]).resolveWithMib(mibViewController) for x in varBinds]
+        # Callback function for receiving notifications
+        # noinspection PyUnusedLocal,PyUnusedLocal,PyUnusedLocal
+        def cbReceiverSnmp(snmpEngine, stateReference, contextEngineId, contextName, varBinds, cbCtx):
+            transportDomain, transportAddress = snmpEngine.msgAndPduDsp.getTransportInfo(stateReference)
+            if (bDebug):
+                szDebug = str("Notification From: %s, Domain: %s, SNMP Engine: %s, Context: %s" %
+                    (transportAddress, transportDomain, contextEngineId.prettyPrint(), contextName.prettyPrint()))
+                print(szDebug)
+                logFile.write(szDebug)
+                logFile.flush()
 
-    for name, val in varBinds:
-        # Append to output String
-        szOut = szOut + ", Oid: {}, Value: {}".format(name.prettyPrint(), val.prettyPrint())
+            # Create output String
+            szOut = "Trap Source{}, Trap OID {}".format(transportAddress, transportDomain)
 
-        if isinstance(val, OctetString):
-            if (name.prettyPrint() != "SNMP-COMMUNITY-MIB::snmpTrapAddress.0"):
-                szOctets = val.asOctets()#.rstrip('\r').rstrip('\n')
-                szOut = szOut + ", Octets: {}".format(szOctets)
-        if (bDebug):
-            print('%s = %s' % (name.prettyPrint(), val.prettyPrint()))
-    outputFile.write(szOut)
-    if "\n" not in szOut:
-        outputFile.write("\n")
-    outputFile.flush()
+            varBinds = [rfc1902.ObjectType(rfc1902.ObjectIdentity(x[0]), x[1]).resolveWithMib(mibViewController) for x in varBinds]
 
+            for name, val in varBinds:
+                # Append to output String
+                szOut = szOut + ", Oid: {}, Value: {}".format(name.prettyPrint(), val.prettyPrint())
 
-# Register SNMP Application at the SNMP engine
-ntfrcv.NotificationReceiver(snmpEngine, cbReceiverSnmp)
-
-# this job would never finish
-snmpEngine.transportDispatcher.jobStarted(1)
-
-def cleanup_started_file():
-    try:
-        os.remove(szSnmpLogfile + ".started")
-    except OSError:
-        # The marker is best-effort cleanup; shutdown must continue if it is
-        # already gone or cannot be removed.
-        pass
-
-
-def close_output_files():
-    outputFile.close()
-    logFile.close()
+                if isinstance(val, OctetString):
+                    if (name.prettyPrint() != "SNMP-COMMUNITY-MIB::snmpTrapAddress.0"):
+                        szOctets = val.asOctets()#.rstrip('\r').rstrip('\n')
+                        szOut = szOut + ", Octets: {}".format(szOctets)
+                if (bDebug):
+                    print('%s = %s' % (name.prettyPrint(), val.prettyPrint()))
+            outputFile.write(szOut)
+            if "\n" not in szOut:
+                outputFile.write("\n")
+            outputFile.flush()
 
 
-# Run I/O dispatcher which would receive queries and send confirmations
-try:
-    try:
-        snmpEngine.transportDispatcher.runDispatcher()
-    except KeyboardInterrupt:
-        print("Received keyboard interrupt, shutting down")
-    finally:
-        cleanup_started_file()
-        snmpEngine.transportDispatcher.closeDispatcher()
-finally:
-    close_output_files()
+        # Register SNMP Application at the SNMP engine
+        ntfrcv.NotificationReceiver(snmpEngine, cbReceiverSnmp)
+
+        # this job would never finish
+        snmpEngine.transportDispatcher.jobStarted(1)
+
+        def cleanup_started_file():
+            try:
+                os.remove(szSnmpLogfile + ".started")
+            except OSError:
+                # The marker is best-effort cleanup; shutdown must continue if it
+                # is already gone or cannot be removed.
+                pass
+
+
+        # Run I/O dispatcher which would receive queries and send confirmations
+        try:
+            snmpEngine.transportDispatcher.runDispatcher()
+        except KeyboardInterrupt:
+            print("Received keyboard interrupt, shutting down")
+        finally:
+            cleanup_started_file()
+            snmpEngine.transportDispatcher.closeDispatcher()


### PR DESCRIPTION
Why:
CodeQL could not prove that several long-lived Python file handles were closed on every path when cleanup was hidden behind lifecycle hooks.

Impact:
The scripts keep the same behavior while making file ownership explicit.

Before/After:
Before, some files were opened in setup code and closed later indirectly. After, each file is owned by a nearby context manager or direct cleanup block.

Technical Overview:
- Move sample plugin log files into context managers around their loops.
- Open Solr and SPM error logs in context managers that own the plugin loop.
- Keep HTTP connection cleanup in onExit while the file context owns the log.
- Wrap the SNMP receiver output and log files in nested context managers.
- Close partially initialized impstats CSV files if header setup fails.
- Keep the existing final impstats close pass for all retained CSV handles.

Validation:
- python3 -m py_compile plugins/external/skeletons/python/plugin.py plugins/external/skeletons/python/plugin-with-feedback.py tests/snmptrapreceiver.py
- python3 -m tokenize plugins/external/solr/rsyslog_solr.py plugins/external/spm/rsyslog_spm_custom_metrics.py plugins/impstats/statslog-analyzer.py
- git diff --check

Stale reports checked separately:
- SimplePlugin.java no longer calls File.createNewFile().
- tests/historical/DiagTalker.java no longer exists on main.

With the help of AI-Agents: Codex