### PR TITLE
tests: document snmp marker cleanup ignore

### DIFF
--- a/tests/snmptrapreceiver.py
+++ b/tests/snmptrapreceiver.py
@@ -109,6 +109,8 @@ def cleanup_started_file():
     try:
         os.remove(szSnmpLogfile + ".started")
     except OSError:
+        # The marker is best-effort cleanup; shutdown must continue if it is
+        # already gone or cannot be removed.
         pass
 
 


### PR DESCRIPTION
Why:
The SNMP trap receiver intentionally ignores failures while removing its optional .started marker, but the empty handler did not say so.

Impact:
No runtime behavior change; the intended shutdown behavior is explicit.

Before/After:
Before, the OSError handler contained only pass. After, it documents why shutdown continues when marker cleanup fails.

Technical Overview:
- Add a short explanatory comment inside cleanup_started_file().
- Keep the existing OSError handling unchanged for Python compatibility.
- Leave marker cleanup best-effort so shutdown is not masked by filesystem state.

Validation:
- python3 -m py_compile tests/snmptrapreceiver.py
- git diff --check

With the help of AI-Agents: Codex