### PR TITLE
devcontainer: allow sudo for mapped users

### DIFF
--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -29,21 +29,89 @@ if [ "$1" == "--rm" ]; then
 fi
 
 if [ "$RSYSLOG_HOME" == "" ]; then
-	export RSYSLOG_HOME=$(pwd)
-	echo info: RSYSLOG_HOME not set, using $RSYSLOG_HOME
+	RSYSLOG_HOME=$(pwd)
+	export RSYSLOG_HOME
+	echo info: RSYSLOG_HOME not set, using "$RSYSLOG_HOME"
 fi
 
 if [ -z "$RSYSLOG_DEV_CONTAINER" ]; then
-	RSYSLOG_DEV_CONTAINER=$(cat $RSYSLOG_HOME/devtools/default_dev_container)
+	RSYSLOG_DEV_CONTAINER=$(cat "$RSYSLOG_HOME"/devtools/default_dev_container)
 fi
 
 printf '/rsyslog is mapped to %s \n' "$RSYSLOG_HOME"
 printf 'using container %s\n' "$RSYSLOG_DEV_CONTAINER"
 printf 'pulling container...\n'
-docker pull $RSYSLOG_DEV_CONTAINER
-printf 'user ids: %s:%s\n' $(id -u) $(id -g)
-printf 'container_uid: %s\n' ${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)}
+docker pull "$RSYSLOG_DEV_CONTAINER"
+container_uid_args=
+container_uid_spec=
+if [ "${RSYSLOG_CONTAINER_UID+x}" ]; then
+	if [ -n "$RSYSLOG_CONTAINER_UID" ]; then
+		case "$RSYSLOG_CONTAINER_UID" in
+			-u\ *)
+				container_uid_args="$RSYSLOG_CONTAINER_UID"
+				container_uid_spec=${RSYSLOG_CONTAINER_UID#-u }
+				;;
+			-u*)
+				container_uid_args="$RSYSLOG_CONTAINER_UID"
+				container_uid_spec=${RSYSLOG_CONTAINER_UID#-u}
+				;;
+			*)
+				container_uid_args="-u $RSYSLOG_CONTAINER_UID"
+				container_uid_spec="$RSYSLOG_CONTAINER_UID"
+				;;
+		esac
+	fi
+else
+	container_uid_spec="$(id -u):$(id -g)"
+	container_uid_args="-u $container_uid_spec"
+fi
+passwd_group_mounts=
+devcontainer_userdb_tmp=
+devcontainer_userdb_cid=
+cleanup_devcontainer_userdb() {
+	if [ -n "$devcontainer_userdb_cid" ]; then
+		docker rm "$devcontainer_userdb_cid" >/dev/null 2>&1 || true
+	fi
+	if [ -n "$devcontainer_userdb_tmp" ]; then
+		rm -rf "$devcontainer_userdb_tmp"
+	fi
+}
+case "$container_uid_spec" in
+	[0-9]*:[0-9]*)
+	container_uid="${container_uid_spec%%:*}"
+	container_gid="${container_uid_spec##*:}"
+	devcontainer_userdb_tmp="$(mktemp -d)"
+	trap cleanup_devcontainer_userdb EXIT
+	devcontainer_userdb_cid=$(docker create "$RSYSLOG_DEV_CONTAINER")
+	docker cp "$devcontainer_userdb_cid:/etc/passwd" "$devcontainer_userdb_tmp/passwd"
+	docker cp "$devcontainer_userdb_cid:/etc/group" "$devcontainer_userdb_tmp/group"
+	docker cp "$devcontainer_userdb_cid:/etc/shadow" "$devcontainer_userdb_tmp/shadow"
+	if ! awk -F: -v uid="$container_uid" '$3 == uid { found = 1 } END { exit found ? 0 : 1 }' \
+		"$devcontainer_userdb_tmp/passwd"; then
+		container_user="rsyslog-dev-$container_uid"
+		shadow_last_change=$(($(date +%s) / 86400))
+		printf 'rsyslog-dev-%s:x:%s:%s:rsyslog devcontainer user:/rsyslog:/bin/bash\n' \
+			"$container_uid" "$container_uid" "$container_gid" >> "$devcontainer_userdb_tmp/passwd"
+		printf '%s::%s:0:99999:7:::\n' "$container_user" "$shadow_last_change" >> \
+			"$devcontainer_userdb_tmp/shadow"
+	fi
+	if ! awk -F: -v gid="$container_gid" '$3 == gid { found = 1 } END { exit found ? 0 : 1 }' \
+		"$devcontainer_userdb_tmp/group"; then
+		printf 'rsyslog-dev-%s:x:%s:\n' "$container_gid" "$container_gid" >> "$devcontainer_userdb_tmp/group"
+	fi
+	chmod 0644 "$devcontainer_userdb_tmp/passwd" "$devcontainer_userdb_tmp/group"
+	chmod 0640 "$devcontainer_userdb_tmp/shadow"
+	passwd_group_mounts="-v $devcontainer_userdb_tmp/passwd:/etc/passwd:ro"
+	passwd_group_mounts="$passwd_group_mounts -v $devcontainer_userdb_tmp/group:/etc/group:ro"
+	passwd_group_mounts="$passwd_group_mounts -v $devcontainer_userdb_tmp/shadow:/etc/shadow:ro"
+	;;
+esac
+printf 'user ids: %s:%s\n' "$(id -u)" "$(id -g)"
+printf 'container_uid: %s\n' "$container_uid_args"
 printf 'container cmd: %s\n' "$*"
+# DOCKER_RUN_EXTRA_OPTS and DOCKER_RUN_EXTRA_FLAGS intentionally support
+# multiple docker-run arguments.
+# shellcheck disable=SC2086
 docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e RSYSLOG_CONFIGURE_OPTIONS_EXTRA \
 	-e RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE \
@@ -73,6 +141,7 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e VERBOSE \
 	--cap-add SYS_ADMIN \
 	--cap-add SYS_PTRACE \
-	${RSYSLOG_CONTAINER_UID--u $(id -u):$(id -g)} \
+	$container_uid_args \
+	$passwd_group_mounts \
 	$DOCKER_RUN_EXTRA_FLAGS \
-	-v "$RSYSLOG_HOME":/rsyslog $RSYSLOG_DEV_CONTAINER "$@"
+	-v "$RSYSLOG_HOME":/rsyslog "$RSYSLOG_DEV_CONTAINER" "$@"

--- a/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
@@ -134,7 +134,8 @@ VOLUME	/rsyslog
 RUN	groupadd rsyslog \
 	&& useradd -g rsyslog  -s /bin/bash rsyslog \
 	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
-	&& echo "buildbot ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+	&& echo "buildbot ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "ALL ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # mysql needs a little help:
 RUN	mkdir -p /var/run/mysqld && \

--- a/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
@@ -118,7 +118,8 @@ VOLUME	/rsyslog
 RUN	groupadd rsyslog \
 	&& useradd -g rsyslog  -s /bin/bash rsyslog \
 	&& echo "rsyslog ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
-	&& echo "buildbot ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+	&& echo "buildbot ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "ALL ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 # mysql needs a little help:
 RUN	mkdir -p /var/run/mysqld && \

--- a/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/Dockerfile
@@ -432,7 +432,8 @@ RUN	groupadd -g 1002 rsyslog998 \
 	&& echo "rsyslog998 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
 	&& echo "rsyslog997 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
 	&& echo "rsyslog996 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
-	&& echo "rsyslog995 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+	&& echo "rsyslog995 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "ALL ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 WORKDIR	/rsyslog
 USER	rsyslog

--- a/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
@@ -432,7 +432,8 @@ RUN	groupadd -g 1002 rsyslog998 \
 	&& echo "rsyslog998 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
 	&& echo "rsyslog997 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
 	&& echo "rsyslog996 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
-	&& echo "rsyslog995 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+	&& echo "rsyslog995 ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers \
+	&& echo "ALL ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 WORKDIR	/rsyslog
 USER	rsyslog


### PR DESCRIPTION
Root cause:

Local devcontainer runs use `devtools/devcontainer.sh`, which defaults to mapping the host uid/gid into the container with `-u $(id -u):$(id -g)`. On Ubuntu 24.04/26.04 images, host uid `1000` resolves to the image `ubuntu` user, which did not have passwordless sudo. As a result, `mysqld-start.sh` failed when it tried to initialize `/var/lib/mysql`, create `/var/run/mysqld`, and start `mysqld_safe` through sudo in a noninteractive container. Unknown numeric uid/gid mappings have a second problem: sudo cannot resolve/validate the invoking account unless the user database contains that uid.

Changes:

- Grant passwordless sudo to all users in the active Ubuntu 20.04, 22.04, 24.04, and 26.04 dev base images.
- Normalize `RSYSLOG_CONTAINER_UID` handling in `devtools/devcontainer.sh`, preserving the empty value that selects the image default user.
- For numeric uid/gid mappings missing from the image user database, generate temporary passwd/group/shadow overlays and mount them read-only so sudo can resolve and validate the invoking account.

Validation:

- Reproduced the original 26.04 uid 1000 failure on the current image: `sudo: interactive authentication is required`.
- Built a 26.04 validation image with the sudoers change.
- Verified `sudo -n true` and `sudo -n id` for uid `1000:1000`.
- Verified arbitrary uid/gid sudo through the generated passwd/group/shadow overlay.
- Ran a MySQL sudo smoke in the rebuilt 26.04 image.
- Ran `bash -n devtools/devcontainer.sh`, `shellcheck devtools/devcontainer.sh`, `git diff --check`, and `visudo -cf /etc/sudoers`.

Campaign note:

A follow-up full Ubuntu 26.04 no-ES container run with `RSYSLOG_CONTAINER_UID=""`, writable checkout, MySQL enabled, Kafka enabled, and `CI_MAKE_CHECK_OPT=-j80` passed: 1220 total, 1195 pass, 25 skip, 0 fail, 0 error.

With the help of AI-Agents: Codex