### PR TITLE
tests: run MySQL-backed checks in parallel

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2364,44 +2364,32 @@ endif
 if ENABLE_MYSQL_TESTS
 TESTS += $(TESTS_MYSQL)
 
-mysql-basic.log: mysqld-start.log
-mysql-basic-cnf6.log: mysql-basic.log
-mysql-asyn.log: mysql-basic-cnf6.log
-mysql-actq-mt.log: mysql-asyn.log
-mysql-actq-mt-withpause.log: mysql-actq-mt.log
-action-tx-single-processing.log: mysql-actq-mt-withpause.log
-action-tx-errfile-maxsize.log: action-tx-single-processing.log
-action-tx-errfile.log: action-tx-errfile-maxsize.log
-
-mysqld-stop.log: action-tx-errfile.log
+MYSQL_PARALLEL_LOGS = \
+	$(filter-out mysqld-start.log mysqld-stop.log, $(TESTS_MYSQL:.sh=.log))
 
 if HAVE_VALGRIND
 TESTS += $(TESTS_MYSQL_VALGRIND)
 
-mysql-basic-vg.log: action-tx-errfile.log
-mysql-asyn-vg.log: mysql-basic-vg.log
-mysql-actq-mt-withpause-vg.log: mysql-asyn-vg.log
-
-mysqld-stop.log: mysql-actq-mt-withpause-vg.log
+MYSQL_PARALLEL_LOGS += $(TESTS_MYSQL_VALGRIND:.sh=.log)
 endif
 
 if ENABLE_OMLIBDBI # we piggy-back on MYSQL_TESTS as we need the same environment
 TESTS += $(TESTS_LIBDBI)
 
-if HAVE_VALGRIND
-libdbi-basic.log: mysql-actq-mt-withpause-vg.log
-else
-libdbi-basic.log: action-tx-errfile.log
-endif
-libdbi-asyn.log: libdbi-basic.log
-mysqld-stop.log: libdbi-asyn.log
+MYSQL_PARALLEL_LOGS += $(TESTS_LIBDBI:.sh=.log)
+
 if HAVE_VALGRIND
 TESTS += $(TESTS_LIBDBI_VALGRIND)
 
-libdbi-basic-vg.log: libdbi-asyn.log
-mysqld-stop.log: libdbi-basic-vg.log
+MYSQL_PARALLEL_LOGS += $(TESTS_LIBDBI_VALGRIND:.sh=.log)
 endif
 endif
+
+# MySQL tests use one shared server but each test creates its own database.
+# Start the server once, run independent database tests in parallel, then stop
+# the server only after all MySQL-backed tests have completed.
+$(MYSQL_PARALLEL_LOGS): mysqld-start.log
+mysqld-stop.log: $(MYSQL_PARALLEL_LOGS)
 endif #  MYSQL_TESTS
 
 


### PR DESCRIPTION
## Summary

Run the MySQL-backed test group in parallel after the shared MySQL server has started, then stop the server only after all MySQL/action/libdbi tests complete.

## Root Cause

`tests/Makefile.am` serialized every MySQL, action transaction, libdbi, and MySQL valgrind test in one strict `.log` chain. That is more restrictive than the testbench requires: `mysql_prep_for_test()` creates a dedicated database for each test, so the tests share the server process but not database state.

This unnecessary serialization makes high-concurrency CI/container runs spend wallclock in a single tail section even when spare parallelism is available.

## Changes

- Replace the linear MySQL `.log` chain with `MYSQL_PARALLEL_LOGS`.
- Derive the core MySQL log list from `TESTS_MYSQL`, filtering out `mysqld-start.log` and `mysqld-stop.log`, so the core test names are not duplicated.
- Keep `mysqld-start.log` as the prerequisite for all MySQL-backed tests.
- Keep `mysqld-stop.log` as the fan-in dependency after all MySQL/action/libdbi and valgrind variants finish.
- Leave test scripts and test assertions unchanged.

## Validation

- `2026-05-07-mysql-parallel-focused-j80-pass2`: Ubuntu 26.04 self-contained no-ES profile, MySQL and Kafka enabled, `make -j80 check`; `1220` total, `1195` pass, `25` skip, `0` fail.
- `2026-05-07-mysql-parallel-devcontainer-j80-pass2`: same broad Ubuntu 26.04 devcontainer shape; all MySQL/action/libdbi tests and valgrind variants passed, including `mysqld-stop.sh`. The run ended with two unrelated known flakes: `dynfile_invld_sync.sh` and `imfile-endregex-timeout-none-polling.sh`.

The second run confirms the intended fan-out/fan-in ordering under load while preserving the shared MySQL server lifecycle.

## Review Follow-up

Addressed Gemini's maintainability comment by deriving the core MySQL log list from `TESTS_MYSQL` instead of duplicating the test names.
