### PR TITLE
Fix operator precedence in conditions

### DIFF
--- a/runtime/net.c
+++ b/runtime/net.c
@@ -838,7 +838,7 @@ static rsRetVal addAllowedSenderLine(char *pName, uchar **ppRestOfConfLine) {
      * for this.
      */
     /* create parser object starting with line string without leading colon */
-    if ((iRet = rsParsConstructFromSz(&pPars, (uchar *)*ppRestOfConfLine) != RS_RET_OK)) {
+    if ((iRet = rsParsConstructFromSz(&pPars, (uchar *)*ppRestOfConfLine)) != RS_RET_OK) {
         LogError(0, iRet, "Error %d constructing parser object - ignoring allowed sender list", iRet);
         return (iRet);
     }

--- a/template.c
+++ b/template.c
@@ -1618,7 +1618,7 @@ static rsRetVal do_Parameter(uchar **pp, struct template *pTpl) {
                     int iOptions;
                     iOptions = (pTpe->data.field.typeRegex == TPL_REGEX_ERE) ? REG_EXTENDED : 0;
                     int errcode;
-                    if ((errcode = regexp.regcomp(&(pTpe->data.field.re), (char *)regex_char, iOptions) != 0)) {
+                    if ((errcode = regexp.regcomp(&(pTpe->data.field.re), (char *)regex_char, iOptions)) != 0) {
                         char errbuff[512];
                         regexp.regerror(errcode, &(pTpe->data.field.re), errbuff, sizeof(errbuff));
                         DBGPRINTF("Template.c: Error in regular expression: %s\n", errbuff);


### PR DESCRIPTION
Correct the precedence bug in the allowed-sender parser and template regex compilation so the function return values are assigned before comparison.\n\nCloses: https://github.com/rsyslog/rsyslog/issues/6741