### PR TITLE
tests: allocate distinct dynamic ports

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2421,6 +2421,50 @@ get_free_port() {
 $PYTHON -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()'
 }
 
+# prints $1 distinct free ports, one per line
+# This is meant for tests that need more than one preselected port in the same
+# config. It avoids duplicate values from repeated get_free_port calls by
+# keeping all probe sockets open until every requested port has been selected.
+# $2 may be "tcp" (default) or "udp".
+get_free_ports() {
+	if [ "$1" == "" ]; then
+		printf 'TESTBENCH_ERROR: get_free_ports requires a port count\n'
+		error_exit 100
+	fi
+	$PYTHON - "$1" "${2:-tcp}" <<'PYTHON'
+import socket
+import sys
+
+try:
+    count = int(sys.argv[1])
+except ValueError:
+    sys.exit("port count must be an integer")
+
+if count < 1:
+    sys.exit("port count must be positive")
+
+proto = sys.argv[2].lower()
+if proto == "tcp":
+    socktype = socket.SOCK_STREAM
+elif proto == "udp":
+    socktype = socket.SOCK_DGRAM
+else:
+    sys.exit("protocol must be tcp or udp")
+
+sockets = []
+try:
+    for _ in range(count):
+        sock = socket.socket(socket.AF_INET, socktype)
+        sock.bind(("", 0))
+        sockets.append(sock)
+    for sock in sockets:
+        print(sock.getsockname()[1])
+finally:
+    for sock in sockets:
+        sock.close()
+PYTHON
+}
+
 
 # return the inode number of file $1; file MUST exist
 get_inode() {

--- a/tests/ratelimit_policy_watch_multi.sh
+++ b/tests/ratelimit_policy_watch_multi.sh
@@ -4,8 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 
-export PORT_A="$(get_free_port)"
-export PORT_B="$(get_free_port)"
+read -r PORT_A PORT_B < <(get_free_ports 2 udp | tr '\n' ' ')
+export PORT_A PORT_B
 export POLICY_A="$(pwd)/${RSYSLOG_DYNNAME}.policy-a.yaml"
 export POLICY_B="$(pwd)/${RSYSLOG_DYNNAME}.policy-b.yaml"
 export OUT_A="$(pwd)/${RSYSLOG_DYNNAME}.out-a.log"


### PR DESCRIPTION
## Summary

This fixes a dynamic port allocation flake seen while babysitting PR #6837.
`ratelimit_policy_watch_multi.sh` generated this invalid configuration in
Ubuntu 24 CI:

```text
input(type="imudp" port="39337" ratelimit.name="watch_a" ruleset="a")
input(type="imudp" port="39337" ratelimit.name="watch_b" ruleset="b")
```

Both ports came from consecutive `get_free_port` calls. Because each call
closes its probe socket before the next call runs, the kernel may return the
same port again. The test then waits for output from both watched inputs and
can stall at 0/20 lines.

## Root Cause

The existing testbench method is a time-of-check/time-of-use probe for one
port. It is tolerable for one listener, but it is a poor fit when a single
test needs multiple preselected ports in the same configuration. Repeating it
can return duplicate port numbers because nothing reserves earlier results
while later results are selected.

For this test the problem is specifically UDP, and `imudp` does not currently
have the `port=0` plus `listenPortFileName` mechanism that many TCP tests use.
So the test still needs preselected UDP ports, but they must be selected as a
set.

## Changes

- Add `get_free_ports <count> [tcp|udp]` to `tests/diag.sh`.
- Keep all probe sockets open until the whole requested set is selected.
- Default to TCP to match `get_free_port`; allow `udp` for UDP listener tests.
- Switch `ratelimit_policy_watch_multi.sh` to request two distinct UDP ports in
  one helper call.

## Negative-Control Proof

I temporarily forced `PORT_B="$PORT_A"` after the new helper call and reran the
test locally. It failed with the same core signature as CI:

```text
wait_file_lines failed, expected 20 got 0 ... took 100 seconds
FAIL: Test ./ratelimit_policy_watch_multi.sh
```

That temporary proof change was removed before this commit. This shows the test
still catches the invalid duplicate-port behavior.

## Validation

- `make -j$(nproc) check TESTS=""`
- `get_free_ports 8 tcp` returned a unique set
- `get_free_ports 8 udp` returned a unique set
- `get_free_ports 100 udp` returned a unique set
- `./tests/ratelimit_policy_watch_multi.sh` passed five consecutive direct runs
- `make -j80 check TESTS='ratelimit_policy_watch_multi.sh'` passed
- Ten concurrent direct runs of `ratelimit_policy_watch_multi.sh` passed
