### PR TITLE
tests: use listener-owned TCP ports

### DIFF
--- a/tests/complex1.sh
+++ b/tests/complex1.sh
@@ -7,10 +7,7 @@
 . ${srcdir:=.}/diag.sh init
 skip_platform "SunOS"  "This test currently does not work on all flavors of Solaris."
 export NUMMESSAGES=40000
-export RSYSLOG_PORT2="$(get_free_port)"
-export RSYSLOG_PORT3="$(get_free_port)"
 generate_conf
-echo ports: $TCPFLOOD_PORT $RSYSLOG_PORT2 $RSYSLOG_PORT3
 add_conf '
 $MaxMessageSize 10k
 
@@ -39,9 +36,10 @@ $omfileFlushInterval 1
 *.* ?dynfile;outfmt
 action(type="omfile" file ="'$RSYSLOG_DYNNAME'.countfile")
 # listener
-$InputTCPServerInputName '$TCPFLOOD_PORT'
+$InputTCPServerInputName R13514
 $InputTCPServerBindRuleset R13514
-$InputTCPServerRun '$TCPFLOOD_PORT'
+$InputTCPServerListenPortFile '$RSYSLOG_DYNNAME'.tcpflood_port
+$InputTCPServerRun 0
 
 
 ## RULESET with listener
@@ -64,9 +62,10 @@ $omfileFlushInterval 1
 *.* ?dynfile;outfmt
 action(type="omfile" file ="'$RSYSLOG_DYNNAME'.countfile")
 # listener
-$InputTCPServerInputName '$RSYSLOG_PORT2'
+$InputTCPServerInputName R_PORT2
 $InputTCPServerBindRuleset R_PORT2
-$InputTCPServerRun '$RSYSLOG_PORT2'
+$InputTCPServerListenPortFile '$RSYSLOG_DYNNAME'.tcpflood_port2
+$InputTCPServerRun 0
 
 
 
@@ -90,9 +89,10 @@ $omfileFlushInterval 1
 *.* ?dynfile;outfmt
 action(type="omfile" file ="'$RSYSLOG_DYNNAME'.countfile")
 # listener
-$InputTCPServerInputName '$RSYSLOG_PORT3'
+$InputTCPServerInputName R_PORT3
 $InputTCPServerBindRuleset R_PORT3
-$InputTCPServerRun '$RSYSLOG_PORT3'
+$InputTCPServerListenPortFile '$RSYSLOG_DYNNAME'.tcpflood_port3
+$InputTCPServerRun 0
 '
 
 count_function() {
@@ -114,6 +114,10 @@ count_function() {
 }
 
 startup
+assign_file_content TCPFLOOD_PORT "$RSYSLOG_DYNNAME.tcpflood_port"
+assign_file_content RSYSLOG_PORT2 "$RSYSLOG_DYNNAME.tcpflood_port2"
+assign_file_content RSYSLOG_PORT3 "$RSYSLOG_DYNNAME.tcpflood_port3"
+echo ports: $TCPFLOOD_PORT $RSYSLOG_PORT2 $RSYSLOG_PORT3
 # send 40,000 messages of 400 bytes plus header max, via three dest ports
 export TCPFLOOD_PORT="$TCPFLOOD_PORT:$RSYSLOG_PORT2:$RSYSLOG_PORT3"
 tcpflood -m$NUMMESSAGES -rd400 -P129 -f5 -n3 -c15 -i1

--- a/tests/rcvr_fail_restore.sh
+++ b/tests/rcvr_fail_restore.sh
@@ -29,7 +29,6 @@ export PORT_RCVR="$TCPFLOOD_PORT"
 #valgrind="valgrind"
 echo starting sender
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 $WorkDirectory '$RSYSLOG_DYNNAME'.spool
 $MainMsgQueueSize 2000

--- a/tests/sndrcv_failover.sh
+++ b/tests/sndrcv_failover.sh
@@ -18,7 +18,6 @@ export RSYSLOG_DEBUGLOG="log"
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 # then SENDER sends to this port (not tcpflood!)
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/sndrcv_tls_certless_serveronly.sh
+++ b/tests/sndrcv_tls_certless_serveronly.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=100
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -19,17 +18,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" 
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/sndrcv_tls_gtls_serveranon_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_serveranon_ossl_clientanon.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -20,17 +19,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" 
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_ossl_serveranon_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_serveranon_ossl_clientanon.sh
@@ -7,24 +7,23 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Name="ossl"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" 
 add_conf '
 # Note: no TLS for the listener, this is for tcpflood!
 module(	load="../plugins/imtcp/.libs/imtcp")


### PR DESCRIPTION
## Root cause
Some TCP forwarding tests used `get_free_port` to preselect ports and then started rsyslog later. Under parallel load another process can bind the selected port before rsyslog does, so the test can fail for a port-allocation race instead of the behavior it intends to cover.

## Fix
Convert obvious listener-owned TCP cases to existing imtcp/imptcp listener port files:

- use `port="0"` / `$InputTCPServerRun 0` where rsyslog owns the listener
- publish the real bound port with existing `listenPortFileName` / `$InputTCPServerListenPortFile`
- read the bound port through existing testbench helpers before starting the sender
- remove dead preselected port assignments that were overwritten or unused

This PR intentionally avoids UDP, helper-owned services, and negative-path tests that need an unused port. Those require separate handling.

## Proof and validation
Negative-control proof: temporarily sent one `complex1.sh` tcpflood destination to port `1`; the test failed with connection refused and nonzero exit, then the temporary edit was reverted.

Validation passed locally:

- `git diff --check`
- `make -j$(nproc) check TESTS=""`
- direct focused tests for `complex1.sh`, `rcvr_fail_restore.sh`, `sndrcv_failover.sh`, and the changed TLS sender/receiver tests
- `make -j80 check TESTS='complex1.sh rcvr_fail_restore.sh sndrcv_failover.sh sndrcv_tls_ossl_serveranon_ossl_clientanon.sh sndrcv_tls_gtls_serveranon_ossl_clientanon.sh sndrcv_tls_certless_serveronly.sh'`

With the help of AI-Agents: Codex
