### PR TITLE
imudp: publish bound dynamic ports

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -703,6 +703,7 @@ EXTRA_DIST = \
     source/reference/parameters/imudp-defaulttz.rst \
     source/reference/parameters/imudp-device.rst \
     source/reference/parameters/imudp-ipfreebind.rst \
+    source/reference/parameters/imudp-listenportfilename.rst \
     source/reference/parameters/imudp-name-appendport.rst \
     source/reference/parameters/imudp-name.rst \
     source/reference/parameters/imudp-port.rst \

--- a/doc/source/configuration/modules/imudp.rst
+++ b/doc/source/configuration/modules/imudp.rst
@@ -95,6 +95,10 @@ Input Parameters
      - .. include:: ../../reference/parameters/imudp-port.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imudp-listenportfilename`
+     - .. include:: ../../reference/parameters/imudp-listenportfilename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imudp-ipfreebind`
      - .. include:: ../../reference/parameters/imudp-ipfreebind.rst
         :start-after: .. summary-start
@@ -354,6 +358,7 @@ Additional Resources
    ../../reference/parameters/imudp-preservecase
    ../../reference/parameters/imudp-address
    ../../reference/parameters/imudp-port
+   ../../reference/parameters/imudp-listenportfilename
    ../../reference/parameters/imudp-ipfreebind
    ../../reference/parameters/imudp-device
    ../../reference/parameters/imudp-ruleset

--- a/doc/source/reference/parameters/imudp-listenportfilename.rst
+++ b/doc/source/reference/parameters/imudp-listenportfilename.rst
@@ -1,0 +1,54 @@
+.. _param-imudp-listenportfilename:
+.. _imudp.parameter.input.listenportfilename:
+
+ListenPortFileName
+==================
+
+.. index::
+   single: imudp; ListenPortFileName
+   single: ListenPortFileName
+
+.. summary-start
+
+Writes the UDP listener's bound port number into the given file.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imudp`.
+
+:Name: ListenPortFileName
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: input=none
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Specifies a file name into which the port number this input listens on is
+written after the UDP socket is bound. It is primarily useful with ``port="0"``,
+where the operating system assigns an available port and rsyslog writes the
+assigned port to the file.
+
+This parameter can be used only when the ``port`` array contains one value and
+that value binds exactly one UDP socket. Wildcard addresses can resolve to
+multiple sockets, for example separate IPv4 and IPv6 sockets, and are rejected
+with ``listenPortFileName`` because one file would be ambiguous. Set
+``address`` to a single local address, or configure separate ``imudp`` inputs
+with separate ``listenPortFileName`` values.
+
+When used with a nonzero single port, rsyslog writes the actual bound port
+number to the file after the bind succeeds.
+
+Input usage
+-----------
+.. _param-imudp-input-listenportfilename:
+.. _imudp.parameter.input.listenportfilename-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imudp" port="0" listenPortFileName="/tmp/imudp.port")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imudp`.

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -110,6 +110,7 @@ struct instanceConf_s {
     uchar *pszBindAddr; /* IP to bind socket to */
     char *pszBindDevice; /* Device to bind socket to */
     uchar *pszBindPort; /* Port to bind socket to */
+    uchar *pszLstnPortFileName; /* file receiving dynamic port for port="0" */
     uchar *pszBindRuleset; /* name of ruleset to bind to */
     uchar *inputname;
     ruleset_t *pBindRuleset; /* ruleset to bind listener to (use system default if unspecified) */
@@ -171,6 +172,7 @@ static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / si
 
 /* input instance parameters */
 static struct cnfparamdescr inppdescr[] = {{"port", eCmdHdlrArray, CNFPARAM_REQUIRED}, /* legacy: InputTCPServerRun */
+                                           {"listenportfilename", eCmdHdlrString, 0},
                                            {"defaulttz", eCmdHdlrString, 0},
                                            {"inputname", eCmdHdlrGetWord, 0},
                                            {"inputname.appendport", eCmdHdlrBinary, 0},
@@ -200,6 +202,7 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
     inst->pBindRuleset = NULL;
 
     inst->pszBindPort = NULL;
+    inst->pszLstnPortFileName = NULL;
     inst->pszBindAddr = NULL;
     inst->pszBindDevice = NULL;
     inst->pszBindRuleset = NULL;
@@ -257,6 +260,38 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal writeListenPortFile(const uchar *const pszLstnPortFileName, const unsigned listenPort) {
+    FILE *fp = NULL;
+    DEFiRet;
+
+    if ((fp = fopen((const char *)pszLstnPortFileName, "w")) == NULL) {
+        LogError(errno, RS_RET_IO_ERROR,
+                 "imudp: listenPortFileName: "
+                 "error while trying to open file");
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (fprintf(fp, "%u", listenPort) < 0) {
+        LogError(errno, RS_RET_IO_ERROR,
+                 "imudp: listenPortFileName: "
+                 "error while trying to write file");
+        fclose(fp);
+        fp = NULL;
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (fclose(fp) != 0) {
+        fp = NULL;
+        LogError(errno, RS_RET_IO_ERROR,
+                 "imudp: listenPortFileName: "
+                 "error while trying to close file");
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    fp = NULL;
+
+finalize_it:
+    if (fp != NULL) fclose(fp);
+    RETiRet;
+}
+
 
 /* This function is called when a new listener shall be added. It takes
  * the instance config description, tries to bind the socket and, if that
@@ -289,12 +324,24 @@ static rsRetVal addListner(instanceConf_t *inst) {
 
     newSocks = net.create_udp_socket(bindAddr, port, 1, inst->rcvbuf, 0, inst->ipfreebind, inst->pszBindDevice);
     if (newSocks != NULL) {
+        if (inst->pszLstnPortFileName != NULL && newSocks[0] != 1) {
+            LogError(0, RS_RET_INVALID_PARAMS,
+                     "imudp: listenPortFileName requires exactly one bound "
+                     "socket, got %d; set address to a single local address",
+                     newSocks[0]);
+            ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+        }
         /* we now need to add the new sockets to the existing set */
         /* ready to copy */
         for (iSrc = 1; iSrc <= newSocks[0]; ++iSrc) {
-            struct sockaddr_in sa;
-            socklen_t salen = sizeof(sa);
+            union {
+                struct sockaddr_storage storage;
+                struct sockaddr_in ipv4;
+                struct sockaddr_in6 ipv6;
+            } sa;
+            socklen_t salen = sizeof(sa.storage);
             const char *suffix;
+            unsigned listenPort = 0;
             CHKmalloc(newlcnfinfo = (struct lstn_s *)calloc(1, sizeof(struct lstn_s)));
             newlcnfinfo->next = NULL;
             newlcnfinfo->sock = newSocks[iSrc];
@@ -302,14 +349,16 @@ static rsRetVal addListner(instanceConf_t *inst) {
             newlcnfinfo->dfltTZ = inst->dfltTZ;
             newlcnfinfo->ratelimiter = NULL;
             /* query socket IPv4 vs IPv6 */
-            sa.sin_family = 0; /* just to keep CLANG static analyzer happy! */
-            if (getsockname(newlcnfinfo->sock, (struct sockaddr *)&sa, &salen) != 0) {
+            sa.storage.ss_family = 0; /* just to keep CLANG static analyzer happy! */
+            if (getsockname(newlcnfinfo->sock, (struct sockaddr *)&sa.storage, &salen) != 0) {
                 suffix = "error_getting_AF...";
             } else {
-                if (sa.sin_family == AF_INET) {
+                if (sa.storage.ss_family == AF_INET) {
                     suffix = "IPv4";
-                } else if (sa.sin_family == AF_INET6) {
+                    listenPort = ntohs(sa.ipv4.sin_port);
+                } else if (sa.storage.ss_family == AF_INET6) {
                     suffix = "IPv6";
+                    listenPort = ntohs(sa.ipv6.sin6_port);
                 } else {
                     suffix = "AF_unknown";
                 }
@@ -353,6 +402,15 @@ static rsRetVal addListner(instanceConf_t *inst) {
             CHKiRet(statsobj.AddCounter(newlcnfinfo->stats, UCHAR_CONSTANT("disallowed"), ctrType_IntCtr,
                                         CTR_FLAG_RESETTABLE, &(newlcnfinfo->ctrDisallowed)));
             CHKiRet(statsobj.ConstructFinalize(newlcnfinfo->stats));
+            if (inst->pszLstnPortFileName != NULL) {
+                if (listenPort == 0) {
+                    LogError(0, RS_RET_IO_ERROR,
+                             "imudp: listenPortFileName: "
+                             "could not determine bound UDP port");
+                    ABORT_FINALIZE(RS_RET_IO_ERROR);
+                }
+                CHKiRet(writeListenPortFile(inst->pszLstnPortFileName, listenPort));
+            }
             /* link to list. Order must be preserved to take care for
              * conflicting matches.
              */
@@ -909,6 +967,8 @@ static rsRetVal createListner(es_str_t *port, struct cnfparamvals *pvals) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "port")) {
             continue; /* array, handled by caller */
+        } else if (!strcmp(inppblk.descr[i].name, "listenportfilename")) {
+            CHKmalloc(inst->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "name")) {
             if (inst->inputname != NULL) {
                 LogError(0, RS_RET_INVALID_PARAMS,
@@ -1007,6 +1067,7 @@ BEGINnewInpInst
     struct cnfparamvals *pvals;
     int i;
     int portIdx;
+    int portFileIdx;
     CODESTARTnewInpInst;
     DBGPRINTF("newInpInst (imudp)\n");
 
@@ -1020,6 +1081,14 @@ BEGINnewInpInst
 
     portIdx = cnfparamGetIdx(&inppblk, "port");
     assert(portIdx != -1);
+    portFileIdx = cnfparamGetIdx(&inppblk, "listenportfilename");
+    assert(portFileIdx != -1);
+    if (pvals[portFileIdx].bUsed && pvals[portIdx].val.d.ar->nmemb > 1) {
+        LogError(0, RS_RET_INVALID_PARAMS,
+                 "imudp: listenPortFileName cannot be used with multiple "
+                 "port values; use one input per port");
+        ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+    }
     for (i = 0; i < pvals[portIdx].val.d.ar->nmemb; ++i) {
         CHKiRet(createListner(pvals[portIdx].val.d.ar->arr[i], pvals));
     }
@@ -1196,6 +1265,7 @@ BEGINfreeCnf
     CODESTARTfreeCnf;
     for (inst = pModConf->root; inst != NULL;) {
         free(inst->pszBindPort);
+        free(inst->pszLstnPortFileName);
         free(inst->pszBindAddr);
         free(inst->pszBindDevice);
         free(inst->pszBindRuleset);

--- a/tests/imudp_ratelimit_name.sh
+++ b/tests/imudp_ratelimit_name.sh
@@ -8,20 +8,22 @@ export SENDMESSAGES=20
 export NUMMESSAGES=5
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines # ensure we wait for expected messages to arrive
 # Receiver PORT
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 
 generate_conf
 add_conf '
 ratelimit(name="imudp_test_limit" interval="2" burst="5")
 
 module(load="../plugins/imudp/.libs/imudp")
-input(type="imudp" port="'$PORT_RCVR'" ratelimit.name="imudp_test_limit")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="imudp_test_limit")
 
 template(name="outfmt" type="string" string="%msg%\n")
 if $msg contains "msgnum:" then 
     action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 # Send 20 messages via UDP
 ./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES

--- a/tests/ratelimit_policy_watch.sh
+++ b/tests/ratelimit_policy_watch.sh
@@ -5,7 +5,7 @@
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
 export POLICY_TMP="$(pwd)/${RSYSLOG_DYNNAME}.policy.tmp.yaml"
 export SENDMESSAGES=20
@@ -21,7 +21,8 @@ add_conf '
 global(processInternalMessages="on")
 ratelimit(name="watch_limiter" policy="'$POLICY_FILE'" policyWatch="on" policyWatchDebounce="200ms")
 module(load="../plugins/imudp/.libs/imudp" batchSize="1")
-input(type="imudp" port="'$PORT_RCVR'" ratelimit.name="watch_limiter" ruleset="main")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="watch_limiter" ruleset="main")
 
 template(name="outfmt" type="string" string="RECEIVED RAW: %rawmsg%\n")
 
@@ -30,6 +31,7 @@ ruleset(name="main") {
 }
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 ./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 wait_file_lines "$RSYSLOG_OUT_LOG" 20 100

--- a/tests/ratelimit_policy_watch_debounce.sh
+++ b/tests/ratelimit_policy_watch_debounce.sh
@@ -4,7 +4,7 @@
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
 export SENDMESSAGES=20
 
@@ -19,7 +19,8 @@ add_conf '
 global(processInternalMessages="on")
 ratelimit(name="debounce_limiter" policy="'$POLICY_FILE'" policyWatch="on" policyWatchDebounce="500ms")
 module(load="../plugins/imudp/.libs/imudp" batchSize="1")
-input(type="imudp" port="'$PORT_RCVR'" ratelimit.name="debounce_limiter" ruleset="main")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="debounce_limiter" ruleset="main")
 
 template(name="outfmt" type="string" string="RECEIVED RAW: %rawmsg%\n")
 
@@ -28,6 +29,7 @@ ruleset(name="main") {
 }
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 cat > "$POLICY_FILE" <<'YAML'
 interval: 1

--- a/tests/ratelimit_policy_watch_invalid.sh
+++ b/tests/ratelimit_policy_watch_invalid.sh
@@ -4,7 +4,7 @@
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
 export SENDMESSAGES=20
 
@@ -19,7 +19,8 @@ add_conf '
 global(processInternalMessages="on")
 ratelimit(name="watch_invalid" policy="'$POLICY_FILE'" policyWatch="on" policyWatchDebounce="200ms")
 module(load="../plugins/imudp/.libs/imudp" batchSize="1")
-input(type="imudp" port="'$PORT_RCVR'" ratelimit.name="watch_invalid" ruleset="main")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="watch_invalid" ruleset="main")
 
 template(name="outfmt" type="string" string="RECEIVED RAW: %rawmsg%\n")
 
@@ -28,6 +29,7 @@ ruleset(name="main") {
 }
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 tcpflood -Tudp -p"$PORT_RCVR" -m "$SENDMESSAGES" -M "msgnum:"
 wait_file_lines "$RSYSLOG_OUT_LOG" 20 100

--- a/tests/ratelimit_policy_watch_multi.sh
+++ b/tests/ratelimit_policy_watch_multi.sh
@@ -4,8 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 
-export PORT_A="$(get_free_port)"
-export PORT_B="$(get_free_port)"
+export PORT_A_FILE="${RSYSLOG_DYNNAME}.imudp_port_a"
+export PORT_B_FILE="${RSYSLOG_DYNNAME}.imudp_port_b"
 export POLICY_A="$(pwd)/${RSYSLOG_DYNNAME}.policy-a.yaml"
 export POLICY_B="$(pwd)/${RSYSLOG_DYNNAME}.policy-b.yaml"
 export OUT_A="$(pwd)/${RSYSLOG_DYNNAME}.out-a.log"
@@ -30,8 +30,10 @@ global(processInternalMessages="on")
 ratelimit(name="watch_a" policy="'$POLICY_A'" policyWatch="on" policyWatchDebounce="200ms")
 ratelimit(name="watch_b" policy="'$POLICY_B'" policyWatch="on" policyWatchDebounce="200ms")
 module(load="../plugins/imudp/.libs/imudp" batchSize="1")
-input(type="imudp" port="'$PORT_A'" ratelimit.name="watch_a" ruleset="a")
-input(type="imudp" port="'$PORT_B'" ratelimit.name="watch_b" ruleset="b")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_A_FILE'"
+      ratelimit.name="watch_a" ruleset="a")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_B_FILE'"
+      ratelimit.name="watch_b" ruleset="b")
 
 template(name="outfmt" type="string" string="RECEIVED RAW: %rawmsg%\n")
 
@@ -53,6 +55,8 @@ count_msgs() {
 }
 
 startup
+assign_file_content PORT_A "$PORT_A_FILE"
+assign_file_content PORT_B "$PORT_B_FILE"
 
 tcpflood -Tudp -p"$PORT_A" -m "$SENDMESSAGES" -M "msgnum:"
 tcpflood -Tudp -p"$PORT_B" -m "$SENDMESSAGES" -M "msgnum:"

--- a/tests/sndrcv_udp.sh
+++ b/tests/sndrcv_udp.sh
@@ -19,25 +19,24 @@ export TCPFLOOD_EXTRA_OPTS="-b1 -W1"
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 add_conf '
-$ModLoad ../plugins/imudp/.libs/imudp
-# then SENDER sends to this port (not tcpflood!)
-$UDPServerRun '$PORT_RCVR'
+module(load="../plugins/imudp/.libs/imudp")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'")
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
-$ModLoad ../plugins/imtcp/.libs/imtcp
+module(load="../plugins/imtcp/.libs/imtcp")
 # this listener is for message generation by the test framework!
-$InputTCPServerRun '$TCPFLOOD_PORT'
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 *.*	@127.0.0.1:'$PORT_RCVR'
 ' 2

--- a/tests/yaml-ratelimit-policywatch.sh
+++ b/tests/yaml-ratelimit-policywatch.sh
@@ -4,7 +4,7 @@
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
 export SENDMESSAGES=20
 
@@ -18,7 +18,8 @@ generate_conf
 add_conf '
 include(file="'${RSYSLOG_DYNNAME}'.yaml")
 module(load="../plugins/imudp/.libs/imudp" batchSize="1")
-input(type="imudp" port="'$PORT_RCVR'" ratelimit.name="yaml_watch" ruleset="main")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="yaml_watch" ruleset="main")
 '
 
 cat > "${RSYSLOG_DYNNAME}.yaml" <<'YAMLEOF'
@@ -45,6 +46,7 @@ sed -i \
     "${RSYSLOG_DYNNAME}.yaml"
 
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 ./tcpflood -Tudp -p$PORT_RCVR -m $SENDMESSAGES -M "msgnum:"
 wait_file_lines "$RSYSLOG_OUT_LOG" 20 100


### PR DESCRIPTION
## Root cause
Several UDP/rate-limit tests used `get_free_port` to choose a port before rsyslog started `imudp`. That only observes that a port is free at that moment; it does not reserve the port. Under parallel load another process can bind the same port before `imudp`, which makes the test fail for infrastructure timing instead of the behavior under test.

This was seen concretely in `ratelimit_policy_watch_multi.sh`, where both generated inputs ended up with the same UDP port in a CI failure.

## Fix
Add `imudp` input parameter `listenPortFileName` / `listenportfilename` and migrate the affected low-risk UDP tests to listener-owned dynamic ports:

- `imudp` binds `port="0"`
- after bind, `imudp` writes the actual bound UDP port to the configured file
- tests read that file with existing testbench helpers before calling `tcpflood`
- migrated tests bind `address="127.0.0.1"` so the port file represents one concrete socket

The implementation rejects ambiguous configurations:

- `listenPortFileName` with multiple `port` array values fails configuration
- `listenPortFileName` with wildcard/default binding that creates more than one UDP socket fails configuration

This avoids last-writer-wins behavior where one file would otherwise represent multiple bound sockets.

## Documentation
The new `imudp` input parameter is documented and added to the imudp parameter table and doc distribution list.

## Proof and validation
Negative-control proof: temporarily forced both `ratelimit_policy_watch_multi.sh` inputs to use the same port; the test failed with `expected 20 got 0`, then the temporary edit was removed.

Additional negative config proof: wildcard/default `listenPortFileName` that bound two sockets failed with the new clear error and wrote no port file.

Validation passed locally:

- `bash devtools/format-code.sh`
- `git diff --check`
- `./autogen.sh --enable-debug --enable-testbench`
- `make -j$(nproc) check TESTS=""`
- focused UDP tests via `make -j$(nproc) check TESTS='imudp_ratelimit_name.sh ratelimit_policy_watch.sh ratelimit_policy_watch_debounce.sh ratelimit_policy_watch_invalid.sh ratelimit_policy_watch_multi.sh yaml-ratelimit-policywatch.sh sndrcv_udp.sh'` (`6 PASS`, `1 SKIP` for non-root `sndrcv_udp.sh`)
- `./doc/tools/build-doc-linux.sh --clean --format html`
- `make dist` verified the new doc file is included

With the help of AI-Agents: Codex
