### PR TITLE
tests: use imudp listener port files

### DIFF
--- a/tests/ratelimit_hup.sh
+++ b/tests/ratelimit_hup.sh
@@ -6,7 +6,7 @@
 . ${srcdir:=.}/diag.sh init
 
 # Define ports and files
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 export POLICY_FILE="$(pwd)/test_policy_hup.yaml"
 
 # Create initial policy (High limits)
@@ -18,12 +18,14 @@ generate_conf
 add_conf '
 ratelimit(name="hup_limiter" policy="'$POLICY_FILE'")
 module(load="../plugins/imudp/.libs/imudp" batchSize="1")
-input(type="imudp" port="'$PORT_RCVR'" ratelimit.name="hup_limiter")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_RCVR_FILE'"
+      ratelimit.name="hup_limiter")
 
 template(name="outfmt" type="string" string="RECEIVED RAW: %rawmsg%\n")
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 # Phase 1: High Limit (Burst 1000)
 # Send 20 messages. All should pass.

--- a/tests/sndrcv_omudpspoof-bigmsg.sh
+++ b/tests/sndrcv_omudpspoof-bigmsg.sh
@@ -17,7 +17,7 @@ export MESSAGESIZE=65000 #65000 #32768 #16384
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_UDP="$(get_free_port)"
+export PORT_UDP_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
@@ -25,7 +25,8 @@ global (
     maxMessageSize="64k"
 )
 
-input(type="imudp" port="'$PORT_UDP'" ruleset="rsImudp")
+input(type="imudp" address="127.0.0.1" port="0" listenPortFileName="'$PORT_UDP_FILE'"
+      ruleset="rsImudp")
 $template outfmt,"%msg%\n" 
 
 ruleset(name="rsImudp") {
@@ -36,6 +37,7 @@ ruleset(name="rsImudp") {
 }
 '
 startup
+assign_file_content PORT_UDP "$PORT_UDP_FILE"
 
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"

--- a/tests/sndrcv_udp_nonstdpt_v6.sh
+++ b/tests/sndrcv_udp_nonstdpt_v6.sh
@@ -6,20 +6,22 @@ echo \[sndrcv_udp_nonstdpt_v6.sh\]: testing sending and receiving via udp
 
 # uncomment for debugging support:
 . ${srcdir:=.}/diag.sh init
+. $srcdir/diag.sh check-ipv6-available
 # start up the instances
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
 add_conf '
 module(load="../plugins/imudp/.libs/imudp")
 # then SENDER sends to this port (not tcpflood!)
-input(type="imudp" address="127.0.0.1" port=`echo $PORT_RCVR`)
+input(type="imudp" address="::1" port="0" listenPortFileName="'$PORT_RCVR_FILE'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
@@ -30,7 +32,7 @@ module(load="../plugins/imtcp/.libs/imtcp")
 input(type="imtcp" port=`echo $TCPFLOOD_PORT`)
 
 action(type="omfwd"
-       target="127.0.0.1" port=`echo $PORT_RCVR`
+       target="::1" port=`echo $PORT_RCVR`
        protocol="udp" udp.sendDelay="1")
 ' 2
 startup 2


### PR DESCRIPTION
## Root cause
A few imudp receiver tests still used `get_free_port` before rsyslog started the listener. That leaves a race window where another parallel test or process can bind the selected UDP port before rsyslog does.

## Fix
Use the existing imudp `listenPortFileName` support for the rsyslog-owned UDP listeners in:

- `ratelimit_hup.sh`
- `sndrcv_udp_nonstdpt_v6.sh`
- `sndrcv_omudpspoof-bigmsg.sh`

The tests now configure imudp with `port="0"`, read the actual bound port through `assign_file_content`, and send to that port. The IPv6 test binds explicitly to `::1` so the imudp port-file contract has exactly one bound socket.

## Proof and validation
Negative-control proof: temporarily skipped the receiver port assignment in `sndrcv_udp_nonstdpt_v6.sh`. The sender then used an empty UDP destination port, `omfwd` logged `sendto() error: Invalid argument`, and the sequence check failed. The temporary edit was removed before the final patch.

Validation passed locally:

- `./autogen.sh --enable-debug --enable-testbench --enable-omudpspoof`
- `make -j80 check TESTS=""`
- `./tests/ratelimit_hup.sh`
- `./tests/sndrcv_udp_nonstdpt_v6.sh`
- `make -j80 check TESTS='ratelimit_hup.sh sndrcv_udp_nonstdpt_v6.sh sndrcv_omudpspoof-bigmsg.sh'` (`2 PASS`, `1 SKIP`)
- `git diff --check`

`sndrcv_omudpspoof-bigmsg.sh` skipped locally because raw socket execution requires root.

With the help of AI-Agents: Codex
