### PR TITLE
tests: use TLS receiver port files

### DIFF
--- a/tests/sndrcv_tls_anon_ipv4.sh
+++ b/tests/sndrcv_tls_anon_ipv4.sh
@@ -10,7 +10,6 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"

--- a/tests/sndrcv_tls_anon_ipv6.sh
+++ b/tests/sndrcv_tls_anon_ipv6.sh
@@ -35,7 +35,6 @@ export PORT_RCVR=$TCPFLOOD_PORT
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/sndrcv_tls_anon_rebind.sh
+++ b/tests/sndrcv_tls_anon_rebind.sh
@@ -12,7 +12,6 @@ export NUMMESSAGES=25000 #25000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	
 	defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
@@ -26,14 +25,14 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
-export PORT_RCVR=$TCPFLOOD_PORT # save this, will be rewritten with next config
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 
 #export RSYSLOG_DEBUG="debug nostdout"
 export RSYSLOG_DEBUGLOG="log2"

--- a/tests/sndrcv_tls_certless_clientonly.sh
+++ b/tests/sndrcv_tls_certless_clientonly.sh
@@ -9,7 +9,6 @@ export NUMMESSAGES=5000
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
 # receiver
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -22,18 +21,18 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 
 # sender
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-#export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global(defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'")
 

--- a/tests/sndrcv_tls_certless_clientonly_mbedtls.sh
+++ b/tests/sndrcv_tls_certless_clientonly_mbedtls.sh
@@ -8,7 +8,6 @@ export NUMMESSAGES=5000
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
 # receiver
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -21,18 +20,18 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 
 # sender (mbedtls tls client)
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-#export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global(defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'")
 

--- a/tests/sndrcv_tls_gtls_native_pq_group.sh
+++ b/tests/sndrcv_tls_gtls_native_pq_group.sh
@@ -14,7 +14,6 @@ fi
 export NUMMESSAGES=1000
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -29,13 +28,14 @@ module(load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.AuthMode="anon"
 	gnutlsPriorityString="'$GNUTLS_PQ_PRIO'")
 
-input(type="imtcp" port="'$PORT_RCVR'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'"
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 
 export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2

--- a/tests/sndrcv_tls_gtls_serveranon_mbedtls_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_serveranon_mbedtls_clientanon.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -20,17 +19,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_gtls_servercert_gtls_clientanon_legacy.sh
+++ b/tests/sndrcv_tls_gtls_servercert_gtls_clientanon_legacy.sh
@@ -10,7 +10,6 @@ export NUMMESSAGES=5000
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
 # receiver
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -23,18 +22,18 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 
 # sender
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-#export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 # Note: no TLS for the listener, this is for tcpflood!
 $ModLoad ../plugins/imtcp/.libs/imtcp

--- a/tests/sndrcv_tls_gtls_servercert_mbedtls_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_servercert_mbedtls_clientanon.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -19,17 +18,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_gtls_servercert_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_gtls_servercert_ossl_clientanon.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -19,17 +18,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" 
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_mbedtls_gnutlspriorityString_no_suite_in_common.sh
+++ b/tests/sndrcv_tls_mbedtls_gnutlspriorityString_no_suite_in_common.sh
@@ -6,7 +6,6 @@ export NUMMESSAGES=1
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -20,15 +19,15 @@ module( load="../plugins/imtcp/.libs/imtcp"
 	PermittedPeer="rsyslog client"
 	gnutlspriorityString="TLS-ECDHE-RSA-WITH-AES-256-GCM-SHA384")
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"

--- a/tests/sndrcv_tls_mbedtls_gnutlspriorityString_suite_in_common.sh
+++ b/tests/sndrcv_tls_mbedtls_gnutlspriorityString_suite_in_common.sh
@@ -13,7 +13,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 MBEDTLS_MAJOR=$(pkg-config --modversion mbedtls | cut -d . -f 1)
 if [ "$MBEDTLS_MAJOR" -ge 3 ]; then
     GNUTLS_1_3_CS="TLS1-3-AES-256-GCM-SHA384,"
@@ -31,17 +30,17 @@ module( load="../plugins/imtcp/.libs/imtcp"
 	PermittedPeer="rsyslog client"
 	gnutlspriorityString="'${GNUTLS_1_3_CS}'TLS-ECDHE-RSA-WITH-AES-128-GCM-SHA256,TLS-ECDHE-ECDSA-WITH-CAMELLIA-256-GCM-SHA384")
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"

--- a/tests/sndrcv_tls_mbedtls_servercert_clientcert.sh
+++ b/tests/sndrcv_tls_mbedtls_servercert_clientcert.sh
@@ -6,7 +6,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/testsuites/x.509/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -19,17 +18,17 @@ module( load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.AuthMode="x509/name"
 	PermittedPeer="rsyslog client")
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/testsuites/x.509/client-cert.pem'"

--- a/tests/sndrcv_tls_ossl_intermediate_ca_chain.sh
+++ b/tests/sndrcv_tls_ossl_intermediate_ca_chain.sh
@@ -88,7 +88,6 @@ cat "$CERTDIR/client-int2-cert.pem" "$CERTDIR/intermediate-ca2-cert.pem" > "$CER
 }
 
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 export SERVER_CN="rsyslogserver"
 export CLIENT_CN="rsyslogclient"
 
@@ -106,7 +105,7 @@ module(  load="../plugins/imtcp/.libs/imtcp"
         StreamDriver.Mode="1"
         PermittedPeer="'$CLIENT_CN'"
         StreamDriver.AuthMode="x509/name" )
-input(  type="imtcp" port="'$PORT_RCVR'" )
+input(  type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'"
@@ -114,10 +113,10 @@ $template dynfile,"'$RSYSLOG_OUT_LOG'"
 '
 
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global(
     defaultNetstreamDriverCAFile="'$CERTDIR'/ca-root-cert.pem"

--- a/tests/sndrcv_tls_ossl_native_pq_group.sh
+++ b/tests/sndrcv_tls_ossl_native_pq_group.sh
@@ -14,7 +14,6 @@ export NUMMESSAGES=1000
 export RSYSLOG_DEBUGLOG="log"
 export OSSL_PQ_CFG='MinProtocol=TLSv1.3\nMaxProtocol=TLSv1.3\nGroups=X25519MLKEM768'
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -28,13 +27,14 @@ module(load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.AuthMode="anon"
 	gnutlsPriorityString="'$OSSL_PQ_CFG'")
 
-input(type="imtcp" port="'$PORT_RCVR'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port")
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'"
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 
 export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2

--- a/tests/sndrcv_tls_ossl_serveranon_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_serveranon_gtls_clientanon.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -20,17 +19,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" 
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_ossl_servercert_gtls_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_servercert_gtls_clientanon.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -20,17 +19,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" 
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_ossl_servercert_ossl_clientanon.sh
+++ b/tests/sndrcv_tls_ossl_servercert_ossl_clientanon.sh
@@ -7,7 +7,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -20,17 +19,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_priorityString.sh
+++ b/tests/sndrcv_tls_priorityString.sh
@@ -10,7 +10,6 @@ export NUMMESSAGES=2500
 # start up the instances
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 # certificates
 global(
@@ -21,7 +20,7 @@ global(
 )
 module(load="../plugins/imtcp/.libs/imtcp" StreamDriver.Name="gtls" StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" gnutlspriorityString="NORMAL:-MD5")
-input(type="imtcp" port="'$PORT_RCVR'")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 
@@ -29,11 +28,11 @@ if $msg contains "msgnum" then {
 	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
 }
 '
-startup 
+startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
 add_conf '
 #certificates
 global(

--- a/tests/sndrcv_tls_servercert_bad_eku_chk_mbedtls_clientanon.sh
+++ b/tests/sndrcv_tls_servercert_bad_eku_chk_mbedtls_clientanon.sh
@@ -8,7 +8,6 @@ export NUMMESSAGES=1000
 
 export RS_REDIR="2>>${RSYSLOG_OUT_LOG}"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert-eku-invld.pem'"
@@ -20,17 +19,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_servercert_bad_eku_no_chk_mbedtls_clientanon.sh
+++ b/tests/sndrcv_tls_servercert_bad_eku_no_chk_mbedtls_clientanon.sh
@@ -6,7 +6,6 @@ export NUMMESSAGES=10000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert-eku-invld.pem'"
@@ -18,17 +17,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )

--- a/tests/sndrcv_tls_servercert_mbedtls_clientanon.sh
+++ b/tests/sndrcv_tls_servercert_mbedtls_clientanon.sh
@@ -6,7 +6,6 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 	defaultNetstreamDriverCertFile="'$srcdir/tls-certs/cert.pem'"
@@ -18,17 +17,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
 	StreamDriver.Mode="1"
 	StreamDriver.AuthMode="anon" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.rcvr_port" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$RSYSLOG_DYNNAME.rcvr_port"
 #export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
 add_conf '
 global( defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 )


### PR DESCRIPTION
## Root cause
Several TLS sender/receiver tests still preselected the receiver port with `get_free_port` before rsyslog started the listener. That creates the same dynamic-port race seen elsewhere: the port is only observed as free, not reserved until rsyslog binds it.

## Fix
Convert the remaining obvious TLS sender/receiver tests where rsyslog owns the receiver listener to use existing imtcp listener port files:

- receiver input uses `port="0" listenPortFileName="...rcvr_port"`
- after receiver startup, the test reads the real bound port with `assign_file_content`
- sender config is generated only after the receiver port is known
- stale sender-side `TCPFLOOD_PORT=$(get_free_port)` assignments were removed where the sender already uses the standard tcpflood listener port file

This PR intentionally leaves `sndrcv_ossl_cert_chain.sh` out because its positive path is currently blocked by expired test certificates and was not suitable for validation in this cleanup pass. DTLS, imhttp, RELP, helper-owned services, and negative/no-listener cases are also deferred.

## Proof and validation
Negative-control proof: temporarily skipped the receiver port assignment in `sndrcv_tls_priorityString.sh`. The sender config then generated an empty receiver port, rsyslog logged connection failure, `wait_file_lines` stayed at `0/2500`, and the test exited nonzero. The temporary edit was removed before the final patch.

Validation passed locally:

- `make -j80 check TESTS=""`
- `./tests/sndrcv_tls_priorityString.sh`
- direct focused tests for representative converted TLS cases
- targeted Automake feasible set: `TOTAL: 13`, `PASS: 11`, `SKIP: 2`, `FAIL: 0`
- `git diff --check`

The skips were native PQ group tests guarded by unavailable local PQ group support. mbedTLS-specific tests were not run directly because `mbedtls.pc` is missing in this local profile.

With the help of AI-Agents: Codex
