### PR TITLE
tests: wait for imfile polling output

### DIFF
--- a/tests/imfile-endregex-timeout-none-polling.sh
+++ b/tests/imfile-endregex-timeout-none-polling.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 . ${srcdir:=.}/diag.sh init
 if [ $(uname) = "SunOS" ] ; then
    echo "Solaris: FIX ME"
@@ -44,7 +46,6 @@ echo ' msgnum:2
 # as imfile waits whether or not there is a follow-up line that it needs
 # to combine.
 echo 'END OF TEST' >> $RSYSLOG_DYNNAME.input
-./msleep 200
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown    # we need to wait until rsyslogd is finished!


### PR DESCRIPTION
## Summary

This stabilizes `imfile-endregex-timeout-none-polling.sh` by replacing the fixed 200 ms pre-shutdown sleep with the standard `wait_file_lines` queue-empty predicate.

## Root Cause

The test starts imfile in polling mode with `pollingInterval="2"` and creates the watched input file only after rsyslogd startup. Under high load, the previous 200 ms wait after appending `END OF TEST` could be shorter than the polling window. `shutdown_when_empty` could then stop rsyslogd before imfile observed the late-created input and before omfile created the expected output file.

The observed flake signature was:

- startup warning that the configured imfile input did not exist yet
- shutdown before any output file was produced
- `cmp: <out.log>: No such file or directory`

## Fix

- Export `NUMMESSAGES=1` for the single expected multiline output record.
- Export `QUEUE_EMPTY_CHECK_FUNC=wait_file_lines` so `shutdown_when_empty` waits until that output record exists.
- Remove the fixed `msleep 200`.

The test assertion is not weakened: the final `cmp` still checks the exact expected multiline output.

## Validation

- `make -j24 check TESTS=""`: passed
- `./tests/imfile-endregex-timeout-none-polling.sh`: 5/5 direct passes
- `make -j80 check TESTS='imfile-endregex-timeout-none-polling.sh'`: passed
- Full `make -j80 check`: owned test passed; run failed only on unrelated `imhttp-post-payload-query-params-vg.sh` where CivetWeb `mg_start` failed under Valgrind. That unrelated candidate was recorded in the flake campaign data.

With the help of AI-Agents: Codex
