### PR TITLE
imbeats: bound Lumberjack frame allocations

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1539,6 +1539,71 @@ jobs:
         if: steps.code_changes.outputs.any_changed != 'true'
         run: echo "No relevant changes detected; skipping VictoriaLogs CI."
 
+  imbeats_CI:
+    needs: compile
+    if: ${{ needs.compile.result == 'success' }}
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    name: imbeats-tests
+    env:
+      DOCKER_RUN_EXTRA_OPTS: >-
+        --network host
+        -v /var/run/docker.sock:/var/run/docker.sock
+        -e GITHUB_WORKSPACE
+    steps:
+      - name: checkout project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Check for code changes
+        id: code_changes
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
+        with:
+          base_sha: ${{ github.event.pull_request.base.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
+          files: |
+            tests/imbeats-*.sh
+            tests/yaml-imbeats-*.sh
+            tests/Makefile.am
+            plugins/imbeats/**
+            configure.ac
+            Makefile.am
+            .github/workflows/run_checks.yml
+          files_ignore: |
+            doc/Makefile.am
+
+      - name: run imbeats filebeat docker test
+        if: steps.code_changes.outputs.any_changed == 'true'
+        env:
+          RSYSLOG_DEV_CONTAINER: rsyslog/rsyslog_dev_base_ubuntu:22.04
+          RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE: >-
+            --enable-testbench --enable-omstdout --enable-imdiag --enable-imbeats
+            --disable-default-tests --disable-imtcp-tests --disable-imfile
+            --disable-imfile-tests --disable-fmhttp
+          CI_MAKE_OPT: -j20
+          CI_MAKE_CHECK_OPT: -j1 TESTS=imbeats-filebeat-docker.sh
+          CI_CHECK_CMD: check
+          ABORT_ALL_ON_TEST_FAIL: 'NO'
+          USE_AUTO_DEBUG: 'off'
+          VERBOSE: '1'
+        run: |
+          chmod -R go+rw .
+          devtools/devcontainer.sh --rm devtools/run-ci.sh
+
+      - name: show error logs (if we errored)
+        if: ${{ (failure() || cancelled()) && steps.code_changes.outputs.any_changed == 'true' }}
+        run: |
+          devtools/gather-check-logs.sh
+          cat failed-tests.log
+
+      - name: Skip imbeats CI, no relevant changes
+        if: steps.code_changes.outputs.any_changed != 'true'
+        run: echo "No relevant changes detected; skipping imbeats CI."
+
   clang_analyzer_CI:
     needs: compile
     if: ${{ needs.compile.result == 'success' }}

--- a/Makefile.am
+++ b/Makefile.am
@@ -194,6 +194,10 @@ if ENABLE_IMDIAG
 SUBDIRS += plugins/imdiag
 endif
 
+if ENABLE_IMBEATS
+SUBDIRS += plugins/imbeats
+endif
+
 if ENABLE_MAIL
 SUBDIRS += plugins/ommail
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -1643,6 +1643,17 @@ AC_ARG_ENABLE(imdiag,
         [enable_imdiag=no]
 )
 
+# imbeats support
+AC_ARG_ENABLE(imbeats,
+        [AS_HELP_STRING([--enable-imbeats],[Enable Beats/Lumberjack v2 input module @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_imbeats="yes" ;;
+          no) enable_imbeats="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-imbeats) ;;
+         esac],
+        [enable_imbeats=no]
+)
+
 
 # mmnormalize
 AC_ARG_ENABLE(mmnormalize,
@@ -2544,6 +2555,7 @@ if test "x$enable_imdiag" = "xyes"; then
 	AC_DEFINE([ENABLE_IMDIAG], [1], [Indicator that IMDIAG is present])
 fi
 AM_CONDITIONAL(ENABLE_IMDIAG, test x$enable_imdiag = xyes)
+AM_CONDITIONAL(ENABLE_IMBEATS, test x$enable_imbeats = xyes)
 AM_CONDITIONAL(ENABLE_OMSTDOUT, test x$enable_omstdout = xyes)
 AM_CONDITIONAL(ENABLE_IMPSTATS, test x$enable_impstats = xyes)
 AM_CONDITIONAL(ENABLE_IMPSTATS_PUSH, test x$enable_impstats_push = xyes)
@@ -3509,6 +3521,7 @@ AC_CONFIG_FILES([Makefile \
 		plugins/impstats/Makefile \
 		plugins/imrelp/Makefile \
 		plugins/imdiag/Makefile \
+		plugins/imbeats/Makefile \
 		plugins/imkafka/Makefile \
 		plugins/omtesting/Makefile \
 		plugins/omgssapi/Makefile \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -184,6 +184,7 @@ EXTRA_DIST = \
     source/configuration/modules/imdiag.rst \
     source/configuration/modules/imdocker.rst \
     source/configuration/modules/imdtls.rst \
+    source/configuration/modules/imbeats.rst \
     source/configuration/modules/imfile.rst \
     source/configuration/modules/imgssapi.rst \
     source/configuration/modules/imhiredis.rst \
@@ -227,6 +228,33 @@ EXTRA_DIST = \
     source/configuration/modules/mmtaghostname.rst \
     source/configuration/modules/mmutf8fix.rst \
     source/configuration/modules/module_workflow.png \
+    source/reference/parameters/imbeats-address.rst \
+    source/reference/parameters/imbeats-gnutlsprioritystring.rst \
+    source/reference/parameters/imbeats-keepalive.rst \
+    source/reference/parameters/imbeats-keepalive-interval.rst \
+    source/reference/parameters/imbeats-keepalive-probes.rst \
+    source/reference/parameters/imbeats-keepalive-time.rst \
+    source/reference/parameters/imbeats-listenportfilename.rst \
+    source/reference/parameters/imbeats-maxdecompressedsize.rst \
+    source/reference/parameters/imbeats-maxframesize.rst \
+    source/reference/parameters/imbeats-maxwindowsize.rst \
+    source/reference/parameters/imbeats-name.rst \
+    source/reference/parameters/imbeats-networknamespace.rst \
+    source/reference/parameters/imbeats-permittedpeer.rst \
+    source/reference/parameters/imbeats-port.rst \
+    source/reference/parameters/imbeats-ruleset.rst \
+    source/reference/parameters/imbeats-streamdriver-authmode.rst \
+    source/reference/parameters/imbeats-streamdriver-cafile.rst \
+    source/reference/parameters/imbeats-streamdriver-certfile.rst \
+    source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst \
+    source/reference/parameters/imbeats-streamdriver-crlfile.rst \
+    source/reference/parameters/imbeats-streamdriver-keyfile.rst \
+    source/reference/parameters/imbeats-streamdriver-mode.rst \
+    source/reference/parameters/imbeats-streamdriver-name.rst \
+    source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst \
+    source/reference/parameters/imbeats-streamdriver-prioritizesan.rst \
+    source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst \
+    source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst \
     source/configuration/modules/omamqp1.rst \
     source/configuration/modules/omazuredce.rst \
     source/configuration/modules/omazureeventhubs.rst \
@@ -293,6 +321,7 @@ EXTRA_DIST = \
     source/containers/development_images.rst \
     source/containers/dockerlogs.rst \
     source/containers/etl.rst \
+    source/containers/imbeats.rst \
     source/containers/index.rst \
     source/containers/minimal.rst \
     source/containers/standard.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -80,3 +80,17 @@ omotel:
   requires_serialization: false
   notes:
     - Transport resources are not yet active; introduce pData locking once they appear.
+
+imbeats:
+  paths: ["plugins/imbeats/"]
+  requires_serialization: true
+  locks:
+    - type: mutex
+      field: instanceConf.mutSessions
+  notes:
+    - Listener threads mutate per-instance session lists under mutSessions.
+    - Use Elastic Agent or Filebeat output.logstash to send Lumberjack v2 traffic to imbeats.
+    - TLS deployments require an installed rsyslog TLS stream-driver package or module, such as rsyslog-gnutls or rsyslog-openssl.
+    - The common Elastic Agent TLS setup validates the rsyslog server certificate but does not present a client certificate; use streamDriver.authMode=anon for that pattern and stricter auth modes only with sender client certificates.
+    - Compressed Lumberjack v2 frames are supported and should be tested with Beats compression enabled.
+    - A concrete sample container definition lives under packaging/docker/rsyslog/imbeats but is not wired into published container builds yet.

--- a/doc/source/configuration/modules/imbeats.rst
+++ b/doc/source/configuration/modules/imbeats.rst
@@ -1,0 +1,397 @@
+******************************
+imbeats: Beats v2 input module
+******************************
+
+.. meta::
+   :description: Receive Elastic Beats and Elastic Agent Logstash output in rsyslog via Lumberjack v2 over TCP or TLS.
+   :keywords: rsyslog, imbeats, beats, elastic agent, filebeat, logstash output, lumberjack, input, tcp, tls
+
+.. summary-start
+
+imbeats receives Elastic Beats and Elastic Agent ``output.logstash`` events via
+Lumberjack protocol v2 over TCP or TLS, keeps the original JSON payload in
+``msg``, maps decoded event fields into the top-level structured tree ``$!``,
+and stores transport/protocol metadata under ``$!metadata!imbeats``.
+
+.. summary-end
+
+===========================  ===========================================================================
+**Module Name:**             **imbeats**
+**Author:**                  **Adiscon and contributors**
+**Available since:**         **8.2604.0**
+===========================  ===========================================================================
+
+
+Purpose
+========
+
+``imbeats`` accepts Elastic Beats and Elastic Agent traffic that uses the
+Logstash-style Lumberjack v2 protocol. Configure Beats or Elastic Agent with
+``output.logstash`` and point it at the rsyslog listener. The module reuses
+rsyslog's ``netstrm`` transport subsystem, so it can listen via plain TCP or
+the configured TLS stream driver.
+
+The first implementation supports:
+
+- Lumberjack v2 only
+- ``W`` window frames
+- ``J`` JSON event frames
+- ``C`` compressed frames
+- cumulative ``A`` acknowledgements
+
+The first implementation intentionally optimizes the internal event shape for
+common Elasticsearch-oriented pipelines:
+
+- ``msg`` keeps the original JSON payload
+- decoded Beat event fields are added under top-level ``$!``
+- transport and protocol metadata is stored under ``$!metadata!imbeats``
+- listener-side size limits reject oversized windows, frames, and compressed
+  payload expansion before unbounded allocation
+
+This default may be revisited later. A user-selectable representation mode is
+not part of the initial release.
+
+
+End-to-end Elastic Agent setup
+==============================
+
+Install rsyslog, ``imbeats``, and a TLS stream-driver package through your
+operating system packages. On Debian or Ubuntu systems using packages that
+ship the GnuTLS stream driver separately, a typical TLS prerequisite is:
+
+.. code-block:: bash
+
+   sudo apt install rsyslog rsyslog-gnutls
+
+If your distribution packages ``imbeats.so`` separately, install that package
+as well. The exact package name depends on the distribution.
+
+The example below listens on the common Beats/Logstash port ``5044`` and uses
+GnuTLS. Replace the certificate paths with files issued for your rsyslog
+receiver host.
+
+.. code-block:: none
+
+   module(load="imbeats")
+
+   input(type="imbeats"
+         port="5044"
+         ruleset="beats_to_file"
+         streamdriver.name="gtls"
+         streamdriver.mode="1"
+         streamdriver.authmode="anon"
+         streamdriver.cafile="/etc/rsyslog.d/tls/ca.pem"
+         streamdriver.certfile="/etc/rsyslog.d/tls/server-cert.pem"
+         streamdriver.keyfile="/etc/rsyslog.d/tls/server-key.pem")
+
+   ruleset(name="beats_to_file") {
+     action(type="omfile" file="/var/log/imbeats.log")
+   }
+
+Configure Elastic Agent or Filebeat to use the Logstash output and point it at
+the rsyslog host:
+
+.. code-block:: yaml
+
+   outputs:
+     default:
+       type: logstash
+       hosts: ["rsyslog.example.net:5044"]
+       compression_level: 9
+       ssl.enabled: true
+       ssl.certificate_authorities:
+         - /etc/elastic-agent/certs/ca.pem
+
+For Filebeat standalone configuration, the same output settings are placed
+under ``output.logstash``:
+
+.. code-block:: yaml
+
+   output.logstash:
+     hosts: ["rsyslog.example.net:5044"]
+     compression_level: 9
+     ssl.enabled: true
+     ssl.certificate_authorities:
+       - /etc/filebeat/certs/ca.pem
+
+Use certificate verification in production. Test-only settings such as
+``ssl.verification_mode: none`` are useful for isolated lab checks but should
+not be used for production ingestion.
+
+The example above lets Elastic Agent or Filebeat validate the rsyslog server
+certificate without requiring the sender to present a client certificate. For
+mutual TLS, also configure the sender with its own client certificate and key,
+then switch the rsyslog listener to the appropriate certificate-validation
+auth mode and permitted peer settings.
+
+
+Troubleshooting Elastic Agent delivery
+======================================
+
+- If rsyslog reports that ``gtls`` or ``ossl`` cannot be loaded, install the
+  matching TLS stream-driver package, such as ``rsyslog-gnutls`` or
+  ``rsyslog-openssl``.
+- If the Beat or Agent logs certificate validation errors, confirm that the
+  sender trusts the CA that issued the rsyslog listener certificate and that
+  the configured host name matches the certificate.
+- If the sender connects but does not deliver events, verify that it is using
+  ``output.logstash`` and not an Elasticsearch or HTTP output.
+- ``imbeats`` accepts compressed Lumberjack v2 frames. Keep compression enabled
+  on the sender unless you are isolating a transport problem.
+- Use the ``events.received``, ``events.submitted``, ``compressed_frames``, and
+  ``protocol_errors`` counters to distinguish traffic, parsing, and protocol
+  failures.
+
+
+Configuration Parameters
+========================
+
+Module Parameters
+-----------------
+
+Currently none.
+
+
+Input Parameters
+----------------
+
+.. list-table::
+   :widths: 34 66
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imbeats-address`
+     - .. include:: ../../reference/parameters/imbeats-address.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-gnutlsprioritystring`
+     - .. include:: ../../reference/parameters/imbeats-gnutlsprioritystring.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-keepalive`
+     - .. include:: ../../reference/parameters/imbeats-keepalive.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-keepalive-interval`
+     - .. include:: ../../reference/parameters/imbeats-keepalive-interval.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-keepalive-probes`
+     - .. include:: ../../reference/parameters/imbeats-keepalive-probes.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-keepalive-time`
+     - .. include:: ../../reference/parameters/imbeats-keepalive-time.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-listenportfilename`
+     - .. include:: ../../reference/parameters/imbeats-listenportfilename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-maxdecompressedsize`
+     - .. include:: ../../reference/parameters/imbeats-maxdecompressedsize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-maxframesize`
+     - .. include:: ../../reference/parameters/imbeats-maxframesize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-maxwindowsize`
+     - .. include:: ../../reference/parameters/imbeats-maxwindowsize.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-name`
+     - .. include:: ../../reference/parameters/imbeats-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-networknamespace`
+     - .. include:: ../../reference/parameters/imbeats-networknamespace.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-permittedpeer`
+     - .. include:: ../../reference/parameters/imbeats-permittedpeer.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-port`
+     - .. include:: ../../reference/parameters/imbeats-port.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-ruleset`
+     - .. include:: ../../reference/parameters/imbeats-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-authmode`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-authmode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-cafile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-cafile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-certfile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-certfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-checkextendedkeypurpose`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-crlfile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-crlfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-keyfile`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-keyfile.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-mode`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-mode.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-name`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-name.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-permitexpiredcerts`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-prioritizesan`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-prioritizesan.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-tlsrevocationcheck`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-streamdriver-tlsverifydepth`
+     - .. include:: ../../reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+
+Examples
+========
+
+RainerScript
+------------
+
+.. code-block:: none
+
+   module(load="imbeats")
+
+   input(type="imbeats"
+         port="5044"
+         ruleset="beats_to_es"
+         streamdriver.name="gtls"
+         streamdriver.mode="1"
+         streamdriver.authmode="anon"
+         streamdriver.cafile="/etc/rsyslog.d/ca.pem"
+         streamdriver.certfile="/etc/rsyslog.d/server-cert.pem"
+         streamdriver.keyfile="/etc/rsyslog.d/server-key.pem")
+
+   ruleset(name="beats_to_es") {
+     action(type="omfile" file="/var/log/imbeats-debug.log")
+   }
+
+YAML
+----
+
+.. code-block:: yaml
+
+   version: 2
+   modules:
+     - load: imbeats
+
+   inputs:
+     - type: imbeats
+       port: "5044"
+       ruleset: beats_to_es
+       streamdriver.name: gtls
+       streamdriver.mode: 1
+       streamdriver.authmode: anon
+       streamdriver.cafile: /etc/rsyslog.d/ca.pem
+       streamdriver.certfile: /etc/rsyslog.d/server-cert.pem
+       streamdriver.keyfile: /etc/rsyslog.d/server-key.pem
+
+   rulesets:
+     - name: beats_to_es
+       script: |
+         action(type="omfile" file="/var/log/imbeats-debug.log")
+
+
+Statistic Counters
+==================
+
+The module exposes these ``impstats`` counters:
+
+- ``connections.accepted``
+- ``connections.closed``
+- ``protocol_errors``
+- ``batches.received``
+- ``batches.acked``
+- ``events.received``
+- ``events.submitted``
+- ``events.failed``
+- ``compressed_frames``
+- ``json_decode_failures``
+- ``ack_failures``
+
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imbeats-address
+   ../../reference/parameters/imbeats-gnutlsprioritystring
+   ../../reference/parameters/imbeats-keepalive
+   ../../reference/parameters/imbeats-keepalive-interval
+   ../../reference/parameters/imbeats-keepalive-probes
+   ../../reference/parameters/imbeats-keepalive-time
+   ../../reference/parameters/imbeats-listenportfilename
+   ../../reference/parameters/imbeats-maxdecompressedsize
+   ../../reference/parameters/imbeats-maxframesize
+   ../../reference/parameters/imbeats-maxwindowsize
+   ../../reference/parameters/imbeats-name
+   ../../reference/parameters/imbeats-networknamespace
+   ../../reference/parameters/imbeats-permittedpeer
+   ../../reference/parameters/imbeats-port
+   ../../reference/parameters/imbeats-ruleset
+   ../../reference/parameters/imbeats-streamdriver-authmode
+   ../../reference/parameters/imbeats-streamdriver-cafile
+   ../../reference/parameters/imbeats-streamdriver-certfile
+   ../../reference/parameters/imbeats-streamdriver-checkextendedkeypurpose
+   ../../reference/parameters/imbeats-streamdriver-crlfile
+   ../../reference/parameters/imbeats-streamdriver-keyfile
+   ../../reference/parameters/imbeats-streamdriver-mode
+   ../../reference/parameters/imbeats-streamdriver-name
+   ../../reference/parameters/imbeats-streamdriver-permitexpiredcerts
+   ../../reference/parameters/imbeats-streamdriver-prioritizesan
+   ../../reference/parameters/imbeats-streamdriver-tlsrevocationcheck
+   ../../reference/parameters/imbeats-streamdriver-tlsverifydepth

--- a/doc/source/containers/imbeats.rst
+++ b/doc/source/containers/imbeats.rst
@@ -1,0 +1,107 @@
+.. _containers-sample-imbeats:
+.. _container.sample.rsyslog-imbeats:
+
+rsyslog/rsyslog-imbeats sample
+==============================
+
+.. meta::
+   :description: Sample rsyslog container definition for receiving Elastic Agent and Filebeat Logstash output with imbeats.
+   :keywords: rsyslog, containers, Docker, imbeats, Elastic Agent, Filebeat, Logstash output, Beats, TLS
+
+.. summary-start
+
+The ``rsyslog/rsyslog-imbeats`` sample container definition receives Elastic
+Agent and Filebeat ``output.logstash`` traffic with ``imbeats`` on port
+``5044``. It is a repository sample and is not part of the published rsyslog
+container image family yet.
+
+.. summary-end
+
+.. index::
+   pair: containers; rsyslog-imbeats sample
+   pair: Docker images; imbeats sample
+
+Status
+------
+
+The sample files live in ``packaging/docker/rsyslog/imbeats``. They are not
+wired into the container ``Makefile``, release builds, Docker Hub metadata, or
+``latest`` tagging. Use them as a concrete starting point when you want to run
+an ``imbeats`` receiver in a container.
+
+The sample assumes that the base image or package source provides the package
+containing ``imbeats.so``. It installs ``rsyslog-gnutls`` as a concrete TLS
+stream-driver package example.
+
+Local build
+-----------
+
+Build the sample directly from its directory:
+
+.. code-block:: bash
+
+   docker build \
+     -t rsyslog-imbeats-sample:local \
+     packaging/docker/rsyslog/imbeats
+
+This direct build is separate from the official container image Makefile.
+
+Docker Compose example
+----------------------
+
+.. code-block:: yaml
+
+   services:
+     rsyslog-imbeats:
+       image: rsyslog-imbeats-sample:local
+       ports:
+         - "5044:5044/tcp"
+       environment:
+         IMBEATS_PORT: "5044"
+         TLS_AUTH_MODE: "anon"
+         TLS_CA_FILE: /etc/rsyslog/tls/ca.pem
+         TLS_CERT_FILE: /etc/rsyslog/tls/server-cert.pem
+         TLS_KEY_FILE: /etc/rsyslog/tls/server-key.pem
+         IMBEATS_OUTPUT_FILE: /var/log/imbeats.log
+       volumes:
+         - ./certs:/etc/rsyslog/tls:ro
+         - ./logs:/var/log
+
+Elastic Agent output
+--------------------
+
+Configure Elastic Agent to send Logstash output to the container:
+
+.. code-block:: yaml
+
+   outputs:
+     default:
+       type: logstash
+       hosts: ["rsyslog-imbeats.example.net:5044"]
+       compression_level: 9
+       ssl.enabled: true
+       ssl.certificate_authorities:
+         - /etc/elastic-agent/certs/ca.pem
+
+For Filebeat standalone configuration, use the same settings under
+``output.logstash``.
+
+Operational notes
+-----------------
+
+- The container listens on ``5044/tcp`` by default.
+- TLS is configured through the mounted certificate paths. Install and load a
+  TLS stream-driver package in images derived from this sample.
+- The default ``TLS_AUTH_MODE=anon`` lets Elastic Agent or Filebeat verify the
+  rsyslog server certificate without requiring a client certificate. Use a
+  stricter certificate-validation auth mode only after configuring client
+  certificates on the sender.
+- Production deployments should use certificate verification. Avoid disabling
+  verification except for isolated tests.
+- The sample writes received event JSON to ``/var/log/imbeats.log``. Mount a
+  custom rsyslog snippet when you want to forward to another destination.
+
+.. seealso::
+
+   - :doc:`../configuration/modules/imbeats` - imbeats module reference
+   - :doc:`user_images` - rsyslog user-focused container images

--- a/doc/source/containers/user_images.rst
+++ b/doc/source/containers/user_images.rst
@@ -5,7 +5,7 @@ User-Focused Images
 
 .. meta::
    :description: Official rsyslog container image variants for end users, including minimal, standard, collector, dockerlogs, and ETL roles.
-   :keywords: rsyslog, containers, Docker, minimal, collector, dockerlogs, ETL
+   :keywords: rsyslog, containers, Docker, minimal, collector, dockerlogs, ETL, imbeats
 
 .. summary-start
 
@@ -35,6 +35,12 @@ Available variants include:
   syslog and forwards events to a Vespa HTTP endpoint using ``omhttp``.
 * ``rsyslog/rsyslog-debug`` – planned variant with troubleshooting tools.
 
+Sample container definitions include:
+
+* :doc:`rsyslog/rsyslog-imbeats <imbeats>` – concrete sample for receiving
+  Elastic Agent and Filebeat ``output.logstash`` traffic with ``imbeats``.
+  This sample is not wired into published image builds yet.
+
 .. toctree::
    :maxdepth: 1
 
@@ -43,6 +49,7 @@ Available variants include:
    collector
    dockerlogs
    etl
+   imbeats
 
 Images are built using the layered ``Makefile`` in
 ``packaging/docker/rsyslog``::

--- a/doc/source/reference/parameters/imbeats-address.rst
+++ b/doc/source/reference/parameters/imbeats-address.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-address:
+.. _imbeats.parameter.input.address:
+
+address
+========
+
+.. meta::
+   :description: Bind address for the imbeats listener.
+   :keywords: rsyslog, imbeats, address
+
+.. index::
+   single: imbeats; address
+   single: address
+
+.. summary-start
+
+Bind the imbeats listener to a specific local address instead of all interfaces.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: address
+:Scope: input
+:Type: string
+:Default: input=all interfaces
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Bind the imbeats listener to a specific local address instead of all interfaces.
+
+Input usage
+-----------
+.. _param-imbeats-input-address:
+.. _imbeats.parameter.input.address-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" address="127.0.0.1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
+++ b/doc/source/reference/parameters/imbeats-gnutlsprioritystring.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-gnutlsprioritystring:
+.. _imbeats.parameter.input.gnutlsprioritystring:
+
+gnutlsPriorityString
+====================
+
+.. meta::
+   :description: GnuTLS priority string for imbeats TLS sessions.
+   :keywords: rsyslog, imbeats, gnutlsprioritystring
+
+.. index::
+   single: imbeats; gnutlsPriorityString
+   single: gnutlsPriorityString
+
+.. summary-start
+
+Override the GnuTLS priority string used by the selected TLS stream driver.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: gnutlsPriorityString
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Override the GnuTLS priority string used by the selected TLS stream driver.
+
+Input usage
+-----------
+.. _param-imbeats-input-gnutlsprioritystring:
+.. _imbeats.parameter.input.gnutlsprioritystring-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" gnutlsPriorityString="NORMAL")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive-interval.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-interval.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-keepalive-interval:
+.. _imbeats.parameter.input.keepalive-interval:
+
+KeepAlive.Interval
+==================
+
+.. meta::
+   :description: TCP keepalive interval for imbeats sessions.
+   :keywords: rsyslog, imbeats, keepalive interval
+
+.. index::
+   single: imbeats; KeepAlive.Interval
+   single: KeepAlive.Interval
+
+.. summary-start
+
+Set the interval between TCP keepalive probes for imbeats sessions.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive.Interval
+:Scope: input
+:Type: integer
+:Default: input=system default
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the interval between TCP keepalive probes for imbeats sessions.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive-interval:
+.. _imbeats.parameter.input.keepalive-interval-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive.interval="10")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive-probes.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-probes.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-keepalive-probes:
+.. _imbeats.parameter.input.keepalive-probes:
+
+KeepAlive.Probes
+================
+
+.. meta::
+   :description: TCP keepalive probe count for imbeats sessions.
+   :keywords: rsyslog, imbeats, keepalive probes
+
+.. index::
+   single: imbeats; KeepAlive.Probes
+   single: KeepAlive.Probes
+
+.. summary-start
+
+Set how many TCP keepalive probes are sent before the peer is considered dead.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive.Probes
+:Scope: input
+:Type: integer
+:Default: input=system default
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set how many TCP keepalive probes are sent before the peer is considered dead.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive-probes:
+.. _imbeats.parameter.input.keepalive-probes-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive.probes="5")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive-time.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive-time.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-keepalive-time:
+.. _imbeats.parameter.input.keepalive-time:
+
+KeepAlive.Time
+==============
+
+.. meta::
+   :description: TCP keepalive idle time for imbeats sessions.
+   :keywords: rsyslog, imbeats, keepalive time
+
+.. index::
+   single: imbeats; KeepAlive.Time
+   single: KeepAlive.Time
+
+.. summary-start
+
+Set the idle time before TCP keepalive probing begins on imbeats sessions.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive.Time
+:Scope: input
+:Type: integer
+:Default: input=system default
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the idle time before TCP keepalive probing begins on imbeats sessions.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive-time:
+.. _imbeats.parameter.input.keepalive-time-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive.time="30")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-keepalive.rst
+++ b/doc/source/reference/parameters/imbeats-keepalive.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-keepalive:
+.. _imbeats.parameter.input.keepalive:
+
+KeepAlive
+=========
+
+.. meta::
+   :description: Enable TCP keepalive for imbeats client sessions.
+   :keywords: rsyslog, imbeats, keepalive
+
+.. index::
+   single: imbeats; KeepAlive
+   single: KeepAlive
+
+.. summary-start
+
+Enable socket-level TCP keepalive on accepted imbeats connections.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: KeepAlive
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Enable socket-level TCP keepalive on accepted imbeats connections.
+
+Input usage
+-----------
+.. _param-imbeats-input-keepalive:
+.. _imbeats.parameter.input.keepalive-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" keepAlive="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-listenportfilename.rst
+++ b/doc/source/reference/parameters/imbeats-listenportfilename.rst
@@ -1,0 +1,48 @@
+.. _param-imbeats-listenportfilename:
+.. _imbeats.parameter.input.listenportfilename:
+
+listenPortFileName
+==================
+
+.. meta::
+   :description: Port file for imbeats listeners.
+   :keywords: rsyslog, imbeats, listenPortFileName
+
+.. index::
+   single: imbeats; listenPortFileName
+   single: listenPortFileName
+
+.. summary-start
+
+Write the actual bound port to a file after an imbeats listener starts.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: listenPortFileName
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Write the actual bound port to a file after an imbeats listener starts.
+Production configurations normally use a fixed Beats listener port such as
+``5044``. Dynamic port allocation with ``port="0"`` is intended for testbench
+and automation scenarios that need to discover an ephemeral listener port.
+
+Input usage
+-----------
+.. _param-imbeats-input-listenportfilename:
+.. _imbeats.parameter.input.listenportfilename-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" listenPortFileName="/run/rsyslog/imbeats.port")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-maxdecompressedsize.rst
+++ b/doc/source/reference/parameters/imbeats-maxdecompressedsize.rst
@@ -1,0 +1,47 @@
+.. _param-imbeats-maxdecompressedsize:
+.. _imbeats.parameter.input.maxdecompressedsize:
+
+maxDecompressedSize
+===================
+
+.. meta::
+   :description: Maximum decompressed Lumberjack payload size accepted by imbeats.
+   :keywords: rsyslog, imbeats, maxDecompressedSize, Lumberjack compression
+
+.. index::
+   single: imbeats; maxDecompressedSize
+   single: maxDecompressedSize
+
+.. summary-start
+
+Limit how large a compressed Lumberjack frame may become after decompression.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: maxDecompressedSize
+:Scope: input
+:Type: positive integer
+:Default: input=67108864
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the maximum byte size accepted after decompressing a Lumberjack compressed
+frame. Frames that expand beyond this value are rejected before unbounded memory
+growth can occur.
+
+Input usage
+-----------
+.. _param-imbeats-input-maxdecompressedsize:
+.. _imbeats.parameter.input.maxdecompressedsize-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" maxDecompressedSize="67108864")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-maxframesize.rst
+++ b/doc/source/reference/parameters/imbeats-maxframesize.rst
@@ -1,0 +1,47 @@
+.. _param-imbeats-maxframesize:
+.. _imbeats.parameter.input.maxframesize:
+
+maxFrameSize
+============
+
+.. meta::
+   :description: Maximum Lumberjack frame payload size accepted by imbeats.
+   :keywords: rsyslog, imbeats, maxFrameSize, Lumberjack frame
+
+.. index::
+   single: imbeats; maxFrameSize
+   single: maxFrameSize
+
+.. summary-start
+
+Limit the JSON or compressed frame payload size imbeats accepts from one Lumberjack frame.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: maxFrameSize
+:Scope: input
+:Type: positive integer
+:Default: input=10485760
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the maximum byte size accepted for an individual Lumberjack JSON frame or
+compressed frame payload. Frames larger than this value are rejected before
+payload allocation.
+
+Input usage
+-----------
+.. _param-imbeats-input-maxframesize:
+.. _imbeats.parameter.input.maxframesize-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" maxFrameSize="10485760")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-maxwindowsize.rst
+++ b/doc/source/reference/parameters/imbeats-maxwindowsize.rst
@@ -1,0 +1,46 @@
+.. _param-imbeats-maxwindowsize:
+.. _imbeats.parameter.input.maxwindowsize:
+
+maxWindowSize
+=============
+
+.. meta::
+   :description: Maximum Lumberjack window size accepted by imbeats.
+   :keywords: rsyslog, imbeats, maxWindowSize, Lumberjack window
+
+.. index::
+   single: imbeats; maxWindowSize
+   single: maxWindowSize
+
+.. summary-start
+
+Limit how many events imbeats accepts in one Lumberjack batch window.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: maxWindowSize
+:Scope: input
+:Type: positive integer
+:Default: input=1024
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the maximum Lumberjack v2 window size accepted by this imbeats listener.
+Connections that announce a larger window are rejected as protocol errors.
+
+Input usage
+-----------
+.. _param-imbeats-input-maxwindowsize:
+.. _imbeats.parameter.input.maxwindowsize-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" maxWindowSize="1024")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-name.rst
+++ b/doc/source/reference/parameters/imbeats-name.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-name:
+.. _imbeats.parameter.input.name:
+
+name
+====
+
+.. meta::
+   :description: Input name for imbeats messages.
+   :keywords: rsyslog, imbeats, name
+
+.. index::
+   single: imbeats; name
+   single: name
+
+.. summary-start
+
+Set the ``inputname`` property used for messages received by this imbeats input.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: name
+:Scope: input
+:Type: string
+:Default: input=imbeats
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the ``inputname`` property used for messages received by this imbeats input.
+
+Input usage
+-----------
+.. _param-imbeats-input-name:
+.. _imbeats.parameter.input.name-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" name="imbeats")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-networknamespace.rst
+++ b/doc/source/reference/parameters/imbeats-networknamespace.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-networknamespace:
+.. _imbeats.parameter.input.networknamespace:
+
+NetworkNamespace
+================
+
+.. meta::
+   :description: Network namespace for imbeats listener sockets.
+   :keywords: rsyslog, imbeats, network namespace
+
+.. index::
+   single: imbeats; NetworkNamespace
+   single: NetworkNamespace
+
+.. summary-start
+
+Open imbeats listener sockets inside the specified Linux network namespace.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: NetworkNamespace
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Open imbeats listener sockets inside the specified Linux network namespace.
+
+Input usage
+-----------
+.. _param-imbeats-input-networknamespace:
+.. _imbeats.parameter.input.networknamespace-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" networkNamespace="ns1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-permittedpeer.rst
+++ b/doc/source/reference/parameters/imbeats-permittedpeer.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-permittedpeer:
+.. _imbeats.parameter.input.permittedpeer:
+
+PermittedPeer
+=============
+
+.. meta::
+   :description: Allowed TLS peer names for imbeats.
+   :keywords: rsyslog, imbeats, permittedpeer
+
+.. index::
+   single: imbeats; PermittedPeer
+   single: PermittedPeer
+
+.. summary-start
+
+Restrict accepted TLS peers to the configured certificate names.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: PermittedPeer
+:Scope: input
+:Type: array
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Restrict accepted TLS peers to the configured certificate names.
+
+Input usage
+-----------
+.. _param-imbeats-input-permittedpeer:
+.. _imbeats.parameter.input.permittedpeer-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" permittedPeer=["beat.example.net"])
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-port.rst
+++ b/doc/source/reference/parameters/imbeats-port.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-port:
+.. _imbeats.parameter.input.port:
+
+port
+====
+
+.. meta::
+   :description: Listening port for imbeats.
+   :keywords: rsyslog, imbeats, port
+
+.. index::
+   single: imbeats; port
+   single: port
+
+.. summary-start
+
+Set the TCP port on which the imbeats listener accepts Lumberjack v2 clients.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: port
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: yes
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the TCP port on which the imbeats listener accepts Lumberjack v2 clients.
+
+Input usage
+-----------
+.. _param-imbeats-input-port:
+.. _imbeats.parameter.input.port-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-ruleset.rst
+++ b/doc/source/reference/parameters/imbeats-ruleset.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-ruleset:
+.. _imbeats.parameter.input.ruleset:
+
+ruleset
+========
+
+.. meta::
+   :description: Ruleset binding for imbeats.
+   :keywords: rsyslog, imbeats, ruleset
+
+.. index::
+   single: imbeats; ruleset
+   single: ruleset
+
+.. summary-start
+
+Bind the imbeats input to a specific ruleset instead of the default ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: ruleset
+:Scope: input
+:Type: string
+:Default: input=default ruleset
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Bind the imbeats input to a specific ruleset instead of the default ruleset.
+
+Input usage
+-----------
+.. _param-imbeats-input-ruleset:
+.. _imbeats.parameter.input.ruleset-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" ruleset="beats")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-authmode.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-authmode:
+.. _imbeats.parameter.input.streamdriver-authmode:
+
+StreamDriver.AuthMode
+=====================
+
+.. meta::
+   :description: TLS authentication mode for imbeats.
+   :keywords: rsyslog, imbeats, streamdriver authmode
+
+.. index::
+   single: imbeats; StreamDriver.AuthMode
+   single: StreamDriver.AuthMode
+
+.. summary-start
+
+Set the TLS authentication mode used by the configured imbeats stream driver.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.AuthMode
+:Scope: input
+:Type: string
+:Default: input=anon
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the TLS authentication mode used by the configured imbeats stream driver.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-authmode:
+.. _imbeats.parameter.input.streamdriver-authmode-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.authMode="anon")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-cafile.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-cafile:
+.. _imbeats.parameter.input.streamdriver-cafile:
+
+StreamDriver.CAFile
+===================
+
+.. meta::
+   :description: CA file for imbeats TLS validation.
+   :keywords: rsyslog, imbeats, streamdriver cafile
+
+.. index::
+   single: imbeats; StreamDriver.CAFile
+   single: StreamDriver.CAFile
+
+.. summary-start
+
+Specify the CA bundle used to validate TLS peers for imbeats.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CAFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the CA bundle used to validate TLS peers for imbeats.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-cafile:
+.. _imbeats.parameter.input.streamdriver-cafile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.caFile="/etc/rsyslog/ca.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-certfile.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-certfile:
+.. _imbeats.parameter.input.streamdriver-certfile:
+
+StreamDriver.CertFile
+=====================
+
+.. meta::
+   :description: Certificate file for imbeats TLS listeners.
+   :keywords: rsyslog, imbeats, streamdriver certfile
+
+.. index::
+   single: imbeats; StreamDriver.CertFile
+   single: StreamDriver.CertFile
+
+.. summary-start
+
+Specify the local certificate presented by TLS-enabled imbeats listeners.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CertFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the local certificate presented by TLS-enabled imbeats listeners.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-certfile:
+.. _imbeats.parameter.input.streamdriver-certfile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.certFile="/etc/rsyslog/cert.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-checkextendedkeypurpose.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-checkextendedkeypurpose:
+.. _imbeats.parameter.input.streamdriver-checkextendedkeypurpose:
+
+StreamDriver.CheckExtendedKeyPurpose
+====================================
+
+.. meta::
+   :description: Extended key usage enforcement for imbeats TLS peers.
+   :keywords: rsyslog, imbeats, extended key usage
+
+.. index::
+   single: imbeats; StreamDriver.CheckExtendedKeyPurpose
+   single: StreamDriver.CheckExtendedKeyPurpose
+
+.. summary-start
+
+Enable extended key usage checks when validating imbeats TLS certificates.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CheckExtendedKeyPurpose
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Enable extended key usage checks when validating imbeats TLS certificates.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-checkextendedkeypurpose:
+.. _imbeats.parameter.input.streamdriver-checkextendedkeypurpose-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.checkExtendedKeyPurpose="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-crlfile.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-crlfile:
+.. _imbeats.parameter.input.streamdriver-crlfile:
+
+StreamDriver.CRLFile
+====================
+
+.. meta::
+   :description: CRL file for imbeats TLS validation.
+   :keywords: rsyslog, imbeats, streamdriver crlfile
+
+.. index::
+   single: imbeats; StreamDriver.CRLFile
+   single: StreamDriver.CRLFile
+
+.. summary-start
+
+Specify the certificate revocation list file used by TLS-enabled imbeats listeners.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.CRLFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the certificate revocation list file used by TLS-enabled imbeats listeners.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-crlfile:
+.. _imbeats.parameter.input.streamdriver-crlfile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.crlFile="/etc/rsyslog/crl.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-keyfile.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-keyfile:
+.. _imbeats.parameter.input.streamdriver-keyfile:
+
+StreamDriver.KeyFile
+====================
+
+.. meta::
+   :description: Private key file for imbeats TLS listeners.
+   :keywords: rsyslog, imbeats, streamdriver keyfile
+
+.. index::
+   single: imbeats; StreamDriver.KeyFile
+   single: StreamDriver.KeyFile
+
+.. summary-start
+
+Specify the private key file used by TLS-enabled imbeats listeners.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.KeyFile
+:Scope: input
+:Type: string
+:Default: input=none
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Specify the private key file used by TLS-enabled imbeats listeners.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-keyfile:
+.. _imbeats.parameter.input.streamdriver-keyfile-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.keyFile="/etc/rsyslog/key.pem")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-mode.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-mode:
+.. _imbeats.parameter.input.streamdriver-mode:
+
+StreamDriver.Mode
+=================
+
+.. meta::
+   :description: Stream driver mode for imbeats.
+   :keywords: rsyslog, imbeats, streamdriver mode
+
+.. index::
+   single: imbeats; StreamDriver.Mode
+   single: StreamDriver.Mode
+
+.. summary-start
+
+Select whether imbeats uses plain TCP or a TLS-enabled stream driver mode.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.Mode
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Select whether imbeats uses plain TCP or a TLS-enabled stream driver mode.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-mode:
+.. _imbeats.parameter.input.streamdriver-mode-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.mode="1")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-name.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-name.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-name:
+.. _imbeats.parameter.input.streamdriver-name:
+
+StreamDriver.Name
+=================
+
+.. meta::
+   :description: Stream driver backend for imbeats.
+   :keywords: rsyslog, imbeats, streamdriver name
+
+.. index::
+   single: imbeats; StreamDriver.Name
+   single: StreamDriver.Name
+
+.. summary-start
+
+Select the netstrm backend used by imbeats, for example ``ptcp``, ``gtls``, or ``ossl``.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.Name
+:Scope: input
+:Type: string
+:Default: input=ptcp
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Select the netstrm backend used by imbeats, for example ``ptcp``, ``gtls``, or ``ossl``.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-name:
+.. _imbeats.parameter.input.streamdriver-name-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.name="ossl")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-permitexpiredcerts.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-permitexpiredcerts:
+.. _imbeats.parameter.input.streamdriver-permitexpiredcerts:
+
+StreamDriver.PermitExpiredCerts
+===============================
+
+.. meta::
+   :description: Expired certificate policy for imbeats TLS peers.
+   :keywords: rsyslog, imbeats, permitexpiredcerts
+
+.. index::
+   single: imbeats; StreamDriver.PermitExpiredCerts
+   single: StreamDriver.PermitExpiredCerts
+
+.. summary-start
+
+Control how the imbeats TLS stream driver handles expired peer certificates.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.PermitExpiredCerts
+:Scope: input
+:Type: string
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Control how the imbeats TLS stream driver handles expired peer certificates.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-permitexpiredcerts:
+.. _imbeats.parameter.input.streamdriver-permitexpiredcerts-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.permitExpiredCerts="off")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-prioritizesan.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-prioritizesan:
+.. _imbeats.parameter.input.streamdriver-prioritizesan:
+
+StreamDriver.PrioritizeSAN
+==========================
+
+.. meta::
+   :description: SAN preference for imbeats TLS name validation.
+   :keywords: rsyslog, imbeats, prioritize SAN
+
+.. index::
+   single: imbeats; StreamDriver.PrioritizeSAN
+   single: StreamDriver.PrioritizeSAN
+
+.. summary-start
+
+Prefer subject alternative names over common names when validating imbeats TLS peer names.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.PrioritizeSAN
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Prefer subject alternative names over common names when validating imbeats TLS peer names.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-prioritizesan:
+.. _imbeats.parameter.input.streamdriver-prioritizesan-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.prioritizeSAN="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-tlsrevocationcheck:
+.. _imbeats.parameter.input.streamdriver-tlsrevocationcheck:
+
+StreamDriver.TlsRevocationCheck
+===============================
+
+.. meta::
+   :description: Revocation checking for imbeats TLS peers.
+   :keywords: rsyslog, imbeats, tls revocation check
+
+.. index::
+   single: imbeats; StreamDriver.TlsRevocationCheck
+   single: StreamDriver.TlsRevocationCheck
+
+.. summary-start
+
+Enable TLS revocation checking for certificates presented to the imbeats listener.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.TlsRevocationCheck
+:Scope: input
+:Type: boolean
+:Default: input=off
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Enable TLS revocation checking for certificates presented to the imbeats listener.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-tlsrevocationcheck:
+.. _imbeats.parameter.input.streamdriver-tlsrevocationcheck-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.tlsRevocationCheck="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
+++ b/doc/source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
@@ -1,0 +1,45 @@
+.. _param-imbeats-streamdriver-tlsverifydepth:
+.. _imbeats.parameter.input.streamdriver-tlsverifydepth:
+
+StreamDriver.TlsVerifyDepth
+===========================
+
+.. meta::
+   :description: Certificate chain depth for imbeats TLS validation.
+   :keywords: rsyslog, imbeats, tls verify depth
+
+.. index::
+   single: imbeats; StreamDriver.TlsVerifyDepth
+   single: StreamDriver.TlsVerifyDepth
+
+.. summary-start
+
+Set the maximum certificate chain depth accepted during imbeats TLS validation.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: StreamDriver.TlsVerifyDepth
+:Scope: input
+:Type: integer
+:Default: input=0
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the maximum certificate chain depth accepted during imbeats TLS validation.
+
+Input usage
+-----------
+.. _param-imbeats-input-streamdriver-tlsverifydepth:
+.. _imbeats.parameter.input.streamdriver-tlsverifydepth-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" streamDriver.tlsVerifyDepth="5")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/packaging/docker/rsyslog/imbeats/.dockerignore
+++ b/packaging/docker/rsyslog/imbeats/.dockerignore
@@ -1,0 +1,5 @@
+*.sw?
+tmp*
+run
+build.sh
+README*

--- a/packaging/docker/rsyslog/imbeats/10-imbeats.conf
+++ b/packaging/docker/rsyslog/imbeats/10-imbeats.conf
@@ -1,0 +1,19 @@
+# Sample imbeats configuration for a container scaffold.
+# Status: not wired into the container Makefile, release flow, Docker Hub
+# metadata, or latest tags yet.
+
+module(load="imbeats")
+
+ruleset(name="imbeats-output") {
+	action(type="omfile" file=`echo $IMBEATS_OUTPUT_FILE`)
+}
+
+input(type="imbeats"
+	port=`echo $IMBEATS_PORT`
+	ruleset="imbeats-output"
+	streamDriver.Name="gtls"
+	streamDriver.Mode="1"
+	streamDriver.AuthMode=`echo $TLS_AUTH_MODE`
+	streamDriver.caFile=`echo $TLS_CA_FILE`
+	streamDriver.certFile=`echo $TLS_CERT_FILE`
+	streamDriver.keyFile=`echo $TLS_KEY_FILE`)

--- a/packaging/docker/rsyslog/imbeats/Dockerfile
+++ b/packaging/docker/rsyslog/imbeats/Dockerfile
@@ -1,0 +1,51 @@
+# Dockerfile for a sample imbeats rsyslog container.
+# Sample status: this image scaffold is not wired into the rsyslog container
+# Makefile, release flow, Docker Hub metadata, or latest tags yet.
+
+# BASE_IMAGE_TAG may point at a local or published standard rsyslog image.
+ARG BASE_IMAGE_TAG="rsyslog/rsyslog:latest"
+
+FROM ${BASE_IMAGE_TAG}
+
+ARG BASE_IMAGE_TAG
+
+# The standard base image defaults to syslog:adm; switch to root for package
+# installation in this derived sample image.
+USER root
+
+LABEL maintainer="Rainer Gerhards <rgerhards@adiscon.com>"
+LABEL description="Sample rsyslog imbeats container. Not published or wired into release automation."
+LABEL com.adiscon.rsyslog.base.image="${BASE_IMAGE_TAG}"
+LABEL org.opencontainers.image.title="rsyslog/rsyslog-imbeats-sample"
+LABEL org.opencontainers.image.description="Sample-only rsyslog container for a TLS-enabled imbeats input."
+LABEL org.opencontainers.image.source="https://github.com/rsyslog/rsyslog"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install a concrete TLS package example for the gtls stream driver.
+# The package or repository source that provides imbeats.so must also be
+# available in the selected base image or configured apt sources. This sample
+# does not publish or pin such a package.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends rsyslog-gnutls && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY 10-imbeats.conf /etc/rsyslog.d/10-imbeats.conf
+
+EXPOSE 5044/tcp
+
+ENV IMBEATS_PORT="5044"
+ENV TLS_CA_FILE=""
+ENV TLS_CERT_FILE=""
+ENV TLS_KEY_FILE=""
+ENV TLS_AUTH_MODE="anon"
+ENV IMBEATS_OUTPUT_FILE="/var/log/imbeats.log"
+ENV RSYSLOG_ROLE=imbeats-sample
+
+# Return to the base image's unprivileged runtime user. The sample listens on
+# port 5044 and writes under /var/log, which the base image prepares for syslog.
+USER syslog:adm
+
+# Inherit CMD from the base image.

--- a/packaging/docker/rsyslog/imbeats/README.md
+++ b/packaging/docker/rsyslog/imbeats/README.md
@@ -1,0 +1,47 @@
+# imbeats sample container
+
+This directory contains a sample-only Docker scaffold for running rsyslog with
+a TLS-enabled `imbeats` input on port `5044/tcp`.
+
+Status: this scaffold is not wired into `packaging/docker/rsyslog/Makefile`,
+release automation, Docker Hub metadata, or `latest` tags yet. Build it
+directly from this directory for local experiments only.
+
+## Build
+
+```sh
+docker build \
+  --build-arg BASE_IMAGE_TAG=rsyslog/rsyslog:latest \
+  -t rsyslog-imbeats-sample .
+```
+
+The Dockerfile installs `rsyslog-gnutls` as a concrete TLS package example.
+The package or package source that provides `imbeats.so` must be available in
+the selected base image or configured apt sources; this sample does not publish
+or pin that package. The image returns to the base image's `syslog:adm`
+runtime user after package installation.
+
+## Run
+
+```sh
+docker run --rm -p 5044:5044/tcp \
+  -e TLS_CA_FILE=/run/certs/ca.pem \
+  -e TLS_CERT_FILE=/run/certs/server-cert.pem \
+  -e TLS_KEY_FILE=/run/certs/server-key.pem \
+  -v "$PWD/certs:/run/certs:ro" \
+  rsyslog-imbeats-sample
+```
+
+Environment variables:
+
+- `IMBEATS_PORT`: input port, defaults to `5044`.
+- `TLS_CA_FILE`: CA file path passed to the imbeats TLS stream driver.
+- `TLS_CERT_FILE`: server certificate path.
+- `TLS_KEY_FILE`: server key path.
+- `TLS_AUTH_MODE`: stream driver auth mode, defaults to `anon`.
+- `IMBEATS_OUTPUT_FILE`: output file, defaults to `/var/log/imbeats.log`.
+
+The default `TLS_AUTH_MODE=anon` matches the common Elastic Agent and Filebeat
+setup where the sender verifies the rsyslog server certificate but does not
+present a client certificate. Use a stricter certificate-validation auth mode
+only after configuring client certificates on the sender.

--- a/plugins/imbeats/MODULE_METADATA.yaml
+++ b/plugins/imbeats/MODULE_METADATA.yaml
@@ -1,0 +1,9 @@
+support_status: core-supported
+maturity_level: fresh
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2026-04-09
+build_dependencies:
+  - "zlib (--enable-imbeats)"
+notes:
+  - "Accepts Elastic Beats via Lumberjack protocol v2 over netstrm-backed TCP or TLS transports."
+  - "Initial event mapping is optimized for Elasticsearch-oriented downstream flow; representation configurability is deferred."

--- a/plugins/imbeats/Makefile.am
+++ b/plugins/imbeats/Makefile.am
@@ -1,0 +1,6 @@
+pkglib_LTLIBRARIES = imbeats.la
+
+imbeats_la_SOURCES = imbeats.c lj_parser.c lj_parser.h
+imbeats_la_CPPFLAGS = -I$(top_srcdir) $(PTHREADS_CFLAGS) $(RSRT_CFLAGS) $(ZLIB_CFLAGS)
+imbeats_la_LDFLAGS = -module -avoid-version $(ZLIB_LIBS)
+imbeats_la_LIBADD =

--- a/plugins/imbeats/README.md
+++ b/plugins/imbeats/README.md
@@ -1,0 +1,22 @@
+# imbeats Notes
+
+`imbeats` is a dedicated Beats/Lumberjack v2 input module built on rsyslog's
+`netstrm` transport subsystem instead of `tcpsrv`.
+
+## Deferred Representation Decision
+
+The first implementation maps decoded Beat event fields into the top-level
+structured message tree `$!` and keeps the original JSON payload in `msg`.
+Transport and protocol metadata is stored under `$!metadata!imbeats`.
+
+This shape is intentional for the common pipeline:
+
+- receive Beat events in rsyslog
+- process or route in rsyslog
+- finally emit JSON to Elasticsearch with minimal reshaping
+
+This is **not** the only valid representation. A more rsyslog-native split such
+as `msg + $!beats + $!metadata!imbeats` remains a reasonable alternative.
+
+The long-term default and any user-selectable representation mode need to be
+decided later based on real usage and operator feedback.

--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -1,0 +1,1072 @@
+/* imbeats.c
+ * Input module for Elastic Beats / Lumberjack v2.
+ *
+ * Transport and TLS are delegated to the netstrm subsystem. Protocol parsing,
+ * JSON decoding, and ACK timing live here.
+ */
+#include "config.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <poll.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+#include <libfastjson/json.h>
+#include <libfastjson/json_tokener.h>
+
+#include "rsyslog.h"
+#include "cfsysline.h"
+#include "module-template.h"
+#include "errmsg.h"
+#include "unicode-helper.h"
+#include "net.h"
+#include "netstrm.h"
+#include "ruleset.h"
+#include "prop.h"
+#include "statsobj.h"
+#include "msg.h"
+#include "dirty.h"
+#include "glbl.h"
+#include "ratelimit.h"
+#include "srUtils.h"
+#include "tcpsrv.h"
+
+#include "lj_parser.h"
+
+MODULE_TYPE_INPUT;
+MODULE_TYPE_NOKEEP;
+MODULE_CNFNAME("imbeats")
+
+#define IMBEATS_DEFAULT_MAX_WINDOW_SIZE 1024
+#define IMBEATS_MAX_WINDOW_SIZE_LIMIT 1000000
+#define IMBEATS_DEFAULT_MAX_FRAME_SIZE (10 * 1024 * 1024)
+#define IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE (64 * 1024 * 1024)
+#define IMBEATS_MAX_BYTE_SIZE_LIMIT 200000000
+
+DEF_IMOD_STATIC_DATA;
+DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(netstrm) DEFobjCurrIf(netstrms) DEFobjCurrIf(prop)
+    DEFobjCurrIf(ruleset) DEFobjCurrIf(statsobj)
+
+        typedef struct session_s session_t;
+
+typedef struct instanceConf_s {
+    struct instanceConf_s *next;
+    uchar *port;
+    uchar *address;
+    uchar *pszBindRuleset;
+    ruleset_t *pBindRuleset;
+    uchar *pszInputName;
+    prop_t *pInputName;
+    uchar *pszLstnPortFileName;
+    char *pszNetworkNamespace;
+
+    uchar *pszStrmDrvrName;
+    int iStrmDrvrMode;
+    uchar *pszStrmDrvrAuthMode;
+    uchar *pszStrmDrvrPermitExpiredCerts;
+    uchar *pszStrmDrvrCAFile;
+    uchar *pszStrmDrvrCRLFile;
+    uchar *pszStrmDrvrKeyFile;
+    uchar *pszStrmDrvrCertFile;
+    uchar *gnutlsPriorityString;
+    permittedPeers_t *pPermPeersRoot;
+    int iStrmDrvrExtendedCertCheck;
+    int iStrmDrvrSANPreference;
+    int iStrmTlsVerifyDepth;
+    int iStrmTlsRevocationCheck;
+
+    int bKeepAlive;
+    int iKeepAliveIntvl;
+    int iKeepAliveProbes;
+    int iKeepAliveTime;
+    uint32_t maxWindowSize;
+    size_t maxFrameSize;
+    size_t maxDecompressedSize;
+
+    netstrms_t *pNS;
+    netstrm_t **listeners;
+    int *listener_socks;
+    size_t listener_count;
+    size_t listener_cap;
+    pthread_t listener_tid;
+    int listener_running;
+    pthread_mutex_t mutSessions;
+    session_t *sessions;
+} instanceConf_t;
+
+typedef struct modConfData_s {
+    rsconf_t *pConf;
+    instanceConf_t *root;
+    instanceConf_t *tail;
+} modConfData_t;
+
+struct session_s {
+    instanceConf_t *inst;
+    netstrm_t *pStrm;
+    pthread_t tid;
+    int done;
+    int sock;
+    uchar *fromHostFQDN;
+    prop_t *fromHost;
+    prop_t *fromHostIP;
+    prop_t *fromHostPort;
+    session_t *next;
+};
+
+static modConfData_t *loadModConf = NULL;
+static modConfData_t *runModConf = NULL;
+static prop_t *pInputName = NULL;
+
+static struct cnfparamdescr modpdescr[] = {};
+static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, 0, modpdescr};
+
+static struct cnfparamdescr inppdescr[] = {
+    {"port", eCmdHdlrString, CNFPARAM_REQUIRED},
+    {"address", eCmdHdlrString, 0},
+    {"ruleset", eCmdHdlrString, 0},
+    {"name", eCmdHdlrString, 0},
+    {"listenportfilename", eCmdHdlrString, 0},
+    {"networknamespace", eCmdHdlrString, 0},
+    {"streamdriver.name", eCmdHdlrString, 0},
+    {"streamdriver.mode", eCmdHdlrNonNegInt, 0},
+    {"streamdriver.authmode", eCmdHdlrString, 0},
+    {"streamdriver.permitexpiredcerts", eCmdHdlrString, 0},
+    {"streamdriver.cafile", eCmdHdlrString, 0},
+    {"streamdriver.crlfile", eCmdHdlrString, 0},
+    {"streamdriver.keyfile", eCmdHdlrString, 0},
+    {"streamdriver.certfile", eCmdHdlrString, 0},
+    {"streamdriver.checkextendedkeypurpose", eCmdHdlrBinary, 0},
+    {"streamdriver.prioritizesan", eCmdHdlrBinary, 0},
+    {"streamdriver.tlsverifydepth", eCmdHdlrPositiveInt, 0},
+    {"streamdriver.tlsrevocationcheck", eCmdHdlrBinary, 0},
+    {"permittedpeer", eCmdHdlrArray, 0},
+    {"keepalive", eCmdHdlrBinary, 0},
+    {"keepalive.probes", eCmdHdlrNonNegInt, 0},
+    {"keepalive.time", eCmdHdlrNonNegInt, 0},
+    {"keepalive.interval", eCmdHdlrNonNegInt, 0},
+    {"gnutlsprioritystring", eCmdHdlrString, 0},
+    {"maxwindowsize", eCmdHdlrPositiveInt, 0},
+    {"maxframesize", eCmdHdlrPositiveInt, 0},
+    {"maxdecompressedsize", eCmdHdlrPositiveInt, 0},
+};
+static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(inppdescr[0]), inppdescr};
+
+static struct {
+    statsobj_t *stats;
+    STATSCOUNTER_DEF(ctrConnectionsAccepted, mutCtrConnectionsAccepted)
+    STATSCOUNTER_DEF(ctrConnectionsClosed, mutCtrConnectionsClosed)
+    STATSCOUNTER_DEF(ctrProtocolErrors, mutCtrProtocolErrors)
+    STATSCOUNTER_DEF(ctrBatchesReceived, mutCtrBatchesReceived)
+    STATSCOUNTER_DEF(ctrBatchesAcked, mutCtrBatchesAcked)
+    STATSCOUNTER_DEF(ctrEventsReceived, mutCtrEventsReceived)
+    STATSCOUNTER_DEF(ctrEventsSubmitted, mutCtrEventsSubmitted)
+    STATSCOUNTER_DEF(ctrEventsFailed, mutCtrEventsFailed)
+    STATSCOUNTER_DEF(ctrCompressedFrames, mutCtrCompressedFrames)
+    STATSCOUNTER_DEF(ctrJsonDecodeFailures, mutCtrJsonDecodeFailures)
+    STATSCOUNTER_DEF(ctrAckFailures, mutCtrAckFailures)
+    STATSCOUNTER_DEF(ctrWindowsRejected, mutCtrWindowsRejected)
+    STATSCOUNTER_DEF(ctrFramesRejected, mutCtrFramesRejected)
+    STATSCOUNTER_DEF(ctrCompressedRejected, mutCtrCompressedRejected)
+} statsCounter;
+
+#include "im-helper.h"
+
+static inline void std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *inst) {
+    LogError(0, NO_ERRCODE, "imbeats: ruleset '%s' for port '%s' not found - using default ruleset instead",
+             inst->pszBindRuleset, inst->port);
+}
+
+static rsRetVal createInstance(instanceConf_t **const pinst);
+static rsRetVal buildListeners(instanceConf_t *inst);
+static rsRetVal destroyInstanceRuntime(instanceConf_t *inst);
+static void *listenerThread(void *arg);
+static void *sessionThread(void *arg);
+
+static rsRetVal validateUInt32Limit(const char *const name,
+                                    const int64_t value,
+                                    const uint32_t max,
+                                    uint32_t *const target) {
+    if (value < 1 || value > max) {
+        LogError(0, RS_RET_PARAM_ERROR, "imbeats: invalid value for '%s' parameter given is %lld, valid range is 1..%u",
+                 name, (long long)value, max);
+        return RS_RET_PARAM_ERROR;
+    }
+    *target = (uint32_t)value;
+    return RS_RET_OK;
+}
+
+static rsRetVal validateSizeLimit(const char *const name, const int64_t value, const size_t max, size_t *const target) {
+    if (value < 1 || (uint64_t)value > max) {
+        LogError(0, RS_RET_PARAM_ERROR,
+                 "imbeats: invalid value for '%s' parameter given is %lld, valid range is 1..%zu", name,
+                 (long long)value, max);
+        return RS_RET_PARAM_ERROR;
+    }
+    *target = (size_t)value;
+    return RS_RET_OK;
+}
+
+static rsRetVal setCnfString(uchar **const target, es_str_t *const value) {
+    *target = (uchar *)es_str2cstr(value, NULL);
+    return (*target == NULL) ? RS_RET_OUT_OF_MEMORY : RS_RET_OK;
+}
+
+static rsRetVal setCnfCString(char **const target, es_str_t *const value) {
+    *target = es_str2cstr(value, NULL);
+    return (*target == NULL) ? RS_RET_OUT_OF_MEMORY : RS_RET_OK;
+}
+
+static rsRetVal createPortProp(struct sockaddr_storage *addr, prop_t **const ppProp) {
+    uint16_t port = 0;
+    char portbuf[8];
+    DEFiRet;
+
+    if (addr->ss_family == AF_INET) {
+        port = ntohs(((struct sockaddr_in *)addr)->sin_port);
+    } else if (addr->ss_family == AF_INET6) {
+        port = ntohs(((struct sockaddr_in6 *)addr)->sin6_port);
+    }
+    snprintf(portbuf, sizeof(portbuf), "%u", port);
+    CHKiRet(prop.Construct(ppProp));
+    CHKiRet(prop.SetString(*ppProp, (uchar *)portbuf, strlen(portbuf)));
+    CHKiRet(prop.ConstructFinalize(*ppProp));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal addListener(void *usr, netstrm_t *pStrm) {
+    instanceConf_t *const inst = (instanceConf_t *)usr;
+    int sock = -1;
+    netstrm_t **new_listeners = NULL;
+    int *new_socks = NULL;
+    DEFiRet;
+
+    assert(inst != NULL);
+    assert(pStrm != NULL);
+
+    if (inst->listener_count == inst->listener_cap) {
+        size_t new_cap = (inst->listener_cap == 0) ? 4 : inst->listener_cap * 2;
+        if (new_cap < inst->listener_cap || new_cap > SIZE_MAX / sizeof(netstrm_t *) ||
+            new_cap > SIZE_MAX / sizeof(int)) {
+            return RS_RET_OUT_OF_MEMORY;
+        }
+        CHKmalloc(new_listeners = malloc(new_cap * sizeof(netstrm_t *)));
+        CHKmalloc(new_socks = malloc(new_cap * sizeof(int)));
+        if (inst->listener_count > 0) {
+            memcpy(new_listeners, inst->listeners, inst->listener_count * sizeof(netstrm_t *));
+            memcpy(new_socks, inst->listener_socks, inst->listener_count * sizeof(int));
+        }
+        free(inst->listeners);
+        free(inst->listener_socks);
+        inst->listeners = new_listeners;
+        inst->listener_socks = new_socks;
+        inst->listener_cap = new_cap;
+        new_listeners = NULL;
+        new_socks = NULL;
+    }
+
+    CHKiRet(netstrm.GetSock(pStrm, &sock));
+    inst->listeners[inst->listener_count] = pStrm;
+    inst->listener_socks[inst->listener_count] = sock;
+    ++inst->listener_count;
+
+finalize_it:
+    free(new_listeners);
+    free(new_socks);
+    RETiRet;
+}
+
+static rsRetVal configureNetstrms(instanceConf_t *const inst) {
+    DEFiRet;
+    assert(inst != NULL);
+
+    CHKiRet(netstrms.Construct(&inst->pNS));
+    if (inst->pszStrmDrvrName != NULL) CHKiRet(netstrms.SetDrvrName(inst->pNS, inst->pszStrmDrvrName));
+    CHKiRet(netstrms.SetDrvrMode(inst->pNS, inst->iStrmDrvrMode));
+    CHKiRet(netstrms.SetDrvrCheckExtendedKeyUsage(inst->pNS, inst->iStrmDrvrExtendedCertCheck));
+    CHKiRet(netstrms.SetDrvrPrioritizeSAN(inst->pNS, inst->iStrmDrvrSANPreference));
+    CHKiRet(netstrms.SetDrvrTlsVerifyDepth(inst->pNS, inst->iStrmTlsVerifyDepth));
+    CHKiRet(netstrms.SetDrvrTlsRevocationCheck(inst->pNS, inst->iStrmTlsRevocationCheck));
+    if (inst->pszStrmDrvrAuthMode != NULL) CHKiRet(netstrms.SetDrvrAuthMode(inst->pNS, inst->pszStrmDrvrAuthMode));
+    CHKiRet(netstrms.SetDrvrPermitExpiredCerts(inst->pNS, inst->pszStrmDrvrPermitExpiredCerts));
+    CHKiRet(netstrms.SetDrvrTlsCAFile(inst->pNS, inst->pszStrmDrvrCAFile));
+    CHKiRet(netstrms.SetDrvrTlsCRLFile(inst->pNS, inst->pszStrmDrvrCRLFile));
+    CHKiRet(netstrms.SetDrvrTlsKeyFile(inst->pNS, inst->pszStrmDrvrKeyFile));
+    CHKiRet(netstrms.SetDrvrTlsCertFile(inst->pNS, inst->pszStrmDrvrCertFile));
+    if (inst->pPermPeersRoot != NULL) CHKiRet(netstrms.SetDrvrPermPeers(inst->pNS, inst->pPermPeersRoot));
+    if (inst->gnutlsPriorityString != NULL)
+        CHKiRet(netstrms.SetDrvrGnutlsPriorityString(inst->pNS, inst->gnutlsPriorityString));
+    CHKiRet(netstrms.ConstructFinalize(inst->pNS));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal buildListeners(instanceConf_t *inst) {
+    tcpLstnParams_t params;
+    DEFiRet;
+
+    memset(&params, 0, sizeof(params));
+    params.pszPort = inst->port;
+    params.pszAddr = inst->address;
+    params.pszLstnPortFileName = inst->pszLstnPortFileName;
+    params.pszNetworkNamespace = inst->pszNetworkNamespace;
+
+    CHKiRet(configureNetstrms(inst));
+    CHKiRet(netstrm.LstnInit(inst->pNS, inst, addListener, 0, &params));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal sessionPollWait(const int fd, const short events, const int timeout_ms) {
+    struct pollfd pfd;
+    pfd.fd = fd;
+    pfd.events = events;
+    pfd.revents = 0;
+    if (poll(&pfd, 1, timeout_ms) < 0) {
+        return RS_RET_IO_ERROR;
+    }
+    return RS_RET_OK;
+}
+
+static rsRetVal sessionRead(session_t *const sess, unsigned char *buf, const size_t len) {
+    size_t off = 0;
+    int oserr;
+    unsigned nextIODirection;
+    rsRetVal iRet;
+
+    assert(sess != NULL);
+    while (off < len && glbl.GetGlobalInputTermState() == 0) {
+        ssize_t need = (ssize_t)(len - off);
+        iRet = netstrm.Rcv(sess->pStrm, buf + off, &need, &oserr, &nextIODirection);
+        if (iRet == RS_RET_OK) {
+            off += need;
+        } else if (iRet == RS_RET_RETRY) {
+            CHKiRet(sessionPollWait(sess->sock, (nextIODirection == NSDSEL_WR) ? POLLOUT : POLLIN, 1000));
+        } else {
+            ABORT_FINALIZE(iRet);
+        }
+    }
+
+    if (off != len) {
+        ABORT_FINALIZE(RS_RET_CLOSED);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal sessionSendAll(session_t *const sess, const unsigned char *buf, const size_t len) {
+    size_t off = 0;
+    rsRetVal iRet;
+
+    while (off < len && glbl.GetGlobalInputTermState() == 0) {
+        ssize_t to_send = (ssize_t)(len - off);
+        iRet = netstrm.Send(sess->pStrm, (uchar *)buf + off, &to_send);
+        if (iRet == RS_RET_OK) {
+            if (to_send == 0) {
+                CHKiRet(sessionPollWait(sess->sock, POLLOUT, 1000));
+            } else {
+                off += to_send;
+            }
+        } else {
+            ABORT_FINALIZE(iRet);
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal submitEvent(session_t *const sess, const struct lj_event_s *const event) {
+    smsg_t *pMsg = NULL;
+    struct json_tokener *tok = NULL;
+    struct fjson_object *json = NULL;
+    struct fjson_object *meta = NULL;
+    rsRetVal iRet = RS_RET_OK;
+    char portbuf[16];
+
+    assert(sess != NULL);
+    assert(event != NULL);
+
+    CHKmalloc(tok = json_tokener_new());
+    json = json_tokener_parse_ex(tok, (const char *)event->payload, event->payload_len);
+    if (tok->err != fjson_tokener_success || json == NULL || !fjson_object_is_type(json, fjson_type_object)) {
+        STATSCOUNTER_INC(statsCounter.ctrJsonDecodeFailures, statsCounter.mutCtrJsonDecodeFailures);
+        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+    }
+
+    CHKiRet(msgConstruct(&pMsg));
+    MsgSetFlowControlType(pMsg, eFLOWCTL_LIGHT_DELAY);
+    MsgSetInputName(pMsg, (sess->inst->pInputName != NULL) ? sess->inst->pInputName : pInputName);
+    MsgSetRawMsg(pMsg, (const char *)event->payload, event->payload_len);
+    MsgSetMSGoffs(pMsg, 0);
+    if (sess->fromHostFQDN != NULL) {
+        if (sess->fromHost != NULL) {
+            MsgSetRcvFrom(pMsg, sess->fromHost);
+        }
+        MsgSetHOSTNAME(pMsg, sess->fromHostFQDN, ustrlen(sess->fromHostFQDN));
+    }
+    if (sess->fromHostIP != NULL) {
+        CHKiRet(MsgSetRcvFromIP(pMsg, sess->fromHostIP));
+    }
+    if (sess->fromHostPort != NULL) {
+        CHKiRet(MsgSetRcvFromPort(pMsg, sess->fromHostPort));
+    }
+    if (sess->inst->pBindRuleset != NULL) {
+        MsgSetRuleset(pMsg, sess->inst->pBindRuleset);
+    }
+
+    /* TODO: representation mode is intentionally Elasticsearch-oriented for v1.
+     * Revisit later whether this should be configurable (for example $! vs $!beats).
+     */
+    CHKiRet(msgAddJSON(pMsg, (uchar *)"!", json, 0, 0));
+    json = NULL;
+
+    CHKmalloc(meta = json_object_new_object());
+    fjson_object_object_add(meta, "protocol", json_object_new_string("lumberjack-v2"));
+    fjson_object_object_add(meta, "sequence", json_object_new_int64(event->seq));
+    fjson_object_object_add(meta, "tls_enabled", json_object_new_boolean(sess->inst->iStrmDrvrMode != 0));
+    if (sess->fromHostFQDN != NULL) {
+        fjson_object_object_add(meta, "peer_hostname", json_object_new_string((char *)sess->fromHostFQDN));
+    }
+    if (sess->fromHostIP != NULL) {
+        fjson_object_object_add(meta, "peer_ip", json_object_new_string(propGetSzStrOrDefault(sess->fromHostIP, "")));
+    }
+    if (sess->fromHostPort != NULL) {
+        snprintf(portbuf, sizeof(portbuf), "%s", propGetSzStrOrDefault(sess->fromHostPort, ""));
+        fjson_object_object_add(meta, "peer_port", json_object_new_string(portbuf));
+    }
+    CHKiRet(msgAddJSON(pMsg, (uchar *)"!metadata!imbeats", meta, 0, 0));
+    meta = NULL;
+
+    CHKiRet(submitMsg2(pMsg));
+    STATSCOUNTER_INC(statsCounter.ctrEventsSubmitted, statsCounter.mutCtrEventsSubmitted);
+
+finalize_it:
+    if (iRet != RS_RET_OK) {
+        STATSCOUNTER_INC(statsCounter.ctrEventsFailed, statsCounter.mutCtrEventsFailed);
+        if (pMsg != NULL) {
+            msgDestruct(&pMsg);
+        }
+    }
+    if (tok != NULL) {
+        json_tokener_free(tok);
+    }
+    if (json != NULL) {
+        fjson_object_put(json);
+    }
+    if (meta != NULL) {
+        fjson_object_put(meta);
+    }
+    RETiRet;
+}
+
+static rsRetVal receiveBatch(session_t *const sess, struct lj_batch_s *batch) {
+    unsigned char hdr[2];
+    uint32_t net32;
+    uint32_t seq = 0;
+    size_t idx;
+    DEFiRet;
+
+    CHKiRet(sessionRead(sess, hdr, sizeof(hdr)));
+    CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+    net32 = ntohl(net32);
+    CHKiRet(lj_parse_window_header(hdr, net32));
+    if (net32 > sess->inst->maxWindowSize) {
+        STATSCOUNTER_INC(statsCounter.ctrWindowsRejected, statsCounter.mutCtrWindowsRejected);
+        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+    }
+    CHKiRet(lj_batch_alloc(batch, net32, sess->inst->maxWindowSize));
+    STATSCOUNTER_INC(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
+
+    while (batch->count < batch->window_size) {
+        unsigned char frame_hdr[2];
+        CHKiRet(sessionRead(sess, frame_hdr, sizeof(frame_hdr)));
+        if (frame_hdr[0] != LJ_VERSION_V2) {
+            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+        }
+        if (frame_hdr[1] == LJ_FRAME_JSON) {
+            uint32_t payload_len;
+            unsigned char *payload = NULL;
+            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+            seq = ntohl(net32);
+            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+            payload_len = ntohl(net32);
+            if (payload_len == 0 || (size_t)payload_len > sess->inst->maxFrameSize) {
+                STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
+                ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+            }
+            CHKmalloc(payload = malloc(payload_len));
+            iRet = sessionRead(sess, payload, payload_len);
+            if (iRet != RS_RET_OK) {
+                free(payload);
+                ABORT_FINALIZE(iRet);
+            }
+            iRet = lj_append_json_event(batch, seq, payload, payload_len);
+            free(payload);
+            CHKiRet(iRet);
+        } else if (frame_hdr[1] == LJ_FRAME_COMPRESSED) {
+            uint32_t compressed_len;
+            unsigned char *payload = NULL;
+            STATSCOUNTER_INC(statsCounter.ctrCompressedFrames, statsCounter.mutCtrCompressedFrames);
+            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
+            compressed_len = ntohl(net32);
+            if (compressed_len == 0 || (size_t)compressed_len > sess->inst->maxFrameSize) {
+                STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
+                STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
+                ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+            }
+            CHKmalloc(payload = malloc(compressed_len));
+            iRet = sessionRead(sess, payload, compressed_len);
+            if (iRet != RS_RET_OK) {
+                free(payload);
+                ABORT_FINALIZE(iRet);
+            }
+            iRet = lj_parse_compressed_frames(batch, payload, compressed_len, sess->inst->maxFrameSize,
+                                              sess->inst->maxDecompressedSize);
+            free(payload);
+            if (iRet == RS_RET_INVALID_VALUE) {
+                STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
+            }
+            CHKiRet(iRet);
+        } else {
+            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+        }
+    }
+
+    for (idx = 0; idx < batch->count; ++idx) {
+        const uint32_t expected = (uint32_t)idx + 1;
+        if (batch->events[idx].seq != expected) {
+            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+        }
+    }
+    STATSCOUNTER_ADD(statsCounter.ctrEventsReceived, statsCounter.mutCtrEventsReceived, batch->count);
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal ackBatch(session_t *const sess, const uint32_t seq) {
+    unsigned char ack[6];
+    uint32_t netseq = htonl(seq);
+    rsRetVal iRet;
+
+    ack[0] = LJ_VERSION_V2;
+    ack[1] = LJ_FRAME_ACK;
+    memcpy(ack + 2, &netseq, sizeof(netseq));
+    iRet = sessionSendAll(sess, ack, sizeof(ack));
+    if (iRet == RS_RET_OK) {
+        STATSCOUNTER_INC(statsCounter.ctrBatchesAcked, statsCounter.mutCtrBatchesAcked);
+    } else {
+        STATSCOUNTER_INC(statsCounter.ctrAckFailures, statsCounter.mutCtrAckFailures);
+    }
+    return iRet;
+}
+
+static void unlinkSession(instanceConf_t *const inst, session_t *const target) {
+    session_t **pp;
+    assert(inst != NULL);
+    assert(target != NULL);
+    pthread_mutex_lock(&inst->mutSessions);
+    for (pp = &inst->sessions; *pp != NULL; pp = &(*pp)->next) {
+        if (*pp == target) {
+            *pp = target->next;
+            break;
+        }
+    }
+    pthread_mutex_unlock(&inst->mutSessions);
+}
+
+static void destroySession(session_t *sess) {
+    if (sess == NULL) {
+        return;
+    }
+    if (sess->pStrm != NULL) {
+        netstrm.Destruct(&sess->pStrm);
+    }
+    if (sess->fromHostIP != NULL) {
+        prop.Destruct(&sess->fromHostIP);
+    }
+    if (sess->fromHost != NULL) {
+        prop.Destruct(&sess->fromHost);
+    }
+    if (sess->fromHostPort != NULL) {
+        prop.Destruct(&sess->fromHostPort);
+    }
+    free(sess->fromHostFQDN);
+    free(sess);
+}
+
+static void *sessionThread(void *arg) {
+    session_t *const sess = (session_t *)arg;
+    rsRetVal iRet = RS_RET_OK;
+
+    assert(sess != NULL);
+
+    while (glbl.GetGlobalInputTermState() == 0) {
+        struct lj_batch_s batch;
+        size_t idx;
+
+        memset(&batch, 0, sizeof(batch));
+        iRet = receiveBatch(sess, &batch);
+        if (iRet != RS_RET_OK) {
+            if (iRet == RS_RET_INVALID_VALUE) {
+                STATSCOUNTER_INC(statsCounter.ctrProtocolErrors, statsCounter.mutCtrProtocolErrors);
+            }
+            lj_batch_free(&batch);
+            break;
+        }
+
+        for (idx = 0; idx < batch.count; ++idx) {
+            iRet = submitEvent(sess, &batch.events[idx]);
+            if (iRet != RS_RET_OK) {
+                break;
+            }
+        }
+        if (iRet == RS_RET_OK) {
+            iRet = ackBatch(sess, batch.events[batch.count - 1].seq);
+        }
+        lj_batch_free(&batch);
+        if (iRet != RS_RET_OK) {
+            break;
+        }
+    }
+
+    STATSCOUNTER_INC(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
+    unlinkSession(sess->inst, sess);
+    destroySession(sess);
+    return NULL;
+}
+
+static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t *const pNewStrm) {
+    session_t *sess = NULL;
+    struct sockaddr_storage *addr = NULL;
+    DEFiRet;
+
+    CHKmalloc(sess = calloc(1, sizeof(*sess)));
+    sess->inst = inst;
+    sess->pStrm = pNewStrm;
+    CHKiRet(netstrm.GetSock(pNewStrm, &sess->sock));
+    if (inst->bKeepAlive) {
+        CHKiRet(netstrm.SetKeepAliveProbes(pNewStrm, inst->iKeepAliveProbes));
+        CHKiRet(netstrm.SetKeepAliveTime(pNewStrm, inst->iKeepAliveTime));
+        CHKiRet(netstrm.SetKeepAliveIntvl(pNewStrm, inst->iKeepAliveIntvl));
+        CHKiRet(netstrm.EnableKeepAlive(pNewStrm));
+    }
+    if (inst->gnutlsPriorityString != NULL) {
+        CHKiRet(netstrm.SetGnutlsPriorityString(pNewStrm, inst->gnutlsPriorityString));
+    }
+    CHKiRet(netstrm.GetRemoteHName(pNewStrm, &sess->fromHostFQDN));
+    if (sess->fromHostFQDN != NULL) {
+        CHKiRet(prop.Construct(&sess->fromHost));
+        CHKiRet(prop.SetString(sess->fromHost, sess->fromHostFQDN, ustrlen(sess->fromHostFQDN)));
+        CHKiRet(prop.ConstructFinalize(sess->fromHost));
+    }
+    CHKiRet(netstrm.GetRemoteIP(pNewStrm, &sess->fromHostIP));
+    CHKiRet(netstrm.GetRemAddr(pNewStrm, &addr));
+    CHKiRet(createPortProp(addr, &sess->fromHostPort));
+
+    pthread_mutex_lock(&inst->mutSessions);
+    sess->next = inst->sessions;
+    inst->sessions = sess;
+    pthread_mutex_unlock(&inst->mutSessions);
+
+    STATSCOUNTER_INC(statsCounter.ctrConnectionsAccepted, statsCounter.mutCtrConnectionsAccepted);
+    if (pthread_create(&sess->tid, NULL, sessionThread, sess) != 0) {
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    pthread_detach(sess->tid);
+    sess = NULL;
+
+finalize_it:
+    if (iRet != RS_RET_OK && sess != NULL) {
+        destroySession(sess);
+    }
+    RETiRet;
+}
+
+static void *listenerThread(void *arg) {
+    instanceConf_t *const inst = (instanceConf_t *)arg;
+    struct pollfd *pfds = NULL;
+    size_t i;
+
+    assert(inst != NULL);
+    pfds = calloc(inst->listener_count, sizeof(struct pollfd));
+    if (pfds == NULL) {
+        return NULL;
+    }
+    for (i = 0; i < inst->listener_count; ++i) {
+        pfds[i].fd = inst->listener_socks[i];
+        pfds[i].events = POLLIN;
+    }
+
+    inst->listener_running = 1;
+    while (glbl.GetGlobalInputTermState() == 0) {
+        if (poll(pfds, inst->listener_count, 1000) <= 0) {
+            continue;
+        }
+        for (i = 0; i < inst->listener_count; ++i) {
+            if ((pfds[i].revents & POLLIN) != 0) {
+                netstrm_t *pNewStrm = NULL;
+                char connInfo[TCPSRV_CONNINFO_SIZE];
+                rsRetVal iRet;
+
+                memset(connInfo, 0, sizeof(connInfo));
+                iRet = netstrm.AcceptConnReq(inst->listeners[i], &pNewStrm, connInfo);
+                if (iRet == RS_RET_OK) {
+                    iRet = spawnSession(inst, pNewStrm);
+                    if (iRet != RS_RET_OK && pNewStrm != NULL) {
+                        netstrm.Destruct(&pNewStrm);
+                    }
+                }
+            }
+        }
+    }
+
+    free(pfds);
+    return NULL;
+}
+
+static rsRetVal destroyInstanceRuntime(instanceConf_t *inst) {
+    size_t i;
+
+    if (inst->listener_running) {
+        pthread_join(inst->listener_tid, NULL);
+        inst->listener_running = 0;
+    }
+
+    for (i = 0; i < inst->listener_count; ++i) {
+        if (inst->listeners[i] != NULL) {
+            netstrm.Destruct(&inst->listeners[i]);
+        }
+    }
+    free(inst->listeners);
+    inst->listeners = NULL;
+    free(inst->listener_socks);
+    inst->listener_socks = NULL;
+    inst->listener_count = 0;
+    inst->listener_cap = 0;
+    if (inst->pNS != NULL) {
+        netstrms.Destruct(&inst->pNS);
+    }
+    return RS_RET_OK;
+}
+
+static rsRetVal createInstance(instanceConf_t **const pinst) {
+    instanceConf_t *inst;
+    DEFiRet;
+
+    CHKmalloc(inst = calloc(1, sizeof(*inst)));
+    pthread_mutex_init(&inst->mutSessions, NULL);
+    inst->iStrmDrvrMode = 0;
+    inst->maxWindowSize = IMBEATS_DEFAULT_MAX_WINDOW_SIZE;
+    inst->maxFrameSize = IMBEATS_DEFAULT_MAX_FRAME_SIZE;
+    inst->maxDecompressedSize = IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE;
+    if (loadModConf->tail == NULL) {
+        loadModConf->root = loadModConf->tail = inst;
+    } else {
+        loadModConf->tail->next = inst;
+        loadModConf->tail = inst;
+    }
+    *pinst = inst;
+
+finalize_it:
+    RETiRet;
+}
+
+BEGINnewInpInst
+    struct cnfparamvals *pvals;
+    instanceConf_t *inst = NULL;
+    int i;
+    CODESTARTnewInpInst;
+    pvals = nvlstGetParams(lst, &inppblk, NULL);
+    if (pvals == NULL) {
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+    }
+    CHKiRet(createInstance(&inst));
+    for (i = 0; i < inppblk.nParams; ++i) {
+        int j;
+        if (!pvals[i].bUsed) continue;
+        if (!strcmp(inppblk.descr[i].name, "port")) {
+            CHKiRet(setCnfString(&inst->port, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "address")) {
+            CHKiRet(setCnfString(&inst->address, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
+            CHKiRet(setCnfString(&inst->pszBindRuleset, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "name")) {
+            CHKiRet(setCnfString(&inst->pszInputName, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "listenportfilename")) {
+            CHKiRet(setCnfString(&inst->pszLstnPortFileName, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "networknamespace")) {
+            CHKiRet(setCnfCString(&inst->pszNetworkNamespace, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.name")) {
+            CHKiRet(setCnfString(&inst->pszStrmDrvrName, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.mode")) {
+            inst->iStrmDrvrMode = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.authmode")) {
+            CHKiRet(setCnfString(&inst->pszStrmDrvrAuthMode, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
+            CHKiRet(setCnfString(&inst->pszStrmDrvrPermitExpiredCerts, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.cafile")) {
+            CHKiRet(setCnfString(&inst->pszStrmDrvrCAFile, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.crlfile")) {
+            CHKiRet(setCnfString(&inst->pszStrmDrvrCRLFile, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.keyfile")) {
+            CHKiRet(setCnfString(&inst->pszStrmDrvrKeyFile, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.certfile")) {
+            CHKiRet(setCnfString(&inst->pszStrmDrvrCertFile, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.checkextendedkeypurpose")) {
+            inst->iStrmDrvrExtendedCertCheck = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.prioritizesan")) {
+            inst->iStrmDrvrSANPreference = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.tlsverifydepth")) {
+            inst->iStrmTlsVerifyDepth = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "streamdriver.tlsrevocationcheck")) {
+            inst->iStrmTlsRevocationCheck = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "permittedpeer")) {
+            for (j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+                uchar *peer = NULL;
+                CHKiRet(setCnfString(&peer, pvals[i].val.d.ar->arr[j]));
+                iRet = net.AddPermittedPeer(&inst->pPermPeersRoot, peer);
+                free(peer);
+                CHKiRet(iRet);
+            }
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive")) {
+            inst->bKeepAlive = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive.probes")) {
+            inst->iKeepAliveProbes = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive.time")) {
+            inst->iKeepAliveTime = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "keepalive.interval")) {
+            inst->iKeepAliveIntvl = (int)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "gnutlsprioritystring")) {
+            CHKiRet(setCnfString(&inst->gnutlsPriorityString, pvals[i].val.d.estr));
+        } else if (!strcmp(inppblk.descr[i].name, "maxwindowsize")) {
+            CHKiRet(validateUInt32Limit("maxWindowSize", pvals[i].val.d.n, IMBEATS_MAX_WINDOW_SIZE_LIMIT,
+                                        &inst->maxWindowSize));
+        } else if (!strcmp(inppblk.descr[i].name, "maxframesize")) {
+            CHKiRet(
+                validateSizeLimit("maxFrameSize", pvals[i].val.d.n, IMBEATS_MAX_BYTE_SIZE_LIMIT, &inst->maxFrameSize));
+        } else if (!strcmp(inppblk.descr[i].name, "maxdecompressedsize")) {
+            CHKiRet(validateSizeLimit("maxDecompressedSize", pvals[i].val.d.n, IMBEATS_MAX_BYTE_SIZE_LIMIT,
+                                      &inst->maxDecompressedSize));
+        }
+    }
+    if (inst->pszInputName != NULL) {
+        CHKiRet(prop.Construct(&inst->pInputName));
+        CHKiRet(prop.SetString(inst->pInputName, inst->pszInputName, ustrlen(inst->pszInputName)));
+        CHKiRet(prop.ConstructFinalize(inst->pInputName));
+    }
+
+finalize_it:
+    CODE_STD_FINALIZERnewInpInst if (pvals != NULL) cnfparamvalsDestruct(pvals, &inppblk);
+ENDnewInpInst
+
+BEGINbeginCnfLoad
+    CODESTARTbeginCnfLoad;
+    loadModConf = pModConf;
+    pModConf->pConf = pConf;
+ENDbeginCnfLoad
+
+BEGINsetModCnf
+    struct cnfparamvals *pvals = NULL;
+    CODESTARTsetModCnf;
+    pvals = nvlstGetParams(lst, &modpblk, NULL);
+    if (pvals != NULL) cnfparamvalsDestruct(pvals, &modpblk);
+ENDsetModCnf
+
+BEGINendCnfLoad
+    CODESTARTendCnfLoad;
+    loadModConf = NULL;
+ENDendCnfLoad
+
+BEGINcheckCnf
+    instanceConf_t *inst;
+    CODESTARTcheckCnf;
+    for (inst = pModConf->root; inst != NULL; inst = inst->next) {
+        std_checkRuleset(pModConf, inst);
+    }
+ENDcheckCnf
+
+BEGINactivateCnfPrePrivDrop
+    CODESTARTactivateCnfPrePrivDrop;
+    runModConf = pModConf;
+ENDactivateCnfPrePrivDrop
+
+BEGINactivateCnf
+    instanceConf_t *inst;
+    CODESTARTactivateCnf;
+    for (inst = pModConf->root; inst != NULL; inst = inst->next) {
+        if (inst->pszBindRuleset != NULL) {
+            const rsRetVal localRet = ruleset.GetRuleset(pModConf->pConf, &inst->pBindRuleset, inst->pszBindRuleset);
+            if (localRet != RS_RET_OK) {
+                iRet = localRet;
+                break;
+            }
+        }
+    }
+ENDactivateCnf
+
+BEGINfreeCnf
+    instanceConf_t *inst, *del;
+    CODESTARTfreeCnf;
+    for (inst = pModConf->root; inst != NULL;) {
+        del = inst;
+        inst = inst->next;
+        destroyInstanceRuntime(del);
+        free(del->port);
+        free(del->address);
+        free(del->pszBindRuleset);
+        free(del->pszInputName);
+        free(del->pszLstnPortFileName);
+        free(del->pszNetworkNamespace);
+        free(del->pszStrmDrvrName);
+        free(del->pszStrmDrvrAuthMode);
+        free(del->pszStrmDrvrPermitExpiredCerts);
+        free(del->pszStrmDrvrCAFile);
+        free(del->pszStrmDrvrCRLFile);
+        free(del->pszStrmDrvrKeyFile);
+        free(del->pszStrmDrvrCertFile);
+        free(del->gnutlsPriorityString);
+        if (del->pPermPeersRoot != NULL) {
+            net.DestructPermittedPeers(&del->pPermPeersRoot);
+        }
+        if (del->pInputName != NULL) {
+            prop.Destruct(&del->pInputName);
+        }
+        pthread_mutex_destroy(&del->mutSessions);
+        free(del);
+    }
+ENDfreeCnf
+
+BEGINrunInput
+    instanceConf_t *inst;
+    CODESTARTrunInput;
+    for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        CHKiRet(buildListeners(inst));
+        if (pthread_create(&inst->listener_tid, NULL, listenerThread, inst) != 0) {
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+    }
+    while (glbl.GetGlobalInputTermState() == 0) {
+        srSleep(0, 250000);
+    }
+    for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        destroyInstanceRuntime(inst);
+    }
+finalize_it:
+ENDrunInput
+
+BEGINwillRun
+    CODESTARTwillRun;
+ENDwillRun
+
+BEGINafterRun
+    CODESTARTafterRun;
+ENDafterRun
+
+BEGINmodExit
+    CODESTARTmodExit;
+    if (pInputName != NULL) {
+        prop.Destruct(&pInputName);
+    }
+    if (statsCounter.stats != NULL) {
+        statsobj.Destruct(&statsCounter.stats);
+    }
+    objRelease(statsobj, CORE_COMPONENT);
+    objRelease(glbl, CORE_COMPONENT);
+    objRelease(net, LM_NET_FILENAME);
+    objRelease(netstrm, LM_NETSTRMS_FILENAME);
+    objRelease(netstrms, LM_NETSTRMS_FILENAME);
+    objRelease(prop, CORE_COMPONENT);
+    objRelease(ruleset, CORE_COMPONENT);
+ENDmodExit
+
+BEGINisCompatibleWithFeature
+    CODESTARTisCompatibleWithFeature;
+    if (eFeat == sFEATURENonCancelInputTermination) iRet = RS_RET_OK;
+ENDisCompatibleWithFeature
+
+BEGINqueryEtryPt
+    CODESTARTqueryEtryPt;
+    CODEqueryEtryPt_STD_IMOD_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_setModCnf_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_PREPRIVDROP_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_IMOD_QUERIES;
+    CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES;
+ENDqueryEtryPt
+
+BEGINmodInit()
+    CODESTARTmodInit;
+    *ipIFVersProvided = CURR_MOD_IF_VERSION;
+    CODEmodInit_QueryRegCFSLineHdlr;
+    CHKiRet(objUse(glbl, CORE_COMPONENT));
+    CHKiRet(objUse(net, LM_NET_FILENAME));
+    CHKiRet(objUse(netstrm, LM_NETSTRMS_FILENAME));
+    CHKiRet(objUse(netstrms, LM_NETSTRMS_FILENAME));
+    CHKiRet(objUse(prop, CORE_COMPONENT));
+    CHKiRet(objUse(ruleset, CORE_COMPONENT));
+    CHKiRet(objUse(statsobj, CORE_COMPONENT));
+
+    CHKiRet(prop.Construct(&pInputName));
+    CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("imbeats"), sizeof("imbeats") - 1));
+    CHKiRet(prop.ConstructFinalize(pInputName));
+
+    CHKiRet(statsobj.Construct(&statsCounter.stats));
+    CHKiRet(statsobj.SetName(statsCounter.stats, UCHAR_CONSTANT("imbeats")));
+    CHKiRet(statsobj.SetOrigin(statsCounter.stats, UCHAR_CONSTANT("imbeats")));
+    STATSCOUNTER_INIT(statsCounter.ctrConnectionsAccepted, statsCounter.mutCtrConnectionsAccepted);
+    STATSCOUNTER_INIT(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
+    STATSCOUNTER_INIT(statsCounter.ctrProtocolErrors, statsCounter.mutCtrProtocolErrors);
+    STATSCOUNTER_INIT(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
+    STATSCOUNTER_INIT(statsCounter.ctrBatchesAcked, statsCounter.mutCtrBatchesAcked);
+    STATSCOUNTER_INIT(statsCounter.ctrEventsReceived, statsCounter.mutCtrEventsReceived);
+    STATSCOUNTER_INIT(statsCounter.ctrEventsSubmitted, statsCounter.mutCtrEventsSubmitted);
+    STATSCOUNTER_INIT(statsCounter.ctrEventsFailed, statsCounter.mutCtrEventsFailed);
+    STATSCOUNTER_INIT(statsCounter.ctrCompressedFrames, statsCounter.mutCtrCompressedFrames);
+    STATSCOUNTER_INIT(statsCounter.ctrJsonDecodeFailures, statsCounter.mutCtrJsonDecodeFailures);
+    STATSCOUNTER_INIT(statsCounter.ctrAckFailures, statsCounter.mutCtrAckFailures);
+    STATSCOUNTER_INIT(statsCounter.ctrWindowsRejected, statsCounter.mutCtrWindowsRejected);
+    STATSCOUNTER_INIT(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
+    STATSCOUNTER_INIT(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.accepted"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsAccepted));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.closed"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsClosed));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("protocol_errors"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrProtocolErrors));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("batches.received"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrBatchesReceived));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("batches.acked"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrBatchesAcked));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("events.received"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrEventsReceived));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("events.submitted"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrEventsSubmitted));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("events.failed"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrEventsFailed));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("compressed_frames"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrCompressedFrames));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("json_decode_failures"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrJsonDecodeFailures));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("ack_failures"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &statsCounter.ctrAckFailures));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("windows.rejected"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrWindowsRejected));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("frames.rejected"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrFramesRejected));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("compressed.rejected"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrCompressedRejected));
+    CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));
+ENDmodInit

--- a/plugins/imbeats/lj_parser.c
+++ b/plugins/imbeats/lj_parser.c
@@ -1,0 +1,206 @@
+/*
+ * Minimal Lumberjack v2 parser helpers for imbeats.
+ *
+ * This layer deliberately stays transport-agnostic. Network reads, ACK timing,
+ * and rsyslog message construction live in imbeats.c.
+ */
+#include "config.h"
+#include "lj_parser.h"
+
+#include <arpa/inet.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <zlib.h>
+
+static rsRetVal append_event_owned(struct lj_batch_s *batch, uint32_t seq, unsigned char *payload, size_t payload_len) {
+    if (batch == NULL || batch->events == NULL || batch->count >= batch->window_size) {
+        free(payload);
+        return RS_RET_PARAM_ERROR;
+    }
+
+    batch->events[batch->count].seq = seq;
+    batch->events[batch->count].payload = payload;
+    batch->events[batch->count].payload_len = payload_len;
+    ++batch->count;
+    return RS_RET_OK;
+}
+
+rsRetVal lj_batch_alloc(struct lj_batch_s *batch, uint32_t window_size, uint32_t max_window_size) {
+    if (batch == NULL || window_size == 0 || window_size > max_window_size) {
+        return RS_RET_PARAM_ERROR;
+    }
+#if SIZE_MAX <= UINT32_MAX
+    if ((size_t)window_size > SIZE_MAX / sizeof(struct lj_event_s)) {
+        return RS_RET_OUT_OF_MEMORY;
+    }
+#endif
+    memset(batch, 0, sizeof(*batch));
+    batch->window_size = window_size;
+    batch->events = calloc(window_size, sizeof(struct lj_event_s));
+    return (batch->events == NULL) ? RS_RET_OUT_OF_MEMORY : RS_RET_OK;
+}
+
+void lj_batch_free(struct lj_batch_s *batch) {
+    size_t i;
+    if (batch == NULL) {
+        return;
+    }
+    for (i = 0; i < batch->count; ++i) {
+        free(batch->events[i].payload);
+    }
+    free(batch->events);
+    memset(batch, 0, sizeof(*batch));
+}
+
+rsRetVal lj_parse_window_header(const unsigned char hdr[2], uint32_t window_size) {
+    if (hdr[0] != LJ_VERSION_V2 || hdr[1] != LJ_FRAME_WINDOW || window_size == 0) {
+        return RS_RET_INVALID_VALUE;
+    }
+    return RS_RET_OK;
+}
+
+rsRetVal lj_append_json_event(struct lj_batch_s *batch,
+                              uint32_t seq,
+                              const unsigned char *payload,
+                              size_t payload_len) {
+    unsigned char *cpy;
+    if (batch == NULL || payload == NULL || payload_len == 0) {
+        return RS_RET_PARAM_ERROR;
+    }
+    if (payload_len > SIZE_MAX - 1) {
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    cpy = malloc(payload_len + 1);
+    if (cpy == NULL) {
+        return RS_RET_OUT_OF_MEMORY;
+    }
+    memcpy(cpy, payload, payload_len);
+    cpy[payload_len] = '\0';
+    return append_event_owned(batch, seq, cpy, payload_len);
+}
+
+static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
+                                         const unsigned char *buf,
+                                         size_t len,
+                                         size_t max_frame_size,
+                                         size_t max_decompressed_size) {
+    size_t off = 0;
+
+    while (off + 2 <= len) {
+        const unsigned char ver = buf[off++];
+        const unsigned char type = buf[off++];
+        uint32_t v1, v2;
+        rsRetVal iRet;
+
+        if (ver != LJ_VERSION_V2) {
+            return RS_RET_INVALID_VALUE;
+        }
+
+        switch (type) {
+            case LJ_FRAME_JSON:
+                if (off + 8 > len) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                memcpy(&v1, buf + off, 4);
+                memcpy(&v2, buf + off + 4, 4);
+                off += 8;
+                v1 = ntohl(v1);
+                v2 = ntohl(v2);
+                if ((size_t)v2 > max_frame_size || (size_t)v2 > len - off) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                iRet = lj_append_json_event(batch, v1, buf + off, v2);
+                if (iRet != RS_RET_OK) {
+                    return iRet;
+                }
+                off += v2;
+                break;
+            case LJ_FRAME_COMPRESSED:
+                if (off + 4 > len) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                memcpy(&v1, buf + off, 4);
+                off += 4;
+                v1 = ntohl(v1);
+                if ((size_t)v1 > max_frame_size || (size_t)v1 > len - off) {
+                    return RS_RET_INVALID_VALUE;
+                }
+                iRet = lj_parse_compressed_frames(batch, buf + off, v1, max_frame_size, max_decompressed_size);
+                if (iRet != RS_RET_OK) {
+                    return iRet;
+                }
+                off += v1;
+                break;
+            default:
+                return RS_RET_INVALID_VALUE;
+        }
+    }
+
+    return (off == len) ? RS_RET_OK : RS_RET_INVALID_VALUE;
+}
+
+rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
+                                    const unsigned char *payload,
+                                    size_t payload_len,
+                                    size_t max_frame_size,
+                                    size_t max_decompressed_size) {
+    z_stream zstrm;
+    unsigned char *out = NULL;
+    size_t out_cap = 0;
+    size_t out_len = 0;
+    int zrc;
+    rsRetVal iRet = RS_RET_OK;
+
+    if (batch == NULL || payload == NULL || max_frame_size == 0 || max_decompressed_size == 0) {
+        return RS_RET_PARAM_ERROR;
+    }
+    if (payload_len == 0 || payload_len > max_frame_size) {
+        return RS_RET_INVALID_VALUE;
+    }
+
+    memset(&zstrm, 0, sizeof(zstrm));
+    zstrm.next_in = (Bytef *)payload;
+    zstrm.avail_in = payload_len;
+
+    zrc = inflateInit(&zstrm);
+    if (zrc != Z_OK) {
+        return RS_RET_ZLIB_ERR;
+    }
+
+    do {
+        if (out_len == out_cap) {
+            size_t new_cap = (out_cap == 0) ? 4096 : out_cap * 2;
+            if (out_cap >= max_decompressed_size) {
+                iRet = RS_RET_INVALID_VALUE;
+                goto finalize_it;
+            }
+            if (new_cap < out_cap || new_cap > max_decompressed_size) {
+                new_cap = max_decompressed_size;
+            }
+            unsigned char *tmp = realloc(out, new_cap);
+            if (tmp == NULL) {
+                iRet = RS_RET_OUT_OF_MEMORY;
+                goto finalize_it;
+            }
+            out = tmp;
+            out_cap = new_cap;
+        }
+
+        zstrm.next_out = out + out_len;
+        zstrm.avail_out = out_cap - out_len;
+        zrc = inflate(&zstrm, Z_NO_FLUSH);
+        out_len = out_cap - zstrm.avail_out;
+        if (zrc != Z_OK && zrc != Z_STREAM_END) {
+            iRet = RS_RET_ZLIB_ERR;
+            goto finalize_it;
+        }
+    } while (zrc != Z_STREAM_END);
+
+    iRet = parse_frames_from_memory(batch, out, out_len, max_frame_size, max_decompressed_size);
+
+finalize_it:
+    inflateEnd(&zstrm);
+    free(out);
+    return iRet;
+}

--- a/plugins/imbeats/lj_parser.h
+++ b/plugins/imbeats/lj_parser.h
@@ -1,0 +1,37 @@
+#ifndef IMBEATS_LJ_PARSER_H
+#define IMBEATS_LJ_PARSER_H
+
+#include "config.h"
+#include <stddef.h>
+#include <stdint.h>
+#include "rsyslog.h"
+
+#define LJ_VERSION_V2 ((unsigned char)'2')
+#define LJ_FRAME_WINDOW ((unsigned char)'W')
+#define LJ_FRAME_JSON ((unsigned char)'J')
+#define LJ_FRAME_COMPRESSED ((unsigned char)'C')
+#define LJ_FRAME_ACK ((unsigned char)'A')
+
+struct lj_event_s {
+    uint32_t seq;
+    unsigned char *payload;
+    size_t payload_len;
+};
+
+struct lj_batch_s {
+    uint32_t window_size;
+    size_t count;
+    struct lj_event_s *events;
+};
+
+rsRetVal lj_batch_alloc(struct lj_batch_s *batch, uint32_t window_size, uint32_t max_window_size);
+void lj_batch_free(struct lj_batch_s *batch);
+rsRetVal lj_parse_window_header(const unsigned char hdr[2], uint32_t window_size);
+rsRetVal lj_append_json_event(struct lj_batch_s *batch, uint32_t seq, const unsigned char *payload, size_t payload_len);
+rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
+                                    const unsigned char *payload,
+                                    size_t payload_len,
+                                    size_t max_frame_size,
+                                    size_t max_decompressed_size);
+
+#endif

--- a/scripts/build_repo_policy_focus_input.py
+++ b/scripts/build_repo_policy_focus_input.py
@@ -65,6 +65,11 @@ def file_exists_at_ref(ref: str, path: str) -> bool:
     return result.returncode == 0
 
 
+def list_tree(ref: str, path: str) -> list[str]:
+    output = run_git(["ls-tree", "-r", "--name-only", ref, "--", path], check=False)
+    return [line for line in output.splitlines() if line]
+
+
 def read_file_at_ref(ref: str, path: str) -> str:
     return run_git(["show", f"{ref}:{path}"])
 
@@ -298,13 +303,6 @@ def build_doc_xref_check(name_status: list[dict[str, object]], base: str, head: 
             "relevant_diff": limited_diff(base, head, relevant_paths) if applicable else "",
         },
     }
-
-
-def list_tree(ref: str, path: str) -> list[str]:
-    output = run_git(["ls-tree", "-r", "--name-only", ref, "--", path], check=False)
-    return [line for line in output.splitlines() if line]
-
-
 def build_module_check(name_status: list[dict[str, object]], base: str, head: str) -> dict[str, object]:
     # Treat a brand-new plugins/ or contrib/ subtree with code or build files as
     # a module candidate, then check only for deterministic onboarding signals.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1036,6 +1036,15 @@ TESTS_IMHTTP_VALGRIND = \
 	imhttp-post-payload-compress-vg.sh \
 	imhttp-getrequest-file-vg.sh
 
+TESTS_IMBEATS = \
+	imbeats-basic.sh \
+	imbeats-compressed.sh \
+	imbeats-limits.sh \
+	imbeats-filebeat-docker.sh
+
+TESTS_IMBEATS_YAML = \
+	yaml-imbeats-basic.sh
+
 TESTS_OMRABBITMQ = \
 	omrabbitmq_no_params.sh \
 	omrabbitmq_params_missing0.sh \
@@ -1878,6 +1887,8 @@ EXTRA_DIST += $(TESTS_IMDOCKER_VALGRIND)
 EXTRA_DIST += $(TESTS_IMCZMQ)
 EXTRA_DIST += $(TESTS_IMHTTP)
 EXTRA_DIST += $(TESTS_IMHTTP_VALGRIND)
+EXTRA_DIST += $(TESTS_IMBEATS)
+EXTRA_DIST += $(TESTS_IMBEATS_YAML)
 EXTRA_DIST += $(TESTS_OMRABBITMQ)
 EXTRA_DIST += $(TESTS_OMRABBITMQ_VALGRIND)
 EXTRA_DIST += $(TESTS_IMHIREDIS)
@@ -2571,6 +2582,15 @@ if HAVE_VALGRIND
 TESTS += $(TESTS_IMHTTP_VALGRIND)
 endif # HAVE_VALGRIND
 endif # ENABLE_IMHTTP
+
+if ENABLE_IMBEATS
+if ENABLE_TESTBENCH
+TESTS += $(TESTS_IMBEATS)
+if HAVE_LIBYAML
+TESTS += $(TESTS_IMBEATS_YAML)
+endif # HAVE_LIBYAML
+endif # ENABLE_TESTBENCH
+endif # ENABLE_IMBEATS
 
 
 

--- a/tests/imbeats-basic.sh
+++ b/tests/imbeats-basic.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!message%|%$!host!name%|%$!metadata!imbeats!protocol%|%$!metadata!imbeats!sequence%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+payload = json.dumps({"message": "hello", "host": {"name": "web01"}}, separators=(",", ":")).encode()
+batch = b"2W" + struct.pack(">I", 1)
+event = b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload
+
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(batch + event)
+ack = sock.recv(6)
+sys.stdout.write(ack.hex())
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"hello","host":{"name":"web01"}}|hello|web01|lumberjack-v2|1'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
+
+exit_test

--- a/tests/imbeats-compressed.sh
+++ b/tests/imbeats-compressed.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!message%|%$!metadata!imbeats!sequence%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+import zlib
+
+port = int(sys.argv[1])
+payload = json.dumps({"message": "compressed"}, separators=(",", ":")).encode()
+nested = b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload
+compressed = zlib.compress(nested)
+wire = b"2W" + struct.pack(">I", 1) + b"2C" + struct.pack(">I", len(compressed)) + compressed
+
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(wire)
+ack = sock.recv(6)
+sys.stdout.write(ack.hex())
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"compressed"}|compressed|1'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
+
+exit_test

--- a/tests/imbeats-filebeat-docker.sh
+++ b/tests/imbeats-filebeat-docker.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+check_command_available docker
+
+if ! docker info >/dev/null 2>&1 ; then
+	echo "docker daemon not available, skipping test"
+	exit 77
+fi
+
+export NUMMESSAGES=200
+export SEQ_CHECK_FILE="${TESTTOOL_DIR}/${RSYSLOG_OUT_LOG}"
+export FB_IMAGE="${FB_IMAGE:-docker.elastic.co/beats/filebeat:9.2.0}"
+export FB_CONTAINER="fb-imbeats-${RSYSLOG_DYNNAME}"
+export FB_WORKDIR="${TESTTOOL_DIR}/${RSYSLOG_DYNNAME}.filebeat"
+if [ -z "$FB_DOCKER_MOUNT_SOURCE" ] && [ -n "$GITHUB_WORKSPACE" ] ; then
+	case "$FB_WORKDIR" in
+		/rsyslog/*) FB_DOCKER_MOUNT_SOURCE="${GITHUB_WORKSPACE}${FB_WORKDIR#/rsyslog}" ;;
+	esac
+fi
+export FB_DOCKER_MOUNT_SOURCE="${FB_DOCKER_MOUNT_SOURCE:-$FB_WORKDIR}"
+export FB_INPUT="${FB_WORKDIR}/input.log"
+export FB_CONFIG="${FB_WORKDIR}/filebeat.yml"
+export FB_LOG="${FB_WORKDIR}/docker.log"
+
+cleanup_filebeat() {
+	docker rm -f "$FB_CONTAINER" >/dev/null 2>&1 || true
+	rm -rf "$FB_WORKDIR"
+}
+trap cleanup_filebeat EXIT
+
+mkdir -p "$FB_WORKDIR/data"
+for i in $(seq 0 $((NUMMESSAGES - 1))) ; do
+	printf 'msgnum:%08d:\n' "$i"
+done > "$FB_INPUT"
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%$!message%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+cat > "$FB_CONFIG" <<EOF
+filebeat.inputs:
+  - type: filestream
+    id: imbeats-test
+    enabled: true
+    paths:
+      - /work/input.log
+
+output.logstash:
+  hosts: ["127.0.0.1:${RS_PORT}"]
+
+logging.level: info
+logging.to_files: false
+EOF
+
+docker image inspect "$FB_IMAGE" >/dev/null 2>&1 || docker pull "$FB_IMAGE" >/dev/null
+
+docker run -d --rm \
+	--name "$FB_CONTAINER" \
+	--network host \
+	--user root \
+	-v "$FB_DOCKER_MOUNT_SOURCE:/work" \
+	"$FB_IMAGE" \
+	filebeat -e --strict.perms=false -c /work/filebeat.yml > "$FB_LOG"
+
+wait_file_lines "$SEQ_CHECK_FILE" "$NUMMESSAGES"
+
+docker rm -f "$FB_CONTAINER" >/dev/null 2>&1 || true
+
+shutdown_when_empty
+wait_shutdown
+
+cmp "$FB_INPUT" "$SEQ_CHECK_FILE"
+exit_test

--- a/tests/imbeats-limits.sh
+++ b/tests/imbeats-limits.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+       log.file="'$RSYSLOG_DYNNAME'.spool/imbeats-stats.log"
+       log.syslog="off" format="cee")
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main"
+      maxWindowSize="2"
+      maxFrameSize="64"
+      maxDecompressedSize="128")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+if ! python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+import zlib
+
+port = int(sys.argv[1])
+
+
+def send_bad(wire):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.settimeout(5)
+        sock.sendall(wire)
+        try:
+            data = sock.recv(6)
+        except (ConnectionResetError, TimeoutError, socket.timeout):
+            data = b""
+        if data:
+            raise SystemExit(f"unexpected ack for rejected frame: {data.hex()}")
+
+
+def send_good(wire):
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.settimeout(5)
+        sock.sendall(wire)
+        return sock.recv(6).hex()
+
+
+send_bad(b"2W" + struct.pack(">I", 3))
+send_bad(b"2W" + struct.pack(">I", 1) + b"2J" + struct.pack(">I", 1) + struct.pack(">I", 65))
+send_bad(b"2W" + struct.pack(">I", 1) + b"2C" + struct.pack(">I", 65))
+
+large_payload = json.dumps({"message": "x" * 140}, separators=(",", ":")).encode()
+compressed = zlib.compress(b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(large_payload)) + large_payload)
+if len(compressed) > 64:
+    raise SystemExit(f"test bug: compressed payload is {len(compressed)} bytes")
+send_bad(b"2W" + struct.pack(">I", 1) + b"2C" + struct.pack(">I", len(compressed)) + compressed)
+
+payload = json.dumps({"message": "ok"}, separators=(",", ":")).encode()
+ack = send_good(b"2W" + struct.pack(">I", 1) + b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload)
+print(ack)
+PY
+then
+	error_exit 1
+fi
+
+rst_msleep 1500
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"ok"}'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
+
+if ! $PYTHON - "$srcdir/$RSYSLOG_DYNNAME.spool/imbeats-stats.log" <<'PY'
+import json
+import sys
+
+stats = {}
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        if "@cee: " not in line:
+            continue
+        line = line.split("@cee: ", 1)[1]
+        data = json.loads(line)
+        if data.get("name") == "imbeats":
+            stats = data
+
+expected = {
+    "windows.rejected": 1,
+    "frames.rejected": 2,
+    "compressed.rejected": 2,
+    "protocol_errors": 4,
+    "events.submitted": 1,
+}
+missing = {key: (stats.get(key), value) for key, value in expected.items() if stats.get(key) != value}
+if missing:
+    raise SystemExit(f"unexpected imbeats stats: {missing}; last stats={stats}")
+PY
+then
+	error_exit 1
+fi
+
+exit_test

--- a/tests/yaml-imbeats-basic.sh
+++ b/tests/yaml-imbeats-basic.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imbeats/.libs/imbeats"'
+add_yaml_conf ''
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%msg%|%$!message%|%$!metadata!imbeats!sequence%\n"'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_imdiag_input
+add_yaml_conf '  - type: imbeats'
+add_yaml_conf '    port: "0"'
+add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.imbeats.port\""
+add_yaml_conf '    ruleset: main'
+add_yaml_conf ''
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf "      action(type=\"omfile\" file=\"${RSYSLOG_OUT_LOG}\" template=\"outfmt\")"
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+payload = json.dumps({"message": "yaml"}, separators=(",", ":")).encode()
+wire = b"2W" + struct.pack(">I", 1) + b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload
+
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(wire)
+sock.recv(6)
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"yaml"}|yaml|1'
+cmp_exact
+
+exit_test


### PR DESCRIPTION
## Summary

This is the first production-readiness follow-up for `imbeats`.

It adds explicit resource bounds for Lumberjack input handling:

- `maxWindowSize`
- `maxFrameSize`
- `maxDecompressedSize`

It also rejects oversized windows, JSON frames, compressed frames, and decompressed payload growth before unbounded allocation, adds impstats rejection counters, and documents the new parameters.

## Validation

- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-impstats --enable-imbeats --enable-omstdout`
- `make -j$(nproc) check TESTS=""`
- `./tests/imbeats-limits.sh`
- `./tests/imbeats-basic.sh`
- `./tests/imbeats-compressed.sh`
- `./tests/yaml-imbeats-basic.sh`
- `./tests/imbeats-filebeat-docker.sh`
- `bash .agent/skills/rsyslog_doc_dist/scripts/check-doc-dist.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
- `bash devtools/format-code.sh`
- `git diff --check`
- `git diff --cached --check`
