### PR TITLE
rosi-collector: prevent Loki 400 queue stalls

### DIFF
--- a/deploy/docker-compose/rosi-collector/README.md
+++ b/deploy/docker-compose/rosi-collector/README.md
@@ -577,6 +577,31 @@ docker inspect rosi-collector-grafana-1 --format '{{.State.Status}} {{.State.Err
    rosi-monitor health  # Includes "Log flow (rsyslog -> omhttp -> Loki)" check
    ```
 
+If rsyslog logs show `omhttp: checkResult error http status code: 400`
+or Loki reports entries as "too far behind", Loki rejected the sample and
+the collector should advance to newer messages. The shipped
+`rsyslog.conf/30-send-loki-http.conf` marks HTTP 400 as non-retriable with
+`httpIgnorableCodes=["400"]` and uses rsyslog `timegenerated` (collector
+receive/process time) as the Loki stream timestamp. The sender-reported
+timestamp remains in the original message text.
+
+After changing files under `rsyslog.conf/`, re-run `scripts/init.sh` to copy
+the updated files into the install directory. If an existing rsyslog
+container is present and the installed `rsyslog.conf/` content changed,
+`init.sh` recreates only that container so the bind-mounted config is
+reloaded. To force the same refresh manually:
+
+```bash
+docker compose up -d --force-recreate rsyslog
+```
+
+When debugging a stale config suspicion, compare the host and container copy:
+
+```bash
+md5sum rsyslog.conf/30-send-loki-http.conf
+docker compose exec rsyslog md5sum /etc/rsyslog.d/30-send-loki-http.conf
+```
+
 ### Prometheus can't scrape node_exporter (server target down)
 
 The node_exporter on the server must bind to the Docker bridge gateway IP for Prometheus (running inside a container) to reach it.

--- a/deploy/docker-compose/rosi-collector/rsyslog.conf/30-send-loki-http.conf
+++ b/deploy/docker-compose/rosi-collector/rsyslog.conf/30-send-loki-http.conf
@@ -1,5 +1,13 @@
 # rsyslog -> Loki direct push via omhttp
 # Sends logs directly to Loki without intermediate agents
+#
+# Loki timestamps: use timegenerated (collector receive/process time) for
+# the push API so backlog or clock-skewed lines are not rejected as "too far
+# behind". Original syslog time remains in the message body (%msg%).
+#
+# HTTP 400 from Loki (reject sample / too far behind / parse errors): treat
+# it as non-retriable so one bad line cannot block the omhttp queue forever
+# (see httpIgnorableCodes).
 
 module(load="omhttp")
 
@@ -15,7 +23,7 @@ template(name="LokiJsonStream" type="list") {
     property(name="syslogseverity-text")
     constant(value="\"")
     constant(value="},\"values\":[[\"")
-    property(name="timereported" dateformat="unixtimestamp")
+    property(name="timegenerated" dateformat="unixtimestamp")
     constant(value="000000000\",\"")
     property(name="msg" format="json")
     constant(value="\"]]}]}")
@@ -32,15 +40,14 @@ ruleset(name="loki") {
         restpath="loki/api/v1/push"
         template="LokiJsonStream"
         httpcontenttype="application/json"
+        httpIgnorableCodes=["400"]
         batch="off"
         queue.type="LinkedList"
         queue.size="10000"
         queue.filename="loki-queue"
         queue.saveOnShutdown="on"
         queue.maxDiskSpace="100m"
-        action.resumeRetryCount="-1"
+        action.resumeRetryCount="100"
         action.resumeInterval="5"
     )
-
-    /var/log/debug;RSYSLOG_SyslogProtocol23Format
 }

--- a/deploy/docker-compose/rosi-collector/scripts/init.sh
+++ b/deploy/docker-compose/rosi-collector/scripts/init.sh
@@ -179,6 +179,27 @@ genpw() {
   openssl rand -base64 48 | tr -d '\n' | head -c 32
 }
 
+## @fn dir_content_hash()
+## @brief Return a stable content hash for all files below a directory.
+## @param dir Directory to hash
+## @description
+##   Used to detect whether bind-mounted collector config files changed during
+##   init.sh. Docker can keep existing bind mounts attached to stale replaced
+##   files until the affected container is recreated.
+dir_content_hash() {
+  local dir="$1"
+
+  if [ ! -d "${dir}" ]; then
+    echo "__missing__"
+    return 0
+  fi
+
+  (
+    cd "${dir}"
+    find . -type f -exec sha256sum {} + | sort
+  ) | sha256sum | awk '{print $1}'
+}
+
 ## @fn is_ip_address()
 ## @brief Check if a string is an IP address (IPv4 or IPv6)
 ## @param addr The address string to check
@@ -234,6 +255,8 @@ install -d -m 0750 "${BASE}"
 chown ${STACK}:${STACK} "${BASE}"
 
 echo "Copying configuration files to ${BASE}..."
+RSYSLOG_CONF_BEFORE="$(dir_content_hash "${BASE}/rsyslog.conf")"
+RSYSLOG_COLLECTOR_CONFIG_CHANGED=0
 
 rsync -a --exclude='*.template' --exclude='prometheus-targets/' "${CONFIGS_DIR}/" "${BASE}/" || {
   echo "Error: Failed to copy config files" >&2
@@ -1640,6 +1663,11 @@ else
   echo "TLS is disabled (SYSLOG_TLS_ENABLED=${SYSLOG_TLS_ENABLED})"
 fi
 
+RSYSLOG_CONF_AFTER="$(dir_content_hash "${BASE}/rsyslog.conf")"
+if [ "${RSYSLOG_CONF_BEFORE}" != "${RSYSLOG_CONF_AFTER}" ]; then
+  RSYSLOG_COLLECTOR_CONFIG_CHANGED=1
+fi
+
 # Note: Docker network may be pre-created later in the script for node_exporter binding.
 # Docker Compose will reuse an existing network with the same name.
 
@@ -1796,6 +1824,44 @@ restart_server_rsyslog() {
 }
 restart_server_rsyslog
 
+recreate_collector_rsyslog_if_changed() {
+  if [ "${RSYSLOG_COLLECTOR_CONFIG_CHANGED:-0}" != "1" ]; then
+    return 0
+  fi
+
+  local services profile_args container_ids
+  services="rsyslog"
+  profile_args=""
+  if [ "${SYSLOG_TLS_ENABLED:-false}" = "true" ]; then
+    services="rsyslog rsyslog-tls"
+    profile_args="--profile tls"
+  fi
+
+  if ! command -v docker >/dev/null 2>&1; then
+    echo "rsyslog collector config changed; Docker is not available." >&2
+    echo "Run manually after Docker is available: cd ${BASE} && docker compose ${profile_args} up -d --no-deps --force-recreate ${services}" >&2
+    return 0
+  fi
+
+  container_ids=$(docker compose -f "${COMPOSE}" --project-directory "${BASE}" ${profile_args} ps --all -q ${services} 2>/dev/null || true)
+  if [ -z "${container_ids}" ]; then
+    echo ""
+    echo "rsyslog collector config changed; no existing rsyslog containers found."
+    echo "The next 'docker compose up -d' will create them with the new config."
+    return 0
+  fi
+
+  echo ""
+  echo "rsyslog collector config changed; recreating rsyslog container(s)..."
+  if docker compose -f "${COMPOSE}" --project-directory "${BASE}" ${profile_args} up -d --no-deps --force-recreate ${services}; then
+    echo "rsyslog container(s) recreated with the updated config."
+  else
+    echo "Warning: Failed to recreate rsyslog container(s)" >&2
+    echo "Run manually: cd ${BASE} && docker compose ${profile_args} up -d --no-deps --force-recreate ${services}" >&2
+  fi
+}
+recreate_collector_rsyslog_if_changed
+
 echo ""
 echo "OK. ROSI Collector environment ready:"
 echo "  ${BASE}"
@@ -1834,4 +1900,3 @@ echo "  # Monitor: rosi-monitor status"
 echo "  # Check node_exporter: systemctl status node_exporter"
 echo ""
 echo "Note: To update config files, re-run this script - it will copy latest configs"
-


### PR DESCRIPTION
ROSI Collector could get stuck when Loki rejected a pushed sample with
HTTP 400, for example because old or clock-skewed sender timestamps were
outside Loki's accepted time window. In that state one bad backlog entry
could keep the omhttp action retrying instead of advancing to newer logs.

Impact:
Loki rejects no longer block the collector queue indefinitely.

Before/After:
Before, ROSI used sender-reported time for Loki timestamps and retried
400 responses. After, it uses collector receive time and drops 400 rejects.

Technical Overview:
Use rsyslog timegenerated for the Loki push API timestamp so queued,
backlogged, or clock-skewed messages are ordered by collector processing
time. The original syslog timestamp remains preserved in the message body.

Configure omhttp with httpIgnorableCodes=["400"] so Loki reject-sample
responses are treated as processed instead of retried forever. Keep other
failure handling bounded by changing action.resumeRetryCount from -1 to
100.

Remove the stray /var/log/debug selector from the Loki ruleset.

Teach init.sh to hash the installed rsyslog.conf directory before and
after copying/generating collector config. If the installed collector
rsyslog config changed and an rsyslog Compose container already exists,
init.sh recreates only that service with --force-recreate so Docker
refreshes the bind-mounted config. First installs still defer to the
normal docker compose up -d flow.

Document the Loki 400 troubleshooting path, the collector timestamp
choice, the automatic init.sh recreate behavior, and the manual checksum
check for stale config suspicions.