### PR TITLE
hardning: config parameter ownership and OOM cleanup

### DIFF
--- a/contrib/imbatchreport/imbatchreport.c
+++ b/contrib/imbatchreport/imbatchreport.c
@@ -652,20 +652,20 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "reports")) {
-            inst->pszFollow_glob = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszFollow_glob = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tag")) {
-            inst->pszTag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszTag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             inst->lenTag = ustrlen(inst->pszTag);
         } else if (!strcmp(inppblk.descr[i].name, "programkey")) {
-            inst->pszProgk = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszProgk = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             inst->lenProgk = ustrlen(inst->pszProgk) + 2;
         } else if (!strcmp(inppblk.descr[i].name, "timestampkey")) {
-            inst->pszTSk = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszTSk = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             inst->lenTSk = ustrlen(inst->pszTSk) + 1;
         } else if (!strcmp(inppblk.descr[i].name, "deduplicatespace")) {
             inst->bDedupSpace = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "severity")) {
             inst->iSeverity = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "facility")) {
@@ -676,7 +676,7 @@ BEGINnewInpInst
                 ABORT_FINALIZE(RS_RET_PARAM_ERROR);
             }
 
-            inst->ff_regex = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->ff_regex = es_str2cstr(pvals[i].val.d.estr, NULL));
 
             while ((temp = strchr(inst->ff_regex, '\t')) != NULL) *temp = ' ';
 
@@ -729,7 +729,7 @@ BEGINnewInpInst
                 ABORT_FINALIZE(RS_RET_PARAM_ERROR);
             }
 
-            inst->ff_regex = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->ff_regex = es_str2cstr(pvals[i].val.d.estr, NULL));
 
             while ((temp = strchr(inst->ff_regex, '\t')) != NULL) *temp = ' ';
 

--- a/contrib/imczmq/imczmq.c
+++ b/contrib/imczmq/imczmq.c
@@ -504,11 +504,11 @@ BEGINsetModCnf
         if (!strcmp(modpblk.descr[i].name, "authenticator")) {
             runModConf->authenticator = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "authtype")) {
-            runModConf->authType = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(runModConf->authType = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "servercertpath")) {
-            runModConf->serverCertPath = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(runModConf->serverCertPath = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "clientcertpath")) {
-            runModConf->clientCertPath = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(runModConf->clientCertPath = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             LogError(0, RS_RET_INVALID_PARAMS,
                      "imczmq: config error, unknown "
@@ -614,7 +614,8 @@ BEGINnewInpInst
             CHKmalloc(inst->topics = es_str2cstr(pvals[i].val.d.estr, NULL));
             CHKiRet(validateTopics(inst->topics));
         } else if (!strcmp(inppblk.descr[i].name, "socktype")) {
-            char *stringType = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *stringType;
+            CHKmalloc(stringType = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (NULL == stringType) {
                 LogError(0, RS_RET_CONFIG_ERROR, "imczmq: out of memory error copying sockType param");
                 ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);

--- a/contrib/imkmsg/imkmsg.c
+++ b/contrib/imkmsg/imkmsg.c
@@ -215,12 +215,13 @@ BEGINsetModCnf
             } else if (!es_strconstcmp(pvals[i].val.d.estr, "off")) {
                 loadModConf->parseKernelStamp = KMSG_PARSE_TS_OFF;
             } else {
-                const char *const cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
+                char *cstr;
+                CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
                 LogError(0, RS_RET_PARAM_ERROR,
                          "imkmsg: unknown "
                          "parse mode '%s'",
                          cstr);
-                free((void *)cstr);
+                free(cstr);
             }
         } else if (!strcmp(modpblk.descr[i].name, "expectedbootcompleteseconds")) {
             loadModConf->expected_boot_complete_secs = pvals[i].val.d.n;
@@ -232,12 +233,13 @@ BEGINsetModCnf
             } else if (!es_strconstcmp(pvals[i].val.d.estr, "new-only")) {
                 loadModConf->readMode = KMSG_READMODE_NEW_ONLY;
             } else {
-                const char *const cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
+                char *cstr;
+                CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
                 LogError(0, RS_RET_PARAM_ERROR,
                          "imkmsg: unknown "
                          "read mode '%s', keeping default setting",
                          cstr);
-                free((void *)cstr);
+                free(cstr);
             }
         } else {
             LogMsg(0, RS_RET_INTERNAL_ERROR, LOG_WARNING,

--- a/contrib/impcap/impcap.c
+++ b/contrib/impcap/impcap.c
@@ -185,17 +185,17 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "interface")) {
-            inst->interface = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->interface = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "file")) {
-            inst->filePath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->filePath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "promiscuous")) {
             inst->promiscuous = (uint8_t)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "filter")) {
-            inst->filter = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->filter = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tag")) {
-            inst->tag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->tag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "no_buffer")) {
             inst->immediateMode = (uint8_t)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "buffer_size")) {
@@ -235,9 +235,9 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "metadata_only")) {
             loadModConf->metadataOnly = (uint8_t)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "metadata_container")) {
-            loadModConf->metadataContainer = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->metadataContainer = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "data_container")) {
-            loadModConf->dataContainer = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->dataContainer = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf("impcap: non-handled param %s in beginSetModCnf\n", modpblk.descr[i].name);
         }

--- a/contrib/improg/improg.c
+++ b/contrib/improg/improg.c
@@ -501,10 +501,10 @@ BEGINnewInpInst
         if (!strcmp(inppblk.descr[i].name, "binary")) {
             CHKiRet(split_binary_parameters(&pInst->pszBinary, &pInst->aParams, &pInst->iParams, pvals[i].val.d.estr));
         } else if (!strcmp(inppblk.descr[i].name, "tag")) {
-            pInst->pszTag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pInst->pszTag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             pInst->lenTag = es_strlen(pvals[i].val.d.estr);
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            pInst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pInst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "severity")) {
             pInst->iSeverity = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "facility")) {

--- a/contrib/imtuxedoulog/imtuxedoulog.c
+++ b/contrib/imtuxedoulog/imtuxedoulog.c
@@ -664,12 +664,12 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "ulogbase")) {
-            inst->pszUlogBaseName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszUlogBaseName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tag")) {
-            inst->pszTag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszTag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             inst->lenTag = es_strlen(pvals[i].val.d.estr);
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "severity")) {
             inst->iSeverity = pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "facility")) {

--- a/contrib/mmcount/mmcount.c
+++ b/contrib/mmcount/mmcount.c
@@ -167,15 +167,15 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "appname")) {
-            pData->pszAppName = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszAppName = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         }
         if (!strcmp(actpblk.descr[i].name, "key")) {
-            pData->pszKey = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszKey = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         }
         if (!strcmp(actpblk.descr[i].name, "value")) {
-            pData->pszValue = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszValue = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         }
         dbgprintf(

--- a/contrib/mmdarwin/mmdarwin.c
+++ b/contrib/mmdarwin/mmdarwin.c
@@ -553,7 +553,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "container")) {
-            loadModConf->container = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->container = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (loadModConf->container[0] != '!' && loadModConf->container[0] != '.') {
                 LogError(0, RS_RET_INVALID_PARAMS,
                          "mmdarwin: container should either"
@@ -613,7 +613,7 @@ BEGINnewActInst
             free(key);
             DBGPRINTF("mmdarwin::newActInst:: certitudeKey is %s\n", pData->pCertitudeKey);
         } else if (!strcmp(actpblk.descr[i].name, "socketpath")) {
-            pData->pSockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pSockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             DBGPRINTF("mmdarwin::newActInst:: sockName is %s\n", pData->pSockName);
         } else if (!strcmp(actpblk.descr[i].name, "socket_max_use")) {
             pData->socketMaxUse = (uint32_t)pvals[i].val.d.n;
@@ -626,7 +626,8 @@ BEGINnewActInst
                 DBGPRINTF("mmdarwin::newActInst:: only sending complete bodies\n");
             }
         } else if (!strcmp(actpblk.descr[i].name, "response")) {
-            char *response = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *response;
+            CHKmalloc(response = es_str2cstr(pvals[i].val.d.estr, NULL));
 
             if (!strcmp(response, "no")) {
                 pData->response = DARWIN_RESPONSE_SEND_NO;
@@ -649,7 +650,8 @@ BEGINnewActInst
 
             free(response);
         } else if (!strcmp(actpblk.descr[i].name, "filtercode")) {
-            char *filterCode = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *filterCode;
+            CHKmalloc(filterCode = es_str2cstr(pvals[i].val.d.estr, NULL));
             pData->filterCode = strtoull(filterCode, NULL, 16);
             free(filterCode);
         } else if (!strcmp(actpblk.descr[i].name, "fields")) {
@@ -658,7 +660,8 @@ BEGINnewActInst
             CHKmalloc(pData->fieldList.varname = calloc(pData->fieldList.nmemb, sizeof(char *)));
 
             for (int j = 0; j < pData->fieldList.nmemb; ++j) {
-                char *const param = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                char *param;
+                CHKmalloc(param = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
                 char *varname = NULL;
                 char *name;
                 if (*param == ':') {

--- a/contrib/mmgrok/mmgrok.c
+++ b/contrib/mmgrok/mmgrok.c
@@ -143,16 +143,16 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "patterndir")) {
-            pData->pszPatternDir = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszPatternDir = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         } else if (!strcmp(actpblk.descr[i].name, "match")) {
-            pData->pszMatch = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszMatch = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         } else if (!strcmp(actpblk.descr[i].name, "source")) {
-            pData->pszSource = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszSource = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         } else if (!strcmp(actpblk.descr[i].name, "target")) {
-            pData->pszTarget = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszTarget = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         } else {
             DBGPRINTF(

--- a/contrib/mmkubernetes/mmkubernetes.c
+++ b/contrib/mmkubernetes/mmkubernetes.c
@@ -562,18 +562,18 @@ BEGINsetModCnf
             continue;
         } else if (!strcmp(modpblk.descr[i].name, "kubernetesurl")) {
             free(loadModConf->kubernetesUrl);
-            loadModConf->kubernetesUrl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->kubernetesUrl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "srcmetadatapath")) {
             free(loadModConf->srcMetadataPath);
-            loadModConf->srcMetadataPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->srcMetadataPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             /* todo: sanitize the path */
         } else if (!strcmp(modpblk.descr[i].name, "dstmetadatapath")) {
             free(loadModConf->dstMetadataPath);
-            loadModConf->dstMetadataPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->dstMetadataPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             /* todo: sanitize the path */
         } else if (!strcmp(modpblk.descr[i].name, "tls.cacert")) {
             free(loadModConf->caCertFile);
-            loadModConf->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)loadModConf->caCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -587,7 +587,7 @@ BEGINsetModCnf
             }
         } else if (!strcmp(modpblk.descr[i].name, "tls.mycert")) {
             free(loadModConf->myCertFile);
-            loadModConf->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)loadModConf->myCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -599,7 +599,7 @@ BEGINsetModCnf
                 fp = NULL;
             }
         } else if (!strcmp(modpblk.descr[i].name, "tls.myprivkey")) {
-            loadModConf->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)loadModConf->myPrivKeyFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -616,10 +616,10 @@ BEGINsetModCnf
             loadModConf->skipVerifyHost = pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "token")) {
             free(loadModConf->token);
-            loadModConf->token = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->token = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "tokenfile")) {
             free(loadModConf->tokenFile);
-            loadModConf->tokenFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tokenFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)loadModConf->tokenFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -637,7 +637,7 @@ BEGINsetModCnf
             loadModConf->de_dot = pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "de_dot_separator")) {
             free(loadModConf->de_dot_separator);
-            loadModConf->de_dot_separator = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->de_dot_separator = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #if HAVE_LOADSAMPLESFROMSTRING == 1
         } else if (!strcmp(modpblk.descr[i].name, "filenamerules")) {
             free(loadModConf->fnRules);
@@ -645,7 +645,7 @@ BEGINsetModCnf
 #endif
         } else if (!strcmp(modpblk.descr[i].name, "filenamerulebase")) {
             free(loadModConf->fnRulebase);
-            loadModConf->fnRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->fnRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)loadModConf->fnRulebase, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -664,7 +664,7 @@ BEGINsetModCnf
 #endif
         } else if (!strcmp(modpblk.descr[i].name, "containerrulebase")) {
             free(loadModConf->contRulebase);
-            loadModConf->contRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->contRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)loadModConf->contRulebase, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -1205,21 +1205,21 @@ BEGINnewActInst
             continue;
         } else if (!strcmp(actpblk.descr[i].name, "kubernetesurl")) {
             free(pData->kubernetesUrl);
-            pData->kubernetesUrl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->kubernetesUrl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "srcmetadatapath")) {
             msgPropDescrDestruct(pData->srcMetadataDescr);
             free(pData->srcMetadataDescr);
             CHKmalloc(pData->srcMetadataDescr = malloc(sizeof(msgPropDescr_t)));
-            srcMetadataPath = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(srcMetadataPath = es_str2cstr(pvals[i].val.d.estr, NULL));
             CHKiRet(msgPropDescrFill(pData->srcMetadataDescr, (uchar *)srcMetadataPath, strlen(srcMetadataPath)));
             /* todo: sanitize the path */
         } else if (!strcmp(actpblk.descr[i].name, "dstmetadatapath")) {
             free(pData->dstMetadataPath);
-            pData->dstMetadataPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->dstMetadataPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             /* todo: sanitize the path */
         } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {
             free(pData->caCertFile);
-            pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->caCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -1231,7 +1231,7 @@ BEGINnewActInst
                 fp = NULL;
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.mycert")) {
-            pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -1242,7 +1242,7 @@ BEGINnewActInst
                 fp = NULL;
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.myprivkey")) {
-            pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myPrivKeyFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -1259,10 +1259,10 @@ BEGINnewActInst
             pData->skipVerifyHost = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "token")) {
             free(pData->token);
-            pData->token = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->token = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tokenfile")) {
             free(pData->tokenFile);
-            pData->tokenFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tokenFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->tokenFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -1281,7 +1281,7 @@ BEGINnewActInst
             pData->de_dot = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "de_dot_separator")) {
             free(pData->de_dot_separator);
-            pData->de_dot_separator = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->de_dot_separator = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #if HAVE_LOADSAMPLESFROMSTRING == 1
         } else if (!strcmp(modpblk.descr[i].name, "filenamerules")) {
             free(pData->fnRules);
@@ -1289,7 +1289,7 @@ BEGINnewActInst
 #endif
         } else if (!strcmp(modpblk.descr[i].name, "filenamerulebase")) {
             free(pData->fnRulebase);
-            pData->fnRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->fnRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->fnRulebase, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -1308,7 +1308,7 @@ BEGINnewActInst
 #endif
         } else if (!strcmp(modpblk.descr[i].name, "containerrulebase")) {
             free(pData->contRulebase);
-            pData->contRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->contRulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->contRulebase, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));

--- a/contrib/mmrfc5424addhmac/mmrfc5424addhmac.c
+++ b/contrib/mmrfc5424addhmac/mmrfc5424addhmac.c
@@ -167,10 +167,10 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "key")) {
-            pData->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             pData->keylen = es_strlen(pvals[i].val.d.estr);
         } else if (!strcmp(actpblk.descr[i].name, "hashfunction")) {
-            ciphername = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(ciphername = es_str2cstr(pvals[i].val.d.estr, NULL));
             pData->algo = EVP_get_digestbyname(ciphername);
             if (pData->algo == NULL) {
                 LogError(0, RS_RET_CRY_INVLD_ALGO,
@@ -182,7 +182,7 @@ BEGINnewActInst
             }
             free(ciphername);
         } else if (!strcmp(actpblk.descr[i].name, "sd_id")) {
-            pData->sdid = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->sdid = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             pData->sdidLen = es_strlen(pvals[i].val.d.estr);
         } else {
             dbgprintf(

--- a/contrib/mmsequence/mmsequence.c
+++ b/contrib/mmsequence/mmsequence.c
@@ -175,7 +175,7 @@ BEGINnewActInst
             } else if (!es_strbufcmp(pvals[i].val.d.estr, (uchar *)"key", sizeof("key") - 1)) {
                 pData->mode = mmSequencePerKey;
             } else {
-                cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
                 LogError(0, RS_RET_INVLD_MODE, "mmsequence: invalid mode '%s' - ignored", cstr);
                 free(cstr);
             }
@@ -194,11 +194,11 @@ BEGINnewActInst
             continue;
         }
         if (!strcmp(actpblk.descr[i].name, "key")) {
-            pData->pszKey = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszKey = es_str2cstr(pvals[i].val.d.estr, NULL));
             continue;
         }
         if (!strcmp(actpblk.descr[i].name, "var")) {
-            cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (strlen(cstr) < 3) {
                 LogError(0, RS_RET_VALUE_NOT_SUPPORTED,
                          "mmsequence: valid variable name should be at least "

--- a/contrib/mmtaghostname/mmtaghostname.c
+++ b/contrib/mmtaghostname/mmtaghostname.c
@@ -136,7 +136,7 @@ BEGINnewActInst
     for (i = 0; i < parserpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(parserpblk.descr[i].name, "tag")) {
-            pData->pszTag = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszTag = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
             pData->lenTag = strlen(pData->pszTag);
         } else if (!strcmp(parserpblk.descr[i].name, "forcelocalhostname")) {
             pData->bForceLocalHostname = pvals[i].val.d.n;

--- a/contrib/omamqp1/omamqp1.c
+++ b/contrib/omamqp1/omamqp1.c
@@ -332,7 +332,8 @@ BEGINnewActInst
         for (i = 0; i < actpblk.nParams; ++i) {
             if (!pvals[i].bUsed) continue;
             if (!strcmp(actpblk.descr[i].name, "host")) {
-                char *u = es_str2cstr(pvals[i].val.d.estr, NULL);
+                char *u;
+                CHKmalloc(u = es_str2cstr(pvals[i].val.d.estr, NULL));
                 cs->url = pn_url_parse(u);
                 if (!cs->url) {
                     LogError(0, RS_RET_CONF_PARSE_ERROR, "omamqp1: Invalid host URL configured: '%s'", u);
@@ -341,13 +342,13 @@ BEGINnewActInst
                 }
                 free(u);
             } else if (!strcmp(actpblk.descr[i].name, "template")) {
-                cs->templateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(cs->templateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             } else if (!strcmp(actpblk.descr[i].name, "target")) {
-                cs->target = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(cs->target = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             } else if (!strcmp(actpblk.descr[i].name, "username")) {
-                cs->username = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(cs->username = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             } else if (!strcmp(actpblk.descr[i].name, "password")) {
-                cs->password = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(cs->password = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             } else if (!strcmp(actpblk.descr[i].name, "reconnectDelay")) {
                 cs->reconnectDelay = (int)pvals[i].val.d.n;
             } else if (!strcmp(actpblk.descr[i].name, "idleTimeout")) {

--- a/contrib/omczmq/omczmq.c
+++ b/contrib/omczmq/omczmq.c
@@ -433,13 +433,13 @@ BEGINsetModCnf
         if (!strcmp(modpblk.descr[i].name, "authenticator")) {
             runModConf->authenticator = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "authtype")) {
-            runModConf->authType = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(runModConf->authType = es_str2cstr(pvals[i].val.d.estr, NULL));
             DBGPRINTF("omczmq: authtype set to %s\n", runModConf->authType);
         } else if (!strcmp(modpblk.descr[i].name, "servercertpath")) {
-            runModConf->serverCertPath = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(runModConf->serverCertPath = es_str2cstr(pvals[i].val.d.estr, NULL));
             DBGPRINTF("omczmq: serverCertPath set to %s\n", runModConf->serverCertPath);
         } else if (!strcmp(modpblk.descr[i].name, "clientcertpath")) {
-            runModConf->clientCertPath = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(runModConf->clientCertPath = es_str2cstr(pvals[i].val.d.estr, NULL));
             DBGPRINTF("omczmq: clientCertPath set to %s\n", runModConf->clientCertPath);
         } else {
             LogError(0, RS_RET_INVALID_PARAMS,
@@ -492,35 +492,51 @@ BEGINnewActInst
         }
 
         if (!strcmp(actpblk.descr[i].name, "endpoints")) {
-            pData->sockEndpoints = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->sockEndpoints = es_str2cstr(pvals[i].val.d.estr, NULL));
             DBGPRINTF("omczmq: sockEndPoints set to '%s'\n", pData->sockEndpoints);
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             DBGPRINTF("omczmq: template set to '%s'\n", pData->tplName);
         } else if (!strcmp(actpblk.descr[i].name, "dynatopic")) {
             pData->dynaTopic = pvals[i].val.d.n;
             DBGPRINTF("omczmq: dynaTopic set to %s\n", pData->dynaTopic ? "true" : "false");
         } else if (!strcmp(actpblk.descr[i].name, "sendtimeout")) {
-            pData->sendTimeout = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
+            char *tmpSendTimeout;
+            CHKmalloc(tmpSendTimeout = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pData->sendTimeout = atoi(tmpSendTimeout);
+            free(tmpSendTimeout);
             DBGPRINTF("omczmq: sendTimeout set to %d\n", pData->sendTimeout);
         } else if (!strcmp(actpblk.descr[i].name, "sendhwm")) {
-            pData->sendTimeout = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
+            char *tmpSendTimeout;
+            CHKmalloc(tmpSendTimeout = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pData->sendHWM = atoi(tmpSendTimeout);
+            free(tmpSendTimeout);
             DBGPRINTF("omczmq: sendHWM set to %d\n", pData->sendHWM);
         }
 #if (CZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MAJOR >= 4 && ZMQ_VERSION_MINOR >= 2)
         else if (!strcmp(actpblk.descr[i].name, "heartbeativl")) {
-            pData->heartbeatIvl = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
+            char *tmpHeartbeatIvl;
+            CHKmalloc(tmpHeartbeatIvl = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pData->heartbeatIvl = atoi(tmpHeartbeatIvl);
+            free(tmpHeartbeatIvl);
             DBGPRINTF("omczmq: heartbeatbeatIvl set to %d\n", pData->heartbeatIvl);
         } else if (!strcmp(actpblk.descr[i].name, "heartbeattimeout")) {
-            pData->heartbeatTimeout = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
+            char *tmpHeartbeatTimeout;
+            CHKmalloc(tmpHeartbeatTimeout = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pData->heartbeatTimeout = atoi(tmpHeartbeatTimeout);
+            free(tmpHeartbeatTimeout);
             DBGPRINTF("omczmq: heartbeatTimeout set to %d\n", pData->heartbeatTimeout);
         } else if (!strcmp(actpblk.descr[i].name, "heartbeatttl")) {
-            pData->heartbeatTimeout = atoi(es_str2cstr(pvals[i].val.d.estr, NULL));
+            char *tmpHeartbeatTimeout;
+            CHKmalloc(tmpHeartbeatTimeout = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pData->heartbeatTTL = atoi(tmpHeartbeatTimeout);
+            free(tmpHeartbeatTimeout);
             DBGPRINTF("omczmq: heartbeatTTL set to %d\n", pData->heartbeatTTL);
         }
 #endif
         else if (!strcmp(actpblk.descr[i].name, "socktype")) {
-            char *stringType = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *stringType;
+            CHKmalloc(stringType = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (stringType != NULL) {
                 if (!strcmp("PUB", stringType)) {
                     pData->sockType = ZMQ_PUB;
@@ -563,7 +579,8 @@ BEGINnewActInst
             DBGPRINTF("omczmq: topicFrame set to %s\n", pData->topicFrame ? "true" : "false");
         } else if (!strcmp(actpblk.descr[i].name, "topics")) {
             pData->topics = zlist_new();
-            char *topics = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *topics;
+            CHKmalloc(topics = es_str2cstr(pvals[i].val.d.estr, NULL));
             DBGPRINTF("omczmq: topics set to %s\n", topics);
             char *topics_org = topics;
             char topic[256];

--- a/contrib/omfile-hardened/omfile-hardened.c
+++ b/contrib/omfile-hardened/omfile-hardened.c
@@ -875,7 +875,7 @@ BEGINsetModCnf
         }
 
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pszFileDfltTplName != NULL) {
                 parser_errmsg(
                     "omfile: warning: default template was already "
@@ -1283,22 +1283,22 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "createdirs")) {
             pData->bCreateDirs = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "file")) {
-            pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             CODE_STD_STRING_REQUESTnewActInst(1);
             pData->bDynamicName = 0;
         } else if (!strcmp(actpblk.descr[i].name, "dynafile")) {
             if (pData->fname != NULL) {
                 parser_errmsg("omfile: both \"file\" and \"dynafile\" set, will use dynafile");
             }
-            pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             CODE_STD_STRING_REQUESTnewActInst(2);
             pData->bDynamicName = 1;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "sig.provider")) {
-            pData->sigprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->sigprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "cry.provider")) {
-            pData->cryprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->cryprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "closetimeout")) {
             pData->iCloseTimeout = (int)pvals[i].val.d.n;
         } else {

--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -592,31 +592,31 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
 
         if (!strcmp(actpblk.descr[i].name, "server")) {
-            pData->server = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->server = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "serverport")) {
             pData->port = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "socketpath")) {
-            pData->socketPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->socketPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "serverpassword")) {
-            pData->serverpassword = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->serverpassword = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dynakey")) {
             pData->dynaKey = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "userpush")) {
             pData->useRPush = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "stream.outField")) {
-            pData->streamOutField = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->streamOutField = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "stream.keyAck")) {
-            pData->streamKeyAck = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->streamKeyAck = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "stream.dynaKeyAck")) {
             pData->streamDynaKeyAck = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "stream.groupAck")) {
-            pData->streamGroupAck = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->streamGroupAck = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "stream.dynaGroupAck")) {
             pData->streamDynaGroupAck = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "stream.indexAck")) {
-            pData->streamIndexAck = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->streamIndexAck = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "stream.dynaIndexAck")) {
             pData->streamDynaIndexAck = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "stream.capacityLimit")) {
@@ -626,7 +626,7 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "stream.del")) {
             pData->streamDel = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "mode")) {
-            pData->modeDescription = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->modeDescription = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcmp(pData->modeDescription, "template")) {
                 pData->mode = OMHIREDIS_MODE_TEMPLATE;
             } else if (!strcmp(pData->modeDescription, "queue")) {
@@ -642,7 +642,7 @@ BEGINnewActInst
                 ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
             }
         } else if (!strcmp(actpblk.descr[i].name, "key")) {
-            pData->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "expiration")) {
             pData->expiration = pvals[i].val.d.n;
             dbgprintf("omhiredis: expiration set to %d\n", pData->expiration);
@@ -650,15 +650,15 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "use_tls")) {
             pData->use_tls = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ca_cert_bundle")) {
-            pData->ca_cert_bundle = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->ca_cert_bundle = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "ca_cert_dir")) {
-            pData->ca_cert_dir = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->ca_cert_dir = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "client_cert")) {
-            pData->client_cert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->client_cert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "client_key")) {
-            pData->client_key = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->client_key = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "sni")) {
-            pData->sni = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->sni = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #endif
         } else {
             dbgprintf(

--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -2547,7 +2547,7 @@ BEGINnewActInst
         if (!strcmp(actpblk.descr[i].name, "server")) {
             servers = pvals[i].val.d.ar;
         } else if (!strcmp(actpblk.descr[i].name, "errorfile")) {
-            pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "serverport")) {
             pData->defaultPort = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "healthchecktimeout")) {
@@ -2557,15 +2557,15 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "restpathtimeout")) {
             pData->restPathTimeout = (long)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "token")) {
-            pData->token = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->token = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "uid")) {
-            pData->uid = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->uid = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "httpcontenttype")) {
-            pData->httpcontenttype = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->httpcontenttype = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "httpheaderkey")) {
-            pData->httpheaderkey = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->httpheaderkey = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "httpheadervalue")) {
-            pData->httpheadervalue = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->httpheadervalue = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "httpheaders")) {
             pData->nHttpHeaders = pvals[i].val.d.ar->nmemb;
             CHKmalloc(pData->httpHeaders = malloc(sizeof(uchar *) * pvals[i].val.d.ar->nmemb));
@@ -2575,21 +2575,21 @@ BEGINnewActInst
                 pData->httpHeaders[j] = (uchar *)cstr;
             }
         } else if (!strcmp(actpblk.descr[i].name, "pwd")) {
-            pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "restpath")) {
-            pData->restPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->restPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "checkpath")) {
-            pData->checkPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->checkPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dynrestpath")) {
             pData->dynRestPath = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "proxyhost")) {
-            pData->proxyHost = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->proxyHost = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "proxyport")) {
             pData->proxyPort = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "batch")) {
             pData->batchMode = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "batch.format")) {
-            batchFormatName = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(batchFormatName = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (strstr(VALID_BATCH_FORMATS, batchFormatName) != NULL) {
                 pData->batchFormatName = (uchar *)batchFormatName;
                 pData->bFreeBatchFormatName = 1;
@@ -2630,9 +2630,9 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "usehttps")) {
             pData->useHttps = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {
-            pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->caCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -2642,7 +2642,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.mycert")) {
-            pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -2652,7 +2652,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.myprivkey")) {
-            pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myPrivKeyFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -2682,7 +2682,7 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "retry")) {
             pData->retryFailures = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "retry.ruleset")) {
-            pData->retryRulesetName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->retryRulesetName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "retry.addmetadata")) {
             pData->retryAddMetadata = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.burst")) {
@@ -2690,9 +2690,9 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
             pData->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.name")) {
-            pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "name")) {
-            pData->statsName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->statsName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "httpignorablecodes")) {
             pData->nIgnorableCodes = pvals[i].val.d.ar->nmemb;
             // note: use zero as sentinel value
@@ -2711,7 +2711,7 @@ BEGINnewActInst
                 }
             }
         } else if (!strcmp(actpblk.descr[i].name, "profile")) {
-            profileName = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(profileName = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "statsbysenders")) {
             pData->statsBySenders = pvals[i].val.d.n;
         } else {

--- a/contrib/omhttpfs/omhttpfs.c
+++ b/contrib/omhttpfs/omhttpfs.c
@@ -710,23 +710,23 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "host")) {
-            pData->host = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->host = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
             pData->port = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "user")) {
-            pData->user = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->user = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
 
         } else if (!strcmp(actpblk.descr[i].name, "https")) {
             pData->https = pvals[i].val.d.n ? 1 : 0;
 
         } else if (!strcmp(actpblk.descr[i].name, "file")) {
-            pData->file = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->file = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
 
         } else if (!strcmp(actpblk.descr[i].name, "isdynfile")) {
             pData->isDynFile = pvals[i].val.d.n ? 1 : 0;
 
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             DBGPRINTF("omhttpfs: program error, non-handled param '%s'\n", actpblk.descr[i].name);
         }

--- a/contrib/omrabbitmq/omrabbitmq.c
+++ b/contrib/omrabbitmq/omrabbitmq.c
@@ -1047,21 +1047,21 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "host")) {
-            host = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(host = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "recover_policy")) {
-            recover = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(recover = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
             port = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "virtual_host")) {
-            vhost = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(vhost = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "user")) {
-            user = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(user = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "password")) {
-            password = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(password = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "ssl")) {
             pData->ssl = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ca_cert")) {
-            pData->caCert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->caCert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "heartbeat_interval")) {
             pData->heartbeat = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "init_openssl")) {
@@ -1071,15 +1071,20 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "verify_hostname")) {
             pData->verifyHostname = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "exchange")) {
-            pData->exchange = cstring_bytes(es_str2cstr(pvals[i].val.d.estr, NULL));
+            char *tmp;
+            CHKmalloc(tmp = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pData->exchange = cstring_bytes(tmp);
         } else if (!strcmp(actpblk.descr[i].name, "routing_key")) {
-            pData->routing_key = cstring_bytes(es_str2cstr(pvals[i].val.d.estr, NULL));
+            char *tmp;
+            CHKmalloc(tmp = es_str2cstr(pvals[i].val.d.estr, NULL));
+            pData->routing_key = cstring_bytes(tmp);
         } else if (!strcmp(actpblk.descr[i].name, "routing_key_template")) {
-            pData->routing_key_template = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->routing_key_template = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "populate_properties")) {
             pData->populate_properties = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "delivery_mode")) {
-            char *temp = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *temp;
+            CHKmalloc(temp = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (temp) {
                 if (!strcasecmp(temp, "TRANSIENT") || !strcmp(temp, "1")) {
                     pData->delivery_mode = 1;
@@ -1102,11 +1107,11 @@ BEGINnewActInst
 #endif
             }
         } else if (!strcmp(actpblk.descr[i].name, "body_template")) {
-            pData->body_template = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->body_template = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "content_type")) {
-            pData->content_type = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->content_type = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "exchange_type")) {
-            pData->exchange_type = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->exchange_type = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "auto_delete")) {
             pData->auto_delete = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "durable")) {

--- a/contrib/pmdb2diag/pmdb2diag.c
+++ b/contrib/pmdb2diag/pmdb2diag.c
@@ -242,7 +242,7 @@ BEGINnewParserInst
         for (i = 0; i < parserpblk.nParams; ++i) {
             if (!pvals[i].bUsed) continue;
             if (!strcmp(parserpblk.descr[i].name, "timeformat")) {
-                inst->timeformat = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(inst->timeformat = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
             } else if (!strcmp(parserpblk.descr[i].name, "timepos")) {
                 inst->timepos = (int)pvals[i].val.d.n;
             } else if (!strcmp(parserpblk.descr[i].name, "levelpos")) {

--- a/contrib/pmsnare/pmsnare.c
+++ b/contrib/pmsnare/pmsnare.c
@@ -173,7 +173,12 @@ BEGINnewParserInst
         } else if (!strcmp(parserpblk.descr[i].name, "parser.escapecontrolcharacterscstyle")) {
             inst->bParserEscapeCCCStyle = pvals[i].val.d.n;
         } else if (!strcmp(parserpblk.descr[i].name, "parser.controlcharacterescapeprefix")) {
-            inst->cCCEscapeChar = (uchar)*es_str2cstr(pvals[i].val.d.estr, NULL);
+            {
+                char *cstr;
+                CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
+                inst->cCCEscapeChar = (uchar)*cstr;
+                free(cstr);
+            }
         } else {
             dbgprintf("pmsnare: program error, non-handled param '%s'\n", parserpblk.descr[i].name);
         }

--- a/plugins/imdtls/imdtls.c
+++ b/plugins/imdtls/imdtls.c
@@ -849,15 +849,15 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "port")) {
-            inst->pszBindPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "address")) {
-            inst->pszBindAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "timeout")) {
             inst->timeout = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "name")) {
-            inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tls.authmode")) {
             char *pszAuthMode = es_str2cstr(pvals[i].val.d.estr, NULL);
             if (!strcasecmp(pszAuthMode, "fingerprint"))
@@ -870,7 +870,7 @@ BEGINnewInpInst
                 inst->pNetOssl->authMode = OSSL_AUTH_CERTANON;
             free(pszAuthMode);
         } else if (!strcmp(inppblk.descr[i].name, "tls.cacert")) {
-            inst->pNetOssl->pszCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pNetOssl->pszCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)inst->pNetOssl->pszCAFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -879,7 +879,7 @@ BEGINnewInpInst
                 fclose(fp);
             }
         } else if (!strcmp(inppblk.descr[i].name, "tls.mycert")) {
-            inst->pNetOssl->pszCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pNetOssl->pszCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)inst->pNetOssl->pszCertFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -888,7 +888,7 @@ BEGINnewInpInst
                 fclose(fp);
             }
         } else if (!strcmp(inppblk.descr[i].name, "tls.myprivkey")) {
-            inst->pNetOssl->pszKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pNetOssl->pszKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)inst->pNetOssl->pszKeyFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -897,7 +897,7 @@ BEGINnewInpInst
                 fclose(fp);
             }
         } else if (!strcmp(inppblk.descr[i].name, "tls.tlscfgcmd")) {
-            inst->tlscfgcmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->tlscfgcmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tls.permittedpeer")) {
             for (j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
                 uchar *const peer = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -1433,7 +1433,7 @@ BEGINsetModCnf
         if (!strcmp(modpblk.descr[i].name, "persiststateinterval")) {
             cs.iPersistStateInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "statefile")) {
-            cs.stateFile = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cs.stateFile = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "filecreatemode")) {
             cs.fCreateMode = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "ratelimit.burst")) {
@@ -1442,7 +1442,7 @@ BEGINsetModCnf
             cs.ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "ratelimit.name")) {
             free(cs.pszRatelimitName);
-            cs.pszRatelimitName = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cs.pszRatelimitName = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "ignorepreviousmessages")) {
             cs.bIgnorePrevious = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "ignorenonvalidstatefile")) {
@@ -1455,13 +1455,13 @@ BEGINsetModCnf
 
             char *fac, *p;
 
-            fac = p = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(fac = p = es_str2cstr(pvals[i].val.d.estr, NULL));
             facilityHdlr((uchar **)&p, (void *)&cs.iDfltFacility);
             free(fac);
         } else if (!strcmp(modpblk.descr[i].name, "usepidfromsystem")) {
             cs.bUseJnlPID = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "usepid")) {
-            cs.usePid = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cs.usePid = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "workaroundjournalbug")) {
             cs.bWorkAroundJournalBug = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "fsync")) {
@@ -1469,7 +1469,7 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "remote")) {
             cs.bRemote = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "defaulttag")) {
-            cs.dfltTag = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cs.dfltTag = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "imjournal: program error, non-handled "
@@ -1540,7 +1540,7 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "main")) {
             inst->bMain = (int)pvals[i].val.d.n;
         } else {

--- a/plugins/imklog/imklog.c
+++ b/plugins/imklog/imklog.c
@@ -346,7 +346,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "logpath")) {
-            loadModConf->pszPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "permitnonkernelfacility")) {
             loadModConf->bPermitNonKernel = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "parsekerneltimestamp")) {
@@ -362,9 +362,9 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "ratelimitinterval")) {
             loadModConf->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "ratelimit.name")) {
-            loadModConf->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "ruleset")) {
-            loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             LogMsg(0, RS_RET_INTERNAL_ERROR, LOG_WARNING,
                    "imklog: RSYSLOG BUG, non-handled param '%s' in "

--- a/plugins/immark/immark.c
+++ b/plugins/immark/immark.c
@@ -159,9 +159,9 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "use.markflag")) {
             loadModConf->bUseMarkFlag = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "ruleset")) {
-            loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "markmessagetext")) {
-            loadModConf->pszMarkMsgText = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszMarkMsgText = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "immark: program error, non-handled "

--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -480,19 +480,11 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "resetcounters")) {
             loadModConf->bResetCtrs = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "log.file")) {
-            loadModConf->logfile = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (loadModConf->logfile == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert log.file parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            CHKmalloc(loadModConf->logfile = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "log.file.overwrite")) {
             loadModConf->bLogOverwrite = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "format")) {
-            mode = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (mode == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert format parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            CHKmalloc(mode = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcasecmp(mode, "json")) {
                 loadModConf->statsFmt = statsFmt_JSON;
             } else if (!strcasecmp(mode, "json-elasticsearch")) {
@@ -510,18 +502,10 @@ BEGINsetModCnf
             }
             free(mode);
         } else if (!strcmp(modpblk.descr[i].name, "ruleset")) {
-            loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (loadModConf->pszBindRuleset == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert ruleset parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            CHKmalloc(loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #ifdef ENABLE_IMPSTATS_PUSH
         } else if (!strcmp(modpblk.descr[i].name, "push.url")) {
-            loadModConf->pushConfig.url = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (loadModConf->pushConfig.url == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert push.url parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            CHKmalloc(loadModConf->pushConfig.url = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             loadModConf->bPushEnabled = 1;
         } else if (!strcmp(modpblk.descr[i].name, "push.labels")) {
             /* Array of label strings */
@@ -534,18 +518,7 @@ BEGINsetModCnf
                 CHKmalloc(loadModConf->pushConfig.labels = (uchar **)calloc(arr->nmemb, sizeof(uchar *)));
                 int j;
                 for (j = 0; j < arr->nmemb; j++) {
-                    loadModConf->pushConfig.labels[j] = (uchar *)es_str2cstr(arr->arr[j], NULL);
-                    if (loadModConf->pushConfig.labels[j] == NULL) {
-                        LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert push label");
-                        /* Free previously allocated labels */
-                        for (int k = 0; k < j; k++) {
-                            free(loadModConf->pushConfig.labels[k]);
-                        }
-                        free(loadModConf->pushConfig.labels);
-                        loadModConf->pushConfig.labels = NULL;
-                        loadModConf->pushConfig.nLabels = 0;
-                        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-                    }
+                    CHKmalloc(loadModConf->pushConfig.labels[j] = (uchar *)es_str2cstr(arr->arr[j], NULL));
                 }
             }
         } else if (!strcmp(modpblk.descr[i].name, "push.timeout.ms")) {
@@ -557,31 +530,16 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "push.label.name")) {
             loadModConf->pushConfig.labelName = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "push.label.job")) {
-            uchar *job = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (job == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert push.label.job parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            uchar *job;
+            CHKmalloc(job = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             free(loadModConf->pushConfig.labelJob);
             loadModConf->pushConfig.labelJob = job;
         } else if (!strcmp(modpblk.descr[i].name, "push.tls.cafile")) {
-            loadModConf->pushConfig.tlsCaFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (loadModConf->pushConfig.tlsCaFile == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert push.tls.cafile parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            CHKmalloc(loadModConf->pushConfig.tlsCaFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "push.tls.certfile")) {
-            loadModConf->pushConfig.tlsCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (loadModConf->pushConfig.tlsCertFile == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert push.tls.certfile parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            CHKmalloc(loadModConf->pushConfig.tlsCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "push.tls.keyfile")) {
-            loadModConf->pushConfig.tlsKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (loadModConf->pushConfig.tlsKeyFile == NULL) {
-                LogError(0, RS_RET_OUT_OF_MEMORY, "impstats: failed to convert push.tls.keyfile parameter");
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            CHKmalloc(loadModConf->pushConfig.tlsKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "push.tls.insecureSkipVerify")) {
             loadModConf->pushConfig.tlsInsecureSkipVerify = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "push.batch.maxBytes")) {

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -2207,11 +2207,11 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "port")) {
-            inst->pszBindPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "address")) {
-            inst->pszBindAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "path")) {
-            inst->pszBindPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindPath = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "unlink")) {
             inst->bUnlink = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "discardtruncatedmsg")) {
@@ -2231,7 +2231,7 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "failonpermsfailure")) {
             inst->bFailOnPerms = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "name")) {
-            inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "maxframesize")) {
             const int max = (int)pvals[i].val.d.n;
             if (max <= 200000000) {
@@ -2244,15 +2244,15 @@ BEGINnewInpInst
                 ABORT_FINALIZE(RS_RET_PARAM_ERROR);
             }
         } else if (!strcmp(inppblk.descr[i].name, "framing.delimiter.regex")) {
-            inst->startRegex = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->startRegex = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "supportoctetcountedframing")) {
             inst->bSuppOctetFram = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "framingfix.cisco.asa")) {
             inst->bSPFramingFix = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "compression.mode")) {
-            cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcasecmp(cstr, "stream:always")) {
                 inst->compressionMode = COMPRESS_STREAM_ALWAYS;
             } else if (!strcasecmp(cstr, "none")) {
@@ -2283,17 +2283,17 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "notifyonconnectionopen")) {
             inst->bEmitMsgOnOpen = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "defaulttz")) {
-            inst->dfltTZ = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->dfltTZ = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
             inst->ratelimitBurst = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
             inst->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.name")) {
-            inst->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "multiline")) {
             inst->multiLine = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "listenportfilename")) {
-            inst->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "socketbacklog")) {
             inst->socketBacklog = (int)pvals[i].val.d.n;
         } else {

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -519,10 +519,10 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "port")) {
-            inst->pszBindPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "address")) {
 #if defined(HAVE_RELPSRVSETLSTNADDR)
-            inst->pszBindAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #else
             parser_errmsg(
                 "imrelp: librelp does not support input parameter 'address'; "
@@ -530,9 +530,9 @@ BEGINnewInpInst
                 "listening on all interfaces");
 #endif
         } else if (!strcmp(inppblk.descr[i].name, "name")) {
-            inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "maxdatasize")) {
             inst->maxDataSize = (size_t)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "flowcontrol")) {
@@ -543,7 +543,8 @@ BEGINnewInpInst
             } else if (!es_strconstcmp(pvals[i].val.d.estr, "full")) {
                 inst->flowCtlType = eFLOWCTL_FULL_DELAY;
             } else {
-                const char *const mode = es_str2cstr(pvals[i].val.d.estr, NULL);
+                char *mode = NULL;
+                CHKmalloc(mode = es_str2cstr(pvals[i].val.d.estr, NULL));
                 parser_errmsg(
                     "imrelp: wrong flowcontrol parameter "
                     "value '%s', using default: 'light'; possible "
@@ -553,7 +554,8 @@ BEGINnewInpInst
             }
         } else if (!strcmp(inppblk.descr[i].name, "oversizemode")) {
 #ifdef HAVE_RELPSRVSETOVERSIZEMODE
-            char *mode = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *mode;
+            CHKmalloc(mode = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcmp(mode, "abort")) {
                 inst->oversizeMode = RELP_OVERSIZE_ABORT;
             } else if (!strcmp(mode, "truncate")) {
@@ -585,19 +587,19 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
             inst->ratelimitBurst = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.name")) {
-            inst->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tls")) {
             inst->bEnableTLS = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "tls.dhbits")) {
             inst->dhBits = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "tls.prioritystring")) {
-            inst->pristring = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pristring = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tls.authmode")) {
-            inst->authmode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->authmode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "tls.compression")) {
             inst->bEnableTLSZip = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "tls.cacert")) {
-            inst->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)inst->caCertFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -606,7 +608,7 @@ BEGINnewInpInst
                 fclose(fp);
             }
         } else if (!strcmp(inppblk.descr[i].name, "tls.mycert")) {
-            inst->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)inst->myCertFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -615,7 +617,7 @@ BEGINnewInpInst
                 fclose(fp);
             }
         } else if (!strcmp(inppblk.descr[i].name, "tls.myprivkey")) {
-            inst->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)inst->myPrivKeyFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -625,7 +627,7 @@ BEGINnewInpInst
             }
         } else if (!strcmp(inppblk.descr[i].name, "tls.tlscfgcmd")) {
 #if defined(HAVE_RELPENGINESETTLSCFGCMD)
-            inst->tlscfgcmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->tlscfgcmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #else
             parser_errmsg(
                 "imrelp: librelp does not support input parameter 'tls.tlscfgcmd'; "
@@ -718,10 +720,10 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "ruleset")) {
-            loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "tls.tlslib")) {
 #if defined(HAVE_RELPENGINESETTLSLIBBYNAME)
-            loadModConf->tlslib = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tlslib = es_str2cstr(pvals[i].val.d.estr, NULL));
 #else
             LogError(0, RS_RET_NOT_IMPLEMENTED,
                      "imrelp warning: parameter tls.tlslib ignored - librelp does not support "

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -651,19 +651,19 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "port")) {
-            inst->cnf_params->pszPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->cnf_params->pszPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "networknamespace")) {
-            inst->pszNetworkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszNetworkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "address")) {
-            inst->cnf_params->pszAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->cnf_params->pszAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "name")) {
-            inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "defaulttz")) {
-            inst->dfltTZ = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->dfltTZ = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "framingfix.cisco.asa")) {
             inst->bSPFramingFix = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.mode")) {
             inst->iStrmDrvrMode = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.CheckExtendedKeyPurpose")) {
@@ -679,23 +679,23 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.TlsRevocationCheck")) {
             inst->iStrmTlsRevocationCheck = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.authmode")) {
-            inst->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
-            inst->pszStrmDrvrPermitExpiredCerts = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszStrmDrvrPermitExpiredCerts = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.cafile")) {
-            inst->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.crlfile")) {
-            inst->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.keyfile")) {
-            inst->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.certfile")) {
-            inst->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "streamdriver.name")) {
-            inst->pszStrmDrvrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszStrmDrvrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "starvationprotection.maxreads")) {
             inst->starvationMaxReads = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "gnutlsprioritystring")) {
-            inst->gnutlsPriorityString = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->gnutlsPriorityString = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "permittedpeer")) {
             for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
                 uchar *const peer = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
@@ -739,17 +739,17 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
             inst->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.name")) {
-            inst->cnf_params->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->cnf_params->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "preservecase")) {
             inst->bPreserveCase = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "socketbacklog")) {
             inst->iSynBacklog = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "listenportfilename")) {
-            inst->cnf_params->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->cnf_params->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "multiline")) {
             inst->cnf_params->bMultiLine = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "framing.delimiter.regex")) {
-            inst->cnf_params->pszStartRegex = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->cnf_params->pszStartRegex = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "imtcp: program error, non-handled "
@@ -878,9 +878,9 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "keepalive.interval")) {
             loadModConf->iKeepAliveIntvl = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "gnutlsprioritystring")) {
-            loadModConf->gnutlsPriorityString = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->gnutlsPriorityString = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "networknamespace")) {
-            loadModConf->pszNetworkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszNetworkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.mode")) {
             loadModConf->iStrmDrvrMode = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.CheckExtendedKeyPurpose")) {
@@ -896,19 +896,19 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.TlsRevocationCheck")) {
             loadModConf->iStrmTlsRevocationCheck = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.authmode")) {
-            loadModConf->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
-            loadModConf->pszStrmDrvrPermitExpiredCerts = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszStrmDrvrPermitExpiredCerts = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.cafile")) {
-            loadModConf->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.crlfile")) {
-            loadModConf->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.keyfile")) {
-            loadModConf->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.certfile")) {
-            loadModConf->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "streamdriver.name")) {
-            loadModConf->pszStrmDrvrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszStrmDrvrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "permittedpeer")) {
             for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
                 uchar *const peer = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);

--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -1148,7 +1148,7 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "schedulingpriority")) {
             loadModConf->iSchedPrio = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "schedulingpolicy")) {
-            loadModConf->pszSchedPolicy = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszSchedPolicy = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "threads")) {
             wrkrMax = (int)pvals[i].val.d.n;
             if (wrkrMax > MAX_WRKR_THREADS) {

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -1343,7 +1343,7 @@ BEGINsetModCnf
         if (!strcmp(modpblk.descr[i].name, "syssock.use")) {
             loadModConf->bOmitLocalLogging = ((int)pvals[i].val.d.n) ? 0 : 1;
         } else if (!strcmp(modpblk.descr[i].name, "syssock.name")) {
-            loadModConf->pLogSockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pLogSockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "syssock.ignoretimestamp")) {
             loadModConf->bIgnoreTimestamp = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "syssock.ignoreownmessages")) {
@@ -1371,7 +1371,7 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "syssock.ratelimit.severity")) {
             loadModConf->ratelimitSeveritySysSock = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "syssock.ratelimit.name")) {
-            loadModConf->pszRatelimitNameSysSock = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->pszRatelimitNameSysSock = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "imuxsock: program error, non-handled "
@@ -1423,7 +1423,7 @@ BEGINnewInpInst
     for (i = 0; i < inppblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(inppblk.descr[i].name, "socket")) {
-            inst->sockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->sockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "createpath")) {
             inst->bCreatePath = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "parsetrusted")) {
@@ -1433,7 +1433,7 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "unlink")) {
             inst->bUnlink = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "hostname")) {
-            inst->pLogHostName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pLogHostName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ignoretimestamp")) {
             inst->bIgnoreTimestamp = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "flowcontrol")) {
@@ -1449,7 +1449,7 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "usespecialparser")) {
             inst->bUseSpecialParser = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
-            inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.interval")) {
             inst->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.burst")) {
@@ -1457,7 +1457,7 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.severity")) {
             inst->ratelimitSeverity = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ratelimit.name")) {
-            inst->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "imuxsock: program error, non-handled "

--- a/plugins/mmaitag/mmaitag.c
+++ b/plugins/mmaitag/mmaitag.c
@@ -161,17 +161,17 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "provider")) {
             free(pData->provider_name);
-            pData->provider_name = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->provider_name = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tag")) {
             free(pData->tag);
-            pData->tag = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tag = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pData->tag[0] == '$') memmove(pData->tag, pData->tag + 1, strlen(pData->tag));
         } else if (!strcmp(actpblk.descr[i].name, "model")) {
             free(pData->model);
-            pData->model = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->model = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "expert.initial_prompt")) {
             free(pData->prompt);
-            pData->prompt = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->prompt = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "inputproperty")) {
             char *c = es_str2cstr(pvals[i].val.d.estr, NULL);
             CHKmalloc(pData->inputProp = malloc(sizeof(msgPropDescr_t)));
@@ -179,10 +179,10 @@ BEGINnewActInst
             free(c);
         } else if (!strcmp(actpblk.descr[i].name, "apikey")) {
             free(pData->apikey);
-            pData->apikey = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->apikey = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "apikey_file")) {
             free(pData->apikey_file);
-            pData->apikey_file = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->apikey_file = es_str2cstr(pvals[i].val.d.estr, NULL));
         }
     }
 

--- a/plugins/mmdblookup/mmdblookup.c
+++ b/plugins/mmdblookup/mmdblookup.c
@@ -224,7 +224,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "container")) {
-            loadModConf->container = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->container = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "mmdblookup: program error, non-handled "
@@ -265,15 +265,16 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "key")) {
-            pData->pszKey = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszKey = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "mmdbfile")) {
-            pData->pszMmdbFile = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszMmdbFile = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "fields")) {
             pData->fieldList.nmemb = pvals[i].val.d.ar->nmemb;
             CHKmalloc(pData->fieldList.name = calloc(pData->fieldList.nmemb, sizeof(char *)));
             CHKmalloc(pData->fieldList.varname = calloc(pData->fieldList.nmemb, sizeof(char *)));
             for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
-                char *const param = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                char *param;
+                CHKmalloc(param = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
                 char *varname = NULL;
                 char *name;
                 if (*param == ':') {

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -521,7 +521,7 @@ BEGINnewActInst
         if (!strcmp(actpblk.descr[i].name, "binary")) {
             CHKiRet(split_binary_parameters(&pData->szBinary, &pData->aParams, &pData->iParams, pvals[i].val.d.estr));
         } else if (!strcmp(actpblk.descr[i].name, "output")) {
-            pData->outputFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->outputFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "forcesingleinstance")) {
             pData->bForceSingleInst = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "interface.input")) {

--- a/plugins/mmfields/mmfields.c
+++ b/plugins/mmfields/mmfields.c
@@ -143,7 +143,7 @@ BEGINnewActInst
         if (!strcmp(actpblk.descr[i].name, "separator")) {
             pData->separator = es_getBufAddr(pvals[i].val.d.estr)[0];
         } else if (!strcmp(actpblk.descr[i].name, "jsonroot")) {
-            pData->jsonRoot = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->jsonRoot = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "mmfields: program error, non-handled "

--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -467,11 +467,11 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "cookie")) {
             free(pData->cookie);
-            pData->cookie = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->cookie = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "container")) {
             free(pData->container);
             size_t lenvar = es_strlen(pvals[i].val.d.estr);
-            pData->container = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->container = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pData->container[0] == '$') {
                 /* pre 8.35, the container name needed to be specified without
                  * the leading $. This was confusing, so we now require a full

--- a/plugins/mmnormalize/mmnormalize.c
+++ b/plugins/mmnormalize/mmnormalize.c
@@ -336,7 +336,7 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "rulebase")) {
-            pData->rulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->rulebase = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "rule")) {
             for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
                 tStr = (char *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
@@ -362,9 +362,9 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "userawmsg")) {
             pData->bUseRawMsg = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "variable")) {
-            varName = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(varName = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "path")) {
-            cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (strlen(cstr) < 2) {
                 LogError(0, RS_RET_VALUE_NOT_SUPPORTED,
                          "mmnormalize: valid path name should be at least "

--- a/plugins/mmpstrucdata/mmpstrucdata.c
+++ b/plugins/mmpstrucdata/mmpstrucdata.c
@@ -141,7 +141,7 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "jsonroot")) {
             size_t lenvar = es_strlen(pvals[i].val.d.estr);
-            pData->jsonRoot = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->jsonRoot = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pData->jsonRoot[0] == '$') {
                 /* pre 8.35, the jsonRoot name needed to be specified without
                  * the leading $. This was confusing, so we now require a full

--- a/plugins/mmsnareparse/mmsnareparse.c
+++ b/plugins/mmsnareparse/mmsnareparse.c
@@ -5385,32 +5385,24 @@ BEGINsetModCnf
     for (i = 0; i < (int)modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "definition.file")) {
-            char *value = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (value == NULL) {
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            char *value;
+            CHKmalloc(value = es_str2cstr(pvals[i].val.d.estr, NULL));
             free(loadModConf->definitionFile);
             loadModConf->definitionFile = value;
         } else if (!strcmp(modpblk.descr[i].name, "definition.json")) {
-            char *value = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (value == NULL) {
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            char *value;
+            CHKmalloc(value = es_str2cstr(pvals[i].val.d.estr, NULL));
             free(loadModConf->definitionJson);
             loadModConf->definitionJson = value;
         } else if (!strcmp(modpblk.descr[i].name, "runtime.config")) {
-            char *value = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (value == NULL) {
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            char *value;
+            CHKmalloc(value = es_str2cstr(pvals[i].val.d.estr, NULL));
             free(loadModConf->runtimeConfigFile);
             loadModConf->runtimeConfigFile = value;
         } else if (!strcmp(modpblk.descr[i].name, "validation.mode")) {
-            char *mode = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *mode;
+            CHKmalloc(mode = es_str2cstr(pvals[i].val.d.estr, NULL));
             rsRetVal r;
-            if (mode == NULL) {
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
             validation_mode_t parsedMode;
             r = parse_validation_mode(mode, &parsedMode);
             free(mode);
@@ -5419,17 +5411,13 @@ BEGINsetModCnf
             }
             loadModConf->validationTemplate.mode = parsedMode;
         } else if (!strcmp(modpblk.descr[i].name, "ignoreTrailingPattern")) {
-            char *value = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (value == NULL) {
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            char *value;
+            CHKmalloc(value = es_str2cstr(pvals[i].val.d.estr, NULL));
             free(loadModConf->ignoreTrailingPattern);
             loadModConf->ignoreTrailingPattern = (uchar *)value;
         } else if (!strcmp(modpblk.descr[i].name, "ignoreTrailingPattern.regex")) {
-            char *value = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (value == NULL) {
-                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
-            }
+            char *value;
+            CHKmalloc(value = es_str2cstr(pvals[i].val.d.estr, NULL));
             free(loadModConf->ignoreTrailingPatternRegex);
             loadModConf->ignoreTrailingPatternRegex = (uchar *)value;
         } else if (!strcmp(modpblk.descr[i].name, "ignoreTrailingPattern.searchWindow")) {
@@ -5578,12 +5566,12 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "container") || !strcmp(actpblk.descr[i].name, "rootpath")) {
             free(pData->container);
-            pData->container = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->container = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pData->container != NULL && pData->container[0] == '$')
                 memmove(pData->container, pData->container + 1, strlen((char *)pData->container));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
             free(templateName);
-            templateName = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(templateName = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "enable.network")) {
             pData->enableNetwork = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "enable.laps")) {
@@ -5598,16 +5586,17 @@ BEGINnewActInst
             pData->emitDebugJson = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "definition.file")) {
             free(definitionFile);
-            definitionFile = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(definitionFile = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "definition.json")) {
             free(definitionJson);
-            definitionJson = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(definitionJson = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "runtime.config")) {
             free(runtimeConfigFile);
-            runtimeConfigFile = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(runtimeConfigFile = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "validation.mode") ||
                    !strcmp(actpblk.descr[i].name, "validation_mode")) {
-            char *mode = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *mode;
+            CHKmalloc(mode = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (mode == NULL) {
                 ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
             }
@@ -5615,7 +5604,8 @@ BEGINnewActInst
             free(mode);
         } else if (!strcmp(actpblk.descr[i].name, "ignoreTrailingPattern")) {
             hasStaticPattern = 1;
-            char *value = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *value;
+            CHKmalloc(value = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (value == NULL) {
                 ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
             }
@@ -5624,7 +5614,8 @@ BEGINnewActInst
             pData->ignoreTrailingPattern_isRegex = 0;
         } else if (!strcmp(actpblk.descr[i].name, "ignoreTrailingPattern.regex")) {
             hasRegexPattern = 1;
-            char *value = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *value;
+            CHKmalloc(value = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (value == NULL) {
                 ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
             }

--- a/plugins/omazuredce/omazuredce.c
+++ b/plugins/omazuredce/omazuredce.c
@@ -1144,19 +1144,19 @@ BEGINnewActInst
 
         if (!strcmp(actpblk.descr[i].name, "template")) {
             free(pData->templateName);
-            pData->templateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->templateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "client_id")) {
-            pData->clientID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->clientID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "client_secret")) {
-            pData->clientSecret = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->clientSecret = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tenant_id")) {
-            pData->tenantID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tenantID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dce_url")) {
-            pData->dceURL = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->dceURL = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dcr_id")) {
-            pData->dcrID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->dcrID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "table_name")) {
-            pData->tableName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tableName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "max_batch_bytes")) {
             pData->maxBatchBytes = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "flush_timeout_ms")) {

--- a/plugins/omazureeventhubs/omazureeventhubs.c
+++ b/plugins/omazureeventhubs/omazureeventhubs.c
@@ -900,29 +900,30 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "amqp_address")) {
-            pData->amqp_address = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->amqp_address = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "azurehost")) {
-            pData->azurehost = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->azurehost = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "azureport")) {
-            pData->azureport = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->azureport = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "azure_key_name")) {
-            pData->azure_key_name = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->azure_key_name = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "azure_key")) {
-            pData->azure_key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->azure_key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "container")) {
-            pData->container = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->container = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "eventproperties")) {
             pData->nEventProperties = pvals[i].val.d.ar->nmemb;
-            CHKmalloc(pData->eventProperties = malloc(sizeof(struct event_property) * pvals[i].val.d.ar->nmemb));
+            CHKmalloc(pData->eventProperties = calloc(pvals[i].val.d.ar->nmemb, sizeof(struct event_property)));
             for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
-                char *cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                char *cstr;
+                CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
                 CHKiRet(processEventProperty(cstr, &pData->eventProperties[j].key, &pData->eventProperties[j].val));
                 free(cstr);
             }
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "statsname")) {
-            pData->statsName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->statsName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             LogError(0, RS_RET_INTERNAL_ERROR, "omazureeventhubs: program error, non-handled param '%s'\n",
                      actpblk.descr[i].name);

--- a/plugins/omclickhouse/omclickhouse.c
+++ b/plugins/omclickhouse/omclickhouse.c
@@ -768,19 +768,19 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "server")) {
-            server = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(server = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
             pData->port = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "user")) {
-            pData->user = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->user = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "pwd")) {
-            pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "healthchecktimeout")) {
             pData->healthCheckTimeout = (long)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "timeout")) {
             pData->timeout = (long)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "usehttps")) {
             pData->useHttps = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "allowunsignedcerts")) {
@@ -788,13 +788,13 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "skipverifyhost")) {
             pData->skipVerifyHost = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "errorfile")) {
-            pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "bulkmode")) {
             pData->bulkmode = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "maxbytes")) {
             pData->maxbytes = (size_t)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {
-            pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->caCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -805,7 +805,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.mycert")) {
-            pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myCertFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));
@@ -816,7 +816,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.myprivkey")) {
-            pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myPrivKeyFile, "r");
             if (fp == NULL) {
                 rs_strerror_r(errno, errStr, sizeof(errStr));

--- a/plugins/omdtls/omdtls.c
+++ b/plugins/omdtls/omdtls.c
@@ -225,7 +225,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "omdtls: program error, non-handled "

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -2237,7 +2237,7 @@ BEGINnewActInst
         if (!strcmp(actpblk.descr[i].name, "server")) {
             servers = pvals[i].val.d.ar;
         } else if (!strcmp(actpblk.descr[i].name, "errorfile")) {
-            pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "erroronly")) {
             pData->errorOnly = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "interleaved")) {
@@ -2249,23 +2249,23 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "indextimeout")) {
             pData->indexTimeout = (long)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "uid")) {
-            pData->uid = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->uid = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "pwd")) {
-            pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "apikey")) {
-            pData->apiKey = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->apiKey = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "searchindex")) {
-            pData->searchIndex = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->searchIndex = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "searchtype")) {
-            pData->searchType = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->searchType = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "pipelinename")) {
-            pData->pipelineName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pipelineName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dynpipelinename")) {
             pData->dynPipelineName = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "skippipelineifempty")) {
             pData->skipPipelineIfEmpty = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "parent")) {
-            pData->parent = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->parent = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dynsearchindex")) {
             pData->dynSrchIdx = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "dynsearchtype")) {
@@ -2281,17 +2281,17 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "skipverifyhost")) {
             pData->skipVerifyHost = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "timeout")) {
-            pData->timeout = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->timeout = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "usehttps")) {
             pData->useHttps = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dynbulkid")) {
             pData->dynBulkId = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "bulkid")) {
-            pData->bulkId = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->bulkId = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {
-            pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->caCertFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: 'tls.cacert' file %s couldn't be accessed",
@@ -2300,7 +2300,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.mycert")) {
-            pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myCertFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: 'tls.mycert' file %s couldn't be accessed",
@@ -2309,7 +2309,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.myprivkey")) {
-            pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myPrivKeyFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: 'tls.myprivkey' file %s couldn't be accessed",
@@ -2318,7 +2318,8 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "writeoperation")) {
-            char *writeop = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *writeop;
+            CHKmalloc(writeop = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (writeop && !strcmp(writeop, "create")) {
                 pData->writeOperation = ES_WRITE_CREATE;
             } else if (writeop && !strcmp(writeop, "index")) {
@@ -2338,9 +2339,9 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
             pData->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.name")) {
-            pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "retryruleset")) {
-            pData->retryRulesetName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->retryRulesetName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "rebindinterval")) {
             pData->rebindInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "esversion.major")) {

--- a/plugins/omjournal/omjournal.c
+++ b/plugins/omjournal/omjournal.c
@@ -151,9 +151,9 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
 
         if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "namespace")) {
-            pData->namespace = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->namespace = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "omjournal: program error, non-handled "

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -2088,7 +2088,7 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "topic")) {
-            pData->topic = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->topic = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "dynakey")) {
             pData->dynaKey = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "dynatopic")) {
@@ -2144,13 +2144,13 @@ BEGINnewActInst
             ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
 #endif
         } else if (!strcmp(actpblk.descr[i].name, "errorfile")) {
-            pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->errorFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "statsfile")) {
-            pData->statsFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->statsFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "key")) {
-            pData->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "reopenonhup")) {
             pData->bReopenOnHup = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "resubmitonfailure")) {
@@ -2158,9 +2158,9 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "keepfailedmessages")) {
             pData->bKeepFailedMessages = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "failedmsgfile")) {
-            pData->failedMsgFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->failedMsgFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "statsname")) {
-            pData->statsName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->statsName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             LogError(0, RS_RET_INTERNAL_ERROR, "omkafka: program error, non-handled param '%s'\n",
                      actpblk.descr[i].name);

--- a/plugins/omlibdbi/omlibdbi.c
+++ b/plugins/omlibdbi/omlibdbi.c
@@ -421,7 +421,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pszFileDfltTplName != NULL) {
                 LogError(0, RS_RET_DUP_PARAM,
                          "omlibdbi: warning: default template "
@@ -429,7 +429,7 @@ BEGINsetModCnf
                          "results.");
             }
         } else if (!strcmp(modpblk.descr[i].name, "driverdirectory")) {
-            loadModConf->dbiDrvrDir = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->dbiDrvrDir = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "omlibdbi: program error, non-handled "
@@ -498,17 +498,17 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "server")) {
-            pData->host = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->host = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "db")) {
-            pData->dbName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->dbName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "uid")) {
-            pData->usrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->usrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "pwd")) {
-            pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pwd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "driver")) {
-            pData->drvrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->drvrName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "omlibdbi: program error, non-handled "

--- a/plugins/ommail/ommail.c
+++ b/plugins/ommail/ommail.c
@@ -672,11 +672,11 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "server")) {
-            pData->md.smtp.pszSrv = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->md.smtp.pszSrv = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
-            pData->md.smtp.pszSrvPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->md.smtp.pszSrvPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "mailfrom")) {
-            pData->md.smtp.pszFrom = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->md.smtp.pszFrom = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "mailto")) {
             for (j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
                 addRcpt(&(pData->md.smtp.lstRcpt), (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
@@ -688,7 +688,7 @@ BEGINnewActInst
                     "can be set");
                 ABORT_FINALIZE(RS_RET_DUP_PARAM);
             }
-            tplSubject = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(tplSubject = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "subject.text")) {
             if (tplSubject != NULL) {
                 parser_errmsg(
@@ -696,11 +696,11 @@ BEGINnewActInst
                     "can be set");
                 ABORT_FINALIZE(RS_RET_DUP_PARAM);
             }
-            pData->constSubject = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->constSubject = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "body.enable")) {
             pData->bEnableBody = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             DBGPRINTF(
                 "ommail: program error, non-handled "

--- a/plugins/ommongodb/ommongodb.c
+++ b/plugins/ommongodb/ommongodb.c
@@ -596,25 +596,25 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "uristr")) {
-            pData->uristr = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->uristr = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "server")) {
-            pData->server = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->server = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "serverport")) {
-            pData->port = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->port = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "db")) {
-            pData->db = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->db = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "collection")) {
-            pData->collection_name = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->collection_name = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "ssl_ca")) {
-            pData->ssl_ca = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->ssl_ca = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "ssl_cert")) {
-            pData->ssl_cert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->ssl_cert = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "uid")) {
-            pData->uid = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->uid = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "pwd")) {
-            pData->pwd = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pwd = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "allowed_error_codes")) {
             const int maxerrcodes = sizeof(pData->allowed_error_codes) / sizeof(uint32_t);
             pData->allowed_error_codes_nbr = pvals[i].val.d.ar->nmemb;

--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -443,13 +443,13 @@ BEGINnewActInst
             memcpy(pData->dbpwd, cstr, len + 1);
             free(cstr);
         } else if (!strcmp(actpblk.descr[i].name, "mysqlconfig.file")) {
-            pData->configfile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->configfile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "mysqlconfig.section")) {
-            pData->configsection = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->configsection = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "socket")) {
-            pData->socket = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->socket = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "ommysql: program error, non-handled "

--- a/plugins/ompgsql/ompgsql.c
+++ b/plugins/ompgsql/ompgsql.c
@@ -438,7 +438,7 @@ BEGINnewActInst
             memcpy(pData->pass, cstr, len + 1);
             free(cstr);
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tpl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tpl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "conninfo")) {
             cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
             len = es_strlen(pvals[i].val.d.estr);

--- a/plugins/omprog/omprog.c
+++ b/plugins/omprog/omprog.c
@@ -1085,9 +1085,9 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "useTransactions")) {
             pData->bUseTransactions = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "beginTransactionMark")) {
-            pData->szBeginTransactionMark = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szBeginTransactionMark = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "commitTransactionMark")) {
-            pData->szCommitTransactionMark = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szCommitTransactionMark = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "forceSingleInstance")) {
             pData->bForceSingleInst = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "signalOnClose")) {
@@ -1097,7 +1097,8 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "killUnresponsive")) {
             pData->bKillUnresponsive = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "hup.signal")) {
-            const char *const sig = es_str2cstr(pvals[i].val.d.estr, NULL);
+            char *sig;
+            CHKmalloc(sig = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcmp(sig, "HUP"))
                 pData->iHUPForward = SIGHUP;
             else if (!strcmp(sig, "USR1"))
@@ -1114,12 +1115,12 @@ BEGINnewActInst
             }
             free((void *)sig);
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->szTemplateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szTemplateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "output")) {
             if (pData->pOutputCaptureCtx == NULL) {
                 CHKiRet(allocOutputCaptureCtx(&pData->pOutputCaptureCtx));
             }
-            pData->pOutputCaptureCtx->szFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pOutputCaptureCtx->szFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "fileCreateMode")) {
             if (pData->pOutputCaptureCtx == NULL) {
                 CHKiRet(allocOutputCaptureCtx(&pData->pOutputCaptureCtx));

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -425,7 +425,7 @@ BEGINsetModCnf
         }
         if (!strcmp(modpblk.descr[i].name, "tls.tlslib")) {
 #if defined(HAVE_RELPENGINESETTLSLIBBYNAME)
-            loadModConf->tlslib = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tlslib = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (relpEngineSetTLSLibByName(pRelpEngine, loadModConf->tlslib) != RELP_RET_OK) {
                 LogMsg(0, RS_RET_CONF_PARAM_INVLD, LOG_WARNING,
                        "omrelp: tlslib '%s' not accepted as valid by librelp - using default", loadModConf->tlslib);
@@ -462,13 +462,13 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "target")) {
-            pData->target = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->target = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
-            pData->port = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->port = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "localclientip")) {
-            pData->localClientIP = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->localClientIP = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "timeout")) {
             pData->timeout = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "conn.timeout")) {
@@ -490,9 +490,9 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "tls.compression")) {
             pData->bEnableTLSZip = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "tls.prioritystring")) {
-            pData->pristring = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pristring = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {
-            pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->caCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->caCertFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -501,7 +501,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.mycert")) {
-            pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myCertFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -510,7 +510,7 @@ BEGINnewActInst
                 fclose(fp);
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.myprivkey")) {
-            pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->myPrivKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             fp = fopen((const char *)pData->myPrivKeyFile, "r");
             if (fp == NULL) {
                 LogError(errno, RS_RET_NO_FILE_ACCESS, "error: certificate file %s couldn't be accessed",
@@ -520,7 +520,7 @@ BEGINnewActInst
             }
         } else if (!strcmp(actpblk.descr[i].name, "tls.tlscfgcmd")) {
 #if defined(HAVE_RELPENGINESETTLSCFGCMD)
-            pData->tlscfgcmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tlscfgcmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
 #else
             LogError(0, RS_RET_NOT_IMPLEMENTED,
                      "omrelp: librelp does not support input parameter "
@@ -528,12 +528,12 @@ BEGINnewActInst
                      "ignoring setting now.");
 #endif
         } else if (!strcmp(actpblk.descr[i].name, "tls.authmode")) {
-            pData->authmode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->authmode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tls.permittedpeer")) {
             pData->permittedPeers.nmemb = pvals[i].val.d.ar->nmemb;
-            CHKmalloc(pData->permittedPeers.name = malloc(sizeof(uchar *) * pData->permittedPeers.nmemb));
+            CHKmalloc(pData->permittedPeers.name = calloc(pData->permittedPeers.nmemb, sizeof(uchar *)));
             for (j = 0; j < pData->permittedPeers.nmemb; ++j) {
-                pData->permittedPeers.name[j] = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                CHKmalloc(pData->permittedPeers.name[j] = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
             }
         } else {
             dbgprintf(

--- a/plugins/omsendertrack/omsendertrack.c
+++ b/plugins/omsendertrack/omsendertrack.c
@@ -757,10 +757,10 @@ BEGINnewActInst
             pData->interval = (int)pvals[i].val.d.n;
             // TODO: add cmdfile
         } else if (!strcmp(actpblk.descr[i].name, "statefile")) {
-            pData->statefile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->statefile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "senderid")) {
             free((void *)pData->senderidTemplate);  // free default template
-            pData->senderidTemplate = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->senderidTemplate = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             DBGPRINTF(
                 "omsendertrack: program error, non-handled "

--- a/plugins/omsnmp/omsnmp.c
+++ b/plugins/omsnmp/omsnmp.c
@@ -472,24 +472,24 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "server")) {
-            pData->szTarget = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szTarget = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
             pData->iPort = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "transport")) {
-            pData->szTransport = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szTransport = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "version")) {
             pData->iSNMPVersion = pvals[i].val.d.n;
             if (pData->iSNMPVersion < 0 || cs.iSNMPVersion > 1) pData->iSNMPVersion = 1;
         } else if (!strcmp(actpblk.descr[i].name, "community")) {
-            pData->szCommunity = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szCommunity = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "enterpriseoid")) {
-            pData->szEnterpriseOID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szEnterpriseOID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "trapoid")) {
-            pData->szSnmpTrapOID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szSnmpTrapOID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "messageoid")) {
-            pData->szSyslogMessageOID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szSyslogMessageOID = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "snmpv1dynsource")) {
-            pData->szSnmpV1Source = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->szSnmpV1Source = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "traptype")) {
             pData->iTrapType = pvals[i].val.d.n;
             if (cs.iTrapType < 0 || cs.iTrapType > 6) {
@@ -499,7 +499,7 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "specifictype")) {
             pData->iSpecificType = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "ompipe: program error, non-handled "

--- a/plugins/omstdout/omstdout.c
+++ b/plugins/omstdout/omstdout.c
@@ -252,7 +252,7 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "ensurelfending")) {
             pData->bEnsureLFEnding = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->templateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->templateName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             DBGPRINTF(
                 "omstdout: program error, non-handled "

--- a/plugins/omudpspoof/omudpspoof.c
+++ b/plugins/omudpspoof/omudpspoof.c
@@ -245,7 +245,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (cs.tplName != NULL) {
                 LogError(0, RS_RET_DUP_PARAM,
                          "omudpspoof: warning: default template "
@@ -633,12 +633,12 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "target")) {
-            pData->host = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->host = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
-            pData->port = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->port = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "sourcetemplate")) {
             free(pData->sourceTpl);
-            pData->sourceTpl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->sourceTpl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "sourceport.start")) {
             pData->sourcePortStart = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "sourceport.end")) {
@@ -646,7 +646,7 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "mtu")) {
             pData->mtu = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             DBGPRINTF(
                 "omudpspoof: program error, non-handled "

--- a/plugins/omuxsock/omuxsock.c
+++ b/plugins/omuxsock/omuxsock.c
@@ -261,7 +261,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (cs.tplName != NULL) {
                 LogError(0, RS_RET_DUP_PARAM,
                          "omuxsock: default template "
@@ -271,11 +271,11 @@ BEGINsetModCnf
         } else if (!strcmp(modpblk.descr[i].name, "abstract")) {
             loadModConf->bAbstract = !!(int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "socketname")) {
-            loadModConf->sockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->sockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "sockettype")) {
             CHKiRet(_decodeSockType(pvals[i].val.d.estr, &loadModConf->sockType, &loadModConf->bConnected));
         } else if (!strcmp(modpblk.descr[i].name, "networknamespace")) {
-            loadModConf->namespace = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->namespace = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "omuxsock: program error, non-handled "
@@ -358,17 +358,17 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "abstract")) {
             pData->bAbstract = !!(int)pvals[i].val.d.n;
             bHaveAbstract = 1;
         } else if (!strcmp(actpblk.descr[i].name, "socketname")) {
-            pData->sockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->sockName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "sockettype")) {
             CHKiRet(_decodeSockType(pvals[i].val.d.estr, &pData->sockType, &pData->bConnected));
             bHaveSocketType = 1;
         } else if (!strcmp(actpblk.descr[i].name, "networknamespace")) {
-            pData->namespace = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->namespace = es_str2cstr(pvals[i].val.d.estr, NULL));
         }
     }
 

--- a/plugins/pmnormalize/pmnormalize.c
+++ b/plugins/pmnormalize/pmnormalize.c
@@ -167,7 +167,7 @@ BEGINnewParserInst
         if (!strcmp(parserpblk.descr[i].name, "undefinedpropertyerror")) {
             inst->undefPropErr = (int)pvals[i].val.d.n;
         } else if (!strcmp(parserpblk.descr[i].name, "rulebase")) {
-            inst->rulebase = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->rulebase = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(parserpblk.descr[i].name, "rule")) {
             es_str_t *rules;
             CHKmalloc(rules = es_newStr(128));

--- a/plugins/pmnull/pmnull.c
+++ b/plugins/pmnull/pmnull.c
@@ -117,7 +117,7 @@ BEGINnewParserInst
     for (i = 0; i < parserpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(parserpblk.descr[i].name, "tag")) {
-            inst->tag = (const char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->tag = (const char *)es_str2cstr(pvals[i].val.d.estr, NULL));
             inst->lenTag = strlen(inst->tag);
         } else if (!strcmp(parserpblk.descr[i].name, "syslogfacility")) {
             syslogfacility = pvals[i].val.d.n;

--- a/runtime/lmcry_gcry.c
+++ b/runtime/lmcry_gcry.c
@@ -119,19 +119,19 @@ static rsRetVal SetCnfParam(void *pT, struct nvlst *lst, int paramType) {
     for (i = 0; i < pblk->nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(pblk->descr[i].name, "cry.key") || !strcmp(pblk->descr[i].name, "queue.cry.key")) {
-            key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             ++nKeys;
         } else if (!strcmp(pblk->descr[i].name, "cry.keyfile") || !strcmp(pblk->descr[i].name, "queue.cry.keyfile")) {
-            keyfile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(keyfile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             ++nKeys;
         } else if (!strcmp(pblk->descr[i].name, "cry.keyprogram") ||
                    !strcmp(pblk->descr[i].name, "queue.cry.keyprogram")) {
-            keyprogram = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(keyprogram = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             ++nKeys;
         } else if (!strcmp(pblk->descr[i].name, "cry.mode") || !strcmp(pblk->descr[i].name, "queue.cry.mode")) {
-            mode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(mode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(pblk->descr[i].name, "cry.algo") || !strcmp(pblk->descr[i].name, "queue.cry.algo")) {
-            algo = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(algo = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             DBGPRINTF(
                 "lmcry_gcry: program error, non-handled "

--- a/runtime/lmcry_ossl.c
+++ b/runtime/lmcry_ossl.c
@@ -105,13 +105,13 @@ static rsRetVal SetCnfParam(void *pT, struct nvlst *lst, int paramType) {
     for (i = 0; i < pblk->nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(pblk->descr[i].name, "cry.key") || !strcmp(pblk->descr[i].name, "queue.cry.key")) {
-            key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(key = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             ++nKeys;
         } else if (!strcmp(pblk->descr[i].name, "cry.keyfile") || !strcmp(pblk->descr[i].name, "queue.cry.keyfile")) {
-            keyfile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(keyfile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             ++nKeys;
         } else if (!strcmp(pblk->descr[i].name, "cry.algo") || !strcmp(pblk->descr[i].name, "queue.cry.algo")) {
-            algomode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(algomode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             DBGPRINTF(
                 "lmcry_ossl: program error, non-handled "

--- a/runtime/lmsig_ksi-ls12.c
+++ b/runtime/lmsig_ksi-ls12.c
@@ -125,15 +125,15 @@ static rsRetVal SetCnfParam(void *pT, struct nvlst *lst) {
     for (i = 0; i < pblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(pblk.descr[i].name, "sig.hashfunction")) {
-            hash = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(hash = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(pblk.descr[i].name, "sig.aggregator.url")) {
-            ag_uri = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(ag_uri = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(pblk.descr[i].name, "sig.aggregator.user")) {
-            ag_loginid = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(ag_loginid = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(pblk.descr[i].name, "sig.aggregator.key")) {
-            ag_key = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(ag_key = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(pblk.descr[i].name, "sig.aggregator.hmacAlg")) {
-            hmac = (char *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(hmac = (char *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(pblk.descr[i].name, "sig.block.levelLimit")) {
             if (pvals[i].val.d.n < 2) {
                 LogError(0, RS_RET_ERR,
@@ -179,7 +179,7 @@ static rsRetVal SetCnfParam(void *pT, struct nvlst *lst) {
         } else if (!strcmp(pblk.descr[i].name, "sig.keeptreehashes")) {
             rsksiSetKeepTreeHashes(pThis->ctx, pvals[i].val.d.n);
         } else if (!strcmp(pblk.descr[i].name, "sig.syncmode")) {
-            cstr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cstr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcasecmp((char *)cstr, "sync"))
                 rsksiSetSyncMode(pThis->ctx, LOGSIG_SYNCHRONOUS);
             else if (!strcasecmp((char *)cstr, "async"))
@@ -188,11 +188,11 @@ static rsRetVal SetCnfParam(void *pT, struct nvlst *lst) {
                 LogError(0, RS_RET_ERR, "sig.syncmode '%s' unknown - using default", cstr);
             free(cstr);
         } else if (!strcmp(pblk.descr[i].name, "sig.randomsource")) {
-            cstr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cstr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             rsksiSetRandomSource(pThis->ctx, (char *)cstr);
             free(cstr);
         } else if (!strcmp(pblk.descr[i].name, "sig.debugfile")) {
-            cstr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cstr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             rsksiSetDebugFile(pThis->ctx, (char *)cstr);
             free(cstr);
         } else if (!strcmp(pblk.descr[i].name, "sig.debuglevel")) {

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -4385,13 +4385,13 @@ rsRetVal qqueueApplyCnfParam(qqueue_t *pThis, struct nvlst *lst) {
         if (!pvals[i].bUsed) continue;
         n_params_set++;
         if (!strcmp(pblk.descr[i].name, "queue.filename")) {
-            pThis->pszFilePrefix = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pThis->pszFilePrefix = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             pThis->lenFilePrefix = es_strlen(pvals[i].val.d.estr);
         } else if (!strcmp(pblk.descr[i].name, "queue.cry.provider")) {
-            pThis->cryprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pThis->cryprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(pblk.descr[i].name, "queue.spooldirectory")) {
             free(pThis->pszSpoolDir);
-            pThis->pszSpoolDir = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pThis->pszSpoolDir = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             pThis->lenSpoolDir = es_strlen(pvals[i].val.d.estr);
             CHKiRet(validateQueueSpoolDir(pThis));
             if (pThis->lenSpoolDir > 0 && pThis->pszSpoolDir[pThis->lenSpoolDir - 1] == '/') {

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -512,7 +512,7 @@ static rsRetVal initFunc_ratelimit(struct cnfobj *o) {
     for (i = 0; i < ratelimitpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(ratelimitpblk.descr[i].name, "name")) {
-            name = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(name = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(ratelimitpblk.descr[i].name, "interval")) {
             interval = (int)pvals[i].val.d.n;
         } else if (!strcmp(ratelimitpblk.descr[i].name, "burst")) {
@@ -520,17 +520,17 @@ static rsRetVal initFunc_ratelimit(struct cnfobj *o) {
         } else if (!strcmp(ratelimitpblk.descr[i].name, "severity")) {
             severity = (int)pvals[i].val.d.n;
         } else if (!strcmp(ratelimitpblk.descr[i].name, "policy")) {
-            policy = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(policy = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(ratelimitpblk.descr[i].name, "policyWatch")) {
             policy_watch = (int)pvals[i].val.d.n;
         } else if (!strcmp(ratelimitpblk.descr[i].name, "policyWatchDebounce")) {
-            policy_watch_debounce = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(policy_watch_debounce = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(ratelimitpblk.descr[i].name, "perSource")) {
             per_source_enabled = (int)pvals[i].val.d.n;
         } else if (!strcmp(ratelimitpblk.descr[i].name, "perSourcePolicy")) {
-            per_source_policy = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(per_source_policy = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(ratelimitpblk.descr[i].name, "perSourceKeyTpl")) {
-            per_source_key_tpl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(per_source_key_tpl = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(ratelimitpblk.descr[i].name, "perSourceMaxStates")) {
             per_source_max_states = (int)pvals[i].val.d.n;
         } else if (!strcmp(ratelimitpblk.descr[i].name, "perSourceTopN")) {

--- a/runtime/timezones.c
+++ b/runtime/timezones.c
@@ -88,8 +88,16 @@ void glblProcessTimezone(struct cnfobj *o) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(timezonepblk.descr[i].name, "id")) {
             id = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (id == NULL) {
+                parser_errmsg("timezone: failed to convert id parameter due to out of memory");
+                goto done;
+            }
         } else if (!strcmp(timezonepblk.descr[i].name, "offset")) {
             offset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            if (offset == NULL) {
+                parser_errmsg("timezone: failed to convert offset parameter due to out of memory");
+                goto done;
+            }
         } else {
             dbgprintf(
                 "glblProcessTimezone: program error, non-handled "

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -1031,7 +1031,7 @@ BEGINsetModCnf
         }
 
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pszFileDfltTplName != NULL) {
                 parser_errmsg(
                     "omfile: warning: default template was already "
@@ -1521,28 +1521,28 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "addlf")) {
             pData->bAddLF = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "file")) {
-            pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             CODE_STD_STRING_REQUESTnewActInst(1);
             pData->bDynamicName = 0;
         } else if (!strcmp(actpblk.descr[i].name, "dynafile")) {
             if (pData->fname != NULL) {
                 parser_errmsg("omfile: both \"file\" and \"dynafile\" set, will use dynafile");
             }
-            pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->fname = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             CODE_STD_STRING_REQUESTnewActInst(2);
             pData->bDynamicName = 1;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "sig.provider")) {
-            pData->sigprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->sigprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "cry.provider")) {
-            pData->cryprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->cryprovName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "closetimeout")) {
             pData->iCloseTimeout = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "rotation.sizelimit")) {
             pData->iSizeLimit = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "rotation.sizelimitcommand")) {
-            pData->pszSizeLimitCmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszSizeLimitCmd = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "rotation.sizelimitcommandpassfilename")) {
             pData->bSizeLimitCmdPassFileName = (int)pvals[i].val.d.n;
         } else {

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -778,7 +778,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (cs.pszTplName != NULL) {
                 LogError(0, RS_RET_DUP_PARAM,
                          "omfwd: warning: default template "
@@ -2006,19 +2006,19 @@ BEGINnewActInst
             pData->nTargets = nTargets;
             CHKmalloc(pData->target_name = (char **)calloc(pData->nTargets, sizeof(char *)));
             for (int j = 0; j < nTargets; ++j) {
-                pData->target_name[j] = (char *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                CHKmalloc(pData->target_name[j] = (char *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
             }
         } else if (!strcmp(actpblk.descr[i].name, "targetsrv")) {
-            pData->targetSrv = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->targetSrv = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "address")) {
-            pData->address = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->address = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "device")) {
-            pData->device = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->device = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "port")) {
             pData->nPorts = pvals[i].val.d.ar->nmemb;
             CHKmalloc(pData->ports = (char **)calloc(pData->nPorts, sizeof(char *)));
             for (int j = 0; j < pData->nPorts; ++j) {
-                pData->ports[j] = (char *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                CHKmalloc(pData->ports[j] = (char *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
             }
         } else if (!strcmp(actpblk.descr[i].name, "protocol")) {
             if (!es_strcasebufcmp(pvals[i].val.d.estr, (uchar *)"udp", 3)) {
@@ -2035,13 +2035,13 @@ BEGINnewActInst
                 pData->protocol = FORW_TCP;
             } else {
                 uchar *str;
-                str = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(str = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
                 LogError(0, RS_RET_INVLD_PROTOCOL, "omfwd: invalid protocol \"%s\"", str);
                 free(str);
                 ABORT_FINALIZE(RS_RET_INVLD_PROTOCOL);
             }
         } else if (!strcmp(actpblk.descr[i].name, "networknamespace")) {
-            pData->networkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->networkNamespace = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tcp_framing")) {
             if (!es_strcasebufcmp(pvals[i].val.d.estr, (uchar *)"traditional", 11)) {
                 pData->tcp_framing = TCP_FRAMING_OCTET_STUFFING;
@@ -2049,7 +2049,7 @@ BEGINnewActInst
                 pData->tcp_framing = TCP_FRAMING_OCTET_COUNTING;
             } else {
                 uchar *str;
-                str = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+                CHKmalloc(str = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
                 LogError(0, RS_RET_CNF_INVLD_FRAMING, "omfwd: invalid framing \"%s\"", str);
                 free(str);
                 ABORT_FINALIZE(RS_RET_CNF_INVLD_FRAMING);
@@ -2067,10 +2067,10 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "conerrskip")) {
             pData->iConErrSkip = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "gnutlsprioritystring")) {
-            pData->gnutlsPriorityString = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->gnutlsPriorityString = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver") ||
                    !strcmp(actpblk.descr[i].name, "streamdriver.name")) {
-            pData->pszStrmDrvr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszStrmDrvr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdrivermode") ||
                    !strcmp(actpblk.descr[i].name, "streamdrivermode")) {
             pData->iStrmDrvrMode = pvals[i].val.d.n;
@@ -2086,9 +2086,10 @@ BEGINnewActInst
             }
         } else if (!strcmp(actpblk.descr[i].name, "streamdriverauthmode") ||
                    !strcmp(actpblk.descr[i].name, "streamdriverauthmode")) {
-            pData->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
-            uchar *val = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            uchar *val;
+            CHKmalloc(val = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (es_strcasebufcmp(pvals[i].val.d.estr, (uchar *)"off", 3) &&
                 es_strcasebufcmp(pvals[i].val.d.estr, (uchar *)"on", 2) &&
                 es_strcasebufcmp(pvals[i].val.d.estr, (uchar *)"warn", 4)) {
@@ -2102,20 +2103,20 @@ BEGINnewActInst
             }
         } else if (!strcmp(actpblk.descr[i].name, "streamdriverremotesni") ||
                    !strcmp(actpblk.descr[i].name, "streamdriver.remotesni")) {
-            pData->pszStrmDrvrRemoteSNI = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszStrmDrvrRemoteSNI = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.cafile")) {
-            pData->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszStrmDrvrCAFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.crlfile")) {
-            pData->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszStrmDrvrCRLFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.keyfile")) {
-            pData->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszStrmDrvrKeyFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.certfile")) {
-            pData->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszStrmDrvrCertFile = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriverpermittedpeers")) {
             uchar *start, *str;
             uchar *p;
             int lenStr;
-            str = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(str = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             start = str;
             lenStr = ustrlen(start); /* we need length after '\0' has been dropped... */
             while (lenStr > 0) {
@@ -2162,11 +2163,11 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "udp.sendbuf")) {
             pData->UDPSendBuf = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "compression.stream.flushontxend")) {
             pData->strmCompFlushOnTxEnd = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "compression.mode")) {
-            cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.estr, NULL));
             if (!strcasecmp(cstr, "stream:always")) {
                 pData->compressionMode = COMPRESS_STREAM_ALWAYS;
             } else if (!strcasecmp(cstr, "none")) {
@@ -2191,7 +2192,7 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
             pData->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.name")) {
-            pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             LogError(0, RS_RET_INTERNAL_ERROR, "omfwd: program error, non-handled parameter '%s'",
                      actpblk.descr[i].name);

--- a/tools/ompipe.c
+++ b/tools/ompipe.c
@@ -215,7 +215,7 @@ BEGINsetModCnf
     for (i = 0; i < modpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(modpblk.descr[i].name, "template")) {
-            loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(loadModConf->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pszFileDfltTplName != NULL) {
                 LogError(0, RS_RET_DUP_PARAM,
                          "ompipe: warning: default template "
@@ -346,9 +346,9 @@ BEGINnewActInst
     for (i = 0; i < actpblk.nParams; ++i) {
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "pipe")) {
-            pData->pipe = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pipe = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tryResumeReopen")) {
             pData->bTryResumeReopen = (int)pvals[i].val.d.n;
         } else {

--- a/tools/omusrmsg.c
+++ b/tools/omusrmsg.c
@@ -548,13 +548,13 @@ BEGINnewActInst
                 populateUsers(pData, pvals[i].val.d.estr);
             }
         } else if (!strcmp(actpblk.descr[i].name, "template")) {
-            pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->tplName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.interval")) {
             pData->ratelimitInterval = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.burst")) {
             pData->ratelimitBurst = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "ratelimit.name")) {
-            pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(pData->pszRatelimitName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else {
             dbgprintf(
                 "omusrmsg: program error, non-handled "

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -175,13 +175,13 @@ BEGINnewParserInst
         } else if (!strcmp(parserpblk.descr[i].name, "detect.headerless")) {
             inst->bHdrLessMode = (int)pvals[i].val.d.n;
         } else if (!strcmp(parserpblk.descr[i].name, "headerless.hostname")) {
-            inst->pszHeaderlessHostname = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszHeaderlessHostname = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(parserpblk.descr[i].name, "headerless.tag")) {
-            inst->pszHeaderlessTag = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszHeaderlessTag = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(parserpblk.descr[i].name, "headerless.ruleset")) {
-            inst->pszHeaderlessRulesetName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszHeaderlessRulesetName = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(parserpblk.descr[i].name, "headerless.errorfile")) {
-            inst->pszHeaderlessErrFile = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inst->pszHeaderlessErrFile = (uchar*)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(parserpblk.descr[i].name, "headerless.drop")) {
             inst->bDropHeaderless = (int)pvals[i].val.d.n;
         } else {


### PR DESCRIPTION
Why
Some config parameter blocks still retained es_str2cstr() results without checking for NULL first. That only shows up on OOM, but an OOM path during startup still needs to fail cleanly.

Impact
Mostly cosmetic in the normal case. The change only affects startup behavior when allocation fails while parsing config parameters.

Before/After
Before: retained config strings could dereference NULL on OOM.
After: the affected config parameter blocks fail cleanly on OOM.

Technical Overview
Wrap retained es_str2cstr() results in CHKmalloc() inside config parameter blocks only.
Leave temporary validation strings alone when they are freed in-place.
Keep the behavior unchanged for successful allocations.
Audit the touched modules for remaining unchecked retained paths.
Validate the tree with make -j$(nproc) check TESTS="".

With the help of AI-Agents: Codex