### PR TITLE
config: add compatibility controls and secure defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,10 @@ Follow these three steps for a typical development task:
 ## Container Images
 
 - Runtime container definitions live in `packaging/docker/rsyslog`.
+- Local GitHub Actions-style validation commands for the Ubuntu 26.04 dev
+  container, `-j60` check runs, clang static analyzer, disabled external
+  services, and Docker storage cleanup are documented in
+  [`devtools/local-container-testing.md`](./devtools/local-container-testing.md).
 - The container Makefile default version must stay clearly non-release.
   Use explicit `VERSION=...` values for release-like local rehearsals and for
   any publish automation.

--- a/action.c
+++ b/action.c
@@ -2291,6 +2291,7 @@ rsRetVal addAction(action_t **ppAction,
                          "the SQL or stdSQL option in your template!\n");
                 ABORT_FINALIZE(RS_RET_RQD_TPLOPT_MISSING);
             }
+            tplNoteUse(pAction->ppTpl[i], iTplOpts & OMSR_TPL_AS_DYNAFILE);
         }
 
         /* set parameter-passing mode */

--- a/devtools/local-container-testing.md
+++ b/devtools/local-container-testing.md
@@ -1,0 +1,84 @@
+# Local Container Testing
+
+This file captures the local validation flow used for compatibility-format work.
+It mirrors the GitHub Actions container path while avoiding external services
+that are usually unnecessary for parser/config changes.
+
+## Ubuntu 26.04 CI-style Build
+
+Start from a clean build tree before switching into the container:
+
+```sh
+make distclean || true
+rm -f tests/runtime_unit_linkedlist tests/runtime_unit_stringbuf
+```
+
+Run the Ubuntu 26.04 dev container with Elasticsearch, Kafka, and MySQL disabled.
+Use `-j60` for local check runs on this host.
+
+```sh
+RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+CC='clang-21' \
+CFLAGS='-g' \
+RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE='--enable-debug --enable-testbench --enable-imdiag --enable-omstdout --disable-elasticsearch --disable-elasticsearch-tests --disable-imkafka --disable-omkafka --disable-kafka-tests --disable-mysql --disable-mysql-tests' \
+CI_MAKE_OPT='-j60' \
+CI_MAKE_CHECK_OPT='-j60 TESTS=' \
+CI_CHECK_CMD='check' \
+devtools/devcontainer.sh --rm devtools/run-ci.sh
+```
+
+Run focused testbench scripts after the container build:
+
+```sh
+RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+devtools/devcontainer.sh --rm ./tests/compat-configformat-rainerscript.sh
+
+RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+devtools/devcontainer.sh --rm ./tests/compat-configformat-yaml.sh
+```
+
+For broader local check runs, prefer:
+
+```sh
+make -j60 check
+```
+
+Clear obvious flakes locally, but do not treat unrelated flaky failures as part
+of the change unless they reproduce against the focused tests.
+
+## Clang Static Analyzer
+
+Clean before switching from a normal container build to analyzer mode so
+scan-build recompiles the tree:
+
+```sh
+make distclean || true
+rm -rf scan-build-report clang-analyzer.log
+```
+
+Run the analyzer with the same Ubuntu 26.04 container and service exclusions:
+
+```sh
+RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+SCAN_BUILD='scan-build' \
+SCAN_BUILD_CC='clang' \
+SCAN_BUILD_REPORT_DIR='scan-build-report' \
+DOCKER_RUN_EXTRA_OPTS='-e SCAN_BUILD -e SCAN_BUILD_CC -e SCAN_BUILD_REPORT_DIR' \
+RSYSLOG_CONFIGURE_OPTIONS_EXTRA='--disable-elasticsearch --disable-elasticsearch-tests --disable-imkafka --disable-omkafka --disable-kafka-tests --disable-mysql --disable-mysql-tests' \
+devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh 2>&1 | tee clang-analyzer.log
+```
+
+## Docker Storage
+
+If Docker storage runs short, prune from least intrusive to most intrusive:
+
+```sh
+docker container prune
+docker image prune
+docker builder prune
+docker system prune
+docker system prune -a
+```
+
+Use `docker system prune -a` only when the cheaper prunes do not recover enough
+space and there are no running containers that must be preserved.

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -347,6 +347,8 @@ EXTRA_DIST = \
     source/faq/impstats-push-mode.rst \
     source/faq/imudp-packet-loss.rst \
     source/faq/index.rst \
+    source/faq/tls_anon_auth_mitm.rst \
+    source/faq/tls_mode0_disables_tls.rst \
     source/faq/vespa-ai-integration.rst \
     source/features.rst \
     source/getting_started/ai-assistants.rst \

--- a/doc/source/faq/imtcp-tls-gibberish.rst
+++ b/doc/source/faq/imtcp-tls-gibberish.rst
@@ -91,6 +91,8 @@ See also
 --------
 
 * :doc:`../concepts/netstrm_drvr` — overview of TLS options in rsyslog
+* :doc:`tls_mode0_disables_tls` — transport mode disables TLS even when TLS params exist
+* :doc:`tls_anon_auth_mitm` — anonymous TLS auth and MITM risk
 * :doc:`../configuration/modules/imtcp` — reference for the TCP input module
 * :doc:`../configuration/modules/imptcp` — reference for the imptcp input module
 * :doc:`../troubleshooting/index` — general debugging tips

--- a/doc/source/faq/index.rst
+++ b/doc/source/faq/index.rst
@@ -13,5 +13,7 @@ FAQ
    imtcp-tls-gibberish
    impstats-push-mode
    etl_tool
+   tls_mode0_disables_tls
+   tls_anon_auth_mitm
    vespa-ai-integration
    does-rsyslog-run-under-windows

--- a/doc/source/faq/tls_anon_auth_mitm.rst
+++ b/doc/source/faq/tls_anon_auth_mitm.rst
@@ -1,0 +1,73 @@
+.. _faq-tls-anon-auth-mitm:
+.. _faq.tls.anon.auth.mitm:
+
+Why does rsyslog warn that anonymous TLS authentication allows MITM?
+=====================================================================
+
+.. meta::
+   :description: Explains why anonymous TLS auth modes do not authenticate peer identity and therefore permit MITM attacks.
+   :keywords: rsyslog, tls, authmode anon, streamdriver.authmode anon, tls.authmode anon, mitm
+
+.. summary-start
+
+TLS with anonymous authentication encrypts traffic but does not authenticate peer identity.
+Because identity is not verified, an active man-in-the-middle (MITM) can impersonate endpoints.
+
+.. summary-end
+
+What this warning means
+-----------------------
+
+The warning appears when TLS is enabled but authentication mode is set to anonymous, for example:
+
+* ``streamdriver.authmode="anon"`` (``imtcp`` / ``omfwd``)
+* ``tls.authmode="anon"`` (``imrelp`` / ``omrelp``)
+
+In this mode, you get encryption on the wire, but you do **not** get authenticated peer identity.
+
+Why this matters
+----------------
+
+Without identity checks (certificate name or chain validation against expected peers), an attacker
+who can intercept traffic can present another endpoint and relay/alter messages. That is exactly the
+MITM risk the warning calls out.
+
+How to fix
+----------
+
+Use authenticated TLS mode instead of anonymous mode:
+
+* Configure certificate trust (CA/cert/key as required by module/driver).
+* Use non-anonymous auth modes (for example x509-based modes) and set permitted peer constraints.
+
+How to turn this warning off
+----------------------------
+
+These messages are emitted by compatibility secure mode ``warn``.
+You can silence them by changing the global policy:
+
+* ``global(compatibility.defaults.secure="backward-compatible")``:
+  keeps old insecure defaults and suppresses these warnings.
+* ``global(compatibility.defaults.secure="strict")``:
+  enforces secure defaults and also suppresses these warnings because insecure
+  defaults are no longer used.
+
+The recommended path is to keep ``warn`` until configuration is remediated,
+then move to ``strict``.
+
+Primary tutorials
+-----------------
+
+* :doc:`../tutorials/tls` — TLS setup fundamentals
+* :doc:`../tutorials/tls_cert_summary` — certificate workflow and trust model
+* :doc:`../tutorials/tls_cert_client` and :doc:`../tutorials/tls_cert_server` — practical endpoint configuration
+
+See also
+--------
+
+* :doc:`tls_mode0_disables_tls` — TLS parameters present but TLS not active
+* :doc:`imtcp-tls-gibberish` — symptom when TLS/plain transport do not match
+* :doc:`../configuration/modules/imtcp`
+* :doc:`../configuration/modules/omfwd`
+* :doc:`../configuration/modules/imrelp`
+* :doc:`../configuration/modules/omrelp`

--- a/doc/source/faq/tls_mode0_disables_tls.rst
+++ b/doc/source/faq/tls_mode0_disables_tls.rst
@@ -1,0 +1,74 @@
+.. _faq-tls-mode0-disables-tls:
+.. _faq.tls.mode0.disables.tls:
+
+Why does rsyslog warn that TLS is not active with streamdriver.mode="0"?
+=========================================================================
+
+.. meta::
+   :description: Explains why TLS settings are ignored when streamdriver.mode=0 or when a transport runs without TLS.
+   :keywords: rsyslog, tls, streamdriver.mode, mode 0, plain tcp, omfwd, imtcp, imrelp, omrelp
+
+.. summary-start
+
+If a connection is configured with plain transport (for example, ``streamdriver.mode="0"``,
+UDP, or RELP ``tls="off"``), TLS is not in use even if other TLS-related parameters are present.
+
+.. summary-end
+
+What this warning means
+-----------------------
+
+The warning indicates that the effective transport is not TLS-protected. Common cases are:
+
+* ``imtcp`` or ``omfwd`` with ``streamdriver.mode="0"`` (plain TCP)
+* ``omfwd`` with ``protocol="udp"``
+* ``imrelp`` / ``omrelp`` with ``tls="off"``
+
+When these settings are active, encryption and certificate checks do not happen for that path.
+
+Why this matters
+----------------
+
+If operators set TLS-related parameters (driver name, auth mode, certs) but transport mode still
+selects plain communication, configuration can look secure while traffic remains unencrypted.
+The warning is emitted to prevent this false sense of security.
+
+How to fix
+----------
+
+Pick one explicit model and make it consistent:
+
+* **Use TLS intentionally:** configure a TLS-capable transport and keep TLS-auth parameters aligned.
+* **Use plain transport intentionally:** remove TLS-only parameters so intent is clear and warnings stop.
+
+How to turn this warning off
+----------------------------
+
+These messages are emitted by compatibility secure mode ``warn``.
+You can silence them by changing the global policy:
+
+* ``global(compatibility.defaults.secure="backward-compatible")``:
+  keeps old insecure defaults and suppresses these warnings.
+* ``global(compatibility.defaults.secure="strict")``:
+  enforces secure defaults and also suppresses these warnings because insecure
+  defaults are no longer used.
+
+The recommended path is to keep ``warn`` until configuration is remediated,
+then move to ``strict``.
+
+Primary tutorials
+-----------------
+
+* :doc:`../tutorials/tls` — end-to-end TLS setup basics
+* :doc:`../tutorials/tls_cert_summary` — certificate-based TLS deployment flow
+* :doc:`../tutorials/reliable_forwarding` — forwarding patterns you can combine with TLS
+
+See also
+--------
+
+* :doc:`tls_anon_auth_mitm` — why anonymous TLS auth still permits MITM
+* :doc:`imtcp-tls-gibberish` — TLS client talking to a plain listener
+* :doc:`../configuration/modules/imtcp`
+* :doc:`../configuration/modules/omfwd`
+* :doc:`../configuration/modules/imrelp`
+* :doc:`../configuration/modules/omrelp`

--- a/doc/source/reference/parameters/omclickhouse-allowunsignedcerts.rst
+++ b/doc/source/reference/parameters/omclickhouse-allowunsignedcerts.rst
@@ -21,15 +21,14 @@ This parameter applies to :doc:`/configuration/modules/omclickhouse`.
 :Name: allowUnsignedCerts
 :Scope: input
 :Type: boolean
-:Default: on
+:Default: off
 :Required?: no
 :Introduced: not specified
 
 Description
 -----------
-The module accepts connections to servers, which have unsigned certificates.
-If this parameter is disabled, the module will verify whether the
-certificates are authentic.
+If set to ``"on"``, the module accepts servers with unsigned certificates.
+By default (``"off"``), TLS peer certificates are verified.
 
 Input usage
 -----------

--- a/doc/source/reference/parameters/omfile-dynafile.rst
+++ b/doc/source/reference/parameters/omfile-dynafile.rst
@@ -39,6 +39,18 @@ used properly escapes file paths*. This is done by using the *securepath*
 parameter in the template's property statements, or the *secpath-drop*
 or *secpath-replace* property options with the property replacer.
 
+When ``global(compatibility.defaults.secure="strict")`` is active,
+dynafile templates default fields without explicit secure path handling
+to ``secpath-replace``.  The ``warn`` setting keeps the historical
+default and emits a warning for dynafile templates that need an explicit
+``securepath`` or ``secpath-*`` option.  The ``backward-compatible``
+setting keeps the historical default silently.
+
+If the same template is used both for ``dynaFile`` and for non-dynafile
+output, rsyslog emits a warning.  In strict mode the secure dynafile
+default still applies to that shared template.  Use separate templates
+when non-dynafile output must preserve literal slashes.
+
 Either file or dynaFile can be used, but not both. If both are given,
 dynaFile will be used.
 

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -58,6 +58,7 @@
 #include "wti.h"
 #include "unicode-helper.h"
 #include "errmsg.h"
+#include "glbl.h"
 #ifdef HAVE_LIBYAML
     #include "yamlconf.h"
 #endif
@@ -4919,7 +4920,15 @@ struct cnfstmt *cnfstmtNewPRIFILT(char *prifilt, struct cnfstmt *t_then) {
         cnfstmt->printable = (uchar *)prifilt;
         cnfstmt->d.s_prifilt.t_then = t_then;
         cnfstmt->d.s_prifilt.t_else = NULL;
-        DecodePRIFilter((uchar *)prifilt, cnfstmt->d.s_prifilt.pmask);
+        if (glblPermitSyslogdConfigFilter(loadConf, prifilt)) {
+            DecodePRIFilter((uchar *)prifilt, cnfstmt->d.s_prifilt.pmask);
+        } else {
+            free(cnfstmt->printable);
+            cnfstmt->printable = NULL;
+            cnfstmt->nodetype = S_NOP;
+            cnfstmtDestructLst(t_then);
+            cnfstmt->d.s_prifilt.t_then = NULL;
+        }
     }
     return cnfstmt;
 }
@@ -4931,7 +4940,13 @@ struct cnfstmt *cnfstmtNewPROPFILT(char *propfilt, struct cnfstmt *t_then) {
         cnfstmt->d.s_propfilt.t_then = t_then;
         cnfstmt->d.s_propfilt.regex_cache = NULL;
         cnfstmt->d.s_propfilt.pCSCompValue = NULL;
-        if (DecodePropFilter((uchar *)propfilt, cnfstmt) != RS_RET_OK) {
+        if (!glblPermitPropertyConfigFilter(loadConf, propfilt)) {
+            free(cnfstmt->printable);
+            cnfstmt->printable = NULL;
+            cnfstmt->nodetype = S_NOP;
+            cnfstmtDestructLst(t_then);
+            cnfstmt->d.s_propfilt.t_then = NULL;
+        } else if (DecodePropFilter((uchar *)propfilt, cnfstmt) != RS_RET_OK) {
             cnfstmt->nodetype = S_NOP; /* disable action! */
             cnfstmtDestructLst(t_then); /* we do no longer need this */
         }

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -496,6 +496,20 @@ finalize_it:
     RETiRet;
 }
 
+/** Warn in secure warn mode when an imrelp listener is configured without TLS. */
+static void warnIfPlainRelpListenerConfigured(const instanceConf_t *const inst) {
+    if (!inst->bEnableTLS) {
+        glblWarnIfInsecureDefault(loadModConf->pConf,
+                                  "imrelp input uses tls=\"off\" (plain RELP without TLS); "
+                                  "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+    } else if (inst->authmode != NULL && strcasecmp((const char *)inst->authmode, "anon") == 0) {
+        glblWarnIfInsecureDefault(
+            loadModConf->pConf,
+            "imrelp uses tls.authmode=\"anon\"; peer identity is not authenticated, so MITM is possible "
+            "(see https://docs.rsyslog.com/doc/faq/tls_anon_auth_mitm.html)");
+    }
+}
+
 
 BEGINnewInpInst
     struct cnfparamvals *pvals;
@@ -672,6 +686,8 @@ BEGINnewInpInst
         if (inst->ratelimitInterval == -1) inst->ratelimitInterval = 0;
         if (inst->ratelimitBurst == -1) inst->ratelimitBurst = 10000;
     }
+
+    warnIfPlainRelpListenerConfigured(inst);
 
     inst->bEnableLstn = -1; /* all ok, ready to start up */
 

--- a/plugins/imtcp/imtcp.c
+++ b/plugins/imtcp/imtcp.c
@@ -329,6 +329,33 @@ static rsRetVal validateLegacySessionLimits(void) {
     return RS_RET_OK;
 }
 
+/** Warn in secure warn mode when imtcp listener transport/auth settings reduce security. */
+static void warnIfInsecureListenerConfigured(const int streamDriverMode,
+                                             const uchar *const streamDriverName,
+                                             const uchar *const authMode) {
+    if (streamDriverMode == 0) {
+        const int tlsHintsConfigured =
+            (authMode != NULL) || (streamDriverName != NULL && strcasecmp((const char *)streamDriverName, "ptcp") != 0);
+        if (tlsHintsConfigured) {
+            glblWarnIfInsecureDefault(loadConf,
+                                      "imtcp has TLS-related settings but streamdriver.mode=\"0\"; mode 0 uses plain "
+                                      "TCP so TLS is not active "
+                                      "(see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html)");
+        } else {
+            glblWarnIfInsecureDefault(loadConf,
+                                      "imtcp input uses streamdriver.mode=\"0\" (plain TCP without TLS); "
+                                      "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+        }
+    }
+
+    if (streamDriverMode != 0 && authMode != NULL && strcasecmp((const char *)authMode, "anon") == 0) {
+        glblWarnIfInsecureDefault(
+            loadConf,
+            "imtcp uses streamdriver.authmode=\"anon\"; server identity is not authenticated, so MITM is possible "
+            "(see https://docs.rsyslog.com/doc/faq/tls_anon_auth_mitm.html)");
+    }
+}
+
 /* callbacks */
 /* this shall go into a specific ACL module! */
 static int isPermittedHost(struct sockaddr *addr,
@@ -773,6 +800,7 @@ BEGINnewInpInst
             inst->ratelimitBurst = 10000;
         }
     }
+    warnIfInsecureListenerConfigured(inst->iStrmDrvrMode, inst->pszStrmDrvrName, inst->pszStrmDrvrAuthMode);
 
 finalize_it:
     CODE_STD_FINALIZERnewInpInst cnfparamvalsDestruct(pvals, &inppblk);
@@ -930,6 +958,8 @@ BEGINsetModCnf
      */
     bLegacyCnfModGlobalsPermitted = 0;
     loadModConf->configSetViaV2Method = 1;
+    warnIfInsecureListenerConfigured(loadModConf->iStrmDrvrMode, loadModConf->pszStrmDrvrName,
+                                     loadModConf->pszStrmDrvrAuthMode);
 
 finalize_it:
     if (pvals != NULL) cnfparamvalsDestruct(pvals, &modpblk);
@@ -972,6 +1002,8 @@ BEGINendCnfLoad
             cs.pszStrmDrvrAuthMode = NULL;
         }
         pModConf->bPreserveCase = cs.bPreserveCase;
+        warnIfInsecureListenerConfigured(pModConf->iStrmDrvrMode, pModConf->pszStrmDrvrName,
+                                         pModConf->pszStrmDrvrAuthMode);
     }
     free(cs.pszStrmDrvrAuthMode);
     cs.pszStrmDrvrAuthMode = NULL;

--- a/plugins/omclickhouse/omclickhouse.c
+++ b/plugins/omclickhouse/omclickhouse.c
@@ -586,7 +586,7 @@ static void ATTR_NONNULL() setInstParamDefaults(instanceData *const pData) {
     pData->authBuf = NULL;
     pData->tplName = NULL;
     pData->useHttps = 1;
-    pData->allowUnsignedCerts = 1;
+    pData->allowUnsignedCerts = 0;
     pData->skipVerifyHost = 0;
     pData->errorFile = NULL;
     pData->bulkmode = 1;

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -446,6 +446,20 @@ finalize_it:
     if (pvals != NULL) cnfparamvalsDestruct(pvals, &modpblk);
 ENDsetModCnf
 
+/** Warn in secure warn mode when an omrelp action is configured without TLS. */
+static void warnIfPlainRelpActionConfigured(const instanceData *const pData) {
+    if (!pData->bEnableTLS) {
+        glblWarnIfInsecureDefault(loadModConf->pConf,
+                                  "omrelp action uses tls=\"off\" (plain RELP without TLS); "
+                                  "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+    } else if (pData->authmode != NULL && strcasecmp((const char *)pData->authmode, "anon") == 0) {
+        glblWarnIfInsecureDefault(
+            loadModConf->pConf,
+            "omrelp uses tls.authmode=\"anon\"; peer identity is not authenticated, so MITM is possible "
+            "(see https://docs.rsyslog.com/doc/faq/tls_anon_auth_mitm.html)");
+    }
+}
+
 BEGINnewActInst
     struct cnfparamvals *pvals;
     int i, j;
@@ -548,6 +562,8 @@ BEGINnewActInst
     CHKiRet(OMSRsetEntry(*ppOMSR, 0,
                          (uchar *)strdup((pData->tplName == NULL) ? "RSYSLOG_ForwardFormat" : (char *)pData->tplName),
                          OMSR_NO_RQD_TPL_OPTS));
+
+    warnIfPlainRelpActionConfigured(pData);
 
     iRet = doCreateRelpClient(pData, &pRelpClt);
     if (pRelpClt != NULL) relpEngineCltDestruct(pRelpEngine, &pRelpClt);

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -164,6 +164,10 @@ static struct cnfparamdescr cnfparamdescr[] = {
     {"net.aclresolvehostname", eCmdHdlrBinary, 0},
     {"net.enabledns", eCmdHdlrBinary, 0},
     {"net.permitACLwarning", eCmdHdlrBinary, 0},
+    {"compatibility.configformat.legacy", eCmdHdlrGetWord, 0},
+    {"compatibility.configformat.syslogd", eCmdHdlrGetWord, 0},
+    {"compatibility.configformat.property", eCmdHdlrGetWord, 0},
+    {"compatibility.defaults.secure", eCmdHdlrGetWord, 0},
     {"abortonuncleanconfig", eCmdHdlrBinary, 0},
     {"abortonfailedqueuestartup", eCmdHdlrBinary, 0},
     {"variables.casesensitive", eCmdHdlrBinary, 0},
@@ -664,6 +668,112 @@ static rsRetVal ATTR_NONNULL() setReportChildProcessExits(const uchar *const mod
     RETiRet;
 }
 
+/** Convert enable/warn/disable config-format policy text to its internal enum. */
+static rsRetVal ATTR_NONNULL()
+    setCompatConfigFormatMode(const char *const param, const uchar *const mode, int *const dst) {
+    DEFiRet;
+    if (!strcmp((const char *)mode, "enable")) {
+        *dst = COMPAT_CONFIGFORMAT_ENABLE;
+    } else if (!strcmp((const char *)mode, "warn")) {
+        *dst = COMPAT_CONFIGFORMAT_WARN;
+    } else if (!strcmp((const char *)mode, "disable")) {
+        *dst = COMPAT_CONFIGFORMAT_DISABLE;
+    } else {
+        parser_errmsg("invalid value '%s' for global parameter %s", mode, param);
+        iRet = RS_RET_CONF_PARAM_INVLD;
+    }
+    RETiRet;
+}
+
+/** Convert strict/backward-compatible/warn secure-defaults policy text to its internal enum. */
+static rsRetVal ATTR_NONNULL() setCompatDefaultsSecure(const uchar *const mode) {
+    DEFiRet;
+    if (!strcmp((const char *)mode, "strict")) {
+        loadConf->globals.compatDefaultsSecure = COMPAT_DEFAULTS_SECURE_STRICT;
+        loadConf->globals.bAbortOnUncleanConfig = 1;
+    } else if (!strcmp((const char *)mode, "backward-compatible")) {
+        loadConf->globals.compatDefaultsSecure = COMPAT_DEFAULTS_SECURE_BACKWARD_COMPATIBLE;
+    } else if (!strcmp((const char *)mode, "warn")) {
+        loadConf->globals.compatDefaultsSecure = COMPAT_DEFAULTS_SECURE_WARN;
+    } else {
+        parser_errmsg("invalid value '%s' for global parameter compatibility.defaults.secure", mode);
+        iRet = RS_RET_CONF_PARAM_INVLD;
+    }
+    RETiRet;
+}
+
+/** Apply a global compatibility enum string during config parsing. */
+static rsRetVal ATTR_NONNULL() processCompatGlobalParam(const char *const name, struct cnfparamvals *const pval) {
+    char *mode;
+    DEFiRet;
+
+    mode = es_str2cstr(pval->val.d.estr, NULL);
+    if (mode == NULL) {
+        parser_errmsg("out of memory processing global parameter %s", name);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
+    if (!strcmp(name, "compatibility.configformat.legacy")) {
+        CHKiRet(setCompatConfigFormatMode(name, (uchar *)mode, &loadConf->globals.compatConfigFormatLegacy));
+    } else if (!strcmp(name, "compatibility.configformat.syslogd")) {
+        CHKiRet(setCompatConfigFormatMode(name, (uchar *)mode, &loadConf->globals.compatConfigFormatSyslogd));
+    } else if (!strcmp(name, "compatibility.configformat.property")) {
+        CHKiRet(setCompatConfigFormatMode(name, (uchar *)mode, &loadConf->globals.compatConfigFormatProperty));
+    } else if (!strcmp(name, "compatibility.defaults.secure")) {
+        CHKiRet(setCompatDefaultsSecure((uchar *)mode));
+    }
+
+finalize_it:
+    free(mode);
+    RETiRet;
+}
+
+/** Emit a compatibility warning through the parser diagnostics path. */
+static void ATTR_NONNULL() compatParserWarnmsg(const char *const msg) {
+    parser_warnmsg("%s", msg);
+}
+
+/** Emit warning/error for compatibility-controlled legacy syntax and say how to re-enable it. */
+static int ATTR_NONNULL()
+    permitCompatSyntax(const int mode, const char *const kind, const char *const text, const char *const option) {
+    int permitted = 1;
+
+    if (mode == COMPAT_CONFIGFORMAT_WARN) {
+        char msg[1024];
+        snprintf(msg, sizeof(msg), "obsolete %s syntax encountered: '%s'", kind, text);
+        msg[sizeof(msg) - 1] = '\0';
+        compatParserWarnmsg(msg);
+    } else if (mode == COMPAT_CONFIGFORMAT_DISABLE) {
+        parser_errmsg("obsolete %s syntax disabled: '%s'; use global(%s=\"enable\") to enable it", kind, text, option);
+        permitted = 0;
+    }
+
+    return permitted;
+}
+
+int glblPermitLegacyConfigDirective(rsconf_t *cnf, const char *directive) {
+    return permitCompatSyntax(cnf->globals.compatConfigFormatLegacy, "$-directive", directive,
+                              "compatibility.configformat.legacy");
+}
+
+int glblPermitSyslogdConfigFilter(rsconf_t *cnf, const char *filter) {
+    return permitCompatSyntax(cnf->globals.compatConfigFormatSyslogd, "classic syslogd filter", filter,
+                              "compatibility.configformat.syslogd");
+}
+
+int glblPermitPropertyConfigFilter(rsconf_t *cnf, const char *filter) {
+    return permitCompatSyntax(cnf->globals.compatConfigFormatProperty, "classic property-based filter", filter,
+                              "compatibility.configformat.property");
+}
+
+void glblWarnIfInsecureDefault(rsconf_t *cnf, const char *detail) {
+    if (cnf != NULL && cnf->globals.compatDefaultsSecure == COMPAT_DEFAULTS_SECURE_WARN) {
+        parser_warnmsg(
+            "backward-compatible insecure default in use: %s; "
+            "use global(compatibility.defaults.secure=\"strict\") to enable the secure default",
+            detail);
+    }
+}
+
 static int getDefPFFamily(rsconf_t *cnf) {
     return cnf->globals.iDefPFFamily;
 }
@@ -1088,6 +1198,12 @@ void glblProcessCnf(struct cnfobj *o) {
         } else if (!strcmp(paramblk.descr[i].name, "security.abortonidresolutionfail")) {
             loadConf->globals.abortOnIDResolutionFail = (int)cnfparamvals[i].val.d.n;
             cnfparamvals[i].bUsed = TRUE;
+        } else if (!strncmp(paramblk.descr[i].name, "compatibility.", 14)) {
+            if (processCompatGlobalParam(paramblk.descr[i].name, &cnfparamvals[i]) == RS_RET_OK) {
+                cnfparamvals[i].bUsed = 1;
+            } else {
+                dbgprintf("glblProcessCnf: failed to process early global parameter '%s'\n", paramblk.descr[i].name);
+            }
         }
     }
 done:
@@ -1352,6 +1468,8 @@ rsRetVal glblDoneLoadCnf(void) {
             SetDisableDNS(!((int)cnfparamvals[i].val.d.n));
         } else if (!strcmp(paramblk.descr[i].name, "net.permitwarning")) {
             SetOptionDisallowWarning(!((int)cnfparamvals[i].val.d.n));
+        } else if (!strncmp(paramblk.descr[i].name, "compatibility.", 14)) {
+            /* processed immediately by glblProcessCnf(), as later syntax depends on it */
         } else if (!strcmp(paramblk.descr[i].name, "abortonuncleanconfig")) {
             loadConf->globals.bAbortOnUncleanConfig = cnfparamvals[i].val.d.n;
         } else if (!strcmp(paramblk.descr[i].name, "abortonfailedqueuestartup")) {
@@ -1425,6 +1543,12 @@ rsRetVal glblDoneLoadCnf(void) {
     if (loadConf->globals.debugOnShutdown && Debug != DEBUG_FULL) {
         Debug = DEBUG_ONDEMAND;
         stddbg = -1;
+    }
+
+    if (loadConf->globals.compatDefaultsSecure == COMPAT_DEFAULTS_SECURE_STRICT) {
+        loadConf->globals.bAbortOnUncleanConfig = 1;
+    } else if (!loadConf->globals.bAbortOnUncleanConfig) {
+        glblWarnIfInsecureDefault(loadConf, "global(abortOnUncleanConfig=\"off\")");
     }
 
 finalize_it:

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -159,5 +159,13 @@ int glblGetOversizeMsgInputMode(rsconf_t *cnf);
 int glblReportOversizeMessage(rsconf_t *cnf);
 void glblReportChildProcessExit(rsconf_t *cnf, const uchar *name, pid_t pid, int status);
 uchar *glblGetLocalHostName(void);
+/** Check whether a legacy $-directive may be processed under the active compatibility policy. */
+int glblPermitLegacyConfigDirective(rsconf_t *cnf, const char *directive);
+/** Check whether a classic syslogd PRI selector may be processed under the active compatibility policy. */
+int glblPermitSyslogdConfigFilter(rsconf_t *cnf, const char *filter);
+/** Check whether a classic property-based selector filter may be processed under the active compatibility policy. */
+int glblPermitPropertyConfigFilter(rsconf_t *cnf, const char *filter);
+/** Emit an insecure-default warning when compatibility.defaults.secure is set to warn. */
+void glblWarnIfInsecureDefault(rsconf_t *cnf, const char *detail);
 
 #endif /* #ifndef GLBL_H_INCLUDED */

--- a/runtime/objomsr.c
+++ b/runtime/objomsr.c
@@ -140,7 +140,7 @@ int OMSRgetEntry(omodStringRequest_t *pThis, int iEntry, uchar **ppTplName, int 
 rsRetVal OMSRgetSupportedTplOpts(unsigned long *pOpts) {
     DEFiRet;
     assert(pOpts != NULL);
-    *pOpts = OMSR_RQD_TPL_OPT_SQL | OMSR_TPL_AS_ARRAY | OMSR_TPL_AS_MSG | OMSR_TPL_AS_JSON;
+    *pOpts = OMSR_RQD_TPL_OPT_SQL | OMSR_TPL_AS_ARRAY | OMSR_TPL_AS_MSG | OMSR_TPL_AS_JSON | OMSR_TPL_AS_DYNAFILE;
     RETiRet;
 }
 

--- a/runtime/objomsr.h
+++ b/runtime/objomsr.h
@@ -31,7 +31,9 @@
 #define OMSR_TPL_AS_ARRAY 2 /* introduced in 4.1.6, 2009-04-03 */
 #define OMSR_TPL_AS_MSG 4 /* introduced in 5.3.4, 2009-11-02 */
 #define OMSR_TPL_AS_JSON 8 /* introduced in 6.5.1, 2012-09-02 */
-/* next option is 16, 32, 64, ... */
+/** Template is used to render a dynamic file name. */
+#define OMSR_TPL_AS_DYNAFILE 16
+/* next option is 32, 64, ... */
 
 struct omodStringRequest_s { /* strings requested by output module for doAction() */
     int iNumEntries; /* number of array entries for data elements below */

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -180,6 +180,10 @@ static void cnfSetDefaults(rsconf_t *pThis) {
 #endif
     pThis->globals.bAbortOnUncleanConfig = 0;
     pThis->globals.bAbortOnFailedQueueStartup = 0;
+    pThis->globals.compatConfigFormatLegacy = COMPAT_CONFIGFORMAT_ENABLE;
+    pThis->globals.compatConfigFormatSyslogd = COMPAT_CONFIGFORMAT_ENABLE;
+    pThis->globals.compatConfigFormatProperty = COMPAT_CONFIGFORMAT_ENABLE;
+    pThis->globals.compatDefaultsSecure = COMPAT_DEFAULTS_SECURE_WARN;
     pThis->globals.bReduceRepeatMsgs = 0;
     pThis->globals.bDebugPrintTemplateList = 1;
     pThis->globals.bDebugPrintModuleList = 0;
@@ -691,6 +695,10 @@ void cnfDoCfsysline(char *ln) {
                                       ln);
     }
     DBGPRINTF("cnf:global:cfsysline: %s\n", ln);
+    if (!glblPermitLegacyConfigDirective(loadConf, ln)) {
+        free(ln);
+        return;
+    }
     /* the legacy system needs the "$" stripped */
     conf.cfsysline((uchar *)ln + 1);
     free(ln);

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -37,6 +37,14 @@
 #define REPORT_CHILD_PROCESS_EXITS_ERRORS 1
 #define REPORT_CHILD_PROCESS_EXITS_ALL 2
 
+#define COMPAT_CONFIGFORMAT_ENABLE 0
+#define COMPAT_CONFIGFORMAT_WARN 1
+#define COMPAT_CONFIGFORMAT_DISABLE 2
+
+#define COMPAT_DEFAULTS_SECURE_STRICT 0
+#define COMPAT_DEFAULTS_SECURE_BACKWARD_COMPATIBLE 1
+#define COMPAT_DEFAULTS_SECURE_WARN 2
+
 #ifndef DFLT_INT_MSGS_SEV_FILTER
     #define DFLT_INT_MSGS_SEV_FILTER 6 /* Warning level and more important */
 #endif
@@ -100,6 +108,10 @@ struct globals_s {
                       config) if there was any issue in conf */
     int bAbortOnFailedQueueStartup; /* similar to bAbortOnUncleanConfig, but abort if a queue
                        startup fails. This is not exactly an unclan config. */
+    int compatConfigFormatLegacy; /* policy for legacy $-directives */
+    int compatConfigFormatSyslogd; /* policy for classic syslogd PRI selectors */
+    int compatConfigFormatProperty; /* policy for classic property-based selector filters */
+    int compatDefaultsSecure; /* policy for defaults that affect secure-by-default behavior */
     int uidDropPriv; /* user-id to which priveleges should be dropped to */
     int gidDropPriv; /* group-id to which priveleges should be dropped to */
     int gidDropPrivKeepSupplemental; /* keep supplemental groups when dropping? */

--- a/template.c
+++ b/template.c
@@ -78,6 +78,83 @@ static rsRetVal tplJsonBuildTree(struct template *pTpl);
 static rsRetVal tplJsonRender(struct template *pTpl, smsg_t *pMsg, actWrkrIParams_t *iparam, struct syslogTime *ttNow);
 static rsRetVal tplJsonRenderChildren(
     const struct tplJsonNode *parent, smsg_t *pMsg, struct syslogTime *ttNow, es_str_t **ppDst, int *pNeedComma);
+
+/** Returns true when at least one field lacks explicit secure path handling. */
+static int tplNeedsDynafileSecureDefault(const struct template *const pTpl) {
+    const struct templateEntry *pTpe;
+
+    assert(pTpl != NULL);
+    for (pTpe = pTpl->pEntryRoot; pTpe != NULL; pTpe = pTpe->pNext) {
+        if (pTpe->eEntryType == FIELD && !pTpe->data.field.options.bSecPathDrop &&
+            !pTpe->data.field.options.bSecPathReplace) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+
+/** Applies the strict dynafile path default to fields without explicit mode. */
+static void tplApplyDynafileSecureDefault(struct template *const pTpl) {
+    struct templateEntry *pTpe;
+
+    assert(pTpl != NULL);
+    for (pTpe = pTpl->pEntryRoot; pTpe != NULL; pTpe = pTpe->pNext) {
+        if (pTpe->eEntryType == FIELD && !pTpe->data.field.options.bSecPathDrop &&
+            !pTpe->data.field.options.bSecPathReplace) {
+            pTpe->data.field.options.bSecPathReplace = 1;
+            pTpe->bComplexProcessing = 1;
+        }
+    }
+    pTpl->bAppliedDynafileSecureDefault = 1;
+}
+
+
+/** Records a template use and enforces compatibility.defaults.secure policy. */
+void tplNoteUse(struct template *const pTpl, const int bDynafile) {
+    assert(pTpl != NULL);
+
+    if (bDynafile) {
+        pTpl->bUsedAsDynafile = 1;
+    } else {
+        pTpl->bUsedAsNonDynafile = 1;
+    }
+
+    if (pTpl->bUsedAsDynafile && pTpl->bUsedAsNonDynafile && !pTpl->bWarnedDynafileMixedUse) {
+        if (loadConf->globals.compatDefaultsSecure == COMPAT_DEFAULTS_SECURE_STRICT) {
+            parser_warnmsg(
+                "template '%s' is used both as an omfile dynafile template and for other output; "
+                "strict secure dynafile defaults apply to the shared template, use separate templates "
+                "if literal slashes must be preserved outside dynafile paths",
+                pTpl->pszName);
+        } else {
+            parser_warnmsg(
+                "template '%s' is used both as an omfile dynafile template and for other output; "
+                "in strict mode, secure dynafile defaults apply to the shared template, use separate "
+                "templates if literal slashes must be preserved outside dynafile paths",
+                pTpl->pszName);
+        }
+        pTpl->bWarnedDynafileMixedUse = 1;
+    }
+
+    if (!bDynafile || !tplNeedsDynafileSecureDefault(pTpl)) {
+        return;
+    }
+
+    if (loadConf->globals.compatDefaultsSecure == COMPAT_DEFAULTS_SECURE_STRICT) {
+        if (!pTpl->bAppliedDynafileSecureDefault) {
+            tplApplyDynafileSecureDefault(pTpl);
+        }
+    } else if (loadConf->globals.compatDefaultsSecure == COMPAT_DEFAULTS_SECURE_WARN &&
+               !pTpl->bWarnedDynafileSecureDefault) {
+        parser_warnmsg(
+            "backward-compatible insecure default in use: omfile dynafile template '%s' has "
+            "fields without securepath handling; use global(compatibility.defaults.secure=\"strict\") "
+            "to default them to secpath-replace",
+            pTpl->pszName);
+        pTpl->bWarnedDynafileSecureDefault = 1;
+    }
+}
 static rsRetVal tplJsonRenderNode(
     const struct tplJsonNode *node, smsg_t *pMsg, struct syslogTime *ttNow, es_str_t **ppOut, int *pHasOutput);
 static rsRetVal tplJsonRenderValue(

--- a/template.h
+++ b/template.h
@@ -61,6 +61,11 @@ struct template {
     char bJsonTreeEnabled;
     struct tplJsonNode *pJsonRoot;
     char bJsonTreeBuilt;
+    unsigned bUsedAsDynafile : 1; /**< template renders an omfile dynamic file name */
+    unsigned bUsedAsNonDynafile : 1; /**< template also has a non-dynafile use */
+    unsigned bWarnedDynafileMixedUse : 1; /**< mixed-use warning was already emitted */
+    unsigned bWarnedDynafileSecureDefault : 1; /**< warn-mode notice was already emitted */
+    unsigned bAppliedDynafileSecureDefault : 1; /**< strict-mode default was already applied */
 };
 
 enum EntryTypes { UNDEFINED = 0, CONSTANT = 1, FIELD = 2 };
@@ -192,6 +197,7 @@ void tplPrintList(rsconf_t *conf);
 void tplLastStaticInit(rsconf_t *conf, struct template *tpl);
 rsRetVal ExtendBuf(actWrkrIParams_t *const iparam, const size_t iMinSize);
 int tplRequiresDateCall(struct template *pTpl);
+void tplNoteUse(struct template *pTpl, int bDynafile);
 /* note: if a compiler warning for undefined type tells you to look at this
  * code line below, the actual cause is that you currently MUST include template.h
  * BEFORE msg.h, even if your code file does not actually need it.

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -273,6 +273,8 @@ TESTS_DEFAULT = \
 	asynwr_deadlock2.sh \
 	asynwr_deadlock4.sh \
 	asynwr_dynfile_flushtxend-off.sh \
+	compat-configformat-rainerscript.sh \
+	compat-defaults-secure-dynafile-rainerscript.sh \
 	abort-uncleancfg-goodcfg.sh \
 	abort-uncleancfg-goodcfg-check.sh \
 	abort-uncleancfg-badcfg-check.sh \
@@ -575,6 +577,8 @@ TESTS_LIBYAML = \
 	config-translate-legacy-debian-default.sh \
 	config-translate-legacy-file-action.sh \
 	config-translate-yaml-to-rs.sh \
+	compat-configformat-yaml.sh \
+	compat-defaults-secure-dynafile-yaml.sh \
 	ratelimit_hup.sh \
 	yaml-basic.sh \
 	yaml-basic-yamlonly.sh \

--- a/tests/compat-configformat-rainerscript.sh
+++ b/tests/compat-configformat-rainerscript.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Validate RainerScript parity for compatibility.* global options.
+. ${srcdir:=.}/diag.sh init
+
+modpath="${RSYSLOG_MODDIR}"
+have_imtcp_module=0
+if ls ../plugins/imtcp/.libs/imtcp.* >/dev/null 2>&1; then
+    have_imtcp_module=1
+fi
+
+run_expect_success() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "FAIL: expected ${cfg} to validate"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+run_expect_failure() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "FAIL: expected ${cfg} to fail validation"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+cat >"${RSYSLOG_DYNNAME}.valid.conf" <<CONF_EOF
+global(
+  compatibility.configformat.legacy="enable"
+  compatibility.configformat.syslogd="enable"
+  compatibility.configformat.property="enable"
+  compatibility.defaults.secure="backward-compatible"
+)
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.valid.conf" "${RSYSLOG_DYNNAME}.valid.log"
+
+cat >"${RSYSLOG_DYNNAME}.secure-default.conf" <<CONF_EOF
+global(compatibility.configformat.legacy="enable")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.secure-default.conf" "${RSYSLOG_DYNNAME}.secure-default.log"
+content_check 'backward-compatible insecure default in use' "${RSYSLOG_DYNNAME}.secure-default.log"
+
+cat >"${RSYSLOG_DYNNAME}.legacy-warn.conf" <<CONF_EOF
+global(compatibility.configformat.legacy="warn")
+\$MainMsgQueueTimeoutShutdown 10000
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.legacy-warn.conf" "${RSYSLOG_DYNNAME}.legacy-warn.log"
+content_check 'obsolete $-directive syntax encountered' "${RSYSLOG_DYNNAME}.legacy-warn.log"
+
+cat >"${RSYSLOG_DYNNAME}.legacy-disable.conf" <<CONF_EOF
+global(compatibility.configformat.legacy="disable")
+\$MainMsgQueueTimeoutShutdown 10000
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_failure "${RSYSLOG_DYNNAME}.legacy-disable.conf" "${RSYSLOG_DYNNAME}.legacy-disable.log"
+content_check 'global(compatibility.configformat.legacy="enable")' "${RSYSLOG_DYNNAME}.legacy-disable.log"
+
+cat >"${RSYSLOG_DYNNAME}.syslogd-warn.conf" <<CONF_EOF
+global(compatibility.configformat.syslogd="warn")
+mail.* action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.syslogd-warn.conf" "${RSYSLOG_DYNNAME}.syslogd-warn.log"
+content_check 'obsolete classic syslogd filter syntax encountered' "${RSYSLOG_DYNNAME}.syslogd-warn.log"
+
+cat >"${RSYSLOG_DYNNAME}.syslogd-disable.conf" <<CONF_EOF
+global(compatibility.configformat.syslogd="disable")
+mail.* action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out2")
+CONF_EOF
+run_expect_failure "${RSYSLOG_DYNNAME}.syslogd-disable.conf" "${RSYSLOG_DYNNAME}.syslogd-disable.log"
+content_check 'global(compatibility.configformat.syslogd="enable")' "${RSYSLOG_DYNNAME}.syslogd-disable.log"
+
+cat >"${RSYSLOG_DYNNAME}.property-warn.conf" <<CONF_EOF
+global(compatibility.configformat.property="warn")
+:msg, contains, "hello" action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.property-warn.conf" "${RSYSLOG_DYNNAME}.property-warn.log"
+content_check 'obsolete classic property-based filter syntax encountered' "${RSYSLOG_DYNNAME}.property-warn.log"
+
+if [ ${have_imtcp_module} -eq 1 ]; then
+    cat >"${RSYSLOG_DYNNAME}.tls-warn.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="${RSYSLOG_DYNNAME}.tlswarn.port" streamdriver.mode="0"
+      streamdriver.name="gtls" streamdriver.authmode="x509/name")
+action(type="omfwd" target="127.0.0.1" protocol="udp")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.tls-warn.conf" "${RSYSLOG_DYNNAME}.tls-warn.log"
+    content_check 'imtcp has TLS-related settings but streamdriver.mode="0"; mode 0 uses plain TCP so TLS is not active' "${RSYSLOG_DYNNAME}.tls-warn.log"
+    content_check 'omfwd action uses protocol="udp" (without TLS)' "${RSYSLOG_DYNNAME}.tls-warn.log"
+
+    cat >"${RSYSLOG_DYNNAME}.tls-anon-warn.conf" <<CONF_EOF
+global(compatibility.defaults.secure="warn")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="${RSYSLOG_DYNNAME}.tlsanon.port" streamdriver.mode="1"
+      streamdriver.name="gtls" streamdriver.authmode="anon")
+action(type="omfwd" target="127.0.0.1" protocol="tcp" streamdriver.mode="1" streamdriver.authmode="anon")
+CONF_EOF
+    run_expect_success "${RSYSLOG_DYNNAME}.tls-anon-warn.conf" "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
+    content_check 'imtcp uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
+    content_check 'omfwd uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
+fi
+
+cat >"${RSYSLOG_DYNNAME}.invalid.conf" <<CONF_EOF
+global(compatibility.configformat.legacy="bad")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+run_expect_failure "${RSYSLOG_DYNNAME}.invalid.conf" "${RSYSLOG_DYNNAME}.invalid.log"
+content_check 'compatibility.configformat.legacy' "${RSYSLOG_DYNNAME}.invalid.log"
+
+cat >"${RSYSLOG_DYNNAME}.strict-dirty.conf" <<CONF_EOF
+global(compatibility.defaults.secure="strict")
+global(typo.parameter="bad")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+timeout 10s ../tools/rsyslogd -C -n -i"${RSYSLOG_DYNNAME}:strict.pid" -M"${modpath}" \
+    -f"${RSYSLOG_DYNNAME}.strict-dirty.conf" >"${RSYSLOG_DYNNAME}.strict-dirty.log" 2>&1
+rc=$?
+if [ $rc -ne 2 ]; then
+    echo "FAIL: expected secure strict mode to abort unclean config with rc 2"
+    cat "${RSYSLOG_DYNNAME}.strict-dirty.log"
+    error_exit 1
+fi
+content_check 'global(AbortOnUncleanConfig="on") is set' "${RSYSLOG_DYNNAME}.strict-dirty.log"
+
+exit_test

--- a/tests/compat-configformat-yaml.sh
+++ b/tests/compat-configformat-yaml.sh
@@ -1,0 +1,237 @@
+#!/bin/bash
+# Validate compatibility.* global options from YAML configs.
+. ${srcdir:=.}/diag.sh init
+
+modpath="${RSYSLOG_MODDIR}"
+
+run_expect_success() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "FAIL: expected ${cfg} to validate"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+run_expect_failure() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -eq 0 ]; then
+        echo "FAIL: expected ${cfg} to fail validation"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+write_yaml_action_config() {
+    local cfg="$1"
+    local extra_global="$2"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+${extra_global}
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+}
+
+write_yaml_syslogd_config() {
+    local cfg="$1"
+    local mode="$2"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  compatibility.configformat.syslogd: "${mode}"
+rulesets:
+  - name: main
+    filter: "mail.*"
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+}
+
+write_yaml_property_config() {
+    local cfg="$1"
+    local mode="$2"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  compatibility.configformat.property: "${mode}"
+rulesets:
+  - name: main
+    filter: ':msg, contains, "hello"'
+    actions:
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.out"
+YAML_EOF
+}
+
+write_yaml_global_only() {
+    local cfg="$1"
+    local mode="$2"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  compatibility.configformat.legacy: "${mode}"
+YAML_EOF
+}
+
+write_yaml_tls_warn_config() {
+    local cfg="$1"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+inputs:
+  - type: imtcp
+    port: "0"
+    listenPortFileName: "${RSYSLOG_DYNNAME}.tlswarn.port"
+    streamdriver.mode: 0
+    streamdriver.name: "gtls"
+    streamdriver.authmode: "x509/name"
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        protocol: "udp"
+YAML_EOF
+}
+
+write_yaml_tls_anon_warn_config() {
+    local cfg="$1"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "warn"
+modules:
+  - load: "../plugins/imtcp/.libs/imtcp"
+inputs:
+  - type: imtcp
+    port: "0"
+    listenPortFileName: "${RSYSLOG_DYNNAME}.tlsanon.port"
+    streamdriver.mode: 1
+    streamdriver.name: "gtls"
+    streamdriver.authmode: "anon"
+rulesets:
+  - name: main
+    actions:
+      - type: omfwd
+        target: "127.0.0.1"
+        protocol: "tcp"
+        streamdriver.mode: 1
+        streamdriver.authmode: "anon"
+YAML_EOF
+}
+
+write_legacy_wrapper() {
+    local cfg="$1"
+    local yaml_cfg="$2"
+    cat >"${cfg}" <<CONF_EOF
+include(file="${yaml_cfg}")
+\$MainMsgQueueTimeoutShutdown 10000
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+}
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.all-valid.yaml" \
+'  compatibility.configformat.legacy: "disable"
+  compatibility.configformat.syslogd: "warn"
+  compatibility.configformat.property: "enable"
+  compatibility.defaults.secure: "strict"'
+run_expect_success "${RSYSLOG_DYNNAME}.all-valid.yaml" "${RSYSLOG_DYNNAME}.all-valid.log"
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.secure-default.yaml" \
+'  compatibility.configformat.legacy: "enable"'
+run_expect_success "${RSYSLOG_DYNNAME}.secure-default.yaml" "${RSYSLOG_DYNNAME}.secure-default.log"
+content_check 'backward-compatible insecure default in use' "${RSYSLOG_DYNNAME}.secure-default.log"
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.secure-warn.yaml" \
+'  compatibility.defaults.secure: "warn"'
+run_expect_success "${RSYSLOG_DYNNAME}.secure-warn.yaml" "${RSYSLOG_DYNNAME}.secure-warn.log"
+content_check 'backward-compatible insecure default in use' "${RSYSLOG_DYNNAME}.secure-warn.log"
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.bad-legacy.yaml" \
+'  compatibility.configformat.legacy: "bogus"'
+run_expect_failure "${RSYSLOG_DYNNAME}.bad-legacy.yaml" "${RSYSLOG_DYNNAME}.bad-legacy.log"
+content_check 'invalid value' "${RSYSLOG_DYNNAME}.bad-legacy.log"
+content_check 'compatibility.configformat.legacy' "${RSYSLOG_DYNNAME}.bad-legacy.log"
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.bad-syslogd.yaml" \
+'  compatibility.configformat.syslogd: "bogus"'
+run_expect_failure "${RSYSLOG_DYNNAME}.bad-syslogd.yaml" "${RSYSLOG_DYNNAME}.bad-syslogd.log"
+content_check 'compatibility.configformat.syslogd' "${RSYSLOG_DYNNAME}.bad-syslogd.log"
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.bad-property.yaml" \
+'  compatibility.configformat.property: "bogus"'
+run_expect_failure "${RSYSLOG_DYNNAME}.bad-property.yaml" "${RSYSLOG_DYNNAME}.bad-property.log"
+content_check 'compatibility.configformat.property' "${RSYSLOG_DYNNAME}.bad-property.log"
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.bad-secure.yaml" \
+'  compatibility.defaults.secure: "bogus"'
+run_expect_failure "${RSYSLOG_DYNNAME}.bad-secure.yaml" "${RSYSLOG_DYNNAME}.bad-secure.log"
+content_check 'compatibility.defaults.secure' "${RSYSLOG_DYNNAME}.bad-secure.log"
+
+write_yaml_action_config "${RSYSLOG_DYNNAME}.strict-dirty.yaml" \
+'  compatibility.defaults.secure: "strict"
+  typo.parameter: "bad"'
+timeout 10s ../tools/rsyslogd -C -n -i"${RSYSLOG_DYNNAME}:strict.pid" -M"${modpath}" \
+    -f"${RSYSLOG_DYNNAME}.strict-dirty.yaml" >"${RSYSLOG_DYNNAME}.strict-dirty.log" 2>&1
+rc=$?
+if [ $rc -ne 2 ]; then
+    echo "FAIL: expected secure strict mode to abort unclean config with rc 2"
+    cat "${RSYSLOG_DYNNAME}.strict-dirty.log"
+    error_exit 1
+fi
+content_check 'global(AbortOnUncleanConfig="on") is set' "${RSYSLOG_DYNNAME}.strict-dirty.log"
+
+for mode in enable warn disable; do
+    write_yaml_global_only "${RSYSLOG_DYNNAME}.legacy-${mode}.yaml" "${mode}"
+    write_legacy_wrapper "${RSYSLOG_DYNNAME}.legacy-${mode}.conf" "${RSYSLOG_DYNNAME}.legacy-${mode}.yaml"
+done
+run_expect_success "${RSYSLOG_DYNNAME}.legacy-enable.conf" "${RSYSLOG_DYNNAME}.legacy-enable.log"
+run_expect_success "${RSYSLOG_DYNNAME}.legacy-warn.conf" "${RSYSLOG_DYNNAME}.legacy-warn.log"
+content_check 'obsolete $-directive syntax encountered' "${RSYSLOG_DYNNAME}.legacy-warn.log"
+run_expect_failure "${RSYSLOG_DYNNAME}.legacy-disable.conf" "${RSYSLOG_DYNNAME}.legacy-disable.log"
+content_check 'global(compatibility.configformat.legacy="enable")' "${RSYSLOG_DYNNAME}.legacy-disable.log"
+
+for mode in enable warn disable; do
+    write_yaml_syslogd_config "${RSYSLOG_DYNNAME}.syslogd-${mode}.yaml" "${mode}"
+done
+run_expect_success "${RSYSLOG_DYNNAME}.syslogd-enable.yaml" "${RSYSLOG_DYNNAME}.syslogd-enable.log"
+run_expect_success "${RSYSLOG_DYNNAME}.syslogd-warn.yaml" "${RSYSLOG_DYNNAME}.syslogd-warn.log"
+content_check 'obsolete classic syslogd filter syntax encountered' "${RSYSLOG_DYNNAME}.syslogd-warn.log"
+run_expect_failure "${RSYSLOG_DYNNAME}.syslogd-disable.yaml" "${RSYSLOG_DYNNAME}.syslogd-disable.log"
+content_check 'global(compatibility.configformat.syslogd="enable")' "${RSYSLOG_DYNNAME}.syslogd-disable.log"
+
+for mode in enable warn disable; do
+    write_yaml_property_config "${RSYSLOG_DYNNAME}.property-${mode}.yaml" "${mode}"
+done
+run_expect_success "${RSYSLOG_DYNNAME}.property-enable.yaml" "${RSYSLOG_DYNNAME}.property-enable.log"
+run_expect_success "${RSYSLOG_DYNNAME}.property-warn.yaml" "${RSYSLOG_DYNNAME}.property-warn.log"
+content_check 'obsolete classic property-based filter syntax encountered' "${RSYSLOG_DYNNAME}.property-warn.log"
+run_expect_failure "${RSYSLOG_DYNNAME}.property-disable.yaml" "${RSYSLOG_DYNNAME}.property-disable.log"
+content_check 'global(compatibility.configformat.property="enable")' "${RSYSLOG_DYNNAME}.property-disable.log"
+
+write_yaml_tls_warn_config "${RSYSLOG_DYNNAME}.tls-warn.yaml"
+run_expect_success "${RSYSLOG_DYNNAME}.tls-warn.yaml" "${RSYSLOG_DYNNAME}.tls-warn.log"
+content_check 'imtcp has TLS-related settings but streamdriver.mode="0"; mode 0 uses plain TCP so TLS is not active' "${RSYSLOG_DYNNAME}.tls-warn.log"
+content_check 'omfwd action uses protocol="udp" (without TLS)' "${RSYSLOG_DYNNAME}.tls-warn.log"
+
+write_yaml_tls_anon_warn_config "${RSYSLOG_DYNNAME}.tls-anon-warn.yaml"
+run_expect_success "${RSYSLOG_DYNNAME}.tls-anon-warn.yaml" "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
+content_check 'imtcp uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
+content_check 'omfwd uses streamdriver.authmode="anon"; server identity is not authenticated, so MITM is possible' "${RSYSLOG_DYNNAME}.tls-anon-warn.log"
+
+exit_test

--- a/tests/compat-defaults-secure-dynafile-rainerscript.sh
+++ b/tests/compat-defaults-secure-dynafile-rainerscript.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+# Validate RainerScript parity for secure dynafile template defaults.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+
+modpath="${RSYSLOG_MODDIR}"
+
+run_expect_success() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "FAIL: expected ${cfg} to validate"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+cat >"${RSYSLOG_DYNNAME}.mixed.conf" <<CONF_EOF
+global(compatibility.defaults.secure="strict")
+template(name="shared" type="string" string="${RSYSLOG_DYNNAME}.mixed_%msg:F,58:2%.log")
+action(type="omfile" dynafile="shared" template="shared")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.mixed.out" template="shared")
+CONF_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.mixed.conf" "${RSYSLOG_DYNNAME}.mixed.log"
+content_check 'used both as an omfile dynafile template and for other output' "${RSYSLOG_DYNNAME}.mixed.log"
+
+generate_conf
+add_conf '
+global(compatibility.defaults.secure="strict")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port")
+
+template(name="dynfile" type="string" string="'${RSYSLOG_DYNNAME}'.rs_%msg:F,58:2%.log")
+template(name="outfmt" type="string" string="%msg:F,58:3%\n")
+
+:msg, contains, "secure-default:" action(type="omfile" dynafile="dynfile" template="outfmt")
+'
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag secure-default:a/b:payload\""
+shutdown_when_empty
+wait_shutdown
+
+printf 'payload\n' >"${RSYSLOG_DYNNAME}.expected"
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected" "${RSYSLOG_DYNNAME}.rs_a_b.log" || {
+    echo "FAIL: strict mode did not replace slash in RainerScript dynafile template"
+    error_exit 1
+}
+
+exit_test

--- a/tests/compat-defaults-secure-dynafile-yaml.sh
+++ b/tests/compat-defaults-secure-dynafile-yaml.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+# Validate secure dynafile template defaults from YAML configuration.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+
+modpath="${RSYSLOG_MODDIR}"
+
+run_expect_success() {
+    local cfg="$1"
+    local log="$2"
+    ../tools/rsyslogd -C -N1 -M"${modpath}" -f"${cfg}" >"${log}" 2>&1
+    local rc=$?
+    if [ $rc -ne 0 ]; then
+        echo "FAIL: expected ${cfg} to validate"
+        cat "${log}"
+        error_exit 1
+    fi
+}
+
+write_yaml_dynafile_config() {
+    local cfg="$1"
+    local mode="$2"
+    cat >"${cfg}" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "${mode}"
+templates:
+  - name: dynfile
+    type: string
+    string: "${RSYSLOG_DYNNAME}.warn_%msg:F,58:2%.log"
+  - name: outfmt
+    type: string
+    string: "%msg:F,58:3%\\n"
+rulesets:
+  - name: main
+    filter: ':msg, contains, "secure-default:"'
+    actions:
+      - type: omfile
+        dynafile: dynfile
+        template: outfmt
+YAML_EOF
+}
+
+write_yaml_dynafile_config "${RSYSLOG_DYNNAME}.warn.yaml" "warn"
+run_expect_success "${RSYSLOG_DYNNAME}.warn.yaml" "${RSYSLOG_DYNNAME}.warn.log"
+content_check 'omfile dynafile template' "${RSYSLOG_DYNNAME}.warn.log"
+content_check 'compatibility.defaults.secure="strict"' "${RSYSLOG_DYNNAME}.warn.log"
+
+write_yaml_dynafile_config "${RSYSLOG_DYNNAME}.backward.yaml" "backward-compatible"
+run_expect_success "${RSYSLOG_DYNNAME}.backward.yaml" "${RSYSLOG_DYNNAME}.backward.log"
+if grep -q 'omfile dynafile template' "${RSYSLOG_DYNNAME}.backward.log"; then
+    echo "FAIL: backward-compatible mode emitted a dynafile secure default warning"
+    cat "${RSYSLOG_DYNNAME}.backward.log"
+    error_exit 1
+fi
+
+cat >"${RSYSLOG_DYNNAME}.mixed.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "strict"
+templates:
+  - name: shared
+    type: string
+    string: "${RSYSLOG_DYNNAME}.mixed_%msg:F,58:2%.log"
+rulesets:
+  - name: main
+    actions:
+      - type: omfile
+        dynafile: shared
+        template: shared
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.mixed.out"
+        template: shared
+YAML_EOF
+run_expect_success "${RSYSLOG_DYNNAME}.mixed.yaml" "${RSYSLOG_DYNNAME}.mixed.log"
+content_check 'used both as an omfile dynafile template and for other output' "${RSYSLOG_DYNNAME}.mixed.log"
+
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.strict.yaml")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'${RSYSLOG_DYNNAME}'.tcpflood_port"
+      ruleset="main")
+'
+
+cat >"${RSYSLOG_DYNNAME}.strict.yaml" <<YAML_EOF
+version: 2
+global:
+  compatibility.defaults.secure: "strict"
+templates:
+  - name: dynfile
+    type: string
+    string: "${RSYSLOG_DYNNAME}.strict_%msg:F,58:2%.log"
+  - name: dynfile-drop
+    type: string
+    string: "${RSYSLOG_DYNNAME}.drop_%msg:F,58:2:secpath-drop%.log"
+  - name: outfmt
+    type: string
+    string: "%msg:F,58:3%\\n"
+  - name: plainfmt
+    type: string
+    string: "%msg:F,58:2%\\n"
+rulesets:
+  - name: main
+    filter: ':msg, contains, "secure-default:"'
+    actions:
+      - type: omfile
+        dynafile: dynfile
+        template: outfmt
+      - type: omfile
+        dynafile: dynfile-drop
+        template: outfmt
+      - type: omfile
+        file: "${RSYSLOG_DYNNAME}.plain.out"
+        template: plainfmt
+YAML_EOF
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag secure-default:a/b:payload\""
+shutdown_when_empty
+wait_shutdown
+
+printf 'payload\n' >"${RSYSLOG_DYNNAME}.expected"
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected" "${RSYSLOG_DYNNAME}.strict_a_b.log" || {
+    echo "FAIL: strict mode did not replace slash in dynafile template"
+    error_exit 1
+}
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected" "${RSYSLOG_DYNNAME}.drop_ab.log" || {
+    echo "FAIL: strict mode overrode explicit secpath-drop"
+    error_exit 1
+}
+printf 'a/b\n' >"${RSYSLOG_DYNNAME}.plain.expected"
+cmp_exact_file "${RSYSLOG_DYNNAME}.plain.expected" "${RSYSLOG_DYNNAME}.plain.out" || {
+    echo "FAIL: strict mode changed a non-dynafile output template"
+    error_exit 1
+}
+
+exit_test

--- a/tools/omfile.c
+++ b/tools/omfile.c
@@ -1594,7 +1594,7 @@ BEGINnewActInst
         /* "filename" is actually a template name, we need this as string 1. So let's add it
          * to the pOMSR. -- rgerhards, 2007-07-27
          */
-        CHKiRet(OMSRsetEntry(*ppOMSR, 1, ustrdup(pData->fname), OMSR_NO_RQD_TPL_OPTS));
+        CHKiRet(OMSRsetEntry(*ppOMSR, 1, ustrdup(pData->fname), OMSR_TPL_AS_DYNAFILE));
         pData->iNumTpls = 2;
         // TODO: create unified code for this (legacy+v6 system)
         /* we now allocate the cache table */
@@ -1669,7 +1669,7 @@ BEGINparseSelectorAct
             /* "filename" is actually a template name, we need this as string 1. So let's add it
              * to the pOMSR. -- rgerhards, 2007-07-27
              */
-            CHKiRet(OMSRsetEntry(*ppOMSR, 1, ustrdup(pData->fname), OMSR_NO_RQD_TPL_OPTS));
+            CHKiRet(OMSRsetEntry(*ppOMSR, 1, ustrdup(pData->fname), OMSR_TPL_AS_DYNAFILE));
             /* we now allocate the cache table */
             CHKmalloc(pData->dynCache =
                           (dynaFileCacheEntry **)calloc(cs.iDynaFileCacheSize, sizeof(dynaFileCacheEntry *)));

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -1973,6 +1973,38 @@ finalize_it:
     RETiRet;
 }
 
+/** Warn in secure warn mode when omfwd is configured without TLS transport protection. */
+static void warnIfNonTlsForwardingConfigured(const instanceData *const pData) {
+    if (pData->protocol == FORW_UDP) {
+        glblWarnIfInsecureDefault(loadModConf->pConf,
+                                  "omfwd action uses protocol=\"udp\" (without TLS); "
+                                  "see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+    } else if (pData->protocol == FORW_TCP && pData->iStrmDrvrMode == 0) {
+        const int tlsHintsConfigured =
+            (pData->pszStrmDrvrAuthMode != NULL) ||
+            (pData->pszStrmDrvr != NULL && strcasecmp((const char *)pData->pszStrmDrvr, "ptcp") != 0);
+        if (tlsHintsConfigured) {
+            glblWarnIfInsecureDefault(loadModConf->pConf,
+                                      "omfwd has TLS-related settings but streamdriver.mode=\"0\"; mode 0 uses plain "
+                                      "TCP so TLS is not active "
+                                      "(see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html)");
+        } else {
+            glblWarnIfInsecureDefault(
+                loadModConf->pConf,
+                "omfwd action uses protocol=\"tcp\" with streamdriver.mode=\"0\" "
+                "(plain TCP without TLS); see https://docs.rsyslog.com/doc/faq/tls_mode0_disables_tls.html");
+        }
+    }
+
+    if (pData->protocol == FORW_TCP && pData->iStrmDrvrMode != 0 && pData->pszStrmDrvrAuthMode != NULL &&
+        strcasecmp((const char *)pData->pszStrmDrvrAuthMode, "anon") == 0) {
+        glblWarnIfInsecureDefault(
+            loadModConf->pConf,
+            "omfwd uses streamdriver.authmode=\"anon\"; server identity is not authenticated, so MITM is possible "
+            "(see https://docs.rsyslog.com/doc/faq/tls_anon_auth_mitm.html)");
+    }
+}
+
 
 BEGINnewActInst
     struct cnfparamvals *pvals;
@@ -2072,7 +2104,7 @@ BEGINnewActInst
                    !strcmp(actpblk.descr[i].name, "streamdriver.name")) {
             CHKmalloc(pData->pszStrmDrvr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdrivermode") ||
-                   !strcmp(actpblk.descr[i].name, "streamdrivermode")) {
+                   !strcmp(actpblk.descr[i].name, "streamdriver.mode")) {
             pData->iStrmDrvrMode = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.CheckExtendedKeyPurpose")) {
             pData->iStrmDrvrExtendedCertCheck = pvals[i].val.d.n;
@@ -2085,7 +2117,7 @@ BEGINnewActInst
                 parser_errmsg("streamdriver.TlsVerifyDepth must be 2 or higher but is %d", (int)pvals[i].val.d.n);
             }
         } else if (!strcmp(actpblk.descr[i].name, "streamdriverauthmode") ||
-                   !strcmp(actpblk.descr[i].name, "streamdriverauthmode")) {
+                   !strcmp(actpblk.descr[i].name, "streamdriver.authmode")) {
             CHKmalloc(pData->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "streamdriver.permitexpiredcerts")) {
             uchar *val;
@@ -2287,6 +2319,8 @@ BEGINnewActInst
         LogError(0, RS_RET_PARAM_ERROR, "omfwd: parameter \"address\" not supported for tcp -- ignored");
     }
 
+    warnIfNonTlsForwardingConfigured(pData);
+
     if (pData->pszRatelimitName != NULL) {
         CHKiRet(ratelimitNewFromConfig(&pData->ratelimiter, loadModConf->pConf, (char *)pData->pszRatelimitName,
                                        "omfwd", NULL));
@@ -2475,6 +2509,7 @@ BEGINparseSelectorAct
             cs.pPermPeers = NULL;
         }
     }
+    warnIfNonTlsForwardingConfigured(pData);
     CODE_STD_FINALIZERparseSelectorAct if (iRet == RS_RET_OK) {
         setupInstStatsCtrs(pData);
     }

--- a/tools/rsyslogd.c
+++ b/tools/rsyslogd.c
@@ -1135,7 +1135,8 @@ rsRetVal logmsgInternal(int iErr, const syslog_pri_t pri, const uchar *const msg
         }
     }
     if (emit_to_stderr || iConfigVerify) {
-        if ((ourConf != NULL && ourConf->globals.bAllMsgToStderr) || pri2sev(pri) == LOG_ERR)
+        if ((ourConf != NULL && ourConf->globals.bAllMsgToStderr) || pri2sev(pri) == LOG_ERR ||
+            (iConfigVerify && pri2sev(pri) <= LOG_WARNING))
             fprintf(stderr, "rsyslogd: %s\n", (bufModMsg == NULL) ? (char *)msg : bufModMsg);
     }
     if (emit_supress_msg) {


### PR DESCRIPTION
Why: administrators need explicit compatibility knobs while moving from legacy syntax and insecure historical defaults.

Impact: global compatibility behavior is now configurable in RainerScript and YAML, and unsafe TLS usage emits warnings.

Before/After: legacy and insecure behavior was mostly implicit; it is now explicit, configurable, and warned.

Technical overview:
Add global compatibility.configformat controls for legacy $-syntax, classic syslogd filters, and property-based filters with enable, warn, and disable modes.
Add compatibility.defaults.secure with strict, warn, and backward-compatible behavior, including failOnUncleanConfig in secure mode.
Add transport-security warnings for inbound and outbound network configs that effectively disable TLS or use anon auth, and include docs URLs in messages.
Add focused docs pages for each TLS warning and interlink them with FAQ/tutorial paths.
Add compatibility testbench coverage for YAML and a focused RainerScript subset, plus secure-dynafile default tests. Set omclickhouse allowUnsignedCerts default to off.

Closes https://github.com/rsyslog/rsyslog/issues/2383

With the help of AI-Agents: Codex
