### PR TITLE
[HARDENING] imjournal: harden disk usage stats update

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -173,6 +173,7 @@ static struct {
     STATSCOUNTER_DEF(ctrRecoveryAttempts, mutCtrRecoveryAttempts);
     uint64 ratelimitDiscardedInInterval;
     uint64 diskUsageBytes;
+    DEF_ATOMIC_HELPER_MUT64(mut_diskUsageBytes);
 } statsCounter;
 struct journalContext_s { /* structure encapsulating all the journald_API-related stuff  */
     sd_journal *j; /* main object encapsulating journal for us, has to be used in every sd_journal*() call */
@@ -1057,9 +1058,12 @@ static rsRetVal doRun(journal_etry_t const *etry) {
             /*
              * update journal disk usage before reading the new message.
              */
-            const int e = sd_journal_get_usage(etry->journalContext->j, (uint64_t *)&statsCounter.diskUsageBytes);
+            uint64_t usage;
+            const int e = sd_journal_get_usage(etry->journalContext->j, &usage);
             if (e < 0) {
                 LogError(-e, RS_RET_ERR, "imjournal: sd_get_usage() failed");
+            } else {
+                ATOMIC_STORE_uint64(&statsCounter.diskUsageBytes, &statsCounter.mut_diskUsageBytes, (uint64)usage);
             }
 
             if (readjournal(etry->journalContext, etry->pBindRuleset) != RS_RET_OK) {
@@ -1267,6 +1271,8 @@ BEGINactivateCnf
                                 CTR_FLAG_RESETTABLE, &(statsCounter.ctrRecoveryAttempts)));
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("ratelimit_discarded_in_interval"), ctrType_IntCtr,
                                 CTR_FLAG_NONE, &(statsCounter.ratelimitDiscardedInInterval)));
+    INIT_ATOMIC_HELPER_MUT64(statsCounter.mut_diskUsageBytes);
+    statsCounter.diskUsageBytes = 0;
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("disk_usage_bytes"), ctrType_IntCtr, CTR_FLAG_NONE,
                                 &(statsCounter.diskUsageBytes)));
     CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));

--- a/runtime/atomic.h
+++ b/runtime/atomic.h
@@ -279,6 +279,7 @@ static inline int ATOMIC_CAS_PTR(void **data, void *oldVal, void *newVal, pthrea
     #define ATOMIC_ADD_uint64(data, phlpmut, value) ((void)__sync_fetch_and_add(data, value))
     #define ATOMIC_DEC_uint64(data, phlpmut) ((void)__sync_sub_and_fetch(data, 1))
     #define ATOMIC_INC_AND_FETCH_uint64(data, phlpmut) __sync_fetch_and_add(data, 1)
+    #define ATOMIC_STORE_uint64(data, phlpmut, value) ((void)__sync_lock_test_and_set((data), (value)))
 
     #define DEF_ATOMIC_HELPER_MUT64(x)
     #define INIT_ATOMIC_HELPER_MUT64(x)
@@ -301,6 +302,12 @@ static inline int ATOMIC_CAS_PTR(void **data, void *oldVal, void *newVal, pthrea
             pthread_mutex_lock(phlpmut);     \
             --(*(data));                     \
             pthread_mutex_unlock(phlpmut);   \
+        }
+    #define ATOMIC_STORE_uint64(data, phlpmut, value) \
+        {                                             \
+            pthread_mutex_lock(phlpmut);              \
+            *(data) = (value);                        \
+            pthread_mutex_unlock(phlpmut);            \
         }
 
 static inline unsigned ATOMIC_INC_AND_FETCH_uint64(uint64 *data, pthread_mutex_t *phlpmut) {


### PR DESCRIPTION
Hardens the imjournal disk usage statistic update when multiple journal reader threads are active. The value remains a best-effort statistic; this change keeps the existing stats behavior and uses the runtime uint64 atomic helper path for the update.