### PR TITLE
[HARDENING] imdiag: clarify controlled diagnostics usage

### DIFF
--- a/doc/source/configuration/modules/imdiag.rst
+++ b/doc/source/configuration/modules/imdiag.rst
@@ -5,16 +5,23 @@ imdiag: Diagnostic instrumentation
 :Author: Rainer Gerhards
 :Available since: at least 5.x
 
+.. warning::
+
+   **Testing and controlled diagnostics**
+
+   This module is intended for the testbench and controlled diagnostics. It
+   provides message injection and queue control over TCP and has no internal
+   access control (ACLs). Limit exposure to trusted hosts with external
+   controls such as firewalls or host isolation.
+
 Purpose
 -------
 
 The imdiag input module exposes a TCP-based diagnostics and control channel
-that can inject messages into the
-main queue, wait for queues to drain, coordinate statistics reporting, and
-exercise other helper functions used by the rsyslog testbench. While imdiag is
-primarily intended for automated testing, it can also be used to diagnose
-production systems. Because the interface permits queue control and message
-injection, it **must only be exposed to trusted hosts**.
+that can inject messages into the main queue, wait for queues to drain,
+coordinate statistics reporting, and exercise other helper functions used by the
+rsyslog testbench. Because the interface permits queue control and message
+injection, expose it only to trusted hosts in controlled environments.
 
 Configuration Parameters
 ------------------------

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -1,4 +1,8 @@
 /* imdiag.c
+ * Diagnostic input module for the testbench and controlled diagnostics.
+ * The module has no internal access control; limit exposure with external
+ * controls such as firewalls or host isolation.
+ *
  * This is a testbench tool. It started out with a broader scope,
  * but we dropped this idea. To learn about rsyslog runtime statistics
  * have a look at impstats.


### PR DESCRIPTION
Clarifies that imdiag is intended for the testbench and controlled diagnostics, and that deployments must limit TCP exposure with external controls because the module does not enforce internal ACLs.