### PR TITLE
[HARDENING] imuxsock: harden trusted property annotation buffer

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -871,6 +871,34 @@ static int copyescaped(uchar *dstbuf, uchar *inbuf, int inlen) {
 }
 
 
+static size_t escapedLen(uchar *inbuf, int inlen) {
+    size_t len = 2; /* surrounding quotes */
+
+    for (int i = 0; i < inlen; ++i) {
+        if (inbuf[i] == '"' || inbuf[i] == '\\') {
+            ++len;
+        }
+        ++len;
+    }
+    return len;
+}
+
+
+static rsRetVal appendTrustedProp(
+    uchar *const dst, const size_t dstLen, size_t *const offs, const uchar *const src, const size_t len) {
+    DEFiRet;
+
+    if (len > dstLen || *offs > dstLen - len) {
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    memcpy(dst + *offs, src, len);
+    *offs += len;
+
+finalize_it:
+    RETiRet;
+}
+
+
 /* submit received message to the queue engine
  * We now parse the message according to expected format so that we
  * can also mangle it if necessary.
@@ -974,10 +1002,23 @@ static rsRetVal SubmitMsg(uchar *pRcv, int lenRcv, lstn_t *pLstn, struct ucred *
         } else {
             uchar msgbuf[8192];
             uchar *pmsgbuf = msgbuf;
-            int toffs; /* offset for trusted properties */
+            const size_t trustedPropBufLen = sizeof(propBuf) - 1;
+            const size_t trustedPropMaxExtra = 3 + /* " @[" */
+                                               96 + /* _PID/_UID/_GID tags plus maximum decimal values */
+                                               7 + trustedPropBufLen + /* _COMM= */
+                                               6 + trustedPropBufLen + /* _EXE= */
+                                               10 + 2 + 2 * trustedPropBufLen + /* _CMDLINE= plus escaped value */
+                                               2; /* closing bracket and NUL */
+            size_t msgbuf_size = sizeof(msgbuf);
+            size_t toffs; /* offset for trusted properties */
+            size_t escaped;
 
-            if ((unsigned)(lenRcv + 4096) >= sizeof(msgbuf)) {
-                CHKmalloc(pmsgbuf = malloc(lenRcv + 4096));
+            if ((size_t)lenRcv > (size_t)-1 - trustedPropMaxExtra) {
+                ABORT_FINALIZE(RS_RET_ERR);
+            }
+            if ((size_t)lenRcv + trustedPropMaxExtra > sizeof(msgbuf)) {
+                msgbuf_size = (size_t)lenRcv + trustedPropMaxExtra;
+                CHKmalloc(pmsgbuf = malloc(msgbuf_size));
             }
 
             memcpy(pmsgbuf, pRcv, lenRcv);
@@ -985,29 +1026,51 @@ static rsRetVal SubmitMsg(uchar *pRcv, int lenRcv, lstn_t *pLstn, struct ucred *
             toffs = lenRcv + 3; /* next free location */
             lenProp = snprintf((char *)propBuf, sizeof(propBuf), "_PID=%lu _UID=%lu _GID=%lu", (long unsigned)cred->pid,
                                (long unsigned)cred->uid, (long unsigned)cred->gid);
-            memcpy(pmsgbuf + toffs, propBuf, lenProp);
-            toffs = toffs + lenProp;
+            if (lenProp < 0) {
+                iRet = RS_RET_ERR;
+            } else {
+                iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, propBuf, (size_t)lenProp);
+            }
+            if (iRet != RS_RET_OK) {
+                if (pmsgbuf != msgbuf) free(pmsgbuf);
+                FINALIZE;
+            }
 
             if (getTrustedProp(cred, "comm", propBuf, sizeof(propBuf), &lenProp) == RS_RET_OK) {
-                memcpy(pmsgbuf + toffs, " _COMM=", 7);
-                memcpy(pmsgbuf + toffs + 7, propBuf, lenProp);
-                toffs = toffs + 7 + lenProp;
+                if ((iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, (uchar *)" _COMM=", 7)) != RS_RET_OK ||
+                    (iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, propBuf, (size_t)lenProp)) != RS_RET_OK) {
+                    if (pmsgbuf != msgbuf) free(pmsgbuf);
+                    FINALIZE;
+                }
             }
             if (getTrustedExe(cred, propBuf, sizeof(propBuf), &lenProp) == RS_RET_OK) {
-                memcpy(pmsgbuf + toffs, " _EXE=", 6);
-                memcpy(pmsgbuf + toffs + 6, propBuf, lenProp);
-                toffs = toffs + 6 + lenProp;
+                if ((iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, (uchar *)" _EXE=", 6)) != RS_RET_OK ||
+                    (iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, propBuf, (size_t)lenProp)) != RS_RET_OK) {
+                    if (pmsgbuf != msgbuf) free(pmsgbuf);
+                    FINALIZE;
+                }
             }
             if (getTrustedProp(cred, "cmdline", propBuf, sizeof(propBuf), &lenProp) == RS_RET_OK) {
-                memcpy(pmsgbuf + toffs, " _CMDLINE=", 10);
-                toffs = toffs + 10 + copyescaped(pmsgbuf + toffs + 10, propBuf, lenProp);
+                if ((iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, (uchar *)" _CMDLINE=", 10)) != RS_RET_OK) {
+                    if (pmsgbuf != msgbuf) free(pmsgbuf);
+                    FINALIZE;
+                }
+                escaped = escapedLen(propBuf, lenProp);
+                if (escaped > msgbuf_size || toffs > msgbuf_size - escaped) {
+                    if (pmsgbuf != msgbuf) free(pmsgbuf);
+                    ABORT_FINALIZE(RS_RET_ERR);
+                }
+                toffs += (size_t)copyescaped(pmsgbuf + toffs, propBuf, lenProp);
             }
 
             /* finalize string */
-            pmsgbuf[toffs] = ']';
-            pmsgbuf[toffs + 1] = '\0';
+            if ((iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, (uchar *)"]", 1)) != RS_RET_OK ||
+                (iRet = appendTrustedProp(pmsgbuf, msgbuf_size, &toffs, (uchar *)"\0", 1)) != RS_RET_OK) {
+                if (pmsgbuf != msgbuf) free(pmsgbuf);
+                FINALIZE;
+            }
 
-            MsgSetRawMsg(pMsg, (char *)pmsgbuf, toffs + 1);
+            MsgSetRawMsg(pMsg, (char *)pmsgbuf, toffs - 1);
             if (pmsgbuf != msgbuf) {
                 free(pmsgbuf);
             }

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -313,6 +313,7 @@ TESTS_DEFAULT = \
 	imuxsock_logger_ruleset_ratelimit.sh \
 	imuxsock_logger_err.sh \
 	imuxsock_logger_parserchain.sh \
+	imuxsock_annotate_large.sh \
 	imuxsock_traillf.sh \
 	imuxsock_ccmiddle.sh \
 	imuxsock_logger_syssock.sh \

--- a/tests/imuxsock_annotate_large.sh
+++ b/tests/imuxsock_annotate_large.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+skip_platform "SunOS" "trusted property annotation depends on Linux credentials/procfs behavior"
+
+export NUMMESSAGES=1
+export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
+generate_conf
+add_conf '
+global(maxMessageSize="8k")
+module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
+input(type="imuxsock"
+      Socket="'$RSYSLOG_DYNNAME'-testbench_socket"
+      Annotate="on"
+      ParseTrusted="off")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+*.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+startup
+long_arg="$(printf 'quoted\\\\value\\"%.0s' {1..300})"
+./syslog_caller -m1 -u "$RSYSLOG_DYNNAME-testbench_socket" -L 3900 -w 1000 -- "$long_arg"
+
+shutdown_when_empty
+wait_shutdown
+
+content_check "_PID="
+content_check "_CMDLINE=\""
+content_check "quoted"
+exit_test

--- a/tests/syslog_caller.c
+++ b/tests/syslog_caller.c
@@ -7,6 +7,9 @@
  * -m number of messages to generate (default 500)
  * -C liblognorm-stdlog channel description
  * -f message format to use
+ * -u Unix datagram socket path
+ * -L generated message length for Unix datagram mode
+ * -w milliseconds to wait after sending messages
  *
  * Part of the testbench for rsyslog.
  *
@@ -38,7 +41,10 @@
 #endif
 #include <errno.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <sys/un.h>
 #include <syslog.h>
+#include <unistd.h>
 #ifdef HAVE_LIBLOGGING_STDLOG
     #include <liblogging/stdlog.h>
 #endif
@@ -46,8 +52,46 @@
 static enum { FMT_NATIVE, FMT_SYSLOG_INJECT_L, FMT_SYSLOG_INJECT_C } fmt = FMT_NATIVE;
 
 static void usage(void) {
-    fprintf(stderr, "usage: syslog_caller num-messages\n");
+    fprintf(stderr, "usage: syslog_caller [-m messages] [-s severity] [-u socket] [-L length] [-w milliseconds]\n");
     exit(1);
+}
+
+static void genRawMsg(char *buf, const size_t buflen, const int sev, const int iRun, const size_t msgLen) {
+    if (msgLen > 0) {
+        const size_t prefixLen = (size_t)snprintf(buf, buflen, "<%d>", sev % 8);
+        if (prefixLen >= buflen) return;
+        const size_t avail = buflen - prefixLen - 1;
+        const size_t len = msgLen < avail ? msgLen : avail;
+        memset(buf + prefixLen, 'A', len);
+        buf[prefixLen + len] = '\0';
+    } else {
+        snprintf(buf, buflen, "<%d>test message nbr %d, severity=%d", sev % 8, iRun, sev % 8);
+    }
+}
+
+static void sendRawUnix(const char *sockName, const int sev, const int iRun, const size_t msgLen) {
+    int sock;
+    struct sockaddr_un sa;
+    char msgbuf[4096];
+
+    if (strlen(sockName) >= sizeof(sa.sun_path)) {
+        fprintf(stderr, "Unix socket path too long: %s\n", sockName);
+        exit(1);
+    }
+    if ((sock = socket(AF_UNIX, SOCK_DGRAM, 0)) < 0) {
+        perror("socket");
+        exit(1);
+    }
+    memset(&sa, 0, sizeof(sa));
+    sa.sun_family = AF_UNIX;
+    strcpy(sa.sun_path, sockName);
+    genRawMsg(msgbuf, sizeof(msgbuf), sev, iRun, msgLen);
+    if (sendto(sock, msgbuf, strlen(msgbuf), 0, (struct sockaddr *)&sa, sizeof(sa)) < 0) {
+        perror("sendto");
+        close(sock);
+        exit(1);
+    }
+    close(sock);
 }
 
 
@@ -74,6 +118,9 @@ int main(int argc, char *argv[]) {
     int bRollingSev = 0;
     int sev = 6;
     int msgs = 500;
+    const char *unixSockName = NULL;
+    size_t msgLen = 0;
+    int waitMs = 0;
 #ifdef HAVE_LIBLOGGING_STDLOG
     stdlog_channel_t logchan = NULL;
     const char *chandesc = "syslog:";
@@ -82,9 +129,9 @@ int main(int argc, char *argv[]) {
 
 #ifdef HAVE_LIBLOGGING_STDLOG
     stdlog_init(STDLOG_USE_DFLT_OPTS);
-    while ((opt = getopt(argc, argv, "m:s:C:f:")) != -1) {
+    while ((opt = getopt(argc, argv, "m:s:C:f:u:L:w:")) != -1) {
 #else
-    while ((opt = getopt(argc, argv, "m:s:")) != -1) {
+    while ((opt = getopt(argc, argv, "m:s:u:L:w:")) != -1) {
 #endif
         switch (opt) {
             case 's':
@@ -100,6 +147,16 @@ int main(int argc, char *argv[]) {
                 break;
             case 'm':
                 msgs = atoi(optarg);
+                break;
+            case 'u':
+                unixSockName = optarg;
+                break;
+            case 'L':
+                msgLen = (size_t)atoi(optarg);
+                if (msgLen >= 4096) msgLen = 4095;
+                break;
+            case 'w':
+                waitMs = atoi(optarg);
                 break;
 #ifdef HAVE_LIBLOGGING_STDLOG
             case 'C':
@@ -121,6 +178,15 @@ int main(int argc, char *argv[]) {
 #endif
                 break;
         }
+    }
+
+    if (unixSockName != NULL) {
+        for (i = 0; i < msgs; ++i) {
+            sendRawUnix(unixSockName, sev, i, msgLen);
+            if (bRollingSev) sev++;
+        }
+        if (waitMs > 0) usleep((unsigned int)waitMs * 1000U);
+        return 0;
     }
 
 #ifdef HAVE_LIBLOGGING_STDLOG


### PR DESCRIPTION
## Summary

This hardens imuxsock trusted-property annotation assembly by replacing fixed slack-space assumptions with explicit size accounting before each append.

The annotation path can add process metadata such as PID, UID, GID, command name, executable path, and escaped command line to the received message. The old code relied on a fixed extra allocation and direct `memcpy()` calls. This change computes the maximum trusted-property expansion, tracks the output offset as `size_t`, and verifies each append before writing.

## Impact

Normal imuxsock behavior is unchanged. Oversized annotation data is handled through the existing error path instead of relying on implicit buffer slack.

## Validation

- `./devtools/format-code.sh`
- `./tests/imuxsock_annotate_large.sh`
