### PR TITLE
imbeats: join session threads during teardown

### DIFF
--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -17,6 +17,7 @@
 #include <poll.h>
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <sys/socket.h>
 
 #include <libfastjson/json.h>
 #include <libfastjson/json_tokener.h>
@@ -97,6 +98,7 @@ typedef struct instanceConf_s {
     size_t listener_cap;
     pthread_t listener_tid;
     int listener_running;
+    int shuttingDown;
     pthread_mutex_t mutSessions;
     session_t *sessions;
 } instanceConf_t;
@@ -112,6 +114,7 @@ struct session_s {
     netstrm_t *pStrm;
     pthread_t tid;
     int done;
+    int threadStarted;
     int sock;
     uchar *fromHostFQDN;
     prop_t *fromHost;
@@ -186,8 +189,30 @@ static inline void std_checkRuleset_genErrMsg(__attribute__((unused)) modConfDat
 static rsRetVal createInstance(instanceConf_t **const pinst);
 static rsRetVal buildListeners(instanceConf_t *inst);
 static rsRetVal destroyInstanceRuntime(instanceConf_t *inst);
+static void destroySession(session_t *sess);
 static void *listenerThread(void *arg);
 static void *sessionThread(void *arg);
+
+static int instanceIsShuttingDown(instanceConf_t *const inst) {
+    int shuttingDown;
+
+    pthread_mutex_lock(&inst->mutSessions);
+    shuttingDown = inst->shuttingDown;
+    pthread_mutex_unlock(&inst->mutSessions);
+    return shuttingDown;
+}
+
+static void setInstanceShuttingDown(instanceConf_t *const inst) {
+    pthread_mutex_lock(&inst->mutSessions);
+    inst->shuttingDown = 1;
+    pthread_mutex_unlock(&inst->mutSessions);
+}
+
+static void clearInstanceShuttingDown(instanceConf_t *const inst) {
+    pthread_mutex_lock(&inst->mutSessions);
+    inst->shuttingDown = 0;
+    pthread_mutex_unlock(&inst->mutSessions);
+}
 
 static rsRetVal validateUInt32Limit(const char *const name,
                                     const int64_t value,
@@ -577,14 +602,60 @@ static void unlinkSession(instanceConf_t *const inst, session_t *const target) {
     session_t **pp;
     assert(inst != NULL);
     assert(target != NULL);
-    pthread_mutex_lock(&inst->mutSessions);
     for (pp = &inst->sessions; *pp != NULL; pp = &(*pp)->next) {
         if (*pp == target) {
             *pp = target->next;
+            target->next = NULL;
+            break;
+        }
+    }
+}
+
+static session_t *takeSession(instanceConf_t *const inst, const int takeAll) {
+    session_t *sess = NULL;
+    session_t **pp;
+
+    pthread_mutex_lock(&inst->mutSessions);
+    for (pp = &inst->sessions; *pp != NULL; pp = &(*pp)->next) {
+        if (takeAll || (*pp)->done) {
+            sess = *pp;
+            *pp = sess->next;
+            sess->next = NULL;
             break;
         }
     }
     pthread_mutex_unlock(&inst->mutSessions);
+    return sess;
+}
+
+static void shutdownSessionSocket(session_t *const sess) {
+    if (sess != NULL && sess->sock >= 0) {
+        (void)shutdown(sess->sock, SHUT_RDWR);
+    }
+}
+
+static void shutdownAllSessionSockets(instanceConf_t *const inst) {
+    session_t *sess;
+
+    pthread_mutex_lock(&inst->mutSessions);
+    for (sess = inst->sessions; sess != NULL; sess = sess->next) {
+        shutdownSessionSocket(sess);
+    }
+    pthread_mutex_unlock(&inst->mutSessions);
+}
+
+static void reapSessions(instanceConf_t *const inst, const int reapAll) {
+    session_t *sess;
+
+    while ((sess = takeSession(inst, reapAll)) != NULL) {
+        if (reapAll) {
+            shutdownSessionSocket(sess);
+        }
+        if (sess->threadStarted) {
+            pthread_join(sess->tid, NULL);
+        }
+        destroySession(sess);
+    }
 }
 
 static void destroySession(session_t *sess) {
@@ -613,7 +684,7 @@ static void *sessionThread(void *arg) {
 
     assert(sess != NULL);
 
-    while (glbl.GetGlobalInputTermState() == 0) {
+    while (glbl.GetGlobalInputTermState() == 0 && !instanceIsShuttingDown(sess->inst)) {
         struct lj_batch_s batch;
         size_t idx;
 
@@ -643,49 +714,63 @@ static void *sessionThread(void *arg) {
     }
 
     STATSCOUNTER_INC(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
-    unlinkSession(sess->inst, sess);
-    destroySession(sess);
+    pthread_mutex_lock(&sess->inst->mutSessions);
+    sess->done = 1;
+    pthread_mutex_unlock(&sess->inst->mutSessions);
     return NULL;
 }
 
-static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t *const pNewStrm) {
+static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t **const ppNewStrm) {
     session_t *sess = NULL;
     struct sockaddr_storage *addr = NULL;
     DEFiRet;
 
+    assert(ppNewStrm != NULL);
+    assert(*ppNewStrm != NULL);
+
+    if (ppNewStrm == NULL || *ppNewStrm == NULL) {
+        return RS_RET_INVALID_VALUE;
+    }
     CHKmalloc(sess = calloc(1, sizeof(*sess)));
+    sess->sock = -1;
     sess->inst = inst;
-    sess->pStrm = pNewStrm;
-    CHKiRet(netstrm.GetSock(pNewStrm, &sess->sock));
+    sess->pStrm = *ppNewStrm;
+    *ppNewStrm = NULL;
+    CHKiRet(netstrm.GetSock(sess->pStrm, &sess->sock));
     if (inst->bKeepAlive) {
-        CHKiRet(netstrm.SetKeepAliveProbes(pNewStrm, inst->iKeepAliveProbes));
-        CHKiRet(netstrm.SetKeepAliveTime(pNewStrm, inst->iKeepAliveTime));
-        CHKiRet(netstrm.SetKeepAliveIntvl(pNewStrm, inst->iKeepAliveIntvl));
-        CHKiRet(netstrm.EnableKeepAlive(pNewStrm));
+        CHKiRet(netstrm.SetKeepAliveProbes(sess->pStrm, inst->iKeepAliveProbes));
+        CHKiRet(netstrm.SetKeepAliveTime(sess->pStrm, inst->iKeepAliveTime));
+        CHKiRet(netstrm.SetKeepAliveIntvl(sess->pStrm, inst->iKeepAliveIntvl));
+        CHKiRet(netstrm.EnableKeepAlive(sess->pStrm));
     }
     if (inst->gnutlsPriorityString != NULL) {
-        CHKiRet(netstrm.SetGnutlsPriorityString(pNewStrm, inst->gnutlsPriorityString));
+        CHKiRet(netstrm.SetGnutlsPriorityString(sess->pStrm, inst->gnutlsPriorityString));
     }
-    CHKiRet(netstrm.GetRemoteHName(pNewStrm, &sess->fromHostFQDN));
+    CHKiRet(netstrm.GetRemoteHName(sess->pStrm, &sess->fromHostFQDN));
     if (sess->fromHostFQDN != NULL) {
         CHKiRet(prop.Construct(&sess->fromHost));
         CHKiRet(prop.SetString(sess->fromHost, sess->fromHostFQDN, ustrlen(sess->fromHostFQDN)));
         CHKiRet(prop.ConstructFinalize(sess->fromHost));
     }
-    CHKiRet(netstrm.GetRemoteIP(pNewStrm, &sess->fromHostIP));
-    CHKiRet(netstrm.GetRemAddr(pNewStrm, &addr));
+    CHKiRet(netstrm.GetRemoteIP(sess->pStrm, &sess->fromHostIP));
+    CHKiRet(netstrm.GetRemAddr(sess->pStrm, &addr));
     CHKiRet(createPortProp(addr, &sess->fromHostPort));
 
     pthread_mutex_lock(&inst->mutSessions);
+    if (inst->shuttingDown) {
+        pthread_mutex_unlock(&inst->mutSessions);
+        ABORT_FINALIZE(RS_RET_FORCE_TERM);
+    }
     sess->next = inst->sessions;
     inst->sessions = sess;
-    pthread_mutex_unlock(&inst->mutSessions);
-
-    STATSCOUNTER_INC(statsCounter.ctrConnectionsAccepted, statsCounter.mutCtrConnectionsAccepted);
     if (pthread_create(&sess->tid, NULL, sessionThread, sess) != 0) {
+        unlinkSession(inst, sess);
+        pthread_mutex_unlock(&inst->mutSessions);
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
-    pthread_detach(sess->tid);
+    sess->threadStarted = 1;
+    pthread_mutex_unlock(&inst->mutSessions);
+    STATSCOUNTER_INC(statsCounter.ctrConnectionsAccepted, statsCounter.mutCtrConnectionsAccepted);
     sess = NULL;
 
 finalize_it:
@@ -710,13 +795,13 @@ static void *listenerThread(void *arg) {
         pfds[i].events = POLLIN;
     }
 
-    inst->listener_running = 1;
-    while (glbl.GetGlobalInputTermState() == 0) {
+    while (glbl.GetGlobalInputTermState() == 0 && !instanceIsShuttingDown(inst)) {
         if (poll(pfds, inst->listener_count, 1000) <= 0) {
+            reapSessions(inst, 0);
             continue;
         }
         for (i = 0; i < inst->listener_count; ++i) {
-            if ((pfds[i].revents & POLLIN) != 0) {
+            if ((pfds[i].revents & POLLIN) != 0 && !instanceIsShuttingDown(inst)) {
                 netstrm_t *pNewStrm = NULL;
                 char connInfo[TCPSRV_CONNINFO_SIZE];
                 rsRetVal iRet;
@@ -724,13 +809,14 @@ static void *listenerThread(void *arg) {
                 memset(connInfo, 0, sizeof(connInfo));
                 iRet = netstrm.AcceptConnReq(inst->listeners[i], &pNewStrm, connInfo);
                 if (iRet == RS_RET_OK) {
-                    iRet = spawnSession(inst, pNewStrm);
+                    iRet = spawnSession(inst, &pNewStrm);
                     if (iRet != RS_RET_OK && pNewStrm != NULL) {
                         netstrm.Destruct(&pNewStrm);
                     }
                 }
             }
         }
+        reapSessions(inst, 0);
     }
 
     free(pfds);
@@ -740,10 +826,13 @@ static void *listenerThread(void *arg) {
 static rsRetVal destroyInstanceRuntime(instanceConf_t *inst) {
     size_t i;
 
+    setInstanceShuttingDown(inst);
     if (inst->listener_running) {
         pthread_join(inst->listener_tid, NULL);
         inst->listener_running = 0;
     }
+    shutdownAllSessionSockets(inst);
+    reapSessions(inst, 1);
 
     for (i = 0; i < inst->listener_count; ++i) {
         if (inst->listeners[i] != NULL) {
@@ -953,10 +1042,12 @@ BEGINrunInput
     instanceConf_t *inst;
     CODESTARTrunInput;
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
+        clearInstanceShuttingDown(inst);
         CHKiRet(buildListeners(inst));
         if (pthread_create(&inst->listener_tid, NULL, listenerThread, inst) != 0) {
             ABORT_FINALIZE(RS_RET_IO_ERROR);
         }
+        inst->listener_running = 1;
     }
     while (glbl.GetGlobalInputTermState() == 0) {
         srSleep(0, 250000);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1040,6 +1040,7 @@ TESTS_IMBEATS = \
 	imbeats-basic.sh \
 	imbeats-compressed.sh \
 	imbeats-limits.sh \
+	imbeats-shutdown-open-session.sh \
 	imbeats-filebeat-docker.sh
 
 TESTS_IMBEATS_YAML = \

--- a/tests/imbeats-shutdown-open-session.sh
+++ b/tests/imbeats-shutdown-open-session.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+rm -f "$RSYSLOG_DYNNAME.imbeats.ready" "$RSYSLOG_DYNNAME.imbeats.client-result"
+
+${PYTHON:-python3} - "$RS_PORT" \
+	"$RSYSLOG_DYNNAME.imbeats.ready" \
+	"$RSYSLOG_DYNNAME.imbeats.client-result" <<'PY' &
+import os
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+ready_file = sys.argv[2]
+result_file = sys.argv[3]
+sockets = []
+
+try:
+    for idx in range(3):
+        sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+        sock.settimeout(10)
+        sockets.append(sock)
+        if idx == 1:
+            sock.sendall(b"2W" + struct.pack(">I", 1))
+        elif idx == 2:
+            sock.sendall(b"2W" + struct.pack(">I", 1) + b"2J" + struct.pack(">I", 1))
+
+    with open(ready_file, "w", encoding="ascii") as fh:
+        fh.write("ready\n")
+
+    for sock in sockets:
+        try:
+            data = sock.recv(1)
+        except socket.timeout:
+            raise SystemExit("server did not close open session during shutdown")
+        except (ConnectionResetError, OSError):
+            data = b""
+        if data:
+            raise SystemExit(f"unexpected data from server during shutdown: {data!r}")
+
+    with open(result_file, "w", encoding="ascii") as fh:
+        fh.write("closed\n")
+finally:
+    for sock in sockets:
+        try:
+            sock.close()
+        except OSError:
+            pass
+    if not os.path.exists(result_file):
+        with open(result_file, "w", encoding="ascii") as fh:
+            fh.write("failed\n")
+PY
+client_pid=$!
+
+for i in {1..50}; do
+	if [ -f "$RSYSLOG_DYNNAME.imbeats.ready" ]; then
+		break
+	fi
+	$TESTTOOL_DIR/msleep 100
+done
+
+if [ ! -f "$RSYSLOG_DYNNAME.imbeats.ready" ]; then
+	kill "$client_pid" 2>/dev/null || true
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown "" 10
+wait "$client_pid" || error_exit 1
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.client-result")" = "closed" || error_exit 1
+
+exit_test


### PR DESCRIPTION
## Summary

- make imbeats session threads joinable instead of detached
- transfer accepted netstream ownership explicitly into sessions
- stop and reap open sessions during instance teardown before freeing config
- add a shutdown regression test for idle and partial open Beats sessions

## Validation

- `git diff --check`
- `bash -n tests/imbeats-shutdown-open-session.sh`
- previously validated before this PR split with `autogen.sh`, `make -j$(nproc) check TESTS=""`, focused imbeats tests, and mock `distcheck`
