### PR TITLE
imbeats: track cumulative Lumberjack sequences

### DIFF
--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -113,6 +113,7 @@ struct session_s {
     pthread_t tid;
     int done;
     int sock;
+    uint32_t lastAckedSeq;
     uchar *fromHostFQDN;
     prop_t *fromHost;
     prop_t *fromHostIP;
@@ -545,7 +546,7 @@ static rsRetVal receiveBatch(session_t *const sess, struct lj_batch_s *batch) {
     }
 
     for (idx = 0; idx < batch->count; ++idx) {
-        const uint32_t expected = (uint32_t)idx + 1;
+        const uint32_t expected = sess->lastAckedSeq + (uint32_t)idx + 1;
         if (batch->events[idx].seq != expected) {
             ABORT_FINALIZE(RS_RET_INVALID_VALUE);
         }
@@ -635,6 +636,9 @@ static void *sessionThread(void *arg) {
         }
         if (iRet == RS_RET_OK) {
             iRet = ackBatch(sess, batch.events[batch.count - 1].seq);
+            if (iRet == RS_RET_OK) {
+                sess->lastAckedSeq = batch.events[batch.count - 1].seq;
+            }
         }
         lj_batch_free(&batch);
         if (iRet != RS_RET_OK) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1039,6 +1039,9 @@ TESTS_IMHTTP_VALGRIND = \
 TESTS_IMBEATS = \
 	imbeats-basic.sh \
 	imbeats-compressed.sh \
+	imbeats-seq-cumulative-two-windows.sh \
+	imbeats-seq-cumulative-after-multi-event-window.sh \
+	imbeats-seq-reset-rejected.sh \
 	imbeats-limits.sh \
 	imbeats-filebeat-docker.sh
 

--- a/tests/imbeats-seq-cumulative-after-multi-event-window.sh
+++ b/tests/imbeats-seq-cumulative-after-multi-event-window.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!metadata!imbeats!sequence%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+
+
+def frame(seq, message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return b"2J" + struct.pack(">I", seq) + struct.pack(">I", len(payload)) + payload
+
+
+with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+    sock.settimeout(5)
+    wire = b"2W" + struct.pack(">I", 2) + frame(1, "one") + frame(2, "two")
+    sock.sendall(wire)
+    print(sock.recv(6).hex())
+    sock.sendall(b"2W" + struct.pack(">I", 1) + frame(3, "three"))
+    print(sock.recv(6).hex())
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"one"}|1
+{"message":"two"}|2
+{"message":"three"}|3'
+cmp_exact
+
+EXPECTED_ACK='324100000002
+324100000003'
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "$EXPECTED_ACK"
+
+exit_test

--- a/tests/imbeats-seq-cumulative-two-windows.sh
+++ b/tests/imbeats-seq-cumulative-two-windows.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!metadata!imbeats!sequence%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+
+
+def frame(seq, message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return b"2J" + struct.pack(">I", seq) + struct.pack(">I", len(payload)) + payload
+
+
+with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+    sock.settimeout(5)
+    sock.sendall(b"2W" + struct.pack(">I", 1) + frame(1, "first"))
+    print(sock.recv(6).hex())
+    sock.sendall(b"2W" + struct.pack(">I", 1) + frame(2, "second"))
+    print(sock.recv(6).hex())
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"first"}|1
+{"message":"second"}|2'
+cmp_exact
+
+EXPECTED_ACK='324100000001
+324100000002'
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "$EXPECTED_ACK"
+
+exit_test

--- a/tests/imbeats-seq-reset-rejected.sh
+++ b/tests/imbeats-seq-reset-rejected.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!metadata!imbeats!sequence%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+
+
+def frame(seq, message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return b"2J" + struct.pack(">I", seq) + struct.pack(">I", len(payload)) + payload
+
+
+with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+    sock.settimeout(5)
+    sock.sendall(b"2W" + struct.pack(">I", 1) + frame(1, "first"))
+    print(sock.recv(6).hex())
+    sock.sendall(b"2W" + struct.pack(">I", 1) + frame(1, "reset"))
+    try:
+        data = sock.recv(6)
+    except (ConnectionResetError, TimeoutError, socket.timeout):
+        data = b""
+    if data:
+        raise SystemExit(f"unexpected ack for reset sequence: {data.hex()}")
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"first"}|1'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
+
+exit_test


### PR DESCRIPTION
## Summary

- track the last acknowledged Lumberjack sequence number per session
- validate later windows against cumulative v2 sequence numbers
- advance session sequence state only after ACK write succeeds
- add regression tests for cumulative multi-window ACKs and rejected resets

## Validation

- `git diff --check`
- `bash -n tests/imbeats-seq-cumulative-two-windows.sh tests/imbeats-seq-cumulative-after-multi-event-window.sh tests/imbeats-seq-reset-rejected.sh`
- previously validated before this PR split with `autogen.sh`, `make -j$(nproc) check TESTS=""`, focused imbeats tests, and mock `distcheck`
