### PR TITLE
imbeats: harden compressed frame parsing

### DIFF
--- a/plugins/imbeats/lj_parser.c
+++ b/plugins/imbeats/lj_parser.c
@@ -14,9 +14,13 @@
 #include <zlib.h>
 
 static rsRetVal append_event_owned(struct lj_batch_s *batch, uint32_t seq, unsigned char *payload, size_t payload_len) {
-    if (batch == NULL || batch->events == NULL || batch->count >= batch->window_size) {
+    if (batch == NULL || batch->events == NULL) {
         free(payload);
         return RS_RET_PARAM_ERROR;
+    }
+    if (batch->count >= batch->window_size) {
+        free(payload);
+        return RS_RET_INVALID_VALUE;
     }
 
     batch->events[batch->count].seq = seq;
@@ -83,8 +87,7 @@ rsRetVal lj_append_json_event(struct lj_batch_s *batch,
 static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
                                          const unsigned char *buf,
                                          size_t len,
-                                         size_t max_frame_size,
-                                         size_t max_decompressed_size) {
+                                         size_t max_frame_size) {
     size_t off = 0;
 
     while (off + 2 <= len) {
@@ -107,7 +110,7 @@ static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
                 off += 8;
                 v1 = ntohl(v1);
                 v2 = ntohl(v2);
-                if ((size_t)v2 > max_frame_size || (size_t)v2 > len - off) {
+                if (v2 == 0 || (size_t)v2 > max_frame_size || (size_t)v2 > len - off) {
                     return RS_RET_INVALID_VALUE;
                 }
                 iRet = lj_append_json_event(batch, v1, buf + off, v2);
@@ -123,15 +126,7 @@ static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
                 memcpy(&v1, buf + off, 4);
                 off += 4;
                 v1 = ntohl(v1);
-                if ((size_t)v1 > max_frame_size || (size_t)v1 > len - off) {
-                    return RS_RET_INVALID_VALUE;
-                }
-                iRet = lj_parse_compressed_frames(batch, buf + off, v1, max_frame_size, max_decompressed_size);
-                if (iRet != RS_RET_OK) {
-                    return iRet;
-                }
-                off += v1;
-                break;
+                return RS_RET_INVALID_VALUE;
             default:
                 return RS_RET_INVALID_VALUE;
         }
@@ -192,12 +187,17 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
         zrc = inflate(&zstrm, Z_NO_FLUSH);
         out_len = out_cap - zstrm.avail_out;
         if (zrc != Z_OK && zrc != Z_STREAM_END) {
-            iRet = RS_RET_ZLIB_ERR;
+            iRet = RS_RET_INVALID_VALUE;
             goto finalize_it;
         }
     } while (zrc != Z_STREAM_END);
 
-    iRet = parse_frames_from_memory(batch, out, out_len, max_frame_size, max_decompressed_size);
+    if (zstrm.avail_in != 0) {
+        iRet = RS_RET_INVALID_VALUE;
+        goto finalize_it;
+    }
+
+    iRet = parse_frames_from_memory(batch, out, out_len, max_frame_size);
 
 finalize_it:
     inflateEnd(&zstrm);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1042,6 +1042,8 @@ TESTS_IMBEATS = \
 	imbeats-seq-cumulative-two-windows.sh \
 	imbeats-seq-cumulative-after-multi-event-window.sh \
 	imbeats-seq-reset-rejected.sh \
+	imbeats-compressed-window-overflow.sh \
+	imbeats-compressed-malformed.sh \
 	imbeats-limits.sh \
 	imbeats-shutdown-open-session.sh \
 	imbeats-filebeat-docker.sh

--- a/tests/imbeats-compressed-malformed.sh
+++ b/tests/imbeats-compressed-malformed.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+require_plugin impstats
+
+generate_conf
+add_conf '
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+       log.file="'$RSYSLOG_DYNNAME'.spool/imbeats-stats.log"
+       log.syslog="off" format="cee")
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+$PYTHON - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+import zlib
+
+port = int(sys.argv[1])
+
+
+def frame(seq, message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return b"2J" + struct.pack(">I", seq) + struct.pack(">I", len(payload)) + payload
+
+
+def send_bad(compressed):
+    wire = b"2W" + struct.pack(">I", 1) + b"2C" + struct.pack(">I", len(compressed)) + compressed
+    with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+        sock.settimeout(5)
+        sock.sendall(wire)
+        try:
+            data = sock.recv(6)
+        except (ConnectionResetError, TimeoutError, socket.timeout):
+            data = b""
+        if data:
+            raise SystemExit(f"unexpected ack for malformed compressed frame: {data.hex()}")
+
+
+send_bad(b"not-a-zlib-stream")
+send_bad(zlib.compress(frame(1, "ok")) + b"trailing-garbage")
+
+nested = b"2C" + struct.pack(">I", len(zlib.compress(frame(1, "nested")))) + zlib.compress(frame(1, "nested"))
+send_bad(zlib.compress(nested))
+
+zero = b"2J" + struct.pack(">I", 1) + struct.pack(">I", 0)
+send_bad(zlib.compress(zero))
+PY
+
+rst_msleep 1500
+
+shutdown_when_empty
+wait_shutdown
+
+test ! -s "$RSYSLOG_OUT_LOG"
+test ! -s "$RSYSLOG_DYNNAME.imbeats.ack"
+
+if ! $PYTHON - "$RSYSLOG_DYNNAME.spool/imbeats-stats.log" <<'PY'
+import json
+import sys
+
+stats = {}
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        if "@cee: " not in line:
+            continue
+        line = line.split("@cee: ", 1)[1]
+        data = json.loads(line)
+        if data.get("name") == "imbeats":
+            stats = data
+
+expected = {
+    "compressed_frames": 4,
+    "compressed.rejected": 4,
+    "protocol_errors": 4,
+    "events.submitted": 0,
+}
+missing = {key: (stats.get(key), value) for key, value in expected.items() if stats.get(key) != value}
+if missing:
+    raise SystemExit(f"unexpected imbeats stats: {missing}; last stats={stats}")
+PY
+then
+	error_exit 1
+fi
+
+exit_test

--- a/tests/imbeats-compressed-window-overflow.sh
+++ b/tests/imbeats-compressed-window-overflow.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+require_plugin impstats
+
+generate_conf
+add_conf '
+module(load="../plugins/impstats/.libs/impstats" interval="1"
+       log.file="'$RSYSLOG_DYNNAME'.spool/imbeats-stats.log"
+       log.syslog="off" format="cee")
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+$PYTHON - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+import zlib
+
+port = int(sys.argv[1])
+
+
+def frame(seq, message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return b"2J" + struct.pack(">I", seq) + struct.pack(">I", len(payload)) + payload
+
+
+nested = frame(1, "one") + frame(2, "overflow")
+compressed = zlib.compress(nested)
+wire = b"2W" + struct.pack(">I", 1) + b"2C" + struct.pack(">I", len(compressed)) + compressed
+
+with socket.create_connection(("127.0.0.1", port), timeout=5) as sock:
+    sock.settimeout(5)
+    sock.sendall(wire)
+    try:
+        data = sock.recv(6)
+    except (ConnectionResetError, TimeoutError, socket.timeout):
+        data = b""
+    if data:
+        raise SystemExit(f"unexpected ack for overfull compressed window: {data.hex()}")
+PY
+
+rst_msleep 1500
+
+shutdown_when_empty
+wait_shutdown
+
+test ! -s "$RSYSLOG_OUT_LOG"
+test ! -s "$RSYSLOG_DYNNAME.imbeats.ack"
+
+if ! $PYTHON - "$RSYSLOG_DYNNAME.spool/imbeats-stats.log" <<'PY'
+import json
+import sys
+
+stats = {}
+with open(sys.argv[1], encoding="utf-8") as fh:
+    for line in fh:
+        if "@cee: " not in line:
+            continue
+        line = line.split("@cee: ", 1)[1]
+        data = json.loads(line)
+        if data.get("name") == "imbeats":
+            stats = data
+
+expected = {
+    "compressed_frames": 1,
+    "compressed.rejected": 1,
+    "protocol_errors": 1,
+    "events.submitted": 0,
+}
+missing = {key: (stats.get(key), value) for key, value in expected.items() if stats.get(key) != value}
+if missing:
+    raise SystemExit(f"unexpected imbeats stats: {missing}; last stats={stats}")
+PY
+then
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary

- reject malformed compressed Lumberjack payloads as protocol input errors
- reject trailing bytes after a zlib stream, nested compressed frames, zero-length nested JSON, and decompressed event overflow
- count compressed rejects through existing imbeats counters
- add regression tests for malformed compressed frames and compressed window overflow

## Validation

- `git diff --check`
- `bash -n tests/imbeats-compressed-window-overflow.sh tests/imbeats-compressed-malformed.sh`
- previously validated before this PR split with `autogen.sh`, `make -j$(nproc) check TESTS=""`, focused imbeats tests, and mock `distcheck`
