### PR TITLE
tests: quote paths in imptcp NUL tests

### DIFF
--- a/tests/imptcp-NUL-rawmsg.sh
+++ b/tests/imptcp-NUL-rawmsg.sh
@@ -9,12 +9,12 @@ input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_por
 
 template(name="outfmt" type="string" string="%rawmsg%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
-			         file=`echo $RSYSLOG_OUT_LOG`)
+			         file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 echo '<167>Mar  6 16:57:54 172.20.245.8 test: msgnum:0 X test message
-<167>Mar  6 16:57:54 172.20.245.8 Xtest: msgnum:1 test message' | tr X '\000' > $RSYSLOG_DYNNAME.input
-tcpflood -B -I $RSYSLOG_DYNNAME.input
+<167>Mar  6 16:57:54 172.20.245.8 Xtest: msgnum:1 test message' | tr X '\000' > "$RSYSLOG_DYNNAME.input"
+tcpflood -B -I "$RSYSLOG_DYNNAME.input"
 shutdown_when_empty
 wait_shutdown
 echo '<167>Mar  6 16:57:54 172.20.245.8 test: msgnum:0 #000 test message

--- a/tests/imptcp-NUL.sh
+++ b/tests/imptcp-NUL.sh
@@ -9,12 +9,12 @@ input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_por
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
-			         file=`echo $RSYSLOG_OUT_LOG`)
+			         file="'$RSYSLOG_OUT_LOG'")
 '
 startup
 echo '<167>Mar  6 16:57:54 172.20.245.8 test: msgnum:0 X test message
-<167>Mar  6 16:57:54 172.20.245.8 Xtest: msgnum:1 test message' | tr X '\000' > $RSYSLOG_DYNNAME.input
-tcpflood -B -I $RSYSLOG_DYNNAME.input
+<167>Mar  6 16:57:54 172.20.245.8 Xtest: msgnum:1 test message' | tr X '\000' > "$RSYSLOG_DYNNAME.input"
+tcpflood -B -I "$RSYSLOG_DYNNAME.input"
 shutdown_when_empty
 wait_shutdown
 seq_check 0 1


### PR DESCRIPTION
## Summary

This is a small testbench cleanup for the two imptcp NUL-byte tests.

- replace the old omfile backtick path expansion with direct quoted shell expansion
- quote the generated input file path for redirection
- quote the generated input file path passed to the `tcpflood` wrapper

## Rationale

The tests continue to use the normal `diag.sh` `tcpflood` wrapper. That wrapper already supplies the dynamic `TCPFLOOD_PORT` selected through `listenPortFileName`, so the test command should not add another `-p` argument.

The useful cleanup here is limited to path handling. It makes the scripts easier to read and avoids shell word splitting if a generated path is ever inspected or run in a less typical environment.

This does not address the observed ASAN/aarch64 thread-registry failure directly; that failure happens during generic rsyslog startup before this test sends its NUL payload.

## Validation

- `bash -n tests/imptcp-NUL.sh tests/imptcp-NUL-rawmsg.sh`
- `git diff --check origin/main`