### PR TITLE
imbeats: verify raw and amended ES pipeline

### DIFF
--- a/tests/imbeats-filebeat-omelasticsearch-docker.sh
+++ b/tests/imbeats-filebeat-omelasticsearch-docker.sh
@@ -24,6 +24,9 @@ export FB_DOCKER_MOUNT_SOURCE="${FB_DOCKER_MOUNT_SOURCE:-$FB_WORKDIR}"
 export FB_INPUT="${FB_WORKDIR}/input.log"
 export FB_CONFIG="${FB_WORKDIR}/filebeat.yml"
 export FB_LOG="${FB_WORKDIR}/docker.log"
+export RAW_INDEX="rsyslog_testbench_beats_raw"
+export AMENDED_INDEX="rsyslog_testbench_beats_amended"
+export MARKER="imbeats-elasticsearch"
 
 cleanup_filebeat() {
 	docker rm -f "$FB_CONTAINER" >/dev/null 2>&1 || true
@@ -31,43 +34,66 @@ cleanup_filebeat() {
 }
 trap cleanup_filebeat EXIT
 
-imbeats_es_shutdown_empty_check() {
-	local base
+es_count_index() {
+	local base="$1"
+	local index="$2"
 	local response
 	local http_status
 	local body
-	local lines
 
-	base=$(es_base_url)
 	response=$(curl --silent --show-error --write-out '\n%{http_code}' \
-		"${base}/rsyslog_testbench/_count")
+		"${base}/${index}/_count")
 	http_status=$(printf '%s' "$response" | tail -n 1)
 	body=$(printf '%s' "$response" | sed '$d')
 	if [ "$http_status" = "404" ]; then
-		lines=0
+		printf '0\n'
 	elif [ "$http_status" = "200" ]; then
-		lines=$(printf '%s' "$body" | "$PYTHON" -c '
+		printf '%s' "$body" | "$PYTHON" -c '
 import json
 import sys
 
 print(json.load(sys.stdin).get("count", 0))
-')
+'
 	else
-		printf '%s imbeats_es_shutdown_empty_check: unexpected Elasticsearch status %s\n' \
-			"$(tb_timestamp)" "$http_status"
+		printf '%s es_count_index: unexpected Elasticsearch status %s for %s\n' \
+			"$(tb_timestamp)" "$http_status" "$index" >&2
 		return 1
 	fi
-	if [ "$lines" -eq "$NUMMESSAGES" ]; then
-		printf '%s imbeats_es_shutdown_empty_check: success, have %d lines\n' "$(tb_timestamp)" "$lines"
+}
+
+imbeats_es_shutdown_empty_check() {
+	local base
+	local raw_lines
+	local amended_lines
+
+	base=$(es_base_url)
+	raw_lines=$(es_count_index "$base" "$RAW_INDEX") || return 1
+	amended_lines=$(es_count_index "$base" "$AMENDED_INDEX") || return 1
+	if [ "$raw_lines" -eq "$NUMMESSAGES" ] && [ "$amended_lines" -eq "$NUMMESSAGES" ]; then
+		printf '%s imbeats_es_shutdown_empty_check: success, have %d raw and %d amended documents\n' \
+			"$(tb_timestamp)" "$raw_lines" "$amended_lines"
 		return 0
 	fi
-	printf '%s imbeats_es_shutdown_empty_check: have %d lines, expecting %d\n' \
-		"$(tb_timestamp)" "$lines" "$NUMMESSAGES"
+	printf '%s imbeats_es_shutdown_empty_check: have %d raw and %d amended documents, expecting %d each\n' \
+		"$(tb_timestamp)" "$raw_lines" "$amended_lines" "$NUMMESSAGES"
 	return 1
+}
+
+fetch_index() {
+	local index="$1"
+	local output="$2"
+	local base
+
+	base=$(es_base_url)
+	curl --silent --show-error "${base}/${index}/_refresh" >/dev/null
+	curl --silent --show-error "${base}/${index}/_search?size=${NUMMESSAGES}" > "$output"
 }
 
 ensure_elasticsearch_ready
 init_elasticsearch
+base=$(es_base_url)
+curl --silent --show-error -XDELETE "${base}/${RAW_INDEX}" >/dev/null || true
+curl --silent --show-error -XDELETE "${base}/${AMENDED_INDEX}" >/dev/null || true
 
 mkdir -p "$FB_WORKDIR/data"
 for i in $(seq 0 $((NUMMESSAGES - 1))) ; do
@@ -79,15 +105,24 @@ add_conf '
 module(load="../plugins/imbeats/.libs/imbeats")
 module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
 
-template(name="es_tpl" type="string"
-         string="{\"msgnum\":\"%$!message:F,58:2%\"}")
+template(name="rawBeatEvent" type="string" string="%msg%")
+template(name="amendedBeatEvent" type="subtree" subtree="$!")
 
 ruleset(name="beats_to_es") {
   action(type="omelasticsearch"
          server="127.0.0.1"
          serverport="'$ES_PORT'"
-         template="es_tpl"
-         searchIndex="rsyslog_testbench")
+         template="rawBeatEvent"
+         searchIndex="'$RAW_INDEX'")
+
+  set $!rsyslog!test!pipeline = "amended";
+  set $!rsyslog!test!marker = "'$MARKER'";
+
+  action(type="omelasticsearch"
+         server="127.0.0.1"
+         serverport="'$ES_PORT'"
+         template="amendedBeatEvent"
+         searchIndex="'$AMENDED_INDEX'")
 }
 
 input(type="imbeats"
@@ -106,6 +141,9 @@ filebeat.inputs:
     enabled: true
     paths:
       - /work/input.log
+    fields_under_root: true
+    fields:
+      rsyslog_test_case: ${MARKER}
 
 output.logstash:
   hosts: ["127.0.0.1:${RS_PORT}"]
@@ -134,6 +172,56 @@ wait_shutdown
 
 docker rm -f "$FB_CONTAINER" >/dev/null 2>&1 || true
 
-es_getdata "$NUMMESSAGES" "$ES_PORT"
-seq_check 0 $((NUMMESSAGES - 1))
+fetch_index "$RAW_INDEX" "$RSYSLOG_DYNNAME.raw.work"
+fetch_index "$AMENDED_INDEX" "$RSYSLOG_DYNNAME.amended.work"
+
+"$PYTHON" - "$RSYSLOG_DYNNAME.raw.work" "$RSYSLOG_DYNNAME.amended.work" "$NUMMESSAGES" "$MARKER" <<'PY' || \
+	error_exit 1
+import json
+import sys
+
+raw_path, amended_path, expected_count, marker = sys.argv[1], sys.argv[2], int(sys.argv[3]), sys.argv[4]
+
+
+def load_sources(path):
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    hits = data["hits"]["hits"]
+    return sorted((hit["_source"] for hit in hits), key=lambda item: item.get("message", ""))
+
+
+raw = load_sources(raw_path)
+amended = load_sources(amended_path)
+
+if len(raw) != expected_count:
+    raise SystemExit(f"raw index has {len(raw)} documents, expected {expected_count}")
+if len(amended) != expected_count:
+    raise SystemExit(f"amended index has {len(amended)} documents, expected {expected_count}")
+
+for idx, (raw_doc, amended_doc) in enumerate(zip(raw, amended)):
+    expected_message = f"msgnum:{idx:08d}:"
+    if raw_doc.get("message") != expected_message:
+        raise SystemExit(f"raw message mismatch at {idx}: {raw_doc.get('message')!r}")
+    if amended_doc.get("message") != expected_message:
+        raise SystemExit(f"amended message mismatch at {idx}: {amended_doc.get('message')!r}")
+    if raw_doc.get("rsyslog_test_case") != marker:
+        raise SystemExit(f"raw Filebeat marker missing at {idx}")
+    if amended_doc.get("rsyslog_test_case") != marker:
+        raise SystemExit(f"amended Filebeat marker changed at {idx}")
+    if "rsyslog" in raw_doc:
+        raise SystemExit(f"raw document unexpectedly contains rsyslog amendments at {idx}")
+
+    rsyslog_meta = amended_doc.get("rsyslog", {}).get("test", {})
+    if rsyslog_meta.get("pipeline") != "amended" or rsyslog_meta.get("marker") != marker:
+        raise SystemExit(f"amended rsyslog metadata missing at {idx}: {rsyslog_meta!r}")
+
+    imbeats_meta = amended_doc.get("metadata", {}).get("imbeats", {})
+    if imbeats_meta.get("protocol") != "lumberjack-v2":
+        raise SystemExit(f"imbeats protocol metadata missing at {idx}: {imbeats_meta!r}")
+    if int(imbeats_meta.get("sequence", -1)) < 1:
+        raise SystemExit(f"imbeats sequence metadata missing at {idx}: {imbeats_meta!r}")
+
+print("validated raw and amended Beats documents")
+PY
+
 exit_test


### PR DESCRIPTION
## Summary

- extend the Filebeat -> imbeats -> omelasticsearch -> Elasticsearch integration test
- validate a raw pass-through index that preserves the original Beat JSON without rsyslog amendments
- validate an amended index that includes rsyslog-added fields and imbeats protocol metadata

## Validation

- `bash -n tests/imbeats-filebeat-omelasticsearch-docker.sh`
- `git diff --check`
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-imbeats --enable-omstdout --enable-elasticsearch --enable-elasticsearch-tests --disable-default-tests --disable-imtcp-tests --disable-imfile --disable-imfile-tests --disable-fmhttp`
- `make -j$(nproc) check TESTS=""`
- `RSYSLOG_TESTBENCH_EXTERNAL_ES_URL=http://127.0.0.1:19200 ES_HOST=127.0.0.1 ES_PORT=19200 ./tests/imbeats-filebeat-omelasticsearch-docker.sh`
