### PR TITLE
imbeats: multiplex sessions for high client counts

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -1591,6 +1591,13 @@ jobs:
           CI_MAKE_OPT: -j20
           CI_MAKE_CHECK_OPT: -j1
           CI_MAKE_CHECK_TESTS: >-
+            imbeats-basic.sh
+            imbeats-compressed.sh
+            imbeats-limits.sh
+            imbeats-limits-impstats.sh
+            imbeats-maxsessions.sh
+            imbeats-multiplex-idle-sessions.sh
+            yaml-imbeats-basic.sh
             imbeats-filebeat-docker.sh
             imbeats-filebeat-omelasticsearch-docker.sh
           CI_CHECK_CMD: check

--- a/configure.ac
+++ b/configure.ac
@@ -3635,6 +3635,7 @@ echo "    imjournal input module enabled:           $enable_imjournal"
 if test "$enable_imjournal" = "optional"; then
 echo "        imjournal use dummy:                  $imjournal_use_dummy"
 fi
+echo "    imbeats input module enabled:             $enable_imbeats"
 echo "    imbatchreport input module enabled:       $enable_imbatchreport"
 echo "    imkafka module will be compiled:          $enable_imkafka"
 if test "$enable_imkafka" = "optional"; then

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -235,6 +235,7 @@ EXTRA_DIST = \
     source/reference/parameters/imbeats-keepalive-probes.rst \
     source/reference/parameters/imbeats-keepalive-time.rst \
     source/reference/parameters/imbeats-listenportfilename.rst \
+    source/reference/parameters/imbeats-maxbatchbytes.rst \
     source/reference/parameters/imbeats-maxdecompressedsize.rst \
     source/reference/parameters/imbeats-maxframesize.rst \
     source/reference/parameters/imbeats-maxwindowsize.rst \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -238,12 +238,14 @@ EXTRA_DIST = \
     source/reference/parameters/imbeats-maxbatchbytes.rst \
     source/reference/parameters/imbeats-maxdecompressedsize.rst \
     source/reference/parameters/imbeats-maxframesize.rst \
+    source/reference/parameters/imbeats-maxsessions.rst \
     source/reference/parameters/imbeats-maxwindowsize.rst \
     source/reference/parameters/imbeats-name.rst \
     source/reference/parameters/imbeats-networknamespace.rst \
     source/reference/parameters/imbeats-permittedpeer.rst \
     source/reference/parameters/imbeats-port.rst \
     source/reference/parameters/imbeats-ruleset.rst \
+    source/reference/parameters/imbeats-starvationprotection-maxreads.rst \
     source/reference/parameters/imbeats-streamdriver-authmode.rst \
     source/reference/parameters/imbeats-streamdriver-cafile.rst \
     source/reference/parameters/imbeats-streamdriver-certfile.rst \
@@ -256,6 +258,7 @@ EXTRA_DIST = \
     source/reference/parameters/imbeats-streamdriver-prioritizesan.rst \
     source/reference/parameters/imbeats-streamdriver-tlsrevocationcheck.rst \
     source/reference/parameters/imbeats-streamdriver-tlsverifydepth.rst \
+    source/reference/parameters/imbeats-workerthreads.rst \
     source/configuration/modules/omamqp1.rst \
     source/configuration/modules/omazuredce.rst \
     source/configuration/modules/omazureeventhubs.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -88,8 +88,10 @@ imbeats:
     - type: mutex
       field: instanceConf.mutSessions
   notes:
-    - Listener threads mutate per-instance session lists under mutSessions.
+    - Listener threads own readiness notification and worker threads process native Lumberjack session state.
     - Use Elastic Agent or Filebeat output.logstash to send Lumberjack v2 traffic to imbeats.
+    - Concurrent Beats sessions are bounded per listener with maxSessions and processed through the listener worker/multiplexing path.
+    - Use starvationProtection.maxReads to keep one busy sender from monopolizing imbeats worker time.
     - TLS deployments require an installed rsyslog TLS stream-driver package or module, such as rsyslog-gnutls or rsyslog-openssl.
     - The common Elastic Agent TLS setup validates the rsyslog server certificate but does not present a client certificate; use streamDriver.authMode=anon for that pattern and stricter auth modes only with sender client certificates.
     - Compressed Lumberjack v2 frames are supported and should be tested with Beats compression enabled.

--- a/doc/source/configuration/modules/imbeats.rst
+++ b/doc/source/configuration/modules/imbeats.rst
@@ -45,8 +45,8 @@ common Elasticsearch-oriented pipelines:
 - ``msg`` keeps the original JSON payload
 - decoded Beat event fields are added under top-level ``$!``
 - transport and protocol metadata is stored under ``$!metadata!imbeats``
-- listener-side size limits reject oversized windows, frames, and compressed
-  payload expansion before unbounded allocation
+- listener-side size limits reject oversized windows, frames, batches, and
+  compressed payload expansion before unbounded allocation
 
 This default may be revisited later. A user-selectable representation mode is
 not part of the initial release.
@@ -193,6 +193,11 @@ Input Parameters
 
    * - :ref:`param-imbeats-listenportfilename`
      - .. include:: ../../reference/parameters/imbeats-listenportfilename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-maxbatchbytes`
+     - .. include:: ../../reference/parameters/imbeats-maxbatchbytes.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
 

--- a/doc/source/configuration/modules/imbeats.rst
+++ b/doc/source/configuration/modules/imbeats.rst
@@ -47,6 +47,8 @@ common Elasticsearch-oriented pipelines:
 - transport and protocol metadata is stored under ``$!metadata!imbeats``
 - listener-side size limits reject oversized windows, frames, batches, and
   compressed payload expansion before unbounded allocation
+- listener-side session limits and worker settings bound concurrent sender
+  fan-in and provide fairness between active sessions
 
 This default may be revisited later. A user-selectable representation mode is
 not part of the initial release.
@@ -196,6 +198,11 @@ Input Parameters
         :start-after: .. summary-start
         :end-before: .. summary-end
 
+   * - :ref:`param-imbeats-maxsessions`
+     - .. include:: ../../reference/parameters/imbeats-maxsessions.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
    * - :ref:`param-imbeats-maxbatchbytes`
      - .. include:: ../../reference/parameters/imbeats-maxbatchbytes.rst
         :start-after: .. summary-start
@@ -238,6 +245,11 @@ Input Parameters
 
    * - :ref:`param-imbeats-ruleset`
      - .. include:: ../../reference/parameters/imbeats-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-starvationprotection-maxreads`
+     - .. include:: ../../reference/parameters/imbeats-starvationprotection-maxreads.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
 
@@ -298,6 +310,11 @@ Input Parameters
 
    * - :ref:`param-imbeats-streamdriver-tlsverifydepth`
      - .. include:: ../../reference/parameters/imbeats-streamdriver-tlsverifydepth.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+   * - :ref:`param-imbeats-workerthreads`
+     - .. include:: ../../reference/parameters/imbeats-workerthreads.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
 
@@ -380,14 +397,17 @@ The module exposes these ``impstats`` counters:
    ../../reference/parameters/imbeats-keepalive-probes
    ../../reference/parameters/imbeats-keepalive-time
    ../../reference/parameters/imbeats-listenportfilename
+   ../../reference/parameters/imbeats-maxbatchbytes
    ../../reference/parameters/imbeats-maxdecompressedsize
    ../../reference/parameters/imbeats-maxframesize
+   ../../reference/parameters/imbeats-maxsessions
    ../../reference/parameters/imbeats-maxwindowsize
    ../../reference/parameters/imbeats-name
    ../../reference/parameters/imbeats-networknamespace
    ../../reference/parameters/imbeats-permittedpeer
    ../../reference/parameters/imbeats-port
    ../../reference/parameters/imbeats-ruleset
+   ../../reference/parameters/imbeats-starvationprotection-maxreads
    ../../reference/parameters/imbeats-streamdriver-authmode
    ../../reference/parameters/imbeats-streamdriver-cafile
    ../../reference/parameters/imbeats-streamdriver-certfile
@@ -400,3 +420,4 @@ The module exposes these ``impstats`` counters:
    ../../reference/parameters/imbeats-streamdriver-prioritizesan
    ../../reference/parameters/imbeats-streamdriver-tlsrevocationcheck
    ../../reference/parameters/imbeats-streamdriver-tlsverifydepth
+   ../../reference/parameters/imbeats-workerthreads

--- a/doc/source/reference/parameters/imbeats-maxbatchbytes.rst
+++ b/doc/source/reference/parameters/imbeats-maxbatchbytes.rst
@@ -1,0 +1,47 @@
+.. _param-imbeats-maxbatchbytes:
+.. _imbeats.parameter.input.maxbatchbytes:
+
+maxBatchBytes
+=============
+
+.. meta::
+   :description: Maximum cumulative Lumberjack batch payload size accepted by imbeats.
+   :keywords: rsyslog, imbeats, maxBatchBytes, Lumberjack batch, size limit
+
+.. index::
+   single: imbeats; maxBatchBytes
+   single: maxBatchBytes
+
+.. summary-start
+
+Limit the cumulative JSON payload bytes accepted in one Lumberjack batch.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: maxBatchBytes
+:Scope: input
+:Type: positive integer
+:Default: input=67108864
+:Required?: no
+:Introduced: 8.2604.0
+
+Description
+-----------
+Set the maximum cumulative byte size of JSON event payloads accepted in one
+Lumberjack batch window. Batches that exceed this limit are rejected before all
+payloads are retained in memory.
+
+Input usage
+-----------
+.. _param-imbeats-input-maxbatchbytes:
+.. _imbeats.parameter.input.maxbatchbytes-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" maxBatchBytes="67108864")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-maxsessions.rst
+++ b/doc/source/reference/parameters/imbeats-maxsessions.rst
@@ -1,0 +1,51 @@
+.. _param-imbeats-maxsessions:
+.. _imbeats.parameter.input.maxsessions:
+
+maxSessions
+===========
+
+.. meta::
+   :description: Maximum simultaneous client sessions accepted by an imbeats input.
+   :keywords: rsyslog, imbeats, maxSessions, Beats sessions, Lumberjack
+
+.. index::
+   single: imbeats; maxSessions
+   single: maxSessions
+
+.. summary-start
+
+Limit how many simultaneous Beats client sessions an imbeats listener accepts.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: maxSessions
+:Scope: input
+:Type: positive integer
+:Default: input=1000
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Set the maximum number of simultaneous client sessions accepted by this
+``imbeats`` listener. When the limit is reached, additional connection attempts
+are rejected while existing sessions continue to run.
+
+Use this limit to bound file descriptors, per-session memory, and sender fan-in
+for a listener. Size it for the number of Beats or Elastic Agent senders that
+may be connected at the same time, including reconnect overlap during restarts.
+
+Input usage
+-----------
+.. _param-imbeats-input-maxsessions:
+.. _imbeats.parameter.input.maxsessions-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" maxSessions="500")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-starvationprotection-maxreads.rst
+++ b/doc/source/reference/parameters/imbeats-starvationprotection-maxreads.rst
@@ -1,0 +1,51 @@
+.. _param-imbeats-starvationprotection-maxreads:
+.. _imbeats.parameter.input.starvationprotection-maxreads:
+
+starvationProtection.maxReads
+=============================
+
+.. meta::
+   :description: Maximum consecutive reads per imbeats session before another session can run.
+   :keywords: rsyslog, imbeats, starvationProtection.maxReads, Beats sessions, fairness
+
+.. index::
+   single: imbeats; starvationProtection.maxReads
+   single: starvationProtection.maxReads
+
+.. summary-start
+
+Limit consecutive reads from one imbeats session before other sessions can run.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: starvationProtection.maxReads
+:Scope: input
+:Type: non-negative integer
+:Default: input=500
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Set the maximum number of consecutive socket reads a worker performs for one
+``imbeats`` session before yielding so other ready sessions can be processed.
+This prevents one busy Beats sender from monopolizing the listener.
+
+Use ``0`` to disable this fairness limit. Positive values cap the number of
+consecutive reads per turn; smaller values favor fairness across sessions,
+while larger values favor throughput for busy senders.
+
+Input usage
+-----------
+.. _param-imbeats-input-starvationprotection-maxreads:
+.. _imbeats.parameter.input.starvationprotection-maxreads-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" starvationProtection.maxReads="300")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/doc/source/reference/parameters/imbeats-workerthreads.rst
+++ b/doc/source/reference/parameters/imbeats-workerthreads.rst
@@ -1,0 +1,52 @@
+.. _param-imbeats-workerthreads:
+.. _imbeats.parameter.input.workerthreads:
+
+workerThreads
+=============
+
+.. meta::
+   :description: Number of worker threads used by an imbeats listener.
+   :keywords: rsyslog, imbeats, workerThreads, Beats sessions, multiplexing
+
+.. index::
+   single: imbeats; workerThreads
+   single: workerThreads
+
+.. summary-start
+
+Set how many worker threads an imbeats listener uses to process client sessions.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imbeats`.
+
+:Name: workerThreads
+:Scope: input
+:Type: positive integer
+:Default: input=2
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Set the number of worker threads used by this ``imbeats`` listener. A value of
+``1`` keeps processing single-threaded. Higher values allow multiple client
+sessions to be processed in parallel when the platform and stream layer support
+session multiplexing.
+
+Increasing this value can improve throughput for many active senders, but each
+worker consumes system resources. Avoid setting it higher than the expected
+active sender count or available CPU capacity.
+
+Input usage
+-----------
+.. _param-imbeats-input-workerthreads:
+.. _imbeats.parameter.input.workerthreads-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imbeats" port="5044" workerThreads="4")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imbeats`.

--- a/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/26.04/Dockerfile
@@ -332,6 +332,7 @@ ENV RSYSLOG_CONFIGURE_OPTIONS=" \
 	--enable-imfile \
 	--enable-imhttp \
 	--enable-imjournal \
+	--enable-imbeats \
 	--enable-imkafka \
 	--enable-impstats \
 	--enable-impstats-push \

--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -15,6 +15,9 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <poll.h>
+#if defined(HAVE_SYS_EPOLL_H) && defined(HAVE_EPOLL_CREATE)
+    #include <sys/epoll.h>
+#endif
 #include <arpa/inet.h>
 #include <netinet/in.h>
 #include <sys/socket.h>
@@ -51,12 +54,22 @@ MODULE_CNFNAME("imbeats")
 #define IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE (64 * 1024 * 1024)
 #define IMBEATS_DEFAULT_MAX_BATCH_BYTES IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE
 #define IMBEATS_MAX_BYTE_SIZE_LIMIT 200000000
+#define IMBEATS_DEFAULT_MAX_SESSIONS 1000
+#define IMBEATS_DEFAULT_WORKER_THREADS 2
+#define IMBEATS_MAX_WORKER_THREADS 1024
+#define IMBEATS_DEFAULT_STARVATION_MAX_READS 500
+#define IMBEATS_ACCEPT_BATCH_LIMIT 64
+
+#if defined(HAVE_SYS_EPOLL_H) && defined(HAVE_EPOLL_CREATE)
+    #define IMBEATS_HAVE_EPOLL 1
+#endif
 
 DEF_IMOD_STATIC_DATA;
 DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(netstrm) DEFobjCurrIf(netstrms) DEFobjCurrIf(prop)
     DEFobjCurrIf(ruleset) DEFobjCurrIf(statsobj)
 
         typedef struct session_s session_t;
+typedef struct imbeats_io_s imbeats_io_t;
 
 typedef struct instanceConf_s {
     struct instanceConf_s *next;
@@ -98,11 +111,26 @@ typedef struct instanceConf_s {
     int *listener_socks;
     size_t listener_count;
     size_t listener_cap;
+    imbeats_io_t *listener_descs;
     pthread_t listener_tid;
     int listener_running;
     int shuttingDown;
     pthread_mutex_t mutSessions;
+    pthread_mutex_t mutWork;
+    pthread_cond_t condWork;
+    int workShutdown;
     session_t *sessions;
+    session_t *workHead;
+    session_t *workTail;
+    pthread_t *worker_tids;
+    unsigned workerThreads;
+    unsigned workersStarted;
+    unsigned starvationMaxReads;
+    unsigned maxSessions;
+    unsigned activeSessions;
+#if defined(IMBEATS_HAVE_EPOLL)
+    int epoll_fd;
+#endif
 } instanceConf_t;
 
 typedef struct modConfData_s {
@@ -114,16 +142,51 @@ typedef struct modConfData_s {
 struct session_s {
     instanceConf_t *inst;
     netstrm_t *pStrm;
-    pthread_t tid;
     int done;
-    int threadStarted;
+    int inWorkQueue;
     int sock;
+    unsigned ioDirection;
     uint32_t lastAckedSeq;
     uchar *fromHostFQDN;
     prop_t *fromHost;
     prop_t *fromHostIP;
     prop_t *fromHostPort;
+    char *fromHostIPStr;
+    char *fromHostPortStr;
+    imbeats_io_t *io;
+    struct lj_batch_s batch;
+    int batchActive;
+    size_t submitIdx;
+    uint32_t pendingSeq;
+    unsigned char fixed[8];
+    unsigned char *payload;
+    size_t payload_len;
+    unsigned char *io_buf;
+    size_t io_need;
+    size_t io_off;
+    unsigned char ack[6];
+    size_t ack_off;
+    enum {
+        IMBEATS_ST_READ_WINDOW_HDR,
+        IMBEATS_ST_READ_WINDOW_SIZE,
+        IMBEATS_ST_READ_FRAME_HDR,
+        IMBEATS_ST_READ_JSON_SEQ,
+        IMBEATS_ST_READ_JSON_LEN,
+        IMBEATS_ST_READ_JSON_PAYLOAD,
+        IMBEATS_ST_READ_COMP_LEN,
+        IMBEATS_ST_READ_COMP_PAYLOAD,
+        IMBEATS_ST_SUBMIT_EVENTS,
+        IMBEATS_ST_SEND_ACK
+    } state;
     session_t *next;
+    session_t *workNext;
+};
+
+struct imbeats_io_s {
+    enum { IMBEATS_IO_LISTENER, IMBEATS_IO_SESSION } type;
+    instanceConf_t *inst;
+    session_t *sess;
+    size_t listener_idx;
 };
 
 static modConfData_t *loadModConf = NULL;
@@ -162,6 +225,9 @@ static struct cnfparamdescr inppdescr[] = {
     {"maxframesize", eCmdHdlrPositiveInt, 0},
     {"maxdecompressedsize", eCmdHdlrPositiveInt, 0},
     {"maxbatchbytes", eCmdHdlrPositiveInt, 0},
+    {"maxsessions", eCmdHdlrPositiveInt, 0},
+    {"workerthreads", eCmdHdlrPositiveInt, 0},
+    {"starvationprotection.maxreads", eCmdHdlrNonNegInt, 0},
 };
 static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(inppdescr[0]), inppdescr};
 
@@ -181,6 +247,9 @@ static struct {
     STATSCOUNTER_DEF(ctrWindowsRejected, mutCtrWindowsRejected)
     STATSCOUNTER_DEF(ctrFramesRejected, mutCtrFramesRejected)
     STATSCOUNTER_DEF(ctrCompressedRejected, mutCtrCompressedRejected)
+    STATSCOUNTER_DEF(ctrConnectionsActive, mutCtrConnectionsActive)
+    STATSCOUNTER_DEF(ctrConnectionsRejected, mutCtrConnectionsRejected)
+    STATSCOUNTER_DEF(ctrStarvationProtect, mutCtrStarvationProtect)
 } statsCounter;
 
 #include "im-helper.h"
@@ -195,7 +264,7 @@ static rsRetVal buildListeners(instanceConf_t *inst);
 static rsRetVal destroyInstanceRuntime(instanceConf_t *inst);
 static void destroySession(session_t *sess);
 static void *listenerThread(void *arg);
-static void *sessionThread(void *arg);
+static void *workerThread(void *arg);
 
 static int instanceIsShuttingDown(instanceConf_t *const inst) {
     int shuttingDown;
@@ -265,6 +334,29 @@ static rsRetVal createPortProp(struct sockaddr_storage *addr, prop_t **const ppP
     snprintf(portbuf, sizeof(portbuf), "%u", port);
     CHKiRet(prop.Construct(ppProp));
     CHKiRet(prop.SetString(*ppProp, (uchar *)portbuf, strlen(portbuf)));
+    CHKiRet(prop.ConstructFinalize(*ppProp));
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal createIPProp(struct sockaddr_storage *addr, prop_t **const ppProp) {
+    char ipbuf[INET6_ADDRSTRLEN];
+    const void *rawAddr = NULL;
+    DEFiRet;
+
+    ipbuf[0] = '\0';
+    if (addr->ss_family == AF_INET) {
+        rawAddr = &((struct sockaddr_in *)addr)->sin_addr;
+    } else if (addr->ss_family == AF_INET6) {
+        rawAddr = &((struct sockaddr_in6 *)addr)->sin6_addr;
+    }
+    if (rawAddr != NULL && inet_ntop(addr->ss_family, rawAddr, ipbuf, sizeof(ipbuf)) == NULL) {
+        ipbuf[0] = '\0';
+    }
+
+    CHKiRet(prop.Construct(ppProp));
+    CHKiRet(prop.SetString(*ppProp, (uchar *)ipbuf, strlen(ipbuf)));
     CHKiRet(prop.ConstructFinalize(*ppProp));
 
 finalize_it:
@@ -341,6 +433,7 @@ finalize_it:
 
 static rsRetVal buildListeners(instanceConf_t *inst) {
     tcpLstnParams_t params;
+    size_t i;
     DEFiRet;
 
     memset(&params, 0, sizeof(params));
@@ -351,70 +444,12 @@ static rsRetVal buildListeners(instanceConf_t *inst) {
 
     CHKiRet(configureNetstrms(inst));
     CHKiRet(netstrm.LstnInit(inst->pNS, inst, addListener, 0, &params));
-
-finalize_it:
-    RETiRet;
-}
-
-static rsRetVal sessionPollWait(const int fd, const short events, const int timeout_ms) {
-    struct pollfd pfd;
-    int pollRet;
-
-    pfd.fd = fd;
-    pfd.events = events;
-    pfd.revents = 0;
-    pollRet = poll(&pfd, 1, timeout_ms);
-    if (pollRet < 0 && errno == EINTR) {
-        return RS_RET_OK;
-    }
-    if (pollRet < 0) {
-        return RS_RET_IO_ERROR;
-    }
-    return RS_RET_OK;
-}
-
-static rsRetVal sessionRead(session_t *const sess, unsigned char *buf, const size_t len) {
-    size_t off = 0;
-    int oserr;
-    unsigned nextIODirection;
-    rsRetVal iRet;
-
-    assert(sess != NULL);
-    while (off < len && glbl.GetGlobalInputTermState() == 0) {
-        ssize_t need = (ssize_t)(len - off);
-        iRet = netstrm.Rcv(sess->pStrm, buf + off, &need, &oserr, &nextIODirection);
-        if (iRet == RS_RET_OK) {
-            off += need;
-        } else if (iRet == RS_RET_RETRY) {
-            CHKiRet(sessionPollWait(sess->sock, (nextIODirection == NSDSEL_WR) ? POLLOUT : POLLIN, 1000));
-        } else {
-            ABORT_FINALIZE(iRet);
-        }
-    }
-
-    if (off != len) {
-        ABORT_FINALIZE(RS_RET_CLOSED);
-    }
-
-finalize_it:
-    RETiRet;
-}
-
-static rsRetVal sessionSendAll(session_t *const sess, const unsigned char *buf, const size_t len) {
-    size_t off = 0;
-    rsRetVal iRet;
-
-    while (off < len && glbl.GetGlobalInputTermState() == 0) {
-        ssize_t to_send = (ssize_t)(len - off);
-        iRet = netstrm.Send(sess->pStrm, (uchar *)buf + off, &to_send);
-        if (iRet == RS_RET_OK) {
-            if (to_send == 0) {
-                CHKiRet(sessionPollWait(sess->sock, POLLOUT, 1000));
-            } else {
-                off += to_send;
-            }
-        } else {
-            ABORT_FINALIZE(iRet);
+    if (inst->listener_count > 0) {
+        CHKmalloc(inst->listener_descs = calloc(inst->listener_count, sizeof(*inst->listener_descs)));
+        for (i = 0; i < inst->listener_count; ++i) {
+            inst->listener_descs[i].type = IMBEATS_IO_LISTENER;
+            inst->listener_descs[i].inst = inst;
+            inst->listener_descs[i].listener_idx = i;
         }
     }
 
@@ -474,11 +509,11 @@ static rsRetVal submitEvent(session_t *const sess, const struct lj_event_s *cons
     if (sess->fromHostFQDN != NULL) {
         fjson_object_object_add(meta, "peer_hostname", json_object_new_string((char *)sess->fromHostFQDN));
     }
-    if (sess->fromHostIP != NULL) {
-        fjson_object_object_add(meta, "peer_ip", json_object_new_string(propGetSzStrOrDefault(sess->fromHostIP, "")));
+    if (sess->fromHostIPStr != NULL) {
+        fjson_object_object_add(meta, "peer_ip", json_object_new_string(sess->fromHostIPStr));
     }
-    if (sess->fromHostPort != NULL) {
-        snprintf(portbuf, sizeof(portbuf), "%s", propGetSzStrOrDefault(sess->fromHostPort, ""));
+    if (sess->fromHostPortStr != NULL) {
+        snprintf(portbuf, sizeof(portbuf), "%s", sess->fromHostPortStr);
         fjson_object_object_add(meta, "peer_port", json_object_new_string(portbuf));
     }
     CHKiRet(msgAddJSON(pMsg, (uchar *)"!metadata!imbeats", meta, 1, 0));
@@ -506,109 +541,257 @@ finalize_it:
     RETiRet;
 }
 
-static rsRetVal receiveBatch(session_t *const sess, struct lj_batch_s *batch) {
-    unsigned char hdr[2];
-    uint32_t net32;
-    uint32_t seq = 0;
-    size_t idx;
-    DEFiRet;
-
-    CHKiRet(sessionRead(sess, hdr, sizeof(hdr)));
-    CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
-    net32 = ntohl(net32);
-    CHKiRet(lj_parse_window_header(hdr, net32));
-    if (net32 > sess->inst->maxWindowSize) {
-        STATSCOUNTER_INC(statsCounter.ctrWindowsRejected, statsCounter.mutCtrWindowsRejected);
-        ABORT_FINALIZE(RS_RET_INVALID_VALUE);
-    }
-    CHKiRet(lj_batch_alloc(batch, net32, sess->inst->maxWindowSize, sess->inst->maxBatchBytes));
-    STATSCOUNTER_INC(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
-
-    while (batch->count < batch->window_size) {
-        unsigned char frame_hdr[2];
-        CHKiRet(sessionRead(sess, frame_hdr, sizeof(frame_hdr)));
-        if (frame_hdr[0] != LJ_VERSION_V2) {
-            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
-        }
-        if (frame_hdr[1] == LJ_FRAME_JSON) {
-            uint32_t payload_len;
-            unsigned char *payload = NULL;
-            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
-            seq = ntohl(net32);
-            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
-            payload_len = ntohl(net32);
-            if (payload_len == 0 || (size_t)payload_len > sess->inst->maxFrameSize) {
-                STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
-                ABORT_FINALIZE(RS_RET_INVALID_VALUE);
-            }
-            CHKmalloc(payload = malloc(payload_len));
-            iRet = sessionRead(sess, payload, payload_len);
-            if (iRet != RS_RET_OK) {
-                free(payload);
-                ABORT_FINALIZE(iRet);
-            }
-            iRet = lj_append_json_event(batch, seq, payload, payload_len);
-            free(payload);
-            if (iRet == RS_RET_INVALID_VALUE) {
-                STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
-            }
-            CHKiRet(iRet);
-        } else if (frame_hdr[1] == LJ_FRAME_COMPRESSED) {
-            uint32_t compressed_len;
-            unsigned char *payload = NULL;
-            STATSCOUNTER_INC(statsCounter.ctrCompressedFrames, statsCounter.mutCtrCompressedFrames);
-            CHKiRet(sessionRead(sess, (unsigned char *)&net32, sizeof(net32)));
-            compressed_len = ntohl(net32);
-            if (compressed_len == 0 || (size_t)compressed_len > sess->inst->maxFrameSize) {
-                STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
-                STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
-                ABORT_FINALIZE(RS_RET_INVALID_VALUE);
-            }
-            CHKmalloc(payload = malloc(compressed_len));
-            iRet = sessionRead(sess, payload, compressed_len);
-            if (iRet != RS_RET_OK) {
-                free(payload);
-                ABORT_FINALIZE(iRet);
-            }
-            iRet = lj_parse_compressed_frames(batch, payload, compressed_len, sess->inst->maxFrameSize,
-                                              sess->inst->maxDecompressedSize);
-            free(payload);
-            if (iRet == RS_RET_INVALID_VALUE) {
-                STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
-            }
-            CHKiRet(iRet);
-        } else {
-            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
-        }
-    }
-
-    for (idx = 0; idx < batch->count; ++idx) {
-        const uint32_t expected = sess->lastAckedSeq + (uint32_t)idx + 1;
-        if (batch->events[idx].seq != expected) {
-            ABORT_FINALIZE(RS_RET_INVALID_VALUE);
-        }
-    }
-    STATSCOUNTER_ADD(statsCounter.ctrEventsReceived, statsCounter.mutCtrEventsReceived, batch->count);
-
-finalize_it:
-    RETiRet;
-}
-
-static rsRetVal ackBatch(session_t *const sess, const uint32_t seq) {
-    unsigned char ack[6];
-    uint32_t netseq = htonl(seq);
+static rsRetVal sessionReadStep(session_t *const sess, unsigned char *const buf, const size_t len) {
+    int oserr = 0;
     rsRetVal iRet;
 
-    ack[0] = LJ_VERSION_V2;
-    ack[1] = LJ_FRAME_ACK;
-    memcpy(ack + 2, &netseq, sizeof(netseq));
-    iRet = sessionSendAll(sess, ack, sizeof(ack));
-    if (iRet == RS_RET_OK) {
-        STATSCOUNTER_INC(statsCounter.ctrBatchesAcked, statsCounter.mutCtrBatchesAcked);
-    } else {
-        STATSCOUNTER_INC(statsCounter.ctrAckFailures, statsCounter.mutCtrAckFailures);
+    assert(sess != NULL);
+    assert(buf != NULL);
+    if (sess->io_buf == NULL) {
+        sess->io_buf = buf;
+        sess->io_need = len;
+        sess->io_off = 0;
     }
-    return iRet;
+    while (sess->io_off < sess->io_need) {
+        ssize_t need = (ssize_t)(sess->io_need - sess->io_off);
+        unsigned nextIODirection = NSDSEL_RD;
+        iRet = netstrm.Rcv(sess->pStrm, sess->io_buf + sess->io_off, &need, &oserr, &nextIODirection);
+        if (iRet == RS_RET_OK) {
+            if (need <= 0) {
+                sess->ioDirection = NSDSEL_RD;
+                return RS_RET_RETRY;
+            }
+            sess->io_off += (size_t)need;
+        } else if (iRet == RS_RET_RETRY) {
+            sess->ioDirection = nextIODirection;
+            return RS_RET_RETRY;
+        } else {
+            return iRet;
+        }
+    }
+    sess->io_buf = NULL;
+    sess->io_need = 0;
+    sess->io_off = 0;
+    return RS_RET_OK;
+}
+
+static rsRetVal sessionValidateBatch(session_t *const sess) {
+    size_t idx;
+    assert(sess != NULL);
+    for (idx = 0; idx < sess->batch.count; ++idx) {
+        const uint32_t expected = sess->lastAckedSeq + (uint32_t)idx + 1;
+        if (sess->batch.events[idx].seq != expected) {
+            return RS_RET_INVALID_VALUE;
+        }
+    }
+    STATSCOUNTER_ADD(statsCounter.ctrEventsReceived, statsCounter.mutCtrEventsReceived, sess->batch.count);
+    return RS_RET_OK;
+}
+
+static void sessionPrepareAck(session_t *const sess) {
+    uint32_t netseq;
+    assert(sess != NULL);
+    assert(sess->batch.count > 0);
+    sess->pendingSeq = sess->batch.events[sess->batch.count - 1].seq;
+    netseq = htonl(sess->pendingSeq);
+    sess->ack[0] = LJ_VERSION_V2;
+    sess->ack[1] = LJ_FRAME_ACK;
+    memcpy(sess->ack + 2, &netseq, sizeof(netseq));
+    sess->ack_off = 0;
+    sess->state = IMBEATS_ST_SEND_ACK;
+}
+
+static void sessionResetForNextBatch(session_t *const sess) {
+    assert(sess != NULL);
+    lj_batch_free(&sess->batch);
+    sess->batchActive = 0;
+    sess->submitIdx = 0;
+    sess->pendingSeq = 0;
+    sess->payload_len = 0;
+    sess->ack_off = 0;
+    sess->state = IMBEATS_ST_READ_WINDOW_HDR;
+}
+
+static rsRetVal sessionSendAckStep(session_t *const sess) {
+    rsRetVal iRet;
+    assert(sess != NULL);
+    while (sess->ack_off < sizeof(sess->ack)) {
+        ssize_t to_send = (ssize_t)(sizeof(sess->ack) - sess->ack_off);
+        iRet = netstrm.Send(sess->pStrm, sess->ack + sess->ack_off, &to_send);
+        if (iRet != RS_RET_OK) {
+            STATSCOUNTER_INC(statsCounter.ctrAckFailures, statsCounter.mutCtrAckFailures);
+            return iRet;
+        }
+        if (to_send == 0) {
+            sess->ioDirection = NSDSEL_WR;
+            return RS_RET_RETRY;
+        }
+        sess->ack_off += (size_t)to_send;
+    }
+    sess->lastAckedSeq = sess->pendingSeq;
+    STATSCOUNTER_INC(statsCounter.ctrBatchesAcked, statsCounter.mutCtrBatchesAcked);
+    sessionResetForNextBatch(sess);
+    return RS_RET_OK;
+}
+
+static rsRetVal sessionProcess(session_t *const sess) {
+    uint32_t net32;
+    unsigned reads = 0;
+    DEFiRet;
+
+    assert(sess != NULL);
+    while (glbl.GetGlobalInputTermState() == 0 && !instanceIsShuttingDown(sess->inst)) {
+        if (sess->inst->starvationMaxReads != 0 && reads >= sess->inst->starvationMaxReads) {
+            STATSCOUNTER_INC(statsCounter.ctrStarvationProtect, statsCounter.mutCtrStarvationProtect);
+            return RS_RET_OK;
+        }
+
+        switch (sess->state) {
+            case IMBEATS_ST_READ_WINDOW_HDR:
+                iRet = sessionReadStep(sess, sess->fixed, 2);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                if (sess->fixed[0] != LJ_VERSION_V2 || sess->fixed[1] != LJ_FRAME_WINDOW) {
+                    ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                }
+                sess->state = IMBEATS_ST_READ_WINDOW_SIZE;
+                break;
+            case IMBEATS_ST_READ_WINDOW_SIZE:
+                iRet = sessionReadStep(sess, sess->fixed, 4);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                memcpy(&net32, sess->fixed, sizeof(net32));
+                net32 = ntohl(net32);
+                CHKiRet(lj_parse_window_header((const unsigned char[]){LJ_VERSION_V2, LJ_FRAME_WINDOW}, net32));
+                if (net32 > sess->inst->maxWindowSize) {
+                    STATSCOUNTER_INC(statsCounter.ctrWindowsRejected, statsCounter.mutCtrWindowsRejected);
+                    ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                }
+                CHKiRet(lj_batch_alloc(&sess->batch, net32, sess->inst->maxWindowSize, sess->inst->maxBatchBytes));
+                sess->batchActive = 1;
+                STATSCOUNTER_INC(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
+                sess->state = IMBEATS_ST_READ_FRAME_HDR;
+                break;
+            case IMBEATS_ST_READ_FRAME_HDR:
+                iRet = sessionReadStep(sess, sess->fixed, 2);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                if (sess->fixed[0] != LJ_VERSION_V2) {
+                    ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                }
+                if (sess->fixed[1] == LJ_FRAME_JSON) {
+                    sess->state = IMBEATS_ST_READ_JSON_SEQ;
+                } else if (sess->fixed[1] == LJ_FRAME_COMPRESSED) {
+                    STATSCOUNTER_INC(statsCounter.ctrCompressedFrames, statsCounter.mutCtrCompressedFrames);
+                    sess->state = IMBEATS_ST_READ_COMP_LEN;
+                } else {
+                    ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                }
+                break;
+            case IMBEATS_ST_READ_JSON_SEQ:
+                iRet = sessionReadStep(sess, sess->fixed, 4);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                memcpy(&net32, sess->fixed, sizeof(net32));
+                sess->pendingSeq = ntohl(net32);
+                sess->state = IMBEATS_ST_READ_JSON_LEN;
+                break;
+            case IMBEATS_ST_READ_JSON_LEN:
+                iRet = sessionReadStep(sess, sess->fixed, 4);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                memcpy(&net32, sess->fixed, sizeof(net32));
+                sess->payload_len = ntohl(net32);
+                if (sess->payload_len == 0 || sess->payload_len > sess->inst->maxFrameSize) {
+                    STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
+                    ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                }
+                CHKmalloc(sess->payload = malloc(sess->payload_len));
+                sess->state = IMBEATS_ST_READ_JSON_PAYLOAD;
+                break;
+            case IMBEATS_ST_READ_JSON_PAYLOAD:
+                iRet = sessionReadStep(sess, sess->payload, sess->payload_len);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                iRet = lj_append_json_event(&sess->batch, sess->pendingSeq, sess->payload, sess->payload_len);
+                free(sess->payload);
+                sess->payload = NULL;
+                sess->payload_len = 0;
+                if (iRet == RS_RET_INVALID_VALUE) {
+                    STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
+                }
+                CHKiRet(iRet);
+                sess->state = (sess->batch.count == sess->batch.window_size) ? IMBEATS_ST_SUBMIT_EVENTS
+                                                                             : IMBEATS_ST_READ_FRAME_HDR;
+                if (sess->state == IMBEATS_ST_SUBMIT_EVENTS) CHKiRet(sessionValidateBatch(sess));
+                break;
+            case IMBEATS_ST_READ_COMP_LEN:
+                iRet = sessionReadStep(sess, sess->fixed, 4);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                memcpy(&net32, sess->fixed, sizeof(net32));
+                sess->payload_len = ntohl(net32);
+                if (sess->payload_len == 0 || sess->payload_len > sess->inst->maxFrameSize) {
+                    STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
+                    STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
+                    ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+                }
+                CHKmalloc(sess->payload = malloc(sess->payload_len));
+                sess->state = IMBEATS_ST_READ_COMP_PAYLOAD;
+                break;
+            case IMBEATS_ST_READ_COMP_PAYLOAD:
+                iRet = sessionReadStep(sess, sess->payload, sess->payload_len);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                iRet = lj_parse_compressed_frames(&sess->batch, sess->payload, sess->payload_len,
+                                                  sess->inst->maxFrameSize, sess->inst->maxDecompressedSize);
+                free(sess->payload);
+                sess->payload = NULL;
+                sess->payload_len = 0;
+                if (iRet == RS_RET_INVALID_VALUE) {
+                    STATSCOUNTER_INC(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
+                }
+                CHKiRet(iRet);
+                sess->state = (sess->batch.count == sess->batch.window_size) ? IMBEATS_ST_SUBMIT_EVENTS
+                                                                             : IMBEATS_ST_READ_FRAME_HDR;
+                if (sess->state == IMBEATS_ST_SUBMIT_EVENTS) CHKiRet(sessionValidateBatch(sess));
+                break;
+            case IMBEATS_ST_SUBMIT_EVENTS:
+                while (sess->submitIdx < sess->batch.count) {
+                    CHKiRet(submitEvent(sess, &sess->batch.events[sess->submitIdx]));
+                    ++sess->submitIdx;
+                    if (sess->inst->starvationMaxReads != 0 && ++reads >= sess->inst->starvationMaxReads) {
+                        STATSCOUNTER_INC(statsCounter.ctrStarvationProtect, statsCounter.mutCtrStarvationProtect);
+                        return RS_RET_OK;
+                    }
+                }
+                sessionPrepareAck(sess);
+                break;
+            case IMBEATS_ST_SEND_ACK:
+                iRet = sessionSendAckStep(sess);
+                if (iRet == RS_RET_RETRY) return iRet;
+                CHKiRet(iRet);
+                ++reads;
+                break;
+            default:
+                ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+        }
+    }
+    ABORT_FINALIZE(RS_RET_CLOSED);
+
+finalize_it:
+    if (iRet == RS_RET_INVALID_VALUE) {
+        STATSCOUNTER_INC(statsCounter.ctrProtocolErrors, statsCounter.mutCtrProtocolErrors);
+    }
+    RETiRet;
 }
 
 static void unlinkSession(instanceConf_t *const inst, session_t *const target) {
@@ -622,23 +805,6 @@ static void unlinkSession(instanceConf_t *const inst, session_t *const target) {
             break;
         }
     }
-}
-
-static session_t *takeSession(instanceConf_t *const inst, const int takeAll) {
-    session_t *sess = NULL;
-    session_t **pp;
-
-    pthread_mutex_lock(&inst->mutSessions);
-    for (pp = &inst->sessions; *pp != NULL; pp = &(*pp)->next) {
-        if (takeAll || (*pp)->done) {
-            sess = *pp;
-            *pp = sess->next;
-            sess->next = NULL;
-            break;
-        }
-    }
-    pthread_mutex_unlock(&inst->mutSessions);
-    return sess;
 }
 
 static void shutdownSessionSocket(session_t *const sess) {
@@ -657,23 +823,31 @@ static void shutdownAllSessionSockets(instanceConf_t *const inst) {
     pthread_mutex_unlock(&inst->mutSessions);
 }
 
-static void reapSessions(instanceConf_t *const inst, const int reapAll) {
+static void destroyAllSessions(instanceConf_t *const inst) {
     session_t *sess;
 
-    while ((sess = takeSession(inst, reapAll)) != NULL) {
-        if (reapAll) {
-            shutdownSessionSocket(sess);
-        }
-        if (sess->threadStarted) {
-            pthread_join(sess->tid, NULL);
-        }
+    pthread_mutex_lock(&inst->mutSessions);
+    sess = inst->sessions;
+    inst->sessions = NULL;
+    inst->activeSessions = 0;
+    pthread_mutex_unlock(&inst->mutSessions);
+
+    while (sess != NULL) {
+        session_t *const next = sess->next;
+        sess->next = NULL;
+        shutdownSessionSocket(sess);
         destroySession(sess);
+        sess = next;
     }
 }
 
 static void destroySession(session_t *sess) {
     if (sess == NULL) {
         return;
+    }
+    free(sess->payload);
+    if (sess->batchActive) {
+        lj_batch_free(&sess->batch);
     }
     if (sess->pStrm != NULL) {
         netstrm.Destruct(&sess->pStrm);
@@ -688,57 +862,118 @@ static void destroySession(session_t *sess) {
         prop.Destruct(&sess->fromHostPort);
     }
     free(sess->fromHostFQDN);
+    free(sess->fromHostIPStr);
+    free(sess->fromHostPortStr);
+    free(sess->io);
     free(sess);
 }
 
-static void *sessionThread(void *arg) {
-    session_t *const sess = (session_t *)arg;
-    rsRetVal iRet = RS_RET_OK;
-
-    assert(sess != NULL);
-
-    while (glbl.GetGlobalInputTermState() == 0 && !instanceIsShuttingDown(sess->inst)) {
-        struct lj_batch_s batch;
-        size_t idx;
-
-        memset(&batch, 0, sizeof(batch));
-        iRet = receiveBatch(sess, &batch);
-        if (iRet != RS_RET_OK) {
-            if (iRet == RS_RET_INVALID_VALUE) {
-                STATSCOUNTER_INC(statsCounter.ctrProtocolErrors, statsCounter.mutCtrProtocolErrors);
-            }
-            lj_batch_free(&batch);
-            break;
+static void closeSession(session_t *const sess) {
+    instanceConf_t *const inst = sess->inst;
+#if defined(IMBEATS_HAVE_EPOLL)
+    if (inst->epoll_fd >= 0 && sess->sock >= 0) {
+        (void)epoll_ctl(inst->epoll_fd, EPOLL_CTL_DEL, sess->sock, NULL);
+    }
+#endif
+    STATSCOUNTER_INC(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
+    pthread_mutex_lock(&inst->mutSessions);
+    if (!sess->done) {
+        sess->done = 1;
+        if (inst->activeSessions > 0) {
+            --inst->activeSessions;
+            STATSCOUNTER_DEC(statsCounter.ctrConnectionsActive, statsCounter.mutCtrConnectionsActive);
         }
+        unlinkSession(inst, sess);
+    }
+    pthread_mutex_unlock(&inst->mutSessions);
+    destroySession(sess);
+}
 
-        for (idx = 0; idx < batch.count; ++idx) {
-            iRet = submitEvent(sess, &batch.events[idx]);
-            if (iRet != RS_RET_OK) {
-                break;
-            }
+static void enqueueSession(session_t *const sess) {
+    instanceConf_t *const inst = sess->inst;
+
+    pthread_mutex_lock(&inst->mutWork);
+    if (!sess->done && !sess->inWorkQueue) {
+        sess->workNext = NULL;
+        if (inst->workTail == NULL) {
+            inst->workHead = sess;
+        } else {
+            inst->workTail->workNext = sess;
         }
-        if (iRet == RS_RET_OK) {
-            iRet = ackBatch(sess, batch.events[batch.count - 1].seq);
-            if (iRet == RS_RET_OK) {
-                sess->lastAckedSeq = batch.events[batch.count - 1].seq;
-            }
+        inst->workTail = sess;
+        sess->inWorkQueue = 1;
+        pthread_cond_signal(&inst->condWork);
+    }
+    pthread_mutex_unlock(&inst->mutWork);
+}
+
+static session_t *dequeueSession(instanceConf_t *const inst) {
+    session_t *sess;
+
+    pthread_mutex_lock(&inst->mutWork);
+    while (inst->workHead == NULL && !inst->workShutdown && glbl.GetGlobalInputTermState() == 0) {
+        pthread_cond_wait(&inst->condWork, &inst->mutWork);
+    }
+    sess = inst->workHead;
+    if (sess != NULL) {
+        inst->workHead = sess->workNext;
+        if (inst->workHead == NULL) {
+            inst->workTail = NULL;
         }
-        lj_batch_free(&batch);
-        if (iRet != RS_RET_OK) {
-            break;
+        sess->workNext = NULL;
+        sess->inWorkQueue = 0;
+    }
+    pthread_mutex_unlock(&inst->mutWork);
+    return sess;
+}
+
+static rsRetVal rearmSession(session_t *const sess) {
+#if defined(IMBEATS_HAVE_EPOLL)
+    struct epoll_event ev;
+    const uint32_t readiness = (sess->ioDirection == NSDSEL_WR) ? EPOLLOUT : EPOLLIN;
+
+    memset(&ev, 0, sizeof(ev));
+    ev.events = readiness | EPOLLONESHOT;
+    ev.data.ptr = sess->io;
+    if (epoll_ctl(sess->inst->epoll_fd, EPOLL_CTL_MOD, sess->sock, &ev) < 0) {
+        LogError(errno, RS_RET_ERR_EPOLL_CTL, "imbeats: epoll_ctl MOD failed on session socket %d", sess->sock);
+        return RS_RET_ERR_EPOLL_CTL;
+    }
+    return RS_RET_OK;
+#else
+    srSleep(0, 100000);
+    enqueueSession(sess);
+    return RS_RET_OK;
+#endif
+}
+
+static void *workerThread(void *arg) {
+    instanceConf_t *const inst = (instanceConf_t *)arg;
+    session_t *sess;
+
+    assert(inst != NULL);
+    while ((sess = dequeueSession(inst)) != NULL) {
+        const rsRetVal iRet = sessionProcess(sess);
+        if (iRet == RS_RET_RETRY) {
+            if (rearmSession(sess) != RS_RET_OK) {
+                closeSession(sess);
+            }
+        } else if (iRet == RS_RET_OK) {
+            enqueueSession(sess);
+        } else {
+            closeSession(sess);
         }
     }
-
-    STATSCOUNTER_INC(statsCounter.ctrConnectionsClosed, statsCounter.mutCtrConnectionsClosed);
-    pthread_mutex_lock(&sess->inst->mutSessions);
-    sess->done = 1;
-    pthread_mutex_unlock(&sess->inst->mutSessions);
     return NULL;
 }
 
 static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t **const ppNewStrm) {
     session_t *sess = NULL;
     struct sockaddr_storage *addr = NULL;
+    int reservedSession = 0;
+#if defined(IMBEATS_HAVE_EPOLL)
+    struct epoll_event ev;
+#endif
     DEFiRet;
 
     assert(ppNewStrm != NULL);
@@ -747,11 +982,30 @@ static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t **const ppNew
     if (ppNewStrm == NULL || *ppNewStrm == NULL) {
         return RS_RET_INVALID_VALUE;
     }
+
+    pthread_mutex_lock(&inst->mutSessions);
+    if (inst->shuttingDown) {
+        pthread_mutex_unlock(&inst->mutSessions);
+        ABORT_FINALIZE(RS_RET_FORCE_TERM);
+    }
+    if (inst->activeSessions >= inst->maxSessions) {
+        pthread_mutex_unlock(&inst->mutSessions);
+        STATSCOUNTER_INC(statsCounter.ctrConnectionsRejected, statsCounter.mutCtrConnectionsRejected);
+        LogError(0, RS_RET_MAX_SESS_REACHED, "imbeats: too many sessions - dropping incoming request");
+        ABORT_FINALIZE(RS_RET_MAX_SESS_REACHED);
+    }
+    ++inst->activeSessions;
+    reservedSession = 1;
+    STATSCOUNTER_INC(statsCounter.ctrConnectionsActive, statsCounter.mutCtrConnectionsActive);
+    pthread_mutex_unlock(&inst->mutSessions);
+
     CHKmalloc(sess = calloc(1, sizeof(*sess)));
     sess->sock = -1;
     sess->inst = inst;
     sess->pStrm = *ppNewStrm;
     *ppNewStrm = NULL;
+    sess->ioDirection = NSDSEL_RD;
+    sess->state = IMBEATS_ST_READ_WINDOW_HDR;
     CHKiRet(netstrm.GetSock(sess->pStrm, &sess->sock));
     if (inst->bKeepAlive) {
         CHKiRet(netstrm.SetKeepAliveProbes(sess->pStrm, inst->iKeepAliveProbes));
@@ -768,78 +1022,239 @@ static rsRetVal spawnSession(instanceConf_t *const inst, netstrm_t **const ppNew
         CHKiRet(prop.SetString(sess->fromHost, sess->fromHostFQDN, ustrlen(sess->fromHostFQDN)));
         CHKiRet(prop.ConstructFinalize(sess->fromHost));
     }
-    CHKiRet(netstrm.GetRemoteIP(sess->pStrm, &sess->fromHostIP));
     CHKiRet(netstrm.GetRemAddr(sess->pStrm, &addr));
+    CHKiRet(createIPProp(addr, &sess->fromHostIP));
+    CHKmalloc(sess->fromHostIPStr = strdup(propGetSzStrOrDefault(sess->fromHostIP, "")));
     CHKiRet(createPortProp(addr, &sess->fromHostPort));
+    CHKmalloc(sess->fromHostPortStr = strdup(propGetSzStrOrDefault(sess->fromHostPort, "")));
+    CHKmalloc(sess->io = calloc(1, sizeof(*sess->io)));
+    sess->io->type = IMBEATS_IO_SESSION;
+    sess->io->inst = inst;
+    sess->io->sess = sess;
 
     pthread_mutex_lock(&inst->mutSessions);
-    if (inst->shuttingDown) {
+    if (inst->shuttingDown || sess->done) {
         pthread_mutex_unlock(&inst->mutSessions);
         ABORT_FINALIZE(RS_RET_FORCE_TERM);
     }
     sess->next = inst->sessions;
     inst->sessions = sess;
-    if (pthread_create(&sess->tid, NULL, sessionThread, sess) != 0) {
-        unlinkSession(inst, sess);
-        pthread_mutex_unlock(&inst->mutSessions);
-        ABORT_FINALIZE(RS_RET_IO_ERROR);
-    }
-    sess->threadStarted = 1;
     pthread_mutex_unlock(&inst->mutSessions);
+
+#if defined(IMBEATS_HAVE_EPOLL)
+    memset(&ev, 0, sizeof(ev));
+    ev.events = EPOLLIN | EPOLLONESHOT;
+    ev.data.ptr = sess->io;
+    if (epoll_ctl(inst->epoll_fd, EPOLL_CTL_ADD, sess->sock, &ev) < 0) {
+        LogError(errno, RS_RET_ERR_EPOLL_CTL, "imbeats: epoll_ctl ADD failed on session socket %d", sess->sock);
+        ABORT_FINALIZE(RS_RET_ERR_EPOLL_CTL);
+    }
+#else
+    enqueueSession(sess);
+#endif
     STATSCOUNTER_INC(statsCounter.ctrConnectionsAccepted, statsCounter.mutCtrConnectionsAccepted);
+    reservedSession = 0;
     sess = NULL;
 
 finalize_it:
+    if (iRet != RS_RET_OK && reservedSession) {
+        pthread_mutex_lock(&inst->mutSessions);
+        if (inst->activeSessions > 0) {
+            --inst->activeSessions;
+            STATSCOUNTER_DEC(statsCounter.ctrConnectionsActive, statsCounter.mutCtrConnectionsActive);
+        }
+        if (sess != NULL) {
+            unlinkSession(inst, sess);
+        }
+        pthread_mutex_unlock(&inst->mutSessions);
+    }
     if (iRet != RS_RET_OK && sess != NULL) {
         destroySession(sess);
     }
     RETiRet;
 }
 
+static rsRetVal startWorkerPool(instanceConf_t *const inst) {
+    unsigned i;
+    DEFiRet;
+
+    assert(inst != NULL);
+    CHKmalloc(inst->worker_tids = calloc(inst->workerThreads, sizeof(pthread_t)));
+    for (i = 0; i < inst->workerThreads; ++i) {
+        if (pthread_create(&inst->worker_tids[i], NULL, workerThread, inst) != 0) {
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        ++inst->workersStarted;
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static void stopWorkerPool(instanceConf_t *const inst) {
+    unsigned i;
+
+    pthread_mutex_lock(&inst->mutWork);
+    inst->workShutdown = 1;
+    pthread_cond_broadcast(&inst->condWork);
+    pthread_mutex_unlock(&inst->mutWork);
+    for (i = 0; i < inst->workersStarted; ++i) {
+        pthread_join(inst->worker_tids[i], NULL);
+    }
+    free(inst->worker_tids);
+    inst->worker_tids = NULL;
+    inst->workersStarted = 0;
+}
+
+static rsRetVal acceptReadyListener(instanceConf_t *const inst, const size_t idx) {
+    unsigned accepted = 0;
+    DEFiRet;
+
+    while (accepted < IMBEATS_ACCEPT_BATCH_LIMIT && !instanceIsShuttingDown(inst) &&
+           glbl.GetGlobalInputTermState() == 0) {
+        netstrm_t *pNewStrm = NULL;
+        char connInfo[TCPSRV_CONNINFO_SIZE];
+
+        memset(connInfo, 0, sizeof(connInfo));
+        iRet = netstrm.AcceptConnReq(inst->listeners[idx], &pNewStrm, connInfo);
+        if (iRet == RS_RET_NO_MORE_DATA) {
+            iRet = RS_RET_OK;
+            break;
+        }
+        if (iRet == RS_RET_OK) {
+            ++accepted;
+            iRet = spawnSession(inst, &pNewStrm);
+            if (iRet != RS_RET_OK && pNewStrm != NULL) {
+                netstrm.Destruct(&pNewStrm);
+            }
+            if (iRet == RS_RET_MAX_SESS_REACHED) {
+                iRet = RS_RET_OK;
+            }
+            CHKiRet(iRet);
+        } else {
+            break;
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+#if defined(IMBEATS_HAVE_EPOLL)
+static rsRetVal addEpollListener(instanceConf_t *const inst, const size_t idx) {
+    struct epoll_event ev;
+    DEFiRet;
+
+    memset(&ev, 0, sizeof(ev));
+    ev.events = EPOLLIN | EPOLLONESHOT;
+    ev.data.ptr = &inst->listener_descs[idx];
+    if (epoll_ctl(inst->epoll_fd, EPOLL_CTL_ADD, inst->listener_socks[idx], &ev) < 0) {
+        LogError(errno, RS_RET_ERR_EPOLL_CTL, "imbeats: epoll_ctl ADD failed on listener socket %d",
+                 inst->listener_socks[idx]);
+        ABORT_FINALIZE(RS_RET_ERR_EPOLL_CTL);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal rearmListener(instanceConf_t *const inst, const size_t idx) {
+    struct epoll_event ev;
+    DEFiRet;
+
+    memset(&ev, 0, sizeof(ev));
+    ev.events = EPOLLIN | EPOLLONESHOT;
+    ev.data.ptr = &inst->listener_descs[idx];
+    if (epoll_ctl(inst->epoll_fd, EPOLL_CTL_MOD, inst->listener_socks[idx], &ev) < 0) {
+        LogError(errno, RS_RET_ERR_EPOLL_CTL, "imbeats: epoll_ctl MOD failed on listener socket %d",
+                 inst->listener_socks[idx]);
+        ABORT_FINALIZE(RS_RET_ERR_EPOLL_CTL);
+    }
+
+finalize_it:
+    RETiRet;
+}
+#endif
+
 static void *listenerThread(void *arg) {
     instanceConf_t *const inst = (instanceConf_t *)arg;
-    struct pollfd *pfds = NULL;
     size_t i;
 
     assert(inst != NULL);
-    pfds = calloc(inst->listener_count, sizeof(struct pollfd));
-    if (pfds == NULL) {
+    if (startWorkerPool(inst) != RS_RET_OK) {
+        setInstanceShuttingDown(inst);
+        stopWorkerPool(inst);
+        return NULL;
+    }
+
+#if defined(IMBEATS_HAVE_EPOLL)
+    inst->epoll_fd = epoll_create(100);
+    if (inst->epoll_fd < 0) {
+        LogError(errno, RS_RET_EPOLL_CR_FAILED, "imbeats: epoll_create failed");
+        setInstanceShuttingDown(inst);
+        stopWorkerPool(inst);
         return NULL;
     }
     for (i = 0; i < inst->listener_count; ++i) {
-        pfds[i].fd = inst->listener_socks[i];
-        pfds[i].events = POLLIN;
+        if (addEpollListener(inst, i) != RS_RET_OK) {
+            setInstanceShuttingDown(inst);
+            break;
+        }
     }
 
     while (glbl.GetGlobalInputTermState() == 0 && !instanceIsShuttingDown(inst)) {
-        const int pollRet = poll(pfds, inst->listener_count, 1000);
-        if (pollRet < 0 && errno == EINTR) {
-            continue;
-        }
-        if (pollRet <= 0) {
-            reapSessions(inst, 0);
-            continue;
-        }
-        for (i = 0; i < inst->listener_count; ++i) {
-            if ((pfds[i].revents & POLLIN) != 0 && !instanceIsShuttingDown(inst)) {
-                netstrm_t *pNewStrm = NULL;
-                char connInfo[TCPSRV_CONNINFO_SIZE];
-                rsRetVal iRet;
+        struct epoll_event events[64];
+        const int nfds = epoll_wait(inst->epoll_fd, events, sizeof(events) / sizeof(events[0]), 1000);
+        int n;
 
-                memset(connInfo, 0, sizeof(connInfo));
-                iRet = netstrm.AcceptConnReq(inst->listeners[i], &pNewStrm, connInfo);
-                if (iRet == RS_RET_OK) {
-                    iRet = spawnSession(inst, &pNewStrm);
-                    if (iRet != RS_RET_OK && pNewStrm != NULL) {
-                        netstrm.Destruct(&pNewStrm);
-                    }
+        if (nfds < 0 && errno == EINTR) {
+            continue;
+        }
+        if (nfds < 0) {
+            LogError(errno, RS_RET_ERR_EPOLL, "imbeats: epoll_wait failed");
+            continue;
+        }
+        for (n = 0; n < nfds && !instanceIsShuttingDown(inst); ++n) {
+            imbeats_io_t *const io = (imbeats_io_t *)events[n].data.ptr;
+            if (io == NULL) {
+                continue;
+            }
+            if (io->type == IMBEATS_IO_LISTENER) {
+                if (acceptReadyListener(inst, io->listener_idx) == RS_RET_OK && !instanceIsShuttingDown(inst)) {
+                    (void)rearmListener(inst, io->listener_idx);
+                }
+            } else if (io->type == IMBEATS_IO_SESSION && io->sess != NULL) {
+                if ((events[n].events & (EPOLLERR | EPOLLHUP)) != 0) {
+                    closeSession(io->sess);
+                } else {
+                    enqueueSession(io->sess);
                 }
             }
         }
-        reapSessions(inst, 0);
     }
-
-    free(pfds);
+    close(inst->epoll_fd);
+    inst->epoll_fd = -1;
+#else
+    while (glbl.GetGlobalInputTermState() == 0 && !instanceIsShuttingDown(inst)) {
+        struct pollfd *pfds = calloc(inst->listener_count, sizeof(struct pollfd));
+        if (pfds == NULL) {
+            break;
+        }
+        for (i = 0; i < inst->listener_count; ++i) {
+            pfds[i].fd = inst->listener_socks[i];
+            pfds[i].events = POLLIN;
+        }
+        if (poll(pfds, inst->listener_count, 1000) > 0) {
+            for (i = 0; i < inst->listener_count; ++i) {
+                if ((pfds[i].revents & POLLIN) != 0) {
+                    (void)acceptReadyListener(inst, i);
+                }
+            }
+        }
+        free(pfds);
+    }
+#endif
+    stopWorkerPool(inst);
     return NULL;
 }
 
@@ -847,12 +1262,12 @@ static rsRetVal destroyInstanceRuntime(instanceConf_t *inst) {
     size_t i;
 
     setInstanceShuttingDown(inst);
+    shutdownAllSessionSockets(inst);
     if (inst->listener_running) {
         pthread_join(inst->listener_tid, NULL);
         inst->listener_running = 0;
     }
-    shutdownAllSessionSockets(inst);
-    reapSessions(inst, 1);
+    destroyAllSessions(inst);
 
     for (i = 0; i < inst->listener_count; ++i) {
         if (inst->listeners[i] != NULL) {
@@ -863,6 +1278,8 @@ static rsRetVal destroyInstanceRuntime(instanceConf_t *inst) {
     inst->listeners = NULL;
     free(inst->listener_socks);
     inst->listener_socks = NULL;
+    free(inst->listener_descs);
+    inst->listener_descs = NULL;
     inst->listener_count = 0;
     inst->listener_cap = 0;
     if (inst->pNS != NULL) {
@@ -877,11 +1294,19 @@ static rsRetVal createInstance(instanceConf_t **const pinst) {
 
     CHKmalloc(inst = calloc(1, sizeof(*inst)));
     pthread_mutex_init(&inst->mutSessions, NULL);
+    pthread_mutex_init(&inst->mutWork, NULL);
+    pthread_cond_init(&inst->condWork, NULL);
     inst->iStrmDrvrMode = 0;
     inst->maxWindowSize = IMBEATS_DEFAULT_MAX_WINDOW_SIZE;
     inst->maxFrameSize = IMBEATS_DEFAULT_MAX_FRAME_SIZE;
     inst->maxDecompressedSize = IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE;
     inst->maxBatchBytes = IMBEATS_DEFAULT_MAX_BATCH_BYTES;
+    inst->maxSessions = IMBEATS_DEFAULT_MAX_SESSIONS;
+    inst->workerThreads = IMBEATS_DEFAULT_WORKER_THREADS;
+    inst->starvationMaxReads = IMBEATS_DEFAULT_STARVATION_MAX_READS;
+#if defined(IMBEATS_HAVE_EPOLL)
+    inst->epoll_fd = -1;
+#endif
     if (loadModConf->tail == NULL) {
         loadModConf->root = loadModConf->tail = inst;
     } else {
@@ -973,6 +1398,18 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "maxbatchbytes")) {
             CHKiRet(validateSizeLimit("maxBatchBytes", pvals[i].val.d.n, IMBEATS_MAX_BYTE_SIZE_LIMIT,
                                       &inst->maxBatchBytes));
+        } else if (!strcmp(inppblk.descr[i].name, "maxsessions")) {
+            inst->maxSessions = (unsigned)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "workerthreads")) {
+            if (pvals[i].val.d.n > IMBEATS_MAX_WORKER_THREADS) {
+                LogError(0, RS_RET_PARAM_ERROR,
+                         "imbeats: invalid value for 'workerThreads' parameter given is %lld, valid range is 1..%u",
+                         (long long)pvals[i].val.d.n, IMBEATS_MAX_WORKER_THREADS);
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            inst->workerThreads = (unsigned)pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "starvationprotection.maxreads")) {
+            inst->starvationMaxReads = (unsigned)pvals[i].val.d.n;
         }
     }
     if (inst->pszInputName != NULL) {
@@ -1058,6 +1495,8 @@ BEGINfreeCnf
             prop.Destruct(&del->pInputName);
         }
         pthread_mutex_destroy(&del->mutSessions);
+        pthread_mutex_destroy(&del->mutWork);
+        pthread_cond_destroy(&del->condWork);
         free(del);
     }
 ENDfreeCnf
@@ -1067,6 +1506,9 @@ BEGINrunInput
     CODESTARTrunInput;
     for (inst = runModConf->root; inst != NULL; inst = inst->next) {
         clearInstanceShuttingDown(inst);
+        pthread_mutex_lock(&inst->mutWork);
+        inst->workShutdown = 0;
+        pthread_mutex_unlock(&inst->mutWork);
         CHKiRet(buildListeners(inst));
         if (pthread_create(&inst->listener_tid, NULL, listenerThread, inst) != 0) {
             ABORT_FINALIZE(RS_RET_IO_ERROR);
@@ -1155,6 +1597,9 @@ BEGINmodInit()
     STATSCOUNTER_INIT(statsCounter.ctrWindowsRejected, statsCounter.mutCtrWindowsRejected);
     STATSCOUNTER_INIT(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
     STATSCOUNTER_INIT(statsCounter.ctrCompressedRejected, statsCounter.mutCtrCompressedRejected);
+    STATSCOUNTER_INIT(statsCounter.ctrConnectionsActive, statsCounter.mutCtrConnectionsActive);
+    STATSCOUNTER_INIT(statsCounter.ctrConnectionsRejected, statsCounter.mutCtrConnectionsRejected);
+    STATSCOUNTER_INIT(statsCounter.ctrStarvationProtect, statsCounter.mutCtrStarvationProtect);
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.accepted"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsAccepted));
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.closed"), ctrType_IntCtr,
@@ -1183,5 +1628,11 @@ BEGINmodInit()
                                 CTR_FLAG_RESETTABLE, &statsCounter.ctrFramesRejected));
     CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("compressed.rejected"), ctrType_IntCtr,
                                 CTR_FLAG_RESETTABLE, &statsCounter.ctrCompressedRejected));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.active"), ctrType_IntCtr, CTR_FLAG_NONE,
+                                &statsCounter.ctrConnectionsActive));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("connections.rejected"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrConnectionsRejected));
+    CHKiRet(statsobj.AddCounter(statsCounter.stats, UCHAR_CONSTANT("starvation_protect"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &statsCounter.ctrStarvationProtect));
     CHKiRet(statsobj.ConstructFinalize(statsCounter.stats));
 ENDmodInit

--- a/plugins/imbeats/imbeats.c
+++ b/plugins/imbeats/imbeats.c
@@ -49,6 +49,7 @@ MODULE_CNFNAME("imbeats")
 #define IMBEATS_MAX_WINDOW_SIZE_LIMIT 1000000
 #define IMBEATS_DEFAULT_MAX_FRAME_SIZE (10 * 1024 * 1024)
 #define IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE (64 * 1024 * 1024)
+#define IMBEATS_DEFAULT_MAX_BATCH_BYTES IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE
 #define IMBEATS_MAX_BYTE_SIZE_LIMIT 200000000
 
 DEF_IMOD_STATIC_DATA;
@@ -90,6 +91,7 @@ typedef struct instanceConf_s {
     uint32_t maxWindowSize;
     size_t maxFrameSize;
     size_t maxDecompressedSize;
+    size_t maxBatchBytes;
 
     netstrms_t *pNS;
     netstrm_t **listeners;
@@ -159,6 +161,7 @@ static struct cnfparamdescr inppdescr[] = {
     {"maxwindowsize", eCmdHdlrPositiveInt, 0},
     {"maxframesize", eCmdHdlrPositiveInt, 0},
     {"maxdecompressedsize", eCmdHdlrPositiveInt, 0},
+    {"maxbatchbytes", eCmdHdlrPositiveInt, 0},
 };
 static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(inppdescr[0]), inppdescr};
 
@@ -478,7 +481,7 @@ static rsRetVal submitEvent(session_t *const sess, const struct lj_event_s *cons
         snprintf(portbuf, sizeof(portbuf), "%s", propGetSzStrOrDefault(sess->fromHostPort, ""));
         fjson_object_object_add(meta, "peer_port", json_object_new_string(portbuf));
     }
-    CHKiRet(msgAddJSON(pMsg, (uchar *)"!metadata!imbeats", meta, 0, 0));
+    CHKiRet(msgAddJSON(pMsg, (uchar *)"!metadata!imbeats", meta, 1, 0));
     meta = NULL;
 
     CHKiRet(submitMsg2(pMsg));
@@ -518,7 +521,7 @@ static rsRetVal receiveBatch(session_t *const sess, struct lj_batch_s *batch) {
         STATSCOUNTER_INC(statsCounter.ctrWindowsRejected, statsCounter.mutCtrWindowsRejected);
         ABORT_FINALIZE(RS_RET_INVALID_VALUE);
     }
-    CHKiRet(lj_batch_alloc(batch, net32, sess->inst->maxWindowSize));
+    CHKiRet(lj_batch_alloc(batch, net32, sess->inst->maxWindowSize, sess->inst->maxBatchBytes));
     STATSCOUNTER_INC(statsCounter.ctrBatchesReceived, statsCounter.mutCtrBatchesReceived);
 
     while (batch->count < batch->window_size) {
@@ -546,6 +549,9 @@ static rsRetVal receiveBatch(session_t *const sess, struct lj_batch_s *batch) {
             }
             iRet = lj_append_json_event(batch, seq, payload, payload_len);
             free(payload);
+            if (iRet == RS_RET_INVALID_VALUE) {
+                STATSCOUNTER_INC(statsCounter.ctrFramesRejected, statsCounter.mutCtrFramesRejected);
+            }
             CHKiRet(iRet);
         } else if (frame_hdr[1] == LJ_FRAME_COMPRESSED) {
             uint32_t compressed_len;
@@ -875,6 +881,7 @@ static rsRetVal createInstance(instanceConf_t **const pinst) {
     inst->maxWindowSize = IMBEATS_DEFAULT_MAX_WINDOW_SIZE;
     inst->maxFrameSize = IMBEATS_DEFAULT_MAX_FRAME_SIZE;
     inst->maxDecompressedSize = IMBEATS_DEFAULT_MAX_DECOMPRESSED_SIZE;
+    inst->maxBatchBytes = IMBEATS_DEFAULT_MAX_BATCH_BYTES;
     if (loadModConf->tail == NULL) {
         loadModConf->root = loadModConf->tail = inst;
     } else {
@@ -963,6 +970,9 @@ BEGINnewInpInst
         } else if (!strcmp(inppblk.descr[i].name, "maxdecompressedsize")) {
             CHKiRet(validateSizeLimit("maxDecompressedSize", pvals[i].val.d.n, IMBEATS_MAX_BYTE_SIZE_LIMIT,
                                       &inst->maxDecompressedSize));
+        } else if (!strcmp(inppblk.descr[i].name, "maxbatchbytes")) {
+            CHKiRet(validateSizeLimit("maxBatchBytes", pvals[i].val.d.n, IMBEATS_MAX_BYTE_SIZE_LIMIT,
+                                      &inst->maxBatchBytes));
         }
     }
     if (inst->pszInputName != NULL) {

--- a/plugins/imbeats/lj_parser.c
+++ b/plugins/imbeats/lj_parser.c
@@ -30,8 +30,11 @@ static rsRetVal append_event_owned(struct lj_batch_s *batch, uint32_t seq, unsig
     return RS_RET_OK;
 }
 
-rsRetVal lj_batch_alloc(struct lj_batch_s *batch, uint32_t window_size, uint32_t max_window_size) {
-    if (batch == NULL || window_size == 0 || window_size > max_window_size) {
+rsRetVal lj_batch_alloc(struct lj_batch_s *batch,
+                        uint32_t window_size,
+                        uint32_t max_window_size,
+                        size_t max_payload_len) {
+    if (batch == NULL || window_size == 0 || window_size > max_window_size || max_payload_len == 0) {
         return RS_RET_PARAM_ERROR;
     }
 #if SIZE_MAX <= UINT32_MAX
@@ -41,6 +44,7 @@ rsRetVal lj_batch_alloc(struct lj_batch_s *batch, uint32_t window_size, uint32_t
 #endif
     memset(batch, 0, sizeof(*batch));
     batch->window_size = window_size;
+    batch->max_payload_len = max_payload_len;
     batch->events = calloc(window_size, sizeof(struct lj_event_s));
     return (batch->events == NULL) ? RS_RET_OUT_OF_MEMORY : RS_RET_OK;
 }
@@ -69,8 +73,12 @@ rsRetVal lj_append_json_event(struct lj_batch_s *batch,
                               const unsigned char *payload,
                               size_t payload_len) {
     unsigned char *cpy;
+    rsRetVal iRet;
     if (batch == NULL || payload == NULL || payload_len == 0) {
         return RS_RET_PARAM_ERROR;
+    }
+    if (payload_len > batch->max_payload_len || batch->total_payload_len > batch->max_payload_len - payload_len) {
+        return RS_RET_INVALID_VALUE;
     }
     if (payload_len > SIZE_MAX - 1) {
         return RS_RET_OUT_OF_MEMORY;
@@ -81,7 +89,11 @@ rsRetVal lj_append_json_event(struct lj_batch_s *batch,
     }
     memcpy(cpy, payload, payload_len);
     cpy[payload_len] = '\0';
-    return append_event_owned(batch, seq, cpy, payload_len);
+    iRet = append_event_owned(batch, seq, cpy, payload_len);
+    if (iRet == RS_RET_OK) {
+        batch->total_payload_len += payload_len;
+    }
+    return iRet;
 }
 
 static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
@@ -144,6 +156,7 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
     unsigned char *out = NULL;
     size_t out_cap = 0;
     size_t out_len = 0;
+    size_t old_count;
     int zrc;
     rsRetVal iRet = RS_RET_OK;
 
@@ -153,6 +166,7 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
     if (payload_len == 0 || payload_len > max_frame_size) {
         return RS_RET_INVALID_VALUE;
     }
+    old_count = batch->count;
 
     memset(&zstrm, 0, sizeof(zstrm));
     zstrm.next_in = (Bytef *)payload;
@@ -197,7 +211,15 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
         goto finalize_it;
     }
 
+    if (out_len == 0) {
+        iRet = RS_RET_INVALID_VALUE;
+        goto finalize_it;
+    }
+
     iRet = parse_frames_from_memory(batch, out, out_len, max_frame_size);
+    if (iRet == RS_RET_OK && batch->count == old_count) {
+        iRet = RS_RET_INVALID_VALUE;
+    }
 
 finalize_it:
     inflateEnd(&zstrm);

--- a/plugins/imbeats/lj_parser.c
+++ b/plugins/imbeats/lj_parser.c
@@ -135,9 +135,6 @@ static rsRetVal parse_frames_from_memory(struct lj_batch_s *batch,
                 if (off + 4 > len) {
                     return RS_RET_INVALID_VALUE;
                 }
-                memcpy(&v1, buf + off, 4);
-                off += 4;
-                v1 = ntohl(v1);
                 return RS_RET_INVALID_VALUE;
             default:
                 return RS_RET_INVALID_VALUE;
@@ -211,12 +208,16 @@ rsRetVal lj_parse_compressed_frames(struct lj_batch_s *batch,
         goto finalize_it;
     }
 
+    /* Empty deflate streams are invalid Lumberjack payloads and must not
+     * produce an ACK-able no-op compressed frame. */
     if (out_len == 0) {
         iRet = RS_RET_INVALID_VALUE;
         goto finalize_it;
     }
 
     iRet = parse_frames_from_memory(batch, out, out_len, max_frame_size);
+    /* A syntactically valid compressed frame must advance the current batch.
+     * Treat no-progress payloads as malformed input instead of spinning. */
     if (iRet == RS_RET_OK && batch->count == old_count) {
         iRet = RS_RET_INVALID_VALUE;
     }

--- a/plugins/imbeats/lj_parser.h
+++ b/plugins/imbeats/lj_parser.h
@@ -21,10 +21,15 @@ struct lj_event_s {
 struct lj_batch_s {
     uint32_t window_size;
     size_t count;
+    size_t total_payload_len;
+    size_t max_payload_len;
     struct lj_event_s *events;
 };
 
-rsRetVal lj_batch_alloc(struct lj_batch_s *batch, uint32_t window_size, uint32_t max_window_size);
+rsRetVal lj_batch_alloc(struct lj_batch_s *batch,
+                        uint32_t window_size,
+                        uint32_t max_window_size,
+                        size_t max_payload_len);
 void lj_batch_free(struct lj_batch_s *batch);
 rsRetVal lj_parse_window_header(const unsigned char hdr[2], uint32_t window_size);
 rsRetVal lj_append_json_event(struct lj_batch_s *batch, uint32_t seq, const unsigned char *payload, size_t payload_len);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1047,7 +1047,10 @@ TESTS_IMBEATS = \
 	imbeats-metadata-collision.sh \
 	imbeats-elastic-agent-windows-fixture.sh \
 	imbeats-limits.sh \
+	imbeats-limits-impstats.sh \
 	imbeats-shutdown-open-session.sh \
+	imbeats-maxsessions.sh \
+	imbeats-multiplex-idle-sessions.sh \
 	imbeats-filebeat-docker.sh
 
 TESTS_IMBEATS_YAML = \

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1044,6 +1044,7 @@ TESTS_IMBEATS = \
 	imbeats-seq-reset-rejected.sh \
 	imbeats-compressed-window-overflow.sh \
 	imbeats-compressed-malformed.sh \
+	imbeats-metadata-collision.sh \
 	imbeats-elastic-agent-windows-fixture.sh \
 	imbeats-limits.sh \
 	imbeats-shutdown-open-session.sh \

--- a/tests/imbeats-compressed-malformed.sh
+++ b/tests/imbeats-compressed-malformed.sh
@@ -59,6 +59,8 @@ send_bad(zlib.compress(frame(1, "ok")) + b"trailing-garbage")
 nested = b"2C" + struct.pack(">I", len(zlib.compress(frame(1, "nested")))) + zlib.compress(frame(1, "nested"))
 send_bad(zlib.compress(nested))
 
+send_bad(zlib.compress(b""))
+
 zero = b"2J" + struct.pack(">I", 1) + struct.pack(">I", 0)
 send_bad(zlib.compress(zero))
 PY
@@ -86,9 +88,9 @@ with open(sys.argv[1], encoding="utf-8") as fh:
             stats = data
 
 expected = {
-    "compressed_frames": 4,
-    "compressed.rejected": 4,
-    "protocol_errors": 4,
+    "compressed_frames": 5,
+    "compressed.rejected": 5,
+    "protocol_errors": 5,
     "events.submitted": 0,
 }
 missing = {key: (stats.get(key), value) for key, value in expected.items() if stats.get(key) != value}

--- a/tests/imbeats-limits-impstats.sh
+++ b/tests/imbeats-limits-impstats.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+export IMBEATS_LIMITS_CHECK_STATS=YES
+script_dir=${srcdir:-$(dirname "$0")}
+. "$script_dir/imbeats-limits.sh"

--- a/tests/imbeats-limits.sh
+++ b/tests/imbeats-limits.sh
@@ -1,12 +1,19 @@
 #!/bin/bash
 . ${srcdir:=.}/diag.sh init
 require_plugin imbeats
+if [ "$IMBEATS_LIMITS_CHECK_STATS" = "YES" ]; then
+	require_plugin impstats
+fi
 
 generate_conf
-add_conf '
+if [ "$IMBEATS_LIMITS_CHECK_STATS" = "YES" ]; then
+	add_conf '
 module(load="../plugins/impstats/.libs/impstats" interval="1"
        log.file="'$RSYSLOG_DYNNAME'.spool/imbeats-stats.log"
        log.syslog="off" format="cee")
+'
+fi
+add_conf '
 module(load="../plugins/imbeats/.libs/imbeats")
 
 template(name="outfmt" type="string" string="%msg%\n")
@@ -93,7 +100,8 @@ cmp_exact
 
 test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
 
-if ! $PYTHON - "$srcdir/$RSYSLOG_DYNNAME.spool/imbeats-stats.log" <<'PY'
+if [ "$IMBEATS_LIMITS_CHECK_STATS" = "YES" ]; then
+	if ! $PYTHON - "$srcdir/$RSYSLOG_DYNNAME.spool/imbeats-stats.log" <<'PY'
 import json
 import sys
 
@@ -118,8 +126,9 @@ missing = {key: (stats.get(key), value) for key, value in expected.items() if st
 if missing:
     raise SystemExit(f"unexpected imbeats stats: {missing}; last stats={stats}")
 PY
-then
-	error_exit 1
+	then
+		error_exit 1
+	fi
 fi
 
 exit_test

--- a/tests/imbeats-limits.sh
+++ b/tests/imbeats-limits.sh
@@ -21,7 +21,8 @@ input(type="imbeats"
       ruleset="main"
       maxWindowSize="2"
       maxFrameSize="64"
-      maxDecompressedSize="128")
+      maxDecompressedSize="128"
+      maxBatchBytes="35")
 '
 
 startup
@@ -59,6 +60,14 @@ def send_good(wire):
 send_bad(b"2W" + struct.pack(">I", 3))
 send_bad(b"2W" + struct.pack(">I", 1) + b"2J" + struct.pack(">I", 1) + struct.pack(">I", 65))
 send_bad(b"2W" + struct.pack(">I", 1) + b"2C" + struct.pack(">I", 65))
+
+payload1 = json.dumps({"message": "first"}, separators=(",", ":")).encode()
+payload2 = json.dumps({"message": "second"}, separators=(",", ":")).encode()
+send_bad(
+    b"2W" + struct.pack(">I", 2)
+    + b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload1)) + payload1
+    + b"2J" + struct.pack(">I", 2) + struct.pack(">I", len(payload2)) + payload2
+)
 
 large_payload = json.dumps({"message": "x" * 140}, separators=(",", ":")).encode()
 compressed = zlib.compress(b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(large_payload)) + large_payload)
@@ -100,9 +109,9 @@ with open(sys.argv[1], encoding="utf-8") as fh:
 
 expected = {
     "windows.rejected": 1,
-    "frames.rejected": 2,
+    "frames.rejected": 3,
     "compressed.rejected": 2,
-    "protocol_errors": 4,
+    "protocol_errors": 5,
     "events.submitted": 1,
 }
 missing = {key: (stats.get(key), value) for key, value in expected.items() if stats.get(key) != value}

--- a/tests/imbeats-maxsessions.sh
+++ b/tests/imbeats-maxsessions.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main"
+      maxSessions="2")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+if ! $PYTHON - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+
+
+def event_wire(seq, message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return (
+        b"2W" + struct.pack(">I", 1)
+        + b"2J" + struct.pack(">I", seq)
+        + struct.pack(">I", len(payload)) + payload
+    )
+
+
+sockets = []
+try:
+    for _ in range(2):
+        sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+        sock.settimeout(5)
+        sockets.append(sock)
+
+    try:
+        extra = socket.create_connection(("127.0.0.1", port), timeout=5)
+    except OSError:
+        extra = None
+    if extra is not None:
+        with extra:
+            extra.settimeout(2)
+            extra.sendall(event_wire(99, "rejected"))
+            try:
+                data = extra.recv(6)
+            except (ConnectionResetError, TimeoutError, socket.timeout):
+                data = b""
+            if data:
+                raise SystemExit(f"unexpected ack from over-limit session: {data.hex()}")
+
+    acks = []
+    for idx, sock in enumerate(sockets, start=1):
+        sock.sendall(event_wire(1, f"accepted-{idx}"))
+        acks.append(sock.recv(6).hex())
+    print("\n".join(acks))
+finally:
+    for sock in sockets:
+        try:
+            sock.close()
+        except OSError:
+            pass
+PY
+then
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"accepted-1"}
+{"message":"accepted-2"}'
+cmp_exact
+
+grep -Fx "324100000001" "$RSYSLOG_DYNNAME.imbeats.ack" >/dev/null || error_exit 1
+test "$(grep -Fx "324100000001" "$RSYSLOG_DYNNAME.imbeats.ack" | wc -l)" -eq 2 || error_exit 1
+
+exit_test

--- a/tests/imbeats-metadata-collision.sh
+++ b/tests/imbeats-metadata-collision.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string"
+         string="%msg%|%$!metadata!imbeats!protocol%|%$!metadata!imbeats!sequence%|%$!metadata!imbeats!tls_enabled%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+python3 - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+payload = json.dumps(
+    {
+        "message": "metadata collision",
+        "metadata": {
+            "imbeats": {
+                "protocol": "attacker",
+                "sequence": 999,
+                "tls_enabled": True,
+            }
+        },
+    },
+    separators=(",", ":"),
+).encode()
+wire = b"2W" + struct.pack(">I", 1) + b"2J" + struct.pack(">I", 1) + struct.pack(">I", len(payload)) + payload
+
+sock = socket.create_connection(("127.0.0.1", port))
+sock.sendall(wire)
+ack = sock.recv(6)
+sys.stdout.write(ack.hex())
+sock.close()
+PY
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"metadata collision","metadata":{"imbeats":{"protocol":"attacker","sequence":999,"tls_enabled":true}}}|lumberjack-v2|1|false'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001"
+
+exit_test

--- a/tests/imbeats-multiplex-idle-sessions.sh
+++ b/tests/imbeats-multiplex-idle-sessions.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+. ${srcdir:=.}/diag.sh init
+require_plugin imbeats
+
+generate_conf
+add_conf '
+module(load="../plugins/imbeats/.libs/imbeats")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+ruleset(name="main") {
+  action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}
+
+input(type="imbeats"
+      port="0"
+      listenPortFileName="'$RSYSLOG_DYNNAME'.imbeats.port"
+      ruleset="main"
+      maxSessions="8"
+      workerThreads="2"
+      starvationProtection.maxReads="1")
+'
+
+startup
+assign_rs_port "$RSYSLOG_DYNNAME.imbeats.port"
+
+if ! $PYTHON - "$RS_PORT" > "$RSYSLOG_DYNNAME.imbeats.ack" <<'PY'
+import json
+import socket
+import struct
+import sys
+
+port = int(sys.argv[1])
+sockets = []
+
+try:
+    for _ in range(5):
+        sock = socket.create_connection(("127.0.0.1", port), timeout=5)
+        sock.settimeout(5)
+        sockets.append(sock)
+
+    payload = json.dumps({"message": "active-after-idle"}, separators=(",", ":")).encode()
+    wire = (
+        b"2W" + struct.pack(">I", 1)
+        + b"2J" + struct.pack(">I", 1)
+        + struct.pack(">I", len(payload)) + payload
+    )
+    active = sockets[-1]
+    active.sendall(wire)
+    ack = active.recv(6)
+    print(ack.hex())
+finally:
+    for sock in sockets:
+        try:
+            sock.close()
+        except OSError:
+            pass
+PY
+then
+	error_exit 1
+fi
+
+shutdown_when_empty
+wait_shutdown
+
+EXPECTED='{"message":"active-after-idle"}'
+cmp_exact
+
+test "$(cat "$RSYSLOG_DYNNAME.imbeats.ack")" = "324100000001" || error_exit 1
+
+exit_test

--- a/tests/yaml-imbeats-basic.sh
+++ b/tests/yaml-imbeats-basic.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 . ${srcdir:=.}/diag.sh init
 require_plugin imbeats
+require_yaml_support
 
 generate_conf --yaml-only
 add_yaml_conf 'modules:'
@@ -17,6 +18,9 @@ add_yaml_conf '  - type: imbeats'
 add_yaml_conf '    port: "0"'
 add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.imbeats.port\""
 add_yaml_conf '    ruleset: main'
+add_yaml_conf '    maxSessions: 1000'
+add_yaml_conf '    workerThreads: 2'
+add_yaml_conf '    starvationProtection.maxReads: 500'
 add_yaml_conf ''
 add_yaml_conf 'rulesets:'
 add_yaml_conf '  - name: main'


### PR DESCRIPTION
## Summary

Rework `imbeats` session handling for high client counts. The input no longer
uses a one-thread-per-session model; it multiplexes native Lumberjack sessions
through a listener/readiness path and a bounded worker pool.

Primary architecture change:

- add native imbeats session state machines for Lumberjack windows, frames,
  event submission, and ACK writes
- add an epoll readiness path with one-shot worker ownership and session rearm
- keep a poll fallback for platforms without epoll support
- add `maxSessions` with default `1000`
- add `workerThreads` with default `2`
- add `starvationProtection.maxReads` with default `500`
- add counters for active, rejected, and starvation-protected sessions

This PR also includes the earlier parser safety fixes from the initial review:

- add `maxBatchBytes` to cap cumulative retained batch payload memory
- reject compressed frames that inflate to empty or no-progress payloads
- force-reset `$!metadata!imbeats` so remote JSON cannot forge module metadata

## Review and CI feedback

Addressed AI review feedback already present on the PR:

- cubic identified a missing hidden toctree entry for `maxBatchBytes`; this is
  now included in the imbeats module page
- Gemini requested explanatory comments around defensive compressed-frame
  parser paths; comments were added for the empty/no-progress rejection cases

The existing failed Ubuntu 20 CI job is in Elasticsearch/omkafka tests
(`es-*` and `omkafka-vg.sh`) and does not point at imbeats. The focused
imbeats checks and doc distribution checks pass locally.

## Validation

- `bash devtools/format-code.sh`
- `git diff --check`
- `make -j$(nproc) -C plugins/imbeats check`
- `./tests/imbeats-basic.sh`
- `./tests/imbeats-compressed.sh`
- `./tests/imbeats-seq-cumulative-two-windows.sh`
- `./tests/imbeats-seq-cumulative-after-multi-event-window.sh`
- `./tests/imbeats-seq-reset-rejected.sh`
- `./tests/imbeats-compressed-window-overflow.sh`
- `./tests/imbeats-compressed-malformed.sh`
- `./tests/imbeats-metadata-collision.sh`
- `./tests/imbeats-limits.sh`
- `./tests/imbeats-shutdown-open-session.sh`
- `./tests/imbeats-elastic-agent-windows-fixture.sh`
- `./tests/imbeats-maxsessions.sh`
- `./tests/imbeats-multiplex-idle-sessions.sh`
- `./tests/yaml-imbeats-basic.sh`
- `make -j$(nproc) check TESTS=""`
- `bash .agent/skills/rsyslog_doc_dist/scripts/check-doc-dist.sh`