### PR TITLE
omrelp: allow TLS auth failure suspension

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -1133,6 +1133,7 @@ EXTRA_DIST = \
     source/reference/parameters/omrelp-tls-mycert.rst \
     source/reference/parameters/omrelp-tls-myprivkey.rst \
     source/reference/parameters/omrelp-tls-permittedpeer.rst \
+    source/reference/parameters/omrelp-tls-permanentfailuredisablesaction.rst \
     source/reference/parameters/omrelp-tls-prioritystring.rst \
     source/reference/parameters/omrelp-tls-tlscfgcmd.rst \
     source/reference/parameters/omrelp-tls-tlslib.rst \

--- a/doc/source/configuration/modules/omrelp.rst
+++ b/doc/source/configuration/modules/omrelp.rst
@@ -131,6 +131,10 @@ Action Parameters
      - .. include:: ../../reference/parameters/omrelp-tls-tlscfgcmd.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omrelp-tls-permanentfailuredisablesaction`
+     - .. include:: ../../reference/parameters/omrelp-tls-permanentfailuredisablesaction.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omrelp-localclientip`
      - .. include:: ../../reference/parameters/omrelp-localclientip.rst
         :start-after: .. summary-start
@@ -160,6 +164,7 @@ Action Parameters
    ../../reference/parameters/omrelp-tls-myprivkey
    ../../reference/parameters/omrelp-tls-prioritystring
    ../../reference/parameters/omrelp-tls-tlscfgcmd
+   ../../reference/parameters/omrelp-tls-permanentfailuredisablesaction
    ../../reference/parameters/omrelp-localclientip
 
 
@@ -211,5 +216,4 @@ be specified. To send a message via RELP, use
 .. code-block:: none
 
    *.*  :omrelp:<server>:<port>;<template>
-
 

--- a/doc/source/reference/parameters/omrelp-tls-permanentfailuredisablesaction.rst
+++ b/doc/source/reference/parameters/omrelp-tls-permanentfailuredisablesaction.rst
@@ -1,0 +1,68 @@
+.. _param-omrelp-tls-permanentfailuredisablesaction:
+.. _omrelp.parameter.action.tls-permanentfailuredisablesaction:
+
+.. meta::
+   :description: Configure whether omrelp disables or suspends an action after TLS authentication failure.
+   :keywords: rsyslog, omrelp, RELP, TLS, authentication failure, action queue
+
+TLS.PermanentFailureDisablesAction
+==================================
+
+.. index::
+   single: omrelp; TLS.PermanentFailureDisablesAction
+   single: TLS.PermanentFailureDisablesAction
+
+.. summary-start
+
+Controls whether TLS authentication failures disable the action or suspend it for retry.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omrelp`.
+
+:Name: TLS.PermanentFailureDisablesAction
+:Scope: action
+:Type: boolean
+:Default: on
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Controls how omrelp handles TLS authentication failures such as certificate
+validation or permitted peer mismatches.
+
+When enabled, the default, omrelp treats these failures as permanent and
+disables the action. This preserves the historical behavior and prevents
+continuous retry loops for configuration errors that usually need operator
+intervention.
+
+When disabled, omrelp suspends the action instead. This lets configured action
+queues continue accepting messages while rsyslog retries according to the
+action retry settings. Use this mode when certificate or CA changes may be
+temporary and queued messages should be retained until the TLS configuration is
+corrected.
+
+Action usage
+------------
+.. _param-omrelp-action-tls-permanentfailuredisablesaction:
+.. _omrelp.parameter.action.tls-permanentfailuredisablesaction-usage:
+
+.. code-block:: rsyslog
+
+   action(type="omrelp" target="centralserv" tls="on"
+          tls.permanentFailureDisablesAction="off")
+
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: omrelp
+       target: centralserv
+       tls: "on"
+       tls.permanentFailureDisablesAction: "off"
+
+See also
+--------
+See also :doc:`../../configuration/modules/omrelp`.

--- a/plugins/omrelp/omrelp.c
+++ b/plugins/omrelp/omrelp.c
@@ -54,6 +54,7 @@
 #include "debug.h"
 #include "parserif.h"
 #include "unicode-helper.h"
+#include "atomic.h"
 
 #ifndef RELP_DFLT_PT
     #define RELP_DFLT_PT "514"
@@ -70,6 +71,7 @@ DEFobjCurrIf(glbl)
 
 #define DFLT_ENABLE_TLS 0
 #define DFLT_ENABLE_TLSZIP 0
+#define DFLT_TLS_PERMFAIL_DISABLES_ACTION 1
 
     static relpEngine_t *pRelpEngine; /* our relp engine */
 
@@ -82,7 +84,9 @@ typedef struct _instanceData {
     unsigned rebindInterval;
     sbool bEnableTLS;
     sbool bEnableTLSZip;
-    sbool bHadAuthFail; /**< set on auth failure, will cause retry to disable action */
+    int bHadAuthFail; /**< set on TLS auth failure */
+    DEF_ATOMIC_HELPER_MUT(mutHadAuthFail);
+    sbool bTlsPermFailDisablesAction;
     uchar *pristring; /* GnuTLS priority string (NULL if not to be provided) */
     uchar *authmode;
     uchar *caCertFile;
@@ -132,18 +136,28 @@ static modConfData_t *runModConf = NULL; /* modConf ptr to use for the current e
 static struct cnfparamdescr modpdescr[] = {{"tls.tlslib", eCmdHdlrString, 0}};
 static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / sizeof(struct cnfparamdescr), modpdescr};
 /* action (instance) parameters */
-static struct cnfparamdescr actpdescr[] = {
-    {"target", eCmdHdlrGetWord, 1},         {"tls", eCmdHdlrBinary, 0},
-    {"tls.compression", eCmdHdlrBinary, 0}, {"tls.prioritystring", eCmdHdlrString, 0},
-    {"tls.cacert", eCmdHdlrString, 0},      {"tls.mycert", eCmdHdlrString, 0},
-    {"tls.myprivkey", eCmdHdlrString, 0},   {"tls.authmode", eCmdHdlrString, 0},
-    {"tls.tlscfgcmd", eCmdHdlrString, 0},   {"tls.permittedpeer", eCmdHdlrArray, 0},
-    {"port", eCmdHdlrGetWord, 0},           {"rebindinterval", eCmdHdlrInt, 0},
-    {"windowsize", eCmdHdlrInt, 0},         {"timeout", eCmdHdlrInt, 0},
-    {"conn.timeout", eCmdHdlrInt, 0},       {"keepalive", eCmdHdlrBinary, 0},
-    {"keepalive.probes", eCmdHdlrInt, 0},   {"keepalive.time", eCmdHdlrInt, 0},
-    {"keepalive.interval", eCmdHdlrInt, 0}, {"localclientip", eCmdHdlrGetWord, 0},
-    {"template", eCmdHdlrGetWord, 0}};
+static struct cnfparamdescr actpdescr[] = {{"target", eCmdHdlrGetWord, 1},
+                                           {"tls", eCmdHdlrBinary, 0},
+                                           {"tls.compression", eCmdHdlrBinary, 0},
+                                           {"tls.prioritystring", eCmdHdlrString, 0},
+                                           {"tls.cacert", eCmdHdlrString, 0},
+                                           {"tls.mycert", eCmdHdlrString, 0},
+                                           {"tls.myprivkey", eCmdHdlrString, 0},
+                                           {"tls.authmode", eCmdHdlrString, 0},
+                                           {"tls.tlscfgcmd", eCmdHdlrString, 0},
+                                           {"tls.permittedpeer", eCmdHdlrArray, 0},
+                                           {"tls.permanentfailuredisablesaction", eCmdHdlrBinary, 0},
+                                           {"port", eCmdHdlrGetWord, 0},
+                                           {"rebindinterval", eCmdHdlrInt, 0},
+                                           {"windowsize", eCmdHdlrInt, 0},
+                                           {"timeout", eCmdHdlrInt, 0},
+                                           {"conn.timeout", eCmdHdlrInt, 0},
+                                           {"keepalive", eCmdHdlrBinary, 0},
+                                           {"keepalive.probes", eCmdHdlrInt, 0},
+                                           {"keepalive.time", eCmdHdlrInt, 0},
+                                           {"keepalive.interval", eCmdHdlrInt, 0},
+                                           {"localclientip", eCmdHdlrGetWord, 0},
+                                           {"template", eCmdHdlrGetWord, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 BEGINinitConfVars /* (re)set config variables to default values */
@@ -202,6 +216,14 @@ static void onGenericErr(char *objinfo, char *errmesg, __attribute__((unused)) r
              errmesg, objinfo);
 }
 
+static const char *authFailActionText(const instanceData *const pData) {
+    return (pData != NULL && !pData->bTlsPermFailDisablesAction) ? "suspending action" : "DISABLING action";
+}
+
+static rsRetVal authFailActionRet(const instanceData *const pData) {
+    return (pData != NULL && !pData->bTlsPermFailDisablesAction) ? RS_RET_SUSPENDED : RS_RET_DISABLE_ACTION;
+}
+
 static void onAuthErr(void *pUsr, char *authinfo, char *errmesg, __attribute__((unused)) relpRetVal errcode) {
     instanceData *pData = (instanceData *)pUsr;
     if (pData == NULL) {
@@ -211,9 +233,9 @@ static void onAuthErr(void *pUsr, char *authinfo, char *errmesg, __attribute__((
     }
     LogError(0, RS_RET_RELP_AUTH_FAIL,
              "omrelp[%s:%s]: authentication error '%s', peer "
-             "is '%s' - DISABLING action",
-             pData->target, getRelpPt(pData), errmesg, authinfo);
-    pData->bHadAuthFail = 1;
+             "is '%s' - %s",
+             pData->target, getRelpPt(pData), errmesg, authinfo, authFailActionText(pData));
+    ATOMIC_STORE_1_TO_INT(&pData->bHadAuthFail, &pData->mutHadAuthFail);
 }
 
 static int relpRetIsAuthErr(const relpRetVal relpRet) {
@@ -306,6 +328,8 @@ BEGINcreateInstance
     pData->bEnableTLS = DFLT_ENABLE_TLS;
     pData->bEnableTLSZip = DFLT_ENABLE_TLSZIP;
     pData->bHadAuthFail = 0;
+    INIT_ATOMIC_HELPER_MUT(pData->mutHadAuthFail);
+    pData->bTlsPermFailDisablesAction = DFLT_TLS_PERMFAIL_DISABLES_ACTION;
     pData->pristring = NULL;
     pData->authmode = NULL;
     pData->localClientIP = NULL;
@@ -352,6 +376,7 @@ BEGINfreeInstance
             free(pData->permittedPeers.name[i]);
         }
     }
+    DESTROY_ATOMIC_HELPER_MUT(pData->mutHadAuthFail);
 ENDfreeInstance
 
 BEGINfreeWrkrInstance
@@ -369,6 +394,7 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->rebindInterval = 0;
     pData->bEnableTLS = DFLT_ENABLE_TLS;
     pData->bEnableTLSZip = DFLT_ENABLE_TLSZIP;
+    pData->bTlsPermFailDisablesAction = DFLT_TLS_PERMFAIL_DISABLES_ACTION;
     pData->pristring = NULL;
     pData->authmode = NULL;
     if (glbl.GetSourceIPofLocalClient() == NULL)
@@ -503,6 +529,8 @@ BEGINnewActInst
             pData->bEnableTLS = (unsigned)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "tls.compression")) {
             pData->bEnableTLSZip = (unsigned)pvals[i].val.d.n;
+        } else if (!strcmp(actpblk.descr[i].name, "tls.permanentfailuredisablesaction")) {
+            pData->bTlsPermFailDisablesAction = (sbool)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "tls.prioritystring")) {
             CHKmalloc(pData->pristring = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "tls.cacert")) {
@@ -606,6 +634,8 @@ static rsRetVal ATTR_NONNULL() doConnect(wrkrInstanceData_t *const pWrkrData) {
 
     if (iRet == RELP_RET_OK) {
         pWrkrData->bIsConnected = 1;
+        pWrkrData->bIsSuspended = 0;
+        ATOMIC_STORE_0_TO_INT(&pWrkrData->pData->bHadAuthFail, &pWrkrData->pData->mutHadAuthFail);
     } else if (iRet == RELP_RET_ERR_NO_TLS) {
         LogError(0, iRet,
                  "omrelp: Could not connect, librelp does NOT "
@@ -621,13 +651,14 @@ static rsRetVal ATTR_NONNULL() doConnect(wrkrInstanceData_t *const pWrkrData) {
         FINALIZE;
     } else {
         if (relpRetIsAuthErr(iRet)) {
-            if (!pWrkrData->pData->bHadAuthFail) {
-                LogError(0, RS_RET_RELP_AUTH_FAIL,
-                         "omrelp[%s:%s]: TLS authentication failed, librelp error %d - DISABLING action",
-                         pWrkrData->pData->target, getRelpPt(pWrkrData->pData), iRet);
-                pWrkrData->pData->bHadAuthFail = 1;
+            if (ATOMIC_CAS(&pWrkrData->pData->bHadAuthFail, 0, 1, &pWrkrData->pData->mutHadAuthFail)) {
+                LogError(0, RS_RET_RELP_AUTH_FAIL, "omrelp[%s:%s]: TLS authentication failed, librelp error %d - %s",
+                         pWrkrData->pData->target, getRelpPt(pWrkrData->pData), iRet,
+                         authFailActionText(pWrkrData->pData));
             }
-            ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
+            pWrkrData->bIsConnected = 0;
+            pWrkrData->bIsSuspended = 1;
+            ABORT_FINALIZE(authFailActionRet(pWrkrData->pData));
         }
         if (pWrkrData->bIsSuspended == 0) {
             LogError(0, RS_RET_RELP_ERR,
@@ -647,7 +678,8 @@ finalize_it:
 
 BEGINtryResume
     CODESTARTtryResume;
-    if (pWrkrData->pData->bHadAuthFail) {
+    if (ATOMIC_FETCH_32BIT(&pWrkrData->pData->bHadAuthFail, &pWrkrData->pData->mutHadAuthFail) &&
+        pWrkrData->pData->bTlsPermFailDisablesAction) {
         ABORT_FINALIZE(RS_RET_DISABLE_ACTION);
     }
     iRet = doConnect(pWrkrData);
@@ -711,7 +743,7 @@ BEGINdoAction
         doRebind(pWrkrData);
     }
 finalize_it:
-    if (pData->bHadAuthFail) iRet = RS_RET_DISABLE_ACTION;
+    if (ATOMIC_FETCH_32BIT(&pData->bHadAuthFail, &pData->mutHadAuthFail)) iRet = authFailActionRet(pData);
     if (iRet == RS_RET_OK) {
         /* we mimic non-commit, as otherwise our endTransaction handler
          * will not get called. While this is not 100% correct, the worst

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1589,7 +1589,8 @@ TESTS_RELP = \
 	 glbl-oversizeMsg-split.sh
 
 TESTS_RELP_OPENSSL = \
-	 omrelp-tls-ossl-authfail-no-cacert.sh
+	 omrelp-tls-ossl-authfail-no-cacert.sh \
+	 omrelp-tls-ossl-authfail-suspend.sh
 
 TESTS_RELP_GNUTLS = \
          sndrcv_relp_tls.sh \

--- a/tests/omrelp-tls-ossl-authfail-suspend.sh
+++ b/tests/omrelp-tls-ossl-authfail-suspend.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# added 2026-05-12 to guard issue #5636, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_plugin imrelp
+require_plugin impstats
+require_plugin omrelp
+require_relpEngineSetTLSLibByName
+
+export NUMMESSAGES=50
+export TB_TEST_MAX_RUNTIME=60
+export PORT_RCVR="$(get_free_port)"
+export STATSFILE="$RSYSLOG_DYNNAME.stats"
+
+generate_conf
+add_conf '
+module(load="../plugins/imrelp/.libs/imrelp" tls.tlslib="openssl")
+
+input(type="imrelp"
+	port="'$PORT_RCVR'"
+	tls="on"
+	tls.cacert="'$srcdir'/tls-certs/ca.pem"
+	tls.mycert="'$srcdir'/tls-certs/cert.pem"
+	tls.myprivkey="'$srcdir'/tls-certs/key.pem")
+
+*.* action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+
+generate_conf 2
+add_conf '
+module(load="../plugins/impstats/.libs/impstats" log.file="'$STATSFILE'" interval="1")
+module(load="../plugins/omrelp/.libs/omrelp" tls.tlslib="openssl")
+
+action(type="omrelp"
+	name="issue_5636_omrelp"
+	target="127.0.0.1"
+	port="'$PORT_RCVR'"
+	tls="on"
+	tls.permanentFailureDisablesAction="off"
+	action.resumeRetryCount="0"
+	action.resumeInterval="60"
+	queue.type="LinkedList")
+action(type="omfile" file="'$RSYSLOG_DYNNAME.errmsgs'")
+' 2
+startup 2
+
+injectmsg2 1 $NUMMESSAGES
+sleep 2
+
+content_check "suspending action" "$RSYSLOG_DYNNAME.errmsgs"
+if grep -q "DISABLING action" "$RSYSLOG_DYNNAME.errmsgs"; then
+	echo "FAIL: omrelp disabled action despite tls.permanentFailureDisablesAction=off"
+	error_exit 1
+fi
+
+content_check --regex \
+	"issue_5636_omrelp queue: origin=core.queue .*enqueued=[5-9][0-9]" \
+	"$STATSFILE"
+
+shutdown_immediate 2
+wait_shutdown 2 30
+shutdown_immediate
+wait_shutdown "" 30
+
+exit_test


### PR DESCRIPTION
## Summary
- add `tls.permanentFailureDisablesAction` for omrelp, defaulting to the current action-disabling behavior
- allow `tls.permanentFailureDisablesAction="off"` to suspend instead, so action queues continue accepting messages while TLS auth problems are fixed
- add OpenSSL RELP regression coverage and document the new parameter

## Validation
- `make -j$(nproc) check TESTS=""`
- `LD_LIBRARY_PATH=/home/rger/proj/librelp/src/.libs ./tests/omrelp-tls-ossl-authfail-no-cacert.sh`
- `LD_LIBRARY_PATH=/home/rger/proj/librelp/src/.libs ./tests/omrelp-tls-ossl-authfail-suspend.sh`
- `./doc/tools/build-doc-linux.sh --clean --format html`
- `git diff --check`

Note: local RELP tests used the freshly built librelp from `/home/rger/proj/librelp/src/.libs` because the installed `/usr/local/lib/librelp.so.0` lacks `relpEngineSetShutdownImmdtPtr`.

Closes https://github.com/rsyslog/rsyslog/issues/5636
