### PR TITLE
tests: wait for MySQL action errorfile rows

### DIFF
--- a/tests/action-tx-errfile.sh
+++ b/tests/action-tx-errfile.sh
@@ -4,13 +4,28 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50 # sufficient for our needs!
 export SEQ_CHECK_OPTIONS=-i2
-check_sql_data_ready() {
+export EXPECTED_ERRFILE="$(cat ${srcdir}/testsuites/action-tx-errfile.result)"
+export EXPECTED_ERRFILE_LINES="$(printf '%s\n' "$EXPECTED_ERRFILE" | wc -l)"
+check_sql_and_errfile_data_ready() {
 	mysql_get_data
-	seq_check --check-only 0 $((NUMMESSAGES - 2))
+	seq_check --check-only 0 $((NUMMESSAGES - 2)) || return 1
+
+	if [ ! -f "$RSYSLOG2_OUT_LOG" ]; then
+		return 1
+	fi
+	current_errfile_lines=$(wc -l < "$RSYSLOG2_OUT_LOG")
+	if [ "$current_errfile_lines" -ne "$EXPECTED_ERRFILE_LINES" ]; then
+		return 1
+	fi
+	printf '%s\n' "$EXPECTED_ERRFILE" | cmp - "$RSYSLOG2_OUT_LOG" > /dev/null
 }
-export QUEUE_EMPTY_CHECK_FUNC=check_sql_data_ready
+export QUEUE_EMPTY_CHECK_FUNC=check_sql_and_errfile_data_ready
 
 generate_conf
+printf '%s\n' \
+	'INFO: this test intentionally generates MySQL syntax errors for odd messages.' \
+	'INFO: odd messages leave $!facility unset, causing ommysql RS_RET_DATAFAIL -2218.' \
+	'INFO: the expected SQL errors must be recorded in action.errorfile.'
 add_conf '
 $ModLoad ../plugins/ommysql/.libs/ommysql
 global(errormessagestostderr.maxnumber="5")
@@ -22,6 +37,9 @@ if((not($msg contains "error")) and ($msg contains "msgnum:")) then {
 	if $.num % 2 == 0 then {
 		set $!facility = $syslogfacility;
 	} else {
+		# Intentionally leave $!facility unset so this odd message generates
+		# a MySQL syntax error. The test verifies that the failed action is
+		# written to action.errorfile, not that SQL insertion succeeds.
 		set $/cntr = 0;
 	}
 	action(type="ommysql" name="mysql_action" server="127.0.0.1" template="tpl"
@@ -33,7 +51,7 @@ startup
 injectmsg
 shutdown_when_empty
 wait_shutdown
-export EXPECTED="$(cat ${srcdir}/testsuites/action-tx-errfile.result)"
+export EXPECTED="$EXPECTED_ERRFILE"
 cmp_exact ${RSYSLOG2_OUT_LOG}
 mysql_get_data
 seq_check  0 $((NUMMESSAGES - 2)) -i2


### PR DESCRIPTION
## Summary

This stabilizes `action-tx-errfile.sh` by making its shutdown readiness check wait for both sides of the test:

- successful even-numbered MySQL rows through `msgnum:00000048`
- exact expected `action.errorfile` rows for the intentionally failed odd-numbered messages

## Root Cause

The test intentionally leaves `$!facility` unset for odd messages. That generates SQL such as:

```sql
insert into SystemEvents (Message, Facility) values (" msgnum:00000049:", )
```

MySQL reports this as a syntax error, `ommysql` maps it to `RS_RET_DATAFAIL` / `-2218`, and the test verifies that the failed action is written to `action.errorfile`.

The old `QUEUE_EMPTY_CHECK_FUNC` only checked successful MySQL inserts with `seq_check --check-only 0 48 -i2`. That proves the even-message DB path completed, but it does not prove the odd-message `action.errorfile` writes completed. Under load, shutdown/comparison could race the final failed action record, leaving 24 errorfile rows instead of 25 and missing only `msgnum:00000049`.

## Fix

The readiness predicate now loads the existing expected errorfile fixture and waits until:

- the MySQL DB sequence check passes, and
- the errorfile has exactly the expected content.

The final `cmp_exact` and DB `seq_check` remain unchanged, so the test semantics are preserved after rsyslogd exits.

## Validation

Worker validation:

- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-mysql --enable-mysql-tests --disable-generate-man-pages`
- `make -j$(nproc) check TESTS=""`
- `bash -n tests/action-tx-errfile.sh`
- `TEST_RUN_TYPE=MOCK-OK make check TESTS='action-tx-errfile.sh'`

Real MySQL validation in `rsyslog/rsyslog_dev_base_ubuntu:26.04`:

- `./tests/mysqld-start.sh`
- `./tests/action-tx-errfile.sh` five consecutive times
- `./tests/mysqld-stop.sh`

All five real direct runs passed. After review, one additional direct run also passed with explicit test-log documentation that the MySQL syntax errors are intentional.

With the help of AI-Agents: Ampere, Codex