### PR TITLE
testbench: skip irrelevant service tests

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -31,6 +31,10 @@ concurrency:
 on:
   pull_request:
 
+env:
+  RSYSLOG_TESTBENCH_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+  RSYSLOG_TESTBENCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
 jobs:
   compile:
     name: compile (${{ matrix.config }})

--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -38,13 +38,13 @@ if [ -z "$RSYSLOG_DEV_CONTAINER" ]; then
 	RSYSLOG_DEV_CONTAINER=$(cat "$RSYSLOG_HOME"/devtools/default_dev_container)
 fi
 
-git_common_dir_mount=
+git_common_dir_mount=()
 if [ -f "$RSYSLOG_HOME/.git" ] && command -v git >/dev/null 2>&1; then
 	git_common_dir=$(git -C "$RSYSLOG_HOME" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
 	if [ -n "$git_common_dir" ] && [ -d "$git_common_dir" ]; then
 		case "$git_common_dir" in
 			"$RSYSLOG_HOME"/*) ;;
-			*) git_common_dir_mount="-v $git_common_dir:$git_common_dir" ;;
+			*) git_common_dir_mount=(-v "$git_common_dir:$git_common_dir") ;;
 		esac
 	fi
 fi
@@ -164,6 +164,6 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	--cap-add SYS_PTRACE \
 	$container_uid_args \
 	$passwd_group_mounts \
-	$git_common_dir_mount \
+	"${git_common_dir_mount[@]}" \
 	$DOCKER_RUN_EXTRA_FLAGS \
 	-v "$RSYSLOG_HOME":/rsyslog "$RSYSLOG_DEV_CONTAINER" "$@"

--- a/devtools/devcontainer.sh
+++ b/devtools/devcontainer.sh
@@ -38,6 +38,17 @@ if [ -z "$RSYSLOG_DEV_CONTAINER" ]; then
 	RSYSLOG_DEV_CONTAINER=$(cat "$RSYSLOG_HOME"/devtools/default_dev_container)
 fi
 
+git_common_dir_mount=
+if [ -f "$RSYSLOG_HOME/.git" ] && command -v git >/dev/null 2>&1; then
+	git_common_dir=$(git -C "$RSYSLOG_HOME" rev-parse --path-format=absolute --git-common-dir 2>/dev/null || true)
+	if [ -n "$git_common_dir" ] && [ -d "$git_common_dir" ]; then
+		case "$git_common_dir" in
+			"$RSYSLOG_HOME"/*) ;;
+			*) git_common_dir_mount="-v $git_common_dir:$git_common_dir" ;;
+		esac
+	fi
+fi
+
 printf '/rsyslog is mapped to %s \n' "$RSYSLOG_HOME"
 printf 'using container %s\n' "$RSYSLOG_DEV_CONTAINER"
 printf 'pulling container...\n'
@@ -136,6 +147,15 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	-e RSYSLOG_TESTBENCH_EXTERNAL_ES_HOST \
 	-e RSYSLOG_TESTBENCH_EXTERNAL_ES_PORT \
 	-e RSYSLOG_TESTBENCH_EXTERNAL_VM_URL \
+	-e RSYSLOG_TESTBENCH_BASE_SHA \
+	-e RSYSLOG_TESTBENCH_HEAD_SHA \
+	-e RSYSLOG_TESTBENCH_CHANGED_FILES \
+	-e RSYSLOG_TESTBENCH_FORCE_SERVICE_TESTS \
+	-e RSYSLOG_TESTBENCH_FORCE_ELASTICSEARCH_TESTS \
+	-e RSYSLOG_TESTBENCH_FORCE_MYSQL_TESTS \
+	-e RSYSLOG_TESTBENCH_FORCE_LIBDBI_TESTS \
+	-e RSYSLOG_TESTBENCH_FORCE_KAFKA_TESTS \
+	-e RSYSLOG_TESTBENCH_SKIP_SERVICE_RELEVANCE \
 	-e CODECOV_commit_sha \
 	-e CODECOV_repo_slug \
 	-e VCS_SLUG \
@@ -144,5 +164,6 @@ docker run $ti $optrm $DOCKER_RUN_EXTRA_OPTS \
 	--cap-add SYS_PTRACE \
 	$container_uid_args \
 	$passwd_group_mounts \
+	$git_common_dir_mount \
 	$DOCKER_RUN_EXTRA_FLAGS \
 	-v "$RSYSLOG_HOME":/rsyslog "$RSYSLOG_DEV_CONTAINER" "$@"

--- a/devtools/local-container-testing.md
+++ b/devtools/local-container-testing.md
@@ -37,6 +37,48 @@ RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
 devtools/devcontainer.sh --rm ./tests/compat-configformat-yaml.sh
 ```
 
+## Service Test Relevance Skips
+
+Heavy service-backed tests self-skip inside the testbench when the local git
+diff does not touch their relevant source paths. This applies to both
+`devtools/run-ci.sh` and direct test scripts launched through
+`devtools/devcontainer.sh`.
+
+The initial gated services are:
+
+- Elasticsearch: `plugins/omelasticsearch/**` and `runtime/*.[ch]`
+- MySQL: `plugins/ommysql/**` and `runtime/*.[ch]`
+- libdbi: `plugins/omlibdbi/**` and `runtime/*.[ch]`
+- Kafka: `plugins/imkafka/**`, `plugins/omkafka/**`, and `runtime/*.[ch]`
+
+Local detection uses the merge base with `origin/main` plus staged, unstaged,
+and untracked files. If the git state cannot be resolved, the testbench runs
+the service tests instead of skipping them.
+
+Force service tests when intentionally validating them without relevant source
+changes:
+
+```sh
+RSYSLOG_TESTBENCH_FORCE_SERVICE_TESTS=1 \
+RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+devtools/devcontainer.sh --rm ./tests/es-basic.sh
+
+RSYSLOG_TESTBENCH_FORCE_KAFKA_TESTS=1 \
+RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+devtools/devcontainer.sh --rm ./tests/kafka-selftest.sh
+```
+
+When validating service-skip behavior, use `-j60` and record wall-clock runtime:
+
+```sh
+/usr/bin/time -p env \
+RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
+CI_MAKE_OPT='-j60' \
+CI_MAKE_CHECK_OPT='-j60' \
+CI_CHECK_CMD='check' \
+devtools/devcontainer.sh --rm devtools/run-ci.sh
+```
+
 For broader local check runs, prefer:
 
 ```sh

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2297,9 +2297,11 @@ module_needs_testing() {
 		return 0
 	fi
 
-	while IFS= read -r changed_file; do
+	while IFS= read -r changed_file || [ -n "$changed_file" ]; do
+		[ -z "$changed_file" ] && continue
+
 		case "$changed_file" in
-			runtime/*.c|runtime/*.h)
+			runtime/*.c|runtime/*.h|configure.ac|Makefile.am|tests/Makefile.am|tests/diag.sh)
 				return 0
 				;;
 		esac

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -51,6 +51,18 @@
 # RSYSLOG_TESTBENCH_ES_MAJOR_VERSION
 #               Detected Elasticsearch major version exposed to the test suite.
 #               Populated automatically by ensure_elasticsearch_ready().
+# RSYSLOG_TESTBENCH_FORCE_SERVICE_TESTS
+#               If set to "1", bypasses changed-file relevance checks for
+#               service-backed tests.
+# RSYSLOG_TESTBENCH_FORCE_<MODULE>_TESTS
+#               If set to "1", bypasses changed-file relevance checks for a
+#               specific module. Current modules: ELASTICSEARCH, MYSQL, LIBDBI,
+#               KAFKA.
+# RSYSLOG_TESTBENCH_SKIP_SERVICE_RELEVANCE
+#               If set to "1", disables service relevance checks and preserves
+#               the historical behavior.
+# RSYSLOG_TESTBENCH_BASE_SHA / RSYSLOG_TESTBENCH_HEAD_SHA
+#               Optional git revisions used by CI to identify changed files.
 #
 #
 # EXIT STATES
@@ -2210,6 +2222,133 @@ skip_test(){
 	exit 77
 }
 
+testbench_changed_files() {
+	if [ "${_RSYSLOG_TESTBENCH_CHANGED_FILES_LOADED:-}" = "1" ]; then
+		return 0
+	fi
+	_RSYSLOG_TESTBENCH_CHANGED_FILES_LOADED=1
+
+	if [ -n "${RSYSLOG_TESTBENCH_CHANGED_FILES:-}" ]; then
+		_RSYSLOG_TESTBENCH_CHANGED_FILES="$RSYSLOG_TESTBENCH_CHANGED_FILES"
+		return 0
+	fi
+
+	if ! command -v git >/dev/null 2>&1 || ! git rev-parse --git-dir >/dev/null 2>&1; then
+		printf 'info: service relevance: git metadata unavailable, running service test\n'
+		_RSYSLOG_TESTBENCH_CHANGED_FILES_UNKNOWN=1
+		return 0
+	fi
+
+	local changed_files=""
+	local base_sha="${RSYSLOG_TESTBENCH_BASE_SHA:-}"
+	local head_sha="${RSYSLOG_TESTBENCH_HEAD_SHA:-}"
+
+	if [ -n "$base_sha" ] && [ -n "$head_sha" ]; then
+		if changed_files=$(git diff --name-only "$base_sha" "$head_sha" 2>/dev/null); then
+			_RSYSLOG_TESTBENCH_CHANGED_FILES="$changed_files"
+			return 0
+		fi
+		printf 'info: service relevance: unable to diff %s..%s, running service test\n' \
+			"$base_sha" "$head_sha"
+		_RSYSLOG_TESTBENCH_CHANGED_FILES_UNKNOWN=1
+		return 0
+	fi
+
+	if base_sha=$(git merge-base HEAD origin/main 2>/dev/null); then
+		changed_files=$(
+			{
+				git diff --name-only "$base_sha"...HEAD
+				git diff --name-only
+				git diff --cached --name-only
+				git ls-files --others --exclude-standard
+			} 2>/dev/null | sort -u
+		)
+		_RSYSLOG_TESTBENCH_CHANGED_FILES="$changed_files"
+		return 0
+	fi
+
+	printf 'info: service relevance: unable to find origin/main merge-base, running service test\n'
+	_RSYSLOG_TESTBENCH_CHANGED_FILES_UNKNOWN=1
+	return 0
+}
+
+_module_force_enabled() {
+	case "$1" in
+		elasticsearch) [ "${RSYSLOG_TESTBENCH_FORCE_ELASTICSEARCH_TESTS:-}" = "1" ] ;;
+		mysql) [ "${RSYSLOG_TESTBENCH_FORCE_MYSQL_TESTS:-}" = "1" ] ;;
+		libdbi) [ "${RSYSLOG_TESTBENCH_FORCE_LIBDBI_TESTS:-}" = "1" ] ;;
+		kafka) [ "${RSYSLOG_TESTBENCH_FORCE_KAFKA_TESTS:-}" = "1" ] ;;
+		*) return 1 ;;
+	esac
+}
+
+module_needs_testing() {
+	local module="$1"
+	local changed_file
+
+	if [ "${RSYSLOG_TESTBENCH_SKIP_SERVICE_RELEVANCE:-}" = "1" ] || \
+	   [ "${RSYSLOG_TESTBENCH_FORCE_SERVICE_TESTS:-}" = "1" ] || \
+	   _module_force_enabled "$module"; then
+		return 0
+	fi
+
+	testbench_changed_files
+	if [ "${_RSYSLOG_TESTBENCH_CHANGED_FILES_UNKNOWN:-}" = "1" ]; then
+		return 0
+	fi
+
+	while IFS= read -r changed_file; do
+		case "$changed_file" in
+			runtime/*.c|runtime/*.h)
+				return 0
+				;;
+		esac
+
+		case "$module:$changed_file" in
+			elasticsearch:plugins/omelasticsearch/*)
+				return 0
+				;;
+			mysql:plugins/ommysql/*)
+				return 0
+				;;
+			libdbi:plugins/omlibdbi/*)
+				return 0
+				;;
+			kafka:plugins/imkafka/*|kafka:plugins/omkafka/*)
+				return 0
+				;;
+		esac
+	done <<EOF
+$_RSYSLOG_TESTBENCH_CHANGED_FILES
+EOF
+
+	return 1
+}
+
+ensure_module_needs_testing() {
+	local module="$1"
+
+	if module_needs_testing "$module"; then
+		return 0
+	fi
+
+	printf 'info: skipping %s service test - no relevant changes detected\n' "$module"
+	exit 77
+}
+
+ensure_any_module_needs_testing() {
+	local module
+
+	for module in "$@"; do
+		if module_needs_testing "$module"; then
+			return 0
+		fi
+	done
+
+	printf 'info: skipping service lifecycle test - no relevant changes detected for: %s\n' "$*"
+	exit 77
+}
+
 
 # Helper function to call rsyslog project test error script
 # $1 is the exit code
@@ -2717,6 +2856,7 @@ otel_exit_handling() {
 }
 
 download_kafka() {
+	ensure_module_needs_testing kafka
 	if [ ! -d $dep_cache_dir ]; then
 		echo "Creating dependency cache dir $dep_cache_dir"
 		mkdir $dep_cache_dir
@@ -3241,6 +3381,7 @@ prepare_elasticsearch() {
 # ensure that a basic, suitable instance of elasticsearch is running. This is part
 # of an effort to avoid restarting elasticsearch more often than necessary.
 ensure_elasticsearch_ready() {
+	ensure_module_needs_testing elasticsearch
 	printf '%s ensuring Elasticsearch ready\n' "$(tb_timestamp)"
         if [ "$RSYSLOG_TESTBENCH_USE_EXTERNAL_ES" = "yes" ]; then
                 local base
@@ -4002,6 +4143,7 @@ except Exception as e:
 # prepare MySQL for next test
 # each test receives its own database so that we also can run in parallel
 mysql_prep_for_test() {
+	ensure_module_needs_testing "${1:-mysql}"
 	mysql -u rsyslog --password=testbench -e "CREATE DATABASE $RSYSLOG_DYNNAME; "
 	mysql -u rsyslog --password=testbench --database $RSYSLOG_DYNNAME \
 		-e "CREATE TABLE SystemEvents (ID int unsigned not null auto_increment primary key, CustomerID bigint,ReceivedAt datetime NULL,DeviceReportedTime datetime NULL,Facility smallint NULL,Priority smallint NULL,FromHost varchar(60) NULL,Message text,NTSeverity int NULL,Importance int NULL,EventSource varchar(60),EventUser varchar(60) NULL,EventCategory int NULL,EventID int NULL,EventBinaryData text NULL,MaxAvailable int NULL,CurrUsage int NULL,MinUsage int NULL,MaxUsage int NULL,InfoUnitID int NULL,SysLogTag varchar(60),EventLogType varchar(60),GenericFileName VarChar(60),SystemID int NULL); CREATE TABLE SystemEventsProperties (ID int unsigned not null auto_increment primary key,SystemEventID int NULL,ParamName varchar(255) NULL,ParamValue text NULL);"
@@ -4540,6 +4682,14 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 
    'wait-kafka-startup')
                 wait_for_kafka_startup "$2" "$3"
+                ;;
+
+   'module-needs-testing')
+                module_needs_testing "$2"
+                ;;
+
+   'ensure-module-needs-testing')
+                ensure_module_needs_testing "$2"
                 ;;
 
    'check-ipv6-available')   # check if IPv6  - will exit 77 when not OK

--- a/tests/elasticsearch-stop.sh
+++ b/tests/elasticsearch-stop.sh
@@ -3,5 +3,6 @@
 # are done (or for manual testing).
 # Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+ensure_module_needs_testing elasticsearch
 cleanup_elasticsearch
 exit_test

--- a/tests/libdbi-asyn.sh
+++ b/tests/libdbi-asyn.sh
@@ -19,7 +19,7 @@ $ActionLibdbiDBName '$RSYSLOG_DYNNAME'
 	action(type="omfile" file="'$RSYSLOG_DYNNAME'.syncfile")
 }
 '
-mysql_prep_for_test
+mysql_prep_for_test libdbi
 startup
 injectmsg
 wait_file_lines $RSYSLOG_DYNNAME.syncfile $NUMMESSAGES 2500

--- a/tests/libdbi-basic.sh
+++ b/tests/libdbi-basic.sh
@@ -13,7 +13,7 @@ $ActionLibdbiPassword testbench
 $ActionLibdbiDBName '$RSYSLOG_DYNNAME'
 :msg, contains, "msgnum:" :omlibdbi:
 '
-mysql_prep_for_test
+mysql_prep_for_test libdbi
 startup
 injectmsg
 shutdown_when_empty

--- a/tests/mysqld-start.sh
+++ b/tests/mysqld-start.sh
@@ -5,6 +5,7 @@
 # Copyright (C) 2018 Rainer Gerhards and Adiscon GmbH
 # Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+ensure_any_module_needs_testing mysql libdbi
 echo pre-start
 ps -ef |grep bin.mysqld
 if [ "$MYSQLD_START_CMD" == "" ]; then

--- a/tests/mysqld-stop.sh
+++ b/tests/mysqld-stop.sh
@@ -5,6 +5,7 @@
 # Copyright (C) 2018 Rainer Gerhards and Adiscon GmbH
 # Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+ensure_any_module_needs_testing mysql libdbi
 if [ "$MYSQLD_STOP_CMD" == "" ]; then
 	exit_test
 fi


### PR DESCRIPTION
## Summary

This adds a lazy service relevance gate to the rsyslog testbench so heavyweight service-backed tests can skip when the current change set cannot affect them.

The initial pilot covers Elasticsearch, MySQL/libdbi, and Kafka. Each service maps to its module paths plus the shared `runtime/*.[ch]` relevance set, with force-run overrides for maintainers.

## Details

- Adds lazy changed-file detection in `tests/diag.sh`.
- Gates Elasticsearch, MySQL/libdbi, and Kafka service entry points before download/startup/fake lifecycle work.
- Passes PR base/head SHAs into container test runs.
- Mounts linked-worktree git metadata into local dev containers so local relevance checks work from separate worktrees.
- Documents local dev-container behavior and runtime recording in `devtools/local-container-testing.md`.

## Validation

- `git diff --check`
- `actionlint .github/workflows/run_checks.yml`
- `bash -n tests/diag.sh devtools/devcontainer.sh tests/mysqld-start.sh tests/mysqld-stop.sh tests/elasticsearch-stop.sh tests/libdbi-basic.sh tests/libdbi-asyn.sh`
- Local dev-container direct skip check for ES/MySQL/libdbi/Kafka lifecycle/service tests: `real 2.27s`
- Local dev-container `-j60` run via `devtools/run-ci.sh`: passed, `real 23.13s`
- Fake component-change relevance checks for ES, MySQL, libdbi, Kafka, runtime, and force override: passed, each about 2s including container startup
