### PR TITLE
[codex] narrow CODEOWNERS ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,15 +1,8 @@
 # Security-sensitive repository metadata
+/.github/CODEOWNERS @rgerhards @alorbach
 /.gitmodules @rgerhards @alorbach
-/.gitattributes @rgerhards @alorbach
 
-# CI workflows
-/.github/workflows/* @rgerhards @alorbach
-
-# Build and release tooling
-/autogen.sh @rgerhards @alorbach
-/configure.ac @rgerhards @alorbach
-/Makefile.am @rgerhards @alorbach
-/devtools/ @rgerhards @alorbach
-
-# Default ownership for the core source tree and all other repository paths
-* @rgerhards @alorbach
+# Workflows that can publish, deploy, or write security findings
+/.github/workflows/codeql.yml @rgerhards @alorbach
+/.github/workflows/doc_deploy_main.yml @rgerhards @alorbach
+/.github/workflows/draft_release.yml @rgerhards @alorbach


### PR DESCRIPTION
## What changed

Narrowed `.github/CODEOWNERS` so `@alorbach` and `@rgerhards` are only required on files that affect repository trust boundaries:

- `/.github/CODEOWNERS`
- `/.gitmodules`
- selected workflows with publish/deploy/security-finding side effects

## Why

The previous wildcard entry made `@alorbach` a code owner for the entire repository, which was broader than intended.

## Impact

This reduces review noise while keeping owner review on paths that can publish, deploy, or alter security-sensitive behavior.

## Validation

- Reviewed the resulting diff in the worktree
- Confirmed the branch is isolated in a separate worktree
