### PR TITLE
tests: isolate minitcpsrv retry ports

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1172,10 +1172,17 @@ assign_file_content() {
 # start a minitcpsrvr with the regular parameters
 # $1 is the output file name
 # $2 is the instance name (1, 2)
+# $3, if set, is a file that releases minitcpsrv from bound/offline to listening
 start_minitcpsrvr() {
-	instance=${2:-1}
-	./minitcpsrv -t127.0.0.1 -p 0 -P "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance" -f "$1" $MINITCPSRV_EXTRA_OPTS &
+	local instance=${2:-1}
+	local wait_listen_opt=""
+	if [ "${3:-}" != "" ]; then
+		wait_listen_opt="-w ${3:-}"
+	fi
+	./minitcpsrv -t127.0.0.1 -p 0 -P "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance" \
+		-f "$1" $wait_listen_opt $MINITCPSRV_EXTRA_OPTS &
 	BGPROCESS=$!
+	MINITCPSRVR_PIDS="${MINITCPSRVR_PIDS:-} $BGPROCESS"
 	wait_file_exists "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance"
 	if [ "$instance" == "1" ]; then
 		export MINITCPSRVR_PORT1="$(cat $RSYSLOG_DYNNAME.minitcpsrvr_port$instance)"
@@ -1183,6 +1190,17 @@ start_minitcpsrvr() {
 		export MINITCPSRVR_PORT2="$(cat $RSYSLOG_DYNNAME.minitcpsrvr_port$instance)"
 	fi
 	echo "### background minitcpsrv process id is $BGPROCESS port $(cat $RSYSLOG_DYNNAME.minitcpsrvr_port$instance) ###"
+}
+
+stop_minitcpsrvrs() {
+	local pid
+	for pid in ${MINITCPSRVR_PIDS:-}; do
+		if kill -0 "$pid" 2>/dev/null; then
+			kill "$pid" 2>/dev/null
+		fi
+		wait "$pid" 2>/dev/null
+	done
+	MINITCPSRVR_PIDS=""
 }
 
 # same as startup_vg, BUT we do NOT wait on the startup message!
@@ -1943,6 +1961,7 @@ do_cleanup() {
 		printf 'rsyslog pid file still exists, trying to shutdown...\n'
 		shutdown_immediate 2
 	fi
+	stop_minitcpsrvrs
 }
 
 
@@ -2395,6 +2414,7 @@ exit_test() {
 	rm -f rsyslog.conf.tlscert stat-file1 rsyslog.empty imfile-state:*
 	rm -f ${TESTCONF_NM}.conf ${TESTCONF_NM}.yaml
 	rm -f tmp.qi nocert
+	stop_minitcpsrvrs
 	rm -fr $RSYSLOG_DYNNAME*  # delete all of our dynamic files
 	unset TCPFLOOD_EXTRA_OPTS
 

--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -50,9 +50,11 @@ int dropConnection_NbrRcv = 0;
 int dropConnection_MaxTimes = 0;
 int opt;
 int sleepStartup = 0;
+int useReusePort = 0;
 char *targetIP = NULL;
 int targetPort = -1;
 char *portFileName = NULL;
+char *waitListenFileName = NULL;
 size_t totalWritten = 0;
 int listen_fd, conn_fd, fd, file_fd, nfds, port = 8080;
 struct sockaddr_in server_addr;
@@ -67,8 +69,18 @@ static void errout(char *reason) {
 }
 
 static void usage(void) {
-    fprintf(stderr, "usage: minitcpsrv -t ip-addr -p port -P portFile -f outfile\n");
+    fprintf(stderr, "usage: minitcpsrv [-R] [-w listenFile] -t ip-addr -p port -P portFile -f outfile\n");
     exit(1);
+}
+
+static void waitForListenRelease(void) {
+    if (waitListenFileName == NULL) return;
+
+    fprintf(stderr, "minitcpsrv waits for listen release file %s\n", waitListenFileName);
+    while (access(waitListenFileName, F_OK) != 0) {
+        sleep(1);
+    }
+    fprintf(stderr, "minitcpsrv listen release file %s found\n", waitListenFileName);
 }
 
 static void createListenSocket(void) {
@@ -81,19 +93,21 @@ static void createListenSocket(void) {
     if (listen_fd < 0) {
         errout("Failed to create listen socket");
     }
-    /* Set SO_REUSEADDR and SO_REUSEPORT options - these are vital for some
-     * Tests. If not both are supported by the OS (e.g. Solaris 10), some tests
-     * will fail. Those need to be excluded.
-     */
+    /* SO_REUSEADDR is enough for the test helper's restart use cases. */
     int opt = 1;
     if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) < 0) {
         errout("setsockopt failed for SO_REUSEADDR");
     }
+    if (useReusePort) {
 #ifdef SO_REUSEPORT
-    if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)) < 0) {
-        errout("setsockopt failed for SO_REUSEPORT");
-    }
+        if (setsockopt(listen_fd, SOL_SOCKET, SO_REUSEPORT, &opt, sizeof(opt)) < 0) {
+            errout("setsockopt failed for SO_REUSEPORT");
+        }
+#else
+        fprintf(stderr, "SO_REUSEPORT requested but not supported on this platform\n");
+        exit(1);
 #endif
+    }
 
     fprintf(stderr, "listen on target port %d\n", targetPort);
     memset(&server_addr, 0, sizeof(server_addr));
@@ -126,10 +140,6 @@ static void createListenSocket(void) {
         }
     } while (!sockBound);
 
-    if (listen(listen_fd, MAX_CONNECTIONS) < 0) {
-        errout("Listen failed");
-    }
-
     if (getsockname(listen_fd, (struct sockaddr *)&srvAddr, &srvAddrLen) == -1) {
         errout("getsockname");
     }
@@ -148,6 +158,15 @@ static void createListenSocket(void) {
         portFileWritten = 1;
     }
 
+    /* The socket is bound but not listening while this waits. TCP connects fail
+     * with connection refused, while the selected port remains reserved.
+     */
+    waitForListenRelease();
+
+    if (listen(listen_fd, MAX_CONNECTIONS) < 0) {
+        errout("Listen failed");
+    }
+
     fds[0].fd = listen_fd;
     fds[0].events = POLLIN;
 }
@@ -161,10 +180,13 @@ int main(int argc, char *argv[]) {
     memset(fds, 0, sizeof(fds));
     memset(buffer_offs, 0, sizeof(buffer_offs));
 
-    while ((opt = getopt(argc, argv, "aB:D:t:p:P:f:s:S:")) != -1) {
+    while ((opt = getopt(argc, argv, "aB:D:Rt:p:P:f:s:S:w:")) != -1) {
         switch (opt) {
             case 'a':  // abort listener: act like the server has died (shutdown and re-open listen socket)
                 abortListener = 1;
+                break;
+            case 'R':
+                useReusePort = 1;
                 break;
             case 'S':  // sleep time after connection drop
                 sleepAfterConnDrop = atoi(optarg);
@@ -195,6 +217,9 @@ int main(int argc, char *argv[]) {
                     fdf = open(optarg, O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
                     if (fdf == -1) errout(argv[3]);
                 }
+                break;
+            case 'w':
+                waitListenFileName = optarg;
                 break;
             default:
                 fprintf(stderr, "invalid option '%c' or value missing - terminating...\n", opt);

--- a/tests/omfwd-lb-2target-retry.sh
+++ b/tests/omfwd-lb-2target-retry.sh
@@ -6,7 +6,10 @@ export NUMMESSAGES=10000  # MUST be an EVEN number!
 
 # starting minitcpsrvr receivers so that we can obtain their port
 # numbers
+TARGET2_LISTEN_RELEASE="$RSYSLOG_DYNNAME.minitcpsrvr2.listen"
+rm -f "$TARGET2_LISTEN_RELEASE"
 start_minitcpsrvr $RSYSLOG_OUT_LOG  1
+start_minitcpsrvr $RSYSLOG2_OUT_LOG 2 "$TARGET2_LISTEN_RELEASE"
 
 # regular startup
 add_conf '
@@ -18,7 +21,7 @@ module(load="builtin:omfwd" template="outfmt")
 
 if $msg contains "msgnum:" then {
 	action(type="omfwd" target=["127.0.0.1", "127.0.0.1"]
-	                    port=["'$MINITCPSRVR_PORT1'", "'$TCPFLOOD_PORT'"]
+	                    port=["'$MINITCPSRVR_PORT1'", "'$MINITCPSRVR_PORT2'"]
 		protocol="tcp"
 		pool.resumeInterval="1"
 		action.resumeRetryCount="-1" action.resumeInterval="5")
@@ -37,16 +40,9 @@ cp "$RSYSLOG_OUT_LOG" tmp.log
 seq_check
 printf "\nSUCCESS for part 1 of the test\n\n"
 
-echo WARNING: The next part of this test is flacky, because there is an
-echo inevitable race on the port number for minitcpsrvr. If another
-echo parallel test has aquired it in the interim, this test here will
-echo invalidly fail.
-./minitcpsrv -t127.0.0.1 -p $TCPFLOOD_PORT -f "$RSYSLOG2_OUT_LOG" \
-	-P "$RSYSLOG_DYNNAME.minitcpsrvr_port2"  &
-# Note: we use the port file just to make sure minitcpsrvr has initialized!
-wait_file_exists "$RSYSLOG_DYNNAME.minitcpsrvr_port2"
-BGPROCESS=$!
-echo "### background minitcpsrv process id is $BGPROCESS port $TCPFLOOD_PORT ###"
+# target2 has held its port bound but not listening since before rsyslog
+# startup. This keeps phase 1 offline without exposing a get_free_port race.
+touch "$TARGET2_LISTEN_RELEASE"
 echo "waiting a bit to ensure rsyslog retries the currently suspended pool member"
 
 sleep 3


### PR DESCRIPTION
## Summary

This PR fixes an omfwd load-balancer retry flake caused by weak testbench TCP receiver isolation.

PR 6883 exposed the concrete failure mode: two unrelated omfwd-lb tests in the same `centos_7` job both used `minitcpsrv` port `39667`. One test then saw short receiver output while the other saw excess receiver output and sequence drift. That is receiver/port cross-talk, not an omfwd-only failure.

## Root Cause

`minitcpsrv` enabled `SO_REUSEPORT` by default. That allows multiple helper receivers to bind/listen on the same TCP port, which is unsafe for parallel test isolation.

`omfwd-lb-2target-retry.sh` also had a documented race: it configured target 2 with an unreserved `$TCPFLOOD_PORT`, then only later started `minitcpsrv` on that port. A parallel test could take the port in the interim.

## Changes

- Keep `SO_REUSEADDR` in `minitcpsrv`, but make `SO_REUSEPORT` opt-in with `-R`.
- Add `minitcpsrv -w <file>` so a helper can bind a port, write its port file, and defer `listen()` until a release file appears.
- Track `start_minitcpsrvr` helper PIDs in `diag.sh` and clean them up from normal and error paths.
- Update `omfwd-lb-2target-retry.sh` so target 2 is started before rsyslog with its port bound but not listening. Phase 1 still sees target 2 as unavailable; phase 2 releases the listener. Existing split and sequence assertions are unchanged.

## Validation

- `bash devtools/format-code.sh`
- `make -C tests minitcpsrv chkseq`
- `./tests/omfwd-lb-2target-retry.sh`
- `(cd tests && ./omfwd-lb-1target-retry-1_byte_buf.sh)`
- `(cd tests && ./omfwd-lb-1target-retry-full_buf.sh)`
- `(cd tests && ./omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh)`
- `(cd tests && ./minitcpsrv_usage_output.sh)`
- 3 coordinator stress iterations running `omfwd-lb-2target-retry.sh` and `omfwd-lb-1target-retry-1_byte_buf.sh` concurrently under light CPU load

Worker-side validation also ran 5 concurrent sibling stress iterations successfully.

## Negative Control

A temporary worker-side change routed both `omfwd-lb-2target-retry.sh` targets to receiver 1. The test failed as expected with:

`ERROR: RSYSLOG2_OUT_LOG has invalid number of messages 5000`

After restoring the correct target 2 port, the test passed again. This shows the changed test still catches invalid load-balancer behavior instead of merely becoming easier to pass.

## Residual Risk

The older target-fail sequence-drift bucket may still expose a second issue after port isolation is fixed. This PR addresses the concrete same-port/cross-talk root cause first without weakening assertions.

With the help of AI-Agents: Codex, Hooke, Bohr
