### PR TITLE
ci: follow up service relevance review

### DIFF
--- a/.agent/skills/rsyslog_pr_babysitting/SKILL.md
+++ b/.agent/skills/rsyslog_pr_babysitting/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: rsyslog_pr_babysitting
+description: Monitor rsyslog pull requests after push or rerun, including GitHub Actions checks, unresolved review threads, bot comments, reruns for known flakes, and concise status reporting.
+---
+
+# rsyslog_pr_babysitting
+
+Use this skill when babysitting an rsyslog PR after pushing, rerunning CI, or
+waiting for review. Babysitting is incomplete unless both CI status and
+unresolved review threads have been checked.
+
+## Poll Cadence
+
+- Poll every 10 to 20 minutes while checks are running; 15 minutes is the
+  default.
+- If babysitting a non-empty set of PRs, check them together on the same
+  cadence instead of starting separate tight loops.
+- Stop babysitting when all monitored PRs are green: no failed checks, no
+  running or queued required checks, and no unresolved actionable review
+  threads. Do not keep polling until merge unless explicitly asked.
+- Do not leave background sleep or polling processes alive when stopping work.
+- Report the commit SHA, failed checks, running checks, and unresolved review
+  findings at each meaningful update.
+
+## CI Poll
+
+Use `gh pr view` for check rollups:
+
+```sh
+gh pr view PR_NUMBER --repo rsyslog/rsyslog \
+  --json statusCheckRollup,reviewDecision,mergeable,state,headRefOid,url
+```
+
+For failures, inspect logs before guessing:
+
+```sh
+gh run view RUN_ID --repo rsyslog/rsyslog --job JOB_ID --log-failed
+gh api -H 'Accept: application/vnd.github+json' \
+  /repos/rsyslog/rsyslog/actions/jobs/JOB_ID/logs
+```
+
+If a failed test is a known or likely flake, record the failing test name and
+reason, then rerun failed jobs only:
+
+```sh
+gh run rerun RUN_ID --repo rsyslog/rsyslog --failed
+```
+
+Do not change code for CI failures until the failing path has been tied to the
+PR's changes.
+
+## Review Thread Poll
+
+Fetch review threads with GraphQL. Flat PR comments are not enough because they
+omit thread state. If a GitHub review-comment skill is available, use its
+thread-aware fetch helper; otherwise query `reviewThreads` directly:
+
+```sh
+gh api graphql \
+  -F owner=rsyslog \
+  -F repo=rsyslog \
+  -F number=PR_NUMBER \
+  -f query='
+query($owner:String!,$repo:String!,$number:Int!) {
+  repository(owner:$owner,name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          comments(first:20) {
+            nodes { author { login } createdAt body }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+For each unresolved, non-outdated thread, track:
+
+- author, path, and line
+- priority words such as high, critical, regression, skip, CI, or workflow
+- whether the requested change is actionable or only needs a response
+
+Do not reply on GitHub, resolve threads, or push fixes unless explicitly asked.
+
+## Status Summary
+
+When reporting, separate:
+
+- CI failures that need code changes
+- likely flakes already rerun
+- unresolved review comments needing decisions
+- checks still running
+
+If all checks pass but unresolved actionable review threads remain, say the PR is
+not fully babysat yet.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ To ensure consistency and high-quality contributions, AI agents SHOULD use the f
 | [`rsyslog_build`](.agent/skills/rsyslog_build/SKILL.md) | Environment setup and incremental parallel builds. |
 | [`rsyslog_test`](.agent/skills/rsyslog_test/SKILL.md) | Standardized validation and debugging via `diag.sh`. |
 | [`rsyslog_local_container_testing`](.agent/skills/rsyslog_local_container_testing/SKILL.md) | CI-style local dev-container validation, analyzer-first flow, service-skip checks, and clean-tree rules. |
+| [`rsyslog_pr_babysitting`](.agent/skills/rsyslog_pr_babysitting/SKILL.md) | Post-push PR monitoring, including CI failures, reruns, and unresolved review-thread checks. |
 | [`rsyslog_doc`](.agent/skills/rsyslog_doc/SKILL.md) | Structured, RAG-optimized documentation and metadata. |
 | [`rsyslog_doc_dist`](.agent/skills/rsyslog_doc_dist/SKILL.md) | Syncing documentation files in `doc/Makefile.am`. |
 | [`rsyslog_module`](.agent/skills/rsyslog_module/SKILL.md) | Technical patterns for concurrency and module authoring. |

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2392,8 +2392,12 @@ module_needs_testing() {
 			imbeats:tests/yaml-imbeats*.sh)
 				return 0
 				;;
-			imjournal:plugins/imjournal/*|imjournal:tests/imjournal*.sh|\
+			imjournal:plugins/imjournal/*|imjournal:plugins/omjournal/*|\
+			imjournal:tests/imjournal*.sh|imjournal:tests/omjournal*.sh|\
 			imjournal:tests/journal_print.c|\
+			omjournal:plugins/imjournal/*|omjournal:plugins/omjournal/*|\
+			omjournal:tests/imjournal*.sh|omjournal:tests/omjournal*.sh|\
+			omjournal:tests/journal_print.c|\
 			journal:plugins/imjournal/*|journal:plugins/omjournal/*|\
 			journal:tests/imjournal*.sh|journal:tests/omjournal*.sh|\
 			journal:tests/journal_print.c)
@@ -2413,12 +2417,12 @@ module_needs_testing() {
 			kafka:tests/*kafka*.sh|kafka:tests/kafka*.sh)
 				return 0
 				;;
-			imhiredis:contrib/imhiredis/*|imhiredis:tests/imhiredis*.sh|\
-			imhiredis:tests/testsuites/redis.conf|imhiredis:tests/testsuites/x.509/*)
-				return 0
-				;;
-			omhiredis:contrib/omhiredis/*|omhiredis:tests/omhiredis*.sh|\
-			omhiredis:tests/testsuites/redis.conf)
+			imhiredis:contrib/imhiredis/*|imhiredis:contrib/omhiredis/*|\
+			imhiredis:tests/imhiredis*.sh|imhiredis:tests/omhiredis*.sh|\
+			imhiredis:tests/testsuites/redis.conf|imhiredis:tests/testsuites/x.509/*|\
+			omhiredis:contrib/imhiredis/*|omhiredis:contrib/omhiredis/*|\
+			omhiredis:tests/imhiredis*.sh|omhiredis:tests/omhiredis*.sh|\
+			omhiredis:tests/testsuites/redis.conf|omhiredis:tests/testsuites/x.509/*)
 				return 0
 				;;
 			hiredis:contrib/imhiredis/*|hiredis:contrib/omhiredis/*|\
@@ -2427,9 +2431,6 @@ module_needs_testing() {
 				return 0
 				;;
 			imdocker:contrib/imdocker/*|imdocker:tests/imdocker*.sh)
-				return 0
-				;;
-			omjournal:plugins/omjournal/*|omjournal:tests/omjournal*.sh)
 				return 0
 				;;
 			omrabbitmq:contrib/omrabbitmq/*|omrabbitmq:tests/omrabbitmq*.sh|\


### PR DESCRIPTION
## Summary
- address follow-up review comments from PR #6889 by making journal and hiredis relevance checks symmetric across related input/output modules
- add an `rsyslog_pr_babysitting` skill so PR babysitting includes both CI status and unresolved review-thread polling
- link the new skill from `AGENTS.md`

## Validation
- `bash -n tests/diag.sh`
- `git diff --check`
- skill frontmatter parsed with Ruby YAML
- fake changed-file matrix for imjournal/omjournal/journal and imhiredis/omhiredis/hiredis

Follow-up to https://github.com/rsyslog/rsyslog/pull/6889.
