### PR TITLE
runtime: add STAILQ fallback for AIX

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -211,7 +211,30 @@ AC_CHECK_HEADERS([malloc.h],[],[],[
      #endif
   ]
 ])
-AC_CHECK_HEADERS([fcntl.h locale.h netdb.h netinet/in.h paths.h stddef.h stdlib.h string.h sys/file.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h sys/stat.h unistd.h utmp.h utmpx.h sys/epoll.h sys/prctl.h sys/select.h getopt.h linux/close_range.h linux/fs.h])
+AC_CHECK_HEADERS([fcntl.h locale.h netdb.h netinet/in.h paths.h stddef.h stdlib.h string.h sys/file.h sys/ioctl.h sys/param.h sys/socket.h sys/time.h sys/stat.h sys/queue.h unistd.h utmp.h utmpx.h sys/epoll.h sys/prctl.h sys/select.h getopt.h linux/close_range.h linux/fs.h])
+
+AC_MSG_CHECKING([for STAILQ macros in sys/queue.h])
+AC_COMPILE_IFELSE(
+    [AC_LANG_PROGRAM(
+        [[
+#include <sys/queue.h>
+struct stailq_test_entry {
+    STAILQ_ENTRY(stailq_test_entry) link;
+};
+STAILQ_HEAD(stailq_test_head, stailq_test_entry);
+        ]],
+        [[
+struct stailq_test_head head;
+STAILQ_INIT(&head);
+return STAILQ_EMPTY(&head) ? 0 : 1;
+        ]]
+    )],
+    [
+        AC_MSG_RESULT([yes])
+        AC_DEFINE([HAVE_SYS_QUEUE_STAILQ], [1], [Define if sys/queue.h provides STAILQ macros])
+    ],
+    [AC_MSG_RESULT([no])]
+)
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_CONST

--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -50,7 +50,7 @@
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <sys/epoll.h>
-#include <sys/queue.h>
+#include "compat_queue.h"
 #include <netinet/tcp.h>
 #include <stdint.h>
 #include <zlib.h>

--- a/plugins/omazureeventhubs/omazureeventhubs.c
+++ b/plugins/omazureeventhubs/omazureeventhubs.c
@@ -30,7 +30,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <sys/uio.h>
-#include <sys/queue.h>
+#include "compat_queue.h"
 #include <sys/types.h>
 #include <math.h>
 #ifdef HAVE_SYS_STAT_H

--- a/plugins/omdtls/omdtls.c
+++ b/plugins/omdtls/omdtls.c
@@ -32,7 +32,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <sys/uio.h>
-#include <sys/queue.h>
+#include "compat_queue.h"
 #include <netdb.h>
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/plugins/omkafka/omkafka.c
+++ b/plugins/omkafka/omkafka.c
@@ -31,7 +31,7 @@
 #include <fcntl.h>
 #include <pthread.h>
 #include <sys/uio.h>
-#include <sys/queue.h>
+#include "compat_queue.h"
 #include <sys/types.h>
 #include <math.h>
 #ifdef HAVE_SYS_STAT_H

--- a/runtime/Makefile.am
+++ b/runtime/Makefile.am
@@ -58,6 +58,7 @@ librsyslog_la_SOURCES = \
 	modules.h \
 	statsobj.c \
 	statsobj.h \
+	compat_queue.h \
 	dynstats.c \
 	dynstats.h \
 	perctile_ringbuf.c \

--- a/runtime/compat_queue.h
+++ b/runtime/compat_queue.h
@@ -1,0 +1,67 @@
+/*
+ * Compatibility helpers for BSD sys/queue.h users.
+ *
+ * Use the platform STAILQ macros when configure found them.  Some platforms
+ * provide sys/queue.h without that subset, so keep the local fallback limited
+ * to the macros used by rsyslog.
+ */
+#ifndef INCLUDED_COMPAT_QUEUE_H
+#define INCLUDED_COMPAT_QUEUE_H
+
+#include <stddef.h>
+#ifdef HAVE_SYS_QUEUE_H
+    #include <sys/queue.h>
+#endif
+
+#ifndef HAVE_SYS_QUEUE_STAILQ
+    #ifndef STAILQ_HEAD
+        #define STAILQ_HEAD(name, type)  \
+            struct name {                \
+                struct type *stqh_first; \
+                struct type **stqh_last; \
+            }
+    #endif
+
+    #ifndef STAILQ_ENTRY
+        #define STAILQ_ENTRY(type)      \
+            struct {                    \
+                struct type *stqe_next; \
+            }
+    #endif
+
+    #ifndef STAILQ_INIT
+        #define STAILQ_INIT(head)                        \
+            do {                                         \
+                (head)->stqh_first = NULL;               \
+                (head)->stqh_last = &(head)->stqh_first; \
+            } while (0)
+    #endif
+
+    #ifndef STAILQ_EMPTY
+        #define STAILQ_EMPTY(head) ((head)->stqh_first == NULL)
+    #endif
+
+    #ifndef STAILQ_FIRST
+        #define STAILQ_FIRST(head) ((head)->stqh_first)
+    #endif
+
+    #ifndef STAILQ_INSERT_TAIL
+        #define STAILQ_INSERT_TAIL(head, elm, field)         \
+            do {                                             \
+                (elm)->field.stqe_next = NULL;               \
+                *(head)->stqh_last = (elm);                  \
+                (head)->stqh_last = &(elm)->field.stqe_next; \
+            } while (0)
+    #endif
+
+    #ifndef STAILQ_REMOVE_HEAD
+        #define STAILQ_REMOVE_HEAD(head, field)                                           \
+            do {                                                                          \
+                if (((head)->stqh_first = (head)->stqh_first->field.stqe_next) == NULL) { \
+                    (head)->stqh_last = &(head)->stqh_first;                              \
+                }                                                                         \
+            } while (0)
+    #endif
+#endif
+
+#endif /* #ifndef INCLUDED_COMPAT_QUEUE_H */

--- a/runtime/dynstats.c
+++ b/runtime/dynstats.c
@@ -33,7 +33,7 @@
 #include "datetime.h"
 #include "unicode-helper.h"
 #include "hashtable_itr.h"
-#include <sys/queue.h>
+#include "compat_queue.h"
 
 /* definitions for objects we access */
 DEFobjStaticHelpers;

--- a/runtime/dynstats.h
+++ b/runtime/dynstats.h
@@ -18,7 +18,7 @@
 #ifndef INCLUDED_DYNSTATS_H
 #define INCLUDED_DYNSTATS_H
 
-#include <sys/queue.h>
+#include "compat_queue.h"
 #include "hashtable.h"
 
 typedef struct hashtable htable;


### PR DESCRIPTION
## Summary

Add `runtime/compat_queue.h` as a wrapper for `sys/queue.h`. A new configure probe checks whether the platform header provides the `STAILQ` macro subset rsyslog uses. Platforms with native `STAILQ` keep using their system macros; platforms without it use the small local fallback.

The patch also switches existing direct `sys/queue.h` users to the wrapper and adds the new header to `runtime/Makefile.am` distribution sources.

## Root Cause

AIX can provide `sys/queue.h` without the BSD `STAILQ_*` macros. `runtime/dynstats.h` now declares a file-write queue using `STAILQ_HEAD`, so builds fail while compiling grammar users that include `rsconf.h` and `dynstats.h`.

## Validation

- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- Confirmed configure probes `sys/queue.h` and `STAILQ` support; local Linux has `sys/queue.h` but not `STAILQ`, so the fallback path was selected.
- `make -j$(nproc) check TESTS=""`
- `./tests/dynstats.sh`
- `./tests/dynstats-persist.sh`
- `make -C plugins/imptcp imptcp.la`
- `make -C plugins/omkafka omkafka_la-omkafka.lo`
- `make -C plugins/omazureeventhubs omazureeventhubs_la-omazureeventhubs.lo`
- `make -C plugins/omdtls omdtls_la-omdtls.lo`
- Simulated an AIX-like header by compiling a small `compat_queue.h` user with an empty shadow `sys/queue.h`, confirming the fallback macros compile and run locally.
- Simulated a native `STAILQ` provider by compiling a small `compat_queue.h` user with `HAVE_SYS_QUEUE_STAILQ=1`, confirming the system-header path compiles and runs locally.

AIX itself was not tested locally.

Closes https://github.com/rsyslog/rsyslog/issues/6885