### PR TITLE
[codex] agents: document local overlay lookup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,12 @@
 
 This file defines the high-level roadmap for AI assistants to understand and contribute to the rsyslog codebase. Technical workflows are now modularized into **Skills**.
 
+## Local Overlay
+
+Before starting work in this repository, read `AGENTS.local.md` if it exists.
+That file contains machine- and workflow-specific instructions that are not
+duplicated here.
+
 ## AI Agent Skills
 
 To ensure consistency and high-quality contributions, AI agents SHOULD use the following standardized skills located in `.agent/skills/`:


### PR DESCRIPTION
## Summary

Add an explicit Local Overlay section to the top-level `AGENTS.md` so agents know to read `AGENTS.local.md` when it exists.

## Why

Local Codex workflows need a clear place for machine- and workflow-specific notes without copying those details into the shared repository guide.

## Impact

Documentation-only change. No source, build, or test behavior changes.

## Validation

- Verified in WSL Ubuntu-24.04 that `AGENTS.md` and the local ignored `AGENTS.local.md` are LF-only.
- Ran `git diff --check -- AGENTS.md` before committing.
- Confirmed only `AGENTS.md` was committed; `AGENTS.local.md` remains ignored and untracked.