### PR TITLE
queue: add per-queue size.enqueued counter (cumulative bytes)

### DIFF
--- a/doc/source/configuration/modules/impstats.rst
+++ b/doc/source/configuration/modules/impstats.rst
@@ -386,7 +386,7 @@ Explanation of output
 Example output for illustration::
 
    Sep 17 11:43:49 localhost rsyslogd-pstats: imuxsock: submitted=16
-   Sep 17 11:43:49 localhost rsyslogd-pstats: main Q: size=1 enqueued=2403 full=0 maxqsize=2
+   Sep 17 11:43:49 localhost rsyslogd-pstats: main Q: size=1 enqueued=2403 size.enqueued=614168 full=0 maxqsize=2
 
 Explanation:
 
@@ -404,6 +404,8 @@ Line 2: shows details for the main queue:
 - ``main Q``, an object
 - ``size``, messages in the queue
 - ``enqueued``, all received messages thus far
+- ``size.enqueued``, cumulative byte volume of all received messages thus far
+  (counted on arrival, before discard/flow-control checks)
 - ``full``, how often was the queue was full
 - ``maxqsize``, the maximum amount of messages that have passed through the
   queue since rsyslog was started

--- a/doc/source/configuration/rsyslog_statistic_counter.rst
+++ b/doc/source/configuration/rsyslog_statistic_counter.rst
@@ -50,6 +50,12 @@ the name of the action).
 
 -  **enqueued** - total number of messages enqueued into this queue since startup
 
+-  **size.enqueued** - cumulative number of bytes enqueued into this queue since startup
+   (sum of ``iLenRawMsg`` for every accepted message). Counted on arrival, before any
+   discard or flow-control check, so it represents the inbound byte volume. Resettable.
+   Use it together with ``enqueued`` to derive the average message size, and with
+   ``discarded.full`` / ``discarded.nf`` to reason about lost volume.
+
 -  **maxsize** - maximum number of active messages the queue ever held
 
 -  **full** - number of times the queue was actually full and could not accept additional messages

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3528,6 +3528,10 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("enqueued"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
                                 &pThis->ctrEnqueued));
 
+    STATSCOUNTER_INIT(pThis->ctrSizeEnqueued, pThis->mutCtrSizeEnqueued);
+    CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("size.enqueued"), ctrType_IntCtr,
+                                CTR_FLAG_RESETTABLE, &pThis->ctrSizeEnqueued));
+
     STATSCOUNTER_INIT(pThis->ctrFull, pThis->mutCtrFull);
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("full"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
                                 &pThis->ctrFull));
@@ -3885,6 +3889,9 @@ static rsRetVal doEnqSingleObj(qqueue_t *pThis, flowControl_t flowCtlType, smsg_
     struct timespec t;
 
     STATSCOUNTER_INC(pThis->ctrEnqueued, pThis->mutCtrEnqueued);
+    /* size.enqueued mirrors enqueued: counted on arrival, before discard checks,
+     * so it represents inbound byte volume (rejected slice tracked by ctrFDscrd). */
+    STATSCOUNTER_ADD(pThis->ctrSizeEnqueued, pThis->mutCtrSizeEnqueued, (uint64_t)pMsg->iLenRawMsg);
     /* first check if we need to discard this message (which will cause CHKiRet() to exit)
      */
     CHKiRet(qqueueChkDiscardMsg(pThis, pThis->iQueueSize, pMsg));

--- a/runtime/queue.c
+++ b/runtime/queue.c
@@ -3529,8 +3529,8 @@ rsRetVal qqueueStart(rsconf_t *cnf, qqueue_t *pThis) /* this is the Construction
                                 &pThis->ctrEnqueued));
 
     STATSCOUNTER_INIT(pThis->ctrSizeEnqueued, pThis->mutCtrSizeEnqueued);
-    CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("size.enqueued"), ctrType_IntCtr,
-                                CTR_FLAG_RESETTABLE, &pThis->ctrSizeEnqueued));
+    CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("size.enqueued"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,
+                                &pThis->ctrSizeEnqueued));
 
     STATSCOUNTER_INIT(pThis->ctrFull, pThis->mutCtrFull);
     CHKiRet(statsobj.AddCounter(pThis->statsobj, UCHAR_CONSTANT("full"), ctrType_IntCtr, CTR_FLAG_RESETTABLE,

--- a/runtime/queue.h
+++ b/runtime/queue.h
@@ -218,6 +218,7 @@ struct queue_s {
         /* for statistics subsystem */
         statsobj_t *statsobj;
         STATSCOUNTER_DEF(ctrEnqueued, mutCtrEnqueued)
+        STATSCOUNTER_DEF(ctrSizeEnqueued, mutCtrSizeEnqueued) /* cumulative bytes enqueued */
         STATSCOUNTER_DEF(ctrFull, mutCtrFull)
         STATSCOUNTER_DEF(ctrFDscrd, mutCtrFDscrd)
         STATSCOUNTER_DEF(ctrNFDscrd, mutCtrNFDscrd)

--- a/tests/omfwd_fast_imuxsock.sh
+++ b/tests/omfwd_fast_imuxsock.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
-# This test exercises DiscardMark / DiscardSeverity queue settings with omfwd
-# fed through an imuxsock input. Success is that the queue statistics show the
-# expected high-volume enqueue/discard behavior while a TCP receiver accepts
-# enough forwarded traffic for the action to stay active.
+# This test verifies DiscardMark / DiscardSeverity queue handling with omfwd and
+# imuxsock input under high message volume.
+#
+# Oracle:
+# The test sends 100000 messages through an imuxsock input into an omfwd action
+# queue configured with discard settings. Success is proven by the impstats queue
+# line: all messages were enqueued, the queue hit the expected max size, and
+# discard counters stayed internally consistent. The regex also asserts the
+# size.enqueued counter added for cumulative byte accounting.
+#
 # added 2021-09-02 by alorbach. Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "SunOS"  "We have no ATOMIC BUILTINS, so OverallQueueSize counting of imdiag is NOT threadsafe and the counting will fail on SunOS"
@@ -90,6 +96,6 @@ wait_shutdown
 # check output file generation, should contain at least 100 logs
 check_file_exists "$RSYSLOG_OUT_LOG"
 check_file_exists "$STATSFILE"
-content_check --regex --output-results "action-1-builtin:omfwd queue: origin=core.queue size=.* enqueued=100000 full=0 discarded.full=0 discarded.nf=.* maxqsize=100" $STATSFILE
+content_check --regex --output-results "action-1-builtin:omfwd queue: origin=core.queue size=.* enqueued=100000 size.enqueued=.* full=0 discarded.full=0 discarded.nf=.* maxqsize=100" $STATSFILE
 
 exit_test


### PR DESCRIPTION
### Summary

Add a new uint64 stats counter ctrSizeEnqueued, exposed by impstats as "size.enqueued" alongside the existing "enqueued" message counter, so operators can monitor the byte volume flowing through every named queue (main / ruleset / action) instead of only the message count.

The counter is incremented in doEnqSingleObj() right after ctrEnqueued, before any discard or flow-control check, so it represents the inbound arrival rate.  Discarded bytes remain visible via ctrFDscrd / ctrNFDscrd on the message side.

Resettable, atomic via STATSCOUNTER_ADD.  Pure addition: no behavioural change for existing counters or queue semantics.

