### PR TITLE
ci: expand weekly cross-arch tests

### DIFF
--- a/.github/workflows/run_cross_arch_weekly.yml
+++ b/.github/workflows/run_cross_arch_weekly.yml
@@ -82,99 +82,55 @@ jobs:
               export CC=gcc
               export TEST_MAX_RUNTIME=1200
               autoreconf -fvi
-              if [ "$ARCH" = "s390x" ]; then
-                apt-get update
-                apt-get install -y --no-install-recommends \
-                  curl liblognorm-dev libmaxminddb-dev libsnmp-dev \
-                  libssl-dev libsystemd-dev libyaml-dev libzstd-dev openssl
-                rm -rf /var/lib/apt/lists/*
-                useradd --create-home rsyslogci
-                chown -R rsyslogci:rsyslogci /rsyslog
-                su rsyslogci -c "./configure --enable-silent-rules \
-                  --enable-testbench --disable-extended-tests \
-                  --enable-imdiag --disable-imdocker \
-                  --enable-imfile --enable-imfile-tests \
-                  --enable-impstats --enable-imptcp \
-                  --enable-mmanon --enable-mmaudit \
-                  --enable-mmcount --enable-mmdblookup \
-                  --enable-mmfields --enable-mmjsonparse \
-                  --enable-mmnormalize --enable-mmpstrucdata \
-                  --enable-mmrm1stspace --enable-mmsequence \
-                  --enable-mmsnmptrapd --enable-mmutf8fix \
-                  --enable-mail \
-                  --disable-omhttp --enable-omjournal \
-                  --enable-omprog --enable-omruleset \
-                  --enable-omstdout --enable-omuxsock \
-                  --enable-pmaixforwardedfrom --enable-pmciscoios \
-                  --enable-pmcisconames --enable-pmlastmsg \
-                  --enable-pmnull --enable-pmsnare \
-                  --enable-gnutls --enable-openssl \
-                  --enable-relp --enable-snmp \
-                  --enable-usertools --enable-imdtls --enable-omdtls \
-                  --enable-imjournal \
-                  --enable-fmhash --enable-libzstd \
-                  --enable-klog --enable-kmsg \
-                  --enable-libsystemd=yes \
-                  --disable-libgcrypt --disable-liblogging-stdlog \
-                  --disable-fmhttp --disable-mysql \
-                  --disable-valgrind --without-valgrind-testbench \
-                  --disable-helgrind --disable-mmkubernetes \
-                  --disable-omkafka --disable-imkafka \
-                  --disable-ommongodb --disable-omrabbitmq \
-                  --disable-mmdarwin \
-                  --disable-root-tests \
-                  --disable-elasticsearch-tests \
-                  --disable-kafka-tests --disable-snmp-tests \
-                  --disable-journal-tests"
-                su rsyslogci -c "grep -q \"^#define HAVE_LIBYAML 1\" config.h"
-                S390X_TESTS="runtime_unit_linkedlist runtime_unit_stringbuf \
-                  yaml-basic.sh yaml-script-call.sh yaml-ratelimit-policywatch.sh \
-                  imudp_ratelimit_name.sh ratelimit_name.sh imrelp_ratelimit_name.sh \
-                  imtcp-basic.sh imtcp-starvation-1.sh \
-                  imtcp_framing_regex_maxmsg_overflow.sh imtcp-impstats.sh \
-                  imptcp_framing_regex.sh imptcp-connection-msg-received.sh \
-                  diskqueue-truncated-segment-startup.sh \
-                  diskqueue-oncorruption-missing-segment.sh \
-                  sndrcv_tls_anon_rebind.sh sndrcv_tls_certvalid_action_level.sh \
-                  sndrcv_tls_ossl_certvalid_action_level.sh \
-                  sndrcv_tls_ossl_anon_rebind.sh \
-                  sndrcv_relp.sh sndrcv_relp_tls_certvalid.sh \
-                  imdtls-basic.sh sndrcv_dtls_certvalid.sh \
-                  imfile-basic.sh imfile-logrotate.sh \
-                  mmjsonparse_simple.sh mmnormalize_variable.sh mmpstrucdata.sh \
-                  omprog-feedback.sh omprog-feedback-timeout.sh \
-                  uxsock_simple.sh"
-                su rsyslogci -c "make -j8 && timeout 40m make -j2 check TESTS=\"$S390X_TESTS\""
-              else
-                ./configure --enable-silent-rules --enable-testbench \
-                  --enable-imdiag --disable-imdocker --enable-imfile \
-                  --disable-default-tests --disable-impstats \
-                  --disable-impstats-push \
-                  --disable-imptcp \
-                  --disable-mmanon --disable-mmaudit \
-                  --disable-mmfields --disable-mmjsonparse \
-                  --disable-mmpstrucdata --disable-mmsequence \
-                  --disable-mmutf8fix --disable-mail \
-                  --disable-omprog --disable-improg \
-                  --disable-omruleset \
-                  --enable-omstdout --disable-omuxsock \
-                  --disable-pmaixforwardedfrom --disable-pmciscoios \
-                  --disable-pmcisconames --disable-pmlastmsg \
-                  --disable-pmsnare \
-                  --disable-libgcrypt --disable-mmnormalize \
-                  --disable-omudpspoof --disable-relp \
-                  --disable-mmsnmptrapd \
-                  --enable-gnutls --enable-usertools \
-                  --disable-mysql \
-                  --disable-valgrind --disable-mmkubernetes \
-                  --disable-omkafka --disable-imkafka \
-                  --disable-ommongodb --disable-omrabbitmq \
-                  --disable-mmdarwin \
-                  --disable-helgrind --disable-uuid \
-                  --disable-fmhttp
-                make -j8
-                make -j3 check
+              apt-get update
+              apt-get install -y --no-install-recommends \
+                curl liblognorm-dev libmaxminddb-dev libsnmp-dev \
+                libssl-dev libsystemd-dev libyaml-dev libzstd-dev openssl
+              rm -rf /var/lib/apt/lists/*
+              useradd --create-home rsyslogci
+              chown -R rsyslogci:rsyslogci /rsyslog
+              su rsyslogci -c "./configure --enable-silent-rules \
+                --enable-testbench --disable-extended-tests \
+                --enable-imdiag --disable-imdocker \
+                --enable-imfile --enable-imfile-tests \
+                --enable-impstats --enable-imptcp \
+                --enable-mmanon --enable-mmaudit \
+                --enable-mmcount --enable-mmdblookup \
+                --enable-mmfields --enable-mmjsonparse \
+                --enable-mmnormalize --enable-mmpstrucdata \
+                --enable-mmrm1stspace --enable-mmsequence \
+                --enable-mmsnmptrapd --enable-mmutf8fix \
+                --enable-mail \
+                --disable-omhttp --enable-omjournal \
+                --enable-omprog --enable-omruleset \
+                --enable-omstdout --enable-omuxsock \
+                --enable-pmaixforwardedfrom --enable-pmciscoios \
+                --enable-pmcisconames --enable-pmlastmsg \
+                --enable-pmnull --enable-pmsnare \
+                --enable-gnutls --enable-openssl \
+                --enable-relp --enable-snmp \
+                --enable-usertools --enable-imdtls --enable-omdtls \
+                --enable-imjournal \
+                --enable-fmhash --enable-libzstd \
+                --enable-klog --enable-kmsg \
+                --enable-libsystemd=yes \
+                --disable-libgcrypt --disable-liblogging-stdlog \
+                --disable-fmhttp --disable-mysql \
+                --disable-valgrind --without-valgrind-testbench \
+                --disable-helgrind --disable-mmkubernetes \
+                --disable-omkafka --disable-imkafka \
+                --disable-ommongodb --disable-omrabbitmq \
+                --disable-mmdarwin \
+                --disable-root-tests \
+                --disable-elasticsearch-tests \
+                --disable-kafka-tests --disable-snmp-tests \
+                --disable-journal-tests"
+              su rsyslogci -c "grep -q \"^#define HAVE_LIBYAML 1\" config.h"
+              make_check_jobs=2
+              if [ "$ARCH" = "armhf" ]; then
+                make_check_jobs=3
               fi
+              su rsyslogci -c "make -j8 && timeout 100m make -j${make_check_jobs} check"
             '
           EXIT_CODE=$?
           STATUS=success


### PR DESCRIPTION
## Summary
- expand the weekly QEMU cross-arch workflow beyond smoke lists
- make armhf use the same richer configure surface as s390x
- run the full configured non-service `make check` set on both QEMU arches

## Notes
External-service/root/heavy families remain disabled for QEMU suitability: Kafka, Elasticsearch, SNMP, journal, root, valgrind, helgrind, and extended tests.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/run_cross_arch_weekly.yml"); puts "yaml ok"'`
- `actionlint .github/workflows/run_cross_arch_weekly.yml`
