### PR TITLE
tests: widen omfwd target-fail inject delay

### DIFF
--- a/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
+++ b/tests/omfwd-lb-1target-retry-test_skeleton-TargetFail.sh
@@ -9,7 +9,7 @@ generate_conf
 export NUMMESSAGES=2000
 export OMFWD_TARGETFAIL_MAX_LOSS=250
 export OMFWD_TARGETFAIL_MIN_RECEIVED=$((NUMMESSAGES - OMFWD_TARGETFAIL_MAX_LOSS))
-export IMDIAG_INJECTMSG_DELAY_MS=1
+export IMDIAG_INJECTMSG_DELAY_MS=3
 
 # Start minitcpsrv with a forced receiver-side TCP session close and a
 # temporary listener restart. The test verifies that omfwd retries and


### PR DESCRIPTION
## Summary

This small side PR widens the imdiag inject delay in
`omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh` from 1 ms to 3 ms.

## Root Cause / Evidence

The previous 1 ms throttle improved the forced receiver-close test but did
not fully close the timing window under heavy local load. During the current
no-ES/no-Kafka Ubuntu 26.04 container campaign, current `main` still failed
`omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh` with only 1696 of the
required 1750 receiver lines.

A focused proof reproduced the failure outside the full suite: current `main`
with the 1 ms delay failed the TargetFail test under 80 CPU-busy loops at
1399/1750 lines.

The test intentionally forces minitcpsrv to close and restart the receiver
while omfwd retries. A small additional inject delay gives omfwd and the
receiver restart path more scheduling margin while keeping the same assertion:
omfwd must reconnect and deliver at least the configured lower bound, with only
the existing bounded TCP/application loss tolerated by `seq_check`.

## Validation

- Built the branch in the Ubuntu 26.04 dev container with no Elasticsearch,
  Kafka, journal, or extended tests enabled.
- Direct run passed:
  `./tests/omfwd-lb-1target-retry-1_byte_buf-TargetFail.sh`
- Focused stress passed: 3 consecutive TargetFail runs under 80 CPU-busy loops
  in the Ubuntu 26.04 dev container.
- Comparator proof: current `main` with 1 ms failed the same focused stress
  setup in iteration 1 at 1399/1750 lines.

## Notes

This does not alter production code, the test objective, or the accepted loss
window. It only adjusts the pacing used by this already-throttled forced-failure
test.
