### PR TITLE
imfile: recover more inotify file updates

### DIFF
--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -336,6 +336,8 @@ static modConfData_t *currModConf = NULL; /* modConf ptr to CURRENT mod conf (ru
 
 
 #ifdef HAVE_INOTIFY_INIT
+enum { IN_FILE_UPDATE_EVENTS = IN_MODIFY | IN_ATTRIB | IN_CLOSE_WRITE };
+
 /* We need to map watch descriptors to our actual objects. Unfortunately, the
  * inotify API does not provide us with any cookie, so a simple O(1) algorithm
  * cannot be done (what a shame...). We assume that maintaining the array is much
@@ -590,9 +592,9 @@ static int in_setupWatch(act_obj_t *const act, const int is_file) {
         goto done;
     }
 
-    wd =
-        inotify_add_watch(ino_fd, act->name,
-                          (is_file) ? IN_MODIFY | IN_DONT_FOLLOW : IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
+    wd = inotify_add_watch(
+        ino_fd, act->name,
+        (is_file) ? IN_FILE_UPDATE_EVENTS | IN_DONT_FOLLOW : IN_CREATE | IN_DELETE | IN_MOVED_FROM | IN_MOVED_TO);
     if (wd < 0) {
         if (errno == EACCES) { /* There is high probability of selinux denial on top-level paths */
             DBGPRINTF("imfile: permission denied when adding watch for '%s'\n", act->name);
@@ -2545,6 +2547,9 @@ static void ATTR_NONNULL(1) in_dbg_showEv(const struct inotify_event *ev) {
     if (ev->mask & IN_CLOSE_WRITE) {
         dbgprintf("INOTIFY event: watch IN_CLOSE_WRITE\n");
     }
+    if (ev->mask & IN_Q_OVERFLOW) {
+        dbgprintf("INOTIFY event: watch IN_Q_OVERFLOW\n");
+    }
     if (ev->mask & IN_CLOSE_NOWRITE) {
         dbgprintf("INOTIFY event: watch IN_CLOSE_NOWRITE\n");
     }
@@ -2576,7 +2581,7 @@ static void ATTR_NONNULL(1) in_dbg_showEv(const struct inotify_event *ev) {
 
 
 static void ATTR_NONNULL(1, 2) in_handleFileEvent(struct inotify_event *ev, const wd_map_t *const etry) {
-    if (ev->mask & IN_MODIFY) {
+    if (ev->mask & IN_FILE_UPDATE_EVENTS) {
         DBGPRINTF("fs_node_notify_file_update: act->name '%s'\n", etry->act->name);
         pollFile(etry->act);
     } else {
@@ -2609,6 +2614,12 @@ static void flag_in_move(fs_edge_t *const edge, const char *name_moved) {
 }
 
 static void ATTR_NONNULL(1) in_processEvent(struct inotify_event *ev) {
+    if (ev->mask & IN_Q_OVERFLOW) {
+        LogMsg(0, RS_RET_ERR, LOG_WARNING, "imfile: inotify queue overflow, scanning configured files");
+        fs_node_walk(runModConf->conf_tree, poll_tree);
+        goto done;
+    }
+
     if (ev->mask & IN_IGNORED) {
         DBGPRINTF("imfile: got IN_IGNORED event\n");
         goto done;


### PR DESCRIPTION
## Summary
- bug fix: avoid missing valid imfile updates when inotify reports close/attribute events or queue overflow instead of a later `IN_MODIFY`
- subscribe file watches to `IN_ATTRIB` and `IN_CLOSE_WRITE` in addition to `IN_MODIFY`
- treat those update-like file events as `pollFile()` triggers
- recover from `IN_Q_OVERFLOW` before watch-descriptor lookup by scanning configured files
- log inotify queue overflow with a non-OK rsRetVal so monitoring does not see event loss as success

## Bug fixed
Inotify mode was too narrow: file polling was driven only by `IN_MODIFY`, and `IN_Q_OVERFLOW` was ignored. Under high load the kernel can coalesce/drop events or report overflow. If rsyslog misses those events without recovery, later file growth, close-write publication, rotation, or attribute-driven updates can remain unread.

The de-flake campaign exposed this as a hidden imfile reliability bug: valid input existed, but imfile did not reliably observe the later update path under high-concurrency pressure.

## Review feedback addressed
- Gemini Code Assist suggested using a non-OK rsRetVal for the inotify queue overflow warning. Updated `LogMsg(..., RS_RET_ERR, LOG_WARNING, ...)` accordingly.

## Validation
- `CFLAGS=-g ./configure --enable-imfile --enable-testbench --enable-imdiag --enable-mmnormalize`
- `CFLAGS='-g' CC=clang make -j$(nproc) check TESTS=`
- `CFLAGS='-g' ./tests/imfile-freshStartTail2.sh`
- `CFLAGS='-g' ./tests/imfile-logrotate-copytruncate.sh`
- `CFLAGS='-g' ./tests/imfile-endmsg.regex-with-example.sh`
- `bash devtools/format-code.sh`
- `git diff --check`

Notes: the direct imfile runs had existing benign warnings noted locally: the logrotate test prints a `/diag.sh` source warning before the repo stub forwards to `tests/diag.sh`, and the endmsg-with-example test prints the existing `statefile.directory` warning.

No PR babysitting requested yet.
