### PR TITLE
java: use nio writer in simple plugin skeleton

### DIFF
--- a/plugins/external/skeletons/java/SimplePlugin.java
+++ b/plugins/external/skeletons/java/SimplePlugin.java
@@ -19,13 +19,21 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 */
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 
 public class SimplePlugin {
 	
 	public static void main(String[] args) throws IOException {
 		try (BufferedReader in = new BufferedReader(new InputStreamReader(System.in));
-			BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream("out.txt", true)))) {
+			BufferedWriter writer = Files.newBufferedWriter(Paths.get("out.txt"), StandardCharsets.UTF_8,
+				StandardOpenOption.CREATE, StandardOpenOption.APPEND)) {
 			String s;
 
 			while ((s = in.readLine()) != null) {


### PR DESCRIPTION
## Summary

This updates the Java external plugin skeleton to open `out.txt` with `Files.newBufferedWriter` using explicit `CREATE` and `APPEND` options.

## Rationale

GitHub CodeQL reports an ignored `File.createNewFile` status for `plugins/external/skeletons/java/SimplePlugin.java` on `main`, even though the current source no longer contains a direct `createNewFile()` call. Switching away from `FileOutputStream` construction makes the file creation and append behavior explicit for the analyzer.

## Impact

No rsyslog runtime behavior changes. This only affects the sample Java skeleton used for external plugin examples.

## Validation

No local runtime testing was run, as requested. I ran `git diff --check` for the touched Java file.
