### PR TITLE
skills: clarify container validation escalation

### DIFF
--- a/.agent/skills/rsyslog_local_container_testing/SKILL.md
+++ b/.agent/skills/rsyslog_local_container_testing/SKILL.md
@@ -9,6 +9,18 @@ Use this skill when validating rsyslog changes through local dev containers.
 Local container validation should mirror the relevant GitHub Actions container
 jobs instead of inventing a parallel local-only flow.
 
+## When To Use
+
+Use this for PR-ready validation whenever local container support is available.
+It is often faster than waiting for GitHub CI to discover environment-specific
+failures, especially static-analyzer findings, compiler/toolchain differences,
+dependency differences, generated build state issues, and service-test skip
+behavior.
+
+Focused host-side tests from `rsyslog_test` are still the right first step when
+debugging a specific behavior. After the patch is stable, run this skill before
+pushing if the change is intended for review.
+
 ## Preferred Order
 
 Run two container validations for broad local confidence. Mirror these

--- a/.agent/skills/rsyslog_test/SKILL.md
+++ b/.agent/skills/rsyslog_test/SKILL.md
@@ -13,6 +13,11 @@ This skill provides guidelines and tools for running tests efficiently. It empha
 2.  **Run Specific Test**: `./tests/<test-name>.sh`
 3.  **Run with Valgrind**: `./tests/<test-name>-vg.sh`
 
+Use focused host-side tests while iterating on a specific behavior. For
+PR-ready validation, use `rsyslog_local_container_testing` when local container
+support is available; it catches CI-environment, compiler/toolchain, service
+skip, and static-analyzer issues that host-side tests often cannot detect.
+
 ## Detailed Instructions
 
 ### 1. Direct Execution Rule
@@ -83,6 +88,19 @@ make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
 ```
 - **Pattern**: This uses the `MOCK-OK` mode in `tests/diag.sh` to exit tests with success immediately, skipping the overhead of actual execution while still verifying shell script invocability and distribution completeness.
 
+### 9. Container Validation Escalation
+If container support is available and the change is intended for a PR, prefer
+running `rsyslog_local_container_testing` before pushing. The local container
+flow is often faster than discovering CI-only failures after the PR is opened,
+especially for analyzer findings, compiler or dependency differences, generated
+build state, and service-test relevance filtering.
+
+Run the fast host-side checks first when debugging a narrow failure. Once the
+patch is stable, escalate to the container validation skill for CI-style
+confidence.
+
 ## Related Skills
 - `rsyslog_build`: Required before running tests.
+- `rsyslog_local_container_testing`: Preferred PR-ready validation path when
+  local containers are available.
 - `rsyslog_module`: Documentation on module-specific test dependencies.

--- a/.agent/skills/rsyslog_test/SKILL.md
+++ b/.agent/skills/rsyslog_test/SKILL.md
@@ -92,7 +92,7 @@ make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
 If container support is available and the change is intended for a PR, prefer
 running `rsyslog_local_container_testing` before pushing. The local container
 flow is often faster than discovering CI-only failures after the PR is opened,
-especially for analyzer findings, compiler or dependency differences, generated
+especially for static-analyzer findings, compiler or dependency differences, generated
 build state, and service-test relevance filtering.
 
 Run the fast host-side checks first when debugging a narrow failure. Once the

--- a/.agent/skills/rsyslog_test/SKILL.md
+++ b/.agent/skills/rsyslog_test/SKILL.md
@@ -102,5 +102,5 @@ confidence.
 ## Related Skills
 - `rsyslog_build`: Required before running tests.
 - `rsyslog_local_container_testing`: Preferred PR-ready validation path when
-  local containers are available.
+  local container support is available.
 - `rsyslog_module`: Documentation on module-specific test dependencies.


### PR DESCRIPTION
## Summary
- point PR-ready validation from `rsyslog_test` to `rsyslog_local_container_testing` when containers are available
- add a `When To Use` section explaining why container checks can save CI round trips
- keep focused host-side tests as the fast iteration path

## Validation
- `git diff --check`
- `git log -1 --show-signature --format=fuller`