### PR TITLE
imuxsock: reject contradictory socket ownership

### DIFF
--- a/doc/source/reference/parameters/imuxsock-createpath.rst
+++ b/doc/source/reference/parameters/imuxsock-createpath.rst
@@ -38,6 +38,12 @@ starts up before the daemons that create these sockets, it is a vehicle
 to enable rsyslogd to listen to those sockets even though their directories
 do not yet exist.
 
+``CreatePath="on"`` means rsyslog manages creation of the socket path.
+Do not combine it with ``Unlink="off"``, because that tells rsyslog not to
+replace or remove the socket path it created. This contradictory configuration
+is rejected. Use the default ``Unlink="on"`` when rsyslog should manage the
+socket lifecycle.
+
 .. versionadded:: 4.7.0
 
 Input usage

--- a/doc/source/reference/parameters/imuxsock-unlink.rst
+++ b/doc/source/reference/parameters/imuxsock-unlink.rst
@@ -29,6 +29,12 @@ If turned on (default), the socket is unlinked and re-created when opened
 and also unlinked when finally closed. Set it to off if you handle socket
 creation yourself.
 
+``Unlink="off"`` is for sockets whose lifecycle is managed outside rsyslog.
+If rsyslog should create the socket path, leave ``Unlink`` at its default
+``on`` value. In particular, ``CreatePath="on"`` cannot be combined with
+``Unlink="off"``: rsyslog would be asked to create the socket path but then
+forbidden from replacing or removing it on restart.
+
 .. note::
 
    Note that handling socket creation oneself has the

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -532,7 +532,17 @@ static rsRetVal
     }
 finalize_it:
     if (iRet != RS_RET_OK) {
-        LogError(errno, iRet, "cannot create '%s'", pLstn->sockName);
+        const int savedErrno = errno;
+        if (savedErrno == EADDRINUSE && !pLstn->bUnlink) {
+            LogError(savedErrno, iRet,
+                     "cannot create '%s': socket path already exists and "
+                     "Unlink=\"off\" prevents rsyslog from replacing it; "
+                     "remove the stale socket or set Unlink=\"on\" if "
+                     "rsyslog should manage this socket",
+                     pLstn->sockName);
+        } else {
+            LogError(savedErrno, iRet, "cannot create '%s'", pLstn->sockName);
+        }
         if (pLstn->fd != -1) {
             close(pLstn->fd);
             pLstn->fd = -1;
@@ -1538,6 +1548,15 @@ BEGINnewInpInst
     } else {
         if (inst->ratelimitInterval == -1) inst->ratelimitInterval = DFLT_ratelimitInterval;
         if (inst->ratelimitBurst == -1) inst->ratelimitBurst = DFLT_ratelimitBurst;
+    }
+
+    if (inst->bCreatePath && !inst->bUnlink) {
+        LogError(0, RS_RET_PARAM_ERROR,
+                 "imuxsock: CreatePath=\"on\" cannot be combined with "
+                 "Unlink=\"off\" for socket '%s'; use Unlink=\"on\" when "
+                 "rsyslog creates/manages the socket path",
+                 inst->sockName);
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     }
 
 finalize_it:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -308,6 +308,7 @@ TESTS_DEFAULT = \
 	dircreate_off.sh \
 	imuxsock_legacy.sh \
 	imuxsock_logger.sh \
+	imuxsock_unlink_off_stale_socket.sh \
 	imuxsock_logger_ratelimit.sh \
 	imuxsock_logger_ruleset.sh \
 	imuxsock_logger_ruleset_ratelimit.sh \

--- a/tests/imuxsock_unlink_off_stale_socket.sh
+++ b/tests/imuxsock_unlink_off_stale_socket.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Verify imuxsock rejects contradictory socket ownership settings and reports a
+# clear runtime diagnostic for stale sockets with Unlink="off".
+. ${srcdir:=.}/diag.sh init
+
+# This intentionally exercises a module activation failure; the current failure
+# path can leave setup allocations for process teardown, so keep this diagnostic
+# test focused on the emitted guidance.
+export ASAN_OPTIONS="detect_leaks=0${ASAN_OPTIONS:+:$ASAN_OPTIONS}"
+
+invalid_sockpath="$RSYSLOG_DYNNAME-invalid/log"
+
+generate_conf
+add_conf '
+module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
+input(type="imuxsock"
+      Socket="'$invalid_sockpath'"
+      CreatePath="on"
+      Unlink="off")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"$RSYSLOG_DYNNAME.invalid.log" 2>&1
+if [ $? -eq 0 ]; then
+	echo "FAIL: expected imuxsock to reject CreatePath=on with Unlink=off"
+	cat "$RSYSLOG_DYNNAME.invalid.log"
+	error_exit 1
+fi
+
+grep -F 'CreatePath="on" cannot be combined with Unlink="off"' \
+	"$RSYSLOG_DYNNAME.invalid.log" >/dev/null || {
+	echo "FAIL: expected contradictory imuxsock config diagnostic"
+	cat "$RSYSLOG_DYNNAME.invalid.log"
+	error_exit 1
+}
+
+sockdir="$RSYSLOG_DYNNAME-imuxsock-dir"
+sockpath="$sockdir/log"
+mkdir "$sockdir"
+
+$PYTHON - "$sockpath" <<'PY'
+import socket
+import sys
+
+sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+sock.bind(sys.argv[1])
+sock.close()
+PY
+
+generate_conf
+add_conf '
+module(load="../plugins/imuxsock/.libs/imuxsock" sysSock.use="off")
+input(type="imuxsock"
+      Socket="'$sockpath'"
+      Unlink="off")
+'
+
+startup
+
+grep -F 'socket path already exists and Unlink="off" prevents rsyslog from replacing it' \
+	"$RSYSLOG_DYNNAME.started" >/dev/null || {
+	echo "FAIL: expected stale imuxsock path diagnostic"
+	cat "$RSYSLOG_DYNNAME.started"
+	error_exit 1
+}
+
+shutdown_when_empty
+wait_shutdown
+exit_test


### PR DESCRIPTION
## Summary
- reject `CreatePath="on"` with `Unlink="off"` for imuxsock inputs
- keep a clearer `EADDRINUSE` diagnostic for stale socket paths with `Unlink="off"`
- document the socket lifecycle ownership rule and add a focused regression test

## Why
`CreatePath="on"` asks rsyslog to create/manage the socket path, while
`Unlink="off"` says the socket path is externally managed. Accepting both lets
restarts leave a stale socket path behind and causes clients to see connection
failures.

## Validation
- `bash devtools/format-code.sh`
- `make -j$(nproc) check TESTS=""`
- `./tests/imuxsock_unlink_off_stale_socket.sh`
- `bash -n tests/imuxsock_unlink_off_stale_socket.sh`
- `git diff --check`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
- container `rsyslog/rsyslog_dev_base_ubuntu:26.04`: `devtools/run-static-analyzer.sh` with `scan-build` (`scan-build: No bugs found`, real 188.24s)
- container `rsyslog/rsyslog_dev_base_ubuntu:26.04`: `devtools/run-ci.sh` with `CC=clang-21`, `CI_MAKE_OPT=-j80`, `CI_MAKE_CHECK_OPT=-j80`, `RSYSLOG_TESTBENCH_CHANGED_FILES=doc/README.md` (1243 total, 1151 pass, 92 skip, 0 fail/error, real 295.36s)

Closes https://github.com/rsyslog/rsyslog/issues/5002
