### PR TITLE
tests: fix imfile stress flakes

### DIFF
--- a/tests/imfile-endmsg.regex-with-example-vg.sh
+++ b/tests/imfile-endmsg.regex-with-example-vg.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-# This test tests imfile endmsg.regex.
+# This test verifies imfile endmsg.regex message assembly under valgrind for
+# CRI-O and JSON container log fragments, including metadata and normalized
+# multiline output.
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export USE_VALGRIND="YES"
@@ -8,11 +10,11 @@ export USE_VALGRIND="YES"
 mkdir $RSYSLOG_DYNNAME.statefiles
 generate_conf
 add_conf '
-module(load="../plugins/imfile/.libs/imfile")
+module(load="../plugins/imfile/.libs/imfile"
+      statefile.directory="'${RSYSLOG_DYNNAME}'.statefiles")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 
 input(type="imfile"
-      statefile.directory="'${RSYSLOG_DYNNAME}'.statefiles"
       File="./'$RSYSLOG_DYNNAME'.*.input"
       Tag="file:" addMetadata="on" escapelf="off"
       endmsg.regex="(^[^ ]+ (stdout|stderr) F )|(\\n\"}$)")

--- a/tests/imfile-endmsg.regex-with-example.sh
+++ b/tests/imfile-endmsg.regex-with-example.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
-# This test tests imfile endmsg.regex.
+# This test verifies imfile endmsg.regex message assembly for CRI-O and JSON
+# container log fragments, including metadata and normalized multiline output.
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILECHECKTIMEOUT="60"
@@ -9,11 +10,11 @@ export IMFILELASTINPUTLINES="6"
 mkdir $RSYSLOG_DYNNAME.statefiles
 generate_conf
 add_conf '
-module(load="../plugins/imfile/.libs/imfile")
+module(load="../plugins/imfile/.libs/imfile"
+      statefile.directory="'${RSYSLOG_DYNNAME}'.statefiles")
 module(load="../plugins/mmnormalize/.libs/mmnormalize")
 
 input(type="imfile"
-      statefile.directory="'${RSYSLOG_DYNNAME}'.statefiles"
       File="./'$RSYSLOG_DYNNAME'.*.input"
       Tag="file:" addMetadata="on" escapelf="off"
       endmsg.regex="(^[^ ]+ (stdout|stderr) F )|(\\n\"}$)")

--- a/tests/imfile-freshStartTail2.sh
+++ b/tests/imfile-freshStartTail2.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
-# add 2018-05-17 by Pascal Withopf, released under ASL 2.0
+# Verifies that freshStartTail still reads a wildcard-matched file created
+# after startup and continues to follow later appends to that same file.
+# Added 2018-05-17 by Pascal Withopf, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILECHECKTIMEOUT="60"
 
+mkdir $RSYSLOG_DYNNAME.spool
 generate_conf
 add_conf '
+global(workDirectory="'$RSYSLOG_DYNNAME'.spool")
 module(load="../plugins/imfile/.libs/imfile")
 
 input(type="imfile" freshStartTail="on" Tag="pro"
@@ -20,6 +24,7 @@ startup
 
 echo '{ "id": "jinqiao1"}' > $RSYSLOG_DYNNAME.input.a
 content_check_with_count '{ "id": "jinqiao1"}' 1 $IMFILECHECKTIMEOUT
+wait_queueempty
 
 echo '{ "id": "jinqiao2"}' >> $RSYSLOG_DYNNAME.input.a
 content_check_with_count '{ "id": "jinqiao2"}' 1 $IMFILECHECKTIMEOUT

--- a/tests/imfile-logrotate-copytruncate.sh
+++ b/tests/imfile-logrotate-copytruncate.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Verifies imfile reopenOnTruncate with logrotate copytruncate: rsyslog must
+# read the pre-rotate file, notice the truncate, then read all post-rotate data.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . $srcdir/diag.sh check-inotify-only
 . ${srcdir:=.}/diag.sh init
@@ -7,6 +9,7 @@ check_command_available logrotate
 export TESTMESSAGES=10000
 export RETRIES=50
 export TESTMESSAGESFULL=19999
+export POST_ROTATE_SENTINEL=1
 
 generate_conf
 add_conf '
@@ -65,8 +68,14 @@ wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
 # Logrotate on logfile
 logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate
 
+# First write a small sentinel after copytruncate and wait for it. This keeps
+# the test focused on the invariant that imfile notices the truncation and
+# resumes reading before the large follow-up batch is appended.
+./inputfilegen -m $POST_ROTATE_SENTINEL -i $TESTMESSAGES >> $RSYSLOG_DYNNAME.input.1.log
+wait_file_lines $RSYSLOG_OUT_LOG $((TESTMESSAGES + POST_ROTATE_SENTINEL)) $RETRIES
+
 # generate more input after logrotate into new logfile
-./inputfilegen -m $TESTMESSAGES -i $TESTMESSAGES >> $RSYSLOG_DYNNAME.input.1.log
+./inputfilegen -m $((TESTMESSAGES - POST_ROTATE_SENTINEL)) -i $((TESTMESSAGES + POST_ROTATE_SENTINEL)) >> $RSYSLOG_DYNNAME.input.1.log
 ls -l $RSYSLOG_DYNNAME.input*
 echo ls ${RSYSLOG_DYNNAME}.spool:
 ls -l ${RSYSLOG_DYNNAME}.spool


### PR DESCRIPTION
## Summary

The local high-concurrency deflake campaign found a repeat imfile cluster under `-j250`: `imfile-freshStartTail2`, `imfile-logrotate-copytruncate`, and `imfile-endmsg.regex-with-example` failed in every run. This PR fixes those as test bugs while preserving the same imfile behavior coverage.

- Move `statefile.directory` in the endmsg tests to the imfile module parameter, where imfile actually accepts it.
- Add explicit per-test work directory and queue synchronization to `imfile-freshStartTail2` before appending to the newly discovered wildcard file.
- Split the copytruncate post-rotate write into a one-record sentinel plus the remaining batch, so the test proves imfile has resumed after truncation before the large follow-up append.

## Validation

- Ubuntu 26.04 dev-container targeted run: touched tests only, `CI_MAKE_CHECK_OPT=-j20`, 4/4 pass, `real 45.51s`.
- Ubuntu 26.04 dev-container imfile-only stress run: `CI_MAKE_CHECK_OPT=-j250`, 75/75 pass, `real 125.02s`.

AI-Assisted: yes