### PR TITLE
omelasticsearch: warn on searchType use

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -2257,6 +2257,10 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "searchindex")) {
             CHKmalloc(pData->searchIndex = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "searchtype")) {
+            LogMsg(0, RS_RET_DEPRECATED, LOG_WARNING,
+                   "omelasticsearch: parameter 'searchType' is deprecated because "
+                   "Elasticsearch mapping types are obsolete; remove this parameter "
+                   "for Elasticsearch 8 and later");
             CHKmalloc(pData->searchType = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "pipelinename")) {
             CHKmalloc(pData->pipelineName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -255,6 +255,7 @@ TESTS_DEFAULT = \
 	imudp_ratelimit_name.sh \
 	omfwd_ratelimit_name.sh \
 	omelasticsearch_ratelimit_name.sh \
+	omelasticsearch-searchtype-deprecated.sh \
 	omhttp_ratelimit_name.sh \
 	imhttp_ratelimit_name.sh \
 	imjournal_ratelimit_name.sh \

--- a/tests/omelasticsearch-searchtype-deprecated.sh
+++ b/tests/omelasticsearch-searchtype-deprecated.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# Verify that explicit omelasticsearch searchType use emits a deprecation warning.
+. ${srcdir:=.}/diag.sh init
+require_plugin omelasticsearch
+
+WARN="omelasticsearch: parameter 'searchType' is deprecated because Elasticsearch mapping types are obsolete; remove this parameter for Elasticsearch 8 and later"
+
+generate_conf
+add_conf '
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omelasticsearch"
+       server="localhost"
+       serverport="19200"
+       searchIndex="rsyslog_testbench"
+       searchType="_doc"
+       template="outfmt")
+'
+
+rsyslogd_config_check > "${RSYSLOG_DYNNAME}.with-searchtype.log" 2>&1
+if [ $? -ne 0 ]; then
+        echo "FAIL: config with searchType did not validate"
+        cat "${RSYSLOG_DYNNAME}.with-searchtype.log"
+        error_exit 1
+fi
+content_check "$WARN" "${RSYSLOG_DYNNAME}.with-searchtype.log"
+
+generate_conf
+add_conf '
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omelasticsearch"
+       server="localhost"
+       serverport="19200"
+       searchIndex="rsyslog_testbench"
+       template="outfmt")
+'
+
+rsyslogd_config_check > "${RSYSLOG_DYNNAME}.without-searchtype.log" 2>&1
+if [ $? -ne 0 ]; then
+        echo "FAIL: config without searchType did not validate"
+        cat "${RSYSLOG_DYNNAME}.without-searchtype.log"
+        error_exit 1
+fi
+if grep -F "$WARN" "${RSYSLOG_DYNNAME}.without-searchtype.log" > /dev/null; then
+        echo "FAIL: config without searchType emitted deprecation warning"
+        cat "${RSYSLOG_DYNNAME}.without-searchtype.log"
+        error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
## Summary

- warn when `omelasticsearch` parses an explicit `searchType` action parameter
- keep existing `searchType` configurations working for compatibility
- add config-check coverage for warning and no-warning paths

## Validation

- `make -j28 check TESTS=`
- `./tests/omelasticsearch-searchtype-deprecated.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j28`

Fixes https://github.com/rsyslog/rsyslog/issues/6835
