### PR TITLE
ci: expose macos check logs

### DIFF
--- a/.agent/skills/rsyslog_pr_babysitting/SKILL.md
+++ b/.agent/skills/rsyslog_pr_babysitting/SKILL.md
@@ -36,8 +36,20 @@ Use `gh pr view` for check rollups:
 
 ```sh
 gh pr view PR_NUMBER --repo rsyslog/rsyslog \
-  --json statusCheckRollup,reviewDecision,mergeable,state,headRefOid,url
+  --json statusCheckRollup,reviewDecision,mergeStateStatus,mergeable,state,headRefOid,url
 ```
+
+Treat `mergeable: CONFLICTING` or `mergeStateStatus: DIRTY` as an
+actionable blocker, not just a status to report. Before resolving it, fetch
+official upstream `main` freshly, for example:
+
+```sh
+git fetch upstream main --prune
+```
+
+Then rebase or merge the PR branch onto that fetched `upstream/main`, resolve
+conflicts locally, validate the affected files, and push the updated branch.
+Do not rely on the fork's `origin/main` for conflict resolution.
 
 For failures, inspect logs before guessing:
 

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -983,7 +983,8 @@ jobs:
           sudo mkdir -p /cores
           sudo sysctl -w kern.corefile=/cores/core-%P
 
-      - name: make check
+      - name: make check (continue on error to collect results)
+        id: run_tests
         if: steps.code_changes.outputs.any_changed == 'true'
         run: |
           # Enable core dumps for debugging segfaults
@@ -1004,7 +1005,13 @@ jobs:
             echo "Running without sanitizers"
           fi
 
+          set +e
           make -j10 check
+          EXIT_CODE=$?
+          STATUS=success
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS=failure; fi
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit 0
 
       - name: List core files before cleanup
         if: steps.code_changes.outputs.any_changed == 'true'
@@ -1039,6 +1046,29 @@ jobs:
           find_core_files | head -20 || true
           CORE_COUNT=$(find_core_files | wc -l || echo 0)
           echo "Total core files found: $CORE_COUNT"
+
+      - name: show error logs and fail if tests failed
+        if: steps.run_tests.outputs.status == 'failure'
+        run: |
+          echo "=== Post-failure diagnostics ==="
+          echo "Note: Comprehensive error analysis including core dumps,"
+          echo "system info, and logs is now handled automatically by"
+          echo "tests/diag.sh during test failures."
+          echo ""
+          echo "=== Basic disk space check ==="
+          df -h . | tail -1 | awk '{print "Free space: " $4 " (" $5 " used)"}'
+          echo ""
+          echo "=== Additional error log collection ==="
+          if [ -f "devtools/gather-check-logs.sh" ]; then
+            devtools/gather-check-logs.sh || true
+          fi
+          if [ -f "failed-tests.log" ]; then
+            echo "=== Failed Tests Summary ==="
+            cat failed-tests.log
+          else
+            echo "failed-tests.log was not generated"
+          fi
+          exit 1
 
       - name: Skip macOS CI, no relevant changes
         if: steps.code_changes.outputs.any_changed != 'true'

--- a/.github/workflows/run_macos_weekly.yml
+++ b/.github/workflows/run_macos_weekly.yml
@@ -131,7 +131,17 @@ jobs:
           name: res-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.sanitizer }}
           path: result.txt
 
-      - name: Fail job if tests failed (but after artifact upload)
+      - name: Show failed test logs
+        if: steps.run_tests.outputs.status == 'failure'
+        run: |
+          devtools/gather-check-logs.sh || true
+          if [ -f failed-tests.log ]; then
+            cat failed-tests.log
+          else
+            echo "failed-tests.log was not generated"
+          fi
+
+      - name: Fail job if tests failed
         if: steps.run_tests.outputs.status == 'failure'
         run: exit 1
 


### PR DESCRIPTION
Summary: Make macOS CI failures print actionable make check diagnostics directly in the GitHub Actions log. The PR macOS job now captures make check status, keeps the cleanup/core-file steps, then runs devtools/gather-check-logs.sh and cats failed-tests.log in the final failing step. The weekly macOS workflow does the same before its synthetic failure step. No test-log artifacts are uploaded. This also updates the rsyslog PR babysitting skill to treat GitHub merge conflicts as actionable blockers and to fetch official upstream main before resolving them. Reference: v8.2604.0 run_checks.yml used the same gather-check-logs.sh plus cat failed-tests.log pattern. Validation: fetched official upstream main freshly, rebased the branch, Ruby YAML load for run_checks.yml and run_macos_weekly.yml, plus git diff --check.