### PR TITLE
imdiag: add module-only modern config

### DIFF
--- a/doc/source/configuration/modules/imdiag.rst
+++ b/doc/source/configuration/modules/imdiag.rst
@@ -44,10 +44,6 @@ Module Parameters
      - .. include:: ../../reference/parameters/imdiag-aborttimeout.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
-   * - :ref:`param-imdiag-listenportfilename-module`
-     - .. include:: ../../reference/parameters/imdiag-listenportfilename-module.rst
-        :start-after: .. summary-start
-        :end-before: .. summary-end
    * - :ref:`param-imdiag-mainmsgqueuetimeoutshutdown`
      - .. include:: ../../reference/parameters/imdiag-mainmsgqueuetimeoutshutdown.rst
         :start-after: .. summary-start
@@ -76,16 +72,6 @@ Module Parameters
      - .. include:: ../../reference/parameters/imdiag-maxsessions.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
-
-Input Parameters
-~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
-
-   * - Parameter
-     - Summary
    * - :ref:`param-imdiag-listenportfilename`
      - .. include:: ../../reference/parameters/imdiag-listenportfilename.rst
         :start-after: .. summary-start
@@ -122,10 +108,9 @@ ephemeral port, and records the chosen port for the testbench to read.
 
 .. code-block:: rsyslog
 
-   module(load="imdiag")
-   input(type="imdiag"
-         listenPortFileName="/var/run/rsyslog/imdiag.port"
-         serverRun="0")
+   module(load="imdiag"
+          listenPortFileName="/var/run/rsyslog/imdiag.port"
+          serverRun="0")
 
 YAML-only testbench configuration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -144,6 +129,7 @@ that it does not conflict with the test's own ``modules:`` section.
    testbench_modules:
      - load: "../plugins/imdiag/.libs/imdiag"
        listenportfilename: "test.imdiag.port"
+       serverrun: "0"
        aborttimeout: "580"
        mainmsgqueuetimeoutshutdown: "10000"
        mainmsgqueuetimeoutenqueue: "30000"
@@ -155,8 +141,6 @@ that it does not conflict with the test's own ``modules:`` section.
      - load: "../plugins/imtcp/.libs/imtcp"
 
    inputs:
-     - type: imdiag
-       port: "0"
      - type: imtcp
        port: "0"
 

--- a/doc/source/development/dev_testbench.rst
+++ b/doc/source/development/dev_testbench.rst
@@ -66,8 +66,8 @@ How It Works
    conflict with the test's own ``modules:`` section.
 
 2. Tests add their own sections with ``add_yaml_conf``.
-3. Tests must call ``add_yaml_imdiag_input`` inside their ``inputs:`` section
-   so that startup detection works.
+3. imdiag startup detection is already configured by ``generate_conf
+   --yaml-only`` through module-scoped testbench parameters.
 
 Helper Functions
 ~~~~~~~~~~~~~~~~
@@ -79,8 +79,9 @@ Helper Functions
   Append a YAML fragment to ``${TESTCONF_NM}[instance].yaml``.
 
 ``add_yaml_imdiag_input [instance]``
-  Append the imdiag ``inputs:`` entry inside an already-opened ``inputs:``
-  block. **Required** in every yaml-only test for startup detection.
+  Historical compatibility helper. It no longer appends YAML because imdiag is
+  configured by ``generate_conf --yaml-only`` as a module-scoped testbench
+  listener.
 
 Startup detection
 ~~~~~~~~~~~~~~~~~
@@ -164,7 +165,6 @@ Example Test
    add_yaml_conf '    string: "%msg:F,58:2%\n"'
    add_yaml_conf ''
    add_yaml_conf 'inputs:'
-   add_yaml_imdiag_input   # required -- provides startup detection
    add_yaml_conf "  - type: imtcp"
    add_yaml_conf '    port: "0"'
    add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.tcpflood_port\""
@@ -188,4 +188,3 @@ Naming and Registration
 Name yaml-only tests ``yaml-<area>-yamlonly.sh`` (or append ``-yamlonly`` to
 an existing test name). Register them in ``tests/Makefile.am`` under
 ``TESTS_LIBYAML`` so they are skipped on systems without libyaml.
-

--- a/doc/source/reference/parameters/imdiag-listenportfilename-module.rst
+++ b/doc/source/reference/parameters/imdiag-listenportfilename-module.rst
@@ -34,8 +34,8 @@ imdiag will create and populate with its chosen listen port number after the
 TCP listener is ready. The testbench reads this file to discover the port
 without needing a fixed port number.
 
-This is the module-scope version of the parameter. The same name can also
-be set at input scope via ``input(type="imdiag" listenPortFileName=...)``.
+This parameter is module-scoped. imdiag's diagnostic command listener is
+configured from ``module(...)`` rather than a dedicated ``input(...)`` object.
 
 Module usage
 ------------

--- a/doc/source/reference/parameters/imdiag-listenportfilename.rst
+++ b/doc/source/reference/parameters/imdiag-listenportfilename.rst
@@ -1,5 +1,5 @@
 .. _param-imdiag-listenportfilename:
-.. _imdiag.parameter.input.listenportfilename:
+.. _imdiag.parameter.module.listenportfilename.listener:
 
 ListenPortFileName
 ==================
@@ -17,9 +17,9 @@ Writes the port chosen for the diagnostic listener to the named file.
 This parameter applies to :doc:`../../configuration/modules/imdiag`.
 
 :Name: ListenPortFileName
-:Scope: input
+:Scope: module
 :Type: string (filename)
-:Default: input=none
+:Default: module=none
 :Required?: yes
 :Introduced: at least 5.x, possibly earlier
 
@@ -34,17 +34,16 @@ The file is overwritten each time the listener starts. When the listener is
 configured with port ``0`` (ephemeral port selection), this file is the only way
 to discover the actual port allocated by the operating system.
 
-Input usage
------------
-.. _param-imdiag-input-listenportfilename:
-.. _imdiag.parameter.input.listenportfilename-usage:
+Module usage
+------------
+.. _param-imdiag-module-listenportfilename-listener:
+.. _imdiag.parameter.module.listenportfilename.listener-usage:
 
 .. code-block:: rsyslog
 
-   module(load="imdiag")
-   input(type="imdiag"
-         listenPortFileName="/var/run/rsyslog/imdiag.port"
-         serverRun="0")
+   module(load="imdiag"
+          listenPortFileName="/var/run/rsyslog/imdiag.port"
+          serverRun="0")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imdiag-serverinputname.rst
+++ b/doc/source/reference/parameters/imdiag-serverinputname.rst
@@ -1,5 +1,5 @@
 .. _param-imdiag-serverinputname:
-.. _imdiag.parameter.input.serverinputname:
+.. _imdiag.parameter.module.serverinputname:
 
 ServerInputName
 ================
@@ -18,9 +18,9 @@ own log messages.
 This parameter applies to :doc:`../../configuration/modules/imdiag`.
 
 :Name: ServerInputName
-:Scope: input
+:Scope: module
 :Type: string
-:Default: input=imdiag
+:Default: module=imdiag
 :Required?: no
 :Introduced: at least 5.x, possibly earlier
 
@@ -33,18 +33,17 @@ always remains ``imdiag``. This parameter must be configured before using
 :ref:`ServerRun <param-imdiag-serverrun>`. This ensures the listener logs use
 the desired identifier from startup onward.
 
-Input usage
------------
-.. _param-imdiag-input-serverinputname:
-.. _imdiag.parameter.input.serverinputname-usage:
+Module usage
+------------
+.. _param-imdiag-module-serverinputname:
+.. _imdiag.parameter.module.serverinputname-usage:
 
 .. code-block:: rsyslog
 
-   module(load="imdiag")
-   input(type="imdiag"
-         listenPortFileName="/var/run/rsyslog/imdiag.port"
-         serverInputName="diag-main"
-         serverRun="19998")
+   module(load="imdiag"
+          listenPortFileName="/var/run/rsyslog/imdiag.port"
+          serverInputName="diag-main"
+          serverRun="19998")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imdiag-serverrun.rst
+++ b/doc/source/reference/parameters/imdiag-serverrun.rst
@@ -1,5 +1,5 @@
 .. _param-imdiag-serverrun:
-.. _imdiag.parameter.input.serverrun:
+.. _imdiag.parameter.module.serverrun:
 
 ServerRun
 =========
@@ -18,9 +18,9 @@ ephemeral port).
 This parameter applies to :doc:`../../configuration/modules/imdiag`.
 
 :Name: ServerRun
-:Scope: input
+:Scope: module
 :Type: integer (port)
-:Default: input=none
+:Default: module=none
 :Required?: yes
 :Introduced: at least 5.x, possibly earlier
 
@@ -46,17 +46,17 @@ more than once logs an error and the additional configuration is ignored. Set
 module-level parameters such as :ref:`MaxSessions <param-imdiag-maxsessions>`
 before invoking ``ServerRun``.
 
-Input usage
------------
-.. _param-imdiag-input-serverrun:
-.. _imdiag.parameter.input.serverrun-usage:
+Module usage
+------------
+.. _param-imdiag-module-serverrun:
+.. _imdiag.parameter.module.serverrun-usage:
 
 .. code-block:: rsyslog
 
-   module(load="imdiag" maxSessions="20")
-   input(type="imdiag"
-         listenPortFileName="/var/run/rsyslog/imdiag.port"
-         serverRun="0")
+   module(load="imdiag"
+          maxSessions="20"
+          listenPortFileName="/var/run/rsyslog/imdiag.port"
+          serverRun="0")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imdiag-serverstreamdriverauthmode.rst
+++ b/doc/source/reference/parameters/imdiag-serverstreamdriverauthmode.rst
@@ -1,5 +1,5 @@
 .. _param-imdiag-serverstreamdriverauthmode:
-.. _imdiag.parameter.input.serverstreamdriverauthmode:
+.. _imdiag.parameter.module.serverstreamdriverauthmode:
 
 ServerStreamDriverAuthMode
 ==========================
@@ -18,9 +18,9 @@ uses the plain TCP driver so the value has no effect.
 This parameter applies to :doc:`../../configuration/modules/imdiag`.
 
 :Name: ServerStreamDriverAuthMode
-:Scope: input
+:Scope: module
 :Type: string
-:Default: input=none
+:Default: module=none
 :Required?: no
 :Introduced: at least 5.x, possibly earlier
 
@@ -37,18 +37,17 @@ Configure this parameter before :ref:`ServerRun <param-imdiag-serverrun>` if you
 need forward compatibility with a future build that supports alternate stream
 drivers. In current releases the setting does not change listener behavior.
 
-Input usage
------------
-.. _param-imdiag-input-serverstreamdriverauthmode:
-.. _imdiag.parameter.input.serverstreamdriverauthmode-usage:
+Module usage
+------------
+.. _param-imdiag-module-serverstreamdriverauthmode:
+.. _imdiag.parameter.module.serverstreamdriverauthmode-usage:
 
 .. code-block:: rsyslog
 
-   module(load="imdiag")
-   input(type="imdiag"
-         listenPortFileName="/var/run/rsyslog/imdiag.port"
-         serverStreamDriverAuthMode="anon"
-         serverRun="19998")
+   module(load="imdiag"
+          listenPortFileName="/var/run/rsyslog/imdiag.port"
+          serverStreamDriverAuthMode="anon"
+          serverRun="19998")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imdiag-serverstreamdrivermode.rst
+++ b/doc/source/reference/parameters/imdiag-serverstreamdrivermode.rst
@@ -1,5 +1,5 @@
 .. _param-imdiag-serverstreamdrivermode:
-.. _imdiag.parameter.input.serverstreamdrivermode:
+.. _imdiag.parameter.module.serverstreamdrivermode:
 
 ServerStreamDriverMode
 ======================
@@ -18,9 +18,9 @@ plain TCP driver so the setting is ignored.
 This parameter applies to :doc:`../../configuration/modules/imdiag`.
 
 :Name: ServerStreamDriverMode
-:Scope: input
+:Scope: module
 :Type: integer
-:Default: input=0
+:Default: module=0
 :Required?: no
 :Introduced: at least 5.x, possibly earlier
 
@@ -33,18 +33,17 @@ mode value. The parameter remains available for configuration compatibility and
 possible future extensions, but it does not alter behavior in current
 releases.
 
-Input usage
------------
-.. _param-imdiag-input-serverstreamdrivermode:
-.. _imdiag.parameter.input.serverstreamdrivermode-usage:
+Module usage
+------------
+.. _param-imdiag-module-serverstreamdrivermode:
+.. _imdiag.parameter.module.serverstreamdrivermode-usage:
 
 .. code-block:: rsyslog
 
-   module(load="imdiag")
-   input(type="imdiag"
-         listenPortFileName="/var/run/rsyslog/imdiag.port"
-         serverStreamDriverMode="1"
-         serverRun="19998")
+   module(load="imdiag"
+          listenPortFileName="/var/run/rsyslog/imdiag.port"
+          serverStreamDriverMode="1"
+          serverRun="19998")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/imdiag-serverstreamdriverpermittedpeer.rst
+++ b/doc/source/reference/parameters/imdiag-serverstreamdriverpermittedpeer.rst
@@ -1,5 +1,5 @@
 .. _param-imdiag-serverstreamdriverpermittedpeer:
-.. _imdiag.parameter.input.serverstreamdriverpermittedpeer:
+.. _imdiag.parameter.module.serverstreamdriverpermittedpeer:
 
 ServerStreamDriverPermittedPeer
 ===============================
@@ -18,9 +18,9 @@ driver used by imdiag does not enforce them.
 This parameter applies to :doc:`../../configuration/modules/imdiag`.
 
 :Name: ServerStreamDriverPermittedPeer
-:Scope: input
+:Scope: module
 :Type: array
-:Default: input=none
+:Default: module=none
 :Required?: no
 :Introduced: at least 5.x, possibly earlier
 
@@ -39,18 +39,17 @@ need to preserve configuration compatibility. When multiple peers are listed,
 provide an array of identity strings even though the ``ptcp`` driver ignores
 them.
 
-Input usage
------------
-.. _param-imdiag-input-serverstreamdriverpermittedpeer:
-.. _imdiag.parameter.input.serverstreamdriverpermittedpeer-usage:
+Module usage
+------------
+.. _param-imdiag-module-serverstreamdriverpermittedpeer:
+.. _imdiag.parameter.module.serverstreamdriverpermittedpeer-usage:
 
 .. code-block:: rsyslog
 
-   module(load="imdiag")
-   input(type="imdiag"
-         listenPortFileName="/var/run/rsyslog/imdiag.port"
-         serverStreamDriverPermittedPeer=["diag.example.com","127.0.0.1"]
-         serverRun="19998")
+   module(load="imdiag"
+          listenPortFileName="/var/run/rsyslog/imdiag.port"
+          serverStreamDriverPermittedPeer=["diag.example.com","127.0.0.1"]
+          serverRun="19998")
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/plugins/imdiag/imdiag.c
+++ b/plugins/imdiag/imdiag.c
@@ -105,7 +105,14 @@ static pthread_t timeoutGuard_thrd; /* thread ID for timeoutGuard thread (if act
 struct modConfData_s {
     rsconf_t *pConf; /* our overall config object */
     uchar *pszLstnPortFileName; /* port file name (module-level param) */
+    uchar *pszServerRun;
+    uchar *pszInjectDelayMode;
+    uchar *pszStrmDrvrAuthMode;
+    uchar *pszInputName;
+    permittedPeers_t *pPermPeersRoot;
     int abortTimeout; /* abort timeout in seconds, -1 = disabled */
+    int iTCPSessMax;
+    int iStrmDrvrMode;
     int configSetViaV2Method; /* 1 if module() was used to configure */
 };
 
@@ -115,6 +122,13 @@ static modConfData_t *loadModConf = NULL; /* modConf ptr for current load proces
 static struct cnfparamdescr modpdescr[] = {
     {"listenportfilename", eCmdHdlrString, 0},
     {"aborttimeout", eCmdHdlrInt, 0},
+    {"serverrun", eCmdHdlrString, 0},
+    {"injectdelaymode", eCmdHdlrString, 0},
+    {"maxsessions", eCmdHdlrInt, 0},
+    {"serverstreamdrivermode", eCmdHdlrInt, 0},
+    {"serverstreamdriverauthmode", eCmdHdlrString, 0},
+    {"serverstreamdriverpermittedpeer", eCmdHdlrArray, 0},
+    {"serverinputname", eCmdHdlrString, 0},
     {"mainmsgqueuetimeoutshutdown", eCmdHdlrInt, 0},
     {"mainmsgqueuetimeoutenqueue", eCmdHdlrInt, 0},
     {"inputshutdowntimeout", eCmdHdlrInt, 0},
@@ -130,6 +144,9 @@ static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / si
 static flowControl_t injectmsgDelayMode = eFLOWCTL_NO_DELAY;
 static int iTCPSessMax = 20; /* max number of sessions */
 static int iStrmDrvrMode = 0; /* mode for stream driver, driver-dependent (0 mostly means plain tcp) */
+static int bLegacyInjectDelayModeSet = 0;
+static int bLegacyTCPSessMaxSet = 0;
+static int bLegacyStrmDrvrModeSet = 0;
 static uchar *pszLstnPortFileName = NULL;
 static uchar *pszStrmDrvrAuthMode = NULL; /* authentication mode to use */
 static uchar *pszInputName = NULL; /* value for inputname property, NULL is OK and handled by core engine */
@@ -681,7 +698,7 @@ finalize_it:
 }
 
 
-static rsRetVal setInjectDelayMode(void __attribute__((unused)) * pVal, uchar *const pszMode) {
+static rsRetVal setInjectDelayModeFromString(const uchar *const pszMode) {
     DEFiRet;
 
     if (!strcasecmp((char *)pszMode, "no")) {
@@ -693,7 +710,17 @@ static rsRetVal setInjectDelayMode(void __attribute__((unused)) * pVal, uchar *c
     } else {
         LogError(0, RS_RET_PARAM_ERROR, "imdiag: invalid imdiagInjectDelayMode '%s' - ignored", pszMode);
     }
+    RETiRet;
+}
+
+
+static rsRetVal setInjectDelayMode(void __attribute__((unused)) * pVal, uchar *const pszMode) {
+    DEFiRet;
+
+    bLegacyInjectDelayModeSet = 1;
+    iRet = setInjectDelayModeFromString(pszMode);
     free(pszMode);
+
     RETiRet;
 }
 
@@ -823,12 +850,39 @@ finalize_it:
 }
 
 
+static rsRetVal setMaxSessions(void __attribute__((unused)) * pVal, int maxSessions) {
+    DEFiRet;
+
+    iTCPSessMax = maxSessions;
+    bLegacyTCPSessMaxSet = 1;
+
+    RETiRet;
+}
+
+
+static rsRetVal setStrmDrvrMode(void __attribute__((unused)) * pVal, int mode) {
+    DEFiRet;
+
+    iStrmDrvrMode = mode;
+    bLegacyStrmDrvrModeSet = 1;
+
+    RETiRet;
+}
+
+
 BEGINbeginCnfLoad
     CODESTARTbeginCnfLoad;
     loadModConf = pModConf;
     pModConf->pConf = pConf;
     pModConf->pszLstnPortFileName = NULL;
+    pModConf->pszServerRun = NULL;
+    pModConf->pszInjectDelayMode = NULL;
+    pModConf->pszStrmDrvrAuthMode = NULL;
+    pModConf->pszInputName = NULL;
+    pModConf->pPermPeersRoot = NULL;
     pModConf->abortTimeout = -1;
+    pModConf->iTCPSessMax = -1;
+    pModConf->iStrmDrvrMode = -1;
     pModConf->configSetViaV2Method = 0;
 ENDbeginCnfLoad
 
@@ -853,6 +907,26 @@ BEGINsetModCnf
             CHKmalloc(loadModConf->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "aborttimeout")) {
             loadModConf->abortTimeout = (int)pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "serverrun")) {
+            CHKmalloc(loadModConf->pszServerRun = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "injectdelaymode")) {
+            CHKmalloc(loadModConf->pszInjectDelayMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "maxsessions")) {
+            loadModConf->iTCPSessMax = (int)pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "serverstreamdrivermode")) {
+            loadModConf->iStrmDrvrMode = (int)pvals[i].val.d.n;
+        } else if (!strcmp(modpblk.descr[i].name, "serverstreamdriverauthmode")) {
+            CHKmalloc(loadModConf->pszStrmDrvrAuthMode = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "serverstreamdriverpermittedpeer")) {
+            for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+                uchar *const peer = (uchar *)es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
+                CHKmalloc(peer);
+                iRet = net.AddPermittedPeer(&loadModConf->pPermPeersRoot, peer);
+                free(peer);
+                CHKiRet(iRet);
+            }
+        } else if (!strcmp(modpblk.descr[i].name, "serverinputname")) {
+            CHKmalloc(loadModConf->pszInputName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "mainmsgqueuetimeoutshutdown")) {
             loadModConf->pConf->globals.mainQ.iMainMsgQtoQShutdown = (int)pvals[i].val.d.n;
         } else if (!strcmp(modpblk.descr[i].name, "mainmsgqueuetimeoutenqueue")) {
@@ -881,6 +955,31 @@ BEGINendCnfLoad
         pszLstnPortFileName = loadModConf->pszLstnPortFileName;
         loadModConf->pszLstnPortFileName = NULL; /* ownership transferred to global */
     }
+    if (loadModConf->pszInjectDelayMode != NULL && !bLegacyInjectDelayModeSet) {
+        CHKiRet(setInjectDelayModeFromString(loadModConf->pszInjectDelayMode));
+    }
+    if (loadModConf->iTCPSessMax != -1 && !bLegacyTCPSessMaxSet) {
+        iTCPSessMax = loadModConf->iTCPSessMax;
+    }
+    if (loadModConf->iStrmDrvrMode != -1 && !bLegacyStrmDrvrModeSet) {
+        iStrmDrvrMode = loadModConf->iStrmDrvrMode;
+    }
+    if (loadModConf->pszStrmDrvrAuthMode != NULL && pszStrmDrvrAuthMode == NULL) {
+        pszStrmDrvrAuthMode = loadModConf->pszStrmDrvrAuthMode;
+        loadModConf->pszStrmDrvrAuthMode = NULL; /* ownership transferred to global */
+    }
+    if (loadModConf->pszInputName != NULL && pszInputName == NULL) {
+        pszInputName = loadModConf->pszInputName;
+        loadModConf->pszInputName = NULL; /* ownership transferred to global */
+    }
+    if (loadModConf->pPermPeersRoot != NULL && pPermPeersRoot == NULL) {
+        pPermPeersRoot = loadModConf->pPermPeersRoot;
+        loadModConf->pPermPeersRoot = NULL; /* ownership transferred to global */
+    }
+    if (loadModConf->pszServerRun != NULL && pOurTcpsrv == NULL) {
+        CHKiRet(addTCPListener(NULL, loadModConf->pszServerRun));
+        loadModConf->pszServerRun = NULL; /* ownership transferred to addTCPListener */
+    }
     if (loadModConf->abortTimeout != -1 && abortTimeout == -1) {
         CHKiRet(setAbortTimeout(NULL, loadModConf->abortTimeout));
     }
@@ -902,6 +1001,13 @@ ENDactivateCnf
 BEGINfreeCnf
     CODESTARTfreeCnf;
     free(pModConf->pszLstnPortFileName);
+    free(pModConf->pszServerRun);
+    free(pModConf->pszInjectDelayMode);
+    free(pModConf->pszStrmDrvrAuthMode);
+    free(pModConf->pszInputName);
+    if (pModConf->pPermPeersRoot != NULL) {
+        net.DestructPermittedPeers(&pModConf->pPermPeersRoot);
+    }
 ENDfreeCnf
 
 
@@ -1025,6 +1131,9 @@ ENDmodExit
 static rsRetVal resetConfigVariables(uchar __attribute__((unused)) * pp, void __attribute__((unused)) * pVal) {
     iTCPSessMax = 200;
     iStrmDrvrMode = 0;
+    bLegacyInjectDelayModeSet = 0;
+    bLegacyTCPSessMaxSet = 0;
+    bLegacyStrmDrvrModeSet = 0;
     free(pszInputName);
     free(pszLstnPortFileName);
     pszLstnPortFileName = NULL;
@@ -1095,9 +1204,9 @@ BEGINmodInit()
                                STD_LOADABLE_MODULE_ID));
     CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiaginjectdelaymode"), 0, eCmdHdlrGetWord, setInjectDelayMode, NULL,
                                STD_LOADABLE_MODULE_ID));
-    CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiagmaxsessions"), 0, eCmdHdlrInt, NULL, &iTCPSessMax,
+    CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiagmaxsessions"), 0, eCmdHdlrInt, setMaxSessions, NULL,
                                STD_LOADABLE_MODULE_ID));
-    CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiagserverstreamdrivermode"), 0, eCmdHdlrInt, NULL, &iStrmDrvrMode,
+    CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiagserverstreamdrivermode"), 0, eCmdHdlrInt, setStrmDrvrMode, NULL,
                                STD_LOADABLE_MODULE_ID));
     CHKiRet(omsdRegCFSLineHdlr(UCHAR_CONSTANT("imdiaglistenportfilename"), 0, eCmdHdlrGetWord, NULL,
                                &pszLstnPortFileName, STD_LOADABLE_MODULE_ID));

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -188,10 +188,9 @@ must validate YAML-loader behaviour or when no RainerScript is desired.
 - Tests add their own `modules:` section (and `inputs:`, `rulesets:`, etc.)
   via `add_yaml_conf`.
 - `add_yaml_conf 'fragment' [instance]` appends arbitrary YAML to the same file.
-- `add_yaml_imdiag_input [instance]` appends the imdiag input entry
-  (`  - type: imdiag / port: "0"`) inside an already-opened `inputs:` block.
-  **Tests must call this** (inside their `inputs:` section) so that startup
-  detection via the imdiag port file works correctly.
+- `add_yaml_imdiag_input [instance]` is a historical compatibility helper.
+  imdiag startup detection is configured by `generate_conf --yaml-only` via
+  module-scoped testbench parameters, so new tests should not call it.
 - `startup_common` detects `RSYSLOG_YAML_ONLY=1` and passes the `.yaml` file
   to rsyslogd instead of the usual `.conf` file.
 
@@ -218,7 +217,6 @@ add_yaml_conf 'modules:'
 add_yaml_conf '  - load: "../plugins/imtcp/.libs/imtcp"'
 add_yaml_conf ''
 add_yaml_conf 'inputs:'
-add_yaml_imdiag_input           # required for startup detection
 add_yaml_conf "  - type: imtcp"
 add_yaml_conf "    port: \"0\""
 add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.tcpflood_port\""

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -274,6 +274,7 @@ TESTS_DEFAULT = \
 	asynwr_deadlock2.sh \
 	asynwr_deadlock4.sh \
 	asynwr_dynfile_flushtxend-off.sh \
+	imdiag-modern-module-config.sh \
 	compat-configformat-rainerscript.sh \
 	compat-defaults-secure-dynafile-rainerscript.sh \
 	abort-uncleancfg-goodcfg.sh \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -403,8 +403,8 @@ local0.* ./'${RSYSLOG_DYNNAME}'.HOSTNAME;hostname
 # YAML-only modes.  Tests that need a non-default value must set the relevant
 # RSTB_* variable before calling generate_conf.
 #
-# Startup detection relies on the imdiag port file in both RainerScript and
-# yaml-only modes; no .started marker file is used.
+# Startup detection relies on the module-level imdiag port file in both
+# RainerScript and yaml-only modes; no .started marker file is used.
 generate_conf() {
 	local yaml_only=0
 	if [ "$1" = "--yaml-only" ]; then
@@ -443,6 +443,7 @@ generate_conf() {
 			printf '\ntestbench_modules:\n'
 			printf '  - load: "../plugins/imdiag/.libs/imdiag"\n'
 			printf '    listenportfilename: "%s.imdiag%s.port"\n' "$RSYSLOG_DYNNAME" "$1"
+			printf '    serverrun: "0"\n'
 			printf '    aborttimeout: "%s"\n' "$TB_TEST_MAX_RUNTIME"
 			printf '    mainmsgqueuetimeoutshutdown: "%s"\n' "$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT"
 			printf '    mainmsgqueuetimeoutenqueue: "%s"\n' "$RSTB_MAIN_Q_TO_ENQUEUE"
@@ -450,22 +451,22 @@ generate_conf() {
 			printf '    defaultactionqueuetimeoutshutdown: "%s"\n' "$RSTB_ACTION_DEFAULT_Q_TO_SHUTDOWN"
 			printf '    defaultactionqueuetimeoutenqueue: "%s"\n' "$RSTB_ACTION_DEFAULT_Q_TO_ENQUEUE"
 			printf '\n###### add modules:, inputs:, rulesets: etc. below\n'
-			printf '###### include imdiag input via add_yaml_imdiag_input\n'
+			printf '###### imdiag listener is configured as a testbench module\n'
 			printf '###### end of testbench instrumentation part, test conf follows:\n'
 		} > ${TESTCONF_NM}$1.yaml
 	else
 		export RSYSLOG_YAML_ONLY=0
 		export TESTCONF_EXT="conf"
 		echo 'module(load="../plugins/imdiag/.libs/imdiag"
+    listenportfilename="'$RSYSLOG_DYNNAME.imdiag$1.port'"
+    serverrun="0"
+    aborttimeout="'$TB_TEST_MAX_RUNTIME'"
     mainmsgqueuetimeoutshutdown="'$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT'"
     mainmsgqueuetimeoutenqueue="'$RSTB_MAIN_Q_TO_ENQUEUE'"
     inputshutdowntimeout="'$RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT'"
     defaultactionqueuetimeoutshutdown="'$RSTB_ACTION_DEFAULT_Q_TO_SHUTDOWN'"
     defaultactionqueuetimeoutenqueue="'$RSTB_ACTION_DEFAULT_Q_TO_ENQUEUE'")
 global(debug.abortOnProgramError="on")
-$IMDiagListenPortFileName '$RSYSLOG_DYNNAME.imdiag$1.port'
-$IMDiagServerRun 0
-$IMDiagAbortTimeout '$TB_TEST_MAX_RUNTIME'
 # Capture rsyslogd own messages (startup, shutdown, errors) to the .started
 # file. Tests use this file to check for expected rsyslogd-internal messages.
 # This rule also ensures at least one output action exists in the default
@@ -496,12 +497,11 @@ add_yaml_conf() {
 	printf '%s\n' "$1" >> ${TESTCONF_NM}$2.yaml
 }
 
-# add the imdiag input entry inside an already-open inputs: section.
-# Call this as the first item after 'add_yaml_conf "inputs:"' so that
-# startup detection via the imdiag port file works correctly.
+# Historical compatibility helper. imdiag is now configured module-wide by
+# generate_conf --yaml-only, so callers no longer need a dedicated input entry.
 # $1 is the instance id, if given
 add_yaml_imdiag_input() {
-	printf '  - type: imdiag\n    port: "0"\n' >> ${TESTCONF_NM}$1.yaml
+	:
 }
 
 rst_msleep() {

--- a/tests/imdiag-modern-module-config.sh
+++ b/tests/imdiag-modern-module-config.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Verify all imdiag module parameters validate with legacy $-directives disabled
+# and the testbench startup path uses module-level serverRun/listenPortFileName.
+. ${srcdir:=.}/diag.sh init
+require_plugin imdiag
+
+modpath="${RSYSLOG_MODDIR}"
+
+cat >"${RSYSLOG_DYNNAME}.allparams.conf" <<CONF_EOF
+global(compatibility.configformat.legacy="disable")
+module(load="../plugins/imdiag/.libs/imdiag"
+       listenPortFileName="${RSYSLOG_DYNNAME}.allparams.imdiag.port"
+       serverRun="0"
+       abortTimeout="60"
+       injectDelayMode="light"
+       maxSessions="10"
+       serverStreamDriverMode="0"
+       serverStreamDriverAuthMode="anon"
+       serverStreamDriverPermittedPeer=["diag.example.com","127.0.0.1"]
+       serverInputName="diag-modern"
+       mainMsgQueueTimeoutShutdown="10000"
+       mainMsgQueueTimeoutEnqueue="30000"
+       inputShutdownTimeout="60000"
+       defaultActionQueueTimeoutShutdown="20000"
+       defaultActionQueueTimeoutEnqueue="30000")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+
+../tools/rsyslogd -C -N1 -M"${modpath}" -f"${RSYSLOG_DYNNAME}.allparams.conf" \
+	>"${RSYSLOG_DYNNAME}.allparams.log" 2>&1
+ret=$?
+if [ $ret -ne 0 ]; then
+	echo "FAIL: expected imdiag module parameters to validate with legacy disabled"
+	cat "${RSYSLOG_DYNNAME}.allparams.log"
+	error_exit 1
+fi
+
+generate_conf
+add_conf '
+global(compatibility.configformat.legacy="disable")
+'
+startup
+shutdown_when_empty
+wait_shutdown
+exit_test

--- a/tests/imgssapi-yaml-include-listen-port-file.sh
+++ b/tests/imgssapi-yaml-include-listen-port-file.sh
@@ -32,10 +32,6 @@ EOF
 
 add_yaml_conf 'include:'
 add_yaml_conf '  - path: "'${RSYSLOG_DYNNAME}'_imgssapi.conf"'
-add_yaml_conf ''
-add_yaml_conf 'inputs:'
-add_yaml_imdiag_input
-
 startup
 
 assign_file_content GSS_PORT "$RSYSLOG_DYNNAME.gss_port"

--- a/tests/yaml-basic-yamlonly.sh
+++ b/tests/yaml-basic-yamlonly.sh
@@ -3,7 +3,7 @@
 #   - generate_conf --yaml-only writes a pure YAML preamble using
 #     testbench_modules: for the imdiag setup (no RainerScript)
 #   - test-specific modules go in a standard modules: section
-#   - add_yaml_imdiag_input adds the imdiag input for startup detection
+#   - imdiag is configured as module-scoped testbench instrumentation
 #   - rsyslogd starts and processes messages using only the YAML loader
 #
 # This test intentionally avoids any RainerScript or legacy-style directives
@@ -26,7 +26,6 @@ add_yaml_conf '    type: string'
 add_yaml_conf "    string: \"%msg:F,58:2%\\n\""
 add_yaml_conf ''
 add_yaml_conf 'inputs:'
-add_yaml_imdiag_input
 add_yaml_conf "  - type: imtcp"
 add_yaml_conf "    port: \"0\""
 add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.tcpflood_port\""

--- a/tests/yaml-imbeats-basic.sh
+++ b/tests/yaml-imbeats-basic.sh
@@ -13,7 +13,6 @@ add_yaml_conf '    type: string'
 add_yaml_conf '    string: "%msg%|%$!message%|%$!metadata!imbeats!sequence%\n"'
 add_yaml_conf ''
 add_yaml_conf 'inputs:'
-add_yaml_imdiag_input
 add_yaml_conf '  - type: imbeats'
 add_yaml_conf '    port: "0"'
 add_yaml_conf "    listenPortFileName: \"${RSYSLOG_DYNNAME}.imbeats.port\""

--- a/tests/yaml-imhttp-apikeyfile.sh
+++ b/tests/yaml-imhttp-apikeyfile.sh
@@ -13,7 +13,6 @@ add_yaml_conf '  - name: outfmt'
 add_yaml_conf '    type: string'
 add_yaml_conf '    string: "%msg%\n"'
 add_yaml_conf 'inputs:'
-add_yaml_imdiag_input
 add_yaml_conf '  - type: imhttp'
 add_yaml_conf '    endpoint: "/postrequest"'
 add_yaml_conf '    ruleset: "main"'

--- a/tests/yaml-imhttp-metrics-apikeyfile.sh
+++ b/tests/yaml-imhttp-metrics-apikeyfile.sh
@@ -11,7 +11,6 @@ add_yaml_conf '    ports: "'$IMHTTP_PORT'"'
 add_yaml_conf '    metricsPath: "/metrics"'
 add_yaml_conf '    metricsApiKeyFile: "'$srcdir'/testsuites/imhttp-apikeys.txt"'
 add_yaml_conf 'inputs:'
-add_yaml_imdiag_input
 add_yaml_conf '  - type: imhttp'
 add_yaml_conf '    endpoint: "/unused"'
 add_yaml_conf '    ruleset: "main"'

--- a/tests/yaml-mmjsontransform-policywatch.sh
+++ b/tests/yaml-mmjsontransform-policywatch.sh
@@ -28,7 +28,6 @@ add_yaml_conf '    type: string'
 add_yaml_conf '    string: "%$!output%\n"'
 add_yaml_conf ''
 add_yaml_conf 'inputs:'
-add_yaml_imdiag_input
 add_yaml_conf '  - type: imtcp'
 add_yaml_conf '    port: "0"'
 add_yaml_conf '    listenPortFileName: "'${RSYSLOG_DYNNAME}'.tcpflood_port"'


### PR DESCRIPTION
## Summary
- add modern module-scope imdiag parameters for all existing `$IMDiag*` settings
- configure the testbench imdiag listener from `module(load=...)` in both RainerScript and YAML-only preambles
- keep legacy `$IMDiag*` directives and the old `input(type="imdiag")` compatibility surface, but stop using the input path in generated testbench configs
- update imdiag/testbench docs and add a legacy-disabled focused test

## Why
The testbench should be able to run with `global(compatibility.configformat.legacy="disable")` without relying on legacy `$IMDiag*` directives or a dedicated imdiag input instance.

## Validation
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout`
- `make -j$(nproc) check TESTS=""`
- `./tests/imdiag-modern-module-config.sh`
- `./tests/yaml-basic-yamlonly.sh`
- `./tests/compat-configformat-rainerscript.sh`
- `./tests/sndrcv.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
- container static analyzer on `rsyslog/rsyslog_dev_base_ubuntu:26.04`: `scan-build: No bugs found`
- container Ubuntu 26.04 build-only CI smoke with `clang-21`: passed, `real 33.94`
- `git diff --check`
