### PR TITLE
agents: clarify PR babysitting stop condition

### DIFF
--- a/.agent/skills/rsyslog_pr_babysitting/SKILL.md
+++ b/.agent/skills/rsyslog_pr_babysitting/SKILL.md
@@ -7,12 +7,20 @@ description: Monitor rsyslog pull requests after push or rerun, including GitHub
 
 Use this skill when babysitting an rsyslog PR after pushing, rerunning CI, or
 waiting for review. Babysitting is incomplete unless both CI status and
-unresolved review threads have been checked.
+unresolved review threads have been checked. Read review comments as part of
+babysitting, including bot or CI comments that explain failed or skipped jobs.
+
+When a user says "babysit PR", the default goal is to watch and act until the
+PR is fully babysat (see stop conditions below), then stop. Do not keep
+polling until merge unless the user explicitly asks for merge-time monitoring.
 
 ## Poll Cadence
 
 - Poll every 10 to 20 minutes while checks are running; 15 minutes is the
   default.
+- If checks are complete but actionable review threads or CI/bot comments
+  remain unresolved, continue on the same cadence until they are handled or the
+  user says to stop.
 - If babysitting a non-empty set of PRs, check them together on the same
   cadence instead of starting separate tight loops.
 - Stop babysitting when all monitored PRs are green: no failed checks, no


### PR DESCRIPTION
## Summary
- clarify the repo-local PR babysitting skill for the phrase `babysit PR`
- make the default stop condition explicit: stop when the monitored PR is fully babysat
- clarify that babysitting includes reading review comments, including bot/CI comments
- require explicit user direction for merge-time monitoring

## Why
This avoids unnecessary continued polling once the useful babysitting work is done, while making sure agents do not stop just because CI passed when actionable review or CI comments remain.

## Validation
- documentation/agent-guidance-only change
- `git diff --check`
