### PR TITLE
configure: make libyaml default-on explicit

### DIFF
--- a/.github/scripts/debian_package_build.sh
+++ b/.github/scripts/debian_package_build.sh
@@ -63,6 +63,7 @@ install_prereqs() {
     g++ \
     git \
     libtool \
+    libyaml-dev \
     make \
     pkg-config \
     python3 \

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -87,6 +87,7 @@ jobs:
               libtokyocabinet-dev \
               libtool \
               libtool-bin \
+              libyaml-dev \
               logrotate \
               net-tools \
               postgresql-client libpq-dev \

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -59,6 +59,7 @@ jobs:
             libsystemd-dev \
             libtool \
             libtool-bin \
+            libyaml-dev \
             libzstd-dev \
             lsof \
             make \

--- a/.github/workflows/draft_release.yml
+++ b/.github/workflows/draft_release.yml
@@ -80,6 +80,7 @@ jobs:
             libsystemd-dev \
             libtool \
             libtool-bin \
+            libyaml-dev \
             libzstd-dev \
             lsof \
             make \

--- a/.github/workflows/imbeats.yml
+++ b/.github/workflows/imbeats.yml
@@ -69,7 +69,7 @@ jobs:
             --enable-testbench --enable-omstdout --enable-imdiag --enable-imbeats
             --enable-elasticsearch --enable-elasticsearch-tests
             --disable-default-tests --disable-imtcp-tests --disable-imfile
-            --disable-imfile-tests --disable-fmhttp
+            --disable-imfile-tests --disable-fmhttp --disable-libyaml
           CI_MAKE_OPT: -j20
           CI_MAKE_CHECK_OPT: -j10
           CI_MAKE_CHECK_TESTS: >-

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -482,25 +482,25 @@ jobs:
           'centos_7')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_centos:7'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
-                     --disable-kafka-tests --disable-snmp-tests"
+                     --disable-kafka-tests --disable-snmp-tests --disable-libyaml"
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               ;;
           'centos_8')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_centos:8'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
-                            --disable-snmp-tests --enable-imdtls --enable-omdtls"
+                            --disable-snmp-tests --enable-imdtls --enable-omdtls --disable-libyaml"
               ;;
           'debian_sid')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:sid'
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
-                            --without-valgrind-testbench --enable-imdtls --enable-omdtls"
+                            --without-valgrind-testbench --enable-imdtls --enable-omdtls --disable-libyaml"
               ;;
           'debian_13')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:13'
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
-                            --without-valgrind-testbench --enable-imdtls --enable-omdtls"
+                            --without-valgrind-testbench --enable-imdtls --enable-omdtls --disable-libyaml"
               ;;
           'ubuntu_26_imtcp_no_epoll')
               # This check tests if imtcp runs in poll (select) mode. We have only slow CI runners for
@@ -525,12 +525,12 @@ jobs:
           'fedora_42')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:42'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
-                     --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls"
+                     --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls --disable-libyaml"
               ;;
           'fedora_43')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_fedora:43'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
-                     --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls"
+                     --disable-kafka-tests --enable-debug --enable-imdtls --enable-omdtls --disable-libyaml"
               ;;
           'ubuntu_20')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:20.04'
@@ -538,7 +538,7 @@ jobs:
               ;;
           'tumbleweed')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_suse:tumbleweed'
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests"
+              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests --disable-libyaml"
               ;;
           'ubuntu_24')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:24.04'
@@ -553,6 +553,7 @@ jobs:
           'ubuntu_22_distcheck')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
               export CI_VALGRIND_SUPPRESSIONS="ubuntu22.04.supp"
+              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-libyaml"
               export CI_CHECK_CMD='distcheck'
               export ABORT_ALL_ON_TEST_FAIL='YES'
               export VERBOSE=1
@@ -627,7 +628,7 @@ jobs:
               export RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE="--enable-testbench --enable-omstdout \
                      --enable-imdiag --enable-impstats --enable-imfile --disable-imfile-tests \
                      --disable-fmhttp --enable-valgrind --disable-default-tests --disable-imtcp-tests \
-                     --enable-elasticsearch-tests --enable-elasticsearch"
+                     --enable-elasticsearch-tests --enable-elasticsearch --disable-libyaml"
               export CI_MAKE_OPT='-j20'
               export CI_MAKE_CHECK_OPT='-j10'
               export CI_CHECK_CMD='check'
@@ -812,7 +813,7 @@ jobs:
           } > /etc/yum.repos.d/adiscon.repo
           dnf install -y dnf-plugins-core
           dnf config-manager --set-enabled crb
-          dnf install -y libestr-devel libfastjson4-devel zlib-devel libuuid-devel libgcrypt-devel libcurl-devel file protobuf-c-compiler protobuf-c-devel snappy-devel python3-docutils dos2unix
+          dnf install -y libestr-devel libfastjson4-devel zlib-devel libuuid-devel libgcrypt-devel libcurl-devel libyaml-devel file protobuf-c-compiler protobuf-c-devel snappy-devel python3-docutils dos2unix
           echo "== Copy mock configs =="
           cp -v packaging/rpm/etc-mock/*.cfg /etc/mock/ || true
           mkdir -p build-result /var/lib/mock
@@ -911,6 +912,7 @@ jobs:
             libgnutls28-dev \
             libestr-dev \
             libfastjson-dev \
+            libyaml-dev \
             python3-docutils
 
       - name: check disk space
@@ -1096,6 +1098,7 @@ jobs:
             libsystemd-dev \
             libtool \
             libtool-bin \
+            libyaml-dev \
             libzstd-dev \
             lsof \
             make \
@@ -1277,6 +1280,7 @@ jobs:
             libtokyocabinet-dev \
             libtool \
             libtool-bin \
+            libyaml-dev \
             libzstd-dev \
             libprotobuf-c-dev \
             protobuf-c-compiler \
@@ -1690,7 +1694,7 @@ jobs:
             --enable-testbench --enable-omstdout --enable-imdiag --enable-impstats
             --disable-imfile --disable-imfile-tests --disable-fmhttp --enable-valgrind
             --disable-default-tests --disable-imtcp-tests --enable-elasticsearch-tests
-            --enable-elasticsearch
+            --enable-elasticsearch --disable-libyaml
           CI_MAKE_OPT: -j20
           CI_MAKE_CHECK_OPT: -j10
           CI_CHECK_CMD: check
@@ -1760,7 +1764,7 @@ jobs:
           RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE: >-
             --enable-testbench --enable-omstdout --enable-imdiag --enable-omhttp
             --disable-default-tests --disable-imtcp-tests --disable-imfile
-            --disable-imfile-tests --disable-fmhttp
+            --disable-imfile-tests --disable-fmhttp --disable-libyaml
           CI_MAKE_OPT: -j20
           CI_MAKE_CHECK_OPT: -j10 TESTS=omhttp-victorialogs-jsonline.sh
           CI_CHECK_CMD: check

--- a/ChangeLog
+++ b/ChangeLog
@@ -5,6 +5,13 @@ This release has many commits in regard to
   * testbench de-flaking
 These will not be mentioned individually, check commit log for details.
 
+IMPORTANT FOR MAINTAINERS
+- libyaml support is now an explicit configure feature. It remains enabled by
+  default and must be satisfied by package builds unless
+  ``--disable-libyaml`` is passed. This removes the previous auto-detection
+  behavior where the presence or absence of libyaml development files silently
+  changed the feature set.
+
 - 2026-05-14: omrelp: add opt-in suspension for TLS auth failures
   omrelp now supports tls.permanentFailureDisablesAction="off". The default
   behavior is unchanged, but when disabled TLS authentication failures suspend

--- a/Makefile.am
+++ b/Makefile.am
@@ -407,6 +407,11 @@ DISTCHECK_CONFIGURE_FLAGS+= \
 	--enable-imdiag \
 	--enable-testbench \
 	--enable-valgrind
+
+if HAVE_LIBYAML
+else
+DISTCHECK_CONFIGURE_FLAGS+= --disable-libyaml
+endif # HAVE_LIBYAML
 # currently not supported in make distcheck:
 # --enable-pgsql-tests
 # --enable-extended-tests --> should probably never be enabled due to runtime

--- a/configure.ac
+++ b/configure.ac
@@ -166,11 +166,24 @@ AC_COMPILE_IFELSE( [AC_LANG_PROGRAM([[#include <limits.h>]],
                  )
 
 # Checks for libraries.
-PKG_CHECK_MODULES([LIBYAML], [yaml-0.1], [
-	AC_DEFINE([HAVE_LIBYAML], [1], [Define if libyaml is available])
-	have_libyaml=yes
+AC_ARG_ENABLE(libyaml,
+	[AS_HELP_STRING([--disable-libyaml],
+		[Disable libyaml-backed YAML configuration and policy file support @<:@default=enabled@:>@])],
+	[case "${enableval}" in
+	 yes) enable_libyaml="yes" ;;
+	  no) enable_libyaml="no" ;;
+	   *) AC_MSG_ERROR(bad value ${enableval} for --enable-libyaml) ;;
+	 esac],
+	[enable_libyaml="yes"]
+)
+AS_IF([test "x$enable_libyaml" = "xyes"], [
+	PKG_CHECK_MODULES([LIBYAML], [yaml-0.1], [
+		AC_DEFINE([HAVE_LIBYAML], [1], [Define if libyaml is available])
+		have_libyaml=yes
+	], [
+		AC_MSG_ERROR([libyaml support is enabled by default but yaml-0.1 was not found. Install libyaml development files or configure with --disable-libyaml.])
+	])
 ], [
-	AC_MSG_WARN([libyaml not found, rate limiting policies from files and YAML configuration support will be disabled])
 	have_libyaml=no
 ])
 AM_CONDITIONAL(HAVE_LIBYAML, test x$have_libyaml = xyes)

--- a/doc/source/configuration/yaml_config.rst
+++ b/doc/source/configuration/yaml_config.rst
@@ -90,10 +90,12 @@ RainerScript fragments and vice versa.
    documented in :doc:`../containers/index`.
 
    In addition, rsyslog must have been compiled with libyaml
-   (``yaml-0.1``).  If libyaml is absent at build time the daemon will
-   print an error and refuse to load a ``.yaml`` / ``.yml`` file.
-   Install the ``libyaml-dev`` (Debian/Ubuntu) or ``libyaml-devel``
-   (RHEL/Fedora) package before compiling.
+   (``yaml-0.1``).  Libyaml support is enabled by default at build time
+   and can be disabled explicitly with ``--disable-libyaml``.  If libyaml
+   support is disabled, the daemon will print an error and refuse to load a
+   ``.yaml`` / ``.yml`` file.  Install the ``libyaml-dev`` (Debian/Ubuntu)
+   or ``libyaml-devel`` (RHEL/Fedora) package before compiling with the
+   default options.
 
 Schema Overview
 ---------------

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -2038,7 +2038,7 @@ CLEANFILES=\
 	rsyslog.input rsyslog.input.* imfile-state:* omkafka-failed.data \
 	rsyslog.input-symlink.log rsyslog-link.*.log targets \
 	HOSTNAME \
-	rstb_* \
+	rstb_* *.test_policy_hup.yaml \
 	zookeeper.pid \
 	tmp.qi nocert
 

--- a/tests/ratelimit_hup.sh
+++ b/tests/ratelimit_hup.sh
@@ -7,7 +7,7 @@
 
 # Define ports and files
 export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
-export POLICY_FILE="$(pwd)/test_policy_hup.yaml"
+export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.test_policy_hup.yaml"
 
 # Create initial policy (High limits)
 echo "interval: 1" > $POLICY_FILE


### PR DESCRIPTION
## Summary

This makes libyaml an explicit default-enabled configure feature instead of an automagic dependency.

Default builds now require `yaml-0.1` and fail fast if the development files are missing. Builders that intentionally need a no-libyaml build can pass `--disable-libyaml`.

## Why

Downstream package builds should not silently gain or lose YAML configuration and YAML policy-file support based on whether libyaml happens to be present in the build environment.

## Notes for Maintainers

The ChangeLog includes an upper-section maintainer note documenting the packaging behavior change.

## Validation

- `./autogen.sh --enable-debug`
- `./configure --help` confirms `--disable-libyaml`
- `./configure --enable-debug --disable-Werror --disable-libyaml && make -j$(nproc) check TESTS=`
- `./configure --enable-debug --disable-Werror --enable-testbench && make -j$(nproc) check TESTS= && ./tests/yaml-basic.sh`
- `git diff --check`

Strict `--enable-debug` without `--disable-Werror` currently hits an unrelated existing `queue.c` unused-parameter warning on current `main`.

Closes https://github.com/rsyslog/rsyslog/issues/6914
