### PR TITLE
tests: fix imfile stress races

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1745,6 +1745,36 @@ TESTS_IMFILE = \
 	config_enabled-on.sh \
 	config_enabled-off.sh
 
+# These imfile tests all stress dynamic inotify watch changes: creating files
+# after startup, wildcard directory expansion, symlink discovery, renames, and
+# logrotate/truncate handling. Running the whole cluster at very high make
+# parallelism can overload shared inotify delivery and hide the behavior each
+# script is meant to test, so keep the cluster ordered while preserving the
+# individual test coverage and assertions.
+imfile-freshStartTail2.log: imfile-freshStartTail1.log
+imfile-freshStartTail3.log: imfile-freshStartTail2.log
+imfile-wildcards.log: imfile-freshStartTail3.log
+imfile-wildcards-dirs.log: imfile-wildcards.log
+imfile-wildcards-dirs2.log: imfile-wildcards-dirs.log
+imfile-wildcards-dirs-multi.log: imfile-wildcards-dirs2.log
+imfile-wildcards-dirs-multi2.log: imfile-wildcards-dirs-multi.log
+imfile-wildcards-dirs-multi3.log: imfile-wildcards-dirs-multi2.log
+imfile-wildcards-dirs-multi4.log: imfile-wildcards-dirs-multi3.log
+imfile-wildcards-dirs-multi5.log: imfile-wildcards-dirs-multi4.log
+imfile-wildcards-dirs-multi5-polling.log: imfile-wildcards-dirs-multi5.log
+imfile-old-state-file.log: imfile-wildcards-dirs-multi5-polling.log
+imfile-rename-while-stopped.log: imfile-old-state-file.log
+imfile-rename.log: imfile-rename-while-stopped.log
+imfile-symlink.log: imfile-rename.log
+imfile-symlink-multi.log: imfile-symlink.log
+imfile-symlink-ext-tmp-dir-tree.log: imfile-symlink-multi.log
+imfile-logrotate.log: imfile-symlink-ext-tmp-dir-tree.log
+imfile-logrotate-async.log: imfile-logrotate.log
+imfile-logrotate-multiple.log: imfile-logrotate-async.log
+imfile-logrotate-copytruncate.log: imfile-logrotate-multiple.log
+imfile-logrotate-nocopytruncate.log: imfile-logrotate-copytruncate.log
+imfile-logrotate-state-files.log: imfile-logrotate-nocopytruncate.log
+
 TESTS_IMFILE_MMNORMALIZE = \
 	imfile-endmsg.regex-with-example.sh
 

--- a/tests/imfile-freshStartTail2.sh
+++ b/tests/imfile-freshStartTail2.sh
@@ -21,10 +21,17 @@ template(name="outfmt" type="string" string="%msg%\n")
 	template="outfmt")
 '
 startup
+# Use a canary post-startup wildcard file to prove imfile has armed the
+# directory watch before creating the file used for the append-following check.
+echo '{ "id": "canary"}' > $RSYSLOG_DYNNAME.input.canary
+content_check_with_count '{ "id": "canary"}' 1 $IMFILECHECKTIMEOUT
 
 echo '{ "id": "jinqiao1"}' > $RSYSLOG_DYNNAME.input.a
 content_check_with_count '{ "id": "jinqiao1"}' 1 $IMFILECHECKTIMEOUT
 wait_queueempty
+# Let imfile settle after the first read before checking that later appends to
+# the same post-startup wildcard file are followed.
+./msleep 1000
 
 echo '{ "id": "jinqiao2"}' >> $RSYSLOG_DYNNAME.input.a
 content_check_with_count '{ "id": "jinqiao2"}' 1 $IMFILECHECKTIMEOUT

--- a/tests/imfile-logrotate-copytruncate.sh
+++ b/tests/imfile-logrotate-copytruncate.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# Verifies imfile reopenOnTruncate with logrotate copytruncate: rsyslog must
-# read the pre-rotate file, notice the truncate, then read all post-rotate data.
+# Verifies imfile reopenOnTruncate with logrotate copytruncate. The oracle is
+# the exact sequence 0..19999: rsyslog must read the pre-rotate file, finish
+# that batch before the destructive copytruncate, notice the truncation, resume
+# with the post-truncate sentinel, and then read all remaining post-rotate data.
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 . $srcdir/diag.sh check-inotify-only
 . ${srcdir:=.}/diag.sh init
@@ -62,8 +64,11 @@ ls -l $RSYSLOG_DYNNAME.input*
 
 startup
 
-# Wait until testmessages are processed by imfile!
+# Wait until the initial file content is visible, then drain the main queue
+# before copytruncate so the test rotates only after the pre-rotate batch is
+# fully processed.
 wait_file_lines $RSYSLOG_OUT_LOG $TESTMESSAGES $RETRIES
+wait_queueempty
 
 # Logrotate on logfile
 logrotate --state $RSYSLOG_DYNNAME.logrotate.state -f $RSYSLOG_DYNNAME.logrotate

--- a/tests/imfile-symlink-multi.sh
+++ b/tests/imfile-symlink-multi.sh
@@ -1,11 +1,13 @@
 #!/bin/bash
-# This test points multiple symlinks (all watched by rsyslog via wildcard)
-# to single file and checks that message is reported once for each symlink
-# with correct corresponding metadata.
+# Verifies imfile wildcard handling for multiple symlinks to one target file.
+# The oracle is exact output metadata: rsyslog must report one record for the
+# original watched file and one record for each wildcard symlink, each with the
+# corresponding symlink filename and file offset.
 # This is part of the rsyslog testbench, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export IMFILEINPUTFILES="10"
+export IMFILECHECKTIMEOUT="60"
 
 mkdir "$RSYSLOG_DYNNAME.work"
 generate_conf
@@ -45,10 +47,13 @@ cp $imfilebefore $RSYSLOG_DYNNAME.targets/target.log
 for i in `seq 2 $IMFILEINPUTFILES`;
 do
 	ln -s $RSYSLOG_DYNNAME.targets/target.log $RSYSLOG_DYNNAME.input.$i.log
-	# Wait little for correct timing
+	# Let imfile observe each newly-created symlink before adding the next.
 	./msleep 50
 done
 
+# Symlink creation is asynchronous from imfile's point of view. Wait until all
+# expected records are visible before shutdown, then keep the exact comparison.
+content_check_with_count "HEADER msgnum:000000" $IMFILEINPUTFILES $IMFILECHECKTIMEOUT
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown        # we need to wait until rsyslogd is finished!
 


### PR DESCRIPTION
## Summary
- Fix imfile stress races found by the deflake campaign.
- Drain the initial copytruncate workload before forcing logrotate.
- Add explicit synchronization around freshStartTail2 wildcard discovery and symlink multi-output checks.
- Order the dynamic imfile inotify/logrotate cluster so broad -j250 stress does not make unrelated imfile instances compete while each script verifies its own behavior.

## Why this is a bug fix
The deflake campaign exposed a hidden real test bug: valid imfile behavior was being raced against asynchronous inotify setup, queue draining, and parallel dynamic imfile tests. The fix keeps the same rsyslog functionality under test and makes the test boundaries deterministic.

## Validation
- Focused container run: imfile-logrotate-copytruncate.sh, imfile-freshStartTail2.sh, imfile-symlink-multi.sh all passed in 45.53s (0:46).
- Pre-ordering full Ubuntu 26.04 -j250 run still reproduced imfile-logrotate-copytruncate.sh and imfile-freshStartTail2.sh, confirming the broader cluster interaction.
- Ordered full Ubuntu 26.04 -j250 run #1: imfile cluster passed; unrelated imbeats-shutdown-open-session.sh failed; runtime 305.46s (5:05).
- Ordered full Ubuntu 26.04 -j250 run #2: imfile cluster passed; unrelated imbeats-shutdown-open-session.sh failed; runtime 279.35s (4:39).

The repeated imbeats failure is recorded separately in the flake-campaign repo for later investigation.