### PR TITLE
agents: clarify test intent comment rule

### DIFF
--- a/.agent/skills/rsyslog_test/SKILL.md
+++ b/.agent/skills/rsyslog_test/SKILL.md
@@ -59,6 +59,10 @@ the test oracle: what condition makes the test pass or fail, and why any
 threshold or wait exists. Keep these comments focused on intent and semantics;
 do not duplicate each shell command.
 
+When changing a test, verify that the head comment still matches the actual
+setup, stimulus, oracle, and pass/fail conditions after the edit; update it in
+the same commit if it does not.
+
 ### 4. Using diag.sh Helpers
 All tests include `tests/diag.sh` using the POSIX `.` command. You should use its standardized helpers:
 - `cmp_exact`: Verify file content matches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,14 @@ Each major subtree contains a specialized `AGENTS.md` that points to area-specif
 - New and changed tests must include inline intent documentation that says what
   behavior, regression, or invariant they test. If an existing test lacks that
   context, add it while touching the test.
+
+  For timing, retry, sampling, concurrency, or negative-path tests, also explain
+  the oracle: what proves success or failure, and why any wait or threshold
+  exists.
+
+  When changing a test, verify that the head comment still matches the actual
+  setup, stimulus, oracle, and pass/fail conditions after the edit; update it in
+  the same commit if it does not.
 - It is fine to organize sources under `tests/unit/`, `tests/helpers/`, or
   similar folders, but register and run those tests from `tests/Makefile.am`.
 - Do not introduce additional recursive `tests/.../Makefile.am` test harnesses.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -28,6 +28,9 @@ agents.
   when the current intent is missing, stale, or vague. For timing, retry,
   sampling, concurrency, or negative-path tests, also explain the oracle: what
   proves success or failure, and why any wait or threshold exists.
+  When changing a test, verify that the head comment still matches the actual
+  setup, stimulus, oracle, and pass/fail conditions after the edit; update it in
+  the same commit if it does not.
 - Prefer harness helpers such as `cmp_exact`, `command_deny`, and
   `require_plugin` over ad-hoc shell to keep diagnostics uniform.
 - **Config format coverage**: When a module parameter or config object is tested


### PR DESCRIPTION
## Summary
- Strengthen the agent guidance for test head comments.
- Require changed tests to cross-check the head comment against setup, stimulus, oracle, and pass/fail conditions after edits.
- Keep the same rule in the top-level guide, testbench guide, and rsyslog test skill.

## Validation
- Documentation-only change.
- Ran `git diff --check`.