### PR TITLE
tests: remove omfwd two-target retry sleep

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1193,14 +1193,19 @@ assign_file_content() {
 # $1 is the output file name
 # $2 is the instance name (1, 2)
 # $3, if set, is a file that releases minitcpsrv from bound/offline to listening
+# $4, if set, is a file minitcpsrv writes after listen() succeeds
 start_minitcpsrvr() {
 	local instance=${2:-1}
 	local wait_listen_opt=""
+	local listen_ready_opt=""
 	if [ "${3:-}" != "" ]; then
 		wait_listen_opt="-w ${3:-}"
 	fi
+	if [ "${4:-}" != "" ]; then
+		listen_ready_opt="-L ${4:-}"
+	fi
 	./minitcpsrv -t127.0.0.1 -p 0 -P "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance" \
-		-f "$1" $wait_listen_opt $MINITCPSRV_EXTRA_OPTS &
+		-f "$1" $wait_listen_opt $listen_ready_opt $MINITCPSRV_EXTRA_OPTS &
 	BGPROCESS=$!
 	MINITCPSRVR_PIDS="${MINITCPSRVR_PIDS:-} $BGPROCESS"
 	wait_file_exists "$RSYSLOG_DYNNAME.minitcpsrvr_port$instance"

--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -55,6 +55,7 @@ char *targetIP = NULL;
 int targetPort = -1;
 char *portFileName = NULL;
 char *waitListenFileName = NULL;
+char *listenReadyFileName = NULL;
 size_t totalWritten = 0;
 int listen_fd, conn_fd, fd, file_fd, nfds, port = 8080;
 struct sockaddr_in server_addr;
@@ -69,8 +70,23 @@ static void errout(char *reason) {
 }
 
 static void usage(void) {
-    fprintf(stderr, "usage: minitcpsrv [-R] [-w listenFile] -t ip-addr -p port -P portFile -f outfile\n");
+    fprintf(stderr,
+            "usage: minitcpsrv [-R] [-w listenFile] [-L listenReadyFile] -t ip-addr -p port -P portFile -f outfile\n");
     exit(1);
+}
+
+static void writeListenReadyMarker(void) {
+    FILE *fp;
+    int ret;
+
+    if (listenReadyFileName == NULL) return;
+    if ((fp = fopen(listenReadyFileName, "w")) == NULL) {
+        errout(listenReadyFileName);
+    }
+    ret = fprintf(fp, "listening\n");
+    if (fclose(fp) != 0 || ret < 0) {
+        errout(listenReadyFileName);
+    }
 }
 
 static void waitForListenRelease(void) {
@@ -166,6 +182,7 @@ static void createListenSocket(void) {
     if (listen(listen_fd, MAX_CONNECTIONS) < 0) {
         errout("Listen failed");
     }
+    writeListenReadyMarker();
 
     fds[0].fd = listen_fd;
     fds[0].events = POLLIN;
@@ -180,7 +197,7 @@ int main(int argc, char *argv[]) {
     memset(fds, 0, sizeof(fds));
     memset(buffer_offs, 0, sizeof(buffer_offs));
 
-    while ((opt = getopt(argc, argv, "aB:D:Rt:p:P:f:s:S:w:")) != -1) {
+    while ((opt = getopt(argc, argv, "aB:D:L:Rt:p:P:f:s:S:w:")) != -1) {
         switch (opt) {
             case 'a':  // abort listener: act like the server has died (shutdown and re-open listen socket)
                 abortListener = 1;
@@ -199,6 +216,9 @@ int main(int argc, char *argv[]) {
                 break;
             case 'D':  // drop connection after this number of recv() operations (not messages)
                 dropConnection_NbrRcv = atoi(optarg);
+                break;
+            case 'L':
+                listenReadyFileName = optarg;
                 break;
             case 't':
                 targetIP = optarg;

--- a/tests/omfwd-lb-2target-retry.sh
+++ b/tests/omfwd-lb-2target-retry.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
-# added 2024-02-24 by rgerhards. Released under ASL 2.0
+# Verifies that native omfwd load balancing can resume a target that was
+# unavailable during the first message batch. Phase 1 keeps target 2 bound but
+# not listening, so all initial messages must go to target 1. Phase 2 releases
+# target 2, waits until minitcpsrv has actually called listen(), then waits
+# until the configured target-pool retry interval has elapsed before injecting
+# another full batch. Before shutdown, the test waits until both receivers show
+# the expected exact line counts; this is the oracle that target 2 resumed and
+# the second batch was split evenly rather than still flowing only to target 1.
+# Added 2024-02-24 by rgerhards. Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
 export NUMMESSAGES=10000  # MUST be an EVEN number!
@@ -7,9 +15,11 @@ export NUMMESSAGES=10000  # MUST be an EVEN number!
 # starting minitcpsrvr receivers so that we can obtain their port
 # numbers
 TARGET2_LISTEN_RELEASE="$RSYSLOG_DYNNAME.minitcpsrvr2.listen"
+TARGET2_LISTEN_READY="$RSYSLOG_DYNNAME.minitcpsrvr2.ready"
 rm -f "$TARGET2_LISTEN_RELEASE"
+rm -f "$TARGET2_LISTEN_READY"
 start_minitcpsrvr $RSYSLOG_OUT_LOG  1
-start_minitcpsrvr $RSYSLOG2_OUT_LOG 2 "$TARGET2_LISTEN_RELEASE"
+start_minitcpsrvr $RSYSLOG2_OUT_LOG 2 "$TARGET2_LISTEN_RELEASE" "$TARGET2_LISTEN_READY"
 
 # regular startup
 add_conf '
@@ -43,17 +53,24 @@ printf "\nSUCCESS for part 1 of the test\n\n"
 # target2 has held its port bound but not listening since before rsyslog
 # startup. This keeps phase 1 offline without exposing a get_free_port race.
 touch "$TARGET2_LISTEN_RELEASE"
-echo "waiting a bit to ensure rsyslog retries the currently suspended pool member"
-
-sleep 3
+echo "waiting until the previously suspended pool member is listening"
+wait_file_exists "$TARGET2_LISTEN_READY"
+echo "waiting for one target-pool retry interval"
+$TESTTOOL_DIR/msleep 1200
 
 injectmsg $NUMMESSAGES $NUMMESSAGES
+
+target2_expected=$(( NUMMESSAGES / 2 ))
+target1_expected=$(( NUMMESSAGES + target2_expected ))
+wait_file_lines --abort-on-oversize "$RSYSLOG2_OUT_LOG" "$target2_expected"
+wait_file_lines --abort-on-oversize "$RSYSLOG_OUT_LOG" "$target1_expected"
 
 shutdown_when_empty
 wait_shutdown
 
-if [ "$(wc -l < $RSYSLOG2_OUT_LOG)" != "$(( NUMMESSAGES / 2 ))" ]; then
-	echo "ERROR: RSYSLOG2_OUT_LOG has invalid number of messages $(( NUMMESSAGES / 2 ))"
+target2_actual="$(wc -l < "$RSYSLOG2_OUT_LOG")"
+if [ "$target2_actual" != "$target2_expected" ]; then
+	echo "ERROR: RSYSLOG2_OUT_LOG has invalid number of messages $target2_actual, expected $target2_expected"
 	cat -n  $RSYSLOG2_OUT_LOG | head -10
 	error_exit 100
 fi


### PR DESCRIPTION
## Summary
- add an optional minitcpsrv listen-ready marker written after `listen()` succeeds
- wire the marker through `start_minitcpsrvr`
- replace the fixed `sleep 3` in `omfwd-lb-2target-retry.sh` with an explicit wait for target 2 to be listening

## Why this is a bug fix
`omfwd-lb-2target-retry.sh` was using a fixed delay after releasing the second target. Under high parallel test stress, that delay was only a timing guess: the second message batch could start before the helper receiver had actually reached `listen()`. The test is meant to verify omfwd load-balancing retry behavior, not helper startup timing.

The final oracle is unchanged: exact message coverage and the expected split across both targets still prove that the previously unavailable target participates again.

## Validation
- full Ubuntu 26.04 container run with `CI_MAKE_CHECK_OPT=-j250`: `omfwd-lb-2target-retry.sh` PASS; suite had 3 unrelated failures recorded separately
- full Ubuntu 26.04 container run with `CI_MAKE_CHECK_OPT=-j250`: `omfwd-lb-2target-retry.sh` PASS; suite had 1 unrelated failure recorded separately

Unrelated findings were recorded in `rsyslog/flake-campaign` under `runs/2026-05-17-omfwd-lb-2target-retry-sync-j250/`.

Refs: https://github.com/rsyslog/rsyslog/issues/6308