### PR TITLE
containers: update Ubuntu libyaml dev images

### DIFF
--- a/packaging/docker/dev_env/ubuntu/base/18.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/Dockerfile
@@ -48,6 +48,7 @@ RUN 	apt-get update && \
 	libtokyocabinet-dev \
 	libtool \
 	libtool-bin \
+	libyaml-dev \
 	logrotate \
 	lsof \
 	make \
@@ -202,6 +203,7 @@ RUN	cd helper-projects \
 RUN	cd helper-projects && \
 	git clone https://github.com/civetweb/civetweb.git \
 	&& cd civetweb \
+	&& git checkout v1.16 \
 	&& (unset CFLAGS; make -j build COPT="-DREENTRANT_TIME"; make install-headers ; make install-slib ) \
 	&& cd .. \
 	&& rm -rf civetweb

--- a/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/Dockerfile
@@ -280,6 +280,7 @@ RUN	cd helper-projects \
 RUN	cd helper-projects && \
 	git clone https://github.com/civetweb/civetweb.git \
 	&& cd civetweb \
+	&& git checkout v1.16 \
 	&& (unset CFLAGS; make -j build COPT="-DREENTRANT_TIME"; make install-headers ; make install-slib ) \
 	&& cd .. \
 	&& rm -rf civetweb \

--- a/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
+++ b/packaging/docker/dev_env/ubuntu/base/22.04/Dockerfile
@@ -50,6 +50,7 @@ RUN 	apt-get update && \
 	libtokyocabinet-dev \
 	libtool \
 	libtool-bin \
+	libyaml-dev \
 	libsnappy-dev \
 	libzstd-dev \
 	logrotate \
@@ -258,15 +259,6 @@ RUN	cd helper-projects \
 	&& (unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j) \
 	&& make install \
 	&& cd .. \
-	&& cd ..
-
-# we need civetweb, as there are no packages for it
-RUN	cd helper-projects && \
-	git clone https://github.com/civetweb/civetweb.git \
-	&& cd civetweb \
-	&& (unset CFLAGS; make -j build COPT="-DREENTRANT_TIME"; make install-headers ; make install-slib ) \
-	&& cd .. \
-	&& rm -rf civetweb \
 	&& cd ..
 
 # next ENV is specifically for running scan-build - so we do not need to


### PR DESCRIPTION
0# Summary\n- add libyaml development packages to Ubuntu 18.04 and 22.04 dev images\n- pin source-built civetweb to v1.16 for Ubuntu 18.04 and 20.04\n- use Ubuntu 22.04 packaged libcivetweb-dev instead of building civetweb from the default branch\n\n## Validation\n- rebuilt rsyslog/rsyslog_dev_base_ubuntu:18.04, :20.04, and :22.04 locally\n- 18.04 gcc8-debug compile-extended equivalent passed\n- 20.04 clang9 compile-extended equivalent passed\n- 20.04 run-ci.sh check equivalent passed with CI_MAKE_CHECK_OPT=-j40\n- 20.04 Kafka distcheck equivalent passed with CI_MAKE_CHECK_OPT=-j40\n- 22.04 run-ci.sh distcheck equivalent passed with CI_MAKE_CHECK_OPT=-j40\n- git diff --check for the touched Dockerfiles passed