### PR TITLE
ci: enable libyaml on Ubuntu 22 jobs

### DIFF
--- a/.github/workflows/imbeats.yml
+++ b/.github/workflows/imbeats.yml
@@ -69,7 +69,7 @@ jobs:
             --enable-testbench --enable-omstdout --enable-imdiag --enable-imbeats
             --enable-elasticsearch --enable-elasticsearch-tests
             --disable-default-tests --disable-imtcp-tests --disable-imfile
-            --disable-imfile-tests --disable-fmhttp --disable-libyaml
+            --disable-imfile-tests --disable-fmhttp
           CI_MAKE_OPT: -j20
           CI_MAKE_CHECK_OPT: -j10
           CI_MAKE_CHECK_TESTS: >-

--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -553,7 +553,6 @@ jobs:
           'ubuntu_22_distcheck')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:22.04'
               export CI_VALGRIND_SUPPRESSIONS="ubuntu22.04.supp"
-              export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-libyaml"
               export CI_CHECK_CMD='distcheck'
               export ABORT_ALL_ON_TEST_FAIL='YES'
               export VERBOSE=1
@@ -628,7 +627,7 @@ jobs:
               export RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE="--enable-testbench --enable-omstdout \
                      --enable-imdiag --enable-impstats --enable-imfile --disable-imfile-tests \
                      --disable-fmhttp --enable-valgrind --disable-default-tests --disable-imtcp-tests \
-                     --enable-elasticsearch-tests --enable-elasticsearch --disable-libyaml"
+                     --enable-elasticsearch-tests --enable-elasticsearch"
               export CI_MAKE_OPT='-j20'
               export CI_MAKE_CHECK_OPT='-j10'
               export CI_CHECK_CMD='check'
@@ -1694,7 +1693,7 @@ jobs:
             --enable-testbench --enable-omstdout --enable-imdiag --enable-impstats
             --disable-imfile --disable-imfile-tests --disable-fmhttp --enable-valgrind
             --disable-default-tests --disable-imtcp-tests --enable-elasticsearch-tests
-            --enable-elasticsearch --disable-libyaml
+            --enable-elasticsearch
           CI_MAKE_OPT: -j20
           CI_MAKE_CHECK_OPT: -j10
           CI_CHECK_CMD: check
@@ -1764,7 +1763,7 @@ jobs:
           RSYSLOG_CONFIGURE_OPTIONS_OVERRIDE: >-
             --enable-testbench --enable-omstdout --enable-imdiag --enable-omhttp
             --disable-default-tests --disable-imtcp-tests --disable-imfile
-            --disable-imfile-tests --disable-fmhttp --disable-libyaml
+            --disable-imfile-tests --disable-fmhttp
           CI_MAKE_OPT: -j20
           CI_MAKE_CHECK_OPT: -j10 TESTS=omhttp-victorialogs-jsonline.sh
           CI_CHECK_CMD: check


### PR DESCRIPTION
## Summary
- remove --disable-libyaml from Ubuntu 22.04-based GitHub Actions jobs
- keep the non-Ubuntu disables in place for CentOS, Debian, Fedora, and Tumbleweed jobs
- follows the Ubuntu dev image updates merged in #6922

## Validation
- git diff --check
- actionlint .github/workflows/run_checks.yml .github/workflows/imbeats.yml
- zizmor --strict-collection .github/workflows