### PR TITLE
tests: harden imbeats shutdown session setup

### DIFF
--- a/tests/imbeats-shutdown-open-session.sh
+++ b/tests/imbeats-shutdown-open-session.sh
@@ -2,6 +2,12 @@
 . ${srcdir:=.}/diag.sh init
 require_plugin imbeats
 
+# This checks that imbeats shutdown closes client sessions that are already
+# accepted and left open in idle or partial-frame protocol states. The client
+# first completes one valid Lumberjack batch on each socket and waits for the
+# expected ack; that ack is the oracle that the session is owned by imbeats
+# before the test starts rsyslog shutdown.
+
 generate_conf
 add_conf '
 module(load="../plugins/imbeats/.libs/imbeats")
@@ -26,6 +32,7 @@ rm -f "$RSYSLOG_DYNNAME.imbeats.ready" "$RSYSLOG_DYNNAME.imbeats.client-result"
 ${PYTHON:-python3} - "$RS_PORT" \
 	"$RSYSLOG_DYNNAME.imbeats.ready" \
 	"$RSYSLOG_DYNNAME.imbeats.client-result" <<'PY' &
+import json
 import os
 import socket
 import struct
@@ -36,10 +43,31 @@ ready_file = sys.argv[2]
 result_file = sys.argv[3]
 sockets = []
 
+def event_wire(seq, message):
+    payload = json.dumps({"message": message}, separators=(",", ":")).encode()
+    return (
+        b"2W" + struct.pack(">I", 1)
+        + b"2J" + struct.pack(">I", seq)
+        + struct.pack(">I", len(payload)) + payload
+    )
+
+def recv_exact(sock, size):
+    data = b""
+    while len(data) < size:
+        chunk = sock.recv(size - len(data))
+        if not chunk:
+            raise SystemExit("server closed session before ack")
+        data += chunk
+    return data
+
 try:
     for idx in range(3):
         sock = socket.create_connection(("127.0.0.1", port), timeout=5)
         sock.settimeout(10)
+        sock.sendall(event_wire(1, f"accepted-{idx}"))
+        ack = recv_exact(sock, 6)
+        if ack != b"2A" + struct.pack(">I", 1):
+            raise SystemExit(f"unexpected ack before shutdown: {ack.hex()}")
         sockets.append(sock)
         if idx == 1:
             sock.sendall(b"2W" + struct.pack(">I", 1))
@@ -73,15 +101,24 @@ finally:
 PY
 client_pid=$!
 
-for i in {1..50}; do
+i=0
+ready_timeout="${TB_TIMEOUT_STARTSTOP:-600}"
+while [ "$i" -lt "$ready_timeout" ]; do
 	if [ -f "$RSYSLOG_DYNNAME.imbeats.ready" ]; then
 		break
 	fi
+	if ! kill -0 "$client_pid" 2>/dev/null; then
+		wait "$client_pid" || true
+		cat "$RSYSLOG_DYNNAME.imbeats.client-result" 2>/dev/null || true
+		error_exit 1
+	fi
 	$TESTTOOL_DIR/msleep 100
+	i=$((i + 1))
 done
 
 if [ ! -f "$RSYSLOG_DYNNAME.imbeats.ready" ]; then
 	kill "$client_pid" 2>/dev/null || true
+	cat "$RSYSLOG_DYNNAME.imbeats.client-result" 2>/dev/null || true
 	error_exit 1
 fi
 


### PR DESCRIPTION
## Summary

The de-flake campaign repeatedly found `imbeats-shutdown-open-session.sh` failing under broad `-j250` stress. The test was marking clients ready after TCP connect, which did not prove that `imbeats` had accepted and registered the sockets it was supposed to close during shutdown.

This changes the setup so each client first sends a valid Lumberjack batch and waits for the expected ack. That ack is the oracle that the session is owned by `imbeats`; only then does the test leave the sockets open in idle/partial-frame states and start shutdown.

Related: https://github.com/rsyslog/rsyslog/issues/6308

## Validation

- `./tests/imbeats-shutdown-open-session.sh` in dev container: pass, 00:02
- Ubuntu 26.04 full `-j250` stress, ack-only candidate: reproduced imbeats failure, 05:24
- Ubuntu 26.04 full `-j250` stress, final patch: imbeats passed; unrelated `tcp_forwarding_retries.sh` and `imuxsock_unlink_off_stale_socket.sh` failed, 05:12
- Ubuntu 26.04 full `-j250` stress, final patch: imbeats passed; unrelated `imuxsock_unlink_off_stale_socket.sh` failed, 04:46

The unrelated failures were recorded in the flake-campaign repo.
