### PR TITLE
tests: split serialized imfile stress chain

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1745,12 +1745,12 @@ TESTS_IMFILE = \
 	config_enabled-on.sh \
 	config_enabled-off.sh
 
-# These imfile tests all stress dynamic inotify watch changes: creating files
-# after startup, wildcard directory expansion, symlink discovery, renames, and
-# logrotate/truncate handling. Running the whole cluster at very high make
-# parallelism can overload shared inotify delivery and hide the behavior each
-# script is meant to test, so keep the cluster ordered while preserving the
-# individual test coverage and assertions.
+# These imfile tests stress dynamic inotify watch changes. Keep each high-churn
+# subcluster ordered while allowing two independent chains to run in parallel:
+# one for wildcard directory expansion and one for old-state, rename, symlink,
+# and logrotate/truncate handling. This preserves the individual test coverage
+# and assertions without making all imfile inotify stress tests wait behind one
+# long serial chain.
 imfile-freshStartTail2.log: imfile-freshStartTail1.log
 imfile-freshStartTail3.log: imfile-freshStartTail2.log
 imfile-wildcards.log: imfile-freshStartTail3.log
@@ -1762,7 +1762,6 @@ imfile-wildcards-dirs-multi3.log: imfile-wildcards-dirs-multi2.log
 imfile-wildcards-dirs-multi4.log: imfile-wildcards-dirs-multi3.log
 imfile-wildcards-dirs-multi5.log: imfile-wildcards-dirs-multi4.log
 imfile-wildcards-dirs-multi5-polling.log: imfile-wildcards-dirs-multi5.log
-imfile-old-state-file.log: imfile-wildcards-dirs-multi5-polling.log
 imfile-rename-while-stopped.log: imfile-old-state-file.log
 imfile-rename.log: imfile-rename-while-stopped.log
 imfile-symlink.log: imfile-rename.log


### PR DESCRIPTION
## Summary

This is a small CI/test-scheduling PoC for the serialized imfile inotify stress cluster.

The wildcard directory tests and the old-state/rename/symlink/logrotate tests were all chained together through Automake `.log` dependencies. That kept high-churn imfile tests from all running at once, but it also forced later scenarios to wait behind the full wildcard-directory sequence even though they test different behavior.

This PR keeps ordering inside each subcluster but removes the cross-dependency between them:

- wildcard/freshStartTail/directory-expansion tests remain serialized
- old-state, rename, symlink, and logrotate/truncate tests remain serialized
- the two ordered chains may now run in parallel

## Why

CI currently pays for a single long imfile chain. The goal is to reduce wall time without weakening the stability guard that was added during the deflake campaign.

## Validation

On the affected 24-test subset with `-j250`:

- split chain: `24/24` pass, `84.35s`
- original single chain: `24/24` pass, `127.37s`

So the local subset comparison saves about `43s` while preserving all tests and the intra-cluster ordering.

## Notes

This is intended as a live CI PoC. If CI shows that these two chains still overload shared imfile/inotify behavior when run together, we can restore the single dependency. The change is deliberately one line plus comment adjustment so it is easy to revert or tune.
