### PR TITLE
containers: enable libyaml in CentOS and Debian CI

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -482,25 +482,25 @@ jobs:
           'centos_7')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_centos:7'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
-                     --disable-kafka-tests --disable-snmp-tests --disable-libyaml"
+                     --disable-kafka-tests --disable-snmp-tests"
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               ;;
           'centos_8')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_centos:8'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
-                            --disable-snmp-tests --enable-imdtls --enable-omdtls --disable-libyaml"
+                            --disable-snmp-tests --enable-imdtls --enable-omdtls"
               ;;
           'debian_sid')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:sid'
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
-                            --without-valgrind-testbench --enable-imdtls --enable-omdtls --disable-libyaml"
+                            --without-valgrind-testbench --enable-imdtls --enable-omdtls"
               ;;
           'debian_13')
               export RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_debian:13'
               export CI_VALGRIND_SUPPRESSIONS='centos7.supp'
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests --disable-kafka-tests \
-                            --without-valgrind-testbench --enable-imdtls --enable-omdtls --disable-libyaml"
+                            --without-valgrind-testbench --enable-imdtls --enable-omdtls"
               ;;
           'ubuntu_26_imtcp_no_epoll')
               # This check tests if imtcp runs in poll (select) mode. We have only slow CI runners for

--- a/packaging/docker/dev_env/centos/base/7/Dockerfile
+++ b/packaging/docker/dev_env/centos/base/7/Dockerfile
@@ -43,6 +43,7 @@ RUN	yum -y update && \
 	libstdc++ \
 	libtool \
 	libuuid-devel \
+	libyaml-devel \
 	lsof \
 	mysql-devel \
 	nc \
@@ -260,6 +261,7 @@ RUN	cd helper-projects \
 RUN	cd helper-projects && \
 	git clone https://github.com/civetweb/civetweb.git \
 	&& cd civetweb \
+	&& git checkout v1.16 \
 	&& (unset CFLAGS; make -j build ; make install-headers ; make install-slib ) \
 	&& cd .. \
 	&& rm -rf civetweb \

--- a/packaging/docker/dev_env/centos/base/8/Dockerfile
+++ b/packaging/docker/dev_env/centos/base/8/Dockerfile
@@ -45,6 +45,7 @@ RUN	dnf -y install \
 	libstdc++ \
 	libtool \
 	libuuid-devel \
+	libyaml-devel \
 	lsof \
 	make \
 	mysql-devel \
@@ -262,6 +263,7 @@ RUN	cd helper-projects \
 RUN	cd helper-projects && \
 	git clone https://github.com/civetweb/civetweb.git \
 	&& cd civetweb \
+	&& git checkout v1.16 \
 	&& (unset CFLAGS; make -j build ; make install-headers ; make install-slib ) \
 	&& cd .. \
 	&& rm -rf civetweb \

--- a/packaging/docker/dev_env/debian/base/13/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/13/Dockerfile
@@ -46,6 +46,7 @@ RUN 	apt-get update && \
 	libsystemd-dev \
 	libtokyocabinet-dev \
 	libtool \
+	libyaml-dev \
 	libzstd-dev \
 	default-mysql-server \
 	net-tools \

--- a/packaging/docker/dev_env/debian/base/sid/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/sid/Dockerfile
@@ -42,6 +42,7 @@ RUN 	apt-get update && \
 	libsystemd-dev \
 	libtokyocabinet-dev \
 	libtool \
+	libyaml-dev \
 	libzstd-dev \
 	default-mysql-server \
 	net-tools \


### PR DESCRIPTION
## Summary
- install libyaml development packages in CentOS 7/8 and Debian 13/sid dev containers
- pin the CentOS CivetWeb source build to upstream v1.16 so those images rebuild reliably
- remove --disable-libyaml from the CentOS 7/8 and Debian 13/sid run_checks entries

## Container updates
- pushed backup tags: rsyslog_dev_base_centos:7_previous, :8_previous; rsyslog_dev_base_debian:13_previous, :sid_previous
- pushed rebuilt images: rsyslog_dev_base_centos:7, :8; rsyslog_dev_base_debian:13, :sid

## Validation
- docker build for all four updated base images
- pkg-config --modversion yaml-0.1 in all four images
- repo-native configure/build smoke via devtools/run-configure.sh and make -j40 in all four images
- git diff --check
- actionlint .github/workflows/run_checks.yml
- zizmor --strict-collection .github/workflows

This branch was rebased after PR #6928 merged, so the stale Tumbleweed cleanup is included in the base.