### PR TITLE
doc: list RFC5424 reserved template

### DIFF
--- a/doc/source/configuration/templates.rst
+++ b/doc/source/configuration/templates.rst
@@ -247,6 +247,8 @@ For modern JSON pipelines, prefer custom list or subtree templates.
      - High-precision forwarding format
    * - RSYSLOG_SyslogProtocol23Format
      - Format from IETF draft syslog-protocol-23
+   * - RSYSLOG_SyslogRFC5424Format
+     - RFC 5424 syslog format without trailing line feed
    * - RSYSLOG_DebugFormat
      - Troubleshooting format listing all properties
    * - RSYSLOG_WallFmt

--- a/doc/source/reference/templates/templates-reserved-names.rst
+++ b/doc/source/reference/templates/templates-reserved-names.rst
@@ -73,6 +73,15 @@ IETF draft *ietf-syslog-protocol-23*, close to `RFC5424
    template(name="RSYSLOG_SyslogProtocol23Format" type="string"
         string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% %PROCID% %MSGID% %STRUCTURED-DATA% %msg%\n")
 
+**RSYSLOG_SyslogRFC5424Format** – RFC 5424 syslog format without a
+trailing line feed. Use this when the transport or framing layer provides
+message separation.
+
+.. code-block:: none
+
+   template(name="RSYSLOG_SyslogRFC5424Format" type="string"
+        string="<%PRI%>1 %TIMESTAMP:::date-rfc3339% %HOSTNAME% %APP-NAME% %PROCID% %MSGID% %STRUCTURED-DATA% %msg%")
+
 **RSYSLOG_DebugFormat** – used for troubleshooting property problems.
 Write to a log file only; do **not** use for production or forwarding.
 
@@ -182,4 +191,3 @@ pgsql.
 
    template(name="RSYSLOG_StdJSONFmt" type="string"
         string="{\"message\":\"%msg:::json%\",\"fromhost\":\"%HOSTNAME:::json%\",\"facility\":\"%syslogfacility-text%\",\"priority\":\"%syslogpriority-text%\",\"timereported\":\"%timereported:::date-rfc3339%\",\"timegenerated\":\"%timegenerated:::date-rfc3339%\"}")
-


### PR DESCRIPTION
## Summary
- add RSYSLOG_SyslogRFC5424Format to the reserved template overview
- document the template string and no-trailing-LF behavior next to SyslogProtocol23Format
- note that the broken parsing link from the issue no longer exists in current docs

## Validation
- ./doc/tools/build-doc-linux.sh --clean --format html

closes https://github.com/rsyslog/rsyslog/issues/5315