### PR TITLE
doc: clarify omfile legacy action separation

### DIFF
--- a/doc/source/configuration/action/index.rst
+++ b/doc/source/configuration/action/index.rst
@@ -7,6 +7,15 @@ Actions defined via the action() object are **not** affected by the
 legacy statements listed here. Use the action() object properties
 instead.
 
+The separation also applies in the other direction. New-style module defaults
+and action parameters are not a migration layer for legacy selector actions.
+For example, ``module(load="builtin:omfile" fileOwner="..." template="...")``
+is intended to configure RainerScript ``action(type="omfile" ...)`` objects.
+Do not rely on it to make legacy file actions such as ``*.* /var/log/messages``
+or ``*.* ?dynafile`` use the same file ownership, permissions, or template
+settings. Convert those outputs to explicit ``action(type="omfile" ...)``
+objects instead.
+
 Generic action configuration Statements
 ---------------------------------------
 These statements can be used with all types of actions.

--- a/doc/source/configuration/modules/omfile.rst
+++ b/doc/source/configuration/modules/omfile.rst
@@ -38,8 +38,20 @@ specify module parameters, use
 
 
 Note that legacy parameters **do not** affect new-style RainerScript configuration
-objects. See :doc:`basic configuration structure doc <../basic_structure>` to
-learn about different configuration languages in use by rsyslog.
+objects. The reverse direction is also not a supported configuration pattern:
+module-level ``omfile`` parameters are defaults for RainerScript
+``action(type="omfile" ...)`` objects, not a reliable way to configure legacy
+selector actions such as ``*.* /var/log/messages`` or ``*.* ?dynafile``.
+
+For new configurations, keep file output configuration in RainerScript and put
+ownership, permission, template, and destination settings either on the
+``module(load="builtin:omfile" ...)`` default or directly on each
+``action(type="omfile" ...)`` object. Do not mix legacy selector actions with
+RainerScript ``omfile`` module/action parameters when exact ownership,
+permission, or template behavior matters.
+
+See :doc:`basic configuration structure doc <../basic_structure>` to learn
+about different configuration languages in use by rsyslog.
 
 .. note::
 


### PR DESCRIPTION
## Summary
- clarify that modern omfile module defaults are for RainerScript action objects
- warn users not to rely on those defaults for legacy selector file actions
- point new configurations to explicit omfile action objects when ownership, permissions, templates, and destinations matter

## Validation
- git diff --check
- ./doc/tools/build-doc-linux.sh --clean --format html

closes https://github.com/rsyslog/rsyslog/issues/4336