### PR TITLE
omelasticsearch: document error-file modes

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -938,9 +938,11 @@ EXTRA_DIST = \
     source/reference/parameters/omelasticsearch-dynsearchindex.rst \
     source/reference/parameters/omelasticsearch-dynsearchtype.rst \
     source/reference/parameters/omelasticsearch-errorfile.rst \
+    source/reference/parameters/omelasticsearch-erroronly.rst \
     source/reference/parameters/omelasticsearch-esversion-major.rst \
     source/reference/parameters/omelasticsearch-healthchecktimeout.rst \
     source/reference/parameters/omelasticsearch-indextimeout.rst \
+    source/reference/parameters/omelasticsearch-interleaved.rst \
     source/reference/parameters/omelasticsearch-maxbytes.rst \
     source/reference/parameters/omelasticsearch-parent.rst \
     source/reference/parameters/omelasticsearch-pipelinename.rst \

--- a/doc/source/configuration/modules/omelasticsearch.rst
+++ b/doc/source/configuration/modules/omelasticsearch.rst
@@ -153,6 +153,14 @@ Action Parameters
      - .. include:: ../../reference/parameters/omelasticsearch-errorfile.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-erroronly`
+     - .. include:: ../../reference/parameters/omelasticsearch-erroronly.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-omelasticsearch-interleaved`
+     - .. include:: ../../reference/parameters/omelasticsearch-interleaved.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-omelasticsearch-tls-cacert`
      - .. include:: ../../reference/parameters/omelasticsearch-tls-cacert.rst
         :start-after: .. summary-start
@@ -238,6 +246,8 @@ Action Parameters
    ../../reference/parameters/omelasticsearch-pwd
    ../../reference/parameters/omelasticsearch-apikey
    ../../reference/parameters/omelasticsearch-errorfile
+   ../../reference/parameters/omelasticsearch-erroronly
+   ../../reference/parameters/omelasticsearch-interleaved
    ../../reference/parameters/omelasticsearch-tls-cacert
    ../../reference/parameters/omelasticsearch-tls-mycert
    ../../reference/parameters/omelasticsearch-tls-myprivkey

--- a/doc/source/reference/parameters/omelasticsearch-erroronly.rst
+++ b/doc/source/reference/parameters/omelasticsearch-erroronly.rst
@@ -1,0 +1,48 @@
+.. _param-omelasticsearch-erroronly:
+.. _omelasticsearch.parameter.module.erroronly:
+
+errorOnly
+=========
+
+.. index::
+   single: omelasticsearch; errorOnly
+   single: errorOnly
+
+.. summary-start
+
+Limit bulk error-file output to failed records.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: errorOnly
+:Scope: action
+:Type: boolean
+:Default: off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When enabled, omelasticsearch writes only records that Elasticsearch reported
+as failed to the configured :ref:`param-omelasticsearch-errorfile`.
+
+This option affects the format of the error file in bulk mode. Without it,
+the error file includes the full bulk request and response context for a
+failed bulk operation. With ``errorOnly="on"``, entries that succeeded inside
+the same bulk response are omitted from the error-file payload.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-erroronly:
+.. _omelasticsearch.parameter.action.erroronly:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" errorFile="..." errorOnly="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`,
+:ref:`param-omelasticsearch-errorfile`, and
+:ref:`param-omelasticsearch-interleaved`.

--- a/doc/source/reference/parameters/omelasticsearch-interleaved.rst
+++ b/doc/source/reference/parameters/omelasticsearch-interleaved.rst
@@ -1,0 +1,50 @@
+.. _param-omelasticsearch-interleaved:
+.. _omelasticsearch.parameter.module.interleaved:
+
+interleaved
+===========
+
+.. index::
+   single: omelasticsearch; interleaved
+   single: interleaved
+
+.. summary-start
+
+Interleave request and response data in bulk error-file output.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/omelasticsearch`.
+
+:Name: interleaved
+:Scope: action
+:Type: boolean
+:Default: off
+:Required?: no
+:Introduced: at least 8.x, possibly earlier
+
+Description
+-----------
+When enabled, omelasticsearch stores request and response data together for
+each item written to the configured
+:ref:`param-omelasticsearch-errorfile`. This makes it easier to correlate a
+bulk request item with the Elasticsearch item response that caused the error
+file entry.
+
+The option can be combined with :ref:`param-omelasticsearch-erroronly` to
+write only failed bulk items while still keeping each failed request next to
+its response.
+
+Action usage
+------------
+.. _param-omelasticsearch-action-interleaved:
+.. _omelasticsearch.parameter.action.interleaved:
+.. code-block:: rsyslog
+
+   action(type="omelasticsearch" errorFile="..." interleaved="on")
+
+See also
+--------
+See also :doc:`../../configuration/modules/omelasticsearch`,
+:ref:`param-omelasticsearch-errorfile`, and
+:ref:`param-omelasticsearch-erroronly`.

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -1809,11 +1809,6 @@ static rsRetVal ATTR_NONNULL() writeDataError(wrkrInstanceData_t *const pWrkrDat
                 DBGPRINTF("omelasticsearch: error initializing error interleaved context.\n");
                 ABORT_FINALIZE(RS_RET_ERR);
             }
-        } else if (pData->retryFailures) {
-            if (initializeRetryFailuresContext(pWrkrData, &ctx) != RS_RET_OK) {
-                DBGPRINTF("omelasticsearch: error initializing retry failures context.\n");
-                ABORT_FINALIZE(RS_RET_ERR);
-            }
         } else {
             DBGPRINTF("omelasticsearch: None of the modes match file write. No data to write.\n");
             ABORT_FINALIZE(RS_RET_ERR);


### PR DESCRIPTION
Summary:
- document the omelasticsearch errorOnly and interleaved action parameters
- register the new parameter pages for distribution
- remove an unreachable retryFailures branch from writeDataError(), where retryFailures is already handled by checkResultBulkmode()

Validation:
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-elasticsearch
- make -j$(nproc) check TESTS=""
- ./doc/tools/build-doc-linux.sh --clean --format html
- PATH=/home/rger/rsyslog-issue-3631-omelasticsearch/doc/.venv-docs/bin:$PATH bash .agent/skills/rsyslog_doc_dist/scripts/check-doc-dist.sh
- git diff --check

Closes: https://github.com/rsyslog/rsyslog/issues/3631
