### PR TITLE
build: honor cross pkg-config for libgcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1443,38 +1443,23 @@ AC_ARG_ENABLE(libgcrypt,
         [enable_libgcrypt=yes]
 )
 if test "x$enable_libgcrypt" = "xyes"; then
-        # Check for the modern pkg-config method first
-        AC_CHECK_PROG([HAVE_PKG_CONFIG], [pkg-config], [yes], [no])
-        if test "x${HAVE_PKG_CONFIG}" = "xno"; then
-                # Fallback to the outdated libgcrypt-config approach
-                AC_PATH_PROG([LIBGCRYPT_CONFIG],[libgcrypt-config],[no])
-                if test "x${LIBGCRYPT_CONFIG}" = "xno"; then
-                        AC_MSG_FAILURE([libgcrypt-config not found in PATH and pkg-config is not available. libgcrypt is missing.])
-                fi
-                AC_CHECK_LIB(
-                        [gcrypt],
-                        [gcry_cipher_open],
-                        [LIBGCRYPT_CFLAGS="`${LIBGCRYPT_CONFIG} --cflags`"
-                        LIBGCRYPT_LIBS="`${LIBGCRYPT_CONFIG} --libs`"
-                        ],
-                        [AC_MSG_FAILURE([libgcrypt is missing])],
-                        [`${LIBGCRYPT_CONFIG} --libs --cflags`]
-                )
-        else
-                # Use the preferred pkg-config approach
-                AC_CHECK_LIB(
-                        [gcrypt],
-                        [gcry_cipher_open],
-                        [LIBGCRYPT_CFLAGS="`pkg-config --cflags libgcrypt gpg-error`"
-                        LIBGCRYPT_LIBS="`pkg-config --libs libgcrypt gpg-error`"
-                        ],
-                        [AC_MSG_FAILURE([libgcrypt is missing])],
-                        [`pkg-config --libs --cflags libgcrypt gpg-error`]
-                )
-		if test "x${LIBGCRYPT_CFLAGS}" = "x" && test "x${LIBGCRYPT_LIBS}" = "x";then
-			AC_PATH_PROG([LIBGCRYPT_CONFIG],[libgcrypt-config],[no])
+        PKG_CHECK_MODULES(
+                [LIBGCRYPT],
+                [libgcrypt gpg-error],
+                [
+                        AC_CHECK_LIB(
+                                [gcrypt],
+                                [gcry_cipher_open],
+                                [],
+                                [AC_MSG_FAILURE([libgcrypt is missing])],
+                                [${LIBGCRYPT_LIBS}]
+                        )
+                ],
+                [
+                        # Fallback to the outdated libgcrypt-config approach
+                        AC_PATH_PROG([LIBGCRYPT_CONFIG],[libgcrypt-config],[no])
                         if test "x${LIBGCRYPT_CONFIG}" = "xno"; then
-                                AC_MSG_FAILURE([libgcrypt-config not found in PATH and pkgconfig file of libgcrypt is not available. libgcrypt is missing.])
+                                AC_MSG_FAILURE([libgcrypt-config not found in PATH and pkg-config is unavailable or could not find libgcrypt/gpg-error. libgcrypt is missing.])
                         fi
                         AC_CHECK_LIB(
                                 [gcrypt],
@@ -1485,8 +1470,8 @@ if test "x$enable_libgcrypt" = "xyes"; then
                                 [AC_MSG_FAILURE([libgcrypt is missing])],
                                 [`${LIBGCRYPT_CONFIG} --libs --cflags`]
                         )
-		fi
-        fi
+                ]
+        )
         AC_DEFINE([ENABLE_LIBGCRYPT], [1], [Indicator that LIBGCRYPT is present])
 fi
 AM_CONDITIONAL(ENABLE_LIBGCRYPT, test x$enable_libgcrypt = xyes)


### PR DESCRIPTION
Summary: make the libgcrypt configure check use the Autoconf-selected pkg-config tool while keeping the libgcrypt-config fallback. Validation: autogen, targeted prefixed-PKG_CONFIG configure check, and make check TESTS empty. closes https://github.com/rsyslog/rsyslog/issues/6683