### PR TITLE
doc: clarify omfile timed flush behavior

### DIFF
--- a/doc/source/configuration/action/index.rst
+++ b/doc/source/configuration/action/index.rst
@@ -88,10 +88,10 @@ These statements are specific to omfile-based actions.
 -  **$OMFileAsyncWriting** [on/**off**], if turned on, the files will be
    written in asynchronous mode via a separate thread. In that case,
    double buffers will be used so that one buffer can be filled while
-   the other buffer is being written. Note that in order to enable
-   $OMFileFlushInterval, $OMFileAsyncWriting must be set to "on".
-   Otherwise, the flush interval will be ignored. Also note that when
-   $OMFileFlushOnTXEnd is "on" but $OMFileAsyncWriting is off, output
+   the other buffer is being written. In order to use
+   $OMFileFlushInterval, $OMFileAsyncWriting must be set to "on";
+   otherwise the flush interval is not applied. Also note that when
+   $OMFileFlushOnTXEnd is "off" but $OMFileAsyncWriting is "off", output
    will only be written when the buffer is full. This may take several
    hours, or even require a rsyslog shutdown. However, a buffer flush
    can be forced in that case by sending rsyslogd a HUP signal.

--- a/doc/source/reference/parameters/omfile-asyncwriting.rst
+++ b/doc/source/reference/parameters/omfile-asyncwriting.rst
@@ -30,8 +30,11 @@ Description
 If turned on, the files will be written in asynchronous mode via a
 separate thread. In that case, double buffers will be used so that
 one buffer can be filled while the other buffer is being written.
-Note that in order to enable FlushInterval, AsyncWriting must be set
-to "on". Otherwise, the flush interval will be ignored.
+
+The :ref:`param-omfile-flushinterval` setting is applied when
+``asyncWriting`` is enabled for the action. Set ``asyncWriting="on"`` when
+using ``flushInterval`` to bound how long buffered data may remain
+unflushed.
 
 Action usage
 ------------
@@ -40,7 +43,17 @@ Action usage
 .. _omfile.parameter.action.asyncwriting:
 .. code-block:: rsyslog
 
-   action(type="omfile" asyncWriting="...")
+   action(type="omfile" file="/var/log/app.log" asyncWriting="on")
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   actions:
+     - type: omfile
+       file: /var/log/app.log
+       asyncWriting: "on"
 
 Notes
 -----

--- a/doc/source/reference/parameters/omfile-flushinterval.rst
+++ b/doc/source/reference/parameters/omfile-flushinterval.rst
@@ -30,6 +30,12 @@ Description
 Defines, in seconds, the interval after which unwritten data is
 flushed.
 
+This parameter is applied when :ref:`param-omfile-asyncwriting` is enabled
+for the action. Use ``flushInterval`` together with ``asyncWriting="on"``
+when :ref:`param-omfile-flushontxend` is disabled, for example to keep gzip
+compression effective while still bounding how long buffered data may remain
+unflushed.
+
 Action usage
 ------------
 
@@ -37,7 +43,20 @@ Action usage
 .. _omfile.parameter.action.flushinterval:
 .. code-block:: rsyslog
 
-   action(type="omfile" flushInterval="...")
+   action(type="omfile" file="/var/log/app.log"
+          asyncWriting="on" flushOnTXEnd="off" flushInterval=1)
+
+YAML usage
+----------
+
+.. code-block:: yaml
+
+   actions:
+     - type: omfile
+       file: /var/log/app.log
+       asyncWriting: "on"
+       flushOnTXEnd: "off"
+       flushInterval: 1
 
 Legacy names (for reference)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/reference/parameters/omfile-flushontxend.rst
+++ b/doc/source/reference/parameters/omfile-flushontxend.rst
@@ -37,6 +37,9 @@ to "on". Then, data is written at the end of each transaction
 recovery thus can handle write errors without data loss.
 Note that this option severely reduces the effect of zip compression
 and should be switched to "off" for that use case.
+If ``flushOnTXEnd`` is disabled, use
+:ref:`param-omfile-flushinterval` to configure timed flushing of buffered
+data.
 Also note that the default -on- is primarily an aid to preserve the
 traditional syslogd behaviour.
 


### PR DESCRIPTION
Summary:
- clarify that omfile `flushInterval` is the timed flush mechanism for buffered data
- document that a nonzero `flushInterval` enables async stream writing internally
- point `flushOnTXEnd="off"` compressed-output users toward `flushInterval`
- update the legacy action overview to remove stale async-writing guidance

Validation:
- `git diff --check`
- `./doc/tools/build-doc-linux.sh --clean --format html`

Closes: https://github.com/rsyslog/rsyslog/issues/5452
