### PR TITLE
agents: require available container validation

### DIFF
--- a/.agent/skills/rsyslog_local_container_testing/SKILL.md
+++ b/.agent/skills/rsyslog_local_container_testing/SKILL.md
@@ -5,9 +5,12 @@ description: Mirror rsyslog run_checks.yml container validation locally, includi
 
 # rsyslog_local_container_testing
 
-Use this skill when validating rsyslog changes through local dev containers.
-Local container validation should mirror the relevant GitHub Actions container
-jobs instead of inventing a parallel local-only flow.
+Use this skill when validating rsyslog implementation changes through local dev
+containers, and treat it as the final pre-finish gate when Docker, Podman, or
+equivalent container tooling is available. Local container validation should
+mirror the relevant GitHub Actions container jobs instead of inventing a
+parallel local-only flow. If container tooling is unavailable, report that
+limitation explicitly rather than silently substituting a weaker gate.
 
 ## When To Use
 
@@ -23,7 +26,8 @@ pushing if the change is intended for review.
 
 ## Preferred Order
 
-Run two container validations for broad local confidence. Mirror these
+For the full final gate, run two container validations for broad local
+confidence. Mirror these
 `.github/workflows/run_checks.yml` paths:
 
 1. The `clang static analyzer` job's container command.
@@ -102,6 +106,8 @@ change set, MySQL, libdbi, and Kafka should appear in the test list but skip via
 local container users rely on.
 
 For a faster build-only smoke check, set `CI_MAKE_CHECK_OPT='-j80 TESTS='`.
+This is useful for intermediate feedback, but it does not satisfy the full
+final validation gate.
 
 ## Service Relevance
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,12 +27,16 @@ To ensure consistency and high-quality contributions, AI agents SHOULD use the f
 
 ## Agent Quick Start: The "Happy Path"
 
-Follow these three steps for a typical development task:
+Follow these steps for a typical development task:
 
 1.  **Build**: Use the `rsyslog_build` skill to set up and compile.
 2.  **Validate**: Use the `rsyslog_test` skill to run relevant shell tests.
-3.  **Commit**: Use the `rsyslog_commit` skill to format code and draft your message.
-    - *Tip*: You do NOT need to re-run your build/test cycle after formatting if you already validated the code immediately before.
+3.  **Container Validation**: Use the `rsyslog_local_container_testing` skill
+    when Docker or Podman container tooling is available.
+4.  **Commit**: Use the `rsyslog_commit` skill to format code and draft your message.
+
+Tip: You do NOT need to re-run your build, test, or container validation cycle
+after formatting if you already validated the code immediately before.
 
 ## Repository Overview
 
@@ -66,6 +70,24 @@ Follow these three steps for a typical development task:
   `daily-stable`.
 - AI agents must not introduce release-looking fallback tags such as
   `2026-03` as the default local container build version.
+
+## Required Final Validation Gate
+
+For implementation tasks, AI agents MUST treat full local container validation
+as the final validation gate when container tooling is available.
+
+- If Docker or Podman is available and usable, run the
+  [`rsyslog_local_container_testing`](.agent/skills/rsyslog_local_container_testing/SKILL.md)
+  skill's full local validation before reporting the task complete.
+- If Docker or Podman is not installed, not running, lacks required
+  permissions, or the required image cannot be obtained, state that exact
+  blocker in the final response.
+- If full local container validation is skipped or blocked, list the targeted
+  validation that was run instead and explicitly mark the work as **not fully
+  container-validated**.
+- Do not describe implementation work as fully validated or complete unless
+  full local container validation passed, or the user explicitly accepted the
+  reduced validation scope after the blocker was reported.
 
 ## Context Discovery (Subtree Guides)
 


### PR DESCRIPTION
## Summary
- add full local container validation as the required final gate for implementation tasks when Docker/Podman is usable
- require explicit blocker reporting when container tooling, permissions, or images are unavailable
- clarify in the container-testing skill that build-only smoke checks are intermediate and do not satisfy the final gate

## Validation
- `git diff --check`

## Notes
This is a process-only documentation change. No code or tests were modified.
