### PR TITLE
doc: remove unavailable StdJSONFmt reference

### DIFF
--- a/doc/source/configuration/templates.rst
+++ b/doc/source/configuration/templates.rst
@@ -261,8 +261,6 @@ For modern JSON pipelines, prefer custom list or subtree templates.
      - Insert command for PostgreSQL
    * - RSYSLOG_spoofadr
      - Sender IP address only
-   * - RSYSLOG_StdJSONFmt
-     - JSON structure of message properties
 
 
 Legacy ``$template`` statement

--- a/doc/source/reference/templates/templates-reserved-names.rst
+++ b/doc/source/reference/templates/templates-reserved-names.rst
@@ -184,10 +184,3 @@ pgsql.
 .. code-block:: none
 
    template(name="RSYSLOG_spoofadr" type="string" string="%fromhost-ip%")
-
-**RSYSLOG_StdJSONFmt** – JSON structure containing message properties.
-
-.. code-block:: none
-
-   template(name="RSYSLOG_StdJSONFmt" type="string"
-        string="{\"message\":\"%msg:::json%\",\"fromhost\":\"%HOSTNAME:::json%\",\"facility\":\"%syslogfacility-text%\",\"priority\":\"%syslogpriority-text%\",\"timereported\":\"%timereported:::date-rfc3339%\",\"timegenerated\":\"%timegenerated:::date-rfc3339%\"}")


### PR DESCRIPTION
## Summary
- remove RSYSLOG_StdJSONFmt from the public reserved-template overview
- remove its reserved-template reference entry so the docs no longer advertise that name

## Validation
- git diff --check
- ./doc/tools/build-doc-linux.sh --clean --format html

Closes: https://github.com/rsyslog/rsyslog/issues/5125

With the help of AI-Agents: Codex
