### PR TITLE
ci: archive Ubuntu 26 failure evidence

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -649,6 +649,32 @@ jobs:
           esac
           devtools/devcontainer.sh --rm devtools/run-ci.sh
 
+      # Failure artifacts are an opt-in transport for flake evidence.  They are
+      # uploaded only for failed Ubuntu 26.04 attempts, including the SAN lane,
+      # and include the run attempt plus matrix lane in the name so reruns
+      # cannot overwrite a previous failed attempt.  Cancelled attempts are not
+      # uploaded because push-cancelled runs usually do not contain useful flake
+      # evidence.  The long-term record belongs in the external flake-campaign
+      # evidence store; these artifacts are intentionally short lived and may be
+      # deleted by the collector after successful processing.
+      - name: Upload Ubuntu 26.04 failure evidence
+        if: >-
+          ${{ failure()
+              && vars.RSYSLOG_UPLOAD_FAILURE_ARTIFACTS == '1'
+              && startsWith(matrix.config, 'ubuntu_26_') }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ci-failure-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.config }}
+          path: |
+            failed-tests.log
+            tests/failed-tests.log
+            tests/test-suite.log
+            tests/*.log
+            tests/*.trs
+            config.log
+          retention-days: 7
+          if-no-files-found: ignore
+
       - name: Skip CI, no relevant changes
         if: steps.code_changes.outputs.any_changed != 'true'
         run: echo "No relevant changes detected; skipping container CI."

--- a/doc/source/development/internal_tooling.rst
+++ b/doc/source/development/internal_tooling.rst
@@ -17,3 +17,25 @@ the limit.  The default is 100.
 The checker reports trailing whitespace, invalid indentation and lines
 that exceed the allowed length.  It exits with a non-zero status when
 violations are found.
+
+CI failure evidence artifacts
+-----------------------------
+
+The pull request check workflow can optionally upload short-lived artifacts for
+failed Ubuntu 26.04 CI attempts.  This is controlled by the repository variable
+``RSYSLOG_UPLOAD_FAILURE_ARTIFACTS``.  Set it to ``1`` to enable uploads; leave
+it unset or set to any other value to keep the default no-upload behavior.
+
+The upload step runs only for failed Ubuntu 26.04 matrix attempts, including
+the sanitizer lane.  Cancelled attempts are intentionally ignored because PR
+pushes often cancel in-flight runs before they produce useful flake evidence.
+Artifact names include the workflow run id, run attempt, and matrix lane.  This
+is intentional: a rerun must not overwrite or hide evidence from an earlier
+failed attempt.  Successful reruns therefore do not remove the previous failed
+attempt artifact.
+
+These artifacts are a transport mechanism, not the permanent flake database.
+Collectors should download the artifact, condense the logs into the shared
+flake evidence store, and may delete the GitHub artifact after the condensed
+record has been committed and pushed.  The workflow keeps a short retention
+period so missed collector passes do not accumulate long-term storage.


### PR DESCRIPTION
## Why

Failed CI attempts can disappear from normal review once a job is rerun. That makes flake evidence harder to preserve and consolidate across agents.

## What changed

- Add an opt-in failure artifact upload step for the `ubuntu_26_*` check matrix lanes.
- Gate uploads on `RSYSLOG_UPLOAD_FAILURE_ARTIFACTS == '1'` so normal runs do not store artifacts.
- Include `run_id`, `run_attempt`, and the matrix lane in artifact names so reruns cannot overwrite earlier failed-attempt evidence.
- Document the repository variable and intended collector flow in the developer docs.

## Validation

- `actionlint .github/workflows/run_checks.yml`
- `.zizmor-venv/bin/zizmor --strict-collection .github/workflows`
- `git diff --check`