### PR TITLE
runtime: avoid libgcry IV shift UB

### DIFF
--- a/runtime/libgcry.c
+++ b/runtime/libgcry.c
@@ -509,24 +509,17 @@ finalize_it:
 /* We use random numbers to initiate the IV. Rsyslog runtime will ensure
  * we get a sufficiently large number.
  */
-#if defined(__clang__)
-    #pragma GCC diagnostic ignored "-Wunknown-attributes"
-#endif
-static rsRetVal
-#if defined(__clang__)
-    __attribute__((no_sanitize("shift"))) /* IV shift causes known overflow */
-#endif
-    seedIV(gcryfile gf, uchar **iv) {
-    long rndnum = 0; /* keep compiler happy -- this value is always overriden */
+static rsRetVal seedIV(gcryfile gf, uchar **iv) {
+    unsigned long rndnum = 0; /* keep compiler happy -- this value is always overriden */
     DEFiRet;
 
     CHKmalloc(*iv = calloc(1, gf->blkLength));
     for (size_t i = 0; i < gf->blkLength; ++i) {
         const int shift = (i % 4) * 8;
         if (shift == 0) { /* need new random data? */
-            rndnum = randomNumber();
+            rndnum = (unsigned long)randomNumber();
         }
-        (*iv)[i] = 0xff & ((rndnum & (255u << shift)) >> shift);
+        (*iv)[i] = (uchar)((rndnum >> shift) & 0xffu);
     }
 finalize_it:
     RETiRet;


### PR DESCRIPTION
Summary: avoid left-shift mask construction while generating libgcry IV bytes, and remove the obsolete clang shift sanitizer suppression. Validation: UBSan autogen/build plus affected queue encryption tests, git diff --check, local Ubuntu 26.04 static analyzer container, and local Ubuntu 26.04 run-ci container passed. closes https://github.com/rsyslog/rsyslog/issues/5167