### PR TITLE
grammar: read pseudo-files in backtick cat

### DIFF
--- a/grammar/lexer.l
+++ b/grammar/lexer.l
@@ -50,6 +50,8 @@
 %{
 #include <libestr.h>
 #include <ctype.h>
+#include <errno.h>
+#include <stdint.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -71,6 +73,8 @@ read_file(const char *const filename)
 	int fd = -1;
 	struct stat sb;
 	ssize_t nread;
+	size_t cap;
+	size_t len = 0;
 	assert(filename != NULL);
 
 	if((fd = open((const char*) filename, O_RDONLY)) == -1) {
@@ -81,18 +85,54 @@ read_file(const char *const filename)
 		goto done;
 	}
 
-	content = malloc(sb.st_size+1);
+	if(!S_ISREG(sb.st_mode)) {
+		goto done;
+	}
+
+	if(sb.st_size < 0) {
+		goto done;
+	}
+
+	if(sb.st_size > 0 && (uintmax_t) sb.st_size > SIZE_MAX - 1) {
+		goto done;
+	}
+	cap = (sb.st_size > 0) ? (size_t) sb.st_size : 4096;
+	content = malloc(cap+1);
 	if(content == NULL) {
 		goto done;
 	}
 
-	nread = read(fd, content, sb.st_size);
-	content[nread] = '\0';
-	if(nread != (ssize_t) sb.st_size) {
-		free(content);
-		content = NULL;
-		goto done;
+	while(1) {
+		if(len == cap) {
+			if(cap > (SIZE_MAX - 1) / 2) {
+				free(content);
+				content = NULL;
+				goto done;
+			}
+			char *const new_content = realloc(content, cap * 2 + 1);
+			if(new_content == NULL) {
+				free(content);
+				content = NULL;
+				goto done;
+			}
+			content = new_content;
+			cap *= 2;
+		}
+		nread = read(fd, content + len, cap - len);
+		if(nread == -1) {
+			if(errno == EINTR) {
+				continue;
+			}
+			free(content);
+			content = NULL;
+			goto done;
+		}
+		if(nread == 0) {
+			break;
+		}
+		len += (size_t) nread;
 	}
+	content[len] = '\0';
 
 done:
 	if(fd != -1) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -77,6 +77,7 @@ TESTS_ELASTICSEARCH_VALGRIND = \
 	es-basic-ha-vg.sh
 
 TESTS_DEFAULT = \
+	backtick-cat-procfs.sh \
 	preservefqdn-localhostname-internal.sh \
 	immark.sh \
 	immark-inputname.sh \

--- a/tests/backtick-cat-procfs.sh
+++ b/tests/backtick-cat-procfs.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Regression test for backtick cat expansion from regular pseudo-files such
+# as /proc. The positive oracle is config validation success: /proc/self/comm
+# commonly reports st_size 0, so failure means read_file still treats
+# pseudo-file size metadata as the exact number of readable bytes. The negative
+# oracle rejects special files such as /dev/zero quickly, proving the fallback
+# EOF read path cannot hang or grow without bound on non-regular inputs. Failed
+# reads are reported as parser errors and config validation fails in expression
+# context.
+. ${srcdir:=.}/diag.sh init
+
+if [ ! -r /proc/self/comm ]; then
+    echo "SKIP: /proc/self/comm is not readable"
+    exit 77
+fi
+
+generate_conf
+add_conf '
+if `cat /proc/self/comm` != "" then
+    stop
+'
+
+../tools/rsyslogd -C -N1 -M"${RSYSLOG_MODDIR}" -f"${TESTCONF_NM}.conf" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -ne 0 ]; then
+    echo "FAIL: expected config validation with /proc backtick cat to succeed"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+if grep -F 'file could not be accessed' "${RSYSLOG_DYNNAME}.log" >/dev/null; then
+    echo "FAIL: /proc backtick cat reported a file access error"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+if [ -r /dev/zero ]; then
+	generate_conf 2
+	add_conf '
+if `cat /dev/zero` == "" then
+    stop
+' 2
+
+	timeout 5s ../tools/rsyslogd -C -N1 -M"${RSYSLOG_MODDIR}" \
+		-f"${TESTCONF_NM}2.conf" >"${RSYSLOG_DYNNAME}.devzero.log" 2>&1
+	ret=$?
+	if [ $ret -eq 124 ]; then
+		echo "FAIL: /dev/zero backtick cat validation timed out"
+		cat "${RSYSLOG_DYNNAME}.devzero.log"
+		error_exit 1
+	fi
+	if [ $ret -eq 0 ]; then
+		echo "FAIL: expected config validation with /dev/zero backtick cat to fail"
+		cat "${RSYSLOG_DYNNAME}.devzero.log"
+		error_exit 1
+	fi
+	if ! grep -F 'file could not be accessed' "${RSYSLOG_DYNNAME}.devzero.log" >/dev/null; then
+		echo "FAIL: /dev/zero backtick cat did not report a file access error"
+		cat "${RSYSLOG_DYNNAME}.devzero.log"
+		error_exit 1
+	fi
+fi
+exit_test


### PR DESCRIPTION
## Summary
- read backtick cat files until EOF instead of requiring bytes read to equal st_size
- keep open/fstat/allocation/read failures as file access errors
- add a /proc/self/comm regression test for pseudo-files with size metadata that does not match readable bytes

## Validation
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout
- make -j28 check TESTS=''
- ./tests/backtick-cat-procfs.sh
- make distcheck TEST_RUN_TYPE=MOCK-OK -j28
- git diff --cached --check
- devcontainer clang static analyzer: No bugs found
- devcontainer Ubuntu 26.04 run-ci.sh check: 1246 total, 1154 pass, 92 skip, 0 fail, 0 error, real 246.70s

closes https://github.com/rsyslog/rsyslog/issues/5403