### PR TITLE
ci: archive failures from all CI lanes

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -34,6 +34,7 @@ on:
 env:
   RSYSLOG_TESTBENCH_BASE_SHA: ${{ github.event.pull_request.base.sha }}
   RSYSLOG_TESTBENCH_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+  RSYSLOG_UPLOAD_FAILURE_ARTIFACTS: '1'
 
 jobs:
   changes:
@@ -650,18 +651,29 @@ jobs:
           devtools/devcontainer.sh --rm devtools/run-ci.sh
 
       # Failure artifacts are an opt-in transport for flake evidence.  They are
-      # uploaded only for failed Ubuntu 26.04 attempts, including the SAN lane,
-      # and include the run attempt plus matrix lane in the name so reruns
-      # cannot overwrite a previous failed attempt.  Cancelled attempts are not
-      # uploaded because push-cancelled runs usually do not contain useful flake
-      # evidence.  The long-term record belongs in the external flake-campaign
-      # evidence store; these artifacts are intentionally short lived and may be
-      # deleted by the collector after successful processing.
-      - name: Upload Ubuntu 26.04 failure evidence
+      # uploaded only for failed CI matrix attempts and include the run attempt
+      # plus matrix lane in the name so reruns cannot overwrite a previous
+      # failed attempt.  Cancelled attempts are not uploaded because
+      # push-cancelled runs usually do not contain useful flake evidence.  The
+      # long-term record belongs in the external flake-campaign evidence store;
+      # these artifacts are intentionally short lived and may be deleted by the
+      # collector after successful processing.  Some logs are created by the
+      # container user, so normalize read permissions before upload.
+      - name: Prepare CI failure evidence
         if: >-
           ${{ failure()
-              && vars.RSYSLOG_UPLOAD_FAILURE_ARTIFACTS == '1'
-              && startsWith(matrix.config, 'ubuntu_26_') }}
+              && env.RSYSLOG_UPLOAD_FAILURE_ARTIFACTS == '1' }}
+        run: |
+          for path in failed-tests.log tests config.log; do
+            if [ -e "$path" ]; then
+              sudo chmod -R a+rX "$path" || true
+            fi
+          done
+
+      - name: Upload CI failure evidence
+        if: >-
+          ${{ failure()
+              && env.RSYSLOG_UPLOAD_FAILURE_ARTIFACTS == '1' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ci-failure-${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.config }}

--- a/doc/source/development/internal_tooling.rst
+++ b/doc/source/development/internal_tooling.rst
@@ -21,18 +21,21 @@ violations are found.
 CI failure evidence artifacts
 -----------------------------
 
-The pull request check workflow can optionally upload short-lived artifacts for
-failed Ubuntu 26.04 CI attempts.  This is controlled by the repository variable
+The pull request check workflow can upload short-lived artifacts for failed CI
+matrix attempts.  This is controlled by the workflow environment variable
 ``RSYSLOG_UPLOAD_FAILURE_ARTIFACTS``.  Set it to ``1`` to enable uploads; leave
-it unset or set to any other value to keep the default no-upload behavior.
+it unset or set to any other value to disable uploads for that workflow.
 
-The upload step runs only for failed Ubuntu 26.04 matrix attempts, including
-the sanitizer lane.  Cancelled attempts are intentionally ignored because PR
-pushes often cancel in-flight runs before they produce useful flake evidence.
-Artifact names include the workflow run id, run attempt, and matrix lane.  This
-is intentional: a rerun must not overwrite or hide evidence from an earlier
-failed attempt.  Successful reruns therefore do not remove the previous failed
-attempt artifact.
+The upload step runs only for failed matrix attempts.  Cancelled attempts are
+intentionally ignored because PR pushes often cancel in-flight runs before they
+produce useful flake evidence.  Artifact names include the workflow run id, run
+attempt, and matrix lane.  This is intentional: a rerun must not overwrite or
+hide evidence from an earlier failed attempt.  Successful reruns therefore do
+not remove the previous failed attempt artifact.
+
+Before upload, the workflow normalizes read permissions on the expected log
+paths.  Container CI can leave some files owned by the container user, and the
+artifact action must be able to read every file matched by the upload globs.
 
 These artifacts are a transport mechanism, not the permanent flake database.
 Collectors should download the artifact, condense the logs into the shared


### PR DESCRIPTION
## Why

Failed-attempt evidence can disappear after reruns outside the Ubuntu 26.04 lanes too. The artifact mechanism should preserve useful failures wherever the shared CI matrix fails.

## What changed

- Broaden the opt-in `ci-failure-*` artifact upload from `ubuntu_26_*` to all failed CI matrix lanes.
- Keep the repository-variable gate `RSYSLOG_UPLOAD_FAILURE_ARTIFACTS == '1'`.
- Keep cancelled attempts ignored, because push-cancelled runs usually do not contain useful flake evidence.
- Update developer documentation to describe the broader matrix scope.

## Validation

- `actionlint .github/workflows/run_checks.yml`
- `.zizmor-venv/bin/zizmor --strict-collection .github/workflows`
- `git diff --check`