### PR TITLE
imptcp: discard oversize byte after truncation

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -1154,6 +1154,8 @@ static rsRetVal ATTR_NONNULL(1, 2) processDataRcvd(ptcpsess_t *const __restrict_
         assert(pThis->inputState == eInMsg);
         if (pThis->eFraming == TCP_FRAMING_OCTET_STUFFING) {
             int iMsg = pThis->iMsg; /* cache value for faster access */
+            const sbool isFrameDelim = (c == '\n') || ((pThis->iAddtlFrameDelim != TCPSRV_NO_ADDTL_DELIMITER) &&
+                                                       (c == pThis->iAddtlFrameDelim));
             if (iMsg >= iMaxLine) {
                 /* emergency, we now need to flush, no matter if we are at end of message or not... */
                 int i = 1;
@@ -1172,7 +1174,9 @@ static rsRetVal ATTR_NONNULL(1, 2) processDataRcvd(ptcpsess_t *const __restrict_
                 iMsg = 0;
                 ++(*pnMsgs);
                 if (pThis->pLstn->pSrv->discardTruncatedMsg == 1) {
-                    pThis->inputState = eInMsgTruncation;
+                    pThis->inputState = isFrameDelim ? eAtStrtFram : eInMsgTruncation;
+                    pThis->iMsg = iMsg;
+                    FINALIZE;
                 }
                 /* we might think if it is better to ignore the rest of the
                  * message than to treat it as a new one. Maybe this is a good
@@ -1180,8 +1184,7 @@ static rsRetVal ATTR_NONNULL(1, 2) processDataRcvd(ptcpsess_t *const __restrict_
                  * rgerhards, 2006-12-04
                  */
             }
-            if ((c == '\n') || ((pThis->iAddtlFrameDelim != TCPSRV_NO_ADDTL_DELIMITER) &&
-                                (c == pThis->iAddtlFrameDelim))) { /* record delimiter? */
+            if (isFrameDelim) { /* record delimiter? */
                 if (pThis->pLstn->pSrv->multiLine) {
                     if ((buffLen == 1) || ((*buff)[1] == '<')) {
                         doSubmitMsg(pThis, stTime, ttGenTime, pMultiSub);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1192,6 +1192,7 @@ TESTS_IMPTCP = \
 	imptcp-connection-msg-disabled.sh \
 	imptcp-connection-msg-received.sh \
 	imptcp-discard-truncated-msg.sh \
+	imptcp-discard-truncated-msg-same-session.sh \
 	imptcp_addtlframedelim.sh \
 	imptcp_conndrop.sh \
 	imptcp_no_octet_counted.sh \

--- a/tests/imptcp-discard-truncated-msg-same-session.sh
+++ b/tests/imptcp-discard-truncated-msg-same-session.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Regression test for imptcp discardTruncatedMsg recovery within one TCP
+# session. The issue reproducer sends an oversized LF-framed message and the
+# next message over the same connection; success proves that the first byte
+# after truncation is not copied into the next message. The oracle is exact
+# output comparison: the second line must start with "<120>", not a leftover
+# byte from the truncated first line.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+$MaxMessageSize 128
+global(processInternalMessages="on")
+module(load="../plugins/imptcp/.libs/imptcp")
+input(type="imptcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port"
+	ruleset="ruleset1" discardTruncatedMsg="on")
+
+template(name="outfmt" type="string" string="%rawmsg%\n")
+ruleset(name="ruleset1") {
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+startup
+assign_tcpflood_port $RSYSLOG_DYNNAME.tcpflood_port
+printf '%s\n%s\n' \
+	'<120> 2023-07-10T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 test5' \
+	'<120> 2023-07-10T11:22:12Z host tag: this is a short msg' \
+	> "$RSYSLOG_DYNNAME.input"
+tcpflood -B -I "$RSYSLOG_DYNNAME.input"
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='<120> 2023-07-10T11:22:12Z host tag: this is a way to long message that has abcdefghijklmnopqrstuvwxyz test1 test2 test3 test4 t
+<120> 2023-07-10T11:22:12Z host tag: this is a short msg'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary

- fix imptcp `discardTruncatedMsg` recovery after a size-limit flush in octet-stuffing mode
- consume the current overflow byte instead of letting it fall through into the next message
- add a same-session regression test for the original netcat/tcpflood pattern

## Validation

- `make -j$(nproc) check TESTS=""`
- `./tests/imptcp-discard-truncated-msg-same-session.sh`
- `./tests/imptcp-discard-truncated-msg.sh`
- `./tests/imptcp-octet-framing-too-long-vg.sh`
- `./tests/imptcp-msg-truncation-on-number.sh`
- `./tests/imptcp-msg-truncation-on-number2.sh`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)`
- local container clang static analyzer, `rsyslog/rsyslog_dev_base_ubuntu:26.04`: no bugs found, `real 171.40`
- local Ubuntu 26.04 container check, `rsyslog/rsyslog_dev_base_ubuntu:26.04`: 1249 total, 1157 pass, 92 skip, 0 fail/error, `real 269.62`

Closes https://github.com/rsyslog/rsyslog/issues/5179
