### PR TITLE
config: add global maxOpenFiles setting

### DIFF
--- a/doc/source/configuration/global/options/rsconf1_maxopenfiles.rst
+++ b/doc/source/configuration/global/options/rsconf1_maxopenfiles.rst
@@ -5,6 +5,9 @@ $MaxOpenFiles
 
 **Type:** global configuration parameter
 
+**Status:** deprecated legacy directive. Use ``global(maxOpenFiles="...")``
+in new configurations.
+
 **Default:** *operating system default*
 
 **Description:**
@@ -18,6 +21,19 @@ Please note that each dynafile also requires up to 100 open file
 handles.
 
 The setting is similar to running "ulimit -n number-of-files".
+
+For new configurations, use the RainerScript global parameter instead:
+
+.. code-block:: none
+
+   global(maxOpenFiles="2000")
+
+The YAML equivalent is:
+
+.. code-block:: yaml
+
+   global:
+     maxOpenFiles: 2000
 
 Please note that depending on permissions and operating system
 configuration, the setrlimit() request issued by rsyslog may fail, in
@@ -33,4 +49,3 @@ warning message in this case.
 For some reason, this settings seems not to work on all platforms. If
 you experience problems, please let us know so that we can (hopefully)
 narrow down the issue.
-

--- a/doc/source/configuration/yaml_config.rst
+++ b/doc/source/configuration/yaml_config.rst
@@ -139,6 +139,7 @@ mapping of parameter names to values.
    global:
      workdirectory: "/var/spool/rsyslog"
      maxmessagesize: 8192
+     maxOpenFiles: 2000
      defaultnetstreamdriver: "gtls"
      privdrop.user.name: "syslog"
      privdrop.group.name: "syslog"

--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -157,6 +157,36 @@ The following parameters can be set:
   Note: some modules provide separate parameters that allow overriding this
   setting (e.g., :doc:`imrelp's MaxDataSize parameter <../../configuration/modules/imrelp>`).
 
+- **maxOpenFiles**
+
+  Configures the maximum number of files that the rsyslog process may keep
+  open at the same time. This includes regular files and sockets, so it also
+  affects the practical upper bound for concurrent TCP connections and dynamic
+  output files.
+
+  The default is the operating-system process limit. The value is applied with
+  ``setrlimit(RLIMIT_NOFILE)`` during configuration activation, before rsyslog
+  drops privileges. The request can still fail if operating-system policy,
+  service manager limits, or the current hard limit do not permit the requested
+  value. On systemd systems, ``LimitNOFILE=`` in the service unit is often the
+  preferred place to raise the hard limit.
+
+  Example:
+
+  .. code-block:: none
+
+     global(maxOpenFiles="2000")
+
+  YAML equivalent:
+
+  .. code-block:: yaml
+
+     global:
+       maxOpenFiles: 2000
+
+  The legacy ``$MaxOpenFiles`` directive remains supported for existing
+  configurations, but new configurations should use ``global(maxOpenFiles=...)``.
+
 .. _global_janitorInterval:
 
 - **janitor.interval** [minutes], available 8.3.3+

--- a/runtime/glbl.c
+++ b/runtime/glbl.c
@@ -29,6 +29,7 @@
 #include "config.h"
 #include <stdlib.h>
 #include <sys/socket.h>
+#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
@@ -164,6 +165,7 @@ static struct cnfparamdescr cnfparamdescr[] = {
     {"net.aclresolvehostname", eCmdHdlrBinary, 0},
     {"net.enabledns", eCmdHdlrBinary, 0},
     {"net.permitACLwarning", eCmdHdlrBinary, 0},
+    {"maxopenfiles", eCmdHdlrPositiveInt, 0},
     {"compatibility.configformat.legacy", eCmdHdlrGetWord, 0},
     {"compatibility.configformat.syslogd", eCmdHdlrGetWord, 0},
     {"compatibility.configformat.property", eCmdHdlrGetWord, 0},
@@ -557,6 +559,38 @@ static rsRetVal setDfltOpensslEngine(void __attribute__((unused)) * pVal, uchar 
     DEFiRet;
     free(loadConf->globals.pszDfltOpensslEngine);
     loadConf->globals.pszDfltOpensslEngine = pNewVal;
+    RETiRet;
+}
+
+/* Set the maximum number of files the rsyslog process may open. */
+rsRetVal glblSetMaxOpenFiles(void __attribute__((unused)) * pVal, int iFiles) {
+    struct rlimit maxFiles;
+    struct rlimit currentLimit;
+
+    DEFiRet;
+
+    if (getrlimit(RLIMIT_NOFILE, &currentLimit) < 0) {
+        currentLimit.rlim_max = 0;
+    }
+
+    maxFiles.rlim_cur = iFiles;
+    maxFiles.rlim_max = iFiles;
+
+    if (setrlimit(RLIMIT_NOFILE, &maxFiles) < 0) {
+        /* NOTE: under valgrind, we seem to be unable to extend the size! */
+        LogError(errno, RS_RET_ERR_RLIM_NOFILE,
+                 "could not set process file limit to %d "
+                 "[current hard limit %llu]",
+                 iFiles, (unsigned long long)currentLimit.rlim_max);
+        ABORT_FINALIZE(RS_RET_ERR_RLIM_NOFILE);
+    }
+#ifdef USE_UNLIMITED_SELECT
+    SetFdSetSize(howmany(iFiles, __NFDBITS) * sizeof(fd_mask));
+#endif
+    DBGPRINTF("Max number of files set to %d [current hard limit %llu].\n", iFiles,
+              (unsigned long long)currentLimit.rlim_max);
+
+finalize_it:
     RETiRet;
 }
 
@@ -1359,6 +1393,8 @@ rsRetVal glblDoneLoadCnf(void) {
             loadConf->globals.bActionReportSuspensionCont = (int)cnfparamvals[i].val.d.n;
         } else if (!strcmp(paramblk.descr[i].name, "maxmessagesize")) {
             setMaxLine(cnfparamvals[i].val.d.n);
+        } else if (!strcmp(paramblk.descr[i].name, "maxopenfiles")) {
+            loadConf->globals.iMaxOpenFiles = (int)cnfparamvals[i].val.d.n;
         } else if (!strcmp(paramblk.descr[i].name, "oversizemsg.errorfile")) {
             free(loadConf->globals.oversizeMsgErrorFile);
             loadConf->globals.oversizeMsgErrorFile = (uchar *)es_str2cstr(cnfparamvals[i].val.d.estr, NULL);

--- a/runtime/glbl.h
+++ b/runtime/glbl.h
@@ -159,6 +159,7 @@ int glblGetOversizeMsgInputMode(rsconf_t *cnf);
 int glblReportOversizeMessage(rsconf_t *cnf);
 void glblReportChildProcessExit(rsconf_t *cnf, const uchar *name, pid_t pid, int status);
 uchar *glblGetLocalHostName(void);
+rsRetVal glblSetMaxOpenFiles(void *pVal, int iFiles);
 /** Check whether a legacy $-directive may be processed under the active compatibility policy. */
 int glblPermitLegacyConfigDirective(rsconf_t *cnf, const char *directive);
 /** Check whether a classic syslogd PRI selector may be processed under the active compatibility policy. */

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -30,7 +30,6 @@
 #include <pwd.h>
 #include <grp.h>
 #include <stdarg.h>
-#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/socket.h>
@@ -229,6 +228,7 @@ static void cnfSetDefaults(rsconf_t *pThis) {
     pThis->globals.bProcessInternalMessages = 0;
     const char *const log_dflt = getenv("RSYSLOG_DFLT_LOG_INTERNAL");
     if (log_dflt != NULL && !strcmp(log_dflt, "1")) pThis->globals.bProcessInternalMessages = 1;
+    pThis->globals.iMaxOpenFiles = 0;
     pThis->globals.glblDevOptions = 0;
     pThis->globals.intMsgRateLimitItv = 60;
     pThis->globals.intMsgRateLimitBurst = 100;
@@ -1086,6 +1086,9 @@ static rsRetVal activate(rsconf_t *cnf) {
 		generateConfigDAG(ourConf->globals.pszConfDAGFile);
 #endif
     setUmask(cnf->globals.umask);
+    if (cnf->globals.iMaxOpenFiles > 0) {
+        CHKiRet(glblSetMaxOpenFiles(NULL, cnf->globals.iMaxOpenFiles));
+    }
 
     /* the output part and the queue is now ready to run. So it is a good time
      * to initialize the inputs. Please note that the net code above should be
@@ -1124,6 +1127,14 @@ finalize_it:
 /* legacy config system: set the action resume interval */
 static rsRetVal setActionResumeInterval(void __attribute__((unused)) * pVal, int iNewVal) {
     return actionSetGlobalResumeInterval(iNewVal);
+}
+
+
+/* set the processes max number of files immediately for legacy $MaxOpenFiles
+ * configs.
+ */
+static rsRetVal setMaxFiles(void *pVal, int iFiles) {
+    return glblSetMaxOpenFiles(pVal, iFiles);
 }
 
 
@@ -1199,36 +1210,6 @@ static rsRetVal setMainMsgQueType(void __attribute__((unused)) * pVal, uchar *ps
 
 
 /* -------------------- end legacy config handlers -------------------- */
-
-
-/* set the processes max number ob files (upon configuration request)
- * 2009-04-14 rgerhards
- */
-static rsRetVal setMaxFiles(void __attribute__((unused)) * pVal, int iFiles) {
-    // TODO this must use a local var, then carry out action during activate!
-    struct rlimit maxFiles;
-
-    DEFiRet;
-
-    maxFiles.rlim_cur = iFiles;
-    maxFiles.rlim_max = iFiles;
-
-    if (setrlimit(RLIMIT_NOFILE, &maxFiles) < 0) {
-        /* NOTE: under valgrind, we seem to be unable to extend the size! */
-        LogError(errno, RS_RET_ERR_RLIM_NOFILE,
-                 "could not set process file limit to %d "
-                 "[kernel max %ld]",
-                 iFiles, (long)maxFiles.rlim_max);
-        ABORT_FINALIZE(RS_RET_ERR_RLIM_NOFILE);
-    }
-#ifdef USE_UNLIMITED_SELECT
-    glbl.SetFdSetSize(howmany(iFiles, __NFDBITS) * sizeof(fd_mask));
-#endif
-    DBGPRINTF("Max number of files set to %d [kernel max %ld].\n", iFiles, (long)maxFiles.rlim_max);
-
-finalize_it:
-    RETiRet;
-}
 
 
 /* legacy config system: reset config variables to default values.  */

--- a/runtime/rsconf.h
+++ b/runtime/rsconf.h
@@ -150,6 +150,7 @@ struct globals_s {
                                    * 1 - yes
                                    * 0 - send them to libstdlog (e.g. to push to journal) or syslog()
                                    */
+    int iMaxOpenFiles; /* requested RLIMIT_NOFILE value, 0 means leave OS limit unchanged */
     uint64_t glblDevOptions; /* to be used by developers only */
     int intMsgRateLimitItv;
     int intMsgRateLimitBurst;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -276,6 +276,7 @@ TESTS_DEFAULT = \
 	asynwr_deadlock4.sh \
 	asynwr_dynfile_flushtxend-off.sh \
 	imdiag-modern-module-config.sh \
+	global-maxopenfiles-rainerscript.sh \
 	compat-configformat-rainerscript.sh \
 	compat-defaults-secure-dynafile-rainerscript.sh \
 	abort-uncleancfg-goodcfg.sh \
@@ -585,6 +586,7 @@ TESTS_LIBYAML = \
 	config-translate-yaml-to-rs.sh \
 	compat-configformat-yaml.sh \
 	compat-defaults-secure-dynafile-yaml.sh \
+	global-maxopenfiles-yaml.sh \
 	ratelimit_hup.sh \
 	yaml-basic.sh \
 	yaml-basic-yamlonly.sh \

--- a/tests/global-maxopenfiles-rainerscript.sh
+++ b/tests/global-maxopenfiles-rainerscript.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Validate the modern global(maxOpenFiles=...) setting.  The test starts
+# rsyslogd so it exercises both the RainerScript global-parameter backend and
+# the activation-time setrlimit path.  The oracle is a clean startup/shutdown
+# using the current shell soft limit, which should be accepted without needing
+# extra privileges.
+. ${srcdir:=.}/diag.sh init
+
+max_open_files="$(ulimit -n)"
+if [ "${max_open_files}" = "unlimited" ]; then
+	max_open_files=4096
+fi
+
+generate_conf
+add_conf '
+global(maxOpenFiles="'${max_open_files}'")
+action(type="omfile" file="'${RSYSLOG_DYNNAME}'.out")
+'
+
+startup
+shutdown_when_empty
+wait_shutdown
+
+exit_test

--- a/tests/global-maxopenfiles-yaml.sh
+++ b/tests/global-maxopenfiles-yaml.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Validate YAML parity for the modern global maxOpenFiles setting.  The config
+# check includes a YAML singleton global section and verifies that the shared
+# global-parameter backend accepts the value without activating setrlimit.
+. ${srcdir:=.}/diag.sh init
+
+modpath="${RSYSLOG_MODDIR}"
+
+cat >"${RSYSLOG_DYNNAME}.conf" <<CONF_EOF
+include(file="${RSYSLOG_DYNNAME}.yaml")
+action(type="omfile" file="${RSYSLOG_DYNNAME}.out")
+CONF_EOF
+
+cat >"${RSYSLOG_DYNNAME}.yaml" <<YAML_EOF
+global:
+  maxOpenFiles: 4096
+YAML_EOF
+
+../tools/rsyslogd -C -N1 -M"${modpath}" -f"${RSYSLOG_DYNNAME}.conf" >"${RSYSLOG_DYNNAME}.log" 2>&1
+rc=$?
+if [ $rc -ne 0 ]; then
+	echo "FAIL: expected YAML global maxOpenFiles to validate"
+	cat "${RSYSLOG_DYNNAME}.log"
+	error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
Summary: Adds modern global(maxOpenFiles=...) and YAML global.maxOpenFiles support for the process open-file limit. Keeps the legacy MaxOpenFiles directive supported and documents it as deprecated for new configurations. Closes https://github.com/rsyslog/rsyslog/issues/4411. Validation: empty-target make check; global-maxopenfiles-rainerscript.sh; global-maxopenfiles-yaml.sh; doc HTML build; distcheck with TEST_RUN_TYPE=MOCK-OK; Ubuntu 26.04 static analyzer container: no bugs found; Ubuntu 26.04 container CI: 1257 total, 1164 pass, 93 skip, 0 fail.