### PR TITLE
gtls: log peer IP for missing client cert

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -52,6 +52,7 @@
 #include "netstrms.h"
 #include "nsd_ptcp.h"
 #include "nsd_gtls.h"
+#include "prop.h"
 #include "unicode-helper.h"
 #include "rsconf.h"
 
@@ -63,7 +64,7 @@ MODULE_TYPE_KEEP;
 
 /* static data */
 DEFobjStaticHelpers;
-DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(datetime) DEFobjCurrIf(nsd_ptcp)
+DEFobjCurrIf(glbl) DEFobjCurrIf(net) DEFobjCurrIf(datetime) DEFobjCurrIf(nsd_ptcp) DEFobjCurrIf(prop)
 
 
     /* Static Helper variables for certless communication */
@@ -1203,6 +1204,25 @@ finalize_it:
 }
 
 
+static rsRetVal getRemotePeerLogName(nsd_gtls_t *const pThis, uchar **const peer) {
+    prop_t *remoteIP = NULL;
+    DEFiRet;
+
+    *peer = NULL;
+    if (!pThis->bIsInitiator && nsd_ptcp.GetRemoteIP((nsd_t *)pThis->pTcp, &remoteIP) == RS_RET_OK &&
+        remoteIP != NULL) {
+        CHKmalloc(*peer = (uchar *)strdup((const char *)propGetSzStr(remoteIP)));
+        FINALIZE;
+    }
+
+    CHKiRet(nsd_ptcp.GetRemoteHName((nsd_t *)pThis->pTcp, peer));
+
+finalize_it:
+    if (remoteIP != NULL) prop.Destruct(&remoteIP);
+    RETiRet;
+}
+
+
 /* check the ID of the remote peer - used for both fingerprint and
  * name authentication. This is common code. Will call into specific
  * drivers once the certificate has been obtained.
@@ -1225,15 +1245,15 @@ static rsRetVal gtlsChkPeerID(nsd_gtls_t *pThis) {
 
     if (list_size < 1) {
         if (pThis->bReportAuthErr == 1) {
-            uchar *fromHost = NULL;
+            uchar *peer = NULL;
             errno = 0;
             pThis->bReportAuthErr = 0;
-            nsd_ptcp.GetRemoteHName((nsd_t *)pThis->pTcp, &fromHost);
+            CHKiRet(getRemotePeerLogName(pThis, &peer));
             LogError(0, RS_RET_TLS_NO_CERT,
                      "error: peer %s did not provide a certificate, "
                      "not permitted to talk to it",
-                     fromHost);
-            free(fromHost);
+                     peer);
+            free(peer);
         }
         ABORT_FINALIZE(RS_RET_TLS_NO_CERT);
     }
@@ -1287,10 +1307,10 @@ static rsRetVal gtlsChkPeerCertValidity(nsd_gtls_t *pThis) {
     cert_list = gnutls_certificate_get_peers(pThis->sess, &cert_list_size);
     if (cert_list_size < 1) {
         errno = 0;
-        uchar *fromHost = NULL;
-        nsd_ptcp.GetRemoteHName((nsd_t *)pThis->pTcp, &fromHost);
-        LogError(0, RS_RET_TLS_NO_CERT, "peer %s did not provide a certificate, not permitted to talk to it", fromHost);
-        free(fromHost);
+        uchar *peer = NULL;
+        CHKiRet(getRemotePeerLogName(pThis, &peer));
+        LogError(0, RS_RET_TLS_NO_CERT, "peer %s did not provide a certificate, not permitted to talk to it", peer);
+        free(peer);
         ABORT_FINALIZE(RS_RET_TLS_NO_CERT);
     }
 #ifdef EXTENDED_CERT_CHECK_AVAILABLE
@@ -2550,6 +2570,7 @@ BEGINObjClassExit(nsd_gtls, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in END 
     gtlsGlblExit(); /* shut down GnuTLS */
 
     /* release objects we no longer need */
+    objRelease(prop, CORE_COMPONENT);
     objRelease(nsd_ptcp, LM_NSD_PTCP_FILENAME);
     objRelease(net, LM_NET_FILENAME);
     objRelease(glbl, CORE_COMPONENT);
@@ -2567,6 +2588,7 @@ BEGINObjClassInit(nsd_gtls, 1, OBJ_IS_LOADABLE_MODULE) /* class, version */
     CHKiRet(objUse(glbl, CORE_COMPONENT));
     CHKiRet(objUse(net, LM_NET_FILENAME));
     CHKiRet(objUse(nsd_ptcp, LM_NSD_PTCP_FILENAME));
+    CHKiRet(objUse(prop, CORE_COMPONENT));
 
     /* now do global TLS init stuff */
     CHKiRet(gtlsGlblInit());

--- a/tests/sndrcv_tls_client_missing_cert.sh
+++ b/tests/sndrcv_tls_client_missing_cert.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verifies the receiver-side TLS diagnostic for clients that do not present a
+# certificate. The diagnostic must include the remote IP address so operators
+# can feed the event into IP-based tooling such as fail2ban.
 . ${srcdir:=.}/diag.sh init
 echo "This test is under review - it seems to have some issues"
 exit 77
@@ -63,6 +66,6 @@ wait_shutdown 2
 shutdown_when_empty
 wait_shutdown
 
-content_check --regex "peer .* did not provide a certificate,"
+content_check --regex "peer 127\\.0\\.0\\.1 did not provide a certificate,"
 
 exit_test


### PR DESCRIPTION
## Summary
- log the numeric remote IP for server-side GnuTLS missing-client-certificate diagnostics when available
- keep hostname fallback for initiator/client paths and cases where the IP property is unavailable
- update the existing skipped regression test oracle to expect 127.0.0.1 once the test is re-enabled

## Validation
- make parallel check with empty TESTS selection
- ad-hoc unskipped copy of tests/sndrcv_tls_client_missing_cert.sh
- Ubuntu 26.04 static analyzer container: no bugs found
- Ubuntu 26.04 container CI: 1255 total, 1162 pass, 93 skip, 0 fail
