### PR TITLE
build: fix ARMv7 warnings under Werror

### DIFF
--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -592,12 +592,12 @@ static rsRetVal processOctetMsgLen(const instanceConf_t *const inst, struct conn
                          "SP but has ASCII value %d.",
                          remoteAddr, ch);
             } else if (connWrkr->parseState.iOctetsRemain > s_iMaxLine) {
-                DBGPRINTF("truncating message with %lu octets - max msg size is %lu\n",
+                DBGPRINTF("truncating message with %zu octets - max msg size is %zu\n",
                           connWrkr->parseState.iOctetsRemain, s_iMaxLine);
                 LogError(0, NO_ERRCODE,
                          "received oversize message from peer: "
-                         "(hostname) (ip) %s: size is %lu bytes, max msg "
-                         "size is %lu, truncating...",
+                         "(hostname) (ip) %s: size is %zu bytes, max msg "
+                         "size is %zu, truncating...",
                          remoteAddr, connWrkr->parseState.iOctetsRemain, s_iMaxLine);
             }
             connWrkr->parseState.inputState = eInMsg;

--- a/contrib/omrabbitmq/omrabbitmq.c
+++ b/contrib/omrabbitmq/omrabbitmq.c
@@ -29,6 +29,7 @@
  *
  */
 #include "config.h"
+#include <inttypes.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -994,11 +995,13 @@ BEGINdbgPrintInstInfo
         dbgprintf("\thost2='%s' \n", pData->server2.host);
         dbgprintf("\tport2=%d\n", pData->server2.port);
         dbgprintf("\tfailback policy :");
-        dbgprintf("\t\tusual server check interval=%ld s", pData->recover_policy.return_check_interval);
-        dbgprintf("\t\tquick oscillation limit=%ld s", pData->recover_policy.quick_oscillation_interval);
+        dbgprintf("\t\tusual server check interval=%" PRIdMAX " s",
+                  (intmax_t)pData->recover_policy.return_check_interval);
+        dbgprintf("\t\tquick oscillation limit=%" PRIdMAX " s",
+                  (intmax_t)pData->recover_policy.quick_oscillation_interval);
         dbgprintf("\t\tmax number of oscillation=%d s", pData->recover_policy.quick_oscillation_max);
-        dbgprintf("\t\tgraceful interval after quick oscillation detection=%ld s",
-                  pData->recover_policy.graceful_interval);
+        dbgprintf("\t\tgraceful interval after quick oscillation detection=%" PRIdMAX " s",
+                  (intmax_t)pData->recover_policy.graceful_interval);
     } else {
         dbgprintf("\thost='%s' \n", pData->server1.host);
         dbgprintf("\tport=%d\n", pData->server1.port);

--- a/plugins/impstats/Makefile.am
+++ b/plugins/impstats/Makefile.am
@@ -17,7 +17,6 @@ nodist_noinst_HEADERS = remote.pb-c.h
 endif
 
 impstats_la_CPPFLAGS = $(RSRT_CFLAGS) -I$(top_srcdir) $(PTHREADS_CFLAGS)
-
 if ENABLE_IMPSTATS_PUSH
 impstats_la_CPPFLAGS += $(IMPSTATS_PUSH_CFLAGS) -DENABLE_IMPSTATS_PUSH
 endif
@@ -33,10 +32,24 @@ endif
 if ENABLE_IMPSTATS_PUSH
 BUILT_SOURCES = remote.pb-c.c remote.pb-c.h
 
-remote.pb-c.c remote.pb-c.h: remote.proto
-	$(PROTOC_C) --proto_path=$(srcdir) --c_out=. $<
+remote.pb-c.c remote.pb-c.h: remote.pb-c.stamp
 
-CLEANFILES = remote.pb-c.c remote.pb-c.h
+remote.pb-c.stamp: remote.proto
+	$(PROTOC_C) --proto_path=$(srcdir) --c_out=. $<
+	{ \
+		echo '#if defined(__GNUC__)'; \
+		echo '#pragma GCC diagnostic push'; \
+		echo '#pragma GCC diagnostic ignored "-Wcast-align"'; \
+		echo '#endif'; \
+		cat remote.pb-c.c; \
+		echo '#if defined(__GNUC__)'; \
+		echo '#pragma GCC diagnostic pop'; \
+		echo '#endif'; \
+	} > remote.pb-c.c.tmp
+	mv remote.pb-c.c.tmp remote.pb-c.c
+	touch $@
+
+CLEANFILES = remote.pb-c.c remote.pb-c.h remote.pb-c.stamp
 endif
 
 EXTRA_DIST = \

--- a/plugins/omdtls/omdtls.c
+++ b/plugins/omdtls/omdtls.c
@@ -564,7 +564,7 @@ static rsRetVal dtls_send(wrkrInstanceData_t *pWrkrData,
 
     iErr = SSL_write(pWrkrData->sslClient, pszParamStr, tzParamStrLen);
     if (iErr > 0) {
-        DBGPRINTF("dtls_send[%p]: Successfully send message '%s' with %ld bytes to %s:%s\n", pWrkrData, pszParamStr,
+        DBGPRINTF("dtls_send[%p]: Successfully send message '%s' with %zu bytes to %s:%s\n", pWrkrData, pszParamStr,
                   tzParamStrLen, pData->target, pData->port);
 
         // Increment Stats Counter

--- a/plugins/omsendertrack/omsendertrack.c
+++ b/plugins/omsendertrack/omsendertrack.c
@@ -33,6 +33,7 @@
  */
 #include "config.h"
 #include "rsyslog.h"
+#include <inttypes.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -186,8 +187,8 @@ static rsRetVal addSender(instanceData *const pData,
     sender_stats_t *stat;
     DEFiRet;
 
-    DBGPRINTF("addSender: Sender: %s, Messages: %" PRIu64 ", FirstSeen: %ld, LastSeen: %ld\n", sender, nMsgs, firstSeen,
-              lastSeen);
+    DBGPRINTF("addSender: Sender: %s, Messages: %" PRIu64 ", FirstSeen: %" PRIdMAX ", LastSeen: %" PRIdMAX "\n", sender,
+              nMsgs, (intmax_t)firstSeen, (intmax_t)lastSeen);
 
     CHKmalloc(stat = calloc(1, sizeof(sender_stats_t)));
     stat->sender = (const uchar *)strdup((const char *)sender);

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -76,6 +76,10 @@ static int dhMinBits = 512; /**< minimum number of bits for Diffie-Hellman key *
 static pthread_mutex_t mutGtlsStrerror;
 /*< a mutex protecting the potentially non-reentrant gtlStrerror() function */
 
+static inline nsd_gtls_t *nsd_gtls_from_nsd(nsd_t *const pNsd) {
+    return (nsd_gtls_t *)(void *)pNsd;
+}
+
 static gnutls_dh_params_t dh_params; /**< server DH parameters for anon mode */
 
 /* Module-level bitfield for warnings that have been logged (shared across all instances)
@@ -1570,7 +1574,7 @@ ENDobjDestruct(nsd_gtls)
  */
 static rsRetVal SetMode(nsd_t *const pNsd, const int mode) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     dbgprintf("(tls) mode: %d\n", mode);
@@ -1598,7 +1602,7 @@ finalize_it:
  */
 static rsRetVal SetAuthMode(nsd_t *pNsd, uchar *mode) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (mode == NULL || !strcasecmp((char *)mode, "x509/name")) {
@@ -1633,7 +1637,7 @@ finalize_it:
  */
 static rsRetVal SetPermitExpiredCerts(nsd_t *pNsd, uchar *mode) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     /* default is set to off! */
@@ -1666,7 +1670,7 @@ finalize_it:
  */
 static rsRetVal SetPermPeers(nsd_t *pNsd, permittedPeers_t *pPermPeers) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (pPermPeers == NULL) FINALIZE;
@@ -1689,7 +1693,7 @@ finalize_it:
  */
 static rsRetVal SetGnutlsPriorityString(nsd_t *pNsd, uchar *gnutlsPriorityString) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     pThis->gnutlsPriorityString = gnutlsPriorityString;
@@ -1705,7 +1709,7 @@ static rsRetVal SetGnutlsPriorityString(nsd_t *pNsd, uchar *gnutlsPriorityString
  */
 static rsRetVal SetCheckExtendedKeyUsage(nsd_t *pNsd, int ChkExtendedKeyUsage) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (ChkExtendedKeyUsage != 0 && ChkExtendedKeyUsage != 1) {
@@ -1729,7 +1733,7 @@ finalize_it:
  */
 static rsRetVal SetPrioritizeSAN(nsd_t *pNsd, int prioritizeSan) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (prioritizeSan != 0 && prioritizeSan != 1) {
@@ -1751,7 +1755,7 @@ finalize_it:
  */
 static rsRetVal SetTlsVerifyDepth(nsd_t *pNsd, int verifyDepth) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (verifyDepth == 0) {
@@ -1766,7 +1770,7 @@ finalize_it:
 
 static rsRetVal SetTlsCAFile(nsd_t *pNsd, const uchar *const caFile) {
     DEFiRet;
-    nsd_gtls_t *const pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *const pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (caFile == NULL) {
@@ -1781,7 +1785,7 @@ finalize_it:
 
 static rsRetVal SetTlsCRLFile(nsd_t *pNsd, const uchar *const crlFile) {
     DEFiRet;
-    nsd_gtls_t *const pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *const pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (crlFile == NULL) {
@@ -1796,7 +1800,7 @@ finalize_it:
 
 static rsRetVal SetTlsKeyFile(nsd_t *pNsd, const uchar *const pszFile) {
     DEFiRet;
-    nsd_gtls_t *const pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *const pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (pszFile == NULL) {
@@ -1811,7 +1815,7 @@ finalize_it:
 
 static rsRetVal SetTlsCertFile(nsd_t *pNsd, const uchar *const pszFile) {
     DEFiRet;
-    nsd_gtls_t *const pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *const pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     if (pszFile == NULL) {
@@ -1827,7 +1831,7 @@ finalize_it:
 /* Set the TLS SNI of the remote server */
 static rsRetVal SetRemoteSNI(nsd_t *pNsd, uchar *remoteSNI) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
 
@@ -1844,7 +1848,7 @@ finalize_it:
 
 static rsRetVal SetTlsRevocationCheck(nsd_t *pNsd, int enabled) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
     pThis->DrvrTlsRevocationCheck = (enabled != 0) ? 1 : 0;
@@ -1866,7 +1870,7 @@ finalize_it:
  */
 static rsRetVal SetSock(nsd_t *pNsd, int sock) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     assert(sock >= 0);
@@ -1877,7 +1881,7 @@ static rsRetVal SetSock(nsd_t *pNsd, int sock) {
 }
 
 static rsRetVal GetRemotePort(nsd_t *pNsd, int *port) {
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     return nsd_ptcp.GetRemotePort(pThis->pTcp, port);
 }
@@ -1891,7 +1895,7 @@ static rsRetVal FmtRemotePortStr(const int port, uchar *const buf, const size_t 
  */
 static rsRetVal SetKeepAliveIntvl(nsd_t *pNsd, int keepAliveIntvl) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     assert(keepAliveIntvl >= 0);
@@ -1906,7 +1910,7 @@ static rsRetVal SetKeepAliveIntvl(nsd_t *pNsd, int keepAliveIntvl) {
  */
 static rsRetVal SetKeepAliveProbes(nsd_t *pNsd, int keepAliveProbes) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     assert(keepAliveProbes >= 0);
@@ -1921,7 +1925,7 @@ static rsRetVal SetKeepAliveProbes(nsd_t *pNsd, int keepAliveProbes) {
  */
 static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
     assert(keepAliveTime >= 0);
@@ -1936,7 +1940,7 @@ static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
  * before the Destruct call. -- rgerhards, 2008-03-24
  */
 static rsRetVal Abort(nsd_t *pNsd) {
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     DEFiRet;
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
@@ -1952,8 +1956,8 @@ static rsRetVal Abort(nsd_t *pNsd) {
 /* Callback after netstrm obj init in nsd_ptcp - permits us to add some data */
 static rsRetVal LstnInitDrvr(netstrm_t *const pThis) {
     DEFiRet;
-    CHKiRet(gtlsInitCred((nsd_gtls_t *)pThis->pDrvrData));
-    CHKiRet(gtlsAddOurCert((nsd_gtls_t *)pThis->pDrvrData));
+    CHKiRet(gtlsInitCred(nsd_gtls_from_nsd(pThis->pDrvrData)));
+    CHKiRet(gtlsAddOurCert(nsd_gtls_from_nsd(pThis->pDrvrData)));
 finalize_it:
     RETiRet;
 }
@@ -1983,7 +1987,7 @@ static rsRetVal ATTR_NONNULL(1, 3, 5) LstnInit(netstrms_t *pNS,
  * rgerhards, 2008-06-09
  */
 static rsRetVal CheckConnection(nsd_t __attribute__((unused)) * pNsd) {
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
 
     dbgprintf("CheckConnection for %p\n", pNsd);
@@ -1994,7 +1998,7 @@ static rsRetVal CheckConnection(nsd_t __attribute__((unused)) * pNsd) {
 /* Provide access to the underlying OS socket.
  */
 static rsRetVal GetSock(nsd_t *pNsd, int *pSock) {
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     return nsd_ptcp.GetSock(pThis->pTcp, pSock);
 }
 
@@ -2004,7 +2008,7 @@ static rsRetVal GetSock(nsd_t *pNsd, int *pSock) {
  */
 static rsRetVal GetRemoteHName(nsd_t *pNsd, uchar **ppszHName) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
     iRet = nsd_ptcp.GetRemoteHName(pThis->pTcp, ppszHName);
     RETiRet;
@@ -2016,7 +2020,7 @@ static rsRetVal GetRemoteHName(nsd_t *pNsd, uchar **ppszHName) {
  */
 static rsRetVal GetRemAddr(nsd_t *pNsd, struct sockaddr_storage **ppAddr) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
     iRet = nsd_ptcp.GetRemAddr(pThis->pTcp, ppAddr);
     RETiRet;
@@ -2026,7 +2030,7 @@ static rsRetVal GetRemAddr(nsd_t *pNsd, struct sockaddr_storage **ppAddr) {
 /* get the remote host's IP address. Caller must Destruct the object. */
 static rsRetVal GetRemoteIP(nsd_t *pNsd, prop_t **ip) {
     DEFiRet;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
     iRet = nsd_ptcp.GetRemoteIP(pThis->pTcp, ip);
     RETiRet;
@@ -2042,7 +2046,7 @@ static rsRetVal AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew, char *const connInfo) 
     DEFiRet;
     int gnuRet;
     nsd_gtls_t *pNew = NULL;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     const char *error_position = NULL;
 
     ISOBJ_TYPE_assert((pThis), nsd_gtls);
@@ -2185,7 +2189,7 @@ finalize_it:
 static rsRetVal Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf, int *const oserr, unsigned *const nextIODirection) {
     DEFiRet;
     ssize_t iBytesCopy; /* how many bytes are to be copied to the client buffer? */
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
 
     if (pThis->bAbortConn) ABORT_FINALIZE(RS_RET_CONNECTION_ABORTREQ);
@@ -2265,7 +2269,7 @@ finalize_it:
 static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
     int iSent;
     int wantsWriteData = 0;
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     DEFiRet;
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
 
@@ -2323,7 +2327,7 @@ finalize_it:
  * rgerhards, 2009-06-02
  */
 static rsRetVal EnableKeepAlive(nsd_t *pNsd) {
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_gtls);
     return nsd_ptcp.EnableKeepAlive(pThis->pTcp);
 }
@@ -2365,7 +2369,7 @@ static int SetServerNameIfPresent(nsd_gtls_t *pThis, uchar *host) {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations" /* TODO: FIX Warnings! */
 static rsRetVal Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device) {
-    nsd_gtls_t *pThis = (nsd_gtls_t *)pNsd;
+    nsd_gtls_t *pThis = nsd_gtls_from_nsd(pNsd);
     int sock;
     int gnuRet;
     const char *error_position;

--- a/runtime/nsd_mbedtls.c
+++ b/runtime/nsd_mbedtls.c
@@ -70,6 +70,10 @@ static DEF_ATOMIC_HELPER_MUT(mutTlsVersionWorkaroundReported);
 
 #define DEFAULT_MAX_DEPTH 5
 
+static inline nsd_mbedtls_t *nsd_mbedtls_from_nsd(nsd_t *const pNsd) {
+    return (nsd_mbedtls_t *)(void *)pNsd;
+}
+
 #if MBEDTLS_DEBUG_LEVEL > 0
 static void debug(void __attribute__((unused)) * ctx,
                   int __attribute__((unused)) level,
@@ -173,8 +177,8 @@ static rsRetVal get_custom_string(char **out) {
     if (localtime_r(&(tv.tv_sec), &tm) == NULL) {
         ABORT_FINALIZE(RS_RET_NO_ERRCODE);
     }
-    if (asprintf(out, "nsd_mbedtls-%04d-%02d-%02d %02d:%02d:%02d:%08ld", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
-                 tm.tm_hour, tm.tm_min, tm.tm_sec, tv.tv_usec) == -1) {
+    if (asprintf(out, "nsd_mbedtls-%04d-%02d-%02d %02d:%02d:%02d:%08lld", tm.tm_year + 1900, tm.tm_mon + 1, tm.tm_mday,
+                 tm.tm_hour, tm.tm_min, tm.tm_sec, (long long)tv.tv_usec) == -1) {
         *out = NULL;
         ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
     }
@@ -279,7 +283,7 @@ ENDobjDestruct(nsd_mbedtls)
  */
 static rsRetVal SetMode(nsd_t *const pNsd, const int mode) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     dbgprintf("(tls) mode: %d\n", mode);
@@ -307,7 +311,7 @@ finalize_it:
  */
 static rsRetVal SetAuthMode(nsd_t *pNsd, uchar *mode) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     if (mode == NULL || !strcasecmp((char *)mode, "x509/name")) {
@@ -340,7 +344,7 @@ finalize_it:
  */
 static rsRetVal SetPermitExpiredCerts(nsd_t *pNsd, uchar *mode) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     /* default is set to off! */
@@ -372,7 +376,7 @@ finalize_it:
  */
 static rsRetVal SetPermPeers(nsd_t *pNsd, permittedPeers_t *pPermPeers) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     if (pPermPeers == NULL) FINALIZE;
@@ -395,7 +399,7 @@ finalize_it:
  */
 static rsRetVal SetGnutlsPriorityString(nsd_t *pNsd, uchar *gnutlsPriorityString) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     int nCipherSuiteId;
     char *pCurrentPos;
     char *pSave;
@@ -444,7 +448,7 @@ finalize_it:
  */
 static rsRetVal SetCheckExtendedKeyUsage(nsd_t *pNsd, int ChkExtendedKeyUsage) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     if (ChkExtendedKeyUsage != 0 && ChkExtendedKeyUsage != 1) {
@@ -469,7 +473,7 @@ finalize_it:
  */
 static rsRetVal SetPrioritizeSAN(nsd_t *pNsd, int prioritizeSan) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     if (prioritizeSan != 0 && prioritizeSan != 1) {
@@ -491,7 +495,7 @@ finalize_it:
  */
 static rsRetVal SetTlsVerifyDepth(nsd_t *pNsd, int verifyDepth) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     pThis->DrvrVerifyDepth = verifyDepth;
@@ -502,7 +506,7 @@ static rsRetVal SetTlsVerifyDepth(nsd_t *pNsd, int verifyDepth) {
 
 static rsRetVal SetTlsCAFile(nsd_t *pNsd, const uchar *const caFile) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
 
@@ -520,7 +524,7 @@ finalize_it:
 
 static rsRetVal SetTlsCRLFile(nsd_t *pNsd, const uchar *const crlFile) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
 
@@ -538,7 +542,7 @@ finalize_it:
 
 static rsRetVal SetTlsKeyFile(nsd_t *pNsd, const uchar *const pszFile) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
 
@@ -556,7 +560,7 @@ finalize_it:
 
 static rsRetVal SetTlsCertFile(nsd_t *pNsd, const uchar *const pszFile) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
 
@@ -574,7 +578,7 @@ finalize_it:
 
 static rsRetVal SetTlsRevocationCheck(nsd_t *pNsd, int enabled) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
     pThis->DrvrTlsRevocationCheck = (enabled != 0) ? 1 : 0;
@@ -596,7 +600,7 @@ finalize_it:
  */
 static rsRetVal SetSock(nsd_t *pNsd, int sock) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
 
@@ -610,7 +614,7 @@ static rsRetVal SetSock(nsd_t *pNsd, int sock) {
  */
 static rsRetVal SetKeepAliveIntvl(nsd_t *pNsd, int keepAliveIntvl) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     assert(keepAliveIntvl >= 0);
@@ -624,7 +628,7 @@ static rsRetVal SetKeepAliveIntvl(nsd_t *pNsd, int keepAliveIntvl) {
  */
 static rsRetVal SetKeepAliveProbes(nsd_t *pNsd, int keepAliveProbes) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     assert(keepAliveProbes >= 0);
@@ -638,7 +642,7 @@ static rsRetVal SetKeepAliveProbes(nsd_t *pNsd, int keepAliveProbes) {
  */
 static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
     assert(keepAliveTime >= 0);
@@ -652,7 +656,7 @@ static rsRetVal SetKeepAliveTime(nsd_t *pNsd, int keepAliveTime) {
  * before the Destruct call. -- rgerhards, 2008-03-24
  */
 static rsRetVal Abort(nsd_t *pNsd) {
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     DEFiRet;
 
     ISOBJ_TYPE_assert((pThis), nsd_mbedtls);
@@ -1080,7 +1084,7 @@ finalize_it:
 static rsRetVal AcceptConnReq(nsd_t *pNsd, nsd_t **ppNew, char *const connInfo) {
     DEFiRet;
     nsd_mbedtls_t *pNew = NULL;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     int mbedtlsRet;
 
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
@@ -1166,7 +1170,7 @@ finalize_it:
  */
 static rsRetVal Rcv(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf, int *const oserr, unsigned *const nextIODirection) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
     int n = 0;
 
@@ -1211,7 +1215,7 @@ finalize_it:
  */
 static rsRetVal Send(nsd_t *pNsd, uchar *pBuf, ssize_t *pLenBuf) {
     int iSent;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     DEFiRet;
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
 
@@ -1242,7 +1246,7 @@ finalize_it:
  * rgerhards, 2009-06-02
  */
 static rsRetVal EnableKeepAlive(nsd_t *pNsd) {
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
     return nsd_ptcp.EnableKeepAlive(pThis->pTcp);
 }
@@ -1251,7 +1255,7 @@ static rsRetVal EnableKeepAlive(nsd_t *pNsd) {
  */
 static rsRetVal Connect(nsd_t *pNsd, int family, uchar *port, uchar *host, char *device) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     int mbedtlsRet;
 
     dbgprintf("Connect to %s:%s\n", host, port);
@@ -1332,7 +1336,7 @@ static rsRetVal ATTR_NONNULL(1, 3, 5) LstnInit(netstrms_t *pNS,
  * rgerhards, 2008-06-09
  */
 static rsRetVal CheckConnection(nsd_t *pNsd) {
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
 
     dbgprintf("CheckConnection for %p\n", pNsd);
@@ -1342,7 +1346,7 @@ static rsRetVal CheckConnection(nsd_t *pNsd) {
 /* Provide access to the underlying OS socket.
  */
 static rsRetVal GetSock(nsd_t *pNsd, int *pSock) {
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
     return nsd_ptcp.GetSock(pThis->pTcp, pSock);
 }
@@ -1352,7 +1356,7 @@ static rsRetVal GetSock(nsd_t *pNsd, int *pSock) {
  */
 static rsRetVal GetRemoteHName(nsd_t *pNsd, uchar **ppszHName) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
     iRet = nsd_ptcp.GetRemoteHName(pThis->pTcp, ppszHName);
     RETiRet;
@@ -1364,7 +1368,7 @@ static rsRetVal GetRemoteHName(nsd_t *pNsd, uchar **ppszHName) {
  */
 static rsRetVal GetRemAddr(nsd_t *pNsd, struct sockaddr_storage **ppAddr) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
     iRet = nsd_ptcp.GetRemAddr(pThis->pTcp, ppAddr);
     RETiRet;
@@ -1373,7 +1377,7 @@ static rsRetVal GetRemAddr(nsd_t *pNsd, struct sockaddr_storage **ppAddr) {
 /* get the remote host's IP address. Caller must Destruct the object. */
 static rsRetVal GetRemoteIP(nsd_t *pNsd, prop_t **ip) {
     DEFiRet;
-    nsd_mbedtls_t *pThis = (nsd_mbedtls_t *)pNsd;
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
     ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
     iRet = nsd_ptcp.GetRemoteIP(pThis->pTcp, ip);
     RETiRet;


### PR DESCRIPTION
## Summary
- fix ARMv7 strict `-Werror` build failures from `size_t`/`time_t` format mismatches
- route TLS driver `nsd_t` downcasts through explicit helpers to avoid ARM `-Wcast-align` failures
- scope the protobuf-c `-Wcast-align` suppression to generated `remote.pb-c.c` only

## Validation
- On Odroid XU4 / ARMv7 Armbian Ubuntu 26.04:
  - `./configure CFLAGS=-g --enable-compile-warning=error` with Ubuntu 26.04 dev-env flags
  - `make -j4`