### PR TITLE
mmanon: defensively harden IP suffix parsing

### DIFF
--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -621,6 +621,9 @@ static int syntax_ipv4(const uchar *const __restrict__ buf,
         goto done;
     }
     i++;
+    if (i >= buflen) {
+        goto done;
+    }
     if (isdigit(buf[i]) == 0 || isPosByte(buf + i, buflen - i, &nproc) == 0) {
         goto done;
     }
@@ -630,6 +633,9 @@ static int syntax_ipv4(const uchar *const __restrict__ buf,
         goto done;
     }
     i++;
+    if (i >= buflen) {
+        goto done;
+    }
     if (isdigit(buf[i]) == 0 || isPosByte(buf + i, buflen - i, &nproc) == 0) {
         goto done;
     }
@@ -639,6 +645,9 @@ static int syntax_ipv4(const uchar *const __restrict__ buf,
         goto done;
     }
     i++;
+    if (i >= buflen) {
+        goto done;
+    }
     if (isdigit(buf[i]) == 0 || isPosByte(buf + i, buflen - i, &nproc) == 0) {
         goto done;
     }
@@ -1760,8 +1769,17 @@ static int syntax_embedded(const uchar *const __restrict__ buf,
                 goto done;
             }
             *v4Start = findV4Start(buf, (*nprocessed) - 1);
-            if (syntax_ipv4(buf + (*v4Start), buflen, &ipv4Len)) {
-                *nprocessed += (ipv4Len - ((*nprocessed) - (*v4Start)));
+            if (*v4Start >= buflen) {
+                isIP = 0;
+                goto done;
+            }
+            if (syntax_ipv4(buf + (*v4Start), buflen - *v4Start, &ipv4Len)) {
+                const size_t ipv4BytesAlreadyScanned = *nprocessed - *v4Start;
+                if (ipv4Len < ipv4BytesAlreadyScanned) {
+                    isIP = 0;
+                    goto done;
+                }
+                *nprocessed += ipv4Len - ipv4BytesAlreadyScanned;
                 isIP = 1;
                 goto done;
             } else {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -728,7 +728,8 @@ TESTS_MMANON = \
 	mmanon_both_modes_compatible.sh \
 	mmanon_recognize_ipembedded.sh \
 	mmanon_ipv6_port.sh \
-	mmanon_random_cons_128_ipembedded.sh
+	mmanon_random_cons_128_ipembedded.sh \
+	mmanon_truncated_dotted_suffix.sh
 
 TESTS_CLICKHOUSE = \
 	clickhouse-start.sh \

--- a/tests/mmanon_truncated_dotted_suffix.sh
+++ b/tests/mmanon_truncated_dotted_suffix.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# This test hardens mmanon against truncated dotted IPv4-looking suffixes.
+# The oracle is normal shutdown plus exact output: malformed suffixes at the
+# end of a rewritten message must be preserved and must not read past the
+# message buffer while IPv4 and embedded-IPv4 scanners continue.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+
+module(load="../plugins/mmanon/.libs/mmanon")
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+ruleset(name="testing") {
+	action(type="mmanon" ipv4.mode="zero" ipv4.bits="32" ipv6.enable="off" embeddedipv4.anonmode="zero" embeddedipv4.bits="128")
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+}'
+
+startup
+tcpflood -m1 -M "\"<129>Mar 10 01:00:00 172.20.245.8 tag: 1.2.3.
+<129>Mar 10 01:00:00 172.20.245.8 tag: 1.2.
+<129>Mar 10 01:00:00 172.20.245.8 tag: 1.
+<129>Mar 10 01:00:00 172.20.245.8 tag: 10.20.30.40 1.2.3.
+<129>Mar 10 01:00:00 172.20.245.8 tag: aa:bb::1.2.3.\""
+
+shutdown_when_empty
+wait_shutdown
+export EXPECTED=' 1.2.3.
+ 1.2.
+ 1.
+ 0.0.0.0 1.2.3.
+ aa:bb::1.2.3.'
+cmp_exact
+exit_test


### PR DESCRIPTION
Summary: defensively harden mmanon IPv4 parsing for truncated dotted suffixes, bound embedded-IPv4 validation to the remaining message buffer, and add a focused regression test. Notes: this came from the mm* audit for parser issues similar to GHSA-2whq-6rcm-64m8. mmpstrucdata was intentionally not changed. Validation: targeted mmanon tests passed, new regression test passed under Valgrind, make distcheck TEST_RUN_TYPE=MOCK-OK passed, and Ubuntu 26.04 dev container clang static analyzer reported no bugs. Full Ubuntu 26.04 container CI was attempted; the new mmanon test passed, but the full suite was blocked by an unrelated reproducible imuxsock_unlink_off_stale_socket.sh failure where stderr contained the expected diagnostic but the test .started file was not created.