### PR TITLE
pm/fm: defensively harden parsing edge cases

### DIFF
--- a/contrib/pmdb2diag/pmdb2diag.c
+++ b/contrib/pmdb2diag/pmdb2diag.c
@@ -53,12 +53,17 @@ MODULE_CNFNAME("pmdb2diag")
 DEF_PMOD_STATIC_DATA;
 DEFobjCurrIf(glbl) DEFobjCurrIf(datetime)
 
-    /* input instance parameters */
-    static struct cnfparamdescr parserpdescr[] = {
-        {"levelpos", eCmdHdlrInt, 0},
-        {"timepos", eCmdHdlrInt, 0},
-        {"timeformat", eCmdHdlrString, 0},
-        {"pidstarttoprogstartshift", eCmdHdlrInt, 0},
+    static char *bounded_memchr(char *const start, const int len, const int ch) {
+    if (len <= 0) return NULL;
+    return memchr(start, ch, len);
+}
+
+/* input instance parameters */
+static struct cnfparamdescr parserpdescr[] = {
+    {"levelpos", eCmdHdlrInt, 0},
+    {"timepos", eCmdHdlrInt, 0},
+    {"timeformat", eCmdHdlrString, 0},
+    {"pidstarttoprogstartshift", eCmdHdlrInt, 0},
 };
 static struct cnfparamblk parserpblk = {CNFPARAMBLK_VERSION, sizeof(parserpdescr) / sizeof(struct cnfparamdescr),
                                         parserpdescr};
@@ -78,21 +83,26 @@ ENDisCompatibleWithFeature
 
 BEGINparse2
     struct tm tm;
-    char *ms, *timepos, *pid, *prog, *eprog, *backslash, *end, *lvl;
-    int lprog, lpid, lvl_len;
+    char *ms, *timepos, *pid, *prog, *eprog, *backslash, *end, *lvl, *rawStart, *space;
+    int lprog, lpid, lvl_len, rawLen;
     char buffer[128];
     CODESTARTparse2;
     assert(pMsg != NULL);
     assert(pMsg->pszRawMsg != NULL);
 
     DBGPRINTF("Message will now be parsed by \"db2diag\" parser.\n");
-    if (pMsg->iLenRawMsg - (int)pMsg->offAfterPRI < pInst->levelpos + 4) ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+    rawStart = (char *)pMsg->pszRawMsg + pMsg->offAfterPRI;
+    rawLen = pMsg->iLenRawMsg - (int)pMsg->offAfterPRI;
+    if (rawLen <= 0 || pInst->levelpos < 0 || pInst->timepos < 0 || pInst->pidstarttoprogstartshift < 0) {
+        ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+    }
+    if (pInst->levelpos > rawLen - 4 || pInst->timepos >= rawLen) ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 
     /* Instead of comparing strings which a waste of cpu cycles we take interpret the 4 first chars of
      * level read it as int32 and compare it to same interpretation of our constant "levels"
      * So this test is not sensitive to ENDIANESS. This is not a clean way but very efficient.
      */
-    lvl = (char *)(pMsg->pszRawMsg + pMsg->offAfterPRI + pInst->levelpos);
+    lvl = rawStart + pInst->levelpos;
 
     switch (*lvl) {
         case 'C': /* Critical */
@@ -129,13 +139,13 @@ BEGINparse2
     }
 
     /* let recheck with the real level len */
-    if (pMsg->iLenRawMsg - (int)pMsg->offAfterPRI < pInst->levelpos + lvl_len) ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+    if (pInst->levelpos > rawLen - lvl_len) ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
 
     DBGPRINTF("db2parse Level %d\n", pMsg->iSeverity);
 
     end = (char *)pMsg->pszRawMsg + pMsg->iLenRawMsg;
 
-    timepos = (char *)pMsg->pszRawMsg + pMsg->offAfterPRI + pInst->timepos;
+    timepos = rawStart + pInst->timepos;
 
     DBGPRINTF("db2parse Time %.30s\n", timepos);
     ms = strptime(timepos, pInst->timeformat, &tm);
@@ -163,10 +173,13 @@ BEGINparse2
         pMsg->tTIMESTAMP.OffsetMinute = tzoff % 60;
     }
 
-    pid = strchr((char *)pMsg->pszRawMsg + pInst->levelpos + lvl_len, ':');
+    pid = bounded_memchr(rawStart + pInst->levelpos + lvl_len, rawLen - (pInst->levelpos + lvl_len), ':');
     if (!pid || pid >= end) ABORT_FINALIZE(0);
+    if (end - pid < 3) ABORT_FINALIZE(0);
     pid += 2;
-    lpid = strchr(pid, ' ') - pid;
+    space = bounded_memchr(pid, end - pid, ' ');
+    if (space == NULL) ABORT_FINALIZE(0);
+    lpid = space - pid;
 
     DBGPRINTF("db2parse pid %.*s\n", lpid, pid);
 
@@ -174,14 +187,14 @@ BEGINparse2
     snprintf(buffer, 128, "%.*s", lpid, pid);
     MsgSetPROCID(pMsg, buffer);
 
+    if (pInst->pidstarttoprogstartshift > end - pid) ABORT_FINALIZE(0);
     prog = pid + pInst->pidstarttoprogstartshift; /* this offset between start of pid to start of prog */
     if (prog >= end) ABORT_FINALIZE(0);
 
-    eprog = strchr(prog, ' '); /* let find the end of the program */
-    if (eprog && eprog >= end) ABORT_FINALIZE(0);
+    eprog = bounded_memchr(prog, end - prog, ' '); /* let find the end of the program */
 
-    backslash = strchr(prog, '\\'); /* perhaps program contain an backslash */
-    if (!backslash || backslash >= end) backslash = end;
+    backslash = bounded_memchr(prog, end - prog, '\\'); /* perhaps program contain an backslash */
+    if (!backslash) backslash = end;
 
     /* Determine the final length of prog */
     lprog = (eprog && eprog < backslash) ? eprog - prog : backslash - prog;
@@ -259,10 +272,14 @@ BEGINnewParserInst
     }
 
     if (inst->timeformat == NULL) {
-        inst->timeformat = strdup("%Y-%m-%d-%H.%M.%S.");
+        CHKmalloc(inst->timeformat = strdup("%Y-%m-%d-%H.%M.%S."));
         inst->sepSec = '.';
-    } else
+    } else if (strlen(inst->timeformat) == 0) {
+        LogError(0, RS_RET_INVALID_PARAMS, "pmdb2diag: timeformat must not be empty");
+        ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+    } else {
         inst->sepSec = inst->timeformat[strlen(inst->timeformat) - 1];
+    }
 
     DBGPRINTF("pmdb2diag: parsing date/time with '%s' at position %d and level at position %d.\n", inst->timeformat,
               inst->timepos, inst->levelpos);

--- a/contrib/pmpanngfw/pmpanngfw.c
+++ b/contrib/pmpanngfw/pmpanngfw.c
@@ -132,7 +132,7 @@ BEGINparse
     }
 
     /* check log type */
-    log_type = *((uint64 *)p2parse);
+    memcpy(&log_type, p2parse, sizeof(log_type));
     for (j = 0; j < (int)NUM_LOG_TYPES; j++) {
         if ((log_type & log_types[j].mask) == log_types[j].value) break;
     }

--- a/contrib/pmsnare/pmsnare.c
+++ b/contrib/pmsnare/pmsnare.c
@@ -113,6 +113,15 @@ struct instanceConf_s {
     struct instanceConf_s *next;
 };
 
+static int hasPrefixWithFollowingTab(const uchar *const p,
+                                     const int len,
+                                     const char *const prefix,
+                                     const int prefixLen,
+                                     const instanceConf_t *const pInst) {
+    return len >= prefixLen + pInst->tabLength && strncasecmp((const char *)p, prefix, prefixLen) == 0 &&
+           strncasecmp((const char *)(p + prefixLen), pInst->tabRepresentation, pInst->tabLength) == 0;
+}
+
 /* Creates the instance and adds it to the list of instances. */
 static rsRetVal createInstance(instanceConf_t **pinst) {
     instanceConf_t *inst;
@@ -265,19 +274,16 @@ BEGINactivateCnf
 ENDactivateCnf
 
 BEGINfreeCnf
-    instanceConf_t *inst, *del;
     CODESTARTfreeCnf;
-    for (inst = modInstances->root; inst != NULL;) {
-        del = inst;
-        inst = inst->next;
-        free(del);
-    }
     free(modInstances);
+    modInstances = NULL;
 ENDfreeCnf
 
 BEGINparse2
     uchar *p2parse;
+    const uchar *tagStart;
     int lenMsg;
+    int tagLen;
     int snaremessage; /* 0 means not a snare message, otherwise it's the index of the tab after the tag  */
 
     CODESTARTparse2;
@@ -322,11 +328,13 @@ BEGINparse2
         dbgprintf("pmsnare: tab [%d]'%s'	msg at the first separator: [%d]'%s'\n", pInst->tabLength,
                   pInst->tabRepresentation, lenMsg, p2parse);
 
-        /* Look for the Snare tag. */
-        if (strncasecmp((char *)(p2parse + pInst->tabLength), "MSWinEventLog", 13) == 0) {
+        /* Look for the Snare tag plus the following separator we rewrite below. */
+        tagStart = p2parse + pInst->tabLength;
+        tagLen = lenMsg - pInst->tabLength;
+        if (hasPrefixWithFollowingTab(tagStart, tagLen, "MSWinEventLog", 13, pInst)) {
             dbgprintf("Found a non-syslog Windows Snare message.\n");
             snaremessage = p2parse - pMsg->pszRawMsg + pInst->tabLength + 13;
-        } else if (strncasecmp((char *)(p2parse + pInst->tabLength), "LinuxKAudit", 11) == 0) {
+        } else if (hasPrefixWithFollowingTab(tagStart, tagLen, "LinuxKAudit", 11, pInst)) {
             dbgprintf("Found a non-syslog Linux Snare message.\n");
             snaremessage = p2parse - pMsg->pszRawMsg + pInst->tabLength + 11;
         } else {
@@ -377,10 +385,10 @@ BEGINparse2
                   pInst->tabRepresentation, lenMsg, p2parse);
 
         /* Look for the Snare tag. */
-        if (lenMsg > 13 && strncasecmp((char *)p2parse, "MSWinEventLog", 13) == 0) {
+        if (hasPrefixWithFollowingTab(p2parse, lenMsg, "MSWinEventLog", 13, pInst)) {
             dbgprintf("Found a syslog Windows Snare message.\n");
             snaremessage = p2parse - pMsg->pszRawMsg + 13;
-        } else if (lenMsg > 11 && strncasecmp((char *)p2parse, "LinuxKAudit", 11) == 0) {
+        } else if (hasPrefixWithFollowingTab(p2parse, lenMsg, "LinuxKAudit", 11, pInst)) {
             dbgprintf("pmsnare: Found a syslog Linux Snare message.\n");
             snaremessage = p2parse - pMsg->pszRawMsg + 11;
         }
@@ -392,6 +400,9 @@ BEGINparse2
         lenMsg = pMsg->iLenRawMsg - snaremessage;
 
         /* Remove the tab after the tag. */
+        if (lenMsg < pInst->tabLength) {
+            ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+        }
         *p2parse = ' ';
         p2parse++;
         lenMsg--;

--- a/plugins/fmhttp/fmhttp.c
+++ b/plugins/fmhttp/fmhttp.c
@@ -23,7 +23,9 @@
  */
 #include "config.h"
 #include "rsyslog.h"
+#include <limits.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <string.h>
 #include <assert.h>
 #include <errno.h>
@@ -51,10 +53,9 @@ struct curl_funcData {
 /* curl callback for doFunc_http_request */
 static size_t curlResult(void *ptr, size_t size, size_t nmemb, void *userdata) {
     char *buf;
+    size_t chunkLen;
     size_t newlen;
-    struct cnffunc *const func = (struct cnffunc *)userdata;
-    assert(func != NULL);
-    struct curl_funcData *const curlData = (struct curl_funcData *)func->funcdata;
+    struct curl_funcData *const curlData = (struct curl_funcData *)userdata;
     assert(curlData != NULL);
 
     if (ptr == NULL) {
@@ -62,15 +63,25 @@ static size_t curlResult(void *ptr, size_t size, size_t nmemb, void *userdata) {
         return 0;
     }
 
-    newlen = curlData->replyLen + size * nmemb;
+    if (nmemb != 0 && size > SIZE_MAX / nmemb) {
+        LogError(0, RS_RET_ERR, "rainerscript: http_request reply too large");
+        return 0;
+    }
+    chunkLen = size * nmemb;
+    if (curlData->replyLen > SIZE_MAX - 1 || chunkLen > SIZE_MAX - curlData->replyLen - 1 ||
+        curlData->replyLen > UINT_MAX || chunkLen > UINT_MAX - curlData->replyLen) {
+        LogError(0, RS_RET_ERR, "rainerscript: http_request reply too large");
+        return 0;
+    }
+    newlen = curlData->replyLen + chunkLen;
     if ((buf = realloc((void *)curlData->reply, newlen + 1)) == NULL) {
         LogError(errno, RS_RET_ERR, "rainerscript: realloc failed in curlResult");
         return 0; /* abort due to failure */
     }
-    memcpy(buf + curlData->replyLen, (char *)ptr, size * nmemb);
+    memcpy(buf + curlData->replyLen, (char *)ptr, chunkLen);
     curlData->replyLen = newlen;
     curlData->reply = buf;
-    return size * nmemb;
+    return chunkLen;
 }
 
 static void ATTR_NONNULL() doFunc_http_request(struct cnffunc *__restrict__ const func,
@@ -85,15 +96,14 @@ static void ATTR_NONNULL() doFunc_http_request(struct cnffunc *__restrict__ cons
     int resultSet = 0;
     CURL *handle = NULL;
     CURLcode res;
+    struct curl_funcData curlData = {.reply = NULL, .replyLen = 0};
     assert(func != NULL);
-    struct curl_funcData *const curlData = (struct curl_funcData *)func->funcdata;
-    assert(curlData != NULL);
     rsRetVal iRet __attribute__((unused)) = RS_RET_OK;
 
     CHKmalloc(handle = curl_easy_init());
     curl_easy_setopt(handle, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, curlResult);
-    curl_easy_setopt(handle, CURLOPT_WRITEDATA, func);
+    curl_easy_setopt(handle, CURLOPT_WRITEDATA, &curlData);
 
     curl_easy_setopt(handle, CURLOPT_URL, url);
     res = curl_easy_perform(handle);
@@ -104,14 +114,12 @@ static void ATTR_NONNULL() doFunc_http_request(struct cnffunc *__restrict__ cons
     }
 
 
-    CHKmalloc(ret->d.estr = es_newStrFromCStr(curlData->reply, curlData->replyLen));
+    CHKmalloc(ret->d.estr = es_newStrFromCStr(curlData.reply, curlData.replyLen));
     ret->datatype = 'S';
     resultSet = 1;
 
 finalize_it:
-    free((void *)curlData->reply);
-    curlData->reply = NULL;
-    curlData->replyLen = 0;
+    free((void *)curlData.reply);
 
     if (handle != NULL) {
         curl_easy_cleanup(handle);
@@ -130,8 +138,8 @@ finalize_it:
 static rsRetVal ATTR_NONNULL(1) initFunc_http_request(struct cnffunc *const func) {
     DEFiRet;
 
-    func->destructable_funcdata = 1;
-    CHKmalloc(func->funcdata = calloc(1, sizeof(struct curl_funcData)));
+    func->destructable_funcdata = 0;
+    func->funcdata = NULL;
     if (func->nParams != 1) {
         parser_errmsg("rsyslog logic error in line %d of file %s\n", __LINE__, __FILE__);
         FINALIZE;
@@ -142,9 +150,7 @@ finalize_it:
 }
 
 static void ATTR_NONNULL(1) destructFunc_http_request(struct cnffunc *const func) {
-    if (func->funcdata != NULL) {
-        free((void *)((struct curl_funcData *)func->funcdata)->reply);
-    }
+    (void)func;
 }
 
 static struct scriptFunct functions[] = {

--- a/plugins/pmciscoios/pmciscoios.c
+++ b/plugins/pmciscoios/pmciscoios.c
@@ -163,6 +163,7 @@ BEGINparse2
         ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
     }
     p2parse += 2;
+    lenMsg -= 2;
 
     /* ORIGIN (optional) */
     if (pInst->bOriginPresent) {
@@ -179,6 +180,7 @@ BEGINparse2
             ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
         }
         p2parse += 2;
+        lenMsg -= 2;
     }
 
     /* XR RSP (optional) */
@@ -193,10 +195,14 @@ BEGINparse2
             ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
         }
         p2parse += 1;
+        lenMsg -= 1;
     }
 
     /* TIMESTAMP */
-    if (p2parse[0] == '*' || p2parse[0] == '.') p2parse++;
+    if (lenMsg > 0 && (p2parse[0] == '*' || p2parse[0] == '.')) {
+        p2parse++;
+        lenMsg--;
+    }
     if (datetime.ParseTIMESTAMP3164(&(pMsg->tTIMESTAMP), &p2parse, &lenMsg, PARSE3164_TZSTRING,
                                     NO_PERMIT_YEAR_AFTER_TIME) == RS_RET_OK) {
         if (pMsg->dfltTZ[0] != '\0') applyDfltTZ(&pMsg->tTIMESTAMP, pMsg->dfltTZ);
@@ -231,7 +237,13 @@ BEGINparse2
         --lenMsg;
     }
     /* delimiter check */
-    if (pInst->bXrPresent) p2parse++;
+    if (pInst->bXrPresent) {
+        if (lenMsg < 1) {
+            ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);
+        }
+        p2parse++;
+        lenMsg--;
+    }
     if (lenMsg < 2 || *p2parse != ':' || *(p2parse + 1) != ' ') {
         DBGPRINTF("pmciscoios: fail after tag: '%s'\n", p2parse);
         ABORT_FINALIZE(RS_RET_COULD_NOT_PARSE);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -199,6 +199,7 @@ TESTS_DEFAULT = \
 	pmrfc3164-AtSignsInHostname.sh \
 	pmrfc3164-AtSignsInHostname_off.sh \
 	pmrfc3164-tagEndingByColon.sh \
+	pmrfc3164_force_tag_no_colon.sh \
 	pmrfc3164-defaultTag.sh \
 	pmrfc3164-headerless.sh \
 	pmrfc3164-drop.sh \
@@ -1664,7 +1665,11 @@ TESTS_OMRULESET = \
 	omruleset-queue.sh
 
 TESTS_PMDB2DIAG = \
-	pmdb2diag_parse.sh
+	pmdb2diag_parse.sh \
+	pmdb2diag_malformed_tail.sh
+
+TESTS_PMCISCOIOS = \
+	pmciscoios_truncated_input.sh
 
 TESTS_PMSNARE = \
 	pmsnare-default.sh \
@@ -1677,6 +1682,7 @@ TESTS_PMSNARE = \
 	pmsnare-cccstyle-udp.sh \
 	pmsnare-ccbackslash.sh \
 	pmsnare-ccbackslash-udp.sh \
+	pmsnare_malformed_tag_tail.sh \
 	pmsnare-modoverride.sh \
 	pmsnare-modoverride-udp.sh
 
@@ -2016,6 +2022,7 @@ EXTRA_DIST += $(TESTS_IMDTLS_OMDTLS_VALGRIND)
 EXTRA_DIST += $(TESTS_OMUDPSPOOF)
 EXTRA_DIST += $(TESTS_OMRULESET)
 EXTRA_DIST += $(TESTS_PMDB2DIAG)
+EXTRA_DIST += $(TESTS_PMCISCOIOS)
 EXTRA_DIST += $(TESTS_PMSNARE)
 EXTRA_DIST += $(TESTS_PMLASTMSG)
 EXTRA_DIST += $(TESTS_IMFILE_EXTENDED)
@@ -3006,6 +3013,11 @@ endif
 
 if ENABLE_PMDB2DIAG
 TESTS += $(TESTS_PMDB2DIAG)
+endif
+
+
+if ENABLE_PMCISCOIOS
+TESTS += $(TESTS_PMCISCOIOS)
 endif
 
 

--- a/tests/pmciscoios_truncated_input.sh
+++ b/tests/pmciscoios_truncated_input.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This test hardens pmciscoios against truncated messages after delimiter
+# skips. The oracle is that malformed Cisco-looking input does not move parser
+# walks past the logical message and a following marker message is processed.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/pmciscoios/.libs/pmciscoios")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+parser(name="custom.ciscoios" type="pmciscoios")
+template(name="outfmt" type="string" string="valid-after\n")
+
+ruleset(name="testing" parser="custom.ciscoios") {
+	if $rawmsg contains "valid-after" then {
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+}'
+
+startup
+tcpflood -m1 -M "\"<14>1: \""
+tcpflood -m1 -M "\"<14>2: .\""
+tcpflood -m1 -M "\"<14>valid-after\""
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='valid-after'
+cmp_exact
+exit_test

--- a/tests/pmdb2diag_malformed_tail.sh
+++ b/tests/pmdb2diag_malformed_tail.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This test hardens pmdb2diag against malformed DB2-like tails. The oracle is
+# that unterminated PID/program delimiters do not trigger unbounded searches or
+# NULL pointer arithmetic, and a following marker message is still processed.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/pmdb2diag/.libs/pmdb2diag")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+parser(type="pmdb2diag" timeformat="%Y-%m-%d-%H.%M.%S." timepos="0" levelpos="59" pidstarttoprogstartshift="49" name="db2.diag.hardened")
+template(name="outfmt" type="string" string="valid-after\n")
+
+ruleset(name="testing" parser="db2.diag.hardened") {
+	if $rawmsg contains "valid-after" then {
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+}'
+
+startup
+tcpflood -m1 -M "\"<14>2015-05-06-16.53.26.989430+120 E1876227378A1702     LEVEL: Info
+PID     :\""
+tcpflood -m1 -M "\"<14>valid-after\""
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='valid-after'
+cmp_exact
+exit_test

--- a/tests/pmrfc3164_force_tag_no_colon.sh
+++ b/tests/pmrfc3164_force_tag_no_colon.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# This test hardens pmrfc3164 force.tagEndingByColon handling. The oracle is
+# that a no-colon token rewinds exactly the consumed bytes, not one byte before
+# the message, and a following marker message is still processed.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+parser(name="custom.rfc3164" type="pmrfc3164" force.tagEndingByColon="on")
+template(name="outfmt" type="string" string="valid-after\n")
+
+ruleset(name="testing" parser="custom.rfc3164") {
+	if $rawmsg contains "valid-after" then {
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+}'
+
+startup
+tcpflood -m1 -M "\"<14>May 21 12:00:01 host token-without-colon\""
+tcpflood -m1 -M "\"<14>valid-after\""
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='valid-after'
+cmp_exact
+exit_test

--- a/tests/pmsnare_malformed_tag_tail.sh
+++ b/tests/pmsnare_malformed_tag_tail.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# This test hardens pmsnare against Snare tag matches without a following tab
+# representation. The oracle is that short tails do not underflow rewrite
+# lengths and a following marker message is still processed.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../contrib/pmsnare/.libs/pmsnare")
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="testing")
+
+template(name="outfmt" type="string" string="valid-after\n")
+
+ruleset(name="testing" parser=["rsyslog.snare", "rsyslog.rfc3164"]) {
+	if $rawmsg contains "valid-after" then {
+		action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+	}
+}'
+
+startup
+tcpflood -m1 -M "\"<14>May 21 12:00:01 host MSWinEventLog\""
+tcpflood -m1 -M "\"<14>May 21 12:00:01 host LinuxKAudit\""
+tcpflood -m1 -M "\"<14>host	MSWinEventLog\""
+tcpflood -m1 -M "\"<14>valid-after\""
+shutdown_when_empty
+wait_shutdown
+
+export EXPECTED='valid-after'
+cmp_exact
+exit_test

--- a/tools/pmrfc3164.c
+++ b/tools/pmrfc3164.c
@@ -468,6 +468,7 @@ BEGINparse2
          * in RFC3164...). We now receive the full size, but will modify the
          * outputs so that only 32 characters max are used by default.
          */
+        uchar* const pTagStart = p2parse;
         i = 0;
         while (lenMsg > 0 && *p2parse != ':' && *p2parse != ' ' && i < CONF_TAG_MAXSIZE - 2) {
             bufParseTAG[i++] = *p2parse++;
@@ -481,8 +482,12 @@ BEGINparse2
             /* Tag need to be ended by a colon or it's not a tag but the
              * begin of the message
              */
-            p2parse -= (i + 1);
-            lenMsg += (i + 1);
+            size_t rewind = i;
+            if (pTagStart > pMsg->pszRawMsg && pTagStart[-1] == ' ') {
+                ++rewind;
+            }
+            p2parse -= rewind;
+            lenMsg += rewind;
             i = 0;
             /* Default TAG is dash (without ':')
              */


### PR DESCRIPTION
## Summary
- defensively harden pmdb2diag, pmsnare, pmciscoios, pmpanngfw, pmrfc3164, and fmhttp edge cases found during the pm/fm audit pass
- add regression tests for malformed parser tails and force.tagEndingByColon no-colon handling

## Validation
- PASS: Ubuntu 26.04 static analyzer container, scan-build reported no bugs
- PASS: targeted local tests: pmciscoios_truncated_input.sh, pmsnare_malformed_tag_tail.sh, pmdb2diag_malformed_tail.sh, pmrfc3164_force_tag_no_colon.sh
- PASS: representative existing tests: pmsnare-default.sh, pmrfc3164-tagEndingByColon.sh, pmrfc3164-defaultTag.sh, rscript_http_request.sh, pmdb2diag_parse.sh
- PASS: valgrind for the four new regression tests
- PASS: make distcheck TEST_RUN_TYPE=MOCK-OK
- BLOCKED: full Ubuntu 26.04 container CI still has 1 unrelated failure in imuxsock_unlink_off_stale_socket.sh; the expected stale-socket diagnostic was emitted on stderr, but the test expected it in the .started file, which was not created

## Notes
mmpstrucdata was intentionally not touched.
