### PR TITLE
contrib: harden buffer and parser bounds handling

### DIFF
--- a/contrib/imdocker/imdocker.c
+++ b/contrib/imdocker/imdocker.c
@@ -325,6 +325,10 @@ static rsRetVal dockerContLogsBufWrite(docker_cont_logs_buf_t *const pThis,
     DEFiRet;
 
     imdocker_buf_t *const mem = pThis->buf;
+    if (mem->len == SIZE_MAX || write_size > SIZE_MAX - mem->len - 1) {
+        LogError(0, RS_RET_ERR, "%s() - buffer size overflow\n", __FUNCTION__);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
     if (mem->len + write_size + 1 > mem->data_size) {
         uchar *const pbuf = realloc(mem->data, mem->len + write_size + 1);
         if (pbuf == NULL) {
@@ -1103,7 +1107,7 @@ static rsRetVal enqMsg(docker_cont_logs_inst_t *pInst,
         size_t lenMsg = pMsg->iLenRawMsg;
         uchar *pszMsg = pMsg->pszRawMsg;
 
-        if (pszMsg[lenMsg - 1] == '\0') {
+        if (lenMsg > 0 && pszMsg[lenMsg - 1] == '\0') {
             DBGPRINTF("dropped NULL at very end of message\n");
             lenMsg--;
         }
@@ -1179,10 +1183,13 @@ static void debug_byte_buffer(const uchar *data, size_t size) {
 static size_t imdocker_container_list_curlCB(void *data, size_t size, size_t nmemb, void *buffer) {
     DEFiRet;
 
-    size_t realsize = size * nmemb;
+    size_t realsize;
     uchar *pbuf = NULL;
     imdocker_buf_t *mem = (imdocker_buf_t *)buffer;
 
+    if (nmemb != 0 && size > SIZE_MAX / nmemb) ABORT_FINALIZE(RS_RET_ERR);
+    realsize = size * nmemb;
+    if (mem->len == SIZE_MAX || realsize > SIZE_MAX - mem->len - 1) ABORT_FINALIZE(RS_RET_ERR);
     if ((pbuf = realloc(mem->data, mem->len + realsize + 1)) == NULL) {
         LogError(errno, RS_RET_ERR, "%s() - realloc failed!\n", __FUNCTION__);
         ABORT_FINALIZE(RS_RET_ERR);
@@ -1328,9 +1335,12 @@ static size_t imdocker_container_logs_curlCB(void *data, size_t size, size_t nme
     docker_cont_logs_inst_t *pInst = (docker_cont_logs_inst_t *)buffer;
     docker_cont_logs_req_t *req = pInst->logsReq;
 
-    size_t realsize = size * nmemb;
+    size_t realsize;
     const uchar *pdata = data;
     size_t write_size = 0;
+
+    if (nmemb != 0 && size > SIZE_MAX / nmemb) ABORT_FINALIZE(RS_RET_ERR);
+    realsize = size * nmemb;
 
 #ifdef ENABLE_DEBUG_BYTE_BUFFER
     debug_byte_buffer((const uchar *)data, realsize);

--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -28,6 +28,7 @@
 #include <unistd.h>
 #include <stdarg.h>
 #include <ctype.h>
+#include <limits.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <sys/types.h>
@@ -1536,8 +1537,13 @@ BEGINsetModCnf
             if (pvals[i].val.d.ar->nmemb == 0) {
                 continue;
             }
-            CHKmalloc(loadModConf->options = calloc(pvals[i].val.d.ar->nmemb, sizeof(struct option)));
-            for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+            const int nmemb = pvals[i].val.d.ar->nmemb;
+            if (nmemb < 0 || (size_t)nmemb > ((size_t)-1) / sizeof(struct option)) {
+                LogError(0, RS_RET_PARAM_ERROR, "imhttp: too many liboptions configured");
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            CHKmalloc(loadModConf->options = calloc((size_t)nmemb, sizeof(struct option)));
+            for (int j = 0; j < nmemb; ++j) {
                 CHKmalloc(cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL));
                 CHKiRet(processCivetwebOptions(cstr, &loadModConf->options[j].name, &loadModConf->options[j].val));
                 ++loadModConf->nOptions;
@@ -1652,7 +1658,16 @@ BEGINactivateCnf
     if (runModConf->docroot.val) {
         count += 2;
     }
+    if (runModConf->nOptions < 0 || (size_t)runModConf->nOptions > ((size_t)-1 - count) / 2 ||
+        (size_t)runModConf->nOptions > ((size_t)-1) / sizeof(*s_httpserv->civetweb_options)) {
+        LogError(0, RS_RET_PARAM_ERROR, "imhttp: too many civetweb options configured");
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
     count += (2 * runModConf->nOptions);
+    if (count > ((size_t)-1) / sizeof(*s_httpserv->civetweb_options)) {
+        LogError(0, RS_RET_PARAM_ERROR, "imhttp: too many civetweb options configured");
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
     CHKmalloc(s_httpserv->civetweb_options = calloc(count, sizeof(*s_httpserv->civetweb_options)));
 
     const char **pcivetweb_options = s_httpserv->civetweb_options;

--- a/contrib/imkmsg/kmsg.c
+++ b/contrib/imkmsg/kmsg.c
@@ -66,7 +66,7 @@ static int bInInitialReading = 1; /* are we in the initial kmsg reading phase? *
  * from the rest.
  */
 static void submitSyslog(modConfData_t *const pModConf, const uchar *buf) {
-    long offs = 0;
+    size_t offs = 0;
     struct timeval tv;
     struct timeval *tp = NULL;
     struct sysinfo info;
@@ -85,11 +85,19 @@ static void submitSyslog(modConfData_t *const pModConf, const uchar *buf) {
     for (; isdigit(*buf); buf++) {
         priority = (priority * 10) + (*buf - '0');
     }
+    if (*buf != ',') {
+        json_object_put(json);
+        return;
+    }
     buf++;
 
     /* get messages sequence number and add it to json */
     for (; isdigit(*buf); buf++) {
         sequnum = (sequnum * 10) + (*buf - '0');
+    }
+    if (*buf != ',') {
+        json_object_put(json);
+        return;
     }
     buf++; /* skip , */
     jval = json_object_new_int(sequnum);
@@ -100,15 +108,21 @@ static void submitSyslog(modConfData_t *const pModConf, const uchar *buf) {
         timestamp = (timestamp * 10) + (*buf - '0');
     }
 
-    while (*buf != ';') {
+    while (*buf != ';' && *buf != '\0') {
         buf++; /* skip everything till the first ; */
+    }
+    if (*buf == '\0') {
+        json_object_put(json);
+        return;
     }
     buf++; /* skip ; */
 
     /* get message */
     offs = 0;
-    for (; *buf != '\n' && *buf != '\0'; buf++, offs++) {
-        msg[offs] = *buf;
+    for (; *buf != '\n' && *buf != '\0'; buf++) {
+        if (offs < sizeof(msg) - 1) {
+            msg[offs++] = *buf;
+        }
     }
     msg[offs] = '\0';
     jval = json_object_new_string((char *)msg);
@@ -121,16 +135,21 @@ static void submitSyslog(modConfData_t *const pModConf, const uchar *buf) {
         /* get name of the property */
         buf++; /* skip ' ' */
         offs = 0;
-        for (; *buf != '=' && *buf != ' '; buf++, offs++) {
-            name[offs] = *buf;
+        for (; *buf != '=' && *buf != ' ' && *buf != '\n' && *buf != '\0'; buf++) {
+            if (offs < sizeof(name) - 1) {
+                name[offs++] = *buf;
+            }
         }
         name[offs] = '\0';
+        if (*buf == '\n' || *buf == '\0') break;
         buf++; /* skip = or ' ' */
         ;
 
         offs = 0;
-        for (; *buf != '\n' && *buf != '\0'; buf++, offs++) {
-            value[offs] = *buf;
+        for (; *buf != '\n' && *buf != '\0'; buf++) {
+            if (offs < sizeof(value) - 1) {
+                value[offs++] = *buf;
+            }
         }
         value[offs] = '\0';
         if (*buf != '\0') {

--- a/contrib/impcap/dns_parser.c
+++ b/contrib/impcap/dns_parser.c
@@ -202,9 +202,13 @@ static const char *get_class(uint16_t x) {
  */
 data_ret_t *dns_parse(const uchar *packet, int pktSize, struct json_object *jparent) {
     const uchar *packet_ptr = packet;
-    const uchar *end_packet = packet + pktSize;
     DBGPRINTF("dns_parse\n");
     DBGPRINTF("packet size %d\n", pktSize);
+    if (pktSize < 12) {
+        DBGPRINTF("DNS packet too small : %d\n", pktSize);
+        RETURN_DATA_AFTER(0)
+    }
+    const uchar *end_packet = packet + pktSize;
 
     /* Union to prevent cast from uchar to smb_header_t */
     union {

--- a/contrib/impcap/eth_parser.c
+++ b/contrib/impcap/eth_parser.c
@@ -142,6 +142,10 @@ data_ret_t *eth_parse(const uchar *packet, int pktSize, struct json_object *jpar
     uint16_t ethType = (uint16_t)ntohs(eth_header->type);
 
     if (ethType == ETHERTYPE_VLAN) {
+        if (pktSize < (int)sizeof(vlan_header_t)) {
+            DBGPRINTF("VLAN packet too small : %d\n", pktSize);
+            RETURN_DATA_AFTER(0)
+        }
         vlan_header_t *vlan_header = (vlan_header_t *)packet;
         json_object_object_add(jparent, "ETH_tag", json_object_new_int(ntohs(vlan_header->vlanTag)));
         ethType = (uint16_t)ntohs(vlan_header->type);
@@ -154,6 +158,7 @@ data_ret_t *eth_parse(const uchar *packet, int pktSize, struct json_object *jpar
         /* this is a LLC header */
         json_object_object_add(jparent, "ETH_len", json_object_new_int(ethType));
         ret = llc_parse(packet + hdrLen, pktSize - hdrLen, jparent);
+        if (ret == NULL) return NULL;
 
         /* packet has the minimum allowed size, so the remaining data is
          * most likely padding, this should not appear as data, so remove it
@@ -169,6 +174,7 @@ data_ret_t *eth_parse(const uchar *packet, int pktSize, struct json_object *jpar
     json_object_object_add(jparent, "ETH_type", json_object_new_int(ethType));
     json_object_object_add(jparent, "ETH_typestr", json_object_new_string((char *)eth_type_to_string(ethType)));
     ret = eth_proto_parse(ethType, (packet + hdrLen), (pktSize - hdrLen), jparent);
+    if (ret == NULL) return NULL;
 
     /* packet has the minimum allowed size, so the remaining data is
      * most likely padding, this should not appear as data, so remove it */

--- a/contrib/impcap/ftp_parser.c
+++ b/contrib/impcap/ftp_parser.c
@@ -93,12 +93,17 @@ data_ret_t *ftp_parse(const uchar *packet, int pktSize, struct json_object *jpar
     if (pktSize < 5) { /* too short for ftp packet*/
         RETURN_DATA_AFTER(0)
     }
-    uchar *packet2 = (uchar *)malloc(pktSize * sizeof(uchar));
+    uchar *packet2 = (uchar *)malloc((size_t)pktSize + 1);
+    if (packet2 == NULL) {
+        RETURN_DATA_AFTER(0)
+    }
 
     memcpy(packet2, packet, pktSize);  // strtok changes original packet
+    packet2[pktSize] = '\0';
+    char *saveptr = NULL;
     uchar *frst_part_ftp;
-    frst_part_ftp = (uchar *)strtok((char *)packet2, " ");  // Get first part of packet ftp
-    strtok(NULL, "\r\n");
+    frst_part_ftp = (uchar *)strtok_r((char *)packet2, " ", &saveptr);  // Get first part of packet ftp
+    strtok_r(NULL, "\r\n", &saveptr);
 
     if (frst_part_ftp) {
         int code = check_Code_ftp(frst_part_ftp);

--- a/contrib/impcap/http_parser.c
+++ b/contrib/impcap/http_parser.c
@@ -131,7 +131,10 @@ data_ret_t *http_parse(const uchar *packet, int pktSize, struct json_object *jpa
         RETURN_DATA_AFTER(0)
     }
 
-    char *pHttp = malloc(pktSize + 1);
+    char *pHttp = malloc((size_t)pktSize + 1);
+    if (pHttp == NULL) {
+        RETURN_DATA_AFTER(0)
+    }
     char *http = pHttp;
     memcpy(http, packet, pktSize);
     *(http + pktSize) = '\0';

--- a/contrib/impcap/impcap.c
+++ b/contrib/impcap/impcap.c
@@ -41,6 +41,7 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <signal.h>
+#include <limits.h>
 #include <json.h>
 
 #include <pcap.h>
@@ -491,9 +492,11 @@ ENDfreeCnf
 char *stringToHex(char *string, size_t length) {
     const char *hexChar = "0123456789ABCDEF";
     char *retBuf;
-    uint16_t i;
+    size_t i;
 
+    if (length > (((size_t)-1) - 1) / 2) return NULL;
     retBuf = malloc((2 * length + 1) * sizeof(char));
+    if (retBuf == NULL) return NULL;
     for (i = 0; i < length; ++i) {
         retBuf[2 * i] = hexChar[(string[i] & 0xF0) >> 4];
         retBuf[2 * i + 1] = hexChar[string[i] & 0x0F];
@@ -551,7 +554,18 @@ void packet_parse(uchar *arg, const struct pcap_pkthdr *pkthdr, const uchar *pac
 
     json_object_object_add(jown, "net_bytes_total", json_object_new_int(pkthdr->len));
 
-    data_ret_t *dataLeft = eth_parse(packet, pkthdr->caplen, jown);
+    if (pkthdr->caplen > INT_MAX) {
+        DBGPRINTF("impcap : captured packet too large to parse: %u\n", pkthdr->caplen);
+        msgDestruct(&pMsg);
+        json_object_put(jown);
+        return;
+    }
+    data_ret_t *dataLeft = eth_parse(packet, (int)pkthdr->caplen, jown);
+    if (dataLeft == NULL) {
+        msgDestruct(&pMsg);
+        json_object_put(jown);
+        return;
+    }
 
     json_object_object_add(jown, "net_bytes_data", json_object_new_int(dataLeft->size));
     char *dataHex = stringToHex(dataLeft->pData, dataLeft->size);

--- a/contrib/impcap/ipv4_parser.c
+++ b/contrib/impcap/ipv4_parser.c
@@ -86,6 +86,10 @@ data_ret_t *ipv4_parse(const uchar *packet, int pktSize, struct json_object *jpa
 
     char addrSrc[20], addrDst[20];
     uint8_t hdrLen = 4 * ipv4_header->ihl; /* 4 x length in words */
+    if (ipv4_header->ihl < 5 || hdrLen > pktSize) {
+        DBGPRINTF("IPv4 invalid header length : %u packet size %d\n", hdrLen, pktSize);
+        RETURN_DATA_AFTER(0)
+    }
 
     inet_ntop(AF_INET, (void *)&ipv4_header->addrSrc, addrSrc, 20);
     inet_ntop(AF_INET, (void *)&ipv4_header->addrDst, addrDst, 20);

--- a/contrib/impcap/ipv6_parser.c
+++ b/contrib/impcap/ipv6_parser.c
@@ -59,6 +59,7 @@ typedef struct __attribute__((__packed__)) ipv6_header_s {
 #define IPV6_NHDR_ICMP6 58
 #define IPV6_NHDR_NONHDR 59
 #define IPV6_NHDR_DOPTS 60
+#define IPV6_NHDR_INVALID 255
 
     uint8_t hopLimit;
     uint8_t addrSrc[16];
@@ -107,6 +108,11 @@ typedef struct frag_header_s {
 
 static inline uint8_t hbh_header_parse(const uchar **packet, int *pktSize) {
     DBGPRINTF("hbh_header_parse\n");
+    if (*pktSize < 2) {
+        DBGPRINTF("IPv6 HBH header too small : %d\n", *pktSize);
+        *pktSize = 0;
+        return IPV6_NHDR_INVALID;
+    }
 
     /* Union to prevent cast from uchar to hbh_header_t */
     union {
@@ -119,8 +125,13 @@ static inline uint8_t hbh_header_parse(const uchar **packet, int *pktSize) {
 
     /* hbh_header->hLength is the number of octets of header in 8-octet units minus 1
      * the header length SHOULD be a multiple of 8 */
-    uint8_t hByteLength = hbh_header->hLength * 8 + 8;
+    int hByteLength = hbh_header->hLength * 8 + 8;
     DBGPRINTF("hByteLength: %d\n", hByteLength);
+    if (*pktSize < hByteLength) {
+        DBGPRINTF("IPv6 HBH header truncated : %d needed %d\n", *pktSize, hByteLength);
+        *pktSize = 0;
+        return IPV6_NHDR_INVALID;
+    }
     *pktSize -= hByteLength;
     *packet += hByteLength;
 
@@ -129,6 +140,11 @@ static inline uint8_t hbh_header_parse(const uchar **packet, int *pktSize) {
 
 static inline uint8_t dest_header_parse(const uchar **packet, int *pktSize) {
     DBGPRINTF("dest_header_parse\n");
+    if (*pktSize < 2) {
+        DBGPRINTF("IPv6 destination header too small : %d\n", *pktSize);
+        *pktSize = 0;
+        return IPV6_NHDR_INVALID;
+    }
 
     /* Union to prevent cast from uchar to dest_header_t */
     union {
@@ -141,8 +157,13 @@ static inline uint8_t dest_header_parse(const uchar **packet, int *pktSize) {
 
     /* dest_header->hLength is the number of octets of header in 8-octet units minus 1
      * the header length SHOULD be a multiple of 8 */
-    uint8_t hByteLength = dest_header->hLength * 8 + 8;
+    int hByteLength = dest_header->hLength * 8 + 8;
     DBGPRINTF("hByteLength: %d\n", hByteLength);
+    if (*pktSize < hByteLength) {
+        DBGPRINTF("IPv6 destination header truncated : %d needed %d\n", *pktSize, hByteLength);
+        *pktSize = 0;
+        return IPV6_NHDR_INVALID;
+    }
     *pktSize -= hByteLength;
     *packet += hByteLength;
 
@@ -151,6 +172,11 @@ static inline uint8_t dest_header_parse(const uchar **packet, int *pktSize) {
 
 static inline uint8_t route_header_parse(const uchar **packet, int *pktSize, struct json_object *jparent) {
     DBGPRINTF("route_header_parse\n");
+    if (*pktSize < 2) {
+        DBGPRINTF("IPv6 route header too small : %d\n", *pktSize);
+        *pktSize = 0;
+        return IPV6_NHDR_INVALID;
+    }
 
     /* Union to prevent cast from uchar to route_header_t */
     union {
@@ -163,7 +189,12 @@ static inline uint8_t route_header_parse(const uchar **packet, int *pktSize, str
 
     /* route_header->hLength is the number of octets of header in 8-octet units minus 1
      * the header length (in bytes) SHOULD be a multiple of 8 */
-    uint8_t hByteLength = route_header->hLength * 8 + 8;
+    int hByteLength = route_header->hLength * 8 + 8;
+    if (*pktSize < hByteLength) {
+        DBGPRINTF("IPv6 route header truncated : %d needed %d\n", *pktSize, hByteLength);
+        *pktSize = 0;
+        return IPV6_NHDR_INVALID;
+    }
     *pktSize -= hByteLength;
     *packet += hByteLength;
 
@@ -194,6 +225,11 @@ static inline uint8_t route_header_parse(const uchar **packet, int *pktSize, str
 #define MFLAG_MASK 0x0001
 static inline uint8_t frag_header_parse(const uchar **packet, int *pktSize, struct json_object *jparent) {
     DBGPRINTF("frag_header_parse\n");
+    if (*pktSize < 8) {
+        DBGPRINTF("IPv6 fragment header too small : %d\n", *pktSize);
+        *pktSize = 0;
+        return IPV6_NHDR_INVALID;
+    }
 
     /* Union to prevent cast from uchar to frag_header_t */
     union {
@@ -291,6 +327,9 @@ data_ret_t *ipv6_parse(const uchar *packet, int pktSize, struct json_object *jpa
             case IPV6_NHDR_NONHDR:
                 hasNext = 0;
                 break;
+            case IPV6_NHDR_INVALID:
+                hasNext = 0;
+                break;
             case IPV6_NHDR_DOPTS:
                 nextHeader = dest_header_parse(&packet, &pktSize);
                 break;
@@ -300,6 +339,8 @@ data_ret_t *ipv6_parse(const uchar *packet, int pktSize, struct json_object *jpa
         }
     } while (hasNext);
 
-    json_object_object_add(jparent, "IP_proto", json_object_new_int(nextHeader));
+    if (nextHeader != IPV6_NHDR_INVALID) {
+        json_object_object_add(jparent, "IP_proto", json_object_new_int(nextHeader));
+    }
     RETURN_DATA_AFTER(0)
 }

--- a/contrib/impcap/llc_parser.c
+++ b/contrib/impcap/llc_parser.c
@@ -73,6 +73,10 @@ data_ret_t *llc_parse(const uchar *packet, int pktSize, struct json_object *jpar
         headerLen = 3;
     } else {
         /* I and S data frames: LLC control is 16 bits */
+        if (pktSize < 4) {
+            DBGPRINTF("LLC packet too small for 16-bit control : %d\n", pktSize);
+            RETURN_DATA_AFTER(0)
+        }
         ctrl = ntohs((uint16_t)packet[2]);
         headerLen = 4;
     }
@@ -87,6 +91,10 @@ data_ret_t *llc_parse(const uchar *packet, int pktSize, struct json_object *jpar
 
     if (dsap == 0xaa && ssap == 0xaa && ctrl == 0x03) {
         /* SNAP header */
+        if (pktSize < headerLen + 5) {
+            DBGPRINTF("LLC SNAP packet too small : %d\n", pktSize);
+            RETURN_DATA_AFTER(headerLen)
+        }
         uint32_t orgCode = packet[headerLen] << 16 | packet[headerLen + 1] << 8 | packet[headerLen + 2];
         uint16_t ethType = packet[headerLen + 3] << 8 | packet[headerLen + 4];
         json_object_object_add(jparent, "SNAP_oui", json_object_new_int(orgCode));

--- a/contrib/impcap/parsers.h
+++ b/contrib/impcap/parsers.h
@@ -70,6 +70,7 @@ typedef struct data_ret_s data_ret_t;
 
     #define RETURN_DATA_AFTER(x)                          \
         data_ret_t *retData = malloc(sizeof(data_ret_t)); \
+        if (retData == NULL) return NULL;                 \
         if (pktSize > x) {                                \
             retData->size = pktSize - x;                  \
             retData->pData = (char *)packet + x;          \

--- a/contrib/impcap/smb_parser.c
+++ b/contrib/impcap/smb_parser.c
@@ -92,7 +92,7 @@ data_ret_t *smb_parse(const uchar *packet, int pktSize, struct json_object *jpar
     int pktSizeCpy = pktSize;
     const uchar *packetCpy = packet;
 
-    while (pktSizeCpy > 0) {
+    while (pktSizeCpy >= 4) {
         /* don't check packetCpy[0] to include SMB version byte at the beginning */
         if (packetCpy[1] == 'S') {
             if (packetCpy[2] == 'M') {

--- a/contrib/impcap/tcp_parser.c
+++ b/contrib/impcap/tcp_parser.c
@@ -97,6 +97,10 @@ data_ret_t *tcp_parse(const uchar *packet, int pktSize, struct json_object *jpar
     uint16_t dstPort = ntohs(tcp_header->dstPort);
 
     uint8_t headerLength = (tcp_header->dor & 0xF0) >> 2;  //>>4 to offset but <<2 to get offset as bytes
+    if (headerLength < 20 || headerLength > pktSize) {
+        DBGPRINTF("TCP invalid header length : %u packet size %d\n", headerLength, pktSize);
+        RETURN_DATA_AFTER(0)
+    }
 
     json_object_object_add(jparent, "net_src_port", json_object_new_int(srcPort));
     json_object_object_add(jparent, "net_dst_port", json_object_new_int(dstPort));

--- a/contrib/imtuxedoulog/imtuxedoulog.c
+++ b/contrib/imtuxedoulog/imtuxedoulog.c
@@ -197,6 +197,7 @@ static rsRetVal parseMsg(smsg_t *pMsg, char *rawMsg, size_t msgLen, instanceConf
     int hour, min, sec;
     rsRetVal ret;
 
+    if (msgLen < 11) return RS_RET_COULD_NOT_PARSE;
     hour = (rawMsg[0] ^ 0x30) * 10 + (rawMsg[1] ^ 0x30);
     min = (rawMsg[2] ^ 0x30) * 10 + (rawMsg[3] ^ 0x30);
     sec = (rawMsg[4] ^ 0x30) * 10 + (rawMsg[5] ^ 0x30);
@@ -225,7 +226,10 @@ static rsRetVal parseMsg(smsg_t *pMsg, char *rawMsg, size_t msgLen, instanceConf
     pMsg->tTIMESTAMP.OffsetHour = syslogTz.OffsetHour;
     pMsg->tTIMESTAMP.OffsetMinute = syslogTz.OffsetMinute;
 
-    pMsg->tTIMESTAMP.secfrac = atoi(rawMsg + 7);
+    pMsg->tTIMESTAMP.secfrac = 0;
+    for (size_t i = 7; i < msgLen && i < 10 && rawMsg[i] >= '0' && rawMsg[i] <= '9'; ++i) {
+        pMsg->tTIMESTAMP.secfrac = (pMsg->tTIMESTAMP.secfrac * 10) + (rawMsg[i] - '0');
+    }
     /* secfracprecision depends on the char on position 9 (case 1 or case 2) */
     pMsg->tTIMESTAMP.secfracPrecision = (rawMsg[9] == '.') ? 2 : 3;
 
@@ -235,21 +239,26 @@ static rsRetVal parseMsg(smsg_t *pMsg, char *rawMsg, size_t msgLen, instanceConf
     else
         *strtData = '\0';
 
+    if ((size_t)(strtData - rawMsg) > msgLen - 2) return RS_RET_COULD_NOT_PARSE;
     strtData = strtData + 2;
 
     /* Case 4 */
-    if (memcmp(strtData, "gtrid", 5) == 0) {
+    if ((size_t)(strtData - rawMsg) <= msgLen - 5 && memcmp(strtData, "gtrid", 5) == 0) {
         strtData = memchr(strtData, ':', msgLen - (strtData - rawMsg));
-        if (strtData != NULL) strtData += 2;
+        if (strtData == NULL || (size_t)(strtData - rawMsg) > msgLen - 2) return RS_RET_COULD_NOT_PARSE;
+        strtData += 2;
     }
 
     text = strtData;
 
     /* ecid point to message text or the word ECID */
-    if (strtData != NULL && memcmp(strtData, "ECID", 4) == 0) {
-        text = memchr(strtData + 6, '>', msgLen - (strtData - rawMsg));
+    if ((size_t)(strtData - rawMsg) <= msgLen - 4 && memcmp(strtData, "ECID", 4) == 0) {
+        char *const ecidEnd = ((size_t)(strtData - rawMsg) <= msgLen - 7)
+                                  ? memchr(strtData + 6, '>', msgLen - (strtData - rawMsg) - 6)
+                                  : NULL;
         /* case 3 : we have the word ECID */
-        if (text != NULL) {
+        if (ecidEnd != NULL && (size_t)(ecidEnd - rawMsg) <= msgLen - 3) {
+            text = ecidEnd;
             *(--strtData) = '[';
             strtData[5] = '=';
             strtData[6] = '\"';

--- a/contrib/omamqp1/omamqp1.c
+++ b/contrib/omamqp1/omamqp1.c
@@ -490,6 +490,10 @@ finalize_it:
 // in case existing buffer too small
 static rsRetVal _grow_buffer(protocolState_t *pState) {
     DEFiRet;
+    if (pState->buffer_size > ((size_t)-1) / 2) {
+        LogError(0, RS_RET_OUT_OF_MEMORY, "omamqp1: encode buffer size overflow");
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
     size_t new_size = pState->buffer_size * 2;
     char *new_buf = realloc(pState->encode_buffer, new_size);
     CHKmalloc(new_buf);

--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -549,10 +549,19 @@ static size_t curlResult(void *ptr, size_t size, size_t nmemb, void *userdata) {
     const char *const p = (const char *)ptr;
     wrkrInstanceData_t *const pWrkrData = (wrkrInstanceData_t *)userdata;
     char *buf;
-    const size_t size_add = size * nmemb;  // Size is always 1
+    size_t size_add;
     size_t newlen;
 
     PTR_ASSERT_CHK(pWrkrData, WRKR_DATA_TYPE_ES);
+    if (nmemb != 0 && size > SIZE_MAX / nmemb) {
+        LogError(0, RS_RET_ERR, "omhttp: reply buffer size overflow in curlResult");
+        pWrkrData->replyLen = 0;
+        if (pWrkrData->reply != NULL && pWrkrData->replyBufLen > 0) {
+            pWrkrData->reply[0] = '\0';
+        }
+        return 0;
+    }
+    size_add = size * nmemb;
     if (size_add > SIZE_MAX - pWrkrData->replyLen) {
         LogError(0, RS_RET_ERR, "omhttp: reply buffer size overflow in curlResult");
         pWrkrData->replyLen = 0;
@@ -562,6 +571,14 @@ static size_t curlResult(void *ptr, size_t size, size_t nmemb, void *userdata) {
         return 0;
     }
     newlen = pWrkrData->replyLen + size_add;
+    if (newlen == SIZE_MAX) {
+        LogError(0, RS_RET_ERR, "omhttp: reply buffer size overflow in curlResult");
+        pWrkrData->replyLen = 0;
+        if (pWrkrData->reply != NULL && pWrkrData->replyBufLen > 0) {
+            pWrkrData->reply[0] = '\0';
+        }
+        return 0;
+    }
     if (pWrkrData->pData->replyMaxBytes > 0 && newlen > pWrkrData->pData->replyMaxBytes) {
         LogError(0, RS_RET_ERR, "omhttp: reply buffer exceeds replymaxbytes limit (%zu)",
                  pWrkrData->pData->replyMaxBytes);
@@ -2567,9 +2584,14 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "httpheadervalue")) {
             CHKmalloc(pData->httpheadervalue = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "httpheaders")) {
-            pData->nHttpHeaders = pvals[i].val.d.ar->nmemb;
-            CHKmalloc(pData->httpHeaders = malloc(sizeof(uchar *) * pvals[i].val.d.ar->nmemb));
-            for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+            const int nmemb = pvals[i].val.d.ar->nmemb;
+            if (nmemb < 0 || (size_t)nmemb > SIZE_MAX / sizeof(uchar *)) {
+                LogError(0, RS_RET_PARAM_ERROR, "omhttp: too many httpheaders configured");
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            pData->nHttpHeaders = nmemb;
+            CHKmalloc(pData->httpHeaders = malloc(sizeof(uchar *) * (size_t)nmemb));
+            for (int j = 0; j < nmemb; ++j) {
                 char *cstr = es_str2cstr(pvals[i].val.d.ar->arr[j], NULL);
                 CHKiRet(checkHeaderParam(cstr));
                 pData->httpHeaders[j] = (uchar *)cstr;
@@ -2664,11 +2686,16 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "reloadonhup")) {
             pData->reloadOnHup = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "httpretrycodes")) {
-            pData->nhttpRetryCodes = pvals[i].val.d.ar->nmemb;
+            const int nmemb = pvals[i].val.d.ar->nmemb;
+            if (nmemb < 0 || (size_t)nmemb > SIZE_MAX / sizeof(unsigned int)) {
+                LogError(0, RS_RET_PARAM_ERROR, "omhttp: too many httpretrycodes configured");
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            pData->nhttpRetryCodes = nmemb;
             // note: use zero as sentinel value
-            CHKmalloc(pData->httpRetryCodes = calloc(pvals[i].val.d.ar->nmemb, sizeof(unsigned int)));
+            CHKmalloc(pData->httpRetryCodes = calloc((size_t)nmemb, sizeof(unsigned int)));
             int count = 0;
-            for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+            for (int j = 0; j < nmemb; ++j) {
                 int bSuccess = 0;
                 long long n = es_str2num(pvals[i].val.d.ar->arr[j], &bSuccess);
                 if (!bSuccess) {
@@ -2694,11 +2721,16 @@ BEGINnewActInst
         } else if (!strcmp(actpblk.descr[i].name, "name")) {
             CHKmalloc(pData->statsName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(actpblk.descr[i].name, "httpignorablecodes")) {
-            pData->nIgnorableCodes = pvals[i].val.d.ar->nmemb;
+            const int nmemb = pvals[i].val.d.ar->nmemb;
+            if (nmemb < 0 || (size_t)nmemb > SIZE_MAX / sizeof(unsigned int)) {
+                LogError(0, RS_RET_PARAM_ERROR, "omhttp: too many httpignorablecodes configured");
+                ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+            }
+            pData->nIgnorableCodes = nmemb;
             // note: use zero as sentinel value
-            CHKmalloc(pData->ignorableCodes = calloc(pvals[i].val.d.ar->nmemb, sizeof(unsigned int)));
+            CHKmalloc(pData->ignorableCodes = calloc((size_t)nmemb, sizeof(unsigned int)));
             int count = 0;
-            for (int j = 0; j < pvals[i].val.d.ar->nmemb; ++j) {
+            for (int j = 0; j < nmemb; ++j) {
                 int bSuccess = 0;
                 long long n = es_str2num(pvals[i].val.d.ar->arr[j], &bSuccess);
                 if (!bSuccess) {
@@ -2807,8 +2839,15 @@ BEGINnewActInst
     }
 
     if (servers != NULL) {
-        pData->numServers = servers->nmemb;
-        pData->serverBaseUrls = malloc(servers->nmemb * sizeof(uchar *));
+        const int nmemb = servers->nmemb;
+        if (nmemb <= 0 || (size_t)nmemb > SIZE_MAX / sizeof(uchar *) ||
+            (pData->statsBySenders && (size_t)nmemb > SIZE_MAX / sizeof(targetStats_t)) ||
+            (size_t)nmemb > SIZE_MAX / sizeof(sbool) || (size_t)nmemb > SIZE_MAX / sizeof(time_t)) {
+            LogError(0, RS_RET_PARAM_ERROR, "omhttp: too many servers configured");
+            ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+        }
+        pData->numServers = nmemb;
+        pData->serverBaseUrls = malloc((size_t)nmemb * sizeof(uchar *));
         if (pData->serverBaseUrls == NULL) {
             LogError(0, RS_RET_ERR,
                      "omhttp: unable to allocate buffer "
@@ -2817,8 +2856,8 @@ BEGINnewActInst
         }
 
         /* Set up the stats object array */
-        const int numStats = pData->statsBySenders ? servers->nmemb : 1;
-        pData->listObjStats = malloc(numStats * sizeof(targetStats_t));
+        const int numStats = pData->statsBySenders ? nmemb : 1;
+        pData->listObjStats = malloc((size_t)numStats * sizeof(targetStats_t));
         if (pData->listObjStats == NULL) {
             LogError(0, RS_RET_ERR,
                      "omhttp: unable to allocate buffer "

--- a/contrib/omhttpfs/omhttpfs.c
+++ b/contrib/omhttpfs/omhttpfs.c
@@ -26,6 +26,8 @@
 #include <assert.h>
 #include <signal.h>
 #include <errno.h>
+#include <limits.h>
+#include <stdint.h>
 #include <unistd.h>
 #include <curl/curl.h>
 #include <json.h>
@@ -305,11 +307,26 @@ static struct curl_slist* httpfs_curl_add_header(struct curl_slist* headers, int
  * @return size_t
  */
 static size_t httpfs_curl_result_callback(void* contents, size_t size, size_t nmemb, void* userp) {
-    size_t realsize = size * nmemb;
+    size_t realsize;
     char* newreply = NULL;
     wrkrInstanceData_t* mem = (wrkrInstanceData_t*)userp;
 
-    newreply = realloc(mem->reply, mem->replyLen + realsize + 1);
+    if (nmemb != 0 && size > SIZE_MAX / nmemb) {
+        dbgprintf("response buffer size overflow\n");
+        return 0;
+    }
+    realsize = size * nmemb;
+    if (mem->replyLen < 0) {
+        dbgprintf("response buffer size overflow\n");
+        return 0;
+    }
+    const size_t replyLen = (size_t)mem->replyLen;
+    if (replyLen == SIZE_MAX || realsize > SIZE_MAX - replyLen - 1 || realsize > (size_t)INT_MAX - replyLen) {
+        dbgprintf("response buffer size overflow\n");
+        return 0;
+    }
+
+    newreply = realloc(mem->reply, replyLen + realsize + 1);
     if (newreply == NULL) {
         /* out of memory! */
         dbgprintf("not enough memory (realloc returned NULL)\n");
@@ -323,8 +340,8 @@ static size_t httpfs_curl_result_callback(void* contents, size_t size, size_t nm
     }
 
     mem->reply = newreply;
-    memcpy(&(mem->reply[mem->replyLen]), contents, realsize);
-    mem->replyLen += realsize;
+    memcpy(&(mem->reply[replyLen]), contents, realsize);
+    mem->replyLen = (int)(replyLen + realsize);
     mem->reply[mem->replyLen] = 0;
 
     return realsize;


### PR DESCRIPTION
Summary:
- defensively harden contrib buffer growth and curl response accumulation against size overflows
- add packet/log boundary checks in impcap, imkmsg, and imtuxedoulog parsing paths
- validate configurable allocation counts before multiplying element sizes

Validation:
- autogen with debug/testbench and touched contrib modules enabled
- make -j nproc
- targeted tests: impcap_basic_dns.sh, impcap_basic_http.sh, impcap_bug_ether.sh, imtuxedoulog_data.sh, imhttp-post-payload-content-length-limit.sh, omhttp-basic.sh, omhttp-multiplehttpheaders.sh
- container static analyzer: rsyslog/rsyslog_dev_base_ubuntu:26.04, scan-build, no bugs found, real 172.10s
- container check: rsyslog/rsyslog_dev_base_ubuntu:26.04, 1263 total / 1170 pass / 93 skip / 0 fail / 0 error, real 239.09s
