### PR TITLE
tests: avoid legacy imdiag directives

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -416,6 +416,10 @@ local0.* ./'${RSYSLOG_DYNNAME}'.HOSTNAME;hostname
 # YAML-only modes.  Tests that need a non-default value must set the relevant
 # RSTB_* variable before calling generate_conf.
 #
+# RSTB_IMDIAG_INJECT_DELAY_MODE, when set, is passed as the imdiag module's
+# injectDelayMode parameter.  Set it before generate_conf for the instance that
+# needs delayed testbench injection.
+#
 # Startup detection relies on the module-level imdiag port file in both
 # RainerScript and yaml-only modes; no .started marker file is used.
 generate_conf() {
@@ -457,6 +461,8 @@ generate_conf() {
 			printf '  - load: "../plugins/imdiag/.libs/imdiag"\n'
 			printf '    listenportfilename: "%s.imdiag%s.port"\n' "$RSYSLOG_DYNNAME" "$1"
 			printf '    serverrun: "0"\n'
+			[ -n "$RSTB_IMDIAG_INJECT_DELAY_MODE" ] &&
+				printf '    injectdelaymode: "%s"\n' "$RSTB_IMDIAG_INJECT_DELAY_MODE"
 			printf '    aborttimeout: "%s"\n' "$TB_TEST_MAX_RUNTIME"
 			printf '    mainmsgqueuetimeoutshutdown: "%s"\n' "$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT"
 			printf '    mainmsgqueuetimeoutenqueue: "%s"\n' "$RSTB_MAIN_Q_TO_ENQUEUE"
@@ -470,22 +476,27 @@ generate_conf() {
 	else
 		export RSYSLOG_YAML_ONLY=0
 		export TESTCONF_EXT="conf"
-		echo 'module(load="../plugins/imdiag/.libs/imdiag"
-    listenportfilename="'$RSYSLOG_DYNNAME.imdiag$1.port'"
-    serverrun="0"
-    aborttimeout="'$TB_TEST_MAX_RUNTIME'"
-    mainmsgqueuetimeoutshutdown="'$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT'"
-    mainmsgqueuetimeoutenqueue="'$RSTB_MAIN_Q_TO_ENQUEUE'"
-    inputshutdowntimeout="'$RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT'"
-    defaultactionqueuetimeoutshutdown="'$RSTB_ACTION_DEFAULT_Q_TO_SHUTDOWN'"
-    defaultactionqueuetimeoutenqueue="'$RSTB_ACTION_DEFAULT_Q_TO_ENQUEUE'")
-global(debug.abortOnProgramError="on")
-# Capture rsyslogd own messages (startup, shutdown, errors) to the .started
-# file. Tests use this file to check for expected rsyslogd-internal messages.
-# This rule also ensures at least one output action exists in the default
-# ruleset, which is required by rsyslogd even when only inputs are configured.
-:syslogtag, contains, "rsyslogd"  ./'${RSYSLOG_DYNNAME}$1'.started
-###### end of testbench instrumentation part, test conf follows:' > ${TESTCONF_NM}$1.conf
+		{
+			printf 'module(load="../plugins/imdiag/.libs/imdiag"\n'
+			printf '    listenportfilename="%s.imdiag%s.port"\n' "$RSYSLOG_DYNNAME" "$1"
+			printf '    serverrun="0"\n'
+			[ -n "$RSTB_IMDIAG_INJECT_DELAY_MODE" ] &&
+				printf '    injectdelaymode="%s"\n' "$RSTB_IMDIAG_INJECT_DELAY_MODE"
+			printf '    aborttimeout="%s"\n' "$TB_TEST_MAX_RUNTIME"
+			printf '    mainmsgqueuetimeoutshutdown="%s"\n' "$RSTB_GLOBAL_QUEUE_SHUTDOWN_TIMEOUT"
+			printf '    mainmsgqueuetimeoutenqueue="%s"\n' "$RSTB_MAIN_Q_TO_ENQUEUE"
+			printf '    inputshutdowntimeout="%s"\n' "$RSTB_GLOBAL_INPUT_SHUTDOWN_TIMEOUT"
+			printf '    defaultactionqueuetimeoutshutdown="%s"\n' "$RSTB_ACTION_DEFAULT_Q_TO_SHUTDOWN"
+			printf '    defaultactionqueuetimeoutenqueue="%s")\n' "$RSTB_ACTION_DEFAULT_Q_TO_ENQUEUE"
+			printf 'global(debug.abortOnProgramError="on")\n'
+			printf '# Capture rsyslogd own messages (startup, shutdown, errors) to the .started\n'
+			printf '# file. Tests use this file to check for expected rsyslogd-internal messages.\n'
+			printf '# This rule also ensures at least one output action exists in the default\n'
+			printf '# ruleset, which is required by rsyslogd even when only inputs are configured.\n'
+			printf 'if $syslogtag contains "rsyslogd" then action(type="omfile" file="./%s%s.started")\n' \
+				"$RSYSLOG_DYNNAME" "$1"
+			printf '###### end of testbench instrumentation part, test conf follows:\n'
+		} > ${TESTCONF_NM}$1.conf
 		# Optionally enforce IPv4 for this test instance.
 		# Set RSTB_FORCE_IPV4=1 to force, or set RSTB_NET_IPPROTO explicitly
 		# to one of: unspecified | ipv4-only | ipv6-only.

--- a/tests/omazureeventhubs-basic-url.sh
+++ b/tests/omazureeventhubs-basic-url.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 export NUMMESSAGES=100
 export NUMMESSAGESFULL=$NUMMESSAGES
@@ -44,7 +45,6 @@ global(
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # Load mods
 module(load="../plugins/omazureeventhubs/.libs/omazureeventhubs")

--- a/tests/omazureeventhubs-basic.sh
+++ b/tests/omazureeventhubs-basic.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 export NUMMESSAGES=100
 export NUMMESSAGESFULL=$NUMMESSAGES
@@ -44,7 +45,6 @@ global(
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # Load mods
 module(load="../plugins/omazureeventhubs/.libs/omazureeventhubs")

--- a/tests/omazureeventhubs-interrupt.sh
+++ b/tests/omazureeventhubs-interrupt.sh
@@ -5,6 +5,7 @@ if [ "$EUID" -ne 0 ]; then
     exit 77 # Not root, skip this test
 fi
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 # ---	If test is needed, create helper script to store environment variables for 
 #	�venthubs access:
@@ -69,7 +70,6 @@ global(
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # Load mods
 module(load="../plugins/omazureeventhubs/.libs/omazureeventhubs")

--- a/tests/omazureeventhubs-list.sh
+++ b/tests/omazureeventhubs-list.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 export NUMMESSAGES=100
 export NUMMESSAGESFULL=$NUMMESSAGES
@@ -38,7 +39,6 @@ add_conf '
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # Load mods
 module(load="../plugins/imtcp/.libs/imtcp")

--- a/tests/omazureeventhubs-stress.sh
+++ b/tests/omazureeventhubs-stress.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 export NUMMESSAGES=50000
 export NUMMESSAGESFULL=$NUMMESSAGES
@@ -48,7 +49,6 @@ global(
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # main_queue(queue.dequeueBatchSize="2048")
 

--- a/tests/omkafka-dynatopic.sh
+++ b/tests/omkafka-dynatopic.sh
@@ -2,6 +2,7 @@
 # added 2019-01-12 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 test_status unreliable 'https://github.com/rsyslog/rsyslog/issues/3197'
 check_command_available kcat
 
@@ -33,7 +34,6 @@ module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/omkafka-headers.sh
+++ b/tests/omkafka-headers.sh
@@ -3,6 +3,7 @@
 ## @brief Verify Kafka headers are produced by omkafka.
 # added 2024-05-05 by AI Assistant
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 check_command_available kafkacat
 
 export KEEP_KAFKA_RUNNING="YES"
@@ -21,7 +22,6 @@ create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
 generate_conf
 add_conf '
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/omkafka-statistics.sh
+++ b/tests/omkafka-statistics.sh
@@ -2,6 +2,7 @@
 # added 2019-01-12 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 test_status unreliable 'https://github.com/rsyslog/rsyslog/issues/3197'
 check_command_available kcat
 
@@ -33,7 +34,6 @@ module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -2,6 +2,7 @@
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 test_status unreliable 'https://github.com/rsyslog/rsyslog/issues/3197'
 check_command_available kcat
 
@@ -33,7 +34,6 @@ module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/omkafkadynakey.sh
+++ b/tests/omkafkadynakey.sh
@@ -2,6 +2,7 @@
 # added 2018-12-18 by ludobrands
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 test_status unreliable 'https://github.com/rsyslog/rsyslog/issues/3197'
 check_command_available kcat
 
@@ -33,7 +34,6 @@ module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/sndrcv_dtls_certvalid.sh
+++ b/tests/sndrcv_dtls_certvalid.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
 export NUMMESSAGES=1000
 export NUMMESSAGESFULL=$NUMMESSAGES
@@ -46,7 +47,6 @@ global(
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # Load modules
 module(	load="../plugins/omdtls/.libs/omdtls" )

--- a/tests/sndrcv_dtls_certvalid_missing.sh
+++ b/tests/sndrcv_dtls_certvalid_missing.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
 export NUMMESSAGES=1
 # export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
@@ -43,7 +44,6 @@ global(
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # Load modules
 module(	load="../plugins/omdtls/.libs/omdtls" )

--- a/tests/sndrcv_dtls_certvalid_permitted.sh
+++ b/tests/sndrcv_dtls_certvalid_permitted.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
 export NUMMESSAGES=1000
 export NUMMESSAGESFULL=$NUMMESSAGES
@@ -47,7 +48,6 @@ global(
 module(load="../plugins/impstats/.libs/impstats"
 	log.file="'$RSYSLOG_DYNNAME.pstats'"
 	interval="1" log.syslog="off")
-$imdiagInjectDelayMode full
 
 # Load modules
 module(	load="../plugins/omdtls/.libs/omdtls" )

--- a/tests/sndrcv_kafka-vg-rcvr.sh
+++ b/tests/sndrcv_kafka-vg-rcvr.sh
@@ -14,6 +14,7 @@ echo Check and Stop previous instances of kafka/zookeeper
 
 echo Init Testbench
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 echo Create kafka/zookeeper instance and topics
 . $srcdir/diag.sh start-zookeeper
@@ -53,7 +54,6 @@ export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
 main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/sndrcv_kafka-vg-sender.sh
+++ b/tests/sndrcv_kafka-vg-sender.sh
@@ -13,6 +13,7 @@ echo Check and Stop previous instances of kafka/zookeeper
 
 echo Init Testbench
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 echo Create kafka/zookeeper instance and topics
 . $srcdir/diag.sh start-zookeeper
@@ -51,7 +52,6 @@ export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
 main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -2,6 +2,7 @@
 # added 2017-05-03 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
@@ -25,7 +26,6 @@ export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -4,6 +4,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 # *** ==============================================================================
 export TESTMESSAGES=50000
@@ -67,7 +68,6 @@ export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -4,6 +4,7 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 echo Init Testbench
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 export TESTMESSAGES=50000
 export TESTMESSAGESFULL=50000
@@ -60,7 +61,6 @@ export RSYSLOG_DEBUGLOG="log2"
 generate_conf 2
 add_conf '
 main_queue(queue.timeoutactioncompletion="10000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 

--- a/tests/sndrcv_kafka_multi_topics.sh
+++ b/tests/sndrcv_kafka_multi_topics.sh
@@ -4,6 +4,7 @@
 : "${STARTUP_MAX_RUNTIME:=300}"
 export STARTUP_MAX_RUNTIME
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 
 export TESTMESSAGES=50000
 export TESTMESSAGESFULL=100000
@@ -31,7 +32,6 @@ export RSYSLOG_DEBUGLOG="log"
 generate_conf
 add_conf '
 main_queue(queue.timeoutactioncompletion="60000" queue.timeoutshutdown="60000")
-$imdiagInjectDelayMode full
 
 module(load="../plugins/omkafka/.libs/omkafka")
 


### PR DESCRIPTION
Summary: add RSTB_IMDIAG_INJECT_DELAY_MODE so imdiag injectdelaymode is emitted as a module parameter; remove remaining legacy imdiag inject delay directives from tests; emit the generated startup marker rule with modern RainerScript syntax. Validation: bash -n on touched shell paths; git diff --check; container static analyzer found no bugs; Ubuntu 26.04 container check passed with 1255 total, 1228 pass, 27 skip, 0 fail, 0 error.