### PR TITLE
docs: add distro component package map

### DIFF
--- a/.github/workflows/distro_component_package_map.yml
+++ b/.github/workflows/distro_component_package_map.yml
@@ -1,0 +1,91 @@
+# Copyright 2026 Rainer Gerhards and Others
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+---
+name: distro component package map
+
+'on':
+  schedule:
+    # Weekly on Monday at 03:27 UTC. This queries public distro package
+    # metadata, so keep it off the critical PR path.
+    - cron: '27 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  update-map:
+    name: update distro component package map
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install metadata tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            python3-defusedxml \
+            zstd
+
+      - name: Generate map
+        run: |
+          python3 scripts/generate_distro_component_map.py \
+            --output doc/security/distro-component-package-map.json
+
+      - name: Detect changes
+        id: changes
+        run: |
+          if git diff --quiet -- doc/security/distro-component-package-map.json; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create pull request
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          branch="automation/distro-component-package-map"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git checkout -B "$branch"
+          git add doc/security/distro-component-package-map.json
+          git commit -m "docs: update distro component package map" \
+            -m "Regenerate best-effort rsyslog component-to-distro-package support data from public package metadata."
+          git push --force-with-lease origin "$branch"
+          cat > /tmp/distro-component-package-map-pr.md <<'EOF'
+          Regenerates the best-effort rsyslog component-to-distro-package
+          support data from public package metadata.
+
+          This is advisory support data only and is not authoritative for any
+          distribution.
+          EOF
+          if gh pr view "$branch" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            gh pr edit "$branch" --repo "$GITHUB_REPOSITORY" \
+              --title "docs: update distro component package map" \
+              --body-file /tmp/distro-component-package-map-pr.md
+          else
+            gh pr create --repo "$GITHUB_REPOSITORY" \
+              --base main \
+              --head "$branch" \
+              --title "docs: update distro component package map" \
+              --body-file /tmp/distro-component-package-map-pr.md \
+              --label documentation \
+              --label security
+          fi

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,7 +16,8 @@ EXTRA_DIST = \
 	COPYING.ASL20 \
 	contrib/gnutls/ca.pem \
 	contrib/gnutls/cert.pem \
-	contrib/gnutls/key.pem
+	contrib/gnutls/key.pem \
+	scripts/generate_distro_component_map.py
 
 SUBDIRS = doc compat grammar runtime . plugins/immark plugins/imuxsock plugins/imtcp plugins/imudp plugins/omtesting
 # external plugin driver is always enabled (core component)

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -69,6 +69,8 @@ EXTRA_DIST = \
     build_rag_db.py \
     contrib/README.md \
     contrib/cron_build_all_branches.sh \
+    security/distro-component-package-map.json \
+    security/distro-component-package-map.md \
     security/ghsa-coordination-review-template.md \
     proposed-toc \
     requirements.txt \

--- a/doc/security/distro-component-package-map.json
+++ b/doc/security/distro-component-package-map.json
@@ -1,0 +1,12163 @@
+{
+  "caveats": [
+    "Generated from public package metadata and not authoritative for any distribution.",
+    "A shipped module file does not mean the module is loaded by default.",
+    "A not_shipped result applies only to searched public repositories, not custom builds or third-party packages.",
+    "Confirm downstream-specific claims with the relevant distribution security team before publication."
+  ],
+  "component_count": 98,
+  "components": {
+    "ffaup": {
+      "kind": "contrib",
+      "module_file": "ffaup.so",
+      "upstream_path": "contrib/ffaup/"
+    },
+    "fmhash": {
+      "kind": "contrib",
+      "module_file": "fmhash.so",
+      "upstream_path": "contrib/fmhash/"
+    },
+    "fmhttp": {
+      "kind": "plugin",
+      "module_file": "fmhttp.so",
+      "upstream_path": "plugins/fmhttp/"
+    },
+    "fmpcre": {
+      "kind": "plugin",
+      "module_file": "fmpcre.so",
+      "upstream_path": "plugins/fmpcre/"
+    },
+    "fmunflatten": {
+      "kind": "contrib",
+      "module_file": "fmunflatten.so",
+      "upstream_path": "contrib/fmunflatten/"
+    },
+    "im3195": {
+      "kind": "plugin",
+      "module_file": "im3195.so",
+      "upstream_path": "plugins/im3195/"
+    },
+    "imbatchreport": {
+      "kind": "contrib",
+      "module_file": "imbatchreport.so",
+      "upstream_path": "contrib/imbatchreport/"
+    },
+    "imbeats": {
+      "kind": "plugin",
+      "module_file": "imbeats.so",
+      "upstream_path": "plugins/imbeats/"
+    },
+    "imczmq": {
+      "kind": "contrib",
+      "module_file": "imczmq.so",
+      "upstream_path": "contrib/imczmq/"
+    },
+    "imdiag": {
+      "kind": "plugin",
+      "module_file": "imdiag.so",
+      "upstream_path": "plugins/imdiag/"
+    },
+    "imdocker": {
+      "kind": "contrib",
+      "module_file": "imdocker.so",
+      "upstream_path": "contrib/imdocker/"
+    },
+    "imdtls": {
+      "kind": "plugin",
+      "module_file": "imdtls.so",
+      "upstream_path": "plugins/imdtls/"
+    },
+    "imfile": {
+      "kind": "plugin",
+      "module_file": "imfile.so",
+      "upstream_path": "plugins/imfile/"
+    },
+    "imgssapi": {
+      "kind": "plugin",
+      "module_file": "imgssapi.so",
+      "upstream_path": "plugins/imgssapi/"
+    },
+    "imhiredis": {
+      "kind": "contrib",
+      "module_file": "imhiredis.so",
+      "upstream_path": "contrib/imhiredis/"
+    },
+    "imhttp": {
+      "kind": "contrib",
+      "module_file": "imhttp.so",
+      "upstream_path": "contrib/imhttp/"
+    },
+    "imjournal": {
+      "kind": "plugin",
+      "module_file": "imjournal.so",
+      "upstream_path": "plugins/imjournal/"
+    },
+    "imkafka": {
+      "kind": "plugin",
+      "module_file": "imkafka.so",
+      "upstream_path": "plugins/imkafka/"
+    },
+    "imklog": {
+      "kind": "plugin",
+      "module_file": "imklog.so",
+      "upstream_path": "plugins/imklog/"
+    },
+    "imkmsg": {
+      "kind": "contrib",
+      "module_file": "imkmsg.so",
+      "upstream_path": "contrib/imkmsg/"
+    },
+    "immark": {
+      "kind": "plugin",
+      "module_file": "immark.so",
+      "upstream_path": "plugins/immark/"
+    },
+    "impcap": {
+      "kind": "contrib",
+      "module_file": "impcap.so",
+      "upstream_path": "contrib/impcap/"
+    },
+    "improg": {
+      "kind": "contrib",
+      "module_file": "improg.so",
+      "upstream_path": "contrib/improg/"
+    },
+    "impstats": {
+      "kind": "plugin",
+      "module_file": "impstats.so",
+      "upstream_path": "plugins/impstats/"
+    },
+    "imptcp": {
+      "kind": "plugin",
+      "module_file": "imptcp.so",
+      "upstream_path": "plugins/imptcp/"
+    },
+    "imrelp": {
+      "kind": "plugin",
+      "module_file": "imrelp.so",
+      "upstream_path": "plugins/imrelp/"
+    },
+    "imsolaris": {
+      "kind": "plugin",
+      "module_file": "imsolaris.so",
+      "upstream_path": "plugins/imsolaris/"
+    },
+    "imtcp": {
+      "kind": "plugin",
+      "module_file": "imtcp.so",
+      "upstream_path": "plugins/imtcp/"
+    },
+    "imtuxedoulog": {
+      "kind": "contrib",
+      "module_file": "imtuxedoulog.so",
+      "upstream_path": "contrib/imtuxedoulog/"
+    },
+    "imudp": {
+      "kind": "plugin",
+      "module_file": "imudp.so",
+      "upstream_path": "plugins/imudp/"
+    },
+    "imuxsock": {
+      "kind": "plugin",
+      "module_file": "imuxsock.so",
+      "upstream_path": "plugins/imuxsock/"
+    },
+    "mmaitag": {
+      "kind": "plugin",
+      "module_file": "mmaitag.so",
+      "upstream_path": "plugins/mmaitag/"
+    },
+    "mmanon": {
+      "kind": "plugin",
+      "module_file": "mmanon.so",
+      "upstream_path": "plugins/mmanon/"
+    },
+    "mmaudit": {
+      "kind": "plugin",
+      "module_file": "mmaudit.so",
+      "upstream_path": "plugins/mmaudit/"
+    },
+    "mmcount": {
+      "kind": "contrib",
+      "module_file": "mmcount.so",
+      "upstream_path": "contrib/mmcount/"
+    },
+    "mmdarwin": {
+      "kind": "contrib",
+      "module_file": "mmdarwin.so",
+      "upstream_path": "contrib/mmdarwin/"
+    },
+    "mmdblookup": {
+      "kind": "plugin",
+      "module_file": "mmdblookup.so",
+      "upstream_path": "plugins/mmdblookup/"
+    },
+    "mmexternal": {
+      "kind": "plugin",
+      "module_file": "mmexternal.so",
+      "upstream_path": "plugins/mmexternal/"
+    },
+    "mmfields": {
+      "kind": "plugin",
+      "module_file": "mmfields.so",
+      "upstream_path": "plugins/mmfields/"
+    },
+    "mmgrok": {
+      "kind": "contrib",
+      "module_file": "mmgrok.so",
+      "upstream_path": "contrib/mmgrok/"
+    },
+    "mmjsonparse": {
+      "kind": "plugin",
+      "module_file": "mmjsonparse.so",
+      "upstream_path": "plugins/mmjsonparse/"
+    },
+    "mmjsontransform": {
+      "kind": "plugin",
+      "module_file": "mmjsontransform.so",
+      "upstream_path": "plugins/mmjsontransform/"
+    },
+    "mmkubernetes": {
+      "kind": "contrib",
+      "module_file": "mmkubernetes.so",
+      "upstream_path": "contrib/mmkubernetes/"
+    },
+    "mmleefparse": {
+      "kind": "plugin",
+      "module_file": "mmleefparse.so",
+      "upstream_path": "plugins/mmleefparse/"
+    },
+    "mmnormalize": {
+      "kind": "plugin",
+      "module_file": "mmnormalize.so",
+      "upstream_path": "plugins/mmnormalize/"
+    },
+    "mmpstrucdata": {
+      "kind": "plugin",
+      "module_file": "mmpstrucdata.so",
+      "upstream_path": "plugins/mmpstrucdata/"
+    },
+    "mmrfc5424addhmac": {
+      "kind": "contrib",
+      "module_file": "mmrfc5424addhmac.so",
+      "upstream_path": "contrib/mmrfc5424addhmac/"
+    },
+    "mmrm1stspace": {
+      "kind": "plugin",
+      "module_file": "mmrm1stspace.so",
+      "upstream_path": "plugins/mmrm1stspace/"
+    },
+    "mmsequence": {
+      "kind": "contrib",
+      "module_file": "mmsequence.so",
+      "upstream_path": "contrib/mmsequence/"
+    },
+    "mmsnareparse": {
+      "kind": "plugin",
+      "module_file": "mmsnareparse.so",
+      "upstream_path": "plugins/mmsnareparse/"
+    },
+    "mmsnmptrapd": {
+      "kind": "plugin",
+      "module_file": "mmsnmptrapd.so",
+      "upstream_path": "plugins/mmsnmptrapd/"
+    },
+    "mmtaghostname": {
+      "kind": "contrib",
+      "module_file": "mmtaghostname.so",
+      "upstream_path": "contrib/mmtaghostname/"
+    },
+    "mmutf8fix": {
+      "kind": "plugin",
+      "module_file": "mmutf8fix.so",
+      "upstream_path": "plugins/mmutf8fix/"
+    },
+    "omamqp1": {
+      "kind": "contrib",
+      "module_file": "omamqp1.so",
+      "upstream_path": "contrib/omamqp1/"
+    },
+    "omazuredce": {
+      "kind": "plugin",
+      "module_file": "omazuredce.so",
+      "upstream_path": "plugins/omazuredce/"
+    },
+    "omazureeventhubs": {
+      "kind": "plugin",
+      "module_file": "omazureeventhubs.so",
+      "upstream_path": "plugins/omazureeventhubs/"
+    },
+    "omclickhouse": {
+      "kind": "plugin",
+      "module_file": "omclickhouse.so",
+      "upstream_path": "plugins/omclickhouse/"
+    },
+    "omczmq": {
+      "kind": "contrib",
+      "module_file": "omczmq.so",
+      "upstream_path": "contrib/omczmq/"
+    },
+    "omdtls": {
+      "kind": "plugin",
+      "module_file": "omdtls.so",
+      "upstream_path": "plugins/omdtls/"
+    },
+    "omelasticsearch": {
+      "kind": "plugin",
+      "module_file": "omelasticsearch.so",
+      "upstream_path": "plugins/omelasticsearch/"
+    },
+    "omfile": {
+      "kind": "legacy-built-in",
+      "module_file": "omfile.so",
+      "upstream_path": "tools/omfile.c"
+    },
+    "omfile-hardened": {
+      "kind": "contrib",
+      "module_file": "omfile-hardened.so",
+      "upstream_path": "contrib/omfile-hardened/"
+    },
+    "omgssapi": {
+      "kind": "plugin",
+      "module_file": "omgssapi.so",
+      "upstream_path": "plugins/omgssapi/"
+    },
+    "omhdfs": {
+      "kind": "plugin",
+      "module_file": "omhdfs.so",
+      "upstream_path": "plugins/omhdfs/"
+    },
+    "omhiredis": {
+      "kind": "contrib",
+      "module_file": "omhiredis.so",
+      "upstream_path": "contrib/omhiredis/"
+    },
+    "omhttp": {
+      "kind": "contrib",
+      "module_file": "omhttp.so",
+      "upstream_path": "contrib/omhttp/"
+    },
+    "omhttpfs": {
+      "kind": "contrib",
+      "module_file": "omhttpfs.so",
+      "upstream_path": "contrib/omhttpfs/"
+    },
+    "omjournal": {
+      "kind": "plugin",
+      "module_file": "omjournal.so",
+      "upstream_path": "plugins/omjournal/"
+    },
+    "omkafka": {
+      "kind": "plugin",
+      "module_file": "omkafka.so",
+      "upstream_path": "plugins/omkafka/"
+    },
+    "omlibdbi": {
+      "kind": "plugin",
+      "module_file": "omlibdbi.so",
+      "upstream_path": "plugins/omlibdbi/"
+    },
+    "ommail": {
+      "kind": "plugin",
+      "module_file": "ommail.so",
+      "upstream_path": "plugins/ommail/"
+    },
+    "ommongodb": {
+      "kind": "plugin",
+      "module_file": "ommongodb.so",
+      "upstream_path": "plugins/ommongodb/"
+    },
+    "ommysql": {
+      "kind": "plugin",
+      "module_file": "ommysql.so",
+      "upstream_path": "plugins/ommysql/"
+    },
+    "omotel": {
+      "kind": "plugin",
+      "module_file": "omotel.so",
+      "upstream_path": "plugins/omotel/"
+    },
+    "ompgsql": {
+      "kind": "plugin",
+      "module_file": "ompgsql.so",
+      "upstream_path": "plugins/ompgsql/"
+    },
+    "ompipe": {
+      "kind": "legacy-built-in",
+      "module_file": "ompipe.so",
+      "upstream_path": "tools/ompipe.c"
+    },
+    "omprog": {
+      "kind": "plugin",
+      "module_file": "omprog.so",
+      "upstream_path": "plugins/omprog/"
+    },
+    "omrabbitmq": {
+      "kind": "contrib",
+      "module_file": "omrabbitmq.so",
+      "upstream_path": "contrib/omrabbitmq/"
+    },
+    "omrelp": {
+      "kind": "plugin",
+      "module_file": "omrelp.so",
+      "upstream_path": "plugins/omrelp/"
+    },
+    "omruleset": {
+      "kind": "plugin",
+      "module_file": "omruleset.so",
+      "upstream_path": "plugins/omruleset/"
+    },
+    "omsendertrack": {
+      "kind": "plugin",
+      "module_file": "omsendertrack.so",
+      "upstream_path": "plugins/omsendertrack/"
+    },
+    "omsnmp": {
+      "kind": "plugin",
+      "module_file": "omsnmp.so",
+      "upstream_path": "plugins/omsnmp/"
+    },
+    "omstdout": {
+      "kind": "plugin",
+      "module_file": "omstdout.so",
+      "upstream_path": "plugins/omstdout/"
+    },
+    "omtcl": {
+      "kind": "contrib",
+      "module_file": "omtcl.so",
+      "upstream_path": "contrib/omtcl/"
+    },
+    "omtesting": {
+      "kind": "plugin",
+      "module_file": "omtesting.so",
+      "upstream_path": "plugins/omtesting/"
+    },
+    "omudpspoof": {
+      "kind": "plugin",
+      "module_file": "omudpspoof.so",
+      "upstream_path": "plugins/omudpspoof/"
+    },
+    "omuxsock": {
+      "kind": "plugin",
+      "module_file": "omuxsock.so",
+      "upstream_path": "plugins/omuxsock/"
+    },
+    "pmaixforwardedfrom": {
+      "kind": "contrib",
+      "module_file": "pmaixforwardedfrom.so",
+      "upstream_path": "contrib/pmaixforwardedfrom/"
+    },
+    "pmciscoios": {
+      "kind": "plugin",
+      "module_file": "pmciscoios.so",
+      "upstream_path": "plugins/pmciscoios/"
+    },
+    "pmcisconames": {
+      "kind": "contrib",
+      "module_file": "pmcisconames.so",
+      "upstream_path": "contrib/pmcisconames/"
+    },
+    "pmdb2diag": {
+      "kind": "contrib",
+      "module_file": "pmdb2diag.so",
+      "upstream_path": "contrib/pmdb2diag/"
+    },
+    "pmlastmsg": {
+      "kind": "plugin",
+      "module_file": "pmlastmsg.so",
+      "upstream_path": "plugins/pmlastmsg/"
+    },
+    "pmnormalize": {
+      "kind": "plugin",
+      "module_file": "pmnormalize.so",
+      "upstream_path": "plugins/pmnormalize/"
+    },
+    "pmnull": {
+      "kind": "plugin",
+      "module_file": "pmnull.so",
+      "upstream_path": "plugins/pmnull/"
+    },
+    "pmpanngfw": {
+      "kind": "contrib",
+      "module_file": "pmpanngfw.so",
+      "upstream_path": "contrib/pmpanngfw/"
+    },
+    "pmrfc3164": {
+      "kind": "legacy-built-in",
+      "module_file": "pmrfc3164.so",
+      "upstream_path": "tools/pmrfc3164.c"
+    },
+    "pmrfc5424": {
+      "kind": "legacy-built-in",
+      "module_file": "pmrfc5424.so",
+      "upstream_path": "tools/pmrfc5424.c"
+    },
+    "pmsnare": {
+      "kind": "contrib",
+      "module_file": "pmsnare.so",
+      "upstream_path": "contrib/pmsnare/"
+    }
+  },
+  "description": "Best-effort support data mapping upstream rsyslog modules to public distro packages.",
+  "schema_version": 1,
+  "sources": {
+    "adiscon-daily-stable-focal": {
+      "channel": "daily-stable",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhash",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhttp",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [
+            {
+              "package": "rsyslog-imbeats",
+              "path": "/usr/lib/rsyslog/imbeats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/imczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/rsyslog/imdocker.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imfile.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/imkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imklog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog-imkmsg",
+              "path": "/usr/lib/rsyslog/imkmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/immark.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [
+            {
+              "package": "rsyslog-impcap",
+              "path": "/usr/lib/rsyslog/impcap.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog-improg",
+              "path": "/usr/lib/rsyslog/improg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/impstats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog-imptcp",
+              "path": "/usr/lib/rsyslog/imptcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/imrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imtcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imudp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/rsyslog/mmdblookup.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmexternal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [
+            {
+              "package": "rsyslog-mmgrok",
+              "path": "/usr/lib/rsyslog/mmgrok.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-mmkubernetes",
+              "path": "/usr/lib/rsyslog/mmkubernetes.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmleefparse",
+              "path": "/usr/lib/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/rsyslog/mmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmpstrucdata.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmsequence.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnareparse",
+              "path": "/usr/lib/rsyslog/mmsnareparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-omclickhouse",
+              "path": "/usr/lib/rsyslog/omclickhouse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/omczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/rsyslog/omelasticsearch.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-redis",
+              "path": "/usr/lib/rsyslog/omhiredis.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-omhttp",
+              "path": "/usr/lib/rsyslog/omhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/omkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/ommail.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "/usr/lib/rsyslog/ommongodb.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/rsyslog/ommysql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [
+            {
+              "package": "rsyslog-omotel",
+              "path": "/usr/lib/rsyslog/omotel.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/rsyslog/ompgsql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omprog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-omrabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/omrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [
+            {
+              "package": "rsyslog-omsendertrack",
+              "path": "/usr/lib/rsyslog/omsendertrack.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omsnmp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog-omstdout",
+              "path": "/usr/lib/rsyslog/omstdout.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/rsyslog/omudpspoof.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmciscoios.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmcisconames.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmlastmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-pmnormalize",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnull.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmsnare.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "adiscon-ppa",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_packages",
+      "release": "focal",
+      "shipped_component_count": 59,
+      "source_urls": [
+        "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+      ],
+      "status": "ok"
+    },
+    "adiscon-daily-stable-jammy": {
+      "channel": "daily-stable",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhash",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhttp",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [
+            {
+              "package": "rsyslog-imbeats",
+              "path": "/usr/lib/rsyslog/imbeats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/imczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/rsyslog/imdocker.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imfile.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-imhttp",
+              "path": "/usr/lib/rsyslog/imhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/imkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imklog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog-imkmsg",
+              "path": "/usr/lib/rsyslog/imkmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/immark.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [
+            {
+              "package": "rsyslog-impcap",
+              "path": "/usr/lib/rsyslog/impcap.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog-improg",
+              "path": "/usr/lib/rsyslog/improg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/impstats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog-imptcp",
+              "path": "/usr/lib/rsyslog/imptcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/imrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imtcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imudp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/rsyslog/mmdblookup.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmexternal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [
+            {
+              "package": "rsyslog-mmgrok",
+              "path": "/usr/lib/rsyslog/mmgrok.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-mmkubernetes",
+              "path": "/usr/lib/rsyslog/mmkubernetes.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmleefparse",
+              "path": "/usr/lib/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/rsyslog/mmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmpstrucdata.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmsequence.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnareparse",
+              "path": "/usr/lib/rsyslog/mmsnareparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [
+            {
+              "package": "rsyslog-omazureeventhubs",
+              "path": "/usr/lib/rsyslog/omazureeventhubs.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-omclickhouse",
+              "path": "/usr/lib/rsyslog/omclickhouse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/omczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/rsyslog/omelasticsearch.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-redis",
+              "path": "/usr/lib/rsyslog/omhiredis.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-omhttp",
+              "path": "/usr/lib/rsyslog/omhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/omkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/ommail.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "/usr/lib/rsyslog/ommongodb.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/rsyslog/ommysql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [
+            {
+              "package": "rsyslog-omotel",
+              "path": "/usr/lib/rsyslog/omotel.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/rsyslog/ompgsql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omprog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-omrabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/omrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [
+            {
+              "package": "rsyslog-omsendertrack",
+              "path": "/usr/lib/rsyslog/omsendertrack.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omsnmp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog-omstdout",
+              "path": "/usr/lib/rsyslog/omstdout.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/rsyslog/omudpspoof.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmciscoios.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmcisconames.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmlastmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-pmnormalize",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnull.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmsnare.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "adiscon-ppa",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_packages",
+      "release": "jammy",
+      "shipped_component_count": 61,
+      "source_urls": [
+        "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+      ],
+      "status": "ok"
+    },
+    "adiscon-daily-stable-noble": {
+      "channel": "daily-stable",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [
+            {
+              "package": "rsyslog-imbeats",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imbeats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imdocker.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-imhttp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [
+            {
+              "package": "rsyslog-impcap",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/impcap.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog-improg",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/improg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog-imptcp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmdblookup.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-kubernetes",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmkubernetes.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmleefparse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnareparse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmsnareparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [
+            {
+              "package": "rsyslog-omazureeventhubs",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omazureeventhubs.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-omclickhouse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omclickhouse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-omhttp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [
+            {
+              "package": "rsyslog-omotel",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omotel.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [
+            {
+              "package": "rsyslog-omsendertrack",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omsendertrack.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omsnmp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog-omstdout",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omstdout.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omudpspoof.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmciscoios.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "adiscon-ppa",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_packages",
+      "release": "noble",
+      "shipped_component_count": 59,
+      "source_urls": [
+        "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+      ],
+      "status": "ok"
+    },
+    "adiscon-v8-stable-focal": {
+      "channel": "v8-stable",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhash",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhttp",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/imczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/rsyslog/imdocker.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imfile.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/imkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imklog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog-imkmsg",
+              "path": "/usr/lib/rsyslog/imkmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/immark.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [
+            {
+              "package": "rsyslog-impcap",
+              "path": "/usr/lib/rsyslog/impcap.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog-improg",
+              "path": "/usr/lib/rsyslog/improg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/impstats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog-imptcp",
+              "path": "/usr/lib/rsyslog/imptcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/imrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imtcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imudp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/rsyslog/mmdblookup.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmexternal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [
+            {
+              "package": "rsyslog-mmgrok",
+              "path": "/usr/lib/rsyslog/mmgrok.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-mmkubernetes",
+              "path": "/usr/lib/rsyslog/mmkubernetes.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmleefparse",
+              "path": "/usr/lib/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/rsyslog/mmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmpstrucdata.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmsequence.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnareparse",
+              "path": "/usr/lib/rsyslog/mmsnareparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-omclickhouse",
+              "path": "/usr/lib/rsyslog/omclickhouse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/omczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/rsyslog/omelasticsearch.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-redis",
+              "path": "/usr/lib/rsyslog/omhiredis.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-omhttp",
+              "path": "/usr/lib/rsyslog/omhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/omkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/ommail.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "/usr/lib/rsyslog/ommongodb.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/rsyslog/ommysql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/rsyslog/ompgsql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omprog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-omrabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/omrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [
+            {
+              "package": "rsyslog-omsendertrack",
+              "path": "/usr/lib/rsyslog/omsendertrack.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omsnmp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog-omstdout",
+              "path": "/usr/lib/rsyslog/omstdout.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/rsyslog/omudpspoof.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmciscoios.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmcisconames.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmlastmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-pmnormalize",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnull.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmsnare.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "adiscon-ppa",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_packages",
+      "release": "focal",
+      "shipped_component_count": 57,
+      "source_urls": [
+        "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz"
+      ],
+      "status": "ok"
+    },
+    "adiscon-v8-stable-jammy": {
+      "channel": "v8-stable",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhash",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhttp",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/imczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/rsyslog/imdocker.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imfile.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-imhttp",
+              "path": "/usr/lib/rsyslog/imhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/imkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imklog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog-imkmsg",
+              "path": "/usr/lib/rsyslog/imkmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/immark.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [
+            {
+              "package": "rsyslog-impcap",
+              "path": "/usr/lib/rsyslog/impcap.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog-improg",
+              "path": "/usr/lib/rsyslog/improg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/impstats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog-imptcp",
+              "path": "/usr/lib/rsyslog/imptcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/imrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imtcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imudp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/rsyslog/mmdblookup.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmexternal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [
+            {
+              "package": "rsyslog-mmgrok",
+              "path": "/usr/lib/rsyslog/mmgrok.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-mmkubernetes",
+              "path": "/usr/lib/rsyslog/mmkubernetes.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmleefparse",
+              "path": "/usr/lib/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/rsyslog/mmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmpstrucdata.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmsequence.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnareparse",
+              "path": "/usr/lib/rsyslog/mmsnareparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [
+            {
+              "package": "rsyslog-omazureeventhubs",
+              "path": "/usr/lib/rsyslog/omazureeventhubs.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-omclickhouse",
+              "path": "/usr/lib/rsyslog/omclickhouse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/rsyslog/omczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/rsyslog/omelasticsearch.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-redis",
+              "path": "/usr/lib/rsyslog/omhiredis.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-omhttp",
+              "path": "/usr/lib/rsyslog/omhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/rsyslog/omkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/ommail.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "/usr/lib/rsyslog/ommongodb.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/rsyslog/ommysql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/rsyslog/ompgsql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omprog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-omrabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/omrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [
+            {
+              "package": "rsyslog-omsendertrack",
+              "path": "/usr/lib/rsyslog/omsendertrack.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omsnmp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog-omstdout",
+              "path": "/usr/lib/rsyslog/omstdout.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/rsyslog/omudpspoof.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmciscoios.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmcisconames.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmlastmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-pmnormalize",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmnull.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/pmsnare.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "adiscon-ppa",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_packages",
+      "release": "jammy",
+      "shipped_component_count": 59,
+      "source_urls": [
+        "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz"
+      ],
+      "status": "ok"
+    },
+    "adiscon-v8-stable-noble": {
+      "channel": "v8-stable",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-fmhash",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-fmhttp",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imdocker.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-imhttp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-imkmsg",
+              "path": "/usr/lib/rsyslog/imkmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [
+            {
+              "package": "rsyslog-impcap",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/impcap.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog-improg",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/improg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog-imptcp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmdblookup.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-kubernetes",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmkubernetes.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmkubernetes",
+              "path": "/usr/lib/rsyslog/mmkubernetes.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmleefparse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmleefparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnareparse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmsnareparse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            },
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [
+            {
+              "package": "rsyslog-omazureeventhubs",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omazureeventhubs.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-omclickhouse",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omclickhouse.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-omhttp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omhttp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-omrabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [
+            {
+              "package": "rsyslog-omsendertrack",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omsendertrack.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omsnmp.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog-omstdout",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omstdout.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omudpspoof.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmciscoios.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-pmnormalize",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "adiscon-ppa",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_packages",
+      "release": "noble",
+      "shipped_component_count": 60,
+      "source_urls": [
+        "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz"
+      ],
+      "status": "ok"
+    },
+    "alpine-edge": {
+      "channel": "main+community",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-http",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-zmq",
+              "path": "/usr/lib/rsyslog/imczmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/rsyslog/imdocker.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [
+            {
+              "package": "rsyslog-dtls",
+              "path": "/usr/lib/rsyslog/imdtls.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imfile.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/rsyslog/imgssapi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imkafka": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imklog.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imkmsg.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/immark.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [
+            {
+              "package": "rsyslog-impcap",
+              "path": "/usr/lib/rsyslog/impcap.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog-prog",
+              "path": "/usr/lib/rsyslog/improg.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/impstats.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imptcp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/imrelp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imtcp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imudp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imuxsock.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [
+            {
+              "package": "rsyslog-mmaitag",
+              "path": "/usr/lib/rsyslog/mmaitag.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [
+            {
+              "package": "rsyslog-mmaudit",
+              "path": "/usr/lib/rsyslog/mmaudit.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmcount": {
+          "packages": [
+            {
+              "package": "rsyslog-mmcount",
+              "path": "/usr/lib/rsyslog/mmcount.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/rsyslog/mmdblookup.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmexternal.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/rsyslog/mmjsonparse.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmjsontransform.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-mmkubernetes",
+              "path": "/usr/lib/rsyslog/mmkubernetes.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmleefparse.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/rsyslog/mmnormalize.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog-mmpstrucdata",
+              "path": "/usr/lib/rsyslog/mmpstrucdata.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsequence",
+              "path": "/usr/lib/rsyslog/mmsequence.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnmptrapd",
+              "path": "/usr/lib/rsyslog/mmsnmptrapd.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmtaghostname": {
+          "packages": [
+            {
+              "package": "rsyslog-mmtaghostname",
+              "path": "/usr/lib/rsyslog/mmtaghostname.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-clickhouse",
+              "path": "/usr/lib/rsyslog/omclickhouse.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-zmq",
+              "path": "/usr/lib/rsyslog/omczmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [
+            {
+              "package": "rsyslog-dtls",
+              "path": "/usr/lib/rsyslog/omdtls.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/rsyslog/omelasticsearch.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/rsyslog/omgssapi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "/usr/lib/rsyslog/omhiredis.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-http",
+              "path": "/usr/lib/rsyslog/omhttp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omkafka": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omlibdbi": {
+          "packages": [
+            {
+              "package": "rsyslog-libdbi",
+              "path": "/usr/lib/rsyslog/omlibdbi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/ommail.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/rsyslog/ommysql.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [
+            {
+              "package": "rsyslog-omotel",
+              "path": "/usr/lib/rsyslog/omotel.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/rsyslog/ompgsql.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog-prog",
+              "path": "/usr/lib/rsyslog/omprog.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-rabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/omrelp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omruleset.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "/usr/lib/rsyslog/omsnmp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omstdout.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [
+            {
+              "package": "rsyslog-testing",
+              "path": "/usr/lib/rsyslog/omtesting.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/rsyslog/omudpspoof.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omuxsock.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog-pmaixforwardedfrom",
+              "path": "/usr/lib/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog-cisco",
+              "path": "/usr/lib/rsyslog/pmciscoios.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog-cisco",
+              "path": "/usr/lib/rsyslog/pmcisconames.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog-pmlastmsg",
+              "path": "/usr/lib/rsyslog/pmlastmsg.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-pmnormalize",
+              "path": "/usr/lib/rsyslog/pmnormalize.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog-pmsnare",
+              "path": "/usr/lib/rsyslog/pmsnare.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "alpine",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "alpine_apk",
+      "release": "edge",
+      "shipped_component_count": 63,
+      "source_urls": [
+        "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/",
+        "https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/"
+      ],
+      "status": "ok"
+    },
+    "alpine-v3.21": {
+      "channel": "main+community",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-http",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-zmq",
+              "path": "/usr/lib/rsyslog/imczmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/rsyslog/imdocker.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imfile.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/rsyslog/imgssapi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imkafka": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imklog.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/immark.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/impstats.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imptcp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/imrelp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imtcp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imudp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imuxsock.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [
+            {
+              "package": "rsyslog-mmaudit",
+              "path": "/usr/lib/rsyslog/mmaudit.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmcount": {
+          "packages": [
+            {
+              "package": "rsyslog-mmcount",
+              "path": "/usr/lib/rsyslog/mmcount.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/rsyslog/mmdblookup.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmexternal.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/rsyslog/mmjsonparse.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmleefparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/rsyslog/mmnormalize.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog-mmpstrucdata",
+              "path": "/usr/lib/rsyslog/mmpstrucdata.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsequence",
+              "path": "/usr/lib/rsyslog/mmsequence.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnmptrapd",
+              "path": "/usr/lib/rsyslog/mmsnmptrapd.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmtaghostname": {
+          "packages": [
+            {
+              "package": "rsyslog-mmtaghostname",
+              "path": "/usr/lib/rsyslog/mmtaghostname.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-clickhouse",
+              "path": "/usr/lib/rsyslog/omclickhouse.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-zmq",
+              "path": "/usr/lib/rsyslog/omczmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/rsyslog/omelasticsearch.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/rsyslog/omgssapi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "/usr/lib/rsyslog/omhiredis.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-http",
+              "path": "/usr/lib/rsyslog/omhttp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omkafka": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omlibdbi": {
+          "packages": [
+            {
+              "package": "rsyslog-libdbi",
+              "path": "/usr/lib/rsyslog/omlibdbi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/ommail.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/rsyslog/ommysql.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/rsyslog/ompgsql.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omprog.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-rabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/omrelp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "/usr/lib/rsyslog/omsnmp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omstdout.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [
+            {
+              "package": "rsyslog-testing",
+              "path": "/usr/lib/rsyslog/omtesting.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/rsyslog/omudpspoof.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog-uxsock",
+              "path": "/usr/lib/rsyslog/omuxsock.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog-pmaixforwardedfrom",
+              "path": "/usr/lib/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmcisconames": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog-pmlastmsg",
+              "path": "/usr/lib/rsyslog/pmlastmsg.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog-pmsnare",
+              "path": "/usr/lib/rsyslog/pmsnare.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "alpine",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "alpine_apk",
+      "release": "v3.21",
+      "shipped_component_count": 49,
+      "source_urls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/",
+        "https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/"
+      ],
+      "status": "ok"
+    },
+    "alpine-v3.22": {
+      "channel": "main+community",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/fmhash.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-http",
+              "path": "/usr/lib/rsyslog/fmhttp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-zmq",
+              "path": "/usr/lib/rsyslog/imczmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-imdocker",
+              "path": "/usr/lib/rsyslog/imdocker.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imfile.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/rsyslog/imgssapi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imkafka": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imklog.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/immark.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/impstats.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imptcp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/imrelp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imtcp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imudp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/imuxsock.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog-mmanon",
+              "path": "/usr/lib/rsyslog/mmanon.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [
+            {
+              "package": "rsyslog-mmaudit",
+              "path": "/usr/lib/rsyslog/mmaudit.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmcount": {
+          "packages": [
+            {
+              "package": "rsyslog-mmcount",
+              "path": "/usr/lib/rsyslog/mmcount.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [
+            {
+              "package": "rsyslog-mmdblookup",
+              "path": "/usr/lib/rsyslog/mmdblookup.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/mmexternal.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib/rsyslog/mmfields.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib/rsyslog/mmjsonparse.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmleefparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib/rsyslog/mmnormalize.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog-mmpstrucdata",
+              "path": "/usr/lib/rsyslog/mmpstrucdata.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog-mmrm1stspace",
+              "path": "/usr/lib/rsyslog/mmrm1stspace.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsequence",
+              "path": "/usr/lib/rsyslog/mmsequence.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnmptrapd",
+              "path": "/usr/lib/rsyslog/mmsnmptrapd.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmtaghostname": {
+          "packages": [
+            {
+              "package": "rsyslog-mmtaghostname",
+              "path": "/usr/lib/rsyslog/mmtaghostname.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog-mmutf8fix",
+              "path": "/usr/lib/rsyslog/mmutf8fix.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-clickhouse",
+              "path": "/usr/lib/rsyslog/omclickhouse.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-zmq",
+              "path": "/usr/lib/rsyslog/omczmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib/rsyslog/omelasticsearch.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib/rsyslog/omgssapi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "/usr/lib/rsyslog/omhiredis.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-http",
+              "path": "/usr/lib/rsyslog/omhttp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omkafka": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omlibdbi": {
+          "packages": [
+            {
+              "package": "rsyslog-libdbi",
+              "path": "/usr/lib/rsyslog/omlibdbi.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/ommail.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib/rsyslog/ommysql.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib/rsyslog/ompgsql.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omprog.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-rabbitmq",
+              "path": "/usr/lib/rsyslog/omrabbitmq.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib/rsyslog/omrelp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "/usr/lib/rsyslog/omsnmp.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib/rsyslog/omstdout.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [
+            {
+              "package": "rsyslog-testing",
+              "path": "/usr/lib/rsyslog/omtesting.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib/rsyslog/omudpspoof.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog-uxsock",
+              "path": "/usr/lib/rsyslog/omuxsock.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog-pmaixforwardedfrom",
+              "path": "/usr/lib/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmcisconames": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog-pmlastmsg",
+              "path": "/usr/lib/rsyslog/pmlastmsg.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog-pmsnare",
+              "path": "/usr/lib/rsyslog/pmsnare.so",
+              "source_url": "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "alpine",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "alpine_apk",
+      "release": "v3.22",
+      "shipped_component_count": 49,
+      "source_urls": [
+        "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/",
+        "https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/"
+      ],
+      "status": "ok"
+    },
+    "debian-bookworm": {
+      "channel": "main",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-kubernetes",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmkubernetes.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmnormalize.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omsnmp.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmciscoios.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmnormalize.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "debian",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_contents",
+      "release": "bookworm",
+      "shipped_component_count": 45,
+      "source_urls": [
+        "https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz"
+      ],
+      "status": "ok"
+    },
+    "debian-sid": {
+      "channel": "main",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-docker",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imdocker.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [
+            {
+              "package": "rsyslog-openssl",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imdtls.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imhiredis.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-kubernetes",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmkubernetes.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmleefparse.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmnormalize.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-clickhouse",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omclickhouse.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [
+            {
+              "package": "rsyslog-openssl",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omdtls.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog-http",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omhttp.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omsnmp.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmciscoios.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmnormalize.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "debian",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_contents",
+      "release": "sid",
+      "shipped_component_count": 52,
+      "source_urls": [
+        "https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz"
+      ],
+      "status": "ok"
+    },
+    "debian-trixie": {
+      "channel": "main",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog-docker",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imdocker.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [
+            {
+              "package": "rsyslog-openssl",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imdtls.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imhiredis.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-kubernetes",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmkubernetes.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmnormalize.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog-clickhouse",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omclickhouse.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [
+            {
+              "package": "rsyslog-openssl",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omdtls.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omsnmp.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmciscoios.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmnormalize.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "debian",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_contents",
+      "release": "trixie",
+      "shipped_component_count": 50,
+      "source_urls": [
+        "https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz"
+      ],
+      "status": "ok"
+    },
+    "fedora-rawhide": {
+      "channel": "everything",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/fmhash.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/fmhttp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imdocker.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imfile.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib64/rsyslog/imgssapi.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imjournal.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib64/rsyslog/imkafka.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imklog.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/immark.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/improg.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/impstats.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imptcp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib64/rsyslog/imrelp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imtcp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imudp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/imuxsock.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/mmanon.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [
+            {
+              "package": "rsyslog-mmaudit",
+              "path": "/usr/lib64/rsyslog/mmaudit.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmcount": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/mmcount.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/mmexternal.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog-mmfields",
+              "path": "/usr/lib64/rsyslog/mmfields.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog-mmjsonparse",
+              "path": "/usr/lib64/rsyslog/mmjsonparse.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-mmkubernetes",
+              "path": "/usr/lib64/rsyslog/mmkubernetes.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/mmleefparse.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmnormalize": {
+          "packages": [
+            {
+              "package": "rsyslog-mmnormalize",
+              "path": "/usr/lib64/rsyslog/mmnormalize.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsequence": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [
+            {
+              "package": "rsyslog-mmsnmptrapd",
+              "path": "/usr/lib64/rsyslog/mmsnmptrapd.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmtaghostname": {
+          "packages": [
+            {
+              "package": "rsyslog-mmtaghostname",
+              "path": "/usr/lib64/rsyslog/mmtaghostname.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/mmutf8fix.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [
+            {
+              "package": "rsyslog-omamqp1",
+              "path": "/usr/lib64/rsyslog/omamqp1.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/omclickhouse.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omczmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "/usr/lib64/rsyslog/omelasticsearch.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "/usr/lib64/rsyslog/omgssapi.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "/usr/lib64/rsyslog/omhiredis.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/omhttp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/omjournal.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "/usr/lib64/rsyslog/omkafka.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [
+            {
+              "package": "rsyslog-libdbi",
+              "path": "/usr/lib64/rsyslog/omlibdbi.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/ommail.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "/usr/lib64/rsyslog/ommongodb.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "/usr/lib64/rsyslog/ommysql.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "/usr/lib64/rsyslog/ompgsql.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/omprog.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [
+            {
+              "package": "rsyslog-rabbitmq",
+              "path": "/usr/lib64/rsyslog/omrabbitmq.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "/usr/lib64/rsyslog/omrelp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "/usr/lib64/rsyslog/omsnmp.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/omstdout.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/omtesting.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omudpspoof": {
+          "packages": [
+            {
+              "package": "rsyslog-udpspoof",
+              "path": "/usr/lib64/rsyslog/omudpspoof.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/omuxsock.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/pmcisconames.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/pmlastmsg.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "/usr/lib64/rsyslog/pmsnare.so",
+              "source_url": "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/e742f2530124f66244147371c354233d0eb9659a7be5237b1a160da3e7ef98fa-filelists.xml.zst"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "fedora",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "fedora_filelists",
+      "release": "rawhide",
+      "shipped_component_count": 53,
+      "source_urls": [
+        "https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/repomd.xml"
+      ],
+      "status": "ok"
+    },
+    "ubuntu-focal": {
+      "channel": "main+universe",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmleefparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omstdout": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "ubuntu",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_contents",
+      "release": "focal",
+      "shipped_component_count": 40,
+      "source_urls": [
+        "https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz"
+      ],
+      "status": "ok"
+    },
+    "ubuntu-jammy": {
+      "channel": "main+universe",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-kubernetes",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmkubernetes.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omsnmp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmciscoios.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "ubuntu",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_contents",
+      "release": "jammy",
+      "shipped_component_count": 43,
+      "source_urls": [
+        "https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz"
+      ],
+      "status": "ok"
+    },
+    "ubuntu-noble": {
+      "channel": "main+universe",
+      "component_count": 98,
+      "components": {
+        "ffaup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmhash": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/fmhash.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "fmhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmpcre": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "fmunflatten": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "im3195": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbatchreport": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imbeats": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imczmq.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imdiag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdocker": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imfile": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imfile.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imgssapi.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imhiredis": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imjournal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkafka.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imklog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imklog.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imkmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imkmsg.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "immark": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/immark.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "impcap": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "improg": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "impstats": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/impstats.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imptcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imptcp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imrelp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imsolaris": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imtcp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imtcp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imtuxedoulog": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "imudp": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imudp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "imuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/imuxsock.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaitag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmanon": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmanon.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmaudit": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmcount": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdarwin": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmdblookup": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmexternal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmexternal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmfields": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmfields.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmgrok": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmjsonparse": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmjsonparse.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmjsontransform": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmkubernetes": {
+          "packages": [
+            {
+              "package": "rsyslog-kubernetes",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmkubernetes.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmleefparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmpstrucdata": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmpstrucdata.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmrfc5424addhmac": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmrm1stspace": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmrm1stspace.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsequence": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmsequence.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "mmsnareparse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmsnmptrapd": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmtaghostname": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "mmutf8fix": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/mmutf8fix.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omamqp1": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazuredce": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omazureeventhubs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omclickhouse": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omczmq": {
+          "packages": [
+            {
+              "package": "rsyslog-czmq",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omczmq.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omdtls": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omelasticsearch": {
+          "packages": [
+            {
+              "package": "rsyslog-elasticsearch",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omelasticsearch.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omfile": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omfile-hardened": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omgssapi": {
+          "packages": [
+            {
+              "package": "rsyslog-gssapi",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omgssapi.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhdfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhiredis": {
+          "packages": [
+            {
+              "package": "rsyslog-hiredis",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omhiredis.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omhttp": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omhttpfs": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omjournal": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omjournal.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omkafka": {
+          "packages": [
+            {
+              "package": "rsyslog-kafka",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omkafka.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omlibdbi": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ommail": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommail.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommongodb": {
+          "packages": [
+            {
+              "package": "rsyslog-mongodb",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommongodb.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ommysql": {
+          "packages": [
+            {
+              "package": "rsyslog-mysql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ommysql.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omotel": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "ompgsql": {
+          "packages": [
+            {
+              "package": "rsyslog-pgsql",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/ompgsql.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "ompipe": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omprog": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omprog.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omrabbitmq": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omrelp": {
+          "packages": [
+            {
+              "package": "rsyslog-relp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omrelp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omruleset": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsendertrack": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omsnmp": {
+          "packages": [
+            {
+              "package": "rsyslog-snmp",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omsnmp.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "omstdout": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtcl": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omtesting": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omudpspoof": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "omuxsock": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/omuxsock.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmaixforwardedfrom": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmaixforwardedfrom.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmciscoios": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmciscoios.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmcisconames": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmcisconames.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmdb2diag": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmlastmsg": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmlastmsg.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        },
+        "pmnormalize": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmnull": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmpanngfw": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc3164": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmrfc5424": {
+          "packages": [],
+          "status": "not_shipped"
+        },
+        "pmsnare": {
+          "packages": [
+            {
+              "package": "rsyslog",
+              "path": "usr/lib/x86_64-linux-gnu/rsyslog/pmsnare.so",
+              "source_url": "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+            }
+          ],
+          "status": "shipped"
+        }
+      },
+      "distro": "ubuntu",
+      "error_count": 0,
+      "errors": [],
+      "metadata_kind": "deb_contents",
+      "release": "noble",
+      "shipped_component_count": 43,
+      "source_urls": [
+        "https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz"
+      ],
+      "status": "ok"
+    }
+  }
+}

--- a/doc/security/distro-component-package-map.md
+++ b/doc/security/distro-component-package-map.md
@@ -1,0 +1,34 @@
+# Distro Component Package Map
+
+`distro-component-package-map.json` is generated best-effort support data that
+maps upstream rsyslog module files to public distribution packages.
+
+The map helps answer a practical security advisory question: if an advisory
+names an affected upstream component such as `mmpstrucdata`, which distro
+package, if any, ships that component?
+
+## Scope
+
+The generated data is advisory support data only. It does not change the GHSA
+package field, which normally identifies the upstream affected product
+(`rsyslog`). Advisory titles, summaries, and affected-configuration sections
+should still name the precise upstream component and required configuration.
+
+## Caveats
+
+- The map is generated from public package metadata and is not authoritative
+  for any distribution.
+- `shipped` means public metadata lists the module file in a package.
+- `not_shipped` means the configured public metadata sources were searched and
+  did not list the module file.
+- A shipped module file does not mean the module is loaded by default.
+- Custom builds, locally copied modules, third-party repositories, private
+  repositories, and downstream patches are outside this map.
+- Confirm downstream-specific security claims with the relevant distribution
+  security team before publication.
+
+## Refresh
+
+The weekly `distro component package map` workflow regenerates the JSON data
+from public distribution metadata and opens a pull request when the checked-in
+map changes.

--- a/scripts/generate_distro_component_map.py
+++ b/scripts/generate_distro_component_map.py
@@ -1,0 +1,648 @@
+#!/usr/bin/env python3
+"""Generate best-effort distro package ownership data for rsyslog modules.
+
+The output is support data for security advisories. It answers the practical
+question "which public distro package ships this upstream module file?" by
+querying deterministic public package metadata.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import hashlib
+import io
+import json
+import os
+import subprocess
+import tarfile
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import defusedxml.ElementTree as ET
+
+
+HTTP_TIMEOUT = 45
+USER_AGENT = "rsyslog-distro-component-map/1.0"
+
+
+@dataclass(frozen=True)
+class Component:
+    name: str
+    upstream_path: str
+    module_file: str
+    kind: str
+
+
+@dataclass(frozen=True)
+class Source:
+    key: str
+    distro: str
+    release: str
+    channel: str
+    kind: str
+    urls: tuple[str, ...]
+
+
+DEB_CONTENT_SOURCES = (
+    Source(
+        key="debian-bookworm",
+        distro="debian",
+        release="bookworm",
+        channel="main",
+        kind="deb_contents",
+        urls=("https://deb.debian.org/debian/dists/bookworm/main/Contents-amd64.gz",),
+    ),
+    Source(
+        key="debian-trixie",
+        distro="debian",
+        release="trixie",
+        channel="main",
+        kind="deb_contents",
+        urls=("https://deb.debian.org/debian/dists/trixie/main/Contents-amd64.gz",),
+    ),
+    Source(
+        key="debian-sid",
+        distro="debian",
+        release="sid",
+        channel="main",
+        kind="deb_contents",
+        urls=("https://deb.debian.org/debian/dists/sid/main/Contents-amd64.gz",),
+    ),
+    Source(
+        key="ubuntu-focal",
+        distro="ubuntu",
+        release="focal",
+        channel="main+universe",
+        kind="deb_contents",
+        urls=("https://archive.ubuntu.com/ubuntu/dists/focal/Contents-amd64.gz",),
+    ),
+    Source(
+        key="ubuntu-jammy",
+        distro="ubuntu",
+        release="jammy",
+        channel="main+universe",
+        kind="deb_contents",
+        urls=("https://archive.ubuntu.com/ubuntu/dists/jammy/Contents-amd64.gz",),
+    ),
+    Source(
+        key="ubuntu-noble",
+        distro="ubuntu",
+        release="noble",
+        channel="main+universe",
+        kind="deb_contents",
+        urls=("https://archive.ubuntu.com/ubuntu/dists/noble/Contents-amd64.gz",),
+    ),
+    Source(
+        key="adiscon-v8-stable-focal",
+        distro="adiscon-ppa",
+        release="focal",
+        channel="v8-stable",
+        kind="deb_packages",
+        urls=(
+            "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz",
+        ),
+    ),
+    Source(
+        key="adiscon-v8-stable-jammy",
+        distro="adiscon-ppa",
+        release="jammy",
+        channel="v8-stable",
+        kind="deb_packages",
+        urls=(
+            "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz",
+        ),
+    ),
+    Source(
+        key="adiscon-v8-stable-noble",
+        distro="adiscon-ppa",
+        release="noble",
+        channel="v8-stable",
+        kind="deb_packages",
+        urls=(
+            "https://ppa.launchpadcontent.net/adiscon/v8-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz",
+        ),
+    ),
+    Source(
+        key="adiscon-daily-stable-focal",
+        distro="adiscon-ppa",
+        release="focal",
+        channel="daily-stable",
+        kind="deb_packages",
+        urls=(
+            "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/focal/main/binary-amd64/Packages.gz",
+        ),
+    ),
+    Source(
+        key="adiscon-daily-stable-jammy",
+        distro="adiscon-ppa",
+        release="jammy",
+        channel="daily-stable",
+        kind="deb_packages",
+        urls=(
+            "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/jammy/main/binary-amd64/Packages.gz",
+        ),
+    ),
+    Source(
+        key="adiscon-daily-stable-noble",
+        distro="adiscon-ppa",
+        release="noble",
+        channel="daily-stable",
+        kind="deb_packages",
+        urls=(
+            "https://ppa.launchpadcontent.net/adiscon/daily-stable/ubuntu/dists/noble/main/binary-amd64/Packages.gz",
+        ),
+    ),
+)
+
+FEDORA_SOURCES = (
+    Source(
+        key="fedora-rawhide",
+        distro="fedora",
+        release="rawhide",
+        channel="everything",
+        kind="fedora_filelists",
+        urls=("https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/repodata/repomd.xml",),
+    ),
+)
+
+ALPINE_SOURCES = (
+    Source(
+        key="alpine-v3.21",
+        distro="alpine",
+        release="v3.21",
+        channel="main+community",
+        kind="alpine_apk",
+        urls=(
+            "https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/",
+            "https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/",
+        ),
+    ),
+    Source(
+        key="alpine-v3.22",
+        distro="alpine",
+        release="v3.22",
+        channel="main+community",
+        kind="alpine_apk",
+        urls=(
+            "https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/",
+            "https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/",
+        ),
+    ),
+    Source(
+        key="alpine-edge",
+        distro="alpine",
+        release="edge",
+        channel="main+community",
+        kind="alpine_apk",
+        urls=(
+            "https://dl-cdn.alpinelinux.org/alpine/edge/main/x86_64/",
+            "https://dl-cdn.alpinelinux.org/alpine/edge/community/x86_64/",
+        ),
+    ),
+)
+
+SOURCES = DEB_CONTENT_SOURCES + FEDORA_SOURCES + ALPINE_SOURCES
+
+
+def fetch_url(url: str, cache_dir: Path, errors: list[dict[str, str]]) -> bytes | None:
+    parsed_url = urllib.parse.urlparse(url)
+    if parsed_url.scheme != "https":
+        errors.append({"url": url, "error": "unsupported URL scheme"})
+        return None
+    cache_key = hashlib.sha256(url.encode("utf-8")).hexdigest()
+    cache_path = cache_dir / cache_key
+    if cache_path.exists():
+        return cache_path.read_bytes()
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT) as response:  # nosec B310 - URL scheme is checked above.
+            data = response.read()
+    except (urllib.error.URLError, TimeoutError) as exc:
+        errors.append({"url": url, "error": str(exc)})
+        return None
+    cache_path.write_bytes(data)
+    return data
+
+
+def discover_components(repo_root: Path) -> list[Component]:
+    components: dict[str, Component] = {}
+    for base, kind in (("plugins", "plugin"), ("contrib", "contrib")):
+        base_path = repo_root / base
+        if not base_path.exists():
+            continue
+        for child in sorted(base_path.iterdir()):
+            if not child.is_dir() or child.name == "external":
+                continue
+            c_file = child / f"{child.name}.c"
+            if not c_file.exists():
+                continue
+            components[child.name] = Component(
+                name=child.name,
+                upstream_path=f"{base}/{child.name}/",
+                module_file=f"{child.name}.so",
+                kind=kind,
+            )
+
+    for tool_module in ("omfile", "ompipe", "omprog", "omstdout", "pmrfc3164", "pmrfc5424"):
+        if (repo_root / "tools" / f"{tool_module}.c").exists():
+            components[tool_module] = Component(
+                name=tool_module,
+                upstream_path=f"tools/{tool_module}.c",
+                module_file=f"{tool_module}.so",
+                kind="legacy-built-in",
+            )
+
+    return list(sorted(components.values(), key=lambda c: c.name))
+
+
+def empty_source_result(source: Source) -> dict[str, Any]:
+    return {
+        "distro": source.distro,
+        "release": source.release,
+        "channel": source.channel,
+        "metadata_kind": source.kind,
+        "source_urls": list(source.urls),
+        "status": "unknown",
+        "error_count": 0,
+        "components": {},
+    }
+
+
+def record_match(result: dict[str, Any], component: Component, package: str, path: str, source_url: str) -> None:
+    entry = result["components"].setdefault(
+        component.name,
+        {
+            "status": "shipped",
+            "packages": [],
+        },
+    )
+    candidate = {
+        "package": package,
+        "path": path,
+        "source_url": source_url,
+    }
+    if candidate not in entry["packages"]:
+        entry["packages"].append(candidate)
+
+
+def finalize_source_result(result: dict[str, Any], components: list[Component]) -> None:
+    for component in components:
+        result["components"].setdefault(component.name, {"status": "not_shipped", "packages": []})
+    shipped = sum(1 for entry in result["components"].values() if entry["status"] == "shipped")
+    if result["status"] == "unknown" and result["error_count"] == len(result["source_urls"]):
+        return
+    result["status"] = "ok"
+    result["component_count"] = len(components)
+    result["shipped_component_count"] = shipped
+
+
+def parse_deb_contents(source: Source, components: list[Component], cache_dir: Path) -> dict[str, Any]:
+    result = empty_source_result(source)
+    module_files = {component.module_file: component for component in components}
+    errors: list[dict[str, str]] = []
+    for url in source.urls:
+        data = fetch_url(url, cache_dir, errors)
+        if data is None:
+            continue
+        with gzip.GzipFile(fileobj=io.BytesIO(data)) as gz:
+            lines = io.TextIOWrapper(gz, encoding="utf-8", errors="replace")
+            for line in lines:
+                line = line.rstrip("\n")
+                if "/rsyslog/" not in line or ".so" not in line:
+                    continue
+                parts = line.split()
+                if len(parts) < 2:
+                    continue
+                path, package_field = parts[0], parts[-1]
+                module = os.path.basename(path)
+                component = module_files.get(module)
+                if component is None:
+                    continue
+                packages = [pkg.split("/")[-1] for pkg in package_field.split(",")]
+                for package in packages:
+                    record_match(result, component, package, path, url)
+    result["errors"] = errors
+    result["error_count"] = len(errors)
+    finalize_source_result(result, components)
+    return result
+
+
+def iter_deb_package_records(data: bytes) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    last_key: str | None = None
+    with gzip.GzipFile(fileobj=io.BytesIO(data)) as gz:
+        lines = io.TextIOWrapper(gz, encoding="utf-8", errors="replace")
+        for raw_line in lines:
+            raw_line = raw_line.rstrip("\n")
+            if not raw_line:
+                if current:
+                    records.append(current)
+                    current = {}
+                    last_key = None
+                continue
+            if raw_line.startswith(" ") and last_key:
+                current[last_key] += "\n" + raw_line
+                continue
+            if ":" not in raw_line:
+                continue
+            key, value = raw_line.split(":", 1)
+            current[key] = value.strip()
+            last_key = key
+    if current:
+        records.append(current)
+    return records
+
+
+def parse_deb_packages(data: bytes) -> list[dict[str, str]]:
+    return iter_deb_package_records(data)
+
+
+def deb_repo_root(packages_url: str) -> str:
+    if "/dists/" in packages_url:
+        return packages_url.split("/dists/", 1)[0] + "/"
+    return packages_url.rsplit("/", 1)[0] + "/"
+
+
+def ar_members(data: bytes) -> dict[str, bytes]:
+    if not data.startswith(b"!<arch>\n"):
+        return {}
+    members: dict[str, bytes] = {}
+    offset = 8
+    while offset + 60 <= len(data):
+        header = data[offset : offset + 60]
+        offset += 60
+        name = header[0:16].decode("utf-8", errors="replace").strip().rstrip("/")
+        size_raw = header[48:58].decode("ascii", errors="replace").strip()
+        try:
+            size = int(size_raw)
+        except ValueError:
+            break
+        payload = data[offset : offset + size]
+        offset += size + (size % 2)
+        members[name] = payload
+    return members
+
+
+def zstd_decompress(data: bytes) -> bytes | None:
+    try:
+        proc = subprocess.run(
+            ["zstd", "-dc"],
+            input=data,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+        )
+    except FileNotFoundError:
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout
+
+
+def iter_deb_files(deb_data: bytes) -> list[str]:
+    members = ar_members(deb_data)
+    data_member_name = next((name for name in members if name.startswith("data.tar.")), None)
+    if data_member_name is None:
+        return []
+    data_member = members[data_member_name]
+    if data_member_name.endswith(".zst"):
+        data_member = zstd_decompress(data_member) or b""
+    files: list[str] = []
+    try:
+        with tarfile.open(fileobj=io.BytesIO(data_member), mode="r:*") as tf:
+            for member in tf.getmembers():
+                if member.isfile() or member.issym():
+                    files.append("/" + member.name.lstrip("./"))
+    except tarfile.TarError:
+        return files
+    return files
+
+
+def parse_deb_package_files(source: Source, components: list[Component], cache_dir: Path) -> dict[str, Any]:
+    result = empty_source_result(source)
+    module_files = {component.module_file: component for component in components}
+    errors: list[dict[str, str]] = []
+    for packages_url in source.urls:
+        data = fetch_url(packages_url, cache_dir, errors)
+        if data is None:
+            continue
+        root_url = deb_repo_root(packages_url)
+        for record in parse_deb_packages(data):
+            package_name = record.get("Package", "")
+            filename = record.get("Filename", "")
+            if "rsyslog" not in package_name or not filename:
+                continue
+            deb_url = urllib.parse.urljoin(root_url, filename)
+            deb_data = fetch_url(deb_url, cache_dir, errors)
+            if deb_data is None:
+                continue
+            for path in iter_deb_files(deb_data):
+                if "/rsyslog/" not in path or not path.endswith(".so"):
+                    continue
+                component = module_files.get(os.path.basename(path))
+                if component is not None:
+                    record_match(result, component, package_name, path, packages_url)
+    result["errors"] = errors
+    result["error_count"] = len(errors)
+    finalize_source_result(result, components)
+    return result
+
+
+def repodata_location(repomd_url: str, repomd_xml: bytes, data_type: str) -> str | None:
+    root = ET.fromstring(repomd_xml)
+    ns = {"repo": "http://linux.duke.edu/metadata/repo"}
+    for data in root.findall("repo:data", ns):
+        if data.attrib.get("type") != data_type:
+            continue
+        location = data.find("repo:location", ns)
+        if location is not None:
+            href = location.attrib.get("href")
+            if href:
+                repo_root = repomd_url.split("/repodata/", 1)[0] + "/"
+                return urllib.parse.urljoin(repo_root, href)
+    return None
+
+
+def parse_fedora_filelists(source: Source, components: list[Component], cache_dir: Path) -> dict[str, Any]:
+    result = empty_source_result(source)
+    module_files = {component.module_file: component for component in components}
+    errors: list[dict[str, str]] = []
+    for repomd_url in source.urls:
+        repomd = fetch_url(repomd_url, cache_dir, errors)
+        if repomd is None:
+            continue
+        filelists_url = repodata_location(repomd_url, repomd, "filelists")
+        if filelists_url is None:
+            errors.append({"url": repomd_url, "error": "filelists metadata not found"})
+            continue
+        data = fetch_url(filelists_url, cache_dir, errors)
+        if data is None:
+            continue
+        if filelists_url.endswith(".gz"):
+            xml_data = gzip.decompress(data)
+        elif filelists_url.endswith(".zst"):
+            xml_data = zstd_decompress(data)
+            if xml_data is None:
+                errors.append({"url": filelists_url, "error": "zstd decompression failed"})
+                continue
+        else:
+            xml_data = data
+        for event, elem in ET.iterparse(io.BytesIO(xml_data), events=("end",)):
+            if not elem.tag.endswith("package"):
+                continue
+            package_name = elem.attrib.get("name", "")
+            if "rsyslog" not in package_name:
+                elem.clear()
+                continue
+            for file_node in elem:
+                if not file_node.tag.endswith("file"):
+                    continue
+                path = file_node.text or ""
+                if "/rsyslog/" not in path or not path.endswith(".so"):
+                    continue
+                component = module_files.get(os.path.basename(path))
+                if component is not None:
+                    record_match(result, component, package_name, path, filelists_url)
+            elem.clear()
+    result["errors"] = errors
+    result["error_count"] = len(errors)
+    finalize_source_result(result, components)
+    return result
+
+
+def parse_apkindex(data: bytes) -> list[dict[str, str]]:
+    packages: list[dict[str, str]] = []
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        apkindex = tf.extractfile("APKINDEX")
+        if apkindex is None:
+            return packages
+        current: dict[str, str] = {}
+        lines = io.TextIOWrapper(apkindex, encoding="utf-8", errors="replace")
+        for raw_line in lines:
+            raw_line = raw_line.rstrip("\r\n")
+            if not raw_line:
+                if current:
+                    packages.append(current)
+                    current = {}
+                continue
+            if ":" not in raw_line:
+                continue
+            key, value = raw_line.split(":", 1)
+            current[key] = value
+        if current:
+            packages.append(current)
+    return packages
+
+
+def iter_apk_files(apk_data: bytes) -> list[str]:
+    files: list[str] = []
+    try:
+        with tarfile.open(fileobj=io.BytesIO(apk_data), mode="r:*") as tf:
+            for member in tf.getmembers():
+                if member.isfile() or member.issym():
+                    files.append("/" + member.name.lstrip("./"))
+    except tarfile.TarError:
+        return files
+    return files
+
+
+def parse_alpine_apk(source: Source, components: list[Component], cache_dir: Path) -> dict[str, Any]:
+    result = empty_source_result(source)
+    module_files = {component.module_file: component for component in components}
+    errors: list[dict[str, str]] = []
+    for base_url in source.urls:
+        index_url = urllib.parse.urljoin(base_url, "APKINDEX.tar.gz")
+        index_data = fetch_url(index_url, cache_dir, errors)
+        if index_data is None:
+            continue
+        for pkg in parse_apkindex(index_data):
+            package_name = pkg.get("P", "")
+            version = pkg.get("V", "")
+            arch = pkg.get("A", "x86_64")
+            if "rsyslog" not in package_name or not version:
+                continue
+            apk_url = urllib.parse.urljoin(base_url, f"{package_name}-{version}.apk")
+            apk_data = fetch_url(apk_url, cache_dir, errors)
+            if apk_data is None:
+                continue
+            for path in iter_apk_files(apk_data):
+                if "/rsyslog/" not in path or not path.endswith(".so"):
+                    continue
+                component = module_files.get(os.path.basename(path))
+                if component is not None:
+                    record_match(result, component, package_name, path, index_url)
+    result["errors"] = errors
+    result["error_count"] = len(errors)
+    finalize_source_result(result, components)
+    return result
+
+
+def generate(repo_root: Path, cache_dir: Path) -> dict[str, Any]:
+    components = discover_components(repo_root)
+    output: dict[str, Any] = {
+        "schema_version": 1,
+        "description": "Best-effort support data mapping upstream rsyslog modules to public distro packages.",
+        "caveats": [
+            "Generated from public package metadata and not authoritative for any distribution.",
+            "A shipped module file does not mean the module is loaded by default.",
+            "A not_shipped result applies only to searched public repositories, not custom builds or third-party packages.",
+            "Confirm downstream-specific claims with the relevant distribution security team before publication.",
+        ],
+        "component_count": len(components),
+        "components": {
+            component.name: {
+                "upstream_path": component.upstream_path,
+                "module_file": component.module_file,
+                "kind": component.kind,
+            }
+            for component in components
+        },
+        "sources": {},
+    }
+    for source in SOURCES:
+        if source.kind == "deb_contents":
+            result = parse_deb_contents(source, components, cache_dir)
+        elif source.kind == "deb_packages":
+            result = parse_deb_package_files(source, components, cache_dir)
+        elif source.kind == "fedora_filelists":
+            result = parse_fedora_filelists(source, components, cache_dir)
+        elif source.kind == "alpine_apk":
+            result = parse_alpine_apk(source, components, cache_dir)
+        else:
+            raise ValueError(f"unknown source kind: {source.kind}")
+        output["sources"][source.key] = result
+    return output
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", default=".", help="rsyslog repository root")
+    parser.add_argument("--output", default="doc/security/distro-component-package-map.json")
+    parser.add_argument("--cache-dir", default=None)
+    args = parser.parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    output_path = repo_root / args.output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.cache_dir:
+        cache_dir = Path(args.cache_dir)
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        data = generate(repo_root, cache_dir)
+    else:
+        with tempfile.TemporaryDirectory() as tmp:
+            data = generate(repo_root, Path(tmp))
+
+    output_path.write_text(json.dumps(data, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add deterministic generator for rsyslog component-to-distro-package support data
- add weekly workflow that opens a PR when the generated public map changes
- include Debian, Ubuntu, Fedora rawhide, Alpine, and Adiscon v8-stable/daily-stable PPA metadata sources
- add initial generated JSON map and documentation/caveats

## Notes

This is advisory support data only. It maps upstream module files to public package metadata so plugin-scoped GHSAs can help users determine likely exposure. It does not change the GHSA package field and is not authoritative for any distribution.

## Validation

- generated initial map from public distro and Adiscon metadata
- deterministic rerun produced no JSON diff
- python3 -m py_compile scripts/generate_distro_component_map.py
- python3 -m json.tool doc/security/distro-component-package-map.json
- git diff --check
- actionlint .github/workflows/distro_component_package_map.yml
- yamllint with repo CI config for the new workflow
- pinned zizmor --strict-collection .github/workflows