### PR TITLE
rainerscript: harden string and JSON bounds

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -27,6 +27,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdint.h>
+#include <limits.h>
 #include <glob.h>
 #include <errno.h>
 #include <pwd.h>
@@ -1479,7 +1481,7 @@ long long var2Number(struct svar *r, int *bSuccess) {
 static es_str_t *var2String(struct svar *__restrict__ const r, int *__restrict__ const bMustFree) {
     es_str_t *estr;
     const char *cstr;
-    rs_size_t lenstr;
+    size_t lenstr;
     if (r->datatype == 'N') {
         *bMustFree = 1;
         estr = es_newStrFromNumber(r->d.n);
@@ -1489,9 +1491,18 @@ static es_str_t *var2String(struct svar *__restrict__ const r, int *__restrict__
             cstr = "", lenstr = 0;
         } else {
             cstr = (char *)json_object_get_string(r->d.json);
-            lenstr = strlen(cstr);
+            if (json_object_get_type(r->d.json) == json_type_string) {
+                lenstr = json_object_get_string_len(r->d.json);
+            } else {
+                lenstr = strlen(cstr);
+            }
+#if SIZE_MAX > UINT_MAX
+            if (lenstr > (size_t)UINT_MAX) {
+                cstr = "", lenstr = 0;
+            }
+#endif
         }
-        estr = es_newStrFromCStr(cstr, lenstr);
+        estr = es_newStrFromCStr(cstr, (es_size_t)lenstr);
     } else {
         *bMustFree = 0;
         estr = r->d.estr;
@@ -1937,7 +1948,11 @@ static void ATTR_NONNULL() doFunc_get_property(struct cnffunc *__restrict__ cons
         case json_type_array: {
             int success = 0;
             long long index = var2Number(&srcVal[1], &success);
-            if (!success || index < 0 || (size_t)index >= sizeof(size_t)) {
+            if (!success || index < 0
+#if LLONG_MAX > SIZE_MAX
+                || (unsigned long long)index > SIZE_MAX
+#endif
+                || (size_t)index >= (size_t)json_object_array_length(json)) {
                 retVal = RS_SCRIPT_EINVAL;
                 FINALIZE;
             }
@@ -2449,8 +2464,24 @@ static void ATTR_NONNULL()
     cnfexprEval(func->expr[2], &srcVal[2], usrptr, pWti);
     es_str_t *es = var2String(&srcVal[0], &bMustFree);
     const int lenSrcStr = es_strlen(es);
-    int start = var2Number(&srcVal[1], NULL);
-    int subStrLen = var2Number(&srcVal[2], NULL);
+    long long startNum = var2Number(&srcVal[1], NULL);
+    long long subStrLenNum = var2Number(&srcVal[2], NULL);
+    int start;
+    int subStrLen;
+    if (startNum < 0) {
+        start = 0;
+    } else if (startNum > INT_MAX) {
+        start = lenSrcStr;
+    } else {
+        start = (int)startNum;
+    }
+    if (subStrLenNum < INT_MIN) {
+        subStrLen = INT_MIN;
+    } else if (subStrLenNum > INT_MAX) {
+        subStrLen = INT_MAX;
+    } else {
+        subStrLen = (int)subStrLenNum;
+    }
     if (start >= lenSrcStr) {
         /* begin PAST the source string - ensure nothing is copied at all */
         start = subStrLen = 0;

--- a/tests/rscript_get_property.sh
+++ b/tests/rscript_get_property.sh
@@ -10,7 +10,8 @@ template(name="outlocal" type="string" string="%$.%\n")
 
 if $msg contains "msgnum" then {
   set $.ret = parse_json("{\"offsets\": [ { \"a\": 9, \"b\": 0, \"c\": \"boo\", \"d\": null },\
-                                         { \"a\": 9, \"b\": 3, \"c\": null, \"d\": null } ],\
+                                         { \"a\": 9, \"b\": 3, \"c\": null, \"d\": null },\
+                                         2, 3, 4, 5, 6, 7, 8, 9 ],\
                                          \"booltest\": true,\
                                          \"int64\": 1234567890,\
                                          \"nulltest\": null,\
@@ -28,7 +29,7 @@ if $msg contains "msgnum" then {
 		set $.res2 = get_property($!parsed!offsets[1], $.test);
 		reset $.test = "bar";
 		set $.res3 = get_property($!foo, $.test);
-		reset $.index = 5;
+		reset $.index = 12;
 		set $.res4 = get_property($!parsed!offsets, $.index);
 		set $.key = "test";
 		set $.res5 = get_property($., $.key);
@@ -49,6 +50,8 @@ if $msg contains "msgnum" then {
 		set $.res14 = get_property($!parsed, $.key);
 		set $.res15 = get_property($msg, "");
 		set $.res16 = get_property("string literal", "");
+		reset $.index = 9;
+		set $.res17 = get_property($!parsed!offsets, $.index);
 
 		# output result
 		unset $.key;
@@ -63,8 +66,8 @@ injectmsg 0 1
 shutdown_when_empty
 wait_shutdown
 
-EXPECTED='{ "parsed": { "offsets": [ { "a": 9, "b": 0, "c": "boo", "d": null }, { "a": 9, "b": 3, "c": null, "d": null } ], "booltest": true, "int64": 1234567890, "nulltest": null, "double": 12345.67890, "foo": 3, "bar": 28 }, "foo": { "bar": 3 } }
-{ "ret": 0, "index": 5, "test": "bar", "res1": { "a": 9, "b": 3, "c": null, "d": null }, "res2": 9, "res3": 3, "res4": "", "res5": "bar", "res6": { "bar": 3 }, "res7": 3, "res8": 3, "res9": 3, "res10": 3, "res11": 1, "res12": 1234567890, "res13": "", "res14": 12345.678900000001, "res15": " msgnum:00000000:", "res16": "" }'
+EXPECTED='{ "parsed": { "offsets": [ { "a": 9, "b": 0, "c": "boo", "d": null }, { "a": 9, "b": 3, "c": null, "d": null }, 2, 3, 4, 5, 6, 7, 8, 9 ], "booltest": true, "int64": 1234567890, "nulltest": null, "double": 12345.67890, "foo": 3, "bar": 28 }, "foo": { "bar": 3 } }
+{ "ret": 0, "index": 9, "test": "bar", "res1": { "a": 9, "b": 3, "c": null, "d": null }, "res2": 9, "res3": 3, "res4": "", "res5": "bar", "res6": { "bar": 3 }, "res7": 3, "res8": 3, "res9": 3, "res10": 3, "res11": 1, "res12": 1234567890, "res13": "", "res14": 12345.678900000001, "res15": " msgnum:00000000:", "res16": "", "res17": 9 }'
 cmp_exact
 
 exit_test

--- a/tests/rscript_substring.sh
+++ b/tests/rscript_substring.sh
@@ -14,6 +14,11 @@ set $!str!var5 = substring("test", 0, 5);
 set $!str!var6 = substring("test", 0, 6);
 set $!str!var7 = substring("test", 3, 4);
 set $!str!var8 = substring("test", 1, 0);
+# Exercise defensive bounds handling for numeric arguments that would
+# otherwise wrap when narrowed before the copy range is clamped.
+set $!str!var9 = substring("test", -9223372036854775808, 2);
+set $!str!var10 = substring("test", 9223372036854775807, 2);
+set $!str!var11 = substring("test", 1, 9223372036854775807);
 
 template(name="outfmt" type="string" string="%!str%\n")
 local4.* action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
@@ -22,11 +27,10 @@ startup
 tcpflood -m1 -y
 shutdown_when_empty
 wait_shutdown
-echo '{ "var1": "", "var2": "test", "var3": "es", "var4": "", "var5": "test", "var6": "test", "var7": "t", "var8": "" }' | cmp - $RSYSLOG_OUT_LOG
+echo '{ "var1": "", "var2": "test", "var3": "es", "var4": "", "var5": "test", "var6": "test", "var7": "t", "var8": "", "var9": "te", "var10": "", "var11": "est" }' | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid function output detected, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG
   error_exit 1
 fi;
 exit_test
-


### PR DESCRIPTION
Summary:
- validate get_property() array indexes against the actual JSON array length
- clamp substring() numeric bounds before narrowing to int
- preserve json-c string scalar lengths when converting JSON values to libestr strings
- extend focused RainerScript tests for high array indexes and extreme substring bounds

Validation:
- scan-build via rsyslog/rsyslog_dev_base_ubuntu:26.04: No bugs found
- full local container CI via rsyslog/rsyslog_dev_base_ubuntu:26.04: 1265 total, 1172 pass, 93 skip, 0 fail
- targeted rerun: global_vars.sh, mmnormalize_tokenized.sh, json_null_array.sh, json_null_array-vg.sh, rscript_get_property.sh, rscript_substring.sh
- git diff --check