### PR TITLE
tests: stabilize ARMv7 Valgrind runs

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3499,7 +3499,7 @@ static int eval_strcmp_like(const struct cnfexpr *__restrict__ const expr,
     int bMustFree, bMustFree2;
     int64_t n_r, n_l;
     int convok_r, convok_l;
-    struct svar r, l; /* memory for subexpression results */
+    struct svar r = {{0}, 0}, l = {{0}, 0}; /* memory for subexpression results */
     int ret;
 
     cnfexprEval(expr->l, &l, usrptr, pWti);
@@ -3535,7 +3535,7 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
                                 struct svar *__restrict__ const ret,
                                 void *__restrict__ const usrptr,
                                 wti_t *__restrict__ const pWti) {
-    struct svar r, l; /* memory for subexpression results */
+    struct svar r = {{0}, 0}, l = {{0}, 0}; /* memory for subexpression results */
     es_str_t *__restrict__ estr_r, *__restrict__ estr_l;
     int convok_r, convok_l;
     int bMustFree, bMustFree2;

--- a/plugins/fmhttp/fmhttp.c
+++ b/plugins/fmhttp/fmhttp.c
@@ -167,6 +167,7 @@ ENDgetFunctArray
 
 BEGINmodExit
     CODESTARTmodExit;
+    curl_global_cleanup();
 ENDmodExit
 
 
@@ -178,6 +179,13 @@ ENDqueryEtryPt
 
 BEGINmodInit()
     CODESTARTmodInit;
+    CURLcode curlRet;
     *ipIFVersProvided = CURR_MOD_IF_VERSION; /* we only support the current interface specification */
+
+    curlRet = curl_global_init(CURL_GLOBAL_DEFAULT);
+    if (curlRet != CURLE_OK) {
+        LogError(0, RS_RET_OBJ_CREATION_FAILED, "fmhttp: curl_global_init failed: %s", curl_easy_strerror(curlRet));
+        ABORT_FINALIZE(RS_RET_OBJ_CREATION_FAILED);
+    }
     CODEmodInit_QueryRegCFSLineHdlr dbgprintf("rsyslog fmhttp init called, compiled with version %s\n", VERSION);
 ENDmodInit

--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -260,7 +260,7 @@ finalize_it:
 }
 
 static rsRetVal execIf(struct cnfstmt *const stmt, smsg_t *const pMsg, wti_t *const pWti) {
-    sbool bRet;
+    int bRet;
     DEFiRet;
     bRet = cnfexprEvalBool(stmt->d.s_if.expr, pMsg, pWti);
     DBGPRINTF("if condition result is %d\n", bRet);

--- a/tests/imtcp_conndrop_tls.sh
+++ b/tests/imtcp_conndrop_tls.sh
@@ -4,7 +4,7 @@
 #
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
-export NUMMESSAGES=50000
+export NUMMESSAGES=${NUMMESSAGES:-50000}
 export QUEUE_EMPTY_CHECK_FUNC=wait_seq_check
 generate_conf
 add_conf '

--- a/tests/known_issues.supp
+++ b/tests/known_issues.supp
@@ -41,6 +41,16 @@
    fun:mainloop
    fun:main
 }
+{
+   <pselect wait call with valid sigset misreported via armhf glibc wrapper>
+   Memcheck:Param
+   pselect6(sig)
+   fun:__pselect32
+   fun:__pselect64
+   fun:wait_timeout
+   fun:mainloop
+   fun:main
+}
 
 {
    <librdkafka mem leak - we cannot work around it>


### PR DESCRIPTION
﻿## Summary
- Fixes deterministic ARMv7 Valgrind failures seen in `make check -j3`.
- Zero-initializes RainerScript temporary `svar` values used during expression evaluation.
- Adds fmhttp libcurl global init/cleanup, an armhf pselect Valgrind suppression, and lets `imtcp_conndrop_tls-vg` actually reduce `NUMMESSAGES` like the imptcp variant.

## Validation
- ARMv7 Odroid XU4 / Armbian 26.2.5: focused rerun of previous persistent failures:
  - `rscript_compare_num-num-vg.log`
  - `rscript_compare_num-numstr-vg.log`
  - `rscript_http_request-vg.log`
  - `dynstats_prevent_premature_eviction-vg.log`
  - `imtcp_conndrop_tls-vg.log`
- ARMv7 Odroid XU4 / Armbian 26.2.5: `make check -j3`
  - total 920, pass 896, skip 24, fail 0, error 0
