### PR TITLE
imudp: harden thread lifecycles and fix stats memory leak

### DIFF
--- a/plugins/imudp/imudp.c
+++ b/plugins/imudp/imudp.c
@@ -144,6 +144,7 @@ static struct wrkrInfo_s {
     struct mmsghdr *recvmsg_mmh;
     struct iovec *recvmsg_iov;
 #endif
+    int started; /* 1 if pthread_create succeeded, 0 otherwise */
 } wrkrInfo[MAX_WRKR_THREADS];
 
 struct modConfData_s {
@@ -1336,19 +1337,31 @@ BEGINrunInput
     pthread_attr_setstacksize(&wrkrThrdAttr, 4096 * 1024);
     for (i = 0; i < runModConf->wrkrMax - 1; ++i) {
         wrkrInfo[i].pThrd = pThrd;
-        pthread_create(&wrkrInfo[i].tid, &wrkrThrdAttr, wrkr, &(wrkrInfo[i]));
+        wrkrInfo[i].started = 0;
+        int err = pthread_create(&wrkrInfo[i].tid, &wrkrThrdAttr, wrkr, &(wrkrInfo[i]));
+        if (err == 0) {
+            wrkrInfo[i].started = 1;
+        } else {
+            LogError(err, RS_RET_SYS_ERR, "imudp: failed to create worker thread %d", i);
+        }
     }
     pthread_attr_destroy(&wrkrThrdAttr);
 
     wrkrInfo[i].pThrd = pThrd;
     wrkrInfo[i].id = i;
+    wrkrInfo[i].started = 0;
     wrkr(&wrkrInfo[i]);
 
     for (i = 0; i < runModConf->wrkrMax - 1; ++i) {
-        pthread_kill(wrkrInfo[i].tid, SIGTTIN);
+        if (wrkrInfo[i].started) {
+            pthread_kill(wrkrInfo[i].tid, SIGTTIN);
+        }
     }
     for (i = 0; i < runModConf->wrkrMax - 1; ++i) {
-        pthread_join(wrkrInfo[i].tid, NULL);
+        if (wrkrInfo[i].started) {
+            pthread_join(wrkrInfo[i].tid, NULL);
+            wrkrInfo[i].started = 0;
+        }
     }
 ENDrunInput
 
@@ -1378,6 +1391,9 @@ BEGINafterRun
     }
     lcnfRoot = lcnfLast = NULL;
     for (i = 0; i < runModConf->wrkrMax; ++i) {
+        if (wrkrInfo[i].stats != NULL) {
+            statsobj.Destruct(&(wrkrInfo[i].stats));
+        }
 #ifdef HAVE_RECVMMSG
         free(wrkrInfo[i].recvmsg_iov);
         free(wrkrInfo[i].recvmsg_mmh);


### PR DESCRIPTION
# Walkthrough - imudp Stability and Security Hardening

This walkthrough documents the comprehensive validation and defensive hardening of the `imudp` network-facing UDP input plugin on a dedicated worktree and feature branch.

## Changes Made

### 1. Thread Lifecycle Hardening (Lifecycle Safety & Stability)
- **Problem**: When worker thread creation fails (e.g., due to system resource exhaustion), subsequent calls to `pthread_kill` and `pthread_join` using the uninitialized thread ID (`tid`) during daemon shutdown or reload trigger undefined behavior (typically a crash or a deadlock hang).
- **Solution**: Added a `started` tracking flag to the worker info structure `struct wrkrInfo_s` inside `plugins/imudp/imudp.c`. We now check the return status of `pthread_create` and only attempt to kill and join worker threads if they were successfully spawned.

### 2. Thread Statistics Registry Leak Fix (Resource Safety & Stability)
- **Problem**: Each worker thread dynamically constructs a local statistics object (`pWrkr->stats`) in its worker entry point. However, these objects were never destructed or unregistered from the statistics registry upon shutdown or reload, leaking memory and registry nodes.
- **Solution**: Centralized the deletion of all worker stats structures during the module's teardown in the `BEGINafterRun` block using `statsobj.Destruct(&(wrkrInfo[i].stats))` for all allocated worker tracks.

---

## Verification and Testing

### 1. Host-Side Diagnostic Testbench
The changes were initially validated on the host by compiling with debug flags and executing targeted UDP tests:
- `imudp_thread_hang.sh` — **PASSED**
- `imudp_ratelimit_name.sh` — **PASSED**
- `imudp_error_msg.sh` — **PASSED**

### 2. Container Validation (Clang Static Analyzer)
As the primary pre-finish gate, we ran the full Clang Static Analyzer within the Ubuntu 26.04 devcontainer environment:
- **Command**:
  ```bash
  RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
  SCAN_BUILD='scan-build' \
  SCAN_BUILD_CC='clang' \
  SCAN_BUILD_REPORT_DIR='scan-build-report' \
  CI_MAKE_OPT='-j20' \
  devtools/devcontainer.sh --rm devtools/run-static-analyzer.sh
  ```
- **Result**: `No bugs found.` and `static analyzer result: 0` (Clean run, no warnings/violations generated for our changes).

### 3. Container Validation (Full Testsuite)
We ran the complete test suite in the official Ubuntu 26.04 devcontainer:
- **Command**:
  ```bash
  /usr/bin/time -p env \
  RSYSLOG_DEV_CONTAINER='rsyslog/rsyslog_dev_base_ubuntu:26.04' \
  RSYSLOG_TESTBENCH_CHANGED_FILES='plugins/imudp/imudp.c' \
  CC='clang-21' \
  CFLAGS='-g' \
  CI_MAKE_OPT='-j80' \
  CI_MAKE_CHECK_OPT='-j80' \
  CI_CHECK_CMD='check' \
  devtools/devcontainer.sh --rm devtools/run-ci.sh
  ```
- **Result**:
  - **TOTAL**: `1265`
  - **PASS**: `1172`
  - **SKIP**: `93` (Expected skips from service relevance filtering)
  - **FAIL**: `0`
  - **ERROR**: `0`
  - **Elapsed Time**: `268.91` seconds

The work has been fully container-validated and verified to be safe, reliable, and compliant.
