### PR TITLE
tests: cover omprog invalid argument exit

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -894,6 +894,7 @@ TESTS_OMPROG = \
 	omprog-restart-terminated-outfile.sh \
 	omprog-single-instance.sh \
 	omprog-single-instance-outfile.sh \
+	omprog-invalid-args.sh \
 	omprog-transactions.sh \
 	omprog-if-error.sh \
 	omprog-transactions-failed-messages.sh \
@@ -3307,6 +3308,7 @@ EXTRA_DIST += \
 	testsuites/omprog-feedback-mt-bin.sh \
 	testsuites/omprog-feedback-timeout-bin.sh \
 	testsuites/omprog-close-unresponsive-bin.sh \
+	testsuites/omprog-invalid-args-bin.sh \
 	testsuites/omprog-restart-terminated-bin.sh \
 	testsuites/omprog-single-instance-bin.sh \
 	testsuites/omprog-transactions-bin.sh \

--- a/tests/omprog-invalid-args.sh
+++ b/tests/omprog-invalid-args.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# This file is part of the rsyslog project, released under ASL 2.0
+
+# Regression coverage for GitHub issue 5017. The omprog child exits during
+# initialization when it receives an invalid argument. Success is proven by
+# synchronized shutdown plus rsyslog's own diagnostic in the configured omfile
+# destination, not by rsyslogd stdout/stderr.
+
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/omprog/.libs/omprog")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+    action(
+        type="omprog"
+        binary="'$srcdir'/testsuites/omprog-invalid-args-bin.sh --invalid"
+        template="outfmt"
+        name="omprog_action"
+        queue.type="Direct"
+        confirmMessages="on"
+        action.resumeRetryCount="0"
+    )
+}
+
+syslog.* {
+    action(type="omfile" template="outfmt" file=`echo $RSYSLOG2_OUT_LOG`)
+}
+'
+
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+expected_prog="${srcdir}/testsuites/omprog-invalid-args-bin.sh"
+content_check "omprog: program '$expected_prog' " "$RSYSLOG2_OUT_LOG"
+content_check "terminated; will be restarted" "$RSYSLOG2_OUT_LOG"
+custom_assert_content_missing "Segmentation fault" "$RSYSLOG2_OUT_LOG"
+
+exit_test

--- a/tests/testsuites/omprog-invalid-args-bin.sh
+++ b/tests/testsuites/omprog-invalid-args-bin.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ "${1:-}" = "--invalid" ]; then
+    exit 2
+fi
+
+echo "OK"
+
+while IFS= read -r line; do
+    echo "OK"
+done


### PR DESCRIPTION
## Summary
- add regression coverage for omprog children that exit during initialization because of invalid arguments
- assert the no-crash path via synchronized shutdown and rsyslog's configured omfile diagnostic destination
- closes https://github.com/rsyslog/rsyslog/issues/5017

## Validation
- `./autogen.sh && ./configure --enable-testbench --enable-omprog --enable-omstdout --enable-imdiag --enable-imfile --disable-elasticsearch-tests --disable-kafka-tests --disable-snmp-tests`
- `make -j80 check TESTS=""`
- `./tests/omprog-invalid-args.sh`
- `make -j80 check TESTS="omprog-invalid-args.sh"`
- after CodeFactor SC2027 fix: `./tests/omprog-invalid-args.sh`
- after CodeFactor SC2027 fix: `git diff --check`
- after CodeFactor SC2027 fix and host reconfigure: `make -j80 check TESTS="omprog-invalid-args.sh"`
- after Gemini POSIX shell review fix: `./tests/omprog-invalid-args.sh`
- after Gemini POSIX shell review fix: `git diff --check`
- after Gemini POSIX shell review fix: `make -j80 check TESTS="omprog-invalid-args.sh"`
- Tier 1 container preflight: `rsyslog/rsyslog_dev_base_ubuntu:26.04`, `clang-21`, `CI_MAKE_OPT=-j80`, `CI_MAKE_CHECK_OPT="-j80 TESTS=omprog-invalid-args.sh"`; passed, `real 37.76s`

## Local preflight notes
- No local checker found a product defect requiring code rework.
- CodeFactor found ShellCheck SC2027 after the PR was opened. `shellcheck` is not installed on this WSL host, so this was not covered locally. The quoting was revised and revalidated.
- Gemini review requested POSIX shell syntax in the helper script. The helper now uses `/bin/sh` plus POSIX `[ ... = ... ]` syntax.
- The fresh worktree needed configure before host make, and the first container invocation had malformed env quoting before rerun.
- After the container preflight, the host tree had to be reconfigured because the generated Makefiles referenced `CC=clang-21`, which is available in the container but not on this host.
