### PR TITLE
ruleset: guard synchronous recursive calls

### DIFF
--- a/runtime/ruleset.c
+++ b/runtime/ruleset.c
@@ -61,6 +61,8 @@ DEFobjCurrIf(parser)
                                               {"parser", eCmdHdlrArray, 0}};
 static struct cnfparamblk rspblk = {CNFPARAMBLK_VERSION, sizeof(rspdescr) / sizeof(struct cnfparamdescr), rspdescr};
 
+#define RULESET_CALL_DEPTH_MAX 1024
+
 /* forward definitions */
 static rsRetVal processBatch(batch_t *pBatch, wti_t *pWti);
 static rsRetVal scriptExec(struct cnfstmt *root, smsg_t *pMsg, wti_t *pWti);
@@ -200,6 +202,37 @@ static rsRetVal execUnset(struct cnfstmt *stmt, smsg_t *pMsg) {
     RETiRet;
 }
 
+static int rulesetCallDepthExceeded(wti_t *const pWti, const char *const rulesetName, const size_t rulesetNameLen) {
+    if (pWti->execState.rulesetCallDepth < RULESET_CALL_DEPTH_MAX) {
+        return 0;
+    }
+
+    LogError(0, RS_RET_ERR,
+             "ruleset call nesting limit of %u reached; call to ruleset '%.*s' "
+             "ignored to avoid runaway recursion",
+             RULESET_CALL_DEPTH_MAX, (int)rulesetNameLen, rulesetName);
+    return 1;
+}
+
+static rsRetVal execSynchronousRulesetCall(struct cnfstmt *const root,
+                                           const char *const rulesetName,
+                                           const size_t rulesetNameLen,
+                                           smsg_t *const pMsg,
+                                           wti_t *const pWti) {
+    DEFiRet;
+
+    if (rulesetCallDepthExceeded(pWti, rulesetName, rulesetNameLen)) {
+        FINALIZE;
+    }
+
+    ++pWti->execState.rulesetCallDepth;
+    iRet = scriptExec(root, pMsg, pWti);
+    --pWti->execState.rulesetCallDepth;
+
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal execCallIndirect(struct cnfstmt *const __restrict__ stmt,
                                  smsg_t *pMsg,
                                  wti_t *const __restrict__ pWti) {
@@ -233,7 +266,7 @@ static rsRetVal execCallIndirect(struct cnfstmt *const __restrict__ stmt,
          */
         submitMsg2(pMsg);
     } else {
-        CHKiRet(scriptExec(pRuleset->root, pMsg, pWti));
+        CHKiRet(execSynchronousRulesetCall(pRuleset->root, (const char *)rsName, ustrlen(rsName), pMsg, pWti));
     }
 finalize_it:
     varDelete(&result);
@@ -244,7 +277,8 @@ finalize_it:
 static rsRetVal execCall(struct cnfstmt *stmt, smsg_t *pMsg, wti_t *pWti) {
     DEFiRet;
     if (stmt->d.s_call.ruleset == NULL) {
-        CHKiRet(scriptExec(stmt->d.s_call.stmt, pMsg, pWti));
+        CHKiRet(execSynchronousRulesetCall(stmt->d.s_call.stmt, (const char *)es_getBufAddr(stmt->d.s_call.name),
+                                           es_strlen(stmt->d.s_call.name), pMsg, pWti));
     } else {
         CHKmalloc(pMsg = MsgDup((smsg_t *)pMsg));
         DBGPRINTF("CALL: forwarding message to async ruleset %p\n", stmt->d.s_call.ruleset->pQueue);

--- a/runtime/wti.h
+++ b/runtime/wti.h
@@ -90,6 +90,7 @@ struct wti_s {
                                     * this is usually set for batches with 0 element, but may
                                     * also be added as a user-selectable option (not implemented yet)
                                     */
+            uint16_t rulesetCallDepth; /* synchronous ruleset call nesting depth */
         } execState; /* state for the execution engine */
 };
 
@@ -138,6 +139,7 @@ static inline void __attribute__((unused)) wtiResetExecState(wti_t *const pWti, 
     wtiSetScriptErrno(pWti, 0);
     pWti->execState.bPrevWasSuspended = 0;
     pWti->execState.bDoAutoCommit = (batchNumMsgs(pBatch) == 1);
+    pWti->execState.rulesetCallDepth = 0;
 }
 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -351,6 +351,7 @@ TESTS_DEFAULT = \
 	rscript_prifilt.sh \
 	rscript_optimizer1.sh \
 	rscript_ruleset_call.sh \
+	rscript_ruleset_call-recursion-limit.sh \
 	rscript_ruleset_call_indirect-basic.sh \
 	rscript_ruleset_call_indirect-var.sh \
 	rscript_ruleset_call_indirect-invld.sh \

--- a/tests/rscript_ruleset_call-recursion-limit.sh
+++ b/tests/rscript_ruleset_call-recursion-limit.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# This covers runaway synchronous ruleset recursion. The test deliberately
+# creates a self-calling ruleset and proves that rsyslog logs the recursion
+# guard diagnostic through its configured omfile destination after synchronized
+# shutdown instead of crashing or relying on stdout/stderr.
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+template(name="counter" type="string" string="%$.counter%\n")
+
+ruleset(name="recurse") {
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="counter")
+    set $.counter = $.counter + 1;
+    call recurse
+}
+
+if $msg contains "msgnum:" then {
+    set $.counter = 1;
+    call recurse
+}
+
+syslog.* {
+    action(type="omfile" template="outfmt" file=`echo $RSYSLOG2_OUT_LOG`)
+}
+'
+startup
+injectmsg 0 1
+shutdown_when_empty
+wait_shutdown
+
+content_check "1024" "$RSYSLOG_OUT_LOG"
+custom_assert_content_missing "1025" "$RSYSLOG_OUT_LOG"
+content_check "ruleset call nesting limit of 1024 reached" "$RSYSLOG2_OUT_LOG"
+custom_assert_content_missing "Segmentation fault" "$RSYSLOG2_OUT_LOG"
+
+exit_test


### PR DESCRIPTION
## Summary

- add a synchronous ruleset call-depth guard to avoid runaway recursive `call` / `call_indirect` chains
- keep queued/asynchronous ruleset calls unchanged
- add a regression test that drives a self-recursive ruleset, verifies output through configured `omfile` destinations, and checks for the guard diagnostic instead of a crash

Closes https://github.com/rsyslog/rsyslog/issues/4637

## Validation

- `make -j80 check TESTS=""`
- `./tests/rscript_ruleset_call-recursion-limit.sh`
- `make -j80 check TESTS="rscript_ruleset_call-recursion-limit.sh"`
- `make distcheck TEST_RUN_TYPE=MOCK-OK -j80`
- Ubuntu 26.04 container static analyzer: `scan-build: No bugs found`
- Ubuntu 26.04 full container check: `# TOTAL: 1266`, `# PASS: 1173`, `# SKIP: 93`, `# FAIL: 0`, `# ERROR: 0`
- Ubuntu 26.04 TSAN container check: `# TOTAL: 1016`, `# PASS: 984`, `# SKIP: 32`, `# FAIL: 0`, `# ERROR: 0`
- Ubuntu 26.04 ASAN/UBSAN container check: first run hit likely flaky `imfile-logrotate-async.sh` timeout at 8284/10000 lines with no sanitizer finding; rerun passed with `# TOTAL: 1074`, `# PASS: 1047`, `# SKIP: 27`, `# FAIL: 0`, `# ERROR: 0`
