### PR TITLE
net_ossl: avoid CN fallback when SAN priority unsupported

### DIFF
--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -908,8 +908,7 @@ static rsRetVal net_ossl_matchpeeridentity(net_ossl_t *pThis,
     assert(pbFoundPositiveMatch != NULL);
 
     if (pThis->pPermPeers) { /* do we have configured peer IDs? */
-        pPeer = pThis->pPermPeers;
-        while (pPeer != NULL) {
+        for (pPeer = pThis->pPermPeers; pPeer != NULL; pPeer = pPeer->pNext) {
             CHKiRet(net.PermittedPeerWildcardMatch(pPeer, pszPeerID, pbFoundPositiveMatch));
             if (*pbFoundPositiveMatch) break;
 
@@ -919,7 +918,6 @@ static rsRetVal net_ossl_matchpeeridentity(net_ossl_t *pThis,
              * if prioritizeSAN set, only check against SAN
              */
             if (!allowX509CheckHost || pPeer->etryType == PERM_PEER_TYPE_WILDCARD) {
-                pPeer = pPeer->pNext;
                 continue;
             } else if (pThis->bSANpriority == 1) {
     #if OPENSSL_VERSION_NUMBER >= 0x10100004L && !defined(LIBRESSL_VERSION_NUMBER) && \
@@ -927,6 +925,7 @@ static rsRetVal net_ossl_matchpeeridentity(net_ossl_t *pThis,
                 x509flags = X509_CHECK_FLAG_NEVER_CHECK_SUBJECT;
     #else
                 dbgprintf("net_ossl_matchpeeridentity: PrioritizeSAN not supported by this OpenSSL-compatible API\n");
+                continue;
     #endif  // OPENSSL_VERSION_NUMBER >= 0x10100004L
             }
 
@@ -947,8 +946,6 @@ static rsRetVal net_ossl_matchpeeridentity(net_ossl_t *pThis,
                 ABORT_FINALIZE(RS_RET_NO_ERRCODE);
             }
 #endif
-            /* Check next peer */
-            pPeer = pPeer->pNext;
         }
     } else {
         LogMsg(0, RS_RET_TLS_NO_CERT, LOG_WARNING,


### PR DESCRIPTION
### Motivation
- `StreamDriver.PrioritizeSAN` should avoid accepting a peer identity through
  CN matching when SAN-only matching cannot be enforced by the active
  OpenSSL-compatible API.

### Description
- In `runtime/net_ossl.c` `net_ossl_matchpeeridentity()`, when
  `bSANpriority == 1` and the API does not expose
  `X509_CHECK_FLAG_NEVER_CHECK_SUBJECT`, skip the `X509_check_host()` fallback
  for that permitted peer instead of calling it with `x509flags == 0`.
- Refactor the permitted-peer loop to advance in one place, keeping the
  unsupported-PrioritizeSAN skip path straightforward and reviewable.

### Testing
- `bash devtools/format-code.sh`
- `git diff --check HEAD^..HEAD`
- Local container clang static analyzer started before the reduced validation
  scope was chosen and completed successfully with `scan-build: No bugs found.`
- Full local container validation was intentionally not run for this small PR;
  GitHub CI already covered the main matrix and has restarted for the amended
  commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f335e2cb48332b4890c9a78ef0351)
