### PR TITLE
mmpstrucdata: support custom SD containers

### DIFF
--- a/.github/workflows/run_checks.yml
+++ b/.github/workflows/run_checks.yml
@@ -599,12 +599,11 @@ jobs:
               # Clang 21 TSAN disables ASLR; Docker's default seccomp profile blocks that.
               export DOCKER_RUN_EXTRA_OPTS='--security-opt seccomp=unconfined'
               # impstats has known and OK races
-              # mmpstrucdata TEMPORARILY disabled because of a threading hang on shutdown
               # imhttp disabled because of race in civetweb (need to consider different lib)
               export RSYSLOG_CONFIGURE_OPTIONS_EXTRA="--disable-elasticsearch-tests \
                     --enable-imfile-tests \
                     --disable-impstats --disable-impstats-push \
-                    --disable-kafka-tests --disable-mmpstrucdata \
+                    --disable-kafka-tests \
                     --enable-omotel \
                     --disable-clickhouse --disable-clickhouse-tests \
                     --disable-kafka-tests \

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -888,6 +888,8 @@ EXTRA_DIST = \
     source/reference/parameters/mmnormalize-userawmsg.rst \
     source/reference/parameters/mmnormalize-variable.rst \
     source/reference/parameters/mmpstrucdata-jsonroot.rst \
+    source/reference/parameters/mmpstrucdata-container.rst \
+    source/reference/parameters/mmpstrucdata-maxstructureddatasize.rst \
     source/reference/parameters/mmpstrucdata-sd_name.lowercase.rst \
     source/reference/parameters/mmrfc5424addhmac-hashfunction.rst \
     source/reference/parameters/mmrfc5424addhmac-key.rst \

--- a/doc/source/configuration/modules/mmpstrucdata.rst
+++ b/doc/source/configuration/modules/mmpstrucdata.rst
@@ -11,7 +11,7 @@ mmpstrucdata: RFC5424 structured data parsing module
 Purpose
 =======
 
-The mmpstrucdata parses the structured data of `RFC5424 <https://datatracker.ietf.org/doc/html/rfc5424>`_ into the message json variable tree. The data parsed, if available, is stored under "jsonRoot!rfc5424-sd!...". Please note that only RFC5424 messages will be processed.
+The mmpstrucdata parses the structured data of `RFC5424 <https://datatracker.ietf.org/doc/html/rfc5424>`_ into the message json variable tree. The data parsed, if available, is stored under "jsonRoot!container!...". By default, ``container`` is ``rfc5424-sd``. Please note that only RFC5424 messages will be processed.
 
 The difference of RFC5424 is in the message layout: the SYSLOG-MSG part only contains the structured-data part instead of the normal message part. Further down you can find a example of a structured-data part.
 
@@ -34,6 +34,14 @@ Action Parameters
      - Summary
    * - :ref:`param-mmpstrucdata-jsonroot`
      - .. include:: ../../reference/parameters/mmpstrucdata-jsonroot.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmpstrucdata-container`
+     - .. include:: ../../reference/parameters/mmpstrucdata-container.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmpstrucdata-maxstructureddatasize`
+     - .. include:: ../../reference/parameters/mmpstrucdata-maxstructureddatasize.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-mmpstrucdata-sd_name.lowercase`
@@ -79,6 +87,16 @@ in user variables before anonymization).
   template(name="jsondump" type="string" string="%msg%: %$!%\\n")
   action(type="omfile" file="/path/to/log" template="jsondump")
 
+The same setup in YAML:
+
+.. code-block:: yaml
+
+  modules:
+    - load: mmpstrucdata
+
+  actions:
+    - type: mmpstrucdata
+
 
 **A more practical one:**
 
@@ -97,6 +115,22 @@ We apply this configuration:
   template(name="sample2" type="string"
     string="ALL: %$!%\\nSD: %$!RFC5424-SD%\\nIUT:%$!rfc5424-sd!exampleSDID@32473!iut%\\nRAWMSG: %rawmsg%\\n\\n")
   action(type="omfile" file="/path/to/log" template="sample2")
+
+The structured-data container name can be changed while keeping the same JSON
+root:
+
+.. code-block:: rsyslog
+
+  action(type="mmpstrucdata" jsonRoot="$!structured-data" container="sd"
+         maxStructuredDataSize="64k")
+
+.. code-block:: yaml
+
+  actions:
+    - type: mmpstrucdata
+      jsonRoot: "$!structured-data"
+      container: sd
+      maxStructuredDataSize: 64k
 
 
 This will output:
@@ -117,5 +151,6 @@ case.
    :hidden:
 
    ../../reference/parameters/mmpstrucdata-jsonroot
+   ../../reference/parameters/mmpstrucdata-container
+   ../../reference/parameters/mmpstrucdata-maxstructureddatasize
    ../../reference/parameters/mmpstrucdata-sd_name.lowercase
-

--- a/doc/source/development/internal_tooling.rst
+++ b/doc/source/development/internal_tooling.rst
@@ -18,6 +18,23 @@ The checker reports trailing whitespace, invalid indentation and lines
 that exceed the allowed length.  It exits with a non-zero status when
 violations are found.
 
+Local CI container user mode
+----------------------------
+
+Most local ``devtools/devcontainer.sh`` runs should use the default user mapping
+so generated files remain owned by the host developer.  Some CI-parity checks
+intentionally override this with ``RSYSLOG_CONTAINER_UID=''`` so the container
+runs with root semantics.  This is useful when a local run needs to mirror
+GitHub Actions behavior closely, including service startup and sudo-backed
+setup steps.
+
+The tradeoff is cleanup risk: root-mode container runs can leave root-owned
+generated files in the shared worktree.  Before switching compiler, sanitizer,
+configure options, container image, or returning to host-side testing, clean
+the tree and remove generated test helper binaries.  If a root-owned generated
+tree blocks cleanup, fix ownership only for that generated tree before removing
+it; do not use broad recursive cleanup outside the worktree.
+
 CI failure evidence artifacts
 -----------------------------
 

--- a/doc/source/reference/parameters/mmpstrucdata-container.rst
+++ b/doc/source/reference/parameters/mmpstrucdata-container.rst
@@ -1,0 +1,55 @@
+.. _param-mmpstrucdata-container:
+.. _mmpstrucdata.parameter.action.container:
+
+container
+=========
+
+.. index::
+   single: mmpstrucdata; container
+   single: container
+
+.. summary-start
+
+Sets the JSON object member name that receives parsed structured data.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmpstrucdata`.
+
+:Name: container
+:Scope: action
+:Type: string
+:Default: action="rfc5424-sd"
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Specifies the JSON member name below :ref:`param-mmpstrucdata-jsonroot` where
+parsed RFC5424 structured data is stored. This parameter changes the member
+name only; it is not a JSON path. Use ``jsonRoot`` to move the parent location.
+
+When an RFC5424 message has no structured data, the module creates this member
+with a JSON ``null`` value.
+
+Action usage
+------------
+.. _param-mmpstrucdata-action-container:
+.. _mmpstrucdata.parameter.action.container-usage:
+
+.. code-block:: rsyslog
+
+   action(type="mmpstrucdata" jsonRoot="$!structured-data" container="sd")
+
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: mmpstrucdata
+       jsonRoot: "$!structured-data"
+       container: sd
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmpstrucdata`.

--- a/doc/source/reference/parameters/mmpstrucdata-jsonroot.rst
+++ b/doc/source/reference/parameters/mmpstrucdata-jsonroot.rst
@@ -25,7 +25,9 @@ This parameter applies to :doc:`../../configuration/modules/mmpstrucdata`.
 
 Description
 -----------
-Specifies into which json container the data shall be parsed to.
+Specifies into which JSON container the module writes its structured-data
+object. The object member name below this root is controlled by
+:ref:`param-mmpstrucdata-container`.
 
 Action usage
 ------------
@@ -35,6 +37,14 @@ Action usage
 .. code-block:: rsyslog
 
    action(type="mmpstrucdata" jsonRoot="!")
+
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: mmpstrucdata
+       jsonRoot: "!"
 
 See also
 --------

--- a/doc/source/reference/parameters/mmpstrucdata-maxstructureddatasize.rst
+++ b/doc/source/reference/parameters/mmpstrucdata-maxstructureddatasize.rst
@@ -1,0 +1,53 @@
+.. _param-mmpstrucdata-maxstructureddatasize:
+.. _mmpstrucdata.parameter.action.maxstructureddatasize:
+
+maxStructuredDataSize
+=====================
+
+.. index::
+   single: mmpstrucdata; maxStructuredDataSize
+   single: maxStructuredDataSize
+
+.. summary-start
+
+Sets the largest RFC5424 structured-data field, in bytes, that
+``mmpstrucdata`` parses.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmpstrucdata`.
+
+:Name: maxStructuredDataSize
+:Scope: action
+:Type: size
+:Default: action=global(maxMessageSize)
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+
+``mmpstrucdata`` skips parsing when a message's RFC5424 structured-data field is
+larger than this value and logs an error. The default follows
+``global(maxMessageSize)`` so normal input-side message-size policy also bounds
+structured-data parsing unless this action parameter is set explicitly.
+
+The value must be greater than zero.
+
+Action usage
+------------
+.. code-block:: rsyslog
+
+   action(type="mmpstrucdata" maxStructuredDataSize="64k")
+
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: mmpstrucdata
+       maxStructuredDataSize: 64k
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmpstrucdata`.

--- a/doc/source/reference/parameters/mmpstrucdata-sd_name.lowercase.rst
+++ b/doc/source/reference/parameters/mmpstrucdata-sd_name.lowercase.rst
@@ -39,6 +39,14 @@ Action usage
 
    action(type="mmpstrucdata" sd_name.lowercase="off")
 
+YAML usage
+----------
+.. code-block:: yaml
+
+   actions:
+     - type: mmpstrucdata
+       sd_name.lowercase: off
+
 See also
 --------
 See also :doc:`../../configuration/modules/mmpstrucdata`.

--- a/plugins/mmpstrucdata/mmpstrucdata.c
+++ b/plugins/mmpstrucdata/mmpstrucdata.c
@@ -39,6 +39,7 @@
 #include "module-template.h"
 #include "errmsg.h"
 #include "parserif.h"
+#include "glbl.h"
 
 MODULE_TYPE_OUTPUT;
 MODULE_TYPE_NOKEEP;
@@ -51,6 +52,8 @@ DEF_OMOD_STATIC_DATA;
 
 typedef struct _instanceData {
     uchar *jsonRoot; /**< container where to store fields */
+    uchar *container; /**< child object where RFC5424 SD is stored */
+    rs_size_t maxStructuredDataSize; /**< maximum SD size this action parses */
     int lowercase_SD_ID;
 } instanceData;
 
@@ -67,7 +70,10 @@ static modConfData_t *runModConf = NULL; /* modConf ptr to use for the current e
 
 /* tables for interfacing with the v6 config system */
 /* action (instance) parameters */
-static struct cnfparamdescr actpdescr[] = {{"jsonroot", eCmdHdlrString, 0}, {"sd_name.lowercase", eCmdHdlrBinary, 0}};
+static struct cnfparamdescr actpdescr[] = {{"jsonroot", eCmdHdlrString, 0},
+                                           {"container", eCmdHdlrString, 0},
+                                           {"maxstructureddatasize", eCmdHdlrSize, 0},
+                                           {"sd_name.lowercase", eCmdHdlrBinary, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 BEGINbeginCnfLoad
@@ -111,6 +117,7 @@ ENDisCompatibleWithFeature
 BEGINfreeInstance
     CODESTARTfreeInstance;
     free(pData->jsonRoot);
+    free(pData->container);
 ENDfreeInstance
 
 BEGINfreeWrkrInstance
@@ -120,6 +127,8 @@ ENDfreeWrkrInstance
 
 static inline void setInstParamDefaults(instanceData *pData) {
     pData->jsonRoot = NULL;
+    pData->container = NULL;
+    pData->maxStructuredDataSize = 0;
     pData->lowercase_SD_ID = 1;
 }
 
@@ -141,6 +150,7 @@ BEGINnewActInst
         if (!pvals[i].bUsed) continue;
         if (!strcmp(actpblk.descr[i].name, "jsonroot")) {
             size_t lenvar = es_strlen(pvals[i].val.d.estr);
+            free(pData->jsonRoot);
             CHKmalloc(pData->jsonRoot = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
             if (pData->jsonRoot[0] == '$') {
                 /* pre 8.35, the jsonRoot name needed to be specified without
@@ -160,6 +170,23 @@ BEGINnewActInst
                     pData->jsonRoot);
                 ABORT_FINALIZE(RS_RET_INVALID_VAR);
             }
+        } else if (!strcmp(actpblk.descr[i].name, "container")) {
+            free(pData->container);
+            CHKmalloc(pData->container = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+            if (pData->container[0] == '\0') {
+                parser_errmsg("mmpstrucdata: invalid empty container name");
+                ABORT_FINALIZE(RS_RET_INVALID_VAR);
+            }
+        } else if (!strcmp(actpblk.descr[i].name, "maxstructureddatasize")) {
+            if (pvals[i].val.d.n < 1) {
+                parser_errmsg("mmpstrucdata: maxStructuredDataSize must be greater than zero");
+                ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+            }
+            if (pvals[i].val.d.n > INT_MAX) {
+                parser_errmsg("mmpstrucdata: maxStructuredDataSize must not exceed INT_MAX");
+                ABORT_FINALIZE(RS_RET_INVALID_VALUE);
+            }
+            pData->maxStructuredDataSize = (rs_size_t)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "sd_name.lowercase")) {
             pData->lowercase_SD_ID = pvals[i].val.d.n;
         } else {
@@ -172,7 +199,9 @@ BEGINnewActInst
     if (pData->jsonRoot == NULL) {
         CHKmalloc(pData->jsonRoot = (uchar *)strdup("!"));
     }
-
+    if (pData->container == NULL) {
+        CHKmalloc(pData->container = (uchar *)strdup("rfc5424-sd"));
+    }
     CODE_STD_FINALIZERnewActInst;
     cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst
@@ -227,7 +256,7 @@ static rsRetVal ATTR_NONNULL()
     i = *curridx;
     for (j = 0; i < lenbuf && j < 32; ++j) {
         if (sdbuf[i] == '=' || sdbuf[i] == '"' || sdbuf[i] == ']' || sdbuf[i] == ' ') break;
-        namebuf[j] = pData->lowercase_SD_ID ? tolower(sdbuf[i]) : sdbuf[i];
+        namebuf[j] = pData->lowercase_SD_ID ? (uchar)tolower((unsigned char)sdbuf[i]) : sdbuf[i];
         ++i;
     }
     namebuf[j] = '\0';
@@ -240,7 +269,7 @@ static rsRetVal ATTR_NONNULL()
     parseSD_PARAM(instanceData *const pData, uchar *sdbuf, int lenbuf, int *curridx, struct json_object *jroot) {
     int i;
     uchar pName[33];
-    uchar pVal[32 * 1024];
+    uchar *pVal = NULL;
     struct json_object *jval;
     DEFiRet;
 
@@ -254,6 +283,7 @@ static rsRetVal ATTR_NONNULL()
         ABORT_FINALIZE(RS_RET_STRUC_DATA_INVLD);
     }
     ++i;
+    CHKmalloc(pVal = malloc(lenbuf - i + 1));
     CHKiRet(parsePARAM_VALUE(sdbuf, lenbuf, &i, pVal));
     if (sdbuf[i] != '"') {
         ABORT_FINALIZE(RS_RET_STRUC_DATA_INVLD);
@@ -265,6 +295,7 @@ static rsRetVal ATTR_NONNULL()
 
     *curridx = i;
 finalize_it:
+    free(pVal);
     RETiRet;
 }
 
@@ -306,14 +337,16 @@ static rsRetVal ATTR_NONNULL()
     ++i; /* eat ']' */
     *curridx = i;
     json_object_object_add(jroot, (char *)sd_id, json);
+    json = NULL;
 finalize_it:
     if (iRet != RS_RET_OK && json != NULL) json_object_put(json);
     RETiRet;
 }
 
 static rsRetVal ATTR_NONNULL() parse_sd(instanceData *const pData, smsg_t *const pMsg) {
-    struct json_object *json, *jroot;
+    struct json_object *json = NULL, *jroot = NULL;
     uchar *sdbuf;
+    rs_size_t sdLenbuf;
     int lenbuf;
     int i = 0;
     DEFiRet;
@@ -322,7 +355,11 @@ static rsRetVal ATTR_NONNULL() parse_sd(instanceData *const pData, smsg_t *const
     if (json == NULL) {
         ABORT_FINALIZE(RS_RET_ERR);
     }
-    MsgGetStructuredData(pMsg, &sdbuf, &lenbuf);
+    MsgGetStructuredData(pMsg, &sdbuf, &sdLenbuf);
+    if (sdLenbuf > INT_MAX) {
+        ABORT_FINALIZE(RS_RET_OVERSIZE_MSG);
+    }
+    lenbuf = (int)sdLenbuf;
     while (i < lenbuf) {
         CHKiRet(parseSD_ELEMENT(pData, sdbuf, lenbuf, &i, json));
     }
@@ -331,21 +368,55 @@ static rsRetVal ATTR_NONNULL() parse_sd(instanceData *const pData, smsg_t *const
     if (jroot == NULL) {
         ABORT_FINALIZE(RS_RET_ERR);
     }
-    json_object_object_add(jroot, "rfc5424-sd", json);
-    msgAddJSON(pMsg, pData->jsonRoot, jroot, 0, 0);
+    json_object_object_add(jroot, (char *)pData->container, json);
+    json = NULL;
+    CHKiRet(msgAddJSON(pMsg, pData->jsonRoot, jroot, 0, 0));
+    jroot = NULL;
 finalize_it:
     if (iRet != RS_RET_OK && json != NULL) json_object_put(json);
+    if (jroot != NULL) json_object_put(jroot);
     RETiRet;
 }
 
+static rsRetVal ATTR_NONNULL() parse_null_sd(instanceData *const pData, smsg_t *const pMsg) {
+    struct json_object *jroot = NULL;
+    DEFiRet;
+
+    CHKmalloc(jroot = json_object_new_object());
+    json_object_object_add(jroot, (char *)pData->container, NULL);
+    CHKiRet(msgAddJSON(pMsg, pData->jsonRoot, jroot, 0, 0));
+    jroot = NULL;
+
+finalize_it:
+    if (jroot != NULL) json_object_put(jroot);
+    RETiRet;
+}
 
 BEGINdoAction_NoStrings
     smsg_t **ppMsg = (smsg_t **)pMsgData;
     smsg_t *pMsg = ppMsg[0];
+    uchar *sdbuf;
+    rs_size_t lenbuf;
+    const rs_size_t maxStructuredDataSize = pWrkrData->pData->maxStructuredDataSize > 0
+                                                ? pWrkrData->pData->maxStructuredDataSize
+                                                : glblGetMaxLine(runModConf->pConf);
     CODESTARTdoAction;
     DBGPRINTF("mmpstrucdata: enter\n");
     if (!MsgHasStructuredData(pMsg)) {
         DBGPRINTF("mmpstrucdata: message does not have structured data\n");
+        FINALIZE;
+    }
+    MsgGetStructuredData(pMsg, &sdbuf, &lenbuf);
+    if (lenbuf == 1 && sdbuf[0] == '-') {
+        DBGPRINTF("mmpstrucdata: RFC5424 message has NILVALUE structured data\n");
+        parse_null_sd(pWrkrData->pData, pMsg);
+        FINALIZE;
+    }
+    if (lenbuf > maxStructuredDataSize) {
+        LogError(0, RS_RET_OVERSIZE_MSG,
+                 "mmpstrucdata: structured data size %lld exceeds "
+                 "maxStructuredDataSize %lld - not parsing",
+                 (long long)lenbuf, (long long)maxStructuredDataSize);
         FINALIZE;
     }
     /* don't check return code - we never want rsyslog to retry

--- a/runtime/msg.h
+++ b/runtime/msg.h
@@ -89,7 +89,7 @@ struct msg {
         char *pszTIMESTAMP_MySQL; /* TIMESTAMP as MySQL formatted string (always 14 characters) */
         char *pszTIMESTAMP_PgSQL; /* TIMESTAMP as PgSQL formatted string (always 21 characters) */
         uchar *pszStrucData; /* STRUCTURED-DATA */
-        uint16_t lenStrucData; /* (cached) length of STRUCTURED-DATA */
+        rs_size_t lenStrucData; /* (cached) length of STRUCTURED-DATA */
         cstr_t *pCSAPPNAME; /* APP-NAME */
         cstr_t *pCSPROCID; /* PROCID */
         cstr_t *pCSMSGID; /* MSGID */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1329,7 +1329,12 @@ TESTS_FMPCRE = \
 TESTS_MMPSTRUCDATA = \
 	mmpstrucdata.sh \
 	mmpstrucdata-escaping.sh \
-	mmpstrucdata-case.sh
+	mmpstrucdata-case.sh \
+	mmpstrucdata-container-null.sh \
+	mmpstrucdata-large-sd.sh \
+	mmpstrucdata-max-sd-size.sh \
+	mmpstrucdata-rfc3164-skip.sh \
+	yaml-mmpstrucdata-container-null.sh
 
 TESTS_MMPSTRUCDATA_VALGRIND = \
 	mmpstrucdata-vg.sh \

--- a/tests/mmpstrucdata-container-null.sh
+++ b/tests/mmpstrucdata-container-null.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Verify mmpstrucdata's custom container name and no-SD null handling.
+# The oracle is rsyslog's configured omfile output after shutdown: one
+# RFC5424 message with structured data must populate the requested container,
+# and one RFC5424 message with "-" structured data must create that same
+# container with a JSON null value.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
+
+template(name="outfmt" type="string" string="%$!structured-data%\n")
+
+action(type="mmpstrucdata" jsonRoot="$!structured-data" container="custom-sd")
+if $msg contains "MMPSTRUCDATA" then
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg literal '<85>1 2026-05-22T08:00:00.000+00:00 host app proc msgid [test@32473 key="value"] MMPSTRUCDATA with sd'
+injectmsg literal '<85>1 2026-05-22T08:00:00.000+00:00 host app proc msgid - MMPSTRUCDATA without sd'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='{ "custom-sd": { "test@32473": { "key": "value" } } }
+{ "custom-sd": null }'
+cmp_exact
+exit_test

--- a/tests/mmpstrucdata-large-sd.sh
+++ b/tests/mmpstrucdata-large-sd.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+# Verify mmpstrucdata handles RFC5424 structured data larger than 65535 bytes.
+# The oracle is a small field after the large value. If the cached structured
+# data length wraps or the parser stops early, that trailing field is not written
+# to the configured omfile destination.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+global(maxMessageSize="100k")
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
+
+template(name="outfmt" type="string" string="%$!structured-data!custom-sd!large@32473!tail%\n")
+
+action(type="mmpstrucdata" jsonRoot="$!structured-data" container="custom-sd")
+if $msg contains "MMPSTRUCDATA" then
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+{
+    printf '%s' '<85>1 2026-05-22T08:00:00.000+00:00 host app proc msgid [large@32473 blob="'
+    awk 'BEGIN { for (i = 0; i < 70000; ++i) printf "x" }'
+    printf '%s\n' '" tail="ok"] MMPSTRUCDATA large sd'
+} >"$RSYSLOG_DYNNAME.input"
+tcpflood -m1 -I "$RSYSLOG_DYNNAME.input"
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='ok'
+cmp_exact
+exit_test

--- a/tests/mmpstrucdata-max-sd-size.sh
+++ b/tests/mmpstrucdata-max-sd-size.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Verify mmpstrucdata's maxStructuredDataSize guard skips oversized structured
+# data. The oracle uses configured omfile output after shutdown for the accepted
+# message; stderr/stdout are not used as proof.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
+
+template(name="outfmt" type="string" string="%$!structured-data!custom-sd!small@32473!ok%\n")
+
+action(type="mmpstrucdata" jsonRoot="$!structured-data" container="custom-sd" maxStructuredDataSize="64")
+if $!structured-data!custom-sd!small@32473!ok == "yes" then
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg literal '<85>1 2026-05-22T08:00:00.000+00:00 host app proc msgid [large@32473 blob="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" tail="skip"] MMPSTRUCDATA too large'
+injectmsg literal '<85>1 2026-05-22T08:00:00.000+00:00 host app proc msgid [small@32473 ok="yes"] MMPSTRUCDATA accepted'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='yes'
+cmp_exact
+exit_test

--- a/tests/mmpstrucdata-rfc3164-skip.sh
+++ b/tests/mmpstrucdata-rfc3164-skip.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Verify mmpstrucdata still ignores legacy messages without RFC5424 structured
+# data. The oracle is absence of configured omfile output after shutdown; if the
+# module created the no-SD JSON null for RFC3164 input, the output file would be
+# created.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+module(load="../plugins/mmpstrucdata/.libs/mmpstrucdata")
+
+template(name="outfmt" type="string" string="%$!structured-data%\n")
+
+action(type="mmpstrucdata" jsonRoot="$!structured-data" container="custom-sd")
+if $!structured-data != "" then
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+startup
+injectmsg literal '<85>May 22 08:00:00 host app: MMPSTRUCDATA legacy without sd'
+shutdown_when_empty
+wait_shutdown
+check_file_not_exists "$RSYSLOG_OUT_LOG"
+exit_test

--- a/tests/yaml-mmpstrucdata-container-null.sh
+++ b/tests/yaml-mmpstrucdata-container-null.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Verify YAML configuration parity for mmpstrucdata container and no-SD null
+# handling. The YAML frontend must pass the same action parameters to the
+# module as RainerScript, and the oracle is the configured omfile output after
+# synchronized shutdown.
+# This file is part of the rsyslog project, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+generate_conf
+add_conf '
+include(file="'${RSYSLOG_DYNNAME}'.yaml")
+$DefaultRuleset main
+'
+
+cat > "${RSYSLOG_DYNNAME}.yaml" << 'YAMLEOF'
+modules:
+  - load: "../plugins/mmpstrucdata/.libs/mmpstrucdata"
+
+templates:
+  - name: outfmt
+    type: string
+    string: "%$!structured-data%\n"
+
+rulesets:
+  - name: main
+    statements:
+      - type: mmpstrucdata
+        jsonRoot: "$!structured-data"
+        container: custom-yaml-sd
+      - if: '$msg contains "MMPSTRUCDATA"'
+        then:
+          - type: omfile
+            file: "${RSYSLOG_OUT_LOG}"
+            template: outfmt
+YAMLEOF
+sed -i "s|\${RSYSLOG_OUT_LOG}|${RSYSLOG_OUT_LOG}|g" "${RSYSLOG_DYNNAME}.yaml"
+
+startup
+injectmsg literal '<85>1 2026-05-22T08:00:00.000+00:00 host app proc msgid [test@32473 key="value"] MMPSTRUCDATA with sd'
+injectmsg literal '<85>1 2026-05-22T08:00:00.000+00:00 host app proc msgid - MMPSTRUCDATA without sd'
+shutdown_when_empty
+wait_shutdown
+export EXPECTED='{ "custom-yaml-sd": { "test@32473": { "key": "value" } } }
+{ "custom-yaml-sd": null }'
+cmp_exact
+exit_test


### PR DESCRIPTION
## Summary

This updates `mmpstrucdata` so parsed RFC5424 structured data can be placed under a configurable child container instead of the fixed `rfc5424-sd` name. It also hardens large structured-data handling by removing the old fixed 32 KiB parameter-value buffer and adding `maxStructuredDataSize`, which defaults to the active global max message size.

The patch also treats RFC5424 NILVALUE structured data (`-`) as JSON null under the configured container, while preserving the existing behavior that RFC3164 or otherwise unstructured messages are ignored.

Special credits to Bogoslovskii Fedor for good analysis that facilitated parts of the implementation.

Co-author: Bogoslovskii Fedor <Fedorasta@gmail.com>

Closes https://github.com/rsyslog/rsyslog/issues/3297
Closes https://github.com/rsyslog/rsyslog/issues/1891

## Details

- add `container` and `maxStructuredDataSize` action parameters
- widen cached structured-data length storage from `uint16_t` to `rs_size_t`
- allocate structured-data parameter values from the actual message length
- add RainerScript and YAML documentation plus parameter reference pages
- add focused tests for custom containers, NILVALUE, very large SD, configured SD limit, and RFC3164 skip behavior
- re-enable `mmpstrucdata` in the Ubuntu 26.04 TSAN workflow
- document local container validation cleanup rules after finding a stale sanitizer object-file failure mode

## Validation

- `git diff --check`
- `actionlint .github/workflows/run_checks.yml`
- `cubic review --json --base main --prompt ...` returned no issues
- host debug build and focused tests passed earlier in this worktree:
  - `make -j80 check TESTS=`
  - `make -j80 check TESTS="mmpstrucdata-container-null.sh yaml-mmpstrucdata-container-null.sh mmpstrucdata-large-sd.sh mmpstrucdata-max-sd-size.sh mmpstrucdata-rfc3164-skip.sh"`
- Ubuntu 26.04 clang static analyzer container passed with no findings
- clean Ubuntu 26.04 non-sanitizer full container lane passed:
  - `TOTAL: 1271`, `PASS: 1244`, `SKIP: 27`, `FAIL: 0`, `ERROR: 0`
- clean Ubuntu 26.04 ASAN/UBSAN focused container rerun passed all five new mmpstrucdata tests
- focused Ubuntu 26.04 TSAN with mmpstrucdata enabled passed all five new mmpstrucdata tests

Full Ubuntu 26.04 TSAN did not hang with mmpstrucdata enabled, but the broad lane is not currently clean due unrelated pre-existing failures before the mmpstrucdata tests run. The focused TSAN coverage for this module is clean.
