### PR TITLE
net_ossl: clarify SAN-priority guard for OpenSSL-compatible backends

### DIFF
--- a/runtime/net_ossl.c
+++ b/runtime/net_ossl.c
@@ -945,6 +945,11 @@ static rsRetVal net_ossl_matchpeeridentity(net_ossl_t *pThis,
         defined(X509_CHECK_FLAG_NEVER_CHECK_SUBJECT)
                 x509flags = X509_CHECK_FLAG_NEVER_CHECK_SUBJECT;
     #else
+                /* Security hard-stop: with older OpenSSL-compatible APIs (notably wolfSSL
+                 * compatibility mode), we cannot request SAN-only matching. Calling
+                 * X509_check_host() with default flags may fall back to CN, which would
+                 * violate PrioritizeSAN semantics and RFC 6125 behavior.
+                 */
                 dbgprintf("net_ossl_matchpeeridentity: PrioritizeSAN not supported by this OpenSSL-compatible API\n");
                 continue;
     #endif  // OPENSSL_VERSION_NUMBER >= 0x10100004L


### PR DESCRIPTION
### Motivation
- Make the security rationale for the `PrioritizeSAN` guard in `net_ossl_matchpeeridentity()` explicit so older OpenSSL-compatible APIs (notably wolfSSL compatibility mode) do not accidentally allow `X509_check_host()` CN-fallback and thus violate the PrioritizeSAN / RFC 6125 semantics.

### Description
- Add a short security-focused comment in `runtime/net_ossl.c` at the branch that logs "PrioritizeSAN not supported by this OpenSSL-compatible API" to explain why the code `continue`s instead of calling `X509_check_host()` with default flags, preventing CN fallback when `X509_CHECK_FLAG_NEVER_CHECK_SUBJECT` is unavailable.

### Testing
- Ran a code inspection and repository searches to locate the guard and verify the change was applied to `net_ossl_matchpeeridentity()` (succeeded).
- Ran `make -j$(nproc) check TESTS=""` but it failed immediately because the tree was not configured and `check` was not available (failed).
- Ran `./autogen.sh` which invoked `configure`; `configure` aborted due to a missing toolchain dependency `protoc-c` in this environment (failed), so a full build/test cycle could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102febda008332b00e5f72b655b7be)