### PR TITLE
shell: clean up ShellCheck findings

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,7 +23,7 @@ fi
 
 conf_flags="--cache-file=config.cache"
 
-if test x$NOCONFIGURE = x; then
+if test -z "$NOCONFIGURE"; then
   echo Running $srcdir/configure $conf_flags "$@" ...
   $srcdir/configure $conf_flags "$@" \
   && echo Now type \`make\' to compile. || exit 1

--- a/devtools/ci/travis/do-run.sh
+++ b/devtools/ci/travis/do-run.sh
@@ -5,6 +5,6 @@ if [ "$TRAVIS_EVENT_TYPE" == "cron" ] &&  [ "$DO_CRON" != "YES" ]; then
 	exit 0 # this must not run under PRs
 fi
 
-export RSYSLOG_HOME=`pwd`
+export RSYSLOG_HOME=$(pwd)
 echo running tests/travis/$RUN, home: $RSYSLOG_HOME
 $RSYSLOG_HOME/tests/travis/$RUN

--- a/doc/tools/buildenv/starter.sh
+++ b/doc/tools/buildenv/starter.sh
@@ -1,5 +1,5 @@
 #!/bin/ash
-if [ "$DEBUG" == "on" ]; then
+if [ "$DEBUG" = "on" ]; then
 	echo "container in debug mode, environment is: "
 	env
 	set -x

--- a/packaging/docker/appliance/alpine/build.sh
+++ b/packaging/docker/appliance/alpine/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $* -t rsyslog/syslog_appliance_alpine:latest .

--- a/packaging/docker/appliance/alpine/internal/build-config
+++ b/packaging/docker/appliance/alpine/internal/build-config
@@ -4,7 +4,7 @@
 # Errors are detected and will lead to abort of the startup.
 
 export CNF_CALL_LOG_TO_LOGFILES=
-if [ "$ENABLE_LOGFILES" == "on" ]; then
+if [ "$ENABLE_LOGFILES" = "on" ]; then
 	if [ -z $LOGFILES_STORE ]; then
 		echo "Error: ENABLE_LOGFILES set, but LOGFILES_STORE not set - please correct"
 		exit 1

--- a/packaging/docker/appliance/alpine/starter.sh
+++ b/packaging/docker/appliance/alpine/starter.sh
@@ -1,17 +1,17 @@
 #!/bin/ash
-source internal/set-defaults
-source /config/container_config
+. internal/set-defaults
+. /config/container_config
 
 if [ "$CONTAINER_SILENT" != "on" ]; then
-	echo `cat CONTAINER.name` version `cat CONTAINER.release` - `cat CONTAINER.homepage`
-	echo `cat CONTAINER.copyright`
+	printf '%s version %s - %s\n' "$(cat CONTAINER.name)" "$(cat CONTAINER.release)" "$(cat CONTAINER.homepage)"
+	cat CONTAINER.copyright
 	echo
 	echo "WARNING: this is an experimental container - do not use in production"
 	echo
 fi
 
 if [ "$USE_VALGRIND" = "on" ]; then
-	source internal/install-valgrind
+	. internal/install-valgrind
 	export VALGRIND=valgrind
 fi
 
@@ -40,10 +40,10 @@ echo "Using rsyslog configuration file: $RSYSLOG_CONF"
 
 
 if [ -f tools/$1 ]; then
-	source tools/$1
+	. tools/$1
 else
 	echo "ERROR: command not known: $*"
 	echo
-	source tools/help
+	. tools/help
 	exit 1
 fi

--- a/packaging/docker/base/alpine/build.sh
+++ b/packaging/docker/base/alpine/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $* -t rsyslog/rsyslog_base_alpine:latest .

--- a/packaging/docker/base/centos7/build.sh
+++ b/packaging/docker/base/centos7/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $* -t rsyslog/rsyslog_base_centos7:latest .

--- a/packaging/docker/dev_env/alpine/build.sh
+++ b/packaging/docker/dev_env/alpine/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 rm -rf common
 cp -r ../common common
 docker build $1 --rm -t rsyslog/rsyslog_dev_full:alpine_latest .

--- a/packaging/docker/dev_env/centos/base/7/build.sh
+++ b/packaging/docker/dev_env/centos/base/7/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 cp -r ../../../common/ common
 docker build $1 -t rsyslog/rsyslog_dev_base_centos:7 .
 rm -r common

--- a/packaging/docker/dev_env/centos/base/7/setup-system.sh
+++ b/packaging/docker/dev_env/centos/base/7/setup-system.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -v
 
 echo STEP: essentials
@@ -8,6 +9,7 @@ echo STEP: essentials
 
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
+(
 cd helper-projects
 
 if [ "$LIBDIR_PATH" != "" ]; then
@@ -27,23 +29,24 @@ fi
 
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
-cd libksi
-autoreconf -fvi
-./configure --libdir=/usr/lib64
-make -j2
-make install
-cd ..
+(
+	cd libksi
+	autoreconf -fvi
+	./configure --libdir=/usr/lib64
+	make -j2
+	make install
+)
 rm -r libksi
 
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
-cd librdkafka
-(unset CFLAGS; ./configure --prefix=/usr $LIBDIR --CFLAGS="-g" ; make -j2)
-make install
-cd ..
+(
+	cd librdkafka
+	(unset CFLAGS; ./configure --prefix=/usr $LIBDIR --CFLAGS="-g" ; make -j2)
+	make install
+)
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 
 # finished installing helpers from source
-cd ..
-
+)

--- a/packaging/docker/dev_env/centos/base/7/tag-previous.sh
+++ b/packaging/docker/dev_env/centos/base/7/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_centos:7 rsyslog/rsyslog_dev_base_centos:7_previous
 docker push rsyslog/rsyslog_dev_base_centos:7_previous

--- a/packaging/docker/dev_env/centos/base/8/build.sh
+++ b/packaging/docker/dev_env/centos/base/8/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_centos:8 .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"

--- a/packaging/docker/dev_env/centos/base/8/setup-system.sh
+++ b/packaging/docker/dev_env/centos/base/8/setup-system.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -v
 
 echo STEP: essentials
@@ -8,6 +9,7 @@ echo STEP: essentials
 
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
+(
 cd helper-projects
 
 if [ "$LIBDIR_PATH" != "" ]; then
@@ -27,23 +29,24 @@ fi
 
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
-cd libksi
-autoreconf -fvi
-./configure --libdir=/usr/lib64
-make -j2
-make install
-cd ..
+(
+	cd libksi
+	autoreconf -fvi
+	./configure --libdir=/usr/lib64
+	make -j2
+	make install
+)
 rm -r libksi
 
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
-cd librdkafka
-(unset CFLAGS; ./configure --prefix=/usr $LIBDIR --CFLAGS="-g" ; make -j2)
-make install
-cd ..
+(
+	cd librdkafka
+	(unset CFLAGS; ./configure --prefix=/usr $LIBDIR --CFLAGS="-g" ; make -j2)
+	make install
+)
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 
 # finished installing helpers from source
-cd ..
-
+)

--- a/packaging/docker/dev_env/centos/base/8/tag-previous.sh
+++ b/packaging/docker/dev_env/centos/base/8/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_centos:8 rsyslog/rsyslog_dev_base_centos:8_previous
 docker push rsyslog/rsyslog_dev_base_centos:8_previous

--- a/packaging/docker/dev_env/centos/buildbot/7/build.sh
+++ b/packaging/docker/dev_env/centos/buildbot/7/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_centos:7 .

--- a/packaging/docker/dev_env/centos/buildbot/7/tag-previous.sh
+++ b/packaging/docker/dev_env/centos/buildbot/7/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_centos:7 rsyslog/rsyslog_dev_buildbot_centos:7_previous
 docker push rsyslog/rsyslog_dev_buildbot_centos:7_previous

--- a/packaging/docker/dev_env/centos/buildbot/8/build.sh
+++ b/packaging/docker/dev_env/centos/buildbot/8/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_centos:8 .

--- a/packaging/docker/dev_env/centos/buildbot/8/tag-previous.sh
+++ b/packaging/docker/dev_env/centos/buildbot/8/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_centos:8 rsyslog/rsyslog_dev_buildbot_centos:8_previous
 docker push rsyslog/rsyslog_dev_buildbot_centos:8_previous

--- a/packaging/docker/dev_env/centos/pkg_base/7/extra/initenv.sh
+++ b/packaging/docker/dev_env/centos/pkg_base/7/extra/initenv.sh
@@ -24,5 +24,5 @@ echo "--------------------------------"
 echo "--------------------------------"
 echo "--- Sync RPM REPO and update GIT "
 ./sync_remote.sh
-git pull && yes | cp -rf etc-mock/* /etc/mock/
+git pull && cp -rf etc-mock/* /etc/mock/
 chown -R pkg ./ 

--- a/packaging/docker/dev_env/centos/pkg_base/7/extra/sync_remote.sh
+++ b/packaging/docker/dev_env/centos/pkg_base/7/extra/sync_remote.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Definitions common to these scripts
 # mybasedir=$(dirname "$0")
 mybasedir=$PKGBASEDIR

--- a/packaging/docker/dev_env/centos/pkg_base/8/extra/initenv.sh
+++ b/packaging/docker/dev_env/centos/pkg_base/8/extra/initenv.sh
@@ -24,5 +24,5 @@ echo "--------------------------------"
 echo "--------------------------------"
 echo "--- Sync RPM REPO and update GIT "
 ./sync_remote.sh
-git pull && yes | cp -rf etc-mock/* /etc/mock/
+git pull && cp -rf etc-mock/* /etc/mock/
 chown -R pkg ./ 

--- a/packaging/docker/dev_env/centos/pkg_base/8/extra/sync_remote.sh
+++ b/packaging/docker/dev_env/centos/pkg_base/8/extra/sync_remote.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Definitions common to these scripts
 # mybasedir=$(dirname "$0")
 mybasedir=$PKGBASEDIR

--- a/packaging/docker/dev_env/centos/pkg_buildbot/7/build.sh
+++ b/packaging/docker/dev_env/centos/pkg_buildbot/7/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_pkg_buildbot_centos:7 .

--- a/packaging/docker/dev_env/centos/pkg_buildbot/7/tag-previous.sh
+++ b/packaging/docker/dev_env/centos/pkg_buildbot/7/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_pkg_buildbot_centos:7 rsyslog/rsyslog_dev_pkg_buildbot_centos:7_previous
 docker push rsyslog/rsyslog_dev_pkg_buildbot_centos:7_previous

--- a/packaging/docker/dev_env/centos/pkg_buildbot/8/build.sh
+++ b/packaging/docker/dev_env/centos/pkg_buildbot/8/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_pkg_buildbot_centos:8 .

--- a/packaging/docker/dev_env/centos/pkg_buildbot/8/tag-previous.sh
+++ b/packaging/docker/dev_env/centos/pkg_buildbot/8/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_pkg_buildbot_centos:8 rsyslog/rsyslog_dev_pkg_buildbot_centos:8_previous
 docker push rsyslog/rsyslog_dev_pkg_buildbot_centos:8_previous

--- a/packaging/docker/dev_env/common/setup-projects.sh
+++ b/packaging/docker/dev_env/common/setup-projects.sh
@@ -1,9 +1,10 @@
+#!/bin/sh
 #export SUDO=
 #export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 #export LD_LIBRARY_PATH=/usr/local/lib
 
 # end config settings
-export CI_HOME=`pwd`
+export CI_HOME=$(pwd)
 echo CI_HOME: $CI_HOME
 mkdir $CI_HOME/proj
 cd $CI_HOME/proj

--- a/packaging/docker/dev_env/debian/base/10/build.sh
+++ b/packaging/docker/dev_env/debian/base/10/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_debian:10 .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"

--- a/packaging/docker/dev_env/debian/base/11/build.sh
+++ b/packaging/docker/dev_env/debian/base/11/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_debian:11 .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"

--- a/packaging/docker/dev_env/debian/base/11/tag-previous.sh
+++ b/packaging/docker/dev_env/debian/base/11/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_debian:11 rsyslog/rsyslog_dev_base_debian:11_previous
 docker push rsyslog/rsyslog_dev_base_debian:11_previous

--- a/packaging/docker/dev_env/debian/base/13/build.sh
+++ b/packaging/docker/dev_env/debian/base/13/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_debian:13 .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"

--- a/packaging/docker/dev_env/debian/base/13/tag-previous.sh
+++ b/packaging/docker/dev_env/debian/base/13/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_debian:13 rsyslog/rsyslog_dev_base_debian:13_previous
 docker push rsyslog/rsyslog_dev_base_debian:13_previous

--- a/packaging/docker/dev_env/debian/base/sid/build.sh
+++ b/packaging/docker/dev_env/debian/base/sid/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_debian:sid .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"

--- a/packaging/docker/dev_env/debian/base/sid/tag-previous.sh
+++ b/packaging/docker/dev_env/debian/base/sid/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_debian:sid rsyslog/rsyslog_dev_base_debian:sid_previous
 docker push rsyslog/rsyslog_dev_base_debian:sid_previous

--- a/packaging/docker/dev_env/debian/buildbot/10/build.sh
+++ b/packaging/docker/dev_env/debian/buildbot/10/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_debian:10 .

--- a/packaging/docker/dev_env/debian/buildbot/10/tag-previous.sh
+++ b/packaging/docker/dev_env/debian/buildbot/10/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_debian:10 rsyslog/rsyslog_dev_base_debian:10_previous
 docker push rsyslog/rsyslog_dev_base_debian:10_previous

--- a/packaging/docker/dev_env/fedora/base/42/build.sh
+++ b/packaging/docker/dev_env/fedora/base/42/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_fedora:42 .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"

--- a/packaging/docker/dev_env/fedora/base/42/tag-previous.sh
+++ b/packaging/docker/dev_env/fedora/base/42/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_fedora:42 rsyslog/rsyslog_dev_base_fedora:42_previous
 docker push rsyslog/rsyslog_dev_base_fedora:42_previous

--- a/packaging/docker/dev_env/fedora/base/43/build.sh
+++ b/packaging/docker/dev_env/fedora/base/43/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_fedora:43 .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:\n"

--- a/packaging/docker/dev_env/fedora/base/43/tag-previous.sh
+++ b/packaging/docker/dev_env/fedora/base/43/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_fedora:43 rsyslog/rsyslog_dev_base_fedora:43_previous
 docker push rsyslog/rsyslog_dev_base_fedora:43_previous

--- a/packaging/docker/dev_env/openeuler/base/24.03-lts/build.sh
+++ b/packaging/docker/dev_env/openeuler/base/24.03-lts/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 OPEN_EULER_VERSION=24.03-lts
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_openeuler:$OPEN_EULER_VERSION . --progress=plain

--- a/packaging/docker/dev_env/openeuler/base/24.03-lts/tag-previous.sh
+++ b/packaging/docker/dev_env/openeuler/base/24.03-lts/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_openeuler:24.03-lts rsyslog/rsyslog_dev_base_openeuler:24.03-lts_previous
 docker push rsyslog/rsyslog_dev_base_openeuler:24.03-lts_previous

--- a/packaging/docker/dev_env/suse/base/tumbleweed/build.sh
+++ b/packaging/docker/dev_env/suse/base/tumbleweed/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 docker build $1 --build-arg BUILD_TIME="$(date)" -t rsyslog/rsyslog_dev_base_suse:tumbleweed .
 printf "\n\n================== BUILD DONE, NOW TESTING CONTAINER:"

--- a/packaging/docker/dev_env/suse/base/tumbleweed/setup-projects.sh
+++ b/packaging/docker/dev_env/suse/base/tumbleweed/setup-projects.sh
@@ -1,9 +1,10 @@
+#!/bin/sh
 #export SUDO=
 #export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 #export LD_LIBRARY_PATH=/usr/local/lib
 
 # end config settings
-export CI_HOME=`pwd`
+export CI_HOME=$(pwd)
 echo CI_HOME: $CI_HOME
 
 printf "\n\n================== libfastjson =======================\n\n"

--- a/packaging/docker/dev_env/suse/base/tumbleweed/tag-previous.sh
+++ b/packaging/docker/dev_env/suse/base/tumbleweed/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_suse:tumbleweed rsyslog/rsyslog_dev_base_suse:tumbleweed_previous
 docker push rsyslog/rsyslog_dev_base_suse:tumbleweed_previous

--- a/packaging/docker/dev_env/suse/buildbot/tumbleweed/build.sh
+++ b/packaging/docker/dev_env/suse/buildbot/tumbleweed/build.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_suse:tumbleweed .
 echo ready to run:    docker push rsyslog/rsyslog_dev_buildbot_suse:tumbleweed

--- a/packaging/docker/dev_env/suse/buildbot/tumbleweed/restore-previous.sh
+++ b/packaging/docker/dev_env/suse/buildbot/tumbleweed/restore-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_suse:tumbleweed_previous rsyslog/rsyslog_dev_buildbot_suse:tumbleweed
 docker push rsyslog/rsyslog_dev_buildbot_suse:tumbleweed

--- a/packaging/docker/dev_env/suse/buildbot/tumbleweed/tag-previous.sh
+++ b/packaging/docker/dev_env/suse/buildbot/tumbleweed/tag-previous.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_suse:tumbleweed rsyslog/rsyslog_dev_buildbot_suse:tumbleweed_previous
 docker push rsyslog/rsyslog_dev_buildbot_suse:tumbleweed_previous
 #revert

--- a/packaging/docker/dev_env/ubuntu/base/18.04/build-arm.sh
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/build-arm.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_base_ubuntu-arm:18.04 -f Dockerfile.arm .
 printf "ready to run docker push rsyslog/rsyslog_dev_base_ubuntu-arm:18.04\n"

--- a/packaging/docker/dev_env/ubuntu/base/18.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_base_ubuntu:18.04 .

--- a/packaging/docker/dev_env/ubuntu/base/18.04/setup-system.sh
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/setup-system.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 export DEBIAN_FRONTEND=noninteractive
 set -v
 
@@ -35,24 +36,27 @@ set -v
 
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
+(
 cd helper-projects
 
 # code style checker - not yet packaged
 git clone https://github.com/rsyslog/codestyle
-cd codestyle
-gcc --std=c99 stylecheck.c -o stylecheck
-mv stylecheck /usr/bin/rsyslog_stylecheck
-cd ..
+(
+	cd codestyle
+	gcc --std=c99 stylecheck.c -o stylecheck
+	mv stylecheck /usr/bin/rsyslog_stylecheck
+)
 rm -r codestyle
 
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
-cd libksi
-autoreconf -fvi
-./configure --prefix=/usr
-make -j2
-make install
-cd ..
+(
+	cd libksi
+	autoreconf -fvi
+	./configure --prefix=/usr
+	make -j2
+	make install
+)
 rm -r libksi
 
 # NOTE: we do NOT install coverity, because
@@ -62,13 +66,13 @@ rm -r libksi
 
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
-cd librdkafka
-(unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2)
-make install
-cd ..
+(
+	cd librdkafka
+	(unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2)
+	make install
+)
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 
 # finished installing helpers from source
-cd ..
-
+)

--- a/packaging/docker/dev_env/ubuntu/base/18.04/tag-previous-arm.sh
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/tag-previous-arm.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_ubuntu-arm:18.04 rsyslog/rsyslog_dev_base_ubuntu-arm:18.04_previous
 docker push rsyslog/rsyslog_dev_base_ubuntu-arm:18.04_previous

--- a/packaging/docker/dev_env/ubuntu/base/18.04/tag-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_ubuntu:18.04 rsyslog/rsyslog_dev_base_ubuntu:18.04_previous
 docker push rsyslog/rsyslog_dev_base_ubuntu:18.04_previous

--- a/packaging/docker/dev_env/ubuntu/base/20.04/build-arm.sh
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/build-arm.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_base_ubuntu-arm:20.04 -f Dockerfile.arm .
 printf "ready to run docker push rsyslog/rsyslog_dev_base_ubuntu-arm:20.04\n"

--- a/packaging/docker/dev_env/ubuntu/base/20.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_base_ubuntu:20.04 .

--- a/packaging/docker/dev_env/ubuntu/base/20.04/setup-system.sh
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/setup-system.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 export DEBIAN_FRONTEND=noninteractive
 set -v
 
@@ -35,24 +36,27 @@ set -v
 
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
+(
 cd helper-projects
 
 # code style checker - not yet packaged
 git clone https://github.com/rsyslog/codestyle
-cd codestyle
-gcc --std=c99 stylecheck.c -o stylecheck
-mv stylecheck /usr/bin/rsyslog_stylecheck
-cd ..
+(
+	cd codestyle
+	gcc --std=c99 stylecheck.c -o stylecheck
+	mv stylecheck /usr/bin/rsyslog_stylecheck
+)
 rm -r codestyle
 
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
-cd libksi
-autoreconf -fvi
-./configure --prefix=/usr
-make -j2
-make install
-cd ..
+(
+	cd libksi
+	autoreconf -fvi
+	./configure --prefix=/usr
+	make -j2
+	make install
+)
 rm -r libksi
 
 # NOTE: we do NOT install coverity, because
@@ -62,13 +66,13 @@ rm -r libksi
 
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
-cd librdkafka
-(unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2)
-make install
-cd ..
+(
+	cd librdkafka
+	(unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2)
+	make install
+)
 # Note: we do NOT delete the source as we may need it to
 # uninstall (in case the user wants to go back to system-default)
 
 # finished installing helpers from source
-cd ..
-
+)

--- a/packaging/docker/dev_env/ubuntu/base/20.04/tag-previous-arm.sh
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/tag-previous-arm.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_ubuntu-arm:20.04 rsyslog/rsyslog_dev_base_ubuntu-arm:20.04_previous
 docker push rsyslog/rsyslog_dev_base_ubuntu-arm:20.04_previous

--- a/packaging/docker/dev_env/ubuntu/base/20.04/tag-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_ubuntu:20.04 rsyslog/rsyslog_dev_base_ubuntu:20.04_previous
 docker push rsyslog/rsyslog_dev_base_ubuntu:20.04_previous

--- a/packaging/docker/dev_env/ubuntu/base/22.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/base/22.04/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_base_ubuntu:22.04 .

--- a/packaging/docker/dev_env/ubuntu/base/22.04/tag-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/base/22.04/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_ubuntu:22.04 rsyslog/rsyslog_dev_base_ubuntu:22.04_previous
 docker push rsyslog/rsyslog_dev_base_ubuntu:22.04_previous

--- a/packaging/docker/dev_env/ubuntu/base/24.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 UBUNTU_VERSION=24.04
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_ubuntu:$UBUNTU_VERSION . --progress=plain

--- a/packaging/docker/dev_env/ubuntu/base/24.04/tag-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/base/24.04/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_ubuntu:24.04 rsyslog/rsyslog_dev_base_ubuntu:24.04_previous
 docker push rsyslog/rsyslog_dev_base_ubuntu:24.04_previous

--- a/packaging/docker/dev_env/ubuntu/base/26.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/base/26.04/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 UBUNTU_VERSION=26.04
 set -e
 docker build $1 -t rsyslog/rsyslog_dev_base_ubuntu:$UBUNTU_VERSION . --progress=plain

--- a/packaging/docker/dev_env/ubuntu/base/26.04/tag-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/base/26.04/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_base_ubuntu:26.04 rsyslog/rsyslog_dev_base_ubuntu:26.04_previous
 docker push rsyslog/rsyslog_dev_base_ubuntu:26.04_previous

--- a/packaging/docker/dev_env/ubuntu/buildbot/18.04/arm/build.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/18.04/arm/build.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_ubuntu-arm:18.04 .
 echo ready too run docker push rsyslog/rsyslog_dev_buildbot_ubuntu-arm:18.04

--- a/packaging/docker/dev_env/ubuntu/buildbot/18.04/arm/tag-previous-arm.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/18.04/arm/tag-previous-arm.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_ubuntu-arm:18.04 rsyslog/rsyslog_dev_buildbot_ubuntu-arm:18.04_previous
 docker push rsyslog/rsyslog_dev_buildbot_ubuntu-arm:18.04_previous

--- a/packaging/docker/dev_env/ubuntu/buildbot/18.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/18.04/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_ubuntu:18.04 .

--- a/packaging/docker/dev_env/ubuntu/buildbot/18.04/tag-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/18.04/tag-previous.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_ubuntu:18.04 rsyslog/rsyslog_dev_buildbot_ubuntu:18.04_previous
 docker push rsyslog/rsyslog_dev_buildbot_ubuntu:18.04_previous

--- a/packaging/docker/dev_env/ubuntu/buildbot/20.04/arm/build.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/20.04/arm/build.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_ubuntu-arm:20.04 .
 echo ready too run docker push rsyslog/rsyslog_dev_buildbot_ubuntu-arm:20.04

--- a/packaging/docker/dev_env/ubuntu/buildbot/20.04/arm/tag-previous-arm.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/20.04/arm/tag-previous-arm.sh
@@ -1,2 +1,3 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_ubuntu-arm:20.04 rsyslog/rsyslog_dev_buildbot_ubuntu-arm:20.04_previous
 docker push rsyslog/rsyslog_dev_buildbot_ubuntu-arm:20.04_previous

--- a/packaging/docker/dev_env/ubuntu/buildbot/20.04/build.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/20.04/build.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker build $1 -t rsyslog/rsyslog_dev_buildbot_ubuntu:20.04 .

--- a/packaging/docker/dev_env/ubuntu/buildbot/20.04/rollback-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/20.04/rollback-previous.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_ubuntu:20.04_previous rsyslog/rsyslog_dev_buildbot_ubuntu:20.04

--- a/packaging/docker/dev_env/ubuntu/buildbot/20.04/tag-previous.sh
+++ b/packaging/docker/dev_env/ubuntu/buildbot/20.04/tag-previous.sh
@@ -1,1 +1,2 @@
+#!/bin/sh
 docker tag rsyslog/rsyslog_dev_buildbot_ubuntu:20.04 rsyslog/rsyslog_dev_buildbot_ubuntu:20.04_previous

--- a/packaging/docker/dev_env/ubuntu/devel/build.sh
+++ b/packaging/docker/dev_env/ubuntu/devel/build.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 rm -rf common
 cp -r ../../common common
 sudo docker build --rm -t rsyslog/rsyslog_dev_full:ubuntu_devel .

--- a/packaging/docker/dev_env/ubuntu/devel/setup-system.sh
+++ b/packaging/docker/dev_env/ubuntu/devel/setup-system.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -q -y
 apt-get install -y software-properties-common python-software-properties

--- a/packaging/rpm/config.sh
+++ b/packaging/rpm/config.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # RPM build configuration for rsyslog packaging/rpm/
 # Sourced by build-rpms.sh and other scripts.
 

--- a/packaging/ubuntu/config.sh
+++ b/packaging/ubuntu/config.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Ubuntu package build configuration for rsyslog packaging/ubuntu/
 # Sourced by build-ubuntu.sh and devtools/run-deb-ubuntu-build.sh.
 

--- a/platform/freebsd/rsyslogd
+++ b/platform/freebsd/rsyslogd
@@ -25,7 +25,7 @@
 . /etc/rc.subr
 
 name="rsyslogd"
-rcvar=`set_rcvar`
+rcvar=$(set_rcvar)
 pidfile="/var/run/rsyslogd.pid"
 command="/usr/sbin/${name}"
 required_files="/etc/rsyslog.conf"
@@ -54,7 +54,7 @@ rsyslogd_precmd()
 	#
 	for _l in $altlog_proglist; do
 		eval _ldir=\$${_l}_chrootdir
-		if checkyesno `set_rcvar $_l` && [ -n "$_ldir" ]; then
+		if checkyesno "$(set_rcvar $_l)" && [ -n "$_ldir" ]; then
 			echo "${_ldir}/var/run/log" >> $_sockfile
 		fi
 	done
@@ -74,7 +74,7 @@ rsyslogd_precmd()
 set_socketlist()
 {
 	_socketargs=
-	for _s in `cat $_sockfile | tr '\n' ' '` ; do
+	for _s in $(cat $_sockfile | tr '\n' ' ') ; do
 		_socketargs="-l $_s $_socketargs"
 	done
 	echo $_socketargs

--- a/tests/CI/clang-analyzer-build.sh
+++ b/tests/CI/clang-analyzer-build.sh
@@ -12,7 +12,7 @@ echo "CC $CC, SCANBUILD $SCANBUILD"
 
 if [ -n "$SCAN_BUILD_REPORT_DIR" ]
 then
-  export CURR_REPORT=`date +%y-%m-%d_%H-%M-%S`
+  export CURR_REPORT=$(date +%y-%m-%d_%H-%M-%S)
   export REPORT_DIR="$SCAN_BUILD_REPORT_DIR/$CURR_REPORT"
   export REPORT_OPT="-o $REPORT_DIR"
 fi

--- a/tests/CI/interactive_exec_test_hook.sh
+++ b/tests/CI/interactive_exec_test_hook.sh
@@ -1,5 +1,7 @@
-cd tests
-export srcdir=&(pwd)
+#!/bin/sh
+cd tests || exit 1
+export srcdir
+srcdir=$(pwd)
 # add tests here below
 # ./omfile-read-only.sh
 exit # currently not needed

--- a/tests/CI/kill_all_instances.sh
+++ b/tests/CI/kill_all_instances.sh
@@ -3,7 +3,7 @@
 # the environment is "clean enough". In the past we have seen some
 # left-over instances on some (buildbot) systems
 echo clean all instances that might still be running
-ps -ef | grep [r]syslogd
+ps -ef | grep '[r]syslogd'
 for pid in $(ps -eo pid,cmd|grep '/tools/[r]syslogd' |sed -e 's/\( *\)\([0-9]*\).*/\2/');
 do
 	echo "killing pid $pid"

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -545,8 +545,7 @@ cmp_exact() {
 		printf 'Testbench ERROR, cmp_exact() needs to have env var EXPECTED set!\n'
 		error_exit 100
 	fi
-	printf '%s\n' "$EXPECTED" | cmp - "$filename"
-	if [ $? -ne 0 ]; then
+	if ! printf '%s\n' "$EXPECTED" | cmp - "$filename"; then
 		printf 'invalid response generated\n'
 		printf '################# %s is:\n' "$filename"
 		cat -n $filename
@@ -567,8 +566,7 @@ cmp_exact_file() {
 		printf 'Testbench ERROR, cmp_exact_file() needs expected and actual filenames!\n'
 		error_exit 100
 	fi
-	cmp "$expected_file" "$actual_file" > /dev/null
-	if [ $? -ne 0 ]; then
+	if ! cmp "$expected_file" "$actual_file" > /dev/null; then
 		printf 'invalid response generated\n'
 		printf '################# %s is:\n' "$actual_file"
 		cat -n "$actual_file"
@@ -680,9 +678,7 @@ wait_process_startup() {
 	if [ "$2" != "" ]; then
 		while test ! -f "$2"; do
 			$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
-			ps -p $(cat $1.pid) &> /dev/null
-			if [ $? -ne 0 ]
-			then
+			if ! ps -p $(cat $1.pid) &> /dev/null; then
 			   echo "ABORT! pid in $1 no longer active during startup!"
 			   error_exit 1
 			fi
@@ -706,8 +702,7 @@ wait_pid_termination() {
 		fi
 		terminated=0
 		while [[ $terminated -eq 0 ]]; do
-			ps -p $out_pid &> /dev/null
-			if [[ $? != 0 ]]; then
+			if ! ps -p $out_pid &> /dev/null; then
 				terminated=1
 			fi
 			$TESTTOOL_DIR/msleep 100
@@ -1399,7 +1394,7 @@ content_check() {
 	else
 	    if [ "$output_results" == "yes" ]; then
 		# Output GREP results
-		echo "SUCCESS: content_check found results for '$1'\n"
+		printf "SUCCESS: content_check found results for '%s'\n\n" "$1"
 		grep "$1" "${file}"
 	    fi
 	fi
@@ -1501,8 +1496,7 @@ content_check_with_count() {
 
 
 custom_content_check() {
-	grep -qF -- "$1" < $2
-	if [ "$?" -ne "0" ]; then
+	if ! grep -qF -- "$1" < $2; then
 	    echo FAIL: custom_content_check failed to find "'$1'" inside "'$2'"
 	    echo "file contents:"
 	    cat -n $2
@@ -1518,8 +1512,7 @@ check_not_present() {
 	else
 		file="$2"
 	fi
-	grep -q -- "$1" < "$file"
-	if [ "$?" -eq "0" ]; then
+	if grep -q -- "$1" < "$file"; then
 		echo FAIL: check_not present found
 		echo $1
 		echo inside file $file of $(wc -l < $file) lines
@@ -1561,8 +1554,7 @@ check_spool_empty() {
 check_journal_testmsg_received() {
 	printf 'checking that journal indeed contains test message - may take a short while...\n'
 	# search reverse, gets us to our message (much) faster .... if it is there...
-	journalctl -a -r | grep -qF "$TESTMSG"
-	if [ $? -ne 0 ]; then
+	if ! journalctl -a -r | grep -qF "$TESTMSG"; then
 		print 'SKIP: cannot read journal - our testmessage not found via journalctl\n'
 		exit 77
 	fi
@@ -1570,8 +1562,7 @@ check_journal_testmsg_received() {
 
 	echo "INFO: $(wc -l < $RSYSLOG_OUT_LOG) lines in $RSYSLOG_OUT_LOG"
 
-	grep -qF "$TESTMSG" < $RSYSLOG_OUT_LOG
-	if [ $? -ne 0 ]; then
+	if ! grep -qF "$TESTMSG" < $RSYSLOG_OUT_LOG; then
 	  echo "FAIL:  $RSYSLOG_OUT_LOG content (tail -n200):"
 	  tail -n200 $RSYSLOG_OUT_LOG
 	  echo "======="
@@ -1698,8 +1689,7 @@ wait_shutdown() {
 		terminated=0
 	fi
 	while [[ $terminated -eq 0 ]]; do
-		ps -p $out_pid &> /dev/null
-		if [[ $? != 0 ]]; then
+		if ! ps -p $out_pid &> /dev/null; then
 			terminated=1
 		fi
 		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
@@ -1931,8 +1921,7 @@ wait_content() {
 
 
 assert_content_missing() {
-	grep -qF -- "$1" < ${RSYSLOG_OUT_LOG}
-	if [ "$?" -eq "0" ]; then
+	if grep -qF -- "$1" < ${RSYSLOG_OUT_LOG}; then
 		echo content-missing assertion failed, some line matched pattern "'$1'"
 		error_exit 1
 	fi
@@ -1940,8 +1929,7 @@ assert_content_missing() {
 
 
 custom_assert_content_missing() {
-	grep -qF -- "$1" < $2
-	if [ "$?" -eq "0" ]; then
+	if grep -qF -- "$1" < $2; then
 		echo content-missing assertion failed, some line in "'$2'" matched pattern "'$1'"
 		cat -n "$2"
 		error_exit 1
@@ -2683,8 +2671,7 @@ seq_check() {
 # $4... are just to have the ability to pass in more options...
 # add -v to chkseq if you need more verbose output
 seq_check2() {
-	$RS_SORTCMD $RS_SORT_NUMERIC_OPT < ${RSYSLOG2_OUT_LOG}  | ./chkseq -s$1 -e$2 $3 $4 $5 $6 $7
-	if [ "$?" -ne "0" ]; then
+	if ! $RS_SORTCMD $RS_SORT_NUMERIC_OPT < ${RSYSLOG2_OUT_LOG}  | ./chkseq -s$1 -e$2 $3 $4 $5 $6 $7; then
 		echo "sequence error detected"
 		error_exit 1
 	fi
@@ -2707,8 +2694,7 @@ gzip_seq_check() {
 		endnum=$2
 	fi
 	ls -l ${RSYSLOG_OUT_LOG}
-	gunzip < ${RSYSLOG_OUT_LOG} | $RS_SORTCMD $RS_SORT_NUMERIC_OPT | ./chkseq -v -s$startnum -e$endnum $3 $4 $5 $6 $7
-	if [ "$?" -ne "0" ]; then
+	if ! gunzip < ${RSYSLOG_OUT_LOG} | $RS_SORTCMD $RS_SORT_NUMERIC_OPT | ./chkseq -v -s$startnum -e$endnum $3 $4 $5 $6 $7; then
 		echo "sequence error detected"
 		error_exit 1
 	fi
@@ -2723,6 +2709,7 @@ tcpflood() {
 	else
 		check_only="no"
 	fi
+	# shellcheck disable=SC2294 # TCPFLOOD_EXTRA_OPTS is intentionally parsed as shell words.
 	eval ./tcpflood -p$TCPFLOOD_PORT "$@" $TCPFLOOD_EXTRA_OPTS
 	res=$?
 	if [ "$check_only" == "yes" ]; then
@@ -2812,8 +2799,7 @@ check_logger_has_option_d() {
 	skip_platform "SunOS"  "We need logger -d option, which we do not have on (all flavors of) Solaris"
 
 	# check also the case for busybox
-	logger --help 2>&1 | head -n1 | grep -q BusyBox
-	if [ $? -eq 0 ]; then
+	if logger --help 2>&1 | head -n1 | grep -q BusyBox; then
 		echo "We need logger -d option, which we do not have have on Busybox"
 		exit 77
 	fi
@@ -3102,39 +3088,31 @@ download_kafka() {
 		else
 			echo "Downloading zookeeper from $dep_zk_url"
 			echo wget -q $dep_zk_url -O $dep_zk_cached_file
-			wget -q $dep_zk_url -O $dep_zk_cached_file
-			if [ $? -ne 0 ]
-			then
-                                echo error during wget, retry:
-                                wget $dep_zk_url -O $dep_zk_cached_file
-                                if [ $? -ne 0 ]
-                                then
-                                        echo "Skipping test - unable to download zookeeper"
-                                        error_exit 77
-                                fi
-                        fi
-                fi
-        fi
+			if ! wget -q $dep_zk_url -O $dep_zk_cached_file; then
+				echo error during wget, retry:
+				if ! wget $dep_zk_url -O $dep_zk_cached_file; then
+					echo "Skipping test - unable to download zookeeper"
+					error_exit 77
+				fi
+			fi
+		fi
+	fi
 	if [ ! -f $dep_kafka_cached_file ]; then
 		if [ -f /local_dep_cache/$RS_KAFKA_DOWNLOAD ]; then
 			printf 'Kafka: satisfying dependency %s from system cache.\n' "$RS_KAFKA_DOWNLOAD"
 			cp /local_dep_cache/$RS_KAFKA_DOWNLOAD $dep_kafka_cached_file
 		else
 			echo "Downloading kafka from $dep_kafka_url"
-			wget -q $dep_kafka_url -O $dep_kafka_cached_file
-			if [ $? -ne 0 ]
-			then
+			if ! wget -q $dep_kafka_url -O $dep_kafka_cached_file; then
 				echo error during wget, retry:
-                                wget $dep_kafka_url -O $dep_kafka_cached_file
-                                if [ $? -ne 0 ]
-                                then
-                                        rm $dep_kafka_cached_file # a 0-size file may be left over
-                                        echo "Skipping test - unable to download kafka"
-                                        error_exit 77
-                                fi
-                        fi
-                fi
-        fi
+				if ! wget $dep_kafka_url -O $dep_kafka_cached_file; then
+					rm $dep_kafka_cached_file # a 0-size file may be left over
+					echo "Skipping test - unable to download kafka"
+					error_exit 77
+				fi
+			fi
+		fi
+	fi
 }
 
 stop_kafka() {
@@ -3142,7 +3120,7 @@ stop_kafka() {
 		return
 	fi
 	i=0
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 		dep_work_kafka_config="kafka-server.properties"
 	else
@@ -3156,7 +3134,7 @@ stop_kafka() {
 	if [ ! -d $dep_work_dir/kafka ]; then
 		echo "Kafka work-dir $dep_work_dir/kafka does not exist, no action needed"
 	else
-		# shellcheck disable=SC2009  - we do not grep on the process name!
+		# shellcheck disable=SC2009 # We do not grep on the process name.
 		kafkapid=$(ps aux | grep -i $dep_work_kafka_config | grep java | grep -v grep | awk '{print $2}')
 
 		echo "Stopping Kafka instance $1 ($dep_work_kafka_config/$kafkapid)"
@@ -3164,7 +3142,7 @@ stop_kafka() {
 
 		# Check if kafka instance went down!
                 while true; do
-                        # shellcheck disable=SC2009  - we do not grep on the process name!
+                        # shellcheck disable=SC2009 # We do not grep on the process name.
                         kafkapid=$(ps aux | grep -i $dep_work_kafka_config | grep java | grep -v grep | awk '{print $2}')
                         if [ -n "$kafkapid" ]; then
                                 $TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
@@ -3188,7 +3166,7 @@ stop_kafka() {
 }
 
 cleanup_kafka() {
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 	else
 		dep_work_dir=$(readlink -f $srcdir/$1)
@@ -3206,7 +3184,7 @@ stop_zookeeper() {
 		return
 	fi
 	i=0
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 		dep_work_tk_config="zoo.cfg"
 	else
@@ -3254,7 +3232,7 @@ stop_zookeeper() {
 }
 
 cleanup_zookeeper() {
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 	else
 		dep_work_dir=$(readlink -f $srcdir/$1)
@@ -3325,7 +3303,7 @@ start_kafka() {
 
         _kafka_instance_layout "$1" dep_work_dir dep_work_kafka_config
 
-        # shellcheck disable=SC2009  - we do not grep on the process name!
+        # shellcheck disable=SC2009 # We do not grep on the process name.
         kafkapid=$(ps aux | grep -i $dep_work_kafka_config | grep java | grep -v grep | awk '{print $2}')
         if [ "$KEEP_KAFKA_RUNNING" == "YES" ] && [ -n "$kafkapid" ]; then
                 printf 'kafka already running, no need to start\n'
@@ -3356,7 +3334,7 @@ start_kafka() {
                 readiness_ok=1
         fi
 
-        # shellcheck disable=SC2009  - we do not grep on the process name!
+        # shellcheck disable=SC2009 # We do not grep on the process name.
         kafkapid=$(ps aux | grep -i $dep_work_kafka_config | grep java | grep -v grep | awk '{print $2}')
         if [ "$readiness_ok" -eq 1 ] && [ -n "$kafkapid" ]; then
                 echo "Kafka instance $dep_work_kafka_config (PID $kafkapid) started ... "
@@ -3386,7 +3364,7 @@ start_kafka() {
                 error_exit 77
         fi
 
-        # shellcheck disable=SC2009  - we do not grep on the process name!
+        # shellcheck disable=SC2009 # We do not grep on the process name.
         kafkapid=$(ps aux | grep -i $dep_work_kafka_config | grep java | grep -v grep | awk '{print $2}')
         if [ -n "$kafkapid" ]; then
                 echo "Kafka instance $dep_work_kafka_config (PID $kafkapid) started ... "
@@ -3402,12 +3380,12 @@ start_kafka() {
 }
 
 create_kafka_topic() {
-	if [ "x$2" == "x" ]; then
+	if [ -z "$2" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 	else
 		dep_work_dir=$(readlink -f $2)
 	fi
-	if [ "x$3" == "x" ]; then
+	if [ -z "$3" ]; then
 		dep_work_port='2181'
 	else
 		dep_work_port=$3
@@ -3416,7 +3394,7 @@ create_kafka_topic() {
 			echo "Kafka work-dir $dep_work_dir/kafka does not exist, did you start kafka?"
 			exit 1
 	fi
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 			echo "Topic-name not provided."
 			exit 1
 	fi
@@ -3458,12 +3436,12 @@ create_kafka_topic() {
 }
 
 delete_kafka_topic() {
-	if [ "x$2" == "x" ]; then
+	if [ -z "$2" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 	else
 		dep_work_dir=$(readlink -f $srcdir/$2)
 	fi
-	if [ "x$3" == "x" ]; then
+	if [ -z "$3" ]; then
 		dep_work_port='2181'
 	else
 		dep_work_port=$3
@@ -3474,14 +3452,14 @@ delete_kafka_topic() {
 }
 
 dump_kafka_topic() {
-	if [ "x$2" == "x" ]; then
+	if [ -z "$2" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 		dep_kafka_log_dump=$(readlink -f rsyslog.out.kafka.log)
 	else
 		dep_work_dir=$(readlink -f $srcdir/$2)
 		dep_kafka_log_dump=$(readlink -f rsyslog.out.kafka$2.log)
 	fi
-	if [ "x$3" == "x" ]; then
+	if [ -z "$3" ]; then
 		dep_work_port='2181'
 	else
 		dep_work_port=$3
@@ -3492,7 +3470,7 @@ dump_kafka_topic() {
 			echo "Kafka work-dir does not exist, did you start kafka?"
 			exit 1
 	fi
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 			echo "Topic-name not provided."
 			exit 1
 	fi
@@ -3501,7 +3479,7 @@ dump_kafka_topic() {
 }
 
 dump_kafka_serverlog() {
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 	else
 		dep_work_dir=$(readlink -f $srcdir/$1)
@@ -3519,7 +3497,7 @@ dump_kafka_serverlog() {
 }
 
 dump_zookeeper_serverlog() {
-	if [ "x$1" == "x" ]; then
+	if [ -z "$1" ]; then
 		dep_work_dir=$(readlink -f .dep_wrk)
 	else
 		dep_work_dir=$(readlink -f $srcdir/$1)
@@ -3795,7 +3773,7 @@ omhttp_start_server() {
         error_exit 1
     fi
 
-    if [ "x$1" == "x" ]; then
+    if [ -z "$1" ]; then
         omhttp_server_port="8080"
     else
         omhttp_server_port="$1"
@@ -3811,7 +3789,8 @@ omhttp_start_server() {
     server_args="-p $omhttp_server_port ${*:2} --port-file $RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
 
     setsid timeout 30m $PYTHON ${omhttp_server_py} ${server_args} >> ${omhttp_server_logfile} 2>&1 &
-    if [ ! $? -eq 0 ]; then
+    # shellcheck disable=SC2181 # Preserve the existing background-start check.
+    if [ $? -ne 0 ]; then
         echo "Failed to start omhttp test server."
         rm -rf $omhttp_work_dir
         error_exit 1
@@ -3857,13 +3836,13 @@ omhttp_stop_server() {
 
 omhttp_get_data() {
     # Args: 1=port 2=endpoint 3=batchformat(optional)
-    if [ "x$1" == "x" ]; then
+    if [ -z "$1" ]; then
         omhttp_server_port=8080
     else
         omhttp_server_port=$1
     fi
 
-    if [ "x$2" == "x" ]; then
+    if [ -z "$2" ]; then
         omhttp_path=""
     else
         omhttp_path=$2
@@ -3872,21 +3851,21 @@ omhttp_get_data() {
     # The test server returns a json encoded array of strings containing whatever omhttp sent to it in each request
     python_init="import json, sys; dat = json.load(sys.stdin)"
     python_print="print('\n'.join(out))"
-    if [ "x$3" == "x" ]; then
+    if [ -z "$3" ]; then
         # dat = ['{"msgnum":"1"}, '{"msgnum":"2"}', '{"msgnum":"3"}', '{"msgnum":"4"}']
         python_parse="$python_init; out = [json.loads(l)['msgnum'] for l in dat]; $python_print"
     else
-       if [ "x$3" == "xjsonarray" ]; then
+       if [ "$3" == "jsonarray" ]; then
             # dat = ['[{"msgnum":"1"},{"msgnum":"2"}]', '[{"msgnum":"3"},{"msgnum":"4"}]']
             python_parse="$python_init; out = [l['msgnum'] for a in dat for l in json.loads(a)]; $python_print"
-        elif [ "x$3" == "xnewline" ]; then
+        elif [ "$3" == "newline" ]; then
             # dat = ['{"msgnum":"1"}\n{"msgnum":"2"}', '{"msgnum":"3"}\n{"msgnum":"4"}']
             python_parse="$python_init; out = [json.loads(l)['msgnum'] for a in dat for l in a.split('\n')]; $python_print"
-        elif [ "x$3" == "xkafkarest" ]; then
+        elif [ "$3" == "kafkarest" ]; then
             # dat = ['{"records":[{"value":{"msgnum":"1"}},{"value":{"msgnum":"2"}}]}',
             #        '{"records":[{"value":{"msgnum":"3"}},{"value":{"msgnum":"4"}}]}']
             python_parse="$python_init; out = [l['value']['msgnum'] for a in dat for l in json.loads(a)['records']]; $python_print"
-        elif [ "x$3" == "xlokirest" ]; then
+        elif [ "$3" == "lokirest" ]; then
             # dat = ['{"streams":[{"msgnum":"1"},{"msgnum":"2"}]}',
             #        '{"streams":[{"msgnum":"3"},{"msgnum":"4"}]}']
             python_parse="$python_init; out = [l['msgnum'] for a in dat for l in json.loads(a)['streams']]; $python_print"
@@ -3911,8 +3890,7 @@ omhttp_validate_metadata_response() {
         error_exit 1
     fi
 
-	$PYTHON ${omhttp_response_validate_py} --error ${RSYSLOG_DYNNAME}/omhttp.error.log --response ${RSYSLOG_DYNNAME}/omhttp.response.log 2>&1
-	if [ $? -ne 0 ] ; then
+	if ! $PYTHON ${omhttp_response_validate_py} --error ${RSYSLOG_DYNNAME}/omhttp.error.log --response ${RSYSLOG_DYNNAME}/omhttp.response.log 2>&1; then
 		printf 'omhttp_validate_metadata_response failed \n'
 		error_exit 1
 	fi
@@ -3959,11 +3937,9 @@ download_otel_collector() {
 		printf 'OTEL Collector: downloading %s from %s\n' "$OTEL_COLLECTOR_DOWNLOAD" "$dep_otel_collector_url"
 		dep_otel_collector_tmp_file="${dep_otel_collector_cached_file}.$$"
 		rm -f "$dep_otel_collector_tmp_file"
-		wget -q "$dep_otel_collector_url" -O "$dep_otel_collector_tmp_file"
-		if [ $? -ne 0 ]; then
+		if ! wget -q "$dep_otel_collector_url" -O "$dep_otel_collector_tmp_file"; then
 			echo "error during wget, retry:"
-			wget "$dep_otel_collector_url" -O "$dep_otel_collector_tmp_file"
-			if [ $? -ne 0 ]; then
+			if ! wget "$dep_otel_collector_url" -O "$dep_otel_collector_tmp_file"; then
 				rm -f "$dep_otel_collector_tmp_file" "$dep_otel_collector_cached_file"
 				echo "Skipping test - unable to download OTEL Collector"
 				error_exit 77
@@ -4534,7 +4510,7 @@ redis_command() {
 # $4 - expected value
 first_column_sum_check() {
 	sum=$(grep "$2" < "$3" | sed -e "$1" | awk '{s+=$1} END {print s}')
-	if [ "x${sum}" != "x$4" ]; then
+	if [ "${sum}" != "$4" ]; then
 	    printf '\n============================================================\n'
 	    echo FAIL: sum of first column with edit-expr "'$1'" run over lines from file "'$3'" matched by "'$2'" equals "'$sum'" which is NOT equal to EXPECTED value of "'$4'"
 	    echo "file contents:"
@@ -4584,13 +4560,13 @@ snmp_start_trapreceiver() {
         error_exit 1
     fi
 
-    if [ "x$1" == "x" ]; then
+    if [ -z "$1" ]; then
         snmp_server_port="10162"
     else
         snmp_server_port="$1"
     fi
 
-    if [ "x$2" == "x" ]; then
+    if [ -z "$2" ]; then
         output_file="${RSYSLOG_DYNNAME}.snmp.out"
     else
         output_file="$2"
@@ -4732,7 +4708,7 @@ wait_for_stats_flush() {
 	new_count=$prev_count
 	start_loop="$(date +%s)"
 	emit_waiting=0
-	while [[ "x$prev_count" == "x$new_count" ]]; do
+	while [[ "$prev_count" == "$new_count" ]]; do
 		# busy spin, because it allows as close timing-coordination
 		# in actual test run as possible
 		if [ $(date +%s) -gt $(( TB_STARTTEST + TB_TEST_MAX_RUNTIME )) ]; then
@@ -4779,7 +4755,7 @@ omfwd_sni_check() {
 	wait_file_lines "$RSYSLOG_DYNNAME.sni-server.stdout" 1
 
 	if ! grep -q "^SNI: $sni\$" $RSYSLOG_DYNNAME.sni-server.stdout; then
-	    echo "Expected 'SNI: $sni', but got '"`cat $RSYSLOG_DYNNAME.sni-server.stdout`"'"
+	    printf "Expected 'SNI: %s', but got '%s'\n" "$sni" "$(cat "$RSYSLOG_DYNNAME.sni-server.stdout")"
 		error_exit 1
 	fi
 }
@@ -4935,8 +4911,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 			cmd="ifconfig -a"
 		fi
 		echo command used for ipv6 detection: $cmd
-		$cmd | grep ::1 > /dev/null
-		if [ $? -ne 0 ] ; then
+		if ! $cmd | grep ::1 > /dev/null; then
 			printf 'this test requires an active IPv6 stack, which we do not have here\n'
 			error_exit 77
 		fi
@@ -4946,8 +4921,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 		# note: we do not wait for the actual termination!
 		;;
    'ensure-no-process-exists')
-    ps -ef | grep -v grep | grep -qF "$2"
-    if [ "x$?" == "x0" ]; then
+    if ps -ef | grep -v grep | grep -qF "$2"; then
       echo "assertion failed: process with name-fragment matching '$2' found"
 		  error_exit 1
     fi
@@ -4983,7 +4957,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 		done
 		prev_purged=$(grep -F 'origin=dynstats' < $2 | grep -F "${3}.purge_triggered=" | sed -e 's/.\+.purge_triggered=//g' | awk '{s+=$1} END {print s}')
 		new_purged=$prev_purged
-		while [[ "x$prev_purged" == "x$new_purged" ]]; do
+		while [[ "$prev_purged" == "$new_purged" ]]; do
 				new_purged=$(grep -F 'origin=dynstats' < "$2" | grep -F "${3}.purge_triggered=" | sed -e 's/.\+\.purge_triggered=//g' | awk '{s+=$1} END {print s}') # busy spin, because it allows as close timing-coordination in actual test run as possible
 				$TESTTOOL_DIR/msleep 10
 		done
@@ -4999,8 +4973,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 		fi
 		;;
    'content-pattern-check')
-		grep -q "$2" < ${RSYSLOG_OUT_LOG}
-		if [ "$?" -ne "0" ]; then
+		if ! grep -q "$2" < ${RSYSLOG_OUT_LOG}; then
 		    echo content-check failed, not every line matched pattern "'$2'"
 		    echo "file contents:"
 		    cat -n $4
@@ -5017,8 +4990,7 @@ make -j$(getconf _NPROCESSORS_ONLN) check TESTS="" || error_exit 100
 		if [ -n "$(find /usr/include -name 'inotify.h' -print -quit)" ]; then
 			echo [inotify mode]
 		elif [ -n "$(find /usr/include/sys/ -name 'port.h' -print -quit)" ]; then
-			grep -qF "PORT_SOURCE_FILE" < /usr/include/sys/port.h
-			if [ "$?" -ne "0" ]; then
+			if ! grep -qF "PORT_SOURCE_FILE" < /usr/include/sys/port.h; then
 				echo [port.h found but FEN API not implemented , skipping...]
 				exit 77 # FEN API not available, skip this test
 			fi

--- a/tests/es-bulk-errfile-popul-def-format.sh
+++ b/tests/es-bulk-errfile-popul-def-format.sh
@@ -42,9 +42,10 @@ shutdown_when_empty
 wait_shutdown
 
 $PYTHON $srcdir/elasticsearch-error-format-check.py default
-if [ $? -ne 0 ]
+ret=$?
+if [ "$ret" -ne 0 ]
 then
-    echo "error: Format for error file different! " $?
+    echo "error: Format for error file different! " "$ret"
     error_exit 1
 fi
 exit_test

--- a/tests/es-bulk-errfile-popul-def-interleaved.sh
+++ b/tests/es-bulk-errfile-popul-def-interleaved.sh
@@ -45,10 +45,10 @@ shutdown_when_empty
 wait_shutdown
 
 $PYTHON $srcdir/elasticsearch-error-format-check.py interleaved
-
-if [ $? -ne 0 ]
+ret=$?
+if [ "$ret" -ne 0 ]
 then
-    echo "error: Format for error file different! " $?
+    echo "error: Format for error file different! " "$ret"
     exit 1
 fi
 exit_test

--- a/tests/es-bulk-errfile-popul-erronly-interleaved.sh
+++ b/tests/es-bulk-errfile-popul-erronly-interleaved.sh
@@ -45,10 +45,10 @@ shutdown_when_empty
 wait_shutdown
 
 $PYTHON $srcdir/elasticsearch-error-format-check.py errorinterleaved
-
-if [ $? -ne 0 ]
+ret=$?
+if [ "$ret" -ne 0 ]
 then
-    echo "error: Format for error file different! " $?
+    echo "error: Format for error file different! " "$ret"
     exit 1
 fi
 exit_test

--- a/tests/es-bulk-errfile-popul-erronly.sh
+++ b/tests/es-bulk-errfile-popul-erronly.sh
@@ -44,10 +44,10 @@ shutdown_when_empty
 wait_shutdown
 
 $PYTHON $srcdir/elasticsearch-error-format-check.py erroronly
-
-if [ $? -ne 0 ]
+ret=$?
+if [ "$ret" -ne 0 ]
 then
-    echo "error: Format for error file different! " $?
+    echo "error: Format for error file different! " "$ret"
     error_exit 1
 fi
 exit_test

--- a/tests/es-bulk-retry.sh
+++ b/tests/es-bulk-retry.sh
@@ -249,7 +249,7 @@ fi
 
 if [ -f ${RSYSLOG_DYNNAME}.spool/es-bulk-errors.log ] ; then
 	found=0
-	for ii in $(seq --format="x%08.f" 1 2 $(expr 2 \* $badarg)) ; do
+	for ii in $(seq --format="x%08.f" 1 2 $((2 * badarg))) ; do
 		if grep -q '^[$][!]:{.*"msgnum": "'$ii'"' ${RSYSLOG_DYNNAME}.spool/es-bulk-errors.log ; then
 			(( found++ ))
 		else

--- a/tests/execonlywhenprevsuspended-nonsusp-queue.sh
+++ b/tests/execonlywhenprevsuspended-nonsusp-queue.sh
@@ -30,7 +30,7 @@ startup
 injectmsg 0 1000
 shutdown_when_empty
 wait_shutdown
-ls *.out.log
+ls ./*.out.log
 seq_check 0 999
 if [ -e ${RSYSLOG2_OUT_LOG} ]; then
     echo "error: \"suspended\" file exists, first 10 lines:"

--- a/tests/failover-no-rptd-vg.sh
+++ b/tests/failover-no-rptd-vg.sh
@@ -18,7 +18,7 @@ wait_shutdown_vg
 check_exit_vg
 # now we need our custom logic to see if the result file is empty
 # (what it should be!)
-if [ -f $RSYSLOG_OUT_LOG -a "$(cat $RSYSLOG_OUT_LOG)" != "" ]; then
+if [ -f "$RSYSLOG_OUT_LOG" ] && [ "$(cat "$RSYSLOG_OUT_LOG")" != "" ]; then
 	echo "ERROR, output file not empty"
 	cat -n "$RSYSLOG_OUT_LOG"
 	error_exit 1

--- a/tests/glbl-umask.sh
+++ b/tests/glbl-umask.sh
@@ -21,7 +21,7 @@ injectmsg 0 1
 shutdown_when_empty
 wait_shutdown
 
-if [ `ls -l $RSYSLOG_OUT_LOG|$RS_HEADCMD -c 10 ` != "-rw-------" ]; then
+if [ "$(ls -l $RSYSLOG_OUT_LOG|$RS_HEADCMD -c 10)" != "-rw-------" ]; then
   echo "invalid file permission (umask),  $RSYSLOG_OUT_LOG has:"
   ls -l $RSYSLOG_OUT_LOG
   error_exit 1

--- a/tests/imdocker-long-logline.sh
+++ b/tests/imdocker-long-logline.sh
@@ -32,7 +32,7 @@ wait_shutdown
 echo "file name: $RSYSLOG_OUT_LOG"
 count=$(grep "aaaaaaa" $RSYSLOG_OUT_LOG | tr -d "\n" | wc -c)
 
-if [ "x$count" == "x$SIZE" ]; then
+if [ "$count" == "$SIZE" ]; then
   echo "correct log line length: $count"
 else
   echo "Incorrect log line length - found $count, expected: $SIZE"

--- a/tests/imfile-endmsg.regex-with-example-vg.sh
+++ b/tests/imfile-endmsg.regex-with-example-vg.sh
@@ -75,9 +75,9 @@ fi
 echo 'date stdout P msgnum:0' > $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:0"}' > $RSYSLOG_DYNNAME.json.input
 echo 'date stdout F msgnum:1' >> $RSYSLOG_DYNNAME.crio.input
-echo '{"time":"date", "stream":"stdout", "log":"msgnum:1\n"}' >> $RSYSLOG_DYNNAME.json.input
+printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:1\n"}' >> $RSYSLOG_DYNNAME.json.input
 echo 'date stdout F msgnum:2' >> $RSYSLOG_DYNNAME.crio.input
-echo '{"time":"date", "stream":"stdout", "log":"msgnum:2\n"}' >> $RSYSLOG_DYNNAME.json.input
+printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:2\n"}' >> $RSYSLOG_DYNNAME.json.input
 
 if [ -n "${USE_GDB:-}" ] ; then
 	sleep 54321 || :
@@ -102,7 +102,7 @@ fi
 wait_queueempty
 
 echo 'date stdout F msgnum:6' >> $RSYSLOG_DYNNAME.crio.input
-echo '{"time":"date", "stream":"stdout", "log":"msgnum:6\n"}' >> $RSYSLOG_DYNNAME.json.input
+printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:6\n"}' >> $RSYSLOG_DYNNAME.json.input
 echo 'date stdout P msgnum:7' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:7"}' >> $RSYSLOG_DYNNAME.json.input
 

--- a/tests/imfile-endmsg.regex-with-example.sh
+++ b/tests/imfile-endmsg.regex-with-example.sh
@@ -79,9 +79,9 @@ fi
 echo 'date stdout P msgnum:0' > $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:0"}' > $RSYSLOG_DYNNAME.json.input
 echo 'date stdout F msgnum:1' >> $RSYSLOG_DYNNAME.crio.input
-echo '{"time":"date", "stream":"stdout", "log":"msgnum:1\n"}' >> $RSYSLOG_DYNNAME.json.input
+printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:1\n"}' >> $RSYSLOG_DYNNAME.json.input
 echo 'date stdout F msgnum:2' >> $RSYSLOG_DYNNAME.crio.input
-echo '{"time":"date", "stream":"stdout", "log":"msgnum:2\n"}' >> $RSYSLOG_DYNNAME.json.input
+printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:2\n"}' >> $RSYSLOG_DYNNAME.json.input
 
 # sleep a little to give rsyslog a chance to begin processing
 if [ -n "${USE_GDB:-}" ] ; then
@@ -105,7 +105,7 @@ else
 fi
 
 echo 'date stdout F msgnum:6' >> $RSYSLOG_DYNNAME.crio.input
-echo '{"time":"date", "stream":"stdout", "log":"msgnum:6\n"}' >> $RSYSLOG_DYNNAME.json.input
+printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:6\n"}' >> $RSYSLOG_DYNNAME.json.input
 echo 'date stdout P msgnum:7' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:7"}' >> $RSYSLOG_DYNNAME.json.input
 

--- a/tests/imfile-endregex-timeout-none-polling.sh
+++ b/tests/imfile-endregex-timeout-none-polling.sh
@@ -50,7 +50,7 @@ echo 'END OF TEST' >> $RSYSLOG_DYNNAME.input
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown    # we need to wait until rsyslogd is finished!
 
-echo 'HEADER msgnum:0\\n msgnum:1\\n msgnum:2\\n msgnum:3' | cmp - $RSYSLOG_OUT_LOG
+printf '%s\n' 'HEADER msgnum:0\\n msgnum:1\\n msgnum:2\\n msgnum:3' | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid multiline message generated, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG

--- a/tests/imfile-endregex-timeout-polling.sh
+++ b/tests/imfile-endregex-timeout-polling.sh
@@ -50,7 +50,7 @@ echo 'END OF TEST' >> $RSYSLOG_DYNNAME.input
 shutdown_when_empty # shut down rsyslogd when done processing messages
 wait_shutdown    # we need to wait until rsyslogd is finished!
 
-echo 'HEADER msgnum:0\\n msgnum:1
+printf '%s\n' 'HEADER msgnum:0\\n msgnum:1
 HEADER  msgnum:2\\n msgnum:3' | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid multiline message generated, $RSYSLOG_OUT_LOG is:"

--- a/tests/imfile-old-state-file.sh
+++ b/tests/imfile-old-state-file.sh
@@ -43,11 +43,11 @@ inode=$(ls -i $RSYSLOG_DYNNAME.input|awk '{print $1}')
 leninode=${#inode}
 newline="+inode:2:${leninode}:${inode}:"
 
-sed s/+inode:2:7:4464465:/${newline}/ <$srcdir/testsuites/imfile-old-state-file_imfile-state_.-rsyslog.input > ${RSYSLOG_DYNNAME}.spool/imfile-state\:.-$RSYSLOG_DYNNAME.input
+sed s/+inode:2:7:4464465:/${newline}/ <$srcdir/testsuites/imfile-old-state-file_imfile-state_.-rsyslog.input > ${RSYSLOG_DYNNAME}.spool/imfile-state:.-$RSYSLOG_DYNNAME.input
 printf "info: new input file: $(ls -i $RSYSLOG_DYNNAME.input)\n"
 printf "info: new inode line: ${newline}\n"
 printf "info: patched state file:\n"
-cat ${RSYSLOG_DYNNAME}.spool/imfile-state\:.-$RSYSLOG_DYNNAME.input
+cat ${RSYSLOG_DYNNAME}.spool/imfile-state:.-$RSYSLOG_DYNNAME.input
 
 startup
 

--- a/tests/imfile-rename.sh
+++ b/tests/imfile-rename.sh
@@ -82,7 +82,7 @@ echo ls ${RSYSLOG_DYNNAME}.spool:
 ls -l ${RSYSLOG_DYNNAME}.spool
 ./msleep 500
 
-let msgcount="2* $TESTMESSAGES"
+msgcount=$((2 * TESTMESSAGES))
 wait_file_lines $RSYSLOG_OUT_LOG $msgcount $RETRIES
 
 shutdown_when_empty # shut down rsyslogd when done processing messages

--- a/tests/imfile-statefile-directory.sh
+++ b/tests/imfile-statefile-directory.sh
@@ -21,7 +21,7 @@ shutdown_when_empty
 wait_shutdown
 seq_check 0 0 # check we got the messages correctly
 # and also check state file name is correct:
-# shellcheck disable=SC2012  - we do not display (or even use) the file name
+	# shellcheck disable=SC2012 # We do not display or use the file name.
 inode=$(ls -i "$RSYSLOG_DYNNAME.input"|awk '{print $1}')
 if [ ! -f "$RSYSLOG_DYNNAME.statefiles/imfile-state:$inode" ]; then
 	printf 'FAIL: state file name incorrect,\nexpected \"%s\"\nstatefiles dir is:\n' \

--- a/tests/imfile-symlink-multi.sh
+++ b/tests/imfile-symlink-multi.sh
@@ -44,7 +44,7 @@ mkdir $RSYSLOG_DYNNAME.targets
 startup
 
 cp $imfilebefore $RSYSLOG_DYNNAME.targets/target.log
-for i in `seq 2 $IMFILEINPUTFILES`;
+for i in $(seq 2 $IMFILEINPUTFILES);
 do
 	ln -s $RSYSLOG_DYNNAME.targets/target.log $RSYSLOG_DYNNAME.input.$i.log
 	# Let imfile observe each newly-created symlink before adding the next.
@@ -60,7 +60,7 @@ wait_shutdown        # we need to wait until rsyslogd is finished!
 sort ${RSYSLOG_OUT_LOG} > ${RSYSLOG_OUT_LOG}.sorted
 
 echo HEADER msgnum:00000000:, filename: ./$RSYSLOG_DYNNAME.input-symlink.log, fileoffset: 0 > $RSYSLOG_DYNNAME.expected
-for i in `seq 2 $IMFILEINPUTFILES` ; do
+for i in $(seq 2 $IMFILEINPUTFILES) ; do
 	echo HEADER msgnum:00000000:, filename: ./$RSYSLOG_DYNNAME.input.${i}.log, fileoffset: 0 >> $RSYSLOG_DYNNAME.expected
 done
 sort < $RSYSLOG_DYNNAME.expected | cmp - ${RSYSLOG_OUT_LOG}.sorted

--- a/tests/improg-simul.sh
+++ b/tests/improg-simul.sh
@@ -38,12 +38,12 @@ done
 trap 'echo "SIGTERM Received" >> '$ERR';echo $0" SIGTERM Received" >&2;exit 0' 15
 if (( DELAY > 0 )); then $mysleep ${DELAY}; fi
 if [ ${ACK} == 1 ]; then
-	while [ "x$order" != "xSTART" ]; do 
+	while [ "$order" != "START" ]; do
 		read -r order
 		echo $order' Received' >> $ERR
 		echo $0' '$order' Received' >&2
 	done
-	while [ "x$order" != "xSTOP" ]; do
+	while [ "$order" != "STOP" ]; do
 		if (( NB > 0 )); then
 			echo ${MESSAGE}
 			echo "Message sent" >&2

--- a/tests/include-obj-text-vg.sh
+++ b/tests/include-obj-text-vg.sh
@@ -3,7 +3,7 @@
 . ${srcdir:=.}/diag.sh init
 generate_conf
 INCLFILE="${srcdir}/testsuites/include-std-omfile-action.conf"
-export CONF_SNIPPET=`cat $INCLFILE`
+export CONF_SNIPPET=$(cat $INCLFILE)
 printf "\nThis SNIPPET will be included via env var:\n$CONF_SNIPPET\n\nEND SNIPPET\n"
 add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/kafka-selftest.sh
+++ b/tests/kafka-selftest.sh
@@ -36,7 +36,7 @@ while [ $timecounter -lt $timeoutend ]; do
 		printf '**** wait-kafka-lines success, have %d lines ****\n\n' "$TESTMESSAGES"
 		break
 	else
-		if [ "x$timecounter" == "x$timeoutend" ]; then
+			if [ "$timecounter" == "$timeoutend" ]; then
 			echo wait-kafka-lines failed, expected $TESTMESSAGES got $count
 			error_exit 1
 		else

--- a/tests/killrsyslog.sh
+++ b/tests/killrsyslog.sh
@@ -2,15 +2,15 @@
 #check if rsyslog instance exists and, if so, kill it
 if [ -e "rsyslog.pid" ]
 then
-  echo rsyslog.pid exists, trying to shut down rsyslogd process `cat rsyslog.pid`.
-  kill -9 `cat rsyslog.pid`
+  echo rsyslog.pid exists, trying to shut down rsyslogd process "$(cat rsyslog.pid)".
+  kill -9 "$(cat rsyslog.pid)"
   sleep 1
   rm rsyslog.pid
 fi
 if [ -e "rsyslog2.pid" ]
 then
-  echo rsyslog2.pid exists, trying to shut down rsyslogd process `cat rsyslog2.pid`.
-  kill -9 `cat rsyslog2.pid`
+  echo rsyslog2.pid exists, trying to shut down rsyslogd process "$(cat rsyslog2.pid)".
+  kill -9 "$(cat rsyslog2.pid)"
   sleep 1
   rm rsyslog2.pid
 fi

--- a/tests/mmkubernetes-cache-expire.sh
+++ b/tests/mmkubernetes-cache-expire.sh
@@ -43,7 +43,7 @@ BGPROCESS=$!
 wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
 echo background mmkubernetes_test_server.py process id is $BGPROCESS
 
-if [ "x${USE_VALGRIND:-NO}" == "xYES" ] ; then
+if [ "${USE_VALGRIND:-NO}" == "YES" ] ; then
 	export EXTRA_VALGRIND_SUPPRESSIONS="--suppressions=$srcdir/mmkubernetes.supp"
 	startup_vg
 else
@@ -84,7 +84,7 @@ EOF
 wait_queueempty
 
 shutdown_when_empty
-if [ "x${USE_VALGRIND:-NO}" == "xYES" ] ; then
+if [ "${USE_VALGRIND:-NO}" == "YES" ] ; then
 	wait_shutdown_vg
 	check_exit_vg
 else

--- a/tests/mysql-actq-mt-withpause-extended.sh
+++ b/tests/mysql-actq-mt-withpause-extended.sh
@@ -31,7 +31,7 @@ do
    wait_queueempty 
    echo waiting for worker threads to timeout
    ./msleep 1000
-   let "strtnum = strtnum+5000"
+   (( strtnum += 5000 ))
 done
 
 

--- a/tests/omfile-addlf.sh
+++ b/tests/omfile-addlf.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 . ${srcdir:=.}/diag.sh init
 
 wait_for_nonempty_file() {

--- a/tests/omfile-read-only.sh
+++ b/tests/omfile-read-only.sh
@@ -30,7 +30,7 @@ wait_shutdown
 # the first message number and calculate based on it what must be
 # present in the output file.
 presort
-let firstnum=$((10#$($RS_HEADCMD -n1 $RSYSLOG_DYNNAME.presort)))
+firstnum=$((10#$($RS_HEADCMD -n1 $RSYSLOG_DYNNAME.presort)))
 echo "info: first message expected to be number $firstnum, using that value."
 seq_check $firstnum $((messages-1))
 exit_test

--- a/tests/omjournal-basic-template.sh
+++ b/tests/omjournal-basic-template.sh
@@ -15,7 +15,7 @@ action(type="omjournal" template="outfmt")
 '
 
 # we generate a cookie so that we can find our record in journal
-COOKIE=`date`
+COOKIE=$(date)
 echo "COOKIE: $COOKIE"
 startup
 tcpflood -m1 -M "\"<133>2011-03-01T11:22:12Z host tag msgh RsysLoG-TESTBENCH $COOKIE\""

--- a/tests/omkafka-dynatopic.sh
+++ b/tests/omkafka-dynatopic.sh
@@ -94,7 +94,7 @@ while [ $timecounter -lt $timeoutend ]; do
 		printf '**** wait-kafka-lines success, have %d lines ****\n\n' "$TESTMESSAGESFULL"
 		break
 	else
-		if [ "x$timecounter" == "x$timeoutend" ]; then
+			if [ "$timecounter" == "$timeoutend" ]; then
 			echo wait-kafka-lines failed, expected $TESTMESSAGESFULL got $count
 			shutdown_when_empty
 			wait_shutdown

--- a/tests/omkafka-statistics.sh
+++ b/tests/omkafka-statistics.sh
@@ -92,7 +92,7 @@ while [ $timecounter -lt $timeoutend ]; do
 		printf '**** wait-kafka-lines success, have %d lines ****\n\n' "$TESTMESSAGESFULL"
 		break
 	else
-		if [ "x$timecounter" == "x$timeoutend" ]; then
+			if [ "$timecounter" == "$timeoutend" ]; then
 			echo wait-kafka-lines failed, expected $TESTMESSAGESFULL got $count
 			shutdown_when_empty
 			wait_shutdown

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -92,7 +92,7 @@ while [ $timecounter -lt $timeoutend ]; do
 		printf '**** wait-kafka-lines success, have %d lines ****\n\n' "$TESTMESSAGESFULL"
 		break
 	else
-		if [ "x$timecounter" == "x$timeoutend" ]; then
+			if [ "$timecounter" == "$timeoutend" ]; then
 			echo wait-kafka-lines failed, expected $TESTMESSAGESFULL got $count
 			shutdown_when_empty
 			wait_shutdown

--- a/tests/omkafkadynakey.sh
+++ b/tests/omkafkadynakey.sh
@@ -112,7 +112,7 @@ while [ $timecounter -lt $timeoutend ]; do
 			error_exit 1
 	        fi
 	else
-		if [ "x$timecounter" == "x$timeoutend" ]; then
+		if [ "$timecounter" == "$timeoutend" ]; then
 			echo wait-kafka-lines failed, expected $TESTMESSAGESFULL got $count
 			shutdown_when_empty
 			wait_shutdown
@@ -151,4 +151,3 @@ kafka_check_broken_broker $RSYSLOG_DYNNAME.othermsg
 seq_check 1 $TESTMESSAGESFULL -d
 
 exit_test
-

--- a/tests/solaris/prep-libfastjson.sh
+++ b/tests/solaris/prep-libfastjson.sh
@@ -1,4 +1,4 @@
-# /bin/bash
+#!/bin/bash
 set -o xtrace
 PWD_HOME=$PWD
 mkdir local_env

--- a/tests/solaris/prep-librelp.sh
+++ b/tests/solaris/prep-librelp.sh
@@ -1,4 +1,4 @@
-# /bin/bash
+#!/bin/bash
 set -o xtrace
 PWD_HOME=$PWD
 mkdir local_env

--- a/tests/testsuites/omprog-defaults-bin.sh
+++ b/tests/testsuites/omprog-defaults-bin.sh
@@ -2,7 +2,7 @@
 
 outfile=$RSYSLOG_OUT_LOG
 
-echo "Starting with parameters: $@" >> $outfile
+echo "Starting with parameters: $*" >> "$outfile"
 while [ $# -gt 0 ]; do
     echo Next parameter is \""$1"\"
     shift

--- a/tests/testsuites/omprog-feedback-bin.sh
+++ b/tests/testsuites/omprog-feedback-bin.sh
@@ -14,9 +14,9 @@ while [[ -n "$line" ]]; do
     echo "=> $message" >> $outfile
 
     if [[ $message == *04* || $message == *07* ]]; then
-        if [[ $retry_count < 2 ]]; then
+        if [ "$retry_count" -lt 2 ]; then
             status="Error: could not process log message"
-            let "retry_count++"
+            (( retry_count++ ))
         else
             status="OK"
             retry_count=0

--- a/tests/testsuites/omprog-feedback-mt-bin.sh
+++ b/tests/testsuites/omprog-feedback-mt-bin.sh
@@ -11,7 +11,7 @@ read line
 while [[ -n "$line" ]]; do
     message=${line//$'\n'}
 
-    if [[ $((RANDOM % 100)) < $1 ]]; then
+    if [ "$((RANDOM % 100))" -lt "$1" ]; then
         status="Error: could not process log message"
         retried=true
     else

--- a/tests/testsuites/omprog-transactions-bin.sh
+++ b/tests/testsuites/omprog-transactions-bin.sh
@@ -40,13 +40,13 @@ while [[ -n "$line" ]]; do
     # messages, forcing them to be retried twice. If --failed_commits is
     # specified, the error is returned when committing the transaction.
     if [[ "$1" != "" && ($message == *04* || $message == *07*) ]]; then
-        if [[ $retry_count < 2 ]]; then
+        if [ "$retry_count" -lt 2 ]; then
             if [[ "$1" == "--failed_commits" ]]; then
                 fail_on_commit=true
             else
                 status="Error: could not process log message"
             fi
-            let "retry_count++"
+            (( retry_count++ ))
         else
             retry_count=0
         fi

--- a/tests/testsuites/x.509/openssl-cmds.sh
+++ b/tests/testsuites/x.509/openssl-cmds.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # CREATE KEY
 #	openssl genpkey -algorithm RSA -out client-revoked-key.pem
 # CREATE REQEST

--- a/tests/travis/docker-ubuntu-devel.sh
+++ b/tests/travis/docker-ubuntu-devel.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 set -e
-TRAVIS_ROOT=`pwd`
+TRAVIS_ROOT=$(pwd)
 docker run -v "$TRAVIS_ROOT":/home/travis rsyslog/rsyslog_dev_full:ubuntu_devel bash -c "cd /home/travis; ./tests/travis/run-ubuntu-devel.sh"

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -26,7 +26,7 @@ if [ "$DISTRIB_CODENAME" == "xenial" ]; then
 fi
 sudo apt-get install build-essential automake pkg-config libtool autoconf autotools-dev gdb valgrind libdbi-dev libsnmp-dev libmysqlclient-dev postgresql-client libglib2.0-dev libtokyocabinet-dev zlib1g-dev uuid-dev libgcrypt11-dev bison flex libcurl4-openssl-dev python-docutils wget libkrb5-dev libnet1-dev
 
-if [ "x$GROK" == "xYES" ]; then sudo apt-get install -qq libgrok1 libgrok-dev ; fi
+if [ "$GROK" == "YES" ]; then sudo apt-get install -qq libgrok1 libgrok-dev ; fi
 sudo apt-get install -qq --force-yes libestr-dev librelp-dev libfastjson-dev liblogging-stdlog-dev \
 	liblognorm-dev \
 	libcurl4-openssl-dev
@@ -35,7 +35,7 @@ sudo apt-get install -qq python-docutils
 sudo apt-get install -qq libmaxminddb-dev libmongoc-dev libbson-dev
 
 # As travis has no xenial images, we always need to install librdkafka from source
-if [ "x$KAFKA" == "xYES" ]; then 
+if [ "$KAFKA" == "YES" ]; then
 	sudo apt-get install -qq liblz4-dev 
 	# For kafka testbench, "kcat" package is needed!
 	git clone https://github.com/edenhill/librdkafka > /dev/null
@@ -43,13 +43,13 @@ if [ "x$KAFKA" == "xYES" ]; then
 	rm -rf librdkafka # get rid of source, e.g. for line length check
 fi
 
-if [ "x$IMHTTP" == "xYES" ]; then
+if [ "$IMHTTP" == "YES" ]; then
 	git clone https://github.com/civetweb/civetweb.git > /dev/null
 	(unset CFLAGS; cd civetweb; make build ; sudo make install-headers PREFIX=/usr ; sudo make install-slib PREFIX=/usr )
 	rm -rf civetweb # get rid of source, e.g. for line length check
 fi
 
-if [ "x$GCC" == "xNEWEST" ]; then
+if [ "$GCC" == "NEWEST" ]; then
 	# currently the best repo we can find...
 	sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 	sudo apt-get update -y -qq
@@ -59,8 +59,8 @@ fi
 
 sudo apt-get install -qq libhiredis-dev # somehow we now need this
 
-if [ "x$ESTEST" == "xYES" ]; then sudo apt-get install -qq elasticsearch ; fi
-if [ "x$IMDOKER" == "xYES" ]; then
+if [ "$ESTEST" == "YES" ]; then sudo apt-get install -qq elasticsearch ; fi
+if [ "$IMDOKER" == "YES" ]; then
 	export IMDOCKER_OPT="--enable-imdocker --enable-imdocker-tests";
 fi
 
@@ -68,8 +68,8 @@ if [ "$CC" == "clang" ]; then export NO_VALGRIND="--without-valgrind-testbench";
 if [ "$CC" == "clang" ]; then sudo apt-get install -qq $CLANG_PKG ; fi
 
 
-if [ "x$KAFKA" == "xYES" ]; then export ENABLE_KAFKA="--enable-omkafka --enable-imkafka --enable-kafka-tests=no" ; fi
-if [ "x$DEBUGLESS" == "xYES" ]; then export ENABLE_DEBUGLESS="--enable-debugless" ; fi
+if [ "$KAFKA" == "YES" ]; then export ENABLE_KAFKA="--enable-omkafka --enable-imkafka --enable-kafka-tests=no" ; fi
+if [ "$DEBUGLESS" == "YES" ]; then export ENABLE_DEBUGLESS="--enable-debugless" ; fi
 
 #
 # uncomment the following if AND ONLY If you need yet-unreleased packages

--- a/tests/travis/run-alpine.sh
+++ b/tests/travis/run-alpine.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 set -e
 autoreconf -fvi
 ./configure --prefix=/usr/local $RSYSLOG_CONFIGURE_OPTIONS

--- a/tests/travis/run-cron.sh
+++ b/tests/travis/run-cron.sh
@@ -12,26 +12,27 @@ fi
 
 # download coverity tool
 mkdir coverity
-cd coverity
-wget --no-verbose http://build.rsyslog.com/CI/cov-analysis.tar.gz
-if [ $? -ne 0 ]; then
-	echo Download Coverity analysis tool failed!
-	exit 1
-fi
-tar xzf cov*.tar.gz
-rm -f cov*.tar.gz
-export PATH="coverity/$(ls -d cov*)/bin:$PATH"
-cd ..
+(
+	cd coverity
+	if ! wget --no-verbose http://build.rsyslog.com/CI/cov-analysis.tar.gz; then
+		echo Download Coverity analysis tool failed!
+		exit 1
+	fi
+	tar xzf cov*.tar.gz
+	rm -f cov*.tar.gz
+) || exit 1
+export PATH="coverity/$(cd coverity && ls -d cov*)/bin:$PATH"
 # Coverity scan tool installed
 
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
-cd libksi
-autoreconf -fvi
-./configure --prefix=/usr
-make -j
-sudo make install
-cd ..
+(
+	cd libksi
+	autoreconf -fvi
+	./configure --prefix=/usr
+	make -j
+	sudo make install
+)
 
 # prep rsyslog for submission
 autoreconf -vfi

--- a/tests/travis/run-osx.sh
+++ b/tests/travis/run-osx.sh
@@ -42,7 +42,7 @@ export CONFIG_FLAGS="--prefix=/opt/rsyslog --enable-silent-rules --enable-testbe
 export USE_AUTO_DEBUG="off" # set to "on" to enable this for travis
 make -j
 
-if [ "x$CHECK" == "xYES" ]
+if [ "$CHECK" == "YES" ]
 then
     set +e  # begin testbench, here we do not want to abort
     make check

--- a/tests/travis/run.sh
+++ b/tests/travis/run.sh
@@ -42,14 +42,14 @@ set -e
 if [ "$CC" == "clang" ] && [ "$DISTRIB_CODENAME" == "trusty" ]; then SCAN_BUILD="scan-build-5.0"; CC=clang-5.0; else SCAN_BUILD="scan-build"; fi
 
 set +e
-ls -l *.tar.gz
-rm -f *.tar.gz # safety check: we must not have tarballs at this stage
-if [ "x$BUILD_FROM_TARBALL" == "xYES" ]; then
+ls -l ./*.tar.gz
+rm -f ./*.tar.gz # safety check: we must not have tarballs at this stage
+if [ "$BUILD_FROM_TARBALL" == "YES" ]; then
 	autoreconf -fvi
 	./configure
 	make dist
-	ls -l *.tar.gz
-	mv *.tar.gz rsyslog.tar.gz
+	ls -l ./*.tar.gz
+	mv ./*.tar.gz rsyslog.tar.gz
 	mkdir unpack
 	cd unpack
 	tar xzf ../rsyslog.tar.gz
@@ -117,9 +117,9 @@ fi
 pwd
 set -e
 autoreconf --force --verbose --install
-if [ "x$GROK" == "xYES" ]; then export GROK="--enable-mmgrok"; fi
-if [ "x$IMHTTP" == "xYES" ]; then export IMHTTP="--enable-imhttp"; fi
-if [ "x$ESTEST" == "xYES" ]; then export ES_TEST_CONFIGURE_OPT="--enable-elasticsearch-tests=minimal" ; fi
+if [ "$GROK" == "YES" ]; then export GROK="--enable-mmgrok"; fi
+if [ "$IMHTTP" == "YES" ]; then export IMHTTP="--enable-imhttp"; fi
+if [ "$ESTEST" == "YES" ]; then export ES_TEST_CONFIGURE_OPT="--enable-elasticsearch-tests=minimal" ; fi
 # at this point, the environment should be setup for ./configure
 if [ "$CC" == "clang" ] && [ "$DISTRIB_CODENAME" == "trusty" ]; then export CC="clang-3.6"; fi
 $CC -v
@@ -159,7 +159,7 @@ set +xv
 export USE_AUTO_DEBUG="off" # set to "on" to enable this for travis
 make -j
 
-if [ "x$CHECK" == "xYES" ]
+if [ "$CHECK" == "YES" ]
 then
     set +e  # begin testbench, here we do not want to abort
     devtools/prep-mysql-db.sh  # prepare mysql for testbench
@@ -179,5 +179,5 @@ then
     #make distcheck
 fi
 
-if [ "x$STAT_AN" == "xYES" ] ; then make clean; export CFLAGS="-O2"; ./configure $CONFIG_FLAGS ; fi
-if [ "x$STAT_AN" == "xYES" ] ; then $SCAN_BUILD --use-cc $CC --status-bugs make -j ; fi
+if [ "$STAT_AN" == "YES" ] ; then make clean; export CFLAGS="-O2"; ./configure $CONFIG_FLAGS ; fi
+if [ "$STAT_AN" == "YES" ] ; then $SCAN_BUILD --use-cc $CC --status-bugs make -j ; fi

--- a/tests/uxsock_multiple_netns.sh
+++ b/tests/uxsock_multiple_netns.sh
@@ -104,8 +104,8 @@ startup
 injectmsg 0 10000
 wait_queueempty
 echo resetting uxsockrcvr
-for pid in ${BGPROCESS[@]}; do
-    kill -HUP $pid
+for pid in "${BGPROCESS[@]}"; do
+    kill -HUP "$pid"
 done
 injectmsg 10000 10000
 shutdown_when_empty # shut down rsyslogd when done processing messages
@@ -114,9 +114,9 @@ wait_shutdown
 # wait for the cp process to finish, do pipe-specific cleanup
 echo shutting down uxsockrcvr...
 # TODO: we should do this more reliable in the long run! (message counter? timeout?)
-for pid in ${BGPROCESS[@]}; do
-    kill $pid
-    wait $pid
+for pid in "${BGPROCESS[@]}"; do
+    kill "$pid"
+    wait "$pid"
 done
 echo background processes have terminated, continue test...
 

--- a/tools/coreanalysis.sh
+++ b/tools/coreanalysis.sh
@@ -12,7 +12,7 @@ if [ "$DIRECTORY" == "" ]; then
 	DIRECTORY="/"
 fi
 
-COREFILES=`ls $DIRECTORY/core* 2> /dev/null`
+COREFILES=$(ls $DIRECTORY/core* 2> /dev/null)
 # &> /dev/null`
 
 select COREFILE in $COREFILES


### PR DESCRIPTION
## Summary

This PR cleans up a focused set of ShellCheck findings reported locally and
by CodeFactor.

The changes are intentionally mechanical:

- add missing script shebangs where ShellCheck could not infer a shell
- mark sourced packaging config fragments as shell fragments
- replace ash-incompatible `source` and `==` usage in Alpine helpers
- clean up selected CodeFactor-reported ShellCheck findings in `diag.sh`,
  test helpers, packaging scripts, and container helper scripts
- fix focused buckets for SC2035, SC2006, SC2028, SC2268, SC2319, and SC2145
- fix remaining small one-offs for SC2003, SC2103, SC2219, SC1001, SC2166,
  SC2062, SC2216, and SC2005
- leave the broad SC2181 cleanup for a separate pass because many cases need
  command-specific review

## Validation

- `shellcheck --norc -i SC2319,SC2006,SC2268,SC2028,SC2035,SC2103,SC2219,SC1001,SC2216,SC1113,SC2003,SC1061,SC2005,SC2166,SC2145,SC2062 -f gcc <CodeFactor shell files>`
- `git diff --name-only --diff-filter=ACMRT upstream/main -- '*.sh' platform/freebsd/rsyslogd packaging/docker/appliance/alpine/starter.sh | xargs shellcheck -S error -f gcc`
- `git diff --name-only --diff-filter=ACMRT upstream/main -- '*.sh' platform/freebsd/rsyslogd packaging/docker/appliance/alpine/starter.sh | xargs bash -n`
- `git diff --check`

Not fully local container-validated in this amend; CI is expected to provide the
full matrix signal.
