### PR TITLE
msg: guard MSG replacement offsets

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2651,6 +2651,18 @@ rsRetVal MsgReplaceMSG(smsg_t *pThis, const uchar *pszMSG, int lenMSG) {
     ISOBJ_TYPE_assert(pThis, msg);
     assert(pszMSG != NULL);
 
+    if (pThis->pszRawMsg == NULL) {
+        pThis->pszRawMsg = pThis->szRawMsg;
+        pThis->szRawMsg[0] = '\0';
+    }
+
+    if (pThis->offMSG < 0 || pThis->offMSG > pThis->iLenRawMsg) {
+        pThis->offMSG = pThis->iLenRawMsg;
+        pThis->iLenMSG = 0;
+    } else if (pThis->iLenMSG < 0 || pThis->iLenMSG > pThis->iLenRawMsg - pThis->offMSG) {
+        pThis->iLenMSG = pThis->iLenRawMsg - pThis->offMSG;
+    }
+
     lenNew = pThis->iLenRawMsg + lenMSG - pThis->iLenMSG;
     if (lenMSG > pThis->iLenMSG && lenNew >= CONF_RAWMSG_BUFSIZE) {
         /*  we have lost our "bet" and need to alloc a new buffer ;) */

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1356,6 +1356,7 @@ TESTS_PMNORMALIZE_VALGRIND = \
 TESTS_MMNORMALIZE = \
         msgvar-concurrency-array.sh \
         msgvar-concurrency-array-event.tags.sh \
+        mmexternal-mmnormalize-json-tree.sh \
         mmnormalize_rule_from_string.sh \
         mmnormalize_rule_from_array.sh \
         mmnormalize_parsesuccess.sh

--- a/tests/mmexternal-mmnormalize-json-tree.sh
+++ b/tests/mmexternal-mmnormalize-json-tree.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# added 2026-05-22 by Codex, released under ASL 2.0
+# Regression coverage for issue #689: mmexternal must be able to merge a
+# returned $! tree after mmnormalize has already populated message variables.
+# The oracle is the configured omfile output after synchronized shutdown, so
+# the test verifies the final rsyslog message state rather than plugin stderr.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+module(load="../plugins/mmexternal/.libs/mmexternal")
+
+template(name="outfmt" type="string" string="%$!all-json%\n")
+
+action(type="mmnormalize" rule=["rule=:%text:rest%"] useRawMsg="off")
+action(type="mmexternal" interface.input="fulljson"
+	binary="'$PYTHON' '${srcdir}'/testsuites/mmexternal-SegFault-mm-python.py")
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+
+startup
+injectmsg literal "<13>Mar 10 01:00:00 host tag:test-message"
+shutdown_when_empty
+wait_shutdown
+
+content_check '"text": "test-message"'
+content_check '"sometag": "somevalue"'
+
+exit_test


### PR DESCRIPTION
## Summary

This PR handles the parser/message-modification bin item that had a concrete localized fix.

- guards `MsgReplaceMSG()` against stale or invalid cached `offMSG`/`iLenMSG` values before replacing the message body
- treats an out-of-range cached message offset as an empty message body at the end of the raw message
- adds regression coverage for the old mmexternal/mmnormalize `$!` merge case using configured omfile output as the oracle

Closes https://github.com/rsyslog/rsyslog/issues/6317
Closes https://github.com/rsyslog/rsyslog/issues/689

Related triage notes from this bin:

- https://github.com/rsyslog/rsyslog/issues/1789 was already handled by the current `pmrfc3164` headerless parsing options and has been closed with a reasoning comment.
- https://github.com/rsyslog/rsyslog/issues/1891 is covered by pending PR https://github.com/rsyslog/rsyslog/pull/6991, so it is intentionally left open here.
- https://github.com/rsyslog/rsyslog/issues/260, https://github.com/rsyslog/rsyslog/issues/5206, https://github.com/rsyslog/rsyslog/issues/4310, https://github.com/rsyslog/rsyslog/issues/3847, and https://github.com/rsyslog/rsyslog/issues/3850 remain broader design or feature decisions and are intentionally not changed in this PR.

## Validation

Host-side:

- `bash devtools/format-code.sh`
- `git diff --check`
- `cubic review --base main --prompt 'Review only this patch. Focus on correctness, memory safety, test validity, and whether findings are caused by this diff. Ignore unrelated pre-existing issues.'` -> no issues found
- `./autogen.sh --enable-testbench --enable-mmnormalize`
- `make -j80 check TESTS=`
- `./tests/mmexternal-mmnormalize-json-tree.sh`
- `./tests/mmexternal-SegFault.sh`
- `./tests/mmexternal-SegFault-empty-jroot-vg.sh`

Container-side:

- clang static analyzer, Ubuntu 26.04 dev container, `CI_MAKE_OPT=-j20`: no bugs found, `real 188.65`
- Ubuntu 26.04 full `devtools/run-ci.sh` check, `CI_MAKE_OPT=-j80`, `CI_MAKE_CHECK_OPT=-j80`: `TOTAL: 1269`, `PASS: 1176`, `SKIP: 93`, `FAIL: 0`, `ERROR: 0`, `real 238.64`
- `clang21-ndebug` compile lane, Ubuntu 26.04 dev container, `make -j80`: passed
- `gcc15-gnu23-debug` compile lane, Ubuntu 26.04 dev container, `make -j80`: passed
- Ubuntu 26.04 ASAN/UBSAN/nullability/unsigned-overflow sanitizer check, `CI_MAKE_OPT=-j80`, `CI_MAKE_CHECK_OPT=-j80`: `TOTAL: 1076`, `PASS: 1000`, `SKIP: 76`, `FAIL: 0`, `ERROR: 0`, `real 256.74`
- Ubuntu 26.04 TSAN check, `CI_MAKE_OPT=-j80`, `CI_MAKE_CHECK_OPT=-j10`: `TOTAL: 1018`, `PASS: 943`, `SKIP: 75`, `FAIL: 0`, `ERROR: 0`, `real 408.79`

Notes:

- The compile lanes require the same CI-style `chmod -R go+rw .` pre-step when `RSYSLOG_CONTAINER_UID=''` is used on this WSL mount; otherwise the container user cannot rewrite generated autotools files.
- The old mmexternal/mmnormalize regression is tested through the final configured omfile output, not rsyslogd stdout/stderr.
