### PR TITLE
config: warn for unmatched include globs

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -5731,7 +5731,7 @@ int ATTR_NONNULL() cnfDoInclude(const char *const name, const int optional) {
     const char *finalName;
     int i;
     int result;
-    glob_t cfgFiles;
+    glob_t cfgFiles = {0};
     int ret = 0;
     struct stat fileInfo;
     struct stat linkInfo;
@@ -5753,13 +5753,15 @@ int ATTR_NONNULL() cnfDoInclude(const char *const name, const int optional) {
 /* Use GLOB_MARK to append a trailing slash for directories. */
 /* Use GLOB_NOMAGIC to detect wildcards that match nothing. */
 #ifdef HAVE_GLOB_NOMAGIC
-    /* Silently ignore wildcards that match nothing */
     result = glob(finalName, GLOB_MARK | GLOB_NOMAGIC, NULL, &cfgFiles);
     if (result == GLOB_NOMATCH) {
 #else
     result = glob(finalName, GLOB_MARK, NULL, &cfgFiles);
     if (result == GLOB_NOMATCH && containsGlobWildcard((char *)finalName)) {
 #endif /* HAVE_GLOB_NOMAGIC */
+        if (optional == 0) {
+            parser_warnmsg("IncludeConfig pattern '%s' did not match any files", finalName);
+        }
         goto done;
     }
 

--- a/tests/incltest_dir_empty_wildcard.sh
+++ b/tests/incltest_dir_empty_wildcard.sh
@@ -1,13 +1,19 @@
 #!/bin/bash
-# This test checks if an empty includeConfig directory causes problems. It
-# should not, as this is a valid situation that by default exists on many
-# distros.
+# Verify that a non-optional $IncludeConfig wildcard that matches no files logs
+# a parser warning but does not prevent rsyslog from starting and processing
+# messages. The warning is checked during config validation because include
+# parsing happens before normal daemon action output is fully configured.
 . ${srcdir:=.}/diag.sh init
 generate_conf
 add_conf "\$IncludeConfig ${srcdir}/testsuites/incltest.d/*.conf-not-there
 "
 add_conf '$template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")'
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+rsyslogd_config_check
+unset RS_REDIR
+content_check "IncludeConfig pattern '${srcdir}/testsuites/incltest.d/*.conf-not-there' did not match any files" \
+	"${RSYSLOG_DYNNAME}.rsyslog.log"
 startup
 # 100 messages are enough - the question is if the include is read ;)
 injectmsg 0 100


### PR DESCRIPTION
## Summary
- warn when a non-optional IncludeConfig wildcard matches no files
- keep unmatched wildcard includes non-fatal for existing distro-style empty include directories
- extend the empty wildcard include regression test to assert the warning and continued message processing

Closes https://github.com/rsyslog/rsyslog/issues/4415

## Validation
- bash devtools/format-code.sh --git-changed
- git diff --check
- make -j$(nproc)
- ./tests/incltest_dir_empty_wildcard.sh
- ./tests/yaml-include.sh
- make -j$(nproc) check TESTS=""
- cd tests && srcdir=. ./validation-run.sh
- clang static analyzer in rsyslog/rsyslog_dev_base_ubuntu:26.04: scan-build: No bugs found
- Ubuntu 26.04 dev-container full check: TOTAL 1267, PASS 1174, SKIP 93, FAIL 0, ERROR 0, real 238.77s