### PR TITLE
imfile: add line-number metadata and soften empty checks

### DIFF
--- a/doc/source/reference/parameters/imfile-addmetadata.rst
+++ b/doc/source/reference/parameters/imfile-addmetadata.rst
@@ -30,6 +30,15 @@ Used to control whether file metadata is added to the message object. By
 default it is enabled for ``input()`` statements that contain wildcards and
 disabled otherwise. This parameter overrides the default behavior.
 
+When metadata is enabled, imfile adds these fields below ``$!metadata``:
+
+* ``filename``: the monitored file name, or the symlink name when the input
+  matched a symlink.
+* ``fileoffset``: the byte offset at which the submitted record starts.
+* ``line_number``: the 1-based line or record number for the monitored file.
+  The value is persisted in the imfile state file and continues across
+  restarts when state is available.
+
 Input usage
 -----------
 .. _param-imfile-input-addmetadata:

--- a/plugins/imfile/imfile.c
+++ b/plugins/imfile/imfile.c
@@ -219,6 +219,7 @@ struct act_obj_s {
     int fd; /* fd to file in order to obtain file_id (needs to be preserved across move) */
     strm_t *pStrm; /* its stream (NULL if not assigned) */
     int nRecords; /**< How many records did we process before persisting the stream? */
+    uint64_t lineNum; /* 1-based line/record number used for metadata */
     ratelimit_t *ratelimiter;
     multi_submit_t multiSub;
     int is_symlink;
@@ -1567,15 +1568,18 @@ finalize_it:
  * not freed - this must be done by the caller.
  */
 #define MAX_OFFSET_REPRESENTATION_NUM_BYTES 20
+#define MAX_LINENUM_REPRESENTATION_NUM_BYTES 20
 static rsRetVal ATTR_NONNULL(1, 2)
-    enqLine(act_obj_t *const act, cstr_t *const __restrict__ cstrLine, const int64 strtOffs) {
+    enqLine(act_obj_t *const act, cstr_t *const __restrict__ cstrLine, const int64 strtOffs, const uint64_t lineNum) {
     DEFiRet;
     const instanceConf_t *const inst = act->edge->instarr[0];  // TODO: same file, multiple instances?
     smsg_t *pMsg;
     uchar file_offset[MAX_OFFSET_REPRESENTATION_NUM_BYTES + 1];
-    const uchar *metadata_names[2] = {(uchar *)"filename", (uchar *)"fileoffset"};
-    const uchar *metadata_values[2];
+    uchar line_number[MAX_LINENUM_REPRESENTATION_NUM_BYTES + 1];
+    const uchar *metadata_names[3] = {(uchar *)"filename", (uchar *)"fileoffset", (uchar *)"line_number"};
+    const uchar *metadata_values[3];
     const size_t msgLen = cstrLen(cstrLine);
+    int lenBuf;
 
     if (msgLen == 0) {
         /* we do not process empty lines */
@@ -1608,9 +1612,21 @@ static rsRetVal ATTR_NONNULL(1, 2)
         } else {
             metadata_values[0] = (const uchar *)act->name;
         }
-        snprintf((char *)file_offset, MAX_OFFSET_REPRESENTATION_NUM_BYTES + 1, "%lld", strtOffs);
+        lenBuf = snprintf((char *)file_offset, sizeof(file_offset), "%lld", strtOffs);
+        if (lenBuf < 0) {
+            msgDestruct(&pMsg);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        file_offset[MAX_OFFSET_REPRESENTATION_NUM_BYTES] = '\0';
         metadata_values[1] = file_offset;
-        msgAddMultiMetadata(pMsg, metadata_names, metadata_values, 2);
+        lenBuf = snprintf((char *)line_number, sizeof(line_number), "%llu", (unsigned long long)lineNum);
+        if (lenBuf < 0) {
+            msgDestruct(&pMsg);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        line_number[MAX_LINENUM_REPRESENTATION_NUM_BYTES] = '\0';
+        metadata_values[2] = line_number;
+        msgAddMultiMetadata(pMsg, metadata_names, metadata_values, 3);
     }
 
     if (inst->perMinuteRateLimits.maxBytesPerMinute || inst->perMinuteRateLimits.maxLinesPerMinute) {
@@ -1706,6 +1722,15 @@ static rsRetVal ATTR_NONNULL(1) openFileWithStateFile(act_obj_t *const act) {
                       saved_gen, act->inode_gen);
             ABORT_FINALIZE(RS_RET_ERR);
         }
+    }
+
+    fjson_object_object_get_ex(json, "line_number", &jval);
+    if (jval != NULL) {
+        if (!fjson_object_is_type(jval, fjson_type_int)) {
+            LogError(0, RS_RET_ERR, "imfile: invalid line_number in state file for '%s'", act->name);
+            ABORT_FINALIZE(RS_RET_ERR);
+        }
+        act->lineNum = (uint64_t)fjson_object_get_int64(jval);
     }
 
     fjson_object_object_get_ex(json, "prev_line_segment", &jval);
@@ -1863,6 +1888,7 @@ static rsRetVal ATTR_NONNULL() pollFileReal(act_obj_t *act, cstr_t **pCStr) {
             startOffs = act->pStrm->iCurrOffs; /* disable check */
         }
         runModConf->bHadFileData = 1; /* this is just a flag, so set it and forget it */
+        ++act->lineNum;
         /* account bytes and lines processed for this file */
         if (act->pStrm != NULL) {
             int64_t endOffs = act->pStrm->iCurrOffs;
@@ -1871,7 +1897,7 @@ static rsRetVal ATTR_NONNULL() pollFileReal(act_obj_t *act, cstr_t **pCStr) {
             }
             STATSCOUNTER_INC(act->linesProcessed, act->mutLinesProcessed);
         }
-        CHKiRet(enqLine(act, *pCStr, strtOffs)); /* process line */
+        CHKiRet(enqLine(act, *pCStr, strtOffs, act->lineNum)); /* process line */
         rsCStrDestruct(pCStr); /* discard string (must be done by us!) */
         if (inst->iPersistStateInterval > 0 && ++act->nRecords >= inst->iPersistStateInterval) {
             persistStrmState(act);
@@ -2409,10 +2435,9 @@ BEGINcheckCnf
         std_checkRuleset(pModConf, inst);
     }
     if (pModConf->root == NULL) {
-        LogError(0, RS_RET_NO_LISTNERS,
-                 "imfile: no files configured to be monitored - "
-                 "no input will be gathered");
-        iRet = RS_RET_NO_LISTNERS;
+        LogMsg(0, NO_ERRCODE, LOG_WARNING,
+               "imfile: no files configured to be monitored - "
+               "no input will be gathered");
     }
 ENDcheckCnf
 
@@ -3060,6 +3085,8 @@ static rsRetVal ATTR_NONNULL() persistStrmState(act_obj_t *const act) {
     json_object_object_add(json, "strt_offs", jval);
     jval = json_object_new_int64((int64_t)act->inode_gen);
     json_object_object_add(json, "inode_gen", jval);
+    jval = json_object_new_int64((int64_t)act->lineNum);
+    json_object_object_add(json, "line_number", jval);
 
     const uchar *const prevLineSegment = strmGetPrevLineSegment(act->pStrm);
     if (prevLineSegment != NULL) {

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1734,6 +1734,8 @@ TESTS_IMFILE = \
 	imfile-statefile-no-file_id.sh \
 	imfile-statefile-no-file_id-TO-file_id.sh \
 	imfile-statefile-directory.sh \
+	imfile-metadata-line-number.sh \
+	imfile-no-monitor-config-check.sh \
 	imfile-bad-state-file.sh \
 	imfile-statefile-delete.sh \
 	imfile-statefile-no-delete.sh \

--- a/tests/imfile-metadata-line-number.sh
+++ b/tests/imfile-metadata-line-number.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# added 2026-05-22 by Codex, released under ASL 2.0
+# Regression coverage for issue #728: imfile metadata includes a persisted,
+# 1-based line_number value. The oracle uses exact omfile output across two
+# daemon starts to prove the value continues from the state file.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+global(workDirectory="'${RSYSLOG_DYNNAME}'.spool")
+module(load="../plugins/imfile/.libs/imfile")
+
+input(type="imfile" tag="file:" file="./'$RSYSLOG_DYNNAME'.input"
+      addMetadata="on" persistStateAfterSubmission="on")
+
+template(name="outfmt" type="list") {
+	property(name="msg" field.number="2" field.delimiter="58")
+	constant(value=" line:")
+	property(name="$!metadata!line_number")
+	constant(value="\n")
+}
+
+if $msg contains "msgnum:" then
+	action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
+'
+
+./inputfilegen -m2 > "$RSYSLOG_DYNNAME.input"
+startup
+wait_file_lines "$RSYSLOG_OUT_LOG" 2
+shutdown_when_empty
+wait_shutdown
+
+./inputfilegen -m2 -i2 >> "$RSYSLOG_DYNNAME.input"
+startup
+wait_file_lines "$RSYSLOG_OUT_LOG" 4
+shutdown_when_empty
+wait_shutdown
+
+printf '00000000 line:1\n00000001 line:2\n00000002 line:3\n00000003 line:4\n' > "$RSYSLOG_DYNNAME.expected"
+cmp_exact_file "$RSYSLOG_DYNNAME.expected" "$RSYSLOG_OUT_LOG"
+
+exit_test

--- a/tests/imfile-no-monitor-config-check.sh
+++ b/tests/imfile-no-monitor-config-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+# added 2026-05-22 by Codex, released under ASL 2.0
+# Regression coverage for issue #2752: loading imfile without file monitors is
+# a warning during config validation, not a hard -N1 failure. The oracle is the
+# successful config-check exit code plus the retained warning text.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/imfile/.libs/imfile")
+'
+
+export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
+rsyslogd_config_check
+unset RS_REDIR
+
+content_check "imfile: no files configured to be monitored - no input will be gathered" \
+	"${RSYSLOG_DYNNAME}.rsyslog.log"
+
+exit_test


### PR DESCRIPTION
## Summary
- persist and expose imfile metadata line_number with addMetadata=on
- keep imfile -N1 config validation successful when no monitors are configured, while retaining a warning
- add focused testbench coverage for both issue paths

Closes https://github.com/rsyslog/rsyslog/issues/728
Closes https://github.com/rsyslog/rsyslog/issues/2752

## Validation
- ./tests/imfile-no-monitor-config-check.sh
- ./tests/imfile-metadata-line-number.sh
- ./tests/imfile-statefile-no-file_id.sh
- make -j28 check TESTS=""
- shellcheck -S warning tests/imfile-metadata-line-number.sh tests/imfile-no-monitor-config-check.sh
- make -j20 distcheck TEST_RUN_TYPE=MOCK-OK
- container clang analyzer: scan-build No bugs found
- Ubuntu 26.04 dev-container CI: 1271 total, 1178 pass, 93 skip, 0 fail/error