### PR TITLE
mmexternal: support one-way helpers and response timeouts

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -834,7 +834,9 @@ EXTRA_DIST = \
     source/reference/parameters/mmexternal-binary.rst \
     source/reference/parameters/mmexternal-forcesingleinstance.rst \
     source/reference/parameters/mmexternal-interface-input.rst \
+    source/reference/parameters/mmexternal-interface-output.rst \
     source/reference/parameters/mmexternal-output.rst \
+    source/reference/parameters/mmexternal-responsetimeout.rst \
     source/reference/parameters/mmfields-jsonroot.rst \
     source/reference/parameters/mmfields-separator.rst \
     source/reference/parameters/mmjsonparse-allow_trailing.rst \

--- a/doc/source/configuration/modules/mmexternal.rst
+++ b/doc/source/configuration/modules/mmexternal.rst
@@ -42,8 +42,16 @@ Action Parameters
      - .. include:: ../../reference/parameters/mmexternal-interface-input.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-mmexternal-interface-output`
+     - .. include:: ../../reference/parameters/mmexternal-interface-output.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-mmexternal-output`
      - .. include:: ../../reference/parameters/mmexternal-output.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-mmexternal-responsetimeout`
+     - .. include:: ../../reference/parameters/mmexternal-responsetimeout.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
    * - :ref:`param-mmexternal-forcesingleinstance`
@@ -56,7 +64,9 @@ Action Parameters
 
    ../../reference/parameters/mmexternal-binary
    ../../reference/parameters/mmexternal-interface-input
+   ../../reference/parameters/mmexternal-interface-output
    ../../reference/parameters/mmexternal-output
+   ../../reference/parameters/mmexternal-responsetimeout
    ../../reference/parameters/mmexternal-forcesingleinstance
 
 
@@ -73,4 +83,3 @@ default search path.
    module (load="mmexternal") # needs to be done only once inside the config
 
    action(type="mmexternal" binary="/path/to/mmexternal.py")
-

--- a/doc/source/reference/parameters/mmexternal-interface-output.rst
+++ b/doc/source/reference/parameters/mmexternal-interface-output.rst
@@ -1,0 +1,59 @@
+.. _param-mmexternal-interface-output:
+.. _mmexternal.parameter.input.interface-output:
+
+interface.output
+================
+
+.. index::
+   single: mmexternal; interface.output
+   single: interface.output
+
+.. summary-start
+
+Selects whether mmexternal expects a JSON response from the external plugin.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmexternal`.
+
+:Name: interface.output
+:Scope: input
+:Type: string
+:Default: json
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+This parameter controls what the external program must write to standard
+output after each received message. It can be set to one of the following
+values:
+
+* ``"json"`` (default): The external program must write one JSON object,
+  followed by a line feed. The object is merged into the rsyslog message.
+* ``"none"``: The external program is not expected to write a response.
+  ``mmexternal`` sends the message and continues immediately.
+
+Use ``"none"`` only for helpers that do not need to modify the rsyslog
+message, for example side-effect-only enrichment or notification programs.
+If such a helper writes substantial data to standard output, the helper may
+eventually block because rsyslog does not read responses in this mode.
+
+Input usage
+-----------
+.. _param-mmexternal-input-interface-output:
+.. _mmexternal.parameter.input.interface-output-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmexternal")
+
+   action(
+       type="mmexternal"
+       binary="/path/to/helper"
+       interface.output="none"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmexternal`.

--- a/doc/source/reference/parameters/mmexternal-responsetimeout.rst
+++ b/doc/source/reference/parameters/mmexternal-responsetimeout.rst
@@ -1,0 +1,57 @@
+.. _param-mmexternal-responsetimeout:
+.. _mmexternal.parameter.input.responsetimeout:
+
+responseTimeout
+===============
+
+.. index::
+   single: mmexternal; responseTimeout
+   single: responseTimeout
+
+.. summary-start
+
+Bounds how long mmexternal waits for a JSON response from the external plugin.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/mmexternal`.
+
+:Name: responseTimeout
+:Scope: input
+:Type: integer
+:Default: 0
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+This parameter sets the maximum time, in milliseconds, that ``mmexternal``
+waits for the external program to return a complete JSON response line.
+The default value ``0`` keeps the historical behavior and waits without a
+module-level timeout.
+
+When the timeout expires, ``mmexternal`` logs a warning, terminates and
+restarts the external program, and continues processing. The current message
+is not retried through the timed-out helper.
+
+The timeout applies only when :ref:`param-mmexternal-interface-output` is
+``"json"``. It has no effect when ``interface.output="none"``.
+
+Input usage
+-----------
+.. _param-mmexternal-input-responsetimeout:
+.. _mmexternal.parameter.input.responsetimeout-usage:
+
+.. code-block:: rsyslog
+
+   module(load="mmexternal")
+
+   action(
+       type="mmexternal"
+       binary="/path/to/mmexternal.py"
+       responseTimeout="500"
+   )
+
+See also
+--------
+See also :doc:`../../configuration/modules/mmexternal`.

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -30,6 +30,7 @@
 #include <errno.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <sys/wait.h>
 #include <sys/uio.h>
 #include "rsyslog.h"
@@ -61,6 +62,10 @@ typedef struct _instanceData {
 #define INPUT_MSG 0
 #define INPUT_RAWMSG 1
 #define INPUT_JSON 2
+    int outputMode; /* what to expect from the external program? */
+#define OUTPUT_JSON 0
+#define OUTPUT_NONE 1
+    long responseTimeout; /* milliseconds to wait for JSON response, 0 means forever */
     uchar *outputFileName; /* name of file for std[out/err] or NULL if to discard */
     pthread_mutex_t mut; /* make sure only one instance is active */
 } instanceData;
@@ -86,10 +91,10 @@ static configSettings_t cs;
 
 /* tables for interfacing with the v6 config system */
 /* action (instance) parameters */
-static struct cnfparamdescr actpdescr[] = {{"binary", eCmdHdlrString, CNFPARAM_REQUIRED},
-                                           {"interface.input", eCmdHdlrString, 0},
-                                           {"output", eCmdHdlrString, 0},
-                                           {"forcesingleinstance", eCmdHdlrBinary, 0}};
+static struct cnfparamdescr actpdescr[] = {
+    {"binary", eCmdHdlrString, CNFPARAM_REQUIRED}, {"interface.input", eCmdHdlrString, 0},
+    {"interface.output", eCmdHdlrString, 0},       {"output", eCmdHdlrString, 0},
+    {"responsetimeout", eCmdHdlrNonNegInt, 0},     {"forcesingleinstance", eCmdHdlrBinary, 0}};
 static struct cnfparamblk actpblk = {CNFPARAMBLK_VERSION, sizeof(actpdescr) / sizeof(struct cnfparamdescr), actpdescr};
 
 BEGINinitConfVars /* (re)set config variables to default values */
@@ -102,6 +107,8 @@ ENDinitConfVars
 BEGINcreateInstance
     CODESTARTcreateInstance;
     pData->inputProp = INPUT_MSG;
+    pData->outputMode = OUTPUT_JSON;
+    pData->responseTimeout = 0;
     pthread_mutex_init(&pData->mut, NULL);
 ENDcreateInstance
 
@@ -188,6 +195,60 @@ done:
 }
 
 
+static void waitForChildExit(wrkrInstanceData_t *__restrict__ const pWrkrData, const long timeoutMs) {
+    int status;
+    int ret = -1;
+    long counter;
+
+    counter = timeoutMs / 10;
+    while ((ret = waitpid(pWrkrData->pid, &status, WNOHANG)) == 0 && counter > 0) {
+        srSleep(0, 10000);
+        --counter;
+    }
+
+    if (ret == 0) {
+        if (kill(pWrkrData->pid, SIGKILL) == -1) {
+            LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGKILL to child process");
+            return;
+        }
+        ret = waitpid(pWrkrData->pid, &status, 0);
+    }
+
+    /* waitpid may fail with ECHILD if rsyslogd's main loop already reaped the child. */
+    if (ret == pWrkrData->pid) {
+        glblReportChildProcessExit(runConf, pWrkrData->pData->szBinary, pWrkrData->pid, status);
+    }
+}
+
+
+static void closeWrkrPipes(wrkrInstanceData_t *__restrict__ const pWrkrData) {
+    if (pWrkrData->fdOutput != -1) {
+        close(pWrkrData->fdOutput);
+        pWrkrData->fdOutput = -1;
+    }
+    if (pWrkrData->fdPipeIn != -1) {
+        close(pWrkrData->fdPipeIn);
+        pWrkrData->fdPipeIn = -1;
+    }
+    if (pWrkrData->fdPipeOut != -1) {
+        close(pWrkrData->fdPipeOut);
+        pWrkrData->fdPipeOut = -1;
+    }
+}
+
+
+static void terminateChild(wrkrInstanceData_t *__restrict__ const pWrkrData, const long timeoutMs) {
+    if (pWrkrData->bIsRunning == 0) return;
+
+    if (kill(pWrkrData->pid, SIGTERM) == -1) {
+        LogError(errno, RS_RET_SYS_ERR, "mmexternal: could not send SIGTERM to child process");
+    }
+    closeWrkrPipes(pWrkrData);
+    waitForChildExit(pWrkrData, timeoutMs);
+    pWrkrData->bIsRunning = 0;
+}
+
+
 /* Get reply from external program. Note that we *must* receive one
  * reply for each message sent (half-duplex protocol). As such, the last
  * char we read MUST be \n ... we cannot have multiple LF as this is
@@ -196,14 +257,21 @@ done:
  * things quite a bit simpler. So don't think the simple code does
  * not handle those border-cases that are describe to cannot exist!
  */
-static void processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *const pMsg) {
-    rsRetVal iRet;
+static rsRetVal processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData, smsg_t *const pMsg) {
+    DEFiRet;
     char errStr[1024];
     ssize_t r;
     int numCharsRead;
     char *newptr;
+    struct pollfd fdToPoll[1];
+
+    if (pWrkrData->pData->outputMode == OUTPUT_NONE) {
+        FINALIZE;
+    }
 
     numCharsRead = 0;
+    fdToPoll[0].fd = pWrkrData->fdPipeIn;
+    fdToPoll[0].events = POLLIN;
     do {
         if (pWrkrData->maxLenRespBuf < numCharsRead + 256) { /* 256 to permit at least a decent read */
             pWrkrData->maxLenRespBuf += 4096;
@@ -215,6 +283,21 @@ static void processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData
                 break;
             }
             pWrkrData->respBuf = newptr;
+        }
+        if (pWrkrData->pData->responseTimeout > 0) {
+            const int pollRet = poll(fdToPoll, 1, pWrkrData->pData->responseTimeout);
+            if (pollRet == -1) {
+                if (errno == EINTR) continue;
+                LogError(errno, RS_RET_SYS_ERR, "mmexternal: error polling for response from program");
+                ABORT_FINALIZE(RS_RET_SYS_ERR);
+            } else if (pollRet == 0) {
+                LogMsg(0, RS_RET_TIMED_OUT, LOG_WARNING,
+                       "mmexternal: program '%s' (pid %ld) did not respond within timeout (%ld ms); "
+                       "will be restarted and current message skipped",
+                       pWrkrData->pData->szBinary, (long)pWrkrData->pid, pWrkrData->pData->responseTimeout);
+                terminateChild(pWrkrData, 1000);
+                FINALIZE;
+            }
         }
         r = read(pWrkrData->fdPipeIn, pWrkrData->respBuf + numCharsRead, pWrkrData->maxLenRespBuf - numCharsRead - 1);
         if (r > 0) {
@@ -238,9 +321,11 @@ static void processProgramReply(wrkrInstanceData_t *__restrict__ const pWrkrData
     if (iRet != RS_RET_OK) {
         LogError(0, iRet, "mmexternal: invalid reply '%s' from program '%s'", pWrkrData->respBuf,
                  pWrkrData->pData->szBinary);
+        iRet = RS_RET_OK;
     }
 
-    return;
+finalize_it:
+    RETiRet;
 }
 
 
@@ -375,19 +460,7 @@ static rsRetVal cleanup(wrkrInstanceData_t *pWrkrData) {
         glblReportChildProcessExit(runConf, pWrkrData->pData->szBinary, pWrkrData->pid, status);
     }
 
-    if (pWrkrData->fdOutput != -1) {
-        close(pWrkrData->fdOutput);
-        pWrkrData->fdOutput = -1;
-    }
-    if (pWrkrData->fdPipeIn != -1) {
-        close(pWrkrData->fdPipeIn);
-        pWrkrData->fdPipeIn = -1;
-    }
-    if (pWrkrData->fdPipeOut != -1) {
-        close(pWrkrData->fdPipeOut);
-        pWrkrData->fdPipeOut = -1;
-    }
-    pWrkrData->bIsRunning = 0;
+    closeWrkrPipes(pWrkrData);
     pWrkrData->bIsRunning = 0;
     RETiRet;
 }
@@ -463,7 +536,7 @@ static rsRetVal callExtProg(wrkrInstanceData_t *__restrict__ const pWrkrData, sm
         }
     } while (lenWritten != lenWrite + 1);
 
-    processProgramReply(pWrkrData, pMsg);
+    CHKiRet(processProgramReply(pWrkrData, pMsg));
 
 finalize_it:
     /* we need to free json input strings, only. All others point to memory
@@ -500,13 +573,17 @@ static void setInstParamDefaults(instanceData *pData) {
     pData->outputFileName = NULL;
     pData->iParams = 0;
     pData->bForceSingleInst = 0;
+    pData->inputProp = INPUT_MSG;
+    pData->outputMode = OUTPUT_JSON;
+    pData->responseTimeout = 0;
 }
 
 
 BEGINnewActInst
     struct cnfparamvals *pvals;
     int i;
-    const char *cstr = NULL;
+    const char *inputCStr = NULL;
+    const char *outputCStr = NULL;
     CODESTARTnewActInst;
     if ((pvals = nvlstGetParams(lst, &actpblk, NULL)) == NULL) {
         ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
@@ -522,18 +599,34 @@ BEGINnewActInst
             CHKiRet(split_binary_parameters(&pData->szBinary, &pData->aParams, &pData->iParams, pvals[i].val.d.estr));
         } else if (!strcmp(actpblk.descr[i].name, "output")) {
             CHKmalloc(pData->outputFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(actpblk.descr[i].name, "responsetimeout")) {
+            pData->responseTimeout = pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "forcesingleinstance")) {
             pData->bForceSingleInst = (int)pvals[i].val.d.n;
         } else if (!strcmp(actpblk.descr[i].name, "interface.input")) {
-            cstr = es_str2cstr(pvals[i].val.d.estr, NULL);
-            if (!strcmp(cstr, "msg"))
+            inputCStr = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(inputCStr);
+            if (!strcmp(inputCStr, "msg"))
                 pData->inputProp = INPUT_MSG;
-            else if (!strcmp(cstr, "rawmsg"))
+            else if (!strcmp(inputCStr, "rawmsg"))
                 pData->inputProp = INPUT_RAWMSG;
-            else if (!strcmp(cstr, "fulljson"))
+            else if (!strcmp(inputCStr, "fulljson"))
                 pData->inputProp = INPUT_JSON;
             else {
-                LogError(0, RS_RET_INVLD_INTERFACE_INPUT, "mmexternal: invalid interface.input parameter '%s'", cstr);
+                LogError(0, RS_RET_INVLD_INTERFACE_INPUT, "mmexternal: invalid interface.input parameter '%s'",
+                         inputCStr);
+                ABORT_FINALIZE(RS_RET_INVLD_INTERFACE_INPUT);
+            }
+        } else if (!strcmp(actpblk.descr[i].name, "interface.output")) {
+            outputCStr = es_str2cstr(pvals[i].val.d.estr, NULL);
+            CHKmalloc(outputCStr);
+            if (!strcmp(outputCStr, "json"))
+                pData->outputMode = OUTPUT_JSON;
+            else if (!strcmp(outputCStr, "none"))
+                pData->outputMode = OUTPUT_NONE;
+            else {
+                LogError(0, RS_RET_INVLD_INTERFACE_INPUT, "mmexternal: invalid interface.output parameter '%s'",
+                         outputCStr);
                 ABORT_FINALIZE(RS_RET_INVLD_INTERFACE_INPUT);
             }
         } else {
@@ -543,9 +636,12 @@ BEGINnewActInst
 
     CHKiRet(OMSRsetEntry(*ppOMSR, 0, NULL, OMSR_TPL_AS_MSG));
     DBGPRINTF("mmexternal: bForceSingleInst %d\n", pData->bForceSingleInst);
-    DBGPRINTF("mmexternal: interface.input '%s', mode %d\n", cstr, pData->inputProp);
+    DBGPRINTF("mmexternal: interface.input '%s', mode %d\n", inputCStr == NULL ? "msg" : inputCStr, pData->inputProp);
+    DBGPRINTF("mmexternal: interface.output '%s', mode %d, responseTimeout %ld\n",
+              outputCStr == NULL ? "json" : outputCStr, pData->outputMode, pData->responseTimeout);
     CODE_STD_FINALIZERnewActInst;
-    free((void *)cstr);
+    free((void *)inputCStr);
+    free((void *)outputCStr);
     cnfparamvalsDestruct(pvals, &actpblk);
 ENDnewActInst
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -127,6 +127,8 @@ TESTS_DEFAULT = \
 	glbl_setenv_err_too_long.sh \
 	glbl_setenv.sh \
 	mmexternal-SegFault.sh \
+	mmexternal-interface-output-none.sh \
+	mmexternal-response-timeout.sh \
 	nested-call-shutdown.sh \
 	dnscache-TTL-0.sh \
 	invalid_nested_include.sh \
@@ -3146,6 +3148,8 @@ EXTRA_DIST += \
 	sndrcv_drvr_noexit.sh \
 	diag.sh \
 	testsuites/mmexternal-SegFault-mm-python.py \
+	testsuites/mmexternal-hang-no-reply.sh \
+	testsuites/mmexternal-no-output.sh \
 	testsuites/mmsnareparse/sample-custom-pattern.data \
 	testsuites/mmsnareparse/sample-windows2022-security.data \
 	testsuites/mmsnareparse/sample-windows2025-security.data \

--- a/tests/mmexternal-interface-output-none.sh
+++ b/tests/mmexternal-interface-output-none.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# added 2026-05-22 by Codex, released under ASL 2.0
+# Regression coverage for issue #260: interface.output="none" lets an
+# external message modification helper consume messages without producing the
+# JSON response required by the default protocol. The oracle checks both the
+# downstream omfile action and the helper side-effect file after synchronized
+# shutdown.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmexternal/.libs/mmexternal")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+action(type="mmexternal"
+	interface.output="none"
+	binary="'${srcdir}'/testsuites/mmexternal-no-output.sh '$RSYSLOG_DYNNAME'.side")
+action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+'
+
+startup
+injectmsg literal "<13>Mar 10 01:00:00 host tag:no-output-message"
+shutdown_when_empty
+wait_shutdown
+
+content_check "no-output-message"
+content_check "no-output-message" "$RSYSLOG_DYNNAME.side"
+
+exit_test

--- a/tests/mmexternal-response-timeout.sh
+++ b/tests/mmexternal-response-timeout.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# added 2026-05-22 by Codex, released under ASL 2.0
+# Regression coverage for issue #5206: responseTimeout bounds how long
+# mmexternal waits for a JSON reply. A helper that never emits LF must be
+# killed and restarted, and the queue must continue to the following action.
+# The oracle is the configured omfile output appearing before shutdown.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+module(load="../plugins/mmexternal/.libs/mmexternal")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+if $msg contains "timeout-message" then {
+	action(type="mmexternal"
+		responseTimeout="500"
+		binary="'${srcdir}'/testsuites/mmexternal-hang-no-reply.sh")
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+injectmsg literal "<13>Mar 10 01:00:00 host tag:timeout-message"
+wait_file_lines "$RSYSLOG_OUT_LOG" 1
+shutdown_when_empty
+wait_shutdown
+
+content_check "timeout-message"
+
+exit_test

--- a/tests/testsuites/mmexternal-hang-no-reply.sh
+++ b/tests/testsuites/mmexternal-hang-no-reply.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+# Helper for mmexternal responseTimeout tests.
+# It consumes one message and then stops responding until rsyslog kills it.
+while IFS= read -r _line; do
+	sleep 60
+done

--- a/tests/testsuites/mmexternal-no-output.sh
+++ b/tests/testsuites/mmexternal-no-output.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Helper for mmexternal interface.output="none" tests.
+# It records received lines and intentionally emits no stdout response.
+out="$1"
+
+while IFS= read -r line; do
+	printf '%s\n' "$line" >> "$out"
+done


### PR DESCRIPTION
## Summary
- add mmexternal interface.output=none for helpers that consume messages without returning JSON
- add responseTimeout for JSON-mode helpers and restart stalled children after timeout
- document both parameters and add focused testbench coverage

Closes https://github.com/rsyslog/rsyslog/issues/260
Closes https://github.com/rsyslog/rsyslog/issues/5206

## Validation
- ./tests/mmexternal-interface-output-none.sh
- ./tests/mmexternal-response-timeout.sh
- ./tests/mmexternal-SegFault.sh
- make -j28 check TESTS=""
- shellcheck -S warning tests/mmexternal-interface-output-none.sh tests/mmexternal-response-timeout.sh tests/testsuites/mmexternal-hang-no-reply.sh tests/testsuites/mmexternal-no-output.sh
- make -j20 distcheck TEST_RUN_TYPE=MOCK-OK
- container clang analyzer: scan-build No bugs found
- Ubuntu 26.04 dev-container CI: 1271 total, 1178 pass, 93 skip, 0 fail/error