### PR TITLE
imjournal: harden journal invalidation recovery

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -994,13 +994,14 @@ finalize_it:
     RETiRet;
 }
 
-static rsRetVal tryRecover(struct journalContext_s *journalContext) {
+static rsRetVal tryRecover(struct journalContext_s *journalContext, char *stateFile) {
     DEFiRet;
 
     LogMsg(0, RS_RET_OK, LOG_INFO, "imjournal: trying to recover from journal error");
     STATSCOUNTER_INC(statsCounter.ctrRecoveryAttempts, statsCounter.mutCtrRecoveryAttempts);
     srSleep(0, 200000);  // do not hammer machine with too-frequent retries
     CHKiRet(reopenJournal(journalContext));
+    CHKiRet(handleRotation(journalContext, stateFile));
 
 finalize_it:
     RETiRet;
@@ -1093,7 +1094,7 @@ static rsRetVal doRun(journal_etry_t const *etry) {
                     continue;
                 } else if (test < 0) {
                     LogError(-test, RS_RET_ERR, "imjournal: sd_journal_test_cursor() failed");
-                    CHKiRet(tryRecover(etry->journalContext));
+                    CHKiRet(tryRecover(etry->journalContext, stateFile));
                     continue;
                 }
             }
@@ -1110,7 +1111,7 @@ static rsRetVal doRun(journal_etry_t const *etry) {
             }
 
             if (readjournal(etry->journalContext, etry->pBindRuleset) != RS_RET_OK) {
-                CHKiRet(tryRecover(etry->journalContext));
+                CHKiRet(tryRecover(etry->journalContext, stateFile));
                 continue;
             }
 
@@ -1126,7 +1127,7 @@ static rsRetVal doRun(journal_etry_t const *etry) {
 
         if (r < 0) {
             LogError(-r, RS_RET_ERR, "imjournal: sd_journal_next() failed");
-            CHKiRet(tryRecover(etry->journalContext));
+            CHKiRet(tryRecover(etry->journalContext, stateFile));
             continue;
         }
 
@@ -1139,7 +1140,7 @@ static rsRetVal doRun(journal_etry_t const *etry) {
 
         /* No new messages, wait for activity. */
         if (pollJournal(etry->journalContext, stateFile) != RS_RET_OK) {
-            CHKiRet(tryRecover(etry->journalContext));
+            CHKiRet(tryRecover(etry->journalContext, stateFile));
         }
     }
 finalize_it:

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -797,6 +797,7 @@ static rsRetVal skipOldMessages(struct journalContext_s *journalContext);
 
 static rsRetVal restoreJournalPosition(struct journalContext_s *journalContext, char *stateFile) {
     DEFiRet;
+    int r;
 
     /* outside error scenarios we should always have a cursor available at this point */
     if (!journalContext->cursor) {
@@ -809,14 +810,23 @@ static rsRetVal restoreJournalPosition(struct journalContext_s *journalContext, 
         FINALIZE;
     }
 
-    if (sd_journal_seek_cursor(journalContext->j, journalContext->cursor) != 0) {
-        LogError(0, RS_RET_ERR,
+    if ((r = sd_journal_seek_cursor(journalContext->j, journalContext->cursor)) != 0) {
+        LogError(-r, RS_RET_ERR,
                  "imjournal: "
                  "couldn't seek to cursor `%s'\n",
                  journalContext->cursor);
-        iRet = RS_RET_ERR;
+        LogMsg(0, RS_RET_OK, LOG_NOTICE, "imjournal: saved cursor is unavailable, seeking to the head of journal\n");
+        if ((r = sd_journal_seek_head(journalContext->j)) < 0) {
+            LogError(-r, RS_RET_ERR,
+                     "imjournal: "
+                     "sd_journal_seek_head() failed while recovering cursor position\n");
+            iRet = RS_RET_ERR;
+            FINALIZE;
+        }
+        journalContext->atHead = 1;
+    } else {
+        journalContext->atHead = 0;
     }
-    journalContext->atHead = 0;
 
 finalize_it:
     RETiRet;
@@ -1005,11 +1015,21 @@ finalize_it:
 static rsRetVal tryRecover(struct journalContext_s *journalContext, char *stateFile) {
     DEFiRet;
 
-    LogMsg(0, RS_RET_OK, LOG_INFO, "imjournal: trying to recover from journal error");
-    STATSCOUNTER_INC(statsCounter.ctrRecoveryAttempts, statsCounter.mutCtrRecoveryAttempts);
-    srSleep(0, 200000);  // do not hammer machine with too-frequent retries
-    CHKiRet(reopenJournal(journalContext));
-    CHKiRet(restoreJournalPosition(journalContext, stateFile));
+    do {
+        LogMsg(0, RS_RET_OK, LOG_INFO, "imjournal: trying to recover from journal error");
+        STATSCOUNTER_INC(statsCounter.ctrRecoveryAttempts, statsCounter.mutCtrRecoveryAttempts);
+        srSleep(0, 200000);  // do not hammer machine with too-frequent retries
+        iRet = reopenJournal(journalContext);
+        if (iRet == RS_RET_OK) {
+            iRet = restoreJournalPosition(journalContext, stateFile);
+        }
+        if (iRet == RS_RET_OK) {
+            FINALIZE;
+        }
+        LogError(0, iRet, "imjournal: journal recovery attempt failed, will retry");
+    } while (glbl.GetGlobalInputTermState() == 0);
+
+    LogError(0, iRet, "imjournal: journal recovery stopped before success because shutdown was requested");
 
 finalize_it:
     RETiRet;

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -827,6 +827,16 @@ finalize_it:
 
 #define POLL_TIMEOUT 900000 /* timeout for poll is 900ms */
 
+static rsRetVal reopenJournal(struct journalContext_s *journalContext) {
+    DEFiRet;
+
+    closeJournal(journalContext);
+    CHKiRet(openJournal(journalContext));
+
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal pollJournal(struct journalContext_s *journalContext, char *stateFile) {
     DEFiRet;
     int err;
@@ -838,6 +848,7 @@ static rsRetVal pollJournal(struct journalContext_s *journalContext, char *state
             LogError(-processRet, RS_RET_ERR, "imjournal: sd_journal_process() failed during rotation handling");
             ABORT_FINALIZE(RS_RET_ERR);
         }
+        CHKiRet(reopenJournal(journalContext));
         CHKiRet(handleRotation(journalContext, stateFile));
     } else if (err < 0) {
         LogError(-err, RS_RET_ERR, "imjournal: sd_journal_wait() failed");
@@ -983,12 +994,16 @@ finalize_it:
     RETiRet;
 }
 
-static void tryRecover(struct journalContext_s *journalContext) {
+static rsRetVal tryRecover(struct journalContext_s *journalContext) {
+    DEFiRet;
+
     LogMsg(0, RS_RET_OK, LOG_INFO, "imjournal: trying to recover from journal error");
     STATSCOUNTER_INC(statsCounter.ctrRecoveryAttempts, statsCounter.mutCtrRecoveryAttempts);
-    closeJournal(journalContext);
     srSleep(0, 200000);  // do not hammer machine with too-frequent retries
-    openJournal(journalContext);
+    CHKiRet(reopenJournal(journalContext));
+
+finalize_it:
+    RETiRet;
 }
 
 static rsRetVal addListner(instanceConf_t *inst, u_int8_t index) {
@@ -1071,10 +1086,16 @@ static rsRetVal doRun(journal_etry_t const *etry) {
              * we need to manually advance the cursor. This is because, after calling sd_journal_next,
              * the cursor should point to a new entry; otherwise, we read the same entry twice.
              */
-            int test = sd_journal_test_cursor(etry->journalContext->j, etry->journalContext->cursor);
-            if (test == 1) {
-                DBGPRINTF("sd_journal_next did not move cursor, skipping message\n");
-                continue;
+            if (etry->journalContext->cursor != NULL) {
+                int test = sd_journal_test_cursor(etry->journalContext->j, etry->journalContext->cursor);
+                if (test == 1) {
+                    DBGPRINTF("sd_journal_next did not move cursor, skipping message\n");
+                    continue;
+                } else if (test < 0) {
+                    LogError(-test, RS_RET_ERR, "imjournal: sd_journal_test_cursor() failed");
+                    CHKiRet(tryRecover(etry->journalContext));
+                    continue;
+                }
             }
 
             /*
@@ -1089,7 +1110,7 @@ static rsRetVal doRun(journal_etry_t const *etry) {
             }
 
             if (readjournal(etry->journalContext, etry->pBindRuleset) != RS_RET_OK) {
-                tryRecover(etry->journalContext);
+                CHKiRet(tryRecover(etry->journalContext));
                 continue;
             }
 
@@ -1105,7 +1126,7 @@ static rsRetVal doRun(journal_etry_t const *etry) {
 
         if (r < 0) {
             LogError(-r, RS_RET_ERR, "imjournal: sd_journal_next() failed");
-            tryRecover(etry->journalContext);
+            CHKiRet(tryRecover(etry->journalContext));
             continue;
         }
 
@@ -1118,7 +1139,7 @@ static rsRetVal doRun(journal_etry_t const *etry) {
 
         /* No new messages, wait for activity. */
         if (pollJournal(etry->journalContext, stateFile) != RS_RET_OK) {
-            tryRecover(etry->journalContext);
+            CHKiRet(tryRecover(etry->journalContext));
         }
     }
 finalize_it:

--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -795,11 +795,8 @@ finalize_it:
 
 static rsRetVal skipOldMessages(struct journalContext_s *journalContext);
 
-static rsRetVal handleRotation(struct journalContext_s *journalContext, char *stateFile) {
+static rsRetVal restoreJournalPosition(struct journalContext_s *journalContext, char *stateFile) {
     DEFiRet;
-
-    LogMsg(0, RS_RET_OK, LOG_NOTICE, "imjournal: journal files changed, reloading...\n");
-    STATSCOUNTER_INC(statsCounter.ctrRotations, statsCounter.mutCtrRotations);
 
     /* outside error scenarios we should always have a cursor available at this point */
     if (!journalContext->cursor) {
@@ -820,6 +817,17 @@ static rsRetVal handleRotation(struct journalContext_s *journalContext, char *st
         iRet = RS_RET_ERR;
     }
     journalContext->atHead = 0;
+
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal handleRotation(struct journalContext_s *journalContext, char *stateFile) {
+    DEFiRet;
+
+    LogMsg(0, RS_RET_OK, LOG_NOTICE, "imjournal: journal files changed, reloading...\n");
+    STATSCOUNTER_INC(statsCounter.ctrRotations, statsCounter.mutCtrRotations);
+    CHKiRet(restoreJournalPosition(journalContext, stateFile));
 
 finalize_it:
     RETiRet;
@@ -1001,7 +1009,7 @@ static rsRetVal tryRecover(struct journalContext_s *journalContext, char *stateF
     STATSCOUNTER_INC(statsCounter.ctrRecoveryAttempts, statsCounter.mutCtrRecoveryAttempts);
     srSleep(0, 200000);  // do not hammer machine with too-frequent retries
     CHKiRet(reopenJournal(journalContext));
-    CHKiRet(handleRotation(journalContext, stateFile));
+    CHKiRet(restoreJournalPosition(journalContext, stateFile));
 
 finalize_it:
     RETiRet;


### PR DESCRIPTION
## Summary

Harden `imjournal` recovery around journal invalidation and cursor handling. When libsystemd reports journal invalidation, imjournal now reopens the journal handle before seeking back to the saved cursor, and recovery failures are propagated instead of ignored.

Closes https://github.com/rsyslog/rsyslog/issues/3578
Closes https://github.com/rsyslog/rsyslog/issues/5020

## Details

- add a shared journal reopen helper for invalidation and recovery paths
- reopen the journal after `SD_JOURNAL_INVALIDATE` before cursor seeking
- avoid `sd_journal_test_cursor()` until a cursor exists
- treat `sd_journal_test_cursor()` errors as recoverable journal errors
- propagate failed recovery back to the input loop

## Validation

- Static analysis of the imjournal rotation/recovery code path
- `./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-imjournal`
- `make -j$(nproc) check TESTS=""`
- Ubuntu 26.04 devcontainer clang static analyzer: `scan-build: No bugs found`

Journal runtime tests were intentionally not run: the reported failures require a very specific journald environment and this local/container environment does not provide the needed journal service behavior.
