### PR TITLE
omelasticsearch: guard dynamic template strings

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -156,6 +156,7 @@ typedef struct instanceConf_s {
     sbool dynBulkId;
     sbool dynPipelineName;
     sbool bulkmode;
+    int iNumTpls;
     size_t maxbytes;
     sbool useHttps;
     sbool allowUnsignedCerts;
@@ -997,8 +998,7 @@ static rsRetVal ATTR_NONNULL(1) validateActionStrings(const instanceData *const 
         ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
     }
 
-    const int iNumTpls = getTemplateCount(pData);
-    for (int i = 0; i < iNumTpls; ++i) {
+    for (int i = 0; i < pData->iNumTpls; ++i) {
         if (tpls[i] == NULL) {
             LogError(0, RS_RET_INVALID_PARAMS,
                      "omelasticsearch: rendered action template string %d is "
@@ -2221,6 +2221,7 @@ static void ATTR_NONNULL() setInstParamDefaults(instanceData *const pData) {
     pData->dynSrchIdx = 0;
     pData->dynSrchType = 0;
     pData->dynParent = 0;
+    pData->iNumTpls = 1;
     pData->useHttps = 0;
     pData->bulkmode = 0;
     pData->maxbytes = 104857600;  // 100 MB Is the default max message size that ships with ElasticSearch
@@ -2473,9 +2474,9 @@ BEGINnewActInst
     if (pData->uid != NULL && pData->apiKey == NULL)
         CHKiRet(computeAuthHeader((char *)pData->uid, (char *)pData->pwd, &pData->authBuf));
 
-    iNumTpls = getTemplateCount(pData);
-    DBGPRINTF("omelasticsearch: requesting %d templates\n", iNumTpls);
-    CODE_STD_STRING_REQUESTnewActInst(iNumTpls);
+    pData->iNumTpls = getTemplateCount(pData);
+    DBGPRINTF("omelasticsearch: requesting %d templates\n", pData->iNumTpls);
+    CODE_STD_STRING_REQUESTnewActInst(pData->iNumTpls);
 
     CHKiRet(OMSRsetEntry(*ppOMSR, 0, (uchar *)strdup((pData->tplName == NULL) ? " StdJSONFmt" : (char *)pData->tplName),
                          OMSR_NO_RQD_TPL_OPTS));

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -975,6 +975,44 @@ done:
 }
 
 
+static int ATTR_NONNULL(1) getTemplateCount(const instanceData *const pData) {
+    int iNumTpls = 1;
+    if (pData->dynSrchIdx) ++iNumTpls;
+    if (pData->dynSrchType) ++iNumTpls;
+    if (pData->dynParent) ++iNumTpls;
+    if (pData->dynBulkId) ++iNumTpls;
+    if (pData->dynPipelineName) ++iNumTpls;
+
+    return iNumTpls;
+}
+
+
+static rsRetVal ATTR_NONNULL(1) validateActionStrings(const instanceData *const pData, uchar **const tpls) {
+    DEFiRet;
+
+    if (tpls == NULL) {
+        LogError(0, RS_RET_INVALID_PARAMS,
+                 "omelasticsearch: action template strings are missing - "
+                 "cannot submit message");
+        ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+    }
+
+    const int iNumTpls = getTemplateCount(pData);
+    for (int i = 0; i < iNumTpls; ++i) {
+        if (tpls[i] == NULL) {
+            LogError(0, RS_RET_INVALID_PARAMS,
+                     "omelasticsearch: rendered action template string %d is "
+                     "NULL - cannot submit message",
+                     i);
+            ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+        }
+    }
+
+finalize_it:
+    RETiRet;
+}
+
+
 static rsRetVal ATTR_NONNULL(1) setPostURL(wrkrInstanceData_t *const pWrkrData, uchar **const tpls) {
     uchar *searchIndex = NULL;
     uchar *searchType = NULL;
@@ -2031,6 +2069,8 @@ BEGINdoAction
     CODESTARTdoAction;
     STATSCOUNTER_INC(indexSubmit, mutIndexSubmit);
 
+    CHKiRet(validateActionStrings(pWrkrData->pData, ppString));
+
     if (pWrkrData->pData->bulkmode) {
         const size_t nBytes = computeMessageSize(pWrkrData, ppString[0], ppString);
 
@@ -2433,12 +2473,7 @@ BEGINnewActInst
     if (pData->uid != NULL && pData->apiKey == NULL)
         CHKiRet(computeAuthHeader((char *)pData->uid, (char *)pData->pwd, &pData->authBuf));
 
-    iNumTpls = 1;
-    if (pData->dynSrchIdx) ++iNumTpls;
-    if (pData->dynSrchType) ++iNumTpls;
-    if (pData->dynParent) ++iNumTpls;
-    if (pData->dynBulkId) ++iNumTpls;
-    if (pData->dynPipelineName) ++iNumTpls;
+    iNumTpls = getTemplateCount(pData);
     DBGPRINTF("omelasticsearch: requesting %d templates\n", iNumTpls);
     CODE_STD_STRING_REQUESTnewActInst(iNumTpls);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -260,6 +260,7 @@ TESTS_DEFAULT = \
 	imudp_ratelimit_name.sh \
 	omfwd_ratelimit_name.sh \
 	omelasticsearch_ratelimit_name.sh \
+	omelasticsearch-dynsearch-template.sh \
 	omelasticsearch-searchtype-deprecated.sh \
 	omhttp_ratelimit_name.sh \
 	imhttp_ratelimit_name.sh \

--- a/tests/omelasticsearch-dynsearch-template.sh
+++ b/tests/omelasticsearch-dynsearch-template.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Regression test for omelasticsearch bulk mode with both a message template and
+# a dynamic search-index template. The oracle is clean startup, processing, and
+# shutdown with an unavailable Elasticsearch endpoint: this exercises the local
+# batch sizing/build path that previously crashed before any remote service was
+# needed.
+. ${srcdir:=.}/diag.sh init
+require_plugin omelasticsearch
+
+generate_conf
+add_conf '
+module(load="../plugins/omelasticsearch/.libs/omelasticsearch")
+
+template(name="msgTpl" type="string" string="{\"msg\":\"%msg%\"}")
+template(name="idxTpl" type="string" string="rsyslog-test-%programname%")
+
+action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
+action(type="omelasticsearch"
+       server="127.0.0.1"
+       serverport="19200"
+       bulkmode="on"
+       dynSearchIndex="on"
+       searchIndex="idxTpl"
+       template="msgTpl"
+       action.resumeRetryCount="0"
+       action.resumeInterval="1")
+'
+
+startup
+injectmsg_literal '<167>1 2003-03-01T01:00:00.000Z host testprog - - - msgnum:0'
+shutdown_when_empty
+wait_shutdown
+
+content_check "msgnum:0" "$RSYSLOG_OUT_LOG"
+exit_test


### PR DESCRIPTION
## Summary
- validate rendered omelasticsearch action template strings before bulk sizing/submission
- reuse one template-count helper for dynamic template slots
- add a regression for bulk mode with both template= and dynSearchIndex/searchIndex templates without requiring a live Elasticsearch service

closes https://github.com/rsyslog/rsyslog/issues/3586

## Validation
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-elasticsearch
- make -j$(nproc) check TESTS=""
- ./tests/omelasticsearch-dynsearch-template.sh
- make check TESTS=omelasticsearch-dynsearch-template.sh
- bash devtools/format-code.sh --git-changed
- make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
- container: Ubuntu 26.04 devcontainer clang static analyzer with omelasticsearch enabled, scan-build: No bugs found
- container: Ubuntu 26.04 devcontainer run-ci with omelasticsearch enabled and CI_MAKE_CHECK_TESTS=omelasticsearch-dynsearch-template.sh, PASS