### PR TITLE
tests: cover omfwd missing target validation

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -39,8 +39,12 @@ agents.
   emission, startup before configuration is usable, or another documented case
   where the message cannot pass through rsyslog's normal output path. Explain
   such exceptions in the test header.
-- Prefer harness helpers such as `cmp_exact`, `command_deny`, and
-  `require_plugin` over ad-hoc shell to keep diagnostics uniform.
+- Prefer harness helpers such as `content_check`, `content_count_check`,
+  `custom_content_check`, `check_not_present`, `cmp_exact`, `command_deny`, and
+  `require_plugin` over ad-hoc shell to keep diagnostics uniform. In
+  particular, use `content_check "needle" "$file"` instead of hand-written
+  `grep ... || { cat "$file"; error_exit 1; }` blocks when asserting log or
+  output content.
 - **Config format coverage**: When a module parameter or config object is tested
   via RainerScript, add a companion YAML test (or extend an existing
   `yaml-<area>-*.sh`) that exercises the same parameter.  Both frontends share

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -139,6 +139,7 @@ TESTS_DEFAULT = \
 	omfwd-lb-2target-basic.sh \
 	omfwd-lb-2target-retry.sh \
 	omfwd-lb-2target-one_fail.sh \
+	omfwd-missing-target.sh \
 	omfwd-tls-invalid-permitExpiredCerts.sh \
 	omfwd-keepalive.sh \
 	omfwd-subtree-tpl.sh \

--- a/tests/omfwd-missing-target.sh
+++ b/tests/omfwd-missing-target.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Regression test for issue #5057: omfwd actions without target or targetSrv
+# must fail during config validation instead of reaching runtime connection
+# setup. The oracle is rsyslogd -N1 exiting with failure and emitting the
+# actionable missing-destination diagnostic.
+. ${srcdir:=.}/diag.sh init
+
+generate_conf
+add_conf '
+template(name="outfmt" type="string" string="%msg%\n")
+
+action(type="omfwd"
+       protocol="tcp"
+       port="1514"
+       template="outfmt"
+       TCP_Framing="octet-counted")
+'
+
+../tools/rsyslogd -N1 -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -eq 0 ]; then
+    echo "FAIL: expected config validation failure for omfwd without target or targetSrv"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+grep -F "omfwd: either target or targetSrv must be specified" "${RSYSLOG_DYNNAME}.log" >/dev/null || {
+    echo "FAIL: expected omfwd missing target error message"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+}
+
+exit_test

--- a/tests/omfwd-missing-target.sh
+++ b/tests/omfwd-missing-target.sh
@@ -23,10 +23,6 @@ if [ $? -eq 0 ]; then
     error_exit 1
 fi
 
-grep -F "omfwd: either target or targetSrv must be specified" "${RSYSLOG_DYNNAME}.log" >/dev/null || {
-    echo "FAIL: expected omfwd missing target error message"
-    cat "${RSYSLOG_DYNNAME}.log"
-    error_exit 1
-}
+content_check "omfwd: either target or targetSrv must be specified" "${RSYSLOG_DYNNAME}.log"
 
 exit_test


### PR DESCRIPTION
## Summary
- add a regression test for omfwd actions that omit both target and targetSrv
- assert config validation emits the missing-destination diagnostic instead of reaching runtime forwarding setup

closes https://github.com/rsyslog/rsyslog/issues/5057

## Validation
- reported-shape config with imtcp/imudp and omfwd without target: rsyslogd -N1 exits 1 with `omfwd: either target or targetSrv must be specified`, no segfault
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout
- make -j$(nproc) check TESTS=""
- ./tests/omfwd-missing-target.sh
- make check TESTS=omfwd-missing-target.sh
- make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
- bash devtools/format-code.sh --git-changed
- container: Ubuntu 26.04 devcontainer clang static analyzer, scan-build: No bugs found
- container: Ubuntu 26.04 devcontainer run-ci with CI_MAKE_CHECK_TESTS=omfwd-missing-target.sh, PASS
- container: locally built runtime image `rsyslog/rsyslog-minimal:codex-i5057` from `packaging/docker/rsyslog` with daily-stable packages; running the #5057 missing-target config exits 1 with the expected omfwd diagnostic, not 139