### PR TITLE
privdrop: log capability context on drop failure

### DIFF
--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -735,7 +735,7 @@ void cnfDoBSDHost(char *ln) {
 
 
 /* drop to specified group
- * if something goes wrong, the function never returns
+ * Returns RS_RET_ERR_DROP_PRIV if the requested group privileges cannot be set.
  */
 static rsRetVal doDropPrivGid(rsconf_t *cnf) {
     int res;
@@ -769,9 +769,7 @@ finalize_it:
 
 
 /* drop to specified user
- * if something goes wrong, the function never returns
- * Note that such an abort can cause damage to on-disk structures, so we should
- * re-design the "interface" in the long term. -- rgerhards, 2008-11-19
+ * Returns RS_RET_ERR_DROP_PRIV if the requested user privileges cannot be set.
  */
 static rsRetVal doDropPrivUid(rsconf_t *cnf) {
     int res;

--- a/runtime/rsconf.c
+++ b/runtime/rsconf.c
@@ -745,14 +745,17 @@ static rsRetVal doDropPrivGid(rsconf_t *cnf) {
     if (!cnf->globals.gidDropPrivKeepSupplemental) {
         res = setgroups(0, NULL); /* remove all supplemental group IDs */
         if (res) {
-            LogError(errno, RS_RET_ERR_DROP_PRIV, "could not remove supplemental group IDs");
+            LogError(errno, RS_RET_ERR_DROP_PRIV,
+                     "could not remove supplemental group IDs via setgroups(): missing CAP_SETGID or insufficient "
+                     "privilege");
             ABORT_FINALIZE(RS_RET_ERR_DROP_PRIV);
         }
         DBGPRINTF("setgroups(0, NULL): %d\n", res);
     }
     res = setgid(cnf->globals.gidDropPriv);
     if (res) {
-        LogError(errno, RS_RET_ERR_DROP_PRIV, "could not set requested group id %d via setgid()",
+        LogError(errno, RS_RET_ERR_DROP_PRIV,
+                 "could not set requested group id %d via setgid(): missing CAP_SETGID or insufficient privilege",
                  cnf->globals.gidDropPriv);
         ABORT_FINALIZE(RS_RET_ERR_DROP_PRIV);
     }
@@ -770,11 +773,12 @@ finalize_it:
  * Note that such an abort can cause damage to on-disk structures, so we should
  * re-design the "interface" in the long term. -- rgerhards, 2008-11-19
  */
-static void doDropPrivUid(rsconf_t *cnf) {
+static rsRetVal doDropPrivUid(rsconf_t *cnf) {
     int res;
     uchar szBuf[1024];
     struct passwd *pw;
     gid_t gid;
+    DEFiRet;
 
     /* Try to set appropriate supplementary groups for this user.
      * Failure is not fatal.
@@ -783,6 +787,12 @@ static void doDropPrivUid(rsconf_t *cnf) {
     if (pw) {
         gid = getgid();
         res = initgroups(pw->pw_name, gid);
+        if (res) {
+            LogError(errno, RS_RET_ERR_DROP_PRIV,
+                     "could not initialize supplemental groups for user id %d via initgroups(): missing CAP_SETGID or "
+                     "insufficient privilege",
+                     cnf->globals.uidDropPriv);
+        }
         DBGPRINTF("initgroups(%s, %ld): %d\n", pw->pw_name, (long)gid, res);
     } else {
         LogError(errno, NO_ERRCODE, "could not get username for userid '%d'", cnf->globals.uidDropPriv);
@@ -790,14 +800,18 @@ static void doDropPrivUid(rsconf_t *cnf) {
 
     res = setuid(cnf->globals.uidDropPriv);
     if (res) {
-        /* if we can not set the userid, this is fatal, so let's unconditionally abort */
-        perror("could not set requested userid");
-        exit(1);
+        LogError(errno, RS_RET_ERR_DROP_PRIV,
+                 "could not set requested user id %d via setuid(): missing CAP_SETUID or insufficient privilege",
+                 cnf->globals.uidDropPriv);
+        ABORT_FINALIZE(RS_RET_ERR_DROP_PRIV);
     }
 
     DBGPRINTF("setuid(%d): %d\n", cnf->globals.uidDropPriv, res);
     snprintf((char *)szBuf, sizeof(szBuf), "rsyslogd's userid changed to %d", cnf->globals.uidDropPriv);
     logmsgInternal(NO_ERRCODE, LOG_SYSLOG | LOG_INFO, szBuf, 0);
+
+finalize_it:
+    RETiRet;
 }
 
 
@@ -814,7 +828,7 @@ static rsRetVal dropPrivileges(rsconf_t *cnf) {
     }
 
     if (cnf->globals.uidDropPriv != 0) {
-        doDropPrivUid(cnf);
+        CHKiRet(doDropPrivUid(cnf));
         DBGPRINTF("user privileges have been dropped to uid %u\n", (unsigned)cnf->globals.uidDropPriv);
     }
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -164,6 +164,7 @@ TESTS_DEFAULT = \
 	rscript_privdropgroupid.sh \
 	privdropuser.sh \
 	privdropuserid.sh \
+	privdrop-setuid-fail.sh \
 	privdropgroup.sh \
 	privdropgroupid.sh \
 	privdropabortonidfail.sh \

--- a/tests/privdrop-setuid-fail.sh
+++ b/tests/privdrop-setuid-fail.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Regression test for issue #6633: failed setuid()/setgroups() calls during
 # privilege drop must produce clear diagnostics with the requested id and missing
 # capability context. The oracle is startup failure with those diagnostics on

--- a/tests/privdrop-setuid-fail.sh
+++ b/tests/privdrop-setuid-fail.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# Regression test for issue #6633: failed setuid()/setgroups() calls during
+# privilege drop must produce clear diagnostics with the requested id and missing
+# capability context. The oracle is startup failure with those diagnostics on
+# stderr; the test runs only as non-root so privilege changes fail with EPERM.
+. ${srcdir:=.}/diag.sh init
+
+if [ "${EUID}" -eq 0 ]; then
+    echo "Skipping: this test needs to run as non-root so privilege dropping fails with EPERM."
+    exit 77
+fi
+
+current_gid="$(id -g)"
+target_uid=""
+for user in daemon syslog nobody; do
+    uid="$(id -u "$user" 2>/dev/null || true)"
+    if [ -n "$uid" ] && [ "$uid" -ne "${EUID}" ] && [ "$uid" -ne 0 ]; then
+        target_uid="$uid"
+        break
+    fi
+done
+if [ -z "$target_uid" ]; then
+    target_uid=$((EUID + 1))
+fi
+
+target_gid=""
+for group in daemon syslog nogroup nobody; do
+    gid="$(getent group "$group" 2>/dev/null | cut -d: -f3 || true)"
+    if [ -n "$gid" ] && [ "$gid" -ne "${current_gid}" ] && [ "$gid" -ne 0 ]; then
+        target_gid="$gid"
+        break
+    fi
+done
+if [ -z "$target_gid" ]; then
+    target_gid=$((current_gid + 1))
+fi
+
+generate_conf
+add_conf '
+global(
+    errormessagestostderr.maxnumber="20"
+    privdrop.user.id="'${target_uid}'"
+)
+
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omfile" file="'${RSYSLOG_OUT_LOG}'" template="outfmt")
+'
+
+../tools/rsyslogd -n -iNONE -f"${TESTCONF_NM}.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.log" 2>&1
+if [ $? -eq 0 ]; then
+    echo "FAIL: expected startup failure when setuid() lacks permission"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+fi
+
+grep -F "could not set requested user id ${target_uid} via setuid()" "${RSYSLOG_DYNNAME}.log" >/dev/null || {
+    echo "FAIL: expected setuid() privilege-drop error message"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+}
+
+grep -F "missing CAP_SETUID or insufficient privilege" "${RSYSLOG_DYNNAME}.log" >/dev/null || {
+    echo "FAIL: expected CAP_SETUID context in privilege-drop error message"
+    cat "${RSYSLOG_DYNNAME}.log"
+    error_exit 1
+}
+
+generate_conf 2
+add_conf '
+global(
+    errormessagestostderr.maxnumber="20"
+    privdrop.group.id="'${target_gid}'"
+)
+
+template(name="outfmt" type="string" string="%msg%\n")
+action(type="omfile" file="'${RSYSLOG_OUT_LOG}'" template="outfmt")
+' 2
+
+../tools/rsyslogd -n -iNONE -f"${TESTCONF_NM}2.conf" -M"$RSYSLOG_MODDIR" >"${RSYSLOG_DYNNAME}.setgid.log" 2>&1
+if [ $? -eq 0 ]; then
+    echo "FAIL: expected startup failure when setgroups()/setgid() lacks permission"
+    cat "${RSYSLOG_DYNNAME}.setgid.log"
+    error_exit 1
+fi
+
+grep -F "missing CAP_SETGID or insufficient privilege" "${RSYSLOG_DYNNAME}.setgid.log" >/dev/null || {
+    echo "FAIL: expected CAP_SETGID context in privilege-drop error message"
+    cat "${RSYSLOG_DYNNAME}.setgid.log"
+    error_exit 1
+}
+
+grep -E "setgroups\\(\\)|setgid\\(\\)" "${RSYSLOG_DYNNAME}.setgid.log" >/dev/null || {
+    echo "FAIL: expected setgroups() or setgid() privilege-drop error message"
+    cat "${RSYSLOG_DYNNAME}.setgid.log"
+    error_exit 1
+}
+
+exit_test


### PR DESCRIPTION
## Summary
- replace the direct perror/exit path for setuid() failures with normal rsyslog LogError/return handling
- expand setgroups(), setgid(), and initgroups() diagnostics with syscall and missing capability context
- add a non-root regression test for CAP_SETUID/CAP_SETGID-style privilege drop failures

Closes https://github.com/rsyslog/rsyslog/issues/6633

## Validation
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout
- make -j$(nproc) check TESTS=""
- ./tests/privdrop-setuid-fail.sh
- make check TESTS=privdrop-setuid-fail.sh
- bash devtools/format-code.sh --git-changed
- git diff --check
- make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
- Ubuntu 26.04 devcontainer static analyzer: scan-build, no bugs found
- Ubuntu 26.04 devcontainer run-ci.sh focused on privdrop-setuid-fail.sh: PASS