### PR TITLE
tests: cover dynafile path from normalized property

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -148,6 +148,7 @@ TESTS_DEFAULT = \
 	omusrmsg_ratelimit_name.sh \
 	omfile-module-params.sh \
 	omfile-dynafilecachesize-invalid.sh \
+	omfile-dynafile-mmnormalize-property.sh \
 	omfile-read-only-errmsg.sh \
 	omfile-null-filename.sh \
 	omfile-whitespace-filename.sh \

--- a/tests/omfile-dynafile-mmnormalize-property.sh
+++ b/tests/omfile-dynafile-mmnormalize-property.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Regression reproducer for issue #3488: mmnormalize populates a JSON property
+# used by an omfile dynafile template. The old crash happened while resolving
+# that property during action processing. The oracle is clean shutdown and the
+# expected dynafile write; any SIGSEGV or failed template lookup fails the test.
+. ${srcdir:=.}/diag.sh init
+require_plugin imtcp
+require_plugin mmnormalize
+
+generate_conf
+add_conf '
+module(load="../plugins/imtcp/.libs/imtcp")
+module(load="../plugins/mmnormalize/.libs/mmnormalize")
+
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port" ruleset="writeData")
+template(name="LogFormat" type="string" string="%msg%\n")
+template(name="WriteFile" type="string" string="'$RSYSLOG_DYNNAME'.%$!clientIP%.log")
+
+ruleset(name="writeData"
+        queue.type="fixedArray"
+        queue.size="10000"
+        queue.dequeueBatchSize="2048"
+        queue.workerThreads="2"
+        queue.workerThreadMinimumMessages="10000") {
+    action(type="mmnormalize" rule="rule=:%clientIP:ipv4% %other:rest%" userawmsg="on")
+    if $parsesuccess == "OK" then {
+        action(type="omfile" DynaFile="WriteFile" template="LogFormat")
+    }
+}
+'
+
+startup
+tcpflood -m1 -O -M '"192.0.2.15 - - \"GET / HTTP/1.1\" 200 17 \"-\" \"-\" \"-\""'
+shutdown_when_empty
+wait_shutdown
+
+printf ' - "GET / HTTP/1.1" 200 17 "-" "-" "-"\n' > "${RSYSLOG_DYNNAME}.expected"
+cmp_exact_file "${RSYSLOG_DYNNAME}.expected" "${RSYSLOG_DYNNAME}.192.0.2.15.log" || {
+    echo "FAIL: dynafile write did not use the normalized clientIP property"
+    cat "${RSYSLOG_DYNNAME}.192.0.2.15.log"
+    error_exit 1
+}
+
+exit_test

--- a/tests/omfile-dynafile-mmnormalize-property.sh
+++ b/tests/omfile-dynafile-mmnormalize-property.sh
@@ -22,7 +22,7 @@ ruleset(name="writeData"
         queue.dequeueBatchSize="2048"
         queue.workerThreads="2"
         queue.workerThreadMinimumMessages="10000") {
-    action(type="mmnormalize" rule="rule=:%clientIP:ipv4% %other:rest%" userawmsg="on")
+    action(type="mmnormalize" rule="rule=:<%pri:number%>%clientIP:ipv4% %other:rest%" userawmsg="on")
     if $parsesuccess == "OK" then {
         action(type="omfile" DynaFile="WriteFile" template="LogFormat")
     }
@@ -30,7 +30,7 @@ ruleset(name="writeData"
 '
 
 startup
-tcpflood -m1 -O -M '"192.0.2.15 - - \"GET / HTTP/1.1\" 200 17 \"-\" \"-\" \"-\""'
+tcpflood -m1 -O -M "'<13>192.0.2.15 - - \"GET / HTTP/1.1\" 200 17 \"-\" \"-\" \"-\"'"
 shutdown_when_empty
 wait_shutdown
 

--- a/tests/omfile-dynafile-mmnormalize-property.sh
+++ b/tests/omfile-dynafile-mmnormalize-property.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Regression reproducer for issue #3488: mmnormalize populates a JSON property
 # used by an omfile dynafile template. The old crash happened while resolving
 # that property during action processing. The oracle is clean shutdown and the
@@ -30,7 +30,7 @@ ruleset(name="writeData"
 '
 
 startup
-tcpflood -m1 -O -M "'<13>192.0.2.15 - - \"GET / HTTP/1.1\" 200 17 \"-\" \"-\" \"-\"'"
+tcpflood -m1 -O -M "\"<13>192.0.2.15 - - \\\"GET / HTTP/1.1\\\" 200 17 \\\"-\\\" \\\"-\\\" \\\"-\\\"\""
 shutdown_when_empty
 wait_shutdown
 


### PR DESCRIPTION
## Summary
- add a regression test for the old #3488 mmnormalize -> omfile dynafile crash path
- verify a normalized JSON property can drive the dynafile template and write cleanly
- record current behavior as fixed on main without changing omfile/runtime code

Closes https://github.com/rsyslog/rsyslog/issues/3488

## Validation
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-mmnormalize
- make -j$(nproc) check TESTS=""
- ./tests/omfile-dynafile-mmnormalize-property.sh
- make check TESTS=omfile-dynafile-mmnormalize-property.sh
- git diff --check
- make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)
- Ubuntu 26.04 devcontainer static analyzer: scan-build, no bugs found
- Ubuntu 26.04 devcontainer run-ci.sh focused on omfile-dynafile-mmnormalize-property.sh: PASS