### PR TITLE
rpm: support prebuilt docs in spec prep

### DIFF
--- a/doc/BUILDS_README.md
+++ b/doc/BUILDS_README.md
@@ -38,10 +38,14 @@ packages. This is required because:
 -   EPEL 8 provides `python3-sphinx` 1.7.x; EPEL 9 provides 3.4.x. Neither
     satisfies the minimum version and the build fails.
 
-Using `pip3 install -U sphinx` and `pip3 install -r requirements.txt` ensures
-the correct Sphinx version and extensions (e.g. `sphinxcontrib.mermaid`) are
-available for the RPM build. A future improvement would be to pre-build docs
-and include them in the tarball so the spec does not need pip at build time.
+When pre-built HTML documentation is present in `doc/build`, the spec reuses
+that output and does not install Python documentation dependencies during the
+RPM build. Current release artifacts that do not already contain `doc/build`
+still use `pip3 install -U sphinx` and `pip3 install -r requirements.txt` so
+the RPM build receives the required Sphinx version and extensions (e.g.
+`sphinxcontrib.mermaid`). Fully removing pip from the default RPM build path
+requires changing the release artifact to include pre-built docs, or providing
+the required Sphinx and extension packages through the RPM build environment.
 
 
 ## Generating release version of the docs

--- a/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
+++ b/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
@@ -43,10 +43,7 @@ BuildRequires: libtool
 BuildRequires: libuuid-devel
 BuildRequires: pkgconfig
 BuildRequires: python3-docutils
-# Sphinx doc build: pip required because EPEL 8/9 system python3-sphinx is 1.7.x
-# but doc/source/conf.py needs_sphinx = '4.5.0'. System packages cannot satisfy
-# this; see doc/BUILDS_README.md "RPM builds".
-BuildRequires: python3-pip
+BuildRequires: python3-sphinx
 # Pillow (rst2pdf/doc deps) build requirements
 BuildRequires: libjpeg-turbo-devel
 # it depens on rhbz#1419228
@@ -562,16 +559,12 @@ if ! grep -q '^version = ' doc/source/conf.py 2>/dev/null; then
   sed -i "/^release = /i version = '%{version}'" doc/source/conf.py
 fi
 cd doc
-echo "Step 1: Installing sphinx and requirements via pip..."
-pip3 install -U sphinx
-pip3 install -r requirements.txt
-
-echo "Step 2: Building Sphinx documentation (output in doc/build)..."
+echo "Step 1: Building Sphinx documentation (output in doc/build)..."
 num_cpus=$(nproc)
 sphinx-build -j$num_cpus -b html source build 2>&1
 echo "✓ Sphinx documentation built"
 
-echo "Step 3: Listing doc directory contents..."
+echo "Step 2: Listing doc directory contents..."
 ls -al 2>&1
 ls -al build 2>&1
 echo "✓ Directory contents listed"

--- a/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
+++ b/packaging/rpm/rpmbuild/SPECS/rsyslog-v8-stable.spec
@@ -43,7 +43,10 @@ BuildRequires: libtool
 BuildRequires: libuuid-devel
 BuildRequires: pkgconfig
 BuildRequires: python3-docutils
-BuildRequires: python3-sphinx
+# Sphinx doc build: pip required because EPEL 8/9 system python3-sphinx is 1.7.x
+# but doc/source/conf.py needs_sphinx = '4.5.0'. System packages cannot satisfy
+# this; see doc/BUILDS_README.md "RPM builds".
+BuildRequires: python3-pip
 # Pillow (rst2pdf/doc deps) build requirements
 BuildRequires: libjpeg-turbo-devel
 # it depens on rhbz#1419228
@@ -558,13 +561,21 @@ ls -al ./ 2>&1 | tee /dev/stderr
 if ! grep -q '^version = ' doc/source/conf.py 2>/dev/null; then
   sed -i "/^release = /i version = '%{version}'" doc/source/conf.py
 fi
-cd doc
-echo "Step 1: Building Sphinx documentation (output in doc/build)..."
-num_cpus=$(nproc)
-sphinx-build -j$num_cpus -b html source build 2>&1
-echo "✓ Sphinx documentation built"
+cd doc || exit 1
+if [ -f build/index.html ]; then
+  echo "Step 1: Using pre-built Sphinx documentation from doc/build"
+else
+  echo "Step 1: Installing sphinx and requirements via pip..."
+  pip3 install -U sphinx
+  pip3 install -r requirements.txt
 
-echo "Step 2: Listing doc directory contents..."
+  echo "Step 2: Building Sphinx documentation (output in doc/build)..."
+  num_cpus=$(nproc)
+  sphinx-build -j$num_cpus -b html source build 2>&1
+  echo "✓ Sphinx documentation built"
+fi
+
+echo "Step 3: Listing doc directory contents..."
 ls -al 2>&1
 ls -al build 2>&1
 echo "✓ Directory contents listed"


### PR DESCRIPTION
### Motivation
- Avoid deployment-breaking RPM packaging changes while reducing the need for live Python dependency installation when release artifacts already contain built documentation.
- The original attempt to replace pip with `python3-sphinx` is not safe for EL8/EL9 because their system Sphinx packages do not satisfy `doc/source/conf.py`'s `needs_sphinx = '4.5.0'` requirement and do not provide all required extensions.

### Description
- Keep the existing `python3-pip` build dependency and pip fallback for current EL8/EL9 RPM builds.
- Reuse pre-built HTML documentation from `doc/build/index.html` when it is already present in the source artifact, skipping Sphinx dependency installation and doc generation in that case.
- Update `doc/BUILDS_README.md` to document that fully removing pip from the default RPM build path requires either pre-built docs in the release artifact or packaged Sphinx/extension dependencies in the RPM build environment.

### Testing
- Verified the changed `%prep` shell fragment with `bash -n` after substituting the RPM `%{version}` macro.
- Ran ShellCheck on the extracted fragment with a shebang wrapper.
- Ran `git diff --check`.
- `rpmspec`/`rpmbuild` are not installed in this WSL environment, so a true RPM parse/build was not run locally.
