### PR TITLE
docs: clarify local validation gates

### DIFF
--- a/.agent/skills/rsyslog_commit/SKILL.md
+++ b/.agent/skills/rsyslog_commit/SKILL.md
@@ -21,6 +21,8 @@ This skill standardizes the final step of the development workflow: committing a
 - **Optional Local Linters**: Before opening or updating a PR, run useful diff-scoped linters when installed: `shellcheck` for changed `*.sh`, `hadolint` for changed Dockerfiles, `trivy config` for changed infrastructure/config files, and `jscpd` for larger changed source/test sets. Guard each command with `command -v`; if a tool is missing, suggest installing it but do not block unrelated build or test validation. Do not run `cppcheck` routinely unless requested; it is too noisy for the rsyslog tree.
 - **Validation**: Ensure `make -j$(nproc) check TESTS=""` passes and relevant tests are run.
   - **Multi-Pass AI Audit**: Run the `/audit` workflow for a rigorous, persona-based review (Memory, Concurrency, Standards) using the project's canned prompts.
+  - **Local Cubic**: Run local Cubic review when `cubic` is installed and reachable. Hosted Cubic/Gemini PR comments are additional review feedback, not a substitute for local Cubic.
+  - **Container Gate**: For implementation changes, run the `rsyslog_local_container_testing` skill's full ordered local container sequence when container tooling is available. Focused `run-ci.sh TEST=...` commands are targeted container tests, not full local container validation unless that skill explicitly permits the reduced lane.
   - **Mock Smoke Check**: If you added or renamed test files, run `make distcheck TEST_RUN_TYPE=MOCK-OK -j$(nproc)` as a final distribution check.
   - **Note**: If you already successfully built and tested your changes immediately *before* formatting, you do NOT need to re-run the build/test cycle. Formatting is a normalization step and does not affect functionality.
 

--- a/.agent/skills/rsyslog_local_container_testing/SKILL.md
+++ b/.agent/skills/rsyslog_local_container_testing/SKILL.md
@@ -65,7 +65,20 @@ confidence. Mirror these
 2. The Ubuntu 26.04 `devtools/run-ci.sh` check run, only after the analyzer run
    is clean or its findings are understood.
 
+This ordered pair is what "full local container validation" means in agent
+status reports. A focused `devtools/run-ci.sh TEST=...` or build-only
+`TESTS=""` container command is useful supplemental evidence, but it is only a
+targeted container test unless this skill explicitly calls that reduced lane
+acceptable for the touched area. Hosted CI, including hosted Cubic/Gemini
+comments, does not replace this local container gate.
+
 Keep runtimes and summarize failures separately for each run.
+
+Use the skill's configured dev image or another explicit CI-equivalent image.
+The Docker Hub `rsyslog/rsyslog_dev_base_ubuntu:26.04` image is acceptable for
+normal local dev-container validation. When the task specifically validates a
+locally built runtime or dev image, use that locally built image/tag for the
+container-under-test and record its image ID.
 
 ## Clean Tree Rule
 
@@ -182,6 +195,10 @@ For a faster build-only smoke check, set `CI_MAKE_CHECK_OPT='-j80 TESTS='`.
 This is useful for intermediate feedback, but it does not satisfy the full
 final validation gate.
 
+Do not replace this run with a focused `TEST=...` lane just because the PR has a
+single new test. The full run validates the CI configure path, generated state,
+service relevance filters, and broad testbench integration.
+
 ## Optional Tier 3: Risk-Triggered Specialist Lanes
 
 Run these only when the changed area justifies the extra local time. The command
@@ -215,12 +232,37 @@ touch their relevant module paths or `runtime/*.[ch]`. Use
 `RSYSLOG_TESTBENCH_FORCE_SERVICE_TESTS=1` or per-family force variables when
 intentionally validating service tests without relevant source changes.
 
+Allowed relaxations are narrow and tied to the touched area:
+
+- imfile-only work may skip unrelated external service lanes.
+- Kafka may be disabled only when neither Kafka modules nor Kafka test plumbing
+  are touched.
+- Elasticsearch may be disabled only when neither omelasticsearch nor
+  Elasticsearch test plumbing are touched.
+- Journal/imjournal runtime tests are static-analysis-only on hosts without a
+  usable journal service. Do not try to force journal runtime tests in that
+  environment; record the static-analysis exception instead.
+
+Record every relaxation with the touched-area rationale. A skipped or relaxed
+lane without that rationale makes the result targeted validation, not full
+local container validation.
+
 ## Reporting
 
 Report:
 
 - exact command shape and container image
+- image tag and image ID
 - elapsed `real` time from `/usr/bin/time -p` where used
 - pass/skip/fail summary from `tests/test-suite.log`
 - whether skips were expected from relevance filtering
+- lanes run, lanes relaxed/skipped, and touched-area rationale for each
+  relaxation
+- whether the result is fully container-validated or targeted
 - unrelated local flakes separately from failures caused by the change
+
+If a full container lane fails, inspect the logs and make up to four concrete
+remediation attempts only when the failure appears locally fixable. Record the
+command, log path, failure summary, each attempt, the affected PR/unit, and
+whether host-side validation passed. If it still fails after those attempts,
+carry the error forward in the session ledger instead of spinning.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,8 @@ Follow these steps for a typical development task:
 2.  **Validate**: Use the `rsyslog_test` skill to run relevant shell tests.
 3.  **Container Validation**: Use the `rsyslog_local_container_testing` skill
     when Docker or Podman container tooling is available.
-4.  **Commit**: Use the `rsyslog_commit` skill to format code and draft your message.
+4.  **Local AI Review**: Run local Cubic review when `cubic` is available.
+5.  **Commit**: Use the `rsyslog_commit` skill to format code and draft your message.
 
 Tip: You do NOT need to re-run your build, test, or container validation cycle
 after formatting if you already validated the code immediately before.
@@ -80,6 +81,18 @@ as the final validation gate when container tooling is available.
 - If Docker or Podman is available and usable, run the
   [`rsyslog_local_container_testing`](.agent/skills/rsyslog_local_container_testing/SKILL.md)
   skill's full local validation before reporting the task complete.
+- Full local container validation means the skill's ordered full sequence,
+  including the static analyzer and Ubuntu 26.04 `run-ci.sh` check run. Focused
+  container tests are useful targeted evidence, but they are not the full gate
+  unless the skill explicitly allows the reduced lane for the touched area.
+- Use the skill's configured CI-equivalent dev image, including Docker Hub dev
+  images when appropriate. Use a locally built image only when validating that
+  local image or the runtime container produced by the task.
+- Run local Cubic validation when `cubic` is installed and reachable. Hosted
+  Cubic or Gemini PR comments are additional review feedback, not substitutes
+  for local Cubic or local container validation.
+- Relax expensive or service-backed lanes only for the narrow touched-area
+  cases documented in the container-testing skill, and record the rationale.
 - If Docker or Podman is not installed, not running, lacks required
   permissions, or the required image cannot be obtained, state that exact
   blocker in the final response.
@@ -89,6 +102,10 @@ as the final validation gate when container tooling is available.
 - Do not describe implementation work as fully validated or complete unless
   full local container validation passed, or the user explicitly accepted the
   reduced validation scope after the blocker was reported.
+- Session ledgers and final summaries for PR work must distinguish fully
+  container-validated work from targeted container-tested-only work. Include the
+  local Cubic status, hosted AI review status, image tag and ID, exact commands,
+  lane relaxations, and pass/fail results.
 
 ## Context Discovery (Subtree Guides)
 

--- a/ai/local-review-workflow.sh
+++ b/ai/local-review-workflow.sh
@@ -7,6 +7,13 @@ set -euo pipefail
 #   Multi-stage rsyslog policy check pipeline using GitHub Copilot CLI.
 #   Runs checks from least to most costly, stopping at first issue.
 #
+# Validation role:
+#   This script runs local review stages, including local Cubic when available.
+#   Hosted Cubic/Gemini PR comments are useful follow-up review feedback, but
+#   they do not substitute for this local Cubic stage. Likewise, local Cubic
+#   does not substitute for the full local container validation sequence in
+#   .agent/skills/rsyslog_local_container_testing/SKILL.md.
+#
 # Default diff:
 #   main...HEAD
 #
@@ -57,9 +64,13 @@ DIFF_SPEC:
 PIPELINE STAGES:
   1. alloc-policy   - Scans .c/.h files for raw malloc/calloc/realloc/strdup calls
   2. mock-distcheck - Runs 'make distcheck TEST_RUN_TYPE=MOCK-OK' for packaging validation
-  3. cubic          - Runs cubic code review (final stage)
+  3. cubic          - Runs local cubic code review (final stage)
 
-NOTE: Agent should build/test working tree BEFORE running this script.
+NOTE: Agent should build/test working tree BEFORE running this script. For
+      implementation PRs, also run the rsyslog_local_container_testing skill's
+      full ordered container gate when container tooling is available. A focused
+      run-ci.sh invocation is targeted container testing, not full validation,
+      unless that skill explicitly permits the reduced lane.
 
 EXIT CODES:
   0  All checks passed (or no changes/skipped)
@@ -394,4 +405,3 @@ fi
 debug "All pipeline checks passed"
 echo "$RESULT"
 exit 0
-


### PR DESCRIPTION
## Summary
- define full local container validation as the ordered skill sequence, not focused run-ci smoke tests
- clarify local Cubic is required when available and hosted AI review is additional feedback
- document image/tag expectations, allowed touched-area relaxations, and required reporting fields

## Validation
- Local Cubic: PASS, no issues
- shellcheck -S warning ai/local-review-workflow.sh: existing advisory warnings only (SC2046 on -j$(nproc), SC2034 unused DIFF_IS_EMPTY)