### PR TITLE
rainerscript: fix array matches on JSON/local variables

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3595,7 +3595,7 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
                     } else {
                         n_l = var2Number(&l, &convok_l);
                         if (convok_l) {
-                            ret->d.n = (n_l == r.d.n); /*CMP*/
+                            ret->d.n = (n_l == var2Number(&r, NULL)); /*CMP*/
                         } else {
                             estr_r = var2String(&r, &bMustFree);
                             ret->d.n = !es_strcmp(l.d.estr, estr_r); /*CMP*/
@@ -3617,7 +3617,7 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
                     } else {
                         n_l = var2Number(&l, &convok_l);
                         if (convok_l) {
-                            ret->d.n = (n_l == r.d.n); /*CMP*/
+                            ret->d.n = (n_l == var2Number(&r, NULL)); /*CMP*/
                         } else {
                             estr_r = var2String(&r, &bMustFree2);
                             ret->d.n = !es_strcmp(estr_l, estr_r); /*CMP*/
@@ -3639,7 +3639,7 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
                         if (bMustFree) es_deleteStr(estr_l);
                     }
                 } else {
-                    ret->d.n = (l.d.n == r.d.n); /*CMP*/
+                    ret->d.n = (l.d.n == var2Number(&r, NULL)); /*CMP*/
                 }
                 varFreeMembers(&r);
             }
@@ -3647,7 +3647,6 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
             break;
         case CMP_NE:
             cnfexprEval(expr->l, &l, usrptr, pWti);
-            cnfexprEval(expr->r, &r, usrptr, pWti);
             ret->datatype = 'N';
             if (l.datatype == 'S') {
                 if (expr->r->nodetype == 'S') {
@@ -3655,35 +3654,46 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
                 } else if (expr->r->nodetype == 'A') {
                     ret->d.n = evalStrArrayCmp(l.d.estr, (struct cnfarray *)expr->r, CMP_NE);
                 } else {
+                    cnfexprEval(expr->r, &r, usrptr, pWti);
                     if (r.datatype == 'S') {
                         ret->d.n = es_strcmp(l.d.estr, r.d.estr); /*CMP*/
                     } else {
                         n_l = var2Number(&l, &convok_l);
                         if (convok_l) {
-                            ret->d.n = (n_l != r.d.n); /*CMP*/
+                            ret->d.n = (n_l != var2Number(&r, NULL)); /*CMP*/
                         } else {
                             estr_r = var2String(&r, &bMustFree);
                             ret->d.n = es_strcmp(l.d.estr, estr_r); /*CMP*/
                             if (bMustFree) es_deleteStr(estr_r);
                         }
                     }
+                    varFreeMembers(&r);
                 }
             } else if (l.datatype == 'J') {
                 estr_l = var2String(&l, &bMustFree);
-                if (r.datatype == 'S') {
-                    ret->d.n = es_strcmp(estr_l, r.d.estr); /*CMP*/
+                if (expr->r->nodetype == 'S') {
+                    ret->d.n = es_strcmp(estr_l, ((struct cnfstringval *)expr->r)->estr); /*CMP*/
+                } else if (expr->r->nodetype == 'A') {
+                    ret->d.n = evalStrArrayCmp(estr_l, (struct cnfarray *)expr->r, CMP_NE);
                 } else {
-                    n_l = var2Number(&l, &convok_l);
-                    if (convok_l) {
-                        ret->d.n = (n_l != r.d.n); /*CMP*/
+                    cnfexprEval(expr->r, &r, usrptr, pWti);
+                    if (r.datatype == 'S') {
+                        ret->d.n = es_strcmp(estr_l, r.d.estr); /*CMP*/
                     } else {
-                        estr_r = var2String(&r, &bMustFree2);
-                        ret->d.n = es_strcmp(estr_l, estr_r); /*CMP*/
-                        if (bMustFree2) es_deleteStr(estr_r);
+                        n_l = var2Number(&l, &convok_l);
+                        if (convok_l) {
+                            ret->d.n = (n_l != var2Number(&r, NULL)); /*CMP*/
+                        } else {
+                            estr_r = var2String(&r, &bMustFree2);
+                            ret->d.n = es_strcmp(estr_l, estr_r); /*CMP*/
+                            if (bMustFree2) es_deleteStr(estr_r);
+                        }
                     }
+                    varFreeMembers(&r);
                 }
                 if (bMustFree) es_deleteStr(estr_l);
             } else {
+                cnfexprEval(expr->r, &r, usrptr, pWti);
                 if (r.datatype == 'S') {
                     n_r = var2Number(&r, &convok_r);
                     if (convok_r) {
@@ -3694,10 +3704,11 @@ void ATTR_NONNULL() cnfexprEval(const struct cnfexpr *__restrict__ const expr,
                         if (bMustFree) es_deleteStr(estr_l);
                     }
                 } else {
-                    ret->d.n = (l.d.n != r.d.n); /*CMP*/
+                    ret->d.n = (l.d.n != var2Number(&r, NULL)); /*CMP*/
                 }
+                varFreeMembers(&r);
             }
-            FREE_BOTH_RET;
+            varFreeMembers(&l);
             break;
         case CMP_LE:
             ret->datatype = 'N';

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -342,6 +342,7 @@ TESTS_DEFAULT = \
 	suspend-omfwd-via-file.sh \
 	externalstate-failed-rcvr.sh \
 	rcvr_fail_restore.sh \
+	snd-array-cmp-json.sh \
 	rscript_b64_decode.sh \
 	rscript_contains.sh \
 	rscript_bare_var_root.sh \

--- a/tests/snd-array-cmp-json.sh
+++ b/tests/snd-array-cmp-json.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# This test verifies that array comparisons (both == and !=) work correctly
+# when the left-hand operand is a JSON-type property or local variable (e.g. $.testvar).
+# This acts as the regression test for issue #487.
+#
+# Intent: Ensure array comparison operators correctly inspect all elements of the
+# right-hand array when compared against a local variable (PROP_LOCAL_VAR), which 
+# evaluates to the JSON-type 'J'.
+#
+# Oracle:
+# - Test 1 (== match): Should pass because $.testvar ("match_me") is in the list.
+# - Test 2 (== no match): Should fail because $.testvar is not in the list.
+# - Test 3 (!= match): Should pass because $.testvar is not in the list (so all are different).
+# - Test 4 (!= no match): Should fail because $.testvar is in the list (so not all are different).
+#
+# If the bug is present, Test 4 incorrectly passes because it only compares $.testvar to "other1".
+# Therefore, success is defined by "T1_PASS" and "T3_PASS" being present, and "T2_FAIL" and "T4_FAIL" being absent.
+
+. ${srcdir:=.}/diag.sh init snd-array-cmp-json.sh
+generate_conf
+add_conf '
+template(name="out" type="string" string="%msg% : %$.status%\n")
+
+set $.testvar = "match_me";
+set $.testnum = 42;
+
+# Test 1: == match (should fire)
+if $.testvar == ["other1", "match_me", "other2"] then {
+    set $.status = "T1_PASS";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+
+# Test 2: == no match (should NOT fire)
+if $.testvar == ["other1", "other2"] then {
+    set $.status = "T2_FAIL";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+
+# Test 3: != match (should fire since match_me is not in the list)
+if $.testvar != ["other1", "other2"] then {
+    set $.status = "T3_PASS";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+
+# Test 4: != no match (should NOT fire since match_me is in the list)
+if $.testvar != ["other1", "match_me", "other2"] then {
+    set $.status = "T4_FAIL";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+
+# Test 5: == match numeric on JSON variable (should fire)
+if $.testnum == 42 then {
+    set $.status = "T5_PASS";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+
+# Test 6: != no match numeric on JSON variable (should NOT fire)
+if $.testnum != 42 then {
+    set $.status = "T6_FAIL";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+
+# Test 7: == no match numeric on JSON variable (should NOT fire)
+if $.testnum == 43 then {
+    set $.status = "T7_FAIL";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+
+# Test 8: != match numeric on JSON variable (should fire)
+if $.testnum != 43 then {
+    set $.status = "T8_PASS";
+    action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="out")
+}
+'
+
+startup
+injectmsg  # Injects a single default log message
+echo doing shutdown
+shutdown_when_empty
+echo wait on shutdown
+wait_shutdown 
+
+content_check "T1_PASS"
+content_check "T3_PASS"
+content_check "T5_PASS"
+content_check "T8_PASS"
+assert_content_missing "T2_FAIL"
+assert_content_missing "T4_FAIL"
+assert_content_missing "T6_FAIL"
+assert_content_missing "T7_FAIL"
+
+exit_test


### PR DESCRIPTION
Restructure CMP_NE in cnfexprEval to support array matching on J-type variables (JSON/local variables). Previously, inequality array matching ($.var != [...]) on J-type variables incorrectly evaluated to a single string comparison against only the first element of the array.

This acts as the fix for rsyslog/rsyslog#487.

Closes: https://github.com/rsyslog/rsyslog/issues/487