### PR TITLE
mmexternal: avoid undrained helper stdout/stderr in `output="none"` mode

### DIFF
--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -353,11 +353,14 @@ static void __attribute__((noreturn)) execBinary(wrkrInstanceData_t *pWrkrData,
             perror("mmexternal: open(/dev/null) failed\n");
         }
     }
-    if (dup2(fdStdOutErr == -1 ? fdDevNull : fdStdOutErr, STDOUT_FILENO) == -1) {
-        perror("mmexternal: dup() stdout failed\n");
-    }
-    if (dup2(fdStdOutErr == -1 ? fdDevNull : fdStdOutErr, STDERR_FILENO) == -1) {
-        perror("mmexternal: dup() stderr failed\n");
+    const int targetFd = (fdStdOutErr == -1) ? fdDevNull : fdStdOutErr;
+    if (targetFd != -1) {
+        if (dup2(targetFd, STDOUT_FILENO) == -1) {
+            perror("mmexternal: dup() stdout failed\n");
+        }
+        if (dup2(targetFd, STDERR_FILENO) == -1) {
+            perror("mmexternal: dup() stderr failed\n");
+        }
     }
 
     /* we close all file handles as we fork soon
@@ -446,7 +449,7 @@ static rsRetVal openPipe(wrkrInstanceData_t *pWrkrData) {
 
     DBGPRINTF("mmexternal: child has pid %d\n", (int)cpid);
     if (useOutputPipe) {
-        pWrkrData->fdPipeIn = dup(pipestdout[0]);
+        pWrkrData->fdPipeIn = pipestdout[0];
         close(pipestdout[1]);
     }
     close(pipestdin[0]);

--- a/plugins/mmexternal/mmexternal.c
+++ b/plugins/mmexternal/mmexternal.c
@@ -339,6 +339,7 @@ static void __attribute__((noreturn)) execBinary(wrkrInstanceData_t *pWrkrData,
                                                  const int fdStdin,
                                                  const int fdStdOutErr) {
     int i;
+    int fdDevNull = -1;
     struct sigaction sigAct;
     sigset_t set;
     char *newenviron[] = {NULL};
@@ -346,10 +347,16 @@ static void __attribute__((noreturn)) execBinary(wrkrInstanceData_t *pWrkrData,
     if (dup2(fdStdin, STDIN_FILENO) == -1) {
         perror("mmexternal: dup() stdin failed\n");
     }
-    if (dup2(fdStdOutErr, STDOUT_FILENO) == -1) {
+    if (fdStdOutErr == -1) {
+        fdDevNull = open("/dev/null", O_WRONLY);
+        if (fdDevNull == -1) {
+            perror("mmexternal: open(/dev/null) failed\n");
+        }
+    }
+    if (dup2(fdStdOutErr == -1 ? fdDevNull : fdStdOutErr, STDOUT_FILENO) == -1) {
         perror("mmexternal: dup() stdout failed\n");
     }
-    if (dup2(fdStdOutErr, STDERR_FILENO) == -1) {
+    if (dup2(fdStdOutErr == -1 ? fdDevNull : fdStdOutErr, STDERR_FILENO) == -1) {
         perror("mmexternal: dup() stderr failed\n");
     }
 
@@ -400,13 +407,14 @@ static void __attribute__((noreturn)) execBinary(wrkrInstanceData_t *pWrkrData,
 static rsRetVal openPipe(wrkrInstanceData_t *pWrkrData) {
     int pipestdin[2];
     int pipestdout[2];
+    int useOutputPipe = pWrkrData->pData->outputMode != OUTPUT_NONE;
     pid_t cpid;
     DEFiRet;
 
     if (pipe(pipestdin) == -1) {
         ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
     }
-    if (pipe(pipestdout) == -1) {
+    if (useOutputPipe && pipe(pipestdout) == -1) {
         ABORT_FINALIZE(RS_RET_ERR_CREAT_PIPE);
     }
 
@@ -427,15 +435,21 @@ static rsRetVal openPipe(wrkrInstanceData_t *pWrkrData) {
     if (cpid == 0) {
         /* we are now the child, just exec the binary. */
         close(pipestdin[1]); /* close those pipe "ports" that */
-        close(pipestdout[0]); /* we don't need */
-        execBinary(pWrkrData, pipestdin[0], pipestdout[1]);
+        if (useOutputPipe) {
+            close(pipestdout[0]); /* we don't need */
+            execBinary(pWrkrData, pipestdin[0], pipestdout[1]);
+        } else {
+            execBinary(pWrkrData, pipestdin[0], -1);
+        }
         /*NO CODE HERE - WILL NEVER BE REACHED!*/
     }
 
     DBGPRINTF("mmexternal: child has pid %d\n", (int)cpid);
-    pWrkrData->fdPipeIn = dup(pipestdout[0]);
+    if (useOutputPipe) {
+        pWrkrData->fdPipeIn = dup(pipestdout[0]);
+        close(pipestdout[1]);
+    }
     close(pipestdin[0]);
-    close(pipestdout[1]);
     pWrkrData->pid = cpid;
     pWrkrData->fdPipeOut = pipestdin[1];
     pWrkrData->bIsRunning = 1;


### PR DESCRIPTION
### Motivation
- The `interface.output="none"` mode previously left the helper's stdout/stderr connected to a pipe that rsyslog does not read, allowing a noisy helper to block on writes and stall rsyslog's blocking `writev()` path. 

### Description
- When `outputMode == OUTPUT_NONE`, `openPipe()` no longer creates the child stdout pipe and the child is started with `fdStdOutErr == -1` instead of a pipe FD, as implemented in `plugins/mmexternal/mmexternal.c`.
- `execBinary()` now treats `fdStdOutErr == -1` as a signal to open `/dev/null` and `dup2()` that descriptor onto `STDOUT_FILENO` and `STDERR_FILENO`, avoiding an unread pipe in one-way mode.
- Existing behavior for reply-producing modes is unchanged: the stdout/stderr pipe is still created and used for half-duplex JSON replies.

### Testing
- Attempted `make -j"$(nproc)" check TESTS=""`, but it failed because the repository did not have a configured `Makefile` (build not bootstrapped), so no full test run was executed.
- Ran `./autogen.sh && ./configure --enable-testbench` to prepare a local build, but `configure` failed due to a missing dependency `protoc-c` (`Please install protobuf-c-compiler`), blocking a complete automated build and test run.
- No automated unit/integration tests were completed in this environment; the change is minimal and targeted to `plugins/mmexternal/mmexternal.c` to preserve existing reply-mode behavior while preventing availability stalls in `output="none"` mode.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fcc1289c833293b4977e467ca5b5)