### PR TITLE
mmjsonparse: avoid json double-free on msgAddJSON errors

### DIFF
--- a/plugins/mmjsonparse/mmjsonparse.c
+++ b/plugins/mmjsonparse/mmjsonparse.c
@@ -295,15 +295,13 @@ static rsRetVal processJSON(wrkrInstanceData_t *pWrkrData, smsg_t *pMsg, struct 
 
     DBGPRINTF("mmjsonparse: processing already parsed JSON object\n");
 
-    /* JSON is already parsed and validated, just add it to the message */
+    /* JSON is already parsed and validated, just add it to the message.
+     * msgAddJSON assumes ownership of json and may release it on both
+     * success and error paths, so do not access json after this call.
+     */
     CHKiRet(msgAddJSON(pMsg, pWrkrData->pData->container, json, 0, 0));
-    /* Note: msgAddJSON takes ownership of the json object on success,
-     * but we need to clean up on failure */
 
 finalize_it:
-    if (iRet != RS_RET_OK && json != NULL) {
-        json_object_put(json);
-    }
     RETiRet;
 }
 


### PR DESCRIPTION
### Motivation
- `processJSON()` in `plugins/mmjsonparse` unconditionally freed the `json` object after calling `msgAddJSON()`, but `msgAddJSON()` may already release `json` on certain error paths, causing a double-free and potential rsyslog crash; the change prevents this unsafe double-free.

### Description
- Removed the unconditional `json_object_put(json)` cleanup from `processJSON()` and added a comment documenting that `msgAddJSON()` assumes ownership of `json` and may release it on both success and error paths, leaving control flow and return behavior unchanged.

### Testing
- Ran code formatting with `devtools/format-code.sh --git-changed` which completed successfully. 
- Attempted `make -j$(nproc) check TESTS=""` but the workspace lacks a `check` target, so full build/test could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fba7c2b883328e8993a653c6010c)