### PR TITLE
gssapi: fix token length framing endianness in send_token()

### DIFF
--- a/runtime/gss-misc.c
+++ b/runtime/gss-misc.c
@@ -243,7 +243,7 @@ static int send_token(int s, gss_buffer_t tok) {
         LogError(0, NO_ERRCODE, "GSS-API token length %lu exceeds wire format limit", (unsigned long)tok->length);
         return -1;
     }
-    len = htonl(tok->length);
+    len = (unsigned int)tok->length;
     lenbuf[0] = (len >> 24) & 0xff;
     lenbuf[1] = (len >> 16) & 0xff;
     lenbuf[2] = (len >> 8) & 0xff;

--- a/runtime/gss-misc.c
+++ b/runtime/gss-misc.c
@@ -237,13 +237,13 @@ static int recv_token(int s, gss_buffer_t tok, size_t max_tok_len, unsigned int 
 static int send_token(int s, gss_buffer_t tok) {
     int ret;
     unsigned char lenbuf[4];
-    unsigned int len;
+    uint32_t len;
 
     if (tok->length > 0xffffffffUL) {
         LogError(0, NO_ERRCODE, "GSS-API token length %lu exceeds wire format limit", (unsigned long)tok->length);
         return -1;
     }
-    len = (unsigned int)tok->length;
+    len = (uint32_t)tok->length;
     lenbuf[0] = (len >> 24) & 0xff;
     lenbuf[1] = (len >> 16) & 0xff;
     lenbuf[2] = (len >> 8) & 0xff;


### PR DESCRIPTION
### Motivation
- A new `gssTokenDecodeLength()` helper decodes the 4-byte GSS token length as a big-endian/network-order value while `send_token()` was still calling `htonl()` and then extracting bytes, causing an endian-dependent framing mismatch that breaks GSS handshakes on little-endian hosts and can trigger plaintext fallback in `imgssapi`.

### Description
- Replace the extra conversion in `runtime/gss-misc.c::send_token()` by changing `len = htonl(tok->length)` to `len = (unsigned int)tok->length` so the emitted 4-byte prefix (shifted bytes) matches the new `gssTokenDecodeLength()` decoder.

### Testing
- Attempted `make -j"$(nproc)" check TESTS='tests/gssapi-basic.sh tests/imgssapi-maxsessions.sh'`, but the `check` target is unavailable in this environment so the automated test run failed; container-based validation (`docker`/`podman`) is also unavailable so full local container validation was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fcc121d483328cd8bba2e1ab246d)