### PR TITLE
imjournal: treat rate-limit discards as non-fatal in readjournal

### DIFF
--- a/plugins/imjournal/imjournal.c
+++ b/plugins/imjournal/imjournal.c
@@ -708,6 +708,9 @@ static rsRetVal readjournal(struct journalContext_s *journalContext, ruleset_t *
     /* submit message */
     iRet = enqMsg((uchar *)message, (uchar *)sys_iden_help, facility, severity, &tv, json, 0, pBindRuleset);
     json = NULL;
+    if (iRet == RS_RET_DISCARDMSG) {
+        iRet = RS_RET_OK;
+    }
     CHKiRet(iRet);
 
 finalize_it:


### PR DESCRIPTION
### Motivation
- Prevent normal rate-limit drops (`RS_RET_DISCARDMSG`) from propagating as fatal errors that trigger `tryRecover()` and unnecessary journal close/sleep/open cycles.

### Description
- In `plugins/imjournal/imjournal.c`, after calling `enqMsg()` in `readjournal()`, normalize `RS_RET_DISCARDMSG` to `RS_RET_OK` before `CHKiRet(iRet)` so rate-limited drops do not escape to the outer loop while preserving discard accounting in `enqMsg()`.

### Testing
- Attempted to run the repository validation command `make -j$(nproc) check TESTS=""`, but the workspace is not configured with generated Makefiles and `make` failed with `No rule to make target 'check'`, so no automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1301c935248332aea847e6e6c76db6)