### PR TITLE
mmjsontransform: avoid leak on policy insert conflict

### DIFF
--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -953,11 +953,20 @@ static rsRetVal jsontransformApplyPolicyRules(struct json_object *src,
             } else {
                 rewrittenValue = json_object_get(value);
             }
-            iRet = jsontransformInsertDotted(dest, targetKey, rewrittenValue, conflict);
+            jsontransformConflict_t insertConflict = {0, NULL};
+            iRet = jsontransformInsertDotted(dest, targetKey, rewrittenValue, &insertConflict);
             if (iRet != RS_RET_OK) {
+                jsontransformConflictCleanup(&insertConflict);
                 goto loop_finalize;
             }
-            if (conflict == NULL || !conflict->occurred) {
+            if (insertConflict.occurred) {
+                if (conflict != NULL && !conflict->occurred) {
+                    conflict->occurred = 1;
+                    conflict->detail = insertConflict.detail;
+                    insertConflict.detail = NULL;
+                }
+                jsontransformConflictCleanup(&insertConflict);
+            } else {
                 rewrittenValue = NULL;
             }
         }

--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -957,7 +957,9 @@ static rsRetVal jsontransformApplyPolicyRules(struct json_object *src,
             if (iRet != RS_RET_OK) {
                 goto loop_finalize;
             }
-            rewrittenValue = NULL;
+            if (conflict == NULL || !conflict->occurred) {
+                rewrittenValue = NULL;
+            }
         }
 
     loop_finalize:


### PR DESCRIPTION
### Motivation
- The YAML policy preprocessing path in `mmjsontransform` can trigger dotted-key or rename collisions that set `conflict->occurred` while returning `RS_RET_OK`, and the caller risked dropping the only cleanup handle for attacker-controlled JSON values, causing a memory leak over repeated messages.

### Description
- Change in `plugins/mmjsontransform/mmjsontransform.c`: `jsontransformApplyPolicyRules()` now only clears `rewrittenValue` after `jsontransformInsertDotted()` when no conflict was recorded (`conflict == NULL || !conflict->occurred`), ensuring loop cleanup retains ownership on conflict paths.
- The fix is intentionally minimal and preserves the existing ownership contract with `jsontransformInsertDotted()` so the existing loop-level `json_object_put()` still frees values when appropriate.

### Testing
- Ran code formatting with `bash devtools/format-code.sh`, which completed successfully.  
- Executed the focused test script `./tests/mmjsontransform-policy-basic.sh`, which could not complete in this environment because `configure` failed due to a missing `protoc-c` dependency, so the test bootstrap aborted before runtime validation.  
- No other automated tests were run in this environment; the patch is small and focused to minimize behavioral impact.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1302b90cdc8332aa1a17aef8fe5540)