### PR TITLE
runtime/statsobj: serialize stats list iteration with object destruction

### DIFF
--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -582,9 +582,12 @@ static ATTR_NO_SANITIZE_THREAD rsRetVal emitPrometheusForObject(statsobj_t *o,
 
 static rsRetVal generatePrometheusStats(rsRetVal (*cb)(void *, const char *), void *usrptr, int8_t bResetCtrs) {
     statsobj_t *o;
+    int listLocked = 0;
     DEFiRet;
 
     /* For each statsobj in our linked list, emit Prometheus lines. */
+    pthread_mutex_lock(&mutStats);
+    listLocked = 1;
     for (o = objRoot; o != NULL; o = o->next) {
         CHKiRet(emitPrometheusForObject(o, cb, usrptr, bResetCtrs));
         /* If the object has a read_notifier, call it now */
@@ -592,10 +595,14 @@ static rsRetVal generatePrometheusStats(rsRetVal (*cb)(void *, const char *), vo
             o->read_notifier(o, o->read_notifier_ctx);
         }
     }
+    pthread_mutex_unlock(&mutStats);
     /* Optionally, handle sender stats as additional metrics:
      * e.g. emit "rsyslog_sender_<sender> <nMsgs>" lines.
      * For simplicity, we skip this, or you can extend similarly. */
 finalize_it:
+    if (listLocked) {
+        pthread_mutex_unlock(&mutStats);
+    }
     RETiRet;
 }
 
@@ -611,6 +618,7 @@ static rsRetVal getAllStatsLines(rsRetVal (*cb)(void *, const char *),
                                  const int8_t bResetCtrs) {
     statsobj_t *o;
     cstr_t *cstr = NULL;
+    int listLocked = 0;
     DEFiRet;
 
 
@@ -619,6 +627,8 @@ static rsRetVal getAllStatsLines(rsRetVal (*cb)(void *, const char *),
         FINALIZE;
     }
 
+    pthread_mutex_lock(&mutStats);
+    listLocked = 1;
     for (o = objRoot; o != NULL; o = o->next) {
         switch (fmt) {
             case statsFmt_Legacy:
@@ -642,10 +652,15 @@ static rsRetVal getAllStatsLines(rsRetVal (*cb)(void *, const char *),
             o->read_notifier(o, o->read_notifier_ctx);
         }
     }
+    pthread_mutex_unlock(&mutStats);
+    listLocked = 0;
 
     getSenderStats(cb, usrptr, fmt, bResetCtrs);
 
 finalize_it:
+    if (listLocked) {
+        pthread_mutex_unlock(&mutStats);
+    }
     if (cstr != NULL) {
         rsCStrDestruct(&cstr);
     }
@@ -666,12 +681,15 @@ static rsRetVal getAllCounters(statsobj_counter_cb_t cb, void *ctx) {
     DEFiRet;
     statsobj_t *o;
     ctr_t *ctr;
+    int listLocked = 0;
 
     if (cb == NULL) {
         ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     }
 
     /* Iterate through all statsobj instances */
+    pthread_mutex_lock(&mutStats);
+    listLocked = 1;
     for (o = objRoot; o != NULL; o = o->next) {
         /* Iterate through all counters in this object */
         pthread_mutex_lock(&o->mutCtr);
@@ -715,8 +733,13 @@ static rsRetVal getAllCounters(statsobj_counter_cb_t cb, void *ctx) {
             o->read_notifier(o, o->read_notifier_ctx);
         }
     }
+    pthread_mutex_unlock(&mutStats);
+    listLocked = 0;
 
 finalize_it:
+    if (listLocked) {
+        pthread_mutex_unlock(&mutStats);
+    }
     RETiRet;
 }
 

--- a/runtime/statsobj.c
+++ b/runtime/statsobj.c
@@ -596,6 +596,7 @@ static rsRetVal generatePrometheusStats(rsRetVal (*cb)(void *, const char *), vo
         }
     }
     pthread_mutex_unlock(&mutStats);
+    listLocked = 0;
     /* Optionally, handle sender stats as additional metrics:
      * e.g. emit "rsyslog_sender_<sender> <nMsgs>" lines.
      * For simplicity, we skip this, or you can extend similarly. */


### PR DESCRIPTION
### Motivation
- Close a race where stats collectors could walk the global `objRoot` list while another thread removed/freed a `statsobj`, which can produce a use-after-free (observed with imfile per-file stats + impstats iteration). 

### Description
- Hold the global `mutStats` lock for the full duration of list traversal in `generatePrometheusStats`, `getAllStatsLines`, and `getAllCounters` so objects cannot be unlinked/freed while being visited. 
- Add a local `listLocked` guard in each function to ensure early-return/error paths only unlock when the lock is actually held. 
- Change localized to a single file: `runtime/statsobj.c` (list-walking/iteration paths only). 

### Testing
- Attempted the targeted test invocation `make -j$(nproc) check TESTS='imfile-statistics.sh'`, but the workspace is not configured/built here and `make` returned `No rule to make target 'check'`. 
- No other automated test or full local container validation was run in this environment, so this change is marked as not fully container-validated per repository validation rules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1305fe3d0883329f218f02c05a6954)