### PR TITLE
runtime: avoid post-fork malloc in execProg

### DIFF
--- a/runtime/srutils.c
+++ b/runtime/srutils.c
@@ -286,19 +286,19 @@ int execProg(uchar *program, int bWait, uchar *arg1, uchar *arg2) {
     int pid;
     int sig;
     struct sigaction sigAct;
-    int i;
-    char **exec_argv;
-    uchar *args[2];
-    int argc = 0;
+    char *exec_argv[4];
+    int argc = 1;
 
+    exec_argv[0] = (char *)program;
     if (arg1 == NULL && arg2 != NULL) {
         arg1 = arg2;
         arg2 = NULL;
     }
-    if (arg1 != NULL) args[argc++] = arg1;
-    if (arg2 != NULL) args[argc++] = arg2;
+    if (arg1 != NULL) exec_argv[argc++] = (char *)arg1;
+    if (arg2 != NULL) exec_argv[argc++] = (char *)arg2;
+    exec_argv[argc] = NULL;
 
-    dbgprintf("exec program '%s' with %d args\n", program, argc);
+    dbgprintf("exec program '%s' with %d args\n", program, argc - 1);
     pid = fork();
     if (pid < 0) {
         return 0;
@@ -330,18 +330,6 @@ int execProg(uchar *program, int bWait, uchar *arg1, uchar *arg2) {
     sigAct.sa_handler = SIG_DFL;
 
     for (sig = 1; sig < NSIG; ++sig) sigaction(sig, &sigAct, NULL);
-
-    exec_argv = (char **)malloc(sizeof(char *) * (argc + 2));
-    if (exec_argv == NULL) {
-        perror("exec");
-        fprintf(stderr, "malloc failed for exec argv\n");
-        exit(1);
-    }
-    exec_argv[0] = (char *)program;
-    for (i = 0; i < argc; ++i) {
-        exec_argv[i + 1] = (char *)args[i];
-    }
-    exec_argv[argc + 1] = NULL;
 
     execvp((char *)program, exec_argv);
     /* In the long term, it's a good idea to implement some enhanced error


### PR DESCRIPTION
### Motivation
- Fix a post-fork unsafe allocation in `execProg()` where the child called `malloc()` after `fork()` and before `execvp()`, which can deadlock in a multithreaded daemon if allocator locks were inherited and the parent synchronously `waitpid()`s the child.

### Description
- Prebuild the `execvp()` argv on stack storage (`char *exec_argv[4]`) before calling `fork()` and remove the child-side `malloc()` and copy loop so no heap allocation occurs between `fork()` and `execvp()`; preserve existing argument-shifting semantics for `arg1`/`arg2`.

### Testing
- Attempted repository validation with `make -j$(nproc) check TESTS=""`, but `make check` was not available in this environment so no tests ran.
- Ran `./autogen.sh && ./configure --enable-testbench`, which aborted due to a missing dependency: `protoc-c not found. Please install protobuf-c-compiler package.`, so a full build and test run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1305fe3f508332804b86a29ec56504)