### PR TITLE
runtime: clamp RFC5424 emulated TAG length to prevent stack overread

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -2288,10 +2288,18 @@ static void ATTR_NONNULL(1) tryEmulateTAG(smsg_t *const pM, const sbool bLockMut
             /* no process ID, use APP-NAME only */
             MsgSetTAG(pM, (uchar *)getAPPNAME(pM, MUTEX_ALREADY_LOCKED), getAPPNAMELen(pM, MUTEX_ALREADY_LOCKED));
         } else {
+            int snRet;
             /* now we can try to emulate */
-            lenTAG = snprintf((char *)bufTAG, CONF_TAG_MAXSIZE, "%s[%s]", getAPPNAME(pM, MUTEX_ALREADY_LOCKED),
-                              getPROCID(pM, MUTEX_ALREADY_LOCKED));
+            snRet = snprintf((char *)bufTAG, CONF_TAG_MAXSIZE, "%s[%s]", getAPPNAME(pM, MUTEX_ALREADY_LOCKED),
+                             getPROCID(pM, MUTEX_ALREADY_LOCKED));
             bufTAG[sizeof(bufTAG) - 1] = '\0'; /* just to make sure... */
+            if (snRet < 0) {
+                lenTAG = 0;
+            } else if ((size_t)snRet >= sizeof(bufTAG)) {
+                lenTAG = sizeof(bufTAG) - 1;
+            } else {
+                lenTAG = snRet;
+            }
             MsgSetTAG(pM, bufTAG, lenTAG);
         }
         /* Signal change in TAG for acquireProgramName */


### PR DESCRIPTION
### Motivation
- `tryEmulateTAG()` computed an emulated `APP-NAME[PROCID]` into a fixed `CONF_TAG_MAXSIZE` stack buffer but passed `snprintf()`'s would-have-written return value directly to `MsgSetTAG()`, creating a possible stack over-read when the formatted output was larger than the buffer. 
- This path is newly reachable from `mmutf8fix` which now retrieves tags for RFC5424 messages, so an attacker-controlled long `APP-NAME`/`PROCID` could trigger the over-read.

### Description
- In `runtime/msg.c` `tryEmulateTAG()` the `snprintf()` return is stored in `snRet` and handled defensively instead of being used raw. 
- Negative `snprintf()` returns set the length to `0`, truncated outputs set `lenTAG` to `CONF_TAG_MAXSIZE - 1`, and otherwise `lenTAG` uses the `snprintf()` result, ensuring the passed length is bounded. 
- The change preserves normal behavior for in-range tags and keeps the stack buffer NUL-terminated.

### Testing
- Attempted to run `make -j$(nproc) check TESTS='mmutf8fix_tag.sh'` but the local environment lacks a top-level `Makefile`, so the test run failed with `No rule to make target 'check'` and no testbench executions completed. 
- No automated tests were executed here after the patch; the fix is intentionally minimal and should be validated in CI or a local build (e.g. `./autogen.sh && ./configure --enable-mmutf8fix && make check TESTS='mmutf8fix_tag.sh'`) to confirm the regression is resolved under full testbench conditions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130e3722b483328719bc100c1a46a0)