### PR TITLE
nsd_mbedtls: reject RemoteSNI and wire interface

### DIFF
--- a/runtime/nsd_mbedtls.c
+++ b/runtime/nsd_mbedtls.c
@@ -1396,6 +1396,16 @@ static rsRetVal GetRemoteIP(nsd_t *pNsd, prop_t **ip) {
     RETiRet;
 }
 
+static rsRetVal GetRemotePort(nsd_t *pNsd, int *port) {
+    nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
+    ISOBJ_TYPE_assert(pThis, nsd_mbedtls);
+    return nsd_ptcp.GetRemotePort(pThis->pTcp, port);
+}
+
+static rsRetVal FmtRemotePortStr(const int port, uchar *const buf, const size_t len) {
+    return nsd_ptcp.FmtRemotePortStr(port, buf, len);
+}
+
 /* queryInterface function */
 BEGINobjQueryInterface(nsd_mbedtls)
     CODESTARTobjQueryInterface(
@@ -1436,9 +1446,11 @@ BEGINobjQueryInterface(nsd_mbedtls)
     pIf->SetPrioritizeSAN = SetPrioritizeSAN;
     pIf->SetTlsVerifyDepth = SetTlsVerifyDepth;
     pIf->SetTlsCAFile = SetTlsCAFile;
-    pIf->SetTlsCRLFile = SetTlsCRLFile;
     pIf->SetTlsKeyFile = SetTlsKeyFile;
     pIf->SetTlsCertFile = SetTlsCertFile;
+    pIf->SetTlsCRLFile = SetTlsCRLFile;
+    pIf->GetRemotePort = GetRemotePort;
+    pIf->FmtRemotePortStr = FmtRemotePortStr;
     pIf->SetRemoteSNI = SetRemoteSNI;
     pIf->SetTlsRevocationCheck = SetTlsRevocationCheck;
 finalize_it:

--- a/runtime/nsd_mbedtls.c
+++ b/runtime/nsd_mbedtls.c
@@ -576,6 +576,19 @@ finalize_it:
     RETiRet;
 }
 
+static rsRetVal SetRemoteSNI(nsd_t __attribute__((unused)) * pNsd, uchar *pszRemoteSNI) {
+    DEFiRet;
+    if (pszRemoteSNI != NULL) {
+        LogError(0, RS_RET_VALUE_NOT_SUPPORTED,
+                 "error: remote SNI setting not supported by "
+                 "mbedtls netstream driver");
+        ABORT_FINALIZE(RS_RET_VALUE_NOT_SUPPORTED);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
 static rsRetVal SetTlsRevocationCheck(nsd_t *pNsd, int enabled) {
     DEFiRet;
     nsd_mbedtls_t *pThis = nsd_mbedtls_from_nsd(pNsd);
@@ -1426,6 +1439,7 @@ BEGINobjQueryInterface(nsd_mbedtls)
     pIf->SetTlsCRLFile = SetTlsCRLFile;
     pIf->SetTlsKeyFile = SetTlsKeyFile;
     pIf->SetTlsCertFile = SetTlsCertFile;
+    pIf->SetRemoteSNI = SetRemoteSNI;
     pIf->SetTlsRevocationCheck = SetTlsRevocationCheck;
 finalize_it:
 ENDobjQueryInterface(nsd_mbedtls)


### PR DESCRIPTION
### Motivation
- Prevent a NULL function-pointer dereference when `omfwd` sets `StreamDriverRemoteSNI` while the mbedTLS netstream driver did not populate `SetRemoteSNI` for interface v18.

### Description
- Add a `SetRemoteSNI` implementation in `runtime/nsd_mbedtls.c` that returns `RS_RET_VALUE_NOT_SUPPORTED` when a non-NULL SNI is provided and is a no-op for `NULL` input, avoiding undefined behavior.
- Register `SetRemoteSNI` in the `nsd_mbedtls` `queryInterface` so the interface table is fully populated for `nsdCURR_IF_VERSION` and callers can safely invoke it.
- The change is minimal and preserves existing behavior by explicitly rejecting the unsupported setting rather than leaving the pointer unset.

### Testing
- Ran code formatting with `bash devtools/format-code.sh --git-changed` which completed successfully on the modified file.
- Attempted `make -j2 check TESTS=""` per repo guidance but the `check` target is unavailable in this unconfigured environment, so full build/test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130e3708048332b302b2baecdd2163)