### PR TITLE
rainerscript: reject embedded NUL bytes in is_in_subnet() args

### DIFF
--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3221,6 +3221,9 @@ static void ATTR_NONNULL() doFunct_is_in_subnet(struct cnffunc *__restrict__ con
 
     ip_estr = var2String(&srcVal[0], &bMustFreeEs1);
     cidr_estr = var2String(&srcVal[1], &bMustFreeEs2);
+    if (ip_estr == NULL || cidr_estr == NULL) {
+        goto finalize_it;
+    }
     ip_str = (char *)es_str2cstr(ip_estr, NULL);
     cidr_str = (char *)es_str2cstr(cidr_estr, NULL);
     bMustFree1 = 1;

--- a/grammar/rainerscript.c
+++ b/grammar/rainerscript.c
@@ -3202,7 +3202,10 @@ static void ATTR_NONNULL() doFunct_is_in_subnet(struct cnffunc *__restrict__ con
                                                 void *__restrict__ const usrptr,
                                                 wti_t *__restrict__ const pWti) {
     struct svar srcVal[2];
-    int bMustFree1, bMustFree2;
+    int bMustFree1 = 0, bMustFree2 = 0;
+    int bMustFreeEs1 = 0, bMustFreeEs2 = 0;
+    es_str_t *ip_estr = NULL;
+    es_str_t *cidr_estr = NULL;
     char *ip_str, *cidr_str;
     char *cidr_ip_part;
     char *cidr_mask_part;
@@ -3216,10 +3219,21 @@ static void ATTR_NONNULL() doFunct_is_in_subnet(struct cnffunc *__restrict__ con
     cnfexprEval(func->expr[0], &srcVal[0], usrptr, pWti);
     cnfexprEval(func->expr[1], &srcVal[1], usrptr, pWti);
 
-    ip_str = (char *)var2CString(&srcVal[0], &bMustFree1);
-    cidr_str = (char *)var2CString(&srcVal[1], &bMustFree2);
+    ip_estr = var2String(&srcVal[0], &bMustFreeEs1);
+    cidr_estr = var2String(&srcVal[1], &bMustFreeEs2);
+    ip_str = (char *)es_str2cstr(ip_estr, NULL);
+    cidr_str = (char *)es_str2cstr(cidr_estr, NULL);
+    bMustFree1 = 1;
+    bMustFree2 = 1;
 
     if (ip_str == NULL || cidr_str == NULL) {
+        goto finalize_it;
+    }
+    /*
+     * Reject embedded NUL bytes in length-counted string values. Otherwise
+     * C-string parsers may accept a truncated prefix and bypass validation.
+     */
+    if (strlen(ip_str) != es_strlen(ip_estr) || strlen(cidr_str) != es_strlen(cidr_estr)) {
         goto finalize_it;
     }
 
@@ -3291,6 +3305,8 @@ static void ATTR_NONNULL() doFunct_is_in_subnet(struct cnffunc *__restrict__ con
 finalize_it:
     if (bMustFree1) free(ip_str);
     if (bMustFree2) free(cidr_str);
+    if (bMustFreeEs1) es_deleteStr(ip_estr);
+    if (bMustFreeEs2) es_deleteStr(cidr_estr);
     varFreeMembers(&srcVal[0]);
     varFreeMembers(&srcVal[1]);
 


### PR DESCRIPTION
### Motivation
- Fix a validation bypass where `is_in_subnet()` accepted length-counted RainerScript strings that contained embedded NUL bytes because the implementation converted values to C strings and parsed them with NUL-terminated APIs (`inet_pton`, `strchr`, `strtol`).
- Prevent attacker-controlled message fields with embedded NULs from being treated as valid IP/CIDR prefixes and thereby bypassing filtering/routing rules.

### Description
- In `doFunct_is_in_subnet()` replaced the `var2CString()`-based flow with `var2String()` + `es_str2cstr()` so the original `es_str_t` length is retained for validation. 
- Added explicit embedded-NUL rejection by comparing `strlen(cstr)` to `es_strlen(estr)` for both IP and CIDR arguments and aborting if they differ. 
- Added and initialized temporary `es_str_t` handles and ownership flags and ensured they are properly cleaned up on all exit paths. 
- Kept the existing parsing/matching logic (IPv4/IPv6 parsing, family checks, mask parsing, masking and comparison) unchanged for valid inputs.

### Testing
- Ran the repository test script `tests/rscript_is_in_subnet.sh` as the targeted validation, but execution was blocked because the build tree is not configured (`make: *** No rule to make target 'check'.  Stop.`), so automated tests could not be executed in this environment. 
- Local static inspection and targeted review confirm the change adds only the embedded-NUL rejection and proper cleanup without altering valid parsing/matching behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130e38ccbc83329e4fc1d64d222f06)