### PR TITLE
impstats: harden overwrite temp file creation

### DIFF
--- a/plugins/impstats/impstats.c
+++ b/plugins/impstats/impstats.c
@@ -772,17 +772,26 @@ BEGINrunInput
 
         char *tmp_logfile = NULL;
         if (runModConf->bLogOverwrite && runModConf->logfile != NULL) {
-            const size_t len_tmp_logfile = strlen(runModConf->logfile) + 5;
+            const size_t len_tmp_logfile = strlen(runModConf->logfile) + sizeof(".tmp.XXXXXX");
             if ((tmp_logfile = malloc(len_tmp_logfile)) == NULL) {
                 LogError(errno, RS_RET_OUT_OF_MEMORY, "impstats: could not allocate memory for temp log file name");
             } else {
-                snprintf(tmp_logfile, len_tmp_logfile, "%s.tmp", runModConf->logfile);
+                snprintf(tmp_logfile, len_tmp_logfile, "%s.tmp.XXXXXX", runModConf->logfile);
                 pthread_mutex_lock(&hup_mutex);
-                runModConf->logfd = open(tmp_logfile, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, S_IRUSR | S_IWUSR);
+                runModConf->logfd = mkstemp(tmp_logfile);
                 if (runModConf->logfd == -1) {
-                    LogError(errno, RS_RET_ERR, "impstats: error opening temp stats file %s", tmp_logfile);
+                    LogError(errno, RS_RET_ERR, "impstats: error creating temp stats file %s", tmp_logfile);
                     free(tmp_logfile);
                     tmp_logfile = NULL;
+                } else {
+                    if (fcntl(runModConf->logfd, F_SETFD, FD_CLOEXEC) != 0) {
+                        LogError(errno, RS_RET_ERR, "impstats: failed to set close-on-exec on temp stats file %s",
+                                 tmp_logfile);
+                    }
+                    if (fchmod(runModConf->logfd, S_IRUSR | S_IWUSR) != 0) {
+                        LogError(errno, RS_RET_ERR, "impstats: failed to set permissions on temp stats file %s",
+                                 tmp_logfile);
+                    }
                 }
                 pthread_mutex_unlock(&hup_mutex);
             }


### PR DESCRIPTION
### Motivation

- Close a local symlink/truncation vulnerability in `impstats` when `log.file.overwrite` is enabled by removing the attacker-predictable `"<logfile>.tmp"` creation path.
- Preserve the existing atomic write-then-`rename()` semantics while preventing a local unprivileged user from pre-creating a symlink to cause privileged rsyslogd to clobber arbitrary files.

### Description

- Replace deterministic temp-path construction with a `mkstemp` template `"%s.tmp.XXXXXX"` and use `mkstemp()` to atomically create a unique temporary file. 
- Explicitly set close-on-exec on the returned FD via `fcntl(..., F_SETFD, FD_CLOEXEC)` and enforce restrictive permissions with `fchmod(..., S_IRUSR|S_IWUSR)`.
- Keep the existing write-then-`rename(tmp, logfile)` flow and existing error logging/cleanup behavior when temp-file creation fails.
- Adjust temporary-name buffer sizing to accommodate the `".tmp.XXXXXX"` template.

### Testing

- Ran the repository C formatter with `devtools/format-code.sh --git-changed`, which completed successfully.
- Attempted `make -j$(nproc) check TESTS=''` but the environment lacked generated build targets so the `make check` target could not be executed (`No rule to make target 'check'`).
- No module-level automated tests were run in this environment; the change is intentionally minimal to preserve existing behavior and should be validated with standard `make check` / testbench in a full build environment before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130e368fcc833293549eef0cf9df77)