### PR TITLE
tests: harden simple shell helper failures

### DIFF
--- a/tests/CI/gather_all_logs.sh
+++ b/tests/CI/gather_all_logs.sh
@@ -4,5 +4,5 @@
 echo gather all logs left from make check.
 echo you only need these if make check is terminated due to timeout
 # IMPORTANT: ! -name "rstb_*" excludes $RSYSLOGDYNNAME*.log
-( cd tests ;
+( cd tests || exit 1
 find . -maxdepth 1 -print0 -name "*.log" ! -name "rstb_*" -exec cat {} +; )

--- a/tests/CI/prep-libestr.sh
+++ b/tests/CI/prep-libestr.sh
@@ -4,14 +4,14 @@ echo "****** PREPARE libestr"
 PWD_HOME=$PWD
 if [ ! -d "local_env" ]; then mkdir local_env; fi
 if [ ! -d "local_env/install" ]; then mkdir local_env/install; fi
-cd local_env
+cd local_env || exit 1
 pwd
 git clone git://github.com/rsyslog/libestr
-cd libestr
+cd libestr || exit 1
 autoreconf -fvi
 ./configure --prefix=/opt/rsyslog > /dev/null
 #./configure --prefix=$PWD_HOME/local_env/install &> /dev/null
 #find /opt/rsyslog
 make
 sudo make install
-cd $PWD_HOME
+cd "$PWD_HOME" || exit 1

--- a/tests/CI/prep-libfastjson.sh
+++ b/tests/CI/prep-libfastjson.sh
@@ -4,13 +4,13 @@ echo "****** PREPARE libfastjson"
 PWD_HOME=$PWD
 if [ ! -d "local_env" ]; then mkdir local_env; fi
 if [ ! -d "local_env/install" ]; then mkdir local_env/install; fi
-cd local_env
+cd local_env || exit 1
 pwd
 git clone git://github.com/rsyslog/libfastjson
-cd libfastjson
+cd libfastjson || exit 1
 autoreconf -fvi
 ./configure --prefix=/opt/rsyslog > /dev/null
 make
 sudo make install
-cd $PWD_HOME
+cd "$PWD_HOME" || exit 1
 #set +o xtrace

--- a/tests/CI/prep-liblogging.sh
+++ b/tests/CI/prep-liblogging.sh
@@ -4,13 +4,13 @@ echo "****** PREPARE liblogging"
 PWD_HOME=$PWD
 if [ ! -d "local_env" ]; then mkdir local_env; fi
 if [ ! -d "local_env/install" ]; then mkdir local_env/install; fi
-cd local_env
+cd local_env || exit 1
 pwd
 git clone git://github.com/rsyslog/liblogging
-cd liblogging
+cd liblogging || exit 1
 autoreconf -fvi
 ./configure --prefix=/opt/rsyslog --disable-man-pages > /dev/null
 make
 sudo make install
-cd $PWD_HOME
+cd "$PWD_HOME" || exit 1
 #set +o xtrace

--- a/tests/action-tx-errfile.sh
+++ b/tests/action-tx-errfile.sh
@@ -4,8 +4,10 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50 # sufficient for our needs!
 export SEQ_CHECK_OPTIONS=-i2
-export EXPECTED_ERRFILE="$(cat ${srcdir}/testsuites/action-tx-errfile.result)"
-export EXPECTED_ERRFILE_LINES="$(printf '%s\n' "$EXPECTED_ERRFILE" | wc -l)"
+EXPECTED_ERRFILE="$(cat "${srcdir}/testsuites/action-tx-errfile.result")" || exit 1
+export EXPECTED_ERRFILE
+EXPECTED_ERRFILE_LINES="$(printf '%s\n' "$EXPECTED_ERRFILE" | wc -l)"
+export EXPECTED_ERRFILE_LINES
 check_sql_and_errfile_data_ready() {
 	mysql_get_data
 	seq_check --check-only 0 $((NUMMESSAGES - 2)) || return 1

--- a/tests/solaris/prep-libfastjson.sh
+++ b/tests/solaris/prep-libfastjson.sh
@@ -3,13 +3,13 @@ set -o xtrace
 PWD_HOME=$PWD
 mkdir local_env
 mkdir local_env/install
-cd local_env
+cd local_env || exit 1
 pwd
 git clone http://github.com/rsyslog/libfastjson
-cd libfastjson
+cd libfastjson || exit 1
 git log -2
 autoreconf -fvi
-./configure --prefix=$PWD_HOME/local_env/install
+./configure --prefix="$PWD_HOME/local_env/install"
 gmake -j2
 gmake install
 pwd

--- a/tests/solaris/prep-librelp.sh
+++ b/tests/solaris/prep-librelp.sh
@@ -3,14 +3,14 @@ set -o xtrace
 PWD_HOME=$PWD
 mkdir local_env
 mkdir local_env/install
-cd local_env
+cd local_env || exit 1
 pwd
 git clone http://github.com/rsyslog/librelp
-cd librelp
+cd librelp || exit 1
 git log -2
 env | grep FLAGS
 autoreconf -fvi
-./configure --prefix=$PWD_HOME/local_env/install
+./configure --prefix="$PWD_HOME/local_env/install"
 gmake -j2 V=1
 gmake install
 pwd

--- a/tests/travis/install.sh
+++ b/tests/travis/install.sh
@@ -39,13 +39,25 @@ if [ "$KAFKA" == "YES" ]; then
 	sudo apt-get install -qq liblz4-dev 
 	# For kafka testbench, "kcat" package is needed!
 	git clone https://github.com/edenhill/librdkafka > /dev/null
-	(unset CFLAGS; cd librdkafka ; ./configure --prefix=/usr --CFLAGS="-g" > /dev/null ; make -j2  > /dev/null ; sudo make install > /dev/null)
+	(
+		unset CFLAGS
+		cd librdkafka || exit 1
+		./configure --prefix=/usr --CFLAGS="-g" > /dev/null &&
+			make -j2 > /dev/null &&
+			sudo make install > /dev/null
+	) || exit 1
 	rm -rf librdkafka # get rid of source, e.g. for line length check
 fi
 
 if [ "$IMHTTP" == "YES" ]; then
 	git clone https://github.com/civetweb/civetweb.git > /dev/null
-	(unset CFLAGS; cd civetweb; make build ; sudo make install-headers PREFIX=/usr ; sudo make install-slib PREFIX=/usr )
+	(
+		unset CFLAGS
+		cd civetweb || exit 1
+		make build &&
+			sudo make install-headers PREFIX=/usr &&
+			sudo make install-slib PREFIX=/usr
+	) || exit 1
 	rm -rf civetweb # get rid of source, e.g. for line length check
 fi
 

--- a/tests/travis/run-cron.sh
+++ b/tests/travis/run-cron.sh
@@ -21,18 +21,20 @@ mkdir coverity
 	tar xzf cov*.tar.gz
 	rm -f cov*.tar.gz
 ) || exit 1
-export PATH="coverity/$(cd coverity && ls -d cov*)/bin:$PATH"
+COVERITY_DIR="$(cd coverity && ls -d cov*)" || exit 1
+export PATH="coverity/$COVERITY_DIR/bin:$PATH"
 # Coverity scan tool installed
 
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
 (
-	cd libksi
+	set -e
+	cd libksi || exit 1
 	autoreconf -fvi
 	./configure --prefix=/usr
 	make -j
 	sudo make install
-)
+) || exit 1
 
 # prep rsyslog for submission
 autoreconf -vfi


### PR DESCRIPTION
## Summary
- add explicit failure handling for simple cd operations in test/CI helpers
- split exported command substitutions that could mask fixture/path failures
- leave broader ShellCheck classes untouched for separate review

## Validation
- shellcheck -S warning on changed test scripts: pass
- bash -n on changed test scripts: pass
- tests-wide ShellCheck: 382 -> 362 warning lines; no new warnings
- git diff --check: pass
- Docker static analyzer on rsyslog/rsyslog_dev_base_ubuntu:26.04: pass, no bugs found
- Docker Ubuntu 26.04 run-ci.sh on rebased HEAD: 1274 total, 1181 pass, 93 skip, 0 fail

## Notes
Local Cubic review was not run because the tool invocation was blocked by the approval reviewer as a possible external data export.