### PR TITLE
imfifo: implement named pipe input module

### DIFF
--- a/.codex/pre_commit_format_gate.sh
+++ b/.codex/pre_commit_format_gate.sh
@@ -174,7 +174,7 @@ except json.JSONDecodeError:
 if payload.get("hook_event_name") != "PreToolUse":
     sys.exit(0)
 
-if payload.get("tool_name") != "Bash":
+if payload.get("tool_name") not in {"Bash", "run_command"}:
     sys.exit(0)
 
 tool_input = payload.get("tool_input") or {}

--- a/.codex/pre_push_container_gate.sh
+++ b/.codex/pre_push_container_gate.sh
@@ -133,10 +133,9 @@ try:
     payload = json.loads(payload_raw)
 except json.JSONDecodeError:
     sys.exit(0)
-
 if payload.get("hook_event_name") != "PreToolUse":
     sys.exit(0)
-if payload.get("tool_name") != "Bash":
+if payload.get("tool_name") not in {"Bash", "run_command"}:
     sys.exit(0)
 
 tool_input = payload.get("tool_input") or {}

--- a/Makefile.am
+++ b/Makefile.am
@@ -183,6 +183,10 @@ if ENABLE_IMFILE
 SUBDIRS += plugins/imfile
 endif
 
+if ENABLE_IMFIFO
+SUBDIRS += plugins/imfifo
+endif
+
 if ENABLE_IMDOCKER
 SUBDIRS += contrib/imdocker
 endif
@@ -641,6 +645,10 @@ endif
 
 if ENABLE_IMFILE
 DISTCHECK_CONFIGURE_FLAGS+= --enable-imfile
+endif
+
+if ENABLE_IMFIFO
+DISTCHECK_CONFIGURE_FLAGS+= --enable-imfifo
 endif
 
 if ENABLE_IMFILE_TESTS

--- a/configure.ac
+++ b/configure.ac
@@ -2251,6 +2251,20 @@ fi
 AM_CONDITIONAL(ENABLE_IMFILE_TESTS, test x$enable_imfile_tests = xyes)
 
 
+# settings for the fifo input module
+AC_ARG_ENABLE(imfifo,
+        [AS_HELP_STRING([--enable-imfifo],[fifo input module enabled @<:@default=no@:>@])],
+        [case "${enableval}" in
+         yes) enable_imfifo="yes" ;;
+          no) enable_imfifo="no" ;;
+           *) AC_MSG_ERROR(bad value ${enableval} for --enable-imfifo) ;;
+         esac],
+        [enable_imfifo=no]
+)
+AM_CONDITIONAL(ENABLE_IMFIFO, test x$enable_imfifo = xyes)
+
+
+
 # settings for the docker log input module
 AC_ARG_ENABLE(imdocker,
         [AS_HELP_STRING([--enable-imdocker],[input docker module enabled @<:@default=no@:>@])],
@@ -3557,6 +3571,7 @@ AC_CONFIG_FILES([Makefile \
 		plugins/omruleset/Makefile \
 		plugins/omuxsock/Makefile \
 		plugins/imfile/Makefile \
+		plugins/imfifo/Makefile \
 		plugins/imsolaris/Makefile \
 		plugins/imptcp/Makefile \
 		plugins/impstats/Makefile \
@@ -3668,6 +3683,7 @@ echo "    plain tcp input module enabled:           $enable_imptcp"
 echo "    DTLS udp input module enabled:            $enable_imdtls"
 echo "    imdiag enabled:                           $enable_imdiag"
 echo "    file input module enabled:                $enable_imfile"
+echo "    fifo input module enabled:                $enable_imfifo"
 echo "    docker log input module enabled:          $enable_imdocker"
 echo "    Solaris input module enabled:             $enable_imsolaris"
 echo "    periodic statistics module enabled:       $enable_impstats"

--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -189,6 +189,7 @@ EXTRA_DIST = \
     source/configuration/modules/imdtls.rst \
     source/configuration/modules/imbeats.rst \
     source/configuration/modules/imfile.rst \
+    source/configuration/modules/imfifo.rst \
     source/configuration/modules/imgssapi.rst \
     source/configuration/modules/imhiredis.rst \
     source/configuration/modules/imhttp.rst \
@@ -560,6 +561,11 @@ EXTRA_DIST = \
     source/reference/parameters/imfile-tag.rst \
     source/reference/parameters/imfile-timeoutgranularity.rst \
     source/reference/parameters/imfile-trimlineoverbytes.rst \
+    source/reference/parameters/imfifo-facility.rst \
+    source/reference/parameters/imfifo-file.rst \
+    source/reference/parameters/imfifo-ruleset.rst \
+    source/reference/parameters/imfifo-severity.rst \
+    source/reference/parameters/imfifo-tag.rst \
     source/reference/parameters/imgssapi-inputgsslistenportfilename.rst \
     source/reference/parameters/imgssapi-inputgssserverkeepalive.rst \
     source/reference/parameters/imgssapi-inputgssservermaxsessions.rst \

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -102,6 +102,6 @@ imfifo:
   requires_serialization: true
   notes:
     - Reads log messages line-by-line from local POSIX named pipes (FIFOs).
-    - Utilizes non-blocking select loops with a 100ms timeout to ensure clean and immediate shutdown.
+    - Utilizes non-blocking poll() loops with a 100ms timeout to ensure clean and immediate shutdown.
     - Uses O_RDWR opening technique to keep a dummy writer in the daemon itself to avoid startup hangs and EOF reopening loops.
 

--- a/doc/ai/module_map.yaml
+++ b/doc/ai/module_map.yaml
@@ -96,3 +96,12 @@ imbeats:
     - The common Elastic Agent TLS setup validates the rsyslog server certificate but does not present a client certificate; use streamDriver.authMode=anon for that pattern and stricter auth modes only with sender client certificates.
     - Compressed Lumberjack v2 frames are supported and should be tested with Beats compression enabled.
     - A concrete sample container definition lives under packaging/docker/rsyslog/imbeats but is not wired into published container builds yet.
+
+imfifo:
+  paths: ["plugins/imfifo/"]
+  requires_serialization: true
+  notes:
+    - Reads log messages line-by-line from local POSIX named pipes (FIFOs).
+    - Utilizes non-blocking select loops with a 100ms timeout to ensure clean and immediate shutdown.
+    - Uses O_RDWR opening technique to keep a dummy writer in the daemon itself to avoid startup hangs and EOF reopening loops.
+

--- a/doc/source/configuration/modules/imfifo.rst
+++ b/doc/source/configuration/modules/imfifo.rst
@@ -1,0 +1,120 @@
+*******************************
+imfifo: Named Pipe Input Module
+*******************************
+
+.. index:: ! imfifo
+
+.. meta::
+   :description: Named pipe (FIFO) input module for rsyslog, reading logs line-by-line from FIFOs on the local filesystem.
+   :keywords: rsyslog, imfifo, input, named pipe, fifo
+
+.. summary-start
+
+This module provides the ability to read log messages line-by-line from named pipes (FIFOs) on the local filesystem.
+
+.. summary-end
+
+===========================  ===========================================================================
+**Module Name:**             **imfifo**
+**Author/Maintainer:**       `Rainer Gerhards <https://rainer.gerhards.net/>`_ <rgerhards@adiscon.com>
+**Introduced:**              8.2606.0
+===========================  ===========================================================================
+
+Purpose
+=======
+
+The `imfifo` module allows rsyslog to monitor local POSIX named pipes (FIFOs). It reads incoming log messages line-by-line and submits them to rsyslog queues for processing.
+
+This module is designed for modern dynamic configuration and supports multiple input instances. This allows you to monitor different named pipes concurrently, each with different tag, ruleset, facility, or severity configurations.
+
+Main Features
+=============
+
+- **Line-by-line Reading**: Messages are read from the named pipe and split on newline (``\n``) boundaries.
+- **O_RDWR Opening Technique**: To prevent rsyslog from blocking indefinitely during startup when no writers are yet connected to the pipe, and to avoid spinning on EOF when a writer disconnects, the module opens named pipes in ``O_RDWR`` mode.
+- **Ruleset Binding**: Each pipe instance can be bound to a specific ruleset for isolated log routing and processing.
+- **Clean Shutdown**: Utilizes non-blocking select loops with a short timeout to ensure rsyslog shuts down cleanly and instantly when requested.
+
+Configuration
+=============
+
+.. note::
+
+   Parameter names are case-insensitive; camelCase is recommended for readability.
+
+Input Parameters
+----------------
+
+.. list-table::
+   :widths: 30 70
+   :header-rows: 1
+
+   * - Parameter
+     - Summary
+   * - :ref:`param-imfifo-file`
+     - .. include:: ../../reference/parameters/imfifo-file.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfifo-tag`
+     - .. include:: ../../reference/parameters/imfifo-tag.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfifo-facility`
+     - .. include:: ../../reference/parameters/imfifo-facility.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfifo-severity`
+     - .. include:: ../../reference/parameters/imfifo-severity.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+   * - :ref:`param-imfifo-ruleset`
+     - .. include:: ../../reference/parameters/imfifo-ruleset.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
+
+Configuration Examples
+======================
+
+The following example loads the ``imfifo`` module and configures two separate input instances to read from different local named pipes.
+
+.. code-block:: rsyslog
+
+   module(load="imfifo")
+
+   # Monitor custom application pipe
+   input(type="imfifo"
+         file="/var/run/app_log.pipe"
+         tag="app-pipe:"
+         severity="info"
+         facility="local3")
+
+   # Monitor system events pipe
+   input(type="imfifo"
+         file="/var/run/sys_events.pipe"
+         tag="sys-events:")
+
+Notes
+=====
+
+- **Named Pipe Creation**: The target named pipes must be pre-created on the filesystem using `mkfifo` before rsyslog starts. For example:
+  
+  .. code-block:: bash
+
+     mkfifo /var/run/app_log.pipe
+     chmod 600 /var/run/app_log.pipe
+
+- **Security & Posture**: To maintain a secure environment, ensure that the permissions on the named pipes are restricted (e.g., owned by the user running rsyslog and set to mode ``600`` or ``620``). Do not allow untrusted users to write to pipes monitored by rsyslog.
+
+See also
+========
+
+- :doc:`../index`
+
+.. toctree::
+   :hidden:
+
+   ../../reference/parameters/imfifo-facility
+   ../../reference/parameters/imfifo-file
+   ../../reference/parameters/imfifo-ruleset
+   ../../reference/parameters/imfifo-severity
+   ../../reference/parameters/imfifo-tag

--- a/doc/source/configuration/modules/imfifo.rst
+++ b/doc/source/configuration/modules/imfifo.rst
@@ -33,7 +33,7 @@ Main Features
 - **Line-by-line Reading**: Messages are read from the named pipe and split on newline (``\n``) boundaries.
 - **O_RDWR Opening Technique**: To prevent rsyslog from blocking indefinitely during startup when no writers are yet connected to the pipe, and to avoid spinning on EOF when a writer disconnects, the module opens named pipes in ``O_RDWR`` mode.
 - **Ruleset Binding**: Each pipe instance can be bound to a specific ruleset for isolated log routing and processing.
-- **Clean Shutdown**: Utilizes non-blocking select loops with a short timeout to ensure rsyslog shuts down cleanly and instantly when requested.
+- **Clean Shutdown**: Utilizes non-blocking poll() loops with a short timeout to ensure rsyslog shuts down cleanly and instantly when requested.
 
 Configuration
 =============

--- a/doc/source/reference/parameters/imfifo-facility.rst
+++ b/doc/source/reference/parameters/imfifo-facility.rst
@@ -1,0 +1,48 @@
+.. _param-imfifo-facility:
+.. _imfifo.parameter.input.facility:
+
+facility
+========
+
+.. meta::
+   :description: Syslog facility to apply to messages read from this named pipe (FIFO).
+   :keywords: rsyslog, imfifo, facility
+
+.. index::
+   single: imfifo; facility
+   single: facility
+
+.. summary-start
+
+Specifies the syslog facility to apply to messages read from this named pipe (FIFO).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfifo`.
+
+:Name: facility
+:Scope: input
+:Type: facility (word/integer)
+:Default: local0
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+The syslog facility to be assigned to all messages read from this named pipe. It can be specified in textual form (for example ``local0``) or as a number (for example ``16``). Textual form is recommended.
+
+Input usage
+-----------
+.. _param-imfifo-input-facility:
+.. _imfifo.parameter.input.facility-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imfifo"
+         file="/var/log/myfifo"
+         tag="fifo-logs:"
+         facility="local4")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfifo`.

--- a/doc/source/reference/parameters/imfifo-file.rst
+++ b/doc/source/reference/parameters/imfifo-file.rst
@@ -1,0 +1,49 @@
+.. _param-imfifo-file:
+.. _imfifo.parameter.input.file:
+
+file
+====
+
+.. meta::
+   :description: Path to the named pipe (FIFO) to monitor.
+   :keywords: rsyslog, imfifo, file, pipe
+
+.. index::
+   single: imfifo; file
+   single: file
+
+.. summary-start
+
+Specifies the absolute filesystem path of the named pipe (FIFO) to read log messages from.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfifo`.
+
+:Name: file
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: none
+:Required?: yes
+:Introduced: 8.2606.0
+
+Description
+-----------
+The path to the named pipe (FIFO) to be monitored. This must be an absolute path.
+The FIFO must exist on the filesystem before Rsyslog starts; `imfifo` will not attempt to create it.
+If the file does not exist or is not a FIFO, an error will be reported at startup and the input instance will not be activated.
+
+Input usage
+-----------
+.. _param-imfifo-input-file:
+.. _imfifo.parameter.input.file-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imfifo"
+         file="/var/log/myfifo"
+         tag="fifo-logs:")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfifo`.

--- a/doc/source/reference/parameters/imfifo-ruleset.rst
+++ b/doc/source/reference/parameters/imfifo-ruleset.rst
@@ -1,0 +1,48 @@
+.. _param-imfifo-ruleset:
+.. _imfifo.parameter.input.ruleset:
+
+ruleset
+=======
+
+.. meta::
+   :description: Bind the imfifo input instance to a specific ruleset.
+   :keywords: rsyslog, imfifo, ruleset
+
+.. index::
+   single: imfifo; ruleset
+   single: ruleset
+
+.. summary-start
+
+Binds this imfifo input instance to a specific ruleset.
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfifo`.
+
+:Name: ruleset
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: none
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+Binds the input instance to a specific ruleset. If specified, messages read from this FIFO will be processed by the ruleset instead of the default ruleset.
+
+Input usage
+-----------
+.. _param-imfifo-input-ruleset:
+.. _imfifo.parameter.input.ruleset-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imfifo"
+         file="/var/log/myfifo"
+         tag="fifo-logs:"
+         ruleset="my_custom_ruleset")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfifo`.

--- a/doc/source/reference/parameters/imfifo-severity.rst
+++ b/doc/source/reference/parameters/imfifo-severity.rst
@@ -1,0 +1,48 @@
+.. _param-imfifo-severity:
+.. _imfifo.parameter.input.severity:
+
+severity
+========
+
+.. meta::
+   :description: Syslog severity to apply to messages read from this named pipe (FIFO).
+   :keywords: rsyslog, imfifo, severity
+
+.. index::
+   single: imfifo; severity
+   single: severity
+
+.. summary-start
+
+Specifies the syslog severity to apply to messages read from this named pipe (FIFO).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfifo`.
+
+:Name: severity
+:Scope: input
+:Type: severity (word/integer)
+:Default: notice
+:Required?: no
+:Introduced: 8.2606.0
+
+Description
+-----------
+The syslog severity to be assigned to all messages read from this named pipe. It can be specified in textual form (for example ``notice``) or as a number (for example ``5``). Textual form is recommended.
+
+Input usage
+-----------
+.. _param-imfifo-input-severity:
+.. _imfifo.parameter.input.severity-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imfifo"
+         file="/var/log/myfifo"
+         tag="fifo-logs:"
+         severity="info")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfifo`.

--- a/doc/source/reference/parameters/imfifo-tag.rst
+++ b/doc/source/reference/parameters/imfifo-tag.rst
@@ -1,0 +1,47 @@
+.. _param-imfifo-tag:
+.. _imfifo.parameter.input.tag:
+
+tag
+===
+
+.. meta::
+   :description: Syslog tag to apply to messages read from this named pipe (FIFO).
+   :keywords: rsyslog, imfifo, tag
+
+.. index::
+   single: imfifo; tag
+   single: tag
+
+.. summary-start
+
+Specifies the syslog tag to apply to messages read from this named pipe (FIFO).
+
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imfifo`.
+
+:Name: tag
+:Scope: input
+:Type: string (see :doc:`../../rainerscript/constant_strings`)
+:Default: none
+:Required?: yes
+:Introduced: 8.2606.0
+
+Description
+-----------
+The syslog tag to be assigned to all messages read from this named pipe. The tag is typically used to identify the source of the logs in later filtering or formatting steps.
+
+Input usage
+-----------
+.. _param-imfifo-input-tag:
+.. _imfifo.parameter.input.tag-usage:
+
+.. code-block:: rsyslog
+
+   input(type="imfifo"
+         file="/var/log/myfifo"
+         tag="fifo-logs:")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imfifo`.

--- a/plugins/imfifo/MODULE_METADATA.yaml
+++ b/plugins/imfifo/MODULE_METADATA.yaml
@@ -1,0 +1,11 @@
+support_status: core-supported
+maturity_level: fresh
+primary_contact: "GitHub Discussions & Issues <https://github.com/rsyslog/rsyslog/discussions>"
+last_reviewed: 2026-05-24
+build_dependencies: []
+runtime_dependencies: []
+ci_targets: []
+documentation:
+  - "doc/source/configuration/modules/imfifo.rst"
+notes: |-
+  Reads log messages line-by-line from local POSIX named pipes (FIFOs).

--- a/plugins/imfifo/Makefile.am
+++ b/plugins/imfifo/Makefile.am
@@ -1,0 +1,6 @@
+pkglib_LTLIBRARIES = imfifo.la
+
+imfifo_la_SOURCES = imfifo.c
+imfifo_la_CPPFLAGS = $(RSRT_CFLAGS) -I$(top_srcdir) $(PTHREADS_CFLAGS)
+imfifo_la_LDFLAGS = -module -avoid-version
+imfifo_la_LIBADD = 

--- a/plugins/imfifo/imfifo.c
+++ b/plugins/imfifo/imfifo.c
@@ -65,6 +65,7 @@ struct instanceConf_s {
     ruleset_t *pBindRuleset; /* ruleset to bind listener to (use system default if unspecified) */
     int fd; /* open FIFO file descriptor */
     cstr_t *ppCStr; /* line accumulator buffer */
+    sbool bLineTruncated; /* current line exceeded maxMessageSize */
     struct instanceConf_s *next;
     struct instanceConf_s *prev;
 };
@@ -80,8 +81,8 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset)
 
     static prop_t *pInputName = NULL;
 static instanceConf_t *confRoot = NULL;
-static fd_set rfds;
-static int nfds = 0;
+static size_t iMaxLine = 0;
+
 
 #include "im-helper.h" /* must be included AFTER the type definitions! */
 
@@ -112,13 +113,14 @@ static rsRetVal ATTR_NONNULL(1) createInstance(instanceConf_t **const ppInst) {
     pInst->pszBindRuleset = NULL;
     pInst->pBindRuleset = NULL;
     pInst->iSeverity = 5; /* notice */
-    pInst->iFacility = 128; /* local0 */
+    pInst->iFacility = 128; /* local0 (shifted) */
 
     pInst->pszTag = NULL;
     pInst->lenTag = 0;
 
     pInst->fd = -1;
     pInst->ppCStr = NULL;
+    pInst->bLineTruncated = RSFALSE;
     pInst->pszFileName = NULL;
 
     *ppInst = pInst;
@@ -156,7 +158,7 @@ static void ATTR_NONNULL(1) lstnFree(instanceConf_t *pInst) {
 
 /* read config  */
 BEGINnewInpInst
-    struct cnfparamvals *pvals;
+    struct cnfparamvals *pvals = NULL;
     instanceConf_t *pInst = NULL;
     int i;
     CODESTARTnewInpInst;
@@ -241,7 +243,7 @@ static rsRetVal enqLine(instanceConf_t *const __restrict__ pInst) {
     MsgSetRawMsg(pMsg, (const char *)rsCStrGetBufBeg(pInst->ppCStr), cstrLen(pInst->ppCStr));
     MsgSetRuleset(pMsg, pInst->pBindRuleset);
 
-    submitMsg2(pMsg);
+    CHKiRet(submitMsg2(pMsg));
 finalize_it:
     RETiRet;
 }
@@ -253,7 +255,11 @@ static rsRetVal readFIFO(instanceConf_t *const pInst) {
 
     nRead = read(pInst->fd, buf, sizeof(buf));
     if (nRead < 0) {
-        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+        if (errno == EAGAIN || errno == EINTR
+#if EWOULDBLOCK != EAGAIN
+            || errno == EWOULDBLOCK
+#endif
+        ) {
             FINALIZE;
         }
         ABORT_FINALIZE(RS_RET_IO_ERROR);
@@ -265,9 +271,15 @@ static rsRetVal readFIFO(instanceConf_t *const pInst) {
     for (ssize_t i = 0; i < nRead; ++i) {
         if (buf[i] == '\n') {
             CHKiRet(enqLine(pInst));
-            rsCStrTruncate(pInst->ppCStr, cstrLen(pInst->ppCStr)); /* Reset buffer */
+            CHKiRet(rsCStrTruncate(pInst->ppCStr, cstrLen(pInst->ppCStr))); /* Reset buffer */
+            pInst->bLineTruncated = RSFALSE;
         } else {
-            CHKiRet(cstrAppendChar(pInst->ppCStr, buf[i]));
+            if (cstrLen(pInst->ppCStr) < iMaxLine) {
+                CHKiRet(cstrAppendChar(pInst->ppCStr, buf[i]));
+            } else if (pInst->bLineTruncated == RSFALSE) {
+                LogError(0, NO_ERRCODE, "imfifo: message larger than maxMessageSize, truncating");
+                pInst->bLineTruncated = RSTRUE;
+            }
         }
     }
 finalize_it:
@@ -275,12 +287,13 @@ finalize_it:
 }
 
 BEGINrunInput
-    struct timeval tv;
-    int retval;
     instanceConf_t *pInst;
     rsRetVal readRet;
+    struct pollfd *pollfds = NULL;
+    int iNumPipes = 0;
     CODESTARTrunInput;
-    FD_ZERO(&rfds);
+
+    iMaxLine = (size_t)glbl.GetMaxLine(runConf);
 
     /* Open all pipes */
     for (pInst = confRoot; pInst != NULL; pInst = pInst->next) {
@@ -306,41 +319,68 @@ BEGINrunInput
             continue;
         }
 
-        FD_SET(pInst->fd, &rfds);
-        if (pInst->fd >= nfds) {
-            nfds = pInst->fd + 1;
-        }
         DBGPRINTF("imfifo: successfully opened FIFO '%s' on fd %d\n", pInst->pszFileName, pInst->fd);
+        iNumPipes++;
     }
 
-    /* Main read/select loop */
-    tv.tv_usec = 100000; /* 0.1 second */
+    if (iNumPipes == 0) {
+        DBGPRINTF("imfifo: no active named pipes to monitor\n");
+        FINALIZE;
+    }
+
+    CHKmalloc(pollfds = calloc((size_t)iNumPipes, sizeof(struct pollfd)));
+
+    /* Main read/poll loop */
     while (glbl.GetGlobalInputTermState() == 0) {
-        fd_set temp;
-        memcpy(&temp, &rfds, sizeof(fd_set));
-        tv.tv_sec = 0;
-        tv.tv_usec = 100000;
+        int nfd = 0;
+        for (pInst = confRoot; pInst != NULL; pInst = pInst->next) {
+            if (pInst->fd != -1) {
+                pollfds[nfd].fd = pInst->fd;
+                pollfds[nfd].events = POLLIN;
+                pollfds[nfd].revents = 0;
+                nfd++;
+            }
+        }
 
-        retval = select(nfds, &temp, NULL, NULL, &tv);
+        if (nfd == 0) {
+            /* No active pipes to monitor, sleep a bit to avoid busy looping */
+            srSleep(0, 100000); /* 100ms */
+            continue;
+        }
 
-        while (retval > 0 && glbl.GetGlobalInputTermState() == 0) {
-            for (pInst = confRoot; pInst != NULL; pInst = pInst->next) {
-                if (pInst->fd != -1 && FD_ISSET(pInst->fd, &temp)) {
-                    readRet = readFIFO(pInst);
-                    if (readRet == RS_RET_EOF) {
-                        /* EOF received, should not happen but close it */
-                        close(pInst->fd);
-                        FD_CLR(pInst->fd, &rfds);
-                        pInst->fd = -1;
-                    } else if (readRet != RS_RET_OK) {
-                        LogError(errno, readRet, "imfifo: error reading from FIFO '%s'", pInst->pszFileName);
+        int retval = poll(pollfds, nfd, 100); /* 100 ms timeout */
+
+        if (retval < 0) {
+            if (errno == EINTR) {
+                continue;
+            }
+            LogError(errno, RS_RET_IO_ERROR, "imfifo: poll failed");
+            break;
+        }
+
+        if (retval > 0) {
+            int current_fd_idx = 0;
+            for (pInst = confRoot; pInst != NULL && current_fd_idx < nfd; pInst = pInst->next) {
+                if (pInst->fd != -1) {
+                    if (pollfds[current_fd_idx].revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL)) {
+                        readRet = readFIFO(pInst);
+                        if (readRet != RS_RET_OK) {
+                            if (readRet != RS_RET_EOF) {
+                                LogError(errno, readRet, "imfifo: error reading from FIFO '%s'", pInst->pszFileName);
+                            }
+                            /* EOF or error received, close it and disable future polling */
+                            close(pInst->fd);
+                            pInst->fd = -1;
+                        }
                     }
-                    retval--;
+                    current_fd_idx++;
                 }
             }
         }
     }
     DBGPRINTF("imfifo: terminating upon request of rsyslog core\n");
+finalize_it:
+    free(pollfds);
 ENDrunInput
 
 BEGINafterRun

--- a/plugins/imfifo/imfifo.c
+++ b/plugins/imfifo/imfifo.c
@@ -1,0 +1,422 @@
+/* imfifo.c
+ * This is the named pipe (FIFO) input module for rsyslog.
+ * It reads logs line-by-line from configured FIFOs.
+ *
+ * Copyright 2026 Adiscon GmbH.
+ *
+ * This file is part of rsyslog.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+#include <stdio.h>
+#include <syslog.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <signal.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/time.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <pthread.h>
+#include <poll.h>
+
+#include "rsyslog.h"
+#include "dirty.h"
+#include "msg.h"
+#include "conf.h"
+#include "syslogd-types.h"
+#include "srUtils.h"
+#include "template.h"
+#include "module-template.h"
+#include "unicode-helper.h"
+#include "errmsg.h"
+#include "cfsysline.h"
+#include "glbl.h"
+#include "prop.h"
+#include "ruleset.h"
+#include "stringbuf.h"
+
+MODULE_TYPE_INPUT;
+MODULE_TYPE_NOKEEP;
+MODULE_CNFNAME("imfifo")
+
+struct instanceConf_s {
+    uchar *pszFileName; /* path to named pipe (FIFO) */
+    uchar *pszTag; /* tag to apply to messages */
+    size_t lenTag;
+    int iFacility;
+    int iSeverity;
+    uchar *pszBindRuleset;
+    ruleset_t *pBindRuleset; /* ruleset to bind listener to (use system default if unspecified) */
+    int fd; /* open FIFO file descriptor */
+    cstr_t *ppCStr; /* line accumulator buffer */
+    struct instanceConf_s *next;
+    struct instanceConf_s *prev;
+};
+
+/* config variables */
+struct modConfData_s {
+    rsconf_t *pConf; /* our overall config object */
+};
+
+/* Module static data */
+DEF_IMOD_STATIC_DATA;
+DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset)
+
+    static prop_t *pInputName = NULL;
+static instanceConf_t *confRoot = NULL;
+static fd_set rfds;
+static int nfds = 0;
+
+#include "im-helper.h" /* must be included AFTER the type definitions! */
+
+static inline void std_checkRuleset_genErrMsg(__attribute__((unused)) modConfData_t *modConf, instanceConf_t *pInst) {
+    LogError(0, NO_ERRCODE,
+             "imfifo: ruleset '%s' for FIFO %s not found - "
+             "using default ruleset instead",
+             pInst->pszBindRuleset, pInst->pszFileName);
+}
+
+/* action (instance) parameters */
+static struct cnfparamdescr inppdescr[] = {{"file", eCmdHdlrString, CNFPARAM_REQUIRED},
+                                           {"tag", eCmdHdlrString, CNFPARAM_REQUIRED},
+                                           {"severity", eCmdHdlrSeverity, 0},
+                                           {"facility", eCmdHdlrFacility, 0},
+                                           {"ruleset", eCmdHdlrString, 0}};
+static struct cnfparamblk inppblk = {CNFPARAMBLK_VERSION, sizeof(inppdescr) / sizeof(struct cnfparamdescr), inppdescr};
+
+/* create input instance, set default parameters, and
+ * add it to the list of instances.
+ */
+static rsRetVal ATTR_NONNULL(1) createInstance(instanceConf_t **const ppInst) {
+    instanceConf_t *pInst;
+    DEFiRet;
+    CHKmalloc(pInst = malloc(sizeof(instanceConf_t)));
+    pInst->next = NULL;
+    pInst->prev = NULL;
+    pInst->pszBindRuleset = NULL;
+    pInst->pBindRuleset = NULL;
+    pInst->iSeverity = 5; /* notice */
+    pInst->iFacility = 128; /* local0 */
+
+    pInst->pszTag = NULL;
+    pInst->lenTag = 0;
+
+    pInst->fd = -1;
+    pInst->ppCStr = NULL;
+    pInst->pszFileName = NULL;
+
+    *ppInst = pInst;
+finalize_it:
+    RETiRet;
+}
+
+/* This adds a new listener object to the bottom of the list, but
+ * it does NOT initialize any data members except for the list
+ * pointers themselves.
+ */
+static rsRetVal ATTR_NONNULL() lstnAdd(instanceConf_t *pInst) {
+    DEFiRet;
+
+    /* insert it at the begin of the list */
+    pInst->prev = NULL;
+    pInst->next = confRoot;
+
+    if (confRoot != NULL) confRoot->prev = pInst;
+
+    confRoot = pInst;
+
+    RETiRet;
+}
+
+/* delete a listener object */
+static void ATTR_NONNULL(1) lstnFree(instanceConf_t *pInst) {
+    DBGPRINTF("lstnFree called for FIFO %s\n", pInst->pszFileName);
+    if (pInst->pszFileName != NULL) free(pInst->pszFileName);
+    if (pInst->pszTag != NULL) free(pInst->pszTag);
+    if (pInst->pszBindRuleset != NULL) free(pInst->pszBindRuleset);
+    if (pInst->ppCStr != NULL) rsCStrDestruct(&pInst->ppCStr);
+    free(pInst);
+}
+
+/* read config  */
+BEGINnewInpInst
+    struct cnfparamvals *pvals;
+    instanceConf_t *pInst = NULL;
+    int i;
+    CODESTARTnewInpInst;
+    DBGPRINTF("newInpInst (imfifo)\n");
+
+    pvals = nvlstGetParams(lst, &inppblk, NULL);
+    if (pvals == NULL) {
+        ABORT_FINALIZE(RS_RET_MISSING_CNFPARAMS);
+    }
+
+    if (Debug) {
+        DBGPRINTF("input param blk in imfifo:\n");
+        cnfparamsPrint(&inppblk, pvals);
+    }
+
+    CHKiRet(createInstance(&pInst));
+
+    for (i = 0; i < inppblk.nParams; ++i) {
+        if (!pvals[i].bUsed) continue;
+        if (!strcmp(inppblk.descr[i].name, "file")) {
+            CHKmalloc(pInst->pszFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(inppblk.descr[i].name, "tag")) {
+            CHKmalloc(pInst->pszTag = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+            pInst->lenTag = es_strlen(pvals[i].val.d.estr);
+        } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
+            CHKmalloc(pInst->pszBindRuleset = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(inppblk.descr[i].name, "severity")) {
+            pInst->iSeverity = pvals[i].val.d.n;
+        } else if (!strcmp(inppblk.descr[i].name, "facility")) {
+            pInst->iFacility = pvals[i].val.d.n;
+        } else {
+            DBGPRINTF(
+                "imfifo: program error, non-handled "
+                "param '%s'\n",
+                inppblk.descr[i].name);
+        }
+    }
+
+    if (pInst->pszFileName == NULL) {
+        LogError(0, RS_RET_FILE_NOT_SPECIFIED, "imfifo: named pipe path is not configured");
+        ABORT_FINALIZE(RS_RET_FILE_NOT_SPECIFIED);
+    }
+
+    CHKiRet(cstrConstruct(&pInst->ppCStr));
+
+    if ((iRet = lstnAdd(pInst)) != RS_RET_OK) {
+        ABORT_FINALIZE(iRet);
+    }
+
+finalize_it:
+    CODE_STD_FINALIZERnewInpInst if (pInst && iRet != RS_RET_OK) lstnFree(pInst);
+    cnfparamvalsDestruct(pvals, &inppblk);
+ENDnewInpInst
+
+BEGINwillRun
+    CODESTARTwillRun;
+    /* we need to create the inputName property (only once during our lifetime) */
+    CHKiRet(prop.Construct(&pInputName));
+    CHKiRet(prop.SetString(pInputName, UCHAR_CONSTANT("imfifo"), sizeof("imfifo") - 1));
+    CHKiRet(prop.ConstructFinalize(pInputName));
+finalize_it:
+ENDwillRun
+
+static rsRetVal enqLine(instanceConf_t *const __restrict__ pInst) {
+    DEFiRet;
+    smsg_t *pMsg;
+
+    if (cstrLen(pInst->ppCStr) == 0) {
+        /* we do not process empty lines */
+        FINALIZE;
+    }
+
+    CHKiRet(msgConstruct(&pMsg));
+
+    MsgSetMSGoffs(pMsg, 0);
+    MsgSetHOSTNAME(pMsg, glbl.GetLocalHostName(), ustrlen(glbl.GetLocalHostName()));
+    MsgSetFlowControlType(pMsg, eFLOWCTL_FULL_DELAY);
+    MsgSetInputName(pMsg, pInputName);
+    MsgSetAPPNAME(pMsg, (const char *)pInst->pszTag);
+    MsgSetTAG(pMsg, pInst->pszTag, pInst->lenTag);
+    msgSetPRI(pMsg, pInst->iFacility | pInst->iSeverity);
+    MsgSetRawMsg(pMsg, (const char *)rsCStrGetBufBeg(pInst->ppCStr), cstrLen(pInst->ppCStr));
+    MsgSetRuleset(pMsg, pInst->pBindRuleset);
+
+    submitMsg2(pMsg);
+finalize_it:
+    RETiRet;
+}
+
+static rsRetVal readFIFO(instanceConf_t *const pInst) {
+    char buf[4096];
+    ssize_t nRead;
+    DEFiRet;
+
+    nRead = read(pInst->fd, buf, sizeof(buf));
+    if (nRead < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR) {
+            FINALIZE;
+        }
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    } else if (nRead == 0) {
+        /* EOF reached (should not happen if opened O_RDWR) */
+        ABORT_FINALIZE(RS_RET_EOF);
+    }
+
+    for (ssize_t i = 0; i < nRead; ++i) {
+        if (buf[i] == '\n') {
+            CHKiRet(enqLine(pInst));
+            rsCStrTruncate(pInst->ppCStr, cstrLen(pInst->ppCStr)); /* Reset buffer */
+        } else {
+            CHKiRet(cstrAppendChar(pInst->ppCStr, buf[i]));
+        }
+    }
+finalize_it:
+    RETiRet;
+}
+
+BEGINrunInput
+    struct timeval tv;
+    int retval;
+    instanceConf_t *pInst;
+    rsRetVal readRet;
+    CODESTARTrunInput;
+    FD_ZERO(&rfds);
+
+    /* Open all pipes */
+    for (pInst = confRoot; pInst != NULL; pInst = pInst->next) {
+        /* Open O_RDWR to prevent blocking on startup and receiving EOF on disconnect */
+        pInst->fd = open((char *)pInst->pszFileName, O_RDWR);
+        if (pInst->fd == -1) {
+            LogError(errno, RS_RET_FILE_NOT_FOUND, "imfifo: named pipe '%s' could not be opened", pInst->pszFileName);
+            continue;
+        }
+
+        struct stat st;
+        if (fstat(pInst->fd, &st) == 0) {
+            if (!S_ISFIFO(st.st_mode)) {
+                LogError(0, RS_RET_INVALID_VAR, "imfifo: '%s' is not a named pipe (FIFO)", pInst->pszFileName);
+                close(pInst->fd);
+                pInst->fd = -1;
+                continue;
+            }
+        } else {
+            LogError(errno, RS_RET_SYS_ERR, "imfifo: fstat failed on '%s'", pInst->pszFileName);
+            close(pInst->fd);
+            pInst->fd = -1;
+            continue;
+        }
+
+        FD_SET(pInst->fd, &rfds);
+        if (pInst->fd >= nfds) {
+            nfds = pInst->fd + 1;
+        }
+        DBGPRINTF("imfifo: successfully opened FIFO '%s' on fd %d\n", pInst->pszFileName, pInst->fd);
+    }
+
+    /* Main read/select loop */
+    tv.tv_usec = 100000; /* 0.1 second */
+    while (glbl.GetGlobalInputTermState() == 0) {
+        fd_set temp;
+        memcpy(&temp, &rfds, sizeof(fd_set));
+        tv.tv_sec = 0;
+        tv.tv_usec = 100000;
+
+        retval = select(nfds, &temp, NULL, NULL, &tv);
+
+        while (retval > 0 && glbl.GetGlobalInputTermState() == 0) {
+            for (pInst = confRoot; pInst != NULL; pInst = pInst->next) {
+                if (pInst->fd != -1 && FD_ISSET(pInst->fd, &temp)) {
+                    readRet = readFIFO(pInst);
+                    if (readRet == RS_RET_EOF) {
+                        /* EOF received, should not happen but close it */
+                        close(pInst->fd);
+                        FD_CLR(pInst->fd, &rfds);
+                        pInst->fd = -1;
+                    } else if (readRet != RS_RET_OK) {
+                        LogError(errno, readRet, "imfifo: error reading from FIFO '%s'", pInst->pszFileName);
+                    }
+                    retval--;
+                }
+            }
+        }
+    }
+    DBGPRINTF("imfifo: terminating upon request of rsyslog core\n");
+ENDrunInput
+
+BEGINafterRun
+    CODESTARTafterRun;
+    instanceConf_t *pInst = confRoot, *nextInst;
+    confRoot = NULL;
+
+    DBGPRINTF("imfifo: afterRun\n");
+
+    while (pInst != NULL) {
+        nextInst = pInst->next;
+
+        if (pInst->fd != -1) {
+            close(pInst->fd);
+            pInst->fd = -1;
+        }
+
+        lstnFree(pInst);
+
+        pInst = nextInst;
+    }
+
+    if (pInputName != NULL) prop.Destruct(&pInputName);
+ENDafterRun
+
+BEGINisCompatibleWithFeature
+    CODESTARTisCompatibleWithFeature;
+    if (eFeat == sFEATURERepeatedMsgReduction) {
+        iRet = RS_RET_OK;
+    }
+ENDisCompatibleWithFeature
+
+BEGINbeginCnfLoad
+    CODESTARTbeginCnfLoad;
+    pModConf->pConf = pConf;
+ENDbeginCnfLoad
+
+BEGINendCnfLoad
+    CODESTARTendCnfLoad;
+ENDendCnfLoad
+
+BEGINcheckCnf
+    instanceConf_t *pInst;
+    CODESTARTcheckCnf;
+    for (pInst = confRoot; pInst != NULL; pInst = pInst->next) {
+        std_checkRuleset(pModConf, pInst);
+    }
+ENDcheckCnf
+
+BEGINactivateCnf
+    CODESTARTactivateCnf;
+ENDactivateCnf
+
+BEGINfreeCnf
+    CODESTARTfreeCnf;
+ENDfreeCnf
+
+BEGINmodExit
+    CODESTARTmodExit;
+    objRelease(ruleset, CORE_COMPONENT);
+    objRelease(glbl, CORE_COMPONENT);
+    objRelease(prop, CORE_COMPONENT);
+ENDmodExit
+
+BEGINqueryEtryPt
+    CODESTARTqueryEtryPt;
+    CODEqueryEtryPt_STD_IMOD_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_QUERIES;
+    CODEqueryEtryPt_STD_CONF2_IMOD_QUERIES;
+    CODEqueryEtryPt_IsCompatibleWithFeature_IF_OMOD_QUERIES;
+ENDqueryEtryPt
+
+BEGINmodInit()
+    CODESTARTmodInit;
+    *ipIFVersProvided = CURR_MOD_IF_VERSION;
+    CODEmodInit_QueryRegCFSLineHdlr CHKiRet(objUse(ruleset, CORE_COMPONENT));
+    CHKiRet(objUse(glbl, CORE_COMPONENT));
+    CHKiRet(objUse(prop, CORE_COMPONENT));
+ENDmodInit

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,7 @@ EXTRA_DIST = \
 TESTS_JSON_OMITIFZERO = json-omitifzero.sh json-omitifzero-subtree.sh json-whitespace.sh
 EXTRA_DIST += $(TESTS_JSON_OMITIFZERO)
 
-TESTS_IMFIFO = imfifo.sh imfifo-vg.sh
+TESTS_IMFIFO = imfifo.sh imfifo-vg.sh yaml-imfifo.sh
 EXTRA_DIST += $(TESTS_IMFIFO)
 
 TESTS_GSSAPI = \
@@ -2349,6 +2349,9 @@ if ENABLE_IMFIFO
 TESTS += imfifo.sh
 if HAVE_VALGRIND
 TESTS += imfifo-vg.sh
+endif
+if HAVE_LIBYAML
+TESTS += yaml-imfifo.sh
 endif
 endif
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,6 +17,9 @@ EXTRA_DIST = \
 TESTS_JSON_OMITIFZERO = json-omitifzero.sh json-omitifzero-subtree.sh json-whitespace.sh
 EXTRA_DIST += $(TESTS_JSON_OMITIFZERO)
 
+TESTS_IMFIFO = imfifo.sh imfifo-vg.sh
+EXTRA_DIST += $(TESTS_IMFIFO)
+
 TESTS_GSSAPI = \
 	imgssapi-listen-port-file.sh \
 	imgssapi-maxsessions.sh
@@ -2339,6 +2342,13 @@ if ENABLE_OMHTTP
 TESTS += $(TESTS_OMHTTP)
 if HAVE_VALGRIND
 TESTS += $(TESTS_OMHTTP_VALGRIND)
+endif
+endif
+
+if ENABLE_IMFIFO
+TESTS += imfifo.sh
+if HAVE_VALGRIND
+TESTS += imfifo-vg.sh
 endif
 endif
 

--- a/tests/imfifo-vg.sh
+++ b/tests/imfifo-vg.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export USE_VALGRIND="YES"
+. ${srcdir:-.}/imfifo.sh

--- a/tests/imfifo.sh
+++ b/tests/imfifo.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Test for the imfifo input module.
+# Creates a POSIX named pipe, configures imfifo to read it,
+# writes log messages, and verifies correctness.
+# Added 2026-05-24, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+
+# Verify imfifo is built and available
+require_plugin imfifo
+
+generate_conf
+add_conf '
+module(load="../plugins/imfifo/.libs/imfifo")
+
+input(type="imfifo"
+      file="'$RSYSLOG_DYNNAME'.fifo"
+      tag="pro:"
+      severity="notice"
+      facility="local4")
+
+template(name="outfmt" type="string" string="%syslogfacility-text%.%syslogseverity-text% %syslogtag% %msg%\n")
+
+if $syslogtag == "pro:" then action(type="omfile" File=`echo $RSYSLOG_OUT_LOG` template="outfmt")
+'
+
+# Create named pipe
+rm -f $RSYSLOG_DYNNAME.fifo
+mkfifo $RSYSLOG_DYNNAME.fifo
+
+# Start rsyslogd
+startup
+
+# Send messages to FIFO in a background task
+(
+  echo "message 1" > $RSYSLOG_DYNNAME.fifo
+  echo "message 2" > $RSYSLOG_DYNNAME.fifo
+  echo "message 3" > $RSYSLOG_DYNNAME.fifo
+) &
+PIPE_WRITER_PID=$!
+
+# Wait a moment for messages to be processed
+./msleep 1000
+
+# Initiate clean shutdown
+shutdown_when_empty
+wait_shutdown
+
+# Clean up background process and FIFO file
+wait $PIPE_WRITER_PID
+rm -f $RSYSLOG_DYNNAME.fifo
+
+# Assert correct output logging
+echo "local4.notice pro: message 1
+local4.notice pro: message 2
+local4.notice pro: message 3" | cmp - $RSYSLOG_OUT_LOG
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
+  cat $RSYSLOG_OUT_LOG
+  error_exit 1
+fi;
+
+exit_test

--- a/tests/imfifo.sh
+++ b/tests/imfifo.sh
@@ -1,7 +1,31 @@
 #!/bin/bash
 # Test for the imfifo input module.
-# Creates a POSIX named pipe, configures imfifo to read it,
-# writes log messages, and verifies correctness.
+#
+# Intent:
+# This test verifies that the 'imfifo' input module correctly reads log messages
+# from a POSIX named pipe (FIFO) and processes them line-by-line under dynamic
+# configuration.
+#
+# Invariant Tested:
+# 1. Dynamic module loading and input instance parsing.
+# 2. Correct extraction of newline-delimited messages from a FIFO.
+# 3. Message routing to standard rsyslog action queue with tags, facility, and severity.
+# 4. A writer that keeps a line open past maxMessageSize cannot grow the
+#    accumulator without bound; the overlong line is truncated and flushed at
+#    the newline.
+#
+# The Oracle:
+# Success is proven by writing three short messages and one overlong message to
+# a FIFO in a background process, cleanly shutting down rsyslog, and asserting that the output file contains
+# exactly the four messages with the expected tags, facility, and severity. The
+# fourth message proves the size oracle by comparing the output with the first
+# maxMessageSize bytes of a longer FIFO line.
+#
+# Timing / Wait Justification:
+# wait_file_lines polls until all expected messages reached the configured
+# output, avoiding fixed sleeps while still synchronizing before
+# shutdown_when_empty.
+#
 # Added 2026-05-24, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 
@@ -10,6 +34,7 @@ require_plugin imfifo
 
 generate_conf
 add_conf '
+global(maxMessageSize="128")
 module(load="../plugins/imfifo/.libs/imfifo")
 
 input(type="imfifo"
@@ -31,15 +56,18 @@ mkfifo $RSYSLOG_DYNNAME.fifo
 startup
 
 # Send messages to FIFO in a background task
+LONG_MSG="$(printf "%*s" 200 "" | tr " " "A")"
+EXPECTED_LONG="${LONG_MSG:0:128}"
 (
   echo "message 1" > $RSYSLOG_DYNNAME.fifo
   echo "message 2" > $RSYSLOG_DYNNAME.fifo
   echo "message 3" > $RSYSLOG_DYNNAME.fifo
+  printf "%s\n" "$LONG_MSG" > $RSYSLOG_DYNNAME.fifo
 ) &
 PIPE_WRITER_PID=$!
 
-# Wait a moment for messages to be processed
-./msleep 1000
+# Wait until all messages have been processed
+wait_file_lines "$RSYSLOG_OUT_LOG" 4 60
 
 # Initiate clean shutdown
 shutdown_when_empty
@@ -52,7 +80,8 @@ rm -f $RSYSLOG_DYNNAME.fifo
 # Assert correct output logging
 echo "local4.notice pro: message 1
 local4.notice pro: message 2
-local4.notice pro: message 3" | cmp - $RSYSLOG_OUT_LOG
+local4.notice pro: message 3
+local4.notice pro: ${EXPECTED_LONG}" | cmp - $RSYSLOG_OUT_LOG
 if [ ! $? -eq 0 ]; then
   echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
   cat $RSYSLOG_OUT_LOG

--- a/tests/yaml-imfifo.sh
+++ b/tests/yaml-imfifo.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# Tests imfifo input parameters configured via YAML.
+#
+# The Setup:
+# A YAML-only configuration loads imfifo, creates a FIFO input with file, tag,
+# severity, facility, and ruleset parameters, and routes messages through an
+# omfile action.
+#
+# The Oracle:
+# Success is proven by writing two newline-delimited messages to the FIFO,
+# waiting until both appear in the output file, and comparing the exact facility,
+# severity, tag, and message text produced by the YAML-configured input.
+#
+# Timing / Wait Justification:
+# wait_file_lines synchronizes on the expected output count before shutdown so
+# the asynchronous FIFO reader and action queue have completed their work.
+#
+# Added 2026-05-26, released under ASL 2.0
+. ${srcdir:=.}/diag.sh init
+require_yaml_support
+require_plugin imfifo
+
+generate_conf --yaml-only
+add_yaml_conf 'modules:'
+add_yaml_conf '  - load: "../plugins/imfifo/.libs/imfifo"'
+add_yaml_conf ''
+add_yaml_conf 'templates:'
+add_yaml_conf '  - name: outfmt'
+add_yaml_conf '    type: string'
+add_yaml_conf '    string: "%syslogfacility-text%.%syslogseverity-text% %programname%: %msg%\n"'
+add_yaml_conf ''
+add_yaml_conf 'inputs:'
+add_yaml_conf '  - type: imfifo'
+add_yaml_conf '    file: "'$RSYSLOG_DYNNAME'.fifo"'
+add_yaml_conf '    tag: "yamlpro:"'
+add_yaml_conf '    severity: "notice"'
+add_yaml_conf '    facility: "local4"'
+add_yaml_conf '    ruleset: "main"'
+add_yaml_conf ''
+add_yaml_conf 'rulesets:'
+add_yaml_conf '  - name: main'
+add_yaml_conf '    script: |'
+add_yaml_conf '      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")'
+
+rm -f $RSYSLOG_DYNNAME.fifo
+mkfifo $RSYSLOG_DYNNAME.fifo
+startup
+
+(
+  echo "yaml message 1" > $RSYSLOG_DYNNAME.fifo
+  echo "yaml message 2" > $RSYSLOG_DYNNAME.fifo
+) &
+PIPE_WRITER_PID=$!
+
+wait_file_lines "$RSYSLOG_OUT_LOG" 2 60
+shutdown_when_empty
+wait_shutdown
+wait $PIPE_WRITER_PID
+rm -f $RSYSLOG_DYNNAME.fifo
+
+echo "local4.notice yamlpro: yaml message 1
+local4.notice yamlpro: yaml message 2" | cmp - $RSYSLOG_OUT_LOG
+if [ ! $? -eq 0 ]; then
+  echo "invalid response generated, $RSYSLOG_OUT_LOG is:"
+  cat $RSYSLOG_OUT_LOG
+  error_exit 1
+fi
+
+exit_test


### PR DESCRIPTION
Why:
Allows rsyslog to read logs line-by-line from local POSIX named pipes (FIFOs) without blocking the startup sequence or spinning on EOF disconnect loops.

Impact:
Adds the 'imfifo' input module and registers its test suite.

Before/After:
Rsyslog had no native named pipe input capability; now imfifo provides dynamic, non-blocking FIFO input instances.

Technical Overview:
- Integrated imfifo into the autotools build system with --enable-imfifo.
- Implemented plugins/imfifo/imfifo.c using the modern v6 config syntax.
- Used open(path, O_RDWR) to keep a dummy writer, avoiding startup hangs and EOF reopen loops.
- Implemented select-polling loop with 100ms timeout for clean, quick shut down responses.
- Splitted incoming chunks by newline, submitting complete messages using submitMsg2.
- Created tests/imfifo.sh and tests/imfifo-vg.sh to verify correct function and Valgrind compatibility.

closes https://github.com/rsyslog/rsyslog/issues/440

With the help of AI-Agents: Antigravity