### PR TITLE
tests: synchronize mmexternal no-output helper

### DIFF
--- a/tests/mmexternal-interface-output-none.sh
+++ b/tests/mmexternal-interface-output-none.sh
@@ -2,9 +2,9 @@
 # added 2026-05-22 by Codex, released under ASL 2.0
 # Regression coverage for issue #260: interface.output="none" lets an
 # external message modification helper consume messages without producing the
-# JSON response required by the default protocol. The oracle checks both the
-# downstream omfile action and the helper side-effect file after synchronized
-# shutdown.
+# JSON response required by the default protocol. Because this mode has no
+# helper reply to synchronize on, the oracle waits for the helper side-effect
+# file before shutdown and then checks both that file and downstream omfile.
 . ${srcdir:=.}/diag.sh init
 
 generate_conf
@@ -21,6 +21,7 @@ action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
 
 startup
 injectmsg literal "<13>Mar 10 01:00:00 host tag:no-output-message"
+wait_file_lines "$RSYSLOG_DYNNAME.side" 1
 shutdown_when_empty
 wait_shutdown
 


### PR DESCRIPTION
## Summary
- fix the Solaris CI race in mmexternal-interface-output-none.sh
- wait for the no-output helper side-effect before shutting rsyslogd down
- keep downstream omfile and side-file content checks as the oracle

closes https://github.com/rsyslog/rsyslog/issues/7030

## Validation
- make -j$(nproc) check TESTS=""
- ./tests/mmexternal-interface-output-none.sh
- shellcheck -S warning tests/mmexternal-interface-output-none.sh
- static analyzer container: rsyslog/rsyslog_dev_base_ubuntu:26.04, image sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276, scan-build: No bugs found
- Ubuntu 26.04 container run-ci.sh: 1274 total, 1181 pass, 93 skip, 0 fail/error, real 253.19s

## AI Review
- Local Cubic attempted but not reachable: Connection failed: Unable to connect.