### PR TITLE
shellcheck: fix masked test assignments

### DIFF
--- a/packaging/docker/dev_env/centos/base/7/setup-system.sh
+++ b/packaging/docker/dev_env/centos/base/7/setup-system.sh
@@ -10,7 +10,7 @@ echo STEP: essentials
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
 (
-cd helper-projects
+cd helper-projects || exit 1
 
 if [ "$LIBDIR_PATH" != "" ]; then
 	export LIBDIR=--libdir=$LIBDIR_PATH
@@ -30,7 +30,7 @@ fi
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
 (
-	cd libksi
+	cd libksi || exit 1
 	autoreconf -fvi
 	./configure --libdir=/usr/lib64
 	make -j2
@@ -41,7 +41,7 @@ rm -r libksi
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
 (
-	cd librdkafka
+	cd librdkafka || exit 1
 	(unset CFLAGS; ./configure --prefix=/usr $LIBDIR --CFLAGS="-g" ; make -j2)
 	make install
 )

--- a/packaging/docker/dev_env/centos/base/8/setup-system.sh
+++ b/packaging/docker/dev_env/centos/base/8/setup-system.sh
@@ -10,7 +10,7 @@ echo STEP: essentials
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
 (
-cd helper-projects
+cd helper-projects || exit 1
 
 if [ "$LIBDIR_PATH" != "" ]; then
 	export LIBDIR=--libdir=$LIBDIR_PATH
@@ -30,7 +30,7 @@ fi
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
 (
-	cd libksi
+	cd libksi || exit 1
 	autoreconf -fvi
 	./configure --libdir=/usr/lib64
 	make -j2
@@ -41,7 +41,7 @@ rm -r libksi
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
 (
-	cd librdkafka
+	cd librdkafka || exit 1
 	(unset CFLAGS; ./configure --prefix=/usr $LIBDIR --CFLAGS="-g" ; make -j2)
 	make install
 )

--- a/packaging/docker/dev_env/centos/pkg_base/7/extra/sync_remote.sh
+++ b/packaging/docker/dev_env/centos/pkg_base/7/extra/sync_remote.sh
@@ -3,8 +3,9 @@
 # mybasedir=$(dirname "$0")
 mybasedir=$PKGBASEDIR
 
-source $mybasedir/config.sh
-cd $mybasedir/
+source "$mybasedir/config.sh"
+: "${szBaseDir:?}"
+cd "$mybasedir/" || exit 1
 echo "-------------------------------------"
 echo "--- Basedir: $szBaseDir"
 echo "--- Sync remote repository	---"

--- a/packaging/docker/dev_env/centos/pkg_base/8/extra/sync_remote.sh
+++ b/packaging/docker/dev_env/centos/pkg_base/8/extra/sync_remote.sh
@@ -3,8 +3,9 @@
 # mybasedir=$(dirname "$0")
 mybasedir=$PKGBASEDIR
 
-source $mybasedir/config.sh
-cd $mybasedir/
+source "$mybasedir/config.sh"
+: "${szBaseDir:?}"
+cd "$mybasedir/" || exit 1
 echo "-------------------------------------"
 echo "--- Basedir: $szBaseDir"
 echo "--- Sync remote repository	---"

--- a/packaging/docker/dev_env/common/setup-projects.sh
+++ b/packaging/docker/dev_env/common/setup-projects.sh
@@ -4,45 +4,46 @@
 #export LD_LIBRARY_PATH=/usr/local/lib
 
 # end config settings
-export CI_HOME=$(pwd)
+CI_HOME=$(pwd)
+export CI_HOME
 echo CI_HOME: $CI_HOME
 mkdir $CI_HOME/proj
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/libestr.git
-cd libestr
+cd libestr || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local && make -j2 || exit $?
 $SUDO make -j2 install || exit $?
 
 printf "\n\n================== libfastjson =======================\n\n"
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/libfastjson.git
-cd libfastjson
+cd libfastjson || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local --disable-journal && make -j2 || exit $?
 $SUDO make -j2 install || exit $?
 
 
 printf "\n\n================== liblogging =======================\n\n"
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/liblogging.git
-cd liblogging
+cd liblogging || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local --disable-journal && make -j2 || exit $?
 $SUDO make -j2 install || exit $?
 
 printf "\n\n================== liblognorm =======================\n\n"
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/liblognorm.git
-cd liblognorm
+cd liblognorm || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local && make -j2 || exit $?
 $SUDO make -j2 install || exit $?
 
 printf "\n\n================== liblrelp =======================\n\n"
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/librelp.git
-cd librelp
+cd librelp || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local --enable-compile-warnings=yes && make -j2 || exit $?
 $SUDO make -j2 install || exit $?
@@ -53,9 +54,9 @@ printf "\n\n================== rsyslog =======================\n\n"
 printf "This is primarily built to make sure that the helper\n"
 printf "projects are correctly built and installed\n\n"
 
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/rsyslog.git
-cd rsyslog
+cd rsyslog || exit 1
 git pull
 mkdir utils
 echo "./configure --prefix=/usr/local $RSYSLOG_CONFIGURE_OPTIONS" --enable-compile-warnings=yes > utils/conf

--- a/packaging/docker/dev_env/suse/base/tumbleweed/setup-projects.sh
+++ b/packaging/docker/dev_env/suse/base/tumbleweed/setup-projects.sh
@@ -4,30 +4,31 @@
 #export LD_LIBRARY_PATH=/usr/local/lib
 
 # end config settings
-export CI_HOME=$(pwd)
+CI_HOME=$(pwd)
+export CI_HOME
 echo CI_HOME: $CI_HOME
 
 printf "\n\n================== libfastjson =======================\n\n"
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/libfastjson.git
-cd libfastjson
+cd libfastjson || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local --disable-journal && make -j2 || exit $?
 $SUDO make -j2 install || exit $?
 
 
 printf "\n\n================== liblognorm =======================\n\n"
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/liblognorm.git
-cd liblognorm
+cd liblognorm || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local && make -j2 || exit $?
 $SUDO make -j2 install || exit $?
 
 printf "\n\n================== liblrelp =======================\n\n"
-cd $CI_HOME/proj
+cd "$CI_HOME/proj" || exit 1
 git clone https://github.com/rsyslog/librelp.git
-cd librelp
+cd librelp || exit 1
 git pull
 autoreconf -fvi && ./configure --prefix=/usr/local --enable-compile-warnings=yes && make -j2 || exit $?
 $SUDO make -j2 install || exit $?

--- a/packaging/docker/dev_env/ubuntu/base/18.04/setup-system.sh
+++ b/packaging/docker/dev_env/ubuntu/base/18.04/setup-system.sh
@@ -37,12 +37,12 @@ set -v
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
 (
-cd helper-projects
+cd helper-projects || exit 1
 
 # code style checker - not yet packaged
 git clone https://github.com/rsyslog/codestyle
 (
-	cd codestyle
+	cd codestyle || exit 1
 	gcc --std=c99 stylecheck.c -o stylecheck
 	mv stylecheck /usr/bin/rsyslog_stylecheck
 )
@@ -51,7 +51,7 @@ rm -r codestyle
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
 (
-	cd libksi
+	cd libksi || exit 1
 	autoreconf -fvi
 	./configure --prefix=/usr
 	make -j2
@@ -67,7 +67,7 @@ rm -r libksi
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
 (
-	cd librdkafka
+	cd librdkafka || exit 1
 	(unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2)
 	make install
 )

--- a/packaging/docker/dev_env/ubuntu/base/20.04/setup-system.sh
+++ b/packaging/docker/dev_env/ubuntu/base/20.04/setup-system.sh
@@ -37,12 +37,12 @@ set -v
 # Now build some custom libraries for whom there are not packages
 mkdir helper-projects
 (
-cd helper-projects
+cd helper-projects || exit 1
 
 # code style checker - not yet packaged
 git clone https://github.com/rsyslog/codestyle
 (
-	cd codestyle
+	cd codestyle || exit 1
 	gcc --std=c99 stylecheck.c -o stylecheck
 	mv stylecheck /usr/bin/rsyslog_stylecheck
 )
@@ -51,7 +51,7 @@ rm -r codestyle
 # we need Guardtime libksi here, otherwise we cannot check the KSI component
 git clone https://github.com/guardtime/libksi.git
 (
-	cd libksi
+	cd libksi || exit 1
 	autoreconf -fvi
 	./configure --prefix=/usr
 	make -j2
@@ -67,7 +67,7 @@ rm -r libksi
 # we need the latest librdkafka as there as always required updates
 git clone https://github.com/edenhill/librdkafka
 (
-	cd librdkafka
+	cd librdkafka || exit 1
 	(unset CFLAGS; ./configure --prefix=/usr --CFLAGS="-g" ; make -j2)
 	make install
 )

--- a/tests/CI/clang-analyzer-build.sh
+++ b/tests/CI/clang-analyzer-build.sh
@@ -12,7 +12,8 @@ echo "CC $CC, SCANBUILD $SCANBUILD"
 
 if [ -n "$SCAN_BUILD_REPORT_DIR" ]
 then
-  export CURR_REPORT=$(date +%y-%m-%d_%H-%M-%S)
+  CURR_REPORT=$(date +%y-%m-%d_%H-%M-%S)
+  export CURR_REPORT
   export REPORT_DIR="$SCAN_BUILD_REPORT_DIR/$CURR_REPORT"
   export REPORT_OPT="-o $REPORT_DIR"
 fi

--- a/tests/faketime_common.sh
+++ b/tests/faketime_common.sh
@@ -30,7 +30,8 @@ rsyslog_testbench_preload_libfaketime() {
     fi
 
     echo "Testing '${RSYSLOG_LIBFAKETIME}' library ..."
-    local faketime_testtime=$(LD_PRELOAD="${RSYSLOG_LIBFAKETIME}" FAKETIME="1991-08-25 20:57:08" TZ=GMT date +%s 2>/dev/null)
+    local faketime_testtime
+    faketime_testtime=$(LD_PRELOAD="${RSYSLOG_LIBFAKETIME}" FAKETIME="1991-08-25 20:57:08" TZ=GMT date +%s 2>/dev/null)
     if [ ${faketime_testtime} -ne 683153828 ] ; then
         echo "'${RSYSLOG_LIBFAKETIME}' failed sanity check, skipping test!"
         exit 77

--- a/tests/fromhost-port-async-ruleset.sh
+++ b/tests/fromhost-port-async-ruleset.sh
@@ -27,6 +27,7 @@ startup
 tcpflood -m $NUMMESSAGES -w "${RSYSLOG_DYNNAME}.tcpflood-port"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED="$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+EXPECTED="$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+export EXPECTED
 cmp_exact
 exit_test

--- a/tests/fromhost-port-tuple.sh
+++ b/tests/fromhost-port-tuple.sh
@@ -23,6 +23,7 @@ startup
 tcpflood -m $NUMMESSAGES -w "${RSYSLOG_DYNNAME}.tcpflood-port"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED="127.0.0.1:$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+EXPECTED="127.0.0.1:$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+export EXPECTED
 cmp_exact
 exit_test

--- a/tests/fromhost-port.sh
+++ b/tests/fromhost-port.sh
@@ -21,6 +21,7 @@ startup
 tcpflood -m $NUMMESSAGES -w "${RSYSLOG_DYNNAME}.tcpflood-port"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED="$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+EXPECTED="$(cat "${RSYSLOG_DYNNAME}.tcpflood-port")"
+export EXPECTED
 cmp_exact
 exit_test

--- a/tests/imdocker-basic.sh
+++ b/tests/imdocker-basic.sh
@@ -4,7 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 NUMMESSAGES=1000
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
-export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+export COOKIE
 
 generate_conf
 add_conf '

--- a/tests/imdocker-image-name.sh
+++ b/tests/imdocker-image-name.sh
@@ -4,7 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
-export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+export COOKIE
 
 generate_conf
 add_conf '

--- a/tests/imdocker-long-logline.sh
+++ b/tests/imdocker-long-logline.sh
@@ -2,7 +2,8 @@
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # imdocker unit tests are enabled with --enable-imdocker-tests
 . ${srcdir:=.}/diag.sh init
-export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+export COOKIE
 SIZE=17000
 generate_conf
 add_conf '

--- a/tests/imdocker-long-options.sh
+++ b/tests/imdocker-long-options.sh
@@ -4,7 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 NUMMESSAGES=50
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
-export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+export COOKIE
 LONG_PREFIX=$(printf 'noop=1&%.0s' $(seq 1 80))
 
 generate_conf

--- a/tests/imdocker-multi-line.sh
+++ b/tests/imdocker-multi-line.sh
@@ -5,7 +5,8 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=999
 export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
-export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+export COOKIE
 
 generate_conf
 add_conf '

--- a/tests/imdocker-new-logs-from-start.sh
+++ b/tests/imdocker-new-logs-from-start.sh
@@ -2,7 +2,8 @@
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # imdocker unit tests are enabled with --enable-imdocker-tests
 . ${srcdir:=.}/diag.sh init
-export COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+COOKIE=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 10 | head -n 1)
+export COOKIE
 generate_conf
 add_conf '
 #template(name="template_msg_only" type="string" string="%msg%\n")

--- a/tests/imdtls-basic-timeout.sh
+++ b/tests/imdtls-basic-timeout.sh
@@ -5,7 +5,8 @@
 export NUMMESSAGES=2000
 export SENDESSAGES=500
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 export TIMEOUT="5"
 
 add_conf '

--- a/tests/imdtls-basic-tlscommands.sh
+++ b/tests/imdtls-basic-tlscommands.sh
@@ -4,7 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=10
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imdtls-basic.sh
+++ b/tests/imdtls-basic.sh
@@ -4,7 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1000
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imdtls-error-cert.sh
+++ b/tests/imdtls-error-cert.sh
@@ -3,7 +3,8 @@
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/imdtls-sessionbreak.sh
+++ b/tests/imdtls-sessionbreak.sh
@@ -6,7 +6,8 @@ export DTLS_SESSIONBREAK_ROUNDS=${DTLS_SESSIONBREAK_ROUNDS:-16}
 export USE_VALGRIND="yes"
 # TODO remote leak check skip and fix memory leaks caused by session break
 export RS_TESTBENCH_LEAK_CHECK=no
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 mkdir $RSYSLOG_DYNNAME.workdir
 generate_conf
@@ -56,7 +57,7 @@ done;
 
 wait_queueempty
 
-netstatresult=$(netstat --all --program 2>&1 | grep "ESTABLISHED" | grep $(cat $RSYSLOG_PIDBASE.pid) | grep $TCPFLOOD_PORT)
+netstatresult=$(netstat --all --program 2>&1 | grep "ESTABLISHED" | grep "$(cat "$RSYSLOG_PIDBASE.pid")" | grep "$TCPFLOOD_PORT")
 openfd=$(ls -l "/proc/$(cat $RSYSLOG_PIDBASE$1.pid)/fd" | wc -l)
 
 shutdown_when_empty

--- a/tests/imfile-basic-2GB-file.sh
+++ b/tests/imfile-basic-2GB-file.sh
@@ -20,7 +20,8 @@ startup
 # initial file: 2GiB - 1 message (54 byte)
 ./inputfilegen -s 2147483584 -d47 -M $RSYSLOG_DYNNAME.msgcnt > $RSYSLOG_DYNNAME.input
 ls -lh $RSYSLOG_DYNNAME.input
-export NUMMESSAGES="$(cat $RSYSLOG_DYNNAME.msgcnt)"
+NUMMESSAGES="$(cat $RSYSLOG_DYNNAME.msgcnt)"
+export NUMMESSAGES
 
 wait_file_lines --delay 2500 --abort-on-oversize "$RSYSLOG_OUT_LOG" $NUMMESSAGES 3000
 

--- a/tests/imfile-logrotate-state-files.sh
+++ b/tests/imfile-logrotate-state-files.sh
@@ -3,7 +3,8 @@
 . ${srcdir:=.}/diag.sh init
 export TESTMESSAGES=1000
 export RETRIES=50
-export TESTMESSAGESFULL=$((3 * $TESTMESSAGES - 1))
+TESTMESSAGESFULL=$((3 * $TESTMESSAGES - 1))
+export TESTMESSAGESFULL
 # export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 # export RSYSLOG_DEBUGLOG="log"
 
@@ -45,7 +46,8 @@ print_state_files() {
 	echo "=== State files after round $round ==="
 	if [ -d "$RSYSLOG_DYNNAME.spool" ]; then
 		echo "State files in spool directory:"
-		local state_count=$(ls -1 "$RSYSLOG_DYNNAME.spool/"imfile-state* 2>/dev/null | wc -l)
+		local state_count
+		state_count=$(ls -1 "$RSYSLOG_DYNNAME.spool/"imfile-state* 2>/dev/null | wc -l)
 		echo "Total state files found: $state_count"
 
 		if [ $state_count -eq 0 ]; then
@@ -83,8 +85,10 @@ print_inode_info() {
 	echo "=== Inode information after round $round ==="
 	for file in "$RSYSLOG_DYNNAME".input.log*; do
 		if [ -f "$file" ]; then
-			local inode=$(stat -c%i "$file" 2>/dev/null || echo "N/A")
-			local size=$(stat -c%s "$file" 2>/dev/null || echo "N/A")
+			local inode
+			inode=$(stat -c%i "$file" 2>/dev/null || echo "N/A")
+			local size
+			size=$(stat -c%s "$file" 2>/dev/null || echo "N/A")
 			echo "File: $file - Inode: $inode - Size: $size bytes"
 		fi
 	done
@@ -93,7 +97,8 @@ print_inode_info() {
 
 write_log_lines() {
 	local round=$1
-	local start_num=$((($round - 1) * $TESTMESSAGES))
+	local start_num
+	start_num=$((($round - 1) * $TESTMESSAGES))
 	echo "Writing $TESTMESSAGES log lines for round $round (starting from msgnum $start_num)"
 	./inputfilegen -m $TESTMESSAGES -i $start_num >> "$RSYSLOG_DYNNAME.input.log"
 }

--- a/tests/imfile-truncate-2GB-file.sh
+++ b/tests/imfile-truncate-2GB-file.sh
@@ -20,7 +20,8 @@ startup
 # initial file: 2GiB - 1 message (54 byte)
 ./inputfilegen -s 2147483584 -d47 -M $RSYSLOG_DYNNAME.msgcnt > $RSYSLOG_DYNNAME.input
 ls -lh $RSYSLOG_DYNNAME.input
-export NUMMESSAGES="$(cat $RSYSLOG_DYNNAME.msgcnt)"
+NUMMESSAGES="$(cat $RSYSLOG_DYNNAME.msgcnt)"
+export NUMMESSAGES
 
 wait_file_lines --delay 2500 --abort-on-oversize "$RSYSLOG_OUT_LOG" $NUMMESSAGES 3000
 

--- a/tests/imjournal_filecreatemode.sh
+++ b/tests/imjournal_filecreatemode.sh
@@ -20,7 +20,8 @@ module(
 '
   startup
 
-  local ACTUAL="$(stat -c "%#a" "$RSYSLOG_DYNNAME.spool/imjournal.state")"
+  local ACTUAL
+  ACTUAL="$(stat -c "%#a" "$RSYSLOG_DYNNAME.spool/imjournal.state")"
   if [ "$ACTUAL" != "$EXPECTED" ]; then
     echo "imjournal fileCreateMode failed, incorrect permissions on state file: expected($EXPECTED) != actual($ACTUAL)"
     error_exit

--- a/tests/imkafka-backgrounded.sh
+++ b/tests/imkafka-backgrounded.sh
@@ -6,7 +6,8 @@ check_command_available kcat
 export KEEP_KAFKA_RUNNING="YES"
 
 export TESTMESSAGES=100000
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka

--- a/tests/imkafka-config-err-param.sh
+++ b/tests/imkafka-config-err-param.sh
@@ -10,7 +10,8 @@ export TESTMESSAGES=1000
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 download_kafka
 stop_zookeeper

--- a/tests/imkafka-config-err-ruleset.sh
+++ b/tests/imkafka-config-err-ruleset.sh
@@ -7,7 +7,8 @@ export KEEP_KAFKA_RUNNING="YES"
 
 export TESTMESSAGES=100000
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 #export EXTRA_EXITCHECK=dumpkafkalogs
 #export EXTRA_EXIT=kafka
 

--- a/tests/imkafka-json-split-empty.sh
+++ b/tests/imkafka-json-split-empty.sh
@@ -11,7 +11,8 @@ export TESTMESSAGESFULL=$TESTMESSAGES
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 download_kafka
 stop_zookeeper

--- a/tests/imkafka-json-split-invalid.sh
+++ b/tests/imkafka-json-split-invalid.sh
@@ -11,7 +11,8 @@ export TESTMESSAGESFULL=$TESTMESSAGES
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 download_kafka
 stop_zookeeper

--- a/tests/imkafka-json-split-nonarray.sh
+++ b/tests/imkafka-json-split-nonarray.sh
@@ -11,7 +11,8 @@ export TESTMESSAGESFULL=$TESTMESSAGES
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 download_kafka
 stop_zookeeper

--- a/tests/imkafka-json-split-timestamp.sh
+++ b/tests/imkafka-json-split-timestamp.sh
@@ -11,7 +11,8 @@ export TESTMESSAGESFULL=$TESTMESSAGES
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 download_kafka
 stop_zookeeper

--- a/tests/imkafka-json-split-valid.sh
+++ b/tests/imkafka-json-split-valid.sh
@@ -11,7 +11,8 @@ export TESTMESSAGESFULL=$TESTMESSAGES
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 download_kafka
 stop_zookeeper

--- a/tests/imkafka.sh
+++ b/tests/imkafka.sh
@@ -11,7 +11,8 @@ export TESTMESSAGESFULL=$TESTMESSAGES
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 download_kafka
 stop_zookeeper

--- a/tests/imkafka_multi_group.sh
+++ b/tests/imkafka_multi_group.sh
@@ -21,7 +21,8 @@ stop_kafka
 start_zookeeper
 start_kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
 

--- a/tests/imkafka_multi_many.sh
+++ b/tests/imkafka_multi_many.sh
@@ -10,7 +10,8 @@ export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/imkafka_multi_single.sh
+++ b/tests/imkafka_multi_single.sh
@@ -16,7 +16,8 @@ stop_kafka
 start_zookeeper
 start_kafka
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 create_kafka_topic $RANDTOPIC '.dep_wrk' '22181'
 

--- a/tests/imtcp-persource-ratelimit.sh
+++ b/tests/imtcp-persource-ratelimit.sh
@@ -3,8 +3,10 @@
 
 . ${srcdir:=.}/diag.sh init
 
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.persource.yaml"
-export INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.persource.yaml"
+export POLICY_FILE
+INPUT_FILE="$(pwd)/${RSYSLOG_DYNNAME}.input"
+export INPUT_FILE
 
 cat > "$POLICY_FILE" <<EOF
 default:
@@ -35,7 +37,7 @@ startup
 
 tcp_port=$(cat $RSYSLOG_DYNNAME.tcp.port)
 
-> "$INPUT_FILE"
+: > "$INPUT_FILE"
 for i in $(seq 1 20); do
     echo "<13>Jan 1 00:00:00 noisyhost app: msgnum:$i" >> "$INPUT_FILE"
 done

--- a/tests/imtcp-tls-mbedtls-basic-brokenhandshake-vg.sh
+++ b/tests/imtcp-tls-mbedtls-basic-brokenhandshake-vg.sh
@@ -7,7 +7,8 @@ if [ "$(valgrind --version)" == "valgrind-3.11.0" ]; then
 fi
 . ${srcdir:=.}/diag.sh init
 export USE_VALGRIND="YES"
-export RSYSLOG_PRELOAD=$(find /usr -name libmbed\*.so | sed ':start;N;s/\n\//:\//;t start;P;D')
+RSYSLOG_PRELOAD=$(find /usr -name libmbed\*.so | sed ':start;N;s/\n\//:\//;t start;P;D')
+export RSYSLOG_PRELOAD
 export NUMMESSAGES=1
 generate_conf
 add_conf '

--- a/tests/imtcp-tls-mbedtls-basic-vg.sh
+++ b/tests/imtcp-tls-mbedtls-basic-vg.sh
@@ -5,5 +5,6 @@ if [ "$(valgrind --version)" == "valgrind-3.11.0" ]; then
 	exit 77
 fi
 export USE_VALGRIND="YES"
-export RSYSLOG_PRELOAD=$(find /usr -name libmbed\*.so | sed ':start;N;s/\n\//:\//;t start;P;D')
+RSYSLOG_PRELOAD=$(find /usr -name libmbed\*.so | sed ':start;N;s/\n\//:\//;t start;P;D')
+export RSYSLOG_PRELOAD
 . ${srcdir:-.}/imtcp-tls-mbedtls-basic.sh

--- a/tests/include-obj-text-vg.sh
+++ b/tests/include-obj-text-vg.sh
@@ -3,7 +3,8 @@
 . ${srcdir:=.}/diag.sh init
 generate_conf
 INCLFILE="${srcdir}/testsuites/include-std-omfile-action.conf"
-export CONF_SNIPPET=$(cat $INCLFILE)
+CONF_SNIPPET=$(cat $INCLFILE)
+export CONF_SNIPPET
 printf "\nThis SNIPPET will be included via env var:\n$CONF_SNIPPET\n\nEND SNIPPET\n"
 add_conf '
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")

--- a/tests/kafka-selftest.sh
+++ b/tests/kafka-selftest.sh
@@ -5,7 +5,8 @@
 check_command_available kcat
 export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 #export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/mmjsontransform-policy-watch-invalid.sh
+++ b/tests/mmjsontransform-policy-watch-invalid.sh
@@ -4,7 +4,8 @@
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
 
 cat > "$POLICY_FILE" <<'YAML'
 version: 1

--- a/tests/mmjsontransform-policy-watch.sh
+++ b/tests/mmjsontransform-policy-watch.sh
@@ -6,8 +6,10 @@
 . $srcdir/diag.sh check-inotify
 
 # port is assigned by diag.sh from listenPortFileName
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
-export POLICY_TMP="$(pwd)/${RSYSLOG_DYNNAME}.policy.tmp.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
+POLICY_TMP="$(pwd)/${RSYSLOG_DYNNAME}.policy.tmp.yaml"
+export POLICY_TMP
 
 cat > "$POLICY_FILE" <<'YAML'
 version: 1

--- a/tests/omazuredce-basic-url.sh
+++ b/tests/omazuredce-basic-url.sh
@@ -7,7 +7,8 @@ require_plugin "omazuredce"
 omazuredce_require_env
 
 export NUMMESSAGES=10
-export AZURE_DCE_URL_ALT="$(omazuredce_url_with_trailing_slash)"
+AZURE_DCE_URL_ALT="$(omazuredce_url_with_trailing_slash)"
+export AZURE_DCE_URL_ALT
 
 generate_conf
 add_conf '

--- a/tests/omazuredce-interrupt.sh
+++ b/tests/omazuredce-interrupt.sh
@@ -21,7 +21,8 @@ if ! command -v ip6tables >/dev/null 2>&1; then
 fi
 
 export NUMMESSAGES=400
-export interrupt_port="$(omazuredce_url_port)"
+interrupt_port="$(omazuredce_url_port)"
+export interrupt_port
 export TEST_TIMEOUT_WAIT=180
 interrupt_status_file="$RSYSLOG_DYNNAME.interrupt.status"
 interrupt_detail_file="$RSYSLOG_DYNNAME.interrupt.detail"

--- a/tests/omfwd-gtls-missing-cert-key.sh
+++ b/tests/omfwd-gtls-missing-cert-key.sh
@@ -4,7 +4,8 @@
 # even when the action retries multiple times (loggedWarnings mechanism)
 . ${srcdir:=.}/diag.sh init
 
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 export RS_REDIR=">${RSYSLOG_DYNNAME}.rsyslog.log 2>&1"
 
 generate_conf

--- a/tests/omfwd_fast_imuxsock.sh
+++ b/tests/omfwd_fast_imuxsock.sh
@@ -14,7 +14,8 @@ fi
 # export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export NUMMESSAGES=100000
 
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 export STATSFILE="$RSYSLOG_DYNNAME.stats"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
 generate_conf

--- a/tests/omfwd_rebind_udp.sh
+++ b/tests/omfwd_rebind_udp.sh
@@ -3,7 +3,8 @@
 # added 2024-12-24 by Antigravity (Rgerhards). Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="builtin:omfwd")
 

--- a/tests/omkafka-dynatopic.sh
+++ b/tests/omkafka-dynatopic.sh
@@ -10,7 +10,8 @@ export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/omkafka-headers.sh
+++ b/tests/omkafka-headers.sh
@@ -7,7 +7,8 @@ export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 check_command_available kafkacat
 
 export KEEP_KAFKA_RUNNING="YES"
-export RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
+RANDTOPIC=$(tr -dc 'a-zA-Z0-9' < /dev/urandom | fold -w 8 | head -n 1)
+export RANDTOPIC
 export EXTRA_EXITCHECK=dumpkafkalogs
 export EXTRA_EXIT=kafka
 

--- a/tests/omkafka-statistics.sh
+++ b/tests/omkafka-statistics.sh
@@ -10,7 +10,8 @@ export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/omkafka.sh
+++ b/tests/omkafka.sh
@@ -10,7 +10,8 @@ export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/omkafkadynakey.sh
+++ b/tests/omkafkadynakey.sh
@@ -10,7 +10,8 @@ export KEEP_KAFKA_RUNNING="YES"
 export TESTMESSAGES=100000
 export TESTMESSAGESFULL=$TESTMESSAGES
 
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/omrabbitmq_data_1server.sh
+++ b/tests/omrabbitmq_data_1server.sh
@@ -8,7 +8,8 @@ if [ ! $? -eq 0 ]; then
   exit 77
 fi
 
-. $RSYSLOG_DYNNAME.source
+# shellcheck source=/dev/null
+. "$RSYSLOG_DYNNAME.source"
 
 generate_conf
 add_conf '
@@ -33,7 +34,8 @@ startup
 injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 server tag - - -  msgrmq')
+EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 server tag - - -  msgrmq')
+export EXPECTED
 echo $EXPECTED | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrabbitmq_data_2servers.sh
+++ b/tests/omrabbitmq_data_2servers.sh
@@ -8,7 +8,8 @@ if [ ! $? -eq 0 ]; then
   exit 77
 fi
 
-. $RSYSLOG_DYNNAME.source
+# shellcheck source=/dev/null
+. "$RSYSLOG_DYNNAME.source"
 export OMRABBITMQ_TEST=1
 
 generate_conf
@@ -35,7 +36,8 @@ startup
 injectmsg literal "<167>Mar  1 01:00:00 192.0.2.8 tag msgrmq"
 shutdown_when_empty
 wait_shutdown
-export EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 192.0.2.8 tag - - -  msgrmq')
+EXPECTED=$(printf 'Exchange:in, routing-key:tag.local4.debug, content-type:rfc5424, facility:local4, severity:debug, hostname:192.0.2.8, fromhost:127.0.0.1, delivery-mode:transient, expiration:5000, timestamp:OK, app-id:tag, msg:<167>1 192.0.2.8 tag - - -  msgrmq')
+export EXPECTED
 echo $EXPECTED | cmp - $RSYSLOG_DYNNAME.amqp.log
 if [ ! $? -eq 0 ]; then
   echo "Expected:"

--- a/tests/omrelp-keepalive.sh
+++ b/tests/omrelp-keepalive.sh
@@ -8,7 +8,8 @@ if ! pkg-config --atleast-version=1.12.0 relp 2>/dev/null ; then
     exit 77
 fi
 
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 generate_conf
 add_conf '

--- a/tests/omrelp-tls-ossl-authfail-no-cacert.sh
+++ b/tests/omrelp-tls-ossl-authfail-no-cacert.sh
@@ -64,7 +64,8 @@ sample_cpu_activity() {
 
 export NUMMESSAGES=100
 export TB_TEST_MAX_RUNTIME=30
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 generate_conf
 add_conf '

--- a/tests/omrelp-tls-ossl-authfail-suspend.sh
+++ b/tests/omrelp-tls-ossl-authfail-suspend.sh
@@ -8,7 +8,8 @@ require_relpEngineSetTLSLibByName
 
 export NUMMESSAGES=50
 export TB_TEST_MAX_RUNTIME=60
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 export STATSFILE="$RSYSLOG_DYNNAME.stats"
 
 generate_conf

--- a/tests/privdrop_common.sh
+++ b/tests/privdrop_common.sh
@@ -5,6 +5,7 @@
 
 # To support <bash-4.2 which don't support "declare -g" we declare
 # the array outside of the function
+# shellcheck disable=SC2034
 declare -A TESTBENCH_TESTUSER
 
 rsyslog_testbench_setup_testuser() {
@@ -25,18 +26,18 @@ rsyslog_testbench_setup_testuser() {
 
 		if [ -n "${RSYSLOG_TESTUSER}" ]; then
 			# User has specified an username/uid we should use in testbench
-			testusers=("${RSYSLOG_TESTUSER}" ${testusers[@]})
+			testusers=("${RSYSLOG_TESTUSER}" "${testusers[@]}")
 		fi
 
 		local testuser=
 		for testuser in "${testusers[@]}"; do
-			testusername=$(id --user --name ${testuser} 2>/dev/null)
+			testusername=$(id --user --name "${testuser}" 2>/dev/null)
 			if [ -z "${testusername}" ]; then
 				echo "'id' did not find user \"${testuser}\" ... skipping, trying next user!"
 				continue
 			fi
 
-			testgroupname=$(id --group --name ${testuser} 2>/dev/null)
+			testgroupname=$(id --group --name "${testuser}" 2>/dev/null)
 			if [ -z "${testgroupname}" ]; then
 				echo "'id' did not find a primary group for \"${testuser}\" ... skipping, trying next user!"
 				continue
@@ -73,28 +74,32 @@ rsyslog_testbench_setup_testuser() {
 _rsyslog_testbench_declare_testuser() {
 	local testuser=$1
 
-	local testusername=$(id --user --name ${testuser} 2>/dev/null)
+	local testusername
+	testusername=$(id --user --name "${testuser}" 2>/dev/null)
 	if [ -z "${testusername}" ]; then
 		# Should never happen
 		echo "FATAL ERROR: Could not get username for user \"${testuser}\"!"
 		exit 1
 	fi
 
-	local testuid=$(id --user ${testuser} 2>/dev/null)
+	local testuid
+	testuid=$(id --user "${testuser}" 2>/dev/null)
 	if [ -z "${testuid}" ]; then
 		# Should never happen
 		echo "FATAL ERROR: Could not get uid for user \"${testuser}\"!"
 		exit 1
 	fi
 
-	local testgroupname=$(id --group --name ${testuser} 2>/dev/null)
+	local testgroupname
+	testgroupname=$(id --group --name "${testuser}" 2>/dev/null)
 	if [ -z "${testgroupname}" ]; then
 		# Should never happen
 		echo "FATAL ERROR: Could not get uid of user \"${testuser}\"!"
 		exit 1
 	fi
 
-	local testgid=$(id --group ${testuser} 2>/dev/null)
+	local testgid
+	testgid=$(id --group "${testuser}" 2>/dev/null)
 	if [ -z "${testgid}" ]; then
 		# Should never happen
 		echo "FATAL ERROR: Could not get primary gid of user \"${testuser}\"!"

--- a/tests/ratelimit_hup.sh
+++ b/tests/ratelimit_hup.sh
@@ -7,7 +7,8 @@
 
 # Define ports and files
 export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.test_policy_hup.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.test_policy_hup.yaml"
+export POLICY_FILE
 
 # Create initial policy (High limits)
 echo "interval: 1" > $POLICY_FILE
@@ -46,7 +47,7 @@ if [ $content_count -lt 20 ]; then
 fi
 
 # Reset log file for Phase 2 (clean slate)
-> $RSYSLOG_OUT_LOG
+: > "$RSYSLOG_OUT_LOG"
 
 # Phase 2: Restrictive Limit (Burst 0 - Drop All)
 echo "Updating policy..."

--- a/tests/ratelimit_policy_watch.sh
+++ b/tests/ratelimit_policy_watch.sh
@@ -6,8 +6,10 @@
 . $srcdir/diag.sh check-inotify
 
 export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
-export POLICY_TMP="$(pwd)/${RSYSLOG_DYNNAME}.policy.tmp.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
+POLICY_TMP="$(pwd)/${RSYSLOG_DYNNAME}.policy.tmp.yaml"
+export POLICY_TMP
 export SENDMESSAGES=20
 
 cat > "$POLICY_FILE" <<'YAML'

--- a/tests/ratelimit_policy_watch_debounce.sh
+++ b/tests/ratelimit_policy_watch_debounce.sh
@@ -5,7 +5,8 @@
 . $srcdir/diag.sh check-inotify
 
 export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
 export SENDMESSAGES=20
 
 cat > "$POLICY_FILE" <<'YAML'

--- a/tests/ratelimit_policy_watch_invalid.sh
+++ b/tests/ratelimit_policy_watch_invalid.sh
@@ -5,7 +5,8 @@
 . $srcdir/diag.sh check-inotify
 
 export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
 export SENDMESSAGES=20
 
 cat > "$POLICY_FILE" <<'YAML'

--- a/tests/ratelimit_policy_watch_multi.sh
+++ b/tests/ratelimit_policy_watch_multi.sh
@@ -6,10 +6,14 @@
 
 export PORT_A_FILE="${RSYSLOG_DYNNAME}.imudp_port_a"
 export PORT_B_FILE="${RSYSLOG_DYNNAME}.imudp_port_b"
-export POLICY_A="$(pwd)/${RSYSLOG_DYNNAME}.policy-a.yaml"
-export POLICY_B="$(pwd)/${RSYSLOG_DYNNAME}.policy-b.yaml"
-export OUT_A="$(pwd)/${RSYSLOG_DYNNAME}.out-a.log"
-export OUT_B="$(pwd)/${RSYSLOG_DYNNAME}.out-b.log"
+POLICY_A="$(pwd)/${RSYSLOG_DYNNAME}.policy-a.yaml"
+export POLICY_A
+POLICY_B="$(pwd)/${RSYSLOG_DYNNAME}.policy-b.yaml"
+export POLICY_B
+OUT_A="$(pwd)/${RSYSLOG_DYNNAME}.out-a.log"
+export OUT_A
+OUT_B="$(pwd)/${RSYSLOG_DYNNAME}.out-b.log"
+export OUT_B
 export SENDMESSAGES=20
 
 cat > "$POLICY_A" <<'YAML'

--- a/tests/sndrcv_dtls_anon_ciphers.sh
+++ b/tests/sndrcv_dtls_anon_ciphers.sh
@@ -6,7 +6,8 @@
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(	

--- a/tests/sndrcv_dtls_certvalid.sh
+++ b/tests/sndrcv_dtls_certvalid.sh
@@ -11,7 +11,8 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(

--- a/tests/sndrcv_dtls_certvalid_ciphers.sh
+++ b/tests/sndrcv_dtls_certvalid_ciphers.sh
@@ -7,7 +7,8 @@
 #export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 export NUMMESSAGES=1
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"

--- a/tests/sndrcv_dtls_certvalid_missing.sh
+++ b/tests/sndrcv_dtls_certvalid_missing.sh
@@ -9,7 +9,8 @@ export NUMMESSAGES=1
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(

--- a/tests/sndrcv_dtls_certvalid_permitted.sh
+++ b/tests/sndrcv_dtls_certvalid_permitted.sh
@@ -11,7 +11,8 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 
 add_conf '
 global(

--- a/tests/sndrcv_kafka.sh
+++ b/tests/sndrcv_kafka.sh
@@ -8,7 +8,8 @@ export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_kafka_fail.sh
+++ b/tests/sndrcv_kafka_fail.sh
@@ -12,7 +12,8 @@ export TESTMESSAGES2=50001
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_kafka_failresume.sh
+++ b/tests/sndrcv_kafka_failresume.sh
@@ -10,7 +10,8 @@ export TESTMESSAGES=50000
 export TESTMESSAGESFULL=50000
 
 # Generate random topic name
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_kafka_multi.sh
+++ b/tests/sndrcv_kafka_multi.sh
@@ -9,7 +9,8 @@ export TESTMESSAGES=100000
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_kafka_multi_topics.sh
+++ b/tests/sndrcv_kafka_multi_topics.sh
@@ -10,8 +10,10 @@ export TESTMESSAGES=50000
 export TESTMESSAGESFULL=100000
 
 # Generate random topic name
-export RANDTOPIC1="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
-export RANDTOPIC2="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+RANDTOPIC1="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC1
+RANDTOPIC2="$(printf '%08x' "$(( (RANDOM<<16) ^ RANDOM ))")"
+export RANDTOPIC2
 
 # Set EXTRA_EXITCHECK to dump kafka/zookeeperlogfiles on failure only.
 export EXTRA_EXITCHECK=dumpkafkalogs

--- a/tests/sndrcv_omsnmpv1_udp.sh
+++ b/tests/sndrcv_omsnmpv1_udp.sh
@@ -11,7 +11,8 @@
 export TESTMESSAGES=10
 
 generate_conf
-export PORT_SNMP="$(get_free_port)"
+PORT_SNMP="$(get_free_port)"
+export PORT_SNMP
 # Start SNMP Trap Receiver
 snmp_start_trapreceiver ${PORT_SNMP} ${RSYSLOG_OUT_LOG}
 

--- a/tests/sndrcv_omsnmpv1_udp_dynsource.sh
+++ b/tests/sndrcv_omsnmpv1_udp_dynsource.sh
@@ -11,7 +11,8 @@
 export TESTMESSAGES=10
 
 generate_conf
-export PORT_SNMP="$(get_free_port)"
+PORT_SNMP="$(get_free_port)"
+export PORT_SNMP
 # Start SNMP Trap Receiver
 snmp_start_trapreceiver ${PORT_SNMP} ${RSYSLOG_OUT_LOG}
 

--- a/tests/sndrcv_omsnmpv1_udp_invalidoid.sh
+++ b/tests/sndrcv_omsnmpv1_udp_invalidoid.sh
@@ -11,7 +11,8 @@
 export TESTMESSAGES=1
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.omsnmp.debuglog"
 generate_conf
-export PORT_SNMP="$(get_free_port)"
+PORT_SNMP="$(get_free_port)"
+export PORT_SNMP
 # Start SNMP Trap Receiver
 snmp_start_trapreceiver ${PORT_SNMP} ${RSYSLOG_OUT_LOG}
 

--- a/tests/sndrcv_ossl_cert_chain.sh
+++ b/tests/sndrcv_ossl_cert_chain.sh
@@ -7,7 +7,8 @@ export NUMMESSAGES=1000
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 ### This is important, as it must be exactly the same
 ### as the ones configured in used certificates
 export HOSTNAME="fedora"
@@ -36,7 +37,8 @@ startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
+TCPFLOOD_PORT="$(get_free_port)"
+export TCPFLOOD_PORT
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/testsuites/certchain/ca-root-cert.pem'"

--- a/tests/sndrcv_relp-vg-rcvr.sh
+++ b/tests/sndrcv_relp-vg-rcvr.sh
@@ -20,7 +20,8 @@ export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
 export RSYSLOG_DEBUG="debug nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 input(type="imrelp" port="'$PORT_RCVR'")

--- a/tests/sndrcv_relp-vg-sender.sh
+++ b/tests/sndrcv_relp-vg-sender.sh
@@ -20,7 +20,8 @@ export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
 export RSYSLOG_DEBUG="debug nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 input(type="imrelp" port="'$PORT_RCVR'")

--- a/tests/sndrcv_relp.sh
+++ b/tests/sndrcv_relp.sh
@@ -7,7 +7,8 @@ export NUMMESSAGES=50000
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 input(type="imrelp" port="'$PORT_RCVR'")

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -31,7 +31,8 @@ startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)"
+TCPFLOOD_PORT="$(get_free_port)"
+export TCPFLOOD_PORT
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
 

--- a/tests/sndrcv_relp_rebind.sh
+++ b/tests/sndrcv_relp_rebind.sh
@@ -8,7 +8,8 @@ echo testing sending and receiving via relp w/ rebind interval
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)
@@ -21,7 +22,8 @@ startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
+TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
+export TCPFLOOD_PORT
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
 

--- a/tests/sndrcv_relp_tls-cfgcmd.sh
+++ b/tests/sndrcv_relp_tls-cfgcmd.sh
@@ -2,7 +2,8 @@
 # added 2019-11-13 by alorbach
 . ${srcdir:=.}/diag.sh init
 require_relpEngineSetTLSLibByName
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf

--- a/tests/sndrcv_relp_tls.sh
+++ b/tests/sndrcv_relp_tls.sh
@@ -8,7 +8,8 @@
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)

--- a/tests/sndrcv_relp_tls_certvalid.sh
+++ b/tests/sndrcv_relp_tls_certvalid.sh
@@ -7,7 +7,8 @@
 export RSYSLOG_DEBUGLOG="log"
 
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)
@@ -42,7 +43,7 @@ startup 2
 
 grep "omrelp error: invalid authmode" $RSYSLOG_DYNNAME.errmsgs > /dev/null
 if [ $? -eq 0 ]; then
-        echo "SKIP: librelp does not support "certvalid" auth mode"
+        echo "SKIP: librelp does not support certvalid auth mode"
 	# mini-cleanup to not leave dangling processes
 	shutdown_immediate 2
 	shutdown_immediate

--- a/tests/sndrcv_relp_tls_chainedcert.sh
+++ b/tests/sndrcv_relp_tls_chainedcert.sh
@@ -10,7 +10,8 @@ export TB_TEST_MAX_RUNTIME=30
 # export RSYSLOG_DEBUGLOG="log"
 
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(	load="../plugins/imrelp/.libs/imrelp"
 	tls.tlslib="openssl")
@@ -47,7 +48,7 @@ action(type="omfile" file="'$RSYSLOG_DYNNAME.errmsgs'")
 startup 2
 
 if grep "omrelp error: invalid authmode" < "$RSYSLOG_DYNNAME.errmsgs" ; then
-        echo "SKIP: librelp does not support "certvalid" auth mode"
+        echo "SKIP: librelp does not support certvalid auth mode"
 	# mini-cleanup to not leave dangling processes
 	shutdown_immediate 2
 	shutdown_immediate

--- a/tests/sndrcv_relp_tls_prio.sh
+++ b/tests/sndrcv_relp_tls_prio.sh
@@ -9,7 +9,8 @@ echo testing sending and receiving via relp with TLS enabled and priority string
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-export PORT_RCVR="$(get_free_port)"
+PORT_RCVR="$(get_free_port)"
+export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)

--- a/tests/sndrcv_udp_nonstdpt_v6.sh
+++ b/tests/sndrcv_udp_nonstdpt_v6.sh
@@ -25,7 +25,8 @@ assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-export TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
+TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
+export TCPFLOOD_PORT
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 # this listener is for message generation by the test framework!

--- a/tests/yaml-mmjsontransform-policywatch.sh
+++ b/tests/yaml-mmjsontransform-policywatch.sh
@@ -5,8 +5,10 @@
 . $srcdir/diag.sh check-inotify
 
 # port is assigned by diag.sh from listenPortFileName
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
-export POLICY_TMP="$(pwd)/${RSYSLOG_DYNNAME}.policy.tmp.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
+POLICY_TMP="$(pwd)/${RSYSLOG_DYNNAME}.policy.tmp.yaml"
+export POLICY_TMP
 
 cat > "$POLICY_FILE" <<'YAML'
 version: 1

--- a/tests/yaml-ratelimit-policywatch.sh
+++ b/tests/yaml-ratelimit-policywatch.sh
@@ -5,7 +5,8 @@
 . $srcdir/diag.sh check-inotify
 
 export PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.imudp_port"
-export POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+POLICY_FILE="$(pwd)/${RSYSLOG_DYNNAME}.policy.yaml"
+export POLICY_FILE
 export SENDMESSAGES=20
 
 cat > "$POLICY_FILE" <<'YAML'


### PR DESCRIPTION
## Summary

- split straightforward test `export`/`local` assignments so command substitution failures are no longer masked
- add explicit `cd ... || exit 1` handling for remaining packaging/dev_env `SC2164` findings
- clean existing ShellCheck warnings in touched files so the PR diff is `shellcheck -S warning` clean

## ShellCheck Impact

Full-tree warning count drops from 521 to 370:

- removes all test `SC2155` findings outside `tests/diag.sh`
- removes all packaging `SC2164` findings
- leaves `tests/diag.sh` `SC2155` for a later focused pass because it is sourced by the whole testbench and needs helper-by-helper review

## Validation

- `shellcheck -S warning` on changed shell scripts: pass, 0 findings
- `git diff --check upstream/main...HEAD`: pass
- `bash -n` on changed shell scripts: pass
- full-tree `shellcheck -S warning`: 370 remaining warnings
- container static analyzer with `rsyslog/rsyslog_dev_base_ubuntu:26.04` (`sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276`): pass, no bugs found
- Ubuntu 26.04 container `run-ci.sh`: pass, 1274 total / 1181 pass / 93 skip / 0 fail / 0 error

Local Cubic review was attempted, but could not be completed: the normal run hit a network failure, and the escalated run was rejected because it would send repository content to an external review service.
