### PR TITLE
fix(imhiredis): default TLS peer name to configured server

### DIFF
--- a/contrib/imhiredis/imhiredis.c
+++ b/contrib/imhiredis/imhiredis.c
@@ -378,14 +378,20 @@ static rsRetVal ATTR_NONNULL() checkInstance(instanceConf_t *const inst) {
 
     // Check and initialize SSL context
     if (inst->use_tls) {
+        const char *tls_peer_name = inst->sni;
+
         if ((inst->client_cert == NULL) ^ (inst->client_key == NULL)) {
             LogMsg(0, RS_RET_CONFIG_ERROR, LOG_ERR,
                    "imhiredis: \"client_cert\" and \"client_key\" must be specified together!");
             ABORT_FINALIZE(RS_RET_CONFIG_ERROR);
         }
 
+        if (tls_peer_name == NULL && inst->redisNodesList->usesSocket == 0) {
+            tls_peer_name = (const char *)inst->redisNodesList->server;
+        }
+
         inst->ssl_conn = redisCreateSSLContext(inst->ca_cert_bundle, inst->ca_cert_dir, inst->client_cert,
-                                               inst->client_key, inst->sni, &ssl_error);
+                                               inst->client_key, tls_peer_name, &ssl_error);
 
         if (!inst->ssl_conn || ssl_error != REDIS_SSL_CTX_NONE) {
             LogError(0, RS_RET_REDIS_ERROR, "imhiredis: TLS configuration Error: %s",


### PR DESCRIPTION
### Motivation
- The imhiredis TLS integration passed a NULL SNI into hiredis when `sni` was not configured, which prevents a peer-name from being provided for TLS hostname verification and allows a CA-trusted but hostname-mismatched certificate to be accepted.
- The change aims to ensure TCP-based TLS connections always present a peer name to the hiredis SSL context so endpoint identity can be enforced by the TLS stack or caller.

### Description
- When `use_tls` is enabled and no explicit `sni` is provided, set a `tls_peer_name` to the configured Redis `server` for TCP connections and keep `sni` precedence when present. 
- Pass `tls_peer_name` into `redisCreateSSLContext(...)` instead of passing `NULL` when `sni` is unset. 
- The change is localized to `contrib/imhiredis/imhiredis.c` and preserves the existing `client_cert`/`client_key` validation logic.

### Testing
- Attempted to run the repository test target with `make -j2 check TESTS=''`, which failed in this environment because the workspace is not configured with generated Makefiles (no `check` target), so no automated test-suite run was completed. 
- The change is intentionally minimal and localized to ease downstream testing in a full CI/dev environment that supplies `libhiredis` dev headers and the normal `make check` tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f62909a2c8332b0aa0ba7beeb41ec)