### PR TITLE
omhiredis: derive TLS server name from server and require peer name when using TLS

### DIFF
--- a/contrib/omhiredis/omhiredis.c
+++ b/contrib/omhiredis/omhiredis.c
@@ -276,9 +276,15 @@ static rsRetVal initHiredis(wrkrInstanceData_t *pWrkrData, int bSilent) {
 
 #ifdef HIREDIS_SSL
     if (pWrkrData->pData->use_tls) {
+        const char *tls_server_name = pWrkrData->pData->sni;
+
+        if (tls_server_name == NULL && pWrkrData->pData->server != NULL) {
+            tls_server_name = (const char *)pWrkrData->pData->server;
+        }
+
         pWrkrData->ssl_conn = redisCreateSSLContext(pWrkrData->pData->ca_cert_bundle, pWrkrData->pData->ca_cert_dir,
                                                     pWrkrData->pData->client_cert, pWrkrData->pData->client_key,
-                                                    pWrkrData->pData->sni, &pWrkrData->ssl_error);
+                                                    tls_server_name, &pWrkrData->ssl_error);
         if (!pWrkrData->ssl_conn || pWrkrData->ssl_error != REDIS_SSL_CTX_NONE) {
             LogError(0, NO_ERRCODE, "omhiredis[%s]: SSL Context error: %s", actionGetName(pWrkrData->pData->pAction),
                      redisSSLContextGetError(pWrkrData->ssl_error));
@@ -673,6 +679,11 @@ BEGINnewActInst
 #ifdef HIREDIS_SSL
     if ((pData->client_cert == NULL) ^ (pData->client_key == NULL)) {
         parser_errmsg("omhiredis: \"client_cert\" and \"client_key\" must be specified together!");
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+    if (pData->use_tls && pData->sni == NULL && pData->server == NULL) {
+        parser_errmsg("omhiredis: TLS requires either \"server\" or \"sni\" to validate server identity");
         ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     }
 #endif


### PR DESCRIPTION
### Motivation
- Close a TLS authentication gap where TLS was enabled but no peer identity was supplied to the hiredis SSL layer, allowing successful handshakes that did not verify the Redis hostname and exposing `AUTH` credentials to a MITM.

### Description
- When `use_tls` is set, derive the TLS server name passed to `redisCreateSSLContext()` from the configured `sni` and fall back to the configured `server` when `sni` is NULL by using a local `tls_server_name` variable in `contrib/omhiredis/omhiredis.c` inside `initHiredis()`.
- Add a configuration sanity check in the instance creation path that requires at least one of `server` or `sni` to be set when `use_tls` is enabled, failing parse with `parser_errmsg()` if neither is present.
- Keep existing behavior when `sni` is explicitly provided and do not change other TLS parameters or the AUTH sequence.

### Testing
- No automated test suite or full local container validation was run in this environment, so this change is **not fully container-validated** per the repository policy. 
- Per-file static inspection and diffs were performed (`git diff` / file view) to verify the intended edits to `contrib/omhiredis/omhiredis.c` were applied and compiled-path headers were checked where available; these checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f65d519748332a84d7daee6022aaf)