### PR TITLE
runtime/nsd_gtls: validate IP SAN length before conversion

### DIFF
--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -1167,11 +1167,11 @@ static rsRetVal gtlsChkPeerName(nsd_gtls_t *pThis, gnutls_x509_crt_t *pCert) {
             CHKiRet(gtlsChkOnePeerName(pThis, (uchar *)szAltName, &bFoundPositiveMatch));
             /* do NOT break, because there may be multiple dNSName's! */
         } else if (gnuRet == GNUTLS_SAN_IPADDRESS) {
+            bHaveSAN = 1;
             const int family = (szAltNameLen == sizeof(struct in6_addr))
                                    ? AF_INET6
                                    : ((szAltNameLen == sizeof(struct in_addr)) ? AF_INET : AF_UNSPEC);
             if (family != AF_UNSPEC) {
-                bHaveSAN = 1;
                 char ipAddress[INET6_ADDRSTRLEN];
                 if (inet_ntop(family, szAltName, ipAddress, INET6_ADDRSTRLEN) != NULL) {
                     dbgprintf("subject alt ipAddr: '%s'\n", ipAddress);

--- a/runtime/nsd_gtls.c
+++ b/runtime/nsd_gtls.c
@@ -448,9 +448,13 @@ static rsRetVal gtlsGetCertInfo(nsd_gtls_t *const pThis, cstr_t **ppStr) {
                 /* do NOT break, because there may be multiple dNSName's! */
             } else if (gnuRet == GNUTLS_SAN_IPADDRESS) {
                 char ipAddress[INET6_ADDRSTRLEN];
+                const int family = (tmp == sizeof(struct in6_addr))
+                                       ? AF_INET6
+                                       : ((tmp == sizeof(struct in_addr)) ? AF_INET : AF_UNSPEC);
                 /* we found it! */
-                inet_ntop(((tmp == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET), szBuf, ipAddress, sizeof(ipAddress));
-                CHKiRet(rsCStrAppendStrf(pStr, "SAN:IPaddress: %s; ", ipAddress));
+                if (family != AF_UNSPEC && inet_ntop(family, szBuf, ipAddress, sizeof(ipAddress)) != NULL) {
+                    CHKiRet(rsCStrAppendStrf(pStr, "SAN:IPaddress: %s; ", ipAddress));
+                }
                 /* do NOT break, because there may be multiple ipAddr's! */
             }
             ++iAltName;
@@ -1163,14 +1167,19 @@ static rsRetVal gtlsChkPeerName(nsd_gtls_t *pThis, gnutls_x509_crt_t *pCert) {
             CHKiRet(gtlsChkOnePeerName(pThis, (uchar *)szAltName, &bFoundPositiveMatch));
             /* do NOT break, because there may be multiple dNSName's! */
         } else if (gnuRet == GNUTLS_SAN_IPADDRESS) {
-            bHaveSAN = 1;
-            char ipAddress[INET6_ADDRSTRLEN];
-            inet_ntop(((szAltNameLen == sizeof(struct in6_addr)) ? AF_INET6 : AF_INET), szAltName, ipAddress,
-                      INET6_ADDRSTRLEN);
-            dbgprintf("subject alt ipAddr: '%s'\n", ipAddress);
-            snprintf((char *)lnBuf, sizeof(lnBuf), "IPaddress: %s; ", ipAddress);
-            CHKiRet(rsCStrAppendStr(pStr, lnBuf));
-            CHKiRet(gtlsChkOnePeerName(pThis, (uchar *)ipAddress, &bFoundPositiveMatch));
+            const int family = (szAltNameLen == sizeof(struct in6_addr))
+                                   ? AF_INET6
+                                   : ((szAltNameLen == sizeof(struct in_addr)) ? AF_INET : AF_UNSPEC);
+            if (family != AF_UNSPEC) {
+                bHaveSAN = 1;
+                char ipAddress[INET6_ADDRSTRLEN];
+                if (inet_ntop(family, szAltName, ipAddress, INET6_ADDRSTRLEN) != NULL) {
+                    dbgprintf("subject alt ipAddr: '%s'\n", ipAddress);
+                    snprintf((char *)lnBuf, sizeof(lnBuf), "IPaddress: %s; ", ipAddress);
+                    CHKiRet(rsCStrAppendStr(pStr, lnBuf));
+                    CHKiRet(gtlsChkOnePeerName(pThis, (uchar *)ipAddress, &bFoundPositiveMatch));
+                }
+            }
             /* do NOT break, because there may be multiple ipAddr's! */
         }
         ++iAltName;


### PR DESCRIPTION
### Motivation
- Fix a GnuTLS IP SAN parsing bug where non-4/16-byte iPAddress SANs could be treated as IPv4 and be matched against configured permitted peers, enabling authorization bypass. 
- Ensure SAN handling follows RFC 5280 by accepting only 4-byte IPv4 and 16-byte IPv6 iPAddress values before conversion and matching.

### Description
- In `runtime/nsd_gtls.c` enforce SAN length checks in both certificate-info formatting (`gtlsGetCertInfo`) and x509/name peer matching (`gtlsChkPeerName`) by selecting `AF_INET` only when `szAltNameLen == sizeof(struct in_addr)` and `AF_INET6` only when `szAltNameLen == sizeof(struct in6_addr)`, otherwise treating the SAN as malformed (`AF_UNSPEC`).
- Call `inet_ntop()` only when the selected family is valid and the conversion succeeds, and skip malformed iPAddress SAN entries instead of coercing them to IPv4.
- Preserve multi-SAN iteration and existing permitted-peer matching semantics while preventing malformed SANs from being passed into `gtlsChkOnePeerName`.

### Testing
- Ran `bash devtools/format-code.sh`, which completed successfully.
- Ran `make -j$(nproc) check TESTS=""`, which failed in this environment with `No rule to make target 'check'` due to missing configure/build artifacts, so full build/test validation was not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f6b5cd9308332b8af5b852b1a318d)