### PR TITLE
omfwd: require peers for targetSrv TLS name auth

### DIFF
--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -2019,7 +2019,7 @@ static rsRetVal validateTargetSrvTlsAuth(const instanceData *const pData) {
     if (pData->pszStrmDrvrAuthMode == NULL || !strcasecmp((const char *)pData->pszStrmDrvrAuthMode, "x509/name")) {
         LogError(0, RS_RET_PARAM_ERROR,
                  "omfwd: targetSrv with TLS requires streamdriverpermittedpeers when using streamdriverauthmode "
-                 "\"x509/name\" (explicitly set permitted peers or use static target)");
+                 "\"x509/name\" or the default auth mode (explicitly set permitted peers or use static target)");
         ABORT_FINALIZE(RS_RET_PARAM_ERROR);
     }
 

--- a/tools/omfwd.c
+++ b/tools/omfwd.c
@@ -2005,6 +2005,28 @@ static void warnIfNonTlsForwardingConfigured(const instanceData *const pData) {
     }
 }
 
+static rsRetVal validateTargetSrvTlsAuth(const instanceData *const pData) {
+    DEFiRet;
+
+    if (pData->targetSrv == NULL || pData->protocol != FORW_TCP || pData->iStrmDrvrMode == 0) {
+        FINALIZE;
+    }
+
+    if (pData->pPermPeers != NULL) {
+        FINALIZE;
+    }
+
+    if (pData->pszStrmDrvrAuthMode == NULL || !strcasecmp((const char *)pData->pszStrmDrvrAuthMode, "x509/name")) {
+        LogError(0, RS_RET_PARAM_ERROR,
+                 "omfwd: targetSrv with TLS requires streamdriverpermittedpeers when using streamdriverauthmode "
+                 "\"x509/name\" (explicitly set permitted peers or use static target)");
+        ABORT_FINALIZE(RS_RET_PARAM_ERROR);
+    }
+
+finalize_it:
+    RETiRet;
+}
+
 
 BEGINnewActInst
     struct cnfparamvals *pvals;
@@ -2259,6 +2281,7 @@ BEGINnewActInst
             parser_warnmsg("omfwd: targetSrv was set, ignoring explicit port list");
             freeConfiguredPorts(pData);
         }
+        CHKiRet(validateTargetSrvTlsAuth(pData));
         CHKiRet(resolveSrvTargets(pData));
     }
 


### PR DESCRIPTION
### Motivation
- DNS SRV discovery (`targetSrv`) can cause omfwd to use SRV-provided hostnames as the TLS reference identity, enabling an authentication bypass when `streamdriver` auth mode uses implicit hostname checks (`x509/name`) and no explicit permitted peers are configured.
- The change prevents unsafe implicit TLS name authentication for SRV-discovered targets by failing config-time validation unless explicit peer identities are configured.

### Description
- Add a new helper `validateTargetSrvTlsAuth()` in `tools/omfwd.c` that enforces the requirement for `streamdriverpermittedpeers` when `targetSrv` is used over TCP with TLS name-based auth (`x509/name` or default `NULL`).
- Invoke `validateTargetSrvTlsAuth()` from `newActInst()` before SRV resolution so unsafe configs fail early and clearly during config processing.
- Keep existing behavior for non-TCP, non-TLS, or when `streamdriverpermittedpeers` is explicitly configured.

### Testing
- Ran code formatting via `bash devtools/format-code.sh`, which completed successfully.
- Attempted full local validation (`./autogen.sh && ./configure --enable-testbench && make -j$(nproc) check TESTS=""`) but the run was blocked by a missing system dependency: `protoc-c not found. Please install protobuf-c-compiler package.`, so the build/test suite could not be completed in this environment.
- No automated unit/integration tests were added or modified as part of this minimal fix; behavior is enforced at config validation time.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f66b9c03c8332b9c3b611e2b5813c)