### PR TITLE
tests: avoid preselected network ports

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1165,6 +1165,161 @@ assign_tcpflood_port() {
 	fi
 }
 
+# Discover the single TCP listener port owned by an rsyslog instance, excluding
+# the imdiag listener used by the testbench. This supports modules that can bind
+# port 0 but do not have native listenPortFileName plumbing yet. Tests should
+# still prefer module-native port files where they exist.
+# $1 - variable name to assign
+# $2 - rsyslog instance number, blank for the first instance
+assign_single_tcp_listener_port() {
+	local var_name="$1"
+	local instance="$2"
+	local pid_file="$RSYSLOG_PIDBASE$instance.pid"
+	local imdiag_var="IMDIAG_PORT$instance"
+	local imdiag_port="${!imdiag_var}"
+	local port
+
+	if [ "$var_name" == "" ]; then
+		printf 'TESTBENCH error: assign_single_tcp_listener_port needs a target variable\n'
+		error_exit 100
+	fi
+	if [ "$(uname -s)" != "Linux" ]; then
+		printf 'SKIP: TCP listener discovery requires Linux /proc socket tables\n'
+		skip_test
+	fi
+	wait_rsyslog_instance_pid "$instance"
+	if [ "$imdiag_port" == "" ]; then
+		printf 'TESTBENCH error: imdiag port for instance "%s" is not known\n' "$instance"
+		error_exit 100
+	fi
+	port=$($PYTHON - "$pid_file" "$imdiag_port" <<'PY'
+import os
+import sys
+
+pid_file, imdiag_port = sys.argv[1], int(sys.argv[2])
+with open(pid_file) as pid_fp:
+    pid = pid_fp.read().strip()
+
+socket_inodes = set()
+fd_dir = "/proc/{}/fd".format(pid)
+try:
+    fd_names = os.listdir(fd_dir)
+except OSError:
+    fd_names = []
+for fd_name in fd_names:
+    try:
+        target = os.readlink(os.path.join(fd_dir, fd_name))
+    except OSError:
+        continue
+    if target.startswith("socket:[") and target.endswith("]"):
+        socket_inodes.add(target[8:-1])
+
+ports = set()
+for table in ("/proc/net/tcp", "/proc/net/tcp6"):
+    if not os.path.exists(table):
+        continue
+    with open(table) as table_fp:
+        next(table_fp)
+        for line in table_fp:
+            fields = line.split()
+            if len(fields) < 10 or fields[3] != "0A" or fields[9] not in socket_inodes:
+                continue
+            port = int(fields[1].split(":")[1], 16)
+            if port != imdiag_port:
+                ports.add(port)
+
+if len(ports) != 1:
+    sys.stderr.write(
+        "expected exactly one non-imdiag TCP listener for pid {}, found {}".format(
+            pid, sorted(ports)
+        )
+        + "\n"
+    )
+    sys.exit(1)
+print(next(iter(ports)))
+PY
+	)
+	if [ $? -ne 0 ] || [ "$port" == "" ]; then
+		printf 'TESTBENCH error: could not discover non-imdiag TCP listener for instance "%s"\n' "$instance"
+		error_exit 100
+	fi
+	export "$var_name=$port"
+	echo "$var_name now: $port"
+}
+
+# Discover the single UDP listener port owned by an rsyslog instance. This is
+# intended for UDP-style inputs that can bind port 0 but do not have native
+# listenPortFileName plumbing yet.
+# $1 - variable name to assign
+# $2 - rsyslog instance number, blank for the first instance
+assign_single_udp_listener_port() {
+	local var_name="$1"
+	local instance="$2"
+	local pid_file="$RSYSLOG_PIDBASE$instance.pid"
+	local port
+
+	if [ "$var_name" == "" ]; then
+		printf 'TESTBENCH error: assign_single_udp_listener_port needs a target variable\n'
+		error_exit 100
+	fi
+	if [ "$(uname -s)" != "Linux" ]; then
+		printf 'SKIP: UDP listener discovery requires Linux /proc socket tables\n'
+		skip_test
+	fi
+	wait_rsyslog_instance_pid "$instance"
+	port=$($PYTHON - "$pid_file" <<'PY'
+import os
+import sys
+
+pid_file = sys.argv[1]
+with open(pid_file) as pid_fp:
+    pid = pid_fp.read().strip()
+
+socket_inodes = set()
+fd_dir = "/proc/{}/fd".format(pid)
+try:
+    fd_names = os.listdir(fd_dir)
+except OSError:
+    fd_names = []
+for fd_name in fd_names:
+    try:
+        target = os.readlink(os.path.join(fd_dir, fd_name))
+    except OSError:
+        continue
+    if target.startswith("socket:[") and target.endswith("]"):
+        socket_inodes.add(target[8:-1])
+
+ports = set()
+for table in ("/proc/net/udp", "/proc/net/udp6"):
+    if not os.path.exists(table):
+        continue
+    with open(table) as table_fp:
+        next(table_fp)
+        for line in table_fp:
+            fields = line.split()
+            if len(fields) < 10 or fields[9] not in socket_inodes:
+                continue
+            ports.add(int(fields[1].split(":")[1], 16))
+
+if len(ports) != 1:
+    sys.stderr.write(
+        "expected exactly one UDP listener for pid {}, found {}".format(
+            pid, sorted(ports)
+        )
+        + "\n"
+    )
+    sys.exit(1)
+print(next(iter(ports)))
+PY
+	)
+	if [ $? -ne 0 ] || [ "$port" == "" ]; then
+		printf 'TESTBENCH error: could not discover UDP listener for instance "%s"\n' "$instance"
+		error_exit 100
+	fi
+	export "$var_name=$port"
+	echo "$var_name now: $port"
+}
+
 
 # assign TCPFLOOD_PORT2 from port file
 # $1 - port file
@@ -4740,11 +4895,16 @@ file_size_check() {
 }
 
 ## Start the helper SNI server for omfwd tests.
-## Args: 1=library (openssl|gnutls), 2=port
+## Args: 1=library (openssl|gnutls), 2=port file
+## The helper binds port 0 and writes the selected listener port before rsyslog
+## is configured. This avoids the get_free_port preselection race where another
+## process can take the chosen port before the helper binds it.
 omfwd_sni_server() {
-	"./$1_sni_server" "$2" "$srcdir/tls-certs/cert.pem" "$srcdir/tls-certs/key.pem" \
+	rm -f "$2"
+	"./$1_sni_server" 0 "$srcdir/tls-certs/cert.pem" "$srcdir/tls-certs/key.pem" "$2" \
 		1>"$RSYSLOG_DYNNAME.sni-server.stdout" &
 	echo "$!" >"$RSYSLOG_DYNNAME.sni-server.pid"
+	wait_file_exists "$2" 10
 }
 
 ## Validate that the SNI server observed the expected name.

--- a/tests/gnutls_sni_server.c
+++ b/tests/gnutls_sni_server.c
@@ -44,7 +44,35 @@
         fprintf(stderr, "LOOP_CHECK: " #cmd " returned %d\n", rval); \
     } while (rval == GNUTLS_E_AGAIN || rval == GNUTLS_E_INTERRUPTED)
 
-int create_socket(const char *port) {
+static void write_listen_port_file(const int sock, const char *const port_file) {
+    if (port_file == NULL) {
+        return;
+    }
+
+    struct sockaddr_storage addr;
+    socklen_t addrlen = sizeof(addr);
+    char port[NI_MAXSERV];
+    FILE *fp;
+
+    if (getsockname(sock, (struct sockaddr *)&addr, &addrlen) != 0) {
+        perror("GTLS-SNI: getsockname failed");
+        exit(EXIT_FAILURE);
+    }
+    if (getnameinfo((struct sockaddr *)&addr, addrlen, NULL, 0, port, sizeof(port), NI_NUMERICSERV) != 0) {
+        perror("GTLS-SNI: getnameinfo failed");
+        exit(EXIT_FAILURE);
+    }
+
+    fp = fopen(port_file, "w");
+    if (fp == NULL) {
+        perror("GTLS-SNI: Unable to open port file");
+        exit(EXIT_FAILURE);
+    }
+    fprintf(fp, "%s\n", port);
+    fclose(fp);
+}
+
+int create_socket(const char *port, const char *port_file) {
     struct addrinfo hints;
     struct addrinfo *res = NULL;
     struct addrinfo *rp;
@@ -75,6 +103,7 @@ int create_socket(const char *port) {
 
         if (bind(s, rp->ai_addr, rp->ai_addrlen) == 0) {
             if (listen(s, 1) == 0) {
+                write_listen_port_file(s, port_file);
                 break;
             }
         }
@@ -116,7 +145,7 @@ int main(int argc, char **argv) {
     setbuf(stdout, NULL);
 
     if (argc < 4) {
-        printf("Usage: gnutls_sni_server PORT CERT_FILE_PATH KEY_FILE_PATH\n");
+        printf("Usage: gnutls_sni_server PORT CERT_FILE_PATH KEY_FILE_PATH [PORT_FILE]\n");
         exit(EXIT_SUCCESS);
     }
 
@@ -124,7 +153,7 @@ int main(int argc, char **argv) {
 
     /* Socket operations
      */
-    listen_sd = create_socket(argv[1]);
+    listen_sd = create_socket(argv[1], argc > 4 ? argv[4] : NULL);
 
     fprintf(stderr, "GTLS-SNI: Server ready, listening on port %s\n", argv[1]);
 

--- a/tests/imdtls-sessionbreak.sh
+++ b/tests/imdtls-sessionbreak.sh
@@ -1,12 +1,18 @@
 #!/bin/bash
 # added 2020-04-10 by alorbach, released under ASL 2.0
+#
+# Exercise imdtls cleanup after repeated abrupt DTLS client termination. The
+# receiver binds an ephemeral UDP port and the testbench discovers the actual
+# port from the running rsyslog process, avoiding get_free_port races with
+# parallel tests. Success is proven by all killed tcpflood clients leaving no
+# established DTLS session owned by the receiver before shutdown.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1000
 export DTLS_SESSIONBREAK_ROUNDS=${DTLS_SESSIONBREAK_ROUNDS:-16}
 export USE_VALGRIND="yes"
 # TODO remote leak check skip and fix memory leaks caused by session break
 export RS_TESTBENCH_LEAK_CHECK=no
-PORT_RCVR="$(get_free_port)"
+PORT_RCVR=0
 export PORT_RCVR
 
 mkdir $RSYSLOG_DYNNAME.workdir
@@ -40,6 +46,7 @@ ruleset(name="spool" queue.type="direct") {
 }
 '
 startup
+assign_single_udp_listener_port PORT_RCVR
 # Stress repeated DTLS client churn to exercise session cleanup and fd reuse.
 for ((i=1;i<=DTLS_SESSIONBREAK_ROUNDS;i++)); do
 	./tcpflood -Tdtls -p$PORT_RCVR -m$NUMMESSAGES -W1000 -d102400 -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -s &
@@ -57,7 +64,7 @@ done;
 
 wait_queueempty
 
-netstatresult=$(netstat --all --program 2>&1 | grep "ESTABLISHED" | grep "$(cat "$RSYSLOG_PIDBASE.pid")" | grep "$TCPFLOOD_PORT")
+netstatresult=$(netstat --all --program 2>&1 | grep "ESTABLISHED" | grep "$(cat "$RSYSLOG_PIDBASE.pid")" | grep "$PORT_RCVR")
 openfd=$(ls -l "/proc/$(cat $RSYSLOG_PIDBASE$1.pid)/fd" | wc -l)
 
 shutdown_when_empty

--- a/tests/imrelp-basic.sh
+++ b/tests/imrelp-basic.sh
@@ -1,17 +1,23 @@
 #!/bin/bash
 # addd 2016-05-13 by RGerhards, released under ASL 2.0
+#
+# Verify basic plain RELP input delivery from tcpflood through imrelp. The
+# receiver binds an ephemeral TCP port and the testbench discovers the actual
+# listener from the running rsyslog process, avoiding get_free_port races with
+# parallel tests. Success is the exact sequence check for all injected messages.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=10000 # MUST be an even number!
 generate_conf
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="'$TCPFLOOD_PORT'")
+input(type="imrelp" address="127.0.0.1" port="0")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt"
 			         file=`echo $RSYSLOG_OUT_LOG`)
 '
 startup
+assign_single_tcp_listener_port TCPFLOOD_PORT
 tcpflood -Trelp-plain -p$TCPFLOOD_PORT -m$NUMMESSAGES
 shutdown_when_empty
 wait_shutdown

--- a/tests/omfwd-srv-discovery-udp.sh
+++ b/tests/omfwd-srv-discovery-udp.sh
@@ -1,13 +1,48 @@
 #!/bin/bash
 ## @brief Validate SRV discovery for omfwd when resolving targets via DNS SRV over UDP.
+## The DNS mock and UDP receiver both bind dynamic ports and publish them before
+## rsyslog starts. Success is proved by the receiver collecting every injected
+## message through the SRV-discovered UDP target.
 . ${srcdir:=.}/diag.sh init
 check_command_available python3
 
 export NUMMESSAGES=40
 DNS_RECORDS="$RSYSLOG_DYNNAME.srv.json"
-UDP_PORT=$(get_free_port)
+UDP_PORT_FILE="$RSYSLOG_DYNNAME.udp_port"
 UDP_OUT="$RSYSLOG_OUT_LOG"
 DNS_PORT_FILE="$RSYSLOG_DYNNAME.dns_port"
+
+python3 - <<'PY' "$UDP_PORT_FILE" "$UDP_OUT" "$NUMMESSAGES" &
+import socket
+import sys
+import time
+
+portfile = sys.argv[1]
+outfile = sys.argv[2]
+expected = int(sys.argv[3])
+sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+sock.bind(("127.0.0.1", 0))
+with open(portfile, "w", encoding="utf-8") as f:
+    f.write(str(sock.getsockname()[1]))
+sock.settimeout(15)
+received = 0
+end_time = time.time() + 20
+with open(outfile, "w", encoding="utf-8", errors="ignore") as f:
+    while received < expected and time.time() < end_time:
+        try:
+            data, _ = sock.recvfrom(65535)
+        except socket.timeout:
+            continue
+        message = data.decode(errors="ignore")
+        message = message.rstrip("\n")
+        f.write(message + "\n")
+        f.flush()
+        received += 1
+sys.exit(0)
+PY
+UDP_PID=$!
+wait_file_exists "$UDP_PORT_FILE"
+UDP_PORT=$(cat "$UDP_PORT_FILE")
 
 cat >"$DNS_RECORDS" <<EOFJSON
 {
@@ -27,34 +62,7 @@ DNS_PORT=$(cat "$DNS_PORT_FILE")
 export RSYSLOG_DNS_SERVER=127.0.0.1
 export RSYSLOG_DNS_PORT="$DNS_PORT"
 export RES_OPTIONS="attempts:1 timeout:1"
-trap 'kill $DNS_PID 2>/dev/null; kill $UDP_PID 2>/dev/null; rm -f "$DNS_PORT_FILE"' EXIT
-
-python3 - <<'PY' "$UDP_PORT" "$UDP_OUT" "$NUMMESSAGES" &
-import socket
-import sys
-import time
-port = int(sys.argv[1])
-outfile = sys.argv[2]
-expected = int(sys.argv[3])
-sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-sock.bind(("127.0.0.1", port))
-sock.settimeout(15)
-received = 0
-end_time = time.time() + 20
-with open(outfile, "w", encoding="utf-8", errors="ignore") as f:
-    while received < expected and time.time() < end_time:
-        try:
-            data, _ = sock.recvfrom(65535)
-        except socket.timeout:
-            continue
-        message = data.decode(errors="ignore")
-        message = message.rstrip("\n")
-        f.write(message + "\n")
-        f.flush()
-        received += 1
-sys.exit(0)
-PY
-UDP_PID=$!
+trap 'kill $DNS_PID 2>/dev/null; kill $UDP_PID 2>/dev/null; rm -f "$DNS_PORT_FILE" "$UDP_PORT_FILE"' EXIT
 
 sleep 1
 
@@ -77,7 +85,7 @@ wait_shutdown
 
 kill $DNS_PID 2>/dev/null
 kill $UDP_PID 2>/dev/null
-rm -f "$DNS_PORT_FILE"
+rm -f "$DNS_PORT_FILE" "$UDP_PORT_FILE"
 unset RSYSLOG_DNS_SERVER RSYSLOG_DNS_PORT
 unset RES_OPTIONS
 trap - EXIT

--- a/tests/omfwd-tls-gtls-auto-sni.sh
+++ b/tests/omfwd-tls-gtls-auto-sni.sh
@@ -4,7 +4,9 @@
 
 . ${srcdir:=.}/diag.sh init
 
-port=$(get_free_port)
+port_file="$RSYSLOG_DYNNAME.sni-server.port"
+omfwd_sni_server "gnutls" "$port_file"
+port=$(cat "$port_file")
 
 generate_conf
 add_conf '
@@ -21,7 +23,6 @@ action(type="omfwd"
         )
 '
 
-omfwd_sni_server "gnutls" "$port"
 startup
 omfwd_sni_check "localhost"
 shutdown_immediate

--- a/tests/omfwd-tls-gtls-configured-sni.sh
+++ b/tests/omfwd-tls-gtls-configured-sni.sh
@@ -4,7 +4,9 @@
 
 . ${srcdir:=.}/diag.sh init
 
-port=$(get_free_port)
+port_file="$RSYSLOG_DYNNAME.sni-server.port"
+omfwd_sni_server "gnutls" "$port_file"
+port=$(cat "$port_file")
 
 generate_conf
 add_conf '
@@ -21,7 +23,6 @@ action(type="omfwd"
         StreamDriverRemoteSNI="custom-sni"
         )
 '
-omfwd_sni_server "gnutls" "$port"
 startup
 omfwd_sni_check "custom-sni"
 shutdown_immediate

--- a/tests/omfwd-tls-gtls-no-sni.sh
+++ b/tests/omfwd-tls-gtls-no-sni.sh
@@ -4,7 +4,9 @@
 
 . ${srcdir:=.}/diag.sh init
 
-port=$(get_free_port)
+port_file="$RSYSLOG_DYNNAME.sni-server.port"
+omfwd_sni_server "gnutls" "$port_file"
+port=$(cat "$port_file")
 
 generate_conf
 add_conf '
@@ -21,7 +23,6 @@ action(type="omfwd"
         )
 '
 
-omfwd_sni_server "gnutls" "$port"
 startup
 omfwd_sni_check "(NULL)"
 shutdown_immediate

--- a/tests/omfwd-tls-ossl-auto-sni.sh
+++ b/tests/omfwd-tls-ossl-auto-sni.sh
@@ -4,7 +4,9 @@
 
 . ${srcdir:=.}/diag.sh init
 
-port=$(get_free_port)
+port_file="$RSYSLOG_DYNNAME.sni-server.port"
+omfwd_sni_server "openssl" "$port_file"
+port=$(cat "$port_file")
 
 generate_conf
 add_conf '
@@ -21,7 +23,6 @@ action(type="omfwd"
         )
 '
 
-omfwd_sni_server "openssl" "$port"
 startup
 omfwd_sni_check "localhost"
 shutdown_immediate

--- a/tests/omfwd-tls-ossl-configured-sni.sh
+++ b/tests/omfwd-tls-ossl-configured-sni.sh
@@ -4,7 +4,9 @@
 
 . ${srcdir:=.}/diag.sh init
 
-port=$(get_free_port)
+port_file="$RSYSLOG_DYNNAME.sni-server.port"
+omfwd_sni_server "openssl" "$port_file"
+port=$(cat "$port_file")
 
 generate_conf
 add_conf '
@@ -22,7 +24,6 @@ action(type="omfwd"
         )
 '
 
-omfwd_sni_server "openssl" "$port"
 startup
 omfwd_sni_check "custom-sni"
 shutdown_immediate

--- a/tests/omfwd-tls-ossl-no-sni.sh
+++ b/tests/omfwd-tls-ossl-no-sni.sh
@@ -4,7 +4,9 @@
 
 . ${srcdir:=.}/diag.sh init
 
-port=$(get_free_port)
+port_file="$RSYSLOG_DYNNAME.sni-server.port"
+omfwd_sni_server "openssl" "$port_file"
+port=$(cat "$port_file")
 
 generate_conf
 add_conf '
@@ -21,7 +23,6 @@ action(type="omfwd"
         )
 '
 
-omfwd_sni_server "openssl" "$port"
 startup
 omfwd_sni_check "(NULL)"
 shutdown_immediate

--- a/tests/omotel-proxy.sh
+++ b/tests/omotel-proxy.sh
@@ -47,13 +47,9 @@ fi
 proxy_port_file="${RSYSLOG_DYNNAME}.proxy_port.file"
 proxy_data_file="${RSYSLOG_DYNNAME}.proxy_data.json"
 
-# Get a free port for the proxy server
-PROXY_PORT=$(get_free_port)
-export PROXY_PORT
-
-echo "Starting proxy server on port: $PROXY_PORT..."
+echo "Starting proxy server on a dynamic port..."
 python3 "$proxy_server_py" \
-	--port "$PROXY_PORT" \
+	--port 0 \
 	--port-file "$proxy_port_file" \
 	--target-host 127.0.0.1 \
 	--target-port "$otel_port" \
@@ -74,11 +70,6 @@ if [ -z "$proxy_port" ]; then
 	echo "ERROR: Proxy port is empty"
 	kill $proxy_pid 2>/dev/null
 	error_exit 1
-fi
-
-# Verify the port matches what we requested
-if [ "$proxy_port" != "$PROXY_PORT" ]; then
-	echo "WARNING: Proxy port mismatch (requested: $PROXY_PORT, got: $proxy_port)"
 fi
 
 echo "Proxy server started on port: $proxy_port (pid: $proxy_pid)"
@@ -200,13 +191,9 @@ sleep 1
 proxy_port_file2="${RSYSLOG_DYNNAME}.proxy2_port.file"
 proxy_data_file2="${RSYSLOG_DYNNAME}.proxy2_data.json"
 
-# Get a free port for the authenticated proxy server
-PROXY_PORT2=$(get_free_port)
-export PROXY_PORT2
-
-echo "Starting authenticated proxy server on port: $PROXY_PORT2..."
+echo "Starting authenticated proxy server on a dynamic port..."
 python3 "$proxy_server_py" \
-	--port "$PROXY_PORT2" \
+	--port 0 \
 	--port-file "$proxy_port_file2" \
 	--target-host 127.0.0.1 \
 	--target-port "$otel_port" \
@@ -219,11 +206,6 @@ proxy_pid2=$!
 
 wait_file_exists "$proxy_port_file2" 10
 proxy_port2=$(cat "$proxy_port_file2")
-
-# Verify the port matches what we requested
-if [ "$proxy_port2" != "$PROXY_PORT2" ]; then
-	echo "WARNING: Authenticated proxy port mismatch (requested: $PROXY_PORT2, got: $proxy_port2)"
-fi
 
 echo "Authenticated proxy server started on port: $proxy_port2 (pid: $proxy_pid2)"
 
@@ -283,4 +265,3 @@ if [ -f "$proxy_data_file2" ]; then
 fi
 
 exit_test
-

--- a/tests/openssl_sni_server.c
+++ b/tests/openssl_sni_server.c
@@ -16,7 +16,35 @@
 
 #define MAX_FQDN_LENGTH 255 /* Defined in RFC 1035 (DNS) */
 
-int create_socket(const char *port) {
+static void write_listen_port_file(const int sock, const char *const port_file) {
+    if (port_file == NULL) {
+        return;
+    }
+
+    struct sockaddr_storage addr;
+    socklen_t addrlen = sizeof(addr);
+    char port[NI_MAXSERV];
+    FILE *fp;
+
+    if (getsockname(sock, (struct sockaddr *)&addr, &addrlen) != 0) {
+        perror("getsockname failed");
+        exit(EXIT_FAILURE);
+    }
+    if (getnameinfo((struct sockaddr *)&addr, addrlen, NULL, 0, port, sizeof(port), NI_NUMERICSERV) != 0) {
+        perror("getnameinfo failed");
+        exit(EXIT_FAILURE);
+    }
+
+    fp = fopen(port_file, "w");
+    if (fp == NULL) {
+        perror("Unable to open port file");
+        exit(EXIT_FAILURE);
+    }
+    fprintf(fp, "%s\n", port);
+    fclose(fp);
+}
+
+int create_socket(const char *port, const char *port_file) {
     struct addrinfo hints;
     struct addrinfo *res = NULL;
     struct addrinfo *rp;
@@ -47,6 +75,7 @@ int create_socket(const char *port) {
 
         if (bind(s, rp->ai_addr, rp->ai_addrlen) == 0) {
             if (listen(s, 1) == 0) {
+                write_listen_port_file(s, port_file);
                 break;
             }
         }
@@ -108,7 +137,7 @@ void configure_context(SSL_CTX *ctx, char *cert_file_path, char *key_file_path) 
 
 int main(int argc, char **argv) {
     if (argc < 4) {
-        printf("Usage: openssl_sni_server PORT CERT_FILE_PATH KEY_FILE_PATH\n");
+        printf("Usage: openssl_sni_server PORT CERT_FILE_PATH KEY_FILE_PATH [PORT_FILE]\n");
         exit(EXIT_SUCCESS);
     }
 
@@ -124,7 +153,7 @@ int main(int argc, char **argv) {
 
     fprintf(stderr, "configured context\n");
 
-    sock = create_socket(argv[1]);
+    sock = create_socket(argv[1], argc > 4 ? argv[4] : NULL);
 
     fprintf(stderr, "Server ready, listening on port %s\n", argv[1]);
 

--- a/tests/sndrcv_ossl_cert_chain.sh
+++ b/tests/sndrcv_ossl_cert_chain.sh
@@ -1,14 +1,20 @@
 #!/bin/bash
 # alorbach, 2019-01-16
 # This file is part of the rsyslog project, released  under ASL 2.0
+#
+# Verify that an OpenSSL omfwd sender can authenticate an imtcp TLS receiver
+# when the trust chain is split between the regular CA file and
+# NetstreamDriverCAExtraFiles. The receiver publishes its dynamic port before
+# the sender instance is configured; success is proved by receiving the full
+# ordered message sequence.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1000
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="${RSYSLOG_DYNNAME}.rcvr_port"
+export PORT_RCVR_FILE
 ### This is important, as it must be exactly the same
 ### as the ones configured in used certificates
 export HOSTNAME="fedora"
@@ -27,18 +33,17 @@ module(	load="../plugins/imtcp/.libs/imtcp"
         PermittedPeer="'$HOSTNAME'"
 	StreamDriver.AuthMode="x509/name" )
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imtcp" port="'$PORT_RCVR'" )
+input(	type="imtcp" port="0" listenPortFileName="'$PORT_RCVR_FILE'" )
 
 $template outfmt,"%msg:F,58:2%\n"
 $template dynfile,"'$RSYSLOG_OUT_LOG'" # trick to use relative path names!
 :msg, contains, "msgnum:" ?dynfile;outfmt
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-TCPFLOOD_PORT="$(get_free_port)"
-export TCPFLOOD_PORT
 add_conf '
 global(
 	defaultNetstreamDriverCAFile="'$srcdir/testsuites/certchain/ca-root-cert.pem'"

--- a/tests/sndrcv_relp-vg-rcvr.sh
+++ b/tests/sndrcv_relp-vg-rcvr.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # added 2022-06-21 by alorbach
+# Verify RELP forwarding while the receiver runs under valgrind. The receiver
+# binds an ephemeral IPv4 listener and the testbench discovers that bound port
+# after startup, avoiding the get_free_port race before the sender connects.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 
@@ -20,16 +23,15 @@ export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
 export RSYSLOG_DEBUG="debug nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="'$PORT_RCVR'")
+input(type="imrelp" address="127.0.0.1" port="0")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup_vg
+assign_single_tcp_listener_port PORT_RCVR
 printf "#### RECEIVER STARTED\n\n"
 
 ########## sender ##########

--- a/tests/sndrcv_relp-vg-sender.sh
+++ b/tests/sndrcv_relp-vg-sender.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # added 2022-06-21 by alorbach
+# Verify RELP forwarding while the sender runs under valgrind. The receiver
+# binds an ephemeral IPv4 listener and the testbench discovers that bound port
+# after startup, avoiding the get_free_port race before the sender connects.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 
@@ -20,16 +23,15 @@ export RS_TEST_VALGRIND_EXTRA_OPTS="--keep-debuginfo=yes --leak-check=full"
 export RSYSLOG_DEBUG="debug nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="'$PORT_RCVR'")
+input(type="imrelp" address="127.0.0.1" port="0")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 printf "#### RECEIVER STARTED\n\n"
 
 ########## sender ##########

--- a/tests/sndrcv_relp.sh
+++ b/tests/sndrcv_relp.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # added 2013-12-10 by Rgerhards
+# Verify basic RELP forwarding between two rsyslog instances. The receiver
+# binds an ephemeral IPv4 listener and the testbench discovers that bound port
+# after startup, avoiding the get_free_port race before the sender connects.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=50000
@@ -7,16 +10,15 @@ export NUMMESSAGES=50000
 #export RSYSLOG_DEBUG="debug nostdout"
 #export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
-input(type="imrelp" port="'$PORT_RCVR'")
+input(type="imrelp" address="127.0.0.1" port="0")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 printf "#### RECEIVER STARTED\n\n"
 
 ########## sender ##########

--- a/tests/sndrcv_relp_dflt_pt.sh
+++ b/tests/sndrcv_relp_dflt_pt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-# this checks if omrelp works with the default port
-# Note: imrelp requires the port, so we cannot and must not
-# check the "default port"
+# Verify that omrelp uses its compiled default port when no port parameter is
+# configured. imrelp must explicitly bind the same default port because this is
+# the behavior under test; success is the full ordered delivery sequence.
 # added 2013-12-10 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
@@ -31,8 +31,6 @@ startup
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-TCPFLOOD_PORT="$(get_free_port)"
-export TCPFLOOD_PORT
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
 

--- a/tests/sndrcv_relp_rebind.sh
+++ b/tests/sndrcv_relp_rebind.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 # added 2017-09-29 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify RELP forwarding while omrelp reconnects aggressively with
+# rebindinterval=1. The receiver binds an ephemeral IPv4 listener and the
+# testbench discovers that bound port after startup, avoiding the get_free_port
+# race before the sender connects. Success is the full ordered delivery
+# sequence.
 . ${srcdir:=.}/diag.sh init
 echo testing sending and receiving via relp w/ rebind interval
 # uncomment for debugging support:
@@ -8,22 +13,19 @@ echo testing sending and receiving via relp w/ rebind interval
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)
-input(type="imrelp" port="'$PORT_RCVR'")
+input(type="imrelp" address="127.0.0.1" port="0")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
-export TCPFLOOD_PORT
 add_conf '
 module(load="../plugins/omrelp/.libs/omrelp")
 

--- a/tests/sndrcv_relp_tls-cfgcmd.sh
+++ b/tests/sndrcv_relp_tls-cfgcmd.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 # added 2019-11-13 by alorbach
+# Verify RELP TLS configuration command handling for incompatible receiver and
+# sender protocol constraints. The receiver binds an ephemeral IPv4 listener and
+# the testbench discovers that bound port after startup, avoiding the
+# get_free_port race before the sender connects. Success is the expected librelp
+# TLS failure on the sender side, with compatibility skips for unsupported TLS
+# libraries or OpenSSL versions.
 . ${srcdir:=.}/diag.sh init
 require_relpEngineSetTLSLibByName
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
@@ -11,7 +15,7 @@ add_conf '
 module(	load="../plugins/imrelp/.libs/imrelp" 
 	tls.tlslib="openssl")
 # then SENDER sends to this port (not tcpflood!)
-input(	type="imrelp" port="'$PORT_RCVR'" tls="on"
+input(	type="imrelp" address="127.0.0.1" port="0" tls="on"
 	tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2
 CipherString=ECDHE-RSA-AES256-GCM-SHA384
 Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.2,-TLSv1.3
@@ -23,6 +27,7 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 generate_conf 2

--- a/tests/sndrcv_relp_tls.sh
+++ b/tests/sndrcv_relp_tls.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # added 2013-12-10 by Rgerhards
-# testing sending and receiving via relp with TLS enabled
+# Verify RELP forwarding with TLS enabled. The imrelp receiver binds an
+# ephemeral IPv4 listener and the testbench discovers that bound port after
+# startup, avoiding the get_free_port race before the omrelp sender connects.
 # This file is part of the rsyslog project, released under ASL 2.0
 # uncomment for debugging support:
 . ${srcdir:=.}/diag.sh init
@@ -8,17 +10,16 @@
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)
-input(type="imrelp" port="'$PORT_RCVR'" tls="on")
+input(type="imrelp" address="127.0.0.1" port="0" tls="on")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2

--- a/tests/sndrcv_relp_tls_certvalid.sh
+++ b/tests/sndrcv_relp_tls_certvalid.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # added 2018-09-13 by PascalWithopf
+# Verify RELP forwarding with TLS certificate validation. The imrelp receiver
+# binds an ephemeral IPv4 listener and the testbench discovers that bound port
+# after startup, avoiding the get_free_port race before the omrelp sender
+# connects. The oracle is full ordered delivery plus absence of authmode errors.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 # uncomment for debugging support:
@@ -7,12 +11,10 @@
 export RSYSLOG_DEBUGLOG="log"
 
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)
-input(type="imrelp" port="'$PORT_RCVR'" tls="on"
+input(type="imrelp" address="127.0.0.1" port="0" tls="on"
 		tls.cacert="'$srcdir'/tls-certs/ca.pem"
 		tls.mycert="'$srcdir'/tls-certs/cert.pem"
 		tls.myprivkey="'$srcdir'/tls-certs/key.pem"
@@ -23,6 +25,7 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"

--- a/tests/sndrcv_relp_tls_chainedcert.sh
+++ b/tests/sndrcv_relp_tls_chainedcert.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # addd 2020-08-25 by alorbach, released under ASL 2.0
+# Verify RELP forwarding with OpenSSL TLS certificate chains. The imrelp
+# receiver binds an ephemeral IPv4 listener and the testbench discovers that
+# bound port after startup, avoiding the get_free_port race before the omrelp
+# sender connects. Success is the full ordered delivery sequence.
 . ${srcdir:=.}/diag.sh init
 require_relpEngineVersion "1.7.0"
 export NUMMESSAGES=1000
@@ -10,14 +14,12 @@ export TB_TEST_MAX_RUNTIME=30
 # export RSYSLOG_DEBUGLOG="log"
 
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(	load="../plugins/imrelp/.libs/imrelp"
 	tls.tlslib="openssl")
 
 # then SENDER sends to this port (not tcpflood!)
-input(type="imrelp" port="'$PORT_RCVR'" 
+input(type="imrelp" address="127.0.0.1" port="0"
 		tls="on"
 		tls.mycert="'$srcdir'/tls-certs/certchained.pem"
 		tls.myprivkey="'$srcdir'/tls-certs/key.pem"
@@ -28,6 +30,7 @@ $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"

--- a/tests/sndrcv_relp_tls_prio.sh
+++ b/tests/sndrcv_relp_tls_prio.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 # added 2013-12-10 by Rgerhards
+# Verify RELP forwarding with TLS and a custom priority string. The receiver
+# binds an ephemeral IPv4 listener and the testbench discovers that bound port
+# after startup, avoiding the get_free_port race before the sender connects.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 echo testing sending and receiving via relp with TLS enabled and priority string set
@@ -9,17 +12,16 @@ echo testing sending and receiving via relp with TLS enabled and priority string
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="log"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 add_conf '
 module(load="../plugins/imrelp/.libs/imrelp")
 # then SENDER sends to this port (not tcpflood!)
-input(type="imrelp" port="'$PORT_RCVR'" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
+input(type="imrelp" address="127.0.0.1" port="0" tls="on" tls.prioritystring="NORMAL:+ANON-DH")
 
 $template outfmt,"%msg:F,58:2%\n"
 :msg, contains, "msgnum:" action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")
 '
 startup
+assign_single_tcp_listener_port PORT_RCVR
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2

--- a/tests/sndrcv_udp_nonstdpt_v6.sh
+++ b/tests/sndrcv_udp_nonstdpt_v6.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # added 2014-11-05 by Rgerhards
 # This file is part of the rsyslog project, released  under ASL 2.0
+#
+# Verify IPv6 UDP forwarding to a non-standard receiver port. The receiver and
+# sender-side tcpflood listener both publish dynamic ports via port files;
+# success is proved by receiving the full ordered sequence over UDP.
 echo ===============================================================================
 echo \[sndrcv_udp_nonstdpt_v6.sh\]: testing sending and receiving via udp
 
@@ -25,12 +29,10 @@ assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export RSYSLOG_DEBUGLOG="log2"
 #valgrind="valgrind"
 generate_conf 2
-TCPFLOOD_PORT="$(get_free_port)" # TODO: move to diag.sh
-export TCPFLOOD_PORT
 add_conf '
 module(load="../plugins/imtcp/.libs/imtcp")
 # this listener is for message generation by the test framework!
-input(type="imtcp" port=`echo $TCPFLOOD_PORT`)
+input(type="imtcp" port="0" listenPortFileName="'$RSYSLOG_DYNNAME'.tcpflood_port")
 
 action(type="omfwd"
        target="::1" port=`echo $PORT_RCVR`


### PR DESCRIPTION
## Summary

This fixes a hidden testbench race found by the deflake campaign: several network tests picked a free port before the intended listener bound it. Under full-suite parallel stress, another test or helper can claim that port in the gap, producing unrelated bind failures.

The change moves affected tests to deterministic listener-owned port selection:

- SNI helpers bind port `0` and write the selected port to a port file.
- `diag.sh` adds helpers to discover the single TCP or UDP listener owned by an rsyslog instance when a module can bind port `0` but lacks native port-file plumbing.
- RELP and DTLS tests use those helpers so senders only connect after the receiver is bound.
- Tests with native `listenPortFileName` support use that support directly.
- UDP SRV and omotel proxy helpers bind port `0` and publish the chosen port.

Refs https://github.com/rsyslog/rsyslog/issues/6308

## Validation

Full Ubuntu 26.04 container validation, `CI_MAKE_CHECK_OPT=-j80`:

- round5-run1: `1277 total`, `1249 pass`, `27 skip`, `1 fail`, runtime `5m13.35s`.
  Failure was known unrelated `imfile-statistics.sh`, recorded in the flake-campaign repo.
- round5-run2: `1277 total`, `1250 pass`, `27 skip`, `0 fail`, runtime `4m58.90s`.
- round5-run3: `1277 total`, `1250 pass`, `27 skip`, `0 fail`, runtime `4m58.32s`.

Earlier validation rounds exposed the port races in the RELP/DTLS family and led to the helper conversions. The final two full runs are clean after those fixes.
