### PR TITLE
imhttp: write bound listener port to file

### DIFF
--- a/contrib/imhttp/imhttp.c
+++ b/contrib/imhttp/imhttp.c
@@ -29,6 +29,7 @@
 #include <stdarg.h>
 #include <ctype.h>
 #include <limits.h>
+#include <fcntl.h>
 #include <netinet/in.h>
 #include <netdb.h>
 #include <sys/types.h>
@@ -71,6 +72,9 @@ DEFobjCurrIf(glbl) DEFobjCurrIf(prop) DEFobjCurrIf(ruleset) DEFobjCurrIf(statsob
 #define BASIC_AUTH_MAX_DECODED ((BASIC_AUTH_MAX_ENCODED / 4) * 3)
 #define DEFAULT_HEALTH_CHECK_PATH "/healthz"
 #define DEFAULT_PROM_METRICS_PATH "/metrics"
+#ifndef O_NOFOLLOW
+    #define O_NOFOLLOW 0
+#endif
 
     struct option {
     const char *name;
@@ -116,6 +120,7 @@ struct modConfData_s {
     struct option docroot;
     struct option *options;
     int nOptions;
+    char *pszLstnPortFileName;
     char *pszHealthCheckPath;
     char *pszMetricsPath;
     char *pszHealthCheckAuthFile;
@@ -170,6 +175,7 @@ static size_t s_iMaxLine = 16384; /* get maximum size we currently support */
 
 /* module-global parameters */
 static struct cnfparamdescr modpdescr[] = {{"ports", eCmdHdlrString, 0},
+                                           {"listenportfilename", eCmdHdlrString, 0},
                                            {"documentroot", eCmdHdlrString, 0},
                                            {"liboptions", eCmdHdlrArray, 0},
                                            {"healthcheckpath", eCmdHdlrString, 0},
@@ -1501,6 +1507,7 @@ BEGINbeginCnfLoad
     loadModConf->docroot.name = NULL;
     loadModConf->nOptions = 0;
     loadModConf->options = NULL;
+    loadModConf->pszLstnPortFileName = NULL;
     loadModConf->pszHealthCheckAuthFile = NULL;
     loadModConf->pszMetricsAuthFile = NULL;
     loadModConf->pszHealthCheckApiKeyFile = NULL;
@@ -1532,6 +1539,9 @@ BEGINsetModCnf
             assert(loadModConf->ports.val == NULL);
             CHKmalloc(loadModConf->ports.name = strdup(CIVETWEB_OPTION_NAME_PORTS));
             CHKmalloc(loadModConf->ports.val = es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(modpblk.descr[i].name, "listenportfilename")) {
+            free(loadModConf->pszLstnPortFileName);
+            CHKmalloc(loadModConf->pszLstnPortFileName = es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(modpblk.descr[i].name, "documentroot")) {
             assert(loadModConf->docroot.name == NULL);
             assert(loadModConf->docroot.val == NULL);
@@ -1608,6 +1618,54 @@ static inline void std_checkRuleset_genErrMsg(ATTR_UNUSED modConfData_t *modConf
              "imhttp: ruleset '%s' for %s not found - "
              "using default ruleset instead",
              inst->pszBindRuleset, inst->pszEndpoint);
+}
+
+static rsRetVal writeListenPortFile(const modConfData_t *const conf) {
+    struct mg_server_port ports[2];
+    char portBuf[32];
+    int nPorts;
+    int fd = -1;
+    int len;
+    ssize_t wr;
+    DEFiRet;
+
+    if (conf->pszLstnPortFileName == NULL) FINALIZE;
+
+    nPorts = mg_get_server_ports(s_httpserv->ctx, sizeof(ports) / sizeof(ports[0]), ports);
+    if (nPorts != 1) {
+        LogError(0, RS_RET_ERR, "imhttp: listenPortFileName requires exactly one bound listener, got %d", nPorts);
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    len = snprintf(portBuf, sizeof(portBuf), "%u", (unsigned)ports[0].port);
+    if (len < 0 || (size_t)len >= sizeof(portBuf)) {
+        LogError(0, RS_RET_ERR, "imhttp: listenPortFileName: internal port formatting error");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    fd = open(conf->pszLstnPortFileName, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
+    if (fd == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "imhttp: listenPortFileName: error while trying to open file");
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    for (int off = 0; off < len;) {
+        wr = write(fd, portBuf + off, (size_t)(len - off));
+        if (wr < 0) {
+            if (errno == EINTR) continue;
+            LogError(errno, RS_RET_IO_ERROR, "imhttp: listenPortFileName: error while trying to write file");
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        off += (int)wr;
+    }
+    if (close(fd) != 0) {
+        fd = -1;
+        LogError(errno, RS_RET_IO_ERROR, "imhttp: listenPortFileName: error while trying to close file");
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    fd = -1;
+
+finalize_it:
+    if (fd != -1) close(fd);
+    RETiRet;
 }
 
 BEGINcheckCnf
@@ -1734,6 +1792,7 @@ BEGINactivateCnf
         LogError(0, RS_RET_INTERNAL_ERROR, "Cannot start CivetWeb - mg_start failed.\n");
         ABORT_FINALIZE(RS_RET_INTERNAL_ERROR);
     }
+    CHKiRet(writeListenPortFile(runModConf));
 
 finalize_it:
     if (iRet != RS_RET_OK) {
@@ -1778,6 +1837,7 @@ BEGINfreeCnf
     free((void *)pModConf->ports.val);
     free((void *)pModConf->docroot.name);
     free((void *)pModConf->docroot.val);
+    free((void *)pModConf->pszLstnPortFileName);
     free((void *)pModConf->pszHealthCheckPath);
     free((void *)pModConf->pszMetricsPath);
     free((void *)pModConf->pszHealthCheckAuthFile);

--- a/doc/source/configuration/modules/imhttp.rst
+++ b/doc/source/configuration/modules/imhttp.rst
@@ -57,6 +57,21 @@ the format ``IP:Port``. For IPv6 addresses, enclose the IP in brackets, e.g., ``
 
 - `Civetweb listening_ports <https://github.com/civetweb/civetweb/blob/master/docs/UserManual.md#listening_ports-8080>`_
 
+listenPortFileName
+^^^^^^^^^^^^^^^^^^
+
+.. csv-table::
+   :header: "type", "mandatory", "format", "default"
+   :widths: auto
+   :class: parameter-table
+
+   "string", "no", "filename", "none"
+
+When ``ports`` configures exactly one listener, writes the actual port number
+selected by CivetWeb to the named file after startup. This is useful with
+``ports="0"`` so tests and automation can avoid preselecting a free port before
+the listener binds.
+
 
 documentroot
 ^^^^^^^^^^^^^^^

--- a/tests/imhttp-getrequest-file.sh
+++ b/tests/imhttp-getrequest-file.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify imhttp static file serving while the HTTP listener uses an
+# OS-assigned port. The fetched file content is the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'"
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'"
 			 documentroot="'$srcdir'/testsuites/docroot")
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 curl -s http://localhost:$IMHTTP_PORT/file.txt > "$RSYSLOG_OUT_LOG"
 shutdown_when_empty
 echo "file name: $RSYSLOG_OUT_LOG"

--- a/tests/imhttp-healthcheck-api-key-auth.sh
+++ b/tests/imhttp-healthcheck-api-key-auth.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify the imhttp healthcheck endpoint while the HTTP listener uses an
+# OS-assigned port. The HTTP status or response body is the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'"
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'"
        healthCheckApiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$IMHTTP_PORT/healthz)
 if [ "$ret" != "401" ]; then

--- a/tests/imhttp-healthcheck.sh
+++ b/tests/imhttp-healthcheck.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify the imhttp healthcheck endpoint while the HTTP listener uses an
+# OS-assigned port. The HTTP status or response body is the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'"
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'"
 )
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 curl -s http://localhost:$IMHTTP_PORT/healthz > "$RSYSLOG_OUT_LOG"
 shutdown_when_empty
 wait_shutdown

--- a/tests/imhttp-metrics-api-key-auth.sh
+++ b/tests/imhttp-metrics-api-key-auth.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify the imhttp metrics endpoint while the HTTP listener uses an
+# OS-assigned port. The HTTP status and metrics response are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'"
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'"
        metricsPath="/metrics"
        metricsApiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$IMHTTP_PORT/metrics)
 if [ "$ret" != "401" ]; then

--- a/tests/imhttp-metrics.sh
+++ b/tests/imhttp-metrics.sh
@@ -1,17 +1,21 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify the imhttp metrics endpoint while the HTTP listener uses an
+# OS-assigned port. The HTTP status and metrics response are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'"
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'"
        metricsPath="/metrics"
 )
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 curl -s http://localhost:$IMHTTP_PORT/metrics > "$RSYSLOG_OUT_LOG"
 shutdown_when_empty
 wait_shutdown

--- a/tests/imhttp-post-payload-api-key-auth.sh
+++ b/tests/imhttp-post-payload-api-key-auth.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest"
       ruleset="ruleset"
       apiKeyFile="'$srcdir'/testsuites/imhttp-apikeys.txt")
@@ -16,6 +19,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(curl -s -o /dev/null -w '%{http_code}' \
   -H 'Authorization: ApiKey wrong-token' \

--- a/tests/imhttp-post-payload-auth-header-limits.sh
+++ b/tests/imhttp-post-payload-auth-header-limits.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest"
       ruleset="ruleset"
       basicAuthFile="'$srcdir'/testsuites/htpasswd"
@@ -17,6 +20,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 LONG_AUTH_VALUE="$(python3 - <<'PY'
 print("A" * 20000)

--- a/tests/imhttp-post-payload-basic-auth-challenge.sh
+++ b/tests/imhttp-post-payload-basic-auth-challenge.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 HEADERS=${RSYSLOG_DYNNAME}.headers
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest"
       ruleset="ruleset"
       basicauthfile="'$srcdir'/testsuites/htpasswd")
@@ -17,6 +20,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(curl -s -D "$HEADERS" -o /dev/null --write-out '%{http_code}' \
   --user user1:badpass http://localhost:$IMHTTP_PORT/postrequest -d 'rejected')

--- a/tests/imhttp-post-payload-basic-auth.sh
+++ b/tests/imhttp-post-payload-basic-auth.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="list") {
   property(name="msg")
@@ -26,7 +28,8 @@ template(name="outfmt" type="list") {
 # user1:1234
 #
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest"
       ruleset="ruleset"
       addmetadata="on"
@@ -36,6 +39,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 # validate invalid passwd
 ret=$(curl -s -o /dev/null -H Content-Type:application/json -H "BAZ: skat" -H "daddle: doodle" -H "fiddle: faddle" \
   --user user1:badpass --write-out '%{http_code}' \

--- a/tests/imhttp-post-payload-compress.sh
+++ b/tests/imhttp-post-payload-compress.sh
@@ -1,15 +1,18 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 #export RSYSLOG_DEBUG="debug"
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 #input(type="imhttp" endpoint="/postrequest" ruleset="ruleset" disablelfdelimiter="on")
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
 ruleset(name="ruleset") {
@@ -17,6 +20,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 NUMMESSAGES=50
 
 for (( i=1; i<=NUMMESSAGES; i++ ))

--- a/tests/imhttp-post-payload-content-length-limit.sh
+++ b/tests/imhttp-post-payload-content-length-limit.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 check_command_available python3
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
 ruleset(name="ruleset") {
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 response=$(python3 - "$IMHTTP_PORT" <<'PY'
 import socket

--- a/tests/imhttp-post-payload-headers.sh
+++ b/tests/imhttp-post-payload-headers.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 #template(name="outfmt" type="string" string="%msg% headers: %metadata%\n")
 template(name="outfmt" type="list") {
@@ -23,13 +25,15 @@ template(name="outfmt" type="list") {
 }
 
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset" addmetadata="on")
 ruleset(name="ruleset") {
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 NUMMESSAGES=100
 for (( i=1; i<=NUMMESSAGES; i++ ))
 do

--- a/tests/imhttp-post-payload-invalid-gzip.sh
+++ b/tests/imhttp-post-payload-invalid-gzip.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
 ruleset(name="ruleset") {
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(printf 'not-a-gzip-stream' | curl -s -o /dev/null --write-out '%{http_code}' \
   --data-binary @- -H "Content-Encoding: gzip" http://localhost:$IMHTTP_PORT/postrequest)

--- a/tests/imhttp-post-payload-large.sh
+++ b/tests/imhttp-post-payload-large.sh
@@ -1,20 +1,24 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 #template(name="outfmt" type="string" string="%msg%\n")
 template(name="outfmt" type="string" string="%rawmsg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
 ruleset(name="ruleset") {
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 NUMMESSAGES=25
 DATA_SOURCE=$srcdir/testsuites/imhttp-large-data.txt
 for (( i=1; i<=NUMMESSAGES; i++ ))

--- a/tests/imhttp-post-payload-mixed-auth.sh
+++ b/tests/imhttp-post-payload-mixed-auth.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest"
       ruleset="ruleset"
       basicAuthFile="'$srcdir'/testsuites/htpasswd"
@@ -17,6 +20,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(curl -s -o /dev/null -w '%{http_code}' \
   -H Content-Type:application/json \

--- a/tests/imhttp-post-payload-multi-lf.sh
+++ b/tests/imhttp-post-payload-multi-lf.sh
@@ -1,14 +1,17 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 #export RSYSLOG_DEBUG="Debug"
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
-module(load="../contrib/imhttp/.libs/imhttp" ports="'$IMHTTP_PORT'")
+module(load="../contrib/imhttp/.libs/imhttp" ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 
 input(type="imhttp" endpoint="/postrequest" disableLFdelimiter="on" ruleset="ruleset")
 ruleset(name="ruleset") {
@@ -16,6 +19,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 NUMMESSAGES=50
 
 for (( i=1; i<=NUMMESSAGES; i++ ))

--- a/tests/imhttp-post-payload-multi.sh
+++ b/tests/imhttp-post-payload-multi.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       liboptions=[ "listening_ports='$IMHTTP_PORT'" ] )
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'" )
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
 ruleset(name="ruleset") {
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 NUMMESSAGES=50
 for (( i=1; i<=NUMMESSAGES; i++ ))
 do

--- a/tests/imhttp-post-payload-octet-oversize.sh
+++ b/tests/imhttp-post-payload-octet-oversize.sh
@@ -1,16 +1,19 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 check_command_available python3
 check_command_available timeout
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 BODY=${RSYSLOG_DYNNAME}.octet-body
 add_conf '
 template(name="outfmt" type="string" string="%rawmsg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest"
       ruleset="ruleset"
       supportoctetcountedframing="on")
@@ -19,6 +22,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 python3 - "$BODY" <<'PY'
 import sys

--- a/tests/imhttp-post-payload-query-params.sh
+++ b/tests/imhttp-post-payload-query-params.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="all" type="string" string="%msg% headers: %$!metadata%\n")
 template(name="outfmt" type="list") {
@@ -23,7 +25,8 @@ template(name="outfmt" type="list") {
 }
 
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset" addmetadata="on")
 ruleset(name="ruleset") {
 	#action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
@@ -31,6 +34,7 @@ ruleset(name="ruleset") {
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 NUMMESSAGES=100
 for (( i=1; i<=NUMMESSAGES; i++ ))
 do

--- a/tests/imhttp-post-payload.sh
+++ b/tests/imhttp-post-payload.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify this imhttp POST-payload variant while the HTTP listener uses an
+# OS-assigned port. The HTTP status and configured output checks are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 generate_conf
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 add_conf '
 template(name="outfmt" type="string" string="%msg%\n")
 module(load="../contrib/imhttp/.libs/imhttp"
-       ports="'$IMHTTP_PORT'")
+       ports="0"
+       listenPortFileName="'$IMHTTP_PORT_FILE'")
 input(type="imhttp" endpoint="/postrequest" ruleset="ruleset")
 ruleset(name="ruleset") {
 	action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="outfmt")
 }
 '
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 sleep 1
 NUMMESSAGES=50
 for (( i=1; i<=NUMMESSAGES; i++ ))

--- a/tests/yaml-imhttp-apikeyfile.sh
+++ b/tests/yaml-imhttp-apikeyfile.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify YAML imhttp API-key authentication while the HTTP listener uses an
+# OS-assigned port. The accepted request and output content are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 require_yaml_support
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 generate_conf --yaml-only
 add_yaml_conf 'modules:'
 add_yaml_conf '  - load: "../contrib/imhttp/.libs/imhttp"'
-add_yaml_conf '    ports: "'$IMHTTP_PORT'"'
+add_yaml_conf '    ports: "0"'
+add_yaml_conf '    listenPortFileName: "'$IMHTTP_PORT_FILE'"'
 add_yaml_conf 'templates:'
 add_yaml_conf '  - name: outfmt'
 add_yaml_conf '    type: string'
@@ -22,6 +25,7 @@ add_yaml_conf '  - name: main'
 add_yaml_conf '    script: |'
 add_yaml_conf '      action(type="omfile" file="'$RSYSLOG_OUT_LOG'" template="outfmt")'
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(curl -s -o /dev/null -w '%{http_code}' \
   -H 'Authorization: ApiKey secret-token-1' \

--- a/tests/yaml-imhttp-metrics-apikeyfile.sh
+++ b/tests/yaml-imhttp-metrics-apikeyfile.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+# Verify YAML imhttp metrics API-key authentication while the HTTP listener uses
+# an OS-assigned port. The HTTP status and metrics response are the oracle.
 
 . ${srcdir:=.}/diag.sh init
 require_yaml_support
-IMHTTP_PORT="$(get_free_port)"
+IMHTTP_PORT_FILE="$RSYSLOG_DYNNAME.imhttp.port"
 generate_conf --yaml-only
 add_yaml_conf 'modules:'
 add_yaml_conf '  - load: "../contrib/imhttp/.libs/imhttp"'
-add_yaml_conf '    ports: "'$IMHTTP_PORT'"'
+add_yaml_conf '    ports: "0"'
+add_yaml_conf '    listenPortFileName: "'$IMHTTP_PORT_FILE'"'
 add_yaml_conf '    metricsPath: "/metrics"'
 add_yaml_conf '    metricsApiKeyFile: "'$srcdir'/testsuites/imhttp-apikeys.txt"'
 add_yaml_conf 'inputs:'
@@ -19,6 +22,7 @@ add_yaml_conf '  - name: main'
 add_yaml_conf '    script: |'
 add_yaml_conf '      action(type="omfile" file="'$RSYSLOG_OUT_LOG'.unused")'
 startup
+assign_file_content IMHTTP_PORT "$IMHTTP_PORT_FILE"
 
 ret=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:$IMHTTP_PORT/metrics)
 if [ "$ret" != "401" ]; then


### PR DESCRIPTION
## Summary
- add imhttp listenPortFileName for ports=0 listener discovery
- convert imhttp shell and YAML tests that preselected HTTP ports to read the bound port file
- document the new imhttp parameter

## Validation
- ./autogen.sh --enable-testbench --enable-imdiag --enable-omstdout --enable-imhttp --enable-valgrind --enable-valgrind-testbench --enable-yaml
- make -j$(nproc) check TESTS=""
- single direct pass of changed imhttp/YAML imhttp shell tests