### PR TITLE
imdtls: write bound listener port to file

### DIFF
--- a/doc/Makefile.am
+++ b/doc/Makefile.am
@@ -514,6 +514,7 @@ EXTRA_DIST = \
     source/reference/parameters/imdocker-pollinginterval.rst \
     source/reference/parameters/imdocker-retrievenewlogsfromstart.rst \
     source/reference/parameters/imdtls-address.rst \
+    source/reference/parameters/imdtls-listenportfilename.rst \
     source/reference/parameters/imdtls-name.rst \
     source/reference/parameters/imdtls-port.rst \
     source/reference/parameters/imdtls-ruleset.rst \

--- a/doc/source/configuration/modules/imdtls.rst
+++ b/doc/source/configuration/modules/imdtls.rst
@@ -63,6 +63,10 @@ Input Parameters
      - .. include:: ../../reference/parameters/imdtls-port.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
+   * - :ref:`param-imdtls-listenportfilename`
+     - .. include:: ../../reference/parameters/imdtls-listenportfilename.rst
+        :start-after: .. summary-start
+        :end-before: .. summary-end
    * - :ref:`param-imdtls-timeout`
      - .. include:: ../../reference/parameters/imdtls-timeout.rst
         :start-after: .. summary-start
@@ -105,6 +109,7 @@ Input Parameters
 
    ../../reference/parameters/imdtls-address
    ../../reference/parameters/imdtls-port
+   ../../reference/parameters/imdtls-listenportfilename
    ../../reference/parameters/imdtls-timeout
    ../../reference/parameters/imdtls-name
    ../../reference/parameters/imdtls-ruleset
@@ -174,4 +179,3 @@ The following sample does the following:
          tls.authmode="certvalid" )
 
    action( type="omfile" file="/var/log/dtls.log")
-

--- a/doc/source/reference/parameters/imdtls-listenportfilename.rst
+++ b/doc/source/reference/parameters/imdtls-listenportfilename.rst
@@ -1,0 +1,46 @@
+.. _param-imdtls-listenportfilename:
+.. _imdtls.parameter.input.listenportfilename:
+
+ListenPortFileName
+==================
+
+.. index::
+   single: imdtls; listenPortFileName
+   single: listenPortFileName
+
+.. summary-start
+
+Writes the UDP port selected by the operating system when imdtls binds to port
+0.
+.. summary-end
+
+This parameter applies to :doc:`../../configuration/modules/imdtls`.
+
+:Name: listenPortFileName
+:Scope: input
+:Type: word
+:Default: none
+:Required?: no
+:Introduced: v8.2606.0
+
+Description
+-----------
+When ``port="0"`` is configured, the operating system selects an available UDP
+port for the imdtls listener. ``listenPortFileName`` writes that selected port
+number to the named file after the socket is bound.
+
+This is primarily useful for tests and automation that must avoid preselecting
+a port before the listener starts.
+
+Input usage
+-----------
+.. _imdtls.parameter.input.listenportfilename-usage:
+
+.. code-block:: rsyslog
+
+   module(load="imdtls")
+   input(type="imdtls" port="0" listenPortFileName="imdtls.port")
+
+See also
+--------
+See also :doc:`../../configuration/modules/imdtls`.

--- a/plugins/imdtls/imdtls.c
+++ b/plugins/imdtls/imdtls.c
@@ -74,6 +74,9 @@ MODULE_CNFNAME("imdtls")
 #define DTLS_LISTEN_PORT "4433"
 // 1800 seconds = 30 minutes
 #define DTLS_DEFAULT_TIMEOUT 1800
+#ifndef O_NOFOLLOW
+    #define O_NOFOLLOW 0
+#endif
 
 /* Module static data */
 DEF_OMOD_STATIC_DATA;
@@ -102,6 +105,7 @@ struct instanceConf_s {
     /* Network properties */
     uchar *pszBindAddr; /* Listening IP Address */
     uchar *pszBindPort; /* Port to bind socket to */
+    uchar *pszLstnPortFileName; /* file receiving port selected by bind(0) */
     int timeout; /* Default timeout for DTLS Sessions */
     /* Common properties */
     uchar *pszBindRuleset; /* name of ruleset to bind to */
@@ -160,6 +164,7 @@ static struct cnfparamblk modpblk = {CNFPARAMBLK_VERSION, sizeof(modpdescr) / si
 /* input instance parameters */
 static struct cnfparamdescr inppdescr[] = {{"port", eCmdHdlrString, CNFPARAM_REQUIRED},
                                            {"address", eCmdHdlrString, 0},
+                                           {"listenportfilename", eCmdHdlrString, 0},
                                            {"timeout", eCmdHdlrPositiveInt, 0},
                                            {"name", eCmdHdlrString, 0},
                                            {"ruleset", eCmdHdlrString, 0},
@@ -184,6 +189,7 @@ static rsRetVal createInstance(instanceConf_t **pinst) {
 
     inst->pszBindAddr = NULL;
     inst->pszBindPort = NULL;
+    inst->pszLstnPortFileName = NULL;
     inst->timeout = 1800;
     inst->pszBindRuleset = loadModConf->pszBindRuleset;
     inst->pszInputName = NULL;
@@ -239,6 +245,59 @@ static void DTLSCloseSocket(instanceConf_t *inst) {
         close(inst->sockfd);
         inst->sockfd = -1;
     }
+}
+
+static rsRetVal writeListenPortFile(instanceConf_t *const inst) {
+    struct sockaddr_in sa = {0};
+    socklen_t salen = sizeof(sa);
+    char portBuf[32];
+    int fd = -1;
+    int len;
+    ssize_t wr;
+    DEFiRet;
+
+    if (inst->pszLstnPortFileName == NULL) FINALIZE;
+
+    if (getsockname(inst->sockfd, (struct sockaddr *)&sa, &salen) != 0) {
+        LogError(errno, RS_RET_IO_ERROR, "imdtls: listenPortFileName: could not determine bound UDP port");
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    if (salen < sizeof(sa) || sa.sin_family != AF_INET) {
+        LogError(0, RS_RET_ERR, "imdtls: listenPortFileName: unexpected bound UDP socket address");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    inst->port = ntohs(sa.sin_port);
+    inst->server_addr.sin_port = sa.sin_port;
+
+    len = snprintf(portBuf, sizeof(portBuf), "%u", (unsigned)inst->port);
+    if (len < 0 || (size_t)len >= sizeof(portBuf)) {
+        LogError(0, RS_RET_ERR, "imdtls: listenPortFileName: internal port formatting error");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+    fd = open((const char *)inst->pszLstnPortFileName, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0600);
+    if (fd == -1) {
+        LogError(errno, RS_RET_IO_ERROR, "imdtls: listenPortFileName: error while trying to open file");
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    for (int off = 0; off < len;) {
+        wr = write(fd, portBuf + off, (size_t)(len - off));
+        if (wr < 0) {
+            if (errno == EINTR) continue;
+            LogError(errno, RS_RET_IO_ERROR, "imdtls: listenPortFileName: error while trying to write file");
+            ABORT_FINALIZE(RS_RET_IO_ERROR);
+        }
+        off += (int)wr;
+    }
+    if (close(fd) != 0) {
+        fd = -1;
+        LogError(errno, RS_RET_IO_ERROR, "imdtls: listenPortFileName: error while trying to close file");
+        ABORT_FINALIZE(RS_RET_IO_ERROR);
+    }
+    fd = -1;
+
+finalize_it:
+    if (fd != -1) close(fd);
+    RETiRet;
 }
 
 static rsRetVal DTLSCreateSocket(instanceConf_t *inst) {
@@ -301,6 +360,7 @@ static rsRetVal DTLSCreateSocket(instanceConf_t *inst) {
                  inst->port, inst->pszBindAddr);
         ABORT_FINALIZE(RS_RET_ERR);
     }
+    CHKiRet(writeListenPortFile(inst));
 finalize_it:
     if (iRet != RS_RET_OK) {
         DTLSCloseSocket(inst);
@@ -852,6 +912,8 @@ BEGINnewInpInst
             CHKmalloc(inst->pszBindPort = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "address")) {
             CHKmalloc(inst->pszBindAddr = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
+        } else if (!strcmp(inppblk.descr[i].name, "listenportfilename")) {
+            CHKmalloc(inst->pszLstnPortFileName = (uchar *)es_str2cstr(pvals[i].val.d.estr, NULL));
         } else if (!strcmp(inppblk.descr[i].name, "timeout")) {
             inst->timeout = (int)pvals[i].val.d.n;
         } else if (!strcmp(inppblk.descr[i].name, "ruleset")) {
@@ -1047,6 +1109,7 @@ BEGINfreeCnf
         if (inst->pszBindAddr != NULL) {
             free(inst->pszBindAddr);
         }
+        free(inst->pszLstnPortFileName);
         free(inst->pszBindRuleset);
         free(inst->pszInputName);
 

--- a/tests/imdtls-basic-timeout.sh
+++ b/tests/imdtls-basic-timeout.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 # added 2023-10-05 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify that imdtls keeps accepting DTLS traffic across spaced send bursts
+# within the configured session timeout. Success is the full message sequence.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=2000
 export SENDESSAGES=500
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 export TIMEOUT="5"
 
 add_conf '
@@ -20,7 +21,8 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 module(	load="../plugins/imdtls/.libs/imdtls" )
 # tls.authmode="anon" )
 input(	type="imdtls"
-	port="'$PORT_RCVR'"
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'"
 	timeout="'$TIMEOUT'"
 	)
 
@@ -32,6 +34,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 # Begin actual testcase
 
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 #	valgrind --tool=helgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 
 ./tcpflood -b1 -W1000 -p$PORT_RCVR -m$SENDESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -L0
 # ./msleep 500

--- a/tests/imdtls-basic-tlscommands.sh
+++ b/tests/imdtls-basic-tlscommands.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # added 2018-04-27 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify that imdtls applies OpenSSL TLS config commands. The sender is
+# configured to fail the handshake, and the expected TLS diagnostic is the oracle.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=10
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -17,11 +18,13 @@ module(	load="../plugins/imdtls/.libs/imdtls" )
 input(	type="imdtls"
 	tls.tlscfgcmd="Protocol=ALL,-SSLv2,-SSLv3,-TLSv1,-TLSv1.1,-TLSv1.3
 	Options=Bugs"
-	port="'$PORT_RCVR'")
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'")
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 # now inject the messages which will fail due protocol configuration
 tcpflood --check-only -k "Protocol=-ALL,TLSv1.3" -p$PORT_RCVR -m$NUMMESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem

--- a/tests/imdtls-basic.sh
+++ b/tests/imdtls-basic.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 # added 2023-10-05 by alorbach
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify that imdtls receives a DTLS message sequence over a kernel-assigned
+# UDP port and preserves the injected message numbers without loss.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1000
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -18,7 +19,8 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 module(	load="../plugins/imdtls/.libs/imdtls" )
 # tls.authmode="anon" )
 input(	type="imdtls"
-	port="'$PORT_RCVR'")
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(	type="omfile" 
@@ -28,6 +30,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 # Begin actual testcase
 
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 #	valgrind --tool=helgrind $RS_TEST_VALGRIND_EXTRA_OPTS $RS_TESTBENCH_VALGRIND_EXTRA_OPTS --log-fd=1 --error-exitcode=10 
 ./tcpflood -b1 -W1000 -p$PORT_RCVR -m$NUMMESSAGES -Tdtls -x$srcdir/tls-certs/ca.pem -Z$srcdir/tls-certs/cert.pem -z$srcdir/tls-certs/key.pem -L0
 

--- a/tests/imdtls-error-cert.sh
+++ b/tests/imdtls-error-cert.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 # added 2018-11-07 by Rainer Gerhards
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify that imdtls reports certificate load errors during startup. No traffic
+# is sent; the configured rsyslog diagnostics are the pass/fail oracle.
 . ${srcdir:=.}/diag.sh init
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -14,7 +14,7 @@ global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
 
 module(	load="../plugins/imdtls/.libs/imdtls" )
 input(	type="imdtls"
-	port="'$PORT_RCVR'")
+	port="0")
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '

--- a/tests/sndrcv_dtls_anon_ciphers.sh
+++ b/tests/sndrcv_dtls_anon_ciphers.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify that omdtls-to-imdtls anonymous DTLS fails cleanly when the configured
+# cipher suites are incompatible. The expected OpenSSL diagnostic is the oracle.
 . ${srcdir:=.}/diag.sh init
 # start up the instances
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 
 add_conf '
 global(	
@@ -20,12 +21,14 @@ module(	load="../plugins/imdtls/.libs/imdtls"
 
 input(	type="imdtls"
 	tls.tlscfgcmd="CipherString=ECDHE-RSA-AES256-SHA384;Ciphersuites=TLS_AES_256_GCM_SHA384"
-	port="'$PORT_RCVR'")
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'")
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 generate_conf 2
 add_conf '

--- a/tests/sndrcv_dtls_certvalid.sh
+++ b/tests/sndrcv_dtls_certvalid.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify successful omdtls-to-imdtls transfer with certificate validation. The
+# receiver must record the exact injected message sequence.
 . ${srcdir:=.}/diag.sh init
 export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
@@ -11,8 +13,7 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 
 add_conf '
 global(
@@ -25,12 +26,14 @@ global(
 
 module(	load="../plugins/imdtls/.libs/imdtls" )
 input(	type="imdtls"
-	port="'$PORT_RCVR'")
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'")
 
 template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 #valgrind="valgrind"

--- a/tests/sndrcv_dtls_certvalid_ciphers.sh
+++ b/tests/sndrcv_dtls_certvalid_ciphers.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify that cert-valid DTLS reports a handshake failure when sender and
+# receiver ciphers do not overlap. The expected TLS diagnostic is the oracle.
 . ${srcdir:=.}/diag.sh init
 # start up the instances
 # uncomment for debugging support:
@@ -7,8 +9,7 @@
 #export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 export NUMMESSAGES=1
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 
 add_conf '
 global(	defaultNetstreamDriverCAFile="'$srcdir/tls-certs/ca.pem'"
@@ -23,11 +24,13 @@ module(	load="../plugins/imdtls/.libs/imdtls"
 
 input(	type="imdtls"
 	tls.tlscfgcmd="CipherString=ECDHE-RSA-AES256-SHA384;Ciphersuites=TLS_AES_256_GCM_SHA384"
-	port="'$PORT_RCVR'")
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'")
 
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 generate_conf 2
 add_conf '

--- a/tests/sndrcv_dtls_certvalid_missing.sh
+++ b/tests/sndrcv_dtls_certvalid_missing.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify cert-valid DTLS behavior when the sender lacks a usable certificate.
+# The receiver output must stay empty after the rejected handshake.
 . ${srcdir:=.}/diag.sh init
 export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
@@ -9,8 +11,7 @@ export NUMMESSAGES=1
 # uncomment for debugging support:
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 
 add_conf '
 global(
@@ -20,7 +21,8 @@ global(
 
 module(	load="../plugins/imdtls/.libs/imdtls" )
 input(	type="imdtls"
-	port="'$PORT_RCVR'"
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'"
 	tls.cacert="'$srcdir'/tls-certs/ca.pem"
 	tls.mycert="'$srcdir'/tls-certs/cert.pem"
 	tls.myprivkey="'$srcdir'/tls-certs/key.pem"
@@ -30,6 +32,7 @@ input(	type="imdtls"
 action(type="omfile" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 #valgrind="valgrind"

--- a/tests/sndrcv_dtls_certvalid_permitted.sh
+++ b/tests/sndrcv_dtls_certvalid_permitted.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+# Verify successful cert-valid DTLS transfer when the peer name is explicitly
+# permitted. The receiver must record the exact injected message sequence.
 . ${srcdir:=.}/diag.sh init
 export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 printf 'using TLS driver: %s\n' ${RS_TLS_DRIVER:=gtls}
@@ -11,8 +13,7 @@ export QUEUE_EMPTY_CHECK_FUNC=wait_file_lines
 #export RSYSLOG_DEBUG="debug nostdout noprintmutexaction"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.receiver.debuglog"
 generate_conf
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
+PORT_RCVR_FILE="$RSYSLOG_DYNNAME.imdtls.port"
 
 add_conf '
 global(
@@ -22,7 +23,8 @@ global(
 
 module(	load="../plugins/imdtls/.libs/imdtls" )
 input(	type="imdtls"
-	port="'$PORT_RCVR'"
+	port="0"
+	listenPortFileName="'$PORT_RCVR_FILE'"
 	tls.cacert="'$srcdir'/tls-certs/ca.pem"
 	tls.mycert="'$srcdir'/tls-certs/cert.pem"
 	tls.myprivkey="'$srcdir'/tls-certs/key.pem"
@@ -34,6 +36,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 :msg, contains, "msgnum:" action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
 '
 startup
+assign_file_content PORT_RCVR "$PORT_RCVR_FILE"
 
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.sender.debuglog"
 #valgrind="valgrind"


### PR DESCRIPTION
## Summary
- add imdtls listenPortFileName for port=0 listener discovery
- convert DTLS tests that preselected UDP ports to read the bound port file
- document and distribute the new imdtls parameter

## Validation
- ./autogen.sh --enable-testbench --enable-imdiag --enable-omstdout --enable-imdtls --enable-omdtls --enable-gnutls --enable-openssl --enable-valgrind --enable-valgrind-testbench
- make -j$(nproc) check TESTS=""
- single direct pass of changed imdtls/DTLS shell tests