### PR TITLE
tests: replace port preselection with port files

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -740,6 +740,43 @@ wait_file_exists() {
 	done
 }
 
+wait_file_exists_for_process() {
+	local file="$1"
+	local pid="$2"
+	local timeout="$3"
+	local description="$4"
+	local log_file="$5"
+	local i=0
+
+	echo "waiting for $description readiness file $file"
+	while true; do
+		if [ -f "$file" ] && [ "$(cat "$file" 2> /dev/null)" != "" ]; then
+			break
+		fi
+		if ! kill -0 "$pid" 2>/dev/null; then
+			echo "ABORT! $description exited before writing readiness file $file"
+			if [ "$log_file" != "" ] && [ -f "$log_file" ]; then
+				echo "$description log follows:"
+				cat "$log_file"
+			fi
+			wait "$pid" 2>/dev/null || :
+			error_exit 1
+		fi
+		$TESTTOOL_DIR/msleep 100 # wait 100 milliseconds
+		((i++))
+		if test $i -gt "$timeout"; then
+			echo "ABORT! Timeout waiting for $description readiness file $file"
+			ls -l "$file" 2>/dev/null || :
+			ps -fp "$pid" || :
+			if [ "$log_file" != "" ] && [ -f "$log_file" ]; then
+				echo "$description log follows:"
+				cat "$log_file"
+			fi
+			error_exit 1
+		fi
+	done
+}
+
 # kafka special wait function: we wait for the output file in order
 # to ensure Kafka/Zookeeper is actually ready to go. This is NOT
 # a generic check function and must only used with those kafka tests
@@ -1400,6 +1437,40 @@ stop_minitcpsrvrs() {
 		wait "$pid" 2>/dev/null
 	done
 	MINITCPSRVR_PIDS=""
+}
+
+start_udp_receiver() {
+	local portfile="$1"
+	local bind_addr="${2:-127.0.0.1}"
+	$PYTHON -u - "$portfile" "$bind_addr" <<'PY' &
+import socket
+import sys
+
+portfile = sys.argv[1]
+bind_addr = sys.argv[2]
+
+family = socket.AF_INET6 if ":" in bind_addr else socket.AF_INET
+sock = socket.socket(family, socket.SOCK_DGRAM)
+sock.bind((bind_addr, 0))
+with open(portfile, "w") as f:
+    f.write("{0}\n".format(sock.getsockname()[1]))
+while True:
+    sock.recvfrom(65535)
+PY
+	local bg_pid=$!
+	UDP_RECEIVER_PIDS="${UDP_RECEIVER_PIDS:-} $bg_pid"
+	wait_file_exists "$portfile"
+}
+
+stop_udp_receivers() {
+	local pid
+	for pid in ${UDP_RECEIVER_PIDS:-}; do
+		if kill -0 "$pid" 2>/dev/null; then
+			kill "$pid" 2>/dev/null
+		fi
+		wait "$pid" 2>/dev/null || :
+	done
+	UDP_RECEIVER_PIDS=""
 }
 
 # same as startup_vg, BUT we do NOT wait on the startup message!
@@ -2169,6 +2240,7 @@ do_cleanup() {
 		shutdown_immediate 2
 	fi
 	stop_minitcpsrvrs
+	stop_udp_receivers
 }
 
 
@@ -2910,6 +2982,7 @@ exit_test() {
 	rm -f ${TESTCONF_NM}.conf ${TESTCONF_NM}.yaml
 	rm -f tmp.qi nocert
 	stop_minitcpsrvrs
+	stop_udp_receivers
 	rm -fr $RSYSLOG_DYNNAME*  # delete all of our dynamic files
 	unset TCPFLOOD_EXTRA_OPTS
 
@@ -3941,7 +4014,8 @@ omhttp_start_server() {
     omhttp_server_logfile="${omhttp_work_dir}/omhttp_server.log"
     mkdir -p ${omhttp_work_dir}
 
-    server_args="-p $omhttp_server_port ${*:2} --port-file $RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
+    omhttp_server_portfile="$RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
+    server_args="-p $omhttp_server_port ${*:2} --port-file $omhttp_server_portfile"
 
     setsid timeout 30m $PYTHON ${omhttp_server_py} ${server_args} >> ${omhttp_server_logfile} 2>&1 &
     # shellcheck disable=SC2181 # Preserve the existing background-start check.
@@ -3952,8 +4026,15 @@ omhttp_start_server() {
     fi
     omhttp_server_pid=$!
 
-    wait_file_exists "$RSYSLOG_DYNNAME.omhttp_server_lstnport.file"
-    omhttp_server_lstnport="$(cat $RSYSLOG_DYNNAME.omhttp_server_lstnport.file)"
+    # The Python omhttp helper writes the port file only after HTTPServer has
+    # bound the socket.  Under very high full-suite parallelism the helper can
+    # be runnable but starved for longer than the generic 40s start/stop wait,
+    # so keep the port-file readiness oracle but tie it to the helper process:
+    # fail immediately if it exits, otherwise allow a helper-specific startup
+    # window before treating it as a testbench failure.
+    wait_file_exists_for_process "$omhttp_server_portfile" "$omhttp_server_pid" \
+        "${OMHTTP_SERVER_STARTUP_TIMEOUT:-1200}" "omhttp test server" "$omhttp_server_logfile"
+    omhttp_server_lstnport="$(cat "$omhttp_server_portfile")"
     echo ${omhttp_server_pid} > ${omhttp_server_pidfile}
     echo "Started omhttp test server with args ${server_args} with process group ${omhttp_server_pid}, port {$omhttp_server_lstnport}"
 }

--- a/tests/mmkubernetes-basic-vg.sh
+++ b/tests/mmkubernetes-basic-vg.sh
@@ -7,13 +7,25 @@
 # execute it under "timeout" control, which ensure it always is
 # terminated. It's not a 100% great method, but hopefully does the
 # trick. -- rgerhards, 2018-07-21
+#
+# Valgrind variant of mmkubernetes-basic.sh. It keeps the same enrichment and
+# statistics oracle while checking the mmkubernetes path under Valgrind.
 #export RSYSLOG_DEBUG="debug"
 USE_VALGRIND=true
 . ${srcdir:=.}/diag.sh init
 check_command_available timeout
 pwd=$( pwd )
-k8s_srv_port=$( get_free_port )
+k8s_srv_port_file="${RSYSLOG_DYNNAME}mmk8s-test-server.port"
 generate_conf
+testsrv=mmk8s-test-server
+echo starting kubernetes \"emulator\"
+timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py 0 ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started ${k8s_srv_port_file} > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+echo background mmkubernetes_test_server.py process id is $BGPROCESS
+
 add_conf '
 global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
 module(load="../plugins/impstats/.libs/impstats" interval="1"
@@ -35,13 +47,6 @@ action(type="mmkubernetes" busyretryinterval="1" token="dummy" kubernetesurl="ht
 )
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="mmk8s_template")
 '
-
-testsrv=mmk8s-test-server
-echo starting kubernetes \"emulator\"
-timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py $k8s_srv_port ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
-BGPROCESS=$!
-wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
-echo background mmkubernetes_test_server.py process id is $BGPROCESS
 
 cat > ${RSYSLOG_DYNNAME}.spool/pod-error1.log <<EOF
 {"log":"not in right format","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z","testid":1}

--- a/tests/mmkubernetes-basic.sh
+++ b/tests/mmkubernetes-basic.sh
@@ -7,13 +7,27 @@
 # execute it under "timeout" control, which ensure it always is
 # terminated. It's not a 100% great method, but hopefully does the
 # trick. -- rgerhards, 2018-07-21
+#
+# Verify basic mmkubernetes metadata enrichment for imfile records, including
+# normal namespace/pod lookups and expected not-found/busy/error responses. The
+# oracle compares enriched JSON output and module statistics against fixed
+# expectations.
 #export RSYSLOG_DEBUG="debug"
 USE_VALGRIND=false
 . ${srcdir:=.}/diag.sh init
 check_command_available timeout
 pwd=$( pwd )
-k8s_srv_port=$( get_free_port )
+k8s_srv_port_file="${RSYSLOG_DYNNAME}mmk8s-test-server.port"
 generate_conf
+testsrv=mmk8s-test-server
+echo starting kubernetes \"emulator\"
+timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py 0 ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started ${k8s_srv_port_file} > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+echo background mmkubernetes_test_server.py process id is $BGPROCESS
+
 add_conf '
 global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
 module(load="../plugins/impstats/.libs/impstats" interval="1"
@@ -35,13 +49,6 @@ action(type="mmkubernetes" busyretryinterval="1" token="dummy" kubernetesurl="ht
 )
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="mmk8s_template")
 '
-
-testsrv=mmk8s-test-server
-echo starting kubernetes \"emulator\"
-timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py $k8s_srv_port ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
-BGPROCESS=$!
-wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
-echo background mmkubernetes_test_server.py process id is $BGPROCESS
 
 cat > ${RSYSLOG_DYNNAME}.spool/pod-error1.log <<EOF
 {"log":"not in right format","stream":"stdout","time":"2018-04-06T17:26:34.492083106Z","testid":1}

--- a/tests/mmkubernetes-cache-expire.sh
+++ b/tests/mmkubernetes-cache-expire.sh
@@ -7,12 +7,25 @@
 # execute it under "timeout" control, which ensure it always is
 # terminated. It's not a 100% great method, but hopefully does the
 # trick. -- rgerhards, 2018-07-21
+#
+# Verify mmkubernetes cache expiry. Records before the TTL boundary should use
+# cached namespace/pod data; records after expiry should miss and refresh the
+# cache. Success is validated by enriched JSON output and cache statistics.
 . ${srcdir:=.}/diag.sh init
 check_command_available timeout
 pwd=$( pwd )
-k8s_srv_port=$( get_free_port )
+k8s_srv_port_file="${RSYSLOG_DYNNAME}mmk8s-test-server.port"
 generate_conf
 cachettl=10
+testsrv=mmk8s-test-server
+echo starting kubernetes \"emulator\"
+timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py 0 ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started ${k8s_srv_port_file} > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
+BGPROCESS=$!
+wait_file_exists "$k8s_srv_port_file"
+k8s_srv_port="$(cat "$k8s_srv_port_file")"
+wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
+echo background mmkubernetes_test_server.py process id is $BGPROCESS
+
 add_conf '
 global(workDirectory="'$RSYSLOG_DYNNAME.spool'")
 module(load="../plugins/impstats/.libs/impstats" interval="1"
@@ -35,13 +48,6 @@ action(type="mmkubernetes" token="dummy" kubernetesurl="http://localhost:'$k8s_s
 )
 action(type="omfile" file=`echo $RSYSLOG_OUT_LOG` template="mmk8s_template")
 '
-
-testsrv=mmk8s-test-server
-echo starting kubernetes \"emulator\"
-timeout 2m $PYTHON -u $srcdir/mmkubernetes_test_server.py $k8s_srv_port ${RSYSLOG_DYNNAME}${testsrv}.pid ${RSYSLOG_DYNNAME}${testsrv}.started > ${RSYSLOG_DYNNAME}.spool/mmk8s_srv.log 2>&1 &
-BGPROCESS=$!
-wait_process_startup ${RSYSLOG_DYNNAME}${testsrv} ${RSYSLOG_DYNNAME}${testsrv}.started
-echo background mmkubernetes_test_server.py process id is $BGPROCESS
 
 if [ "${USE_VALGRIND:-NO}" == "YES" ] ; then
 	export EXTRA_VALGRIND_SUPPRESSIONS="--suppressions=$srcdir/mmkubernetes.supp"

--- a/tests/mmkubernetes_test_server.py
+++ b/tests/mmkubernetes_test_server.py
@@ -153,8 +153,14 @@ class SimpleHTTPRequestHandler(BaseHTTPRequestHandler):
 
 
 port = int(sys.argv[1])
+port_file = sys.argv[4] if len(sys.argv) > 4 else ""
 
 httpd = HTTPServer(('localhost', port), SimpleHTTPRequestHandler)
+listen_port = httpd.server_address[1]
+
+if port_file:
+    with open(port_file, "w") as ff:
+        ff.write('{0}\n'.format(listen_port))
 
 # write "started" to file named in argv[3]
 with open(sys.argv[3], "w") as ff:

--- a/tests/omfwd_fast_imuxsock.sh
+++ b/tests/omfwd_fast_imuxsock.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# This test tries tests DiscardMark / DiscardSeverity queue settings with omfwd with IMUXSOCK input
+# This test exercises DiscardMark / DiscardSeverity queue settings with omfwd
+# fed through an imuxsock input. Success is that the queue statistics show the
+# expected high-volume enqueue/discard behavior while a TCP receiver accepts
+# enough forwarded traffic for the action to stay active.
 # added 2021-09-02 by alorbach. Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 skip_platform "SunOS"  "We have no ATOMIC BUILTINS, so OverallQueueSize counting of imdiag is NOT threadsafe and the counting will fail on SunOS"
@@ -14,11 +17,12 @@ fi
 # export RSYSLOG_DEBUG="debug nologfuncflow noprintmutexaction nostdout"
 export NUMMESSAGES=100000
 
-PORT_RCVR="$(get_free_port)"
-export PORT_RCVR
 export STATSFILE="$RSYSLOG_DYNNAME.stats"
 export RSYSLOG_DEBUGLOG="$RSYSLOG_DYNNAME.debuglog"
 generate_conf
+start_minitcpsrvr "$RSYSLOG_OUT_LOG" 1
+PORT_RCVR="$MINITCPSRVR_PORT1"
+export PORT_RCVR
 add_conf '
 global(	debug.whitelist="on"
 	debug.files=["imdiag.c", "queue.c"]
@@ -74,10 +78,6 @@ if $msg contains "test message nbr" then
 	    queue.type="linkedlist"
 	)
 '
-./minitcpsrv -t127.0.0.1 -p$PORT_RCVR -f $RSYSLOG_OUT_LOG &
-BGPROCESS=$!
-echo background tcp dummy receiver process id is $BGPROCESS
-
 # now do the usual run
 startup
 

--- a/tests/omfwd_rebind_udp.sh
+++ b/tests/omfwd_rebind_udp.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 # This test reproduces the issue where RebindInterval causes action suspension
+# with UDP forwarding. The UDP receiver is only a blackhole that keeps the
+# target port genuinely bound; success is the expected rebind debug message
+# without any action suspension diagnostics.
 # added 2024-12-24 by Antigravity (Rgerhards). Released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 generate_conf
-PORT_RCVR="$(get_free_port)"
+start_udp_receiver "${RSYSLOG_DYNNAME}.udp_receiver.port"
+PORT_RCVR="$(cat "${RSYSLOG_DYNNAME}.udp_receiver.port")"
 export PORT_RCVR
 add_conf '
 module(load="builtin:omfwd")

--- a/tests/omhttp-basic-ignorecodes.sh
+++ b/tests/omhttp-basic-ignorecodes.sh
@@ -1,13 +1,18 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+#
+# Verify that omhttp treats configured HTTP status codes as ignorable. The test
+# server fails requests after the first half of the message stream; success is
+# that only the accepted first half remains and the ignored failures do not
+# break shutdown or sequence validation.
 
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
 
 export NUMMESSAGES=10000
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-with-401-or-403-after 5000
+omhttp_start_server 0 --fail-with-401-or-403-after 5000
+port="$omhttp_server_lstnport"
 
 generate_conf
 add_conf '

--- a/tests/omhttp-batch-retry-metadata.sh
+++ b/tests/omhttp-batch-retry-metadata.sh
@@ -1,13 +1,17 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+#
+# Verify omhttp batch retry metadata. The helper returns retryable HTTP 207
+# responses at a fixed cadence; success is complete sequence delivery plus
+# metadata output that records the response for retried messages.
 
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
 
 export NUMMESSAGES=50000
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-every 100 --fail-with 207
+omhttp_start_server 0 --fail-every 100 --fail-with 207
+port="$omhttp_server_lstnport"
 
 generate_conf
 add_conf '

--- a/tests/omhttp-retry-timeout.sh
+++ b/tests/omhttp-retry-timeout.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 # This file is part of the rsyslog project, released under ASL 2.0
+#
+# Verify that omhttp retry handling copes with delayed failing responses when
+# restPathTimeout is shorter than the helper's failure delay. Success is that
+# retries eventually deliver the full sequence without duplicates or gaps.
 
 #  Starting actual testbench
 . ${srcdir:=.}/diag.sh init
@@ -7,8 +11,8 @@
 export NUMMESSAGES=2500
 export SEQ_CHECK_OPTIONS="-d"
 
-port="$(get_free_port)"
-omhttp_start_server $port --fail-every 1000 --fail-with-delay-secs 2
+omhttp_start_server 0 --fail-every 1000 --fail-with-delay-secs 2
+port="$omhttp_server_lstnport"
 
 generate_conf
 add_conf '


### PR DESCRIPTION
## Summary

- replace several `get_free_port` preselection flows with helpers that bind port `0` and publish the actual port through a port file
- extend the mmkubernetes test helper to report its bound port
- add a small UDP blackhole helper for UDP receiver tests
- update touched test head comments to document intent and oracle

## Why

`get_free_port` is inherently racy under high-concurrency CI: the selected port can be taken before the intended helper binds it. These changes move low-risk test helpers to the same bind-first pattern already used by newer test plumbing.

## Validation

- `bash -n` on changed shell tests and `tests/diag.sh`
- `python3 -m py_compile tests/mmkubernetes_test_server.py tests/omhttp_server.py`
- forced focused SNMP support check in `rsyslog/rsyslog_dev_base_ubuntu:26.04`
- full local Ubuntu 26.04 dev-container check:
  - `TOTAL: 1280`
  - `PASS: 1187`
  - `SKIP: 93`
  - `FAIL: 0`
  - runtime: 4m35s

## Deferred

RELP tests still need librelp-side support to report the actual bound listener port cleanly. Broader generic service defaults such as Redis/OTEL and the fallback `TCPFLOOD_PORT` path are intentionally left for separate, more targeted work.
