### PR TITLE
omazuredce: avoid gzip buffer underallocation

### DIFF
--- a/plugins/omazuredce/omazuredce.c
+++ b/plugins/omazuredce/omazuredce.c
@@ -413,9 +413,11 @@ static size_t decimalDigits(size_t v) {
     return n;
 }
 
+#define GZIP_WRAPPER_OVERHEAD 32U
+
 static size_t estimatePayloadBytesForRequest(instanceData *pData, size_t payloadLen) {
     if (pData->compressionLevel != 0) {
-        return (size_t)compressBound((uLong)payloadLen);
+        return (size_t)compressBound((uLong)payloadLen) + GZIP_WRAPPER_OVERHEAD;
     }
 
     return payloadLen;
@@ -465,7 +467,7 @@ static rsRetVal gzipCompressBuffer(const uint8_t *input,
 
     *out = NULL;
     *outLen = 0;
-    bound = (size_t)compressBound((uLong)inputLen);
+    bound = (size_t)compressBound((uLong)inputLen) + GZIP_WRAPPER_OVERHEAD;
     if (*bufferCap < bound) {
         CHKmalloc(tmpBuf = (uint8_t *)realloc(*buffer, bound));
         *buffer = tmpBuf;


### PR DESCRIPTION
### Motivation
- Fix an availability bug where `compressBound()` was used for gzip-wrapped output, which can underestimate required space and cause `deflate()` to return a non-`Z_STREAM_END` error and repeatedly retry the same batch.

### Description
- Add a conservative `GZIP_WRAPPER_OVERHEAD` constant and apply it to the compressed-size estimate in `estimatePayloadBytesForRequest()` to account for gzip header/trailer overhead.
- Use the same adjusted bound when allocating the gzip output buffer in `gzipCompressBuffer()` so the deflate target buffer is not underallocated.
- Preserve the existing compression flow and error handling while preventing false `RS_RET_ZLIB_ERR` failures on incompressible payloads.

### Testing
- Attempted to run the module test script `./tests/omazuredce-compression.sh`, but the test run could not complete because `configure` failed due to missing `protoc-c` (`protobuf-c-compiler`), so full automated validation is blocked by tooling availability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fcc14ed0833283f0b904480b5975)