### PR TITLE
ratelimit: avoid double-free on TCP submit helper error paths

### DIFF
--- a/plugins/imptcp/imptcp.c
+++ b/plugins/imptcp/imptcp.c
@@ -986,8 +986,7 @@ static rsRetVal doSubmitMsg(ptcpsess_t *pThis, struct syslogTime *stTime, time_t
         DBGPRINTF("imptcp: message discarded by ratelimit helper\n");
         iRet = RS_RET_OK;
     } else {
-        DBGPRINTF("imptcp: ratelimit helper returned error %d, dropping message and continuing\n", localRet);
-        msgDestruct(&pMsg);
+        DBGPRINTF("imptcp: ratelimit helper returned error %d, continuing\n", localRet);
         iRet = RS_RET_OK;
     }
 

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -453,8 +453,7 @@ static rsRetVal defaultDoSubmitMessage(tcps_sess_t *pThis,
         DBGPRINTF("tcps_sess: message discarded by ratelimit helper\n");
         iRet = RS_RET_OK;
     } else {
-        DBGPRINTF("tcps_sess: ratelimit helper returned error %d, dropping message and continuing\n", localRet);
-        msgDestruct(&pMsg);
+        DBGPRINTF("tcps_sess: ratelimit helper returned error %d, continuing\n", localRet);
         iRet = RS_RET_OK;
     }
 


### PR DESCRIPTION
### Motivation
- A prior change attempted to free messages on unexpected ratelimit-helper errors but did so unconditionally from the caller, which can double-free when the ratelimit helper or queue consumer already consumed/freed the same `pMsg`.
- The intent is to fix the memory-safety regression while preserving the non-fatal behavior of continuing processing for unexpected helper errors.

### Description
- Remove the caller-side `msgDestruct(&pMsg)` in the non-`RS_RET_DISCARDMSG` error branches in `runtime/tcps_sess.c` and `plugins/imptcp/imptcp.c` to avoid double-free/UAF.
- Update the debug text in those branches to no longer claim the caller is dropping/freeing the message.
- Preserve existing control flow and return semantics by keeping `iRet = RS_RET_OK` so processing continues for non-discard helper errors.

### Testing
- Attempted to run the repository test target via `make -j2 check TESTS=''`, which failed in this environment with `No rule to make target 'check'` and therefore could not complete a full build/test run here.
- Verified the minimal code edits with `git diff` and line-level inspections to ensure only the two target caller-side frees and debug messages were changed and no other behavior was altered.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1302b92ab88332bb7f63c64981b723)