### PR TITLE
omazuredce: bound HTTP response buffering

### DIFF
--- a/plugins/omazuredce/omazuredce.c
+++ b/plugins/omazuredce/omazuredce.c
@@ -165,21 +165,40 @@ finalize_it:
     RETiRet;
 }
 
+#define AZURE_MAX_TOKEN_RESPONSE_BYTES (1024 * 1024)
+#define AZURE_MAX_INGEST_RESPONSE_BYTES (16 * 1024)
+
 typedef struct tokenRespBuf_s {
     char *data;
     size_t len;
+    size_t maxLen;
 } tokenRespBuf_t;
 
 static size_t tokenWriteCb(void *contents, size_t size, size_t nmemb, void *userp) {
-    const size_t realsz = size * nmemb;
+    size_t realsz;
+    size_t newLen;
     tokenRespBuf_t *buf = (tokenRespBuf_t *)userp;
-    char *newData = realloc(buf->data, buf->len + realsz + 1);
+    char *newData;
+
+    if (size != 0 && nmemb > SIZE_MAX / size) {
+        return 0;
+    }
+    realsz = size * nmemb;
+    if (realsz > buf->maxLen || buf->len > buf->maxLen - realsz) {
+        return 0;
+    }
+    newLen = buf->len + realsz;
+    if (newLen == SIZE_MAX) {
+        return 0;
+    }
+
+    newData = realloc(buf->data, newLen + 1);
     if (newData == NULL) {
         return 0;
     }
     buf->data = newData;
     memcpy(buf->data + buf->len, contents, realsz);
-    buf->len += realsz;
+    buf->len = newLen;
     buf->data[buf->len] = '\0';
     return realsz;
 }
@@ -235,7 +254,7 @@ static rsRetVal requestAccessToken(instanceData *pData) {
     long httpCode = 0;
     size_t bodyLen;
     struct curl_slist *headers = NULL;
-    tokenRespBuf_t response = {NULL, 0};
+    tokenRespBuf_t response = {NULL, 0, AZURE_MAX_TOKEN_RESPONSE_BYTES};
     char *token = NULL;
     struct json_object *tokenResp = NULL;
     struct json_object *tokenField = NULL;
@@ -295,6 +314,10 @@ static rsRetVal requestAccessToken(instanceData *pData) {
               safeStr(pData->clientID));
     curlRes = curl_easy_perform(curl);
     if (curlRes != CURLE_OK) {
+        if (curlRes == CURLE_WRITE_ERROR) {
+            LogError(0, RS_RET_IO_ERROR,
+                     "omazuredce: token response exceeded %zu bytes or failed while buffering", response.maxLen);
+        }
         LogError(0, RS_RET_IO_ERROR, "omazuredce: token request failed: %s", curl_easy_strerror(curlRes));
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
@@ -505,7 +528,7 @@ static rsRetVal postBatchToAzure(instanceData *pData, wrkrInstanceData_t *pWrkrD
     size_t sendLen = payloadLen;
     CURLcode curlRes;
     long httpCode = 0;
-    tokenRespBuf_t response = {NULL, 0};
+    tokenRespBuf_t response = {NULL, 0, AZURE_MAX_INGEST_RESPONSE_BYTES};
     struct curl_slist *headers = NULL;
     char *accessToken = NULL;
     int n;
@@ -571,6 +594,10 @@ static rsRetVal postBatchToAzure(instanceData *pData, wrkrInstanceData_t *pWrkrD
                   compressionLevelName(pData->compressionLevel));
         curlRes = curl_easy_perform(pWrkrData->curl);
         if (curlRes != CURLE_OK) {
+            if (curlRes == CURLE_WRITE_ERROR) {
+                LogError(0, RS_RET_SUSPENDED,
+                         "omazuredce: ingest response exceeded %zu bytes or failed while buffering", response.maxLen);
+            }
             LogError(0, RS_RET_SUSPENDED, "omazuredce: batch post failed: %s", curl_easy_strerror(curlRes));
             ABORT_FINALIZE(RS_RET_SUSPENDED);
         }

--- a/plugins/omazuredce/omazuredce.c
+++ b/plugins/omazuredce/omazuredce.c
@@ -184,11 +184,8 @@ static size_t tokenWriteCb(void *contents, size_t size, size_t nmemb, void *user
         return 0;
     }
     realsz = size * nmemb;
-    if (realsz > buf->maxLen || buf->len > buf->maxLen - realsz) {
-        return 0;
-    }
     newLen = buf->len + realsz;
-    if (newLen == SIZE_MAX) {
+    if (newLen > buf->maxLen || newLen < buf->len) {
         return 0;
     }
 
@@ -315,10 +312,11 @@ static rsRetVal requestAccessToken(instanceData *pData) {
     curlRes = curl_easy_perform(curl);
     if (curlRes != CURLE_OK) {
         if (curlRes == CURLE_WRITE_ERROR) {
-            LogError(0, RS_RET_IO_ERROR,
-                     "omazuredce: token response exceeded %zu bytes or failed while buffering", response.maxLen);
+            LogError(0, RS_RET_IO_ERROR, "omazuredce: token response exceeded %zu bytes or failed while buffering",
+                     response.maxLen);
+        } else {
+            LogError(0, RS_RET_IO_ERROR, "omazuredce: token request failed: %s", curl_easy_strerror(curlRes));
         }
-        LogError(0, RS_RET_IO_ERROR, "omazuredce: token request failed: %s", curl_easy_strerror(curlRes));
         ABORT_FINALIZE(RS_RET_IO_ERROR);
     }
     curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &httpCode);
@@ -597,8 +595,9 @@ static rsRetVal postBatchToAzure(instanceData *pData, wrkrInstanceData_t *pWrkrD
             if (curlRes == CURLE_WRITE_ERROR) {
                 LogError(0, RS_RET_SUSPENDED,
                          "omazuredce: ingest response exceeded %zu bytes or failed while buffering", response.maxLen);
+            } else {
+                LogError(0, RS_RET_SUSPENDED, "omazuredce: batch post failed: %s", curl_easy_strerror(curlRes));
             }
-            LogError(0, RS_RET_SUSPENDED, "omazuredce: batch post failed: %s", curl_easy_strerror(curlRes));
             ABORT_FINALIZE(RS_RET_SUSPENDED);
         }
         curl_easy_getinfo(pWrkrData->curl, CURLINFO_RESPONSE_CODE, &httpCode);


### PR DESCRIPTION
### Motivation
- The module previously buffered OAuth and ingest HTTP responses without size caps or arithmetic-overflow checks, allowing a malicious or compromised endpoint to trigger unbounded allocations and OOM.
- The fix limits buffered response sizes per context and prevents integer overflow before `realloc`/`memcpy` to harden against network-driven availability attacks.

### Description
- Add `AZURE_MAX_TOKEN_RESPONSE_BYTES` (1 MiB) and `AZURE_MAX_INGEST_RESPONSE_BYTES` (16 KiB) and extend `tokenRespBuf_t` with a `maxLen` field to enforce per-request caps.
- Harden `tokenWriteCb` to check `size * nmemb` overflow, verify addition bounds before allocation, and return write-failure when a chunk would exceed the configured cap so libcurl aborts safely.
- Initialize `tokenRespBuf_t` with context-specific `maxLen` for the OAuth token flow and for batch/ingest POSTs, keeping existing callback wiring unchanged.
- Improve error logging paths by detecting `CURLE_WRITE_ERROR` and emitting a clear message when buffering fails due to exceeding the caps.

### Testing
- Attempted `make -j$(nproc) plugins/omazuredce/.libs/omazuredce.so` which failed because the tree is not configured in this environment (no rule for the target).
- Attempted `make -j$(nproc) check TESTS=""` which failed because `check` is not available in the current unconfigured tree.
- `docker --version` returned not found, so full local container validation could not be performed and this change is not fully container-validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a102066399c8332b2ffa51202d87a58)