### PR TITLE
imrelp: enforce per-source named ratelimits

### DIFF
--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -241,7 +241,8 @@ static relpRetVal onSyslogRcv(void *pUsr, uchar *pHostname, uchar *pIP, uchar *m
     CHKiRet(MsgSetRcvFromIPStr(pMsg, pIP, ustrlen(pIP), &pProp));
     CHKiRet(prop.Destruct(&pProp));
     if (inst->data.ratelimiter != NULL) {
-        CHKiRet(ratelimitAddMsg(inst->data.ratelimiter, NULL, pMsg));
+        CHKiRet(ratelimitAddMsgPerSource(inst->data.ratelimiter, NULL, pMsg, (const char *)pIP, ustrlen(pIP),
+                                         pMsg->ttGenTime));
     } else {
         CHKiRet(submitMsg2(pMsg));
     }

--- a/plugins/imrelp/imrelp.c
+++ b/plugins/imrelp/imrelp.c
@@ -241,8 +241,12 @@ static relpRetVal onSyslogRcv(void *pUsr, uchar *pHostname, uchar *pIP, uchar *m
     CHKiRet(MsgSetRcvFromIPStr(pMsg, pIP, ustrlen(pIP), &pProp));
     CHKiRet(prop.Destruct(&pProp));
     if (inst->data.ratelimiter != NULL) {
-        CHKiRet(ratelimitAddMsgPerSource(inst->data.ratelimiter, NULL, pMsg, (const char *)pIP, ustrlen(pIP),
-                                         pMsg->ttGenTime));
+        iRet = ratelimitAddMsgPerSource(inst->data.ratelimiter, NULL, pMsg, (const char *)pIP, ustrlen(pIP),
+                                        pMsg->ttGenTime);
+        if (iRet == RS_RET_DISCARDMSG) {
+            ABORT_FINALIZE(RS_RET_OK);
+        }
+        CHKiRet(iRet);
     } else {
         CHKiRet(submitMsg2(pMsg));
     }


### PR DESCRIPTION
### Motivation
- Named ratelimiters with per-source policies were accepted for `imrelp` but the RELP receive path used `ratelimitAddMsg()`, which does not enforce per-source checks, allowing configured per-source limits to be bypassed.

### Description
- In `plugins/imrelp/imrelp.c` switch the RELP receive callback to call `ratelimitAddMsgPerSource()` and pass the RELP peer IP as the per-source key and `pMsg->ttGenTime`, while preserving the existing `submitMsg2()` fallback when no ratelimiter is configured.

### Testing
- Ran `devtools/format-code.sh --git-changed` which completed successfully; attempted `make -j$(nproc) check TESTS=""` but it could not run to completion in this workspace because the tree is not configured/bootstrap'ed (so full automated `make check` was not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1304ccec688332a3133bac862306d8)