### PR TITLE
impstats: fix double-free in remote write batching cleanup

### DIFF
--- a/plugins/impstats/impstats_push.c
+++ b/plugins/impstats/impstats_push.c
@@ -506,7 +506,6 @@ rsRetVal impstats_push_send(impstats_push_config_t *config, statsobj_if_t *stats
         batch_wr = prom_write_request_new_with_series(batch_series, batch_count);
         if (batch_wr == NULL) {
             prom_write_request_free_series(batch_series, batch_count);
-            free(batch_series);
             ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
         }
 
@@ -527,7 +526,6 @@ finalize_it:
     if (wr) prom_write_request_free(wr);
     if (series) {
         prom_write_request_free_series(series, series_count);
-        free(series);
     }
     RETiRet;
 }


### PR DESCRIPTION
### Motivation
- Fix a double-free crash in the impstats Remote Write batching path where callers freed a detached `Prometheus__TimeSeries **` array even though `prom_write_request_free_series()` (via `free_timeseries_array()`) already frees the array pointer.

### Description
- Remove redundant `free(batch_series)` in the `batch_wr == NULL` allocation-failure path in `plugins/impstats/impstats_push.c` to avoid double-free of the batch array.
- Remove redundant `free(series)` in the final cleanup of `impstats_push_send()` in `plugins/impstats/impstats_push.c` because `prom_write_request_free_series(series, series_count)` already frees the array.
- Keep all other ownership semantics and behavior unchanged and limit the change to the minimal fixes required.

### Testing
- Attempted to build the plugin object with `make -j$(nproc) plugins/impstats/impstats_push.lo`, but the target was unavailable in this environment (missing generated build files), so no compile-run tests were executed.
- Attempted `make -j$(nproc) check TESTS=""`, but the `check` target was unavailable before bootstrap/configure, so no test-suite run was possible.
- Performed targeted source inspection (`nl -ba plugins/impstats/impstats_push.c`) and reviewed the diff to confirm the redundant `free()` calls were removed and committed the change as `impstats: fix double-free in remote write batching cleanup`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1305fed5988332b9fa67b08fe419a4)