### PR TITLE
imuxsock: prevent ratelimit.name bypass in credentialed sender path

### DIFF
--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -415,7 +415,7 @@ static rsRetVal addListner(instanceConf_t *inst) {
         CHKiRet(prop.SetString(listeners[nfd].hostName, inst->pLogHostName, ustrlen(inst->pLogHostName)));
         CHKiRet(prop.ConstructFinalize(listeners[nfd].hostName));
     }
-    if (inst->pszRatelimitName != NULL || inst->ratelimitInterval > 0) {
+    if (inst->ratelimitInterval > 0) {
         if ((listeners[nfd].ht =
                  create_hashtable(100, hash_from_key_fn, key_equals_fn, (void (*)(void *))ratelimitDestruct)) == NULL) {
             /* in this case, we simply turn off rate-limiting */
@@ -437,7 +437,7 @@ static rsRetVal addListner(instanceConf_t *inst) {
     listeners[nfd].bCreatePath = inst->bCreatePath;
     listeners[nfd].sockName = ustrdup(inst->sockName);
     listeners[nfd].bUseCreds = (inst->bDiscardOwnMsgs || inst->bWritePid || inst->ratelimitInterval ||
-                                inst->pszRatelimitName || inst->bAnnotate || inst->bUseSysTimeStamp)
+                                inst->bAnnotate || inst->bUseSysTimeStamp)
                                    ? 1
                                    : 0;
     listeners[nfd].bAnnotate = inst->bAnnotate;
@@ -1290,7 +1290,7 @@ static rsRetVal activateListeners(void) {
             }
         }
 #endif
-        if (runModConf->pszRatelimitNameSysSock != NULL || runModConf->ratelimitIntervalSysSock > 0) {
+        if (runModConf->ratelimitIntervalSysSock > 0) {
             if ((listeners[0].ht = create_hashtable(100, hash_from_key_fn, key_equals_fn, NULL)) == NULL) {
                 /* in this case, we simply turn of rate-limiting */
                 LogError(0, NO_ERRCODE,
@@ -1310,8 +1310,8 @@ static rsRetVal activateListeners(void) {
         listeners[0].ratelimitBurst = runModConf->ratelimitBurstSysSock;
         listeners[0].ratelimitSev = runModConf->ratelimitSeveritySysSock;
         listeners[0].bUseCreds = (runModConf->bWritePidSysSock || runModConf->ratelimitIntervalSysSock ||
-                                  runModConf->pszRatelimitNameSysSock || runModConf->bAnnotateSysSock ||
-                                  runModConf->bDiscardOwnMsgs || runModConf->bUseSysTimeStamp)
+                                  runModConf->bAnnotateSysSock || runModConf->bDiscardOwnMsgs ||
+                                  runModConf->bUseSysTimeStamp)
                                      ? 1
                                      : 0;
         listeners[0].bWritePid = runModConf->bWritePidSysSock;

--- a/plugins/imuxsock/imuxsock.c
+++ b/plugins/imuxsock/imuxsock.c
@@ -436,7 +436,7 @@ static rsRetVal addListner(instanceConf_t *inst) {
     listeners[nfd].flags = inst->bIgnoreTimestamp ? IGNDATE : NOFLAG;
     listeners[nfd].bCreatePath = inst->bCreatePath;
     listeners[nfd].sockName = ustrdup(inst->sockName);
-    listeners[nfd].bUseCreds = (inst->bDiscardOwnMsgs || inst->bWritePid || inst->ratelimitInterval ||
+    listeners[nfd].bUseCreds = (inst->bDiscardOwnMsgs || inst->bWritePid || inst->ratelimitInterval > 0 ||
                                 inst->bAnnotate || inst->bUseSysTimeStamp)
                                    ? 1
                                    : 0;
@@ -1309,11 +1309,11 @@ static rsRetVal activateListeners(void) {
         listeners[0].ratelimitInterval = runModConf->ratelimitIntervalSysSock;
         listeners[0].ratelimitBurst = runModConf->ratelimitBurstSysSock;
         listeners[0].ratelimitSev = runModConf->ratelimitSeveritySysSock;
-        listeners[0].bUseCreds = (runModConf->bWritePidSysSock || runModConf->ratelimitIntervalSysSock ||
-                                  runModConf->bAnnotateSysSock || runModConf->bDiscardOwnMsgs ||
-                                  runModConf->bUseSysTimeStamp)
-                                     ? 1
-                                     : 0;
+        listeners[0].bUseCreds =
+            (runModConf->bWritePidSysSock || runModConf->ratelimitIntervalSysSock > 0 || runModConf->bAnnotateSysSock ||
+             runModConf->bDiscardOwnMsgs || runModConf->bUseSysTimeStamp)
+                ? 1
+                : 0;
         listeners[0].bWritePid = runModConf->bWritePidSysSock;
         listeners[0].bAnnotate = runModConf->bAnnotateSysSock;
         listeners[0].bParseTrusted = runModConf->bParseTrusted;


### PR DESCRIPTION
### Motivation
- Close a bypass where `ratelimit.name` caused credentialed local senders to hit a per-PID legacy limiter constructed from sentinel `-1` values (which become large unsigned values), allowing local log-flooding to bypass an administrator-configured named rate limit.

### Description
- Change `plugins/imuxsock/imuxsock.c` so a per-PID hashtable is created only when interval-based ratelimiting is configured (`ratelimitInterval > 0`), preventing name-only configurations from enabling the per-PID legacy path in `addListner` and `activateListeners`.
- Remove `pszRatelimitName` from the `bUseCreds` gating so credentials are not collected solely because a named ratelimit is present, keeping credentialed traffic on the configured named default ratelimiter.

### Testing
- Ran `make -j$(nproc) check TESTS=""` in this workspace and it failed because the top-level generated `Makefile` / `check` target is not present (bootstrap/configure was not executed here), so no repository-level automated tests were executed in this session.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1305fe51608332805a9fb9c9391c22)