### PR TITLE
imkafka: cap split.json.records fan-out

### DIFF
--- a/plugins/imkafka/imkafka.c
+++ b/plugins/imkafka/imkafka.c
@@ -170,6 +170,10 @@ typedef struct instanceConf_s {
     STATSCOUNTER_DEF(ctrMaxLag, mutCtrMaxLag);
 } instanceConf_t;
 
+/* Hard fan-out ceiling for split.json.records to avoid queue amplification
+ * from a single broker message. */
+#define IMKAFKA_MAX_JSON_SPLIT_RECORDS 10000
+
 typedef struct modConfData_s {
     rsconf_t *pConf; /* our overall config object */
     uchar *topic;
@@ -492,6 +496,13 @@ static rsRetVal splitJsonRecords(instanceConf_t *const __restrict__ inst,
     if (record_count == 0) {
         /* Empty array - forward original message (not an error, just no records to split) */
         DBGPRINTF("imkafka: splitJsonRecords: empty records array, forwarding as-is\n");
+        ABORT_FINALIZE(RS_RET_ERR);
+    }
+
+    if (record_count > IMKAFKA_MAX_JSON_SPLIT_RECORDS) {
+        LogMsg(0, NO_ERRCODE, LOG_WARNING,
+               "imkafka: splitJsonRecords: records array has %d elements, limit is %d; forwarding batch as-is",
+               record_count, IMKAFKA_MAX_JSON_SPLIT_RECORDS);
         ABORT_FINALIZE(RS_RET_ERR);
     }
 


### PR DESCRIPTION
### Motivation
- Prevent an unbounded fan-out when `split.json.records` is enabled which can convert a single Kafka payload into an arbitrarily large number of rsyslog messages and cause availability/resource exhaustion.

### Description
- Add a hard ceiling `IMKAFKA_MAX_JSON_SPLIT_RECORDS` (set to `10000`) and check `record_count` in `splitJsonRecords()` to log a warning and return `RS_RET_ERR` (falling back to existing single-message handling) when the array exceeds the limit, preserving existing behavior when `split.json.records` is disabled.

### Testing
- Ran code formatting via `bash devtools/format-code.sh --git-changed` (succeeded); attempted `make -j$(nproc) check TESTS=""` but it failed in this environment with `No rule to make target 'check'`, so a full build/test and the AGENTS.md-required local container validation were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1305ff43188332b21eed6585a7d38d)