### PR TITLE
tests: deflake imfile endmsg example waits

### DIFF
--- a/tests/imfile-endmsg.regex-with-example-vg.sh
+++ b/tests/imfile-endmsg.regex-with-example-vg.sh
@@ -3,9 +3,16 @@
 # This test verifies imfile endmsg.regex message assembly under valgrind for
 # CRI-O and JSON container log fragments, including metadata and normalized
 # multiline output.
+# The oracle is six completed output records: two completed records from each
+# input in the first batch, then one multiline record from each input after the
+# final terminator arrives. The trailing partial records must remain buffered.
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
 export USE_VALGRIND="YES"
+# The final multiline record can be delayed heavily when the full test suite
+# runs at extreme concurrency. This timeout bounds that wait while preserving
+# the exact six-record oracle below.
+export IMFILECHECKTIMEOUT="180"
 
 mkdir $RSYSLOG_DYNNAME.statefiles
 generate_conf
@@ -92,13 +99,13 @@ echo '{"time":"date", "stream":"stdout", "log":"msgnum:4"}' >> $RSYSLOG_DYNNAME.
 echo 'date stdout P msgnum:5' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:5"}' >> $RSYSLOG_DYNNAME.json.input
 
-# give it time to finish
 if [ -n "${USE_GDB:-}" ] ; then
 	sleep 54321 || :
-else
-	sleep 1 # of course, this is racy
 fi
-# so we do at least wait for the queue to be empty - this should work in hopefully most cases
+
+# The second batch is intentionally incomplete. Drain the queue before appending
+# the terminators so the test checks imfile's cross-append multiline state
+# instead of depending on a fixed sleep under load.
 wait_queueempty
 
 echo 'date stdout F msgnum:6' >> $RSYSLOG_DYNNAME.crio.input
@@ -106,7 +113,7 @@ printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:6\n"}' >> $RSYSL
 echo 'date stdout P msgnum:7' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:7"}' >> $RSYSLOG_DYNNAME.json.input
 
-wait_file_lines $RSYSLOG_OUT_LOG 6
+wait_file_lines $RSYSLOG_OUT_LOG 6 $IMFILECHECKTIMEOUT
 
 shutdown_when_empty
 wait_shutdown

--- a/tests/imfile-endmsg.regex-with-example.sh
+++ b/tests/imfile-endmsg.regex-with-example.sh
@@ -2,9 +2,15 @@
 # This is part of the rsyslog testbench, licensed under ASL 2.0
 # This test verifies imfile endmsg.regex message assembly for CRI-O and JSON
 # container log fragments, including metadata and normalized multiline output.
+# The oracle is six completed output records: two completed records from each
+# input in the first batch, then one multiline record from each input after the
+# final terminator arrives. The trailing partial records must remain buffered.
 . ${srcdir:=.}/diag.sh init
 . $srcdir/diag.sh check-inotify
-export IMFILECHECKTIMEOUT="60"
+# The final multiline record can be delayed heavily when the full test suite
+# runs at extreme concurrency. This timeout bounds that wait while preserving
+# the exact six-record oracle below.
+export IMFILECHECKTIMEOUT="180"
 export IMFILELASTINPUTLINES="6"
 
 mkdir $RSYSLOG_DYNNAME.statefiles
@@ -83,12 +89,11 @@ printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:1\n"}' >> $RSYSL
 echo 'date stdout F msgnum:2' >> $RSYSLOG_DYNNAME.crio.input
 printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:2\n"}' >> $RSYSLOG_DYNNAME.json.input
 
-# sleep a little to give rsyslog a chance to begin processing
 if [ -n "${USE_GDB:-}" ] ; then
 	sleep 54321 || :
-else
-	sleep 1
 fi
+
+wait_file_lines $RSYSLOG_OUT_LOG 4 $IMFILECHECKTIMEOUT
 
 echo 'date stdout P msgnum:3' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:3"}' >> $RSYSLOG_DYNNAME.json.input
@@ -97,19 +102,21 @@ echo '{"time":"date", "stream":"stdout", "log":"msgnum:4"}' >> $RSYSLOG_DYNNAME.
 echo 'date stdout P msgnum:5' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:5"}' >> $RSYSLOG_DYNNAME.json.input
 
-# give it time to finish
 if [ -n "${USE_GDB:-}" ] ; then
 	sleep 54321 || :
-else
-	sleep 1
 fi
+
+# The second batch is intentionally incomplete. Drain the queue before appending
+# the terminators so the test checks imfile's cross-append multiline state
+# instead of depending on a fixed sleep under load.
+wait_queueempty
 
 echo 'date stdout F msgnum:6' >> $RSYSLOG_DYNNAME.crio.input
 printf '%s\n' '{"time":"date", "stream":"stdout", "log":"msgnum:6\n"}' >> $RSYSLOG_DYNNAME.json.input
 echo 'date stdout P msgnum:7' >> $RSYSLOG_DYNNAME.crio.input
 echo '{"time":"date", "stream":"stdout", "log":"msgnum:7"}' >> $RSYSLOG_DYNNAME.json.input
 
-content_check_with_count "$RSYSLOG_DYNNAME" $IMFILELASTINPUTLINES $IMFILECHECKTIMEOUT
+wait_file_lines $RSYSLOG_OUT_LOG $IMFILELASTINPUTLINES $IMFILECHECKTIMEOUT
 
 shutdown_when_empty # shut down rsyslogd when done processing messages
 if [ "${USE_VALGRIND:-false}" == "true" ] ; then
@@ -118,9 +125,6 @@ if [ "${USE_VALGRIND:-false}" == "true" ] ; then
 else
 	wait_shutdown    # we need to wait until rsyslogd is finished!
 fi
-
-# give it time to write the output file
-sleep 1
 
 ## check if we have the correct number of messages
 


### PR DESCRIPTION
## Summary

This is a test-only de-flake fix for the imfile `endmsg.regex` example tests.

The tests validate CRI-O and JSON fragment assembly with `endmsg.regex`. Under high-concurrency full-suite stress, the normal test could wait on fixed sleeps and then time out at four output records instead of the six-record oracle. The `-vg` sibling showed the same oracle could still complete, but sometimes after more than the original 60 second budget.

## What changed

- Documented the exact six-record oracle and trailing partial-record invariant in both tests.
- Replaced blind sleeps in the normal test with observable waits:
  - wait for the first four output records,
  - drain the queue before appending final terminators.
- Applied the same 180 second bounded final line-count wait to normal and `-vg` tests.

## Validation

Full Ubuntu 26.04 forced-service stress runs:

```text
RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04
RSYSLOG_TESTBENCH_FORCE_SERVICE_TESTS=1
CC=clang-21
CFLAGS=-g
CI_MAKE_OPT=-j80
CI_MAKE_CHECK_OPT=-j400
CI_CHECK_CMD=check
devtools/devcontainer.sh --rm devtools/run-ci.sh
```

Run 1:

```text
# TOTAL: 1280
# PASS:  1253
# SKIP:  27
# FAIL:  0
real 328.57
```

Run 2:

```text
# TOTAL: 1280
# PASS:  1243
# SKIP:  27
# FAIL:  10
real 339.85
```

Both `imfile-endmsg.regex-with-example.sh` and `imfile-endmsg.regex-with-example-vg.sh` passed in both runs. The run-2 failures were unrelated omhttp/Loki high-stress failures plus `omrelp-tls-ossl-authfail-suspend.sh`, recorded separately in the flake-campaign notes.

References https://github.com/rsyslog/rsyslog/issues/6308
