### PR TITLE
tests: fix pipe and imfile statistics sync oracles

### DIFF
--- a/tests/imfile-statistics.sh
+++ b/tests/imfile-statistics.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # This is part of the rsyslog testbench, licensed under ASL 2.0
+#
+# Test imfile per-file statistics for two wildcard-matched files and one
+# explicitly configured file. The oracle is twofold: all three input files must
+# produce one contiguous output sequence, and impstats must report the expected
+# byte and line counters for each input file. The output wait uses the aggregate
+# message count so shutdown does not race ahead after only one file's data was
+# observed.
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=1000
+export NUM_INPUT_FILES=3
+export TOTALMESSAGES=$((NUM_INPUT_FILES * NUMMESSAGES))
 generate_conf
 # NOTE: do NOT set a working directory!
 add_conf '
@@ -35,10 +44,10 @@ startup
 ./inputfilegen -m $NUMMESSAGES -i 1000 	>> "$RSYSLOG_DYNNAME"_2.input
 ./inputfilegen -m $NUMMESSAGES -i 2000 	>> "$RSYSLOG_DYNNAME".input_3
 
-wait_file_lines
+wait_file_lines "$RSYSLOG_OUT_LOG" "$TOTALMESSAGES"
 shutdown_when_empty
 wait_shutdown
-seq_check 0 2999
+seq_check 0 $((TOTALMESSAGES - 1))
 content_check "imfile: no working or state file directory set" $RSYSLOG_DYNNAME.othermsgs
 
 EXPECTED_BYTES=$((17 * NUMMESSAGES)) # Test data is 17 bytes per line

--- a/tests/pipeaction.sh
+++ b/tests/pipeaction.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-# Test for the pipe output action.
-# will create a fifo in the current directory, write to it and
-# then do the usual sequence checks.
+# Test the pipe output action with a disk-backed main queue.
+#
+# The test creates a FIFO, lets rsyslog write formatted messages to it, and
+# copies the FIFO stream into the normal sequence-check output file. Success
+# requires all injected messages to reach the external FIFO reader before
+# shutdown; main-queue-empty alone is not enough because the pipe reader is
+# outside rsyslog's queue accounting.
 # added 2009-11-05 by RGerhards
 
 # create the pipe and start a background process that copies data from 
@@ -32,6 +36,7 @@ echo background cp process id is $CPPROCESS
 # now do the usual run
 startup
 injectmsg 0 $NUMMESSAGES
+wait_file_lines "$RSYSLOG_OUT_LOG" "$NUMMESSAGES"
 shutdown_when_empty
 wait_shutdown
 


### PR DESCRIPTION
## Summary

This fixes two test synchronization bugs exposed by the local deflake stress campaign:

- `pipeaction.sh` now waits for the external FIFO reader output file to contain every injected message before shutdown.
- `imfile-statistics.sh` now waits for the aggregate output from all three input files before shutdown and sequence validation.

Both tests also now document their intent and oracle at the top of the script.

## Root Cause

`pipeaction.sh` treated rsyslog main queue empty as sufficient before shutdown. That does not prove the external FIFO reader has drained and copied all pipe output, because that reader is outside rsyslog queue accounting.

`imfile-statistics.sh` injects three files with 1,000 lines each, but bare `wait_file_lines` only waited for `NUMMESSAGES`, i.e. 1,000 lines. The later `seq_check 0 2999` already expected all 3,000 records, so the wait oracle was weaker than the actual test invariant.

## Validation

Full Ubuntu 26.04 dev-container check run at `-j400`:

```text
CI_MAKE_CHECK_OPT=-j400
1280 total, 1187 pass, 93 skip, 0 fail
runtime: 5m32.61s
```

The stressed full run included passing `pipeaction.sh`, `imfile-statistics.sh`, and `imfile-endmsg.regex-with-example.sh`.
