### PR TITLE
tests: start slow kafka checks earlier

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -966,8 +966,10 @@ TESTS_OMOTEL = \
         omotel-tls.sh \
         omotel-trace-correlation.sh
 
+TESTS_KAFKA_SELFTEST = \
+	kafka-selftest.sh
+
 TESTS_KAFKA = \
-	kafka-selftest.sh \
 	omkafka.sh \
 	omkafkadynakey.sh \
 	omkafka-headers.sh \
@@ -1786,14 +1788,13 @@ TESTS_IMFILE = \
 	config_enabled-off.sh
 
 # These imfile tests stress dynamic inotify watch changes. Keep each high-churn
-# subcluster ordered while allowing two independent chains to run in parallel:
-# one for wildcard directory expansion and one for old-state, rename, symlink,
-# and logrotate/truncate handling. This preserves the individual test coverage
-# and assertions without making all imfile inotify stress tests wait behind one
-# long serial chain.
+# subcluster ordered while allowing independent chains to run in parallel:
+# freshStartTail state handling, wildcard directory expansion, rename/symlink
+# handling, and logrotate/truncate handling. This preserves the individual test
+# coverage and assertions without making all imfile inotify stress tests wait
+# behind one long serial chain.
 imfile-freshStartTail2.log: imfile-freshStartTail1.log
 imfile-freshStartTail3.log: imfile-freshStartTail2.log
-imfile-wildcards.log: imfile-freshStartTail3.log
 imfile-wildcards-dirs.log: imfile-wildcards.log
 imfile-wildcards-dirs2.log: imfile-wildcards-dirs.log
 imfile-wildcards-dirs-multi.log: imfile-wildcards-dirs2.log
@@ -1807,7 +1808,6 @@ imfile-rename.log: imfile-rename-while-stopped.log
 imfile-symlink.log: imfile-rename.log
 imfile-symlink-multi.log: imfile-symlink.log
 imfile-symlink-ext-tmp-dir-tree.log: imfile-symlink-multi.log
-imfile-logrotate.log: imfile-symlink-ext-tmp-dir-tree.log
 imfile-logrotate-async.log: imfile-logrotate.log
 imfile-logrotate-multiple.log: imfile-logrotate-async.log
 imfile-logrotate-copytruncate.log: imfile-logrotate-multiple.log
@@ -1960,6 +1960,7 @@ EXTRA_DIST += $(TESTS_OMHTTP)
 EXTRA_DIST += $(TESTS_OMHTTP_VALGRIND)
 EXTRA_DIST += $(TESTS_OMHTTP_VICTORIALOGS)
 EXTRA_DIST += $(TESTS_OMOTEL)
+EXTRA_DIST += $(TESTS_KAFKA_SELFTEST)
 EXTRA_DIST += $(TESTS_KAFKA)
 EXTRA_DIST += $(TESTS_KAFKA_VALGRIND)
 EXTRA_DIST += $(TESTS_OMAZUREEVENTHUBS)
@@ -2638,9 +2639,19 @@ endif
 if ENABLE_OMKAFKA
 if ENABLE_IMKAFKA
 if ENABLE_KAFKA_TESTS
+TESTS += $(TESTS_KAFKA_SELFTEST)
+if HAVE_VALGRIND
+TESTS += $(TESTS_KAFKA_VALGRIND)
+endif
 TESTS += $(TESTS_KAFKA)
 
+if HAVE_VALGRIND
+omkafka-vg.log: kafka-selftest.log
+imkafka-vg.log: omkafka-vg.log
+omkafka.log: imkafka-vg.log
+else
 omkafka.log: kafka-selftest.log
+endif
 imkafka.log: omkafka.log
 imkafka-backgrounded.log: imkafka.log
 imkafka-config-err-ruleset.log: imkafka-backgrounded.log
@@ -2654,12 +2665,6 @@ sndrcv_kafka_multi_topics.log: imkafka_multi_group.log
 omkafkadynakey.log: sndrcv_kafka_multi_topics.log
 omkafka-headers.log: omkafkadynakey.log
 
-if HAVE_VALGRIND
-TESTS += $(TESTS_KAFKA_VALGRIND)
-
-omkafka-vg.log: omkafka-headers.log
-imkafka-vg.log: omkafka-vg.log
-endif
 endif
 endif
 endif


### PR DESCRIPTION
## Summary

This adjusts test scheduling so the slow Kafka valgrind checks start much earlier in the Automake test run, instead of waiting behind the normal Kafka chain.

It also relaxes the imfile inotify stress ordering into independent subchains for freshStartTail, wildcard directory expansion, rename/symlink handling, and logrotate/truncate handling. The individual test dependencies inside each high-churn cluster remain ordered, so the test scope and assertions are unchanged.

## Why

The high-concurrency local campaign showed the long tail is dominated by a few slow tests. Starting the Kafka valgrind pair early lets them use available parallel capacity while other tests are still running.

## Validation

Validated locally with a full Ubuntu 26.04 dev-container stress run on the reorder branch plus the then-pending #7050 imfile-endmsg fix, which is now merged into `main`:

```text
RSYSLOG_DEV_CONTAINER=rsyslog/rsyslog_dev_base_ubuntu:26.04
CC=clang-21
CFLAGS=-g
CI_MAKE_OPT=-j80
CI_MAKE_CHECK_OPT=-j400
CI_CHECK_CMD=check
```

Result: 1280 total, 1252 pass, 27 skip, 1 unrelated fail in `tcp_forwarding_dflt_tpl.sh`, runtime 5m51.56s.

Relevant evidence from that run:

- Kafka path passed: `kafka-selftest.sh`, `omkafka-vg.sh`, `imkafka-vg.sh`, `omkafka.sh`, `imkafka.sh`, and later Kafka tests.
- Imfile split chains passed, including wildcard, logrotate, rename, symlink, and freshStartTail tests.
- The only failure was an unrelated `minitcpsrv` listener readiness race in `tcp_forwarding_dflt_tpl.sh`, recorded separately for follow-up.

With the help of AI-Agents: Codex
