### PR TITLE
tests: wait for minitcpsrv readiness

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -1428,6 +1428,23 @@ start_minitcpsrvr() {
 	echo "### background minitcpsrv process id is $BGPROCESS port $(cat $RSYSLOG_DYNNAME.minitcpsrvr_port$instance) ###"
 }
 
+# Start minitcpsrv on a caller-selected port and wait until listen() has
+# completed. Use this for fixed-port tests that start rsyslog immediately after
+# the receiver. Tests that need an ephemeral port should use start_minitcpsrvr().
+start_minitcpsrv_ready() {
+	local output_file="$1"
+	local listen_port="$2"
+	shift 2
+	local ready_file="$RSYSLOG_DYNNAME.minitcpsrv.$listen_port.ready"
+
+	rm -f "$ready_file"
+	./minitcpsrv -t127.0.0.1 -p "$listen_port" -f "$output_file" -L "$ready_file" "$@" &
+	BGPROCESS=$!
+	MINITCPSRVR_PIDS="${MINITCPSRVR_PIDS:-} $BGPROCESS"
+	echo "### background minitcpsrv process id is $BGPROCESS port $listen_port ###"
+	wait_file_exists "$ready_file"
+}
+
 stop_minitcpsrvrs() {
 	local pid
 	for pid in ${MINITCPSRVR_PIDS:-}; do

--- a/tests/minitcpsrvr.c
+++ b/tests/minitcpsrvr.c
@@ -89,6 +89,21 @@ static void writeListenReadyMarker(void) {
     }
 }
 
+static void writePortFileMarker(void) {
+    FILE *fp;
+
+    if (portFileName == NULL) return;
+    if ((fp = fopen(portFileName, "w+")) == NULL) {
+        errout(portFileName);
+    }
+    if (fprintf(fp, "%d", targetPort) < 0) {
+        errout(portFileName);
+    }
+    if (fclose(fp) != 0) {
+        errout(portFileName);
+    }
+}
+
 static void waitForListenRelease(void) {
     if (waitListenFileName == NULL) return;
 
@@ -102,7 +117,6 @@ static void waitForListenRelease(void) {
 static void createListenSocket(void) {
     struct sockaddr_in srvAddr;
     unsigned int srvAddrLen;
-    static int portFileWritten = 0;
     int r;
 
     listen_fd = socket(AF_INET, SOCK_STREAM, 0);
@@ -161,27 +175,19 @@ static void createListenSocket(void) {
     }
     targetPort = ntohs(srvAddr.sin_port);
 
-    if (portFileName != NULL && !portFileWritten) {
-        FILE *fp;
-        if (getsockname(listen_fd, (struct sockaddr *)&srvAddr, &srvAddrLen) == -1) {
-            errout("getsockname");
-        }
-        if ((fp = fopen(portFileName, "w+")) == NULL) {
-            errout(portFileName);
-        }
-        fprintf(fp, "%d", ntohs(srvAddr.sin_port));
-        fclose(fp);
-        portFileWritten = 1;
-    }
-
     /* The socket is bound but not listening while this waits. TCP connects fail
      * with connection refused, while the selected port remains reserved.
+     * Publish the port before this wait so tests can configure a sender while
+     * intentionally keeping the receiver offline. Normal starts publish it only
+     * after listen() succeeds so port-file users do not race the listener.
      */
+    if (waitListenFileName != NULL) writePortFileMarker();
     waitForListenRelease();
 
     if (listen(listen_fd, MAX_CONNECTIONS) < 0) {
         errout("Listen failed");
     }
+    if (waitListenFileName == NULL) writePortFileMarker();
     writeListenReadyMarker();
 
     fds[0].fd = listen_fd;

--- a/tests/omfwd-subtree-tpl.sh
+++ b/tests/omfwd-subtree-tpl.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# Verify omfwd forwards messages when using subtree-type templates
+# Verify omfwd forwards messages when using subtree-type templates. The oracle
+# is the received JSON subtree payload, and the receiver must be listening
+# before rsyslog starts so the single test message is not lost to startup
+# timing.
 unset RSYSLOG_DYNNAME
 . ${srcdir:=.}/diag.sh init
 
@@ -15,8 +18,7 @@ if $msg contains "msgnum:" then {
 }
 '
 
-./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
-BGPROCESS=$!
+start_minitcpsrv_ready "$RSYSLOG_OUT_LOG" "$TCPFLOOD_PORT"
 
 startup
 injectmsg 0 1
@@ -25,4 +27,3 @@ wait_shutdown
 
 content_check '{ "foo": "bar" }' "$RSYSLOG_OUT_LOG"
 exit_test
-

--- a/tests/omfwd_impstats-tcp.sh
+++ b/tests/omfwd_impstats-tcp.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# This test tests impstats omfwd counters in TCP mode
-# added 2021-02-11 by rgerhards. Released under ASL 2.0
+# Verify impstats reports omfwd TCP byte counters after forwarding a complete
+# message sequence. The oracle is both a non-zero bytes.sent statistic and the
+# received 0..9999 sequence. The receiver readiness wait avoids startup loss
+# that would make the counter check ambiguous.
+# Added 2021-02-11 by rgerhards. Released under ASL 2.0.
 . ${srcdir:=.}/diag.sh init
 generate_conf
 export STATSFILE="$RSYSLOG_DYNNAME.stats"
@@ -21,9 +24,7 @@ module(load="builtin:omfwd" template="outfmt")
 if $msg contains "msgnum:" then
 	action(type="omfwd" target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp")
 '
-./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
-BGPROCESS=$!
-echo background minitcpsrv process id is $BGPROCESS
+start_minitcpsrv_ready "$RSYSLOG_OUT_LOG" "$TCPFLOOD_PORT"
 
 # now do the usual run
 startup

--- a/tests/suspend-omfwd-via-file.sh
+++ b/tests/suspend-omfwd-via-file.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
-# This tests the action suspension via a file
+# Verify omfwd action suspension and resumption controlled by an external state
+# file. The oracle is the complete forwarded sequence after the action is first
+# active, then suspended, then resumed. The receiver readiness wait keeps this
+# focused on external-state suspension instead of listener startup timing.
 # This file is part of the rsyslog project, released under ASL 2.0
 # Written 2019-07-10 by Rainer Gerhards
 . ${srcdir:=.}/diag.sh init
@@ -22,9 +25,7 @@ template(name="outfmt" type="string" string="%msg:F,58:2%\n")
 }
 '
 
-./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
-BGPROCESS=$!
-echo background minitcpsrv process id is $BGPROCESS
+start_minitcpsrv_ready "$RSYSLOG_OUT_LOG" "$TCPFLOOD_PORT"
 
 startup
 injectmsg 0 5000

--- a/tests/tcp_forwarding_dflt_tpl.sh
+++ b/tests/tcp_forwarding_dflt_tpl.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
-# This test tests tcp forwarding with assigned default template.
-# added 2015-05-30 by rgerhards. Released under ASL 2.0
+# Verify TCP forwarding uses the module-level default omfwd template. The
+# oracle is the complete 0..9999 forwarded message sequence rendered by that
+# default template. The receiver readiness wait avoids losing the first batch to
+# a listener startup race under high-concurrency test runs.
+# Added 2015-05-30 by rgerhards. Released under ASL 2.0.
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
@@ -17,9 +20,7 @@ module(load="builtin:omfwd" template="outfmt")
 if $msg contains "msgnum:" then
 	action(type="omfwd" target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp")
 '
-./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
-BGPROCESS=$!
-echo background minitcpsrv process id is $BGPROCESS
+start_minitcpsrv_ready "$RSYSLOG_OUT_LOG" "$TCPFLOOD_PORT"
 
 # now do the usual run
 startup

--- a/tests/tcp_forwarding_ns_tpl.sh
+++ b/tests/tcp_forwarding_ns_tpl.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
-# This test tests tcp forwarding in a network namespace with assigned template.
-# To do so, a simple tcp listener service is started in a network namespace.
+# Verify TCP forwarding with an action-level template into a network namespace.
+# The oracle is the complete 0..9999 forwarded sequence received by the helper
+# listener inside the namespace. The ready file is written after listen()
+# succeeds, avoiding a sender/listener startup race.
 # Released under GNU GPLv3+
 echo ===============================================================================
 echo \[tcp_forwarding_ns_tpl.sh\]: test for tcp forwarding in a network namespace with assigned template
@@ -27,9 +29,13 @@ ip netns add rsyslog_test_ns
 ip netns exec rsyslog_test_ns ip link set dev lo up
 
 # run server in namespace
-ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p"$TCPFLOOD_PORT" -f $RSYSLOG_OUT_LOG &
+MINITCPSRV_READY="$RSYSLOG_DYNNAME.minitcpsrv.$TCPFLOOD_PORT.ready"
+rm -f "$MINITCPSRV_READY"
+ip netns exec rsyslog_test_ns ./minitcpsrv -t127.0.0.1 -p"$TCPFLOOD_PORT" \
+	-f "$RSYSLOG_OUT_LOG" -L "$MINITCPSRV_READY" &
 BGPROCESS=$!
 echo background minitcpsrvr process id is $BGPROCESS
+wait_file_exists "$MINITCPSRV_READY"
 
 # now do the usual run
 startup

--- a/tests/tcp_forwarding_tpl.sh
+++ b/tests/tcp_forwarding_tpl.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
-# This test tests tcp forwarding with assigned template. To do so, a simple
-# tcp listener service is started.
-# added 2012-10-30 by Rgerhards. Released under ASL 2.0
+# Verify TCP forwarding uses an action-level template. The oracle is the
+# complete 0..9999 forwarded message sequence rendered by that template. The
+# receiver readiness wait avoids losing the first batch to a listener startup
+# race under high-concurrency test runs.
+# Added 2012-10-30 by Rgerhards. Released under ASL 2.0.
 
 # create the pipe and start a background process that copies data from 
 # it to the "regular" work file
@@ -15,9 +17,7 @@ if $msg contains "msgnum:" then
 	action(type="omfwd" template="outfmt"
 	       target="127.0.0.1" port="'$TCPFLOOD_PORT'" protocol="tcp")
 '
-./minitcpsrv -t127.0.0.1 -p$TCPFLOOD_PORT -f $RSYSLOG_OUT_LOG &
-BGPROCESS=$!
-echo background minitcpsrvr process id is $BGPROCESS
+start_minitcpsrv_ready "$RSYSLOG_OUT_LOG" "$TCPFLOOD_PORT"
 
 # now do the usual run
 startup


### PR DESCRIPTION
## Why

Several TCP forwarding tests started rsyslog immediately after spawning a fixed-port minitcpsrv receiver. Under high-concurrency runs, rsyslog could connect before the helper had completed `listen()`, causing listener-startup loss unrelated to the forwarding behavior under test.

## What changed

- Publish normal minitcpsrv port files only after `listen()` succeeds.
- Preserve pre-listen port publication for explicit listen-release tests, where the receiver is intentionally held offline.
- Add `start_minitcpsrv_ready()` for fixed-port receiver tests.
- Convert direct fixed-port minitcpsrv users that should not race listener startup.
- Leave `tcp_forwarding_retries.sh` unchanged because its delayed receiver is the test stimulus.

## Validation

- Focused Ubuntu 26.04 container run: passed the converted tests plus `tcp_forwarding_retries.sh`.
- Full Ubuntu 26.04 `-j400` container run: affected tests passed; only unrelated `sndrcv_relp_tls_chainedcert.sh` failed by RELP TLS timeout and was recorded in the flake-campaign repo.
