### PR TITLE
tests: widen service relevance defaults

### DIFF
--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2405,6 +2405,7 @@ module_needs_testing() {
 			*/*)
 				case "$changed_file" in
 					runtime/*.c|runtime/*.h|m4/*|\
+					runtime/Makefile.am|compat/Makefile.am|tools/Makefile.am|grammar/Makefile.am|\
 					.github/workflows/*|\
 					tests/Makefile.am|tests/diag.sh|tests/*.sh|tests/testsuites/*)
 						return 0

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2402,11 +2402,21 @@ module_needs_testing() {
 		[ -z "$changed_file" ] && continue
 
 		case "$changed_file" in
-			runtime/*.c|runtime/*.h|*.c|*.h|\
-			configure.ac|Makefile.am|*.mk|m4/*|\
-			.github/workflows/*|\
-			tests/Makefile.am|tests/diag.sh|tests/*.sh|tests/testsuites/*)
-				return 0
+			*/*)
+				case "$changed_file" in
+					runtime/*.c|runtime/*.h|m4/*|\
+					.github/workflows/*|\
+					tests/Makefile.am|tests/diag.sh|tests/*.sh|tests/testsuites/*)
+						return 0
+						;;
+				esac
+				;;
+			*)
+				case "$changed_file" in
+					*.c|*.h|configure.ac|Makefile.am|*.mk)
+						return 0
+						;;
+				esac
 				;;
 		esac
 

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -2402,7 +2402,10 @@ module_needs_testing() {
 		[ -z "$changed_file" ] && continue
 
 		case "$changed_file" in
-			runtime/*.c|runtime/*.h|configure.ac|Makefile.am|tests/Makefile.am|tests/diag.sh)
+			runtime/*.c|runtime/*.h|*.c|*.h|\
+			configure.ac|Makefile.am|*.mk|m4/*|\
+			.github/workflows/*|\
+			tests/Makefile.am|tests/diag.sh|tests/*.sh|tests/testsuites/*)
 				return 0
 				;;
 		esac


### PR DESCRIPTION
### Motivation
- Service-backed tests were self-skipping for cross-cutting changes because the generic changed-file allow-list in `module_needs_testing()` was too narrow. 
- The intent is to keep the skip optimization while avoiding false-green CI when shared core, build-system, workflow, or testbench scripts change.

### Description
- Broaden the generic changed-file patterns in `tests/diag.sh` so top-level `*.c`/`*.h` edits are treated as globally relevant. 
- Add build and CI metadata (`*.mk`, `m4/*`, `.github/workflows/*`) and testbench/service script paths (`tests/*.sh`, `tests/testsuites/*`) to the allow-list. 
- Preserve all module-specific path-matching logic so targeted module triggers remain unchanged.

### Testing
- Ran a shell syntax check with `bash -n tests/diag.sh`, which succeeded. 
- Verified the updated region with `nl -ba tests/diag.sh | sed -n '2396,2420p'` to confirm the intended pattern changes. 
- Docker/container validation could not be performed in this environment (Docker unavailable), so this change is not fully container-validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f33637d6083328f496f9e27736da2)