### PR TITLE
configure: avoid leaking -lgcrypt into global LIBS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1470,7 +1470,7 @@ if test "x$enable_libgcrypt" = "xyes"; then
                         AC_CHECK_LIB(
                                 [gcrypt],
                                 [gcry_cipher_open],
-                                [],
+                                [:],
                                 [AC_MSG_FAILURE([libgcrypt is missing])],
                                 [${LIBGCRYPT_LIBS}]
                         )


### PR DESCRIPTION
### Motivation
- Fix a build/configure regression where an empty `action-if-found` in `AC_CHECK_LIB` caused Autoconf to prepend a bare `-lgcrypt` into the global `LIBS`, which can break cross-builds and non-standard libgcrypt installations.

### Description
- Replace the empty success action `[]` with an explicit no-op `[:]` in the `AC_CHECK_LIB([gcrypt], [gcry_cipher_open], ...)` probe inside the `PKG_CHECK_MODULES` libgcrypt path in `configure.ac` to prevent leaking `-lgcrypt` into global `LIBS`.

### Testing
- Validated the one-line edit by inspecting the relevant `configure.ac` region with `sed`/`nl`, confirmed the `git diff -- configure.ac` showed the `[]`→`[:]` change, and committed the patch; no full build/test suite or container validation was run for this trivial configure-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f86b0da4833284381e0dc4cd8ac5)