### PR TITLE
runtime: bound KSI debug record logging by length

### DIFF
--- a/runtime/lmsig_ksi-ls12.c
+++ b/runtime/lmsig_ksi-ls12.c
@@ -23,6 +23,7 @@
 #include "config.h"
 
 #include "rsyslog.h"
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -269,10 +270,18 @@ static rsRetVal OnFileOpen(void *pT, uchar *fn, void *pGF) {
  */
 static rsRetVal OnRecordWrite(void *pF, uchar *rec, rs_size_t lenRec) {
     const rs_size_t payloadLen = (lenRec > 0) ? (lenRec - 1) : 0;
+    const int printLen = (payloadLen > (rs_size_t)INT_MAX) ? INT_MAX : (int)payloadLen;
     DEFiRet;
-    DBGPRINTF("lmsig_ksi-ls12: onRecordWrite (%d): %.*s\n", (int)payloadLen, (int)payloadLen, rec);
+
+    if (rec == NULL) {
+        DBGPRINTF("lmsig_ksi-ls12: onRecordWrite (%lu): (null)\n", (unsigned long)payloadLen);
+        ABORT_FINALIZE(RS_RET_INVALID_PARAMS);
+    }
+
+    DBGPRINTF("lmsig_ksi-ls12: onRecordWrite (%lu): %.*s\n", (unsigned long)payloadLen, printLen, rec);
     sigblkAddRecordKSI(pF, rec, payloadLen);
 
+finalize_it:
     RETiRet;
 }
 

--- a/runtime/lmsig_ksi-ls12.c
+++ b/runtime/lmsig_ksi-ls12.c
@@ -268,9 +268,10 @@ static rsRetVal OnFileOpen(void *pT, uchar *fn, void *pGF) {
  * rgerhards, 2013-03-17
  */
 static rsRetVal OnRecordWrite(void *pF, uchar *rec, rs_size_t lenRec) {
+    const rs_size_t payloadLen = (lenRec > 0) ? (lenRec - 1) : 0;
     DEFiRet;
-    DBGPRINTF("lmsig_ksi-ls12: onRecordWrite (%d): %s\n", lenRec - 1, rec);
-    sigblkAddRecordKSI(pF, rec, lenRec - 1);
+    DBGPRINTF("lmsig_ksi-ls12: onRecordWrite (%d): %.*s\n", (int)payloadLen, (int)payloadLen, rec);
+    sigblkAddRecordKSI(pF, rec, payloadLen);
 
     RETiRet;
 }


### PR DESCRIPTION
### Motivation
- Prevent an out-of-bounds read and potential debug-log disclosure/crash when a non-NUL-terminated record buffer (e.g. the `omfile` addLF temporary buffer) is passed to the KSI signature provider and formatted with `%s` in debug logging.

### Description
- Update `OnRecordWrite` in `runtime/lmsig_ksi-ls12.c` to compute `payloadLen = (lenRec > 0) ? (lenRec - 1) : 0`, use a length-bounded debug print `"%.*s"` with `(int)payloadLen`, and pass `payloadLen` to `sigblkAddRecordKSI()` so the debug formatting no longer requires a NUL-terminated string.

### Testing
- Attempted `make -j"$(nproc)" check TESTS=""` and it failed in this environment because the repository is not bootstrapped/configured (`make: *** No rule to make target 'check'.  Stop.`), so no repository-wide automated tests were executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f9d0402c83328876379b640e7890)