### PR TITLE
runtime: avoid regexp unload double free

### DIFF
--- a/runtime/regexp.c
+++ b/runtime/regexp.c
@@ -227,6 +227,13 @@ static void destroy_perthread_regexs(void) {
     pthread_mutex_lock(&mut_regexp);
     if (hashtable_count(perthread_regexs)) {
         itr = hashtable_iterator(perthread_regexs);
+        if (itr == NULL) {
+            hashtable_destroy(perthread_regexs, 0);
+            perthread_regexs = NULL;
+            pthread_mutex_unlock(&mut_regexp);
+            LogError(0, RS_RET_OUT_OF_MEMORY, "error creating per-thread regexp iterator during regexp class unload");
+            return;
+        }
         do {
             perthread_regex_t *entry = (perthread_regex_t *)hashtable_iterator_value(itr);
 

--- a/runtime/regexp.c
+++ b/runtime/regexp.c
@@ -218,6 +218,32 @@ static void _regfree(regex_t *preg) {
     pthread_mutex_unlock(&mut_regexp);
 }
 
+static void destroy_perthread_regexs(void) {
+    struct hashtable_itr *itr = NULL;
+    int ret = 0;
+
+    if (perthread_regexs == NULL) return;
+
+    pthread_mutex_lock(&mut_regexp);
+    if (hashtable_count(perthread_regexs)) {
+        itr = hashtable_iterator(perthread_regexs);
+        do {
+            perthread_regex_t *entry = (perthread_regex_t *)hashtable_iterator_value(itr);
+
+            ret = hashtable_iterator_advance(itr);
+            pthread_mutex_lock(&entry->lock);
+            pthread_mutex_unlock(&entry->lock);
+            pthread_mutex_destroy(&entry->lock);
+            regfree(&entry->preg);
+            free(entry);
+        } while (ret);
+        free(itr);
+    }
+    hashtable_destroy(perthread_regexs, 0);
+    perthread_regexs = NULL;
+    pthread_mutex_unlock(&mut_regexp);
+}
+
 static int _regcomp(regex_t *preg, const char *regex, int cflags) {
     int ret = 0;
     regex_t **ppreg = NULL;
@@ -343,9 +369,10 @@ ENDObjClassInit(regexp)
 BEGINObjClassExit(regexp, OBJ_IS_LOADABLE_MODULE) /* class, version */
     if (USE_PERTHREAD_REGEX) {
         /* release objects we no longer need */
-        pthread_mutex_destroy(&mut_regexp);
+        destroy_perthread_regexs();
         if (regex_to_uncomp) hashtable_destroy(regex_to_uncomp, 1);
-        if (perthread_regexs) hashtable_destroy(perthread_regexs, 0);
+        regex_to_uncomp = NULL;
+        pthread_mutex_destroy(&mut_regexp);
     }
 ENDObjClassExit(regexp)
 

--- a/runtime/regexp.c
+++ b/runtime/regexp.c
@@ -345,7 +345,7 @@ BEGINObjClassExit(regexp, OBJ_IS_LOADABLE_MODULE) /* class, version */
         /* release objects we no longer need */
         pthread_mutex_destroy(&mut_regexp);
         if (regex_to_uncomp) hashtable_destroy(regex_to_uncomp, 1);
-        if (perthread_regexs) hashtable_destroy(perthread_regexs, 1);
+        if (perthread_regexs) hashtable_destroy(perthread_regexs, 0);
     }
 ENDObjClassExit(regexp)
 


### PR DESCRIPTION
### Motivation
- Fix a reachable double-free during module unload where `perthread_regexs` stores the same `perthread_regex_t*` as both key and value and was being destroyed with `hashtable_destroy(..., 1)` which frees key and value.

### Description
- Change `hashtable_destroy(perthread_regexs, 1)` to `hashtable_destroy(perthread_regexs, 0)` in `runtime/regexp.c` so entries that use the same pointer for key and value are not double-freed, while leaving `regex_to_uncomp` destruction unchanged.

### Testing
- Ran `bash devtools/format-code.sh` successfully to format the modified files.
- Attempted `make -j"$(nproc)" check TESTS=""` but the local environment reported `No rule to make target 'check'`, so a full build/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f9d063488332bf73177bee0dc2df)