### PR TITLE
runtime: guard optional regexp object lifecycle in tcp server

### DIFF
--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -892,9 +892,9 @@ BEGINObjClassExit(tcps_sess, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in END
     objRelease(datetime, CORE_COMPONENT);
     objRelease(prop, CORE_COMPONENT);
     objRelease(parser, CORE_COMPONENT);
-    #ifdef FEATURE_REGEXP
+#ifdef FEATURE_REGEXP
     objRelease(regexp, LM_REGEXP_FILENAME);
-    #endif
+#endif
 ENDObjClassExit(tcps_sess)
 
 
@@ -908,9 +908,9 @@ BEGINObjClassInit(tcps_sess, 1, OBJ_IS_CORE_MODULE) /* class, version - CHANGE c
     CHKiRet(objUse(datetime, CORE_COMPONENT));
     CHKiRet(objUse(prop, CORE_COMPONENT));
     CHKiRet(objUse(parser, CORE_COMPONENT));
-    #ifdef FEATURE_REGEXP
+#ifdef FEATURE_REGEXP
     CHKiRet(objUse(regexp, LM_REGEXP_FILENAME));
-    #endif
+#endif
 
     CHKiRet(objUse(glbl, CORE_COMPONENT));
     objRelease(glbl, CORE_COMPONENT);

--- a/runtime/tcps_sess.c
+++ b/runtime/tcps_sess.c
@@ -892,7 +892,9 @@ BEGINObjClassExit(tcps_sess, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in END
     objRelease(datetime, CORE_COMPONENT);
     objRelease(prop, CORE_COMPONENT);
     objRelease(parser, CORE_COMPONENT);
+    #ifdef FEATURE_REGEXP
     objRelease(regexp, LM_REGEXP_FILENAME);
+    #endif
 ENDObjClassExit(tcps_sess)
 
 
@@ -906,7 +908,9 @@ BEGINObjClassInit(tcps_sess, 1, OBJ_IS_CORE_MODULE) /* class, version - CHANGE c
     CHKiRet(objUse(datetime, CORE_COMPONENT));
     CHKiRet(objUse(prop, CORE_COMPONENT));
     CHKiRet(objUse(parser, CORE_COMPONENT));
+    #ifdef FEATURE_REGEXP
     CHKiRet(objUse(regexp, LM_REGEXP_FILENAME));
+    #endif
 
     CHKiRet(objUse(glbl, CORE_COMPONENT));
     objRelease(glbl, CORE_COMPONENT);

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -2385,7 +2385,9 @@ BEGINObjClassExit(tcpsrv, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in END MA
     objRelease(netstrms, DONT_LOAD_LIB);
     objRelease(netstrm, LM_NETSTRMS_FILENAME);
     objRelease(net, LM_NET_FILENAME);
+    #ifdef FEATURE_REGEXP
     objRelease(regexp, LM_REGEXP_FILENAME);
+    #endif
 ENDObjClassExit(tcpsrv)
 
 
@@ -2404,7 +2406,9 @@ BEGINObjClassInit(tcpsrv, 1, OBJ_IS_LOADABLE_MODULE) /* class, version - CHANGE 
     CHKiRet(objUse(ruleset, CORE_COMPONENT));
     CHKiRet(objUse(statsobj, CORE_COMPONENT));
     CHKiRet(objUse(prop, CORE_COMPONENT));
+    #ifdef FEATURE_REGEXP
     CHKiRet(objUse(regexp, LM_REGEXP_FILENAME));
+    #endif
 
     /* set our own handlers */
     OBJSetMethodHandler(objMethod_DEBUGPRINT, tcpsrvDebugPrint);

--- a/runtime/tcpsrv.c
+++ b/runtime/tcpsrv.c
@@ -2385,9 +2385,9 @@ BEGINObjClassExit(tcpsrv, OBJ_IS_LOADABLE_MODULE) /* CHANGE class also in END MA
     objRelease(netstrms, DONT_LOAD_LIB);
     objRelease(netstrm, LM_NETSTRMS_FILENAME);
     objRelease(net, LM_NET_FILENAME);
-    #ifdef FEATURE_REGEXP
+#ifdef FEATURE_REGEXP
     objRelease(regexp, LM_REGEXP_FILENAME);
-    #endif
+#endif
 ENDObjClassExit(tcpsrv)
 
 
@@ -2406,9 +2406,9 @@ BEGINObjClassInit(tcpsrv, 1, OBJ_IS_LOADABLE_MODULE) /* class, version - CHANGE 
     CHKiRet(objUse(ruleset, CORE_COMPONENT));
     CHKiRet(objUse(statsobj, CORE_COMPONENT));
     CHKiRet(objUse(prop, CORE_COMPONENT));
-    #ifdef FEATURE_REGEXP
+#ifdef FEATURE_REGEXP
     CHKiRet(objUse(regexp, LM_REGEXP_FILENAME));
-    #endif
+#endif
 
     /* set our own handlers */
     OBJSetMethodHandler(objMethod_DEBUGPRINT, tcpsrvDebugPrint);


### PR DESCRIPTION
### Motivation
- A recent change added unconditional `objUse/objRelease(regexp, LM_REGEXP_FILENAME)` calls in `tcpsrv` and `tcps_sess`, which creates a hard runtime dependency on `lmregexp` even when builds are configured with `--disable-regexp`, causing imtcp/tcpsrv initialization to fail in no-regexp builds.

### Description
- Wrap `objUse(regexp, LM_REGEXP_FILENAME)` and `objRelease(regexp, LM_REGEXP_FILENAME)` in `#ifdef FEATURE_REGEXP` guards in `runtime/tcpsrv.c`.
- Wrap `objUse(regexp, LM_REGEXP_FILENAME)` and `objRelease(regexp, LM_REGEXP_FILENAME)` in `#ifdef FEATURE_REGEXP` guards in `runtime/tcps_sess.c`.
- Change is minimal and preserves existing regex-framing behavior when `FEATURE_REGEXP` is enabled while removing the unconditional dependency when it is not.

### Testing
- Ran the repository-guided incremental validation attempt: `make -j$(nproc) check TESTS=""`, which failed in this environment with `No rule to make target 'check'` so full automated build/test could not be executed here.
- Verified the guarded calls are present in the modified files by inspecting the updated source (`runtime/tcpsrv.c` and `runtime/tcps_sess.c`) after the change; no further automated tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15f9d053f0833281ebf6694a2188b8)