### PR TITLE
dynstats: coalesce pending persistence writes per bucket

### DIFF
--- a/runtime/dynstats.c
+++ b/runtime/dynstats.c
@@ -1309,6 +1309,7 @@ static void ATTR_NONNULL(1) destroyFileWriteWorker(dynstats_buckets_t *bkts) {
 
 static rsRetVal ATTR_NONNULL(1) enqueueFileWriteTask(dynstats_bucket_t *b, const char *file_name, const char *content) {
     file_write_entry_t *task;
+    file_write_entry_t *queued_task;
     dynstats_buckets_t *bkts;
     DEFiRet;
 
@@ -1316,6 +1317,22 @@ static rsRetVal ATTR_NONNULL(1) enqueueFileWriteTask(dynstats_bucket_t *b, const
     bkts = b->bkts;
     if (!bkts) {
         FINALIZE;
+    }
+
+    task = NULL;
+    pthread_mutex_lock(&bkts->work_q.mut);
+    STAILQ_FOREACH(queued_task, &bkts->work_q.q, link) {
+        if (queued_task->bucket == b) {
+            char *new_content = strdup(content);
+            if (new_content == NULL) {
+                pthread_mutex_unlock(&bkts->work_q.mut);
+                ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+            }
+            free((void *)queued_task->content);
+            queued_task->content = new_content;
+            pthread_mutex_unlock(&bkts->work_q.mut);
+            FINALIZE;
+        }
     }
 
     CHKmalloc(task = malloc(sizeof(file_write_entry_t)));
@@ -1329,10 +1346,10 @@ static rsRetVal ATTR_NONNULL(1) enqueueFileWriteTask(dynstats_bucket_t *b, const
         free(task);
         task =
             NULL; /* Prevent double-free in error handler if it existed, though here finalize handles NULL task check */
+        pthread_mutex_unlock(&bkts->work_q.mut);
         ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
     }
 
-    pthread_mutex_lock(&bkts->work_q.mut);
     STAILQ_INSERT_TAIL(&bkts->work_q.q, task, link);
     bkts->work_q.size++;
     STATSCOUNTER_INC(bkts->work_q.ctrEnq, bkts->work_q.mutCtrEnq);

--- a/runtime/dynstats.c
+++ b/runtime/dynstats.c
@@ -1335,7 +1335,11 @@ static rsRetVal ATTR_NONNULL(1) enqueueFileWriteTask(dynstats_bucket_t *b, const
         }
     }
 
-    CHKmalloc(task = malloc(sizeof(file_write_entry_t)));
+    task = malloc(sizeof(file_write_entry_t));
+    if (task == NULL) {
+        pthread_mutex_unlock(&bkts->work_q.mut);
+        ABORT_FINALIZE(RS_RET_OUT_OF_MEMORY);
+    }
     task->bucket = b;
     task->name = strdup(file_name);
     task->content = strdup(content);


### PR DESCRIPTION
### Motivation
- The dynstats persistence worker accepted unlimited queued write tasks, each duplicating a full serialized bucket state, which allowed repeated updates to attacker-controlled metrics to drive unbounded memory growth and long shutdowns.
- The goal is to prevent unbounded queue growth while preserving async persistence semantics and existing worker lifecycle.

### Description
- Change `enqueueFileWriteTask()` to scan the `work_q` under `work_q.mut` and, if a queued task for the same bucket exists, replace only its `content` with the new serialized JSON and return instead of appending a new task.
- Preserve the original enqueue path and worker wake-up behavior when no pending task exists, and keep existing stats counters and bookkeeping intact.
- The fix is minimal and limited to `runtime/dynstats.c`, avoiding broader synchronization or architecture changes.

### Testing
- Attempted to run the repository test target with `make -j$(nproc) check TESTS=""`, but the environment reported `No rule to make target 'check'`, so automated test harnesses were not executed here.
- Verified the patched logic via code inspection and line-numbered diffs to ensure pending-task coalescing and correct mutex unlocking were introduced; no automated unit or integration tests were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f5a6c9eec8332a472c3a7ac10939e)