### PR TITLE
testbench: bind OTEL collector on dynamic port

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -3340,6 +3340,7 @@ EXTRA_DIST += \
 	testsuites/omprog-single-instance-bin.sh \
 	testsuites/omprog-transactions-bin.sh \
 	omotel_proxy_server.py \
+	otel_collector_find_port.py \
 	testsuites/ommail-sendmail-bin.sh \
 	testsuites/imfile-old-state-file_imfile-state_.-rsyslog.input \
 	imfile-endmsg.regex.crio.rulebase \

--- a/tests/diag.sh
+++ b/tests/diag.sh
@@ -4212,6 +4212,32 @@ otel_collector_extract_cached_file() {
 	(cd "$otelcol_work_dir" && tar -zxf "$dep_otel_collector_cached_file") > /dev/null
 }
 
+otel_collector_discover_otlp_port() {
+	local otelcol_pid="$1"
+	local python_bin="${PYTHON:-}"
+	local find_port_py="$srcdir/otel_collector_find_port.py"
+
+	if [ "$(uname -s)" != "Linux" ]; then
+		printf 'SKIP: OTEL Collector dynamic port discovery requires Linux /proc socket tables\n'
+		skip_test
+	fi
+	if [ -n "$python_bin" ] && ! command -v "$python_bin" >/dev/null 2>&1; then
+		python_bin=""
+	fi
+	if [ -z "$python_bin" ]; then
+		if command -v python3 >/dev/null 2>&1; then
+			python_bin=$(command -v python3)
+		elif command -v python >/dev/null 2>&1; then
+			python_bin=$(command -v python)
+		fi
+	fi
+	if [ -z "$python_bin" ]; then
+		echo "ERROR: no Python interpreter available to discover OTEL Collector port"
+		return 1
+	fi
+	"$python_bin" "$find_port_py" "$otelcol_pid"
+}
+
 # prepare OTEL Collector instance for test
 prepare_otel_collector() {
 	# Ensure RSYSLOG_DYNNAME is set for per-test directory isolation
@@ -4307,17 +4333,18 @@ prepare_otel_collector() {
 	# Ensure the output directory exists (OTEL Collector file exporter may not create it)
 	mkdir -p "$(dirname "$otel_output_file")"
 
-	# Get a free port for the collector (use existing get_free_port function for portability)
-	if [ -z "$OTEL_COLLECTOR_PORT" ]; then
-		OTEL_COLLECTOR_PORT=$(get_free_port)
-	fi
+	# Let the collector bind dynamic localhost ports itself. This avoids the
+	# classic get_free_port race where a parallel test can claim the port
+	# between discovery and collector startup. start_otel_collector() discovers
+	# the actual OTLP listener after the collector process owns it.
+	OTEL_COLLECTOR_PORT="${OTEL_COLLECTOR_PORT:-0}"
+	OTEL_METRICS_PORT="${OTEL_METRICS_PORT:-0}"
+	OTEL_COLLECTOR_ENDPOINT="${OTEL_COLLECTOR_ENDPOINT:-127.0.0.1:$OTEL_COLLECTOR_PORT}"
+	OTEL_METRICS_ENDPOINT="${OTEL_METRICS_ENDPOINT:-127.0.0.1:$OTEL_METRICS_PORT}"
 	export OTEL_COLLECTOR_PORT
-
-	# Get a free port for metrics/telemetry
-	if [ -z "$OTEL_METRICS_PORT" ]; then
-		OTEL_METRICS_PORT=$(get_free_port)
-	fi
 	export OTEL_METRICS_PORT
+	export OTEL_COLLECTOR_ENDPOINT
+	export OTEL_METRICS_ENDPOINT
 
 	if [ ! -f $srcdir/testsuites/$dep_work_otel_collector_config ]; then
 		echo "OTEL Collector config template not found: $srcdir/testsuites/$dep_work_otel_collector_config"
@@ -4332,8 +4359,8 @@ prepare_otel_collector() {
 	# Ensure it's properly escaped for sed replacement string (only &, \, and delimiter need escaping)
 	otel_output_file_escaped=$(printf '%s\n' "$otel_output_file" | sed -e 's/[&|\\]/\\&/g')
 	sed -i "s|\${OTEL_OUTPUT_FILE}|$otel_output_file_escaped|g" "$otelcol_work_dir/config.yaml"
-	sed -i "s|\${OTEL_METRICS_PORT}|$OTEL_METRICS_PORT|g" "$otelcol_work_dir/config.yaml"
-	sed -i "s|endpoint: 0.0.0.0:0|endpoint: 0.0.0.0:$OTEL_COLLECTOR_PORT|g" "$otelcol_work_dir/config.yaml"
+	sed -i "s|\${OTEL_COLLECTOR_ENDPOINT}|$OTEL_COLLECTOR_ENDPOINT|g" "$otelcol_work_dir/config.yaml"
+	sed -i "s|\${OTEL_METRICS_ENDPOINT}|$OTEL_METRICS_ENDPOINT|g" "$otelcol_work_dir/config.yaml"
 
 	if [ ! -f "$otelcol_work_dir/config.yaml" ]; then
 		echo "Failed to create OTEL Collector config file"
@@ -4388,7 +4415,7 @@ start_otel_collector() {
 	otelcol_binary_rel="./otelcol-contrib"
 
 	# Start collector in background and capture output (both stdout and stderr)
-	(cd "$otelcol_work_dir" && $otelcol_binary_rel --config=config.yaml > $dep_work_otel_collector_logfile 2>&1) &
+	(cd "$otelcol_work_dir" && exec $otelcol_binary_rel --config=config.yaml > $dep_work_otel_collector_logfile 2>&1) &
 	otelcol_pid=$!
 	echo $otelcol_pid > $dep_work_otel_collector_pidfile
 
@@ -4399,23 +4426,46 @@ start_otel_collector() {
 		sleep 0.5
 	fi
 
-	# Use the port we configured (no discovery needed)
-	otel_port="$OTEL_COLLECTOR_PORT"
-	if [ -z "$otel_port" ]; then
-		echo "ERROR: OTEL_COLLECTOR_PORT not set. Did you call prepare_otel_collector()?"
+	if ! kill -0 $otelcol_pid 2>/dev/null; then
+		echo "OTEL Collector process exited during startup"
+		if [ -f $dep_work_otel_collector_logfile ]; then
+			echo "Dumping OTEL Collector log:"
+			cat $dep_work_otel_collector_logfile
+		fi
 		error_exit 1
 	fi
-	echo $otel_port > $otel_port_file
-	echo "OTEL Collector configured to listen on port $otel_port"
 
-	# Wait a bit more for collector to be fully ready
+	# Wait a bit more for collector to be fully ready and listening.
 	if [ -n "$TESTTOOL_DIR" ] && [ -f "$TESTTOOL_DIR/msleep" ]; then
 		$TESTTOOL_DIR/msleep 1000
 	else
 		sleep 1
 	fi
 
-	# Verify port is listening using existing helper function
+	otel_port=""
+	case "$OTEL_COLLECTOR_ENDPOINT" in
+	*:0) ;;
+	*:[0-9]*)
+		otel_port="${OTEL_COLLECTOR_ENDPOINT##*:}"
+		;;
+	esac
+	if [ -z "$otel_port" ]; then
+		otel_port=$(otel_collector_discover_otlp_port "$otelcol_pid")
+	fi
+	if [ -z "$otel_port" ]; then
+		echo "ERROR: unable to discover OTEL Collector OTLP HTTP listener port"
+		if [ -f $dep_work_otel_collector_logfile ]; then
+			echo "Dumping OTEL Collector log:"
+			cat $dep_work_otel_collector_logfile
+		fi
+		kill $otelcol_pid 2>/dev/null
+		error_exit 1
+	fi
+
+	# Publish the port only after proving it belongs to the collector process.
+	echo $otel_port > $otel_port_file
+	echo "OTEL Collector discovered OTLP listener on port $otel_port"
+
 	if ! wait_for_tcp_service "127.0.0.1" "$otel_port" 10 "OTEL Collector"; then
 		echo "OTEL Collector port $otel_port is not listening"
 		if [ -f $dep_work_otel_collector_logfile ]; then

--- a/tests/omotel-proxy.sh
+++ b/tests/omotel-proxy.sh
@@ -188,6 +188,12 @@ echo "=== Test 2: Proxy with authentication ==="
 stop_proxy
 sleep 1
 
+# Restart OTEL Collector before creating the authenticated proxy so the proxy
+# forwards to the current dynamic collector port.
+prepare_otel_collector
+start_otel_collector
+otel_port2=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
+
 proxy_port_file2="${RSYSLOG_DYNNAME}.proxy2_port.file"
 proxy_data_file2="${RSYSLOG_DYNNAME}.proxy2_data.json"
 
@@ -196,7 +202,7 @@ python3 "$proxy_server_py" \
 	--port 0 \
 	--port-file "$proxy_port_file2" \
 	--target-host 127.0.0.1 \
-	--target-port "$otel_port" \
+	--target-port "$otel_port2" \
 	--require-auth \
 	--user "testuser" \
 	--password "testpass" \
@@ -219,11 +225,6 @@ stop_proxy2() {
 	fi
 }
 trap 'stop_proxy2' EXIT
-
-# Restart OTEL Collector for second test
-prepare_otel_collector
-start_otel_collector
-otel_port2=$(cat ${RSYSLOG_DYNNAME}.otel_port.file)
 
 generate_conf
 add_conf '

--- a/tests/otel_collector_find_port.py
+++ b/tests/otel_collector_find_port.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Find the OTLP HTTP listener port owned by an OTEL Collector process."""
+
+import argparse
+import glob
+import os
+import socket
+import sys
+import urllib.error
+import urllib.request
+
+
+def get_socket_inodes(pid):
+    """Return socket inode strings referenced by pid's file descriptors."""
+    socket_inodes = set()
+    for fd in glob.glob("/proc/{0}/fd/*".format(pid)):
+        try:
+            target = os.readlink(fd)
+        except OSError:
+            continue
+        if target.startswith("socket:[") and target.endswith("]"):
+            socket_inodes.add(target[8:-1])
+    return socket_inodes
+
+
+def iter_listen_ports(socket_inodes):
+    """Yield TCP listen ports whose socket inode belongs to the process."""
+    for proc_net in ("/proc/net/tcp", "/proc/net/tcp6"):
+        try:
+            with open(proc_net, encoding="ascii") as net_file:
+                lines = net_file.read().splitlines()[1:]
+        except OSError:
+            continue
+
+        for line in lines:
+            parts = line.split()
+            if len(parts) < 10 or parts[3] != "0A" or parts[9] not in socket_inodes:
+                continue
+            try:
+                _, port_hex = parts[1].rsplit(":", 1)
+                yield int(port_hex, 16)
+            except ValueError:
+                continue
+
+
+def is_otlp_http_port(port):
+    """Return true if the port behaves like an OTLP HTTP /v1/logs endpoint."""
+    req = urllib.request.Request(
+        "http://127.0.0.1:{0}/v1/logs".format(port),
+        data=b"{}",
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        # Probe only a fixed localhost URL with an integer port discovered from
+        # the collector process, so urlopen cannot be redirected to arbitrary
+        # schemes or hosts here.
+        with urllib.request.urlopen(req, timeout=1) as response:  # nosec B310
+            status = response.getcode()
+    except urllib.error.HTTPError as exc:
+        status = exc.code
+    except (OSError, urllib.error.URLError, socket.timeout):
+        return False
+
+    # The OTLP HTTP receiver answers on /v1/logs even for invalid probe
+    # payloads; the collector metrics endpoint does not expose that route.
+    return status != 404
+
+
+def find_otlp_port(pid):
+    """Return the discovered OTLP HTTP listener port, or None."""
+    socket_inodes = get_socket_inodes(pid)
+    if not socket_inodes:
+        return None
+
+    for port in sorted(set(iter_listen_ports(socket_inodes))):
+        if is_otlp_http_port(port):
+            return port
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Find the OTLP HTTP listener port owned by an OTEL Collector process."
+    )
+    parser.add_argument("pid", help="OTEL Collector process id")
+    args = parser.parse_args()
+
+    port = find_otlp_port(args.pid)
+    if port is None:
+        return 1
+
+    print(port)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/testsuites/otel-collector-config.yaml
+++ b/tests/testsuites/otel-collector-config.yaml
@@ -2,7 +2,7 @@ receivers:
   otlp:
     protocols:
       http:
-        endpoint: 0.0.0.0:0
+        endpoint: ${OTEL_COLLECTOR_ENDPOINT}
 
 exporters:
   file:
@@ -13,7 +13,7 @@ exporters:
 service:
   telemetry:
     metrics:
-      address: 0.0.0.0:${OTEL_METRICS_PORT}
+      address: ${OTEL_METRICS_ENDPOINT}
   pipelines:
     logs:
       receivers: [otlp]


### PR DESCRIPTION
## Summary
- let the OTEL Collector bind localhost dynamic ports instead of preselecting with `get_free_port`
- discover the collector-owned OTLP HTTP listener from `/proc` socket ownership and a `/v1/logs` probe
- publish the test port file only after discovery and readiness succeed

## Why
The de-flake campaign exposed a real testbench race: a parallel test could claim the `get_free_port` result before `otelcol` bound it. The readiness check could then connect to the wrong service, while omotel retried against a dead collector path.

## Validation
- `bash -n tests/diag.sh tests/omotel-batch.sh tests/omotel-basic.sh`
- `python3 -m py_compile tests/otel_collector_find_port.py`
- `devtools/format-python.sh --check-if-available tests/otel_collector_find_port.py` (pycodestyle not installed locally)
- container targeted: `./omotel-batch.sh && ./omotel-basic.sh` passed
- container targeted after moving helper in-tree: `./omotel-batch.sh` passed
- full Ubuntu 26.04 container check: 1280 total, 1187 pass, 93 skip, 0 fail, 0 error, 4m47.77s

Note: the full generic Ubuntu 26.04 run did not enable `omotel`; the targeted container runs above are the direct OTEL coverage for this helper change.
