### PR TITLE
doc: fix invalid SIGINT config parameter spelling in rsyslogd.8

### DIFF
--- a/tools/rsyslogd.8
+++ b/tools/rsyslogd.8
@@ -167,7 +167,7 @@ will die. This signal is only processed if
 was started with the
 .B "\-d"
 debug option, if the
-.B shutdown.enable.ctl-c
+.B shutdown.enable.ctlc
 global config parameter is set, or if running as PID 1 (e.g. in a container).
 .TP
 .B USR1


### PR DESCRIPTION
### Motivation
- The rsyslogd man page documented the SIGINT enable parameter as `shutdown.enable.ctl-c`, but the runtime parser and config handling use `shutdown.enable.ctlc`, which can cause configuration parse errors and prevent the intended SIGINT behavior.

### Description
- Update `tools/rsyslogd.8` to replace `shutdown.enable.ctl-c` with the correct `shutdown.enable.ctlc` so the documentation matches the implemented parameter name.

### Testing
- Ran a set of automated checks that confirmed the change and its presence: `rg -n "shutdown\.enable\.ctl-?c|SIGINT|shutdown\.enable\.ctlc" tools/rsyslogd.8 runtime/glbl.c tools/rsyslogd.c` (succeeded), `git diff -- tools/rsyslogd.8` (succeeded), `nl -ba tools/rsyslogd.8 | sed -n '160,176p'` (confirmed updated lines), and the change was committed successfully as `doc: fix shutdown.enable.ctlc spelling in rsyslogd man page`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16a165fb8c833286dba83198bad564)