### PR TITLE
testbench: fix da-mainmsg-q flow control

### DIFF
--- a/tests/da-mainmsg-q.sh
+++ b/tests/da-mainmsg-q.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
-# Test for DA mode on the main message queue
-# This test checks if DA mode operates correctly. To do so,
-# it uses a small in-memory queue size, so that DA mode is initiated
-# rather soon, and disk spooling used. There is some uncertainty (based
-# on machine speeds), but in general the test should work rather well.
-# We add a few messages after the initial run, just so that we can
-# check everything recovers from DA mode correctly.
+# Test disk-assisted mode on the main message queue. The test uses a very small
+# in-memory main queue so the 2000-message burst must spill to disk and then
+# drain back into the configured omfile action. imdiag injection is marked fully
+# delayable so the diagnostic injector does not overrun the intentionally tiny
+# queue; the behavior under test is DA queue persistence and recovery, not
+# non-delayable input loss. The oracle is the complete output sequence 0..2099:
+# first the pre-DA messages, then the DA-triggering burst, then a final small
+# post-DA burst that proves normal processing resumed.
 # added 2009-04-22 by Rgerhards
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
+export RSTB_IMDIAG_INJECT_DELAY_MODE=full
 generate_conf
 add_conf '
 $ModLoad ../plugins/imtcp/.libs/imtcp
@@ -42,6 +44,7 @@ wait_file_lines $RSYSLOG_OUT_LOG 2050 # wait to ensure DA queue is "empty"
 
 # send another handful
 injectmsg 2050 50
+wait_file_lines $RSYSLOG_OUT_LOG 2100
 
 shutdown_when_empty
 wait_shutdown


### PR DESCRIPTION
## Summary

This fixes a `da-mainmsg-q.sh` flake found during the de-flake campaign.
The test is supposed to validate disk-assisted main queue behavior, but its
own imdiag injection could overrun the deliberately tiny queue under CI stress.

## Root Cause

`da-mainmsg-q.sh` configures a small main queue so that a 2000-message burst
spills to disk-assisted mode. The burst was injected through imdiag using the
default non-delayable flow-control mode, so the diagnostic injector could cause
message loss before the test had isolated the DA queue behavior it was meant to
verify.

There was also a weaker final oracle: after the post-DA 50-message recovery
burst, the test shut down based on queue-empty without first observing the final
omfile output count.

## Changes

- Mark imdiag-generated messages as fully delayable for this test via
  `RSTB_IMDIAG_INJECT_DELAY_MODE=full` before `generate_conf`.
- Keep the small DA queue configuration unchanged.
- Wait for 2100 output lines after the final recovery burst before shutdown.
- Refresh the test header to document the behavior, stimulus, and oracle.

## Validation

- `bash -n tests/da-mainmsg-q.sh`
- Targeted Ubuntu 26.04 container run: `da-mainmsg-q.sh` passed.
- Full Ubuntu 26.04 container check:
  - image: `rsyslog/rsyslog_dev_base_ubuntu:26.04`
  - image ID: `sha256:8edc2cda1e0d2b6f6eca70aaea24bb92db161a3bca5116418a9a6cc9fe5eecf6`
  - command shape: `devtools/devcontainer.sh --rm devtools/run-ci.sh` with `CI_MAKE_CHECK_OPT=-j80`, `RSYSLOG_TESTBENCH_CHANGED_FILES=tests/da-mainmsg-q.sh`
  - result: `1280 total, 1187 pass, 93 skip, 0 fail`
  - runtime: `4m18s`
