### PR TITLE
ommysql: guard transaction commit after disconnect

### DIFF
--- a/plugins/ommysql/ommysql.c
+++ b/plugins/ommysql/ommysql.c
@@ -352,6 +352,10 @@ BEGINcommitTransaction
         }
     }
 
+    if (pWrkrData->hmysql == NULL) {
+        DBGPRINTF("ommysql: transaction connection closed before commit\n");
+        ABORT_FINALIZE(RS_RET_SUSPENDED);
+    }
     if (mysql_commit(pWrkrData->hmysql) != 0) {
         DBGPRINTF("ommysql: server error: transaction not committed\n");
         reportDBError(pWrkrData, 0);

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -815,6 +815,7 @@ TESTS_MYSQL = \
 	mysql-asyn.sh \
 	mysql-actq-mt.sh \
 	mysql-actq-mt-withpause.sh \
+	mysql-unavailable-transaction.sh \
 	action-tx-single-processing.sh \
 	action-tx-errfile-maxsize.sh \
 	action-tx-errfile.sh \

--- a/tests/mysql-unavailable-transaction.sh
+++ b/tests/mysql-unavailable-transaction.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Regression coverage for GitHub issue #4199. ommysql must suspend cleanly when
+# the database connection is unavailable while transaction support is active.
+# The oracle is synchronized shutdown plus the normal ommysql diagnostic in
+# rsyslog's configured output path; the test must not crash or hang.
+. ${srcdir:=.}/diag.sh init
+require_plugin ommysql
+
+export NUMMESSAGES=1
+mysql_port="$(get_free_port)"
+
+generate_conf
+add_conf '
+module(load="../plugins/ommysql/.libs/ommysql")
+
+template(name="outfmt" type="string" string="%msg%\n")
+
+:msg, contains, "msgnum:" {
+	action(type="ommysql"
+		server="127.0.0.1"
+		serverport="'$mysql_port'"
+		db="'$RSYSLOG_DYNNAME'"
+		uid="rsyslog"
+		pwd="testbench"
+		queue.type="Direct"
+		action.resumeRetryCount="0"
+		action.resumeInterval="1")
+}
+
+syslog.* {
+	action(type="omfile" template="outfmt" file="'$RSYSLOG_OUT_LOG'")
+}
+'
+
+startup
+injectmsg
+shutdown_when_empty
+wait_shutdown
+
+content_check "ommysql:" "$RSYSLOG_OUT_LOG"
+check_not_present "Segmentation fault" "$RSYSLOG_OUT_LOG"
+
+exit_test


### PR DESCRIPTION
## Summary
- guard ommysql transaction commit when reconnect failure already closed the MySQL handle
- add regression coverage for an unavailable MySQL endpoint while transactional action handling is active

Closes https://github.com/rsyslog/rsyslog/issues/4199

## Local validation
- shellcheck -S warning tests/mysql-unavailable-transaction.sh
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout --enable-mysql --enable-mysql-tests
- make -j$(nproc)
- ./tests/mysql-unavailable-transaction.sh
- make check TESTS=mysql-unavailable-transaction.sh
- rsyslog/rsyslog_dev_base_ubuntu:26.04 (sha256:0261050851cd52e531d6b11d840563bd603d4af23b2a3728e09c040772c64276): static analyzer, no bugs found
- rsyslog/rsyslog_dev_base_ubuntu:26.04 (same image): full devcontainer run-ci.sh, 1283 total / 1203 pass / 80 skip / 0 fail / 0 error
- cubic review --base upstream/main --json: no issues

## Container lane notes
- MySQL support/tests were kept enabled because this PR touches ommysql.
- Kafka/Elasticsearch were disabled only for the static analyzer lane as unrelated analyzer cost controls.
- Full Ubuntu 26.04 run-ci used the skill default feature set and let service-backed tests self-skip where services were unavailable.