### PR TITLE
configure: detect relpCltSetKeepAlive support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2005,6 +2005,8 @@ if test "x$enable_relp" = "xyes"; then
                       [AC_DEFINE([HAVE_RELPENGINESETTLSLIBBYNAME], [1], [Define if relpEngineSetTLSLibByName exists.])])
         AC_CHECK_FUNC([relpSrvSetTlsConfigCmd],
                       [AC_DEFINE([HAVE_RELPENGINESETTLSCFGCMD], [1], [Define if relpSrvSetTlsConfigCmd exists.])])
+        AC_CHECK_FUNC([relpCltSetKeepAlive],
+                      [AC_DEFINE([HAVE_RELPCLTSETKEEPALIVE], [1], [Define if relpCltSetKeepAlive exists.])])
         AC_CHECK_FUNC([relpSrvSetTlsConfigCmd],
                       [HAVE_RELPENGINESETTLSCFGCMD=1])
 


### PR DESCRIPTION
### Motivation
- omrelp accepts keepalive-related configuration but the call that applies them is guarded by `#if defined(HAVE_RELPCLTSETKEEPALIVE)` while `configure.ac` did not probe for `relpCltSetKeepAlive`, allowing the option to be parsed but silently ignored when the macro was not defined.

### Description
- Add an `AC_CHECK_FUNC([relpCltSetKeepAlive], ...)` probe in `configure.ac` so `HAVE_RELPCLTSETKEEPALIVE` is defined when the librelp API is available, enabling the existing compile-time guard in `plugins/omrelp/omrelp.c` to work as intended.

### Testing
- Ran `./autogen.sh` which regenerated the configure machinery and exercised the new probe path; `./configure` progressed but ultimately failed on a missing environment dependency (`snappy` headers), which is unrelated to this change and prevented a full `make check` in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16b3bfddb88332837779491744f962)