### PR TITLE
docker: fix ClickHouse configure flag in Debian 13 dev image

### DIFF
--- a/packaging/docker/dev_env/debian/base/13/Dockerfile
+++ b/packaging/docker/dev_env/debian/base/13/Dockerfile
@@ -257,7 +257,7 @@ ENV	RSYSLOG_CONFIGURE_OPTIONS \
 	--enable-omjournal \
 	--disable-omkafka \
 	--enable-ommongodb \
-	--enable-omclickhouse \
+	--enable-clickhouse \
 	--enable-omprog \
 	--enable-omrelp-default-port=13515 \
 	--enable-omruleset \


### PR DESCRIPTION
### Motivation
- The Debian 13 development Dockerfile passed `--enable-omclickhouse`, but `configure.ac` defines the ClickHouse toggle as `--enable-clickhouse`, so the intended `omclickhouse` module remained disabled in the dev image.

### Description
- Replace `--enable-omclickhouse` with `--enable-clickhouse` in `packaging/docker/dev_env/debian/base/13/Dockerfile` so the Dockerfile uses the same Autoconf option defined by `AC_ARG_ENABLE(clickhouse)`.

### Testing
- Verified the change by running `rg -n "clickhouse" packaging/docker/dev_env/debian/base/13/Dockerfile configure.ac` and inspecting the Dockerfile snippet with `nl -ba packaging/docker/dev_env/debian/base/13/Dockerfile | sed -n '254,266p'`, both showing the corrected `--enable-clickhouse` entry.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16d467cc8883329b968d8695bdd2f9)