### PR TITLE
doc: correct mmrfc5424addhmac SD-ID parameter spelling

### DIFF
--- a/doc/source/configuration/modules/mmrfc5424addhmac.rst
+++ b/doc/source/configuration/modules/mmrfc5424addhmac.rst
@@ -51,7 +51,7 @@ Action Parameters
      - .. include:: ../../reference/parameters/mmrfc5424addhmac-hashfunction.rst
         :start-after: .. summary-start
         :end-before: .. summary-end
-   * - :ref:`sdId <param-mmrfc5424addhmac-sd-id>`
+   * - :ref:`sd_id <param-mmrfc5424addhmac-sd-id>`
      - .. include:: ../../reference/parameters/mmrfc5424addhmac-sd-id.rst
         :start-after: .. summary-start
         :end-before: .. summary-end

--- a/doc/source/reference/parameters/mmrfc5424addhmac-sd-id.rst
+++ b/doc/source/reference/parameters/mmrfc5424addhmac-sd-id.rst
@@ -1,12 +1,13 @@
 .. _param-mmrfc5424addhmac-sd-id:
+.. _mmrfc5424addhmac.parameter.action.sd_id:
 .. _mmrfc5424addhmac.parameter.action.sdId:
 
-sdId
-====
+sd_id
+=====
 
 .. index::
-   single: mmrfc5424addhmac; sdId
-   single: sdId
+   single: mmrfc5424addhmac; sd_id
+   single: sd_id
 
 .. summary-start
 
@@ -16,7 +17,7 @@ Sets the RFC5424 structured data ID added to the message.
 
 This parameter applies to :doc:`../../configuration/modules/mmrfc5424addhmac`.
 
-:Name: sdId
+:Name: sd_id
 :Scope: action
 :Type: string
 :Default: none
@@ -30,12 +31,14 @@ will be added. Note that nothing is added if this SD-ID is already present.
 
 Action usage
 ------------
+.. _param-mmrfc5424addhmac-action-sd_id:
 .. _param-mmrfc5424addhmac-action-sdId:
+.. _mmrfc5424addhmac.parameter.action.sd_id-usage:
 .. _mmrfc5424addhmac.parameter.action.sdId-usage:
 
 .. code-block:: rsyslog
 
-   action(type="mmrfc5424addhmac" sdId="exampleSDID@32473")
+   action(type="mmrfc5424addhmac" sd_id="exampleSDID@32473")
 
 See also
 --------


### PR DESCRIPTION
### Motivation

- The module implementation requires the action parameter `sd_id` but the new docs published a camelCase `sdId`, which causes copy/paste configurations to fail during config validation because the descriptor has no `sdId` alias.

### Description

- Change the module parameter summary to reference `sd_id` instead of `sdId` in `doc/source/configuration/modules/mmrfc5424addhmac.rst`.
- Update the parameter reference page `doc/source/reference/parameters/mmrfc5424addhmac-sd-id.rst` to use `sd_id` for the title, `:Name:`, index entries, and the action usage example.
- Add and preserve backward-compatible anchors for `sdId` so existing links continue to resolve while the canonical name is `sd_id`.
- Commit message: `doc: fix mmrfc5424addhmac sd_id parameter name`.

### Testing

- Built the documentation with `./doc/tools/build-doc-linux.sh --clean --format html` and the build succeeded.
- Verified the changed pages render and the example now uses `sd_id` so it matches the runtime parameter descriptor (no runtime code changes were required).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16dd6f49248332bc04ab128c3646a7)