### PR TITLE
tests: avoid mysql action queue timeout flakes

### DIFF
--- a/tests/mysql-actq-mt-withpause.sh
+++ b/tests/mysql-actq-mt-withpause.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# test for mysql with multithread actionq
+# Verify that ommysql keeps multi-worker action queue delivery lossless across
+# worker idle timeout cycles.  The test injects three batches separated by
+# queue-empty waits and short sleeps so action workers can time out and be
+# restarted.  The 80s enqueue timeout is a CI tolerance budget: if a stressed
+# MySQL service cannot drain the action queue in that time, the failure should
+# be reevaluated instead of masking a persistent service or test issue.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=150000
@@ -14,7 +19,7 @@ module(load="../plugins/ommysql/.libs/ommysql")
 	queue.workerthreads="5"
 	queue.workerthreadMinimumMessages="500"
 	queue.timeoutWorkerthreadShutdown="1000"
-	queue.timeoutEnqueue="30000"
+	queue.timeoutEnqueue="80000"
 	)
 } 
 '

--- a/tests/mysql-actq-mt.sh
+++ b/tests/mysql-actq-mt.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
-# test for mysql with multithread actionq
+# Verify that ommysql preserves all messages when a bounded linked-list action
+# queue is drained by multiple worker threads.  The queue size is intentionally
+# small compared to the injected message count so the test covers backpressure.
+# The 80s enqueue timeout is a CI tolerance budget: if a stressed MySQL service
+# cannot drain the action queue in that time, the failure should be investigated
+# instead of silently turning the test into an unbounded wait.
 # This file is part of the rsyslog project, released under ASL 2.0
 . ${srcdir:=.}/diag.sh init
 export NUMMESSAGES=150000
@@ -14,7 +19,7 @@ module(load="../plugins/ommysql/.libs/ommysql")
 	queue.workerthreads="5"
 	queue.workerthreadMinimumMessages="500"
 	queue.timeoutWorkerthreadShutdown="1000"
-	queue.timeoutEnqueue="30000"
+	queue.timeoutEnqueue="80000"
 	queue.timeoutShutdown="30000"
 	)
 } 


### PR DESCRIPTION
## Summary
- make MySQL action-queue tests stop depending on a fixed 30s enqueue deadline
- keep bounded queue and multi-worker settings so backpressure coverage remains intact
- document each test's intent and oracle inline

## Why
Recent flake evidence showed `mysql-actq-mt*` dropping a message after `queue timeout(30000ms)`. These tests are meant to validate lossless ommysql delivery under bounded action queue pressure, not whether a shared/stressed MySQL service drains within a particular wall-clock interval.

## Validation
- `bash -n tests/mysql-actq-mt.sh tests/mysql-actq-mt-withpause.sh`
- `git diff --check`

Full local container validation was not run in this unconfigured worktree; CI should exercise the MySQL service lane.
