### PR TITLE
mmanon: avoid assert on malformed embedded IPv4-in-IPv6

### DIFF
--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -1703,9 +1703,9 @@ static size_t findV4Start(const uchar *const __restrict__ buf, size_t dotPos) {
         }
         dotPos--;
     }
-    assert(!"embedded IPv4 must have a ':' before its first '.'");
-    /* If assertions are disabled, fall back to start-of-substring; parsing will
-     * then fail and the caller will treat the sequence as non-IPv4. */
+    /* No ':' was found before the first dot. Treat this as a non-embedded
+     * IPv4 case by returning the start of the substring. The subsequent
+     * syntax_ipv4() check will fail and the caller will reject the candidate. */
     return 0;
 }
 


### PR DESCRIPTION
### Motivation
- Remove a reachable `assert()` in the mmanon embedded-IPv4 parser that can be triggered by attacker-controlled log text and abort rsyslogd in debug/assert-enabled builds.

### Description
- Replace the `assert()` in `plugins/mmanon/mmanon.c::findV4Start()` with a non-failing fallback that returns `0`, preserving the existing path where `syntax_ipv4()` will reject the candidate and keeping the change minimal and localized.

### Testing
- Ran `bash devtools/format-code.sh --git-changed` which completed successfully, and attempted `make -j$(nproc) check TESTS=""` which could not run in this environment because the checkout is not configured (no `check` target available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130e3674b8833298b904cafdaf6aef)