### PR TITLE
lookup: report active table reloads as pending

### DIFF
--- a/runtime/lookup.c
+++ b/runtime/lookup.c
@@ -123,7 +123,7 @@ static rsRetVal lookupNew(lookup_ref_t **ppThis) {
 
     CHKmalloc(pThis = calloc(1, sizeof(lookup_ref_t)));
     CHKmalloc(t = calloc(1, sizeof(lookup_t)));
-    pThis->do_reload = pThis->do_stop = 0;
+    pThis->do_reload = pThis->is_reloading = pThis->do_stop = 0;
     pThis->reload_on_hup = 1; /*DO reload on HUP (default)*/
 
     pThis->next = NULL;
@@ -157,7 +157,7 @@ static rsRetVal lookupActivateTable(lookup_ref_t *pThis) {
     CHKiConcCtrl(pthread_attr_init(&pThis->reloader_thd_attr));
     pThis->reloader_attr_initialized = 1;
     initialized++; /*4*/
-    pThis->do_reload = pThis->do_stop = 0;
+    pThis->do_reload = pThis->is_reloading = pThis->do_stop = 0;
     CHKiConcCtrl(pthread_create(&pThis->reloader, &pThis->reloader_thd_attr, lookupTableReloader, pThis));
     pThis->reloader_started = 1;
     initialized++; /*5*/
@@ -205,6 +205,7 @@ static void lookupStopReloader(lookup_ref_t *pThis) {
     pthread_mutex_lock(&pThis->reloader_mut);
     freeStubValueForReloadFailure(pThis);
     pThis->do_reload = 0;
+    pThis->is_reloading = 0;
     pThis->do_stop = 1;
     pthread_cond_signal(&pThis->run_reloader);
     pthread_mutex_unlock(&pThis->reloader_mut);
@@ -965,7 +966,7 @@ finalize_it:
 static uint8_t lookupIsReloadPending(lookup_ref_t *pThis) {
     uint8_t reload_pending;
     pthread_mutex_lock(&pThis->reloader_mut);
-    reload_pending = pThis->do_reload;
+    reload_pending = pThis->do_reload || pThis->is_reloading;
     pthread_mutex_unlock(&pThis->reloader_mut);
     return reload_pending;
 }
@@ -1028,9 +1029,11 @@ void *lookupTableReloader(void *self) {
             uchar *stub_val = pThis->stub_value_for_reload_failure;
             pThis->stub_value_for_reload_failure = NULL;
             pThis->do_reload = 0;
+            pThis->is_reloading = 1;
             pthread_mutex_unlock(&pThis->reloader_mut);
             lookupDoReload(pThis, stub_val);
             pthread_mutex_lock(&pThis->reloader_mut);
+            pThis->is_reloading = 0;
         } else {
             pthread_cond_wait(&pThis->run_reloader, &pThis->reloader_mut);
         }

--- a/runtime/lookup.h
+++ b/runtime/lookup.h
@@ -91,6 +91,8 @@ struct lookup_ref_s {
     uint8_t reloader_attr_initialized;
     uint8_t reloader_started;
     uint8_t do_reload;
+    /* Set after do_reload is consumed until the table swap is complete. */
+    uint8_t is_reloading;
     uint8_t do_stop;
     uint8_t reload_on_hup;
 };


### PR DESCRIPTION
## Summary
- fix lookup-table reload pending accounting so active reload work remains visible to imdiag waiters
- prevent HUP/reload tests from resuming while the reloader has consumed the request but has not yet swapped the table

## Why
The de-flake campaign found lookup-table tests observing old or stubbed values after await_lookup_table_reload returned. The runtime cleared do_reload before lookupDoReload() completed, so the wait helper could return inside the active reload window.

## Validation
- ./autogen.sh --enable-debug --enable-testbench --enable-imdiag --enable-omstdout
- make -j$(nproc) check TESTS=""
- ./tests/array_lookup_table.sh
- ./tests/lookup_table_bad_configs.sh
- git diff --check
- Ubuntu 26.04 dev container focused lookup reload run, 9/9 pass:
  - array_lookup_table.sh
  - array_lookup_table-vg.sh
  - array_lookup_table_misuse-vg.sh
  - lookup_table_bad_configs.sh
  - lookup_table_bad_configs-vg.sh
  - lookup_table_rscript_reload.sh
  - lookup_table_rscript_reload-vg.sh
  - lookup_table_rscript_reload_without_stub.sh
  - lookup_table_rscript_reload_without_stub-vg.sh