### PR TITLE
omhttp: refresh health-check headers after gzip rebuild

### DIFF
--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -232,6 +232,7 @@ typedef struct serverData_s {
     CURL *curlCheckConnHandle; /* libcurl session handle for checking the server connection */
     CURL *curlPostHandle; /* libcurl session handle for posting data to the server */
     HEADER *curlHeader; /* json POST request info */
+    HEADER *curlCheckHeader; /* health-check request headers */
     uchar *fullUrlPost; /* Keep the full url in cache if dynRestPath is off else last URL used */
     uchar *fullUrlHealth; /* Keep the full url healthCheck in cache */
     uchar *restPATH; /* Keep restPath last used */
@@ -393,6 +394,7 @@ BEGINcreateWrkrInstance
         pWrkrData->listServerDataWkr[i]->curlCheckConnHandle = NULL;
         pWrkrData->listServerDataWkr[i]->curlPostHandle = NULL;
         pWrkrData->listServerDataWkr[i]->curlHeader = NULL;
+        pWrkrData->listServerDataWkr[i]->curlCheckHeader = NULL;
         pWrkrData->listServerDataWkr[i]->fullUrlPost = NULL;
         pWrkrData->listServerDataWkr[i]->fullUrlHealth = NULL;
         pWrkrData->listServerDataWkr[i]->restPATH = NULL;
@@ -1420,8 +1422,10 @@ finalize_it:
         slist = temp;                                \
     } while (0);
 
-static rsRetVal ATTR_NONNULL()
-    buildCurlHeaders(wrkrInstanceData_t *pWrkrData, serverData_t *serverData, sbool contentEncodeGzip) {
+static rsRetVal ATTR_NONNULL() buildCurlHeaders(wrkrInstanceData_t *pWrkrData,
+                                                serverData_t *serverData,
+                                                HEADER **targetHeader,
+                                                sbool contentEncodeGzip) {
     struct curl_slist *slist = NULL;
     /* Optimization: Temp pointer to capture return without losing list on error */
     struct curl_slist *temp = NULL;
@@ -1476,8 +1480,9 @@ static rsRetVal ATTR_NONNULL()
         SAFE_APPEND(HTTP_HEADER_ENCODING_GZIP);
     }
 
-    curl_slist_free_all(serverData->curlHeader);
-    serverData->curlHeader = slist;
+    curl_slist_free_all(*targetHeader);
+    *targetHeader = slist;
+    slist = NULL;
     serverData->gzipHeaderEnabled = contentEncodeGzip;
 
 finalize_it:
@@ -1552,16 +1557,14 @@ static rsRetVal ATTR_NONNULL(1, 2) curlPost(wrkrInstanceData_t *pWrkrData,
          * Set Header if first request to the destination server
          */
         if (serverData->curlHeader == NULL) {
-            CHKiRet(buildCurlHeaders(pWrkrData, serverData, compressed));
+            CHKiRet(buildCurlHeaders(pWrkrData, serverData, &serverData->curlHeader, compressed));
             curl_easy_setopt(serverData->curlPostHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
-            curl_easy_setopt(serverData->curlCheckConnHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
         }
     }
 
     if (serverData->curlHeader == NULL || serverData->gzipHeaderEnabled != compressed) {
-        CHKiRet(buildCurlHeaders(pWrkrData, serverData, compressed));
+        CHKiRet(buildCurlHeaders(pWrkrData, serverData, &serverData->curlHeader, compressed));
         curl_easy_setopt(serverData->curlPostHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
-        curl_easy_setopt(serverData->curlCheckConnHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
     }
 
     /* Set Curl object here */
@@ -2119,6 +2122,7 @@ static void ATTR_NONNULL()
 static void ATTR_NONNULL() curlCheckConnSetup(wrkrInstanceData_t *const pWrkrData, serverData_t *serverData) {
     PTR_ASSERT_SET_TYPE(pWrkrData, WRKR_DATA_TYPE_ES);
     curlSetupCommon(pWrkrData, serverData, serverData->curlCheckConnHandle);
+    curl_easy_setopt(serverData->curlCheckConnHandle, CURLOPT_HTTPHEADER, serverData->curlCheckHeader);
     curl_easy_setopt(serverData->curlCheckConnHandle, CURLOPT_TIMEOUT_MS, pWrkrData->pData->healthCheckTimeout);
 }
 
@@ -2149,7 +2153,8 @@ static rsRetVal ATTR_NONNULL() curlSetup(wrkrInstanceData_t *const pWrkrData) {
     for (i = 0; i < pWrkrData->pData->numServers; i++) {
         serverData = pWrkrData->listServerDataWkr[i];
         assert(serverData != NULL);
-        CHKiRet(buildCurlHeaders(pWrkrData, serverData, 0));
+        CHKiRet(buildCurlHeaders(pWrkrData, serverData, &serverData->curlHeader, 0));
+        CHKiRet(buildCurlHeaders(pWrkrData, serverData, &serverData->curlCheckHeader, 0));
         CHKmalloc(serverData->curlCheckConnHandle = curl_easy_init());
         CHKmalloc(serverData->curlPostHandle = curl_easy_init());
         curlPostSetup(pWrkrData, serverData);
@@ -2182,6 +2187,8 @@ static void cleanupServerData(serverData_t *serverData) {
     serverData->restPATH = NULL;
     curl_slist_free_all(serverData->curlHeader);
     serverData->curlHeader = NULL;
+    curl_slist_free_all(serverData->curlCheckHeader);
+    serverData->curlCheckHeader = NULL;
     serverData->gzipHeaderEnabled = 0;
 }
 

--- a/contrib/omhttp/omhttp.c
+++ b/contrib/omhttp/omhttp.c
@@ -1554,12 +1554,14 @@ static rsRetVal ATTR_NONNULL(1, 2) curlPost(wrkrInstanceData_t *pWrkrData,
         if (serverData->curlHeader == NULL) {
             CHKiRet(buildCurlHeaders(pWrkrData, serverData, compressed));
             curl_easy_setopt(serverData->curlPostHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
+            curl_easy_setopt(serverData->curlCheckConnHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
         }
     }
 
     if (serverData->curlHeader == NULL || serverData->gzipHeaderEnabled != compressed) {
         CHKiRet(buildCurlHeaders(pWrkrData, serverData, compressed));
         curl_easy_setopt(serverData->curlPostHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
+        curl_easy_setopt(serverData->curlCheckConnHandle, CURLOPT_HTTPHEADER, serverData->curlHeader);
     }
 
     /* Set Curl object here */


### PR DESCRIPTION
### Motivation
- Fix a use-after-free in `contrib/omhttp/omhttp.c` where `buildCurlHeaders()` can free and replace `serverData->curlHeader` while the health-check handle (`curlCheckConnHandle`) still holds a pointer to the freed `curl_slist`, causing crashes during `curl_easy_perform()`.

### Description
- Update `curlPost()` to re-apply `CURLOPT_HTTPHEADER` on `serverData->curlCheckConnHandle` whenever `serverData->curlHeader` is created or rebuilt so both POST and health-check handles reference the current header list (change in `contrib/omhttp/omhttp.c`).

### Testing
- Ran `git diff --check` on the modified file and it reported no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130d2b2b608332a13a0ecbfbebadee)