### PR TITLE
mmanon: make random suffix generation fully reachable

### DIFF
--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -892,8 +892,13 @@ static unsigned code_ipv4_int(unsigned ip, wrkrInstanceData_t *pWrkrData, int bi
             return (unsigned)shiftIP_subst;
         case RANDOMINT:
             shiftIP_subst = ((shiftIP_subst >> bits) << bits);
-            // multiply the random number between 0 and 1 with a mask of (2^n)-1:
-            random = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * ((1ull << bits) - 1));
+            // mask random bits directly so every suffix value remains reachable.
+            {
+                const uint32_t mask = (bits == 32) ? UINT32_MAX : (uint32_t)((1ull << bits) - 1);
+                const uint32_t random32 =
+                    (((uint32_t)rand_r(&(pWrkrData->randstatus))) << 16) ^ ((uint32_t)rand_r(&(pWrkrData->randstatus)));
+                random = (unsigned)(random32 & mask);
+            }
             return (unsigned)shiftIP_subst + random;
         case SIMPLE:  // can't happen, since this case is caught at the start of anonipv4()
         default:
@@ -1229,17 +1234,17 @@ static void code_ipv6_int(struct ipv6_int *ip, wrkrInstanceData_t *pWrkrData, in
         case RANDOMINT:
             if (bits == 128) {
                 for (int i = 0; i < 8; i++) {
-                    tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * 0xff);
+                    tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & 0xff);
                     ip->high <<= 8;
                     ip->high |= tmpRand;
 
-                    tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * 0xff);
+                    tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & 0xff);
                     ip->low <<= 8;
                     ip->low |= tmpRand;
                 }
             } else if (bits > 64) {
                 for (int i = 0; i < 8; i++) {
-                    tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * 0xff);
+                    tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & 0xff);
                     ip->low <<= 8;
                     ip->low |= tmpRand;
                 }
@@ -1248,19 +1253,19 @@ static void code_ipv6_int(struct ipv6_int *ip, wrkrInstanceData_t *pWrkrData, in
                 fullbits = bits / 8;
                 bits = bits % 8;
                 while (fullbits > 0) {
-                    tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * 0xff);
+                    tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & 0xff);
                     randhigh <<= 8;
                     randhigh |= tmpRand;
                     fullbits--;
                 }
-                tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * ((1 << bits) - 1));
+                tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & ((1u << bits) - 1));
                 randhigh <<= bits;
                 randhigh |= tmpRand;
 
                 ip->high |= randhigh;
             } else if (bits == 64) {
                 for (int i = 0; i < 8; i++) {
-                    tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * 0xff);
+                    tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & 0xff);
                     ip->low <<= 8;
                     ip->low |= tmpRand;
                 }
@@ -1268,12 +1273,12 @@ static void code_ipv6_int(struct ipv6_int *ip, wrkrInstanceData_t *pWrkrData, in
                 fullbits = bits / 8;
                 bits = bits % 8;
                 while (fullbits > 0) {
-                    tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * 0xff);
+                    tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & 0xff);
                     randlow <<= 8;
                     randlow |= tmpRand;
                     fullbits--;
                 }
-                tmpRand = (unsigned)((rand_r(&(pWrkrData->randstatus)) / (double)RAND_MAX) * ((1 << bits) - 1));
+                tmpRand = (unsigned)(rand_r(&(pWrkrData->randstatus)) & ((1u << bits) - 1));
                 randlow <<= bits;
                 randlow |= tmpRand;
 

--- a/plugins/mmanon/mmanon.c
+++ b/plugins/mmanon/mmanon.c
@@ -597,6 +597,15 @@ static int isPosByte(const uchar *const __restrict__ buf, const size_t buflen, s
     }
 }
 
+static uint32_t random_u32(wrkrInstanceData_t *pWrkrData) {
+    uint32_t value = 0;
+
+    for (size_t i = 0; i < sizeof(value); ++i) {
+        value = (value << 8) | (uint32_t)(rand_r(&(pWrkrData->randstatus)) & 0xffu);
+    }
+    return value;
+}
+
 /**
  * \brief Check whether a buffer starts with an IPv4 address.
  *
@@ -895,8 +904,7 @@ static unsigned code_ipv4_int(unsigned ip, wrkrInstanceData_t *pWrkrData, int bi
             // mask random bits directly so every suffix value remains reachable.
             {
                 const uint32_t mask = (bits == 32) ? UINT32_MAX : (uint32_t)((1ull << bits) - 1);
-                const uint32_t random32 =
-                    (((uint32_t)rand_r(&(pWrkrData->randstatus))) << 16) ^ ((uint32_t)rand_r(&(pWrkrData->randstatus)));
+                const uint32_t random32 = random_u32(pWrkrData);
                 random = (unsigned)(random32 & mask);
             }
             return (unsigned)shiftIP_subst + random;


### PR DESCRIPTION
### Motivation
- The previous suffix generation scaled `rand_r()` via floating-point (`rand_r()/RAND_MAX`) which made edge values (notably the all-ones suffix) practically unreachable for small `bits` values and could drive pathological retry behavior in `random-consistent-unique` mode. 
- The intent is to ensure every anonymized suffix value is reachable so uniqueness retries cannot be indefinitely starved by unreachable values. 

### Description
- Replace floating-point scaling in IPv4 suffix generation with a direct bitmask-based extraction from `rand_r()` so every suffix value in the configured bit width is reachable (changes in `plugins/mmanon/mmanon.c` around `code_ipv4_int`).
- Apply the same reachable-bit approach to IPv6 and embedded-IPv4 random byte/bit generation by using masked integer extraction from `rand_r()` instead of floating-point multiplication (changes in `plugins/mmanon/mmanon.c` inside `code_ipv6_int`).
- Keep existing anonymization semantics and unique-table insertion behavior while removing the practical impossibility of generating certain suffix values.

### Testing
- Ran `./autogen.sh` successfully to bootstrap the build system in this environment. 
- Attempted `./configure --enable-testbench` but configuration failed due to a missing external dependency `protoc-c` (the `protobuf-c-compiler` package), preventing a full local build and test pass. 
- Could not run `make check` or the full testbench in this environment, so no automated tests were completed against the compiled binaries here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130e36b840833294905d9f666cb6a9)