### PR TITLE
omotel: use getProgramName() to avoid unsafe PROGNAME union access

### DIFF
--- a/plugins/omotel/omotel.c
+++ b/plugins/omotel/omotel.c
@@ -1306,8 +1306,8 @@ static const char *extractAppName(const smsg_t *msg) {
         return candidate;
     }
 
-    if (msg->iLenPROGNAME > 0 && msg->PROGNAME.ptr != NULL) {
-        return (const char *)msg->PROGNAME.ptr;
+    if (msg->iLenPROGNAME > 0) {
+        return (const char *)getProgramName((smsg_t *)msg, LOCK_MUTEX);
     }
 
     return NULL;

--- a/plugins/omotel/omotel.c
+++ b/plugins/omotel/omotel.c
@@ -1294,7 +1294,7 @@ static const char *cstrToConst(cstr_t *value) {
     return value == NULL ? NULL : (const char *)rsCStrGetSzStrNoNULL(value);
 }
 
-static const char *extractAppName(const smsg_t *msg) {
+static const char *extractAppName(smsg_t *msg) {
     const char *candidate;
 
     if (msg == NULL) {
@@ -1307,7 +1307,7 @@ static const char *extractAppName(const smsg_t *msg) {
     }
 
     if (msg->iLenPROGNAME > 0) {
-        return (const char *)getProgramName((smsg_t *)msg, LOCK_MUTEX);
+        return (const char *)getProgramName(msg, LOCK_MUTEX);
     }
 
     return NULL;


### PR DESCRIPTION
### Motivation
- Prevent a crash where `omotel` read `PROGNAME.ptr` directly and passed a bogus pointer into `strdup()` when program names were stored inline in `PROGNAME.szBuf`.

### Description
- Replace the direct union-pointer fallback in `extractAppName()` with a call to `getProgramName((smsg_t *)msg, LOCK_MUTEX)` in `plugins/omotel/omotel.c`, preserving the existing app-name fallback semantics while correctly handling inline vs. heap-backed program names.

### Testing
- Attempted the module-focused regression `./tests/omotel-http-batch.sh`, but the test run could not complete because `configure` failed due to a missing tool (`protoc-c`), so automated test validation is blocked by the environment dependency and did not finish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130e36badc8332b291d4aeffd4502a)