### PR TITLE
containers: warn on anonymous collector TLS

### DIFF
--- a/doc/source/containers/collector.rst
+++ b/doc/source/containers/collector.rst
@@ -97,7 +97,17 @@ that loads or uses ``omkafka``.
 .. _containers-user-collector-tls_auth_mode:
 .. envvar:: TLS_AUTH_MODE
 
-   Netstream authentication mode for the TLS listener. Default ``x509/certvalid``.
+   Netstream authentication mode for the TLS listener. Default ``anon`` for
+   compatibility with existing deployments.
+
+   When ``ENABLE_TLS=on`` and ``TLS_AUTH_MODE=anon``, the container prints a
+   startup warning because the connection is encrypted but the sender is not
+   authenticated. For production deployments that need sender authentication,
+   set ``TLS_AUTH_MODE=x509/certvalid`` and configure ``TLS_CA_FILE`` so clients
+   must present certificates signed by the trusted CA. Stronger peer-name or
+   fingerprint checks require a custom rsyslog configuration snippet because
+   the packaged collector environment variables do not expose permitted-peer
+   settings.
 
 .. _containers-user-collector-write_all_file:
 .. envvar:: WRITE_ALL_FILE

--- a/doc/source/containers/collector.rst
+++ b/doc/source/containers/collector.rst
@@ -97,7 +97,7 @@ that loads or uses ``omkafka``.
 .. _containers-user-collector-tls_auth_mode:
 .. envvar:: TLS_AUTH_MODE
 
-   Netstream authentication mode for the TLS listener. Default ``anon``.
+   Netstream authentication mode for the TLS listener. Default ``x509/certvalid``.
 
 .. _containers-user-collector-write_all_file:
 .. envvar:: WRITE_ALL_FILE

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -82,7 +82,7 @@ ENV WRITE_JSON_FILE=on
 ENV TLS_CA_FILE=""
 ENV TLS_CERT_FILE=""
 ENV TLS_KEY_FILE=""
-ENV TLS_AUTH_MODE="anon"
+ENV TLS_AUTH_MODE="x509/certvalid"
 
 # Define the container role for the entrypoint script
 ENV RSYSLOG_ROLE=collector

--- a/packaging/docker/rsyslog/collector/Dockerfile
+++ b/packaging/docker/rsyslog/collector/Dockerfile
@@ -82,7 +82,7 @@ ENV WRITE_JSON_FILE=on
 ENV TLS_CA_FILE=""
 ENV TLS_CERT_FILE=""
 ENV TLS_KEY_FILE=""
-ENV TLS_AUTH_MODE="x509/certvalid"
+ENV TLS_AUTH_MODE="anon"
 
 # Define the container role for the entrypoint script
 ENV RSYSLOG_ROLE=collector

--- a/packaging/docker/rsyslog/minimal/start.sh
+++ b/packaging/docker/rsyslog/minimal/start.sh
@@ -6,7 +6,8 @@ if [ -n "$RSYSLOG_HOSTNAME" ]; then
     echo "Using pre-set container hostname"
 else
     echo "Obtaining RSYSLOG_HOSTNAME from /etc/hostname"
-    export RSYSLOG_HOSTNAME="$(cat /etc/hostname)"
+    RSYSLOG_HOSTNAME="$(cat /etc/hostname)"
+    export RSYSLOG_HOSTNAME
 fi
 echo "rsyslog uses hostname '$RSYSLOG_HOSTNAME'"
 
@@ -26,6 +27,10 @@ case "$RSYSLOG_ROLE" in
     echo "Remote log target: ${REMOTE_SERVER_NAME}:${REMOTE_SERVER_PORT}"
     ;;
   collector)
+    if [ "${ENABLE_TLS:-off}" = "on" ] && [ "${TLS_AUTH_MODE:-anon}" = "anon" ]; then
+        echo "WARNING: collector TLS is enabled with TLS_AUTH_MODE=anon; clients are not authenticated." >&2
+        echo "WARNING: set TLS_AUTH_MODE=x509/certvalid with TLS_CA_FILE and client certificates for sender authentication." >&2
+    fi
     ;;
   minimal|*)
     ;;


### PR DESCRIPTION
### Motivation
- Avoid silently encouraging anonymous TLS for the collector image while preserving existing deployments that enable TLS without client certificates.
- The original default change to `x509/certvalid` would require sender/client certificates and could break current collector users.

### Description
- Restore the collector image default `TLS_AUTH_MODE=anon` for compatibility.
- Add a collector startup warning when `ENABLE_TLS=on` and `TLS_AUTH_MODE=anon`, making the authentication risk visible without breaking existing configs.
- Update the collector documentation to describe the warning and the production path for sender authentication with `TLS_AUTH_MODE=x509/certvalid` plus `TLS_CA_FILE` and client certificates.
- Document that stronger peer-name or fingerprint checks need a custom rsyslog snippet because the packaged collector env interface does not expose permitted-peer settings.

### Testing
- Ran `bash -n packaging/docker/rsyslog/minimal/start.sh`.
- Ran `shellcheck -S warning packaging/docker/rsyslog/minimal/start.sh`.
- Ran `git diff --check`.
- Smoke-tested `packaging/docker/rsyslog/minimal/start.sh` directly for warning and non-warning cases.
- Built the collector image family with `make collector VERSION=codex-pr7086`.
- Smoke-tested the built `rsyslog/rsyslog-collector:codex-pr7086` image for warning and non-warning cases.
- Built rendered docs with `./doc/tools/build-doc-linux.sh --clean --format html --jobs "${RSYSLOG_LOCAL_DOC_JOBS:-$(nproc)}"`.

Note: Docker reported a build-time warning `SecretsUsedInArgOrEnv` for `ENV TLS_AUTH_MODE`; this is a false positive for this non-secret mode selector.
