### PR TITLE
doc: clarify mbedtls requires StreamDriverMode=1 to enable TLS

### DIFF
--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -47,8 +47,8 @@ Best Practices
 
 - **Use TLS where possible:**  
   When sending logs over untrusted networks, configure TLS with TCP by setting a TLS-capable
-  driver (`StreamDriver="ossl"`, `StreamDriver="gtls"` or `StreamDriver="mbedtls"`)
-  **and** `StreamDriverMode="1"`, or switch to `omdtls` (for UDP).
+  driver (``StreamDriver="ossl"``, ``StreamDriver="gtls"`` or ``StreamDriver="mbedtls"``)
+  **and** ``StreamDriverMode="1"``, or switch to ``omdtls`` (for UDP).
 
 - **Enable queues for TCP forwarding:**  
   Always define a queue (`queue.type="linkedList"`) to avoid blocking if the 

--- a/doc/source/configuration/modules/omfwd.rst
+++ b/doc/source/configuration/modules/omfwd.rst
@@ -46,9 +46,9 @@ Best Practices
   If you need **encrypted UDP**, consider :doc:`omdtls <omdtls>`.
 
 - **Use TLS where possible:**  
-  When sending logs over untrusted networks, configure TLS (`StreamDriver="ossl"`, 
-  `StreamDriver="gtls"` or `StreamDriver="mbedtls"`) with `omfwd` (for TCP) or switch 
-  to `omdtls` (for UDP).
+  When sending logs over untrusted networks, configure TLS with TCP by setting a TLS-capable
+  driver (`StreamDriver="ossl"`, `StreamDriver="gtls"` or `StreamDriver="mbedtls"`)
+  **and** `StreamDriverMode="1"`, or switch to `omdtls` (for UDP).
 
 - **Enable queues for TCP forwarding:**  
   Always define a queue (`queue.type="linkedList"`) to avoid blocking if the 

--- a/doc/source/configuration/modules/omfwd/parameters/basic.rst
+++ b/doc/source/configuration/modules/omfwd/parameters/basic.rst
@@ -153,11 +153,11 @@ Protocol
 
    "word", "udp", "no", "none"
 
-Type of protocol to use for forwarding. Note that ``tcp`` includes both legacy 
-plain TCP syslog and 
-`RFC5425 <https://datatracker.ietf.org/doc/html/rfc5425>`_-based TLS-encrypted 
-syslog. The selection depends on the StreamDriver parameter. If StreamDriver is 
-set to "ossl", "gtls" or "mbedtls", it will use TLS-encrypted syslog.
+Type of protocol to use for forwarding. Note that ``tcp`` includes both legacy
+plain TCP syslog and
+`RFC5425 <https://datatracker.ietf.org/doc/html/rfc5425>`_-based TLS-encrypted
+syslog. For TLS, configure a TLS-capable stream driver (``StreamDriver="ossl"``,
+``"gtls"``, or ``"mbedtls"``) **and** set ``StreamDriverMode="1"``.
 
 Template
 ========

--- a/doc/source/rainerscript/global.rst
+++ b/doc/source/rainerscript/global.rst
@@ -145,7 +145,9 @@ The following parameters can be set:
 
 - **defaultNetstreamDriver**
 
-  Set it to "ossl", "gtls" or "mbedtls" to enable TLS.
+  Set it to "ossl", "gtls" or "mbedtls" to select a TLS-capable driver.
+  TLS is used only when stream driver mode is also set to TLS mode
+  (for example, ``StreamDriverMode="1"`` on actions that use the driver).
   This `guide <http://www.rsyslog.com/doc/rsyslog_secure_tls.html>`_
   shows how to use TLS.
 


### PR DESCRIPTION
### Motivation

- Documentation added mbedtls as a TLS-capable stream driver but implied that selecting `StreamDriver=

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fd47ff488332806d5c751e6e15d6)