### PR TITLE
mmjsontransform: fix child ownership on dotted-key merge conflicts

### DIFF
--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -1060,6 +1060,7 @@ static rsRetVal jsontransformInsertDotted(struct json_object *dest,
 
     if (*segStart == '\0') {
         CHKiRet(jsontransformConflictSet(conflict, "dotted path '%s' ends with an empty segment", path));
+        json_object_put(value);
         goto finalize_it;
     }
 
@@ -1072,6 +1073,7 @@ static rsRetVal jsontransformInsertDotted(struct json_object *dest,
         if (!json_object_is_type(existing, json_type_object) || !json_object_is_type(value, json_type_object)) {
             CHKiRet(
                 jsontransformConflictSet(conflict, "dotted path '%s' collides with existing non-object value", path));
+            json_object_put(value);
             goto finalize_it;
         }
         CHKiRet(jsontransformMergeObjects(existing, value, conflict, path));
@@ -1186,8 +1188,8 @@ static rsRetVal jsontransformRewriteObject(struct json_object *src,
         }
         if (strchr(key, '.') != NULL) {
             CHKiRet(jsontransformInsertDotted(dest, key, child, conflict));
-            if (conflict != NULL && conflict->occurred) goto conflict;
             child = NULL;
+            if (conflict != NULL && conflict->occurred) goto conflict;
             free(valueContext);
             valueContext = NULL;
         } else {

--- a/plugins/mmjsontransform/mmjsontransform.c
+++ b/plugins/mmjsontransform/mmjsontransform.c
@@ -1017,6 +1017,7 @@ static rsRetVal jsontransformInsertDotted(struct json_object *dest,
     struct json_object *current = dest;
     char *segment = NULL;
     char *leaf = NULL;
+    sbool valueOwned = 1;
     DEFiRet;
 
     while (*ptr != '\0') {
@@ -1060,7 +1061,6 @@ static rsRetVal jsontransformInsertDotted(struct json_object *dest,
 
     if (*segStart == '\0') {
         CHKiRet(jsontransformConflictSet(conflict, "dotted path '%s' ends with an empty segment", path));
-        json_object_put(value);
         goto finalize_it;
     }
 
@@ -1073,18 +1073,20 @@ static rsRetVal jsontransformInsertDotted(struct json_object *dest,
         if (!json_object_is_type(existing, json_type_object) || !json_object_is_type(value, json_type_object)) {
             CHKiRet(
                 jsontransformConflictSet(conflict, "dotted path '%s' collides with existing non-object value", path));
-            json_object_put(value);
             goto finalize_it;
         }
         CHKiRet(jsontransformMergeObjects(existing, value, conflict, path));
         json_object_put(value);
+        valueOwned = 0;
         goto finalize_it;
     }
     json_object_object_add(current, leaf, value);
+    valueOwned = 0;
     free(leaf);
     leaf = NULL;
 
 finalize_it:
+    if (valueOwned) json_object_put(value);
     free(segment);
     free(leaf);
     RETiRet;
@@ -1187,7 +1189,8 @@ static rsRetVal jsontransformRewriteObject(struct json_object *src,
             goto conflict;
         }
         if (strchr(key, '.') != NULL) {
-            CHKiRet(jsontransformInsertDotted(dest, key, child, conflict));
+            iRet = jsontransformInsertDotted(dest, key, child, conflict);
+            if (iRet != RS_RET_OK) goto conflict;
             child = NULL;
             if (conflict != NULL && conflict->occurred) goto conflict;
             free(valueContext);


### PR DESCRIPTION
### Motivation
- Prevent a double-free/use-after-free in the `mmjsontransform` unflatten (dotted-key) path where `jsontransformInsertDotted()` could consume `value` while the caller still owned and later freed the same object. 
- The bug allows a crafted JSON input to trigger a daemon crash when the module is enabled, so a minimal ownership fix is needed to keep behavior and API unchanged while removing the crash vector.

### Description
- Adjusted ownership handling in `plugins/mmjsontransform/mmjsontransform.c` to align consumer/caller responsibilities for `value`/`child` during dotted-key insertion and conflict paths. 
- In `jsontransformInsertDotted()` the rewritten `value` is now released with `json_object_put(value)` on dotted-path conflict returns (empty segment and non-object collision) so the callee does not retain an owned pointer when returning an error. 
- In `jsontransformRewriteObject()` the `child` pointer is cleared (`child = NULL`) immediately after calling `jsontransformInsertDotted()` so the caller will not attempt to free `child` again if the insert routine consumed it during merge handling.

### Testing
- Attempted to run the module smoke test `./tests/mmjsontransform-basic.sh`, but the test run failed during bootstrap/configure due to a missing system dependency (`libsnappy-dev`), so full runtime test execution could not be completed in this environment. 
- No additional automated test suites completed here; static/CI validation should be run by maintainers or CI to confirm the fix under a full build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fe9685088332a35b58c8e61e039c)