### PR TITLE
mmsnareparse: avoid quadratic provider scans in Snare payload detection

### DIFF
--- a/plugins/mmsnareparse/mmsnareparse.c
+++ b/plugins/mmsnareparse/mmsnareparse.c
@@ -3170,6 +3170,8 @@ static const char *locate_snare_payload(const char *msg, smsg_t *pMsg) {
                             }
                         }
                     }
+                    eventIdStart = eventIdEnd;
+                    continue;
                 }
                 eventIdStart++;
             }
@@ -3216,6 +3218,8 @@ static const char *locate_snare_payload(const char *msg, smsg_t *pMsg) {
                                   searchStart);
                         return searchStart;
                     }
+                    searchStart = eventIdEnd;
+                    continue;
                 }
                 searchStart++;
             }

--- a/plugins/mmsnareparse/mmsnareparse.c
+++ b/plugins/mmsnareparse/mmsnareparse.c
@@ -3147,29 +3147,32 @@ static const char *locate_snare_payload(const char *msg, smsg_t *pMsg) {
                       msWinEventLog);
             return msWinEventLog;
         }
-        // Look for the EventID pattern (4-digit number) which comes before the provider
-        const char *eventIdStart = cursor;
-        while (*eventIdStart != '\0') {
-            if (*eventIdStart >= '0' && *eventIdStart <= '9') {
-                // Found a digit, check if it's a 4-digit EventID
-                const char *eventIdEnd = eventIdStart;
-                while (*eventIdEnd >= '0' && *eventIdEnd <= '9') {
-                    eventIdEnd++;
-                }
-                if (eventIdEnd - eventIdStart == 4) {
-                    // Found a 4-digit number, check if it's followed by tab and provider
-                    if (*eventIdEnd == '\t' || *eventIdEnd == ' ') {
-                        const char *afterEventId = skip_lws_const(eventIdEnd);
-                        if (afterEventId != NULL &&
-                            strstr(afterEventId, "Microsoft-Windows-Security-Auditing") != NULL) {
-                            dbgprintf("[mmsnareparse DEBUG] locate_snare_payload: found EventID pattern at '%s'\n",
-                                      eventIdStart);
-                            return eventIdStart;
+        // Look for the EventID pattern (4-digit number) which comes before the provider.
+        // Search provider once to avoid repeated full-suffix scans on malformed input.
+        const char *providerPos = strstr(cursor, "Microsoft-Windows-Security-Auditing");
+        if (providerPos != NULL) {
+            const char *eventIdStart = cursor;
+            while (*eventIdStart != '\0' && eventIdStart < providerPos) {
+                if (*eventIdStart >= '0' && *eventIdStart <= '9') {
+                    // Found a digit, check if it's a 4-digit EventID
+                    const char *eventIdEnd = eventIdStart;
+                    while (*eventIdEnd >= '0' && *eventIdEnd <= '9') {
+                        eventIdEnd++;
+                    }
+                    if (eventIdEnd - eventIdStart == 4) {
+                        // Found a 4-digit number, check if it's followed by whitespace before the provider
+                        if (*eventIdEnd == '\t' || *eventIdEnd == ' ') {
+                            const char *afterEventId = skip_lws_const(eventIdEnd);
+                            if (afterEventId != NULL && afterEventId <= providerPos) {
+                                dbgprintf("[mmsnareparse DEBUG] locate_snare_payload: found EventID pattern at '%s'\n",
+                                          eventIdStart);
+                                return eventIdStart;
+                            }
                         }
                     }
                 }
+                eventIdStart++;
             }
-            eventIdStart++;
         }
         // After syslog parsing, MSWinEventLog may be removed from the message
         // Try to find MSWinEventLog anywhere in the original message


### PR DESCRIPTION
### Motivation
- The Snare payload probe could perform a full `strstr()` over the remaining message for every 4-digit candidate token, producing quadratic CPU work on crafted non-Snare input and enabling a CPU DoS. 
- The intent is to keep the existing EventID+provider heuristic but remove the repeated full-suffix scans that amplify cost on malformed messages.

### Description
- Modify `locate_snare_payload()` in `plugins/mmsnareparse/mmsnareparse.c` to perform a single provider lookup with `strstr(cursor, "Microsoft-Windows-Security-Auditing")` and then only scan EventID candidates up to the provider location. 
- Replace the per-candidate `strstr(afterEventId, ...)` calls with a bounded candidate loop that checks `afterEventId <= providerPos` before accepting a match. 
- Preserve the original heuristic (4-digit EventID followed by whitespace and provider) and existing debug logging while eliminating repeated full-suffix rescans.

### Testing
- Attempted to run the module regression via `./tests/mmsnareparse-basic.sh`, but the test harness aborted during bootstrap/configure with `configure: error: snappy header not found - install libsnappy-dev`, so the test suite could not complete here. 
- Performed code inspection and local diff validation showing the provider is now located once and candidate scanning is bounded, which removes the quadratic `strstr()` pattern. 
- This change is scoped to the payload-location heuristic and is marked as **not fully container-validated** due to the missing build dependency in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fe962d688332884ccfb78b0d7d4e)