### PR TITLE
omelasticsearch: bound startup version probe response size

### DIFF
--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -560,8 +560,7 @@ static size_t ATTR_NONNULL(1, 4)
     }
     newlen = buffer->len + size_add;
     if (newlen > ES_VERSION_DETECT_MAX_RESPONSE) {
-        LogError(0, RS_RET_ERR,
-                 "omelasticsearch: platform detection response exceeded %u-byte limit",
+        LogError(0, RS_RET_ERR, "omelasticsearch: platform detection response exceeded %u-byte limit",
                  (unsigned)ES_VERSION_DETECT_MAX_RESPONSE);
         return 0;
     }

--- a/plugins/omelasticsearch/omelasticsearch.c
+++ b/plugins/omelasticsearch/omelasticsearch.c
@@ -527,6 +527,9 @@ struct versionDetectBuffer {
     size_t len;
 };
 
+/* Keep startup platform probes bounded: root endpoint metadata is tiny JSON. */
+#define ES_VERSION_DETECT_MAX_RESPONSE (1024U * 1024U)
+
 /**
  * @brief cURL write callback used during platform/version detection.
  *
@@ -541,12 +544,29 @@ struct versionDetectBuffer {
 static size_t ATTR_NONNULL(1, 4)
     curlVersionResult(void *const ptr, const size_t size, const size_t nmemb, void *const userdata) {
     struct versionDetectBuffer *const buffer = (struct versionDetectBuffer *)userdata;
-    const size_t size_add = size * nmemb;
+    size_t size_add;
+    size_t newlen;
     char *tmp;
 
-    if (size_add == 0) return 0;
+    if (size == 0 || nmemb == 0) return 0;
+    if (nmemb > SIZE_MAX / size) {
+        LogError(0, RS_RET_ERR, "omelasticsearch: platform detection response size overflow");
+        return 0;
+    }
+    size_add = size * nmemb;
+    if (buffer->len > SIZE_MAX - size_add) {
+        LogError(0, RS_RET_ERR, "omelasticsearch: platform detection response size overflow");
+        return 0;
+    }
+    newlen = buffer->len + size_add;
+    if (newlen > ES_VERSION_DETECT_MAX_RESPONSE) {
+        LogError(0, RS_RET_ERR,
+                 "omelasticsearch: platform detection response exceeded %u-byte limit",
+                 (unsigned)ES_VERSION_DETECT_MAX_RESPONSE);
+        return 0;
+    }
 
-    tmp = realloc(buffer->data, buffer->len + size_add + 1);
+    tmp = realloc(buffer->data, newlen + 1);
     if (tmp == NULL) {
         LogError(errno, RS_RET_OUT_OF_MEMORY, "omelasticsearch: realloc failed in curlVersionResult");
         return 0;
@@ -554,7 +574,7 @@ static size_t ATTR_NONNULL(1, 4)
 
     memcpy(tmp + buffer->len, ptr, size_add);
     buffer->data = tmp;
-    buffer->len += size_add;
+    buffer->len = newlen;
     buffer->data[buffer->len] = '\0';
 
     return size_add;


### PR DESCRIPTION
### Motivation
- Prevent unbounded memory growth in the omelasticsearch startup platform/version probe where the cURL write callback previously appended the entire HTTP response without size limits or overflow checks, allowing a malicious or compromised upstream to trigger OOM during configuration validation.

### Description
- Add a hard cap `ES_VERSION_DETECT_MAX_RESPONSE` (1 MiB) for buffered platform-detection responses and abort accumulation when the limit is exceeded. 
- Add explicit `size * nmemb` and `len + size_add` overflow checks in the startup probe write callback `curlVersionResult` and switch to validated `newlen` for allocations and accounting. 
- Use the bounded `realloc` size and preserve existing behavior for valid small JSON payloads (NUL-termination and returning the number of bytes consumed). The changes are localized to `plugins/omelasticsearch/omelasticsearch.c`.

### Testing
- Attempted to validate compilation with `./autogen.sh && ./configure --enable-testbench --enable-elasticsearch`, but `configure` aborted due to a missing system dependency: `snappy header not found - install libsnappy-dev`. This prevented a full build/test run in the current environment. 
- Attempted `make -j$(nproc) check TESTS=""` but it could not run because the repository was not configured/built in this environment (`No rule to make target 'check'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fe9668148332b2dd92b4dd0b0822)