### PR TITLE
runtime: fix fromhost-port extraction before rcvFrom union swap

### DIFF
--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -313,6 +313,7 @@ static rsRetVal resolveDNS(smsg_t *const pMsg) {
     prop_t *port = NULL;
     char portbuf[8];
     uint16_t pnum;
+    const struct sockaddr_storage *pfrominet;
     DEFiRet;
 
     MsgLock(pMsg);
@@ -324,15 +325,12 @@ static rsRetVal resolveDNS(smsg_t *const pMsg) {
             localRet = net.cvthname(pMsg->rcvFrom.pfrominet, &localName, NULL, &ip);
         }
         if (localRet == RS_RET_OK) {
-            /* we pass down the props, so no need for AddRef */
-            MsgSetRcvFromWithoutAddRef(pMsg, localName);
-            MsgSetRcvFromIPWithoutAddRef(pMsg, ip);
-
+            pfrominet = pMsg->rcvFrom.pfrominet;
             if (pMsg->pRcvFromPort == NULL) {
-                if (pMsg->rcvFrom.pfrominet->ss_family == AF_INET)
-                    pnum = ntohs(((struct sockaddr_in *)pMsg->rcvFrom.pfrominet)->sin_port);
-                else if (pMsg->rcvFrom.pfrominet->ss_family == AF_INET6)
-                    pnum = ntohs(((struct sockaddr_in6 *)pMsg->rcvFrom.pfrominet)->sin6_port);
+                if (pfrominet != NULL && pfrominet->ss_family == AF_INET)
+                    pnum = ntohs(((const struct sockaddr_in *)pfrominet)->sin_port);
+                else if (pfrominet != NULL && pfrominet->ss_family == AF_INET6)
+                    pnum = ntohs(((const struct sockaddr_in6 *)pfrominet)->sin6_port);
                 else
                     pnum = 0;
                 snprintf(portbuf, sizeof(portbuf), "%u", pnum);
@@ -340,6 +338,9 @@ static rsRetVal resolveDNS(smsg_t *const pMsg) {
                 MsgSetRcvFromPortWithoutAddRef(pMsg, port);
                 port = NULL;
             }
+            /* we pass down the props, so no need for AddRef */
+            MsgSetRcvFromWithoutAddRef(pMsg, localName);
+            MsgSetRcvFromIPWithoutAddRef(pMsg, ip);
         }
     }
 finalize_it:

--- a/runtime/msg.c
+++ b/runtime/msg.c
@@ -308,8 +308,8 @@ static void ATTR_NONNULL() MsgSetRulesetByName(smsg_t *const pMsg, cstr_t *const
 static rsRetVal resolveDNS(smsg_t *const pMsg) {
     rsRetVal localRet;
     prop_t *propFromHost = NULL;
-    prop_t *ip;
-    prop_t *localName;
+    prop_t *ip = NULL;
+    prop_t *localName = NULL;
     prop_t *port = NULL;
     char portbuf[8];
     uint16_t pnum;
@@ -340,7 +340,9 @@ static rsRetVal resolveDNS(smsg_t *const pMsg) {
             }
             /* we pass down the props, so no need for AddRef */
             MsgSetRcvFromWithoutAddRef(pMsg, localName);
+            localName = NULL;
             MsgSetRcvFromIPWithoutAddRef(pMsg, ip);
+            ip = NULL;
         }
     }
 finalize_it:
@@ -351,6 +353,8 @@ finalize_it:
     }
     MsgUnlock(pMsg);
     if (propFromHost != NULL) prop.Destruct(&propFromHost);
+    if (localName != NULL) prop.Destruct(&localName);
+    if (ip != NULL) prop.Destruct(&ip);
     if (port != NULL) prop.Destruct(&port);
     RETiRet;
 }


### PR DESCRIPTION
### Motivation
- A recent change derived `fromhost-port` from `pMsg->rcvFrom.pfrominet` after `MsgSetRcvFromWithoutAddRef()` replaced the union member, causing type confusion and incorrect port values for NEEDS_DNSRESOL messages (notably remote UDP inputs). 

### Description
- Snapshot the original sockaddr into a local `const struct sockaddr_storage *pfrominet` and use it to extract the port before mutating the `rcvFrom` union. 
- Add null checks and AF_INET/AF_INET6 handling when deriving `pnum` from the saved `pfrominet`. 
- Move `MsgSetRcvFromWithoutAddRef()` and `MsgSetRcvFromIPWithoutAddRef()` to occur after port creation so the union swap happens last. 
- Change is localized to `resolveDNS()` in `runtime/msg.c` and preserves existing public behavior for `fromhost`, `fromhost-ip`, and `fromhost-port` properties. 

### Testing
- Ran the focused shell test `./tests/fromhost-port.sh` as the primary automated validation. 
- The test run could not complete in this environment due to missing build/test prerequisites (`libsnappy-dev` and test tools like `tcpflood` / `rsyslogd`), so the automated test did not pass here. 
- No other automated test failures were produced by available local steps, but full container/local testbench validation remains necessary to confirm end-to-end behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16fe95f1708332a92ce93df41d9b6c)