### PR TITLE
testbench: document flake-prone test antipatterns

### DIFF
--- a/.agent/skills/rsyslog_test/SKILL.md
+++ b/.agent/skills/rsyslog_test/SKILL.md
@@ -69,6 +69,39 @@ configured rsyslog output destination, usually testbench omfile output such as
 the oracle unless the test is specifically about process-level output or the
 exception is documented in the test header.
 
+### 3.1 Deflake Antipattern Review
+Before adding or heavily changing shell tests, run the advisory antipattern
+scanner on the touched files:
+
+```bash
+devtools/check-test-antipatterns.sh tests/<changed-test>.sh
+```
+
+The scanner prefers `rg` and falls back to `grep`/`find`, so it should also work
+in minimal CI-style containers. Findings are review prompts, not automatic
+failures. Fix practical matches; if a match is intentional, document the
+deterministic oracle in the test header.
+
+Known flake-prone patterns from prior fixes:
+
+- Port preselection with `get_free_port`; prefer listener `port="0"` plus a
+  port file or helper readiness written after `listen(2)` succeeds.
+- Fixed sleeps used as synchronization; prefer explicit readiness or completion
+  helpers such as port files, `wait_file_lines`, `wait_queueempty`, stats
+  counters, or imdiag waits.
+- Readiness files written before the underlying service is actually ready.
+- Negative-path tests that assume auth failure, retry, disconnect, or timeout
+  timing instead of waiting for a specific state or diagnostic.
+- CPU tick, runtime, or timeout thresholds without a header comment explaining
+  the oracle and why the value is safe under loaded CI runners.
+- Background helpers without deterministic readiness and cleanup.
+- Queue tests that assume immediate drain or shutdown ordering without
+  queue-specific synchronization.
+- Shared external state such as fixed ports, filenames, spool directories,
+  topics, databases, or service names.
+- Deflake changes that reduce the tested behavior or race window instead of
+  preserving the original invariant with a better oracle.
+
 ### 4. Using diag.sh Helpers
 All tests include `tests/diag.sh` using the POSIX `.` command. You should use its standardized helpers:
 - `cmp_exact`: Verify file content matches.

--- a/devtools/check-test-antipatterns.sh
+++ b/devtools/check-test-antipatterns.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+	cat <<'EOF'
+usage: devtools/check-test-antipatterns.sh [path ...]
+
+Advisory scan for testbench patterns that have caused flakes in past CI runs.
+The scanner prefers ripgrep when available and falls back to find + grep.
+
+Findings are review prompts, not automatic failures. A match can be acceptable
+when the test header documents why the pattern is intentional and what oracle
+keeps the test deterministic.
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+	usage
+	exit 0
+fi
+
+tmpfiles="$(mktemp)"
+cleanup() {
+	rm -f "$tmpfiles"
+}
+trap cleanup EXIT
+
+add_shell_files() {
+	local path
+	for path in "$@"; do
+		if [ -d "$path" ]; then
+			find "$path" -type f -name '*.sh' -print
+		elif [ -f "$path" ]; then
+			case "$path" in
+			*.sh) printf '%s\n' "$path" ;;
+			esac
+		fi
+	done
+}
+
+if [ "$#" -eq 0 ]; then
+	add_shell_files tests > "$tmpfiles"
+else
+	add_shell_files "$@" > "$tmpfiles"
+fi
+
+sort -u "$tmpfiles" -o "$tmpfiles"
+
+if [ ! -s "$tmpfiles" ]; then
+	printf 'No shell tests found.\n'
+	exit 0
+fi
+
+print_matches() {
+	local title="$1"
+	local pattern="$2"
+	local rationale="$3"
+	local matches
+
+	printf '\n## %s\n\n%s\n\n' "$title" "$rationale"
+	if command -v rg >/dev/null 2>&1; then
+		matches="$(xargs -r rg --line-number --with-filename --no-heading --color=never \
+			--regexp "$pattern" < "$tmpfiles" || true)"
+	else
+		matches="$(xargs -r grep -nH -E -- "$pattern" < "$tmpfiles" || true)"
+	fi
+
+	if [ -n "$matches" ]; then
+		printf '```text\n%s\n```\n' "$matches"
+		return 0
+	fi
+
+	printf 'No matches.\n'
+	return 1
+}
+
+findings=0
+
+printf '# rsyslog test antipattern scan\n'
+printf '\nScanned %s shell test files.\n' "$(wc -l < "$tmpfiles")"
+
+if print_matches "Port preselection" \
+	'get_free_port|get_free_port[[:space:]]' \
+	'Preselecting a free port is inherently racy: another process can bind it before the test listener does. Prefer listener port="0" plus a port file, or a helper that writes readiness only after listen(2) succeeds.'; then
+	findings=$((findings + 1))
+fi
+
+if print_matches "Fixed sleeps as synchronization" \
+	'(^|[[:space:];])m?sleep[[:space:]][0-9]' \
+	'Fixed sleeps often encode timing assumptions. Prefer explicit readiness or completion oracles such as port files, wait_file_lines, wait_queueempty, stats counters, or imdiag waits. If a sleep intentionally creates retry pressure, document that in the test header.'; then
+	findings=$((findings + 1))
+fi
+
+if print_matches "Fixed TCP/UDP port literals" \
+	'(port|PORT)[_[:alnum:]]*="?[1-9][0-9]{3,4}"?|:[1-9][0-9]{3,4}' \
+	'Fixed port literals can collide with concurrently running tests or host services. Prefer dynamic listener port allocation with a port file. Review matches manually; some are input data, expected messages, or legacy constants.'; then
+	findings=$((findings + 1))
+fi
+
+if print_matches "Backgrounded helpers" \
+	'[^#].*[[:space:]]&([[:space:]]*(#.*)?)?$' \
+	'Background processes need deterministic readiness and cleanup. Prefer testbench helpers that write readiness files after the service is actually ready, and ensure exit_test or explicit cleanup owns the process lifecycle.'; then
+	findings=$((findings + 1))
+fi
+
+if print_matches "CPU/runtime thresholds" \
+	'CPU ticks|threshold|TB_TEST_MAX_RUNTIME|TEST_MAX_RUNTIME|STARTUP_MAX_RUNTIME|TIMEOUT|timeout[[:space:]]+[0-9]' \
+	'Timeouts and CPU/runtime thresholds are acceptable only with a clear oracle and rationale. For timing, sampling, retry, concurrency, or negative-path tests, the test header should explain what the threshold proves and why it is large enough under CI stress.'; then
+	findings=$((findings + 1))
+fi
+
+if print_matches "Ad-hoc content checks" \
+	'grep[[:space:]].*(error_exit|exit[[:space:]]+[0-9])|cat[[:space:]].*error_exit' \
+	'Ad-hoc grep/cat assertions often produce inconsistent diagnostics or miss synchronization. Prefer content_check, custom_content_check, check_not_present, cmp_exact, and related diag.sh helpers unless the test needs custom logic.'; then
+	findings=$((findings + 1))
+fi
+
+printf '\nSummary: %d antipattern classes had matches.\n' "$findings"
+printf 'This advisory scan exits successfully so it can be used during review without blocking unrelated work.\n'

--- a/devtools/check-test-antipatterns.sh
+++ b/devtools/check-test-antipatterns.sh
@@ -59,10 +59,10 @@ print_matches() {
 
 	printf '\n## %s\n\n%s\n\n' "$title" "$rationale"
 	if command -v rg >/dev/null 2>&1; then
-		matches="$(xargs -r rg --line-number --with-filename --no-heading --color=never \
+		matches="$(xargs rg --line-number --with-filename --no-heading --color=never \
 			--regexp "$pattern" < "$tmpfiles" || true)"
 	else
-		matches="$(xargs -r grep -nH -E -- "$pattern" < "$tmpfiles" || true)"
+		matches="$(xargs grep -nH -E -- "$pattern" < "$tmpfiles" || true)"
 	fi
 
 	if [ -n "$matches" ]; then
@@ -98,7 +98,7 @@ if print_matches "Fixed TCP/UDP port literals" \
 fi
 
 if print_matches "Backgrounded helpers" \
-	'[^#].*[[:space:]]&([[:space:]]*(#.*)?)?$' \
+	'^[[:space:]]*[^#[:space:]].*[[:space:]]&([[:space:]]*(#.*)?)?$' \
 	'Background processes need deterministic readiness and cleanup. Prefer testbench helpers that write readiness files after the service is actually ready, and ensure exit_test or explicit cleanup owns the process lifecycle.'; then
 	findings=$((findings + 1))
 fi

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -20,6 +20,56 @@ agents.
 - Use this guide together with the top-level `AGENTS.md` and the component
   guide that matches the module you are testing.
 
+## Flake-prone test antipatterns
+
+These patterns come from actual deflake fixes. They are not banned in every
+case, but new or changed tests must either avoid them or explain why they are
+safe in that specific test. Before adding or heavily changing tests, run the
+advisory scan:
+
+```bash
+devtools/check-test-antipatterns.sh tests/<changed-test>.sh
+```
+
+The tool uses `rg` when available and falls back to `grep`, so it can run in
+minimal containers. Findings are review prompts, not automatic blockers.
+
+- **Port preselection with `get_free_port`**: selecting a free port before the
+  listener binds is racy. Another process can take the port in the gap. Prefer
+  listener `port="0"` plus a port file, or helper-owned readiness where the file
+  is written only after `listen(2)` succeeds.
+- **Fixed sleeps as synchronization**: `sleep 1`, `msleep 3000`, and similar
+  waits usually encode host-speed assumptions. Prefer explicit readiness or
+  completion oracles such as port files, `wait_file_lines`, `wait_queueempty`,
+  stats counters, or imdiag waits. If a sleep intentionally creates retry
+  pressure, document that timing role and the success/failure oracle.
+- **Readiness files written too early**: a port or ready file must mean the
+  consumer can proceed now, not merely that setup has started or a port number
+  was chosen.
+- **Negative-path tests without a deterministic oracle**: auth failures,
+  retries, disconnects, timeouts, and shutdown-abort paths must wait for a
+  specific state, diagnostic, queue condition, or process result instead of
+  assuming it happened after a delay.
+- **CPU tick, runtime, or timeout thresholds without rationale**: thresholds
+  are acceptable only when the test header explains what the number proves and
+  why it is high enough under loaded CI runners.
+- **Background helpers without lifecycle control**: backgrounded servers,
+  clients, or probes need deterministic readiness and cleanup. Prefer existing
+  testbench helpers; if custom plumbing is required, make ownership and cleanup
+  explicit.
+- **Queue tests assuming immediate drain or shutdown ordering**: use
+  queue-specific synchronization where possible. Do not assume that input
+  completion, shutdown start, or a fixed delay means all queued messages reached
+  the tested stage.
+- **Shared external state**: fixed filenames, spool directories, service names,
+  ports, topics, databases, and state files can collide under parallel
+  `make check`. Use dynamic names derived from the testbench instance where
+  possible.
+- **Scope-reducing deflake fixes**: do not make a test pass by removing the
+  behavior, race window, or invariant it was meant to exercise. If the oracle or
+  setup changes, refresh the head comment and verify the original behavior is
+  still covered.
+
 ## Writing & updating tests
 - Base new shell tests on existing ones; include `. $srcdir/diag.sh` to gain the
   helper functions (timeouts, Valgrind integration, rsyslogd launch helpers).
@@ -45,6 +95,10 @@ agents.
   particular, use `content_check "needle" "$file"` instead of hand-written
   `grep ... || { cat "$file"; error_exit 1; }` blocks when asserting log or
   output content.
+- Fix practical matches from `devtools/check-test-antipatterns.sh` when
+  touching a test. If a match is intentional, explain the deterministic oracle
+  in the test header instead of leaving the pattern as unexplained timing or
+  concurrency folklore.
 - **Config format coverage**: When a module parameter or config object is tested
   via RainerScript, add a companion YAML test (or extend an existing
   `yaml-<area>-*.sh`) that exercises the same parameter.  Both frontends share


### PR DESCRIPTION
## Summary
- document flake-prone test antipatterns from the deflake campaign
- add an advisory `devtools/check-test-antipatterns.sh` scanner
- update the rsyslog test skill so future generated tests inherit the guidance

## Validation
- `shellcheck -S warning devtools/check-test-antipatterns.sh`
- `devtools/check-test-antipatterns.sh --help`
- `devtools/check-test-antipatterns.sh tests/imfile-basic.sh tests/imtcp-basic.sh`
- `PATH=/bin devtools/check-test-antipatterns.sh tests/imfile-basic.sh tests/imtcp-basic.sh`
- `devtools/check-test-antipatterns.sh tests` completed as an advisory full-tree scan
- `git diff --check`

Not fully container-validated: this is documentation plus an advisory devtools scanner, so I used targeted script/lint validation rather than the full local container gate.
